### PR TITLE
[mono] Raise soft RLIMIT_NOFILE on Linux

### DIFF
--- a/src/mono/CMakeLists.txt
+++ b/src/mono/CMakeLists.txt
@@ -909,6 +909,8 @@ else()
 endif()
 
 if(CLR_CMAKE_HOST_ALPINE_LINUX)
+  # Setting RLIMIT_NOFILE breaks debugging of coreclr on Alpine Linux for some reason
+  add_definitions(-DDONT_SET_RLIMIT_NOFILE)
   # On Alpine Linux, we need to ensure that the reported stack range for the primary thread is
   # larger than the initial committed stack size.
   add_definitions(-DENSURE_PRIMARY_STACK_SIZE)

--- a/src/mono/mono/mini/driver.c
+++ b/src/mono/mono/mini/driver.c
@@ -1919,7 +1919,7 @@ increase_descriptor_limit (void)
 		// Set our soft limit for file descriptors to be the same
 		// as the max limit.
 		limit.rlim_cur = limit.rlim_max;
-#ifdef TARGET_OSX
+#ifdef __APPLE__
 		// Based on compatibility note in setrlimit(2) manpage for OSX,
 		// trim the limit to OPEN_MAX.
 		if (limit.rlim_cur > OPEN_MAX)

--- a/src/mono/mono/mini/driver.c
+++ b/src/mono/mono/mini/driver.c
@@ -69,7 +69,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <locale.h>
-#if TARGET_OSX
+#ifdef HAVE_SYS_RESOURCE_H
 #   include <sys/resource.h>
 #endif
 
@@ -1909,23 +1909,28 @@ switch_gc (char* argv[], const char* target_gc)
 #endif
 }
 
-#ifdef TARGET_OSX
-
-/*
- * tries to increase the minimum number of files, if the number is below 1024
- */
 static void
-darwin_change_default_file_handles ()
+increase_descriptor_limit (void)
 {
+#if defined(HAVE_GETRLIMIT) && !defined(DONT_SET_RLIMIT_NOFILE)
 	struct rlimit limit;
 
-	if (getrlimit (RLIMIT_NOFILE, &limit) == 0){
-		if (limit.rlim_cur < 1024){
-			limit.rlim_cur = MAX(1024,limit.rlim_cur);
-			setrlimit (RLIMIT_NOFILE, &limit);
-		}
+	if (getrlimit (RLIMIT_NOFILE, &limit) == 0) {
+		// Set our soft limit for file descriptors to be the same
+		// as the max limit.
+		limit.rlim_cur = limit.rlim_max;
+#ifdef TARGET_OSX
+		// Based on compatibility note in setrlimit(2) manpage for OSX,
+		// trim the limit to OPEN_MAX.
+		if (limit.rlim_cur > OPEN_MAX)
+			limit.rlim_cur = OPEN_MAX;
+#endif
+		setrlimit (RLIMIT_NOFILE, &limit);
 	}
+#endif
 }
+
+#ifdef TARGET_OSX
 
 static void
 switch_arch (char* argv[], const char* target_arch)
@@ -2084,9 +2089,7 @@ mono_main (int argc, char* argv[])
 
 	setlocale (LC_ALL, "");
 
-#if TARGET_OSX
-	darwin_change_default_file_handles ();
-#endif
+	increase_descriptor_limit ();
 
 	if (g_hasenv ("MONO_NO_SMP"))
 		mono_set_use_smp (FALSE);


### PR DESCRIPTION
Replace darwin_change_default_file_handles by a new routine increase_descriptor_limit, which mirrors the logic in the CoreCLR INIT_IncreaseDescriptorLimit routine.

Fixes https://github.com/dotnet/runtime/issues/82428.