### PR TITLE
Fix FnPtrTypeDesc::GetManagedClassObject

### DIFF
--- a/src/coreclr/vm/typedesc.cpp
+++ b/src/coreclr/vm/typedesc.cpp
@@ -522,26 +522,9 @@ OBJECTREF FnPtrTypeDesc::GetManagedClassObject()
     }
     CONTRACTL_END;
 
-    if (m_hExposedClassObject == NULL) {
-        REFLECTCLASSBASEREF  refClass = NULL;
-        GCPROTECT_BEGIN(refClass);
-        refClass = (REFLECTCLASSBASEREF) AllocateObject(g_pRuntimeTypeClass);
-
-        LoaderAllocator *pLoaderAllocator = GetLoaderAllocator();
-        TypeHandle th = TypeHandle(this);
-        ((ReflectClassBaseObject*)OBJECTREFToObject(refClass))->SetType(th);
-        ((ReflectClassBaseObject*)OBJECTREFToObject(refClass))->SetKeepAlive(pLoaderAllocator->GetExposedObject());
-
-        // Let all threads fight over who wins using InterlockedCompareExchange.
-        // Only the winner can set m_hExposedClassObject from NULL.
-        LOADERHANDLE hExposedClassObject = pLoaderAllocator->AllocateHandle(refClass);
-
-        if (InterlockedCompareExchangeT(&m_hExposedClassObject, hExposedClassObject, static_cast<LOADERHANDLE>(NULL)))
-        {
-            pLoaderAllocator->FreeHandle(hExposedClassObject);
-        }
-
-        GCPROTECT_END();
+    if (m_hExposedClassObject == NULL)
+    {
+        TypeHandle(this).AllocateManagedClassObject(&m_hExposedClassObject);
     }
     return GetManagedClassObjectIfExists();
 }

--- a/src/coreclr/vm/typehandle.cpp
+++ b/src/coreclr/vm/typehandle.cpp
@@ -349,8 +349,7 @@ bool TypeHandle::IsManagedClassObjectPinned() const
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
-    // Function pointers are always mapped to typeof(IntPtr)
-    return !GetLoaderAllocator()->CanUnload() || IsFnPtrType();
+    return !GetLoaderAllocator()->CanUnload();
 }
 
 void TypeHandle::AllocateManagedClassObject(RUNTIMETYPEHANDLE* pDest)

--- a/src/libraries/System.Runtime/tests/System/Reflection/TypeDelegatorTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/TypeDelegatorTests.cs
@@ -59,7 +59,6 @@ namespace System.Reflection.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/82252", TestRuntimes.CoreCLR)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]          
         public void FunctionPointers()
         {


### PR DESCRIPTION
The code was missing support for allocating RuntimeType objects on frozen heap

Fixes #82252