### PR TITLE
Fix paths in "Stripping symbols" message

### DIFF
--- a/eng/native/functions.cmake
+++ b/eng/native/functions.cmake
@@ -423,7 +423,7 @@ function(strip_symbols targetName outputFilename)
         VERBATIM
         COMMAND ${DSYMUTIL} ${DSYMUTIL_OPTS} ${strip_source_file}
         COMMAND ${strip_command}
-        COMMENT "Stripping symbols from ${strip_source_file} into file ${strip_destination_file}"
+        COMMAND sh -c "echo Stripping symbols from $(basename '${strip_source_file}') into $(basename '${strip_destination_file}')"
         )
     else (CLR_CMAKE_TARGET_OSX OR CLR_CMAKE_TARGET_MACCATALYST OR CLR_CMAKE_TARGET_IOS OR CLR_CMAKE_TARGET_TVOS)
 
@@ -434,7 +434,7 @@ function(strip_symbols targetName outputFilename)
         COMMAND ${CMAKE_OBJCOPY} --only-keep-debug ${strip_source_file} ${strip_destination_file}
         COMMAND ${CMAKE_OBJCOPY} --strip-debug --strip-unneeded ${strip_source_file}
         COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=${strip_destination_file} ${strip_source_file}
-        COMMENT "Stripping symbols from ${strip_source_file} into file ${strip_destination_file}"
+        COMMAND sh -c "echo Stripping symbols from $(basename '${strip_source_file}') into $(basename '${strip_destination_file}')"
         )
     endif (CLR_CMAKE_TARGET_OSX OR CLR_CMAKE_TARGET_MACCATALYST OR CLR_CMAKE_TARGET_IOS OR CLR_CMAKE_TARGET_TVOS)
   endif(CLR_CMAKE_HOST_UNIX)


### PR DESCRIPTION
From build logs:

before:
> `Stripping symbols from $<TARGET_FILE:System.Globalization.Native> into file $<TARGET_FILE:System.Globalization.Native>.dwarf`

after:
> `Stripping symbols from libSystem.Globalization.Native.dylib into libSystem.Globalization.Native.dylib.dwarf`
