### PR TITLE
Baseline another JIT test

### DIFF
--- a/src/tests/JIT/Directed/debugging/debuginfo/tester.csproj
+++ b/src/tests/JIT/Directed/debugging/debuginfo/tester.csproj
@@ -5,6 +5,7 @@
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This test starts failing once we reflection-root the test assembly.

Cc @dotnet/ilc-contrib 