### PR TITLE
[release/7.0][wasm] Use latest sdk 7.0 sdk for workload testing, and perf runs

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -168,8 +168,8 @@
     <MoqVersion>4.12.0</MoqVersion>
     <FsCheckVersion>2.14.3</FsCheckVersion>
     <!-- Uncomment to set a fixed version, else the latest is used -->
-    <SdkVersionForWorkloadTesting>7.0.100</SdkVersionForWorkloadTesting>
-    <DotNetChannelToUseForWorkloadTesting>7.0.1xx</DotNetChannelToUseForWorkloadTesting>
+    <!--<SdkVersionForWorkloadTesting>7.0.100</SdkVersionForWorkloadTesting>-->
+    <DotNetChannelToUseForWorkloadTesting>7.0</DotNetChannelToUseForWorkloadTesting>
     <CompilerPlatformTestingVersion>1.1.2-beta1.22403.2</CompilerPlatformTestingVersion>
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>7.0.0-preview-20221010.1</MicrosoftPrivateIntellisenseVersion>

--- a/eng/pipelines/coreclr/templates/run-scenarios-job.yml
+++ b/eng/pipelines/coreclr/templates/run-scenarios-job.yml
@@ -107,6 +107,7 @@ jobs:
         - AdditionalHelixPreCommands: $(HelixPreCommandOSX)
         - AdditionalHelixPostCommands: $(HelixPostCommandOSX)
 
+    - ExtraSetupArguments: ''
     - ${{ if ne(parameters.runtimeType, 'wasm') }}:
       - ExtraSetupArguments: --install-dir $(PayloadDirectory)/dotnet
     - ${{ if and(eq(parameters.runtimeType, 'wasm'), in(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
Fixes 7.0 perf runs:

```
Traceback (most recent call last):
  File "/mnt/vss/_work/1/s/Payload/performance/scripts/ci_setup.py", line 373, in <module>
    __main(sys.argv[1:])
  File "/mnt/vss/_work/1/s/Payload/performance/scripts/ci_setup.py", line 318, in __main
    dotnet_version = dotnet.get_dotnet_version(target_framework_moniker, args.cli) if args.dotnet_versions == [] else args.dotnet_versions[0]
  File "/mnt/vss/_work/1/s/Payload/performance/scripts/dotnet.py", line 549, in get_dotnet_version
    sdk_path = get_sdk_path(dotnet_path) if sdk_path is None else sdk_path
  File "/mnt/vss/_work/1/s/Payload/performance/scripts/dotnet.py", line 533, in get_sdk_path
    base_path = get_base_path(dotnet_path)
  File "/mnt/vss/_work/1/s/Payload/performance/scripts/dotnet.py", line 527, in get_base_path
    'Did not find "Base Path:" entry on the `dotnet --info` command'
RuntimeError: Did not find "Base Path:" entry on the `dotnet --info` command
```