### PR TITLE
remove test references to archaic Linux versions

### DIFF
--- a/src/libraries/Common/tests/System/Drawing/Helpers.cs
+++ b/src/libraries/Common/tests/System/Drawing/Helpers.cs
@@ -14,9 +14,7 @@ namespace System.Drawing
     {
         public const string IsDrawingSupported = nameof(Helpers) + "." + nameof(GetIsDrawingSupported);
         public const string IsWindowsOrAtLeastLibgdiplus6 = nameof(Helpers) + "." + nameof(GetIsWindowsOrAtLeastLibgdiplus6);
-        public const string RecentGdiplusIsAvailable = nameof(Helpers) + "." + nameof(GetRecentGdiPlusIsAvailable);
-        public const string RecentGdiplusIsAvailable2 = nameof(Helpers) + "." + nameof(GetRecentGdiPlusIsAvailable2);
-        public const string GdiPlusIsAvailableNotRedhat73 = nameof(Helpers) + "." + nameof(GetGdiPlusIsAvailableNotRedhat73);
+        public const string RecentGdiplusIsAvailable = IsWindowsOrAtLeastLibgdiplus6;
         public const string GdiPlusIsAvailableNotWindows7 = nameof(Helpers) + "." + nameof(GetGdiPlusIsAvailableNotWindows7);
         public const string AnyInstalledPrinters = nameof(Helpers) + "." + nameof(IsAnyInstalledPrinters);
         public const string WindowsRS3OrEarlier = nameof(Helpers) + "." + nameof(IsWindowsRS3OrEarlier);
@@ -60,41 +58,9 @@ namespace System.Drawing
 
         public static bool IsWindowsRS3OrEarlier => !PlatformDetection.IsWindows10Version1803OrGreater;
 
-        public static bool GetRecentGdiPlusIsAvailable2()
-        {
-            // RedHat as well as Fedora 25 and OpenSUSE 4.22 are running outdated versions of libgdiplus
-            if (PlatformDetection.IsRedHatFamily || PlatformDetection.IsFedora || PlatformDetection.IsOpenSUSE)
-            {
-                return false;
-            }
-
-            return GetIsDrawingSupported();
-        }
-
-        public static bool GetGdiPlusIsAvailableNotRedhat73()
-        {
-            if (PlatformDetection.IsRedHatFamily)
-            {
-                return false;
-            }
-
-            return GetIsDrawingSupported();
-        }
-
         public static bool GetGdiPlusIsAvailableNotWindows7()
         {
             if (PlatformDetection.IsWindows7)
-            {
-                return false;
-            }
-
-            return GetIsDrawingSupported();
-        }
-
-        public static bool GetRecentGdiPlusIsAvailable()
-        {
-            // RedHat is running outdated versions of libgdiplus
-            if (PlatformDetection.IsRedHatFamily)
             {
                 return false;
             }

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -21,15 +21,7 @@ namespace System
         public static bool IsAlpine => IsDistroAndVersion("alpine");
         public static bool IsAlpine313 => IsDistroAndVersion("alpine", 3, 13);
         public static bool IsAlpine314 => IsDistroAndVersion("alpine", 3, 14);
-        public static bool IsDebian8 => IsDistroAndVersion("debian", 8);
-        public static bool IsDebian9 => IsDistroAndVersion("debian", 9);
         public static bool IsDebian10 => IsDistroAndVersion("debian", 10);
-        public static bool IsUbuntu1604 => IsDistroAndVersion("ubuntu", 16, 4);
-        public static bool IsUbuntu1704 => IsDistroAndVersion("ubuntu", 17, 4);
-        public static bool IsUbuntu1710 => IsDistroAndVersion("ubuntu", 17, 10);
-        public static bool IsUbuntu1710OrHigher => IsDistroAndVersionOrHigher("ubuntu", 17, 10);
-        public static bool IsUbuntu1804 => IsDistroAndVersion("ubuntu", 18, 04);
-        public static bool IsUbuntu1810OrHigher => IsDistroAndVersionOrHigher("ubuntu", 18, 10);
         public static bool IsMariner => IsDistroAndVersion("mariner");
         public static bool IsMariner1 => IsDistroAndVersion("mariner", 1);
         public static bool IsSLES => IsDistroAndVersion("sles");

--- a/src/libraries/System.Drawing.Common/tests/Text/InstalledFontCollectionTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Text/InstalledFontCollectionTests.cs
@@ -7,7 +7,7 @@ namespace System.Drawing.Text.Tests
 {
     public class InstalledFontCollectionTests
     {
-        [ConditionalFact(Helpers.GdiPlusIsAvailableNotRedhat73)]
+        [ConditionalFact(Helpers.IsWindowsOrAtLeastLibgdiplus6)]
         public void Ctor_Default()
         {
             using (var fontCollection = new InstalledFontCollection())
@@ -16,7 +16,7 @@ namespace System.Drawing.Text.Tests
             }
         }
 
-        [ConditionalFact(Helpers.GdiPlusIsAvailableNotRedhat73)]
+        [ConditionalFact(Helpers.IsWindowsOrAtLeastLibgdiplus6)]
         public void Families_GetWhenDisposed_ReturnsNonEmpty()
         {
             var fontCollection = new InstalledFontCollection();

--- a/src/libraries/System.Drawing.Common/tests/Text/InstalledFontCollectionTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Text/InstalledFontCollectionTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace System.Drawing.Text.Tests
 {
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported))]
     public class InstalledFontCollectionTests
     {
         [Fact]

--- a/src/libraries/System.Drawing.Common/tests/Text/InstalledFontCollectionTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Text/InstalledFontCollectionTests.cs
@@ -7,7 +7,6 @@ namespace System.Drawing.Text.Tests
 {
     public class InstalledFontCollectionTests
     {
-        [ConditionalFact(Helpers.IsWindowsOrAtLeastLibgdiplus6)]
         public void Ctor_Default()
         {
             using (var fontCollection = new InstalledFontCollection())
@@ -16,7 +15,6 @@ namespace System.Drawing.Text.Tests
             }
         }
 
-        [ConditionalFact(Helpers.IsWindowsOrAtLeastLibgdiplus6)]
         public void Families_GetWhenDisposed_ReturnsNonEmpty()
         {
             var fontCollection = new InstalledFontCollection();
@@ -25,7 +23,6 @@ namespace System.Drawing.Text.Tests
             Assert.NotEmpty(fontCollection.Families);
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Dispose_MultipleTimes_Nop()
         {
             var fontCollection = new InstalledFontCollection();

--- a/src/libraries/System.Drawing.Common/tests/Text/InstalledFontCollectionTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Text/InstalledFontCollectionTests.cs
@@ -7,6 +7,7 @@ namespace System.Drawing.Text.Tests
 {
     public class InstalledFontCollectionTests
     {
+        [Fact]
         public void Ctor_Default()
         {
             using (var fontCollection = new InstalledFontCollection())
@@ -15,6 +16,7 @@ namespace System.Drawing.Text.Tests
             }
         }
 
+        [Fact]
         public void Families_GetWhenDisposed_ReturnsNonEmpty()
         {
             var fontCollection = new InstalledFontCollection();
@@ -23,6 +25,7 @@ namespace System.Drawing.Text.Tests
             Assert.NotEmpty(fontCollection.Families);
         }
 
+        [Fact]
         public void Dispose_MultipleTimes_Nop()
         {
             var fontCollection = new InstalledFontCollection();

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/PngCodecTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/PngCodecTests.cs
@@ -37,7 +37,7 @@ using Xunit;
 
 namespace MonoTests.System.Drawing.Imaging
 {
-    [ConditionalClass(typeof(PlatformDetection),nameof(PlatformDetection.IsDrawingSupported))]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported))]
     public class PngCodecTest
     {
         /* Checks bitmap features on a known 1bbp bitmap */

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/PngCodecTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/PngCodecTests.cs
@@ -37,32 +37,9 @@ using Xunit;
 
 namespace MonoTests.System.Drawing.Imaging
 {
+    [ConditionalClass(typeof(PlatformDetection),nameof(PlatformDetection.IsDrawingSupported))]
     public class PngCodecTest
     {
-        private bool IsArm64Process()
-        {
-            if (Environment.OSVersion.Platform != PlatformID.Unix || !Environment.Is64BitProcess)
-                return false;
-
-            try
-            {
-                var process = new global::System.Diagnostics.Process();
-                process.StartInfo.FileName = "uname";
-                process.StartInfo.Arguments = "-m";
-                process.StartInfo.RedirectStandardOutput = true;
-                process.StartInfo.UseShellExecute = false;
-                process.Start();
-                process.WaitForExit();
-                var output = process.StandardOutput.ReadToEnd();
-
-                return output.Trim() == "aarch64";
-            }
-            catch
-            {
-                return false;
-            }
-        }
-
         /* Checks bitmap features on a known 1bbp bitmap */
         [Fact]
         public void Bitmap1bitFeatures()
@@ -275,9 +252,6 @@ namespace MonoTests.System.Drawing.Imaging
         [Fact]
         public void Bitmap2bitFeatures()
         {
-            if (IsArm64Process())
-                Assert.True(false, "https://bugzilla.xamarin.com/show_bug.cgi?id=41171");
-
             string sInFile = Helpers.GetTestBitmapPath("81674-2bpp.png");
             using (Bitmap bmp = new Bitmap(sInFile))
             {
@@ -307,9 +281,6 @@ namespace MonoTests.System.Drawing.Imaging
         [Fact]
         public void Bitmap2bitPixels()
         {
-            if (IsArm64Process())
-                Assert.True(false, "https://bugzilla.xamarin.com/show_bug.cgi?id=41171");
-
             string sInFile = Helpers.GetTestBitmapPath("81674-2bpp.png");
             using (Bitmap bmp = new Bitmap(sInFile))
             {
@@ -336,9 +307,6 @@ namespace MonoTests.System.Drawing.Imaging
         [Fact]
         public void Bitmap2bitData()
         {
-            if (IsArm64Process())
-                Assert.True(false, "https://bugzilla.xamarin.com/show_bug.cgi?id=41171");
-
             string sInFile = Helpers.GetTestBitmapPath("81674-2bpp.png");
             using (Bitmap bmp = new Bitmap(sInFile))
             {

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/PngCodecTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/PngCodecTests.cs
@@ -659,21 +659,25 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
+        [Fact]
         public void Save_24bppRgb()
         {
             Save(PixelFormat.Format24bppRgb, PixelFormat.Format24bppRgb, true);
         }
 
+        [Fact]
         public void Save_32bppRgb()
         {
             Save(PixelFormat.Format32bppRgb, PixelFormat.Format32bppArgb, true);
         }
 
+        [Fact]
         public void Save_32bppArgb()
         {
             Save(PixelFormat.Format32bppArgb, PixelFormat.Format32bppArgb, true);
         }
 
+        [Fact]
         public void Save_32bppPArgb()
         {
             Save(PixelFormat.Format32bppPArgb, PixelFormat.Format32bppArgb, true);

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/PngCodecTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/PngCodecTests.cs
@@ -64,7 +64,6 @@ namespace MonoTests.System.Drawing.Imaging
         }
 
         /* Checks bitmap features on a known 1bbp bitmap */
-        [ConditionalFact(Helpers.RecentGdiplusIsAvailable)]
         public void Bitmap1bitFeatures()
         {
             string sInFile = Helpers.GetTestBitmapPath("1bit.png");
@@ -93,7 +92,6 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
-        [ConditionalFact(Helpers.RecentGdiplusIsAvailable)]
         public void Bitmap1bitPixels()
         {
             string sInFile = Helpers.GetTestBitmapPath("1bit.png");
@@ -169,7 +167,6 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
-        [ConditionalFact(Helpers.RecentGdiplusIsAvailable)]
         public void Bitmap1bitData()
         {
             string sInFile = Helpers.GetTestBitmapPath("1bit.png");
@@ -272,7 +269,6 @@ namespace MonoTests.System.Drawing.Imaging
         }
 
         /* Checks bitmap features on a known 2bbp bitmap */
-        [ConditionalFact(Helpers.RecentGdiplusIsAvailable)]
         public void Bitmap2bitFeatures()
         {
             if (IsArm64Process())
@@ -304,7 +300,6 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
-        [ConditionalFact(Helpers.RecentGdiplusIsAvailable)]
         public void Bitmap2bitPixels()
         {
             if (IsArm64Process())
@@ -333,7 +328,6 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
-        [ConditionalFact(Helpers.RecentGdiplusIsAvailable)]
         public void Bitmap2bitData()
         {
             if (IsArm64Process())
@@ -395,7 +389,6 @@ namespace MonoTests.System.Drawing.Imaging
         }
 
         /* Checks bitmap features on a known 4bbp bitmap */
-        [ConditionalFact(Helpers.RecentGdiplusIsAvailable)]
         public void Bitmap4bitFeatures()
         {
             string sInFile = Helpers.GetTestBitmapPath("4bit.png");
@@ -438,7 +431,6 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
-        [ConditionalFact(Helpers.RecentGdiplusIsAvailable)]
         public void Bitmap4bitPixels()
         {
             string sInFile = Helpers.GetTestBitmapPath("4bit.png");
@@ -515,7 +507,6 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
-        [ConditionalFact(Helpers.RecentGdiplusIsAvailable)]
         public void Bitmap4bitData()
         {
             string sInFile = Helpers.GetTestBitmapPath("4bit.png");
@@ -659,25 +650,21 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
-        [ConditionalFact(Helpers.RecentGdiplusIsAvailable)]
         public void Save_24bppRgb()
         {
             Save(PixelFormat.Format24bppRgb, PixelFormat.Format24bppRgb, true);
         }
 
-        [ConditionalFact(Helpers.RecentGdiplusIsAvailable)]
         public void Save_32bppRgb()
         {
             Save(PixelFormat.Format32bppRgb, PixelFormat.Format32bppArgb, true);
         }
 
-        [ConditionalFact(Helpers.RecentGdiplusIsAvailable)]
         public void Save_32bppArgb()
         {
             Save(PixelFormat.Format32bppArgb, PixelFormat.Format32bppArgb, true);
         }
 
-        [ConditionalFact(Helpers.RecentGdiplusIsAvailable)]
         public void Save_32bppPArgb()
         {
             Save(PixelFormat.Format32bppPArgb, PixelFormat.Format32bppArgb, true);

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/PngCodecTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/PngCodecTests.cs
@@ -64,6 +64,7 @@ namespace MonoTests.System.Drawing.Imaging
         }
 
         /* Checks bitmap features on a known 1bbp bitmap */
+        [Fact]
         public void Bitmap1bitFeatures()
         {
             string sInFile = Helpers.GetTestBitmapPath("1bit.png");
@@ -92,6 +93,7 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
+        [Fact]
         public void Bitmap1bitPixels()
         {
             string sInFile = Helpers.GetTestBitmapPath("1bit.png");
@@ -167,6 +169,7 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
+        [Fact]
         public void Bitmap1bitData()
         {
             string sInFile = Helpers.GetTestBitmapPath("1bit.png");
@@ -269,6 +272,7 @@ namespace MonoTests.System.Drawing.Imaging
         }
 
         /* Checks bitmap features on a known 2bbp bitmap */
+        [Fact]
         public void Bitmap2bitFeatures()
         {
             if (IsArm64Process())
@@ -300,6 +304,7 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
+        [Fact]
         public void Bitmap2bitPixels()
         {
             if (IsArm64Process())
@@ -328,6 +333,7 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
+        [Fact]
         public void Bitmap2bitData()
         {
             if (IsArm64Process())
@@ -389,6 +395,7 @@ namespace MonoTests.System.Drawing.Imaging
         }
 
         /* Checks bitmap features on a known 4bbp bitmap */
+        [Fact]
         public void Bitmap4bitFeatures()
         {
             string sInFile = Helpers.GetTestBitmapPath("4bit.png");
@@ -431,6 +438,7 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
+        [Fact]
         public void Bitmap4bitPixels()
         {
             string sInFile = Helpers.GetTestBitmapPath("4bit.png");
@@ -507,6 +515,7 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
+        [Fact]
         public void Bitmap4bitData()
         {
             string sInFile = Helpers.GetTestBitmapPath("4bit.png");

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/PngCodecTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing.Imaging/PngCodecTests.cs
@@ -272,7 +272,7 @@ namespace MonoTests.System.Drawing.Imaging
         }
 
         /* Checks bitmap features on a known 2bbp bitmap */
-        [ConditionalFact(Helpers.RecentGdiplusIsAvailable2)]
+        [ConditionalFact(Helpers.RecentGdiplusIsAvailable)]
         public void Bitmap2bitFeatures()
         {
             if (IsArm64Process())
@@ -304,7 +304,7 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
-        [ConditionalFact(Helpers.RecentGdiplusIsAvailable2)]
+        [ConditionalFact(Helpers.RecentGdiplusIsAvailable)]
         public void Bitmap2bitPixels()
         {
             if (IsArm64Process())
@@ -333,7 +333,7 @@ namespace MonoTests.System.Drawing.Imaging
             }
         }
 
-        [ConditionalFact(Helpers.RecentGdiplusIsAvailable2)]
+        [ConditionalFact(Helpers.RecentGdiplusIsAvailable)]
         public void Bitmap2bitData()
         {
             if (IsArm64Process())

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
@@ -1903,7 +1903,6 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsWindowsOrAtLeastLibgdiplus6)]
         public void MeasureString_Whitespace()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -1989,7 +1988,6 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsWindowsOrAtLeastLibgdiplus6)]
         public void MeasureCharacterRanges_TwoLines()
         {
             string text = "this\nis a test";

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
@@ -39,6 +39,7 @@ using Xunit;
 
 namespace MonoTests.System.Drawing
 {
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported))]
     public class GraphicsTest : IDisposable
     {
         private RectangleF[] rects;
@@ -103,7 +104,7 @@ namespace MonoTests.System.Drawing
             Assert.Equal(expected, actual, precision);
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DefaultProperties()
         {
             using (Bitmap bmp = new Bitmap(200, 200))
@@ -123,7 +124,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void SetGetProperties()
         {
             using (Bitmap bmp = new Bitmap(200, 200))
@@ -153,7 +154,7 @@ namespace MonoTests.System.Drawing
         }
 
         // Properties
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void Clip()
         {
             RectangleF[] rects;
@@ -171,7 +172,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void Clip_NotAReference()
         {
             using (Bitmap bmp = new Bitmap(200, 200))
@@ -184,7 +185,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void ExcludeClip()
         {
             using (Bitmap bmp = new Bitmap(200, 200))
@@ -213,7 +214,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void IntersectClip()
         {
             using (Bitmap bmp = new Bitmap(200, 200))
@@ -232,7 +233,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void ResetClip()
         {
             using (Bitmap bmp = new Bitmap(200, 200))
@@ -252,7 +253,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void SetClip()
         {
             RectangleF[] rects;
@@ -296,7 +297,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void SetSaveReset()
         {
             using (Bitmap bmp = new Bitmap(200, 200))
@@ -362,7 +363,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void LoadIndexed_BmpFile()
         {
             // Tests that we can load an indexed file, but...
@@ -398,7 +399,7 @@ namespace MonoTests.System.Drawing
             AssertEquals(msg + ".compare.Height", b1.Height, b2.Height);
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void Clip_GetBounds()
         {
             using (var b = new BitmapAndGraphics(16, 16))
@@ -413,7 +414,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void Clip_TranslateTransform()
         {
             using (var b = new BitmapAndGraphics(16, 16))
@@ -445,7 +446,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void Transform_NonInvertibleMatrix()
         {
             using (Matrix matrix = new Matrix(123, 24, 82, 16, 47, 30))
@@ -459,7 +460,7 @@ namespace MonoTests.System.Drawing
         }
 
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void Multiply_NonInvertibleMatrix()
         {
             using (Matrix matrix = new Matrix(123, 24, 82, 16, 47, 30))
@@ -480,7 +481,7 @@ namespace MonoTests.System.Drawing
             AssertEquals(msg + ".Height", h, bounds.Height, 1);
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void ClipBounds()
         {
             using (var b = new BitmapAndGraphics(16, 16))
@@ -495,7 +496,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void ClipBounds_Rotate()
         {
             using (var b = new BitmapAndGraphics(16, 16))
@@ -512,7 +513,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void ClipBounds_Scale()
         {
             RectangleF clip = new Rectangle(0, 0, 8, 8);
@@ -530,7 +531,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void ClipBounds_Translate()
         {
             using (var b = new BitmapAndGraphics(16, 16))
@@ -550,7 +551,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void ClipBounds_Transform_Translation()
         {
             using (var b = new BitmapAndGraphics(16, 16))
@@ -567,7 +568,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void ClipBounds_Transform_Scale()
         {
             using (var b = new BitmapAndGraphics(16, 16))
@@ -585,7 +586,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void ClipBounds_Multiply()
         {
             using (var b = new BitmapAndGraphics(16, 16))
@@ -603,7 +604,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void ClipBounds_Cumulative_Effects()
         {
             using (var b = new BitmapAndGraphics(16, 16))
@@ -638,7 +639,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void Clip_TranslateTransform_BoundsChange()
         {
             using (var b = new BitmapAndGraphics(16, 16))
@@ -662,7 +663,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void Clip_RotateTransform_BoundsChange()
         {
             using (var b = new BitmapAndGraphics(16, 16))
@@ -687,7 +688,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void Clip_ScaleTransform_NoBoundsChange()
         {
             using (var b = new BitmapAndGraphics(16, 16))
@@ -710,7 +711,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void ScaleTransform_X0()
         {
             using (var b = new BitmapAndGraphics(16, 16))
@@ -720,7 +721,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void ScaleTransform_Y0()
         {
             using (var b = new BitmapAndGraphics(16, 16))
@@ -730,7 +731,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void TranslateTransform_Order()
         {
             using (var b = new BitmapAndGraphics(16, 16))
@@ -773,7 +774,7 @@ namespace MonoTests.System.Drawing
         static Point[] TooSmallCurve = new Point[2] { new Point(0, 0), new Point(15, 5) };
         static PointF[] LargeCurveF = new PointF[4] { new PointF(0, 0), new PointF(15, 5), new PointF(5, 15), new PointF(0, 20) };
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawCurve_NotEnoughPoints()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -789,7 +790,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawCurve_SinglePoint()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -800,7 +801,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawCurve3_NotEnoughPoints()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -811,7 +812,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawCurve_NegativeTension()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -825,7 +826,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawCurve_PositiveTension()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -839,7 +840,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawCurve_ZeroSegments()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -849,7 +850,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawCurve_NegativeSegments()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -859,7 +860,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawCurve_OffsetTooLarge()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -871,7 +872,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawCurve_Offset_0()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -884,7 +885,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawCurve_Offset_1()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -897,7 +898,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawCurve_Offset_2()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -911,7 +912,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawRectangle_Negative()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -928,7 +929,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawRectangles_Negative()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -954,7 +955,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void FillRectangle_Negative()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -971,7 +972,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void FillRectangles_Negative()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -1041,7 +1042,7 @@ namespace MonoTests.System.Drawing
             AssertEquals(message + ".Matrix.y0", y0, elements[5], 2);
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void BeginContainer()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -1076,7 +1077,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void BeginContainer_Rect()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -1112,7 +1113,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void BeginContainer_RectF()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -1156,13 +1157,13 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void BeginContainer_GraphicsUnit_Display()
         {
             Assert.Throws<ArgumentException>(() => BeginContainer_GraphicsUnit(GraphicsUnit.Display));
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void BeginContainer_GraphicsUnit_Valid()
         {
             BeginContainer_GraphicsUnit(GraphicsUnit.Document);
@@ -1172,19 +1173,19 @@ namespace MonoTests.System.Drawing
             BeginContainer_GraphicsUnit(GraphicsUnit.Point);
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void BeginContainer_GraphicsUnit_World()
         {
             Assert.Throws<ArgumentException>(() => BeginContainer_GraphicsUnit(GraphicsUnit.World));
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void BeginContainer_GraphicsUnit_Bad()
         {
             Assert.Throws<ArgumentException>(() => BeginContainer_GraphicsUnit((GraphicsUnit)int.MinValue));
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void EndContainer_Null()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -1194,7 +1195,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void Save()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -1236,7 +1237,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void Restore_Null()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -1246,7 +1247,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void FillRectangles_BrushNull_Rectangle()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -1256,7 +1257,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void FillRectangles_Rectangle_Null()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -1266,7 +1267,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void FillRectanglesZeroRectangle()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -1276,7 +1277,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void FillRectangles_BrushNull_RectangleF()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -1286,7 +1287,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void FillRectangles_RectangleF_Null()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -1296,7 +1297,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void FillRectanglesZeroRectangleF()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -1306,7 +1307,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void FillRectangles_NormalBehavior()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -1352,7 +1353,7 @@ namespace MonoTests.System.Drawing
             return bitmap;
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void FillDrawRectangle_Width_Default()
         {
             // default pen size
@@ -1442,7 +1443,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void FillDrawRectangle_Width_3()
         {
             // odd pen size
@@ -1523,7 +1524,7 @@ namespace MonoTests.System.Drawing
             return bitmap;
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawFillRectangle_Width_Default()
         {
             // default pen size
@@ -1606,7 +1607,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawFillRectangle_Width_3()
         {
             // odd pen size
@@ -1674,7 +1675,7 @@ namespace MonoTests.System.Drawing
             return bitmap;
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawLines_Width_Default()
         {
             // default pen size
@@ -1707,7 +1708,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void MeasureString_StringFont()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -1727,7 +1728,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void MeasureString_StringFont_Null()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -1737,7 +1738,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void MeasureString_StringFontSizeF()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -1764,19 +1765,19 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void MeasureString_StringFontInt_ShortString()
         {
             MeasureString_StringFontInt("a");
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void MeasureString_StringFontInt_LongString()
         {
             MeasureString_StringFontInt("A very long string...");
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void MeasureString_StringFormat_Alignment()
         {
             string text = "Hello Mono::";
@@ -1802,7 +1803,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void MeasureString_StringFormat_Alignment_DirectionVertical()
         {
             string text = "Hello Mono::";
@@ -1829,7 +1830,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void MeasureString_StringFormat_LineAlignment()
         {
             string text = "Hello Mono::";
@@ -1854,7 +1855,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void MeasureString_StringFormat_LineAlignment_DirectionVertical()
         {
             string text = "Hello Mono::";
@@ -1881,7 +1882,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void MeasureString_CharactersFitted()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -1949,7 +1950,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void MeasureCharacterRanges_NullOrEmptyText()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -1967,7 +1968,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void MeasureCharacterRanges_EmptyStringFormat()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -1979,7 +1980,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void MeasureCharacterRanges_FontNull()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -2031,21 +2032,21 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void MeasureCharacterRanges_FirstTooFar()
         {
             string text = "this\nis a test";
             Assert.Throws<ArgumentException>(() => MeasureCharacterRanges(text, text.Length, 1));
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void MeasureCharacterRanges_LengthTooLong()
         {
             string text = "this\nis a test";
             Assert.Throws<ArgumentException>(() => MeasureCharacterRanges(text, 0, text.Length + 1));
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void MeasureCharacterRanges_Prefix()
         {
             string text = "Hello &Mono::";
@@ -2080,7 +2081,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void MeasureCharacterRanges_NullStringFormat()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -2109,7 +2110,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void Measure()
         {
             using (Graphics gfx = Graphics.FromImage(new Bitmap(1, 1)))
@@ -2143,7 +2144,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void MeasureLimits()
         {
             using (Graphics gfx = Graphics.FromImage(new Bitmap(1, 1)))
@@ -2172,7 +2173,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawString_EndlessLoop()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -2190,7 +2191,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawString_EndlessLoop_Wrapping()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -2222,7 +2223,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void GetReleaseHdcInternal()
         {
             using (Bitmap b = new Bitmap(10, 10))
@@ -2236,7 +2237,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void ReleaseHdcInternal_IntPtrZero()
         {
             using (Bitmap b = new Bitmap(10, 10))
@@ -2246,7 +2247,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void ReleaseHdcInternal_TwoTimes()
         {
             using (Bitmap b = new Bitmap(10, 10))
@@ -2257,7 +2258,7 @@ namespace MonoTests.System.Drawing
                 Assert.Throws<ArgumentException>(() => g.ReleaseHdcInternal(hdc));
             }
         }
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void TestReleaseHdc()
         {
             using (Bitmap b = new Bitmap(10, 10))
@@ -2271,7 +2272,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void TestReleaseHdcException()
         {
             using (Bitmap b = new Bitmap(10, 10))
@@ -2281,7 +2282,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void TestReleaseHdcException2()
         {
             using (Bitmap b = new Bitmap(10, 10))
@@ -2292,7 +2293,7 @@ namespace MonoTests.System.Drawing
                 Assert.Throws<ArgumentException>(() => g.ReleaseHdc());
             }
         }
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void VisibleClipBound()
         {
             if (PlatformDetection.IsArmOrArm64Process)
@@ -2328,7 +2329,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void VisibleClipBound_BigClip()
         {
             if (PlatformDetection.IsArmOrArm64Process)
@@ -2375,7 +2376,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void Rotate()
         {
             if (PlatformDetection.IsArmOrArm64Process)
@@ -2402,7 +2403,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void Scale()
         {
             using (Bitmap bmp = new Bitmap(100, 50))
@@ -2423,7 +2424,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void Translate()
         {
             using (Bitmap bmp = new Bitmap(100, 50))
@@ -2444,7 +2445,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawIcon_NullRectangle()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2454,7 +2455,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawIcon_IconRectangle()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2472,7 +2473,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawIcon_NullIntInt()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2482,7 +2483,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawIcon_IconIntInt()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2493,7 +2494,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawIconUnstretched_NullRectangle()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2503,7 +2504,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawIconUnstretched_IconRectangle()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2521,7 +2522,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_NullRectangleF()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2531,7 +2532,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImageRectangleF()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2544,7 +2545,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_NullPointF()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2554,7 +2555,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImagePointF()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2564,7 +2565,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_NullPointFArray()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2574,7 +2575,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImagePointFArrayNull()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2586,7 +2587,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImagePointFArrayEmpty()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2596,7 +2597,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImagePointFArray()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2607,7 +2608,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_NullRectangle()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2617,7 +2618,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImageRectangle()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2634,7 +2635,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_NullPoint()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2644,7 +2645,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImagePoint()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2654,7 +2655,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_NullPointArray()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2664,7 +2665,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImagePointArrayNull()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2674,7 +2675,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImagePointArrayEmpty()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2684,7 +2685,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImagePointArray()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2695,7 +2696,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_NullIntInt()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2705,7 +2706,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImageIntInt_Overflow()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2715,7 +2716,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImageIntInt()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2725,7 +2726,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_NullFloat()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2735,7 +2736,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImageFloatFloat_Overflow()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2745,7 +2746,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImageFloatFloat()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2755,7 +2756,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_NullRectangleRectangleGraphicsUnit()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2775,26 +2776,26 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImageRectangleRectangleGraphicsUnit_Display()
         {
             Assert.Throws<ArgumentException>(() => DrawImage_ImageRectangleRectangleGraphicsUnit(GraphicsUnit.Display));
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImageRectangleRectangleGraphicsUnit_Pixel()
         {
             // this unit works
             DrawImage_ImageRectangleRectangleGraphicsUnit(GraphicsUnit.Pixel);
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImageRectangleRectangleGraphicsUnit_World()
         {
             Assert.Throws<ArgumentException>(() => DrawImage_ImageRectangleRectangleGraphicsUnit(GraphicsUnit.World));
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_NullPointRectangleGraphicsUnit()
         {
             Rectangle r = new Rectangle(1, 2, 3, 4);
@@ -2816,47 +2817,47 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImageNullRectangleGraphicsUnit()
         {
             Assert.Throws<ArgumentNullException>(() => DrawImage_ImagePointRectangleGraphicsUnit(null));
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImagePoint0RectangleGraphicsUnit()
         {
             Assert.Throws<ArgumentException>(() => DrawImage_ImagePointRectangleGraphicsUnit(new Point[0]));
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImagePoint1RectangleGraphicsUnit()
         {
             Point p = new Point(1, 1);
             Assert.Throws<ArgumentException>(() => DrawImage_ImagePointRectangleGraphicsUnit(new Point[1] { p }));
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImagePoint2RectangleGraphicsUnit()
         {
             Point p = new Point(1, 1);
             Assert.Throws<ArgumentException>(() => DrawImage_ImagePointRectangleGraphicsUnit(new Point[2] { p, p }));
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImagePoint3RectangleGraphicsUnit()
         {
             Point p = new Point(1, 1);
             DrawImage_ImagePointRectangleGraphicsUnit(new Point[3] { p, p, p });
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImagePoint4RectangleGraphicsUnit()
         {
             Point p = new Point(1, 1);
             Assert.Throws<NotImplementedException>(() => DrawImage_ImagePointRectangleGraphicsUnit(new Point[4] { p, p, p, p }));
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_NullPointFRectangleGraphicsUnit()
         {
             Rectangle r = new Rectangle(1, 2, 3, 4);
@@ -2878,47 +2879,47 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImageNullFRectangleGraphicsUnit()
         {
             Assert.Throws<ArgumentNullException>(() => DrawImage_ImagePointFRectangleGraphicsUnit(null));
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImagePointF0RectangleGraphicsUnit()
         {
             Assert.Throws<ArgumentException>(() => DrawImage_ImagePointFRectangleGraphicsUnit(new PointF[0]));
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImagePointF1RectangleGraphicsUnit()
         {
             PointF p = new PointF(1, 1);
             Assert.Throws<ArgumentException>(() => DrawImage_ImagePointFRectangleGraphicsUnit(new PointF[1] { p }));
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImagePointF2RectangleGraphicsUnit()
         {
             PointF p = new PointF(1, 1);
             Assert.Throws<ArgumentException>(() => DrawImage_ImagePointFRectangleGraphicsUnit(new PointF[2] { p, p }));
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImagePointF3RectangleGraphicsUnit()
         {
             PointF p = new PointF(1, 1);
             DrawImage_ImagePointFRectangleGraphicsUnit(new PointF[3] { p, p, p });
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImagePointF4RectangleGraphicsUnit()
         {
             PointF p = new PointF(1, 1);
             Assert.Throws<NotImplementedException>(() => DrawImage_ImagePointFRectangleGraphicsUnit(new PointF[4] { p, p, p, p }));
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImagePointRectangleGraphicsUnitNull()
         {
             Point p = new Point(1, 1);
@@ -2931,7 +2932,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImage_ImagePointRectangleGraphicsUnitAttributes()
         {
             Point p = new Point(1, 1);
@@ -2945,7 +2946,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImageUnscaled_NullPoint()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2955,7 +2956,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImageUnscaled_ImagePoint()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2965,7 +2966,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImageUnscaled_NullRectangle()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2975,7 +2976,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImageUnscaled_ImageRectangle()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2985,7 +2986,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImageUnscaled_NullIntInt()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -2995,7 +2996,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImageUnscaled_ImageIntInt()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -3005,7 +3006,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImageUnscaled_NullIntIntIntInt()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -3015,7 +3016,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImageUnscaled_ImageIntIntIntInt()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -3025,7 +3026,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImageUnscaledAndClipped_Null()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -3035,7 +3036,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawImageUnscaledAndClipped()
         {
             using (Bitmap bmp = new Bitmap(40, 40))
@@ -3056,7 +3057,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawPath_Pen_Null()
         {
             using (Bitmap bmp = new Bitmap(20, 20))
@@ -3067,7 +3068,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawPath_Path_Null()
         {
             using (Bitmap bmp = new Bitmap(20, 20))
@@ -3077,7 +3078,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void DrawPath_Arcs()
         {
             using (Bitmap bmp = new Bitmap(20, 20))
@@ -3104,7 +3105,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void FillPath_Brush_Null()
         {
             using (Bitmap bmp = new Bitmap(20, 20))
@@ -3115,7 +3116,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void FillPath_Path_Null()
         {
             using (Bitmap bmp = new Bitmap(20, 20))
@@ -3125,7 +3126,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void FillPath_Arcs()
         {
             using (Bitmap bmp = new Bitmap(20, 20))
@@ -3152,7 +3153,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void TransformPoints()
         {
             using (Bitmap bmp = new Bitmap(10, 10))
@@ -3179,7 +3180,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void Dpi()
         {
             float x, y;
@@ -3198,13 +3199,8 @@ namespace MonoTests.System.Drawing
                 }
             }
         }
-    }
 
-    public class GraphicsFullTrustTest
-    {
-        // note: this test would fail, on ReleaseHdc, without fulltrust
-        // i.e. it's a demand and not a linkdemand
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void GetReleaseHdc()
         {
             using (Bitmap b = new Bitmap(100, 100))

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
@@ -1903,7 +1903,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.GdiPlusIsAvailableNotRedhat73)]
+        [ConditionalFact(Helpers.IsWindowsOrAtLeastLibgdiplus6)]
         public void MeasureString_Whitespace()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -1989,7 +1989,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [ConditionalFact(Helpers.GdiPlusIsAvailableNotRedhat73)]
+        [ConditionalFact(Helpers.IsWindowsOrAtLeastLibgdiplus6)]
         public void MeasureCharacterRanges_TwoLines()
         {
             string text = "this\nis a test";

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
@@ -1903,6 +1903,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
+        [Fact]
         public void MeasureString_Whitespace()
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
@@ -1988,6 +1989,7 @@ namespace MonoTests.System.Drawing
             }
         }
 
+        [Fact]
         public void MeasureCharacterRanges_TwoLines()
         {
             string text = "this\nis a test";

--- a/src/libraries/System.Runtime/tests/System/ArrayTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ArrayTests.cs
@@ -4780,6 +4780,8 @@ namespace System.Tests
     [Collection(nameof(DisableParallelization))]
     public class DangerousArrayTests
     {
+        static readonly GCMemoryInfo memoryInfo = GC.GetGCMemoryInfo();
+
         [OuterLoop] // Allocates large array
         [ConditionalFact]
         public static void Copy_LargeMultiDimensionalArray()
@@ -4790,11 +4792,11 @@ namespace System.Tests
                 throw new SkipTestException("Unable to allocate enough memory");
             }
 
-            if (PlatformDetection.IsUbuntu1804 || PlatformDetection.IsSLES)
+            if (memoryInfo.TotalAvailableMemoryBytes < 4_000_000_000 )
             {
                 // On these platforms, occasionally the OOM Killer will terminate the
                 // tests when they're using ~1GB, before they complete.
-                throw new SkipTestException("Prone to OOM killer");
+                throw new SkipTestException($"Prone to OOM killer. {memoryInfo.TotalAvailableMemoryBytes} is available.");
             }
 
             short[,] a = AllocateLargeMDArray(2, 2_000_000_000);
@@ -4816,11 +4818,11 @@ namespace System.Tests
                 throw new SkipTestException("Unable to allocate enough memory");
             }
 
-            if (PlatformDetection.IsUbuntu1804 || PlatformDetection.IsSLES)
+            if (memoryInfo.TotalAvailableMemoryBytes < 4_000_000_000 )
             {
                 // On these platforms, occasionally the OOM Killer will terminate the
                 // tests when they're using ~1GB, before they complete.
-                throw new SkipTestException("Prone to OOM killer");
+                throw new SkipTestException($"Prone to OOM killer. ${memoryInfo.TotalAvailableMemoryBytes} is available.");
             }
 
             short[,] a = AllocateLargeMDArray(2, 2_000_000_000);


### PR DESCRIPTION
follow-up on #34361.
We no longer seems to build and run Drawing tests on Linux. 
But `GetRecentGdiPlusIsAvailable2` and `GetGdiPlusIsAvailableNotRedhat73` seems clearly outdated. 
I replaced them with `IsWindowsOrAtLeastLibgdiplus6` to be consistent and that seems to work OK on recent Linux distributions.  (in case we ever change our minds) 
