### PR TITLE
Disable bigevent test under GCStress

### DIFF
--- a/src/tests/tracing/eventpipe/bigevent/bigevent.csproj
+++ b/src/tests/tracing/eventpipe/bigevent/bigevent.csproj
@@ -5,8 +5,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
-    <!-- GCStress timeout: https://github.com/dotnet/runtime/issues/51133 -->
+    <!-- GCStress timeout: https://github.com/dotnet/runtime/issues/51133, https://github.com/dotnet/runtime/issues/82251 -->
     <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm64' and '$(TargetOS)' == 'osx'">true</GCStressIncompatible>
+    <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm'">true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
Tracking: https://github.com/dotnet/runtime/issues/82251