### PR TITLE
Hold temporary keychain refs for certificates imported with X509Certificate2Collection.Import

### DIFF
--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509.macOS.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509.macOS.cs
@@ -264,6 +264,8 @@ internal static partial class Interop
                 out identityHandle,
                 out osStatus);
 
+            SafeTemporaryKeychainHandle.TrackItem(identityHandle);
+
             if (result == 1)
             {
                 Debug.Assert(!identityHandle.IsInvalid);
@@ -288,13 +290,25 @@ internal static partial class Interop
         {
             SafeSecIdentityHandle identityHandle;
             int osStatus;
+            int result;
 
-            int result = AppleCryptoNative_X509MoveToKeychain(
-                cert,
-                targetKeychain,
-                privateKey ?? SafeSecKeyRefHandle.InvalidHandle,
-                out identityHandle,
-                out osStatus);
+            // Ensure the keychain is not disposed, if there is any associated one
+            using (SafeKeychainHandle keychain = Interop.AppleCrypto.SecKeychainItemCopyKeychain(cert))
+            {
+                // AppleCryptoNative_X509MoveToKeychain can change the keychain of the input
+                // certificate, so we need to reflect that change.
+                SafeTemporaryKeychainHandle.UntrackItem(cert);
+
+                result = AppleCryptoNative_X509MoveToKeychain(
+                    cert,
+                    targetKeychain,
+                    privateKey ?? SafeSecKeyRefHandle.InvalidHandle,
+                    out identityHandle,
+                    out osStatus);
+
+                SafeTemporaryKeychainHandle.TrackItem(cert);
+                SafeTemporaryKeychainHandle.TrackItem(identityHandle);
+            }
 
             if (result == 0)
             {

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509.macOS.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509.macOS.cs
@@ -297,7 +297,7 @@ internal static partial class Interop
             {
                 // AppleCryptoNative_X509MoveToKeychain can change the keychain of the input
                 // certificate, so we need to reflect that change.
-                SafeTemporaryKeychainHandle.UntrackItem(cert);
+                SafeTemporaryKeychainHandle.UntrackItem(cert.DangerousGetHandle());
 
                 result = AppleCryptoNative_X509MoveToKeychain(
                     cert,

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.ImportExport.iOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.ImportExport.iOS.cs
@@ -157,8 +157,5 @@ namespace System.Security.Cryptography.X509Certificates
 
             return result ?? FromDerBlob(rawData, GetDerCertContentType(rawData), password, keyStorageFlags);
         }
-
-        // No temporary keychain on iOS
-        partial void DisposeTempKeychain();
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.ImportExport.macOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.ImportExport.macOS.cs
@@ -12,7 +12,7 @@ namespace System.Security.Cryptography.X509Certificates
 {
     internal sealed partial class AppleCertificatePal : ICertificatePal
     {
-        private SafeKeychainHandle? _tempKeychain;
+        internal SafeKeychainHandle? _tempKeychain;
 
         public static ICertificatePal FromBlob(
             ReadOnlySpan<byte> rawData,

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.ImportExport.macOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.ImportExport.macOS.cs
@@ -12,8 +12,6 @@ namespace System.Security.Cryptography.X509Certificates
 {
     internal sealed partial class AppleCertificatePal : ICertificatePal
     {
-        internal SafeKeychainHandle? _tempKeychain;
-
         public static ICertificatePal FromBlob(
             ReadOnlySpan<byte> rawData,
             SafePasswordHandle password,
@@ -53,20 +51,7 @@ namespace System.Security.Cryptography.X509Certificates
 
                 using (keychain)
                 {
-                    AppleCertificatePal ret = ImportPkcs12(rawData, password, exportable, keychain);
-                    if (!persist)
-                    {
-                        // If we used temporary keychain we need to prevent deletion.
-                        // on 10.15+ if keychain is unlinked, certain certificate operations may fail.
-                        bool success = false;
-                        keychain.DangerousAddRef(ref success);
-                        if (success)
-                        {
-                            ret._tempKeychain = keychain;
-                        }
-                    }
-
-                    return ret;
+                    return ImportPkcs12(rawData, password, exportable, keychain);
                 }
             }
 
@@ -90,11 +75,6 @@ namespace System.Security.Cryptography.X509Certificates
             identityHandle.Dispose();
             certHandle.Dispose();
             throw new CryptographicException();
-        }
-
-        public void DisposeTempKeychain()
-        {
-            Interlocked.Exchange(ref _tempKeychain, null)?.DangerousRelease();
         }
 
         internal unsafe byte[] ExportPkcs8(ReadOnlySpan<char> password)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.ImportExport.macOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.ImportExport.macOS.cs
@@ -94,7 +94,7 @@ namespace System.Security.Cryptography.X509Certificates
 
         public void DisposeTempKeychain()
         {
-            Interlocked.Exchange(ref _tempKeychain, null)?.Dispose();
+            Interlocked.Exchange(ref _tempKeychain, null)?.DangerousRelease();
         }
 
         internal unsafe byte[] ExportPkcs8(ReadOnlySpan<char> password)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.cs
@@ -100,8 +100,6 @@ namespace System.Security.Cryptography.X509Certificates
 
             _certHandle = null!;
             _identityHandle = null;
-
-            DisposeTempKeychain();
         }
 
         internal SafeSecCertificateHandle CertificateHandle => _certHandle;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.macOS.LoaderPal.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.macOS.LoaderPal.cs
@@ -119,6 +119,11 @@ namespace System.Security.Cryptography.X509Certificates
 
                         X509Certificate2 cert = new X509Certificate2(newPal);
                         collection.Add(cert);
+
+                        if (newPal != pal)
+                        {
+                            pal.Dispose();
+                        }
                     }
                 }
             }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.macOS.LoaderPal.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.macOS.LoaderPal.cs
@@ -117,18 +117,6 @@ namespace System.Security.Cryptography.X509Certificates
                             newPal = pal.MoveToKeychain(_keychain, safeSecKeyRefHandle) ?? pal;
                         }
 
-                        if (_keychain is SafeTemporaryKeychainHandle)
-                        {
-                            // If we used temporary keychain we need to prevent deletion.
-                            // on 10.15+ if keychain is unlinked, certain certificate operations may fail.
-                            bool success = false;
-                            _keychain.DangerousAddRef(ref success);
-                            if (success)
-                            {
-                                newPal._tempKeychain = _keychain;
-                            }
-                        }
-
                         X509Certificate2 cert = new X509Certificate2(newPal);
                         collection.Add(cert);
                     }


### PR DESCRIPTION
Fixes #80176

`SafeSecCertificateHandle` explictly tracks the associated temporary keychain through calls to `SafeTemporaryKeychainHandle.TrackItem` and `SafeTemporaryKeychainHandle.UntrackItem`. `UntrackItem` is called from `ReleaseHandle` when the certificate handle is being disposed/finalized. `TrackItem` is called on all the places where the certificate/identity handle is created.

`X509MoveToKeychain` takes a `SafeSecCertificateHandle` as input parameter. The native API could change the keychain associated with this certificate. This was not accounted for and it resulted in mismatched tracking of reference count on the temporary keychain. For example, the handle could initially be without a keychain, so the first `SafeTemporaryKeychainHandle.TrackItem` call on it was a no-op. When the certificate is moved into temporary keychain and the handle is later disposed, `SafeTemporaryKeychainHandle.UntrackItem` gets called and decrements a reference count that was not previously incremented.

Additionally, several temporary `AppleCertificatePal` objects were not disposed during PKCS#12 import. When they eventually get garbage collected it causes the associated `SafeSecCertificateHandle` objects to be released, and this results in the unbalanced reference counts releasing the native keychain object for the temporary keychain.

This affects APIs like `new X509Certificate2(...)` and `X509Certificate2Collection.Import` when importing PKCS#12 certificates.

PR #41787 previously tried to fix the issue, but it did so only partially and largely by accident. It introduced an additional explicit keychain reference in the `new X509Certificate2(...)` code path through `DangerousAddRef`. This negated the effect of the incorrect tracking in `X509MoveToKeychain`. The additional keychain reference was then released through `Dispose` instead of `DangerousReleaseRef` which silently failed since the reference count was already zero at that point. Effectively it meant the `new X509Certificate2(...)` code path succeeded but only as a side-effect of the extra `DangerousAddRef`. The same workaround was not applied for the `X509Certificate2Collection.Import` though.