### PR TITLE
Replace `SafeLocalAllocHandle` in `System.Net.HttpListener`

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/HttpApi/Interop.HttpApi.cs
+++ b/src/libraries/Common/src/Interop/Windows/HttpApi/Interop.HttpApi.cs
@@ -484,7 +484,7 @@ internal static partial class Interop
         internal static unsafe partial uint HttpReceiveHttpRequest(SafeHandle requestQueueHandle, ulong requestId, uint flags, HTTP_REQUEST* pRequestBuffer, uint requestBufferLength, uint* pBytesReturned, NativeOverlapped* pOverlapped);
 
         [LibraryImport(Libraries.HttpApi, SetLastError = true)]
-        internal static unsafe partial uint HttpSendHttpResponse(SafeHandle requestQueueHandle, ulong requestId, uint flags, HTTP_RESPONSE* pHttpResponse, void* pCachePolicy, uint* pBytesSent, SafeLocalAllocHandle pRequestBuffer, uint requestBufferLength, NativeOverlapped* pOverlapped, void* pLogData);
+        internal static unsafe partial uint HttpSendHttpResponse(SafeHandle requestQueueHandle, ulong requestId, uint flags, HTTP_RESPONSE* pHttpResponse, void* pCachePolicy, uint* pBytesSent, void* pRequestBuffer, uint requestBufferLength, NativeOverlapped* pOverlapped, void* pLogData);
 
         [LibraryImport(Libraries.HttpApi, SetLastError = true)]
         internal static unsafe partial uint HttpWaitForDisconnect(SafeHandle requestQueueHandle, ulong connectionId, NativeOverlapped* pOverlapped);
@@ -493,7 +493,7 @@ internal static partial class Interop
         internal static unsafe partial uint HttpReceiveRequestEntityBody(SafeHandle requestQueueHandle, ulong requestId, uint flags, void* pEntityBuffer, uint entityBufferLength, out uint bytesReturned, NativeOverlapped* pOverlapped);
 
         [LibraryImport(Libraries.HttpApi, SetLastError = true)]
-        internal static unsafe partial uint HttpSendResponseEntityBody(SafeHandle requestQueueHandle, ulong requestId, uint flags, ushort entityChunkCount, HTTP_DATA_CHUNK* pEntityChunks, uint* pBytesSent, SafeLocalAllocHandle pRequestBuffer, uint requestBufferLength, NativeOverlapped* pOverlapped, void* pLogData);
+        internal static unsafe partial uint HttpSendResponseEntityBody(SafeHandle requestQueueHandle, ulong requestId, uint flags, ushort entityChunkCount, HTTP_DATA_CHUNK* pEntityChunks, uint* pBytesSent, void* pRequestBuffer, uint requestBufferLength, NativeOverlapped* pOverlapped, void* pLogData);
 
         [LibraryImport(Libraries.HttpApi, SetLastError = true)]
         internal static partial uint HttpCloseRequestQueue(IntPtr pReqQueueHandle);

--- a/src/libraries/System.Net.HttpListener/src/System.Net.HttpListener.csproj
+++ b/src/libraries/System.Net.HttpListener/src/System.Net.HttpListener.csproj
@@ -159,8 +159,6 @@
              Link="Common\Interop\Windows\Kernel32\Interop.LoadLibraryEx_IntPtr.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.SECURITY_ATTRIBUTES.cs"
              Link="Common\Interop\Windows\Kernel32\Interop.SECURITY_ATTRIBUTES.cs" />
-    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs"
-             Link="Common\Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs" />
     <!-- Add NTAuthentication -->
     <Compile Include="$(CommonPath)System\Net\DebugSafeHandleZeroOrMinusOneIsInvalid.cs"
              Link="Common\System\Net\DebugSafeHandleZeroOrMinusOneIsInvalid.cs" />

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
@@ -1625,7 +1625,7 @@ namespace System.Net
                                 &httpResponse,
                                 null,
                                 &DataWritten,
-                                SafeLocalAllocHandle.Zero,
+                                null,
                                 0,
                                 null,
                                 null);

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListenerResponse.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListenerResponse.Windows.cs
@@ -283,7 +283,7 @@ namespace System.Net
                                     pResponse,
                                     null,
                                     &bytesSent,
-                                    SafeLocalAllocHandle.Zero,
+                                    null,
                                     0,
                                     asyncResult == null ? null : asyncResult._pOverlapped,
                                     null);
@@ -310,7 +310,7 @@ namespace System.Net
                                 pResponse,
                                 null,
                                 &bytesSent,
-                                SafeLocalAllocHandle.Zero,
+                                null,
                                 0,
                                 asyncResult == null ? null : asyncResult._pOverlapped,
                                 null);

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketHttpListenerDuplexStream.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketHttpListenerDuplexStream.cs
@@ -476,7 +476,7 @@ namespace System.Net.WebSockets
                         eventArgs.EntityChunkCount,
                         (Interop.HttpApi.HTTP_DATA_CHUNK*)eventArgs.EntityChunks,
                         &bytesSent,
-                        SafeLocalAllocHandle.Zero,
+                        null,
                         0,
                         eventArgs.NativeOverlapped,
                         null);


### PR DESCRIPTION
* [`Interop+HttpApi+HTTP_DATA_CHUNK.pBuffer`](https://github.com/dotnet/runtime/blob/6d325e1aa46879677a56b722fc20ef919ec173f5/src/libraries/Common/src/Interop/Windows/HttpApi/Interop.HttpApi.cs#L120).
* Interop+HttpApi.HttpSendResponseEntityBody
* Interop+HttpApi.HttpSendHttpResponse
