### PR TITLE
[6.0] Check for pending IO in the portable thread pool's worker threads

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Threading.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Threading.cs
@@ -71,5 +71,9 @@ internal static partial class Interop
 
         [DllImport(Libraries.Kernel32)]
         internal static extern bool SetThreadPriority(SafeWaitHandle hThread, int nPriority);
+
+        [DllImport(Libraries.Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool GetThreadIOPendingFlag(nint hThread, out BOOL lpIOIsPending);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -2271,8 +2271,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\PortableThreadPool.WaitThread.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\PortableThreadPool.WorkerThread.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\PortableThreadPool.WorkerTracking.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Threading\PortableThreadPool.CpuUtilizationReader.Unix.cs" Condition="'$(TargetsUnix)' == 'true' or '$(TargetsBrowser)' == 'true'" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Threading\PortableThreadPool.CpuUtilizationReader.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Threading\PortableThreadPool.Unix.cs" Condition="'$(TargetsUnix)' == 'true' or '$(TargetsBrowser)' == 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Threading\PortableThreadPool.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\LowLevelLifoSemaphore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\LowLevelLifoSemaphore.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\RegisteredWaitHandle.Portable.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -1684,6 +1684,9 @@
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SystemTimeToFileTime.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.SystemTimeToFileTime.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.Threading.cs">
+      <Link>Common\Interop\Windows\Kernel32\Interop.Threading.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.TimeZone.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.TimeZone.cs</Link>
     </Compile>
@@ -2301,9 +2304,6 @@
   <ItemGroup Condition="'$(FeatureCoreCLR)' != 'true' and '$(TargetsWindows)' == 'true'">
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Thread.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\WaitHandle.Windows.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.Threading.cs">
-      <Link>Interop\Windows\Kernel32\Interop.Threading.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(FeatureGenericMath)' == 'true'">
     <Compile Include="$(MSBuildThisFileDirectory)System\IAdditionOperators.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.Unix.cs
@@ -5,6 +5,11 @@ namespace System.Threading
 {
     internal sealed partial class PortableThreadPool
     {
+        private static partial class WorkerThread
+        {
+            private static bool IsIOPending => false;
+        }
+
         private struct CpuUtilizationReader
         {
             private Interop.Sys.ProcessCpuInformation _cpuInfo;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.Windows.cs
@@ -8,6 +8,20 @@ namespace System.Threading
 {
     internal sealed partial class PortableThreadPool
     {
+        private static partial class WorkerThread
+        {
+            private static bool IsIOPending
+            {
+                get
+                {
+                    bool success =
+                        Interop.Kernel32.GetThreadIOPendingFlag(Interop.Kernel32.GetCurrentThread(), out Interop.BOOL isIOPending);
+                    Debug.Assert(success);
+                    return !success || isIOPending != Interop.BOOL.FALSE;
+                }
+            }
+        }
+
         private struct CpuUtilizationReader
         {
             public long _idleTime;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Diagnostics.Tracing;
 
 namespace System.Threading
@@ -11,7 +10,7 @@ namespace System.Threading
         /// <summary>
         /// The worker thread infastructure for the CLR thread pool.
         /// </summary>
-        private static class WorkerThread
+        private static partial class WorkerThread
         {
             // This value represents an assumption of how much uncommited stack space a worker thread may use in the future.
             // Used in calculations to estimate when to throttle the rate of thread injection to reduce the possibility of
@@ -103,12 +102,7 @@ namespace System.Threading
                     }
 
                     // The thread cannot exit if it has IO pending, otherwise the IO may be canceled
-                    bool success =
-                        Interop.Kernel32.GetThreadIOPendingFlag(
-                            Interop.Kernel32.GetCurrentThread(),
-                            out Interop.BOOL isIOPending);
-                    Debug.Assert(success);
-                    if (!success || isIOPending != Interop.BOOL.FALSE)
+                    if (IsIOPending)
                     {
                         continue;
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.Tracing;
 
 namespace System.Threading
@@ -99,6 +100,17 @@ namespace System.Threading
                             // the number of working workers to reflect that we are done working for now
                             RemoveWorkingWorker(threadPoolInstance);
                         }
+                    }
+
+                    // The thread cannot exit if it has IO pending, otherwise the IO may be canceled
+                    bool success =
+                        Interop.Kernel32.GetThreadIOPendingFlag(
+                            Interop.Kernel32.GetCurrentThread(),
+                            out Interop.BOOL isIOPending);
+                    Debug.Assert(success);
+                    if (!success || isIOPending != Interop.BOOL.FALSE)
+                    {
+                        continue;
                     }
 
                     threadAdjustmentLock.Acquire();


### PR DESCRIPTION
- Port of https://github.com/dotnet/runtime/pull/82245
- When Resource Monitor is attached, some async IO operations are bound to the thread that issued it even though the IO handle is bound to an IOCP. If the thread exits, the async IO operation is aborted. This can lead to hangs or unexpected exceptions.
- Added a check that was missing in the portable thread pool implementation to prevent exiting a worker thread when it has pending IO

Port of fix for https://github.com/dotnet/runtime/issues/82207

## Customer Impact

When Resource Monitor is attached to a .NET process, some async IO operations are aborted when thread pool worker threads exit. This leads to a hang in ASP.NET apps, where it's unable to accept new connections. The issue may also manifest as an unexpected exception. Customers have reported seeing regular instances of this issue in several apps, and the apps have to be restarted. The issue may also occur with other perf monitor tools attached. A workaround is to configure the runtime to not use the portable thread pool.

## Regression?

Yes, from 5.0. In 6.0 the portable thread pool is used by default for worker threads.

## Testing

Verified with the repro that the behavior is the same as before.

## Risk

Low. The check for pending IO already existed in the native thread pool implementation and this change adds the check to the portable thread pool implementation.