### PR TITLE
Include LibraryImportGenerator in WindowsDesktop transport package

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -246,7 +246,7 @@
       <!-- Add ReferenceCopyLocalPaths for ProjectReferences which are flagged as Pack="true" into the package. -->
       <_projectReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('Pack', 'true'))" />
       <TfmSpecificPackageFile Include="@(_projectReferenceCopyLocalPaths)"
-                              PackagePath="$([MSBuild]::ValueOrDefault('%(ReferenceCopyLocalPaths.PackagePath)', '$(BuildOutputTargetFolder)\$(_referringTargetFramework)\'))" />
+                              PackagePath="$([MSBuild]::ValueOrDefault('%(_projectReferenceCopyLocalPaths.PackagePath)', '$(BuildOutputTargetFolder)\$(_referringTargetFramework)\'))%(_projectReferenceCopyLocalPaths.DestinationSubDirectory)" />
       <TfmSpecificDebugSymbolsFile Include="@(TfmSpecificPackageFile->WithMetadataValue('Extension', '.pdb'))"
                                    TargetPath="/%(TfmSpecificPackageFile.PackagePath)/%(Filename)%(Extension)"
                                    TargetFramework="$(_referringTargetFramework)"

--- a/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
+++ b/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
@@ -27,5 +27,13 @@
                       Pack="true"
                       Private="true"
                       IncludeReferenceAssemblyInPackage="true" />
+    <!-- Include the LibraryImportGenerator in order for WinForms's System.Drawing.Common library to have
+         access to the source generator which depends on it for its net6.0 build. -->
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\LibraryImportGenerator\LibraryImportGenerator.csproj;
+                               $(LibrariesProjectRoot)System.Runtime.InteropServices\gen\Microsoft.Interop.SourceGeneration\Microsoft.Interop.SourceGeneration.csproj"
+                      PrivateAssets="all"
+                      Pack="true"
+                      Private="true"
+                      PackagePath="tools\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Include the LibraryImportGenerator in order for WinForms's System.Drawing.Common library to have access to the source generator which depends on it for its net6.0 build.

Unblocks https://github.com/dotnet/winforms/pull/8633/

On the consuming side, the following msbuild code adds the source generator to the compiler:

```xml
  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
    <PackageDownload Include="Microsoft.Internal.Runtime.WindowsDesktop.Transport" Version="[$(MicrosoftInternalRuntimeWindowsDesktopTransportPackageVersion)]" />
    <Analyzer Include="$(NuGetPackageRoot)microsoft.internal.runtime.windowsdesktop.transport\$(MicrosoftInternalRuntimeWindowsDesktopTransportPackageVersion)\tools\Microsoft.Interop.LibraryImportGenerator.dll" />
    <Analyzer Include="$(NuGetPackageRoot)microsoft.internal.runtime.windowsdesktop.transport\$(MicrosoftInternalRuntimeWindowsDesktopTransportPackageVersion)\tools\Microsoft.Interop.SourceGeneration.dll" />
  </ItemGroup>
```