### PR TITLE
Fixing a FATAL_GC_ERROR in loh_allocate_in_condemned when in extremely low memory

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -27892,7 +27892,7 @@ BOOL gc_heap::loh_enque_pinned_plug (uint8_t* plug, size_t len)
 }
 
 inline
-BOOL gc_heap::loh_size_fit_p (size_t size, uint8_t* alloc_pointer, uint8_t* alloc_limit)
+BOOL gc_heap::loh_size_fit_p (size_t size, uint8_t* alloc_pointer, uint8_t* alloc_limit, bool end_p)
 {
     dprintf (1235, ("trying to fit %zd(%zd) between %p and %p (%zd)",
         size,
@@ -27901,7 +27901,11 @@ BOOL gc_heap::loh_size_fit_p (size_t size, uint8_t* alloc_pointer, uint8_t* allo
         alloc_limit,
         (alloc_limit - alloc_pointer)));
 
-    return ((alloc_pointer + 2* AlignQword (loh_padding_obj_size) +  size) <= alloc_limit);
+    // If it's at the end, we don't need to allocate the tail padding
+    size_t pad = 1 + (end_p ? 0 : 1);
+    pad *= AlignQword (loh_padding_obj_size);
+
+    return ((alloc_pointer + pad + size) <= alloc_limit);
 }
 
 uint8_t* gc_heap::loh_allocate_in_condemned (size_t size)
@@ -27915,7 +27919,8 @@ uint8_t* gc_heap::loh_allocate_in_condemned (size_t size)
 retry:
     {
         heap_segment* seg = generation_allocation_segment (gen);
-        if (!(loh_size_fit_p (size, generation_allocation_pointer (gen), generation_allocation_limit (gen))))
+        if (!(loh_size_fit_p (size, generation_allocation_pointer (gen), generation_allocation_limit (gen), 
+                              (generation_allocation_limit (gen) == heap_segment_plan_allocated (seg)))))
         {
             if ((!(loh_pinned_plug_que_empty_p()) &&
                  (generation_allocation_limit (gen) ==
@@ -27953,7 +27958,10 @@ retry:
                 }
                 else
                 {
-                    if (loh_size_fit_p (size, generation_allocation_pointer (gen), heap_segment_reserved (seg)) &&
+                    if (loh_size_fit_p (size, generation_allocation_pointer (gen), heap_segment_reserved (seg), true) &&
+                        // We are overestimating here by padding with 2 loh_padding_obj_size objects which we shouldn't need
+                        // to do if it's at the end of the region. However, grow_heap_segment is already overestimating by
+                        // a lot more - it would be worth fixing when we are in extreme low memory situations.
                         (grow_heap_segment (seg, (generation_allocation_pointer (gen) + size + 2* AlignQword (loh_padding_obj_size)))))
                     {
                         dprintf (1235, ("growing seg from %p to %p\n", heap_segment_committed (seg),

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -2549,7 +2549,7 @@ protected:
 
     PER_HEAP_METHOD mark* loh_oldest_pin();
 
-    PER_HEAP_METHOD BOOL loh_size_fit_p (size_t size, uint8_t* alloc_pointer, uint8_t* alloc_limit);
+    PER_HEAP_METHOD BOOL loh_size_fit_p (size_t size, uint8_t* alloc_pointer, uint8_t* alloc_limit, bool end_p);
 
     PER_HEAP_METHOD uint8_t* loh_allocate_in_condemned (size_t size);
 


### PR DESCRIPTION
I'm running GCPerfSim with this commandline and this env -
```
corerun.exe GCPerfSim.dll -tc 60 -tagb 100 -tlgb 9.5 -lohar 0 -pohar 0 -sohsr 100-4000 -lohsr 102400-204800 -pohsr 100-204800 -sohsi 50 -lohsi 0 -pohsi 0 -sohpi 0 -lohpi 0  -sohfi 0 -lohfi 0 -pohfi 0 -allocType simple -testKind time

set COMPlus_GCServer=1
set COMPlus_GCHeapCount=1e
set COMPlus_GCHeapHardLimit=280000000
```
this causes us to hit this FATAL_GC_ERROR. We have one object which is at the very end of the region and we are asking for its size and padding of 2 * loh_padding_obj_size. since (heap_segment_allocated - heap_segment_mem) is (size + loh_padding_obj_size), loh_size_fit_p reports its not fitting so we call grow_heap_segment and at this point we are so low on memory we don't have ~16 pages left so we try to goto the next region and there's no more regions (in this case this is the only region in gen3).

We shouldn't be asking for (2 * loh_padding_obj_size) for padding because this is at the end of a region (same with segments).