### PR TITLE
SetThreadDpiAwareness for host error dialog

### DIFF
--- a/src/native/corehost/apphost/apphost.windows.cpp
+++ b/src/native/corehost/apphost/apphost.windows.cpp
@@ -326,7 +326,7 @@ namespace
         HMODULE user32 = ::LoadLibraryExW(L"user32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
         if (user32 != nullptr)
         {
-            typedef DPI_AWARENESS_CONTEXT(WINAPI* set_thread_dpi)(DPI_AWARENESS_CONTEXT context);
+            using set_thread_dpi = DPI_AWARENESS_CONTEXT(WINAPI*)(DPI_AWARENESS_CONTEXT context);
             set_thread_dpi set_thread_dpi_func = (set_thread_dpi)::GetProcAddress(user32, "SetThreadDpiAwarenessContext");
 
             // Since this is only for errors shown when the process is about to exit, we

--- a/src/native/corehost/apphost/apphost.windows.cpp
+++ b/src/native/corehost/apphost/apphost.windows.cpp
@@ -323,6 +323,20 @@ namespace
 
         trace::verbose(_X("Showing error dialog for application: '%s' - error code: 0x%x - url: '%s' - details: %s"), executable_name, error_code, url.c_str(), details.c_str());
 
+        HMODULE user32 = ::LoadLibraryExW(L"user32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+        if (user32 != nullptr)
+        {
+            typedef DPI_AWARENESS_CONTEXT(WINAPI* set_thread_dpi)(DPI_AWARENESS_CONTEXT context);
+            set_thread_dpi set_thread_dpi_func = (set_thread_dpi)::GetProcAddress(user32, "SetThreadDpiAwarenessContext");
+
+            // Since this is only for errors shown when the process is about to exit, we
+            // skip resetting to the previous context to minimize impact on apphost size
+            if (set_thread_dpi_func != nullptr)
+                (void) set_thread_dpi_func(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+    
+            ::FreeLibrary(user32);
+        }
+
         if (enable_visual_styles())
         {
             // Task dialog requires enabling visual styles


### PR DESCRIPTION
When possible, set the DPI awareness before showing the host error dialog. This is the result of a [great suggestion ](https://github.com/dotnet/runtime/pull/76762#discussion_r990507319) from @reflectronic for avoiding a blurry dialog on high DPI monitors.

Before:
![image](https://user-images.githubusercontent.com/47805090/217966032-1d8c6cfe-4e64-45cf-bb61-03fc122f0b60.png)

After:
![image](https://user-images.githubusercontent.com/47805090/217966018-80b37098-4e26-4a5d-b8d0-4137e514d772.png)
