### PR TITLE
Refine exception for http timeout

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -611,7 +611,7 @@ namespace System.Net.Http
                     if (!cancellationToken.IsCancellationRequested)
                     {
                         Debug.Assert(_timeout.TotalSeconds > 0);
-                        e = toThrow = new TaskCanceledException(SR.Format(SR.net_http_request_timedout, _timeout.TotalSeconds), new TimeoutException(e.Message, e), oce.CancellationToken);
+                        e = toThrow = new TaskCanceledException(SR.Format(SR.net_http_request_timedout, _timeout != s_infiniteTimeout ? _timeout.TotalSeconds.ToString() : "Infinity"), new TimeoutException(e.Message, e), oce.CancellationToken);
                     }
                 }
             }


### PR DESCRIPTION
The current exception message for http timeout when `HttpClient.Timeout == Threading.Timeout.InfiniteTimeSpan` is `The request was canceled due to the configured HttpClient.Timeout of -0.001 seconds elapsing.`

`-0.001` is not intuitive. This pull request refines this case to display `Infinity`