### PR TITLE
[wasm] Add jiterpreter trace transfer and other optimizations

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -8745,11 +8745,16 @@ mono_jiterp_interp_entry (JiterpEntryData *_data, stackval *sp_args, void *res)
 		mono_jiterp_stackval_to_data (type, frame.stack, res);
 }
 
-EMSCRIPTEN_KEEPALIVE void
-mono_jiterp_auto_safepoint (InterpFrame *frame, guint16 *ip)
+EMSCRIPTEN_KEEPALIVE volatile size_t *
+mono_jiterp_get_polling_required_address ()
 {
-	if (G_UNLIKELY (mono_polling_required))
-		do_safepoint (frame, get_context(), ip);
+	return &mono_polling_required;
+}
+
+EMSCRIPTEN_KEEPALIVE void
+mono_jiterp_do_safepoint (InterpFrame *frame, guint16 *ip)
+{
+	do_safepoint (frame, get_context(), ip);
 }
 
 EMSCRIPTEN_KEEPALIVE gpointer

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -145,16 +145,6 @@ mono_jiterp_encode_leb_signed_boundary (unsigned char * destination, int bits, i
 //  so that jiterpreter traces don't have to inline dozens of wasm instructions worth of
 //  complex logic - these are designed to match interp.c
 
-EMSCRIPTEN_KEEPALIVE double
-mono_jiterp_fmod (double lhs, double rhs) {
-	return fmod(lhs, rhs);
-}
-
-EMSCRIPTEN_KEEPALIVE double
-mono_jiterp_atan2 (double lhs, double rhs) {
-	return atan2(lhs, rhs);
-}
-
 // If a trace is jitted for a method that hasn't been tiered yet, we need to
 //  update the interpreter entry count for the method.
 EMSCRIPTEN_KEEPALIVE int
@@ -1198,6 +1188,73 @@ EMSCRIPTEN_KEEPALIVE int
 mono_jiterp_debug_count ()
 {
 	return mono_debug_count();
+}
+
+EMSCRIPTEN_KEEPALIVE double
+mono_jiterp_math_rem (double lhs, double rhs) {
+	return fmod(lhs, rhs);
+}
+
+EMSCRIPTEN_KEEPALIVE double
+mono_jiterp_math_atan2 (double lhs, double rhs) {
+	return atan2(lhs, rhs);
+}
+
+EMSCRIPTEN_KEEPALIVE double
+mono_jiterp_math_acos (double value)
+{
+	return acos(value);
+}
+
+EMSCRIPTEN_KEEPALIVE double
+mono_jiterp_math_cos (double value)
+{
+	return cos(value);
+}
+
+EMSCRIPTEN_KEEPALIVE double
+mono_jiterp_math_asin (double value)
+{
+	return asin(value);
+}
+
+EMSCRIPTEN_KEEPALIVE double
+mono_jiterp_math_sin (double value)
+{
+	return sin(value);
+}
+
+EMSCRIPTEN_KEEPALIVE double
+mono_jiterp_math_atan (double value)
+{
+	return atan(value);
+}
+
+EMSCRIPTEN_KEEPALIVE double
+mono_jiterp_math_tan (double value)
+{
+	return tan(value);
+}
+
+EMSCRIPTEN_KEEPALIVE int
+mono_jiterp_trace_transfer (
+	int displacement, JiterpreterThunk trace, void *frame, void *pLocals
+) {
+	// This indicates that we lost a race condition, so there's no trace to call. Just bail out.
+	// FIXME: Detect this at trace generation time and spin until the trace is available
+	if (!trace)
+		return displacement;
+
+	// When we transfer control to a trace that represents a loop body, at the end of the loop
+	//  body it may branch back to itself. In that case, we can just call it again - the
+	//  safepoint was already performed by the trace.
+	int relative_displacement = 0;
+	while (relative_displacement == 0)
+		relative_displacement = trace(frame, pLocals);
+
+	// We got a relative displacement other than 0, so the trace bailed out somewhere or
+	//  branched to another branch target. Time to return (and our caller will return too.)
+	return displacement + relative_displacement;
 }
 
 // HACK: fix C4206

--- a/src/mono/mono/mini/interp/jiterpreter.h
+++ b/src/mono/mono/mini/interp/jiterpreter.h
@@ -124,8 +124,11 @@ typedef struct {
 	JiterpEntryDataCache cache;
 } JiterpEntryData;
 
+volatile size_t *
+mono_jiterp_get_polling_required_address (void);
+
 void
-mono_jiterp_auto_safepoint (InterpFrame *frame, guint16 *ip);
+mono_jiterp_do_safepoint (InterpFrame *frame, guint16 *ip);
 
 void
 mono_jiterp_interp_entry (JiterpEntryData *_data, stackval *sp_args, void *res);

--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -125,6 +125,7 @@ const fn_signatures: SigLine[] = [
     [true, "mono_jiterp_imethod_to_ftnptr", "number", ["number"]],
     [true, "mono_jiterp_debug_count", "number", []],
     [true, "mono_jiterp_get_trace_hit_count", "number", ["number"]],
+    [true, "mono_jiterp_get_polling_required_address", "number", []],
 ];
 
 export interface t_Cwraps {
@@ -271,6 +272,7 @@ export interface t_Cwraps {
     mono_jiterp_imethod_to_ftnptr(imethod: VoidPtr): VoidPtr;
     mono_jiterp_debug_count(): number;
     mono_jiterp_get_trace_hit_count(traceIndex: number): number;
+    mono_jiterp_get_polling_required_address(): Int32Ptr;
 }
 
 const wrapped_c_functions: t_Cwraps = <any>{};


### PR DESCRIPTION
(this PR depends on #82130)

This PR contains a few small optimizations and changes:
* Adds the concept of 'trace transfer' where if a trace compile stopped due to reaching another trace's entry point, we will now enter that other trace directly (with the aid of a helper function). The helper function will also notice if the target trace branches back to itself and continue running it, which allows a subset of loops to run without returning to the interpreter. (Right now this loop optimization only seems to activate a small percentage of the time, but it does work.)
* Optimize appendName for the common case of single-character names, and use encodeInto instead of encode. Before this in a browser-bench run out of ~550ms of trace compile time, 80ms was appendName alone 😟
* 'safepoint needed' checks are now done inline in traces instead of via a function call into runtime C (as suggested by @vargaz), which should make them a bit cheaper.
* The math functions like asin and tan are now all implemented in C - previously we used the JS Math object for them since you're meant to be able to do that in wasm, but I realized the output of the JS ones might not precisely match what the regular interpreter's libc would produce. So now they will be consistent.