### PR TITLE
Fix BuildAsStandalone=true for tests in merged groups

### DIFF
--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -12,7 +12,10 @@
   <!-- Default priority building values. -->
   <PropertyGroup>
     <DisableProjectBuild Condition="'$(IsMergedTestRunnerAssembly)' == 'true' and $(BuildAsStandalone)">true</DisableProjectBuild>
-    <OutputType Condition="('$(IsMergedTestRunnerAssembly)' == 'true' and !$(BuildAsStandalone)) or '$(RequiresProcessIsolation)' == 'true'">Exe</OutputType>
+    <OutputType Condition=
+        "('$(IsMergedTestRunnerAssembly)' == 'true' and !$(BuildAsStandalone))
+        or '$(RequiresProcessIsolation)' == 'true'
+        or ('$(IsMergedTestRunnerAssembly)' != 'true' and '$(BuildAsStandalone)' == 'true')">Exe</OutputType>
     <CLRTestKind Condition="'$(CLRTestKind)' == '' and '$(OutputType)' == 'Exe'">BuildAndRun</CLRTestKind>
     <CLRTestKind Condition="'$(CLRTestKind)' == ''">BuildOnly</CLRTestKind>
     <CLRTestPriority Condition="'$(CLRTestPriority)' == ''">0</CLRTestPriority>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/AdvSimd.Arm64/AdvSimd.Arm64_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/AdvSimd.Arm64/AdvSimd.Arm64_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/AdvSimd.Arm64/AdvSimd.Arm64_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/AdvSimd.Arm64/AdvSimd.Arm64_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/AdvSimd/AdvSimd_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/AdvSimd/AdvSimd_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/AdvSimd/AdvSimd_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/AdvSimd/AdvSimd_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Aes/Aes_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Aes/Aes_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Aes/Aes_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Aes/Aes_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/ArmBase.Arm64/ArmBase.Arm64_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/ArmBase.Arm64/ArmBase.Arm64_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/ArmBase.Arm64/ArmBase.Arm64_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/ArmBase.Arm64/ArmBase.Arm64_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/ArmBase/ArmBase_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/ArmBase/ArmBase_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/ArmBase/ArmBase_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/ArmBase/ArmBase_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/ArmBase/Yield_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/ArmBase/Yield_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/ArmBase/Yield_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/ArmBase/Yield_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Crc32.Arm64/Crc32.Arm64_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Crc32.Arm64/Crc32.Arm64_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Crc32.Arm64/Crc32.Arm64_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Crc32.Arm64/Crc32.Arm64_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Crc32/Crc32_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Crc32/Crc32_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Crc32/Crc32_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Crc32/Crc32_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Dp/Dp_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Dp/Dp_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Dp/Dp_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Dp/Dp_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Rdm.Arm64/Rdm.Arm64_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Rdm.Arm64/Rdm.Arm64_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Rdm.Arm64/Rdm.Arm64_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Rdm.Arm64/Rdm.Arm64_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Rdm/Rdm_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Rdm/Rdm_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Rdm/Rdm_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Rdm/Rdm_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Sha1/Sha1_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Sha1/Sha1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Sha1/Sha1_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Sha1/Sha1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Sha256/Sha256_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Sha256/Sha256_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Sha256/Sha256_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Sha256/Sha256_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/General/ConstantFolding/ScalarConstantFoldings.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/ConstantFolding/ScalarConstantFoldings.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/HardwareIntrinsics/General/ConstantFolding/SimdConstantFoldings.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/ConstantFolding/SimdConstantFoldings.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/HardwareIntrinsics/General/HwiOp/CompareVectorWithZero.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/HwiOp/CompareVectorWithZero.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/HardwareIntrinsics/General/HwiOp/HwiSideEffects.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/HwiOp/HwiSideEffects.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/tests/JIT/HardwareIntrinsics/General/HwiOp/HwiValueNumbering.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/HwiOp/HwiValueNumbering.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/tests/JIT/HardwareIntrinsics/General/NotSupported/NotSupported_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/NotSupported/NotSupported_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/General/NotSupported/NotSupported_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/NotSupported/NotSupported_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/General/Regression/GitHub_43569/GitHub_43569.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Regression/GitHub_43569/GitHub_43569.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/General/Regression/GitHub_47236/GitHub_47236.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Regression/GitHub_47236/GitHub_47236.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/General/Regression/GitHub_75791/GitHub_75791.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Regression/GitHub_75791/GitHub_75791.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector128/Vector128_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector128/Vector128_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector128/Vector128_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector128/Vector128_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector128_1/Vector128_1_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector128_1/Vector128_1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector128_1/Vector128_1_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector128_1/Vector128_1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector256/Vector256_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector256/Vector256_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector256/Vector256_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector256/Vector256_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector256_1/Vector256_1_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector256_1/Vector256_1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!-- https://github.com/dotnet/runtime/issues/57352 -->

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector256_1/Vector256_1_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector256_1/Vector256_1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!-- https://github.com/dotnet/runtime/issues/57352 -->

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector512/Vector512_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector512/Vector512_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector512/Vector512_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector512/Vector512_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector512_1/Vector512_1_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector512_1/Vector512_1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector512_1/Vector512_1_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector512_1/Vector512_1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector64/Vector64_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector64/Vector64_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector64/Vector64_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector64/Vector64_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector64_1/Vector64_1_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector64_1/Vector64_1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector64_1/Vector64_1_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector64_1/Vector64_1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Aes/Aes_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Aes/Aes_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Aes_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Aes/Aes_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Aes/Aes_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Aes_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Avx1/Avx1_handwritten_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Avx1/Avx1_handwritten_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Avx1_handwritten_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Avx1/Avx1_handwritten_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Avx1/Avx1_handwritten_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Avx1_handwritten_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Avx1/Avx1_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Avx1/Avx1_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Avx1_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Avx1/Avx1_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Avx1/Avx1_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Avx1_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Avx1_Vector128/Avx1_Vector128_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Avx1_Vector128/Avx1_Vector128_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Avx1_Vector128_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Avx1_Vector128/Avx1_Vector128_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Avx1_Vector128/Avx1_Vector128_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Avx1_Vector128_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Avx2/Avx2_handwritten_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Avx2/Avx2_handwritten_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Avx2_handwritten_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Avx2/Avx2_handwritten_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Avx2/Avx2_handwritten_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Avx2_handwritten_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Avx2/Avx2_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Avx2/Avx2_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Avx2_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Avx2/Avx2_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Avx2/Avx2_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Avx2_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Avx2_Vector128/Avx2_Vector128_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Avx2_Vector128/Avx2_Vector128_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Avx2_Vector128_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Avx2_Vector128/Avx2_Vector128_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Avx2_Vector128/Avx2_Vector128_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Avx2_Vector128_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/AvxVnni/MultiplyWideningAndAdd_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/AvxVnni/MultiplyWideningAndAdd_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_AvxVnni_MultiplyWideningAndAdd_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- It takes a long time to complete (on a non-AVX machine) -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>

--- a/src/tests/JIT/HardwareIntrinsics/X86/AvxVnni/MultiplyWideningAndAdd_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/AvxVnni/MultiplyWideningAndAdd_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_AvxVnni_MultiplyWideningAndAdd_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- It takes a long time to complete (on a non-AVX machine) -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>

--- a/src/tests/JIT/HardwareIntrinsics/X86/AvxVnni_Vector128/MultiplyWideningAndAdd_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/AvxVnni_Vector128/MultiplyWideningAndAdd_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_AvxVnni_Vector128_MultiplyWideningAndAdd_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- It takes a long time to complete (on a non-AVX machine) -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>

--- a/src/tests/JIT/HardwareIntrinsics/X86/AvxVnni_Vector128/MultiplyWideningAndAdd_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/AvxVnni_Vector128/MultiplyWideningAndAdd_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_AvxVnni_Vector128_MultiplyWideningAndAdd_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- It takes a long time to complete (on a non-AVX machine) -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Bmi1.X64/Bmi1.X64_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Bmi1.X64/Bmi1.X64_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Bmi1.X64_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Bmi1.X64/Bmi1.X64_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Bmi1.X64/Bmi1.X64_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Bmi1.X64_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Bmi1/Bmi1_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Bmi1/Bmi1_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Bmi1_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Bmi1/Bmi1_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Bmi1/Bmi1_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Bmi1_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Bmi2.X64/Bmi2.X64_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Bmi2.X64/Bmi2.X64_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Bmi2.X64_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Bmi2.X64/Bmi2.X64_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Bmi2.X64/Bmi2.X64_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Bmi2.X64_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Bmi2/Bmi2_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Bmi2/Bmi2_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Bmi2_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Bmi2/Bmi2_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Bmi2/Bmi2_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Bmi2_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Fma_Vector128/Fma_Vector128_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Fma_Vector128/Fma_Vector128_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Fma_Vector128_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Fma_Vector128/Fma_Vector128_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Fma_Vector128/Fma_Vector128_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Fma_Vector128_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Fma_Vector256/Fma_Vector256_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Fma_Vector256/Fma_Vector256_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Fma_Vector256_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Fma_Vector256/Fma_Vector256_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Fma_Vector256/Fma_Vector256_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Fma_Vector256_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/General/General_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/General/General_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_General_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/General/General_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/General/General_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_General_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Lzcnt.X64/Lzcnt.X64_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Lzcnt.X64/Lzcnt.X64_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Lzcnt_x64_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Lzcnt.X64/Lzcnt.X64_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Lzcnt.X64/Lzcnt.X64_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Lzcnt_x64_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Lzcnt/Lzcnt_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Lzcnt/Lzcnt_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Lzcnt_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Lzcnt/Lzcnt_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Lzcnt/Lzcnt_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Lzcnt_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Pclmulqdq/Pclmulqdq_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Pclmulqdq/Pclmulqdq_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Pclmulqdq_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Pclmulqdq/Pclmulqdq_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Pclmulqdq/Pclmulqdq_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Pclmulqdq_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Popcnt.X64/Popcnt.X64_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Popcnt.X64/Popcnt.X64_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Popcnt_x64_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Popcnt.X64/Popcnt.X64_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Popcnt.X64/Popcnt.X64_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Popcnt_x64_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Popcnt/Popcnt_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Popcnt/Popcnt_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Popcnt_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Popcnt/Popcnt_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Popcnt/Popcnt_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Popcnt_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_17073/GitHub_17073.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_17073/GitHub_17073.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_17435/GitHub_17435.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_17435/GitHub_17435.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_17957/GitHub_17957_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_17957/GitHub_17957_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_17957/GitHub_17957_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_17957/GitHub_17957_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_21666/GitHub_21666_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_21666/GitHub_21666_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_21666/GitHub_21666_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_21666/GitHub_21666_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_21855/GitHub_21855_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_21855/GitHub_21855_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_21855/GitHub_21855_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_21855/GitHub_21855_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_21899/GitHub_21899_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_21899/GitHub_21899_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_21899/GitHub_21899_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_21899/GitHub_21899_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_22815/GitHub_22815_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_22815/GitHub_22815_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_22815/GitHub_22815_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_22815/GitHub_22815_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_23438/GitHub_23438_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_23438/GitHub_23438_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_23438/GitHub_23438_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_23438/GitHub_23438_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse1.X64/Sse1.X64_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse1.X64/Sse1.X64_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse1.X64_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse1.X64/Sse1.X64_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse1.X64/Sse1.X64_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse1.X64_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse1/Sse1_handwritten_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse1/Sse1_handwritten_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse1_handwritten_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse1/Sse1_handwritten_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse1/Sse1_handwritten_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse1_handwritten_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse1/Sse1_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse1/Sse1_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse1_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse1/Sse1_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse1/Sse1_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse1_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse2.X64/Sse2.X64_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse2.X64/Sse2.X64_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse2.X64_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse2.X64/Sse2.X64_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse2.X64/Sse2.X64_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse2.X64_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse2.X64/StoreNonTemporal_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse2.X64/StoreNonTemporal_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse2.X64.StoreNonTemporal_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse2.X64/StoreNonTemporal_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse2.X64/StoreNonTemporal_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse2.X64.StoreNonTemporal_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse2/Sse2_handwritten_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse2/Sse2_handwritten_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse2_handwritten_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse2/Sse2_handwritten_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse2/Sse2_handwritten_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse2_handwritten_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse2/Sse2_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse2/Sse2_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse2_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse2/Sse2_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse2/Sse2_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse2_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse3/Sse3_handwritten_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse3/Sse3_handwritten_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse3_handwritten_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse3/Sse3_handwritten_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse3/Sse3_handwritten_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse3_handwritten_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse3/Sse3_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse3/Sse3_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse3_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse3/Sse3_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse3/Sse3_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse3_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse41.X64/Sse41.X64_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse41.X64/Sse41.X64_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse41.X64_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse41.X64/Sse41.X64_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse41.X64/Sse41.X64_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse41.X64_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse41/Sse41_handwritten_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse41/Sse41_handwritten_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse41_handwritten_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse41/Sse41_handwritten_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse41/Sse41_handwritten_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse41_handwritten_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse41/Sse41_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse41/Sse41_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse41_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse41/Sse41_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse41/Sse41_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse41_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse41_Overloaded/Sse41_Overloaded_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse41_Overloaded/Sse41_Overloaded_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse41_Overloaded_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse41_Overloaded/Sse41_Overloaded_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse41_Overloaded/Sse41_Overloaded_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse41_Overloaded_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse42.X64/Crc32_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse42.X64/Crc32_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Crc32_X64_handwritten_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse42.X64/Crc32_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse42.X64/Crc32_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Crc32_X64_handwritten_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse42/Crc32_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse42/Crc32_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Crc32_handwritten_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse42/Crc32_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse42/Crc32_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Crc32_handwritten_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse42/Sse42_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse42/Sse42_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse42_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse42/Sse42_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse42/Sse42_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Sse42_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Ssse3/Ssse3_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Ssse3/Ssse3_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Ssse3_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Ssse3/Ssse3_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Ssse3/Ssse3_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Ssse3_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/X86Base.X64/X86Base.X64_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/X86Base.X64/X86Base.X64_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_X86Base.X64_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- https://github.com/dotnet/runtime/issues/73454;https://github.com/dotnet/runtime/pull/61707#issuecomment-973122341 -->
     <MonoAotIncompatible>true</MonoAotIncompatible>

--- a/src/tests/JIT/HardwareIntrinsics/X86/X86Base.X64/X86Base.X64_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/X86Base.X64/X86Base.X64_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_X86Base.X64_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- https://github.com/dotnet/runtime/issues/73454;https://github.com/dotnet/runtime/pull/61707#issuecomment-973122341 -->
     <MonoAotIncompatible>true</MonoAotIncompatible>

--- a/src/tests/JIT/HardwareIntrinsics/X86/X86Base/CpuId_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/X86Base/CpuId_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_CpuId_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/X86Base/CpuId_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/X86Base/CpuId_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_CpuId_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/X86Base/Pause_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/X86Base/Pause_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Pause_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!-- https://github.com/dotnet/runtime/issues/73454;https://github.com/dotnet/runtime/pull/61707#issuecomment-973122341 -->

--- a/src/tests/JIT/HardwareIntrinsics/X86/X86Base/Pause_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/X86Base/Pause_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Pause_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!-- https://github.com/dotnet/runtime/issues/73454;https://github.com/dotnet/runtime/pull/61707#issuecomment-973122341 -->

--- a/src/tests/JIT/HardwareIntrinsics/X86/X86Base/X86Base_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/X86Base/X86Base_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_X86Base_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- https://github.com/dotnet/runtime/issues/73454;https://github.com/dotnet/runtime/pull/61707#issuecomment-973122341 -->
     <MonoAotIncompatible>true</MonoAotIncompatible>

--- a/src/tests/JIT/HardwareIntrinsics/X86/X86Base/X86Base_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/X86Base/X86Base_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_X86Base_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- https://github.com/dotnet/runtime/issues/73454;https://github.com/dotnet/runtime/pull/61707#issuecomment-973122341 -->
     <MonoAotIncompatible>true</MonoAotIncompatible>

--- a/src/tests/JIT/HardwareIntrinsics/X86/X86Serialize/Serialize_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/X86Serialize/Serialize_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Serialize_r</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/X86Serialize/Serialize_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/X86Serialize/Serialize_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>X86_Serialize_ro</AssemblyName>
-    <BuildAsStandalone>false</BuildAsStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
- Stop unconditionally settings `BuildAsStandalone=false` in the individual HardwareIntrinsics tests. This overrides an environment variable setting `BuildAsStandalone=true` (but not `msbuild /p`).  The HardwareIntrinsics `Directory.Build.props` already sets `BuildAsStandalone=false` as a *default*. (from #74886)
- Add `BuildAsStandalone` to the check in the top-level `Directory.Build.props` for setting `OutputType=Exe`. It already included `RequiresProcessIsolation`. Note that there is already code for `IsMergedTestRunnerAssembly` cases checking that they are *not* `BuildAsStandalone`, so this new logic is only applied to non-`IsMergedTestRunnerAssembly` cases.

Fixes #81984