### PR TITLE
Add ability specify core_root when run

### DIFF
--- a/src/tests/run.sh
+++ b/src/tests/run.sh
@@ -15,6 +15,7 @@ function print_usage {
     echo '  android                          : Set build OS to Android.'
     echo '  --test-env=<path>                : Script to set environment variables for tests'
     echo '  --testRootDir=<path>             : Root directory of the test build (e.g. runtime/artifacts/tests/windows.x64.Debug).'
+    echo '  --coreRootDir=<path>             : Directory to the CORE_ROOT location.'
     echo '  --enableEventLogging             : Enable event logging through LTTNG.'
     echo '  --sequential                     : Run tests sequentially (default is to run in parallel).'
     echo '  --runcrossgen2tests              : Runs the ReadyToRun tests compiled with Crossgen2'
@@ -54,6 +55,7 @@ buildArch="$arch"
 buildOS=
 buildConfiguration="Debug"
 testRootDir=
+coreRootDir=
 testEnv=
 gcsimulator=
 longgc=
@@ -134,6 +136,9 @@ do
             ;;
         --testRootDir=*)
             testRootDir=${i#*=}
+            ;;
+        --coreRootDir=*)
+            coreRootDir=${i#*=}
             ;;
         --enableEventLogging)
             ((eventLogging = 1))
@@ -218,6 +223,11 @@ fi
 if [[ -n "$testRootDir" ]]; then
     runtestPyArguments+=("-test_location" "$testRootDir")
     echo "Test Location                 : ${testRootDir}"
+fi
+
+if [[ -n "$coreRootDir" ]]; then
+    runtestPyArguments+=("-core_root" "$coreRootDir")
+    echo "CORE_ROOT                     : ${coreRootDir}"
 fi
 
 if [[ -n "${testEnv}" ]]; then


### PR DESCRIPTION
I use this to run tests of Loongarch, it was long time ago when I implement this, but most likely missing crossgen2 do not allow me properly build Core_Root automatically, so I have to specify it manually from well known location.