### PR TITLE
JIT: Transform SELECT(relop, 1/0, 0/1) to relop

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3309,18 +3309,14 @@ GenTree* Lowering::LowerSelect(GenTreeConditional* select)
                 assert(reversed == cond);
             }
 
-            GenTree* newNode = cond;
-            if (select->TypeIs(TYP_LONG))
-            {
-                GenTree* cast = comp->gtNewCastNode(TYP_LONG, newNode, false, TYP_LONG);
-                BlockRange().InsertAfter(newNode, cast);
-                newNode = cast;
-            }
+            // Codegen supports also TYP_LONG typed compares so we can just
+            // retype the compare instead of inserting a cast.
+            cond->gtType = select->TypeGet();
 
             BlockRange().Remove(trueVal);
             BlockRange().Remove(falseVal);
             BlockRange().Remove(select);
-            use.ReplaceWith(newNode);
+            use.ReplaceWith(cond);
 
             return cond->gtNext;
         }

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -137,6 +137,7 @@ private:
     GenTree* OptimizeConstCompare(GenTree* cmp);
     GenTree* LowerCompare(GenTree* cmp);
     GenTree* LowerJTrue(GenTreeOp* jtrue);
+    GenTree* LowerSelect(GenTreeConditional* cond);
     GenTreeCC* LowerNodeCC(GenTree* node, GenCondition condition);
     void LowerJmpMethod(GenTree* jmp);
     void LowerRet(GenTreeUnOp* ret);


### PR DESCRIPTION
Fix #81479

Initially I generalized this to handle any power of two via `LSH(cond, shift)`. Like GCC and Clang do here: https://godbolt.org/z/hxPf3Ka8e
However, it had worse performance than a cmov from my measurements (around 20% slower). It would use one less register in many situations though.

We could also do this directly in if-conversion, though then we wouldn't get potential future SELECTs created in different places.

Example:

```csharp
[MethodImpl(MethodImplOptions.NoInlining)]
public bool IfElseCondition(bool input)
{
    if (input)
    {
        return false;
    }
    else
    {
        return true;
    }
}
```
Before:
```asm
G_M21872_IG02:              ;; offset=0000H
       84D2                 test     dl, dl
       7403                 je       SHORT G_M21872_IG05
                                                ;; size=4 bbWeight=1 PerfScore 1.25
G_M21872_IG03:              ;; offset=0004H
       33C0                 xor      eax, eax
                                                ;; size=2 bbWeight=0.50 PerfScore 0.12
G_M21872_IG04:              ;; offset=0006H
       C3                   ret
                                                ;; size=1 bbWeight=0.50 PerfScore 0.50
G_M21872_IG05:              ;; offset=0007H
       B801000000           mov      eax, 1
                                                ;; size=5 bbWeight=0.50 PerfScore 0.12
G_M21872_IG06:              ;; offset=000CH
       C3                   ret
                                                ;; size=1 bbWeight=0.50 PerfScore 0.50
```

After #81267:
```asm
G_M21872_IG02:              ;; offset=0000H
       B801000000           mov      eax, 1
       33C9                 xor      ecx, ecx
       84D2                 test     dl, dl
       0F45C1               cmovne   eax, ecx
                                                ;; size=12 bbWeight=1 PerfScore 1.00
G_M21872_IG03:              ;; offset=000CH
       C3                   ret
```

After #81267 + this PR:
```asm
G_M21872_IG02:              ;; offset=0000H
       33C0                 xor      eax, eax
       84D2                 test     dl, dl
       0F94C0               sete     al
                                                ;; size=7 bbWeight=1 PerfScore 1.50
G_M21872_IG03:              ;; offset=0007H
       C3                   ret
```