### PR TITLE
Let GenTreeCopyOrReload handle scenarios when FEATURE_MULTIREG_RET is disabled

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -1033,7 +1033,6 @@ unsigned GenTree::GetMultiRegCount(Compiler* comp) const
         return AsCopyOrReload()->GetRegCount();
     }
 
-
 #ifdef FEATURE_HW_INTRINSICS
     if (OperIsHWIntrinsic())
     {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -975,12 +975,12 @@ bool GenTree::IsMultiRegNode() const
         return AsMultiRegOp()->GetRegCount() > 1;
     }
 #endif
+#endif // FEATURE_MULTIREG_RET
 
     if (OperIs(GT_COPY, GT_RELOAD))
     {
         return true;
     }
-#endif // FEATURE_MULTIREG_RET
 
 #ifdef FEATURE_HW_INTRINSICS
     if (OperIsHWIntrinsic())
@@ -1026,12 +1026,13 @@ unsigned GenTree::GetMultiRegCount(Compiler* comp) const
         return AsMultiRegOp()->GetRegCount();
     }
 #endif
+#endif // FEATURE_MULTIREG_RET
 
     if (OperIs(GT_COPY, GT_RELOAD))
     {
         return AsCopyOrReload()->GetRegCount();
     }
-#endif // FEATURE_MULTIREG_RET
+
 
 #ifdef FEATURE_HW_INTRINSICS
     if (OperIsHWIntrinsic())
@@ -11696,7 +11697,8 @@ void Compiler::gtDispLeaf(GenTree* tree, IndentStack* indentStack)
                             fieldVarDsc->PrintVarReg();
                         }
 
-                        if (fieldVarDsc->lvTracked && fgLocalVarLivenessDone && tree->AsLclVar()->IsLastUse(index))
+                        if (fieldVarDsc->lvTracked && fgLocalVarLivenessDone &&
+                            tree->AsLclVarCommon()->IsLastUse(index))
                         {
                             printf(" (last use)");
                         }

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -8038,8 +8038,7 @@ struct GenTreePutArgSplit : public GenTreePutArgStk
 
 // Represents GT_COPY or GT_RELOAD node
 //
-// As it turns out, these are only needed on targets that happen to have multi-reg returns.
-// However, they are actually needed on any target that has any multi-reg ops.
+// Needed to support multi-reg ops.
 //
 struct GenTreeCopyOrReload : public GenTreeUnOp
 {

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -8044,12 +8044,12 @@ struct GenTreePutArgSplit : public GenTreePutArgStk
 //
 struct GenTreeCopyOrReload : public GenTreeUnOp
 {
-#if FEATURE_MULTIREG_RET
+//#if FEATURE_MULTIREG_RET
     // State required to support copy/reload of a multi-reg call node.
     // The first register is always given by GetRegNum().
     //
     regNumberSmall gtOtherRegs[MAX_MULTIREG_COUNT - 1];
-#endif
+//#endif
 
     //----------------------------------------------------------
     // ClearOtherRegs: set gtOtherRegs to REG_NA.
@@ -8062,12 +8062,12 @@ struct GenTreeCopyOrReload : public GenTreeUnOp
     //
     void ClearOtherRegs()
     {
-#if FEATURE_MULTIREG_RET
+//#if FEATURE_MULTIREG_RET
         for (unsigned i = 0; i < MAX_MULTIREG_COUNT - 1; ++i)
         {
             gtOtherRegs[i] = REG_NA;
         }
-#endif
+//#endif
     }
 
     //-----------------------------------------------------------
@@ -8088,11 +8088,11 @@ struct GenTreeCopyOrReload : public GenTreeUnOp
             return GetRegNum();
         }
 
-#if FEATURE_MULTIREG_RET
+//#if FEATURE_MULTIREG_RET
         return (regNumber)gtOtherRegs[idx - 1];
-#else
-        return REG_NA;
-#endif
+//#else
+        //return REG_NA;
+//#endif
     }
 
     //-----------------------------------------------------------
@@ -8113,18 +8113,18 @@ struct GenTreeCopyOrReload : public GenTreeUnOp
         {
             SetRegNum(reg);
         }
-#if FEATURE_MULTIREG_RET
+//#if FEATURE_MULTIREG_RET
         else
         {
             gtOtherRegs[idx - 1] = (regNumberSmall)reg;
             assert(gtOtherRegs[idx - 1] == reg);
         }
-#else
-        else
-        {
-            unreached();
-        }
-#endif
+//#else
+//        else
+//        {
+//            unreached();
+//        }
+//#endif
     }
 
     //----------------------------------------------------------------------------
@@ -8153,7 +8153,7 @@ struct GenTreeCopyOrReload : public GenTreeUnOp
 
     unsigned GetRegCount() const
     {
-#if FEATURE_MULTIREG_RET
+//#if FEATURE_MULTIREG_RET
         // We need to return the highest index for which we have a valid register.
         // Note that the gtOtherRegs array is off by one (the 0th register is GetRegNum()).
         // If there's no valid register in gtOtherRegs, GetRegNum() must be valid.
@@ -8168,7 +8168,7 @@ struct GenTreeCopyOrReload : public GenTreeUnOp
                 return i;
             }
         }
-#endif
+//#endif
         // We should never have a COPY or RELOAD with no valid registers.
         assert(GetRegNum() != REG_NA);
         return 1;
@@ -9097,12 +9097,13 @@ inline regNumber GenTree::GetRegByIndex(int regIndex) const
         return AsMultiRegOp()->GetRegNumByIdx(regIndex);
     }
 #endif
+#endif // FEATURE_MULTIREG_RET
 
     if (OperIs(GT_COPY, GT_RELOAD))
     {
         return AsCopyOrReload()->GetRegNumByIdx(regIndex);
     }
-#endif // FEATURE_MULTIREG_RET
+
 
 #ifdef FEATURE_HW_INTRINSICS
     if (OperIs(GT_HWINTRINSIC))

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -8039,17 +8039,14 @@ struct GenTreePutArgSplit : public GenTreePutArgStk
 // Represents GT_COPY or GT_RELOAD node
 //
 // As it turns out, these are only needed on targets that happen to have multi-reg returns.
-// However, they are actually needed on any target that has any multi-reg ops. It is just
-// coincidence that those are the same (and there isn't a FEATURE_MULTIREG_OPS).
+// However, they are actually needed on any target that has any multi-reg ops.
 //
 struct GenTreeCopyOrReload : public GenTreeUnOp
 {
-//#if FEATURE_MULTIREG_RET
     // State required to support copy/reload of a multi-reg call node.
     // The first register is always given by GetRegNum().
     //
     regNumberSmall gtOtherRegs[MAX_MULTIREG_COUNT - 1];
-//#endif
 
     //----------------------------------------------------------
     // ClearOtherRegs: set gtOtherRegs to REG_NA.
@@ -8062,12 +8059,10 @@ struct GenTreeCopyOrReload : public GenTreeUnOp
     //
     void ClearOtherRegs()
     {
-//#if FEATURE_MULTIREG_RET
         for (unsigned i = 0; i < MAX_MULTIREG_COUNT - 1; ++i)
         {
             gtOtherRegs[i] = REG_NA;
         }
-//#endif
     }
 
     //-----------------------------------------------------------
@@ -8088,11 +8083,7 @@ struct GenTreeCopyOrReload : public GenTreeUnOp
             return GetRegNum();
         }
 
-//#if FEATURE_MULTIREG_RET
         return (regNumber)gtOtherRegs[idx - 1];
-//#else
-        //return REG_NA;
-//#endif
     }
 
     //-----------------------------------------------------------
@@ -8113,18 +8104,11 @@ struct GenTreeCopyOrReload : public GenTreeUnOp
         {
             SetRegNum(reg);
         }
-//#if FEATURE_MULTIREG_RET
         else
         {
             gtOtherRegs[idx - 1] = (regNumberSmall)reg;
             assert(gtOtherRegs[idx - 1] == reg);
         }
-//#else
-//        else
-//        {
-//            unreached();
-//        }
-//#endif
     }
 
     //----------------------------------------------------------------------------
@@ -8153,7 +8137,6 @@ struct GenTreeCopyOrReload : public GenTreeUnOp
 
     unsigned GetRegCount() const
     {
-//#if FEATURE_MULTIREG_RET
         // We need to return the highest index for which we have a valid register.
         // Note that the gtOtherRegs array is off by one (the 0th register is GetRegNum()).
         // If there's no valid register in gtOtherRegs, GetRegNum() must be valid.
@@ -8168,7 +8151,7 @@ struct GenTreeCopyOrReload : public GenTreeUnOp
                 return i;
             }
         }
-//#endif
+
         // We should never have a COPY or RELOAD with no valid registers.
         assert(GetRegNum() != REG_NA);
         return 1;
@@ -9103,7 +9086,6 @@ inline regNumber GenTree::GetRegByIndex(int regIndex) const
     {
         return AsCopyOrReload()->GetRegNumByIdx(regIndex);
     }
-
 
 #ifdef FEATURE_HW_INTRINSICS
     if (OperIs(GT_HWINTRINSIC))


### PR DESCRIPTION
Currently Windows ABI doesn't allow to split the result and return it in multiple registers. However, in #66551, we exposed an API that will let us return the result in multiple registers. The ABI doesn't allow us to do, but since `DivRem` added in #66551 is an intrinsic, we should continue to let the instruction return the result in multiple registers. Thanks @tannergooding for helping me understand this concept.

`GenTreeCopyOrReload` had special code to handle scenario when `FEATURE_MULTIREG_RET` was allowed (on unix x64/arm64 and windows arm64) but this was breaking with `DivRem` support. The fix is to have `GenTreeCopyOrReload` also handle scenarios when `FEATURE_MULTIREG_RET` is disabled.

Fixes: #82397