### PR TITLE
Update linux-instructions.md

### DIFF
--- a/docs/workflow/building/coreclr/linux-instructions.md
+++ b/docs/workflow/building/coreclr/linux-instructions.md
@@ -30,7 +30,7 @@ Please note that choosing the same image as the host OS you are running on will 
 Once you have chosen an image, the build is one command run from the root of the runtime repository:
 
 ```bash
-docker run --rm -v <RUNTIME_REPO_PATH>:/runtime -w /runtime mcr.microsoft.com/dotnet-buildtools/prereqs:mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-20210714125435-9b5bbc2 ./build.sh --subset clr
+docker run --rm -v <RUNTIME_REPO_PATH>:/runtime -w /runtime mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-20210714125435-9b5bbc2 ./build.sh --subset clr
 ```
 
 Dissecting the command:


### PR DESCRIPTION
I suppose head of the URL was redondant — gave me "docker: invalid refence format" when I tried the original command, and worked fine when I removed the first "mcr.microsoft.com/dotnet-buildtools/prereqs:"