### PR TITLE
[NativeAOT] Implement thunk page generation and mapping for iOS-like platforms

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -158,6 +158,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-L/usr/local/lib -lgssapi_krb5" Condition="'$(_targetOS)' == 'freebsd'" />
       <!-- FreeBSD's inotify is an installed package and not found in default libraries  -->
       <LinkerArg Include="-L/usr/local/lib -linotify" Condition="'$(_targetOS)' == 'freebsd'" />
+      <LinkerArg Include="-Wl,-segprot,__THUNKS,rx,rx" Condition="'$(_IsiOSLikePlatform)' == 'true'" />
 
       <LinkerArg Include="@(NativeFramework->'-framework %(Identity)')" Condition="'$(_IsApplePlatform)' == 'true'" />
     </ItemGroup>

--- a/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
@@ -6,7 +6,13 @@ project(Runtime)
 # Include auto-generated files on include path
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-add_definitions(-DFEATURE_RX_THUNKS)
+if (CLR_CMAKE_TARGET_APPLE AND NOT CLR_CMAKE_TARGET_OSX)
+  list(APPEND RUNTIME_SOURCES_ARCH_ASM
+    ${ARCH_SOURCES_DIR}/ThunkPoolThunks.${ASM_SUFFIX}
+  )
+else()
+  add_definitions(-DFEATURE_RX_THUNKS)
+endif()
 
 if (CLR_CMAKE_TARGET_WIN32)
   if (CLR_CMAKE_HOST_ARCH_ARM OR CLR_CMAKE_HOST_ARCH_ARM64)

--- a/src/coreclr/nativeaot/Runtime/amd64/ThunkPoolThunks.S
+++ b/src/coreclr/nativeaot/Runtime/amd64/ThunkPoolThunks.S
@@ -1,0 +1,126 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.intel_syntax noprefix
+#include <unixasmmacros.inc>
+
+//;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;  DATA SECTIONS  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+#define THUNK_CODESIZE 0x10 // 3 instructions, 4 bytes each (and we also have 4 bytes of padding)
+#define THUNK_DATASIZE 0x10 // 2 qwords
+
+#define POINTER_SIZE 0x08
+
+#define THUNKS_MAP_SIZE 0x8000
+
+#define PAGE_SIZE 0x1000
+#define PAGE_SIZE_LOG2 12
+
+// THUNK_POOL_NUM_THUNKS_PER_PAGE = min(PAGE_SIZE / THUNK_CODESIZE, (PAGE_SIZE - POINTER_SIZE) / THUNK_DATASIZE)
+#define THUNK_POOL_NUM_THUNKS_PER_PAGE 0xff
+
+//;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Thunk Pages ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+.macro THUNKS_PAGE_BLOCK
+    IN_PAGE_INDEX = 0
+    .rept THUNK_POOL_NUM_THUNKS_PER_PAGE
+
+    .p2align 4
+
+    // Set r10 to the address of the current thunk's data block.
+    lea     r10, [rip + THUNKS_MAP_SIZE - 7]
+
+    // jump to the location pointed at by the last qword in the data page
+    jmp     qword ptr[r10 + PAGE_SIZE - POINTER_SIZE - (THUNK_DATASIZE * IN_PAGE_INDEX)]
+
+    IN_PAGE_INDEX = IN_PAGE_INDEX + 1
+    .endr
+.endm
+
+#ifdef TARGET_APPLE
+    // Create two segments in the Mach-O file:
+    // __THUNKS with executable permissions
+    // __THUNKS_DATA with read/write permissions
+
+    .section __THUNKS,__thunks,regular,pure_instructions
+    .p2align PAGE_SIZE_LOG2
+PATCH_LABEL ThunkPool
+    .rept (THUNKS_MAP_SIZE / PAGE_SIZE)
+    .p2align PAGE_SIZE_LOG2
+    THUNKS_PAGE_BLOCK
+    .endr
+    .p2align PAGE_SIZE_LOG2
+    .section __THUNKS_DATA,__thunks,regular
+    .p2align PAGE_SIZE_LOG2
+    .space THUNKS_MAP_SIZE
+    .p2align PAGE_SIZE_LOG2
+#else
+#error Unsupported OS
+#endif
+
+//;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; General Helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+//
+// IntPtr RhpGetThunksBase()
+//
+LEAF_ENTRY RhpGetThunksBase
+    // Return the address of the first thunk pool to the caller (this is really the base address)
+    lea     rax, [rip + C_FUNC(ThunkPool)]
+    ret
+LEAF_END RhpGetThunksBase
+
+//
+// int RhpGetNumThunksPerBlock()
+//
+LEAF_ENTRY RhpGetNumThunksPerBlock
+    mov     rax, THUNK_POOL_NUM_THUNKS_PER_PAGE
+    ret
+LEAF_END RhpGetNumThunksPerBlock
+
+//
+// int RhpGetThunkSize()
+//
+LEAF_ENTRY RhpGetThunkSize
+    mov     rax, THUNK_CODESIZE
+    ret
+LEAF_END RhpGetThunkSize
+
+//
+// int RhpGetNumThunkBlocksPerMapping()
+//
+LEAF_ENTRY RhpGetNumThunkBlocksPerMapping
+    mov     rax, (THUNKS_MAP_SIZE / PAGE_SIZE)
+    ret
+LEAF_END RhpGetNumThunkBlocksPerMapping
+
+//
+// int RhpGetThunkBlockSize
+//
+LEAF_ENTRY RhpGetThunkBlockSize
+    mov     rax, PAGE_SIZE
+    ret
+LEAF_END RhpGetThunkBlockSize
+
+//
+// IntPtr RhpGetThunkDataBlockAddress(IntPtr thunkStubAddress)
+//
+LEAF_ENTRY RhpGetThunkDataBlockAddress
+    mov     rax, rdi
+    mov     rdi, PAGE_SIZE - 1
+    not     rdi
+    and     rax, rdi
+    add     rax, THUNKS_MAP_SIZE
+    ret
+LEAF_END RhpGetThunkDataBlockAddress
+
+//
+// IntPtr RhpGetThunkStubsBlockAddress(IntPtr thunkDataAddress)
+//
+LEAF_ENTRY RhpGetThunkStubsBlockAddress
+    mov     rax, rdi
+    mov     rdi, PAGE_SIZE - 1
+    not     rdi
+    and     rax, rdi
+    sub     rax, THUNKS_MAP_SIZE
+    ret
+LEAF_END RhpGetThunkStubsBlockAddress

--- a/src/coreclr/nativeaot/Runtime/arm64/ThunkPoolThunks.S
+++ b/src/coreclr/nativeaot/Runtime/arm64/ThunkPoolThunks.S
@@ -1,0 +1,133 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <unixasmmacros.inc>
+
+//;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;  DATA SECTIONS  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+#define THUNK_CODESIZE 0x10 // 3 instructions, 4 bytes each (and we also have 4 bytes of padding)
+#define THUNK_DATASIZE 0x10 // 2 qwords
+
+#define POINTER_SIZE 0x08
+
+#define THUNKS_MAP_SIZE 0x8000
+
+#ifdef TARGET_APPLE
+#define PAGE_SIZE 0x4000
+#define PAGE_SIZE_LOG2 14
+#else
+#error Unsupported OS
+#endif
+
+// THUNK_POOL_NUM_THUNKS_PER_PAGE = min(PAGE_SIZE / THUNK_CODESIZE, (PAGE_SIZE - POINTER_SIZE) / THUNK_DATASIZE)
+#define THUNK_POOL_NUM_THUNKS_PER_PAGE 0x3ff
+
+//;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Thunk Pages ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+.macro THUNKS_PAGE_BLOCK
+    IN_PAGE_INDEX = 0
+    .rept THUNK_POOL_NUM_THUNKS_PER_PAGE
+
+    // Set xip0 to the address of the current thunk's data block.
+    adr      xip0, THUNKS_MAP_SIZE
+
+    // start                                        : xip0 points to the current thunks first data cell in the data page
+    // set xip0 to beginning of data page           : xip0 <- xip0 - (THUNK_DATASIZE * current thunk's index)
+    // fix offset to point to last QWROD in page    : xip1 <- [xip0 + PAGE_SIZE - POINTER_SIZE]
+    // tailcall to the location pointed at by the last qword in the data page
+    ldr      xip1, [xip0, #(PAGE_SIZE - POINTER_SIZE - (THUNK_DATASIZE * IN_PAGE_INDEX))]
+    br       xip1
+
+    brk     0xf000      // Stubs need to be 16-byte aligned for CFG table. Filling padding with a
+                        // deterministic brk instruction, instead of having it just filled with zeros.
+
+    IN_PAGE_INDEX = IN_PAGE_INDEX + 1
+    .endr
+.endm
+
+#ifdef TARGET_APPLE
+    // Create two segments in the Mach-O file:
+    // __THUNKS with executable permissions
+    // __THUNKS_DATA with read/write permissions
+
+    .section __THUNKS,__thunks,regular,pure_instructions
+    .p2align PAGE_SIZE_LOG2
+PATCH_LABEL ThunkPool
+    .rept (THUNKS_MAP_SIZE / PAGE_SIZE)
+    .p2align PAGE_SIZE_LOG2
+    THUNKS_PAGE_BLOCK
+    .endr
+    .p2align PAGE_SIZE_LOG2
+    .section __THUNKS_DATA,__thunks,regular
+    .p2align PAGE_SIZE_LOG2
+    .space THUNKS_MAP_SIZE
+    .p2align PAGE_SIZE_LOG2
+#else
+#error Unsupported OS
+#endif
+
+//;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; General Helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+//
+// IntPtr RhpGetThunksBase()
+//
+LEAF_ENTRY RhpGetThunksBase
+    // Return the address of the first thunk pool to the caller (this is really the base address)
+    adrp     x0, C_FUNC(ThunkPool)@PAGE
+    add      x0, x0, C_FUNC(ThunkPool)@PAGEOFF
+    ret
+LEAF_END RhpGetThunksBase
+
+//
+// int RhpGetNumThunksPerBlock()
+//
+LEAF_ENTRY RhpGetNumThunksPerBlock
+    mov     x0, THUNK_POOL_NUM_THUNKS_PER_PAGE
+    ret
+LEAF_END RhpGetNumThunksPerBlock
+
+//
+// int RhpGetThunkSize()
+//
+LEAF_ENTRY RhpGetThunkSize
+    mov     x0, THUNK_CODESIZE
+    ret
+LEAF_END RhpGetThunkSize
+
+//
+// int RhpGetNumThunkBlocksPerMapping()
+//
+LEAF_ENTRY RhpGetNumThunkBlocksPerMapping
+    mov     x0, (THUNKS_MAP_SIZE / PAGE_SIZE)
+    ret
+LEAF_END RhpGetNumThunkBlocksPerMapping
+
+//
+// int RhpGetThunkBlockSize
+//
+LEAF_ENTRY RhpGetThunkBlockSize
+    mov     x0, PAGE_SIZE
+    ret
+LEAF_END RhpGetThunkBlockSize
+
+//
+// IntPtr RhpGetThunkDataBlockAddress(IntPtr thunkStubAddress)
+//
+LEAF_ENTRY RhpGetThunkDataBlockAddress
+    mov     x12, PAGE_SIZE - 1
+    bic     x0, x0, x12
+    mov     x12, THUNKS_MAP_SIZE
+    add     x0, x0, x12
+    ret
+LEAF_END RhpGetThunkDataBlockAddress
+
+//
+// IntPtr RhpGetThunkStubsBlockAddress(IntPtr thunkDataAddress)
+//
+LEAF_ENTRY RhpGetThunkStubsBlockAddress
+    mov     x12, PAGE_SIZE - 1
+    bic     x0, x0, x12
+    mov     x12, THUNKS_MAP_SIZE
+    sub     x0, x0, x12
+    ret
+LEAF_END RhpGetThunkStubsBlockAddress

--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -55,8 +55,7 @@
 #endif
 
 #ifdef TARGET_APPLE
-#include <sys/proc_info.h>
-#include <libproc.h>
+#include <minipal/getexepath.h>
 #include <mach-o/getsect.h>
 #endif
 
@@ -503,18 +502,13 @@ static const struct section_64 *thunks_data_section;
 REDHAWK_PALEXPORT UInt32_BOOL REDHAWK_PALAPI PalAllocateThunksFromTemplate(HANDLE hTemplateModule, uint32_t templateRva, size_t templateSize, void** newThunksOut)
 {
 #ifdef TARGET_APPLE
-    char pathbuf[PROC_PIDPATHINFO_MAXSIZE];
-    int ret;
     int f;
+    char *exepath;
 
-    // NOTE: We ignore hTemplateModule, it is alwyas the current module
-    ret = proc_pidpath(getpid(), pathbuf, sizeof(pathbuf));
-    if (ret <= 0)
-    {
-        return UInt32_FALSE;
-    }
-
-    f = open(pathbuf, O_RDONLY);
+    // NOTE: We ignore hTemplateModule, it is always the current module
+    exepath = minipal_getexepath();
+    f = open(exepath, O_RDONLY);
+    free(exepath);
     if (f < 0)
     {
         return UInt32_FALSE;

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -641,8 +641,8 @@
   <PropertyGroup Condition="'$(TestBuildMode)' == 'nativeaot'">
     <!-- NativeAOT compiled output is placed into a 'native' subdirectory: we need to tweak
          rpath so that the test can load its native library dependencies if there's any -->
-    <IlcRPath Condition="'$(TargetOS)' != 'osx'">$ORIGIN/..</IlcRPath>
-    <IlcRPath Condition="'$(TargetOS)' == 'osx'">@executable_path/..</IlcRPath>
+    <IlcRPath Condition="'$(TargetOS)' == 'osx' or '$(TargetsAppleMobile)' == 'true'">@executable_path/..</IlcRPath>
+    <IlcRPath Condition="'$(IlcRPath)' == ''">$ORIGIN/..</IlcRPath>
 
     <!-- Works around "Error: Native compilation can run on x64 and arm64 hosts only"
       Microsoft.NETCore.Native.targets expect IlcHostArch to be set but it doesn't have to -->


### PR DESCRIPTION
Fixes #82090

Marked as draft for the moment since there are still missing bits in the build and test infrastructure. I manually tested it using the PInvoke NativeAOT test compiled for maccatalyst-arm64 and maccatalyst-x64. The PAL interfaces could likely be cleaned up quite a bit since the implementation has different requirements from the old Windows-only code.