### PR TITLE
Replace `dynamic` with static math in a JIT test

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/GitHub_23861/GitHub_23861.cs
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_23861/GitHub_23861.cs
@@ -27,19 +27,19 @@ namespace GitHub_23861
 
         public static void LessThanAllDouble() { TestVectorLessThanAll<double>(); }
 
-        private static void TestVectorLessThanAll<T>() where T : struct
+        private static void TestVectorLessThanAll<T>() where T : struct, INumber<T>
         {
             T[] values1 = new T[Vector<T>.Count];
             for (int g = 0; g < Vector<T>.Count; g++)
             {
-                values1[g] = (T)(dynamic)g;
+                values1[g] = T.CreateChecked<int>(g);
             }
             Vector<T> vec1 = new Vector<T>(values1);
 
             T[] values2 = new T[Vector<T>.Count];
             for (int g = 0; g < Vector<T>.Count; g++)
             {
-                values2[g] = (T)(dynamic)(g + 25);
+                values2[g] = T.CreateChecked<int>(g + 25);
             }
             Vector<T> vec2 = new Vector<T>(values2);
 

--- a/src/tests/JIT/Regression/JitBlue/GitHub_23861/GitHub_23861.cs
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_23861/GitHub_23861.cs
@@ -32,14 +32,14 @@ namespace GitHub_23861
             T[] values1 = new T[Vector<T>.Count];
             for (int g = 0; g < Vector<T>.Count; g++)
             {
-                values1[g] = T.CreateChecked<int>(g);
+                values1[g] = T.CreateTruncating<int>(g);
             }
             Vector<T> vec1 = new Vector<T>(values1);
 
             T[] values2 = new T[Vector<T>.Count];
             for (int g = 0; g < Vector<T>.Count; g++)
             {
-                values2[g] = T.CreateChecked<int>(g + 25);
+                values2[g] = T.CreateTruncating<int>(g + 25);
             }
             Vector<T> vec2 = new Vector<T>(values2);
 


### PR DESCRIPTION
The test doesn't work with NativeAOT because of the `dynamic`. I believe this should be equivalent and less offensive.

Cc @dotnet/ilc-contrib 