### PR TITLE
Keep side effects in impOptimizeCastClassOrIsInst

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -16115,11 +16115,6 @@ bool Compiler::gtTreeHasSideEffects(GenTree* tree, GenTreeFlags flags /* = GTF_S
         return false;
     }
 
-    if (tree->OperIs(GT_RET_EXPR))
-    {
-        return gtTreeHasSideEffects(tree->AsRetExpr()->gtInlineCandidate, flags);
-    }
-
     if (sideEffectFlags == GTF_CALL)
     {
         if (tree->OperGet() == GT_CALL)

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -16115,6 +16115,11 @@ bool Compiler::gtTreeHasSideEffects(GenTree* tree, GenTreeFlags flags /* = GTF_S
         return false;
     }
 
+    if (tree->OperIs(GT_RET_EXPR))
+    {
+        return gtTreeHasSideEffects(tree->AsRetExpr()->gtInlineCandidate, flags);
+    }
+
     if (sideEffectFlags == GTF_CALL)
     {
         if (tree->OperGet() == GT_CALL)

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5698,7 +5698,6 @@ GenTree* Compiler::impOptimizeCastClassOrIsInst(GenTree* op1, CORINFO_RESOLVED_T
             if (isExact && !isCastClass)
             {
                 JITDUMP("Cast will fail, optimizing to return null\n");
-                GenTree* result = gtNewIconNode(0, TYP_REF);
 
                 // If the cast was fed by a box, we can remove that too.
                 if (op1->IsBoxedValue())
@@ -5707,7 +5706,11 @@ GenTree* Compiler::impOptimizeCastClassOrIsInst(GenTree* op1, CORINFO_RESOLVED_T
                     gtTryRemoveBoxUpstreamEffects(op1);
                 }
 
-                return result;
+                if (gtTreeHasSideEffects(op1, GTF_ALL_EFFECT))
+                {
+                    impAppendTree(op1, CHECK_SPILL_ALL, impCurStmtDI);
+                }
+                return gtNewNull();
             }
             else if (isExact)
             {

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5706,7 +5706,7 @@ GenTree* Compiler::impOptimizeCastClassOrIsInst(GenTree* op1, CORINFO_RESOLVED_T
                     gtTryRemoveBoxUpstreamEffects(op1);
                 }
 
-                if (gtTreeHasSideEffects(op1, GTF_ALL_EFFECT))
+                if (gtTreeHasSideEffects(op1, GTF_SIDE_EFFECT))
                 {
                     impAppendTree(op1, CHECK_SPILL_ALL, impCurStmtDI);
                 }


### PR DESCRIPTION
Somehow we never hit this issue until recently in https://github.com/dotnet/runtime/issues/82030 as the code is not new.

Fixes https://github.com/dotnet/runtime/issues/82030