### PR TITLE
Fixing a bug that causes us to mistakenly demote a gen2 region to gen0

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -28876,7 +28876,8 @@ void gc_heap::process_remaining_regions (int current_plan_gen_num, generation* c
         return;
     }
 
-    set_region_plan_gen_num_sip (current_region, current_plan_gen_num);
+    decide_on_demotion_pin_surv (current_region);
+
     if (!heap_segment_swept_in_plan (current_region))
     {
         heap_segment_plan_allocated (current_region) = generation_allocation_pointer (consing_gen);


### PR DESCRIPTION
We are seeing a gen0 region that's almost fully occupied (< 24 bytes free) with one giant plug (ie, no free objects at all in the region). This causes allocate_in_condemned_generations to go into an infinite loop because in ephemeral generations we expect short plugs, ie, we should be able to allocate a min free object in front of each plug. And normally we can because when we allocate objects in gen0 we make sure to break up the allocation contexts with min free objects and when we compact into gen1 we form short plugs.

We are in this situation when all of the following conditions are true -

+ we did a gen2 compacting GC that generates a pinned plug in a gen2 region almost as big as the whole region. my guess for the reason why there's this giant pinned plug is because that gen2 region was already really compact so when we called allocate_in_condemned_generations on the non pinned plugs that are next to some pinned plugs in it we discovered we can't move the non pinned plugs anyway so we artificially pinned them and formed a giant pinned plug. and during this GC those objects were no longer pinned so we have one giant non pinned plug.
+ this gen2 region needs to be the last region with pinned plugs;
+ this gen2 region hasn't been consumed by allocate_in_condemned_generations yet so it was processed by process_remaining_regions;

Then in process_remaining_regions we'll set the plan_gen_num for that gen2 region to 0 because we are doing

set_region_plan_gen_num_sip (current_region, current_plan_gen_num);

instead of going through the demotion logic to decide whether we should demote this region or not.