### PR TITLE
[mono][aot] Enable dedup on tvOS device + arm64 simulators

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -14894,11 +14894,6 @@ aot_assembly (MonoAssembly *ass, guint32 jit_opts, MonoAotOptions *aot_options)
 	TV_GETTIME (btv);
 
 	acfg->stats.jit_time = GINT64_TO_INT (TV_ELAPSED (atv, btv));
-	// Current implementation uses dedup_methods hash table for storing extra methods which are emitted in a dedup AOT image.
-	// Previously, cfg->skip flag in dedup_skip_methods is used for indicating if a method should be emitted in an AOT image.
-#if 0
-	dedup_skip_methods (acfg);
-#endif
 	if (acfg->dedup_collect_only) {
 		/* We only collected methods from this assembly */
 		acfg_free (acfg);

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -14896,8 +14896,7 @@ aot_assembly (MonoAssembly *ass, guint32 jit_opts, MonoAotOptions *aot_options)
 	acfg->stats.jit_time = GINT64_TO_INT (TV_ELAPSED (atv, btv));
 	// Current implementation uses dedup_methods hash table for storing extra methods which are emitted in a dedup AOT image.
 	// Previously, cfg->skip flag in dedup_skip_methods is used for indicating if a method should be emitted in an AOT image.
-	// Method dedup_skip_methods is used only for wasm.
-#ifdef TARGET_WASM
+#ifdef 0
 	dedup_skip_methods (acfg);
 #endif
 	if (acfg->dedup_collect_only) {

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -14896,7 +14896,7 @@ aot_assembly (MonoAssembly *ass, guint32 jit_opts, MonoAotOptions *aot_options)
 	acfg->stats.jit_time = GINT64_TO_INT (TV_ELAPSED (atv, btv));
 	// Current implementation uses dedup_methods hash table for storing extra methods which are emitted in a dedup AOT image.
 	// Previously, cfg->skip flag in dedup_skip_methods is used for indicating if a method should be emitted in an AOT image.
-#ifdef 0
+#if 0
 	dedup_skip_methods (acfg);
 #endif
 	if (acfg->dedup_collect_only) {

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -4492,8 +4492,6 @@ inst_is_private (MonoGenericInst *inst)
 gboolean
 mono_aot_can_dedup (MonoMethod *method)
 {
-	// Dedup enabled for wasm and iOS
-#if defined(TARGET_WASM) || defined(TARGET_IOS)
 	/* Use a set of wrappers/instances which work and useful */
 	switch (method->wrapper_type) {
 	case MONO_WRAPPER_RUNTIME_INVOKE:
@@ -4541,12 +4539,6 @@ mono_aot_can_dedup (MonoMethod *method)
 		return TRUE;
 	}
 	return FALSE;
-#else
-	gboolean not_normal_gshared = method->is_inflated && !mono_method_is_generic_sharable_full (method, TRUE, FALSE, FALSE);
-	gboolean extra_method = (method->wrapper_type != MONO_WRAPPER_NONE) || not_normal_gshared;
-
-	return extra_method;
-#endif
 }
 
 

--- a/src/mono/msbuild/apple/build/AppleApp.props
+++ b/src/mono/msbuild/apple/build/AppleApp.props
@@ -2,7 +2,7 @@
   <!-- iOS/tvOS device + arm64 simulators need to AOT -->
   <PropertyGroup Condition="'$(TargetOS)' == 'ios' or '$(TargetOS)' == 'tvos' or (('$(TargetOS)' == 'iossimulator' or '$(TargetOS)' == 'tvossimulator') And '$(TargetArchitecture)' == 'arm64')">
     <RunAOTCompilation Condition="'$(RunAOTCompilation)' == ''">true</RunAOTCompilation>
-    <iOSLikeDedup Condition="'$(RunAOTCompilation)' == 'true' and '$(TargetOS)' == 'ios'">true</iOSLikeDedup>
+    <iOSLikeDedup>true</iOSLikeDedup>
   </PropertyGroup>
 
   <!-- iOS/tvOS arm64 simulators do not support JIT, so force interpreter fallback, devices should FullAOT -->


### PR DESCRIPTION
This PR enables the dedup feature on ioslike platforms (tvOS device + arm64 simulators). It contributes to https://github.com/dotnet/runtime/issues/80419.