### PR TITLE
[JIT] Always transform `AND(X, CNS(-1))` to `X`

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -998,24 +998,18 @@ void CodeGen::genCodeForBinary(GenTreeOp* treeNode)
         src = op2;
     }
 
+#ifdef TARGET_64BIT
     // We can skip emitting 'and reg0, -1` if we know that the upper 32bits of 'reg0' are zero'ed.
     if (compiler->opts.OptimizationEnabled())
     {
-        if ((oper == GT_AND) && (targetType == TYP_INT) && !treeNode->gtSetFlags() && op2->IsIntegralConst(-1))
+        if ((oper == GT_AND) && (targetType == TYP_INT) && !treeNode->gtSetFlags() && op2->IsIntegralConst(-1) &&
+            emit->AreUpper32BitsZero(targetReg))
         {
-#ifdef TARGET_X86
-            // We can always skip this on x86 as the result will never change.
             genProduceReg(treeNode);
             return;
-#else  // TARGET_X86
-            if (emit->AreUpper32BitsZero(targetReg))
-            {
-                genProduceReg(treeNode);
-                return;
-            }
-#endif // !TARGET_X86
         }
     }
+#endif // TARGET_64BIT
 
     // try to use an inc or dec
     if (oper == GT_ADD && !varTypeIsFloating(treeNode) && src->isContainedIntOrIImmed() && !treeNode->gtOverflowEx())

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -1001,11 +1001,19 @@ void CodeGen::genCodeForBinary(GenTreeOp* treeNode)
     // We can skip emitting 'and reg0, -1` if we know that the upper 32bits of 'reg0' are zero'ed.
     if (compiler->opts.OptimizationEnabled())
     {
-        if ((oper == GT_AND) && (targetType == TYP_INT) && !treeNode->gtSetFlags() && op2->IsIntegralConst(-1) &&
-            emit->AreUpper32BitsZero(targetReg))
+        if ((oper == GT_AND) && (targetType == TYP_INT) && !treeNode->gtSetFlags() && op2->IsIntegralConst(-1))
         {
+#ifdef TARGET_X86
+            // We can always skip this on x86 as the result will never change.
             genProduceReg(treeNode);
             return;
+#else // TARGET_X86
+            if (emit->AreUpper32BitsZero(targetReg))
+            {
+                genProduceReg(treeNode);
+                return;
+            }
+#endif // !TARGET_X86
         }
     }
 

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -998,19 +998,6 @@ void CodeGen::genCodeForBinary(GenTreeOp* treeNode)
         src = op2;
     }
 
-#ifdef TARGET_64BIT
-    // We can skip emitting 'and reg0, -1` if we know that the upper 32bits of 'reg0' are zero'ed.
-    if (compiler->opts.OptimizationEnabled())
-    {
-        if ((oper == GT_AND) && (targetType == TYP_INT) && !treeNode->gtSetFlags() && op2->IsIntegralConst(-1) &&
-            emit->AreUpper32BitsZero(targetReg))
-        {
-            genProduceReg(treeNode);
-            return;
-        }
-    }
-#endif // TARGET_64BIT
-
     // try to use an inc or dec
     if (oper == GT_ADD && !varTypeIsFloating(treeNode) && src->isContainedIntOrIImmed() && !treeNode->gtOverflowEx())
     {

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -1007,7 +1007,7 @@ void CodeGen::genCodeForBinary(GenTreeOp* treeNode)
             // We can always skip this on x86 as the result will never change.
             genProduceReg(treeNode);
             return;
-#else // TARGET_X86
+#else  // TARGET_X86
             if (emit->AreUpper32BitsZero(targetReg))
             {
                 genProduceReg(treeNode);

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -476,6 +476,7 @@ bool emitter::IsFlagsAlwaysModified(instrDesc* id)
     return true;
 }
 
+#ifdef TARGET_64BIT
 //------------------------------------------------------------------------
 // AreUpper32BitsZero: check if some previously emitted
 //     instruction set the upper 32 bits of reg to zero.
@@ -506,11 +507,6 @@ bool emitter::AreUpper32BitsZero(regNumber reg)
     {
         return false;
     }
-
-#ifdef TARGET_X86
-    // There are no upper 32-bits on x86, so return false.
-    return false;
-#endif // TARGET_X86
 
     instrDesc* id  = emitLastIns;
     insFormat  fmt = id->idInsFmt();
@@ -599,12 +595,10 @@ bool emitter::AreUpper32BitsZero(regNumber reg)
                 return false;
             }
 
-#ifdef TARGET_AMD64
             if (id->idIns() == INS_movsxd)
             {
                 return false;
             }
-#endif
 
             // movzx always zeroes the upper 32 bits.
             if (id->idIns() == INS_movzx)
@@ -647,11 +641,6 @@ bool emitter::AreUpper32BitsSignExtended(regNumber reg)
         return false;
     }
 
-#ifdef TARGET_X86
-    // There are no upper 32-bits on x86, so return false.
-    return false;
-#endif // TARGET_X86
-
     instrDesc* id = emitLastIns;
 
     if (id->idReg1() != reg)
@@ -665,16 +654,15 @@ bool emitter::AreUpper32BitsSignExtended(regNumber reg)
         return true;
     }
 
-#ifdef TARGET_AMD64
     // movsxd is always an 8 byte operation. W-bit is set.
     if (id->idIns() == INS_movsxd)
     {
         return true;
     }
-#endif
 
     return false;
 }
+#endif // TARGET_64BIT
 
 //------------------------------------------------------------------------
 // AreFlagsSetToZeroCmp: Checks if the previous instruction set the SZ, and optionally OC, flags to

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -507,6 +507,11 @@ bool emitter::AreUpper32BitsZero(regNumber reg)
         return false;
     }
 
+#ifdef TARGET_X86
+    // There are no upper 32-bits on x86, so return false.
+    return false;
+#endif // TARGET_X86
+
     instrDesc* id  = emitLastIns;
     insFormat  fmt = id->idInsFmt();
 
@@ -641,6 +646,11 @@ bool emitter::AreUpper32BitsSignExtended(regNumber reg)
     {
         return false;
     }
+
+#ifdef TARGET_X86
+    // There are no upper 32-bits on x86, so return false.
+    return false;
+#endif // TARGET_X86
 
     instrDesc* id = emitLastIns;
 

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -127,8 +127,10 @@ bool IsRedundantStackMov(instruction ins, insFormat fmt, emitAttr size, regNumbe
 static bool IsJccInstruction(instruction ins);
 static bool IsJmpInstruction(instruction ins);
 
+#ifdef TARGET_64BIT
 bool AreUpper32BitsZero(regNumber reg);
 bool AreUpper32BitsSignExtended(regNumber reg);
+#endif // TARGET_64BIT
 
 bool AreFlagsSetToZeroCmp(regNumber reg, emitAttr opSize, genTreeOps treeOps);
 bool AreFlagsSetForSignJumpOpt(regNumber reg, emitAttr opSize, GenTree* tree);

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -346,7 +346,18 @@ GenTree* Lowering::LowerNode(GenTree* node)
         case GT_AND:
         case GT_OR:
         case GT_XOR:
+        {
+            if (comp->opts.OptimizationEnabled() && node->OperIs(GT_AND))
+            {
+                GenTree* replacementNode = TryLowerAndNegativeOne(node->AsOp());
+                if (replacementNode != nullptr)
+                {
+                    return replacementNode->gtNext;
+                }
+            }
+
             return LowerBinaryArithmetic(node->AsOp());
+        }
 
         case GT_MUL:
         case GT_MULHI:
@@ -7704,6 +7715,51 @@ void Lowering::TryRetypingFloatingPointStoreToIntegerStore(GenTree* store)
             store->ChangeType(type);
         }
     }
+}
+
+//----------------------------------------------------------------------------------------------
+// Lowering::TryLowerAndNegativeOne:
+//    If safe, lowers a tree AND(X, CNS(-1)) to X.
+//
+// Arguments:
+//    node - GT_AND node of integral type
+//
+// Return Value:
+//    Returns the replacement node if one is created else nullptr indicating no replacement
+GenTree* Lowering::TryLowerAndNegativeOne(GenTreeOp* node)
+{
+    assert(node->OperIs(GT_AND));
+
+    if (!varTypeIsIntegral(node))
+        return nullptr;
+
+    if (node->gtSetFlags())
+        return nullptr;
+
+    if (node->isContained())
+        return nullptr;
+
+    GenTree* op2 = node->gtGetOp2();
+
+    if (!op2->IsIntegralConst(-1))
+        return nullptr;
+
+#ifndef TARGET_64BIT
+    assert(op2->TypeIs(TYP_INT));
+#endif // !TARGET_64BIT
+
+    LIR::Use use;
+    if (!BlockRange().TryGetUse(node, &use))
+        return nullptr;
+
+    GenTree* op1 = node->gtGetOp1();
+
+    use.ReplaceWith(op1);
+
+    BlockRange().Remove(op2);
+    BlockRange().Remove(node);
+
+    return op1;
 }
 
 #if defined(FEATURE_HW_INTRINSICS)

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -307,6 +307,7 @@ private:
     void LowerStoreIndir(GenTreeStoreInd* node);
     GenTree* LowerAdd(GenTreeOp* node);
     GenTree* LowerMul(GenTreeOp* mul);
+    GenTree* TryLowerAndNegativeOne(GenTreeOp* node);
     GenTree* LowerBinaryArithmetic(GenTreeOp* binOp);
     bool LowerUnsignedDivOrMod(GenTreeOp* divMod);
     GenTree* LowerConstIntDivOrMod(GenTree* node);

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -266,7 +266,7 @@ GenTree* Lowering::TryLowerAndNegativeOne(GenTreeOp* node)
         return nullptr;
 
 #ifdef TARGET_64BIT
-    if (!node->TypeIs(TYP_LONG) || !op2->TypeIs(TYP_LONG))
+    if (!node->TypeIs(TYP_INT, TYP_LONG))
         return nullptr;
 #else  // TARGET_64BIT
     assert(op2->TypeIs(TYP_INT));

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -283,7 +283,7 @@ GenTree* Lowering::TryLowerAndNegativeOne(GenTreeOp* node)
 
     use.ReplaceWith(op1);
 
-    BlockRange().Remove(node->gtGetOp2());
+    BlockRange().Remove(op2);
     BlockRange().Remove(node);
 
     return op1;

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -241,54 +241,6 @@ GenTree* Lowering::LowerMul(GenTreeOp* mul)
     return mul->gtNext;
 }
 
-//----------------------------------------------------------------------------------------------
-// Lowering::TryLowerAndNegativeOne:
-//    If safe, lowers a tree AND(X, CNS(-1)) to X.
-//
-// Arguments:
-//    node - GT_AND node of integral type
-//
-// Return Value:
-//    Returns the replacement node if one is created else nullptr indicating no replacement
-GenTree* Lowering::TryLowerAndNegativeOne(GenTreeOp* node)
-{
-    assert(node->OperIs(GT_AND));
-
-    if (!varTypeIsIntegral(node))
-        return nullptr;
-
-    if (node->gtSetFlags())
-        return nullptr;
-
-    GenTree* op2 = node->gtGetOp2();
-
-    if (!op2->IsIntegralConst(-1))
-        return nullptr;
-
-#ifdef TARGET_64BIT
-    if (!node->TypeIs(TYP_INT, TYP_LONG))
-        return nullptr;
-#else  // TARGET_64BIT
-    assert(op2->TypeIs(TYP_INT));
-
-    if (!node->TypeIs(TYP_INT))
-        return nullptr;
-#endif // !TARGET_64BIT
-
-    LIR::Use use;
-    if (!BlockRange().TryGetUse(node, &use))
-        return nullptr;
-
-    GenTree* op1 = node->gtGetOp1();
-
-    use.ReplaceWith(op1);
-
-    BlockRange().Remove(op2);
-    BlockRange().Remove(node);
-
-    return op1;
-}
-
 //------------------------------------------------------------------------
 // LowerBinaryArithmetic: lowers the given binary arithmetic node.
 //
@@ -336,15 +288,6 @@ GenTree* Lowering::LowerBinaryArithmetic(GenTreeOp* binOp)
         }
     }
 #endif
-
-    if (comp->opts.OptimizationEnabled() && binOp->OperIs(GT_AND))
-    {
-        GenTree* replacementNode = TryLowerAndNegativeOne(binOp);
-        if (replacementNode != nullptr)
-        {
-            return replacementNode->gtNext;
-        }
-    }
 
     ContainCheckBinary(binOp);
 


### PR DESCRIPTION
## Description

We should always try to lower `AND(X, CNS(-1))` to `X` if possible. We do this transformation in lowering to pick up this pattern as a result of decomposing longs on 32bit archs.