### PR TITLE
[6.0] Update WASM Windows helix queue

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -181,6 +181,6 @@ jobs:
 
     # WebAssembly windows
     - ${{ if eq(parameters.platform, 'Browser_wasm_win') }}:
-      - (Windows.Server.Core.1909.Amd64.Open)windows.amd64.server2022.open@mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-2004-helix-webassembly-amd64
+      - (Windows.Amd64.Server2022.Open)windows.amd64.server2022.open@mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-ltsc2022-helix-webassembly
 
     ${{ insert }}: ${{ parameters.jobParameters }}


### PR DESCRIPTION
This backport PR hit failures in wasm due to the image not existing anymore: https://github.com/dotnet/runtime/pull/82062

This fix matches the image we use in main: https://github.com/carlossanlop/runtime/blob/a6741d9c609cf402e319d67cc902cb574c15afa4/eng/pipelines/libraries/helix-queues-setup.yml#L200