### PR TITLE
[wasm] Reimplement jiterpreter float-to-int conversions

### DIFF
--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -438,18 +438,6 @@ mono_jiterp_conv (void *dest, void *src, int opcode) {
 			return 1;
 		}
 
-		case MINT_CONV_I4_R8:
-		case MINT_CONV_I4_R4: {
-			double val;
-			if (opcode == MINT_CONV_I4_R4)
-				val = *(float*)src;
-			else
-				val = *(double*)src;
-			// Whatever interp.c would do is what we want.
-			*(gint32*)dest = (gint32)val;
-			return 1;
-		}
-
 		case MINT_CONV_OVF_I4_R8:
 		case MINT_CONV_OVF_I4_R4: {
 			double val;
@@ -463,18 +451,6 @@ mono_jiterp_conv (void *dest, void *src, int opcode) {
 				return 1;
 			}
 			return 0;
-		}
-
-		case MINT_CONV_I8_R8:
-		case MINT_CONV_I8_R4: {
-			double val;
-			if (opcode == MINT_CONV_I8_R4)
-				val = *(float*)src;
-			else
-				val = *(double*)src;
-			// Whatever interp.c would do is what we want.
-			*(gint64*)dest = (gint64)val;
-			return 1;
 		}
 
 		case MINT_CONV_OVF_I8_R8:

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -121,6 +121,26 @@ mono_jiterp_encode_leb52 (unsigned char * destination, double doubleValue, int v
 	}
 }
 
+EMSCRIPTEN_KEEPALIVE int
+mono_jiterp_encode_leb_signed_boundary (unsigned char * destination, int bits, int sign) {
+	if (!destination)
+		return 0;
+
+	int64_t value;
+	switch (bits) {
+		case 32:
+			value = sign >= 0 ? INT_MAX : INT_MIN;
+			break;
+		case 64:
+			value = sign >= 0 ? INT64_MAX : INT64_MIN;
+			break;
+		default:
+			return 0;
+	}
+
+	return mono_jiterp_encode_leb64_ref(destination, &value, TRUE);
+}
+
 // Many of the following functions implement various opcodes or provide support for opcodes
 //  so that jiterpreter traces don't have to inline dozens of wasm instructions worth of
 //  complex logic - these are designed to match interp.c

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -384,7 +384,7 @@ mono_jiterp_box_ref (MonoVTable *vtable, MonoObject **dest, void *src, gboolean 
 }
 
 EMSCRIPTEN_KEEPALIVE int
-mono_jiterp_conv_ovf (void *dest, void *src, int opcode) {
+mono_jiterp_conv (void *dest, void *src, int opcode) {
 	switch (opcode) {
 		case MINT_CONV_OVF_I4_I8: {
 			gint64 val = *(gint64*)src;
@@ -418,6 +418,18 @@ mono_jiterp_conv_ovf (void *dest, void *src, int opcode) {
 			return 1;
 		}
 
+		case MINT_CONV_I4_R8:
+		case MINT_CONV_I4_R4: {
+			double val;
+			if (opcode == MINT_CONV_I4_R4)
+				val = *(float*)src;
+			else
+				val = *(double*)src;
+			// Whatever interp.c would do is what we want.
+			*(gint32*)dest = (gint32)val;
+			return 1;
+		}
+
 		case MINT_CONV_OVF_I4_R8:
 		case MINT_CONV_OVF_I4_R4: {
 			double val;
@@ -431,6 +443,29 @@ mono_jiterp_conv_ovf (void *dest, void *src, int opcode) {
 				return 1;
 			}
 			return 0;
+		}
+
+		case MINT_CONV_I8_R8:
+		case MINT_CONV_I8_R4: {
+			double val;
+			if (opcode == MINT_CONV_I8_R4)
+				val = *(float*)src;
+			else
+				val = *(double*)src;
+			// Whatever interp.c would do is what we want.
+			*(gint64*)dest = (gint64)val;
+			return 1;
+		}
+
+		case MINT_CONV_OVF_I8_R8:
+		case MINT_CONV_OVF_I8_R4: {
+			double val;
+			if (opcode == MINT_CONV_OVF_I8_R4)
+				val = *(float*)src;
+			else
+				val = *(double*)src;
+
+			return mono_try_trunc_i64(val, dest);
 		}
 	}
 

--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -106,6 +106,7 @@ const fn_signatures: SigLine[] = [
     [true, "mono_jiterp_get_offset_of_array_data", "number", []],
     [false, "mono_jiterp_encode_leb52", "number", ["number", "number", "number"]],
     [false, "mono_jiterp_encode_leb64_ref", "number", ["number", "number", "number"]],
+    [false, "mono_jiterp_encode_leb_signed_boundary", "number", ["number", "number", "number"]],
     [true, "mono_jiterp_type_is_byref", "number", ["number"]],
     [true, "mono_jiterp_get_size_of_stackval", "number", []],
     [true, "mono_jiterp_parse_option", "number", ["string"]],
@@ -248,6 +249,10 @@ export interface t_Cwraps {
     // Returns bytes written (or 0 if writing failed)
     // Source is the address of a 64-bit int or uint
     mono_jiterp_encode_leb64_ref(destination: VoidPtr, source: VoidPtr, valueIsSigned: number): number;
+    // Returns bytes written (or 0 if writing failed)
+    // bits is either 32 or 64 (the size of the value)
+    // sign is >= 0 for INTnn_MAX and < 0 for INTnn_MIN
+    mono_jiterp_encode_leb_signed_boundary(destination: VoidPtr, bits: number, sign: number): number;
     mono_jiterp_type_is_byref(type: MonoType): number;
     mono_jiterp_get_size_of_stackval(): number;
     mono_jiterp_type_get_raw_value_size(type: MonoType): number;

--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -141,6 +141,10 @@ export class WasmBuilder {
         return this.current.appendF64(value);
     }
 
+    appendBoundaryValue (bits: number, sign: number) {
+        return this.current.appendBoundaryValue(bits, sign);
+    }
+
     appendULeb (value: number | MintOpcodePtr) {
         return this.current.appendULeb(<any>value);
     }
@@ -601,6 +605,17 @@ export class BlobBuilder {
         this.view.setFloat64(this.size, value, true);
         this.size += 8;
         return result;
+    }
+
+    appendBoundaryValue (bits: number, sign: number) {
+        if (this.size + 8 >= this.capacity)
+            throw new Error("Buffer full");
+
+        const bytesWritten = cwraps.mono_jiterp_encode_leb_signed_boundary(<any>(this.buffer + this.size), bits, sign);
+        if (bytesWritten < 1)
+            throw new Error(`Failed to encode ${bits} bit boundary value with sign ${sign}`);
+        this.size += bytesWritten;
+        return bytesWritten;
     }
 
     appendULeb (value: number) {

--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -517,7 +517,7 @@ export class WasmBuilder {
 
     getArrayView (fullCapacity?: boolean) {
         if (this.stackSize > 1)
-            throw new Error("Stack not empty");
+            throw new Error("Jiterpreter block stack not empty");
         return this.stack[0].getArrayView(fullCapacity);
     }
 

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -251,7 +251,7 @@ function getTraceImports () {
         ["newobj_i", "newobj_i", getRawCwrap("mono_jiterp_try_newobj_inlined")],
         ["ld_del_ptr", "ld_del_ptr", getRawCwrap("mono_jiterp_ld_delegate_method_ptr")],
         ["ldtsflda", "ldtsflda", getRawCwrap("mono_jiterp_ldtsflda")],
-        ["conv_ovf", "conv_ovf", getRawCwrap("mono_jiterp_conv_ovf")],
+        ["conv", "conv", getRawCwrap("mono_jiterp_conv")],
         ["relop_fp", "relop_fp", getRawCwrap("mono_jiterp_relop_fp")],
         ["safepoint", "safepoint", getRawCwrap("mono_jiterp_auto_safepoint")],
         ["hashcode", "hashcode", getRawCwrap("mono_jiterp_get_hashcode")],
@@ -461,7 +461,7 @@ function initialize_builder (builder: WasmBuilder) {
         }, WasmValtype.void, true
     );
     builder.defineType(
-        "conv_ovf", {
+        "conv", {
             "destination": WasmValtype.i32,
             "source": WasmValtype.i32,
             "opcode": WasmValtype.i32,
@@ -751,6 +751,11 @@ function generate_wasm (
             console.log(`// MONO_WASM: ${traceName} generated, blob follows //`);
             let s = "", j = 0;
             try {
+                // We may have thrown an uncaught exception while inside a block,
+                //  so we need to pop it for getArrayView to work.
+                while (builder.activeBlocks > 0)
+                    builder.endBlock();
+
                 if (builder.inSection)
                     builder.endSection();
             } catch {

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -630,8 +630,9 @@ function generate_wasm (
             "math_lhs32": WasmValtype.i32,
             "math_rhs32": WasmValtype.i32,
             "math_lhs64": WasmValtype.i64,
-            "math_rhs64": WasmValtype.i64
-            // "tempi64": WasmValtype.i64
+            "math_rhs64": WasmValtype.i64,
+            "temp_f32": WasmValtype.f32,
+            "temp_f64": WasmValtype.f64,
         });
 
         if (emitPadding) {


### PR DESCRIPTION
The wasm spec does not specify what happens when you convert a float to an int if the float isn't finite, and v8 decided that 'unspecified' means 'throw a runtime error'. This PR reimplements them by imitating what clang -O3 does so it should match the interpreter.

![image](https://user-images.githubusercontent.com/198130/217960746-aaf492c3-a930-49b0-a752-da2f7b60424d.png)

In my testing this fixes the issue revealed by https://github.com/dotnet/runtime/issues/81900, but I should note we don't have a way to automatically detect this kind of regression with our current CI. I manually verified it using the combination of an artificially jiterpreter-friendly test + setting the jiterpreter to compile traces after 1 hit, none of which is in this PR:

```csharp
[Fact]
        public void Vector128SqrtForIntegersProducesGarbageOnConversionFailure()
        {
            var negativeOne = Vector128<Int64>.AllBitsSet;
            for (int i = 0; i < 40960; i++) { // loop to ensure that the jiterpreter has a chance to compile the loop body and take over
                var expected = Vector128.Create(-9223372036854775808L); // this appears to be the "indefinite integer value" described by intel in their spec documents for instructions like CVTTSD2SI
                Assert.True(expected.Equals(Vector128.Sqrt(negativeOne)));
            }
        }
```

This PR also fixes a bug in the jiterpreter's instrumentation that would make it fail to dump the compiled wasm binary if an exception was thrown during codegen.