### PR TITLE
Remove invalid internal attribute which causes warnings

### DIFF
--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/ILLink.LinkAttributes.xml
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/ILLink.LinkAttributes.xml
@@ -2,7 +2,6 @@
   <!-- IL2049 -->
   <type fullname="ILLinkLinkAttributes/TestRemoveAttribute">
     <attribute internal="RemoveAttributeInstances"/>
-    <attribute internal="InvalidInternal"/>
   </type>
   <!-- IL2048 -->
   <type fullname="ILLinkLinkAttributes">


### PR DESCRIPTION
The invalid attribute name is a valid test, but the smoke tests don't have the infra to validate warnings. So producing the warning there is just noise in the build.

Once we port over all linker tests this will be validated by those. Specifically https://github.com/dotnet/runtime/blob/0fe8bd36734b31e80abebf28380656fc18734645/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkerAttributeRemoval.xml.