### PR TITLE
Bump generic cycle detection cutoff for the test tree

### DIFF
--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -665,6 +665,9 @@
 
     <!-- xunit calls MakeGenericType to check if something is IEquatable -->
     <IlcArg Condition="'$(EagerlyValidateTypeConstruction)' != 'false'" Include="--feature:System.Reflection.IsTypeConstructionEagerlyValidated=false" />
+
+    <!-- Bump the generic cycle tolerance. There's at least one test with a cycle that is reachable at runtime to depth 6 -->
+    <IlcArg Include="--maxgenericcycle:7" />
   </ItemGroup>
 
   <Import Project="$(CoreCLRBuildIntegrationDir)Microsoft.DotNet.ILCompiler.SingleEntry.targets" Condition="'$(TestBuildMode)' == 'nativeaot'" />


### PR DESCRIPTION
There's a JIT test that expects being able to recurse a bit deeper than what we allow by default.

Cc @dotnet/ilc-contrib 