### PR TITLE
JIT: add option to use interlocked add for PGO edge count updates

### DIFF
--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -567,6 +567,7 @@ CONFIG_STRING(JitEnablePatchpointRange, W("JitEnablePatchpointRange"))
 #endif
 
 // Profile instrumentation options
+CONFIG_INTEGER(JitInterlockedProfiling, W("JitInterlockedProfiling"), 0)
 CONFIG_INTEGER(JitMinimalJitProfiling, W("JitMinimalJitProfiling"), 1)
 CONFIG_INTEGER(JitMinimalPrejitProfiling, W("JitMinimalPrejitProfiling"), 0)
 


### PR DESCRIPTION
Mainly intended for use in determining what is leading to some consistency issues with our current edge profiles. We might consider enabling this in some of our static PGO collections.

Enabled via JitInterlockedProfile=1.