### PR TITLE
Fix processing of x86 test results

### DIFF
--- a/src/tests/run.py
+++ b/src/tests/run.py
@@ -1143,6 +1143,10 @@ def find_test_from_name(host_os, test_location, test_name):
     for index, item in enumerate(loc_split):
         if not append:
             test_path = os.path.join(starting_path, item)
+            # Ensure the joined path is correct. Avoid forming /Vector256/1/ for Vector256_1
+            # where both Vector256 and Vector256_1 are valid dirs.
+            if not os.path.isdir(os.path.dirname(test_path)):
+                test_path = starting_path + "_" + item
         else:
             append = False
             test_path, size_of_largest_name_file = match_filename(starting_path + "_" + item)


### PR DESCRIPTION
While searching the directory for tests, run.py constructs the filenames. It constructs a path by joining parts of the string split with `_`. While doing so, run.py assumes that if the constructed string is a filename or dir then the next part of the string is a subdirectory. Thus, a path construction may continue by joining the next item as a full or partial name of a subdirectory. This assumption fails in the following scenario. While processing the location `.../Vector256_1/Vector256_1_ro/Vector256_1_ro.cmd` the `.../Vector256` matches with the existing dir so the script constructs the path incorrectly as `.../Vector256/1/Vector256`.