### PR TITLE
[6.0] Use Ubuntu 18.04 instead of 16.04 in libraries helix-queue-setup

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -35,9 +35,9 @@ jobs:
     # Linux arm64
     - ${{ if eq(parameters.platform, 'Linux_arm64') }}:
       - ${{ if eq(parameters.jobParameters.isFullMatrix, true) }}:
-        - (Ubuntu.1804.ArmArch.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-helix-arm64v8
+        - (Ubuntu.1804.Arm64.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8
       - ${{ if eq(parameters.jobParameters.isFullMatrix, false) }}:
-        - (Ubuntu.1804.ArmArch.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-helix-arm64v8
+        - (Ubuntu.1804.Arm64.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8
 
     # Linux musl x64
     - ${{ if eq(parameters.platform, 'Linux_musl_x64') }}:


### PR DESCRIPTION
In the PR that fixed the 6.0 helix queues from yesterday, one of the failures was that the 16.04 image was non-existent. I didn't want to restart the CI with a new commit so I'm sending this separately.

The `main` conditions are different, but I decided to use the Ubuntu 18.04 lines instead of Debian one or the 22.04 one.

https://github.com/dotnet/runtime/blob/c4156f847517445a67032dbd135709f312c8745e/eng/pipelines/libraries/helix-queues-setup.yml#L41-L48

Error example in the previous PRs:
https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-pull-81933-merge-931aa8d4c74f404797/Common.Tests.Attempt.3/1/console.72389342.log?helixlogtype=result

```
ildtools/prereqs:ubuntu-16.04-helix-arm64v8 on a000UZY
running $HELIX_CORRELATION_PAYLOAD/scripts/60c4fe1a4bce4301ab44d47fd393e06b/execute.sh in /datadisks/disk1/work/A89D0922/w/C1C10A4C/e max 2700 seconds

Output:
Unable to pull image mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-helix-arm64v8
Exit Code:-4
```