### PR TITLE
[wasm] Better support for automated tests in jiterpreter; more opcodes

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -3803,16 +3803,6 @@ mono_interp_tier_enter_jiterpreter (
 {
 	// g_assert(thunk);
 	ptrdiff_t offset = thunk(frame, locals);
-	gboolean trace_requires_safepoint = FALSE;
-	/*
-	* The trace signals that we need to perform a safepoint by adding a very
-	*  large amount to the relative displacement. This is because setting a bit
-	*  in JS via the | operator doesn't work for negative numbers
-	*/
-	if (offset >= 0xE000000) {
-		offset -= 0xF000000;
-		trace_requires_safepoint = TRUE;
-	}
 	/*
 	* Verify that the offset returned by the thunk is not total garbage
 	* FIXME: These constants might actually be too small since a method
@@ -3825,9 +3815,6 @@ mono_interp_tier_enter_jiterpreter (
 		mini_tiered_inc (frame->imethod->method, &frame->imethod->tiered_counter, 0);
 	}
 #endif
-	if (trace_requires_safepoint) {
-		SAFEPOINT;
-	}
 	return offset;
 }
 #endif // HOST_BROWSER

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -3794,6 +3794,44 @@ max_d (double lhs, double rhs)
 		return fmax (lhs, rhs);
 }
 
+#ifdef HOST_BROWSER
+MONO_ALWAYS_INLINE static ptrdiff_t
+mono_interp_tier_enter_jiterpreter (
+	JiterpreterThunk thunk, InterpFrame *frame, unsigned char *locals, ThreadContext *context,
+	const guint16 *ip
+)
+{
+	// g_assert(thunk);
+	ptrdiff_t offset = thunk(frame, locals);
+	gboolean trace_requires_safepoint = FALSE;
+	/*
+	* The trace signals that we need to perform a safepoint by adding a very
+	*  large amount to the relative displacement. This is because setting a bit
+	*  in JS via the | operator doesn't work for negative numbers
+	*/
+	if (offset >= 0xE000000) {
+		offset -= 0xF000000;
+		trace_requires_safepoint = TRUE;
+	}
+	/*
+	* Verify that the offset returned by the thunk is not total garbage
+	* FIXME: These constants might actually be too small since a method
+	*  could have massive amounts of IL - maybe we should disable the jiterpreter
+	*  for methods that big
+	*/
+	// g_assertf((offset >= -0xFFFFF) && (offset <= 0xFFFFF), "thunk returned an obviously invalid offset: %i", offset);
+#ifdef ENABLE_EXPERIMENT_TIERED
+	if (offset < 0) {
+		mini_tiered_inc (frame->imethod->method, &frame->imethod->tiered_counter, 0);
+	}
+#endif
+	if (trace_requires_safepoint) {
+		SAFEPOINT;
+	}
+	return offset;
+}
+#endif // HOST_BROWSER
+
 /*
  * If CLAUSE_ARGS is non-null, start executing from it.
  * The ERROR argument is used to avoid declaring an error object for every interp frame, its not used
@@ -7640,6 +7678,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 				 *  table. when growing the function pointer table we will also need to synchronize that.
 				 */
 				JiterpreterThunk prepare_result = mono_interp_tier_prepare_jiterpreter_fast(frame, frame->imethod->method, ip, frame->imethod->jinfo->code_start, frame->imethod->jinfo->code_size);
+				ptrdiff_t offset;
 				switch ((guint32)(void*)prepare_result) {
 					case JITERPRETER_TRAINING:
 						// jiterpreter still updating hit count before deciding to generate a trace,
@@ -7648,9 +7687,9 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 						break;
 					case JITERPRETER_NOT_JITTED:
 						// Patch opcode to disable it because this trace failed to JIT.
-						mono_memory_barrier();
+						mono_memory_barrier ();
 						*mutable_ip = MINT_TIER_NOP_JITERPRETER;
-						mono_memory_barrier();
+						mono_memory_barrier ();
 						ip += 3;
 						break;
 					default:
@@ -7663,11 +7702,17 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 						 *  here so that implementing thread support will be easier later.)
 						 */
 						*mutable_ip = MINT_TIER_NOP_JITERPRETER;
-						mono_memory_barrier();
+						mono_memory_barrier ();
 						*(volatile JiterpreterThunk*)(ip + 1) = prepare_result;
-						mono_memory_barrier();
+						mono_memory_barrier ();
 						*mutable_ip = MINT_TIER_ENTER_JITERPRETER;
-						ip += 3;
+						// now execute the trace
+						// this isn't important for performance, but it makes it easier to use the
+						//  jiterpreter early in automated tests where code only runs once
+						offset = mono_interp_tier_enter_jiterpreter (
+							prepare_result, frame, locals, context, ip
+						);
+						ip = (guint16*) (((guint8*)ip) + offset);
 						break;
 				}
 			} else {
@@ -7679,31 +7724,9 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 
 		MINT_IN_CASE(MINT_TIER_ENTER_JITERPRETER) {
 			JiterpreterThunk thunk = (void*)READ32(ip + 1);
-			gboolean trace_requires_safepoint = FALSE;
-			g_assert(thunk);
-			ptrdiff_t offset = thunk(frame, locals);
-			/*
-			 * The trace signals that we need to perform a safepoint by adding a very
-			 *  large amount to the relative displacement. This is because setting a bit
-			 *  in JS via the | operator doesn't work for negative numbers
-			 */
-			if (offset >= 0xE000000) {
-				offset -= 0xF000000;
-				trace_requires_safepoint = TRUE;
-			}
-			/*
-			 * Verify that the offset returned by the thunk is not total garbage
-			 * FIXME: These constants might actually be too small since a method
-			 *  could have massive amounts of IL - maybe we should disable the jiterpreter
-			 *  for methods that big
-			 */
-			g_assertf((offset >= -0xFFFFF) && (offset <= 0xFFFFF), "thunk returned an obviously invalid offset: %i", offset);
-			if (offset <= 0) {
-				BACK_BRANCH_PROFILE (offset);
-			}
-			if (trace_requires_safepoint) {
-				SAFEPOINT;
-			}
+			ptrdiff_t offset = mono_interp_tier_enter_jiterpreter (
+				thunk, frame, locals, context, ip
+			);
 			ip = (guint16*) (((guint8*)ip) + offset);
 			MINT_IN_BREAK;
 		}

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -735,6 +735,7 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 		case MINT_INTRINS_TRY_GET_HASHCODE:
 		case MINT_INTRINS_RUNTIMEHELPERS_OBJECT_HAS_COMPONENT_SIZE:
 		case MINT_INTRINS_ENUM_HASFLAG:
+		case MINT_INTRINS_ORDINAL_IGNORE_CASE_ASCII:
 		case MINT_ADD_MUL_I4_IMM:
 		case MINT_ADD_MUL_I8_IMM:
 		case MINT_ARRAY_RANK:

--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -194,15 +194,9 @@ export class WasmBuilder {
         }
     }
 
-    ip_const (value: MintOpcodePtr, highBit?: boolean) {
+    ip_const (value: MintOpcodePtr) {
         this.appendU8(WasmOpcode.i32_const);
-        let relativeValue = <any>value - <any>this.base;
-        if (highBit) {
-            // it is impossible to do this in JS as far as i can tell
-            // relativeValue |= 0x80000000;
-            relativeValue += 0xF000000;
-        }
-        this.appendLeb(relativeValue);
+        this.appendLeb(<any>value - <any>this.base);
     }
 
     i52_const (value: number) {

--- a/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
@@ -2202,10 +2202,10 @@ function emit_branch (
     builder.appendULeb(0);
 
     if (displacement < 0) {
-        // This is a backwards branch, and right now we always bail out for those -
-        //  so just return.
-        // FIXME: Why is this not a safepoint?
-        append_bailout(builder, destination, BailoutReason.BackwardBranch, true);
+        // This is a backwards branch, and right now we always bail out for those - so perform a
+        //  safepoint and then return. (This removes a safepoint check from all trace returns.)
+        append_safepoint(builder, ip);
+        append_bailout(builder, destination, BailoutReason.BackwardBranch);
     } else {
         // Do a safepoint *before* changing our IP, if necessary
         if (isSafepoint)
@@ -2796,8 +2796,8 @@ function emit_arrayop (builder: WasmBuilder, ip: MintOpcodePtr, opcode: MintOpco
     return true;
 }
 
-function append_bailout (builder: WasmBuilder, ip: MintOpcodePtr, reason: BailoutReason, highBit?: boolean) {
-    builder.ip_const(ip, highBit);
+function append_bailout (builder: WasmBuilder, ip: MintOpcodePtr, reason: BailoutReason) {
+    builder.ip_const(ip);
     if (builder.options.countBailouts) {
         builder.i32_const(reason);
         builder.callImport("bailout");

--- a/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
@@ -1602,8 +1602,10 @@ const unopTable : { [opcode: number]: OpRec3 | undefined } = {
 
     [MintOpcode.MINT_CONV_R4_I4]: [WasmOpcode.f32_convert_s_i32, WasmOpcode.i32_load, WasmOpcode.f32_store],
     [MintOpcode.MINT_CONV_R8_I4]: [WasmOpcode.f64_convert_s_i32, WasmOpcode.i32_load, WasmOpcode.f64_store],
+    [MintOpcode.MINT_CONV_R_UN_I4]: [WasmOpcode.f64_convert_u_i32, WasmOpcode.i32_load, WasmOpcode.f64_store],
     [MintOpcode.MINT_CONV_R4_I8]: [WasmOpcode.f32_convert_s_i64, WasmOpcode.i64_load, WasmOpcode.f32_store],
     [MintOpcode.MINT_CONV_R8_I8]: [WasmOpcode.f64_convert_s_i64, WasmOpcode.i64_load, WasmOpcode.f64_store],
+    [MintOpcode.MINT_CONV_R_UN_I8]: [WasmOpcode.f64_convert_u_i64, WasmOpcode.i64_load, WasmOpcode.f64_store],
     [MintOpcode.MINT_CONV_R8_R4]: [WasmOpcode.f64_promote_f32,   WasmOpcode.f32_load, WasmOpcode.f64_store],
     [MintOpcode.MINT_CONV_R4_R8]: [WasmOpcode.f32_demote_f64,    WasmOpcode.f64_load, WasmOpcode.f32_store],
 

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -993,7 +993,6 @@ export function jiterpreter_dump_stats (b?: boolean, concise?: boolean) {
                         continue;
 
                     // not worth implementing / too difficult
-                    case "intrins_ordinal_ignore_case_ascii":
                     case "intrins_marvin_block":
                     case "intrins_ascii_chars_to_uppercase":
                     case "newarr":


### PR DESCRIPTION
* Rearrange the jiterpreter's compile and enter logic so that we enter a trace immediately after compiling it. If you set the minimum hit count to 1 and disable tiering, this appears to run most automated tests in the jiterpreter, which is useful for verifying opcode implementations and flushing out bugs.
* Move the 'do we need to safepoint after this trace?' logic from the end of enter_jiterpreter into the traces themselves now that traces can perform safepoints. Should improve performance for short traces.
* Implemented a few more opcodes that looked worthwhile based on statistics.