### PR TITLE
Allow ConcurrentDictionary concurrencyLevel == -1

### DIFF
--- a/src/libraries/System.Collections.Concurrent/src/Resources/Strings.resx
+++ b/src/libraries/System.Collections.Concurrent/src/Resources/Strings.resx
@@ -108,9 +108,6 @@
   <data name="BlockingCollection_ValidateCollectionsArray_ZeroSize" xml:space="preserve">
     <value>The collections argument is a zero-length array.</value>
   </data>
-  <data name="Collection_CopyTo_ArgumentOutOfRangeException" xml:space="preserve">
-    <value>The index argument must be greater than or equal zero.</value>
-  </data>
   <data name="ConcurrentCollection_SyncRoot_NotSupported" xml:space="preserve">
     <value>The SyncRoot property may not be used for the synchronization of concurrent collections.</value>
   </data>
@@ -120,14 +117,8 @@
   <data name="ConcurrentDictionary_SourceContainsDuplicateKeys" xml:space="preserve">
     <value>The source argument contains duplicate keys.</value>
   </data>
-  <data name="ConcurrentDictionary_ConcurrencyLevelMustBePositive" xml:space="preserve">
-    <value>The concurrencyLevel argument must be positive.</value>
-  </data>
-  <data name="ConcurrentDictionary_CapacityMustNotBeNegative" xml:space="preserve">
-    <value>The capacity argument must be greater than or equal to zero.</value>
-  </data>
-  <data name="ConcurrentDictionary_IndexIsNegative" xml:space="preserve">
-    <value>The index argument is less than zero.</value>
+  <data name="ConcurrentDictionary_ConcurrencyLevelMustBePositiveOrNegativeOne" xml:space="preserve">
+    <value>The concurrencyLevel argument must be positive, or -1 to indicate a default level.</value>
   </data>
   <data name="ConcurrentDictionary_ArrayNotLargeEnough" xml:space="preserve">
     <value>The index is equal to or greater than the length of the array, or the number of elements in the dictionary is greater than the available space from index to the end of the destination array.</value>
@@ -144,14 +135,8 @@
   <data name="ConcurrentDictionary_TypeOfValueIncorrect" xml:space="preserve">
     <value>The value was of an incorrect type for this dictionary.</value>
   </data>
-  <data name="ConcurrentStack_PushPopRange_CountOutOfRange" xml:space="preserve">
-    <value>The count argument must be greater than or equal to zero.</value>
-  </data>
   <data name="ConcurrentStack_PushPopRange_InvalidCount" xml:space="preserve">
     <value>The sum of the startIndex and count arguments must be less than or equal to the collection's Count.</value>
-  </data>
-  <data name="ConcurrentStack_PushPopRange_StartOutOfRange" xml:space="preserve">
-    <value>The startIndex argument must be greater than or equal to zero.</value>
   </data>
   <data name="Partitioner_DynamicPartitionsNotSupported" xml:space="preserve">
     <value>Dynamic partitions are not supported by this partitioner.</value>

--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -74,7 +74,7 @@ namespace System.Collections.Concurrent
         /// comparer for the key type.
         /// </summary>
         /// <param name="concurrencyLevel">The estimated number of threads that will update the
-        /// <see cref="ConcurrentDictionary{TKey,TValue}"/> concurrently.</param>
+        /// <see cref="ConcurrentDictionary{TKey,TValue}"/> concurrently, or -1 to indicate a default value.</param>
         /// <param name="capacity">The initial number of elements that the <see cref="ConcurrentDictionary{TKey,TValue}"/> can contain.</param>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="concurrencyLevel"/> is less than 1.</exception>
         /// <exception cref="ArgumentOutOfRangeException"> <paramref name="capacity"/> is less than 0.</exception>
@@ -125,7 +125,7 @@ namespace System.Collections.Concurrent
         /// <see cref="IEqualityComparer{TKey}"/>.
         /// </summary>
         /// <param name="concurrencyLevel">
-        /// The estimated number of threads that will update the <see cref="ConcurrentDictionary{TKey,TValue}"/> concurrently.
+        /// The estimated number of threads that will update the <see cref="ConcurrentDictionary{TKey,TValue}"/> concurrently, or -1 to indicate a default value.
         /// </param>
         /// <param name="collection">The <see cref="IEnumerable{T}"/> whose elements are copied to the new
         /// <see cref="ConcurrentDictionary{TKey,TValue}"/>.</param>
@@ -146,7 +146,7 @@ namespace System.Collections.Concurrent
         /// class that is empty, has the specified concurrency level, has the specified initial capacity, and
         /// uses the specified <see cref="IEqualityComparer{TKey}"/>.
         /// </summary>
-        /// <param name="concurrencyLevel">The estimated number of threads that will update the <see cref="ConcurrentDictionary{TKey,TValue}"/> concurrently.</param>
+        /// <param name="concurrencyLevel">The estimated number of threads that will update the <see cref="ConcurrentDictionary{TKey,TValue}"/> concurrently, or -1 to indicate a default value.</param>
         /// <param name="capacity">The initial number of elements that the <see cref="ConcurrentDictionary{TKey,TValue}"/> can contain.</param>
         /// <param name="comparer">The <see cref="IEqualityComparer{TKey}"/> implementation to use when comparing keys.</param>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="concurrencyLevel"/> is less than 1. -or- <paramref name="capacity"/> is less than 0.</exception>
@@ -157,7 +157,15 @@ namespace System.Collections.Concurrent
 
         internal ConcurrentDictionary(int concurrencyLevel, int capacity, bool growLockArray, IEqualityComparer<TKey>? comparer)
         {
-            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(concurrencyLevel);
+            if (concurrencyLevel == -1)
+            {
+                concurrencyLevel = DefaultConcurrencyLevel;
+            }
+            else
+            {
+                ArgumentOutOfRangeException.ThrowIfNegativeOrZero(concurrencyLevel);
+            }
+
             ArgumentOutOfRangeException.ThrowIfNegative(capacity);
 
             // The capacity should be at least as large as the concurrency level. Otherwise, we would have locks that don't guard

--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -157,13 +157,14 @@ namespace System.Collections.Concurrent
 
         internal ConcurrentDictionary(int concurrencyLevel, int capacity, bool growLockArray, IEqualityComparer<TKey>? comparer)
         {
-            if (concurrencyLevel == -1)
+            if (concurrencyLevel <= 0)
             {
+                if (concurrencyLevel != -1)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(concurrencyLevel), SR.ConcurrentDictionary_ConcurrencyLevelMustBePositiveOrNegativeOne);
+                }
+
                 concurrencyLevel = DefaultConcurrencyLevel;
-            }
-            else
-            {
-                ArgumentOutOfRangeException.ThrowIfNegativeOrZero(concurrencyLevel);
             }
 
             ArgumentOutOfRangeException.ThrowIfNegative(capacity);

--- a/src/libraries/System.Collections.Concurrent/tests/ConcurrentDictionary/ConcurrentDictionaryTests.cs
+++ b/src/libraries/System.Collections.Concurrent/tests/ConcurrentDictionary/ConcurrentDictionaryTests.cs
@@ -607,6 +607,28 @@ namespace System.Collections.Concurrent.Tests
             Assert.Equal(1, dictionary.Values.Count);
         }
 
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(1)]
+        [InlineData(10)]
+        public static void TestConstructor_ConcurrencyLevel(int concurrencyLevel)
+        {
+            var dictionary = new ConcurrentDictionary<int, int>(concurrencyLevel, 0);
+            Assert.Equal(0, dictionary.Count);
+            Assert.True(dictionary.TryAdd(1, 2));
+            Assert.Equal(1, dictionary.Count);
+
+            dictionary = new ConcurrentDictionary<int, int>(concurrencyLevel, 10, EqualityComparer<int>.Default);
+            Assert.Equal(0, dictionary.Count);
+            Assert.True(dictionary.TryAdd(3, 4));
+            Assert.Equal(1, dictionary.Count);
+
+            dictionary = new ConcurrentDictionary<int, int>(concurrencyLevel, new[] { new KeyValuePair<int, int>(1, 1) }, null);
+            Assert.Equal(1, dictionary.Count);
+            Assert.True(dictionary.TryAdd(5, 6));
+            Assert.Equal(2, dictionary.Count);
+        }
+
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDebuggerTypeProxyAttributeSupported))]
         public static void TestDebuggerAttributes()
         {
@@ -717,7 +739,7 @@ namespace System.Collections.Concurrent.Tests
             // "TestConstructor:  FAILED.  Constructor didn't throw AORE when <1 concurrencyLevel passed");
 
             Assert.Throws<ArgumentOutOfRangeException>(
-               () => new ConcurrentDictionary<int, int>(-1, 0));
+               () => new ConcurrentDictionary<int, int>(-2, 0));
             // "TestConstructor:  FAILED.  Constructor didn't throw AORE when < 0 capacity passed");
         }
 


### PR DESCRIPTION
Rather than throwing for it, treat it as a sentinel meaning the default concurrency level.

Fixes https://github.com/dotnet/runtime/issues/77948