### PR TITLE
Try fixing runtime-extra-platforms runs

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.EventSource/tests/Microsoft.Extensions.Logging.EventSource.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.EventSource/tests/Microsoft.Extensions.Logging.EventSource.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
     <EventSourceSupport Condition="'$(TestNativeAot)' == 'true'">true</EventSourceSupport>
-    <EnableNativeEventPipe Condition="'$(TestNativeAot)' == 'true'">true</EnableNativeEventPipe>
+    <EnableNativeEventPipe Condition="'$(TestNativeAot)' == 'true' and '$(TargetPlatformIdentifier)' == 'windows'">true</EnableNativeEventPipe>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Runtime-extra-platforms are broken on Mac/Linux right now (see failures in #81747).

Looks like this was broken by #80382 that did run runtime-extra-platforms, but then made a change to this project file in https://github.com/dotnet/runtime/pull/80382/commits/97dfa128d58120e81bf13c2bd7d75698fe208e01 without rerunning the leg. I'm assuming this works on Windows.

cc @dotnet/ilc-contrib 