### PR TITLE
Transform IntCon(0) to VecCon(0) for WithElement case - fixes emitter assertion for crossgen2

### DIFF
--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -1221,9 +1221,9 @@ private:
                     // new value. This gives us a new TYP_SIMD16 with all elements in the right spots
 
                     GenTree* indexNode = m_compiler->gtNewIconNode(3, TYP_INT);
-                    hwiNode = m_compiler->gtNewSimdWithElementNode(TYP_SIMD16, elementNode, indexNode, simdLclNode,
-                                                                    CORINFO_TYPE_FLOAT, 16,
-                                                                    /* isSimdAsHWIntrinsic */ true);
+                    hwiNode =
+                        m_compiler->gtNewSimdWithElementNode(TYP_SIMD16, elementNode, indexNode, simdLclNode,
+                                                             CORINFO_TYPE_FLOAT, 16, /* isSimdAsHWIntrinsic */ true);
                 }
 
                 user->AsOp()->gtOp2 = hwiNode;

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -1209,13 +1209,21 @@ private:
                     assert(elementType == TYP_SIMD12);
                     assert(varDsc->TypeGet() == TYP_SIMD16);
 
+                    // If we are not doing struct promotion and we have zero-initialization,
+                    // then we need to produce a VecCon(0).
+                    if (elementNode->IsIntegralConst(0))
+                    {
+                        DEBUG_DESTROY_NODE(elementNode);
+                        elementNode = m_compiler->gtNewZeroConNode(TYP_SIMD12);
+                    }
+
                     // We inverse the operands here and take elementNode as the main value and simdLclNode[3] as the
                     // new value. This gives us a new TYP_SIMD16 with all elements in the right spots
 
                     GenTree* indexNode = m_compiler->gtNewIconNode(3, TYP_INT);
-                    hwiNode =
-                        m_compiler->gtNewSimdWithElementNode(TYP_SIMD16, elementNode, indexNode, simdLclNode,
-                                                             CORINFO_TYPE_FLOAT, 16, /* isSimdAsHWIntrinsic */ true);
+                    hwiNode = m_compiler->gtNewSimdWithElementNode(TYP_SIMD16, elementNode, indexNode, simdLclNode,
+                                                                    CORINFO_TYPE_FLOAT, 16,
+                                                                    /* isSimdAsHWIntrinsic */ true);
                 }
 
                 user->AsOp()->gtOp2 = hwiNode;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/81963
This fixes the assertion that was occurring in the emitter recently.
Thanks to @tannergooding for his help on this.