### PR TITLE
Remove a number of unnecessary intermediate allocations in JsonMetadataServices.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
@@ -15,44 +15,20 @@ namespace System.Text.Json.Serialization.Converters
     /// <typeparam name="T">The type to converter</typeparam>
     internal sealed class JsonMetadataServicesConverter<T> : JsonResumableConverter<T>
     {
-        private readonly Func<JsonConverter<T>>? _converterCreator;
-        private JsonConverter<T>? _converter;
-
         // A backing converter for when fast-path logic cannot be used.
-        internal JsonConverter<T> Converter
-        {
-            get
-            {
-                _converter ??= _converterCreator!();
-                Debug.Assert(_converter != null);
-                Debug.Assert(_converter.ConverterStrategy == ConverterStrategy);
-                return _converter;
-            }
-        }
+        internal JsonConverter<T> Converter { get; }
 
         internal override Type? KeyType => Converter.KeyType;
-
         internal override Type? ElementType => Converter.ElementType;
 
         internal override bool ConstructorIsParameterized => Converter.ConstructorIsParameterized;
         internal override bool SupportsCreateObjectDelegate => Converter.SupportsCreateObjectDelegate;
         internal override bool CanHaveMetadata => Converter.CanHaveMetadata;
 
-        public JsonMetadataServicesConverter(Func<JsonConverter<T>> converterCreator, ConverterStrategy converterStrategy)
-        {
-            if (converterCreator is null)
-            {
-                ThrowHelper.ThrowArgumentNullException(nameof(converterCreator));
-            }
-
-            _converterCreator = converterCreator;
-            ConverterStrategy = converterStrategy;
-        }
-
         public JsonMetadataServicesConverter(JsonConverter<T> converter)
         {
-            _converter = converter;
             ConverterStrategy = converter.ConverterStrategy;
+            Converter = converter;
         }
 
         internal override bool OnTryRead(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options, scoped ref ReadStack state, out T? value)
@@ -61,19 +37,16 @@ namespace System.Text.Json.Serialization.Converters
         internal override bool OnTryWrite(Utf8JsonWriter writer, T value, JsonSerializerOptions options, ref WriteStack state)
         {
             JsonTypeInfo jsonTypeInfo = state.Current.JsonTypeInfo;
-
-            Debug.Assert(options == jsonTypeInfo.Options);
+            Debug.Assert(jsonTypeInfo is JsonTypeInfo<T> typeInfo && typeInfo.SerializeHandler != null);
 
             if (!state.SupportContinuation &&
                 jsonTypeInfo.CanUseSerializeHandler &&
                 !state.CurrentContainsMetadata) // Do not use the fast path if state needs to write metadata.
             {
-                Debug.Assert(jsonTypeInfo is JsonTypeInfo<T> typeInfo && typeInfo.SerializeHandler != null);
                 ((JsonTypeInfo<T>)jsonTypeInfo).SerializeHandler!(writer, value);
                 return true;
             }
 
-            jsonTypeInfo.ValidateCanBeUsedForMetadataSerialization();
             return Converter.OnTryWrite(writer, value, options, ref state);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -275,6 +275,7 @@ namespace System.Text.Json.Serialization.Converters
             ref WriteStack state)
         {
             JsonTypeInfo jsonTypeInfo = state.Current.JsonTypeInfo;
+            jsonTypeInfo.ValidateCanBeUsedForPropertyMetadataSerialization();
 
             object obj = value; // box once
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
@@ -541,7 +541,7 @@ namespace System.Text.Json.Serialization.Converters
         {
             JsonTypeInfo jsonTypeInfo = state.Current.JsonTypeInfo;
 
-            jsonTypeInfo.ValidateCanBeUsedForMetadataSerialization();
+            jsonTypeInfo.ValidateCanBeUsedForPropertyMetadataSerialization();
 
             if (jsonTypeInfo.ParameterCount != jsonTypeInfo.ParameterCache!.Count)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Collections.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Collections.cs
@@ -22,7 +22,7 @@ namespace System.Text.Json.Serialization.Metadata
             => CreateCore(
                 options,
                 collectionInfo,
-                () => new ArrayConverter<TElement[], TElement>());
+                new ArrayConverter<TElement[], TElement>());
 
         /// <summary>
         /// Creates serialization metadata for types assignable to <see cref="List{T}"/>.
@@ -40,7 +40,7 @@ namespace System.Text.Json.Serialization.Metadata
             => CreateCore(
                 options,
                 collectionInfo,
-                () => new ListOfTConverter<TCollection, TElement>());
+                new ListOfTConverter<TCollection, TElement>());
 
         /// <summary>
         /// Creates serialization metadata for types assignable to <see cref="Dictionary{TKey, TValue}"/>.
@@ -60,7 +60,7 @@ namespace System.Text.Json.Serialization.Metadata
             => CreateCore(
                 options,
                 collectionInfo,
-                () => new DictionaryOfTKeyTValueConverter<TCollection, TKey, TValue>());
+                new DictionaryOfTKeyTValueConverter<TCollection, TKey, TValue>());
 
 
 #pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
@@ -92,7 +92,7 @@ namespace System.Text.Json.Serialization.Metadata
             return CreateCore(
                 options,
                 collectionInfo,
-                () => new ImmutableDictionaryOfTKeyTValueConverter<TCollection, TKey, TValue>(),
+                new ImmutableDictionaryOfTKeyTValueConverter<TCollection, TKey, TValue>(),
                 createObjectWithArgs: createRangeFunc);
         }
 
@@ -114,7 +114,7 @@ namespace System.Text.Json.Serialization.Metadata
             => CreateCore(
                 options,
                 collectionInfo,
-                () => new IDictionaryOfTKeyTValueConverter<TCollection, TKey, TValue>());
+                new IDictionaryOfTKeyTValueConverter<TCollection, TKey, TValue>());
 
         /// <summary>
         /// Creates serialization metadata for types assignable to <see cref="IReadOnlyDictionary{TKey, TValue}"/>.
@@ -134,9 +134,8 @@ namespace System.Text.Json.Serialization.Metadata
             => CreateCore(
                 options,
                 collectionInfo,
-                () => new IReadOnlyDictionaryOfTKeyTValueConverter<TCollection, TKey, TValue>());
+                new IReadOnlyDictionaryOfTKeyTValueConverter<TCollection, TKey, TValue>());
 
-#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
         /// <summary>
         /// Creates serialization metadata for non-dictionary immutable collection types.
         /// </summary>
@@ -147,7 +146,6 @@ namespace System.Text.Json.Serialization.Metadata
         /// <param name="createRangeFunc">A method to create an immutable dictionary instance.</param>
         /// <returns>Serialization metadata for the given type.</returns>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
         public static JsonTypeInfo<TCollection> CreateImmutableEnumerableInfo<TCollection, TElement>(
             JsonSerializerOptions options,
             JsonCollectionInfoValues<TCollection> collectionInfo,
@@ -162,7 +160,7 @@ namespace System.Text.Json.Serialization.Metadata
             return CreateCore(
                 options,
                 collectionInfo,
-                () => new ImmutableEnumerableOfTConverter<TCollection, TElement>(),
+                new ImmutableEnumerableOfTConverter<TCollection, TElement>(),
                 createObjectWithArgs: createRangeFunc);
         }
 
@@ -181,7 +179,7 @@ namespace System.Text.Json.Serialization.Metadata
             => CreateCore(
                 options,
                 collectionInfo,
-                () => new IListConverter<TCollection>());
+                new IListConverter<TCollection>());
 
         /// <summary>
         /// Creates serialization metadata for types assignable to <see cref="IList{T}"/>.
@@ -199,7 +197,7 @@ namespace System.Text.Json.Serialization.Metadata
             => CreateCore(
                 options,
                 collectionInfo,
-                () => new IListOfTConverter<TCollection, TElement>());
+                new IListOfTConverter<TCollection, TElement>());
 
         /// <summary>
         /// Creates serialization metadata for types assignable to <see cref="ISet{T}"/>.
@@ -217,7 +215,7 @@ namespace System.Text.Json.Serialization.Metadata
             => CreateCore(
                 options,
                 collectionInfo,
-                () => new ISetOfTConverter<TCollection, TElement>());
+                new ISetOfTConverter<TCollection, TElement>());
 
         /// <summary>
         /// Creates serialization metadata for types assignable to <see cref="ICollection{T}"/>.
@@ -235,7 +233,7 @@ namespace System.Text.Json.Serialization.Metadata
             => CreateCore(
                 options,
                 collectionInfo,
-                () => new ICollectionOfTConverter<TCollection, TElement>());
+                new ICollectionOfTConverter<TCollection, TElement>());
 
         /// <summary>
         /// Creates serialization metadata for types assignable to <see cref="Stack{T}"/>.
@@ -253,7 +251,7 @@ namespace System.Text.Json.Serialization.Metadata
             => CreateCore(
                 options,
                 collectionInfo,
-                () => new StackOfTConverter<TCollection, TElement>());
+                new StackOfTConverter<TCollection, TElement>());
 
         /// <summary>
         /// Creates serialization metadata for types assignable to <see cref="Queue{T}"/>.
@@ -271,7 +269,7 @@ namespace System.Text.Json.Serialization.Metadata
             => CreateCore(
                 options,
                 collectionInfo,
-                () => new QueueOfTConverter<TCollection, TElement>());
+                new QueueOfTConverter<TCollection, TElement>());
 
         /// <summary>
         /// Creates serialization metadata for types assignable to <see cref="ConcurrentStack{T}"/>.
@@ -289,7 +287,7 @@ namespace System.Text.Json.Serialization.Metadata
             => CreateCore(
                 options,
                 collectionInfo,
-                () => new ConcurrentStackOfTConverter<TCollection, TElement>());
+                new ConcurrentStackOfTConverter<TCollection, TElement>());
 
         /// <summary>
         /// Creates serialization metadata for types assignable to <see cref="Queue{T}"/>.
@@ -307,7 +305,7 @@ namespace System.Text.Json.Serialization.Metadata
             => CreateCore(
                 options,
                 collectionInfo,
-                () => new ConcurrentQueueOfTConverter<TCollection, TElement>());
+                new ConcurrentQueueOfTConverter<TCollection, TElement>());
 
         /// <summary>
         /// Creates serialization metadata for types assignable to <see cref="IEnumerable{T}"/>.
@@ -325,7 +323,7 @@ namespace System.Text.Json.Serialization.Metadata
             => CreateCore(
                 options,
                 collectionInfo,
-                () => new IEnumerableOfTConverter<TCollection, TElement>());
+                new IEnumerableOfTConverter<TCollection, TElement>());
 
         /// <summary>
         /// Creates serialization metadata for types assignable to <see cref="IAsyncEnumerable{T}"/>.
@@ -343,7 +341,7 @@ namespace System.Text.Json.Serialization.Metadata
             => CreateCore(
                 options,
                 collectionInfo,
-                () => new IAsyncEnumerableOfTConverter<TCollection, TElement>());
+                new IAsyncEnumerableOfTConverter<TCollection, TElement>());
 
         /// <summary>
         /// Creates serialization metadata for types assignable to <see cref="IDictionary"/>.
@@ -360,7 +358,7 @@ namespace System.Text.Json.Serialization.Metadata
             => CreateCore(
                 options,
                 collectionInfo,
-                () => new IDictionaryConverter<TCollection>());
+                new IDictionaryConverter<TCollection>());
 
 #pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
         /// <summary>
@@ -412,7 +410,7 @@ namespace System.Text.Json.Serialization.Metadata
             return CreateCore(
                 options,
                 collectionInfo,
-                () => new StackOrQueueConverter<TCollection>(),
+                new StackOrQueueConverter<TCollection>(),
                 createObjectWithArgs: null,
                 addFunc: addFunc);
         }
@@ -432,6 +430,6 @@ namespace System.Text.Json.Serialization.Metadata
             => CreateCore(
                 options,
                 collectionInfo,
-                () => new IEnumerableConverter<TCollection>());
+                new IEnumerableConverter<TCollection>());
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
@@ -88,7 +88,7 @@ namespace System.Text.Json.Serialization.Metadata
         {
             PropertyRef propertyRef;
 
-            ValidateCanBeUsedForMetadataSerialization();
+            ValidateCanBeUsedForPropertyMetadataSerialization();
             ulong key = GetKey(propertyName);
 
             // Keep a local copy of the cache in case it changes by another thread.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -304,12 +304,12 @@ namespace System.Text.Json.Serialization.Metadata
 
         // Configure would normally have thrown why initializing properties for source gen but type had SerializeHandler
         // so it is allowed to be used for fast-path serialization but it will throw if used for metadata-based serialization
-        internal bool MetadataSerializationNotSupported { get; set; }
+        internal bool PropertyMetadataSerializationNotSupported { get; set; }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void ValidateCanBeUsedForMetadataSerialization()
+        internal void ValidateCanBeUsedForPropertyMetadataSerialization()
         {
-            if (MetadataSerializationNotSupported)
+            if (PropertyMetadataSerializationNotSupported)
             {
                 ThrowHelper.ThrowInvalidOperationException_NoMetadataForTypeProperties(Options.TypeInfoResolver, Type);
             }


### PR DESCRIPTION
Removes a number of delayed converter initializations/wrappers that are no longer necessary.