### PR TITLE
Optimize type check efficiency with .IsValueType

### DIFF
--- a/src/libraries/Common/tests/System/Collections/IListTest.cs
+++ b/src/libraries/Common/tests/System/Collections/IListTest.cs
@@ -1742,7 +1742,7 @@ namespace Tests.Collections
 
         protected override sealed bool ItemsMustBeNonNull
         {
-            get { return default(T) != null; }
+            get { return typeof(T).IsValueType; }
         }
 
         protected override sealed object GenerateItem()

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.cs
@@ -19,7 +19,7 @@ namespace System.Collections.Immutable
 #if NETCOREAPP
             return typeof(T).IsValueType;
 #else
-            if (default(T) != null)
+            if (typeof(T).IsValueType)
             {
                 return true;
             }

--- a/src/libraries/System.Collections/tests/Generic/Comparers/Comparer.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/Comparers/Comparer.Generic.Tests.cs
@@ -78,7 +78,7 @@ namespace System.Collections.Generic.Tests
             // throw if both inputs are non-null and one of them is not of type T
             IComparer comparer = Comparer<T>.Default;
             StrongBox<T> notOfTypeT = new StrongBox<T>(default(T));
-            if (default(T) != null) // if default(T) is null these asserts will fail as IComparer.Compare returns early if either side is null
+            if (typeof(T).IsValueType) // if default(T) is null these asserts will fail as IComparer.Compare returns early if either side is null
             {
                 AssertExtensions.Throws<ArgumentException>(null, () => comparer.Compare(notOfTypeT, default(T))); // lhs is the problem
                 AssertExtensions.Throws<ArgumentException>(null, () => comparer.Compare(default(T), notOfTypeT)); // rhs is the problem

--- a/src/libraries/System.Collections/tests/Generic/Comparers/EqualityComparer.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/Comparers/EqualityComparer.Generic.Tests.cs
@@ -85,7 +85,7 @@ namespace System.Collections.Generic.Tests
             Assert.Equal(default(T) == null, comparer.Equals(null, default(T)));
             Assert.True(comparer.Equals(null, null));
 
-            if (default(T) != null) // if default(T) is null this assert will fail as IEqualityComparer.Equals returns early if either input is null
+            if (typeof(T).IsValueType) // if default(T) is null this assert will fail as IEqualityComparer.Equals returns early if either input is null
             {
                 AssertExtensions.Throws<ArgumentException>(null, () => comparer.Equals(notOfTypeT, default(T))); // lhs is the problem
                 AssertExtensions.Throws<ArgumentException>(null, () => comparer.Equals(default(T), notOfTypeT)); // rhs is the problem

--- a/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/ReadOnlyCollectionBuilder.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/ReadOnlyCollectionBuilder.cs
@@ -451,7 +451,7 @@ namespace System.Runtime.CompilerServices
 
         private static void ValidateNullValue(object? value, string argument)
         {
-            if (value == null && default(T) != null)
+            if (value == null && typeof(T).IsValueType)
             {
                 throw Error.InvalidNullValue(typeof(T), argument);
             }

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Enumerables/AggregationMinMaxHelpers.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Enumerables/AggregationMinMaxHelpers.cs
@@ -31,7 +31,7 @@ namespace System.Linq
 
             AssociativeAggregationOperator<T, Pair<bool, T>, T> aggregation =
                 new AssociativeAggregationOperator<T, Pair<bool, T>, T>(source, new Pair<bool, T>(false, default!), null,
-                                                                        true, intermediateReduce, finalReduce, resultSelector, default(T) != null, QueryAggregationOptions.AssociativeCommutative);
+                                                                        true, intermediateReduce, finalReduce, resultSelector, typeof(T).IsValueType, QueryAggregationOptions.AssociativeCommutative);
 
             return aggregation.Aggregate();
         }
@@ -71,7 +71,7 @@ namespace System.Linq
                            // the existing accumulated result is equal to the sign requested by the function factory,
                            // we will return a new pair that contains the current element as the best item.  We will
                            // ignore null elements (for reference and nullable types) in the input stream.
-                           if ((default(T) != null || element != null) &&
+                           if ((typeof(T).IsValueType || element != null) &&
                                (!accumulator.First || Util.Sign(comparer.Compare(element, accumulator.Second)) == sign))
                            {
                                return new Pair<bool, T>(true, element);
@@ -98,7 +98,7 @@ namespace System.Linq
                            if (element.First &&
                                (!accumulator.First || Util.Sign(comparer.Compare(element.Second, accumulator.Second)) == sign))
                            {
-                               Debug.Assert(default(T) != null || element.Second != null, "nulls unexpected in final reduce");
+                               Debug.Assert(typeof(T).IsValueType || element.Second != null, "nulls unexpected in final reduce");
                                return new Pair<bool, T>(true, element.Second);
                            }
 

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -232,7 +232,7 @@ namespace System
 
             nint index = 0; // Use nint for arithmetic to avoid unnecessary 64->32->64 truncations
 
-            if (default(T) != null || (object?)value != null)
+            if (typeof(T).IsValueType || (object?)value != null)
             {
                 Debug.Assert(value is not null);
 
@@ -303,7 +303,7 @@ namespace System
             Debug.Assert(length >= 0);
 
             nint index = 0; // Use nint for arithmetic to avoid unnecessary 64->32->64 truncations
-            if (default(T) != null || (object?)value != null)
+            if (typeof(T).IsValueType || (object?)value != null)
             {
                 Debug.Assert(value is not null);
 
@@ -393,7 +393,7 @@ namespace System
 
             T lookUp;
             int index = 0;
-            if (default(T) != null || ((object?)value0 != null && (object?)value1 != null))
+            if (typeof(T).IsValueType || ((object?)value0 != null && (object?)value1 != null))
             {
                 Debug.Assert(value0 is not null && value1 is not null);
 
@@ -499,7 +499,7 @@ namespace System
 
             T lookUp;
             int index = 0;
-            if (default(T) != null || ((object?)value0 != null && (object?)value1 != null && (object?)value2 != null))
+            if (typeof(T).IsValueType || ((object?)value0 != null && (object?)value1 != null && (object?)value2 != null))
             {
                 Debug.Assert(value0 is not null && value1 is not null && value2 is not null);
 
@@ -713,7 +713,7 @@ namespace System
         {
             Debug.Assert(length >= 0);
 
-            if (default(T) != null || (object?)value != null)
+            if (typeof(T).IsValueType || (object?)value != null)
             {
                 Debug.Assert(value is not null);
 
@@ -797,7 +797,7 @@ namespace System
             Debug.Assert(length >= 0);
 
             T lookUp;
-            if (default(T) != null || ((object?)value0 != null && (object?)value1 != null))
+            if (typeof(T).IsValueType || ((object?)value0 != null && (object?)value1 != null))
             {
                 Debug.Assert(value0 is not null && value1 is not null);
 
@@ -902,7 +902,7 @@ namespace System
             Debug.Assert(length >= 0);
 
             T lookUp;
-            if (default(T) != null || ((object?)value0 != null && (object?)value1 != null && (object?)value2 != null))
+            if (typeof(T).IsValueType || ((object?)value0 != null && (object?)value1 != null && (object?)value2 != null))
             {
                 Debug.Assert(value0 is not null && value1 is not null && value2 is not null);
 


### PR DESCRIPTION
### What
This pull request replaces cases of default(T) != null with typeof(T).IsValueType for better assembly performance, as mentioned in #82291.

### Effect
Before
<img width="1418" alt="Before" src="https://user-images.githubusercontent.com/102875484/219712034-94f4fa34-43e4-490a-839c-5883fcf8358f.png">

After
<img width="1439" alt="After" src="https://user-images.githubusercontent.com/102875484/219712037-225d1ecf-63a8-4fa9-8428-67b8e45954f5.png">

This is my first time contributing to open source projects. Please let me know if there are any formatting issues.

Fix #82291