### PR TITLE
Add NT_SIGINFO NOTE to ELF dumps

### DIFF
--- a/src/coreclr/debug/createdump/crashinfo.cpp
+++ b/src/coreclr/debug/createdump/crashinfo.cpp
@@ -8,7 +8,7 @@ CrashInfo* g_crashInfo;
 
 static bool ModuleInfoCompare(const ModuleInfo* lhs, const ModuleInfo* rhs) { return lhs->BaseAddress() < rhs->BaseAddress(); }
 
-CrashInfo::CrashInfo(CreateDumpOptions& options) :
+CrashInfo::CrashInfo(const CreateDumpOptions& options) :
     m_ref(1),
     m_pid(options.Pid),
     m_ppid(-1),

--- a/src/coreclr/debug/createdump/crashinfo.cpp
+++ b/src/coreclr/debug/createdump/crashinfo.cpp
@@ -8,16 +8,16 @@ CrashInfo* g_crashInfo;
 
 static bool ModuleInfoCompare(const ModuleInfo* lhs, const ModuleInfo* rhs) { return lhs->BaseAddress() < rhs->BaseAddress(); }
 
-CrashInfo::CrashInfo(pid_t pid, bool gatherFrames, pid_t crashThread, uint32_t signal) :
+CrashInfo::CrashInfo(CreateDumpOptions& options) :
     m_ref(1),
-    m_pid(pid),
+    m_pid(options.Pid),
     m_ppid(-1),
     m_hdac(nullptr),
     m_pClrDataEnumRegions(nullptr),
     m_pClrDataProcess(nullptr),
-    m_gatherFrames(gatherFrames),
-    m_crashThread(crashThread),
-    m_signal(signal),
+    m_gatherFrames(options.CrashReport),
+    m_crashThread(options.CrashThread),
+    m_signal(options.Signal),
     m_moduleInfos(&ModuleInfoCompare),
     m_mainModule(nullptr),
     m_cbModuleMappings(0),
@@ -30,6 +30,11 @@ CrashInfo::CrashInfo(pid_t pid, bool gatherFrames, pid_t crashThread, uint32_t s
 #else
     m_auxvValues.fill(0);
     m_fdMem = -1;
+    memset(&m_siginfo, 0, sizeof(m_siginfo));
+    m_siginfo.si_signo = options.Signal;
+    m_siginfo.si_code = options.SignalCode;
+    m_siginfo.si_errno = options.SignalErrno;
+    m_siginfo.si_addr = options.SignalAddress;
 #endif
 }
 

--- a/src/coreclr/debug/createdump/crashinfo.h
+++ b/src/coreclr/debug/createdump/crashinfo.h
@@ -58,6 +58,7 @@ private:
 #ifdef __APPLE__
     vm_map_t m_task;                                // the mach task for the process
 #else
+    siginfo_t m_siginfo;                            // signal info (if any)
     bool m_canUseProcVmReadSyscall;
     int m_fdMem;                                    // /proc/<pid>/mem handle
     int m_fdPagemap;                                // /proc/<pid>/pagemap handle
@@ -83,7 +84,7 @@ private:
     void operator=(const CrashInfo&) = delete;
 
 public:
-    CrashInfo(pid_t pid, bool gatherFrames, pid_t crashThread, uint32_t signal);
+    CrashInfo(CreateDumpOptions& options);
     virtual ~CrashInfo();
 
     // Memory usage stats
@@ -127,6 +128,7 @@ public:
 #ifndef __APPLE__
     inline const std::vector<elf_aux_entry>& AuxvEntries() const { return m_auxvEntries; }
     inline size_t GetAuxvSize() const { return m_auxvEntries.size() * sizeof(elf_aux_entry); }
+    inline const siginfo_t* SigInfo() const { return &m_siginfo; }
 #endif
 
     // IUnknown

--- a/src/coreclr/debug/createdump/crashinfo.h
+++ b/src/coreclr/debug/createdump/crashinfo.h
@@ -84,7 +84,7 @@ private:
     void operator=(const CrashInfo&) = delete;
 
 public:
-    CrashInfo(CreateDumpOptions& options);
+    CrashInfo(const CreateDumpOptions& options);
     virtual ~CrashInfo();
 
     // Memory usage stats

--- a/src/coreclr/debug/createdump/crashreportwriter.cpp
+++ b/src/coreclr/debug/createdump/crashreportwriter.cpp
@@ -175,17 +175,17 @@ CrashReportWriter::WriteCrashReport()
     }
     CloseArray();               // threads
     CloseObject();              // payload
-#ifdef __APPLE__
     OpenObject("parameters");
     if (exceptionType != nullptr)
     {
         WriteValue("ExceptionType", exceptionType);
     }
+#ifdef __APPLE__
     WriteSysctl("kern.osproductversion", "OSVersion");
     WriteSysctl("hw.model", "SystemModel");
     WriteValue("SystemManufacturer", "apple");
-    CloseObject();              // parameters
 #endif // __APPLE__
+    CloseObject();              // parameters
 }
 
 #ifdef __APPLE__

--- a/src/coreclr/debug/createdump/createdump.h
+++ b/src/coreclr/debug/createdump/createdump.h
@@ -20,6 +20,9 @@ extern void trace_verbose_printf(const char* format, ...);
 #define TRACE_VERBOSE(args, ...)
 #endif
 
+// Keep in sync with the definitions in dbgutil.cpp and daccess.h
+#define DACCESS_TABLE_SYMBOL "g_dacTable"
+
 #ifdef HOST_64BIT
 #define PRIA "016"
 #else
@@ -87,6 +90,24 @@ typedef int T_CONTEXT;
 #include <vector>
 #include <array>
 #include <string>
+
+typedef struct
+{
+    const char* DumpPathTemplate;
+    const char* DumpType;
+    MINIDUMP_TYPE MinidumpType;
+    bool CreateDump;
+    bool CrashReport;
+    int Pid;
+    int CrashThread;
+    int Signal;
+#if defined(HOST_UNIX) && !defined(HOST_OSX)
+    int SignalCode;
+    int SignalErrno;
+    void* SignalAddress;
+#endif
+} CreateDumpOptions;
+
 #ifdef HOST_UNIX
 #ifdef __APPLE__
 #include <mach/mach.h>
@@ -107,12 +128,9 @@ typedef int T_CONTEXT;
 #define MAX_LONGPATH   1024
 #endif
 
+extern bool CreateDump(CreateDumpOptions& options);
 extern bool FormatDumpName(std::string& name, const char* pattern, const char* exename, int pid);
-extern bool CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP_TYPE minidumpType, bool createDump, bool crashReport, int crashThread, int signal);
 
 extern std::string GetLastErrorString();
 extern void printf_status(const char* format, ...);
 extern void printf_error(const char* format, ...);
-
-// Keep in sync with the definitions in dbgutil.cpp and daccess.h
-#define DACCESS_TABLE_SYMBOL "g_dacTable"

--- a/src/coreclr/debug/createdump/createdump.h
+++ b/src/coreclr/debug/createdump/createdump.h
@@ -128,7 +128,7 @@ typedef struct
 #define MAX_LONGPATH   1024
 #endif
 
-extern bool CreateDump(CreateDumpOptions& options);
+extern bool CreateDump(const CreateDumpOptions& options);
 extern bool FormatDumpName(std::string& name, const char* pattern, const char* exename, int pid);
 
 extern std::string GetLastErrorString();

--- a/src/coreclr/debug/createdump/createdumpunix.cpp
+++ b/src/coreclr/debug/createdump/createdumpunix.cpp
@@ -11,7 +11,7 @@ long g_pageSize = 0;
 // The Linux/MacOS create dump code
 //
 bool
-CreateDump(CreateDumpOptions& options)
+CreateDump(const CreateDumpOptions& options)
 {
     ReleaseHolder<CrashInfo> crashInfo = new CrashInfo(options);
     DumpWriter dumpWriter(*crashInfo);

--- a/src/coreclr/debug/createdump/createdumpunix.cpp
+++ b/src/coreclr/debug/createdump/createdumpunix.cpp
@@ -11,9 +11,9 @@ long g_pageSize = 0;
 // The Linux/MacOS create dump code
 //
 bool
-CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP_TYPE minidumpType, bool createDump, bool crashReport, int crashThread, int signal)
+CreateDump(CreateDumpOptions& options)
 {
-    ReleaseHolder<CrashInfo> crashInfo = new CrashInfo(pid, crashReport, crashThread, signal);
+    ReleaseHolder<CrashInfo> crashInfo = new CrashInfo(options);
     DumpWriter dumpWriter(*crashInfo);
     std::string dumpPath;
     bool result = false;
@@ -29,11 +29,11 @@ CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP
     {
         goto exit;
     }
-    printf_status("Gathering state for process %d %s\n", pid, crashInfo->Name().c_str());
+    printf_status("Gathering state for process %d %s\n", options.Pid, crashInfo->Name().c_str());
 
-    if (signal != 0 || crashThread != 0)
+    if (options.Signal != 0 || options.CrashThread != 0)
     {
-        printf_status("Crashing thread %08x signal %08x\n", crashThread, signal);
+        printf_status("Crashing thread %04x signal %d (%04x)\n", options.CrashThread, options.Signal, options.Signal);
     }
 
     // Suspend all the threads in the target process and build the list of threads
@@ -42,32 +42,32 @@ CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP
         goto exit;
     }
     // Gather all the info about the process, threads (registers, etc.) and memory regions
-    if (!crashInfo->GatherCrashInfo(minidumpType))
+    if (!crashInfo->GatherCrashInfo(options.MinidumpType))
     {
         goto exit;
     }
     // Format the dump pattern template now that the process name on MacOS has been obtained
-    if (!FormatDumpName(dumpPath, dumpPathTemplate, crashInfo->Name().c_str(), pid))
+    if (!FormatDumpName(dumpPath, options.DumpPathTemplate, crashInfo->Name().c_str(), options.Pid))
     {
         goto exit;
     }
     // Write the crash report json file if enabled
-    if (crashReport)
+    if (options.CrashReport)
     {
         CrashReportWriter crashReportWriter(*crashInfo);
         crashReportWriter.WriteCrashReport(dumpPath);
     }
-    if (createDump)
+    if (options.CreateDump)
     {
         // Gather all the useful memory regions from the DAC
-        if (!crashInfo->EnumerateMemoryRegionsWithDAC(minidumpType))
+        if (!crashInfo->EnumerateMemoryRegionsWithDAC(options.MinidumpType))
         {
             goto exit;
         }
         // Join all adjacent memory regions
         crashInfo->CombineMemoryRegions();
     
-        printf_status("Writing %s to file %s\n", dumpType, dumpPath.c_str());
+        printf_status("Writing %s to file %s\n", options.DumpType, dumpPath.c_str());
 
         // Write the actual dump file
         if (!dumpWriter.OpenDump(dumpPath.c_str()))
@@ -85,7 +85,7 @@ CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP
     }
     result = true;
 exit:
-    if (kill(pid, 0) == 0)
+    if (kill(options.Pid, 0) == 0)
     {
         printf_status("Target process is alive\n");
     }
@@ -98,7 +98,7 @@ exit:
         }
         else
         {
-            printf_error("kill(%d, 0) FAILED %s (%d)\n", pid, strerror(err), err);
+            printf_error("kill(%d, 0) FAILED %s (%d)\n", options.Pid, strerror(err), err);
         }
     }
     crashInfo->CleanupAndResumeProcess();

--- a/src/coreclr/debug/createdump/createdumpwindows.cpp
+++ b/src/coreclr/debug/createdump/createdumpwindows.cpp
@@ -18,14 +18,14 @@ typedef struct _PROCESS_BASIC_INFORMATION_ {
 // The Windows create dump code
 //
 bool
-CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP_TYPE minidumpType, bool createDump, bool crashReport, int crashThread, int signal)
+CreateDump(CreateDumpOptions& options)
 {
     HANDLE hFile = INVALID_HANDLE_VALUE;
     HANDLE hProcess = NULL;
     bool result = false;
 
-    _ASSERTE(createDump);
-    _ASSERTE(!crashReport);
+    _ASSERTE(options.CreateDump);
+    _ASSERTE(!options.CrashReport);
 
     ArrayHolder<char> pszName = new char[MAX_LONGPATH + 1];
     std::string dumpPath;
@@ -38,7 +38,7 @@ CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP
         printf_error("Failed to get parent process id status %d\n", status);
         goto exit;
     }
-    pid = (int)processInformation.InheritedFromUniqueProcessId;
+    int pid = (int)processInformation.InheritedFromUniqueProcessId;
 
     hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, pid);
     if (hProcess == NULL)
@@ -51,11 +51,11 @@ CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP
         printf_error("Get process name FAILED - %s\n", GetLastErrorString().c_str());
         goto exit;
     }
-    if (!FormatDumpName(dumpPath, dumpPathTemplate, pszName, pid))
+    if (!FormatDumpName(dumpPath, options.DumpPathTemplate, pszName, pid))
     {
         goto exit;
     }
-    printf_status("Writing %s for process %d to file %s\n", dumpType, pid, dumpPath.c_str());
+    printf_status("Writing %s for process %d to file %s\n", options.DumpType, pid, dumpPath.c_str());
 
     hFile = CreateFileA(dumpPath.c_str(), GENERIC_READ | GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
     if (hFile == INVALID_HANDLE_VALUE)
@@ -67,7 +67,7 @@ CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP
     // Retry the write dump on ERROR_PARTIAL_COPY
     for (int i = 0; i < 5; i++)
     {
-        if (MiniDumpWriteDump(hProcess, pid, hFile, minidumpType, NULL, NULL, NULL))
+        if (MiniDumpWriteDump(hProcess, pid, hFile, options.MinidumpType, NULL, NULL, NULL))
         {
             result = true;
             break;

--- a/src/coreclr/debug/createdump/createdumpwindows.cpp
+++ b/src/coreclr/debug/createdump/createdumpwindows.cpp
@@ -18,7 +18,7 @@ typedef struct _PROCESS_BASIC_INFORMATION_ {
 // The Windows create dump code
 //
 bool
-CreateDump(CreateDumpOptions& options)
+CreateDump(const CreateDumpOptions& options)
 {
     HANDLE hFile = INVALID_HANDLE_VALUE;
     HANDLE hProcess = NULL;

--- a/src/coreclr/debug/createdump/dumpwriterelf.h
+++ b/src/coreclr/debug/createdump/dumpwriterelf.h
@@ -54,21 +54,22 @@ private:
     bool WriteAuxv();
     size_t GetNTFileInfoSize(size_t* alignmentBytes = nullptr);
     bool WriteNTFileInfo();
-    bool WriteThread(const ThreadInfo& thread, int fatal_signal);
+    bool WriteThread(const ThreadInfo& thread);
     bool WriteData(const void* buffer, size_t length) { return WriteData(m_fd, buffer, length); }
 
     size_t GetProcessInfoSize() const { return sizeof(Nhdr) + 8 + sizeof(prpsinfo_t); }
     size_t GetAuxvInfoSize() const { return sizeof(Nhdr) + 8 + m_crashInfo.GetAuxvSize(); }
     size_t GetThreadInfoSize() const
     {
-        return m_crashInfo.Threads().size() * ((sizeof(Nhdr) + 8 + sizeof(prstatus_t))
-            + sizeof(Nhdr) + 8 + sizeof(user_fpregs_struct)
+        return (m_crashInfo.Signal() != 0 ? (sizeof(Nhdr) + 8 + sizeof(siginfo_t)) : 0)
+              + (m_crashInfo.Threads().size() * ((sizeof(Nhdr) + 8 + sizeof(prstatus_t))
+              + (sizeof(Nhdr) + 8 + sizeof(user_fpregs_struct))
 #if defined(__i386__)
-            + sizeof(Nhdr) + 8 + sizeof(user_fpxregs_struct)
+              + (sizeof(Nhdr) + 8 + sizeof(user_fpxregs_struct))
 #endif
 #if defined(__arm__) && defined(__VFP_FP__) && !defined(__SOFTFP__)
-            + sizeof(Nhdr) + 8 + sizeof(user_vfpregs_struct)
+              + (sizeof(Nhdr) + 8 + sizeof(user_vfpregs_struct))
 #endif
-        );
+        ));
     }
 };

--- a/src/coreclr/debug/createdump/dumpwriterelf.h
+++ b/src/coreclr/debug/createdump/dumpwriterelf.h
@@ -31,6 +31,10 @@
 #define NT_FILE		0x46494c45
 #endif
 
+#ifndef NT_SIGINFO	
+#define NT_SIGINFO	0x53494749
+#endif
+
 class DumpWriter
 {
 private:

--- a/src/coreclr/debug/createdump/threadinfo.cpp
+++ b/src/coreclr/debug/createdump/threadinfo.cpp
@@ -387,3 +387,9 @@ ThreadInfo::GetThreadStack()
         TRACE("Thread %04x null stack pointer\n", m_tid);
     }
 }
+
+bool
+ThreadInfo::IsCrashThread() const
+{
+    return m_tid == m_crashInfo.CrashThread();
+}

--- a/src/coreclr/debug/createdump/threadinfo.h
+++ b/src/coreclr/debug/createdump/threadinfo.h
@@ -156,6 +156,7 @@ public:
     inline const uint64_t GetFramePointer() const { return m_gpRegisters.ARM_fp; }
 #endif
 #endif // __APPLE__
+    bool IsCrashThread() const;
 
 private:
     void UnwindNativeFrames(CONTEXT* pContext);

--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -380,7 +380,7 @@ static void invoke_previous_action(struct sigaction* action, int code, siginfo_t
         if (signalRestarts)
         {
             // This signal mustn't be ignored because it will be restarted.
-            PROCAbort(code);
+            PROCAbort(code, siginfo);
         }
         return;
     }
@@ -395,7 +395,7 @@ static void invoke_previous_action(struct sigaction* action, int code, siginfo_t
         {
             // We can't invoke the original handler because returning from the
             // handler doesn't restart the exception.
-            PROCAbort(code);
+            PROCAbort(code, siginfo);
         }
     }
     else if (IsSaSigInfo(action))
@@ -413,7 +413,7 @@ static void invoke_previous_action(struct sigaction* action, int code, siginfo_t
 
     PROCNotifyProcessShutdown(IsRunningOnAlternateStack(context));
 
-    PROCCreateCrashDumpIfEnabled(code);
+    PROCCreateCrashDumpIfEnabled(code, siginfo);
 }
 
 /*++
@@ -585,13 +585,13 @@ static void sigsegv_handler(int code, siginfo_t *siginfo, void *context)
 
                 if (SwitchStackAndExecuteHandler(code | StackOverflowFlag, siginfo, context, (size_t)handlerStackTop))
                 {
-                    PROCAbort(SIGSEGV);
+                    PROCAbort(SIGSEGV, siginfo);
                 }
             }
             else
             {
                 (void)!write(STDERR_FILENO, StackOverflowMessage, sizeof(StackOverflowMessage) - 1);
-                PROCAbort(SIGSEGV);
+                PROCAbort(SIGSEGV, siginfo);
             }
         }
 
@@ -746,7 +746,7 @@ static void sigterm_handler(int code, siginfo_t *siginfo, void *context)
         DWORD val = 0;
         if (enableDumpOnSigTerm.IsSet() && enableDumpOnSigTerm.TryAsInteger(10, val) && val == 1)
         {
-            PROCCreateCrashDumpIfEnabled(code);
+            PROCCreateCrashDumpIfEnabled(code, siginfo);
         }
         // g_pSynchronizationManager shouldn't be null if PAL is initialized.
         _ASSERTE(g_pSynchronizationManager != nullptr);

--- a/src/coreclr/pal/src/include/pal/process.h
+++ b/src/coreclr/pal/src/include/pal/process.h
@@ -151,11 +151,12 @@ Function:
 
 Parameters:
   signal - POSIX signal number
+  siginfo - POSIX signal info
 
   Does not return
 --*/
 PAL_NORETURN
-VOID PROCAbort(int signal = SIGABRT);
+VOID PROCAbort(int signal = SIGABRT, siginfo_t* siginfo = nullptr);
 
 /*++
 Function:
@@ -180,7 +181,7 @@ Parameters:
 
 (no return value)
 --*/
-VOID PROCCreateCrashDumpIfEnabled(int signal);
+VOID PROCCreateCrashDumpIfEnabled(int signal, siginfo_t* siginfo);
 
 /*++
 Function:

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -2009,6 +2009,28 @@ PROCFormatInt(ULONG32 value)
     return buffer;
 }
 
+/*++
+Function:
+    PROCFormatInt64
+
+    Helper function to format an ULONG32 as a string.
+
+--*/
+char*
+PROCFormatInt64(ULONG64 value)
+{
+    char* buffer = (char*)InternalMalloc(128);
+    if (buffer != nullptr)
+    {
+        if (sprintf_s(buffer, 128, "%lld", value) == -1)
+        {
+            free(buffer);
+            buffer = nullptr;
+        }
+    }
+    return buffer;
+}
+
 static const INT UndefinedDumpType = 0;
 
 /*++
@@ -2376,7 +2398,7 @@ Parameters:
 (no return value)
 --*/
 VOID
-PROCCreateCrashDumpIfEnabled(int signal)
+PROCCreateCrashDumpIfEnabled(int signal, siginfo_t* siginfo)
 {
     // If enabled, launch the create minidump utility and wait until it completes
     if (!g_argvCreateDump.empty())
@@ -2384,13 +2406,16 @@ PROCCreateCrashDumpIfEnabled(int signal)
         std::vector<const char*> argv(g_argvCreateDump);
         char* signalArg = nullptr;
         char* crashThreadArg = nullptr;
+        char* signalCodeArg = nullptr;
+        char* signalErrnoArg = nullptr;
+        char* signalAddressArg = nullptr;
 
         if (signal != 0)
         {
             // Remove the terminating nullptr
             argv.pop_back();
 
-            // Add the Windows exception code to the command line
+            // Add the signal number to the command line
             signalArg = PROCFormatInt(signal);
             if (signalArg != nullptr)
             {
@@ -2405,6 +2430,29 @@ PROCCreateCrashDumpIfEnabled(int signal)
                 argv.push_back("--crashthread");
                 argv.push_back(crashThreadArg);
             }
+
+            if (siginfo != nullptr)
+            {
+                signalCodeArg = PROCFormatInt(siginfo->si_code);
+                if (signalCodeArg != nullptr)
+                {
+                    argv.push_back("--code");
+                    argv.push_back(signalCodeArg);
+                }
+                signalErrnoArg = PROCFormatInt(siginfo->si_errno);
+                if (signalErrnoArg != nullptr)
+                {
+                    argv.push_back("--errno");
+                    argv.push_back(signalErrnoArg);
+                }
+                signalAddressArg = PROCFormatInt64((ULONG64)siginfo->si_addr);
+                if (signalAddressArg != nullptr)
+                {
+                    argv.push_back("--address");
+                    argv.push_back(signalAddressArg);
+                }
+            }
+
             argv.push_back(nullptr);
         }
 
@@ -2412,6 +2460,9 @@ PROCCreateCrashDumpIfEnabled(int signal)
 
         free(signalArg);
         free(crashThreadArg);
+        free(signalCodeArg);
+        free(signalErrnoArg);
+        free(signalAddressArg);
     }
 }
 
@@ -2429,12 +2480,12 @@ Parameters:
 --*/
 PAL_NORETURN
 VOID
-PROCAbort(int signal)
+PROCAbort(int signal, siginfo_t* siginfo)
 {
     // Do any shutdown cleanup before aborting or creating a core dump
     PROCNotifyProcessShutdown();
 
-    PROCCreateCrashDumpIfEnabled(signal);
+    PROCCreateCrashDumpIfEnabled(signal, siginfo);
 
     // Restore all signals; the SIGABORT handler to prevent recursion and
     // the others to prevent multiple core dumps from being generated.

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -2013,7 +2013,7 @@ PROCFormatInt(ULONG32 value)
 Function:
     PROCFormatInt64
 
-    Helper function to format an ULONG32 as a string.
+    Helper function to format an ULONG64 as a string.
 
 --*/
 char*


### PR DESCRIPTION
Linux Watson needs this to better triage ELF dumps.

Add CreateDumpOptions helper struct to pass all the command options around. Add the "--code", "--errno", "--address" command line options used to fill the NT_SIGINFO NOTE. The runtime passes to createdump on a crash.

Added "ExceptionType" field to "Parameters" section of the Linux crash report json.