### PR TITLE
[tests] Retain OutDir for ioslike tests

### DIFF
--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -101,7 +101,7 @@ jobs:
                 $(_additionalBuildArguments)
           displayName: Restore and Build Product
 
-        - ${{ if in(parameters.osGroup, 'osx', 'ios', 'tvos') }}:
+        - ${{ if in(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator') }}:
           - script: |
               du -sh $(Build.SourcesDirectory)/*
               df -h

--- a/eng/testing/tests.ioslike.targets
+++ b/eng/testing/tests.ioslike.targets
@@ -179,8 +179,6 @@
                   SourceDirectory="$(_AppBundleDir)"
                   DestinationFile="$([MSBuild]::NormalizePath('$(TestArchiveTestsDir)', '$(TestProjectName).zip'))"
                   Overwrite="true" />
-
-    <RemoveDir Condition="'$(NeedsToBuildAppsOnHelixLocal)' != 'true'" Directories="$(OutDir)" />
   </Target>
 
 </Project>

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -323,8 +323,6 @@
     <!-- App Crash https://github.com/dotnet/runtime/issues/53624 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Requests/tests/System.Net.Requests.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj" />
-    <!-- Reference deleted by _CopyTestArchive https://github.com/dotnet/runtime/issues/80976 -->
-    <ProjectExclusions Include="$(RepoRoot)/src/tests/FunctionalTests/iOS/Simulator/StartupHook/iOS.Simulator.StartupHook.Test.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(RunDisabledWasmTests)' != 'true' and '$(RunAOTCompilation)' != 'true'">


### PR DESCRIPTION
`$(OutDir)` was removed in the ioslike tests build for the purpose of saving space, however some projects that include references will need assemblies in the `$(OutDir)` directory for the `CoreCompile` target. In the libraries tests, there is a workaround for this. This PR examines whether or not the `$(OutDir)` needs to be removed, using a metric of <100MB remaining when it is not removed to determine that it should continue to be removed.