### PR TITLE
Use optimistic concurrency when configuring JsonTypeInfo metadata.

### DIFF
--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -650,6 +650,9 @@
   <data name="InvalidJsonTypeInfoOperationForKind" xml:space="preserve">
     <value>Invalid JsonTypeInfo operation for JsonTypeInfoKind '{0}'.</value>
   </data>
+  <data name="JsonTypeInfoAlreadyBeingConfigured" xml:space="preserve">
+    <value>This JsonTypeInfo instance is already being configured by another thread.</value>
+  </data>
   <data name="CreateObjectConverterNotCompatible" xml:space="preserve">
     <value>The converter for type '{0}' does not support setting 'CreateObject' delegates.</value>
   </data>

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -128,6 +128,7 @@ The System.Text.Json library is built-in as part of the shared framework in .NET
     <Compile Include="System\Text\Json\Serialization\Metadata\DefaultJsonTypeInfoResolver.Helpers.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\DefaultJsonTypeInfoResolver.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\IJsonTypeInfoResolver.cs" />
+    <Compile Include="System\Text\Json\Serialization\Metadata\IMetadataResolutionContext.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\JsonDerivedType.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\JsonPolymorphismOptions.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\JsonTypeInfoOfT.ReadHelper.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -70,7 +70,7 @@ namespace System.Text.Json
             if (IsReadOnly)
             {
                 typeInfo = CacheContext.GetOrAddTypeInfo(type);
-                Debug.Assert(!ensureConfigured || typeInfo?.IsConfigured != false);
+                Debug.Assert(!ensureConfigured || typeInfo is null or { IsConfigured: true });
             }
             else if (resolveIfMutable)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/IMetadataResolutionContext.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/IMetadataResolutionContext.cs
@@ -4,7 +4,7 @@
 namespace System.Text.Json.Serialization.Metadata
 {
     /// <summary>
-    /// Used for resolving metadata recursively withing a <see cref="JsonTypeInfo"/> graph.
+    /// Used for resolving metadata recursively within a <see cref="JsonTypeInfo"/> graph.
     /// </summary>
     internal interface IMetadataResolutionContext
     {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/IMetadataResolutionContext.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/IMetadataResolutionContext.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Text.Json.Serialization.Metadata
+{
+    /// <summary>
+    /// Used for resolving metadata recursively withing a <see cref="JsonTypeInfo"/> graph.
+    /// </summary>
+    internal interface IMetadataResolutionContext
+    {
+        JsonTypeInfo Resolve(Type type);
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -997,7 +997,7 @@ namespace System.Text.Json.Serialization.Metadata
             public JsonPropertyInfo JsonPropertyInfo { get; }
         }
 
-        internal void ConfigureProperties(IMetadataResolutionContext context)
+        private void ConfigureProperties(IMetadataResolutionContext context)
         {
             Debug.Assert(Kind == JsonTypeInfoKind.Object);
             Debug.Assert(PropertyCache is null);
@@ -1067,7 +1067,7 @@ namespace System.Text.Json.Serialization.Metadata
                     : JsonUnmappedMemberHandling.Skip);
         }
 
-        internal void ConfigureConstructorParameters()
+        private void ConfigureConstructorParameters()
         {
             Debug.Assert(Kind == JsonTypeInfoKind.Object);
             Debug.Assert(Converter.ConstructorIsParameterized);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -209,6 +209,12 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        public static void ThrowInvalidOperationException_JsonTypeInfoAlreadyBeingConfigured()
+        {
+            throw new InvalidOperationException(SR.JsonTypeInfoAlreadyBeingConfigured);
+        }
+
+        [DoesNotReturn]
         public static void ThrowJsonException_JsonRequiredPropertyMissing(JsonTypeInfo parent, BitArray requiredPropertiesSet)
         {
             StringBuilder listOfMissingPropertiesBuilder = new();


### PR DESCRIPTION
Removes locking from the JsonTypeInfo/JsonPropertyInfo configure methods by employing an optimistic concurrency scheme when generating and configuring metadata in the caching context. This is done using a transient thread-local cache which generates and configures the metadata graph _before_ it gets committed to the global cache and other threads can see it.

It also moves the exception caching mechanism from `JsonTypeInfo` to `CachingContext`, ensuring that exceptions are kept even in cases where the underlying resolver throws without producing `JsonTypeInfo` instance.

Note that the change introduces a ~10% performance regression in cold start benchmarks where cache reuse cannot take place. This is an expected trade-off attributable to using an intermediate cache when generating metadata. I think we should take that regression.