### PR TITLE
Fix race condition in AllocateManagedClassObject

### DIFF
--- a/src/coreclr/vm/typehandle.cpp
+++ b/src/coreclr/vm/typehandle.cpp
@@ -365,7 +365,7 @@ void TypeHandle::AllocateManagedClassObject(RUNTIMETYPEHANDLE* pDest)
         // Take a lock here since we don't want to allocate redundant objects which won't be collected
         CrstHolder exposedClassLock(AppDomain::GetMethodTableExposedClassObjectLock());
 
-        if (*pDest == NULL)
+        if (VolatileLoad(pDest) == NULL)
         {
             FrozenObjectHeapManager* foh = SystemDomain::GetFrozenObjectHeapManager();
             Object* obj = foh->TryAllocateObject(g_pRuntimeTypeClass, g_pRuntimeTypeClass->GetBaseSize());
@@ -377,7 +377,7 @@ void TypeHandle::AllocateManagedClassObject(RUNTIMETYPEHANDLE* pDest)
             RUNTIMETYPEHANDLE handle = (RUNTIMETYPEHANDLE)obj;
             // Set the bit to 1 (we'll have to reset it before use)
             handle |= 1;
-            *pDest = handle;
+            VolatileStore(pDest, handle);
         }
     }
     else


### PR DESCRIPTION
This PR applies @jkotas's patch https://github.com/dotnet/runtime/issues/81884#issuecomment-1424429007

I've verified the other places where FOH->TryAllocate is used:
1) [AllocateStaticBox](https://github.com/dotnet/runtime/blob/c16c7367ad02c064856867874b7e0cec7739ad5b/src/coreclr/vm/methodtable.cpp#L3565) - should be fine as its return value is saved via write barrier + additional volatile operations [here](https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/methodtable.cpp#L3531-L3536)
2) [AllocateString](https://github.com/dotnet/runtime/blob/c16c7367ad02c064856867874b7e0cec7739ad5b/src/coreclr/vm/gchelpers.cpp#L894-L902) - should be fine, `pIsFrozen` is a stack local. The result of `AllocateString` is saved [here](https://github.com/dotnet/runtime/blob/c16c7367ad02c064856867874b7e0cec7739ad5b/src/coreclr/vm/stringliteralmap.cpp#L503-L508) and the `AddStringLiteral` itself is invoked under string-literal-lock

Hopefully, closes https://github.com/dotnet/runtime/issues/81884