### PR TITLE
Split generic virtual method slot use and impl tracking

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
@@ -10,6 +10,8 @@ using Internal.TypeSystem;
 namespace ILCompiler.DependencyAnalysis
 {
     /// <summary>
+    /// Represents a use of a generic virtual method slot. This node only tracks
+    /// the use of the slot definition.
     /// This analysis node is used for computing GVM dependencies for the following cases:
     ///    1) Derived types where the GVM is overridden
     ///    2) Variant-interfaces GVMs
@@ -19,17 +21,14 @@ namespace ILCompiler.DependencyAnalysis
     /// </summary>
     public class GVMDependenciesNode : DependencyNodeCore<NodeFactory>
     {
-        private const int UniversalCanonGVMDepthHeuristic_CanonDepth = 2;
         private readonly MethodDesc _method;
 
         public GVMDependenciesNode(MethodDesc method)
         {
             Debug.Assert(method.GetCanonMethodTarget(CanonicalFormKind.Specific) == method);
             Debug.Assert(method.HasInstantiation);
-
-            // This is either a generic virtual method or a MethodImpl for a static interface method.
-            // We can't test for static MethodImpl so at least sanity check it's static and noninterface.
-            Debug.Assert(method.IsVirtual || (method.Signature.IsStatic && !method.OwningType.IsInterface));
+            Debug.Assert(method.IsVirtual);
+            Debug.Assert(MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(method) == method);
 
             _method = method;
         }
@@ -39,41 +38,10 @@ namespace ILCompiler.DependencyAnalysis
         public override bool StaticDependenciesAreComputed => true;
         protected override string GetName(NodeFactory factory) => "__GVMDependenciesNode_" + factory.NameMangler.GetMangledMethodName(_method);
 
-        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
-            DependencyList dependencies = null;
-
-            context.MetadataManager.GetDependenciesDueToVirtualMethodReflectability(ref dependencies, context, _method);
-
             if (!_method.IsAbstract)
-            {
-                bool validInstantiation =
-                    _method.IsSharedByGenericInstantiations || (      // Non-exact methods are always valid instantiations (always pass constraints check)
-                        _method.Instantiation.CheckValidInstantiationArguments() &&
-                        _method.OwningType.Instantiation.CheckValidInstantiationArguments() &&
-                        _method.CheckConstraints());
-
-                if (validInstantiation)
-                {
-                    if (context.TypeSystemContext.SupportsUniversalCanon && _method.IsGenericDepthGreaterThan(UniversalCanonGVMDepthHeuristic_CanonDepth))
-                    {
-                        // fall back to using the universal generic variant of the generic method
-                        return dependencies;
-                    }
-
-                    bool getUnboxingStub = _method.OwningType.IsValueType && !_method.Signature.IsStatic;
-                    dependencies ??= new DependencyList();
-                    dependencies.Add(context.MethodEntrypoint(_method, getUnboxingStub), "GVM Dependency - Canon method");
-
-                    if (_method.IsSharedByGenericInstantiations)
-                    {
-                        dependencies.Add(context.NativeLayout.TemplateMethodEntry(_method), "GVM Dependency - Template entry");
-                        dependencies.Add(context.NativeLayout.TemplateMethodLayout(_method), "GVM Dependency - Template");
-                    }
-                }
-            }
-
-            return dependencies;
+                yield return new DependencyListEntry(factory.GenericVirtualMethodImpl(_method), "Implementation of the generic virtual method");
         }
 
         public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context) => null;
@@ -173,7 +141,12 @@ namespace ILCompiler.DependencyAnalysis
                                 for (int instArg = 0; instArg < openInstantiation.Length; instArg++)
                                     openInstantiation[instArg] = context.GetSignatureVariable(instArg, method: true);
                                 MethodDesc implementingMethodInstantiation = slotDecl.MakeInstantiatedMethod(openInstantiation).InstantiateSignature(potentialOverrideType.Instantiation, _method.Instantiation);
-                                dynamicDependencies.Add(new CombinedDependencyListEntry(factory.GVMDependencies(implementingMethodInstantiation.GetCanonMethodTarget(CanonicalFormKind.Specific)), null, "ImplementingMethodInstantiation"));
+
+                                // Static virtuals cannot be further overriden so this is an impl use. Otherwise it's a virtual slot use.
+                                if (implementingMethodInstantiation.Signature.IsStatic)
+                                    dynamicDependencies.Add(new CombinedDependencyListEntry(factory.GenericVirtualMethodImpl(implementingMethodInstantiation.GetCanonMethodTarget(CanonicalFormKind.Specific)), null, "ImplementingMethodInstantiation"));
+                                else
+                                    dynamicDependencies.Add(new CombinedDependencyListEntry(factory.GVMDependencies(implementingMethodInstantiation.GetCanonMethodTarget(CanonicalFormKind.Specific)), null, "ImplementingMethodInstantiation"));
 
                                 factory.MetadataManager.NoteOverridingMethod(_method, implementingMethodInstantiation);
                             }
@@ -225,7 +198,7 @@ namespace ILCompiler.DependencyAnalysis
                     if (instantiatedTargetMethod != _method)
                     {
                         dynamicDependencies.Add(new CombinedDependencyListEntry(
-                            factory.GVMDependencies(instantiatedTargetMethod), null, "DerivedMethodInstantiation"));
+                            factory.GenericVirtualMethodImpl(instantiatedTargetMethod), null, "DerivedMethodInstantiation"));
 
                         factory.MetadataManager.NoteOverridingMethod(_method, instantiatedTargetMethod);
                     }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
@@ -57,14 +57,6 @@ namespace ILCompiler.DependencyAnalysis
                     (methodOwningType.IsSealed() || _method.IsFinal))
                     return false;
 
-                // We model static (non-virtual) methods that are MethodImpls for a static interface method.
-                // But those cannot be overriden (they're not virtual to begin with).
-                if (!methodOwningType.IsInterface && _method.Signature.IsStatic)
-                {
-                    Debug.Assert(!_method.IsVirtual);
-                    return false;
-                }
-
                 return true;
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericVirtualMethodImplNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericVirtualMethodImplNode.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Collections.Generic;
+
+using ILCompiler.DependencyAnalysisFramework;
+
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a use of a generic virtual method body implementation.
+    /// </summary>
+    public class GenericVirtualMethodImplNode : DependencyNodeCore<NodeFactory>
+    {
+        private const int UniversalCanonGVMDepthHeuristic_CanonDepth = 2;
+        private readonly MethodDesc _method;
+
+        public GenericVirtualMethodImplNode(MethodDesc method)
+        {
+            Debug.Assert(method.GetCanonMethodTarget(CanonicalFormKind.Specific) == method);
+            Debug.Assert(method.HasInstantiation);
+
+            // This is either a generic virtual method or a MethodImpl for a static interface method.
+            // We can't test for static MethodImpl so at least sanity check it's static and noninterface.
+            Debug.Assert(method.IsVirtual || (method.Signature.IsStatic && !method.OwningType.IsInterface));
+
+            _method = method;
+        }
+
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool StaticDependenciesAreComputed => true;
+        protected override string GetName(NodeFactory factory) => "__GVMImplNode_" + factory.NameMangler.GetMangledMethodName(_method);
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
+        {
+            DependencyList dependencies = null;
+
+            factory.MetadataManager.GetDependenciesDueToVirtualMethodReflectability(ref dependencies, factory, _method);
+
+            bool validInstantiation =
+                _method.IsSharedByGenericInstantiations || (      // Non-exact methods are always valid instantiations (always pass constraints check)
+                    _method.Instantiation.CheckValidInstantiationArguments() &&
+                    _method.OwningType.Instantiation.CheckValidInstantiationArguments() &&
+                    _method.CheckConstraints());
+
+            if (validInstantiation)
+            {
+                if (factory.TypeSystemContext.SupportsUniversalCanon && _method.IsGenericDepthGreaterThan(UniversalCanonGVMDepthHeuristic_CanonDepth))
+                {
+                    // fall back to using the universal generic variant of the generic method
+                    return dependencies;
+                }
+
+                bool getUnboxingStub = _method.OwningType.IsValueType && !_method.Signature.IsStatic;
+                dependencies ??= new DependencyList();
+                dependencies.Add(factory.MethodEntrypoint(_method, getUnboxingStub), "GVM Dependency - Canon method");
+
+                if (_method.IsSharedByGenericInstantiations)
+                {
+                    dependencies.Add(factory.NativeLayout.TemplateMethodEntry(_method), "GVM Dependency - Template entry");
+                    dependencies.Add(factory.NativeLayout.TemplateMethodLayout(_method), "GVM Dependency - Template");
+                }
+            }
+
+            return dependencies;
+        }
+
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context) => null;
+
+        public override bool HasDynamicDependencies => false;
+
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -284,6 +284,11 @@ namespace ILCompiler.DependencyAnalysis
                 return new GVMDependenciesNode(method);
             });
 
+            _gvmImpls = new NodeCache<MethodDesc, GenericVirtualMethodImplNode>(method =>
+            {
+                return new GenericVirtualMethodImplNode(method);
+            });
+
             _gvmTableEntries = new NodeCache<TypeDesc, TypeGVMEntriesNode>(type =>
             {
                 return new TypeGVMEntriesNode(type);
@@ -929,6 +934,12 @@ namespace ILCompiler.DependencyAnalysis
         public GVMDependenciesNode GVMDependencies(MethodDesc method)
         {
             return _gvmDependenciesNode.GetOrAdd(method);
+        }
+
+        private NodeCache<MethodDesc, GenericVirtualMethodImplNode> _gvmImpls;
+        public GenericVirtualMethodImplNode GenericVirtualMethodImpl(MethodDesc method)
+        {
+            return _gvmImpls.GetOrAdd(method);
         }
 
         private NodeCache<TypeDesc, TypeGVMEntriesNode> _gvmTableEntries;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectedMethodNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectedMethodNode.cs
@@ -64,14 +64,17 @@ namespace ILCompiler.DependencyAnalysis
             {
                 if (_method.IsVirtual)
                 {
+                    // Virtual method use is tracked on the slot defining method only.
+                    MethodDesc slotDefiningMethod = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(_method);
                     if (_method.HasInstantiation)
                     {
-                        dependencies.Add(factory.GVMDependencies(_method.GetCanonMethodTarget(CanonicalFormKind.Specific)), "GVM callable reflectable method");
+                        // FindSlotDefiningMethod might uninstantiate. We might want to fix the method not to do that.
+                        if (slotDefiningMethod.IsMethodDefinition)
+                            slotDefiningMethod = factory.TypeSystemContext.GetInstantiatedMethod(slotDefiningMethod, _method.Instantiation);
+                        dependencies.Add(factory.GVMDependencies(slotDefiningMethod.GetCanonMethodTarget(CanonicalFormKind.Specific)), "GVM callable reflectable method");
                     }
                     else
                     {
-                        // Virtual method use is tracked on the slot defining method only.
-                        MethodDesc slotDefiningMethod = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(_method);
                         if (!factory.VTable(slotDefiningMethod.OwningType).HasFixedSlots)
                             dependencies.Add(factory.VirtualMethodUse(slotDefiningMethod), "Virtually callable reflectable method");
                     }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -393,6 +393,7 @@
     <Compile Include="Compiler\DependencyAnalysis\ExternSymbolsImportedNodeProvider.cs" />
     <Compile Include="Compiler\DependencyAnalysis\FieldRvaDataNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericStaticBaseInfoNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\GenericVirtualMethodImplNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\IndirectionExtensions.cs" />
     <Compile Include="Compiler\DependencyAnalysis\InlineableStringsResourceNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\InterfaceDispatchCellSectionNode.cs" />


### PR DESCRIPTION
I'm looking at generic virtual method again because of #80602.

The analysis of generic virtual methods within the compiler is an N * M algorithm where N is the number of unique generic virtual method instantiations called and M is the number of types that implement generic virtual methods.

We use dynamic dependencies within the dependency analysis engine to model this relationship.

It is important to try to limit the N and M. Looking at things, I realized the N we're currently operating on is bigger than it needs to be:

```csharp
Foo f = new Bar();
f.Blah<int>();
f = new Baz();
f.Blah<double>();

class Foo { public virtual void Blah<T>() { } }
class Bar : Foo { public override void Blah<T> { } }
class Baz : Foo { public override void Blah<T> { } }
```

Previously, the analysis would see M = 3 and N = 6 because we would track each of the overrides as something that needs to be considered for each M. This changes the analysis to only look at the definition of the slot, i.e. N = 2 (one for int, other for double).

The result of the analysis will still be same, it will just take less time. The new `GenericVirtualMethodImpl` node responds false to `HasDynamicDependencies` and doesn't participate in expensive activities.

Cc @dotnet/ilc-contrib 