### PR TITLE
[Android] Disable failing System.Net.Sockets test

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -1433,6 +1433,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [SkipOnPlatform(TestPlatforms.Linux | TestPlatforms.OSX | TestPlatforms.MacCatalyst | TestPlatforms.iOS | TestPlatforms.tvOS, "Expected behavior is different on Apple platforms and Linux")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/81946", TestPlatforms.Android)]
         public void BeginReceiveMessageFromV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>


### PR DESCRIPTION
Ref #81946 

I'm not sure if we expect this test to pass so I disabled it with `ActiveIssue`.