### PR TITLE
[release/7.0] Fix XmlSqlBinaryReader and introduce a corpus of SqlXml tests (#81878)

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -134,6 +134,10 @@
       <Uri>https://github.com/dotnet/runtime-assets</Uri>
       <Sha>0c78106337dbe19ce4dd99140636865cdc99d008</Sha>
     </Dependency>
+    <Dependency Name="System.Data.Common.TestData" Version="7.0.0-beta.23113.5">
+      <Uri>https://github.com/dotnet/runtime-assets</Uri>
+      <Sha>5d91c58fd4730b63f8bb74aad6e697460e93580e</Sha>
+    </Dependency>
     <Dependency Name="System.Drawing.Common.TestData" Version="7.0.0-beta.22553.1">
       <Uri>https://github.com/dotnet/runtime-assets</Uri>
       <Sha>0c78106337dbe19ce4dd99140636865cdc99d008</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -120,6 +120,7 @@
     <!-- Runtime-Assets dependencies -->
     <SystemRuntimeNumericsTestDataVersion>7.0.0-beta.22553.1</SystemRuntimeNumericsTestDataVersion>
     <SystemComponentModelTypeConverterTestDataVersion>7.0.0-beta.22553.1</SystemComponentModelTypeConverterTestDataVersion>
+    <SystemDataCommonTestDataVersion>7.0.0-beta.23113.5</SystemDataCommonTestDataVersion>
     <SystemDrawingCommonTestDataVersion>7.0.0-beta.22553.1</SystemDrawingCommonTestDataVersion>
     <SystemFormatsTarTestDataVersion>7.0.0-beta.22553.1</SystemFormatsTarTestDataVersion>
     <SystemIOCompressionTestDataVersion>7.0.0-beta.22553.1</SystemIOCompressionTestDataVersion>

--- a/src/libraries/System.Data.Common/tests/System.Data.Common.Tests.csproj
+++ b/src/libraries/System.Data.Common/tests/System.Data.Common.Tests.csproj
@@ -121,6 +121,7 @@
   </ItemGroup>
   <!-- S.D.SqlClient isn't live built anymore. -->
   <ItemGroup>
+    <PackageReference Include="System.Data.Common.TestData" Version="$(SystemDataCommonTestDataVersion)" />
     <PackageReference Include="System.Data.SqlClient" Version="$(SystemDataSqlClientVersion)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Private.Xml/src/System/Xml/BinaryXml/XmlBinaryReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/BinaryXml/XmlBinaryReader.cs
@@ -3493,7 +3493,9 @@ namespace System.Xml
             Debug.Assert(_checkCharacters, "this.checkCharacters");
             // grab local copy (perf)
 
-            ReadOnlySpan<byte> data = _data.AsSpan(_tokDataPos, _end - _tokDataPos);
+            // Get the bytes for the current token. _tokDataPos is the beginning position,
+            // and _pos has advanced to the next token (1 past the end of this token).
+            ReadOnlySpan<byte> data = _data.AsSpan(_tokDataPos, _pos - _tokDataPos);
             Debug.Assert(data.Length % 2 == 0, "Data size should not be odd");
 
             if (!attr)


### PR DESCRIPTION
Backport of #81878 to `release/7.0`. See #82062 for the corresponding backport to `release/6.0`.

## Customer Impact
As reported in #74852, a regression was introduced in .NET 6 with #43379 that prevents `SqlXml.CreateReader()` from processing SQL Binary XML content (see [MS-BINXML](https://learn.microsoft.com/en-us/openspecs/sql_server_protocols/ms-binxml/d5bd1f42-8643-435c-a0df-0ba8680a19ee)).

The regression is caused by seeking beyond the end of the current token during token validation. This is due to a simple mistake of using `_end` instead of `_pos` when `_end` represents the end of the _entire buffer_ and `_pos` represents the position _1 byte beyond the end of the current token_.

We currently have 2 customers reporting that their migrations to .NET 6 are blocked by this regression. While we have not yet obtained their validation that the .NET 8 builds work for them, our collective confidence in the fix is high. We will get their validation as soon as possible, but we wanted to get this fix queued up for the March servicing releases rather than waiting for that validation.

## Testing
While the root cause and fix for this regression were well understood since @WaynePaiMS submitted #74852, this issue surfaced a substantial test hole. We did not have any tests validating that SQL Binary XML content could be processed. Such tests existed in .NET Framework, but they had not been ported to .NET Core+.

The fix includes reintroduction of the same collection of tests that were used in .NET Framework, including regression tests that had been added over time. The test cases include collections of SQL Binary and Text XML files. A new unit test processes the test files in both forms, validating that the processed XML matches the results of processing the text form directly through `XmlTextReader` (without `SqlXml.CreateReader()`). The tests were reviewed for thoroughness and named to match the scenarios they cover.

The details of those test cases can be seen here:
https://github.com/dotnet/runtime-assets/tree/main/src/System.Data.Common.TestData

## Regression
Yes. The regression categorically prevents SQL XML Binary data from being processed, and this is currently blocking customers from migrating from .NET Core 3.1 and .NET 5.0 to .NET 6 or .NET 7.

## Risk
Low. SQL Binary XML processing is categorically broken in .NET 6 and .NET 7. The root cause and fix are understood, and the fix introduces a body of tests to ensure `SqlXml.CreateReader()` produces the same result for SQL Binary XML files as it does for Text XML files, and those tests also ensure that it's processing of Text XML files matches the results of using `XmlTextReader` directly.