### PR TITLE
Call SetLastError when MAPMapPEFile fails

### DIFF
--- a/src/coreclr/pal/src/map/map.cpp
+++ b/src/coreclr/pal/src/map/map.cpp
@@ -2496,6 +2496,7 @@ done:
     }
     else
     {
+        SetLastError(palError);
         retval = NULL;
         LOGEXIT("MAPMapPEFile error: %d\n", palError);
 


### PR DESCRIPTION
If we don't add this call, the last error can get trampled (for example when enabling native sanitizers) and lead to really weird diagnostics where loading an assembly fails with `ERROR_SUCCESS`.