### PR TITLE
Fix ISOSDacInterface::TraverseLoaderHeap

### DIFF
--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -3227,6 +3227,10 @@ ClrDataAccess::QueryInterface(THIS_
     {
         ifaceRet = static_cast<ISOSDacInterface12*>(this);
     }
+    else if (IsEqualIID(interfaceId, __uuidof(ISOSDacInterface13)))
+    {
+        ifaceRet = static_cast<ISOSDacInterface13*>(this);
+    }
     else
     {
         *iface = NULL;

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -3621,6 +3621,7 @@ void DacDbiInterfaceImpl::EnumerateMemRangesForLoaderAllocator(PTR_LoaderAllocat
         if (pVcsMgr->resolve_heap != NULL) heapsToEnumerate.Push(pVcsMgr->resolve_heap);
         if (pVcsMgr->dispatch_heap != NULL) heapsToEnumerate.Push(pVcsMgr->dispatch_heap);
         if (pVcsMgr->cache_entry_heap != NULL) heapsToEnumerate.Push(pVcsMgr->cache_entry_heap);
+        if (pVcsMgr->vtable_heap != NULL) heapsToEnumerate.Push(pVcsMgr->vtable_heap);
     }
 
     TADDR rangeAccumAsTaddr = TO_TADDR(rangeAcummulator);

--- a/src/coreclr/debug/daccess/dacimpl.h
+++ b/src/coreclr/debug/daccess/dacimpl.h
@@ -815,7 +815,8 @@ class ClrDataAccess
       public ISOSDacInterface9,
       public ISOSDacInterface10,
       public ISOSDacInterface11,
-      public ISOSDacInterface12
+      public ISOSDacInterface12,
+      public ISOSDacInterface13
 {
 public:
     ClrDataAccess(ICorDebugDataTarget * pTarget, ICLRDataTarget * pLegacyTarget=0);
@@ -1204,6 +1205,8 @@ public:
     virtual HRESULT STDMETHODCALLTYPE GetGlobalAllocationContext(
         CLRDATA_ADDRESS *allocPtr,
         CLRDATA_ADDRESS *allocLimit);
+
+    virtual HRESULT STDMETHODCALLTYPE TraverseLoaderHeap(CLRDATA_ADDRESS loaderHeapAddr, LoaderHeapKind kind, VISITHEAP pCallback);
 
     //
     // ClrDataAccess.

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -3425,7 +3425,7 @@ static HRESULT TraverseLoaderHeapBlock(PTR_LoaderHeapBlock firstBlock, VISITHEAP
     //      this function need to check the return before acting on data given
     //      by the callback.
     //  3.  If we hit an exception, we'll return a failing HRESULT as before.
-    const int iterationMax = 4096;
+    const int iterationMax = 8192;
 
     int i = 0;
     PTR_LoaderHeapBlock block = firstBlock;

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -3416,6 +3416,42 @@ ClrDataAccess::TraverseRCWCleanupList(CLRDATA_ADDRESS cleanupListPtr, VISITRCWFO
 #endif // FEATURE_COMINTEROP
 }
 
+static HRESULT TraverseLoaderHeapBlock(PTR_LoaderHeapBlock firstBlock, VISITHEAP pFunc)
+{
+    // If we are given a bad address, we may end up mis-interpreting random memory
+    // as a loader heap.  We'll do three things to try to avoid this:
+    //  1.  Put a cap on the number of heaps we enumerate at some sensible number.
+    //  2.  If we detect the block is bad, return a failure HRESULT.  Callers of
+    //      this function need to check the return before acting on data given
+    //      by the callback.
+    //  3.  If we hit an exception, we'll return a failing HRESULT as before.
+    const int iterationMax = 4096;
+
+    int i = 0;
+    PTR_LoaderHeapBlock block = firstBlock;
+
+    while (block != nullptr && i++ < iterationMax)
+    {
+        if (!block.IsValid())
+            return E_POINTER;
+
+        TADDR addr = PTR_TO_TADDR(block->pVirtualAddress);
+        size_t size = block->dwVirtualSize;
+
+        BOOL bCurrentBlock = (block == firstBlock);
+        pFunc(addr, size, bCurrentBlock);
+
+        block = block->pNext;
+        
+        // Ensure we only see the first block once and that we aren't looping
+        // infinitely.
+        if (block == firstBlock)
+            return E_POINTER;
+    }
+
+    return i < iterationMax ? S_OK : S_FALSE;
+}
+
 HRESULT
 ClrDataAccess::TraverseLoaderHeap(CLRDATA_ADDRESS loaderHeapAddr, VISITHEAP pFunc)
 {
@@ -3423,19 +3459,36 @@ ClrDataAccess::TraverseLoaderHeap(CLRDATA_ADDRESS loaderHeapAddr, VISITHEAP pFun
         return E_INVALIDARG;
 
     SOSDacEnter();
+    
+    hr = TraverseLoaderHeapBlock(PTR_LoaderHeap(TO_TADDR(loaderHeapAddr))->m_pFirstBlock, pFunc);
 
-    LoaderHeap *pLoaderHeap = PTR_LoaderHeap(TO_TADDR(loaderHeapAddr));
-    PTR_LoaderHeapBlock block = pLoaderHeap->m_pFirstBlock;
-    while (block.IsValid())
+    SOSDacLeave();
+    return hr;
+}
+
+
+
+HRESULT
+ClrDataAccess::TraverseLoaderHeap(CLRDATA_ADDRESS loaderHeapAddr, LoaderHeapKind kind, VISITHEAP pCallback)
+{
+    if (loaderHeapAddr == 0 || pCallback == 0)
+        return E_INVALIDARG;
+
+    SOSDacEnter();
+
+    switch (kind)
     {
-        TADDR addr = PTR_TO_TADDR(block->pVirtualAddress);
-        size_t size = block->dwVirtualSize;
+        case LoaderHeapKindNormal:
+            hr = TraverseLoaderHeapBlock(PTR_LoaderHeap(TO_TADDR(loaderHeapAddr))->m_pFirstBlock, pCallback);
+            break;
 
-        BOOL bCurrentBlock = (block == pLoaderHeap->m_pFirstBlock);
+        case LoaderHeapKindExplicitControl:
+            hr = TraverseLoaderHeapBlock(PTR_ExplicitControlLoaderHeap(TO_TADDR(loaderHeapAddr))->m_pFirstBlock, pCallback);
+            break;
 
-        pFunc(addr,size,bCurrentBlock);
-
-        block = block->pNext;
+        default:
+            hr = E_NOTIMPL;
+            break;
     }
 
     SOSDacLeave();
@@ -3458,41 +3511,40 @@ ClrDataAccess::TraverseVirtCallStubHeap(CLRDATA_ADDRESS pAppDomain, VCSHeapType 
     }
     else
     {
-        LoaderHeap *pLoaderHeap = NULL;
+        PTR_LoaderHeap pLoaderHeap = NULL;
         switch(heaptype)
         {
             case IndcellHeap:
                 pLoaderHeap = pVcsMgr->indcell_heap;
                 break;
+
             case LookupHeap:
                 pLoaderHeap = pVcsMgr->lookup_heap;
                 break;
+
             case ResolveHeap:
                 pLoaderHeap = pVcsMgr->resolve_heap;
                 break;
+
             case DispatchHeap:
                 pLoaderHeap = pVcsMgr->dispatch_heap;
                 break;
+
             case CacheEntryHeap:
                 pLoaderHeap = pVcsMgr->cache_entry_heap;
                 break;
+
+            case VtableHeap:
+                pLoaderHeap = pVcsMgr->vtable_heap;
+                break;
+
             default:
                 hr = E_INVALIDARG;
         }
 
         if (SUCCEEDED(hr))
         {
-            PTR_LoaderHeapBlock block = pLoaderHeap->m_pFirstBlock;
-            while (block.IsValid())
-            {
-                TADDR addr = PTR_TO_TADDR(block->pVirtualAddress);
-                size_t size = block->dwVirtualSize;
-
-                BOOL bCurrentBlock = (block == pLoaderHeap->m_pFirstBlock);
-                pFunc(addr, size, bCurrentBlock);
-
-                block = block->pNext;
-            }
+            hr = TraverseLoaderHeapBlock(pLoaderHeap->m_pFirstBlock, pFunc);
         }
     }
 

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -3424,7 +3424,7 @@ ClrDataAccess::TraverseLoaderHeap(CLRDATA_ADDRESS loaderHeapAddr, VISITHEAP pFun
 
     SOSDacEnter();
 
-    ExplicitControlLoaderHeap *pLoaderHeap = PTR_ExplicitControlLoaderHeap(TO_TADDR(loaderHeapAddr));
+    LoaderHeap *pLoaderHeap = PTR_LoaderHeap(TO_TADDR(loaderHeapAddr));
     PTR_LoaderHeapBlock block = pLoaderHeap->m_pFirstBlock;
     while (block.IsValid())
     {

--- a/src/coreclr/inc/sospriv.idl
+++ b/src/coreclr/inc/sospriv.idl
@@ -42,11 +42,13 @@ typedef int mdToken;
 typedef unsigned int size_t;
 typedef int ModuleMapType;
 typedef int VCSHeapType;
+typedef int LoaderHeapKind;
 cpp_quote("#endif")
 
 
 cpp_quote("typedef enum { TYPEDEFTOMETHODTABLE, TYPEREFTOMETHODTABLE } ModuleMapType;")
-cpp_quote("typedef enum {IndcellHeap, LookupHeap, ResolveHeap, DispatchHeap, CacheEntryHeap} VCSHeapType;")
+cpp_quote("typedef enum {IndcellHeap, LookupHeap, ResolveHeap, DispatchHeap, CacheEntryHeap, VtableHeap} VCSHeapType;")
+cpp_quote("typedef enum {LoaderHeapKindNormal = 0, LoaderHeapKindExplicitControl = 1} LoaderHeapKind;")
 
 typedef void (*MODULEMAPTRAVERSE)(UINT index, CLRDATA_ADDRESS methodTable,LPVOID token);
 typedef void (*VISITHEAP)(CLRDATA_ADDRESS blockData,size_t blockSize,BOOL blockIsCurrentBlock);
@@ -458,4 +460,14 @@ interface ISOSDacInterface11 : IUnknown
 interface ISOSDacInterface12 : IUnknown
 {
     HRESULT GetGlobalAllocationContext(CLRDATA_ADDRESS* allocPtr, CLRDATA_ADDRESS* allocLimit);
+}
+
+[
+    object,
+    local,
+    uuid(3176a8ed-597b-4f54-a71f-83695c6a8c5d)
+]
+interface ISOSDacInterface13 : IUnknown
+{
+    HRESULT TraverseLoaderHeap(CLRDATA_ADDRESS loaderHeapAddr, LoaderHeapKind kind, VISITHEAP pCallback);
 }

--- a/src/coreclr/pal/prebuilt/idl/sospriv_i.cpp
+++ b/src/coreclr/pal/prebuilt/idl/sospriv_i.cpp
@@ -5,11 +5,9 @@
 /* link this file in with the server and any clients */
 
 
- /* File created by MIDL compiler version 8.01.0622 */
-/* at Mon Jan 18 19:14:07 2038
- */
-/* Compiler settings for C:/ssd/runtime/src/coreclr/inc/sospriv.idl:
-    Oicf, W1, Zp8, env=Win32 (32b run), target_arch=X86 8.01.0622 
+ /* File created by MIDL compiler version 8.01.0626 */
+/* Compiler settings for sospriv.idl:
+    Oicf, W1, Zp8, env=Win64 (32b run), target_arch=AMD64 8.01.0626 
     protocol : dce , ms_ext, c_ext, robust
     error checks: allocation ref bounds_check enum stub_data 
     VC __declspec() decoration level: 
@@ -114,6 +112,8 @@ MIDL_DEFINE_GUID(IID, IID_ISOSDacInterface11,0x96BA1DB9,0x14CD,0x4492,0x80,0x65,
 
 MIDL_DEFINE_GUID(IID, IID_ISOSDacInterface12,0x1b93bacc,0x8ca4,0x432d,0x94,0x3a,0x3e,0x6e,0x7e,0xc0,0xb0,0xa3);
 
+
+MIDL_DEFINE_GUID(IID, IID_ISOSDacInterface13,0x3176a8ed,0x597b,0x4f54,0xa7,0x1f,0x83,0x69,0x5c,0x6a,0x8c,0x5d);
 
 #undef MIDL_DEFINE_GUID
 

--- a/src/coreclr/pal/prebuilt/inc/sospriv.h
+++ b/src/coreclr/pal/prebuilt/inc/sospriv.h
@@ -196,7 +196,8 @@ typedef int VCSHeapType;
 
 #endif
 typedef enum { TYPEDEFTOMETHODTABLE, TYPEREFTOMETHODTABLE } ModuleMapType;
-typedef enum {IndcellHeap, LookupHeap, ResolveHeap, DispatchHeap, CacheEntryHeap} VCSHeapType;
+typedef enum {IndcellHeap, LookupHeap, ResolveHeap, DispatchHeap, CacheEntryHeap, VtableHeap} VCSHeapType;
+typedef enum {LoaderHeapKindNormal = 0, LoaderHeapKindExplicitControl = 1} LoaderHeapKind;
 typedef void ( *MODULEMAPTRAVERSE )(
     UINT index,
     CLRDATA_ADDRESS methodTable,
@@ -3070,6 +3071,94 @@ EXTERN_C const IID IID_ISOSDacInterface12;
 
 
 #endif 	/* __ISOSDacInterface12_INTERFACE_DEFINED__ */
+
+    
+#ifndef __ISOSDacInterface13_INTERFACE_DEFINED__
+#define __ISOSDacInterface13_INTERFACE_DEFINED__
+
+/* interface ISOSDacInterface13 */
+/* [uuid][local][object] */ 
+
+
+EXTERN_C const IID IID_ISOSDacInterface13;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("3176a8ed-597b-4f54-a71f-83695c6a8c5d")
+    ISOSDacInterface13 : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE TraverseLoaderHeap( 
+            CLRDATA_ADDRESS loaderHeapAddr,
+            LoaderHeapKind kind,
+            VISITHEAP pCallback) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ISOSDacInterface13Vtbl
+    {
+        BEGIN_INTERFACE
+        
+        DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            ISOSDacInterface13 * This,
+            /* [in] */ REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        DECLSPEC_XFGVIRT(IUnknown, AddRef)
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            ISOSDacInterface13 * This);
+        
+        DECLSPEC_XFGVIRT(IUnknown, Release)
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            ISOSDacInterface13 * This);
+        
+        DECLSPEC_XFGVIRT(ISOSDacInterface13, TraverseLoaderHeap)
+        HRESULT ( STDMETHODCALLTYPE *TraverseLoaderHeap )( 
+            ISOSDacInterface13 * This,
+            CLRDATA_ADDRESS loaderHeapAddr,
+            LoaderHeapKind kind,
+            VISITHEAP pCallback);
+        
+        END_INTERFACE
+    } ISOSDacInterface13Vtbl;
+
+    interface ISOSDacInterface13
+    {
+        CONST_VTBL struct ISOSDacInterface13Vtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ISOSDacInterface13_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ISOSDacInterface13_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ISOSDacInterface13_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ISOSDacInterface13_TraverseLoaderHeap(This,loaderHeapAddr,kind,pCallback)	\
+    ( (This)->lpVtbl -> TraverseLoaderHeap(This,loaderHeapAddr,kind,pCallback) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ISOSDacInterface13_INTERFACE_DEFINED__ */
 
 
 /* Additional Prototypes for ALL interfaces */


### PR DESCRIPTION
There are two main kinds of LoaderHeaps in the runtime:  `LoaderHeap` which has a vtable and `ExplicitControlLoaderHeap` which doesn't have a vtable.  For example, `LoaderCodeHeap` has an `ExplicitControlLoaderHeap` as one of its members, and hands out pointers directly to it.

Since `TraverseLoaderHeap` takes an opaque pointer, it can't satisfy both versions of LoaderHeaps without the caller manipulating the pointer.  Instead, this change:

1.  This reverts the previous attempt to fix this issue in https://github.com/dotnet/runtime/pull/67885.  The original `TraverseHeap` goes back to previous .Net behavior before .Net 7 (this keeps us down to only one set of weird behavior).
2. Implements a new interface/function which takes in the LoaderHeap kind.  The caller still has to know what kind of loader heap it has, but that was always the case...we are now making it explicit.
3. Unifies the LoaderHeap walking code and adds some sanity checks/bounds checks.  Do a better job validating blocks before enumerating them in the callback.
4. Adds AppDomain::vtable_heap to the kinds of heaps `TraverseVirtCallStubHeap` will traverse.
5. Adds the vtable_heap to the things that the DBI will enumerate in EnumerateMemRangesForLoaderAllocator.

These changes were tested with this ClrMD PR:  https://github.com/microsoft/clrmd/pull/1072.