### PR TITLE
Remove ConfigurationBinder usage from Console Logging

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleFormatterConfigureOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleFormatterConfigureOptions.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Versioning;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Configuration;
+using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Extensions.Logging
+{
+    /// <summary>
+    /// Configures a ConsoleFormatterOptions object from an IConfiguration.
+    /// </summary>
+    /// <remarks>
+    /// Doesn't use ConfigurationBinder in order to allow ConfigurationBinder, and all its dependencies,
+    /// to be trimmed. This improves app size and startup.
+    /// </remarks>
+    [UnsupportedOSPlatform("browser")]
+    internal sealed class ConsoleFormatterConfigureOptions : IConfigureOptions<ConsoleFormatterOptions>
+    {
+        private readonly IConfiguration _configuration;
+
+        public ConsoleFormatterConfigureOptions(ILoggerProviderConfiguration<ConsoleLoggerProvider> providerConfiguration)
+        {
+            _configuration = providerConfiguration.GetFormatterOptionsSection();
+        }
+
+        public void Configure(ConsoleFormatterOptions options) => Bind(_configuration, options);
+
+        public static void Bind(IConfiguration configuration, ConsoleFormatterOptions options)
+        {
+            if (configuration["IncludeScopes"] is string includeScopes)
+            {
+                options.IncludeScopes = bool.Parse(includeScopes);
+            }
+
+            if (configuration["TimestampFormat"] is string timestampFormat)
+            {
+                options.TimestampFormat = timestampFormat;
+            }
+
+            if (configuration["UseUtcTimestamp"] is string useUtcTimestamp)
+            {
+                options.UseUtcTimestamp = bool.Parse(useUtcTimestamp);
+            }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleFormatterConfigureOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleFormatterConfigureOptions.cs
@@ -30,9 +30,9 @@ namespace Microsoft.Extensions.Logging
 
         public static void Bind(IConfiguration configuration, ConsoleFormatterOptions options)
         {
-            if (configuration["IncludeScopes"] is string includeScopes)
+            if (ConsoleLoggerConfigureOptions.ParseBool(configuration, "IncludeScopes", out bool includeScopes))
             {
-                options.IncludeScopes = bool.Parse(includeScopes);
+                options.IncludeScopes = includeScopes;
             }
 
             if (configuration["TimestampFormat"] is string timestampFormat)
@@ -40,9 +40,9 @@ namespace Microsoft.Extensions.Logging
                 options.TimestampFormat = timestampFormat;
             }
 
-            if (configuration["UseUtcTimestamp"] is string useUtcTimestamp)
+            if (ConsoleLoggerConfigureOptions.ParseBool(configuration, "UseUtcTimestamp", out bool useUtcTimestamp))
             {
-                options.UseUtcTimestamp = bool.Parse(useUtcTimestamp);
+                options.UseUtcTimestamp = useUtcTimestamp;
             }
         }
     }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerConfigureOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerConfigureOptions.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Globalization;
+using System.Runtime.Versioning;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Configuration;
+using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Extensions.Logging
+{
+    /// <summary>
+    /// Configures a ConsoleLoggerOptions object from an IConfiguration.
+    /// </summary>
+    /// <remarks>
+    /// Doesn't use ConfigurationBinder in order to allow ConfigurationBinder, and all its dependencies,
+    /// to be trimmed. This improves app size and startup.
+    /// </remarks>
+    [UnsupportedOSPlatform("browser")]
+    internal sealed class ConsoleLoggerConfigureOptions : IConfigureOptions<ConsoleLoggerOptions>
+    {
+        private readonly IConfiguration _configuration;
+
+        public ConsoleLoggerConfigureOptions(ILoggerProviderConfiguration<ConsoleLoggerProvider> providerConfiguration)
+        {
+            _configuration = providerConfiguration.Configuration;
+        }
+
+        public void Configure(ConsoleLoggerOptions options)
+        {
+            if (_configuration["DisableColors"] is string disableColors)
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                options.DisableColors = bool.Parse(disableColors);
+#pragma warning restore CS0618 // Type or member is obsolete
+            }
+
+            if (_configuration["Format"] is string format)
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                options.Format = ParseEnum<ConsoleLoggerFormat>(format);
+#pragma warning restore CS0618 // Type or member is obsolete
+            }
+
+            if (_configuration["FormatterName"] is string formatterName)
+            {
+                options.FormatterName = formatterName;
+            }
+
+            if (_configuration["IncludeScopes"] is string includeScopes)
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                options.IncludeScopes = bool.Parse(includeScopes);
+#pragma warning restore CS0618 // Type or member is obsolete
+            }
+
+            if (_configuration["LogToStandardErrorThreshold"] is string logToStandardErrorThreshold)
+            {
+                options.LogToStandardErrorThreshold = ParseEnum<LogLevel>(logToStandardErrorThreshold);
+            }
+
+            if (_configuration["MaxQueueLength"] is string maxQueueLength)
+            {
+                options.MaxQueueLength = int.Parse(maxQueueLength, NumberStyles.Integer, NumberFormatInfo.InvariantInfo);
+            }
+
+            if (_configuration["QueueFullMode"] is string queueFullMode)
+            {
+                options.QueueFullMode = ParseEnum<ConsoleLoggerQueueFullMode>(queueFullMode);
+            }
+
+            if (_configuration["TimestampFormat"] is string timestampFormat)
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                options.TimestampFormat = timestampFormat;
+#pragma warning restore CS0618 // Type or member is obsolete
+            }
+
+            if (_configuration["UseUtcTimestamp"] is string useUtcTimestamp)
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                options.UseUtcTimestamp = bool.Parse(useUtcTimestamp);
+#pragma warning restore CS0618 // Type or member is obsolete
+            }
+        }
+
+        public static T ParseEnum<T>(string value) where T : struct =>
+#if NETSTANDARD || NETFRAMEWORK
+            (T)Enum.Parse(typeof(T), value, ignoreCase: true);
+#else
+            Enum.Parse<T>(value, ignoreCase: true);
+#endif
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerConfigureOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerConfigureOptions.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Extensions.Logging
         private static void ThrowInvalidConfigurationException(IConfiguration configuration, string key, Type valueType, Exception innerException)
         {
             IConfigurationSection section = configuration.GetSection(key);
-            throw new InvalidOperationException(string.Format(SR.InvalidConfigurationData, section.Path, valueType), innerException);
+            throw new InvalidOperationException(SR.Format(SR.InvalidConfigurationData, section.Path, valueType), innerException);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerConfigureOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerConfigureOptions.cs
@@ -30,45 +30,45 @@ namespace Microsoft.Extensions.Logging
 
         public void Configure(ConsoleLoggerOptions options)
         {
-            if (_configuration["DisableColors"] is string disableColors)
+            if (ParseBool(_configuration, "DisableColors", out bool disableColors))
             {
 #pragma warning disable CS0618 // Type or member is obsolete
-                options.DisableColors = bool.Parse(disableColors);
+                options.DisableColors = disableColors;
 #pragma warning restore CS0618 // Type or member is obsolete
             }
 
-            if (_configuration["Format"] is string format)
-            {
 #pragma warning disable CS0618 // Type or member is obsolete
-                options.Format = ParseEnum<ConsoleLoggerFormat>(format);
-#pragma warning restore CS0618 // Type or member is obsolete
+            if (ParseEnum(_configuration, "Format", out ConsoleLoggerFormat format))
+            {
+                options.Format = format;
             }
+#pragma warning restore CS0618 // Type or member is obsolete
 
             if (_configuration["FormatterName"] is string formatterName)
             {
                 options.FormatterName = formatterName;
             }
 
-            if (_configuration["IncludeScopes"] is string includeScopes)
+            if (ParseBool(_configuration, "IncludeScopes", out bool includeScopes))
             {
 #pragma warning disable CS0618 // Type or member is obsolete
-                options.IncludeScopes = bool.Parse(includeScopes);
+                options.IncludeScopes = includeScopes;
 #pragma warning restore CS0618 // Type or member is obsolete
             }
 
-            if (_configuration["LogToStandardErrorThreshold"] is string logToStandardErrorThreshold)
+            if (ParseEnum(_configuration, "LogToStandardErrorThreshold", out LogLevel logToStandardErrorThreshold))
             {
-                options.LogToStandardErrorThreshold = ParseEnum<LogLevel>(logToStandardErrorThreshold);
+                options.LogToStandardErrorThreshold = logToStandardErrorThreshold;
             }
 
-            if (_configuration["MaxQueueLength"] is string maxQueueLength)
+            if (ParseInt(_configuration, "MaxQueueLength", out int maxQueueLength))
             {
-                options.MaxQueueLength = int.Parse(maxQueueLength, NumberStyles.Integer, NumberFormatInfo.InvariantInfo);
+                options.MaxQueueLength = maxQueueLength;
             }
 
-            if (_configuration["QueueFullMode"] is string queueFullMode)
+            if (ParseEnum(_configuration, "QueueFullMode", out ConsoleLoggerQueueFullMode queueFullMode))
             {
-                options.QueueFullMode = ParseEnum<ConsoleLoggerQueueFullMode>(queueFullMode);
+                options.QueueFullMode = queueFullMode;
             }
 
             if (_configuration["TimestampFormat"] is string timestampFormat)
@@ -78,19 +78,95 @@ namespace Microsoft.Extensions.Logging
 #pragma warning restore CS0618 // Type or member is obsolete
             }
 
-            if (_configuration["UseUtcTimestamp"] is string useUtcTimestamp)
+            if (ParseBool(_configuration, "UseUtcTimestamp", out bool useUtcTimestamp))
             {
 #pragma warning disable CS0618 // Type or member is obsolete
-                options.UseUtcTimestamp = bool.Parse(useUtcTimestamp);
+                options.UseUtcTimestamp = useUtcTimestamp;
 #pragma warning restore CS0618 // Type or member is obsolete
             }
         }
 
-        public static T ParseEnum<T>(string value) where T : struct =>
-#if NETSTANDARD || NETFRAMEWORK
-            (T)Enum.Parse(typeof(T), value, ignoreCase: true);
+        /// <summary>
+        /// Parses the configuration value at the specified key into a bool.
+        /// </summary>
+        /// <returns>true if the value was successfully found and parsed. false if the key wasn't found.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when invalid data was found at the specified configuration key.</exception>
+        public static bool ParseBool(IConfiguration configuration, string key, out bool value)
+        {
+            if (configuration[key] is string valueString)
+            {
+                try
+                {
+                    value = bool.Parse(valueString);
+                    return true;
+                }
+                catch (Exception e)
+                {
+                    ThrowInvalidConfigurationException(configuration, key, typeof(bool), e);
+                }
+            }
+
+            value = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Parses the configuration value at the specified key into an enum.
+        /// </summary>
+        /// <returns>true if the value was successfully found and parsed. false if the key wasn't found.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when invalid data was found at the specified configuration key.</exception>
+        public static bool ParseEnum<T>(IConfiguration configuration, string key, out T value) where T : struct
+        {
+            if (configuration[key] is string valueString)
+            {
+                try
+                {
+                    value =
+#if NETFRAMEWORK || NETSTANDARD2_0
+                        (T)Enum.Parse(typeof(T), valueString, ignoreCase: true);
 #else
-            Enum.Parse<T>(value, ignoreCase: true);
+                        Enum.Parse<T>(valueString, ignoreCase: true);
 #endif
+                    return true;
+                }
+                catch (Exception e)
+                {
+                    ThrowInvalidConfigurationException(configuration, key, typeof(T), e);
+                }
+            }
+
+            value = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Parses the configuration value at the specified key into an int.
+        /// </summary>
+        /// <returns>true if the value was successfully found and parsed. false if the key wasn't found.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when invalid data was found at the specified configuration key.</exception>
+        public static bool ParseInt(IConfiguration configuration, string key, out int value)
+        {
+            if (configuration[key] is string valueString)
+            {
+                try
+                {
+                    value = int.Parse(valueString, NumberStyles.Integer, NumberFormatInfo.InvariantInfo);
+                    return true;
+                }
+                catch (Exception e)
+                {
+                    ThrowInvalidConfigurationException(configuration, key, typeof(int), e);
+                }
+            }
+
+            value = default;
+            return false;
+        }
+
+        private static void ThrowInvalidConfigurationException(IConfiguration configuration, string key, Type valueType, Exception innerException)
+        {
+            IConfigurationSection section = configuration.GetSection(key);
+            throw new InvalidOperationException(string.Format(SR.InvalidConfigurationData, section.Path, valueType), innerException);
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerExtensions.cs
@@ -25,22 +25,18 @@ namespace Microsoft.Extensions.Logging
         /// Adds a console logger named 'Console' to the factory.
         /// </summary>
         /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
-        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
-            Justification = "AddConsoleFormatter and RegisterProviderOptions are only called with Options types which only have simple properties.")]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-            Justification = "AddConsoleFormatter and RegisterProviderOptions are only dangerous when the Options type cannot be statically analyzed, but that is not the case here. " +
-            "The DynamicallyAccessedMembers annotations on them will make sure to preserve the right members from the different options objects.")]
-        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(JsonWriterOptions))]
         public static ILoggingBuilder AddConsole(this ILoggingBuilder builder)
         {
             builder.AddConfiguration();
 
-            builder.AddConsoleFormatter<JsonConsoleFormatter, JsonConsoleFormatterOptions>();
-            builder.AddConsoleFormatter<SystemdConsoleFormatter, ConsoleFormatterOptions>();
-            builder.AddConsoleFormatter<SimpleConsoleFormatter, SimpleConsoleFormatterOptions>();
+            builder.AddConsoleFormatter<JsonConsoleFormatter, JsonConsoleFormatterOptions, JsonConsoleFormatterConfigureOptions>();
+            builder.AddConsoleFormatter<SystemdConsoleFormatter, ConsoleFormatterOptions, ConsoleFormatterConfigureOptions>();
+            builder.AddConsoleFormatter<SimpleConsoleFormatter, SimpleConsoleFormatterOptions, SimpleConsoleFormatterConfigureOptions>();
 
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, ConsoleLoggerProvider>());
-            LoggerProviderOptions.RegisterProviderOptions<ConsoleLoggerOptions, ConsoleLoggerProvider>(builder.Services);
+
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<ConsoleLoggerOptions>, ConsoleLoggerConfigureOptions>());
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IOptionsChangeTokenSource<ConsoleLoggerOptions>, LoggerProviderOptionsChangeTokenSource<ConsoleLoggerOptions, ConsoleLoggerProvider>>());
 
             return builder;
         }
@@ -135,13 +131,7 @@ namespace Microsoft.Extensions.Logging
             where TOptions : ConsoleFormatterOptions
             where TFormatter : ConsoleFormatter
         {
-            builder.AddConfiguration();
-
-            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ConsoleFormatter, TFormatter>());
-            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<TOptions>, ConsoleLoggerFormatterConfigureOptions<TFormatter, TOptions>>());
-            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IOptionsChangeTokenSource<TOptions>, ConsoleLoggerFormatterOptionsChangeTokenSource<TFormatter, TOptions>>());
-
-            return builder;
+            return AddConsoleFormatter<TFormatter, TOptions, ConsoleLoggerFormatterConfigureOptions<TFormatter, TOptions>>(builder);
         }
 
         /// <summary>
@@ -161,6 +151,25 @@ namespace Microsoft.Extensions.Logging
             builder.Services.Configure(configure);
             return builder;
         }
+
+        private static ILoggingBuilder AddConsoleFormatter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TFormatter, TOptions, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TConfigureOptions>(this ILoggingBuilder builder)
+            where TOptions : ConsoleFormatterOptions
+            where TFormatter : ConsoleFormatter
+            where TConfigureOptions : class, IConfigureOptions<TOptions>
+        {
+            builder.AddConfiguration();
+
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ConsoleFormatter, TFormatter>());
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<TOptions>, TConfigureOptions>());
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IOptionsChangeTokenSource<TOptions>, ConsoleLoggerFormatterOptionsChangeTokenSource<TFormatter, TOptions>>());
+
+            return builder;
+        }
+
+        internal static IConfiguration GetFormatterOptionsSection(this ILoggerProviderConfiguration<ConsoleLoggerProvider> providerConfiguration)
+        {
+            return providerConfiguration.Configuration.GetSection("FormatterOptions");
+        }
     }
 
     [UnsupportedOSPlatform("browser")]
@@ -171,7 +180,7 @@ namespace Microsoft.Extensions.Logging
         [RequiresDynamicCode(ConsoleLoggerExtensions.RequiresDynamicCodeMessage)]
         [RequiresUnreferencedCode(ConsoleLoggerExtensions.TrimmingRequiresUnreferencedCodeMessage)]
         public ConsoleLoggerFormatterConfigureOptions(ILoggerProviderConfiguration<ConsoleLoggerProvider> providerConfiguration) :
-            base(providerConfiguration.Configuration.GetSection("FormatterOptions"))
+            base(providerConfiguration.GetFormatterOptionsSection())
         {
         }
     }
@@ -182,7 +191,7 @@ namespace Microsoft.Extensions.Logging
         where TFormatter : ConsoleFormatter
     {
         public ConsoleLoggerFormatterOptionsChangeTokenSource(ILoggerProviderConfiguration<ConsoleLoggerProvider> providerConfiguration)
-            : base(providerConfiguration.Configuration.GetSection("FormatterOptions"))
+            : base(providerConfiguration.GetFormatterOptionsSection())
         {
         }
     }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatterConfigureOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatterConfigureOptions.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Runtime.Versioning;
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Configuration;
+using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Extensions.Logging
+{
+    /// <summary>
+    /// Configures a JsonConsoleFormatterOptions object from an IConfiguration.
+    /// </summary>
+    /// <remarks>
+    /// Doesn't use ConfigurationBinder in order to allow ConfigurationBinder, and all its dependencies,
+    /// to be trimmed. This improves app size and startup.
+    /// </remarks>
+    [UnsupportedOSPlatform("browser")]
+    internal sealed class JsonConsoleFormatterConfigureOptions : IConfigureOptions<JsonConsoleFormatterOptions>
+    {
+        private readonly IConfiguration _configuration;
+
+        public JsonConsoleFormatterConfigureOptions(ILoggerProviderConfiguration<ConsoleLoggerProvider> providerConfiguration)
+        {
+            _configuration = providerConfiguration.GetFormatterOptionsSection();
+        }
+
+        public void Configure(JsonConsoleFormatterOptions options)
+        {
+            ConsoleFormatterConfigureOptions.Bind(_configuration, options);
+
+            if (_configuration.GetSection("JsonWriterOptions") is IConfigurationSection jsonWriterOptionsConfig)
+            {
+                JsonWriterOptions jsonWriterOptions = options.JsonWriterOptions;
+
+                if (jsonWriterOptionsConfig["Indented"] is string indented)
+                {
+                    jsonWriterOptions.Indented = bool.Parse(indented);
+                }
+
+                if (jsonWriterOptionsConfig["MaxDepth"] is string maxDepth)
+                {
+                    jsonWriterOptions.MaxDepth = int.Parse(maxDepth, NumberStyles.Integer, NumberFormatInfo.InvariantInfo);
+                }
+
+                if (jsonWriterOptionsConfig["SkipValidation"] is string skipValidation)
+                {
+                    jsonWriterOptions.SkipValidation = bool.Parse(skipValidation);
+                }
+
+                options.JsonWriterOptions = jsonWriterOptions;
+            }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatterConfigureOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatterConfigureOptions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
 using System.Runtime.Versioning;
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
@@ -36,19 +35,19 @@ namespace Microsoft.Extensions.Logging
             {
                 JsonWriterOptions jsonWriterOptions = options.JsonWriterOptions;
 
-                if (jsonWriterOptionsConfig["Indented"] is string indented)
+                if (ConsoleLoggerConfigureOptions.ParseBool(jsonWriterOptionsConfig, "Indented", out bool indented))
                 {
-                    jsonWriterOptions.Indented = bool.Parse(indented);
+                    jsonWriterOptions.Indented = indented;
                 }
 
-                if (jsonWriterOptionsConfig["MaxDepth"] is string maxDepth)
+                if (ConsoleLoggerConfigureOptions.ParseInt(jsonWriterOptionsConfig, "MaxDepth", out int maxDepth))
                 {
-                    jsonWriterOptions.MaxDepth = int.Parse(maxDepth, NumberStyles.Integer, NumberFormatInfo.InvariantInfo);
+                    jsonWriterOptions.MaxDepth = maxDepth;
                 }
 
-                if (jsonWriterOptionsConfig["SkipValidation"] is string skipValidation)
+                if (ConsoleLoggerConfigureOptions.ParseBool(jsonWriterOptionsConfig, "SkipValidation", out bool skipValidation))
                 {
-                    jsonWriterOptions.SkipValidation = bool.Parse(skipValidation);
+                    jsonWriterOptions.SkipValidation = skipValidation;
                 }
 
                 options.JsonWriterOptions = jsonWriterOptions;

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Resources/Strings.resx
@@ -129,4 +129,7 @@
   <data name="WarningMessageOnDrop" xml:space="preserve">
     <value>{0} message(s) dropped because of queue size limit. Increase the queue size or decrease logging verbosity to avoid this. You may change `ConsoleLoggerQueueFullMode` to stop dropping messages.</value>
   </data>
+  <data name="InvalidConfigurationData" xml:space="preserve">
+    <value>Failed to convert configuration value at '{0}' to type '{1}'.</value>
+  </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatterConfigureOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatterConfigureOptions.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Versioning;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Configuration;
+using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Extensions.Logging
+{
+    /// <summary>
+    /// Configures a SimpleConsoleFormatterOptions object from an IConfiguration.
+    /// </summary>
+    /// <remarks>
+    /// Doesn't use ConfigurationBinder in order to allow ConfigurationBinder, and all its dependencies,
+    /// to be trimmed. This improves app size and startup.
+    /// </remarks>
+    [UnsupportedOSPlatform("browser")]
+    internal sealed class SimpleConsoleFormatterConfigureOptions : IConfigureOptions<SimpleConsoleFormatterOptions>
+    {
+        private readonly IConfiguration _configuration;
+
+        public SimpleConsoleFormatterConfigureOptions(ILoggerProviderConfiguration<ConsoleLoggerProvider> providerConfiguration)
+        {
+            _configuration = providerConfiguration.GetFormatterOptionsSection();
+        }
+
+        public void Configure(SimpleConsoleFormatterOptions options)
+        {
+            ConsoleFormatterConfigureOptions.Bind(_configuration, options);
+
+            if (_configuration["ColorBehavior"] is string colorBehavior)
+            {
+                options.ColorBehavior = ConsoleLoggerConfigureOptions.ParseEnum<LoggerColorBehavior>(colorBehavior);
+            }
+
+            if (_configuration["SingleLine"] is string singleLine)
+            {
+                options.SingleLine = bool.Parse(singleLine);
+            }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatterConfigureOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatterConfigureOptions.cs
@@ -30,14 +30,14 @@ namespace Microsoft.Extensions.Logging
         {
             ConsoleFormatterConfigureOptions.Bind(_configuration, options);
 
-            if (_configuration["ColorBehavior"] is string colorBehavior)
+            if (ConsoleLoggerConfigureOptions.ParseEnum(_configuration, "ColorBehavior", out LoggerColorBehavior colorBehavior))
             {
-                options.ColorBehavior = ConsoleLoggerConfigureOptions.ParseEnum<LoggerColorBehavior>(colorBehavior);
+                options.ColorBehavior = colorBehavior;
             }
 
-            if (_configuration["SingleLine"] is string singleLine)
+            if (ConsoleLoggerConfigureOptions.ParseBool(_configuration, "SingleLine", out bool singleLine))
             {
-                options.SingleLine = bool.Parse(singleLine);
+                options.SingleLine = singleLine;
             }
         }
     }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerConfigureOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerConfigureOptions.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Extensions.Logging.Console.Test
+{
+    public class ConsoleLoggerConfigureOptions
+    {
+        [Fact]
+        public void EnsureConsoleLoggerOptions_ConfigureOptions_SupportsAllProperties()
+        {
+            // NOTE: if this test fails, it is because a property was added to one of the following types.
+            // When adding a new property to one of these types, ensure the corresponding
+            // IConfigureOptions class is updated for the new property.
+
+            BindingFlags flags = BindingFlags.Public | BindingFlags.Instance;
+            Assert.Equal(9, typeof(ConsoleLoggerOptions).GetProperties(flags).Length);
+            Assert.Equal(3, typeof(ConsoleFormatterOptions).GetProperties(flags).Length);
+            Assert.Equal(5, typeof(SimpleConsoleFormatterOptions).GetProperties(flags).Length);
+            Assert.Equal(4, typeof(JsonConsoleFormatterOptions).GetProperties(flags).Length);
+            Assert.Equal(4, typeof(JsonWriterOptions).GetProperties(flags).Length);
+        }
+
+        [Theory]
+        [InlineData("Console:LogToStandardErrorThreshold", "invalid")]
+        [InlineData("Console:MaxQueueLength", "notANumber")]
+        [InlineData("Console:QueueFullMode", "invalid")]
+        [InlineData("Console:FormatterOptions:IncludeScopes", "not a bool")]
+        [InlineData("Console:FormatterOptions:UseUtcTimestamp", "not a bool")]
+        [InlineData("Console:FormatterOptions:ColorBehavior", "not a behavior")]
+        [InlineData("Console:FormatterOptions:SingleLine", "not a bool")]
+        [InlineData("Console:FormatterOptions:JsonWriterOptions:Indented", "not a bool")]
+        [InlineData("Console:FormatterOptions:JsonWriterOptions:MaxDepth", "not an int")]
+        [InlineData("Console:FormatterOptions:JsonWriterOptions:SkipValidation", "not a bool")]
+        public void ConsoleLoggerConfigureOptions_InvalidConfigurationData(string key, string value)
+        {
+            var configuration = new ConfigurationManager();
+            configuration.AddInMemoryCollection(new[] { new KeyValuePair<string, string>(key, value) });
+
+            IServiceProvider serviceProvider = new ServiceCollection()
+                .AddLogging(builder => builder
+                    .AddConfiguration(configuration)
+                    .AddConsole())
+                .BuildServiceProvider();
+
+            InvalidOperationException e = Assert.Throws<InvalidOperationException>(() => serviceProvider.GetRequiredService<ILoggerProvider>());
+
+            // "Console:" is stripped off from the config path since that config section is read by the ConsoleLogger, and not part of the Options path.
+            string configPath = key.Substring("Console:".Length);
+            Assert.Contains(configPath, e.Message);
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerExtensionsTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerExtensionsTests.cs
@@ -374,8 +374,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
                 )
                 .BuildServiceProvider();
 
-            // the configuration binder throws TargetInvocationException when setting options property MaxQueueLength throws exception
-            Assert.Throws<TargetInvocationException>(() => serviceProvider.GetRequiredService<ILoggerProvider>());
+            Assert.Throws<ArgumentOutOfRangeException>(() => serviceProvider.GetRequiredService<ILoggerProvider>());
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
@@ -6,6 +6,8 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Extensions.Configuration;
@@ -1344,6 +1346,21 @@ namespace Microsoft.Extensions.Logging.Console.Test
             Assert.NotNull(logger.ScopeProvider);
             var formatter = Assert.IsType<SimpleConsoleFormatter>(logger.Formatter);
             Assert.True(formatter.FormatterOptions.IncludeScopes);
+        }
+
+        [Fact]
+        public void EnsureConsoleLoggerOptions_ConfigureOptions_SupportsAllProperties()
+        {
+            // NOTE: if this test fails, it is because a property was added to one of the following types.
+            // When adding a new property to one of these types, ensure the corresponding
+            // IConfigureOptions class is updated for the new property.
+
+            BindingFlags flags = BindingFlags.Public | BindingFlags.Instance;
+            Assert.Equal(9, typeof(ConsoleLoggerOptions).GetProperties(flags).Length);
+            Assert.Equal(3, typeof(ConsoleFormatterOptions).GetProperties(flags).Length);
+            Assert.Equal(5, typeof(SimpleConsoleFormatterOptions).GetProperties(flags).Length);
+            Assert.Equal(4, typeof(JsonConsoleFormatterOptions).GetProperties(flags).Length);
+            Assert.Equal(4, typeof(JsonWriterOptions).GetProperties(flags).Length);
         }
 
         public static TheoryData<ConsoleLoggerFormat, LogLevel> FormatsAndLevels

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
@@ -1348,21 +1348,6 @@ namespace Microsoft.Extensions.Logging.Console.Test
             Assert.True(formatter.FormatterOptions.IncludeScopes);
         }
 
-        [Fact]
-        public void EnsureConsoleLoggerOptions_ConfigureOptions_SupportsAllProperties()
-        {
-            // NOTE: if this test fails, it is because a property was added to one of the following types.
-            // When adding a new property to one of these types, ensure the corresponding
-            // IConfigureOptions class is updated for the new property.
-
-            BindingFlags flags = BindingFlags.Public | BindingFlags.Instance;
-            Assert.Equal(9, typeof(ConsoleLoggerOptions).GetProperties(flags).Length);
-            Assert.Equal(3, typeof(ConsoleFormatterOptions).GetProperties(flags).Length);
-            Assert.Equal(5, typeof(SimpleConsoleFormatterOptions).GetProperties(flags).Length);
-            Assert.Equal(4, typeof(JsonConsoleFormatterOptions).GetProperties(flags).Length);
-            Assert.Equal(4, typeof(JsonWriterOptions).GetProperties(flags).Length);
-        }
-
         public static TheoryData<ConsoleLoggerFormat, LogLevel> FormatsAndLevels
         {
             get


### PR DESCRIPTION
This allows ConfigurationBinder, and its dependencies like TypeConverter, to be trimmed in an application that uses Console Logging, like an ASP.NET API application.

Fix #81931