### PR TITLE
[tests][iOSSim] Disable StartupHook

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -336,6 +336,8 @@
     <!-- App Crash https://github.com/dotnet/runtime/issues/53624 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Requests/tests/System.Net.Requests.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj" />
+    <!-- Reference deleted by _CopyTestArchive https://github.com/dotnet/runtime/issues/80976 -->
+    <ProjectExclusions Include="$(RepoRoot)/src/tests/FunctionalTests/iOS/Simulator/StartupHook/iOS.Simulator.StartupHook.Test.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(RunDisabledWasmTests)' != 'true' and '$(RunAOTCompilation)' != 'true'">


### PR DESCRIPTION
Disables the test on iOSSimulator and MacCatalyst platforms until https://github.com/dotnet/runtime/issues/80976 is fixed.