### PR TITLE
Add RID for Fedora 39

### DIFF
--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtime.compatibility.json
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtime.compatibility.json
@@ -4862,6 +4862,38 @@
     "any",
     "base"
   ],
+  "fedora.39": [
+    "fedora.39",
+    "fedora",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.39-arm64": [
+    "fedora.39-arm64",
+    "fedora.39",
+    "fedora-arm64",
+    "fedora",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.39-x64": [
+    "fedora.39-x64",
+    "fedora.39",
+    "fedora-x64",
+    "fedora",
+    "linux-x64",
+    "linux",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
   "freebsd": [
     "freebsd",
     "unix",

--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
@@ -1567,6 +1567,23 @@
         "fedora-x64"
       ]
     },
+    "fedora.39": {
+      "#import": [
+        "fedora"
+      ]
+    },
+    "fedora.39-arm64": {
+      "#import": [
+        "fedora.39",
+        "fedora-arm64"
+      ]
+    },
+    "fedora.39-x64": {
+      "#import": [
+        "fedora.39",
+        "fedora-x64"
+      ]
+    },
     "freebsd": {
       "#import": [
         "unix"

--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtimeGroups.props
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtimeGroups.props
@@ -86,7 +86,7 @@
     <RuntimeGroup Include="fedora">
       <Parent>linux</Parent>
       <Architectures>x64;arm64</Architectures>
-      <Versions>23;24;25;26;27;28;29;30;31;32;33;34;35;36;37;38</Versions>
+      <Versions>23;24;25;26;27;28;29;30;31;32;33;34;35;36;37;38;39</Versions>
       <TreatVersionsAsCompatible>false</TreatVersionsAsCompatible>
     </RuntimeGroup>
 


### PR DESCRIPTION
```
$ podman run -it registry.fedoraproject.org/fedora:rawhide bash -c 'cat /etc/os-release'
NAME="Fedora Linux"
VERSION="39 (Container Image Prerelease)"
ID=fedora
VERSION_ID=39
VERSION_CODENAME=""
PLATFORM_ID="platform:f39"
PRETTY_NAME="Fedora Linux 39 (Container Image Prerelease)"
ANSI_COLOR="0;38;2;60;110;180"
LOGO=fedora-logo-icon
CPE_NAME="cpe:/o:fedoraproject:fedora:39"
DEFAULT_HOSTNAME="fedora"
HOME_URL="https://fedoraproject.org/"
DOCUMENTATION_URL="https://docs.fedoraproject.org/en-US/fedora/rawhide/system-administrators-guide/"
SUPPORT_URL="https://ask.fedoraproject.org/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"
REDHAT_BUGZILLA_PRODUCT="Fedora"
REDHAT_BUGZILLA_PRODUCT_VERSION=rawhide
REDHAT_SUPPORT_PRODUCT="Fedora"
REDHAT_SUPPORT_PRODUCT_VERSION=rawhide
SUPPORT_END=2024-05-14
VARIANT="Container Image"
VARIANT_ID=container
```


The changes to runtime.json and runtime.compatibility.json were generated by tooling.