### PR TITLE
Fix clr build on illumos-x64

### DIFF
--- a/src/coreclr/nativeaot/Runtime/startup.cpp
+++ b/src/coreclr/nativeaot/Runtime/startup.cpp
@@ -189,63 +189,63 @@ bool DetectCPUFeatures()
 
     int cpuidInfo[4];
 
-    const int EAX = 0;
-    const int EBX = 1;
-    const int ECX = 2;
-    const int EDX = 3;
+    const int R_EAX = 0;
+    const int R_EBX = 1;
+    const int R_ECX = 2;
+    const int R_EDX = 3;
 
     __cpuid(cpuidInfo, 0x00000000);
-    uint32_t maxCpuId = static_cast<uint32_t>(cpuidInfo[EAX]);
+    uint32_t maxCpuId = static_cast<uint32_t>(cpuidInfo[R_EAX]);
 
     if (maxCpuId >= 1)
     {
         __cpuid(cpuidInfo, 0x00000001);
 
-        if (((cpuidInfo[EDX] & (1 << 25)) != 0) && ((cpuidInfo[EDX] & (1 << 26)) != 0))                     // SSE & SSE2
+        if (((cpuidInfo[R_EDX] & (1 << 25)) != 0) && ((cpuidInfo[R_EDX] & (1 << 26)) != 0))                     // SSE & SSE2
         {
-            if ((cpuidInfo[ECX] & (1 << 25)) != 0)                                                          // AESNI
+            if ((cpuidInfo[R_ECX] & (1 << 25)) != 0)                                                          // AESNI
             {
                 g_cpuFeatures |= XArchIntrinsicConstants_Aes;
             }
 
-            if ((cpuidInfo[ECX] & (1 << 1)) != 0)                                                           // PCLMULQDQ
+            if ((cpuidInfo[R_ECX] & (1 << 1)) != 0)                                                           // PCLMULQDQ
             {
                 g_cpuFeatures |= XArchIntrinsicConstants_Pclmulqdq;
             }
 
-            if ((cpuidInfo[ECX] & (1 << 0)) != 0)                                                           // SSE3
+            if ((cpuidInfo[R_ECX] & (1 << 0)) != 0)                                                           // SSE3
             {
                 g_cpuFeatures |= XArchIntrinsicConstants_Sse3;
 
-                if ((cpuidInfo[ECX] & (1 << 9)) != 0)                                                       // SSSE3
+                if ((cpuidInfo[R_ECX] & (1 << 9)) != 0)                                                       // SSSE3
                 {
                     g_cpuFeatures |= XArchIntrinsicConstants_Ssse3;
 
-                    if ((cpuidInfo[ECX] & (1 << 19)) != 0)                                                  // SSE4.1
+                    if ((cpuidInfo[R_ECX] & (1 << 19)) != 0)                                                  // SSE4.1
                     {
                         g_cpuFeatures |= XArchIntrinsicConstants_Sse41;
 
-                        if ((cpuidInfo[ECX] & (1 << 20)) != 0)                                              // SSE4.2
+                        if ((cpuidInfo[R_ECX] & (1 << 20)) != 0)                                              // SSE4.2
                         {
                             g_cpuFeatures |= XArchIntrinsicConstants_Sse42;
 
-                            if ((cpuidInfo[ECX] & (1 << 22)) != 0)                                          // MOVBE
+                            if ((cpuidInfo[R_ECX] & (1 << 22)) != 0)                                          // MOVBE
                             {
                                 g_cpuFeatures |= XArchIntrinsicConstants_Movbe;
                             }
 
-                            if ((cpuidInfo[ECX] & (1 << 23)) != 0)                                          // POPCNT
+                            if ((cpuidInfo[R_ECX] & (1 << 23)) != 0)                                          // POPCNT
                             {
                                 g_cpuFeatures |= XArchIntrinsicConstants_Popcnt;
                             }
 
-                            if (((cpuidInfo[ECX] & (1 << 27)) != 0) && ((cpuidInfo[ECX] & (1 << 28)) != 0)) // OSXSAVE & AVX
+                            if (((cpuidInfo[R_ECX] & (1 << 27)) != 0) && ((cpuidInfo[R_ECX] & (1 << 28)) != 0)) // OSXSAVE & AVX
                             {
                                 if (PalIsAvxEnabled() && (xmmYmmStateSupport() == 1))
                                 {
                                     g_cpuFeatures |= XArchIntrinsicConstants_Avx;
 
-                                    if ((cpuidInfo[ECX] & (1 << 12)) != 0)                                  // FMA
+                                    if ((cpuidInfo[R_ECX] & (1 << 12)) != 0)                                  // FMA
                                     {
                                         g_cpuFeatures |= XArchIntrinsicConstants_Fma;
                                     }
@@ -254,30 +254,30 @@ bool DetectCPUFeatures()
                                     {
                                         __cpuidex(cpuidInfo, 0x00000007, 0x00000000);
 
-                                        if ((cpuidInfo[EBX] & (1 << 5)) != 0)                               // AVX2
+                                        if ((cpuidInfo[R_EBX] & (1 << 5)) != 0)                               // AVX2
                                         {
                                             g_cpuFeatures |= XArchIntrinsicConstants_Avx2;
 
                                             __cpuidex(cpuidInfo, 0x00000007, 0x00000001);
-                                            if ((cpuidInfo[EAX] & (1 << 4)) != 0)                           // AVX-VNNI
+                                            if ((cpuidInfo[R_EAX] & (1 << 4)) != 0)                           // AVX-VNNI
                                             {
                                                 g_cpuFeatures |= XArchIntrinsicConstants_AvxVnni;
                                             }
 
                                             if (PalIsAvx512Enabled() && (avx512StateSupport() == 1))       // XGETBV XRC0[7:5] == 111
                                             {
-                                                if ((cpuidInfo[EBX] & (1 << 16)) != 0)                     // AVX512F
+                                                if ((cpuidInfo[R_EBX] & (1 << 16)) != 0)                     // AVX512F
                                                 {
                                                     g_cpuFeatures |= XArchIntrinsicConstants_Avx512f;
 
                                                     bool isAVX512_VLSupported = false;
-                                                    if ((cpuidInfo[EBX] & (1 << 31)) != 0)                 // AVX512VL
+                                                    if ((cpuidInfo[R_EBX] & (1 << 31)) != 0)                 // AVX512VL
                                                     {
                                                         g_cpuFeatures |= XArchIntrinsicConstants_Avx512f_vl;
                                                         isAVX512_VLSupported = true;
                                                     }
 
-                                                    if ((cpuidInfo[EBX] & (1 << 30)) != 0)                 // AVX512BW
+                                                    if ((cpuidInfo[R_EBX] & (1 << 30)) != 0)                 // AVX512BW
                                                     {
                                                         g_cpuFeatures |= XArchIntrinsicConstants_Avx512bw;
                                                         if (isAVX512_VLSupported)
@@ -286,7 +286,7 @@ bool DetectCPUFeatures()
                                                         }
                                                     }
 
-                                                    if ((cpuidInfo[EBX] & (1 << 28)) != 0)                 // AVX512CD
+                                                    if ((cpuidInfo[R_EBX] & (1 << 28)) != 0)                 // AVX512CD
                                                     {
                                                         g_cpuFeatures |= XArchIntrinsicConstants_Avx512cd;
                                                         if (isAVX512_VLSupported)
@@ -295,7 +295,7 @@ bool DetectCPUFeatures()
                                                         }
                                                     }
 
-                                                    if ((cpuidInfo[EBX] & (1 << 17)) != 0)                 // AVX512DQ
+                                                    if ((cpuidInfo[R_EBX] & (1 << 17)) != 0)                 // AVX512DQ
                                                     {
                                                         g_cpuFeatures |= XArchIntrinsicConstants_Avx512dq;
                                                         if (isAVX512_VLSupported)
@@ -319,12 +319,12 @@ bool DetectCPUFeatures()
         {
             __cpuidex(cpuidInfo, 0x00000007, 0x00000000);
 
-            if ((cpuidInfo[EBX] & (1 << 3)) != 0)                                                           // BMI1
+            if ((cpuidInfo[R_EBX] & (1 << 3)) != 0)                                                           // BMI1
             {
                 g_cpuFeatures |= XArchIntrinsicConstants_Bmi1;
             }
 
-            if ((cpuidInfo[EBX] & (1 << 8)) != 0)                                                           // BMI2
+            if ((cpuidInfo[R_EBX] & (1 << 8)) != 0)                                                           // BMI2
             {
                 g_cpuFeatures |= XArchIntrinsicConstants_Bmi2;
             }
@@ -332,13 +332,13 @@ bool DetectCPUFeatures()
     }
 
     __cpuid(cpuidInfo, 0x80000000);
-    uint32_t maxCpuIdEx = static_cast<uint32_t>(cpuidInfo[EAX]);
+    uint32_t maxCpuIdEx = static_cast<uint32_t>(cpuidInfo[R_EAX]);
 
     if (maxCpuIdEx >= 0x80000001)
     {
         __cpuid(cpuidInfo, 0x80000001);
 
-        if ((cpuidInfo[ECX] & (1 << 5)) != 0)                                                               // LZCNT
+        if ((cpuidInfo[R_ECX] & (1 << 5)) != 0)                                                               // LZCNT
         {
             g_cpuFeatures |= XArchIntrinsicConstants_Lzcnt;
         }
@@ -346,8 +346,8 @@ bool DetectCPUFeatures()
 #ifdef HOST_AMD64
         // AMD has a "fast" mode for fxsave/fxrstor, which omits the saving of xmm registers.  The OS will enable this mode
         // if it is supported.  So if we continue to use fxsave/fxrstor, we must manually save/restore the xmm registers.
-        // fxsr_opt is bit 25 of EDX
-        if ((cpuidInfo[EDX] & (1 << 25)) != 0)
+        // fxsr_opt is bit 25 of R_EDX
+        if ((cpuidInfo[R_EDX] & (1 << 25)) != 0)
             g_fHasFastFxsave = true;
 #endif
     }

--- a/src/coreclr/nativeaot/Runtime/startup.cpp
+++ b/src/coreclr/nativeaot/Runtime/startup.cpp
@@ -189,63 +189,63 @@ bool DetectCPUFeatures()
 
     int cpuidInfo[4];
 
-    const int R_EAX = 0;
-    const int R_EBX = 1;
-    const int R_ECX = 2;
-    const int R_EDX = 3;
+    const int CPUID_EAX = 0;
+    const int CPUID_EBX = 1;
+    const int CPUID_ECX = 2;
+    const int CPUID_EDX = 3;
 
     __cpuid(cpuidInfo, 0x00000000);
-    uint32_t maxCpuId = static_cast<uint32_t>(cpuidInfo[R_EAX]);
+    uint32_t maxCpuId = static_cast<uint32_t>(cpuidInfo[CPUID_EAX]);
 
     if (maxCpuId >= 1)
     {
         __cpuid(cpuidInfo, 0x00000001);
 
-        if (((cpuidInfo[R_EDX] & (1 << 25)) != 0) && ((cpuidInfo[R_EDX] & (1 << 26)) != 0))                     // SSE & SSE2
+        if (((cpuidInfo[CPUID_EDX] & (1 << 25)) != 0) && ((cpuidInfo[CPUID_EDX] & (1 << 26)) != 0))                     // SSE & SSE2
         {
-            if ((cpuidInfo[R_ECX] & (1 << 25)) != 0)                                                          // AESNI
+            if ((cpuidInfo[CPUID_ECX] & (1 << 25)) != 0)                                                          // AESNI
             {
                 g_cpuFeatures |= XArchIntrinsicConstants_Aes;
             }
 
-            if ((cpuidInfo[R_ECX] & (1 << 1)) != 0)                                                           // PCLMULQDQ
+            if ((cpuidInfo[CPUID_ECX] & (1 << 1)) != 0)                                                           // PCLMULQDQ
             {
                 g_cpuFeatures |= XArchIntrinsicConstants_Pclmulqdq;
             }
 
-            if ((cpuidInfo[R_ECX] & (1 << 0)) != 0)                                                           // SSE3
+            if ((cpuidInfo[CPUID_ECX] & (1 << 0)) != 0)                                                           // SSE3
             {
                 g_cpuFeatures |= XArchIntrinsicConstants_Sse3;
 
-                if ((cpuidInfo[R_ECX] & (1 << 9)) != 0)                                                       // SSSE3
+                if ((cpuidInfo[CPUID_ECX] & (1 << 9)) != 0)                                                       // SSSE3
                 {
                     g_cpuFeatures |= XArchIntrinsicConstants_Ssse3;
 
-                    if ((cpuidInfo[R_ECX] & (1 << 19)) != 0)                                                  // SSE4.1
+                    if ((cpuidInfo[CPUID_ECX] & (1 << 19)) != 0)                                                  // SSE4.1
                     {
                         g_cpuFeatures |= XArchIntrinsicConstants_Sse41;
 
-                        if ((cpuidInfo[R_ECX] & (1 << 20)) != 0)                                              // SSE4.2
+                        if ((cpuidInfo[CPUID_ECX] & (1 << 20)) != 0)                                              // SSE4.2
                         {
                             g_cpuFeatures |= XArchIntrinsicConstants_Sse42;
 
-                            if ((cpuidInfo[R_ECX] & (1 << 22)) != 0)                                          // MOVBE
+                            if ((cpuidInfo[CPUID_ECX] & (1 << 22)) != 0)                                          // MOVBE
                             {
                                 g_cpuFeatures |= XArchIntrinsicConstants_Movbe;
                             }
 
-                            if ((cpuidInfo[R_ECX] & (1 << 23)) != 0)                                          // POPCNT
+                            if ((cpuidInfo[CPUID_ECX] & (1 << 23)) != 0)                                          // POPCNT
                             {
                                 g_cpuFeatures |= XArchIntrinsicConstants_Popcnt;
                             }
 
-                            if (((cpuidInfo[R_ECX] & (1 << 27)) != 0) && ((cpuidInfo[R_ECX] & (1 << 28)) != 0)) // OSXSAVE & AVX
+                            if (((cpuidInfo[CPUID_ECX] & (1 << 27)) != 0) && ((cpuidInfo[CPUID_ECX] & (1 << 28)) != 0)) // OSXSAVE & AVX
                             {
                                 if (PalIsAvxEnabled() && (xmmYmmStateSupport() == 1))
                                 {
                                     g_cpuFeatures |= XArchIntrinsicConstants_Avx;
 
-                                    if ((cpuidInfo[R_ECX] & (1 << 12)) != 0)                                  // FMA
+                                    if ((cpuidInfo[CPUID_ECX] & (1 << 12)) != 0)                                  // FMA
                                     {
                                         g_cpuFeatures |= XArchIntrinsicConstants_Fma;
                                     }
@@ -254,30 +254,30 @@ bool DetectCPUFeatures()
                                     {
                                         __cpuidex(cpuidInfo, 0x00000007, 0x00000000);
 
-                                        if ((cpuidInfo[R_EBX] & (1 << 5)) != 0)                               // AVX2
+                                        if ((cpuidInfo[CPUID_EBX] & (1 << 5)) != 0)                               // AVX2
                                         {
                                             g_cpuFeatures |= XArchIntrinsicConstants_Avx2;
 
                                             __cpuidex(cpuidInfo, 0x00000007, 0x00000001);
-                                            if ((cpuidInfo[R_EAX] & (1 << 4)) != 0)                           // AVX-VNNI
+                                            if ((cpuidInfo[CPUID_EAX] & (1 << 4)) != 0)                           // AVX-VNNI
                                             {
                                                 g_cpuFeatures |= XArchIntrinsicConstants_AvxVnni;
                                             }
 
                                             if (PalIsAvx512Enabled() && (avx512StateSupport() == 1))       // XGETBV XRC0[7:5] == 111
                                             {
-                                                if ((cpuidInfo[R_EBX] & (1 << 16)) != 0)                     // AVX512F
+                                                if ((cpuidInfo[CPUID_EBX] & (1 << 16)) != 0)                     // AVX512F
                                                 {
                                                     g_cpuFeatures |= XArchIntrinsicConstants_Avx512f;
 
                                                     bool isAVX512_VLSupported = false;
-                                                    if ((cpuidInfo[R_EBX] & (1 << 31)) != 0)                 // AVX512VL
+                                                    if ((cpuidInfo[CPUID_EBX] & (1 << 31)) != 0)                 // AVX512VL
                                                     {
                                                         g_cpuFeatures |= XArchIntrinsicConstants_Avx512f_vl;
                                                         isAVX512_VLSupported = true;
                                                     }
 
-                                                    if ((cpuidInfo[R_EBX] & (1 << 30)) != 0)                 // AVX512BW
+                                                    if ((cpuidInfo[CPUID_EBX] & (1 << 30)) != 0)                 // AVX512BW
                                                     {
                                                         g_cpuFeatures |= XArchIntrinsicConstants_Avx512bw;
                                                         if (isAVX512_VLSupported)
@@ -286,7 +286,7 @@ bool DetectCPUFeatures()
                                                         }
                                                     }
 
-                                                    if ((cpuidInfo[R_EBX] & (1 << 28)) != 0)                 // AVX512CD
+                                                    if ((cpuidInfo[CPUID_EBX] & (1 << 28)) != 0)                 // AVX512CD
                                                     {
                                                         g_cpuFeatures |= XArchIntrinsicConstants_Avx512cd;
                                                         if (isAVX512_VLSupported)
@@ -295,7 +295,7 @@ bool DetectCPUFeatures()
                                                         }
                                                     }
 
-                                                    if ((cpuidInfo[R_EBX] & (1 << 17)) != 0)                 // AVX512DQ
+                                                    if ((cpuidInfo[CPUID_EBX] & (1 << 17)) != 0)                 // AVX512DQ
                                                     {
                                                         g_cpuFeatures |= XArchIntrinsicConstants_Avx512dq;
                                                         if (isAVX512_VLSupported)
@@ -319,12 +319,12 @@ bool DetectCPUFeatures()
         {
             __cpuidex(cpuidInfo, 0x00000007, 0x00000000);
 
-            if ((cpuidInfo[R_EBX] & (1 << 3)) != 0)                                                           // BMI1
+            if ((cpuidInfo[CPUID_EBX] & (1 << 3)) != 0)                                                           // BMI1
             {
                 g_cpuFeatures |= XArchIntrinsicConstants_Bmi1;
             }
 
-            if ((cpuidInfo[R_EBX] & (1 << 8)) != 0)                                                           // BMI2
+            if ((cpuidInfo[CPUID_EBX] & (1 << 8)) != 0)                                                           // BMI2
             {
                 g_cpuFeatures |= XArchIntrinsicConstants_Bmi2;
             }
@@ -332,13 +332,13 @@ bool DetectCPUFeatures()
     }
 
     __cpuid(cpuidInfo, 0x80000000);
-    uint32_t maxCpuIdEx = static_cast<uint32_t>(cpuidInfo[R_EAX]);
+    uint32_t maxCpuIdEx = static_cast<uint32_t>(cpuidInfo[CPUID_EAX]);
 
     if (maxCpuIdEx >= 0x80000001)
     {
         __cpuid(cpuidInfo, 0x80000001);
 
-        if ((cpuidInfo[R_ECX] & (1 << 5)) != 0)                                                               // LZCNT
+        if ((cpuidInfo[CPUID_ECX] & (1 << 5)) != 0)                                                               // LZCNT
         {
             g_cpuFeatures |= XArchIntrinsicConstants_Lzcnt;
         }
@@ -346,8 +346,8 @@ bool DetectCPUFeatures()
 #ifdef HOST_AMD64
         // AMD has a "fast" mode for fxsave/fxrstor, which omits the saving of xmm registers.  The OS will enable this mode
         // if it is supported.  So if we continue to use fxsave/fxrstor, we must manually save/restore the xmm registers.
-        // fxsr_opt is bit 25 of R_EDX
-        if ((cpuidInfo[R_EDX] & (1 << 25)) != 0)
+        // fxsr_opt is bit 25 of CPUID_EDX
+        if ((cpuidInfo[CPUID_EDX] & (1 << 25)) != 0)
             g_fHasFastFxsave = true;
 #endif
     }

--- a/src/coreclr/vm/cgensys.h
+++ b/src/coreclr/vm/cgensys.h
@@ -104,11 +104,6 @@ extern "C" DWORD __stdcall xmmYmmStateSupport();
 extern "C" DWORD __stdcall avx512StateSupport();
 #endif
 
-const int CPUID_EAX = 0;
-const int CPUID_EBX = 1;
-const int CPUID_ECX = 2;
-const int CPUID_EDX = 3;
-
 inline bool TargetHasAVXSupport()
 {
 #if (defined(TARGET_X86) || defined(TARGET_AMD64))

--- a/src/coreclr/vm/cgensys.h
+++ b/src/coreclr/vm/cgensys.h
@@ -109,6 +109,7 @@ inline bool TargetHasAVXSupport()
 #if (defined(TARGET_X86) || defined(TARGET_AMD64))
     int cpuInfo[4];
     __cpuid(cpuInfo, 0x00000001);           // All x86/AMD64 targets support cpuid.
+    const int CPUID_ECX = 2;
     return ((cpuInfo[CPUID_ECX] & (1 << 28)) != 0); // The AVX feature is ECX bit 28.
 #endif // (defined(TARGET_X86) || defined(TARGET_AMD64))
     return false;

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -1442,66 +1442,66 @@ void EEJitManager::SetCpuInfo()
 
     int cpuidInfo[4];
 
-    const int R_EAX = CPUID_EAX;
-    const int R_EBX = CPUID_EBX;
-    const int R_ECX = CPUID_ECX;
-    const int R_EDX = CPUID_EDX;
+    const int CPUID_EAX = 0;
+    const int CPUID_EBX = 1;
+    const int CPUID_ECX = 2;
+    const int CPUID_EDX = 3;
 
     __cpuid(cpuidInfo, 0x00000000);
-    uint32_t maxCpuId = static_cast<uint32_t>(cpuidInfo[R_EAX]);
+    uint32_t maxCpuId = static_cast<uint32_t>(cpuidInfo[CPUID_EAX]);
 
     if (maxCpuId >= 1)
     {
         __cpuid(cpuidInfo, 0x00000001);
 
-        if (((cpuidInfo[R_EDX] & (1 << 25)) != 0) && ((cpuidInfo[R_EDX] & (1 << 26)) != 0))                     // SSE & SSE2
+        if (((cpuidInfo[CPUID_EDX] & (1 << 25)) != 0) && ((cpuidInfo[CPUID_EDX] & (1 << 26)) != 0))                     // SSE & SSE2
         {
             CPUCompileFlags.Set(InstructionSet_SSE);
             CPUCompileFlags.Set(InstructionSet_SSE2);
 
-            if ((cpuidInfo[R_ECX] & (1 << 25)) != 0)                                                          // AESNI
+            if ((cpuidInfo[CPUID_ECX] & (1 << 25)) != 0)                                                          // AESNI
             {
                 CPUCompileFlags.Set(InstructionSet_AES);
             }
 
-            if ((cpuidInfo[R_ECX] & (1 << 1)) != 0)                                                           // PCLMULQDQ
+            if ((cpuidInfo[CPUID_ECX] & (1 << 1)) != 0)                                                           // PCLMULQDQ
             {
                 CPUCompileFlags.Set(InstructionSet_PCLMULQDQ);
             }
 
-            if ((cpuidInfo[R_ECX] & (1 << 0)) != 0)                                                           // SSE3
+            if ((cpuidInfo[CPUID_ECX] & (1 << 0)) != 0)                                                           // SSE3
             {
                 CPUCompileFlags.Set(InstructionSet_SSE3);
 
-                if ((cpuidInfo[R_ECX] & (1 << 9)) != 0)                                                       // SSSE3
+                if ((cpuidInfo[CPUID_ECX] & (1 << 9)) != 0)                                                       // SSSE3
                 {
                     CPUCompileFlags.Set(InstructionSet_SSSE3);
 
-                    if ((cpuidInfo[R_ECX] & (1 << 19)) != 0)                                                  // SSE4.1
+                    if ((cpuidInfo[CPUID_ECX] & (1 << 19)) != 0)                                                  // SSE4.1
                     {
                         CPUCompileFlags.Set(InstructionSet_SSE41);
 
-                        if ((cpuidInfo[R_ECX] & (1 << 20)) != 0)                                              // SSE4.2
+                        if ((cpuidInfo[CPUID_ECX] & (1 << 20)) != 0)                                              // SSE4.2
                         {
                             CPUCompileFlags.Set(InstructionSet_SSE42);
 
-                            if ((cpuidInfo[R_ECX] & (1 << 22)) != 0)                                          // MOVBE
+                            if ((cpuidInfo[CPUID_ECX] & (1 << 22)) != 0)                                          // MOVBE
                             {
                                 CPUCompileFlags.Set(InstructionSet_MOVBE);
                             }
 
-                            if ((cpuidInfo[R_ECX] & (1 << 23)) != 0)                                          // POPCNT
+                            if ((cpuidInfo[CPUID_ECX] & (1 << 23)) != 0)                                          // POPCNT
                             {
                                 CPUCompileFlags.Set(InstructionSet_POPCNT);
                             }
 
-                            if (((cpuidInfo[R_ECX] & (1 << 27)) != 0) && ((cpuidInfo[R_ECX] & (1 << 28)) != 0)) // OSXSAVE & AVX
+                            if (((cpuidInfo[CPUID_ECX] & (1 << 27)) != 0) && ((cpuidInfo[CPUID_ECX] & (1 << 28)) != 0)) // OSXSAVE & AVX
                             {
                                 if(DoesOSSupportAVX() && (xmmYmmStateSupport() == 1))                       // XGETBV == 11
                                 {
                                     CPUCompileFlags.Set(InstructionSet_AVX);
 
-                                    if ((cpuidInfo[R_ECX] & (1 << 12)) != 0)                                  // FMA
+                                    if ((cpuidInfo[CPUID_ECX] & (1 << 12)) != 0)                                  // FMA
                                     {
                                         CPUCompileFlags.Set(InstructionSet_FMA);
                                     }
@@ -1510,24 +1510,24 @@ void EEJitManager::SetCpuInfo()
                                     {
                                         __cpuidex(cpuidInfo, 0x00000007, 0x00000000);
 
-                                        if ((cpuidInfo[R_EBX] & (1 << 5)) != 0)                               // AVX2
+                                        if ((cpuidInfo[CPUID_EBX] & (1 << 5)) != 0)                               // AVX2
                                         {
                                             CPUCompileFlags.Set(InstructionSet_AVX2);
 
                                             if (DoesOSSupportAVX512() && (avx512StateSupport() == 1))      // XGETBV XRC0[7:5] == 111
                                             {
-                                                if ((cpuidInfo[R_EBX] & (1 << 16)) != 0)                     // AVX512F
+                                                if ((cpuidInfo[CPUID_EBX] & (1 << 16)) != 0)                     // AVX512F
                                                 {
                                                     CPUCompileFlags.Set(InstructionSet_AVX512F);
 
                                                     bool isAVX512_VLSupported = false;
-                                                    if ((cpuidInfo[R_EBX] & (1 << 31)) != 0)                 // AVX512VL
+                                                    if ((cpuidInfo[CPUID_EBX] & (1 << 31)) != 0)                 // AVX512VL
                                                     {
                                                         CPUCompileFlags.Set(InstructionSet_AVX512F_VL);
                                                         isAVX512_VLSupported = true;
                                                     }
 
-                                                    if ((cpuidInfo[R_EBX] & (1 << 30)) != 0)                 // AVX512BW
+                                                    if ((cpuidInfo[CPUID_EBX] & (1 << 30)) != 0)                 // AVX512BW
                                                     {
                                                         CPUCompileFlags.Set(InstructionSet_AVX512BW);
                                                         if (isAVX512_VLSupported)                          // AVX512BW_VL
@@ -1536,7 +1536,7 @@ void EEJitManager::SetCpuInfo()
                                                         }
                                                     }
 
-                                                    if ((cpuidInfo[R_EBX] & (1 << 28)) != 0)                 // AVX512CD
+                                                    if ((cpuidInfo[CPUID_EBX] & (1 << 28)) != 0)                 // AVX512CD
                                                     {
                                                         CPUCompileFlags.Set(InstructionSet_AVX512CD);
                                                         if (isAVX512_VLSupported)                          // AVX512CD_VL
@@ -1545,7 +1545,7 @@ void EEJitManager::SetCpuInfo()
                                                         }
                                                     }
 
-                                                    if ((cpuidInfo[R_EBX] & (1 << 17)) != 0)                 // AVX512DQ
+                                                    if ((cpuidInfo[CPUID_EBX] & (1 << 17)) != 0)                 // AVX512DQ
                                                     {
                                                         CPUCompileFlags.Set(InstructionSet_AVX512DQ);
                                                         if (isAVX512_VLSupported)                          // AVX512DQ_VL
@@ -1557,7 +1557,7 @@ void EEJitManager::SetCpuInfo()
                                             }
 
                                             __cpuidex(cpuidInfo, 0x00000007, 0x00000001);
-                                            if ((cpuidInfo[R_EAX] & (1 << 4)) != 0)                           // AVX-VNNI
+                                            if ((cpuidInfo[CPUID_EAX] & (1 << 4)) != 0)                           // AVX-VNNI
                                             {
                                                 CPUCompileFlags.Set(InstructionSet_AVXVNNI);
                                             }
@@ -1580,17 +1580,17 @@ void EEJitManager::SetCpuInfo()
         {
             __cpuidex(cpuidInfo, 0x00000007, 0x00000000);
 
-            if ((cpuidInfo[R_EBX] & (1 << 3)) != 0)                                                           // BMI1
+            if ((cpuidInfo[CPUID_EBX] & (1 << 3)) != 0)                                                           // BMI1
             {
                 CPUCompileFlags.Set(InstructionSet_BMI1);
             }
 
-            if ((cpuidInfo[R_EBX] & (1 << 8)) != 0)                                                           // BMI2
+            if ((cpuidInfo[CPUID_EBX] & (1 << 8)) != 0)                                                           // BMI2
             {
                 CPUCompileFlags.Set(InstructionSet_BMI2);
             }
 
-            if ((cpuidInfo[R_EDX] & (1 << 14)) != 0)
+            if ((cpuidInfo[CPUID_EDX] & (1 << 14)) != 0)
             {
                 CPUCompileFlags.Set(InstructionSet_X86Serialize);                                            // SERIALIZE
             }
@@ -1598,13 +1598,13 @@ void EEJitManager::SetCpuInfo()
     }
 
     __cpuid(cpuidInfo, 0x80000000);
-    uint32_t maxCpuIdEx = static_cast<uint32_t>(cpuidInfo[R_EAX]);
+    uint32_t maxCpuIdEx = static_cast<uint32_t>(cpuidInfo[CPUID_EAX]);
 
     if (maxCpuIdEx >= 0x80000001)
     {
         __cpuid(cpuidInfo, 0x80000001);
 
-        if ((cpuidInfo[R_ECX] & (1 << 5)) != 0)                                                               // LZCNT
+        if ((cpuidInfo[CPUID_ECX] & (1 << 5)) != 0)                                                               // LZCNT
         {
             CPUCompileFlags.Set(InstructionSet_LZCNT);
         }

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -1442,66 +1442,66 @@ void EEJitManager::SetCpuInfo()
 
     int cpuidInfo[4];
 
-    const int EAX = CPUID_EAX;
-    const int EBX = CPUID_EBX;
-    const int ECX = CPUID_ECX;
-    const int EDX = CPUID_EDX;
+    const int R_EAX = CPUID_EAX;
+    const int R_EBX = CPUID_EBX;
+    const int R_ECX = CPUID_ECX;
+    const int R_EDX = CPUID_EDX;
 
     __cpuid(cpuidInfo, 0x00000000);
-    uint32_t maxCpuId = static_cast<uint32_t>(cpuidInfo[EAX]);
+    uint32_t maxCpuId = static_cast<uint32_t>(cpuidInfo[R_EAX]);
 
     if (maxCpuId >= 1)
     {
         __cpuid(cpuidInfo, 0x00000001);
 
-        if (((cpuidInfo[EDX] & (1 << 25)) != 0) && ((cpuidInfo[EDX] & (1 << 26)) != 0))                     // SSE & SSE2
+        if (((cpuidInfo[R_EDX] & (1 << 25)) != 0) && ((cpuidInfo[R_EDX] & (1 << 26)) != 0))                     // SSE & SSE2
         {
             CPUCompileFlags.Set(InstructionSet_SSE);
             CPUCompileFlags.Set(InstructionSet_SSE2);
 
-            if ((cpuidInfo[ECX] & (1 << 25)) != 0)                                                          // AESNI
+            if ((cpuidInfo[R_ECX] & (1 << 25)) != 0)                                                          // AESNI
             {
                 CPUCompileFlags.Set(InstructionSet_AES);
             }
 
-            if ((cpuidInfo[ECX] & (1 << 1)) != 0)                                                           // PCLMULQDQ
+            if ((cpuidInfo[R_ECX] & (1 << 1)) != 0)                                                           // PCLMULQDQ
             {
                 CPUCompileFlags.Set(InstructionSet_PCLMULQDQ);
             }
 
-            if ((cpuidInfo[ECX] & (1 << 0)) != 0)                                                           // SSE3
+            if ((cpuidInfo[R_ECX] & (1 << 0)) != 0)                                                           // SSE3
             {
                 CPUCompileFlags.Set(InstructionSet_SSE3);
 
-                if ((cpuidInfo[ECX] & (1 << 9)) != 0)                                                       // SSSE3
+                if ((cpuidInfo[R_ECX] & (1 << 9)) != 0)                                                       // SSSE3
                 {
                     CPUCompileFlags.Set(InstructionSet_SSSE3);
 
-                    if ((cpuidInfo[ECX] & (1 << 19)) != 0)                                                  // SSE4.1
+                    if ((cpuidInfo[R_ECX] & (1 << 19)) != 0)                                                  // SSE4.1
                     {
                         CPUCompileFlags.Set(InstructionSet_SSE41);
 
-                        if ((cpuidInfo[ECX] & (1 << 20)) != 0)                                              // SSE4.2
+                        if ((cpuidInfo[R_ECX] & (1 << 20)) != 0)                                              // SSE4.2
                         {
                             CPUCompileFlags.Set(InstructionSet_SSE42);
 
-                            if ((cpuidInfo[ECX] & (1 << 22)) != 0)                                          // MOVBE
+                            if ((cpuidInfo[R_ECX] & (1 << 22)) != 0)                                          // MOVBE
                             {
                                 CPUCompileFlags.Set(InstructionSet_MOVBE);
                             }
 
-                            if ((cpuidInfo[ECX] & (1 << 23)) != 0)                                          // POPCNT
+                            if ((cpuidInfo[R_ECX] & (1 << 23)) != 0)                                          // POPCNT
                             {
                                 CPUCompileFlags.Set(InstructionSet_POPCNT);
                             }
 
-                            if (((cpuidInfo[ECX] & (1 << 27)) != 0) && ((cpuidInfo[ECX] & (1 << 28)) != 0)) // OSXSAVE & AVX
+                            if (((cpuidInfo[R_ECX] & (1 << 27)) != 0) && ((cpuidInfo[R_ECX] & (1 << 28)) != 0)) // OSXSAVE & AVX
                             {
                                 if(DoesOSSupportAVX() && (xmmYmmStateSupport() == 1))                       // XGETBV == 11
                                 {
                                     CPUCompileFlags.Set(InstructionSet_AVX);
 
-                                    if ((cpuidInfo[ECX] & (1 << 12)) != 0)                                  // FMA
+                                    if ((cpuidInfo[R_ECX] & (1 << 12)) != 0)                                  // FMA
                                     {
                                         CPUCompileFlags.Set(InstructionSet_FMA);
                                     }
@@ -1510,24 +1510,24 @@ void EEJitManager::SetCpuInfo()
                                     {
                                         __cpuidex(cpuidInfo, 0x00000007, 0x00000000);
 
-                                        if ((cpuidInfo[EBX] & (1 << 5)) != 0)                               // AVX2
+                                        if ((cpuidInfo[R_EBX] & (1 << 5)) != 0)                               // AVX2
                                         {
                                             CPUCompileFlags.Set(InstructionSet_AVX2);
 
                                             if (DoesOSSupportAVX512() && (avx512StateSupport() == 1))      // XGETBV XRC0[7:5] == 111
                                             {
-                                                if ((cpuidInfo[EBX] & (1 << 16)) != 0)                     // AVX512F
+                                                if ((cpuidInfo[R_EBX] & (1 << 16)) != 0)                     // AVX512F
                                                 {
                                                     CPUCompileFlags.Set(InstructionSet_AVX512F);
 
                                                     bool isAVX512_VLSupported = false;
-                                                    if ((cpuidInfo[EBX] & (1 << 31)) != 0)                 // AVX512VL
+                                                    if ((cpuidInfo[R_EBX] & (1 << 31)) != 0)                 // AVX512VL
                                                     {
                                                         CPUCompileFlags.Set(InstructionSet_AVX512F_VL);
                                                         isAVX512_VLSupported = true;
                                                     }
 
-                                                    if ((cpuidInfo[EBX] & (1 << 30)) != 0)                 // AVX512BW
+                                                    if ((cpuidInfo[R_EBX] & (1 << 30)) != 0)                 // AVX512BW
                                                     {
                                                         CPUCompileFlags.Set(InstructionSet_AVX512BW);
                                                         if (isAVX512_VLSupported)                          // AVX512BW_VL
@@ -1536,7 +1536,7 @@ void EEJitManager::SetCpuInfo()
                                                         }
                                                     }
 
-                                                    if ((cpuidInfo[EBX] & (1 << 28)) != 0)                 // AVX512CD
+                                                    if ((cpuidInfo[R_EBX] & (1 << 28)) != 0)                 // AVX512CD
                                                     {
                                                         CPUCompileFlags.Set(InstructionSet_AVX512CD);
                                                         if (isAVX512_VLSupported)                          // AVX512CD_VL
@@ -1545,7 +1545,7 @@ void EEJitManager::SetCpuInfo()
                                                         }
                                                     }
 
-                                                    if ((cpuidInfo[EBX] & (1 << 17)) != 0)                 // AVX512DQ
+                                                    if ((cpuidInfo[R_EBX] & (1 << 17)) != 0)                 // AVX512DQ
                                                     {
                                                         CPUCompileFlags.Set(InstructionSet_AVX512DQ);
                                                         if (isAVX512_VLSupported)                          // AVX512DQ_VL
@@ -1557,7 +1557,7 @@ void EEJitManager::SetCpuInfo()
                                             }
 
                                             __cpuidex(cpuidInfo, 0x00000007, 0x00000001);
-                                            if ((cpuidInfo[EAX] & (1 << 4)) != 0)                           // AVX-VNNI
+                                            if ((cpuidInfo[R_EAX] & (1 << 4)) != 0)                           // AVX-VNNI
                                             {
                                                 CPUCompileFlags.Set(InstructionSet_AVXVNNI);
                                             }
@@ -1580,17 +1580,17 @@ void EEJitManager::SetCpuInfo()
         {
             __cpuidex(cpuidInfo, 0x00000007, 0x00000000);
 
-            if ((cpuidInfo[EBX] & (1 << 3)) != 0)                                                           // BMI1
+            if ((cpuidInfo[R_EBX] & (1 << 3)) != 0)                                                           // BMI1
             {
                 CPUCompileFlags.Set(InstructionSet_BMI1);
             }
 
-            if ((cpuidInfo[EBX] & (1 << 8)) != 0)                                                           // BMI2
+            if ((cpuidInfo[R_EBX] & (1 << 8)) != 0)                                                           // BMI2
             {
                 CPUCompileFlags.Set(InstructionSet_BMI2);
             }
 
-            if ((cpuidInfo[EDX] & (1 << 14)) != 0)
+            if ((cpuidInfo[R_EDX] & (1 << 14)) != 0)
             {
                 CPUCompileFlags.Set(InstructionSet_X86Serialize);                                            // SERIALIZE
             }
@@ -1598,13 +1598,13 @@ void EEJitManager::SetCpuInfo()
     }
 
     __cpuid(cpuidInfo, 0x80000000);
-    uint32_t maxCpuIdEx = static_cast<uint32_t>(cpuidInfo[EAX]);
+    uint32_t maxCpuIdEx = static_cast<uint32_t>(cpuidInfo[R_EAX]);
 
     if (maxCpuIdEx >= 0x80000001)
     {
         __cpuid(cpuidInfo, 0x80000001);
 
-        if ((cpuidInfo[ECX] & (1 << 5)) != 0)                                                               // LZCNT
+        if ((cpuidInfo[R_ECX] & (1 << 5)) != 0)                                                               // LZCNT
         {
             CPUCompileFlags.Set(InstructionSet_LZCNT);
         }


### PR DESCRIPTION
https://github.com/dotnet/runtime/commit/70e1072edc6c1a399f77a4de7de84045193f1409 relaxed the condition around `add_subdirectory(nativeaot)` in `src/coreclr/CMakeLists.txt`, which also enabled nativeaot runtime build on illumos-x64. 

The inclusion chain:
```sh
/crossrootfs/x64/usr/include/sys/regset.h
/crossrootfs/x64/usr/include/ucontext.h
/runtime/src/coreclr/nativeaot/Runtime/unix/UnixContext.h
/runtime/src/coreclr/nativeaot/Runtime/thread.h
/runtime/src/coreclr/nativeaot/Runtime/startup.cpp
```
causes a conflict with redefinition of these constants: https://github.com/illumos/illumos-gate/blob/967a528a/usr/src/uts/intel/sys/regset.h#L103-L106. Those constants are unrelated to cpuidInfo on the platform (illumos x64 also uses 0, 1, 2, 3 for cpuid https://github.com/illumos/illumos-gate/blob/967a528a/usr/src/lib/libc/amd64/gen/proc64_id.c#L42).

I was going to update the cmake condition to exclude illumos, but since this naming conflict was the only error, I went ahead and prefixed the constant names with `R_`.