### PR TITLE
add source-build pre-built detection

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -16,6 +16,7 @@
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
+    <add key="dotnet-libraries-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries-transport/nuget/v3/index.json" />
     <!-- TODO: Remove dotnet7 feeds when dependencies publish into dotnet8 feeds: https://github.com/dotnet/runtime/issues/63375. -->
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="dotnet7-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7-transport/nuget/v3/index.json" />

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -38,6 +38,7 @@
       <InnerBuildArgs>$(InnerBuildArgs) --nodereuse false</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) --warnAsError false</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) --outputrid $(TargetRid)</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:ArcadeBuildFromSource=true</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) /p:RuntimeOS=$(RuntimeOS)</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(OfficialBuildId)' != ''">$(InnerBuildArgs) /p:OfficialBuildId=$(OfficialBuildId)</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(ContinuousIntegrationBuild)' != ''">$(InnerBuildArgs) /p:ContinuousIntegrationBuild=$(ContinuousIntegrationBuild)</InnerBuildArgs>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -8,9 +8,6 @@
     <Usage Id="Microsoft.NETCore.App.Crossgen2.linux-x64" Version="8.*" />
     <Usage Id="Microsoft.NETCore.App.Runtime.linux-x64" Version="8.*" />
     <!-- Should be removed as part of https://github.com/dotnet/runtime/issues/82298 -->
-    <Usage Id="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" IsDirectDependency="true" IsAutoReferenced="true" />
-    <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="1.0.3" />
-    <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="1.0.3" />
-    <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" />
+    <Usage Id="Microsoft.NETFramework.ReferenceAssemblies*" Version="1.0.3" />
   </Usages>
 </UsageData>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,5 +1,16 @@
+<!-- See aka.ms/dotnet/prebuilts for guidance on what pre-builts are and how to eliminate them. -->
 <UsageData>
   <IgnorePatterns>
-    <UsagePattern IdentityGlob="*/*" />
+    <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*" />
   </IgnorePatterns>
+  <Usages>
+    <!-- Allowed and pinned to major version due to https://github.com/dotnet/source-build/issues/3228 -->
+    <Usage Id="Microsoft.NETCore.App.Crossgen2.linux-x64" Version="8.*" />
+    <Usage Id="Microsoft.NETCore.App.Runtime.linux-x64" Version="8.*" />
+    <!-- Should be removed as part of https://github.com/dotnet/runtime/issues/82298 -->
+    <Usage Id="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" IsDirectDependency="true" IsAutoReferenced="true" />
+    <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="1.0.3" />
+    <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="1.0.3" />
+    <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" />
+  </Usages>
 </UsageData>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,6 +5,11 @@
       <Sha>31f422237eabbd5c89ecbd0f4a6f53e2c495422f</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.23053.1">
+      <Uri>https://github.com/dotnet/source-build-externals</Uri>
+      <Sha>cec4a8acb52c92bae0425385016df5ac957fe616</Sha>
+      <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
+    </Dependency>
       <Dependency Name="Microsoft.NETCore.Runtime.ICU.Transport" Version="8.0.0-preview.2.23113.1">
       <Uri>https://github.com/dotnet/icu</Uri>
       <Sha>71423dd665d17bd333d0028ce9c6f169f88ab59b</Sha>
@@ -110,11 +115,6 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.23053.1">
-      <Uri>https://github.com/dotnet/source-build-externals</Uri>
-      <Sha>cec4a8acb52c92bae0425385016df5ac957fe616</Sha>
-      <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
-    </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23115.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>83284ab08840fe5f429ecd9fa935e81527023553</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,6 +1,11 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NETCore.Runtime.ICU.Transport" Version="8.0.0-preview.2.23113.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.22616.1">
+      <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
+      <Sha>31f422237eabbd5c89ecbd0f4a6f53e2c495422f</Sha>
+      <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
+    </Dependency>
+      <Dependency Name="Microsoft.NETCore.Runtime.ICU.Transport" Version="8.0.0-preview.2.23113.1">
       <Uri>https://github.com/dotnet/icu</Uri>
       <Sha>71423dd665d17bd333d0028ce9c6f169f88ab59b</Sha>
     </Dependency>
@@ -76,7 +81,12 @@
       <Uri>https://github.com/dotnet/llvm-project</Uri>
       <Sha>76f334f354eb653a7b409a5319b591ea09df5a43</Sha>
     </Dependency>
-    <Dependency Name="System.CommandLine" Version="2.0.0-beta4.22355.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.command-line-api" Version="0.1.356401">
+      <Uri>https://github.com/dotnet/command-line-api</Uri>
+      <Sha>5618b2d243ccdeb5c7e50a298b33b13036b4351b</Sha>
+      <SourceBuild RepoName="command-line-api" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="System.CommandLine" Version="2.0.0-beta4.22564.1">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>5618b2d243ccdeb5c7e50a298b33b13036b4351b</Sha>
     </Dependency>
@@ -100,9 +110,25 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.23053.1">
+      <Uri>https://github.com/dotnet/source-build-externals</Uri>
+      <Sha>cec4a8acb52c92bae0425385016df5ac957fe616</Sha>
+      <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23115.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>83284ab08840fe5f429ecd9fa935e81527023553</Sha>
+      <SourceBuild RepoName="arcade" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.2.0-beta-23066-01" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
+      <Uri>https://github.com/dotnet/sourcelink</Uri>
+      <Sha>d047202874ad79d72c75b6354c0f8a9a12d1b054</Sha>
+      <SourceBuild RepoName="sourcelink" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.23066.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
+      <Uri>https://github.com/dotnet/xliff-tasks</Uri>
+      <Sha>ca611a68bb48cedf72a782d41622453cb2dab100</Sha>
+      <SourceBuild RepoName="xliff-tasks" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="8.0.0-beta.23115.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
@@ -279,6 +305,7 @@
     <Dependency Name="System.Text.Json" Version="8.0.0-preview.2.23112.4">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>252018c3d3fffdb592413cf61d5b80cf751e0a59</Sha>
+      <SourceBuild RepoName="runtime" ManagedOnly="false" />
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="8.0.0-preview.2.23112.4">
       <Uri>https://github.com/dotnet/runtime</Uri>
@@ -331,6 +358,7 @@
     <Dependency Name="Microsoft.CodeAnalysis" Version="4.6.0-1.23073.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>6acaa7b7c0efea8ea292ca26888c0346fbf8b0c1</Sha>
+      <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.6.0-1.23073.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>


### PR DESCRIPTION
Resolves 

In progress of being added to SBRP:
- [ ] `Microsoft.CodeAnalysis 4.4.0` 
- [ ] `Microsoft.Build 17.3.2`
- [ ] `Microsoft.Extensions.DependencyModel 6.0.0`
- [x] `System.Reflection.Metadata 6.0.1` -> https://github.com/dotnet/source-build-reference-packages/pull/506

Allowed pre-builts:
 - `Microsoft.NETCore.App.Crossgen2` and `Microsoft.NETCore.App.Runtime` -> https://github.com/dotnet/source-build/issues/3228
 - `Microsoft.NETFramework.ReferenceAssemblies` -> https://github.com/dotnet/runtime/issues/82298

Using old intermediates:
 - `System.CommandLine 2.0.0-beta4.22355.1` -> see discussion in https://github.com/dotnet/runtime/issues/81468