### PR TITLE
[browser][wbt] Cache build output

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
@@ -365,7 +365,7 @@ namespace Wasm.Build.Tests
 
                 // use this test's id for the run logs
                 _logPath = Path.Combine(s_buildEnv.LogRootPath, id);
-                return (_projectDir, "FIXME");
+                return (_projectDir, product.BuildOutput);
             }
 
             if (options.CreateProject)
@@ -435,14 +435,14 @@ namespace Wasm.Build.Tests
                 }
 
                 if (options.UseCache)
-                    _buildContext.CacheBuild(buildArgs, new BuildProduct(_projectDir, logFilePath, true));
+                    _buildContext.CacheBuild(buildArgs, new BuildProduct(_projectDir, logFilePath, true, result.buildOutput));
 
                 return (_projectDir, result.buildOutput);
             }
-            catch
+            catch (Exception ex)
             {
                 if (options.UseCache)
-                    _buildContext.CacheBuild(buildArgs, new BuildProduct(_projectDir, logFilePath, false));
+                    _buildContext.CacheBuild(buildArgs, new BuildProduct(_projectDir, logFilePath, false, $"The build attempt resulted in exception: {ex}."));
                 throw;
             }
         }
@@ -1100,7 +1100,7 @@ namespace Wasm.Build.Tests
                             bool AOT,
                             string ProjectFileContents,
                             string? ExtraBuildArgs);
-    public record BuildProduct(string ProjectDir, string LogFile, bool Result);
+    public record BuildProduct(string ProjectDir, string LogFile, bool Result, string BuildOutput);
     internal record FileStat (bool Exists, DateTime LastWriteTimeUtc, long Length, string FullPath);
     internal record BuildPaths(string ObjWasmDir, string ObjDir, string BinDir, string BundleDir);
 


### PR DESCRIPTION
Currently when we want to run WBT with different test data and to check if a certain string is in the output of the build in all of them, we will get `value XYZ not found in "FIXME"`.
Using cached output would be useful e.g. in https://github.com/dotnet/runtime/pull/80421.