### PR TITLE
Disable DictionaryExpansion.cmd test on win-x86

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -286,6 +286,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/GitHub_34094/Test34094/*">
             <Issue>https://github.com/dotnet/runtime/issues/57458</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/DictionaryExpansion/DictionaryExpansion/*">
+            <Issue>https://github.com/dotnet/runtime/issues/75244</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- Windows arm32 specific excludes -->


### PR DESCRIPTION
Tracking: https://github.com/dotnet/runtime/issues/75244