### PR TITLE
[NativeAOT] Cache and reuse some allocations during Linq.Expression evaluation.

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/DelegateHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/DelegateHelpers.cs
@@ -12,9 +12,33 @@ namespace Internal.Runtime.CompilerHelpers
     {
         private static object[] s_emptyObjectArray = Array.Empty<object>();
 
-        internal static object[] GetEmptyObjectArray()
+        private const int CacheLength = 16;
+        [ThreadStatic]
+        private static object[][] _arrayCache;
+
+        internal static void ReturnObjectArray(object[] array)
         {
-            return s_emptyObjectArray;
+            int length = array.Length;
+            if (length < CacheLength)
+            {
+                Array.Clear(array);
+                _arrayCache[length] = array;
+            }
+        }
+
+        internal static object[] GetObjectArray(int length)
+        {
+            if (length == 0)
+                return s_emptyObjectArray;
+
+            object[] result = null!;
+            if (length < CacheLength)
+            {
+                _arrayCache ??= new object[CacheLength][];
+                result = _arrayCache[length];
+            }
+
+            return result ?? new object[length];
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/DelegateHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/DelegateHelpers.cs
@@ -16,16 +16,6 @@ namespace Internal.Runtime.CompilerHelpers
         [ThreadStatic]
         private static object[][] _arrayCache;
 
-        internal static void ReturnObjectArray(object[] array)
-        {
-            int length = array.Length;
-            if (length < CacheLength)
-            {
-                Array.Clear(array);
-                _arrayCache[length] = array;
-            }
-        }
-
         internal static object[] GetObjectArray(int length)
         {
             if (length == 0)
@@ -39,6 +29,16 @@ namespace Internal.Runtime.CompilerHelpers
             }
 
             return result ?? new object[length];
+        }
+
+        internal static void ReturnObjectArray(object[] array)
+        {
+            int length = array.Length;
+            if (length < CacheLength)
+            {
+                Array.Clear(array);
+                _arrayCache[length] = array;
+            }
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/DelegateHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/DelegateHelpers.cs
@@ -14,7 +14,7 @@ namespace Internal.Runtime.CompilerHelpers
 
         private const int CacheLength = 16;
         [ThreadStatic]
-        private static object[][] _arrayCache;
+        private static object[][] t_arrayCache;
 
         internal static object[] GetObjectArray(int length)
         {
@@ -22,10 +22,10 @@ namespace Internal.Runtime.CompilerHelpers
                 return s_emptyObjectArray;
 
             object[] result = null!;
-            if (length < CacheLength)
+            if (length <= CacheLength)
             {
-                _arrayCache ??= new object[CacheLength][];
-                result = _arrayCache[length];
+                t_arrayCache ??= new object[CacheLength][];
+                result = t_arrayCache[length - 1];
             }
 
             return result ?? new object[length];
@@ -34,10 +34,10 @@ namespace Internal.Runtime.CompilerHelpers
         internal static void ReturnObjectArray(object[] array)
         {
             int length = array.Length;
-            if (length < CacheLength)
+            if (length <= CacheLength)
             {
                 Array.Clear(array);
-                _arrayCache[length] = array;
+                t_arrayCache[length - 1] = array;
             }
         }
     }

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateThunks.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateThunks.cs
@@ -524,35 +524,32 @@ namespace Internal.IL.Stubs
             codeStream.Emit(ILOpcode.call, emitter.NewToken(getObjectArrayMethod));
             codeStream.EmitStLoc(argsLocal);
 
-            if (Signature.Length > 0)
+            for (int i = 0; i < Signature.Length; i++)
             {
-                for (int i = 0; i < Signature.Length; i++)
+                TypeDesc paramType = Signature[i];
+                bool paramIsByRef = false;
+
+                if (paramType.IsByRef)
                 {
-                    TypeDesc paramType = Signature[i];
-                    bool paramIsByRef = false;
-
-                    if (paramType.IsByRef)
-                    {
-                        hasRefArgs |= paramType.IsByRef;
-                        paramIsByRef = true;
-                        paramType = ((ByRefType)paramType).ParameterType;
-                    }
-
                     hasRefArgs |= paramType.IsByRef;
-
-                    codeStream.EmitLdLoc(argsLocal);
-                    codeStream.EmitLdc(i);
-                    codeStream.EmitLdArg(i + 1);
-
-                    ILToken paramToken = emitter.NewToken(paramType);
-
-                    if (paramIsByRef)
-                    {
-                        codeStream.Emit(ILOpcode.ldobj, paramToken);
-                    }
-                    codeStream.Emit(ILOpcode.box, paramToken);
-                    codeStream.Emit(ILOpcode.stelem_ref);
+                    paramIsByRef = true;
+                    paramType = ((ByRefType)paramType).ParameterType;
                 }
+
+                hasRefArgs |= paramType.IsByRef;
+
+                codeStream.EmitLdLoc(argsLocal);
+                codeStream.EmitLdc(i);
+                codeStream.EmitLdArg(i + 1);
+
+                ILToken paramToken = emitter.NewToken(paramType);
+
+                if (paramIsByRef)
+                {
+                    codeStream.Emit(ILOpcode.ldobj, paramToken);
+                }
+                codeStream.Emit(ILOpcode.box, paramToken);
+                codeStream.Emit(ILOpcode.stelem_ref);
             }
 
             ILExceptionRegionBuilder tryFinallyRegion = null;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AddInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AddInstruction.cs
@@ -18,7 +18,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class AddInt16 : AddInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -36,7 +36,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class AddInt32 : AddInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -54,7 +54,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class AddInt64 : AddInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -72,7 +72,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class AddUInt16 : AddInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -90,7 +90,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class AddUInt32 : AddInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -108,7 +108,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class AddUInt64 : AddInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -126,7 +126,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class AddSingle : AddInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -144,7 +144,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class AddDouble : AddInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -190,7 +190,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class AddOvfInt16 : AddOvfInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -208,7 +208,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class AddOvfInt32 : AddOvfInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -226,7 +226,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class AddOvfInt64 : AddOvfInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -244,7 +244,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class AddOvfUInt16 : AddOvfInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -262,7 +262,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class AddOvfUInt32 : AddOvfInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -280,7 +280,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class AddOvfUInt64 : AddOvfInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AndInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/AndInstruction.cs
@@ -17,7 +17,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class AndSByte : AndInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -33,7 +33,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class AndInt16 : AndInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -49,7 +49,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class AndInt32 : AndInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -65,7 +65,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class AndInt64 : AndInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -81,7 +81,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class AndByte : AndInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -97,7 +97,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class AndUInt16 : AndInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -113,7 +113,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class AndUInt32 : AndInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -129,7 +129,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class AndUInt64 : AndInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -145,7 +145,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class AndBoolean : AndInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ArrayOperations.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ArrayOperations.cs
@@ -18,7 +18,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ProducedStack => 1;
         public override string InstructionName => "NewArrayInit";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             Array array = Array.CreateInstance(_elementType, _elementCount);
             for (int i = _elementCount - 1; i >= 0; i--)
@@ -43,7 +43,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ProducedStack => 1;
         public override string InstructionName => "NewArray";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             int length = ConvertHelper.ToInt32NoNull(frame.Pop());
             // To make behavior aligned with array creation emitted by C# compiler if length is less than
@@ -69,7 +69,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ProducedStack => 1;
         public override string InstructionName => "NewArrayBounds";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             var lengths = new int[_rank];
             for (int i = _rank - 1; i >= 0; i--)
@@ -100,7 +100,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ProducedStack => 1;
         public override string InstructionName => "GetArrayItem";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             int index = ConvertHelper.ToInt32NoNull(frame.Pop());
             Array array = (Array)frame.Pop()!;
@@ -118,7 +118,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ConsumedStack => 3;
         public override string InstructionName => "SetArrayItem";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             object? value = frame.Pop();
             int index = ConvertHelper.ToInt32NoNull(frame.Pop());
@@ -138,7 +138,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private ArrayLengthInstruction() { }
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             object obj = frame.Pop()!;
             frame.Push(((Array)obj).Length);

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
@@ -222,7 +222,7 @@ namespace System.Linq.Expressions.Interpreter
             _target = (Action)target.CreateDelegate(typeof(Action));
         }
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             _target();
             frame.StackIndex -= 0;
@@ -245,7 +245,7 @@ namespace System.Linq.Expressions.Interpreter
             _target = (Action<T0>)target.CreateDelegate(typeof(Action<T0>));
         }
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             object firstArg = frame.Data[frame.StackIndex - 1];
 
@@ -284,7 +284,7 @@ namespace System.Linq.Expressions.Interpreter
             _target = (Action<T0, T1>)target.CreateDelegate(typeof(Action<T0, T1>));
         }
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             object firstArg = frame.Data[frame.StackIndex - 2];
 
@@ -323,7 +323,7 @@ namespace System.Linq.Expressions.Interpreter
             _target = (Action<T0, T1, T2>)target.CreateDelegate(typeof(Action<T0, T1, T2>));
         }
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             object firstArg = frame.Data[frame.StackIndex - 3];
 
@@ -362,7 +362,7 @@ namespace System.Linq.Expressions.Interpreter
             _target = (Action<T0, T1, T2, T3>)target.CreateDelegate(typeof(Action<T0, T1, T2, T3>));
         }
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             object firstArg = frame.Data[frame.StackIndex - 4];
 
@@ -399,7 +399,7 @@ namespace System.Linq.Expressions.Interpreter
             _target = (Func<TRet>)target.CreateDelegate(typeof(Func<TRet>));
         }
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             frame.Data[frame.StackIndex - 0] = _target();
             frame.StackIndex -= -1;
@@ -422,7 +422,7 @@ namespace System.Linq.Expressions.Interpreter
             _target = (Func<T0, TRet>)target.CreateDelegate(typeof(Func<T0, TRet>));
         }
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             object firstArg = frame.Data[frame.StackIndex - 1];
             object result;
@@ -463,7 +463,7 @@ namespace System.Linq.Expressions.Interpreter
             _target = (Func<T0, T1, TRet>)target.CreateDelegate(typeof(Func<T0, T1, TRet>));
         }
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             object firstArg = frame.Data[frame.StackIndex - 2];
             object result;
@@ -504,7 +504,7 @@ namespace System.Linq.Expressions.Interpreter
             _target = (Func<T0, T1, T2, TRet>)target.CreateDelegate(typeof(Func<T0, T1, T2, TRet>));
         }
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             object firstArg = frame.Data[frame.StackIndex - 3];
             object result;
@@ -545,7 +545,7 @@ namespace System.Linq.Expressions.Interpreter
             _target = (Func<T0, T1, T2, T3, TRet>)target.CreateDelegate(typeof(Func<T0, T1, T2, T3, TRet>));
         }
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             object firstArg = frame.Data[frame.StackIndex - 4];
             object result;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -284,7 +284,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private const int CacheLength = 16;
         [ThreadStatic]
-        private static object?[]?[]? _argsCache;
+        private static object?[]?[]? t_argsCache;
 
         public override int ArgumentCount => _argumentCount;
 
@@ -359,10 +359,10 @@ namespace System.Linq.Expressions.Interpreter
         private static object?[]? GetCachedArgs(int length)
         {
             object?[]? result = null;
-            if (length < CacheLength)
+            if (length <= CacheLength)
             {
-                _argsCache ??= new object?[CacheLength][];
-                result = _argsCache[length];
+                t_argsCache ??= new object?[CacheLength][];
+                result = t_argsCache[length - 1];
             }
 
             return result;
@@ -371,10 +371,10 @@ namespace System.Linq.Expressions.Interpreter
         protected static void ReturnCachedArgs(object?[] args)
         {
             int length = args.Length;
-            if (length > 0 && length < CacheLength)
+            if (length > 0 && length <= CacheLength)
             {
                 Array.Clear(args);
-                _argsCache![length] = args;
+                t_argsCache![length - 1] = args;
             }
         }
 

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -296,7 +296,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int ProducedStack => _target.ReturnType == typeof(void) ? 0 : 1;
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             int first = frame.StackIndex - _argumentCount;
 
@@ -304,7 +304,7 @@ namespace System.Linq.Expressions.Interpreter
             object?[] args;
             if (_target.IsStatic)
             {
-                args = GetArgs(frame, first, 0);
+                args = GetArgs(ref frame, first, 0);
                 try
                 {
                     ret = _target.Invoke(null, args);
@@ -320,7 +320,7 @@ namespace System.Linq.Expressions.Interpreter
                 object? instance = frame.Data[first];
                 NullCheck(instance);
 
-                args = GetArgs(frame, first, 1);
+                args = GetArgs(ref frame, first, 1);
 
                 if (TryGetLightLambdaTarget(instance, out LightLambda? targetLambda))
                 {
@@ -378,7 +378,7 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
-        protected object?[] GetArgs(InterpretedFrame frame, int first, int skip)
+        protected object?[] GetArgs(ref InterpretedFrame frame, int first, int skip)
         {
             int count = _argumentCount - skip;
 
@@ -414,7 +414,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int ProducedStack => _target.ReturnType == typeof(void) ? 0 : 1;
 
-        public sealed override int Run(InterpretedFrame frame)
+        public sealed override int Run(ref InterpretedFrame frame)
         {
             int first = frame.StackIndex - _argumentCount;
             object?[]? args = null;
@@ -425,7 +425,7 @@ namespace System.Linq.Expressions.Interpreter
                 object? ret;
                 if (_target.IsStatic)
                 {
-                    args = GetArgs(frame, first, 0);
+                    args = GetArgs(ref frame, first, 0);
                     try
                     {
                         ret = _target.Invoke(null, args);
@@ -441,7 +441,7 @@ namespace System.Linq.Expressions.Interpreter
                     instance = frame.Data[first];
                     NullCheck(instance);
 
-                    args = GetArgs(frame, first, 1);
+                    args = GetArgs(ref frame, first, 1);
 
                     if (TryGetLightLambdaTarget(instance, out LightLambda? targetLambda))
                     {
@@ -480,7 +480,7 @@ namespace System.Linq.Expressions.Interpreter
                     {
                         // -1: instance param, just copy back the exact instance invoked with, which
                         // gets passed by reference from reflection for value types.
-                        arg.Update(frame, arg.ArgumentIndex == -1 ? instance : args[arg.ArgumentIndex]);
+                        arg.Update(ref frame, arg.ArgumentIndex == -1 ? instance : args[arg.ArgumentIndex]);
                     }
 
                     ReturnCachedArgs(args);

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DecrementInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DecrementInstruction.cs
@@ -18,7 +18,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class DecrementInt16 : DecrementInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)
@@ -35,7 +35,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class DecrementInt32 : DecrementInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)
@@ -52,7 +52,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class DecrementInt64 : DecrementInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)
@@ -69,7 +69,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class DecrementUInt16 : DecrementInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)
@@ -86,7 +86,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class DecrementUInt32 : DecrementInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)
@@ -103,7 +103,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class DecrementUInt64 : DecrementInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)
@@ -120,7 +120,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class DecrementSingle : DecrementInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)
@@ -137,7 +137,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class DecrementDouble : DecrementInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DefaultValueInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DefaultValueInstruction.cs
@@ -25,7 +25,7 @@ namespace System.Linq.Expressions.Interpreter
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2077:UnrecognizedReflectionPattern",
             Justification = "_type is a ValueType. You can always get an uninitialized ValueType.")]
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             frame.Push(RuntimeHelpers.GetUninitializedObject(_type));
             return 1;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DivInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/DivInstruction.cs
@@ -18,7 +18,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class DivInt16 : DivInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -36,7 +36,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class DivInt32 : DivInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -54,7 +54,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class DivInt64 : DivInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -72,7 +72,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class DivUInt16 : DivInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -90,7 +90,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class DivUInt32 : DivInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -108,7 +108,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class DivUInt64 : DivInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -126,7 +126,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class DivSingle : DivInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -144,7 +144,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class DivDouble : DivInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/EqualInstruction.cs
@@ -20,7 +20,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualBoolean : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -42,7 +42,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualSByte : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -64,7 +64,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualInt16 : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -86,7 +86,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualChar : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -108,7 +108,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualInt32 : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -130,7 +130,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualInt64 : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -152,7 +152,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualByte : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -174,7 +174,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualUInt16 : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -196,7 +196,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualUInt32 : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -218,7 +218,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualUInt64 : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -240,7 +240,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualSingle : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -262,7 +262,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualDouble : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -284,7 +284,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualReference : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 frame.Push(frame.Pop() == frame.Pop());
                 return 1;
@@ -293,7 +293,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualBooleanLiftedToNull : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -311,7 +311,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualSByteLiftedToNull : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -329,7 +329,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualInt16LiftedToNull : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -347,7 +347,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualCharLiftedToNull : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -365,7 +365,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualInt32LiftedToNull : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -383,7 +383,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualInt64LiftedToNull : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -401,7 +401,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualByteLiftedToNull : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -419,7 +419,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualUInt16LiftedToNull : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -437,7 +437,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualUInt32LiftedToNull : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -455,7 +455,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualUInt64LiftedToNull : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -473,7 +473,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualSingleLiftedToNull : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -491,7 +491,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class EqualDoubleLiftedToNull : EqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ExclusiveOrInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ExclusiveOrInstruction.cs
@@ -17,7 +17,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class ExclusiveOrSByte : ExclusiveOrInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -33,7 +33,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class ExclusiveOrInt16 : ExclusiveOrInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -49,7 +49,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class ExclusiveOrInt32 : ExclusiveOrInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -65,7 +65,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class ExclusiveOrInt64 : ExclusiveOrInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -81,7 +81,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class ExclusiveOrByte : ExclusiveOrInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -97,7 +97,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class ExclusiveOrUInt16 : ExclusiveOrInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -113,7 +113,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class ExclusiveOrUInt32 : ExclusiveOrInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -129,7 +129,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class ExclusiveOrUInt64 : ExclusiveOrInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -145,7 +145,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class ExclusiveOrBoolean : ExclusiveOrInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/FieldOperations.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/FieldOperations.cs
@@ -30,7 +30,7 @@ namespace System.Linq.Expressions.Interpreter
         public override string InstructionName => "LoadStaticField";
         public override int ProducedStack => 1;
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             frame.Push(_field.GetValue(obj: null));
             return 1;
@@ -48,7 +48,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ConsumedStack => 1;
         public override int ProducedStack => 1;
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             object? self = frame.Pop();
 
@@ -69,7 +69,7 @@ namespace System.Linq.Expressions.Interpreter
         public override string InstructionName => "StoreField";
         public override int ConsumedStack => 2;
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             object? value = frame.Pop();
             object? self = frame.Pop();
@@ -92,7 +92,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override int ConsumedStack => 1;
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             object? value = frame.Pop();
             _field.SetValue(null, value);

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanInstruction.cs
@@ -28,7 +28,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -51,7 +51,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -74,7 +74,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -97,7 +97,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -120,7 +120,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -143,7 +143,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -166,7 +166,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -189,7 +189,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -212,7 +212,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -235,7 +235,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -258,7 +258,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanOrEqualInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/GreaterThanOrEqualInstruction.cs
@@ -28,7 +28,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -51,7 +51,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -74,7 +74,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -97,7 +97,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -120,7 +120,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -143,7 +143,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -166,7 +166,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -189,7 +189,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -212,7 +212,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -235,7 +235,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -258,7 +258,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/IncrementInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/IncrementInstruction.cs
@@ -18,7 +18,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class IncrementInt16 : IncrementInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)
@@ -35,7 +35,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class IncrementInt32 : IncrementInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)
@@ -52,7 +52,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class IncrementInt64 : IncrementInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)
@@ -69,7 +69,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class IncrementUInt16 : IncrementInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)
@@ -86,7 +86,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class IncrementUInt32 : IncrementInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)
@@ -103,7 +103,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class IncrementUInt64 : IncrementInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)
@@ -120,7 +120,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class IncrementSingle : IncrementInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)
@@ -137,7 +137,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class IncrementDouble : IncrementInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Instruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Instruction.cs
@@ -17,7 +17,7 @@ namespace System.Linq.Expressions.Interpreter
         public int StackBalance => ProducedStack - ConsumedStack;
         public int ContinuationsBalance => ProducedContinuations - ConsumedContinuations;
 
-        public abstract int Run(InterpretedFrame frame);
+        public abstract int Run(ref InterpretedFrame frame);
 
         public abstract string InstructionName { get; }
 

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
@@ -52,6 +52,28 @@ namespace System.Linq.Expressions.Interpreter
             _pendingValue = Interpreter.NoValue;
         }
 
+        internal void Clear()
+        {
+            StackIndex = Interpreter.LocalCount;
+            Array.Clear(Data);
+
+            if (_continuations != null)
+            {
+                Array.Clear(_continuations);
+            }
+
+            _pendingContinuation = -1;
+            _pendingValue = Interpreter.NoValue;
+
+            InstructionIndex = 0;
+            _parent = null;
+            _continuationIndex = 0;
+
+#if FEATURE_THREAD_ABORT
+            CurrentAbortHandler = null;
+#endif
+        }
+
         public DebugInfo? GetDebugInfo(int instructionIndex)
         {
             return DebugInfo.GetMatchingDebugInfo(Interpreter._debugInfos, instructionIndex);

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Interpreter.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/Interpreter.cs
@@ -13,7 +13,7 @@ namespace System.Linq.Expressions.Interpreter
     /// For code that is only run a small number of times this can be a
     /// sweet spot.
     ///
-    /// The core loop in the interpreter is the <see cref="Run(InterpretedFrame)"/>  method.
+    /// The core loop in the interpreter is the <see cref="Run(ref InterpretedFrame)"/>  method.
     /// </summary>
     internal sealed class Interpreter
     {
@@ -53,13 +53,13 @@ namespace System.Linq.Expressions.Interpreter
         /// Each group of subsequent frames of Run method corresponds to a single interpreted frame.
         /// </remarks>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public void Run(InterpretedFrame frame)
+        public void Run(ref InterpretedFrame frame)
         {
             Instruction[] instructions = _instructions.Instructions;
             int index = frame.InstructionIndex;
             while (index < instructions.Length)
             {
-                index += instructions[index].Run(frame);
+                index += instructions[index].Run(ref frame);
                 frame.InstructionIndex = index;
             }
         }

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LeftShiftInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LeftShiftInstruction.cs
@@ -17,7 +17,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class LeftShiftSByte : LeftShiftInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? shift = frame.Pop();
                 object? value = frame.Pop();
@@ -35,7 +35,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class LeftShiftInt16 : LeftShiftInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? shift = frame.Pop();
                 object? value = frame.Pop();
@@ -53,7 +53,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class LeftShiftInt32 : LeftShiftInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? shift = frame.Pop();
                 object? value = frame.Pop();
@@ -71,7 +71,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class LeftShiftInt64 : LeftShiftInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? shift = frame.Pop();
                 object? value = frame.Pop();
@@ -89,7 +89,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class LeftShiftByte : LeftShiftInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? shift = frame.Pop();
                 object? value = frame.Pop();
@@ -107,7 +107,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class LeftShiftUInt16 : LeftShiftInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? shift = frame.Pop();
                 object? value = frame.Pop();
@@ -125,7 +125,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class LeftShiftUInt32 : LeftShiftInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? shift = frame.Pop();
                 object? value = frame.Pop();
@@ -143,7 +143,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class LeftShiftUInt64 : LeftShiftInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? shift = frame.Pop();
                 object? value = frame.Pop();

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanInstruction.cs
@@ -28,7 +28,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -51,7 +51,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -74,7 +74,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -97,7 +97,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -120,7 +120,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -143,7 +143,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -166,7 +166,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -189,7 +189,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -212,7 +212,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -235,7 +235,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -258,7 +258,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanOrEqualInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LessThanOrEqualInstruction.cs
@@ -28,7 +28,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -51,7 +51,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -74,7 +74,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -97,7 +97,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -120,7 +120,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -143,7 +143,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -166,7 +166,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -189,7 +189,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -212,7 +212,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -235,7 +235,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -258,7 +258,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.Generated.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.Generated.cs
@@ -15,14 +15,14 @@ namespace System.Linq.Expressions.Interpreter
         {
             var frame = MakeFrame();
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
             return (TRet)frame.Pop();
         }
         internal void RunVoid0()
         {
             var frame = MakeFrame();
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
         }
 
 #if FEATURE_MAKE_RUN_METHODS
@@ -46,7 +46,7 @@ namespace System.Linq.Expressions.Interpreter
             var frame = MakeFrame();
             frame.Data[0] = arg0;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
             return (TRet)frame.Pop();
         }
         internal void RunVoid1<T0>(T0 arg0)
@@ -54,7 +54,7 @@ namespace System.Linq.Expressions.Interpreter
             var frame = MakeFrame();
             frame.Data[0] = arg0;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
         }
 #if FEATURE_MAKE_RUN_METHODS
         internal static Delegate MakeRun1<T0, TRet>(LightLambda lambda)
@@ -72,7 +72,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[0] = arg0;
             frame.Data[1] = arg1;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
             return (TRet)frame.Pop();
         }
         internal void RunVoid2<T0, T1>(T0 arg0, T1 arg1)
@@ -81,7 +81,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[0] = arg0;
             frame.Data[1] = arg1;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
         }
 #if FEATURE_MAKE_RUN_METHODS
         internal static Delegate MakeRun2<T0, T1, TRet>(LightLambda lambda)
@@ -100,7 +100,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[1] = arg1;
             frame.Data[2] = arg2;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
             return (TRet)frame.Pop();
         }
 
@@ -111,7 +111,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[1] = arg1;
             frame.Data[2] = arg2;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
         }
 
 #if FEATURE_MAKE_RUN_METHODS
@@ -132,7 +132,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[2] = arg2;
             frame.Data[3] = arg3;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
             return (TRet)frame.Pop();
         }
         internal void RunVoid4<T0, T1, T2, T3>(T0 arg0, T1 arg1, T2 arg2, T3 arg3)
@@ -143,7 +143,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[2] = arg2;
             frame.Data[3] = arg3;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
         }
 #if FEATURE_MAKE_RUN_METHODS
         internal static Delegate MakeRun4<T0, T1, T2, T3, TRet>(LightLambda lambda)
@@ -164,7 +164,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[3] = arg3;
             frame.Data[4] = arg4;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
             return (TRet)frame.Pop();
         }
         internal void RunVoid5<T0, T1, T2, T3, T4>(T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
@@ -176,7 +176,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[3] = arg3;
             frame.Data[4] = arg4;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
         }
 #if FEATURE_MAKE_RUN_METHODS
         internal static Delegate MakeRun5<T0, T1, T2, T3, T4, TRet>(LightLambda lambda)
@@ -198,7 +198,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[4] = arg4;
             frame.Data[5] = arg5;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
             return (TRet)frame.Pop();
         }
 
@@ -212,7 +212,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[4] = arg4;
             frame.Data[5] = arg5;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
         }
 #if FEATURE_MAKE_RUN_METHODS
         internal static Delegate MakeRun6<T0, T1, T2, T3, T4, T5, TRet>(LightLambda lambda)
@@ -235,7 +235,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[5] = arg5;
             frame.Data[6] = arg6;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
             return (TRet)frame.Pop();
         }
 
@@ -250,7 +250,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[5] = arg5;
             frame.Data[6] = arg6;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
         }
 #if FEATURE_MAKE_RUN_METHODS
         internal static Delegate MakeRun7<T0, T1, T2, T3, T4, T5, T6, TRet>(LightLambda lambda)
@@ -274,7 +274,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[6] = arg6;
             frame.Data[7] = arg7;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
             return (TRet)frame.Pop();
         }
         internal void RunVoid8<T0, T1, T2, T3, T4, T5, T6, T7>(T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
@@ -289,7 +289,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[6] = arg6;
             frame.Data[7] = arg7;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
         }
 #if FEATURE_MAKE_RUN_METHODS
         internal static Delegate MakeRun8<T0, T1, T2, T3, T4, T5, T6, T7, TRet>(LightLambda lambda)
@@ -314,7 +314,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[7] = arg7;
             frame.Data[8] = arg8;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
             return (TRet)frame.Pop();
         }
         internal void RunVoid9<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
@@ -330,7 +330,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[7] = arg7;
             frame.Data[8] = arg8;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
         }
 #if FEATURE_MAKE_RUN_METHODS
         internal static Delegate MakeRun9<T0, T1, T2, T3, T4, T5, T6, T7, T8, TRet>(LightLambda lambda)
@@ -356,7 +356,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[8] = arg8;
             frame.Data[9] = arg9;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
             return (TRet)frame.Pop();
         }
         internal void RunVoid10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
@@ -373,7 +373,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[8] = arg8;
             frame.Data[9] = arg9;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
         }
 #if FEATURE_MAKE_RUN_METHODS
         internal static Delegate MakeRun10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TRet>(LightLambda lambda)
@@ -400,7 +400,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[9] = arg9;
             frame.Data[10] = arg10;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
             return (TRet)frame.Pop();
         }
         internal void RunVoid11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
@@ -418,7 +418,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[9] = arg9;
             frame.Data[10] = arg10;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
         }
 #if FEATURE_MAKE_RUN_METHODS
         internal static Delegate MakeRun11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TRet>(LightLambda lambda)
@@ -446,7 +446,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[10] = arg10;
             frame.Data[11] = arg11;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
             return (TRet)frame.Pop();
         }
         internal void RunVoid12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
@@ -465,7 +465,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[10] = arg10;
             frame.Data[11] = arg11;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
         }
 #if FEATURE_MAKE_RUN_METHODS
         internal static Delegate MakeRun12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TRet>(LightLambda lambda)
@@ -494,7 +494,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[11] = arg11;
             frame.Data[12] = arg12;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
             return (TRet)frame.Pop();
         }
         internal void RunVoid13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
@@ -514,7 +514,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[11] = arg11;
             frame.Data[12] = arg12;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
         }
 #if FEATURE_MAKE_RUN_METHODS
         internal static Delegate MakeRun13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TRet>(LightLambda lambda)
@@ -544,7 +544,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[12] = arg12;
             frame.Data[13] = arg13;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
             return (TRet)frame.Pop();
         }
         internal void RunVoid14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
@@ -565,7 +565,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[12] = arg12;
             frame.Data[13] = arg13;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
         }
 #if FEATURE_MAKE_RUN_METHODS
         internal static Delegate MakeRun14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TRet>(LightLambda lambda)
@@ -596,7 +596,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[13] = arg13;
             frame.Data[14] = arg14;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
             return (TRet)frame.Pop();
         }
         internal void RunVoid15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
@@ -618,7 +618,7 @@ namespace System.Linq.Expressions.Interpreter
             frame.Data[13] = arg13;
             frame.Data[14] = arg14;
             var current = frame.Enter();
-            try { _interpreter.Run(frame); } finally { frame.Leave(current); }
+            try { _interpreter.Run(ref frame); } finally { frame.Leave(current); }
         }
 #if FEATURE_MAKE_RUN_METHODS
         internal static Delegate MakeRun15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TRet>(LightLambda lambda)

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
@@ -412,11 +412,8 @@ namespace System.Linq.Expressions.Interpreter
             {
                 if (frameCache[i] == null)
                 {
-                    frame = Interlocked.Exchange(ref frameCache[i], frame)!;
-                    if (frame == null)
-                    {
-                        return;
-                    }
+                    frameCache[i] = frame;
+                    return;
                 }
             }
         }

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
@@ -379,10 +379,12 @@ namespace System.Linq.Expressions.Interpreter
 #endif
         }
 
-        private static void ReturnCachedFrame(ref InterpretedFrame frame)
+        private static void DestroyFrame(ref InterpretedFrame frame)
         {
-            // TODO: VS free Data and _continuations
+            frame.ReturnRentedArrays();
+#if DEBUG
             frame = default;
+#endif
         }
 
         private InterpretedFrame MakeFrame()
@@ -407,7 +409,7 @@ namespace System.Linq.Expressions.Interpreter
                 frame.Leave(currentFrame);
                 arg0 = (T0)frame.Data[0];
                 arg1 = (T1)frame.Data[1];
-                ReturnCachedFrame(ref frame);
+                DestroyFrame(ref frame);
             }
         }
 #endif
@@ -435,7 +437,7 @@ namespace System.Linq.Expressions.Interpreter
             }
             object? result = frame.Pop();
 
-            ReturnCachedFrame(ref frame);
+            DestroyFrame(ref frame);
             return result;
         }
 
@@ -459,7 +461,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
 
                 InterpretedFrame.Leave(currentFrame);
-                ReturnCachedFrame(ref frame);
+                DestroyFrame(ref frame);
             }
 
             return null;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightLambda.cs
@@ -379,9 +379,10 @@ namespace System.Linq.Expressions.Interpreter
 #endif
         }
 
-        private static void ReturnCachedFrame(InterpretedFrame frame)
+        private static void ReturnCachedFrame(ref InterpretedFrame frame)
         {
-            frame.Clear();
+            // TODO: VS free Data and _continuations
+            frame = default;
         }
 
         private InterpretedFrame MakeFrame()
@@ -399,14 +400,14 @@ namespace System.Linq.Expressions.Interpreter
             var currentFrame = frame.Enter();
             try
             {
-                _interpreter.Run(frame);
+                _interpreter.Run(ref frame);
             }
             finally
             {
                 frame.Leave(currentFrame);
                 arg0 = (T0)frame.Data[0];
                 arg1 = (T1)frame.Data[1];
-                ReturnCachedFrame(frame);
+                ReturnCachedFrame(ref frame);
             }
         }
 #endif
@@ -421,7 +422,7 @@ namespace System.Linq.Expressions.Interpreter
             void* currentFrame = frame.Enter();
             try
             {
-                _interpreter.Run(frame);
+                _interpreter.Run(ref frame);
             }
             finally
             {
@@ -434,7 +435,7 @@ namespace System.Linq.Expressions.Interpreter
             }
             object? result = frame.Pop();
 
-            ReturnCachedFrame(frame);
+            ReturnCachedFrame(ref frame);
             return result;
         }
 
@@ -448,7 +449,7 @@ namespace System.Linq.Expressions.Interpreter
             void* currentFrame = frame.Enter();
             try
             {
-                _interpreter.Run(frame);
+                _interpreter.Run(ref frame);
             }
             finally
             {
@@ -458,7 +459,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
 
                 InterpretedFrame.Leave(currentFrame);
-                ReturnCachedFrame(frame);
+                ReturnCachedFrame(ref frame);
             }
 
             return null;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LocalAccess.cs
@@ -44,7 +44,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ProducedStack => 1;
         public override string InstructionName => "LoadLocal";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             frame.Data[frame.StackIndex++] = frame.Data[_index];
             return 1;
@@ -66,7 +66,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ProducedStack => 1;
         public override string InstructionName => "LoadLocalBox";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             var box = (IStrongBox)frame.Data[_index]!;
             frame.Data[frame.StackIndex++] = box.Value;
@@ -84,7 +84,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ProducedStack => 1;
         public override string InstructionName => "LoadLocalClosure";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             IStrongBox box = frame.Closure![_index];
             frame.Data[frame.StackIndex++] = box.Value;
@@ -102,7 +102,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ProducedStack => 1;
         public override string InstructionName => "LoadLocal";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             IStrongBox box = frame.Closure![_index];
             frame.Data[frame.StackIndex++] = box;
@@ -125,7 +125,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ProducedStack => 1;
         public override string InstructionName => "AssignLocal";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             frame.Data[_index] = frame.Peek();
             return 1;
@@ -147,7 +147,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ConsumedStack => 1;
         public override string InstructionName => "StoreLocal";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             frame.Data[_index] = frame.Pop();
             return 1;
@@ -170,7 +170,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ProducedStack => 1;
         public override string InstructionName => "AssignLocalBox";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             var box = (IStrongBox)frame.Data[_index]!;
             box.Value = frame.Peek();
@@ -188,7 +188,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ConsumedStack => 1;
         public override string InstructionName => "StoreLocalBox";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             var box = (IStrongBox)frame.Data[_index]!;
             box.Value = frame.Data[--frame.StackIndex];
@@ -207,7 +207,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ProducedStack => 1;
         public override string InstructionName => "AssignLocalClosure";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             IStrongBox box = frame.Closure![_index];
             box.Value = frame.Peek();
@@ -223,7 +223,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ProducedStack => 1;
         public override string InstructionName => "ValueTypeCopy";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             object? o = frame.Pop();
             frame.Push(o == null ? o : RuntimeHelpers.GetObjectValue(o));
@@ -249,7 +249,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 frame.Data[_index] = null;
                 return 1;
@@ -274,7 +274,7 @@ namespace System.Linq.Expressions.Interpreter
                 _defaultValue = defaultValue;
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 frame.Data[_index] = _defaultValue;
                 return 1;
@@ -300,7 +300,7 @@ namespace System.Linq.Expressions.Interpreter
                 _defaultValue = defaultValue;
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 frame.Data[_index] = new StrongBox<object>(_defaultValue);
                 return 1;
@@ -317,7 +317,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 frame.Data[_index] = new StrongBox<object>();
                 return 1;
@@ -333,7 +333,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 frame.Data[_index] = new StrongBox<object?>(frame.Data[_index]);
                 return 1;
@@ -349,7 +349,7 @@ namespace System.Linq.Expressions.Interpreter
             {
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 // nop
                 return 1;
@@ -381,7 +381,7 @@ namespace System.Linq.Expressions.Interpreter
 
             [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2077:UnrecognizedReflectionPattern",
                 Justification = "_type is a ValueType. You can always get an uninitialized ValueType.")]
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 try
                 {
@@ -420,7 +420,7 @@ namespace System.Linq.Expressions.Interpreter
 
             [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2077:UnrecognizedReflectionPattern",
                 Justification = "_type is a ValueType. You can always get an uninitialized ValueType.")]
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? value;
 
@@ -462,7 +462,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ConsumedStack => _count;
         public override string InstructionName => "GetRuntimeVariables";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             var ret = new IStrongBox[_count];
             for (int i = ret.Length - 1; i >= 0; i--)

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ModuloInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ModuloInstruction.cs
@@ -18,7 +18,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class ModuloInt16 : ModuloInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -36,7 +36,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class ModuloInt32 : ModuloInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -54,7 +54,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class ModuloInt64 : ModuloInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -72,7 +72,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class ModuloUInt16 : ModuloInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -90,7 +90,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class ModuloUInt32 : ModuloInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -108,7 +108,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class ModuloUInt64 : ModuloInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -126,7 +126,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class ModuloSingle : ModuloInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -144,7 +144,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class ModuloDouble : ModuloInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/MulInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/MulInstruction.cs
@@ -18,7 +18,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class MulInt16 : MulInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -36,7 +36,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class MulInt32 : MulInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -54,7 +54,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class MulInt64 : MulInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -72,7 +72,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class MulUInt16 : MulInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -90,7 +90,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class MulUInt32 : MulInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -108,7 +108,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class MulUInt64 : MulInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -126,7 +126,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class MulSingle : MulInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -144,7 +144,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class MulDouble : MulInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -191,7 +191,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class MulOvfInt16 : MulOvfInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -209,7 +209,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class MulOvfInt32 : MulOvfInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -227,7 +227,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class MulOvfInt64 : MulOvfInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -245,7 +245,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class MulOvfUInt16 : MulOvfInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -263,7 +263,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class MulOvfUInt32 : MulOvfInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -281,7 +281,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class MulOvfUInt64 : MulOvfInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NegateInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NegateInstruction.cs
@@ -18,7 +18,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NegateInt16 : NegateInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)
@@ -35,7 +35,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NegateInt32 : NegateInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)
@@ -52,7 +52,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NegateInt64 : NegateInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)
@@ -69,7 +69,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NegateSingle : NegateInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)
@@ -86,7 +86,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NegateDouble : NegateInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)
@@ -128,7 +128,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NegateCheckedInt32 : NegateCheckedInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)
@@ -145,7 +145,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NegateCheckedInt16 : NegateCheckedInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)
@@ -162,7 +162,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NegateCheckedInt64 : NegateCheckedInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 if (obj == null)

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NewInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NewInstruction.cs
@@ -22,11 +22,11 @@ namespace System.Linq.Expressions.Interpreter
         public override int ProducedStack => 1;
         public override string InstructionName => "New";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             int first = frame.StackIndex - _argumentCount;
 
-            object?[] args = GetArgs(frame, first);
+            object?[] args = GetArgs(ref frame, first);
 
             object ret;
             try
@@ -45,7 +45,7 @@ namespace System.Linq.Expressions.Interpreter
             return 1;
         }
 
-        protected object?[] GetArgs(InterpretedFrame frame, int first)
+        protected object?[] GetArgs(ref InterpretedFrame frame, int first)
         {
             if (_argumentCount > 0)
             {
@@ -79,11 +79,11 @@ namespace System.Linq.Expressions.Interpreter
 
         public override string InstructionName => "ByRefNew";
 
-        public sealed override int Run(InterpretedFrame frame)
+        public sealed override int Run(ref InterpretedFrame frame)
         {
             int first = frame.StackIndex - _argumentCount;
 
-            object?[] args = GetArgs(frame, first);
+            object?[] args = GetArgs(ref frame, first);
 
             try
             {
@@ -105,7 +105,7 @@ namespace System.Linq.Expressions.Interpreter
             {
                 foreach (ByRefUpdater arg in _byrefArgs)
                 {
-                    arg.Update(frame, args[arg.ArgumentIndex]);
+                    arg.Update(ref frame, args[arg.ArgumentIndex]);
                 }
             }
 

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotEqualInstruction.cs
@@ -20,7 +20,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualBoolean : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -42,7 +42,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualSByte : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -64,7 +64,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualInt16 : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -86,7 +86,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualChar : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -108,7 +108,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualInt32 : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -130,7 +130,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualInt64 : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -152,7 +152,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualByte : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -174,7 +174,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualUInt16 : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -196,7 +196,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualUInt32 : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -218,7 +218,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualUInt64 : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -240,7 +240,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualSingle : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -262,7 +262,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualDouble : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -284,7 +284,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualReference : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 frame.Push(frame.Pop() != frame.Pop());
                 return 1;
@@ -293,7 +293,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualSByteLiftedToNull : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -311,7 +311,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualInt16LiftedToNull : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -329,7 +329,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualCharLiftedToNull : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -347,7 +347,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualInt32LiftedToNull : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -365,7 +365,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualInt64LiftedToNull : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -383,7 +383,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualByteLiftedToNull : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -401,7 +401,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualUInt16LiftedToNull : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -419,7 +419,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualUInt32LiftedToNull : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -437,7 +437,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualUInt64LiftedToNull : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -455,7 +455,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualSingleLiftedToNull : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();
@@ -473,7 +473,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotEqualDoubleLiftedToNull : NotEqualInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NotInstruction.cs
@@ -17,7 +17,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotBoolean : NotInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? value = frame.Pop();
                 if (value == null)
@@ -34,7 +34,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotInt64 : NotInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? value = frame.Pop();
                 if (value == null)
@@ -51,7 +51,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotInt32 : NotInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? value = frame.Pop();
                 if (value == null)
@@ -68,7 +68,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotInt16 : NotInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? value = frame.Pop();
                 if (value == null)
@@ -85,7 +85,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotUInt64 : NotInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? value = frame.Pop();
                 if (value == null)
@@ -102,7 +102,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotUInt32 : NotInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? value = frame.Pop();
                 if (value == null)
@@ -119,7 +119,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotUInt16 : NotInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? value = frame.Pop();
                 if (value == null)
@@ -136,7 +136,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotByte : NotInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? value = frame.Pop();
                 if (value == null)
@@ -153,7 +153,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class NotSByte : NotInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? value = frame.Pop();
                 if (value == null)

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NullCheckInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NullCheckInstruction.cs
@@ -13,7 +13,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ProducedStack => 1;
         public override string InstructionName => "Unbox";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             NullCheck(frame.Peek());
             return 1;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NumericConvertInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/NumericConvertInstruction.cs
@@ -17,7 +17,7 @@ namespace System.Linq.Expressions.Interpreter
             _isLiftedToNull = isLiftedToNull;
         }
 
-        public sealed override int Run(InterpretedFrame frame)
+        public sealed override int Run(ref InterpretedFrame frame)
         {
             object? obj = frame.Pop();
             object? converted;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OrInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/OrInstruction.cs
@@ -17,7 +17,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class OrSByte : OrInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -33,7 +33,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class OrInt16 : OrInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -49,7 +49,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class OrInt32 : OrInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -65,7 +65,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class OrInt64 : OrInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -81,7 +81,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class OrByte : OrInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -97,7 +97,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class OrUInt16 : OrInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -113,7 +113,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class OrUInt32 : OrInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -129,7 +129,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class OrUInt64 : OrInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? left = frame.Pop();
                 object? right = frame.Pop();
@@ -145,7 +145,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class OrBoolean : OrInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? right = frame.Pop();
                 object? left = frame.Pop();

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/RightShiftInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/RightShiftInstruction.cs
@@ -17,7 +17,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class RightShiftSByte : RightShiftInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? shift = frame.Pop();
                 object? value = frame.Pop();
@@ -35,7 +35,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class RightShiftInt16 : RightShiftInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? shift = frame.Pop();
                 object? value = frame.Pop();
@@ -53,7 +53,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class RightShiftInt32 : RightShiftInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? shift = frame.Pop();
                 object? value = frame.Pop();
@@ -71,7 +71,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class RightShiftInt64 : RightShiftInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? shift = frame.Pop();
                 object? value = frame.Pop();
@@ -89,7 +89,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class RightShiftByte : RightShiftInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? shift = frame.Pop();
                 object? value = frame.Pop();
@@ -107,7 +107,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class RightShiftUInt16 : RightShiftInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? shift = frame.Pop();
                 object? value = frame.Pop();
@@ -125,7 +125,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class RightShiftUInt32 : RightShiftInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? shift = frame.Pop();
                 object? value = frame.Pop();
@@ -143,7 +143,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class RightShiftUInt64 : RightShiftInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? shift = frame.Pop();
                 object? value = frame.Pop();

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/StackOperations.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/StackOperations.cs
@@ -18,7 +18,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ProducedStack => 1;
         public override string InstructionName => "LoadObject";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             frame.Data[frame.StackIndex++] = _value;
             return 1;
@@ -39,7 +39,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ProducedStack => 1;
         public override string InstructionName => "LoadCachedObject";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             frame.Data[frame.StackIndex++] = frame.Interpreter._objects![_index];
             return 1;
@@ -60,7 +60,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ConsumedStack => 1;
         public override string InstructionName => "Pop";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             frame.Pop();
             return 1;
@@ -77,7 +77,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override string InstructionName => "Dup";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             frame.Dup();
             return 1;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/SubInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/SubInstruction.cs
@@ -18,7 +18,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class SubInt16 : SubInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -36,7 +36,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class SubInt32 : SubInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -54,7 +54,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class SubInt64 : SubInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -72,7 +72,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class SubUInt16 : SubInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -90,7 +90,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class SubUInt32 : SubInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -108,7 +108,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class SubUInt64 : SubInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -126,7 +126,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class SubSingle : SubInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -144,7 +144,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class SubDouble : SubInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -190,7 +190,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class SubOvfInt16 : SubOvfInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -208,7 +208,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class SubOvfInt32 : SubOvfInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -226,7 +226,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class SubOvfInt64 : SubOvfInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -244,7 +244,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class SubOvfUInt16 : SubOvfInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -262,7 +262,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class SubOvfUInt32 : SubOvfInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;
@@ -280,7 +280,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class SubOvfUInt64 : SubOvfInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 int index = frame.StackIndex;
                 object?[] stack = frame.Data;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -23,7 +23,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ProducedStack => 1;
         public override string InstructionName => "CreateDelegate";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             IStrongBox[]? closure;
             if (ConsumedStack > 0)
@@ -59,7 +59,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ProducedStack => 1;
         public override string InstructionName => "TypeIs";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             frame.Push(_type.IsInstanceOfType(frame.Pop()));
             return 1;
@@ -81,7 +81,7 @@ namespace System.Linq.Expressions.Interpreter
         public override int ProducedStack => 1;
         public override string InstructionName => "TypeAs";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             object? value = frame.Pop();
             frame.Push(_type.IsInstanceOfType(value) ? value : null);
@@ -101,7 +101,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private TypeEqualsInstruction() { }
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             object? type = frame.Pop();
             object? obj = frame.Pop();
@@ -122,7 +122,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class HasValue : NullableMethodCallInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 frame.Push(obj != null);
@@ -132,7 +132,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class GetValue : NullableMethodCallInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 if (frame.Peek() == null)
                 {
@@ -158,7 +158,7 @@ namespace System.Linq.Expressions.Interpreter
 
             [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2077:UnrecognizedReflectionPattern",
                 Justification = "_defaultValueType is a ValueType. You can always get an uninitialized ValueType.")]
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 if (frame.Peek() == null)
                 {
@@ -173,7 +173,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int ConsumedStack => 2;
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? dflt = frame.Pop();
                 object? obj = frame.Pop();
@@ -186,7 +186,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             public override int ConsumedStack => 2;
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? other = frame.Pop();
                 object? obj = frame.Pop();
@@ -208,7 +208,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class ToStringClass : NullableMethodCallInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 frame.Push(obj == null ? "" : obj.ToString());
@@ -218,7 +218,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class GetHashCodeClass : NullableMethodCallInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? obj = frame.Pop();
                 frame.Push(obj?.GetHashCode() ?? 0);
@@ -266,7 +266,7 @@ namespace System.Linq.Expressions.Interpreter
 
         private sealed class CastInstructionT<T> : CastInstruction
         {
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? value = frame.Pop();
                 frame.Push((T)value!);
@@ -295,7 +295,7 @@ namespace System.Linq.Expressions.Interpreter
                 }
             }
 
-            public override int Run(InterpretedFrame frame)
+            public override int Run(ref InterpretedFrame frame)
             {
                 object? value = frame.Pop();
                 if (value != null)
@@ -317,12 +317,12 @@ namespace System.Linq.Expressions.Interpreter
                 }
                 else
                 {
-                    ConvertNull(frame);
+                    ConvertNull(ref frame);
                 }
                 return 1;
             }
 
-            protected abstract void ConvertNull(InterpretedFrame frame);
+            protected abstract void ConvertNull(ref InterpretedFrame frame);
 
             private sealed class Ref : CastInstructionNoT
             {
@@ -331,7 +331,7 @@ namespace System.Linq.Expressions.Interpreter
                 {
                 }
 
-                protected override void ConvertNull(InterpretedFrame frame)
+                protected override void ConvertNull(ref InterpretedFrame frame)
                 {
                     frame.Push(null);
                 }
@@ -344,7 +344,7 @@ namespace System.Linq.Expressions.Interpreter
                 {
                 }
 
-                protected override void ConvertNull(InterpretedFrame frame)
+                protected override void ConvertNull(ref InterpretedFrame frame)
                 {
                     throw new NullReferenceException();
                 }
@@ -387,7 +387,7 @@ namespace System.Linq.Expressions.Interpreter
             _t = t;
         }
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             object? from = frame.Pop();
             Debug.Assert(
@@ -411,7 +411,7 @@ namespace System.Linq.Expressions.Interpreter
             _t = t;
         }
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             object? from = frame.Pop();
             Debug.Assert(from != null);
@@ -477,7 +477,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override string InstructionName => "Quote";
 
-        public override int Run(InterpretedFrame frame)
+        public override int Run(ref InterpretedFrame frame)
         {
             Expression? operand = _operand;
             if (_hoistedVariables != null)


### PR DESCRIPTION
- There are allocations of argument arrays when calling to expression lambdas and when invoking ordinary methods from expression lambdas. (both ways we need to put the arguments in an object array)
These arrays can be cached and reused.

- When expression lambda is called, an `InterpreterFrame` is allocated, mainly holding evaluation stack and some additional info. 
We can keep the frame instance (or several, if called concurrently or recursively), and reuse if/when called again. 

These allocations are relatively small, but can add up when the same lambda is called repeatedly and can trigger extra GCs. 

These allocations are specific to NativeAOT and contribute to differences in performance between NativeAOT and CorClr. 
Ideally, the allocation profiles would be similar between runtimes.

I see about ~3%~ 5% improvement in RPC on BasicMinimalApi benchmark with these changes.