### PR TITLE
Add test that uses the host's fallback RID

### DIFF
--- a/src/installer/tests/TestUtils/NetCoreAppBuilder.cs
+++ b/src/installer/tests/TestUtils/NetCoreAppBuilder.cs
@@ -348,7 +348,10 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 .WithRuntimeFallbacks("win-x86", "win", "any")
                 .WithRuntimeFallbacks("win", "any")
                 .WithRuntimeFallbacks("linux-x64", "linux", "any")
-                .WithRuntimeFallbacks("linux", "any");
+                .WithRuntimeFallbacks("linux-musl-x64", "linux", "any")
+                .WithRuntimeFallbacks("linux", "any")
+                .WithRuntimeFallbacks("osx.10.12-x64", "osx-x64", "osx", "any")
+                .WithRuntimeFallbacks("osx-x64", "osx", "any");
         }
 
         public NetCoreAppBuilder WithCustomizer(Action<NetCoreAppBuilder> customizer)


### PR DESCRIPTION
Add test that explicitly sets the RID to an unknown value (one not in the graph). In that case, the host uses the `FALLBACK_HOST_RID` defined at compile-time when resolving assets.