### PR TITLE
Disable EnsureCleanEnvironment on wasm since it can't possibly work

### DIFF
--- a/src/tests/tracing/eventpipe/common/IpcTraceTest.cs
+++ b/src/tests/tracing/eventpipe/common/IpcTraceTest.cs
@@ -344,7 +344,7 @@ namespace Tracing.Tests.Common
         // the process that created them, so we don't need to check on that platform.
         static public bool EnsureCleanEnvironment()
         {
-            if (!OperatingSystem.IsWindows())
+            if (!OperatingSystem.IsWindows() && !OperatingSystem.IsBrowser())
             {
                 Func<(IEnumerable<IGrouping<int,FileInfo>>, List<int>)> getPidsAndSockets = () =>
                 {


### PR DESCRIPTION
This previous test failure https://helixre107v0xdeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-pull-81811-merge-d89ce95366874b81b8/PayloadGroup0/1/console.969b1dd5.log?helixlogtype=result appears to be the result of test scaffolding relying on System.Diagnostics.Process on all non-Windows OSes, including WASM (which doesn't have processes). The scaffolding appears to be trying to clean up persistent state that doesn't exist in the WASM environment, so it seems appropriate to just disable the method on WASM.

cc @mdh1418 