### PR TITLE
JIT: Pick some low-hanging fruit in LSRA throughput

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -11083,7 +11083,6 @@ void LinearScan::RegisterSelection::reset(Interval* interval, RefPosition* refPo
     constAvailableApplied = false;
 
     regType         = linearScan->getRegisterType(currentInterval, refPosition);
-    nextRefPos      = refPosition->nextRefPosition;
     candidates      = refPosition->registerAssignment;
     preferences     = currentInterval->registerPreferences;
 
@@ -11752,6 +11751,7 @@ regMaskTP LinearScan::RegisterSelection::select(Interval*    currentInterval,
     // process data-structures
     if (RefTypeIsDef(refPosition->refType))
     {
+        RefPosition* nextRefPos = refPosition->nextRefPosition;
         if (currentInterval->hasConflictingDefUse)
         {
             linearScan->resolveConflictingDefAndUse(currentInterval, refPosition);

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -11083,7 +11083,6 @@ void LinearScan::RegisterSelection::reset(Interval* interval, RefPosition* refPo
     constAvailableApplied = false;
 
     regType         = linearScan->getRegisterType(currentInterval, refPosition);
-    currentLocation = refPosition->nodeLocation;
     nextRefPos      = refPosition->nextRefPosition;
     candidates      = refPosition->registerAssignment;
     preferences     = currentInterval->registerPreferences;
@@ -11462,7 +11461,7 @@ void LinearScan::RegisterSelection::try_SPILL_COST()
 
         // Can and should the interval in this register be spilled for this one,
         // if we don't find a better alternative?
-        if ((linearScan->getNextIntervalRef(spillCandidateRegNum, regType) == currentLocation) &&
+        if ((linearScan->getNextIntervalRef(spillCandidateRegNum, regType) == refPosition->nodeLocation) &&
             !assignedInterval->getNextRefPosition()->RegOptional())
         {
             continue;
@@ -11962,8 +11961,8 @@ regMaskTP LinearScan::RegisterSelection::select(Interval*    currentInterval,
             regNumber    checkConflictReg      = genRegNumFromMask(checkConflictBit);
             LsraLocation checkConflictLocation = linearScan->nextFixedRef[checkConflictReg];
 
-            if ((checkConflictLocation == currentLocation) ||
-                (refPosition->delayRegFree && (checkConflictLocation == (currentLocation + 1))))
+            if ((checkConflictLocation == refPosition->nodeLocation) ||
+                (refPosition->delayRegFree && (checkConflictLocation == (refPosition->nodeLocation + 1))))
             {
                 candidates &= ~checkConflictBit;
             }

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -11094,7 +11094,6 @@ void LinearScan::RegisterSelection::reset(Interval* interval, RefPosition* refPo
     rangeEndLocation    = refPosition->getRangeEndLocation();
     relatedLastLocation = rangeEndLocation;
     preferCalleeSave    = currentInterval->preferCalleeSave;
-    rangeEndRefPosition = nullptr;
     lastRefPosition     = currentInterval->lastRefPosition;
     lastLocation        = MinLocation;
     prevRegRec          = currentInterval->assignedReg;

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -11095,7 +11095,6 @@ void LinearScan::RegisterSelection::reset(Interval* interval, RefPosition* refPo
     relatedLastLocation = rangeEndLocation;
     preferCalleeSave    = currentInterval->preferCalleeSave;
     lastRefPosition     = currentInterval->lastRefPosition;
-    prevRegRec          = currentInterval->assignedReg;
 
     // These are used in the post-selection updates, and must be set for any selection.
     freeCandidates    = RBM_NONE;
@@ -11206,7 +11205,7 @@ void LinearScan::RegisterSelection::try_THIS_ASSIGNED()
         return;
     }
 
-    if (prevRegRec != nullptr)
+    if (currentInterval->assignedReg != nullptr)
     {
         found = applySelection(THIS_ASSIGNED, freeCandidates & preferences & prevRegBit);
     }
@@ -11391,7 +11390,7 @@ void LinearScan::RegisterSelection::try_BEST_FIT()
 void LinearScan::RegisterSelection::try_IS_PREV_REG()
 {
     // TODO: We do not check found here.
-    if ((prevRegRec != nullptr) && coversFullApplied)
+    if ((currentInterval->assignedReg != nullptr) && coversFullApplied)
     {
         found = applySingleRegSelection(IS_PREV_REG, prevRegBit);
     }
@@ -11973,8 +11972,9 @@ regMaskTP LinearScan::RegisterSelection::select(Interval*    currentInterval,
     // been restored as inactive after a kill?
     // NOTE: this is not currently considered one of the selection criteria - it always wins
     // if it is the assignedInterval of 'prevRegRec'.
-    if (!found && (prevRegRec != nullptr))
+    if (!found && (currentInterval->assignedReg != nullptr))
     {
+        RegRecord* prevRegRec = currentInterval->assignedReg;
         prevRegBit = genRegMask(prevRegRec->regNum);
         if ((prevRegRec->assignedInterval == currentInterval) && ((candidates & prevRegBit) != RBM_NONE))
         {

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -11097,7 +11097,6 @@ void LinearScan::RegisterSelection::reset(Interval* interval, RefPosition* refPo
     freeCandidates        = RBM_NONE;
     matchingConstants     = RBM_NONE;
     unassignedSet         = RBM_NONE;
-    foundRegBit           = RBM_NONE;
     coversSet             = RBM_NONE;
     preferenceSet         = RBM_NONE;
     coversRelatedSet      = RBM_NONE;
@@ -12066,6 +12065,7 @@ regMaskTP LinearScan::RegisterSelection::select(Interval*    currentInterval,
 Selection_Done:
     if (skipAllocation)
     {
+        foundRegBit = RBM_NONE;
         return RBM_NONE;
     }
 

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -11079,9 +11079,9 @@ void LinearScan::RegisterSelection::reset(Interval* interval, RefPosition* refPo
     currentInterval = interval;
     refPosition     = refPos;
 
-    regType         = linearScan->getRegisterType(currentInterval, refPosition);
-    candidates      = refPosition->registerAssignment;
-    preferences     = currentInterval->registerPreferences;
+    regType     = linearScan->getRegisterType(currentInterval, refPosition);
+    candidates  = refPosition->registerAssignment;
+    preferences = currentInterval->registerPreferences;
 
     // This is not actually a preference, it's merely to track the lclVar that this
     // "specialPutArg" is using.
@@ -11184,9 +11184,9 @@ void LinearScan::RegisterSelection::try_CONST_AVAILABLE()
         regMaskTP newCandidates = candidates & matchingConstants;
         if (newCandidates != RBM_NONE)
         {
-            candidates = newCandidates;
+            candidates            = newCandidates;
             constAvailableApplied = true;
-            found = isSingleRegister(newCandidates);
+            found                 = isSingleRegister(newCandidates);
         }
     }
 }
@@ -11298,8 +11298,8 @@ void LinearScan::RegisterSelection::try_COVERS_FULL()
     regMaskTP newCandidates = candidates & coversFullSet & freeCandidates;
     if (newCandidates != RBM_NONE)
     {
-        candidates = newCandidates;
-        found = isSingleRegister(candidates);
+        candidates        = newCandidates;
+        found             = isSingleRegister(candidates);
         coversFullApplied = true;
     }
 }
@@ -11319,7 +11319,7 @@ void LinearScan::RegisterSelection::try_BEST_FIT()
     regMaskTP bestFitSet = RBM_NONE;
     // If the best score includes COVERS_FULL, pick the one that's killed soonest.
     // If none cover the full range, the BEST_FIT is the one that's killed later.
-    bool         earliestIsBest = coversFullApplied;
+    bool         earliestIsBest  = coversFullApplied;
     LsraLocation bestFitLocation = earliestIsBest ? MaxLocation : MinLocation;
     for (regMaskTP bestFitCandidates = candidates; bestFitCandidates != RBM_NONE;)
     {
@@ -11972,7 +11972,7 @@ regMaskTP LinearScan::RegisterSelection::select(Interval*    currentInterval,
     if (!found && (currentInterval->assignedReg != nullptr))
     {
         RegRecord* prevRegRec = currentInterval->assignedReg;
-        prevRegBit = genRegMask(prevRegRec->regNum);
+        prevRegBit            = genRegMask(prevRegRec->regNum);
         if ((prevRegRec->assignedInterval == currentInterval) && ((candidates & prevRegBit) != RBM_NONE))
         {
             candidates = prevRegBit;

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -11095,7 +11095,6 @@ void LinearScan::RegisterSelection::reset(Interval* interval, RefPosition* refPo
     relatedLastLocation = rangeEndLocation;
     preferCalleeSave    = currentInterval->preferCalleeSave;
     lastRefPosition     = currentInterval->lastRefPosition;
-    lastLocation        = MinLocation;
     prevRegRec          = currentInterval->assignedReg;
 
     // These are used in the post-selection updates, and must be set for any selection.

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -11079,9 +11079,6 @@ void LinearScan::RegisterSelection::reset(Interval* interval, RefPosition* refPo
     currentInterval = interval;
     refPosition     = refPos;
 
-    coversFullApplied     = false;
-    constAvailableApplied = false;
-
     regType         = linearScan->getRegisterType(currentInterval, refPosition);
     candidates      = refPosition->registerAssignment;
     preferences     = currentInterval->registerPreferences;
@@ -11097,19 +11094,19 @@ void LinearScan::RegisterSelection::reset(Interval* interval, RefPosition* refPo
     lastRefPosition     = currentInterval->lastRefPosition;
 
     // These are used in the post-selection updates, and must be set for any selection.
-    freeCandidates    = RBM_NONE;
-    matchingConstants = RBM_NONE;
-    unassignedSet     = RBM_NONE;
-
-    coversSet        = RBM_NONE;
-    preferenceSet    = RBM_NONE;
-    coversRelatedSet = RBM_NONE;
-    coversFullSet    = RBM_NONE;
-
-    foundRegBit          = REG_NA;
-    found                = false;
-    skipAllocation       = false;
-    coversSetsCalculated = false;
+    freeCandidates        = RBM_NONE;
+    matchingConstants     = RBM_NONE;
+    unassignedSet         = RBM_NONE;
+    foundRegBit           = RBM_NONE;
+    coversSet             = RBM_NONE;
+    preferenceSet         = RBM_NONE;
+    coversRelatedSet      = RBM_NONE;
+    coversFullSet         = RBM_NONE;
+    coversSetsCalculated  = false;
+    found                 = false;
+    skipAllocation        = false;
+    coversFullApplied     = false;
+    constAvailableApplied = false;
 }
 
 // ----------------------------------------------------------

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1268,7 +1268,6 @@ private:
         RefPosition* lastRefPosition;
         regMaskTP    callerCalleePrefs = RBM_NONE;
         LsraLocation lastLocation;
-        RegRecord*   prevRegRec = nullptr;
 
         regMaskTP prevRegBit = RBM_NONE;
 

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1288,7 +1288,6 @@ private:
         bool      skipAllocation       = false;
         bool      coversFullApplied = false;
         bool      constAvailableApplied = false;
-        regNumber foundReg             = REG_NA;
 
         // If the selected register is already assigned to the current internal
         FORCEINLINE bool isAlreadyAssigned()

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1255,7 +1255,6 @@ private:
         RefPosition* refPosition     = nullptr;
 
         RegisterType regType         = RegisterType::TYP_UNKNOWN;
-        RefPosition* nextRefPos      = nullptr;
 
         regMaskTP candidates;
         regMaskTP preferences     = RBM_NONE;

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1269,13 +1269,14 @@ private:
         regMaskTP    callerCalleePrefs = RBM_NONE;
         LsraLocation lastLocation;
 
+        regMaskTP foundRegBit;
+
         regMaskTP prevRegBit = RBM_NONE;
 
         // These are used in the post-selection updates, and must be set for any selection.
         regMaskTP freeCandidates;
         regMaskTP matchingConstants;
         regMaskTP unassignedSet;
-        regMaskTP foundRegBit;
 
         // Compute the sets for COVERS, OWN_PREFERENCE, COVERS_RELATED, COVERS_FULL and UNASSIGNED together,
         // as they all require similar computation.

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1255,7 +1255,6 @@ private:
         RefPosition* refPosition     = nullptr;
 
         RegisterType regType         = RegisterType::TYP_UNKNOWN;
-        LsraLocation currentLocation = MinLocation;
         RefPosition* nextRefPos      = nullptr;
 
         regMaskTP candidates;

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1254,7 +1254,7 @@ private:
         Interval*    currentInterval = nullptr;
         RefPosition* refPosition     = nullptr;
 
-        RegisterType regType         = RegisterType::TYP_UNKNOWN;
+        RegisterType regType = RegisterType::TYP_UNKNOWN;
 
         regMaskTP candidates;
         regMaskTP preferences     = RBM_NONE;
@@ -1283,10 +1283,10 @@ private:
         regMaskTP preferenceSet;
         regMaskTP coversRelatedSet;
         regMaskTP coversFullSet;
-        bool      coversSetsCalculated = false;
-        bool      found                = false;
-        bool      skipAllocation       = false;
-        bool      coversFullApplied = false;
+        bool      coversSetsCalculated  = false;
+        bool      found                 = false;
+        bool      skipAllocation        = false;
+        bool      coversFullApplied     = false;
         bool      constAvailableApplied = false;
 
         // If the selected register is already assigned to the current internal

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1242,7 +1242,7 @@ private:
         // Did we apply CONST_AVAILABLE heuristics
         FORCEINLINE bool isConstAvailable()
         {
-            return (score & CONST_AVAILABLE) != 0;
+            return constAvailableApplied;
         }
 
     private:
@@ -1251,7 +1251,6 @@ private:
         ScoreMappingTable* mappingTable                                 = nullptr;
 #endif
         LinearScan*  linearScan      = nullptr;
-        int          score           = 0;
         Interval*    currentInterval = nullptr;
         RefPosition* refPosition     = nullptr;
 
@@ -1290,6 +1289,8 @@ private:
         bool      coversSetsCalculated = false;
         bool      found                = false;
         bool      skipAllocation       = false;
+        bool      coversFullApplied = false;
+        bool      constAvailableApplied = false;
         regNumber foundReg             = REG_NA;
 
         // If the selected register is already assigned to the current internal


### PR DESCRIPTION
Probably easiest to review this commit-by-commit.

- Remove `LinearScan::RegisterSelection::score`, replace it by a couple of bools 
- Remove various fields from `LinearScan::RegisterSelection::reset`, either by inlining their definitions at their uses, or because they are unconditionally assigned before their uses anyway
- Reorder all fields that are zero initialized to happen in sequence