### PR TITLE
Remove CPU cache contention for instrumented code

### DIFF
--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -5407,12 +5407,12 @@ void JIT_PartialCompilationPatchpoint(int* counter, int ilOffset)
 
 static unsigned HandleHistogramProfileRand()
 {
-    // generate a random number (xorshift32)
+    // Generate a random number (xorshift32)
     //
-    // intentionally simple so we can have multithreaded
-    // access w/o tearing state.
+    // Intentionally simple for faster random. It's stored in TLS to avoid
+    // multithread contention.
     //
-    static volatile unsigned s_rng = 100;
+    static thread_local unsigned s_rng = 100;
 
     unsigned x = s_rng;
     x ^= x << 13;


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/76520

## Problem

Tier0 with instrumentation demonstrates up to 5x lower RPS than the non-instrumented Tier0:

![image](https://user-images.githubusercontent.com/523221/217977379-3728a860-2cbf-4d5e-8606-2294e5e9b098.png)


After various investigations we came to the conclusion that the main overhead is not from the counters/class probes in the codegen but the cache contention they cause trying to update the same addresses in memory from different threads. Both block counters and class probes are 50%/50% guilty for it. I've verified that by doing two things:
1) Modified JIT to update stack locals instead of `inc[(reloc)]` for block counters. ("fake counters")
2) Made `JIT_ClassProfile32` no-op in VM while JIT still emits calls to it for class probes.

Both steps restored missing RPS from the Tier0-instr. More experiments are listed here:
![image](https://user-images.githubusercontent.com/523221/217974572-650b0585-3050-44c6-83f6-36dc5ccd2b62.png)
![image](https://user-images.githubusercontent.com/523221/217978985-a00ae7f1-e067-465b-946d-6b6ab351eea8.png)


After some brainstorming with @jakobbotsch and @AndyAyersMS we detected a low-hanging fruit in `HandleHistogramProfileRand`. TLS random might slightly decrease the quality of the class histogram if the same method is invoked with different objects in parallel, but that sounds like a reasonable price to reduce the contention.

## Benchmarks

Tier0 TE results. Both Base and Diff use PGO instrumentation, Diff has this fix.

#### Plaintext-MVC
```
| load                   |                        Base |                        Diff |          |
| ---------------------- | --------------------------- | --------------------------- | -------- |
| Requests/sec           |                     130,722 |                     223,201 |  +70.74% |
| Latency 50th (ms)      |                       23.37 |                       10.89 |  -53.40% |
| Latency 75th (ms)      |                       32.82 |                       15.54 |  -52.65% |
```

#### JSON-JSON
```
| load                   |                        Base |                        Diff |          |
| ---------------------- | --------------------------- | --------------------------- | -------- |
| Requests/sec           |                     145,746 |                     249,565 |  +71.23% |
| Latency 50th (ms)      |                        1.75 |                        1.00 |  -42.86% |
| Latency 75th (ms)      |                        2.06 |                        1.20 |  -41.75% |
```

Up to +70% RPS. While this is not necessarily will result in faster "time to start/first request" - it definitely will improve throughput/latency of a non-fully warmed up code. It also highlights the general problem we have in other places.

## Alternative solutions
Use better source of random, e.g. `cntvct_el0` on arm64. Related: https://github.com/dotnet/runtime/issues/72387#issuecomment-1264653875