### PR TITLE
Fix build.cmd -s clr.aot+libs

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -108,7 +108,7 @@
     <NativeAotSupported Condition="('$(TargetOS)' == 'windows' or '$(TargetOS)' == 'linux' or '$(TargetOS)' == 'osx' or '$(TargetOS)' == 'freebsd') and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64')">true</NativeAotSupported>
 
     <!-- If we're building clr.nativeaotlibs and not building the CLR runtime, compile libraries against NativeAOT CoreLib -->
-    <UseNativeAotCoreLib Condition="$(_subset.Contains('+clr.nativeaotlibs+')) and !$(_subset.Contains('+clr.native+')) and !$(_subset.Contains('+clr.runtime+'))">true</UseNativeAotCoreLib>
+    <UseNativeAotCoreLib Condition="'$(TestNativeAot)' == 'true' or ($(_subset.Contains('+clr.nativeaotlibs+')) and !$(_subset.Contains('+clr.native+')) and !$(_subset.Contains('+clr.runtime+')))">true</UseNativeAotCoreLib>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/externals.csproj
+++ b/src/libraries/externals.csproj
@@ -72,7 +72,7 @@
   <Target Name="OverrideRuntimeCoreCLR"
           DependsOnTargets="ResolveRuntimeFilesFromLocalBuild"
           AfterTargets="AfterResolveReferences"
-          Condition="'$(RuntimeFlavor)' != 'Mono' and '$(TestNativeAot)' != 'true' and '$(UseNativeAotCoreLib)' != 'true'">
+          Condition="'$(RuntimeFlavor)' != 'Mono' and '$(UseNativeAotCoreLib)' != 'true'">
     <ItemGroup>
       <RuntimeFiles Include="@(HostFxrFile)" Condition="Exists('@(HostFxrFile)')" />
       <RuntimeFiles Include="@(HostPolicyFile)" Condition="Exists('@(HostPolicyFile)')" />

--- a/src/libraries/externals.csproj
+++ b/src/libraries/externals.csproj
@@ -72,7 +72,7 @@
   <Target Name="OverrideRuntimeCoreCLR"
           DependsOnTargets="ResolveRuntimeFilesFromLocalBuild"
           AfterTargets="AfterResolveReferences"
-          Condition="'$(RuntimeFlavor)' != 'Mono' and '$(TestNativeAot)' != 'true'">
+          Condition="'$(RuntimeFlavor)' != 'Mono' and '$(TestNativeAot)' != 'true' and '$(UseNativeAotCoreLib)' != 'true'">
     <ItemGroup>
       <RuntimeFiles Include="@(HostFxrFile)" Condition="Exists('@(HostFxrFile)')" />
       <RuntimeFiles Include="@(HostPolicyFile)" Condition="Exists('@(HostPolicyFile)')" />


### PR DESCRIPTION
The [instructions to build NativeAOT](https://github.com/dotnet/runtime/blob/main/docs/workflow/building/coreclr/nativeaot.md#building) suggest this invocation:

```
build.cmd -s clr.aot+libs
```

However I get this error while building:

```
C:\runtime\src\libraries\externals.csproj(90,5): error : Could not locate CoreCLR IL files.
```

Here is the target that generates the error:

https://github.com/dotnet/runtime/blob/main/src/libraries/externals.csproj#L72-L91

It looks like it is only supposed to run when compiling against vanilla CoreCLR.

### Workaround

Before this change, I built using this command:

```
build.cmd -s clr.aot+libs /p:TestNativeAot=true
```