### PR TITLE
[release/6.0] System.Console: allow terminfo files to be larger than 4KiB.

### DIFF
--- a/src/libraries/System.Console/src/System/TermInfo.cs
+++ b/src/libraries/System.Console/src/System/TermInfo.cs
@@ -258,9 +258,8 @@ namespace System
                     // Read in all of the terminfo data
                     long termInfoLength = Interop.CheckIo(Interop.Sys.LSeek(fd, 0, Interop.Sys.SeekWhence.SEEK_END)); // jump to the end to get the file length
                     Interop.CheckIo(Interop.Sys.LSeek(fd, 0, Interop.Sys.SeekWhence.SEEK_SET)); // reset back to beginning
-                    const int MaxTermInfoLength = 4096; // according to the term and tic man pages, 4096 is the terminfo file size max
                     const int HeaderLength = 12;
-                    if (termInfoLength <= HeaderLength || termInfoLength > MaxTermInfoLength)
+                    if (termInfoLength <= HeaderLength)
                     {
                         throw new InvalidOperationException(SR.IO_TermInfoInvalid);
                     }


### PR DESCRIPTION
Backport of #82038 to release/6.0

## Customer Impact

Upcoming Fedora 38 provides a TermInfo file which is larger than artificial limit we have set in .NET Core 1.0. Usage of any `Console` APIs ends up with an exception. This PR removes the max file size check.

## Testing

@tmds has provided the fix and tested the changes on Fedora 38.

## Risk

I can't think of any, as TermInfo files are stored in a secure location.

No OOB changes needed for System.Console.