### PR TITLE
Remove duplicate range check in VSB.Append(char)

### DIFF
--- a/src/libraries/Common/src/System/Text/ValueStringBuilder.cs
+++ b/src/libraries/Common/src/System/Text/ValueStringBuilder.cs
@@ -170,9 +170,10 @@ namespace System.Text
         public void Append(char c)
         {
             int pos = _pos;
-            if ((uint)pos < (uint)_chars.Length)
+            Span<char> chars = _chars;
+            if ((uint)pos < (uint)chars.Length)
             {
-                _chars[pos] = c;
+                chars[pos] = c;
                 _pos = pos + 1;
             }
             else


### PR DESCRIPTION
<details>
<summary>Diffs from CoreLib</summary>

```
Top file improvements (bytes):
       -2033 : System.Private.CoreLib.dasm (-0.06% of base)

1 total files with Code Size differences (1 improved, 0 regressed), 0 unchanged.

Top method regressions (bytes):
         391 ( 6.35% of base) : System.Private.CoreLib.dasm - System.Number:NumberToStringFormat(byref,byref,System.ReadOnlySpan`1[ushort],System.Globalization.NumberFormatInfo)
           6 ( 0.10% of base) : System.Private.CoreLib.dasm - System.DateTimeFormat:FormatCustomized(System.DateTime,System.ReadOnlySpan`1[ushort],System.Globalization.DateTimeFormatInfo,System.TimeSpan,byref)

Top method improvements (bytes):
        -159 (-11.04% of base) : System.Private.CoreLib.dasm - System.TimeZoneInfo+StringSerializer:GetSerializedString(System.TimeZoneInfo):System.String
         -76 (-9.28% of base) : System.Private.CoreLib.dasm - System.Globalization.HebrewNumber:Append(byref,int)
         -76 (-11.41% of base) : System.Private.CoreLib.dasm - System.TimeZoneInfo+StringSerializer:SerializeTransitionTime(System.TimeZoneInfo+TransitionTime,byref)
         -60 (-5.46% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[long]:ToString(System.String,System.IFormatProvider):System.String:this (2 methods)
         -60 (-5.09% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[ulong]:ToString(System.String,System.IFormatProvider):System.String:this (2 methods)
         -57 (-5.07% of base) : System.Private.CoreLib.dasm - System.Reflection.AssemblyNameParser:GetNextToken(byref):int:this
         -53 (-7.55% of base) : System.Private.CoreLib.dasm - System.PasteArguments:AppendArgument(byref,System.String)
         -52 (-4.46% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256`1[long]:ToString(System.String,System.IFormatProvider):System.String:this (2 methods)
         -52 (-4.19% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256`1[ulong]:ToString(System.String,System.IFormatProvider):System.String:this (2 methods)
         -52 (-4.46% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector512`1[long]:ToString(System.String,System.IFormatProvider):System.String:this (2 methods)
         -52 (-4.19% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector512`1[ulong]:ToString(System.String,System.IFormatProvider):System.String:this (2 methods)
         -45 (-8.67% of base) : System.Private.CoreLib.dasm - System.Reflection.AssemblyNameFormatter:AppendQuoted(byref,System.String)
         -41 (-6.13% of base) : System.Private.CoreLib.dasm - System.IO.Enumeration.FileSystemName:TranslateWin32Expression(System.String):System.String
         -40 (-5.83% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[long]:ToString(System.String,System.IFormatProvider):System.String:this (2 methods)
         -40 (-5.51% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[ulong]:ToString(System.String,System.IFormatProvider):System.String:this (2 methods)
         -37 (-4.62% of base) : System.Private.CoreLib.dasm - System.Reflection.AssemblyNameFormatter:ComputeDisplayName(System.String,System.Version,System.String,ubyte[],int,int):System.String
         -36 (-3.97% of base) : System.Private.CoreLib.dasm - System.ApplicationId:ToString():System.String:this
         -35 (-7.35% of base) : System.Private.CoreLib.dasm - System.DateTimeFormat:FormatCustomizedRoundripTimeZone(System.DateTime,System.TimeSpan,byref)
         -32 (-3.93% of base) : System.Private.CoreLib.dasm - System.Globalization.CalendarData:NormalizeDatePattern(System.String):System.String
         -31 (-5.93% of base) : System.Private.CoreLib.dasm - System.TypeNameParser:EscapeTypeName(System.String):System.String
         -30 (-4.55% of base) : System.Private.CoreLib.dasm - System.IO.PathInternal:NormalizeDirectorySeparators(System.String):System.String
         -30 (-3.22% of base) : System.Private.CoreLib.dasm - System.Net.WebUtility:HtmlDecode(System.ReadOnlySpan`1[ushort],byref)
         -30 (-4.42% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[int]:ToString(System.String,System.IFormatProvider):System.String:this
         -30 (-4.62% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[uint]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-6.15% of base) : System.Private.CoreLib.dasm - System.Reflection.Emit.DynamicMethod:ToString():System.String:this
         -26 (-4.29% of base) : System.Private.CoreLib.dasm - System.Reflection.RuntimeMethodInfo:ToString():System.String:this
         -26 (-3.61% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[byte]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-4.21% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[double]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-4.08% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[float]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-3.62% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[int]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-3.61% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[short]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-3.78% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[ubyte]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-3.79% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[uint]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-3.78% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[ushort]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-3.61% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256`1[byte]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-4.08% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256`1[double]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-4.08% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256`1[float]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-3.62% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256`1[int]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-3.61% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256`1[short]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-3.78% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256`1[ubyte]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-3.79% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256`1[uint]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-3.78% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256`1[ushort]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-3.61% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector512`1[byte]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-4.08% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector512`1[double]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-4.08% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector512`1[float]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-3.62% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector512`1[int]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-3.61% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector512`1[short]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-3.78% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector512`1[ubyte]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-3.79% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector512`1[uint]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-3.78% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector512`1[ushort]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-3.61% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[byte]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-4.21% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[float]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-3.61% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[short]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-3.78% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[ubyte]:ToString(System.String,System.IFormatProvider):System.String:this
         -26 (-3.78% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[ushort]:ToString(System.String,System.IFormatProvider):System.String:this
         -24 (-4.01% of base) : System.Private.CoreLib.dasm - System.DateTimeFormat:FormatCustomizedTimeZone(System.DateTime,System.TimeSpan,int,bool,byref)
         -24 (-2.06% of base) : System.Private.CoreLib.dasm - System.IO.Path:GetRelativePath(System.String,System.String,int):System.String
         -23 (-4.70% of base) : System.Private.CoreLib.dasm - System.Number:FormatGeneral(byref,byref,int,System.Globalization.NumberFormatInfo,ushort,bool)
         -23 (-3.07% of base) : System.Private.CoreLib.dasm - System.TimeZoneInfo+StringSerializer:GetNextStringValue():System.String:this
         -20 (-3.81% of base) : System.Private.CoreLib.dasm - System.AggregateException:get_Message():System.String:this         -20 (-2.68% of base) : System.Private.CoreLib.dasm - System.Reflection.CustomAttributeData:ToString():System.String:this
         -19 (-1.91% of base) : System.Private.CoreLib.dasm - System.Number:FormatFixed(byref,byref,int,int[],System.String,System.String)
         -18 (-11.11% of base) : System.Private.CoreLib.dasm - System.DateTimeFormat:Append2DigitNumber(byref,int)
         -17 (-9.24% of base) : System.Private.CoreLib.dasm - System.TimeZoneInfo+StringSerializer:SerializeSubstitute(System.String,byref)
         -16 (-4.41% of base) : System.Private.CoreLib.dasm - System.DateTimeFormat:ParseQuoteString(System.ReadOnlySpan`1[ushort],int,byref):int
         -16 (-1.77% of base) : System.Private.CoreLib.dasm - System.IO.Path:Combine(System.String[]):System.String
         -16 (-2.40% of base) : System.Private.CoreLib.dasm - System.PasteArguments:Paste(System.Collections.Generic.IEnumerable`1[System.String],bool):System.String
         -16 (-4.37% of base) : System.Private.CoreLib.dasm - System.Reflection.RuntimeConstructorInfo:ToString():System.String:this
         -16 (-3.69% of base) : System.Private.CoreLib.dasm - System.Reflection.RuntimePropertyInfo:ToString():System.String:this
         -16 (-4.30% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[double]:ToString(System.String,System.IFormatProvider):System.String:this
         -13 (-1.95% of base) : System.Private.CoreLib.dasm - System.Net.WebUtility:HtmlEncode(System.ReadOnlySpan`1[ushort],byref)
         -12 (-4.07% of base) : System.Private.CoreLib.dasm - System.DateTimeParse:TryParseQuoteString(System.ReadOnlySpan`1[ushort],int,byref,byref):bool
         -12 (-1.20% of base) : System.Private.CoreLib.dasm - System.Globalization.TimeSpanFormat+FormatLiterals:Init(System.ReadOnlySpan`1[ushort],bool):this
         -12 (-1.94% of base) : System.Private.CoreLib.dasm - System.IO.PathInternal:RemoveRelativeSegments(System.ReadOnlySpan`1[ushort],int,byref):bool
         -11 (-3.15% of base) : System.Private.CoreLib.dasm - System.Number:FormatScientific(byref,byref,int,System.Globalization.NumberFormatInfo,ushort)
         -10 (-1.83% of base) : System.Private.CoreLib.dasm - System.IO.Path:Join(System.String[]):System.String
         -10 (-0.55% of base) : System.Private.CoreLib.dasm - System.Reflection.CustomAttributeTypedArgument:ToString(bool):System.String:this
         -10 (-11.76% of base) : System.Private.CoreLib.dasm - System.Text.ValueStringBuilder:GrowAndAppend(ushort):this          -8 (-0.64% of base) : System.Private.CoreLib.dasm - System.Text.CompositeFormat:TryParseLiterals(System.ReadOnlySpan`1[ushort],System.Collections.Generic.List`1[System.ValueTuple`4[System.String,int,int,System.String]]):bool
          -8 (-0.43% of base) : System.Private.CoreLib.dasm - System.Text.ValueStringBuilder:AppendFormatHelper(System.IFormatProvider,System.String,System.ReadOnlySpan`1[System.Object]):this
          -7 (-1.60% of base) : System.Private.CoreLib.dasm - System.Number:FormatExponent(byref,System.Globalization.NumberFormatInfo,int,ushort,int,bool)
          -7 (-1.66% of base) : System.Private.CoreLib.dasm - System.Number:FormatPercent(byref,byref,int,System.Globalization.NumberFormatInfo)
          -6 (-0.39% of base) : System.Private.CoreLib.dasm - System.Globalization.TimeSpanFormat:FormatCustomized(System.TimeSpan,System.ReadOnlySpan`1[ushort],System.Globalization.DateTimeFormatInfo,byref)
          -4 (-0.96% of base) : System.Private.CoreLib.dasm - System.Number:FormatCurrency(byref,byref,int,System.Globalization.NumberFormatInfo)
          -4 (-1.33% of base) : System.Private.CoreLib.dasm - System.Number:FormatNumber(byref,byref,int,System.Globalization.NumberFormatInfo)

87 total methods with Code Size differences (85 improved, 2 regressed), 27734 unchanged.
```

@MihuBot

</details>

Example improvement: https://www.diffchecker.com/m1G2G2z2