### PR TITLE
Console.Unix: fix escape sequence for setting title on 'screen' TERM.

### DIFF
--- a/src/libraries/System.Console/src/System/TerminalFormatStrings.cs
+++ b/src/libraries/System.Console/src/System/TerminalFormatStrings.cs
@@ -211,7 +211,7 @@ internal sealed class TerminalFormatStrings
             case "konsole":
                 return "\x1B]30;%p1%s\x07";
             case "screen":
-                return "\x1Bk%p1%s\x1B";
+                return "\x1Bk%p1%s\x1B\\";
             default:
                 return string.Empty;
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/82110.

This escape sequence is used in more cases with .NET 7 (`screen*` vs `screen`).

Because the escape sequence is not complete, it can cause issues when followed
by another escape sequence, like a call to `GetCursorPosition`.

@adamsitnik @SteveL-MSFT @dotnet/area-system-console ptal.