### PR TITLE
Add pool provider template reference

### DIFF
--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -2,6 +2,9 @@ parameters:
   - name: stages
     type: stageList
 
+variables:
+- template: /eng/common/templates/variables/pool-providers.yml
+
 resources:
   containers:
     - container: linux_arm

--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -2,9 +2,6 @@ parameters:
   - name: stages
     type: stageList
 
-variables:
-- template: /eng/common/templates/variables/pool-providers.yml
-
 resources:
   containers:
     - container: linux_arm

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -132,12 +132,12 @@ jobs:
       pool:
         # Public Linux Build Pool
         ${{ if and(or(in(parameters.osGroup, 'linux', 'freebsd', 'android', 'tizen'), eq(parameters.jobParameters.hostedOs, 'linux')), eq(variables['System.TeamProject'], 'public')) }}:
-          name:  NetCore-Public
+          name:  $(DncEngPublicBuildPool)
           demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
 
         # Official Build Linux Pool
         ${{ if and(or(in(parameters.osGroup, 'linux', 'freebsd', 'android', 'tizen'), eq(parameters.jobParameters.hostedOs, 'linux')), ne(variables['System.TeamProject'], 'public')) }}:
-          name: NetCore1ESPool-Internal
+          name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
 
         # OSX Build Pool (we don't have on-prem OSX BuildPool
@@ -146,12 +146,12 @@ jobs:
 
         # Official Build Windows Pool
         ${{ if and(or(eq(parameters.osGroup, 'windows'), eq(parameters.jobParameters.hostedOs, 'windows')), ne(variables['System.TeamProject'], 'public')) }}:
-          name: NetCore1ESPool-Internal
+          name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals windows.vs2022.amd64
 
         # Public Windows Build Pool
         ${{ if and(or(eq(parameters.osGroup, 'windows'), eq(parameters.jobParameters.hostedOs, 'windows')), eq(variables['System.TeamProject'], 'public')) }}:
-          name: NetCore-Public
+          name: $(DncEngPublicBuildPool)
           demands: ImageOverride -equals windows.vs2022.amd64.open
 
 

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -21,6 +21,7 @@ jobs:
     dependOnEvaluatePaths: ${{ and(eq(variables['Build.Reason'], 'PullRequest'), in(variables['Build.DefinitionName'], 'runtime', 'runtime-staging', 'runtime-community', 'runtime-extra-platforms', 'runtime-wasm', 'runtime-wasm-libtests', 'runtime-wasm-non-libtests', 'dotnet-linker-tests', 'runtime-dev-innerloop', 'runtime-coreclr superpmi-replay', 'runtime-coreclr superpmi-diffs')) }}
 
     variables:
+      - template: /eng/common/templates/variables/pool-providers.yml
       # Disable component governance in our CI builds. These builds are not shipping nor
       # are they a service. Also the component governance jobs issue lots of inconsequential
       # warnings and errors into our build timelines that make it hard to track down

--- a/eng/pipelines/libraries/enterprise/linux.yml
+++ b/eng/pipelines/libraries/enterprise/linux.yml
@@ -38,7 +38,7 @@ extends:
       - job: EnterpriseLinuxTests
         timeoutInMinutes: 120
         pool:
-          name: NetCore-Public
+          name: $(DncEngPublicBuildPool)
           demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
         steps:
         - bash: |

--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -36,7 +36,7 @@ extends:
         variables:
           DUMPS_SHARE_MOUNT_ROOT: "/dumps-share"
         pool:
-          name: NetCore-Public
+          name: $(DncEngPublicBuildPool)
           demands: ImageOverride -equals 1es-ubuntu-1804-open
 
         steps:
@@ -102,7 +102,7 @@ extends:
         variables:
           DUMPS_SHARE_MOUNT_ROOT: "C:/dumps-share"
         pool:
-          name: NetCore-Public
+          name: $(DncEngPublicBuildPool)
           demands: ImageOverride -equals 1es-windows-2022-open
 
         steps:

--- a/eng/pipelines/libraries/stress/ssl.yml
+++ b/eng/pipelines/libraries/stress/ssl.yml
@@ -35,7 +35,7 @@ extends:
         displayName: Docker Linux
         timeoutInMinutes: 120
         pool:
-          name: NetCore-Public
+          name: $(DncEngPublicBuildPool)
           demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
 
         steps:
@@ -60,7 +60,7 @@ extends:
         displayName: Docker NanoServer
         timeoutInMinutes: 120
         pool:
-          name: NetCore-Public
+          name: $(DncEngPublicBuildPool)
           demands: ImageOverride -equals 1es-windows-2022-open
 
         steps:

--- a/eng/pipelines/libraries/variables.yml
+++ b/eng/pipelines/libraries/variables.yml
@@ -1,5 +1,6 @@
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - template: /eng/common/templates/variables/pool-providers.yml
   - name: buildScriptFileName
     value: libraries
   - name: sourcesRoot

--- a/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
@@ -9,7 +9,7 @@ jobs:
   displayName: Prepare Signed Artifacts
   dependsOn: ${{ parameters.dependsOn }}
   pool:
-    name: NetCore1ESPool-Internal
+    name: $(DncEngInternalBuildPool)
     demands: ImageOverride -equals 1es-windows-2022
   # Double the default timeout.
   timeoutInMinutes: 240

--- a/eng/pipelines/official/stages/publish.yml
+++ b/eng/pipelines/official/stages/publish.yml
@@ -2,6 +2,9 @@ parameters:
   PublishRidAgnosticPackagesFromPlatform: windows_x64
   publishingInfraVersion: 3
 
+variables:
+- template: /eng/common/templates/variables/pool-providers.yml
+
 stages:
 
 - stage: PrepareForPublish

--- a/eng/pipelines/official/stages/publish.yml
+++ b/eng/pipelines/official/stages/publish.yml
@@ -2,15 +2,13 @@ parameters:
   PublishRidAgnosticPackagesFromPlatform: windows_x64
   publishingInfraVersion: 3
 
-variables:
-- template: /eng/common/templates/variables/pool-providers.yml
-
 stages:
 
 - stage: PrepareForPublish
   displayName: Prepare for Publish
+  variables:
+  - template: /eng/common/templates/variables/pool-providers.yml
   jobs:
-
   # Prep artifacts: sign them and upload pipeline artifacts expected by stages-based publishing.
   - template: /eng/pipelines/official/jobs/prepare-signed-artifacts.yml
     parameters:

--- a/eng/pipelines/official/stages/publish.yml
+++ b/eng/pipelines/official/stages/publish.yml
@@ -20,7 +20,7 @@ stages:
       publishAssetsImmediately: true
       dependsOn: PrepareSignedArtifacts
       pool:
-        name: NetCore1ESPool-Internal
+        name: $(DncEngInternalBuildPool)
         demands: ImageOverride -equals 1es-windows-2022
       symbolPublishingAdditionalParameters: '/p:PublishSpecialClrFiles=true'
 


### PR DESCRIPTION
Use template to determine pool provider to use. 

The provider can't be expanded in the pipeline-with-resources step as the expansion breaks once global variables are consolidated. All variables end up in the global scope correctly, but several expansion points are expanded before assignment - particularly the ones at the pipeline scope - meaning that several parameters derived from them are empty and cause issues in further expansion decisions.