### PR TITLE
Add CollectionsMarshal.SetCount(list, count)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CollectionsMarshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CollectionsMarshal.cs
@@ -39,5 +39,46 @@ namespace System.Runtime.InteropServices
         /// <remarks>Items should not be added to or removed from the <see cref="Dictionary{TKey, TValue}"/> while the ref <typeparamref name="TValue"/> is in use.</remarks>
         public static ref TValue? GetValueRefOrAddDefault<TKey, TValue>(Dictionary<TKey, TValue> dictionary, TKey key, out bool exists) where TKey : notnull
             => ref Dictionary<TKey, TValue>.CollectionsMarshalHelper.GetValueRefOrAddDefault(dictionary, key, out exists);
+
+        /// <summary>
+        /// Sets the count of the <see cref="List{T}"/> to the specified value.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="list">The list to set the count of.</param>
+        /// <param name="count">The value to set the list's count to.</param>
+        /// <exception cref="NullReferenceException">
+        /// <paramref name="list"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="count"/> is negative/>.
+        /// </exception>
+        /// <remarks>
+        /// When increasing the count, uninitialized is being exposed.
+        /// </remarks>
+        public static void SetCount<T>(List<T> list, int count)
+        {
+            if (count < 0)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException_NeedNonNegNum(nameof(count));
+            }
+
+            if (count == list._size)
+            {
+                return;
+            }
+
+            list._version++;
+
+            if (count > list.Capacity)
+            {
+                list.Grow(count);
+            }
+            else if (count < list._size && RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                Array.Clear(list._items, count, list._size - count);
+            }
+
+            list._size = count;
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CollectionsMarshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CollectionsMarshal.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace System.Runtime.InteropServices
 {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CollectionsMarshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CollectionsMarshal.cs
@@ -43,17 +43,16 @@ namespace System.Runtime.InteropServices
         /// <summary>
         /// Sets the count of the <see cref="List{T}"/> to the specified value.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
         /// <param name="list">The list to set the count of.</param>
         /// <param name="count">The value to set the list's count to.</param>
         /// <exception cref="NullReferenceException">
         /// <paramref name="list"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="count"/> is negative/>.
+        /// <paramref name="count"/> is negative.
         /// </exception>
         /// <remarks>
-        /// When increasing the count, uninitialized is being exposed.
+        /// When increasing the count, uninitialized data is being exposed.
         /// </remarks>
         public static void SetCount<T>(List<T> list, int count)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CollectionsMarshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CollectionsMarshal.cs
@@ -62,11 +62,6 @@ namespace System.Runtime.InteropServices
                 ThrowHelper.ThrowArgumentOutOfRangeException_NeedNonNegNum(nameof(count));
             }
 
-            if (count == list._size)
-            {
-                return;
-            }
-
             list._version++;
 
             if (count > list.Capacity)

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -483,6 +483,7 @@ namespace System.Runtime.InteropServices
         public static System.Span<T> AsSpan<T>(System.Collections.Generic.List<T>? list) { throw null; }
         public static ref TValue GetValueRefOrNullRef<TKey, TValue>(System.Collections.Generic.Dictionary<TKey, TValue> dictionary, TKey key) where TKey : notnull { throw null; }
         public static ref TValue? GetValueRefOrAddDefault<TKey, TValue>(System.Collections.Generic.Dictionary<TKey, TValue> dictionary, TKey key, out bool exists) where TKey : notnull { throw null; }
+        public static void SetCount<T>(System.Collections.Generic.List<T> list, int count) { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class, Inherited=false)]
     public sealed partial class ComDefaultInterfaceAttribute : System.Attribute

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/CollectionsMarshalTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/CollectionsMarshalTests.cs
@@ -525,22 +525,22 @@ namespace System.Runtime.InteropServices.Tests
             CollectionsMarshal.SetCount(list, 3);
             Assert.Equal(3, list.Count);
             Assert.Throws<ArgumentOutOfRangeException>(() => list[3]);
-            SequenceEquals(CollectionsMarshal.AsSpan(list), new int[] { 1, 2, 3 });
+            SequenceEquals<int>(CollectionsMarshal.AsSpan(list), new int[] { 1, 2, 3 });
 
             // make sure that size increase preserves content
             CollectionsMarshal.SetCount(list, 5);
-            SequenceEquals(CollectionsMarshal.AsSpan(list)[..3], new int[] { 1, 2, 3 });
+            SequenceEquals<int>(CollectionsMarshal.AsSpan(list)[..3], new int[] { 1, 2, 3 });
 
             // make sure that reallocations preserve content
             int newCount = list.Capacity * 2;
             CollectionsMarshal.SetCount(list, newCount);
             Assert.Equal(newCount, list.Count);
-            SequenceEquals(CollectionsMarshal.AsSpan(list)[..3], new int[] { 1, 2, 3 });
+            SequenceEquals<int>(CollectionsMarshal.AsSpan(list)[..3], new int[] { 1, 2, 3 });
 
             List<string> listReference = new() { "a", "b", "c", "d", "e" };
             CollectionsMarshal.SetCount(listReference, 3);
             // verify that reference types aren't cleared
-            SequenceEquals(CollectionsMarshal.AsSpan(listReference), new string[] { "a", "b", "c" });
+            SequenceEquals<string>(CollectionsMarshal.AsSpan(listReference), new string[] { "a", "b", "c" });
 
             static void SequenceEquals<T>(ReadOnlySpan<T> actual, ReadOnlySpan<T> expected)
             {

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/CollectionsMarshalTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/CollectionsMarshalTests.cs
@@ -541,6 +541,9 @@ namespace System.Runtime.InteropServices.Tests
             CollectionsMarshal.SetCount(listReference, 3);
             // verify that reference types aren't cleared
             SequenceEquals<string>(CollectionsMarshal.AsSpan(listReference), new string[] { "a", "b", "c" });
+            CollectionsMarshal.SetCount(listReference, 5);
+            // verify that removed reference types are cleared
+            SequenceEquals<string>(CollectionsMarshal.AsSpan(listReference), new string[] { "a", "b", "c", null, null });
 
             static void SequenceEquals<T>(ReadOnlySpan<T> actual, ReadOnlySpan<T> expected)
             {

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/CollectionsMarshalTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/CollectionsMarshalTests.cs
@@ -542,7 +542,7 @@ namespace System.Runtime.InteropServices.Tests
             Assert.True(!Unsafe.AreSame(ref intRef, ref MemoryMarshal.GetReference(CollectionsMarshal.AsSpan(list))));
 
             List<string> listReference = new() { "a", "b", "c", "d", "e" };
-            ref int stringRef = ref MemoryMarshal.GetReference(CollectionsMarshal.AsSpan(listReference));
+            ref string stringRef = ref MemoryMarshal.GetReference(CollectionsMarshal.AsSpan(listReference));
             CollectionsMarshal.SetCount(listReference, 3);
             // verify that reference types aren't cleared
             SequenceEquals<string>(CollectionsMarshal.AsSpan(listReference), new string[] { "a", "b", "c" });


### PR DESCRIPTION
Adds the ability to resize lists, exposed in
CollectionsMarshal due to potentially risky
behaviour caused by the lack of element initialization.

Supersedes #77794.

Fixes #55217.