### PR TITLE
Include more details in exception from wrong async callback

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -3992,4 +3992,7 @@
   <data name="Argument_DirectorySeparatorInvalid" xml:space="preserve">
     <value>The value may not contain directory separator characters.</value>
   </data>
+  <data name="Argument_UnexpectedStateForKnownCallback" xml:space="preserve">
+    <value>An unexpected state object was encountered. This is usually a sign of a bug in async method custom infrastructure, such as a custom awaiter or IValueTaskSource implementation.</value>
+  </data>
 </root>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -14,14 +14,16 @@ namespace System.Runtime.CompilerServices
         /// <summary>Shim used to invoke an <see cref="Action"/> passed as the state argument to a <see cref="Action{Object}"/>.</summary>
         internal static readonly Action<object?> s_invokeActionDelegate = static state =>
         {
-            if (!(state is Action action))
+            if (state is Action action)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.state);
-                return;
+                action();
             }
-
-            action();
+            else
+            {
+                ThrowHelper.ThrowUnexpectedStateForKnownCallback(state);
+            }
         };
+
         /// <summary>The value being awaited.</summary>
         private readonly ValueTask _value;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ValueTask.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ValueTask.cs
@@ -239,8 +239,13 @@ namespace System.Threading.Tasks
                     // This could only happen if the IValueTaskSource passed the wrong state
                     // or if this callback were invoked multiple times such that the state
                     // was previously nulled out.
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.state);
+                    ThrowUnexpectedStateForKnownCallback(state);
                     return;
+
+                    static void ThrowUnexpectedStateForKnownCallback(object? state) =>
+                        ThrowHelper.ThrowUnexpectedStateForKnownCallback(state is ValueTaskSourceAsTask vsts ?
+                            $"{nameof(ValueTaskSourceAsTask)}.{nameof(_source)} : {vsts._source}" :
+                            $"{nameof(state)} : {state}");
                 }
 
                 vtst._source = null;
@@ -638,8 +643,13 @@ namespace System.Threading.Tasks
                     // This could only happen if the IValueTaskSource<TResult> passed the wrong state
                     // or if this callback were invoked multiple times such that the state
                     // was previously nulled out.
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.state);
+                    ThrowUnexpectedStateForKnownCallback(state);
                     return;
+
+                    static void ThrowUnexpectedStateForKnownCallback(object? state) =>
+                        ThrowHelper.ThrowUnexpectedStateForKnownCallback(state is ValueTaskSourceAsTask vsts ?
+                            $"{nameof(ValueTaskSourceAsTask)}.{nameof(_source)} : {vsts._source}" :
+                            $"{nameof(state)} : {state}");
                 }
 
                 vtst._source = null;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ValueTask.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ValueTask.cs
@@ -243,9 +243,12 @@ namespace System.Threading.Tasks
                     return;
 
                     static void ThrowUnexpectedStateForKnownCallback(object? state) =>
-                        ThrowHelper.ThrowUnexpectedStateForKnownCallback(state is ValueTaskSourceAsTask vsts ?
-                            $"{nameof(ValueTaskSourceAsTask)}.{nameof(_source)} : {vsts._source}" :
-                            $"{nameof(state)} : {state}");
+                        throw new ArgumentOutOfRangeException(
+                            nameof(state),
+                            state is ValueTaskSourceAsTask vsts ?
+                                $"{nameof(ValueTaskSourceAsTask)}.{nameof(_source)} : {vsts._source}" :
+                                $"{nameof(state)} : {state}",
+                            SR.Argument_UnexpectedStateForKnownCallback);
                 }
 
                 vtst._source = null;
@@ -647,9 +650,12 @@ namespace System.Threading.Tasks
                     return;
 
                     static void ThrowUnexpectedStateForKnownCallback(object? state) =>
-                        ThrowHelper.ThrowUnexpectedStateForKnownCallback(state is ValueTaskSourceAsTask vsts ?
-                            $"{nameof(ValueTaskSourceAsTask)}.{nameof(_source)} : {vsts._source}" :
-                            $"{nameof(state)} : {state}");
+                        throw new ArgumentOutOfRangeException(
+                            nameof(state),
+                            state is ValueTaskSourceAsTask vsts ?
+                                $"{nameof(ValueTaskSourceAsTask)}.{nameof(_source)} : {vsts._source}" :
+                                $"{nameof(state)} : {state}",
+                            SR.Argument_UnexpectedStateForKnownCallback);
                 }
 
                 vtst._source = null;

--- a/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
@@ -450,6 +450,12 @@ namespace System
         }
 
         [DoesNotReturn]
+        internal static void ThrowUnexpectedStateForKnownCallback(object? state)
+        {
+            throw new ArgumentOutOfRangeException(nameof(state), state, SR.Argument_UnexpectedStateForKnownCallback);
+        }
+
+        [DoesNotReturn]
         internal static void ThrowInvalidOperationException_InvalidOperation_EnumNotStarted()
         {
             throw new InvalidOperationException(SR.InvalidOperation_EnumNotStarted);
@@ -796,8 +802,6 @@ namespace System
                     return "comparable";
                 case ExceptionArgument.source:
                     return "source";
-                case ExceptionArgument.state:
-                    return "state";
                 case ExceptionArgument.length:
                     return "length";
                 case ExceptionArgument.comparisonType:
@@ -1130,7 +1134,6 @@ namespace System
         comparer,
         comparable,
         source,
-        state,
         length,
         comparisonType,
         manager,


### PR DESCRIPTION
Every now and then, we get reports of an exception due to an invalid object being passed to one of our callback delegates that expects specific state.  To help diagnose those better, this adds more details about what state was actually provided.