### PR TITLE
Considerably speed up building the test tree on Windows

### DIFF
--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -639,6 +639,11 @@
   <Import Project="$(MSBuildThisFileDirectory)Common\runonly.targets" Condition="'$(CLRTestKind)' == 'RunOnly'" />
 
   <PropertyGroup Condition="'$(TestBuildMode)' == 'nativeaot'">
+    <!-- The test infra already sets up the environment for native compilation.
+         The ILC targets don't have to do that. The batch script to set up environment
+         variables is horribly slow (seeing 1.4 seconds on a 11th gen Intel Core i7) -->
+    <IlcUseEnvironmentalTools>true</IlcUseEnvironmentalTools>
+
     <!-- NativeAOT compiled output is placed into a 'native' subdirectory: we need to tweak
          rpath so that the test can load its native library dependencies if there's any -->
     <IlcRPath Condition="'$(TargetOS)' != 'osx'">$ORIGIN/..</IlcRPath>


### PR DESCRIPTION
Building the JIT\Directed tree on my machine:

Before: 5 minutes 7 seconds.
After: 3 minutes 34 seconds.

Not kidding.

We run vswhere and vcvarsall. My bet is on vcvarsall - opening the visual studio tools command prompt always takes an eternity.

Cc @dotnet/ilc-contrib 