### PR TITLE
Enable EventPipe when EventSource is enabled

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
@@ -26,7 +26,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <LinkerSubsystem Condition="'$(OutputType)' == 'WinExe' and '$(LinkerSubsystem)' == ''">WINDOWS</LinkerSubsystem>
     <LinkerSubsystem Condition="'$(OutputType)' == 'Exe' and '$(LinkerSubsystem)' == ''">CONSOLE</LinkerSubsystem>
     <EventPipeName>eventpipe-disabled</EventPipeName>
-    <EventPipeName Condition="'$(EnableNativeEventPipe)' == 'true'">eventpipe-enabled</EventPipeName>
+    <EventPipeName Condition="'$(EnableNativeEventPipe)' == 'true' or '$(EventSourceSupport)' == 'true'">eventpipe-enabled</EventPipeName>
   </PropertyGroup>
 
   <!-- Ensure that runtime-specific paths have already been set -->

--- a/src/coreclr/tools/aot/crossgen2/crossgen2.props
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2.props
@@ -15,7 +15,7 @@
     <Configurations>Debug;Release;Checked</Configurations>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <EventSourceSupport>true</EventSourceSupport>
-    <EnableNativeEventPipe Condition="'$(TargetPlatformIdentifier)' == 'windows'">true</EnableNativeEventPipe>
+    <EnableNativeEventPipe Condition="'$(TargetOS)' == 'windows'">true</EnableNativeEventPipe>
     <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 

--- a/src/coreclr/tools/aot/crossgen2/crossgen2.props
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2.props
@@ -15,6 +15,7 @@
     <Configurations>Debug;Release;Checked</Configurations>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <EventSourceSupport>true</EventSourceSupport>
+    <EnableNativeEventPipe>true</EnableNativeEventPipe>
     <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 

--- a/src/coreclr/tools/aot/crossgen2/crossgen2.props
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2.props
@@ -15,7 +15,6 @@
     <Configurations>Debug;Release;Checked</Configurations>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <EventSourceSupport>true</EventSourceSupport>
-    <EnableNativeEventPipe Condition="'$(TargetOS)' == 'windows'">true</EnableNativeEventPipe>
     <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 

--- a/src/coreclr/tools/aot/crossgen2/crossgen2.props
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2.props
@@ -15,7 +15,7 @@
     <Configurations>Debug;Release;Checked</Configurations>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <EventSourceSupport>true</EventSourceSupport>
-    <EnableNativeEventPipe>true</EnableNativeEventPipe>
+    <EnableNativeEventPipe Condition="'$(TargetPlatformIdentifier)' == 'windows'">true</EnableNativeEventPipe>
     <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 

--- a/src/libraries/Microsoft.Extensions.Logging.EventSource/tests/Microsoft.Extensions.Logging.EventSource.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.EventSource/tests/Microsoft.Extensions.Logging.EventSource.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
     <EventSourceSupport Condition="'$(TestNativeAot)' == 'true'">true</EventSourceSupport>
-    <EnableNativeEventPipe Condition="'$(TestNativeAot)' == 'true' and '$(TargetPlatformIdentifier)' == 'windows'">true</EnableNativeEventPipe>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/NativeAotTests/System.Diagnostics.DiagnosticSource.NativeAotTests.proj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/NativeAotTests/System.Diagnostics.DiagnosticSource.NativeAotTests.proj
@@ -1,12 +1,7 @@
 <Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
 
-
-  <ItemGroup Condition="'$([MSBuild]::IsOSPlatform(Windows))' == 'true'">
-    <TestConsoleAppSourceFiles Include="DiagnosticSourceEventSourceTests.cs"
-                               EnabledProperties="EventSourceSupport;EnableNativeEventPipe" />
-  </ItemGroup>
-  <ItemGroup Condition="'$([MSBuild]::IsOSPlatform(Windows))' == 'false'">
+  <ItemGroup>
     <TestConsoleAppSourceFiles Include="DiagnosticSourceEventSourceTests.cs"
                                EnabledProperties="EventSourceSupport" />
   </ItemGroup>


### PR DESCRIPTION
Fixes issue #81943. CrossGen2 has `EventSourceSupport` enabled and needs the `EventPipe `library in Windows.