### PR TITLE
Console.Tests: extend VerifyInstalledTermInfosParse test.

### DIFF
--- a/src/libraries/System.Console/src/System/TermInfo.DatabaseFactory.cs
+++ b/src/libraries/System.Console/src/System/TermInfo.DatabaseFactory.cs
@@ -15,13 +15,25 @@ internal static partial class TermInfo
         /// The default locations in which to search for terminfo databases.
         /// This is the ordering of well-known locations used by ncurses.
         /// </summary>
-        internal static readonly string[] s_terminfoLocations = {
+        internal static readonly string[] SystemTermInfoLocations = {
             "/etc/terminfo",
             "/lib/terminfo",
             "/usr/share/terminfo",
             "/usr/share/misc/terminfo",
             "/usr/local/share/terminfo"
         };
+
+        internal static string? HomeTermInfoLocation
+        {
+            get
+            {
+                string? home = PersistedFiles.GetHomeDirectory();
+                return home is null ? null : home + "/.terminfo";
+            }
+        }
+
+        internal static string? EnvVarTermInfoLocation
+            => Environment.GetEnvironmentVariable("TERMINFO");
 
         /// <summary>Read the database for the current terminal as specified by the "TERM" environment variable.</summary>
         /// <returns>The database, or null if it could not be found.</returns>
@@ -40,21 +52,21 @@ internal static partial class TermInfo
             Database? db;
 
             // First try a location specified in the TERMINFO environment variable.
-            string? terminfo = Environment.GetEnvironmentVariable("TERMINFO");
-            if (!string.IsNullOrWhiteSpace(terminfo) && (db = ReadDatabase(term, terminfo)) != null)
+            string? terminfo = EnvVarTermInfoLocation;
+            if ((db = ReadDatabase(term, terminfo)) != null)
             {
                 return db;
             }
 
             // Then try in the user's home directory.
-            string? home = PersistedFiles.GetHomeDirectory();
-            if (!string.IsNullOrWhiteSpace(home) && (db = ReadDatabase(term, home + "/.terminfo")) != null)
+            terminfo = HomeTermInfoLocation;
+            if ((db = ReadDatabase(term, terminfo)) != null)
             {
                 return db;
             }
 
             // Then try a set of well-known locations.
-            foreach (string terminfoLocation in s_terminfoLocations)
+            foreach (string terminfoLocation in SystemTermInfoLocations)
             {
                 if ((db = ReadDatabase(term, terminfoLocation)) != null)
                 {


### PR DESCRIPTION
- Run against TERMINFO envvar, and HOME terminfo too.
- Don't stop on first problem, aggregate exceptions.
- Include database file name in the exception.

@adamsitnik ptal.