### PR TITLE
Fix major performance regression in legacy struct marshalling APIs

### DIFF
--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -5282,6 +5282,14 @@ MethodDesc* NDirect::CreateStructMarshalILStub(MethodTable* pMT)
     }
     CONTRACT_END;
 
+    LoaderAllocator* pLoaderAllocator = pMT->GetLoaderAllocator();
+
+    EEMarshalingData* pMarshallingData = pLoaderAllocator->GetMarshalingData();
+
+    MethodDesc* pCachedStubMD = pMarshallingData->LookupStructILStub(pMT);
+    if (pCachedStubMD != NULL)
+        return pCachedStubMD;
+
     DWORD dwStubFlags = NDIRECTSTUB_FL_STRUCT_MARSHAL;
 
     BOOL bestFit, throwOnUnmappableChar;
@@ -5340,7 +5348,7 @@ MethodDesc* NDirect::CreateStructMarshalILStub(MethodTable* pMT)
     sigBuilder.NewArg(&cleanupWorkList);
 
     DWORD cbMetaSigSize = sigBuilder.GetSigSize();
-    AllocMemHolder<BYTE> szMetaSig(pMT->GetLoaderAllocator()->GetHighFrequencyHeap()->AllocMem(S_SIZE_T(cbMetaSigSize)));
+    AllocMemHolder<BYTE> szMetaSig(pLoaderAllocator->GetHighFrequencyHeap()->AllocMem(S_SIZE_T(cbMetaSigSize)));
     sigBuilder.GetSig(szMetaSig, cbMetaSigSize);
 
     StubSigDesc sigDesc(pMT, Signature(szMetaSig, cbMetaSigSize), pMT->GetModule());
@@ -5372,6 +5380,8 @@ MethodDesc* NDirect::CreateStructMarshalILStub(MethodTable* pMT)
     {
         szMetaSig.SuppressRelease();
     }
+
+    pMarshallingData->CacheStructILStub(pMT, pStubMD);
 
     RETURN pStubMD;
 }
@@ -5784,17 +5794,7 @@ void MarshalStructViaILStub(MethodDesc* pStubMD, void* pManagedData, void* pNati
     }
     CONTRACTL_END;
 
-    ARG_SLOT args[] =
-    {
-        PtrToArgSlot(pManagedData),
-        PtrToArgSlot(pNativeData),
-        (ARG_SLOT)operation,
-        PtrToArgSlot(ppCleanupWorkList)
-    };
-
-    MethodDescCallSite callSite(pStubMD);
-
-    callSite.Call(args);
+    MarshalStructViaILStubCode(pStubMD->GetSingleCallableAddrOfCode(), pManagedData, pNativeData, operation, ppCleanupWorkList);
 }
 
 void MarshalStructViaILStubCode(PCODE pStubCode, void* pManagedData, void* pNativeData, StructMarshalStubs::MarshalOperation operation, void** ppCleanupWorkList /* = nullptr */)

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -5381,6 +5381,9 @@ MethodDesc* NDirect::CreateStructMarshalILStub(MethodTable* pMT)
         szMetaSig.SuppressRelease();
     }
 
+    // The CreateInteropILStub() handles only creating a single stub.
+    // The stub returned will be okay to return even if the call below loses
+    // the race to insert into the cache.
     pMarshallingData->CacheStructILStub(pMT, pStubMD);
 
     RETURN pStubMD;

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -5288,7 +5288,7 @@ MethodDesc* NDirect::CreateStructMarshalILStub(MethodTable* pMT)
 
     MethodDesc* pCachedStubMD = pMarshallingData->LookupStructILStub(pMT);
     if (pCachedStubMD != NULL)
-        return pCachedStubMD;
+        RETURN pCachedStubMD;
 
     DWORD dwStubFlags = NDIRECTSTUB_FL_STRUCT_MARSHAL;
 

--- a/src/coreclr/vm/loaderallocator.hpp
+++ b/src/coreclr/vm/loaderallocator.hpp
@@ -624,6 +624,12 @@ public:
     // basis.
     EEMarshalingData *GetMarshalingData();
 
+    EEMarshalingData* GetMarshalingDataIfAvailable()
+    {
+        LIMITED_METHOD_CONTRACT;
+        return m_pMarshalingData;
+    }
+
 private:
     // Deletes marshaling data at shutdown (which contains cached factories that needs to be released)
     void DeleteMarshalingData();

--- a/src/coreclr/vm/marshalnative.cpp
+++ b/src/coreclr/vm/marshalnative.cpp
@@ -123,8 +123,10 @@ FCIMPL3(VOID, MarshalNative::StructureToPtr, Object* pObjUNSAFE, LPVOID ptr, CLR
     }
     else if (pMT->HasLayout())
     {
-        MethodDesc* structMarshalStub;
+        EEMarshalingData* pEEMarshalingData = pMT->GetLoaderAllocator()->GetMarshalingDataIfAvailable();
+        MethodDesc* structMarshalStub = (pEEMarshalingData != NULL) ? pEEMarshalingData->LookupStructILStubSpeculative(pMT) : NULL;
 
+        if (structMarshalStub == NULL)
         {
             GCX_PREEMP();
             structMarshalStub = NDirect::CreateStructMarshalILStub(pMT);
@@ -178,8 +180,10 @@ FCIMPL3(VOID, MarshalNative::PtrToStructureHelper, LPVOID ptr, Object* pObjIn, C
     }
     else if (pMT->HasLayout())
     {
-        MethodDesc* structMarshalStub;
+        EEMarshalingData* pEEMarshalingData = pMT->GetLoaderAllocator()->GetMarshalingDataIfAvailable();
+        MethodDesc* structMarshalStub = (pEEMarshalingData != NULL) ? pEEMarshalingData->LookupStructILStubSpeculative(pMT) : NULL;
 
+        if (structMarshalStub == NULL)
         {
             GCX_PREEMP();
             structMarshalStub = NDirect::CreateStructMarshalILStub(pMT);
@@ -227,11 +231,14 @@ FCIMPL2(VOID, MarshalNative::DestroyStructure, LPVOID ptr, ReflectClassBaseObjec
     }
     else if (th.HasLayout())
     {
-        MethodDesc* structMarshalStub;
+        MethodTable* pMT = th.GetMethodTable();
+        EEMarshalingData* pEEMarshalingData = pMT->GetLoaderAllocator()->GetMarshalingDataIfAvailable();
+        MethodDesc* structMarshalStub = (pEEMarshalingData != NULL) ? pEEMarshalingData->LookupStructILStubSpeculative(pMT) : NULL;
 
+        if (structMarshalStub == NULL)
         {
             GCX_PREEMP();
-            structMarshalStub = NDirect::CreateStructMarshalILStub(th.GetMethodTable());
+            structMarshalStub = NDirect::CreateStructMarshalILStub(pMT);
         }
 
         MarshalStructViaILStub(structMarshalStub, nullptr, ptr, StructMarshalStubs::MarshalOperation::Cleanup);

--- a/src/coreclr/vm/mlinfo.h
+++ b/src/coreclr/vm/mlinfo.h
@@ -240,6 +240,26 @@ public:
     void *operator new(size_t size, LoaderHeap *pHeap);
     void operator delete(void *pMem);
 
+#ifndef DACCESS_COMPILE
+    MethodDesc* LookupStructILStubSpeculative(MethodTable* pMT)
+    {
+        WRAPPER_NO_CONTRACT;
+        HashDatum res = 0;
+        m_structILStubCache.GetValueSpeculative(pMT, &res);
+        return (MethodDesc*)res;
+    }
+
+    MethodDesc* LookupStructILStub(MethodTable* pMT)
+    {
+        WRAPPER_NO_CONTRACT;
+        HashDatum res = 0;
+        m_structILStubCache.GetValue(pMT, &res);
+        return (MethodDesc*)res;
+    }
+
+    void CacheStructILStub(MethodTable* pMT, MethodDesc* pStubMD);
+#endif
+
     // This method returns the custom marshaling helper associated with the name cookie pair. If the
     // CM info has not been created yet for this pair then it will be created and returned.
     CustomMarshalerHelper *GetCustomMarshalerHelper(Assembly *pAssembly, TypeHandle hndManagedType, LPCUTF8 strMarshalerTypeName, DWORD cMarshalerTypeNameBytes, LPCUTF8 strCookie, DWORD cCookieStrBytes);
@@ -250,11 +270,10 @@ public:
 #ifdef FEATURE_COMINTEROP
     // This method retrieves OLE_COLOR marshaling info.
     OleColorMarshalingInfo *GetOleColorMarshalingInfo();
-
-
 #endif // FEATURE_COMINTEROP
 
 private:
+    EEPtrHashTable                      m_structILStubCache;
     EECMHelperHashTable                 m_CMHelperHashtable;
     EEPtrHashTable                      m_SharedCMHelperToCMInfoMap;
     LoaderAllocator*                    m_pAllocator;


### PR DESCRIPTION
This change adds a simple cache for the marshalling stubs. This cache improves performance of the test mentioned in the issue by 20+x.

Fixes #45100