### PR TITLE
Build test tree with partial trimming

### DIFF
--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -648,6 +648,10 @@
       Microsoft.NETCore.Native.targets expect IlcHostArch to be set but it doesn't have to -->
     <DisableUnsupportedError>true</DisableUnsupportedError>
 
+    <!-- The default TrimMode in the SDK is full. But trimming most of the tests would just make them fail,
+         so the default for the test tree is partial. -->
+    <TrimMode Condition="'$(AggressiveTrimming)' != 'true'">partial</TrimMode>
+
     <IlcToolsPath>$(CoreCLRILCompilerDir)</IlcToolsPath>
     <IlcBuildTasksPath>$(CoreCLRILCompilerDir)netstandard/ILCompiler.Build.Tasks.dll</IlcBuildTasksPath>
     <IlcSdkPath>$(CoreCLRAotSdkDir)</IlcSdkPath>

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -650,7 +650,7 @@
 
     <!-- The default TrimMode in the SDK is full. But trimming most of the tests would just make them fail,
          so the default for the test tree is partial. -->
-    <TrimMode Condition="'$(AggressiveTrimming)' != 'true'">partial</TrimMode>
+    <TrimMode Condition="'$(EnableAggressiveTrimming)' != 'true'">partial</TrimMode>
 
     <IlcToolsPath>$(CoreCLRILCompilerDir)</IlcToolsPath>
     <IlcBuildTasksPath>$(CoreCLRILCompilerDir)netstandard/ILCompiler.Build.Tasks.dll</IlcBuildTasksPath>

--- a/src/tests/nativeaot/Directory.Build.props
+++ b/src/tests/nativeaot/Directory.Build.props
@@ -8,6 +8,6 @@
     <EagerlyValidateTypeConstruction>false</EagerlyValidateTypeConstruction>
 
     <!-- We expect trimming to be fully enabled in these tests -->
-    <AggressiveTrimming>true</AggressiveTrimming>
+    <EnableAggressiveTrimming>true</EnableAggressiveTrimming>
   </PropertyGroup>
 </Project>

--- a/src/tests/nativeaot/Directory.Build.props
+++ b/src/tests/nativeaot/Directory.Build.props
@@ -6,5 +6,8 @@
     <!-- NativeAOT tests don't need this xunit Assert compat quirk.
          The tests explicitly test customer scenarios with eager type construction checks present. -->
     <EagerlyValidateTypeConstruction>false</EagerlyValidateTypeConstruction>
+
+    <!-- We expect trimming to be fully enabled in these tests -->
+    <AggressiveTrimming>true</AggressiveTrimming>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Some tests are not compatible with trimming. There are some that fail if they can't find things they need. There are also some that reflection-interate over test methods and will happily succeed if they don't find any test methods.

Cc @dotnet/ilc-contrib 