### PR TITLE
Temporarily disable ParallelCrash, ParallelCrashMainThread under GCStress

### DIFF
--- a/src/tests/baseservices/exceptions/simple/ParallelCrash.csproj
+++ b/src/tests/baseservices/exceptions/simple/ParallelCrash.csproj
@@ -4,6 +4,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <CLRTestExitCode>134</CLRTestExitCode>
     <CLRTestExitCode Condition="'$(TestWrapperTargetsWindows)' == 'true'">-2146232797</CLRTestExitCode>
+    <!-- Temporarily disabled due to https://github.com/dotnet/runtime/issues/80356 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ParallelCrash.cs" />

--- a/src/tests/baseservices/exceptions/simple/ParallelCrashMainThread.csproj
+++ b/src/tests/baseservices/exceptions/simple/ParallelCrashMainThread.csproj
@@ -6,5 +6,7 @@
     <CLRTestExecutionArguments>1</CLRTestExecutionArguments>
     <CLRTestExitCode>134</CLRTestExitCode>
     <CLRTestExitCode Condition="'$(TestWrapperTargetsWindows)' == 'true'">-2146232797</CLRTestExitCode>
+    <!-- Temporarily disabled due to https://github.com/dotnet/runtime/issues/80356 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
These are regularly failing in GCStress testing.

Tracking: https://github.com/dotnet/runtime/issues/80356