### PR TITLE
Don't instrument methods with [Intrinsic]

### DIFF
--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -2189,6 +2189,15 @@ PhaseStatus Compiler::fgPrepareToInstrumentMethod()
     const bool minimalProfiling =
         prejit ? (JitConfig.JitMinimalPrejitProfiling() > 0) : (JitConfig.JitMinimalJitProfiling() > 0);
 
+    // In majority of cases, methods marked with [Intrinsic] are imported directly
+    // in Tier1 so the profile will never be consumed. Thus, let's avoid unnecessary probes.
+    if (minimalProfiling && (info.compFlags & CORINFO_FLG_INTRINSIC) != 0)
+    {
+        fgCountInstrumentor     = new (this, CMK_Pgo) NonInstrumentor(this);
+        fgHistogramInstrumentor = new (this, CMK_Pgo) NonInstrumentor(this);
+        return PhaseStatus::MODIFIED_NOTHING;
+    }
+
     if (minimalProfiling && (fgBBcount < 2))
     {
         // Don't instrumenting small single-block methods.


### PR DESCRIPTION
Let's assume all methods with `[Intrinsic]` don't need any instrumentation because they're imported as JIT intrinsics in Tier1 and their actual profile is never taken. There are few cases where we might not expand an intrinsic in Tier1 but so far they don't look like profile is a big deal for them.

The main problem this PR fixes are block counters inside those intrinsics and the cache contention they cause. As a bonus - we create less compilations now (slight decrease in working set).

**Plaintex benchmark on aspnet-citrine-lin machine** 
with Tier0-instrumented (forced to stay in that tier forever):

```
| load                   |        Main |          PR |         |
| ---------------------- | ----------- | ----------- | ------- |
| CPU Usage (%)          |          11 |          12 |  +9.09% |
| Cores usage (%)        |         300 |         337 | +12.33% |
| Working Set (MB)       |         121 |         121 |   0.00% |
| Private Memory (MB)    |         358 |         358 |   0.00% |
| Start Time (ms)        |           0 |           0 |         |
| First Request (ms)     |         204 |         204 |   0.00% |
| Requests/sec           |     489,719 |     551,725 | +12.66% |
| Requests               |   7,380,118 |   8,317,673 | +12.70% |
| Mean latency (ms)      |        4.77 |        4.27 | -10.48% |
| Max latency (ms)       |       54.49 |       54.86 |  +0.68% |
| Bad responses          |           0 |           0 |         |
| Socket errors          |           0 |           0 |         |
| Read throughput (MB/s) |       76.13 |       85.77 | +12.66% |
| Latency 50th (ms)      |        4.94 |        4.35 | -11.94% |
| Latency 75th (ms)      |        7.17 |        6.33 | -11.72% |
| Latency 90th (ms)      |        8.91 |        7.90 | -11.34% |
```

NOTE: such methods are still call-counted, it's just that they will jump directly to Tier1 after R2R (or Tier0) after 30 calls.

cc @AndyAyersMS 