### PR TITLE
Add LoaderAllocator as a dac/sos concept

### DIFF
--- a/src/coreclr/debug/daccess/dacimpl.h
+++ b/src/coreclr/debug/daccess/dacimpl.h
@@ -1206,7 +1206,11 @@ public:
         CLRDATA_ADDRESS *allocPtr,
         CLRDATA_ADDRESS *allocLimit);
 
-    virtual HRESULT STDMETHODCALLTYPE TraverseLoaderHeap(CLRDATA_ADDRESS loaderHeapAddr, LoaderHeapKind kind, VISITHEAP pCallback);
+    // ISOSDacInterface13
+    virtual HRESULT STDMETHODCALLTYPE TraverseLoaderHeap(CLRDATA_ADDRESS loaderHeapAddr, LoaderHeapKind kind, VISITHEAP pCallback);        
+    virtual HRESULT STDMETHODCALLTYPE GetDomainLoaderAllocator(CLRDATA_ADDRESS domainAddress, CLRDATA_ADDRESS *pLoaderAllocator);
+    virtual HRESULT STDMETHODCALLTYPE GetLoaderAllocatorHeapNames(int count, const char **ppNames, int *pNeeded);
+    virtual HRESULT STDMETHODCALLTYPE GetLoaderAllocatorHeaps(CLRDATA_ADDRESS loaderAllocator, int count, CLRDATA_ADDRESS *pLoaderHeaps, LoaderHeapKind *pKinds, int *pNeeded);
 
     //
     // ClrDataAccess.

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -3573,9 +3573,10 @@ HRESULT ClrDataAccess::GetDomainLoaderAllocator(CLRDATA_ADDRESS domainAddress, C
     return hr;
 }
 
-// The ordering of these entries must match the order enumerated in GetLoaderAllocatorHeaps
-const int LoaderHeapArrayCount = 12;
-static const char *LoaderAllocatorLoaderHeapNames[LoaderHeapArrayCount] = 
+// The ordering of these entries must match the order enumerated in GetLoaderAllocatorHeaps.
+// This array isn't fixed, we can reorder/add/remove entries as long as the corresponding
+// code in GetLoaderAllocatorHeaps is updated to match.
+static const char *LoaderAllocatorLoaderHeapNames[] = 
 {
     "LowFrequencyHeap",
     "HighFrequencyHeap",
@@ -3599,14 +3600,15 @@ HRESULT ClrDataAccess::GetLoaderAllocatorHeaps(CLRDATA_ADDRESS loaderAllocatorAd
 
     SOSDacEnter();
 
+    const int loaderHeapCount = ARRAY_SIZE(LoaderAllocatorLoaderHeapNames);
     PTR_LoaderAllocator pLoaderAllocator = PTR_LoaderAllocator(TO_TADDR(loaderAllocatorAddress));
 
     if (pNeeded)
-        *pNeeded = LoaderHeapArrayCount;
+        *pNeeded = loaderHeapCount;
 
     if (pLoaderHeaps)
     {
-        if (count < LoaderHeapArrayCount)
+        if (count < loaderHeapCount)
         {
             hr = E_INVALIDARG;
         }
@@ -3624,7 +3626,7 @@ HRESULT ClrDataAccess::GetLoaderAllocatorHeaps(CLRDATA_ADDRESS loaderAllocatorAd
             VirtualCallStubManager *pVcsMgr = pLoaderAllocator->GetVirtualCallStubManager();
             if (pVcsMgr == nullptr)
             {
-                for (; i < min(count, LoaderHeapArrayCount); i++)
+                for (; i < min(count, loaderHeapCount); i++)
                     pLoaderHeaps[i] = 0;
             }
             else
@@ -3651,15 +3653,16 @@ HRESULT
 ClrDataAccess::GetLoaderAllocatorHeapNames(int count, const char **ppNames, int *pNeeded)
 {
     SOSDacEnter();
-
+    
+    const int loaderHeapCount = ARRAY_SIZE(LoaderAllocatorLoaderHeapNames);
     if (pNeeded)
-        *pNeeded = LoaderHeapArrayCount;
+        *pNeeded = loaderHeapCount;
 
     if (ppNames)
-        for (int i = 0; i < min(count, LoaderHeapArrayCount); i++)
+        for (int i = 0; i < min(count, loaderHeapCount); i++)
             ppNames[i] = LoaderAllocatorLoaderHeapNames[i];
 
-    if (count < LoaderHeapArrayCount)
+    if (count < loaderHeapCount)
         hr = S_FALSE;
 
     SOSDacLeave();

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -3574,7 +3574,8 @@ HRESULT ClrDataAccess::GetDomainLoaderAllocator(CLRDATA_ADDRESS domainAddress, C
 }
 
 // The ordering of these entries must match the order enumerated in GetLoaderAllocatorHeaps
-static const char *LoaderAllocatorLoaderHeapNames[] = 
+const int LoaderHeapArrayCount = 12;
+static const char *LoaderAllocatorLoaderHeapNames[LoaderHeapArrayCount] = 
 {
     "LowFrequencyHeap",
     "HighFrequencyHeap",
@@ -3590,7 +3591,6 @@ static const char *LoaderAllocatorLoaderHeapNames[] =
     "VtableHeap",
 };
 
-const int LoaderHeapCount = 12;
 
 HRESULT ClrDataAccess::GetLoaderAllocatorHeaps(CLRDATA_ADDRESS loaderAllocatorAddress, int count, CLRDATA_ADDRESS *pLoaderHeaps, LoaderHeapKind *pKinds, int *pNeeded)
 {
@@ -3602,11 +3602,11 @@ HRESULT ClrDataAccess::GetLoaderAllocatorHeaps(CLRDATA_ADDRESS loaderAllocatorAd
     PTR_LoaderAllocator pLoaderAllocator = PTR_LoaderAllocator(TO_TADDR(loaderAllocatorAddress));
 
     if (pNeeded)
-        *pNeeded = LoaderHeapCount;
+        *pNeeded = LoaderHeapArrayCount;
 
     if (pLoaderHeaps)
     {
-        if (count < LoaderHeapCount)
+        if (count < LoaderHeapArrayCount)
         {
             hr = E_INVALIDARG;
         }
@@ -3624,7 +3624,7 @@ HRESULT ClrDataAccess::GetLoaderAllocatorHeaps(CLRDATA_ADDRESS loaderAllocatorAd
             VirtualCallStubManager *pVcsMgr = pLoaderAllocator->GetVirtualCallStubManager();
             if (pVcsMgr == nullptr)
             {
-                for (; i < min(count, LoaderHeapCount); i++)
+                for (; i < min(count, LoaderHeapArrayCount); i++)
                     pLoaderHeaps[i] = 0;
             }
             else
@@ -3653,13 +3653,13 @@ ClrDataAccess::GetLoaderAllocatorHeapNames(int count, const char **ppNames, int 
     SOSDacEnter();
 
     if (pNeeded)
-        *pNeeded = LoaderHeapCount;
+        *pNeeded = LoaderHeapArrayCount;
 
     if (ppNames)
-        for (int i = 0; i < min(count, LoaderHeapCount); i++)
+        for (int i = 0; i < min(count, LoaderHeapArrayCount); i++)
             ppNames[i] = LoaderAllocatorLoaderHeapNames[i];
 
-    if (count < LoaderHeapCount)
+    if (count < LoaderHeapArrayCount)
         hr = S_FALSE;
 
     SOSDacLeave();

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -3590,6 +3590,8 @@ static const char *LoaderAllocatorLoaderHeapNames[] =
     "VtableHeap",
 };
 
+const int LoaderHeapCount = 12;
+
 HRESULT ClrDataAccess::GetLoaderAllocatorHeaps(CLRDATA_ADDRESS loaderAllocatorAddress, int count, CLRDATA_ADDRESS *pLoaderHeaps, LoaderHeapKind *pKinds, int *pNeeded)
 {
     if (loaderAllocatorAddress == 0)
@@ -3597,15 +3599,14 @@ HRESULT ClrDataAccess::GetLoaderAllocatorHeaps(CLRDATA_ADDRESS loaderAllocatorAd
 
     SOSDacEnter();
 
-    const int total = _countof(LoaderAllocatorLoaderHeapNames);
     PTR_LoaderAllocator pLoaderAllocator = PTR_LoaderAllocator(TO_TADDR(loaderAllocatorAddress));
 
     if (pNeeded)
-        *pNeeded = total;
+        *pNeeded = LoaderHeapCount;
 
     if (pLoaderHeaps)
     {
-        if (count < total)
+        if (count < LoaderHeapCount)
         {
             hr = E_INVALIDARG;
         }
@@ -3623,7 +3624,7 @@ HRESULT ClrDataAccess::GetLoaderAllocatorHeaps(CLRDATA_ADDRESS loaderAllocatorAd
             VirtualCallStubManager *pVcsMgr = pLoaderAllocator->GetVirtualCallStubManager();
             if (pVcsMgr == nullptr)
             {
-                for (; i < min(count, total); i++)
+                for (; i < min(count, LoaderHeapCount); i++)
                     pLoaderHeaps[i] = 0;
             }
             else
@@ -3635,6 +3636,10 @@ HRESULT ClrDataAccess::GetLoaderAllocatorHeaps(CLRDATA_ADDRESS loaderAllocatorAd
                 pLoaderHeaps[i++] = HOST_CDADDR(pVcsMgr->cache_entry_heap);
                 pLoaderHeaps[i++] = HOST_CDADDR(pVcsMgr->vtable_heap);
             }
+            
+            // All of the above are "LoaderHeap" and not the ExplicitControl version.
+            for (int j = 0; j < i; j++)
+                pKinds[j] = LoaderHeapKindNormal;
         }
     }
 
@@ -3647,15 +3652,14 @@ ClrDataAccess::GetLoaderAllocatorHeapNames(int count, const char **ppNames, int 
 {
     SOSDacEnter();
 
-    const int needed = _countof(LoaderAllocatorLoaderHeapNames);
     if (pNeeded)
-        *pNeeded = needed;
+        *pNeeded = LoaderHeapCount;
 
     if (ppNames)
-        for (int i = 0; i < min(count, needed); i++)
+        for (int i = 0; i < min(count, LoaderHeapCount); i++)
             ppNames[i] = LoaderAllocatorLoaderHeapNames[i];
 
-    if (count < needed)
+    if (count < LoaderHeapCount)
         hr = S_FALSE;
 
     SOSDacLeave();

--- a/src/coreclr/inc/dacprivate.h
+++ b/src/coreclr/inc/dacprivate.h
@@ -250,8 +250,8 @@ struct MSLAYOUT DacpModuleData
     CLRDATA_ADDRESS FileReferencesMap = 0;
     CLRDATA_ADDRESS ManifestModuleReferencesMap = 0;
 
-    CLRDATA_ADDRESS pLookupTableHeap = 0;
-    CLRDATA_ADDRESS pThunkHeap = 0;
+    CLRDATA_ADDRESS LoaderAllocator = 0;
+    CLRDATA_ADDRESS ThunkHeap = 0;
 
     ULONG64 dwModuleIndex = 0;
 

--- a/src/coreclr/inc/sospriv.idl
+++ b/src/coreclr/inc/sospriv.idl
@@ -470,4 +470,7 @@ interface ISOSDacInterface12 : IUnknown
 interface ISOSDacInterface13 : IUnknown
 {
     HRESULT TraverseLoaderHeap(CLRDATA_ADDRESS loaderHeapAddr, LoaderHeapKind kind, VISITHEAP pCallback);
+    HRESULT GetDomainLoaderAllocator(CLRDATA_ADDRESS domainAddress, CLRDATA_ADDRESS *pLoaderAllocator);
+    HRESULT GetLoaderAllocatorHeapNames(int count, const char **ppNames, int *pNeeded);
+    HRESULT GetLoaderAllocatorHeaps(CLRDATA_ADDRESS loaderAllocator, int count, CLRDATA_ADDRESS *pLoaderHeaps, LoaderHeapKind *pKinds, int *pNeeded);
 }

--- a/src/coreclr/pal/prebuilt/inc/sospriv.h
+++ b/src/coreclr/pal/prebuilt/inc/sospriv.h
@@ -3093,6 +3093,21 @@ EXTERN_C const IID IID_ISOSDacInterface13;
             LoaderHeapKind kind,
             VISITHEAP pCallback) = 0;
         
+        virtual HRESULT STDMETHODCALLTYPE GetDomainLoaderAllocator( 
+            CLRDATA_ADDRESS domainAddress,
+            CLRDATA_ADDRESS *pLoaderAllocator) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetLoaderAllocatorHeapNames( 
+            int count,
+            const char **ppNames,
+            int *pNeeded) = 0;
+        
+        virtual HRESULT STDMETHODCALLTYPE GetLoaderAllocatorHeaps( 
+            CLRDATA_ADDRESS loaderAllocator,
+            int count,
+            CLRDATA_ADDRESS *pLoaderHeaps,
+            LoaderHeapKind *pKinds,
+            int *pNeeded) = 0;
     };
     
     


### PR DESCRIPTION
- DacpModuleData: Repurposed two unused fields to produce the module's LoaderAllocator and ThunkHeap.  The LoaderAllocator often will be the same as the SystemDomain's, except in the case of collectable assemblies.
- Added the way to get the direct LoaderAllocator address from an AppDomain.
- Added a new way to enumerate the heaps associated with a LoaderAllocator in a future-proof way.  Now when the implementation of CLR changes to add, remove, or rename/repurpose an existing heap, we can still produce the right diagnostic data without needing to ship a new interface.

This does expose LoaderAllocators as a new concept to the dac, but the original design of hiding them actually causes a lot more problems than it solves.

For example, the SystemDomain and AppDomain share the same LoaderAllocator and associated heaps...but that implementation detail is opaque to something like ClrMD or SOS (and was different on desktop CLR, so it's tough to take a dependency on that detail).  This means things like !eeheap would dutifully double report heap ranges and sizes.  We are now able to distinguish when we've already seen the same LoaderAllocator and take appropriate action.

We also now need to know AppDomain's LoaderAllocator address to compare to DacpModuleData's to see if we should enumerate that module's heaps or not.

Lastly, the interface was written so that it could be backported to Desktop CLR if we ever deem that necessary.  That's why we have a function to get any AppDomain's LoaderAllocator, even though in .Net Core we only have one.  It's unlikely we'll ever backport it, but we do have that option.