### PR TITLE
Fix unitialized local in impCastClassOrIsInstToTree

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5938,6 +5938,7 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
         const unsigned clsTmpNum = lvaGrabTemp(true DEBUGARG("spilling class handle"));
         impAssignTempGen(clsTmpNum, op2);
         op2 = gtNewLclvNode(clsTmpNum, op2->TypeGet());
+        lvaTable[clsTmpNum].lvIsCSE = true;
     }
     temp = gtNewMethodTableLookup(temp);
     condMT =

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5933,11 +5933,11 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
     // thus we can use gtClone(op1) from now on
     //
 
-    GenTree* op2Var = op2;
     if (isCastClass && !partialExpand)
     {
-        op2Var                                                  = fgInsertCommaFormTemp(&op2);
-        lvaTable[op2Var->AsLclVarCommon()->GetLclNum()].lvIsCSE = true;
+        const unsigned clsTmpNum = lvaGrabTemp(true DEBUGARG("spilling class handle"));
+        impAssignTempGen(clsTmpNum, op2);
+        op2 = gtNewLclvNode(clsTmpNum, op2->TypeGet());
     }
     temp = gtNewMethodTableLookup(temp);
     condMT =
@@ -5971,7 +5971,7 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
             // use the special helper that skips the cases checked by our inlined cast
             specialHelper = CORINFO_HELP_CHKCASTCLASS_SPECIAL;
         }
-        condTrue = gtNewHelperCallNode(specialHelper, TYP_REF, partialExpand ? op2 : op2Var, gtClone(op1));
+        condTrue = gtNewHelperCallNode(specialHelper, TYP_REF, gtClone(op2), gtClone(op1));
     }
     else if (partialExpand)
     {

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5937,13 +5937,11 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
     //
 
     GenTree* op2Var = op2;
-    if (isCastClass && !partialExpand)
+    if (isCastClass && !partialExpand && (exactCls == NO_CLASS_HANDLE))
     {
-        const unsigned clsTmpNum = lvaGrabTemp(true DEBUGARG("spilling class handle"));
-        impAssignTempGen(clsTmpNum, op2);
-        lvaTable[clsTmpNum].lvIsCSE = true;
-        op2                         = gtNewLclvNode(clsTmpNum, op2->TypeGet());
-        op2Var                      = gtNewLclvNode(clsTmpNum, op2->TypeGet());
+        // if exactCls is not null we won't have to clone op2 (it will be used only for the fallback)
+        op2Var                                                  = fgInsertCommaFormTemp(&op2);
+        lvaTable[op2Var->AsLclVarCommon()->GetLclNum()].lvIsCSE = true;
     }
     temp = gtNewMethodTableLookup(temp);
     condMT =

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5936,12 +5936,14 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
     // thus we can use gtClone(op1) from now on
     //
 
+    GenTree* op2Var = op2;
     if (isCastClass && !partialExpand)
     {
         const unsigned clsTmpNum = lvaGrabTemp(true DEBUGARG("spilling class handle"));
         impAssignTempGen(clsTmpNum, op2);
-        op2 = gtNewLclvNode(clsTmpNum, op2->TypeGet());
         lvaTable[clsTmpNum].lvIsCSE = true;
+        op2                         = gtNewLclvNode(clsTmpNum, op2->TypeGet());
+        op2Var                      = gtNewLclvNode(clsTmpNum, op2->TypeGet());
     }
     temp = gtNewMethodTableLookup(temp);
     condMT =
@@ -5975,7 +5977,7 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
             // use the special helper that skips the cases checked by our inlined cast
             specialHelper = CORINFO_HELP_CHKCASTCLASS_SPECIAL;
         }
-        condTrue = gtNewHelperCallNode(specialHelper, TYP_REF, gtClone(op2), gtClone(op1));
+        condTrue = gtNewHelperCallNode(specialHelper, TYP_REF, partialExpand ? op2 : op2Var, gtClone(op1));
     }
     else if (partialExpand)
     {

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1324,9 +1324,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/opt/ValueNumbering/TypeTestFolding/*">
             <Issue>https://github.com/dotnet/runtime/issues/71883</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/PGO/ProfileCastClassAndIsInst/**">
-            <Issue>https://github.com/dotnet/runtime/issues/82071</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/DevDiv_461649/DevDiv_461649/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/155: Reflection emit</Issue>
         </ExcludeList>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/82071

`op2` is supposed to be a class handle which is saved to a local via COMMA (importer-level CSE). There was a case related to getExactClasses where that COMMA didn't present in the tree. 
Asm diff for `CastToGenericInterface` in https://github.com/dotnet/runtime/issues/82071: https://www.diffchecker.com/lV4PCEeJ/