### PR TITLE
Force building of Mono manifest packages when building via source-build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,10 @@
          For offline builds we still set OfficialBuildId but we need to build all the packages for a single
          leg only, so we also take DotNetBuildFromSource  into account. -->
     <BuildingAnOfficialBuildLeg Condition="'$(BuildingAnOfficialBuildLeg)' == '' and '$(OfficialBuildId)' != '' and '$(DotNetBuildFromSource)' != 'true'">true</BuildingAnOfficialBuildLeg>
+    <!-- When doing a source build, we want to build the various text-only manifests in
+         all cases, rather than ordinarily where we build them during mobile or wasm
+         build legs. This makes the manifests available on source-only builds. -->
+    <ForceBuildMobileManifests Condition="'$(DotNetBuildFromSource)' == 'true'">true</ForceBuildMobileManifests>
   </PropertyGroup>
 
   <PropertyGroup Label="CalculateTargetOS">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -91,6 +91,7 @@
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-8.0.100-preview.1" Version="8.0.0-preview.1.23101.1">
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>c47bbefece200e429f8ed33494121fa9945f0ef9</Sha>
+      <SourceBuild RepoName="emsdk" ManagedOnly="true" />
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/81790