### PR TITLE
Run check before generating the config file

### DIFF
--- a/src/native/corehost/hostmisc/configure.cmake
+++ b/src/native/corehost/hostmisc/configure.cmake
@@ -2,6 +2,6 @@ include(CheckStructHasMember)
 include(CheckSymbolExists)
 
 check_struct_has_member("struct dirent" d_type dirent.h HAVE_DIRENT_D_TYPE)
+check_symbol_exists(getauxval sys/auxv.h HAVE_GETAUXVAL)
 
 configure_file(${CMAKE_CURRENT_LIST_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
-check_symbol_exists(getauxval sys/auxv.h HAVE_GETAUXVAL)


### PR DESCRIPTION
Logs don't reflect it but the real result of this check was missing from config file of static singlefilehost (only) (which is built as part of coreclr). I was grepping something else under `artifacts/obj` when I found that the value of `HAVE_GETAUXVAL` was 0 in `artifacts/obj/coreclr/linux.arm64.Debug/Corehost.Static/config.h`, and 1 in all other generated config files where it is defined.