### PR TITLE
System.Console: allow terminfo files to be larger than 4KiB.

### DIFF
--- a/src/libraries/System.Console/src/System/TermInfo.DatabaseFactory.cs
+++ b/src/libraries/System.Console/src/System/TermInfo.DatabaseFactory.cs
@@ -119,11 +119,8 @@ internal static partial class TermInfo
             {
                 // Read in all of the terminfo data
                 long termInfoLength = RandomAccess.GetLength(fd);
-                // according to the term and tic man pages, 4096 is the terminfo file size max
-                // Fedora includes terminfo files that are slightly larger than 4096.
-                const int MaxTermInfoLength = 8096;
                 const int HeaderLength = 12;
-                if (termInfoLength <= HeaderLength || termInfoLength > MaxTermInfoLength)
+                if (termInfoLength <= HeaderLength)
                 {
                     throw new InvalidOperationException(SR.IO_TermInfoInvalid);
                 }

--- a/src/libraries/System.Console/src/System/TermInfo.DatabaseFactory.cs
+++ b/src/libraries/System.Console/src/System/TermInfo.DatabaseFactory.cs
@@ -119,7 +119,9 @@ internal static partial class TermInfo
             {
                 // Read in all of the terminfo data
                 long termInfoLength = RandomAccess.GetLength(fd);
-                const int MaxTermInfoLength = 4096; // according to the term and tic man pages, 4096 is the terminfo file size max
+                // according to the term and tic man pages, 4096 is the terminfo file size max
+                // Fedora includes terminfo files that are slightly larger than 4096.
+                const int MaxTermInfoLength = 8096;
                 const int HeaderLength = 12;
                 if (termInfoLength <= HeaderLength || termInfoLength > MaxTermInfoLength)
                 {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/82026.

@adamsitnik @dotnet/area-system-console ptal.