### PR TITLE
[NativeAOT] Add ability to generate library and exe entry points

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -52,8 +52,8 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <ItemGroup>
       <NativeLibrary Condition="'$(IlcMultiModule)' == 'true'" Include="$(SharedLibrary)" />
-      <NativeLibrary Condition="'$(NativeLib)' == ''" Include="$(IlcSdkPath)libbootstrapper.a" />
-      <NativeLibrary Condition="'$(NativeLib)' != ''" Include="$(IlcSdkPath)libbootstrapperdll.a" />
+      <NativeLibrary Condition="'$(NativeLib)' == '' and '$(CustomNativeMain)' != 'true'" Include="$(IlcSdkPath)libbootstrapper.a" />
+      <NativeLibrary Condition="'$(NativeLib)' != '' or '$(CustomNativeMain)' == 'true'" Include="$(IlcSdkPath)libbootstrapperdll.a" />
       <NativeLibrary Include="$(IlcSdkPath)$(FullRuntimeName).a" />
       <NativeLibrary Include="$(IlcSdkPath)$(EventPipeName)$(LibFileExt)" />
       <NativeLibrary Condition="'$(LinkStandardCPlusPlusLibrary)' != 'true' and '$(StaticICULinking)' != 'true'" Include="$(IlcSdkPath)libstdc++compat.a" />
@@ -145,8 +145,8 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-Wl,-z,relro" Condition="'$(TargetOS)' != 'osx'" />
       <!-- binskim warning BA3011 The BIND_NOW flag is missing -->
       <LinkerArg Include="-Wl,-z,now" Condition="'$(TargetOS)' != 'osx'" />
-      <LinkerArg Include="-Wl,-u,$(_SymbolPrefix)NativeAOT_StaticInitialization" Condition="('$(UseLLVMLinker)' == 'true' or '$(TargetOS)' == 'osx' or '$(TargetOS)' == 'freebsd') and '$(NativeLib)' == 'Shared'" />
-      <LinkerArg Include="-Wl,--require-defined,NativeAOT_StaticInitialization" Condition="'$(UseLLVMLinker)' != 'true' and '$(TargetOS)' == 'linux' and '$(NativeLib)' == 'Shared'" />
+      <LinkerArg Include="-Wl,-u,$(_SymbolPrefix)NativeAOT_StaticInitialization" Condition="('$(UseLLVMLinker)' == 'true' or '$(TargetOS)' == 'osx' or '$(TargetOS)' == 'freebsd') and ('$(NativeLib)' == 'Shared' or '$(CustomNativeMain)' == 'true')" />
+      <LinkerArg Include="-Wl,--require-defined,NativeAOT_StaticInitialization" Condition="'$(UseLLVMLinker)' != 'true' and '$(TargetOS)' == 'linux' and ('$(NativeLib)' == 'Shared' or '$(CustomNativeMain)' == 'true')" />
       <!-- this workaround can be deleted once the minimum supported glibc version
            (runtime's official build machine's glibc version) is at least 2.33
            see https://github.com/bminor/glibc/commit/99468ed45f5a58f584bab60364af937eb6f8afda -->

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
@@ -21,7 +21,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <FullRuntimeName>Runtime.WorkstationGC</FullRuntimeName>
     <FullRuntimeName Condition="'$(ServerGarbageCollection)' == 'true' or '$(ControlFlowGuard)' == 'Guard'">Runtime.ServerGC</FullRuntimeName>
     <BootstrapperName>bootstrapper</BootstrapperName>
-    <BootstrapperName Condition="'$(NativeLib)' != ''">bootstrapperdll</BootstrapperName>
+    <BootstrapperName Condition="'$(NativeLib)' != '' or '$(CustomNativeMain)' == 'true'">bootstrapperdll</BootstrapperName>
     <EntryPointSymbol Condition="'$(EntryPointSymbol)' == ''">wmainCRTStartup</EntryPointSymbol>
     <LinkerSubsystem Condition="'$(OutputType)' == 'WinExe' and '$(LinkerSubsystem)' == ''">WINDOWS</LinkerSubsystem>
     <LinkerSubsystem Condition="'$(OutputType)' == 'Exe' and '$(LinkerSubsystem)' == ''">CONSOLE</LinkerSubsystem>
@@ -84,7 +84,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="/INCREMENTAL:NO" />
       <LinkerArg Condition="'$(LinkerSubsystem)' != ''" Include="/SUBSYSTEM:$(LinkerSubsystem)" />
       <LinkerArg Condition="'$(OutputType)' == 'WinExe' or '$(OutputType)' == 'Exe'" Include="/ENTRY:$(EntryPointSymbol) /NOEXP /NOIMPLIB" />
-      <LinkerArg Condition="'$(NativeLib)' == 'Shared'" Include="/INCLUDE:NativeAOT_StaticInitialization" />
+      <LinkerArg Condition="'$(NativeLib)' == 'Shared' or '$(CustomNativeMain)' == 'true'" Include="/INCLUDE:NativeAOT_StaticInitialization" />
       <LinkerArg Include="/NATVIS:&quot;$(MSBuildThisFileDirectory)NativeAOT.natvis&quot;" />
       <LinkerArg Condition="'$(ControlFlowGuard)' == 'Guard'" Include="/guard:cf" />
     </ItemGroup>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -208,7 +208,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Include="@(RdXmlFile->'--rdxml:%(FullPath)')" />
       <IlcArg Include="@(TrimmerRootDescriptor->'--descriptor:%(FullPath)')" />
       <IlcArg Condition="'$(NativeLib)' != ''" Include="--nativelib" />
-      <IlcArg Condition="'$(CustomNativeMain)' == 'true'" Include="--split-exe-initalization" />
+      <IlcArg Condition="'$(CustomNativeMain)' == 'true'" Include="--splitinit" />
       <IlcArg Condition="$(ExportsFile) != ''" Include="--exportsfile:$(ExportsFile)" />
       <IlcArg Include="@(AutoInitializedAssemblies->'--initassembly:%(Identity)')" />
       <IlcArg Include="@(RuntimeHostConfigurationOption->'--appcontextswitch:%(Identity)=%(Value)')" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -208,6 +208,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Include="@(RdXmlFile->'--rdxml:%(FullPath)')" />
       <IlcArg Include="@(TrimmerRootDescriptor->'--descriptor:%(FullPath)')" />
       <IlcArg Condition="'$(NativeLib)' != ''" Include="--nativelib" />
+      <IlcArg Condition="'$(CustomNativeMain)' == 'true'" Include="--split-exe-initalization" />
       <IlcArg Condition="$(ExportsFile) != ''" Include="--exportsfile:$(ExportsFile)" />
       <IlcArg Include="@(AutoInitializedAssemblies->'--initassembly:%(Identity)')" />
       <IlcArg Include="@(RuntimeHostConfigurationOption->'--appcontextswitch:%(Identity)=%(Value)')" />

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MainMethodRootProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MainMethodRootProvider.cs
@@ -22,11 +22,13 @@ namespace ILCompiler
 
         private EcmaModule _module;
         private IReadOnlyCollection<MethodDesc> _libraryInitializers;
+        private bool _generateLibraryAndModuleInitializers;
 
-        public MainMethodRootProvider(EcmaModule module, IReadOnlyCollection<MethodDesc> libraryInitializers)
+        public MainMethodRootProvider(EcmaModule module, IReadOnlyCollection<MethodDesc> libraryInitializers, bool generateLibraryAndModuleInitializers)
         {
             _module = module;
             _libraryInitializers = libraryInitializers;
+            _generateLibraryAndModuleInitializers = generateLibraryAndModuleInitializers;
         }
 
         public void AddCompilationRoots(IRootingServiceProvider rootProvider)
@@ -36,7 +38,7 @@ namespace ILCompiler
                 throw new Exception("No managed entrypoint defined for executable module");
 
             TypeDesc owningType = _module.GetGlobalModuleType();
-            var startupCodeMain = new StartupCodeMainMethod(owningType, mainMethod, _libraryInitializers);
+            var startupCodeMain = new StartupCodeMainMethod(owningType, mainMethod, _libraryInitializers, _generateLibraryAndModuleInitializers);
 
             rootProvider.AddCompilationRoot(startupCodeMain, "Startup Code Main Method", ManagedEntryPointMethodName);
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
@@ -19,12 +19,14 @@ namespace Internal.IL.Stubs.StartupCode
         private MainMethodWrapper _mainMethod;
         private MethodSignature _signature;
         private IReadOnlyCollection<MethodDesc> _libraryInitializers;
+        private bool _generateLibraryAndModuleInitializers;
 
-        public StartupCodeMainMethod(TypeDesc owningType, MethodDesc mainMethod, IReadOnlyCollection<MethodDesc> libraryInitializers)
+        public StartupCodeMainMethod(TypeDesc owningType, MethodDesc mainMethod, IReadOnlyCollection<MethodDesc> libraryInitializers, bool generateLibraryAndModuleInitializers)
         {
             _owningType = owningType;
             _mainMethod = new MainMethodWrapper(owningType, mainMethod);
             _libraryInitializers = libraryInitializers;
+            _generateLibraryAndModuleInitializers = generateLibraryAndModuleInitializers;
         }
 
         public override TypeSystemContext Context
@@ -68,7 +70,7 @@ namespace Internal.IL.Stubs.StartupCode
                 codeStream.MarkDebuggerStepThroughPoint();
 
             // Allow the class library to run explicitly ordered class constructors first thing in start-up.
-            if (_libraryInitializers != null)
+            if (_generateLibraryAndModuleInitializers && _libraryInitializers != null)
             {
                 foreach (MethodDesc method in _libraryInitializers)
                 {
@@ -118,7 +120,7 @@ namespace Internal.IL.Stubs.StartupCode
 
             // Run module initializers
             MethodDesc runModuleInitializers = startup?.GetMethod("RunModuleInitializers", null);
-            if (runModuleInitializers != null)
+            if (_generateLibraryAndModuleInitializers && runModuleInitializers != null)
             {
                 codeStream.Emit(ILOpcode.call, emitter.NewToken(runModuleInitializers));
             }

--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -34,6 +34,8 @@ namespace ILCompiler
             new(new[] { "--gdwarf-5" }, "Generate source-level debug information with dwarf version 5");
         public Option<bool> NativeLib { get; } =
             new(new[] { "--nativelib" }, "Compile as static or shared library");
+        public Option<bool> SplitExeInitalization { get; } =
+            new(new[] { "--split-exe-initalization" }, "Split initalization of an executable between the library entrypoint and a main entrypoint");
         public Option<string> ExportsFile { get; } =
             new(new[] { "--exportsfile" }, "File to write exported method definitions");
         public Option<string> DgmlLogFileName { get; } =
@@ -174,6 +176,7 @@ namespace ILCompiler
             AddOption(EnableDebugInfo);
             AddOption(UseDwarf5);
             AddOption(NativeLib);
+            AddOption(SplitExeInitalization);
             AddOption(ExportsFile);
             AddOption(DgmlLogFileName);
             AddOption(GenerateFullDgmlLog);

--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -34,8 +34,8 @@ namespace ILCompiler
             new(new[] { "--gdwarf-5" }, "Generate source-level debug information with dwarf version 5");
         public Option<bool> NativeLib { get; } =
             new(new[] { "--nativelib" }, "Compile as static or shared library");
-        public Option<bool> SplitExeInitalization { get; } =
-            new(new[] { "--split-exe-initalization" }, "Split initalization of an executable between the library entrypoint and a main entrypoint");
+        public Option<bool> SplitExeInitialization { get; } =
+            new(new[] { "--splitinit" }, "Split initialization of an executable between the library entrypoint and a main entrypoint");
         public Option<string> ExportsFile { get; } =
             new(new[] { "--exportsfile" }, "File to write exported method definitions");
         public Option<string> DgmlLogFileName { get; } =
@@ -176,7 +176,7 @@ namespace ILCompiler
             AddOption(EnableDebugInfo);
             AddOption(UseDwarf5);
             AddOption(NativeLib);
-            AddOption(SplitExeInitalization);
+            AddOption(SplitExeInitialization);
             AddOption(ExportsFile);
             AddOption(DgmlLogFileName);
             AddOption(GenerateFullDgmlLog);

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -185,7 +185,7 @@ namespace ILCompiler
                 }
 
                 bool nativeLib = Get(_command.NativeLib);
-                bool splitExeInitalization = Get(_command.SplitExeInitalization);
+                bool SplitExeInitialization = Get(_command.SplitExeInitialization);
                 if (multiFile)
                 {
                     List<EcmaModule> inputModules = new List<EcmaModule>();
@@ -206,7 +206,7 @@ namespace ILCompiler
                 }
                 else
                 {
-                    if (entrypointModule == null && (!nativeLib || splitExeInitalization))
+                    if (entrypointModule == null && (!nativeLib || SplitExeInitialization))
                         throw new Exception("No entrypoint module");
 
                     if (!systemModuleIsInputModule)
@@ -222,17 +222,17 @@ namespace ILCompiler
                     compilationRoots.Add(new NativeLibraryInitializerRootProvider(typeSystemContext.GeneratedAssembly, CreateInitializerList(typeSystemContext)));
                     compilationRoots.Add(new RuntimeConfigurationRootProvider(runtimeOptions));
                     compilationRoots.Add(new ExpectedIsaFeaturesRootProvider(instructionSetSupport));
-                    if (splitExeInitalization)
+                    if (SplitExeInitialization)
                     {
                         compilationRoots.Add(new MainMethodRootProvider(entrypointModule, CreateInitializerList(typeSystemContext), generateLibraryAndModuleInitializers: false));
                     }
                 }
                 else if (entrypointModule != null)
                 {
-                    compilationRoots.Add(new MainMethodRootProvider(entrypointModule, CreateInitializerList(typeSystemContext), generateLibraryAndModuleInitializers: !splitExeInitalization));
+                    compilationRoots.Add(new MainMethodRootProvider(entrypointModule, CreateInitializerList(typeSystemContext), generateLibraryAndModuleInitializers: !SplitExeInitialization));
                     compilationRoots.Add(new RuntimeConfigurationRootProvider(runtimeOptions));
                     compilationRoots.Add(new ExpectedIsaFeaturesRootProvider(instructionSetSupport));
-                    if (splitExeInitalization)
+                    if (SplitExeInitialization)
                     {
                         compilationRoots.Add(new NativeLibraryInitializerRootProvider(typeSystemContext.GeneratedAssembly, CreateInitializerList(typeSystemContext)));
                     }

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/ILCompilerDriver.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/ILCompilerDriver.cs
@@ -62,7 +62,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				compilationRoots.Add (new ExportedMethodsRootProvider (module));
 			}
 
-			compilationRoots.Add (new MainMethodRootProvider (entrypointModule, CreateInitializerList (typeSystemContext, options)));
+			compilationRoots.Add (new MainMethodRootProvider (entrypointModule, CreateInitializerList (typeSystemContext, options), generateLibraryAndModuleInitializers: true));
 
 			ILProvider ilProvider = new NativeAotILProvider ();
 

--- a/src/tests/nativeaot/CustomMain/CMakeLists.txt
+++ b/src/tests/nativeaot/CustomMain/CMakeLists.txt
@@ -1,0 +1,7 @@
+project (CustomMainNative)
+include_directories(${INC_PLATFORM_DIR})
+
+add_library (CustomMainNative STATIC CustomMainNative.cpp)
+
+# add the install targets
+install (TARGETS CustomMainNative DESTINATION bin)

--- a/src/tests/nativeaot/CustomMain/CustomMain.cs
+++ b/src/tests/nativeaot/CustomMain/CustomMain.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/tests/nativeaot/CustomMain/CustomMain.cs
+++ b/src/tests/nativeaot/CustomMain/CustomMain.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+class Program
+{
+    static readonly Program Instance = new();
+
+    [UnmanagedCallersOnly(EntryPoint = "SetExitCodeInManagedSide", CallConvs = new Type[] { typeof(CallConvCdecl) })]
+    static void SetExitCode(int exitCode)
+    {
+        Instance.ExitCode = exitCode;
+    }
+
+    int ExitCode;
+
+    static int Main(string[] args)
+    {
+        Console.WriteLine("hello from managed code");
+        return Instance.ExitCode;
+    }
+}

--- a/src/tests/nativeaot/CustomMain/CustomMain.cs
+++ b/src/tests/nativeaot/CustomMain/CustomMain.cs
@@ -7,12 +7,18 @@ using System.Runtime.InteropServices;
 
 class Program
 {
-    static readonly Program Instance = new();
+    static int s_exitCode;
 
-    [UnmanagedCallersOnly(EntryPoint = "SetExitCodeInManagedSide", CallConvs = new Type[] { typeof(CallConvCdecl) })]
-    static void SetExitCode(int exitCode)
+    [ModuleInitializer]
+    internal static void InitializeModule()
     {
-        Instance.ExitCode = exitCode;
+        s_exitCode += 50;
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "IncrementExitCode", CallConvs = new Type[] { typeof(CallConvCdecl) })]
+    static void IncrementExitCode(int amount)
+    {
+        s_exitCode += amount;
     }
 
     int ExitCode;
@@ -20,6 +26,6 @@ class Program
     static int Main(string[] args)
     {
         Console.WriteLine("hello from managed code");
-        return Instance.ExitCode;
+        return s_exitCode;
     }
 }

--- a/src/tests/nativeaot/CustomMain/CustomMain.cs
+++ b/src/tests/nativeaot/CustomMain/CustomMain.cs
@@ -7,12 +7,21 @@ using System.Runtime.InteropServices;
 
 class Program
 {
+    // Each of the module initializer, class constructor, and IncrementExitCode
+    // should be executed exactly once, causing this to each 100 by program exit.
     static int s_exitCode;
 
     [ModuleInitializer]
     internal static void InitializeModule()
     {
-        s_exitCode += 50;
+        s_exitCode += 8;
+    }
+
+    static Program()
+    {
+        s_exitCode += 31;
+        // A side-effecting operation to prevent this cctor from being pre-inited at compile time.
+        Console.WriteLine("hello from static constructor");
     }
 
     [UnmanagedCallersOnly(EntryPoint = "IncrementExitCode", CallConvs = new Type[] { typeof(CallConvCdecl) })]
@@ -25,7 +34,7 @@ class Program
 
     static int Main(string[] args)
     {
-        Console.WriteLine("hello from managed code");
+        Console.WriteLine("hello from managed main");
         return s_exitCode;
     }
 }

--- a/src/tests/nativeaot/CustomMain/CustomMain.csproj
+++ b/src/tests/nativeaot/CustomMain/CustomMain.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CustomNativeMain>true</CustomNativeMain>
+    <StaticLibraryPrefix Condition="'$(TargetOS)' != 'windows'">lib</StaticLibraryPrefix>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="CustomMain.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <CMakeProjectReference Include="CMakeLists.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <NativeLibrary Include="$(OutputPath)$(StaticLibraryPrefix)CustomMainNative$(LibFileExt)" />
+  </ItemGroup>
+</Project>

--- a/src/tests/nativeaot/CustomMain/CustomMainNative.cpp
+++ b/src/tests/nativeaot/CustomMain/CustomMainNative.cpp
@@ -18,7 +18,7 @@ int __cdecl wmain(int argc, wchar_t* argv[])
 int main(int argc, char* argv[])
 #endif
 {
-    puts("hello from native code");
-    IncrementExitCode(50);
+    puts("hello from native main");
+    IncrementExitCode(61);
     return __managed__Main(argc, argv);
 }

--- a/src/tests/nativeaot/CustomMain/CustomMainNative.cpp
+++ b/src/tests/nativeaot/CustomMain/CustomMainNative.cpp
@@ -10,7 +10,7 @@ extern "C" int __managed__Main(int argc, wchar_t* argv[]);
 extern "C" int __managed__Main(int argc, char* argv[]);
 #endif
 
-extern "C" void SetExitCodeInManagedSide(int32_t exitCode);
+extern "C" void IncrementExitCode(int32_t amount);
 
 #if defined(_WIN32)
 int __cdecl wmain(int argc, wchar_t* argv[])
@@ -19,6 +19,6 @@ int main(int argc, char* argv[])
 #endif
 {
     puts("hello from native code");
-    SetExitCodeInManagedSide(100);
+    IncrementExitCode(50);
     return __managed__Main(argc, argv);
 }

--- a/src/tests/nativeaot/CustomMain/CustomMainNative.cpp
+++ b/src/tests/nativeaot/CustomMain/CustomMainNative.cpp
@@ -1,0 +1,22 @@
+
+#include <stdio.h>
+#include <stdint.h>
+
+#if defined(_WIN32)
+extern "C" int __managed__Main(int argc, wchar_t* argv[]);
+#else
+extern "C" int __managed__Main(int argc, char* argv[]);
+#endif
+
+extern "C" void SetExitCodeInManagedSide(int32_t exitCode);
+
+#if defined(_WIN32)
+int __cdecl wmain(int argc, wchar_t* argv[])
+#else
+int main(int argc, char* argv[])
+#endif
+{
+    puts("hello from native code");
+    SetExitCodeInManagedSide(100);
+    return __managed__Main(argc, argv);
+}

--- a/src/tests/nativeaot/CustomMain/CustomMainNative.cpp
+++ b/src/tests/nativeaot/CustomMain/CustomMainNative.cpp
@@ -1,3 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 #include <stdio.h>
 #include <stdint.h>


### PR DESCRIPTION
This PR adds a new flag to ILC, `--split-exe-initalization` . The flag splits the initialization that is normally done for executable into two parts. The `__managed__Startup` function runs classlib and module initializers. The `__managed__Main` function performs the remaining initialization and executes the entry-point of the managed application.

The use case for this is to allow calling `UnamanagedCallersOnly` functions before the managed `main` function. Running on iOS is the first use case for this feature (#80905).

It was not clear to me how to fit this into the larger NativeAot build system. Should this be thought of as "a static library that also has a `__managed__Main` compiled in" or as "an executable that splits its initialization into two parts"? So I added support to ILC for both cases: compiling with the `--nativelib` flag and without it.

Lastly, I added some build integration the "an executable that splits its initialization into two parts" case, along with test. The idea is the user sets the `CustomNativeMain` property in their project. They are then responsible for providing a `NativeLibrary` item pointing to an object file containing their native `main` function. At runtime, when they call their first managed function, NativeAOT initialization will run. This includes calling `__managed__Main`, so the user cannot forget to initialize the runtime.

Related issues: #81097 #77957