### PR TITLE
Refactor computing lvaLongVars/lvaFloatVars

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6138,6 +6138,9 @@ protected:
     // written to, and SZ-array element type equivalence classes updated.
     void optComputeLoopSideEffects();
 
+    // Compute the sets of long and float vars (lvaLongVars, lvaFloatVars).
+    void optComputeInterestingVarSets();
+
 #ifdef DEBUG
     bool optAnyChildNotRemoved(unsigned loopNum);
 #endif // DEBUG


### PR DESCRIPTION
Compute them before loop hoisting, where they are actually used, not at the beginning of value numbering.