### PR TITLE
[mono] Disable few quaternion intrinsics

### DIFF
--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -2111,10 +2111,15 @@ emit_vector_2_3_4 (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *f
 	case SN_op_Multiply:
 	case SN_op_Subtraction:
 	case SN_Max:
-	case SN_Min:
+	case SN_Min: {
+		const char *klass_name = m_class_get_name (klass);
+		// FIXME https://github.com/dotnet/runtime/issues/82408
+		if (!strcmp (klass_name, "Quaternion") && (id == SN_op_Multiply || id == SN_Multiply || id == SN_op_Division || id == SN_Divide))
+			return NULL;
 		if (!(!fsig->hasthis && fsig->param_count == 2 && mono_metadata_type_equal (fsig->ret, type) && mono_metadata_type_equal (fsig->params [0], type) && mono_metadata_type_equal (fsig->params [1], type)))
 			return NULL;
 		return emit_simd_ins_for_binary_op (cfg, klass, fsig, args, MONO_TYPE_R4, id);
+	}
 	case SN_Dot: {
 #if defined(TARGET_ARM64) || defined(TARGET_WASM)
 		int instc0 = OP_FMUL;

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -2114,7 +2114,7 @@ emit_vector_2_3_4 (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *f
 	case SN_Min: {
 		const char *klass_name = m_class_get_name (klass);
 		// FIXME https://github.com/dotnet/runtime/issues/82408
-		if (!strcmp (klass_name, "Quaternion") && (id == SN_op_Multiply || id == SN_Multiply || id == SN_op_Division || id == SN_Divide))
+		if ((id == SN_op_Multiply || id == SN_Multiply || id == SN_op_Division || id == SN_Divide) && !strcmp (klass_name, "Quaternion"))
 			return NULL;
 		if (!(!fsig->hasthis && fsig->param_count == 2 && mono_metadata_type_equal (fsig->ret, type) && mono_metadata_type_equal (fsig->params [0], type) && mono_metadata_type_equal (fsig->params [1], type)))
 			return NULL;


### PR DESCRIPTION
For * and / operators as these are not the same as vector operations. Opened https://github.com/dotnet/runtime/issues/82408 to implement correct ones in future.