### PR TITLE
Separate the generation of PerfMap and JitDump files

### DIFF
--- a/src/coreclr/vm/perfmap.cpp
+++ b/src/coreclr/vm/perfmap.cpp
@@ -60,6 +60,7 @@ void PerfMap::Initialize()
 
         s_enabled = true;
     }
+
     if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_PerfMapEnabled) == ALL || CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_PerfMapEnabled) == JITDUMP)
     {   
         const char* jitdumpPath;
@@ -174,6 +175,11 @@ void PerfMap::WriteLine(SString& line)
 {
     STANDARD_VM_CONTRACT;
 
+    if (m_FileStream == nullptr || m_ErrorEncountered)
+    {
+        return;
+    }
+
     EX_TRY
     {
         // Write the line.
@@ -271,7 +277,8 @@ void PerfMap::LogJITCompiledMethod(MethodDesc * pMethod, PCODE pCode, size_t cod
         line.Printf(FMT_CODE_ADDR " %x %s\n", pCode, codeSize, name.GetUTF8());
 
         // Write the line.
-        if(s_Current !=nullptr && s_Current->m_FileStream != nullptr && !s_Current->m_ErrorEncountered){
+        if(s_Current != nullptr)
+        {
             s_Current->WriteLine(line);
         }
         PAL_PerfJitDump_LogMethod((void*)pCode, codeSize, name.GetUTF8(), nullptr, nullptr);

--- a/src/coreclr/vm/perfmap.cpp
+++ b/src/coreclr/vm/perfmap.cpp
@@ -22,13 +22,21 @@ Volatile<bool> PerfMap::s_enabled = false;
 PerfMap * PerfMap::s_Current = nullptr;
 bool PerfMap::s_ShowOptimizationTiers = false;
 
+enum 
+{
+    DISABLED,
+    ALL,
+    JITDUMP,
+    PERFMAP
+};
+
 // Initialize the map for the process - called from EEStartupHelper.
 void PerfMap::Initialize()
 {
     LIMITED_METHOD_CONTRACT;
 
     // Only enable the map if requested.
-    if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_PerfMapEnabled))
+    if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_PerfMapEnabled) == ALL || CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_PerfMapEnabled) == PERFMAP)
     {
         // Get the current process id.
         int currentPid = GetCurrentProcessId();
@@ -49,7 +57,9 @@ void PerfMap::Initialize()
         }
 
         s_enabled = true;
-
+    }
+    if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_PerfMapEnabled) == ALL || CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_PerfMapEnabled) == JITDUMP)
+    {    
         const char* jitdumpPath;
         char jitdumpPathBuffer[4096];
 

--- a/src/coreclr/vm/perfmap.h
+++ b/src/coreclr/vm/perfmap.h
@@ -24,6 +24,9 @@ private:
     // Indicates whether optimization tiers should be shown for methods in perf maps
     static bool s_ShowOptimizationTiers;
 
+    // Set to true if an error is encountered when writing to the file.
+    static unsigned s_StubsMapped;
+
     // The file stream to write the map to.
     CFileStream * m_FileStream;
 
@@ -32,9 +35,6 @@ private:
 
     // Set to true if an error is encountered when writing to the file.
     bool m_ErrorEncountered;
-
-    // Set to true if an error is encountered when writing to the file.
-    static unsigned s_StubsMapped;
 
     // Construct a new map for the specified pid.
     PerfMap(int pid);

--- a/src/coreclr/vm/perfmap.h
+++ b/src/coreclr/vm/perfmap.h
@@ -34,7 +34,7 @@ private:
     bool m_ErrorEncountered;
 
     // Set to true if an error is encountered when writing to the file.
-    unsigned m_StubsMapped;
+    static unsigned s_StubsMapped;
 
     // Construct a new map for the specified pid.
     PerfMap(int pid);


### PR DESCRIPTION
When the DOTNET_PerfMapEnabled environment variable is turned on, both PerfMap and JitDump files are generated. However, JitDump support was added to the 5.4 Linux kernel and are a superset of functionality over PerfMap. Thus, allowing the user to choose which file type to generate, based on factors such as kernel version and tool support, instead of always generating both would provide a performance improvement. The new values for PerfMapEnabled would be the following:

Value| Behavior
------ | ------
0   | Disabled  
1   | Generate both
2   | Generate only JitDump
3   | Generate only PerfMap

This provides the original functionality of setting DOTNET_PerfMapEnabled=1 to generate both file types while also allowing the generation of only one file type.