### PR TITLE
Tiny speedup to HasGenericVirtualMethods

### DIFF
--- a/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
@@ -100,9 +100,9 @@ namespace ILCompiler
         /// </summary>
         public static bool HasGenericVirtualMethods(this TypeDesc type)
         {
-            foreach (var method in type.GetAllMethods())
+            foreach (var method in type.GetAllVirtualMethods())
             {
-                if (method.IsVirtual && method.HasInstantiation)
+                if (method.HasInstantiation)
                     return true;
             }
 


### PR DESCRIPTION
This avoids materializing/resolving non-virtual methods.

Cc @dotnet/ilc-contrib 