### PR TITLE
Replace RichNav with Code Index

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -21,8 +21,6 @@
     <add key="dotnet7-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7-transport/nuget/v3/index.json" />
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <add key="dotnet8-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-transport/nuget/v3/index.json" />
-    <!-- Used for the Rich Navigation indexing task -->
-    <add key="richnav" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -29,9 +29,6 @@ parameters:
   testResultsFormat: ''
   extraStepsTemplate: ''
   extraStepsParameters: {}
-  enableRichCodeNavigation: false
-  richCodeNavigationLanguage: 'csharp'
-  richCodeNavigationEnvironment: 'production'
   isManualCodeQLBuild: false
 
 jobs:
@@ -56,9 +53,6 @@ jobs:
 
     workspace:
       clean: all
-    enableRichCodeNavigation: ${{ parameters.enableRichCodeNavigation }}
-    richCodeNavigationLanguage: ${{ parameters.richCodeNavigationLanguage }}
-    richCodeNavigationEnvironment: ${{ parameters.richCodeNavigationEnvironment }}
 
     ${{ if and(ne(parameters.dependOnEvaluatePaths, true),ne(parameters.dependsOn,'')) }}:
       dependsOn: ${{ parameters.dependsOn }}
@@ -105,12 +99,6 @@ jobs:
         ${{ if in(parameters.osGroup, 'ios', 'tvos', 'maccatalyst')}}:
           value: /p:BuildDarwinFrameworks=true
         ${{ if notin(parameters.osGroup, 'ios', 'tvos', 'maccatalyst')}}:
-          value: ''
-
-      - name: _richCodeNavigationParam
-        ${{ if eq(parameters.enableRichCodeNavigation, true) }}:
-          value: /p:EnableRichCodeNavigation=true
-        ${{ if ne(parameters.enableRichCodeNavigation, true) }}:
           value: ''
 
       - name: _sclEnableCommand
@@ -184,7 +172,7 @@ jobs:
         - task: CodeQL3000Init@0
           displayName: Initialize CodeQL (manually-injected)
 
-      - script: $(_sclEnableCommand) $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch ${{ parameters.archType }} $(_osParameter) ${{ parameters.buildArgs }} $(_officialBuildParameter) $(_crossBuildPropertyArg) $(_cxx11Parameter) $(_richCodeNavigationParam) $(_buildDarwinFrameworksParameter) $(_overrideTestScriptWindowsCmdParameter)
+      - script: $(_sclEnableCommand) $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch ${{ parameters.archType }} $(_osParameter) ${{ parameters.buildArgs }} $(_officialBuildParameter) $(_crossBuildPropertyArg) $(_cxx11Parameter) $(_buildDarwinFrameworksParameter) $(_overrideTestScriptWindowsCmdParameter)
         displayName: Build product
         ${{ if eq(parameters.useContinueOnErrorDuringBuild, true) }}:
           continueOnError: ${{ parameters.shouldContinueOnError }}

--- a/eng/pipelines/runtime-richnav.yml
+++ b/eng/pipelines/runtime-richnav.yml
@@ -1,26 +1,33 @@
-trigger:
-  batch: true
-  branches:
-    include:
-      - main
-      - release/*.*
-  paths:
-    include:
-    - '*'
-    exclude:
-    - '**.md'
-    - eng/Version.Details.xml
-    - .devcontainer/*
-    - .github/*
-    - docs/*
-    - LICENSE.TXT
-    - PATENTS.TXT
-    - THIRD-PARTY-NOTICES.TXT
+# disabled until https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1746670 is fixed
+trigger: none
+
+# trigger:
+#   batch: true
+#   branches:
+#     include:
+#       - main
+#       - release/*.*
+#   paths:
+#     include:
+#     - '*'
+#     exclude:
+#     - '**.md'
+#     - eng/Version.Details.xml
+#     - .devcontainer/*
+#     - .github/*
+#     - docs/*
+#     - LICENSE.TXT
+#     - PATENTS.TXT
+#     - THIRD-PARTY-NOTICES.TXT
 
 pr: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: CodeIndex.Enabled
+    value: true
+  - name: CodeIndex.Languages
+    value: csharp,cpp
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -36,9 +43,6 @@ extends:
           platforms:
             - windows_x64
           jobParameters:
-            enableRichCodeNavigation: true
-            richCodeNavigationEnvironment: "production"
-            richCodeNavigationLanguage: "csharp"
             timeoutInMinutes: 240
             buildArgs: -s libs.sfx+libs.oob -allConfigurations
 
@@ -49,8 +53,5 @@ extends:
           platforms:
             - windows_x64
           jobParameters:
-            enableRichCodeNavigation: true
             nameSuffix: Mono
-            richCodeNavigationEnvironment: "production"
-            richCodeNavigationLanguage: "csharp,cpp"
             buildArgs: -s mono -c debug


### PR DESCRIPTION
RichNav is now known as Code Index: https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/28554/Index-Your-Repo

The separate AzDO feed in nuget.config is not needed anymore which should make restore a bit faster.

Sample build with this PR: https://dev.azure.com/dnceng-public/public/_build/results?buildId=171103&view=results (note that there's currently an error due to new MSBuild binlog version which is tracked by https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1746670/, this already happens with the old task)