### PR TITLE
Fix CancellationTokenSource_CancelAsync_AllCallbacksInvoked test

### DIFF
--- a/src/libraries/System.Threading.Tasks/tests/CancellationTokenTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/CancellationTokenTests.cs
@@ -1787,7 +1787,9 @@ namespace System.Threading.Tasks.Tests
             Task t = cts.CancelAsync();
             Assert.True(cts.IsCancellationRequested);
 
-            t.Wait(); // synchronously block to ensure this thread isn't reused
+            ((IAsyncResult)t).AsyncWaitHandle.WaitOne(); // synchronously block without inlining to ensure this thread isn't reused
+            t.Wait(); // propagate any exceptions
+
             Assert.Equal(Iters * (Iters + 1) / 2, sum);
         }
 


### PR DESCRIPTION
If the task internally queued by CancelAsync hasn't started yet by the time we block waiting for it, Wait could inline it and end up running it on the current thread.

Fixes https://github.com/dotnet/runtime/issues/82140