### PR TITLE
Avoid taking lock for empty bucket in ConcurrentDictionary.TryRemove

### DIFF
--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -390,52 +390,57 @@ namespace System.Collections.Concurrent
                 object[] locks = tables._locks;
                 ref Node? bucket = ref GetBucketAndLock(tables, hashcode, out uint lockNo);
 
-                lock (locks[lockNo])
+                // Do a hot read on number of items stored in the bucket.  If it's empty, we can avoid
+                // taking the lock and fail fast.
+                if (tables._countPerLock[lockNo] != 0)
                 {
-                    // If the table just got resized, we may not be holding the right lock, and must retry.
-                    // This should be a rare occurrence.
-                    if (tables != _tables)
+                    lock (locks[lockNo])
                     {
-                        tables = _tables;
-                        if (!ReferenceEquals(comparer, tables._comparer))
+                        // If the table just got resized, we may not be holding the right lock, and must retry.
+                        // This should be a rare occurrence.
+                        if (tables != _tables)
                         {
-                            comparer = tables._comparer;
-                            hashcode = GetHashCode(comparer, key);
-                        }
-                        continue;
-                    }
-
-                    Node? prev = null;
-                    for (Node? curr = bucket; curr is not null; curr = curr._next)
-                    {
-                        Debug.Assert((prev is null && curr == bucket) || prev!._next == curr);
-
-                        if (hashcode == curr._hashcode && NodeEqualsKey(comparer, curr, key))
-                        {
-                            if (matchValue)
+                            tables = _tables;
+                            if (!ReferenceEquals(comparer, tables._comparer))
                             {
-                                bool valuesMatch = EqualityComparer<TValue>.Default.Equals(oldValue, curr._value);
-                                if (!valuesMatch)
+                                comparer = tables._comparer;
+                                hashcode = GetHashCode(comparer, key);
+                            }
+                            continue;
+                        }
+
+                        Node? prev = null;
+                        for (Node? curr = bucket; curr is not null; curr = curr._next)
+                        {
+                            Debug.Assert((prev is null && curr == bucket) || prev!._next == curr);
+
+                            if (hashcode == curr._hashcode && NodeEqualsKey(comparer, curr, key))
+                            {
+                                if (matchValue)
                                 {
-                                    value = default;
-                                    return false;
+                                    bool valuesMatch = EqualityComparer<TValue>.Default.Equals(oldValue, curr._value);
+                                    if (!valuesMatch)
+                                    {
+                                        value = default;
+                                        return false;
+                                    }
                                 }
-                            }
 
-                            if (prev is null)
-                            {
-                                Volatile.Write(ref bucket, curr._next);
-                            }
-                            else
-                            {
-                                prev._next = curr._next;
-                            }
+                                if (prev is null)
+                                {
+                                    Volatile.Write(ref bucket, curr._next);
+                                }
+                                else
+                                {
+                                    prev._next = curr._next;
+                                }
 
-                            value = curr._value;
-                            tables._countPerLock[lockNo]--;
-                            return true;
+                                value = curr._value;
+                                tables._countPerLock[lockNo]--;
+                                return true;
+                            }
+                            prev = curr;
                         }
-                        prev = curr;
                     }
                 }
 


### PR DESCRIPTION
Even when uncontended, the lock represents the most expensive work performed by the method.  We can avoid taking it if we see that the bucket's count is empty.

```C#
[MemoryDiagnoser(false)]
public partial class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    private ConcurrentDictionary<MyKey, int> _empty = new ConcurrentDictionary<MyKey, int>();
    private ConcurrentDictionary<MyKey, int> _one = new ConcurrentDictionary<MyKey, int>(new KeyValuePair<MyKey, int>[] { default });

    [Benchmark]
    public bool TryRemoveEmpty() => _empty.TryRemove(default, out _);

    [Benchmark]
    public bool TryRemoveNotEmpty() => _one.TryRemove(default, out _);

    private struct MyKey : IEquatable<MyKey>
    {
        public override int GetHashCode() => 0;
        public bool Equals(MyKey other) => false;
    }
}
```

|            Method |         Toolchain |      Mean |     Error |    StdDev | Ratio |
|------------------ |------------------ |----------:|----------:|----------:|------:|
|    TryRemoveEmpty | \main\corerun.exe | 20.806 ns | 0.4297 ns | 0.4598 ns |  1.00 |
|    TryRemoveEmpty |   \pr\corerun.exe |  6.220 ns | 0.0567 ns | 0.0530 ns |  0.30 |
|                   |                   |           |           |           |       |
| TryRemoveNotEmpty | \main\corerun.exe | 20.761 ns | 0.2766 ns | 0.2452 ns |  1.00 |
| TryRemoveNotEmpty |   \pr\corerun.exe | 20.037 ns | 0.1032 ns | 0.0915 ns |  0.97 |