### PR TITLE
Cache copies of register sets and data that varies with AVX512

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -36,13 +36,16 @@ public:
 
 private:
 #if defined(TARGET_AMD64)
+    regMaskTP rbmAllFloat;
+    regMaskTP rbmFltCalleeTrash;
+
     regMaskTP get_RBM_ALLFLOAT() const
     {
-        return compiler->rbmAllFloat;
+        return this->rbmAllFloat;
     }
     regMaskTP get_RBM_FLT_CALLEE_TRASH() const
     {
-        return compiler->rbmFltCalleeTrash;
+        return this->rbmFltCalleeTrash;
     }
 #endif // TARGET_AMD64
 

--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -35,20 +35,6 @@ public:
         GenTree* addr, bool fold, bool* revPtr, GenTree** rv1Ptr, GenTree** rv2Ptr, unsigned* mulPtr, ssize_t* cnsPtr);
 
 private:
-#if defined(TARGET_AMD64)
-    regMaskTP rbmAllFloat;
-    regMaskTP rbmFltCalleeTrash;
-
-    regMaskTP get_RBM_ALLFLOAT() const
-    {
-        return this->rbmAllFloat;
-    }
-    regMaskTP get_RBM_FLT_CALLEE_TRASH() const
-    {
-        return this->rbmFltCalleeTrash;
-    }
-#endif // TARGET_AMD64
-
 #if defined(TARGET_XARCH)
     // Bit masks used in negating a float or double number.
     // This is to avoid creating more than one data constant for these bitmasks when a

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -68,6 +68,14 @@ CodeGenInterface::CodeGenInterface(Compiler* theCompiler)
 {
 }
 
+#if defined(TARGET_AMD64)
+void CodeGenInterface::CopyRegisterInfo()
+{
+    rbmAllFloat       = compiler->rbmAllFloat;
+    rbmFltCalleeTrash = compiler->rbmFltCalleeTrash;
+}
+#endif // TARGET_AMD64
+
 /*****************************************************************************/
 
 CodeGen::CodeGen(Compiler* theCompiler) : CodeGenInterface(theCompiler)
@@ -139,11 +147,6 @@ CodeGen::CodeGen(Compiler* theCompiler) : CodeGenInterface(theCompiler)
     genSaveFpLrWithAllCalleeSavedRegisters = false;
     genForceFuncletFrameType5              = false;
 #endif // TARGET_ARM64
-
-#ifdef TARGET_AMD64
-    rbmAllFloat       = compiler->rbmAllFloat;
-    rbmFltCalleeTrash = compiler->rbmFltCalleeTrash;
-#endif // TARGET_AMD64
 }
 
 #if defined(TARGET_X86) || defined(TARGET_ARM)

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -139,7 +139,13 @@ CodeGen::CodeGen(Compiler* theCompiler) : CodeGenInterface(theCompiler)
     genSaveFpLrWithAllCalleeSavedRegisters = false;
     genForceFuncletFrameType5              = false;
 #endif // TARGET_ARM64
+
+#ifdef TARGET_AMD64
+    rbmAllFloat       = compiler->rbmAllFloat;
+    rbmFltCalleeTrash = compiler->rbmFltCalleeTrash;
+#endif // TARGET_AMD64
 }
+
 #if defined(TARGET_X86) || defined(TARGET_ARM)
 
 //---------------------------------------------------------------------

--- a/src/coreclr/jit/codegeninterface.h
+++ b/src/coreclr/jit/codegeninterface.h
@@ -59,6 +59,23 @@ public:
         return compiler;
     }
 
+#if defined(TARGET_AMD64)
+    regMaskTP rbmAllFloat;
+    regMaskTP rbmFltCalleeTrash;
+
+    // Call this function after the equivalent fields in Compiler have been initialized.
+    void CopyRegisterInfo();
+
+    regMaskTP get_RBM_ALLFLOAT() const
+    {
+        return this->rbmAllFloat;
+    }
+    regMaskTP get_RBM_FLT_CALLEE_TRASH() const
+    {
+        return this->rbmFltCalleeTrash;
+    }
+#endif // TARGET_AMD64
+
     // genSpillVar is called by compUpdateLifeVar.
     // TODO-Cleanup: We should handle the spill directly in CodeGen, rather than
     // calling it from compUpdateLifeVar.  Then this can be non-virtual.

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -3334,17 +3334,12 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     rbmAllFloat         = RBM_ALLFLOAT_INIT;
     rbmFltCalleeTrash   = RBM_FLT_CALLEE_TRASH_INIT;
     cntCalleeTrashFloat = CNT_CALLEE_TRASH_FLOAT_INIT;
-    availableRegCount   = ACTUAL_REG_COUNT;
 
     if (DoJitStressEvexEncoding())
     {
         rbmAllFloat |= RBM_HIGHFLOAT;
         rbmFltCalleeTrash |= RBM_HIGHFLOAT;
         cntCalleeTrashFloat += CNT_CALLEE_TRASH_HIGHFLOAT;
-    }
-    else
-    {
-        availableRegCount -= CNT_HIGHFLOAT;
     }
 #endif // TARGET_AMD64
 }

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -3341,6 +3341,8 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
         rbmFltCalleeTrash |= RBM_HIGHFLOAT;
         cntCalleeTrashFloat += CNT_CALLEE_TRASH_HIGHFLOAT;
     }
+
+    codeGen->CopyRegisterInfo();
 #endif // TARGET_AMD64
 }
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -10753,20 +10753,19 @@ private:
     regMaskTP rbmAllFloat;
     regMaskTP rbmFltCalleeTrash;
     unsigned  cntCalleeTrashFloat;
-    unsigned  availableRegCount;
 
 public:
     regMaskTP get_RBM_ALLFLOAT() const
     {
-        return rbmAllFloat;
+        return this->rbmAllFloat;
     }
     regMaskTP get_RBM_FLT_CALLEE_TRASH() const
     {
-        return rbmFltCalleeTrash;
+        return this->rbmFltCalleeTrash;
     }
     unsigned get_CNT_CALLEE_TRASH_FLOAT() const
     {
-        return cntCalleeTrashFloat;
+        return this->cntCalleeTrashFloat;
     }
 
 #endif // TARGET_AMD64

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -120,17 +120,6 @@ void emitLocation::Print(LONG compMethodID) const
 }
 #endif // DEBUG
 
-#if defined(TARGET_AMD64)
-inline regMaskTP emitter::get_RBM_FLT_CALLEE_TRASH() const
-{
-    return emitComp->rbmFltCalleeTrash;
-}
-inline unsigned emitter::get_AVAILABLE_REG_COUNT() const
-{
-    return emitComp->availableRegCount;
-}
-#endif // TARGET_AMD64
-
 /*****************************************************************************
  *
  *  Return the name of an instruction format.
@@ -654,6 +643,10 @@ void emitter::emitBegCG(Compiler* comp, COMP_HANDLE cmpHandle)
     if (!comp->opts.disAsm)
         m_debugInfoSize = 0;
 #endif
+
+#if defined(TARGET_AMD64)
+    rbmFltCalleeTrash = emitComp->rbmFltCalleeTrash;
+#endif // TARGET_AMD64
 }
 
 void emitter::emitEndCG()

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1991,8 +1991,12 @@ public:
 
 private:
 #if defined(TARGET_AMD64)
-    regMaskTP get_RBM_FLT_CALLEE_TRASH() const;
-    unsigned  get_AVAILABLE_REG_COUNT() const;
+    regMaskTP rbmFltCalleeTrash;
+
+    regMaskTP get_RBM_FLT_CALLEE_TRASH() const
+    {
+        return this->rbmFltCalleeTrash;
+    }
 #endif // TARGET_AMD64
 
     CORINFO_FIELD_HANDLE emitFltOrDblConst(double constValue, emitAttr attr);

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -754,6 +754,17 @@ LinearScan::LinearScan(Compiler* theCompiler)
 
     pendingDelayFree = false;
     tgtPrefUse       = nullptr;
+
+#if defined(TARGET_AMD64)
+    rbmAllFloat       = compiler->rbmAllFloat;
+    rbmFltCalleeTrash = compiler->rbmFltCalleeTrash;
+    availableRegCount = ACTUAL_REG_COUNT;
+
+    if (!compiler->DoJitStressEvexEncoding())
+    {
+        availableRegCount -= CNT_HIGHFLOAT;
+    }
+#endif // TARGET_AMD64
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -636,6 +636,17 @@ LinearScan::LinearScan(Compiler* theCompiler)
     , refPositions(theCompiler->getAllocator(CMK_LSRA_RefPosition))
     , listNodePool(theCompiler)
 {
+#if defined(TARGET_AMD64)
+    rbmAllFloat       = compiler->rbmAllFloat;
+    rbmFltCalleeTrash = compiler->rbmFltCalleeTrash;
+    availableRegCount = ACTUAL_REG_COUNT;
+
+    if (!compiler->DoJitStressEvexEncoding())
+    {
+        availableRegCount -= CNT_HIGHFLOAT;
+    }
+#endif // TARGET_AMD64
+
     regSelector  = new (theCompiler, CMK_LSRA) RegisterSelection(this);
     firstColdLoc = MaxLocation;
 
@@ -754,17 +765,6 @@ LinearScan::LinearScan(Compiler* theCompiler)
 
     pendingDelayFree = false;
     tgtPrefUse       = nullptr;
-
-#if defined(TARGET_AMD64)
-    rbmAllFloat       = compiler->rbmAllFloat;
-    rbmFltCalleeTrash = compiler->rbmFltCalleeTrash;
-    availableRegCount = ACTUAL_REG_COUNT;
-
-    if (!compiler->DoJitStressEvexEncoding())
-    {
-        availableRegCount -= CNT_HIGHFLOAT;
-    }
-#endif // TARGET_AMD64
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1936,17 +1936,21 @@ private:
     int BuildLclHeap(GenTree* tree);
 
 #if defined(TARGET_AMD64)
+    regMaskTP rbmAllFloat;
+    regMaskTP rbmFltCalleeTrash;
+    unsigned  availableRegCount;
+
     regMaskTP get_RBM_ALLFLOAT() const
     {
-        return compiler->rbmAllFloat;
+        return this->rbmAllFloat;
     }
     regMaskTP get_RBM_FLT_CALLEE_TRASH() const
     {
-        return compiler->rbmFltCalleeTrash;
+        return this->rbmFltCalleeTrash;
     }
     unsigned get_AVAILABLE_REG_COUNT() const
     {
-        return compiler->availableRegCount;
+        return this->availableRegCount;
     }
 #endif // TARGET_AMD64
 


### PR DESCRIPTION
1. Fix availableRegCount to only be stored in LSRA, where it is used.
2. Make copies of rbmAllFloat/rbmFltCalleeTrash to CodeGen and LSRA classes during construction, so access is "closer", in case TP is impacted. (This also makes it possible to define inline accessors in the `emitter` class.)