### PR TITLE
Workloads: Fix a regression in file permissions for workload packs

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml.in
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml.in
@@ -1,0 +1,3 @@
+<FileList>
+    ${PermissionsProperties}
+</FileList>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.sfxproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <NativeRuntimeAsset Include="$(IntermediateOutputPath)$(TargetCrossRid).Sdk.props" TargetPath="Sdk/Sdk.props" />
+    <NativeRuntimeAsset Condition="!$([MSBuild]::IsOsPlatform('Windows'))" Include="$(IntermediateOutputPath)Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml" TargetPath="data/UnixFilePermissions.xml" />
   </ItemGroup>
 
   <Target Name="WriteTemplateFiles" BeforeTargets="ValidateProperties">
@@ -38,7 +39,15 @@
     <PropertyGroup>
       <_PermissionsFiles>@(_ToolFile -> '&lt;File Path=&quot;tools/%(RecursiveDir)%(FileName)%(Extension)&quot; Permission=&quot;755&quot; /&gt;', ' ')</_PermissionsFiles>
     </PropertyGroup>
+    <ItemGroup>
+      <_PermissionsProperties Include="PermissionsProperties" Value="$(_PermissionsFiles)" />
+    </ItemGroup>
 
+    <GenerateFileFromTemplate
+      Condition="!$([MSBuild]::IsOsPlatform('Windows'))"
+      TemplateFile="Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml.in"
+      Properties="@(_PermissionsProperties)"
+      OutputPath="$(IntermediateOutputPath)Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml" />
     <GenerateFileFromTemplate
       TemplateFile="Microsoft.NETCore.App.MonoCrossAOT.Sdk.props.in"
       Properties="@(_SdkPropsProperties)"

--- a/src/mono/wasm/Wasm.Build.Tests/WorkloadTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WorkloadTests.cs
@@ -1,0 +1,119 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Xml;
+using System.Xml.Serialization;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+#nullable enable
+
+namespace Wasm.Build.Tests
+{
+    public class WorkloadTests : BuildTestBase
+    {
+        public WorkloadTests(ITestOutputHelper output, SharedBuildPerTestClassFixture buildContext)
+            : base(output, buildContext)
+        {
+        }
+
+        [Fact]
+        [SkipOnPlatform(TestPlatforms.Windows, "Not applicable on windows")]
+        public void FilesInUnixFilesPermissionsXmlExist()
+        {
+            // not doing any project generation here
+            _enablePerTestCleanup = false;
+
+            // find all the UnixFilePermissions ..
+            string packsDir = Path.Combine(Path.GetDirectoryName(s_buildEnv.DotNet)!, "packs");
+            Assert.True(Directory.Exists(packsDir), $"Could not find packs directory {packsDir}");
+
+            var unixPermFiles = Directory.EnumerateFiles(packsDir, "UnixFilePermissions.xml", new EnumerationOptions { RecurseSubdirectories = true });
+            foreach (string unixPermFile in unixPermFiles)
+            {
+                Assert.True(File.Exists(unixPermFile), $"Could not find {unixPermFile}");
+                FileList? list = FileList.Deserialize(unixPermFile);
+                if (list == null)
+                    throw new Exception($"Could not read unix permissions file {unixPermFile}");
+
+                // File is in <packs>/<packName>/<version>/data/UnixFilePermissions.xml
+                // and <FileList><File Path="tools/bin/2to3" Permission="755" />
+                string thisPackDir = Path.Combine(Path.GetDirectoryName(unixPermFile)!, "..");
+                foreach (FileListFile flf in list.File)
+                {
+                    if (flf.Path == null)
+                        throw new Exception($"Path for FileListFile should not be null. xml: {unixPermFile}");
+
+                    var targetFile = Path.Combine(thisPackDir, flf.Path);
+                    Assert.True(File.Exists(targetFile), $"Expected file {targetFile} to exist in the pack, as it is referenced in {unixPermFile}");
+                }
+            }
+
+            // We don't install the cross compiler pack from nupkg, so we don't
+            // have the unixFilePermissions for that
+            // Expect just the emscripten ones here for now
+
+            // linux doesn't have Emscripten.Python package, so only 2 there
+            int expectedPermFileCount = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? 3 : 4;
+
+            int permFileCount = unixPermFiles.Count();
+            if (permFileCount != expectedPermFileCount)
+                throw new XunitException($"Expected to find 3 UnixFilePermissions.xml files, but got {permFileCount}."
+                                            + $"{Environment.NewLine}Files: {string.Join(", ", unixPermFiles)}");
+        }
+    }
+
+    [Serializable]
+    [XmlType(AnonymousType = true)]
+    [XmlRoot(Namespace = "", IsNullable = false)]
+    public class FileList
+    {
+        private FileListFile[]? fileField;
+
+        [XmlElement("File")]
+        public FileListFile[] File
+        {
+            get => fileField ?? Array.Empty<FileListFile>();
+            set => fileField = value;
+        }
+
+        public static FileList? Deserialize(string pathToXml)
+        {
+            var serializer = new XmlSerializer(typeof(FileList));
+
+            using var fs = new FileStream(pathToXml, FileMode.Open, FileAccess.Read);
+            var reader = XmlReader.Create(fs);
+            FileList? fileList = (FileList?)serializer.Deserialize(reader);
+            return fileList;
+        }
+    }
+
+    // From https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/NugetPackageDownloader/WorkloadUnixFilePermissionsFileList.cs
+    [Serializable]
+    [XmlType(AnonymousType = true)]
+    public class FileListFile
+    {
+        private string? pathField;
+
+        private string? permissionField;
+
+        [XmlAttribute]
+        public string? Path
+        {
+            get => pathField;
+            set => pathField = value;
+        }
+
+        [XmlAttribute]
+        public string? Permission
+        {
+            get => permissionField;
+            set => permissionField = value;
+        }
+    }
+}


### PR DESCRIPTION
Reverts
https://github.com/dotnet/runtime/commit/b6e2dbe97c917d9e5ae722fde543d1ab5581b5f7 essentially.

Fixes https://github.com/dotnet/runtime/issues/82201 .

This especially shows up on macOS when doing a system install. When installing the workload to a user directory, the permissions get set correctly, which is why this was not caught by Wasm.Build.Tests .