### PR TITLE
RegularExpressions.Tests: match MicrosoftCodeAnalysisVersion used by RegularExpressions.Generator when DotNetBuildFromSource.

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/System.Text.RegularExpressions.Tests.csproj
@@ -11,7 +11,7 @@
     <IsHighAotMemoryUsageTest>true</IsHighAotMemoryUsageTest> <!-- to avoid OOMs with source generation in wasm: https://github.com/dotnet/runtime/pull/60701 -->
 
     <!-- Remove once the repo moves to a sufficiently high-enough version for file-scoped types -->
-    <MicrosoftCodeAnalysisVersion>4.4.0-1.22356.23</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisVersion Condition="'$(DotNetBuildFromSource)' != 'true'">4.4.0-1.22356.23</MicrosoftCodeAnalysisVersion>
 
   </PropertyGroup>
   <ItemGroup>

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/System.Text.RegularExpressions.Tests.csproj
@@ -10,9 +10,6 @@
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <IsHighAotMemoryUsageTest>true</IsHighAotMemoryUsageTest> <!-- to avoid OOMs with source generation in wasm: https://github.com/dotnet/runtime/pull/60701 -->
 
-    <!-- Remove once the repo moves to a sufficiently high-enough version for file-scoped types -->
-    <MicrosoftCodeAnalysisVersion Condition="'$(DotNetBuildFromSource)' != 'true'">4.4.0-1.22356.23</MicrosoftCodeAnalysisVersion>
-
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AttRegexTests.cs" />


### PR DESCRIPTION
When DotNetBuildFromSource is set, RegularExpressions.Generator uses MicrosoftCodeAnalysis 4.6, and this test project references that project, and uses MicrosoftCodeAnalysis 4.4. The project fails to compile with:

> CSC : error CS1705: Assembly 'System.Text.RegularExpressions.Generator' with identity 'System.Text.RegularExpressions.Generator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' uses 'Microsoft.CodeAnalysis, Version=4.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' which has a higher version than referenced assembly 'Microsoft.CodeAnalysis' with identity 'Microsoft.CodeAnalysis, Version=4.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' [/home/tmds/repos/runtime/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/System.Text.RegularExpressions.Tests.csproj::TargetFramework=net8.0]

cc @ViktorHofer @jkoritzinsky