### PR TITLE
Stop setting DOTNET_JitStress in a couple of newly added tests

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_81585/Runtime_81585.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_81585/Runtime_81585.csproj
@@ -7,7 +7,4 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
-  <ItemGroup>
-    <CLRTestEnvironmentVariable Include="DOTNET_JitStress" Value="1" />
-  </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_81725/Runtime_81725.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_81725/Runtime_81725.csproj
@@ -8,6 +8,6 @@
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
   <ItemGroup>
-    <CLRTestEnvironmentVariable Include="DOTNET_JitStress" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitStressModeNames" Value="STRESS_FOLD" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Workaround #82164.

Runtime_81585 did not need any stress mode to repro, and the other one needs only STRESS_FOLD (and actually didn't repro it with `DOTNET_JitStress=1` after the class had been renamed from `Program`)