### PR TITLE
[JIT] On importing a CEE_INITOBJ for a simd, construct a VecCon(0)

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -10593,6 +10593,12 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 JITDUMP(" %08X", resolvedToken.token);
 
                 lclTyp = JITtype2varType(info.compCompHnd->asCorInfoType(resolvedToken.hClass));
+                
+                if (lclTyp == TYP_STRUCT)
+                {
+                    lclTyp = impNormStructType(resolvedToken.hClass);
+                }
+
                 if (lclTyp != TYP_STRUCT)
                 {
                     op2 = gtNewZeroConNode(genActualType(lclTyp));

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -10593,7 +10593,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 JITDUMP(" %08X", resolvedToken.token);
 
                 lclTyp = JITtype2varType(info.compCompHnd->asCorInfoType(resolvedToken.hClass));
-                
+
                 if (lclTyp == TYP_STRUCT)
                 {
                     lclTyp = impNormStructType(resolvedToken.hClass);

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -10599,14 +10599,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 if (lclTyp == TYP_STRUCT)
                 {
                     layout = typGetObjLayout(resolvedToken.hClass);
-                    if (varTypeIsSIMD(layout->GetType()))
-                    {
-                        lclTyp = layout->GetType();
-                    }
-                    else
-                    {
-                        lclTyp = impNormStructType(resolvedToken.hClass);
-                    }
+                    lclTyp = layout->GetType();
                 }
 
                 if (lclTyp != TYP_STRUCT)

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -10615,8 +10615,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     goto STIND_VALUE;
                 }
 
-                assert(layout != nullptr);
-
                 op1 = impPopStack().val;
                 op1 = gtNewStructVal(layout, op1);
                 op2 = gtNewIconNode(0);

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -10611,10 +10611,11 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
                 if (lclTyp != TYP_STRUCT)
                 {
-                    assert(layout == nullptr);
                     op2 = gtNewZeroConNode(genActualType(lclTyp));
                     goto STIND_VALUE;
                 }
+
+                assert(layout != nullptr);
 
                 op1 = impPopStack().val;
                 op1 = gtNewStructVal(layout, op1);

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -10585,7 +10585,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 goto EVAL_APPEND;
 
             case CEE_INITOBJ:
-
+            {
                 assertImp(sz == sizeof(unsigned));
 
                 _impResolveToken(CORINFO_TOKENKIND_Class);
@@ -10613,6 +10613,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 op2 = gtNewIconNode(0);
                 op1 = gtNewBlkOpNode(op1, op2, (prefixFlags & PREFIX_VOLATILE) != 0);
                 goto SPILL_APPEND;
+            }
 
             case CEE_INITBLK:
 


### PR DESCRIPTION
When we handle `CEE_INITOBJ` in the importer, if we know that the type is a simd type, then construct a `VecCon(0)` for the zero-initialization instead of an `IntCon(0)`.