### PR TITLE
Replace `SafeLocalAllocHandle` in `System.Diagnostics.PerformanceCounter`

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ConvertStringSecurityDescriptorToSecurityDescriptor.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ConvertStringSecurityDescriptorToSecurityDescriptor.cs
@@ -11,10 +11,10 @@ internal static partial class Interop
     {
         [LibraryImport(Interop.Libraries.Advapi32, EntryPoint = "ConvertStringSecurityDescriptorToSecurityDescriptorW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static partial bool ConvertStringSecurityDescriptorToSecurityDescriptor(
+        internal static unsafe partial bool ConvertStringSecurityDescriptorToSecurityDescriptor(
             string StringSecurityDescriptor,
             int StringSDRevision,
-            out SafeLocalAllocHandle pSecurityDescriptor,
-            IntPtr SecurityDescriptorSize);
+            out void* pSecurityDescriptor,
+            uint* SecurityDescriptorSize);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SECURITY_ATTRIBUTES.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SECURITY_ATTRIBUTES.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
         internal struct SECURITY_ATTRIBUTES
         {
             internal uint nLength;
-            internal IntPtr lpSecurityDescriptor;
+            internal unsafe void* lpSecurityDescriptor;
             internal BOOL bInheritHandle;
         }
     }

--- a/src/libraries/Common/src/System/IO/FileSystem.DirectoryCreation.Windows.cs
+++ b/src/libraries/Common/src/System/IO/FileSystem.DirectoryCreation.Windows.cs
@@ -80,7 +80,7 @@ namespace System.IO
                 Interop.Kernel32.SECURITY_ATTRIBUTES secAttrs = new Interop.Kernel32.SECURITY_ATTRIBUTES
                 {
                     nLength = (uint)sizeof(Interop.Kernel32.SECURITY_ATTRIBUTES),
-                    lpSecurityDescriptor = (IntPtr)pSecurityDescriptor
+                    lpSecurityDescriptor = pSecurityDescriptor
                 };
 
                 while (stackDir.Count > 0)

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System.Diagnostics.PerformanceCounter.csproj
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System.Diagnostics.PerformanceCounter.csproj
@@ -93,8 +93,6 @@ System.Diagnostics.PerformanceCounter</PackageDescription>
              Link="Common\Interop\Windows\Kernel32\Interop.HandleOptions.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LoadLibrary.cs"
              Link="Common\Interop\Windows\Kernel32\Interop.LoadLibrary.cs" />
-    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalAlloc.cs"
-             Link="Common\Interop\Windows\Kernel32\Interop.LocalAlloc.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.MapViewOfFile.cs"
              Link="Common\Interop\Windows\Kernel32\Interop.MapViewOfFile.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.MemOptions.cs"

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System.Diagnostics.PerformanceCounter.csproj
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System.Diagnostics.PerformanceCounter.csproj
@@ -93,6 +93,8 @@ System.Diagnostics.PerformanceCounter</PackageDescription>
              Link="Common\Interop\Windows\Kernel32\Interop.HandleOptions.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LoadLibrary.cs"
              Link="Common\Interop\Windows\Kernel32\Interop.LoadLibrary.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalAlloc.cs"
+             Link="Common\Interop\Windows\Kernel32\Interop.LocalAlloc.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.MapViewOfFile.cs"
              Link="Common\Interop\Windows\Kernel32\Interop.MapViewOfFile.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.MemOptions.cs"
@@ -119,8 +121,6 @@ System.Diagnostics.PerformanceCounter</PackageDescription>
              Link="Common\Interop\Windows\Pdh\Interop.PdhFormatFromRawValue.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\PerfCounter\Interop.PerformanceData.cs"
              Link="Common\Interop\Windows\PerfCounter\Interop.PerformanceData.cs" />
-    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs"
-             Link="Common\Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs" />
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafePerfProviderHandle.cs"
              Link="Common\Microsoft\Win32\SafeHandles\SafePerfProviderHandle.cs" />
     <Compile Include="$(CommonPath)System\Diagnostics\NetFrameworkUtils.cs"

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/SharedPerformanceCounter.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/SharedPerformanceCounter.cs
@@ -1761,7 +1761,7 @@ namespace System.Diagnostics
                 }
                 finally
                 {
-                    Interop.Kernel32.LocalFree((IntPtr)pSecurityDescriptor);
+                    Marshal.FreeHGlobal((IntPtr)pSecurityDescriptor);
                 }
 
                 Interlocked.CompareExchange(ref *(int*)_fileViewAddress.DangerousGetHandle().ToPointer(), initialOffset, 0);

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/SharedPerformanceCounter.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/SharedPerformanceCounter.cs
@@ -1669,7 +1669,7 @@ namespace System.Diagnostics
             {
                 string mappingName = fileMappingName;
 
-                SafeLocalAllocHandle securityDescriptorPointer = null;
+                void* pSecurityDescriptor = null;
                 try
                 {
                     // The sddl string consists of these parts:
@@ -1681,12 +1681,17 @@ namespace System.Diagnostics
                     // ;S-1-5-33)   the same permission granted to AU is also granted to restricted services
                     string sddlString = "D:(A;OICI;FRFWGRGW;;;AU)(A;OICI;FRFWGRGW;;;S-1-5-33)";
 
-                    if (!Interop.Advapi32.ConvertStringSecurityDescriptorToSecurityDescriptor(sddlString, Interop.Kernel32.PerformanceCounterOptions.SDDL_REVISION_1,
-                                                                                                    out securityDescriptorPointer, IntPtr.Zero))
+                    if (!Interop.Advapi32.ConvertStringSecurityDescriptorToSecurityDescriptor(
+                        sddlString,
+                        Interop.Kernel32.PerformanceCounterOptions.SDDL_REVISION_1,
+                        out pSecurityDescriptor,
+                        null))
+                    {
                         throw new InvalidOperationException(SR.SetSecurityDescriptorFailed);
+                    }
 
                     Interop.Kernel32.SECURITY_ATTRIBUTES securityAttributes = default;
-                    securityAttributes.lpSecurityDescriptor = securityDescriptorPointer.DangerousGetHandle();
+                    securityAttributes.lpSecurityDescriptor = pSecurityDescriptor;
                     securityAttributes.bInheritHandle = Interop.BOOL.FALSE;
 
                     //
@@ -1756,7 +1761,7 @@ namespace System.Diagnostics
                 }
                 finally
                 {
-                    securityDescriptorPointer?.Close();
+                    Interop.Kernel32.LocalFree((IntPtr)pSecurityDescriptor);
                 }
 
                 Interlocked.CompareExchange(ref *(int*)_fileViewAddress.DangerousGetHandle().ToPointer(), initialOffset, 0);

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
@@ -282,7 +282,7 @@ namespace System.IO
             {
                 fixed (byte* pSecurityDescriptor = security.GetSecurityDescriptorBinaryForm())
                 {
-                    secAttrs.lpSecurityDescriptor = (IntPtr)pSecurityDescriptor;
+                    secAttrs.lpSecurityDescriptor = pSecurityDescriptor;
                     handle = CreateFileHandleInternal(fullPath, mode, rights, share, flagsAndAttributes, &secAttrs);
                 }
             }

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
@@ -586,7 +586,7 @@ namespace System.IO.Pipes
                 pinningHandle = GCHandle.Alloc(securityDescriptor, GCHandleType.Pinned);
                 fixed (byte* pSecurityDescriptor = securityDescriptor)
                 {
-                    secAttrs.lpSecurityDescriptor = (IntPtr)pSecurityDescriptor;
+                    secAttrs.lpSecurityDescriptor = pSecurityDescriptor;
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
@@ -765,7 +765,7 @@ namespace System.IO
                 path,
                 dwDesiredAccess: 0,
                 FileShare.ReadWrite | FileShare.Delete,
-                lpSecurityAttributes: (Interop.Kernel32.SECURITY_ATTRIBUTES*)IntPtr.Zero,
+                lpSecurityAttributes: null,
                 FileMode.Open,
                 dwFlagsAndAttributes: flags,
                 hTemplateFile: IntPtr.Zero);

--- a/src/libraries/System.Threading.AccessControl/src/System/Threading/EventWaitHandleAcl.cs
+++ b/src/libraries/System.Threading.AccessControl/src/System/Threading/EventWaitHandleAcl.cs
@@ -49,7 +49,7 @@ namespace System.Threading
                 var secAttrs = new Interop.Kernel32.SECURITY_ATTRIBUTES
                 {
                     nLength = (uint)sizeof(Interop.Kernel32.SECURITY_ATTRIBUTES),
-                    lpSecurityDescriptor = (IntPtr)pSecurityDescriptor
+                    lpSecurityDescriptor = pSecurityDescriptor
                 };
 
                 SafeWaitHandle handle = Interop.Kernel32.CreateEventEx(

--- a/src/libraries/System.Threading.AccessControl/src/System/Threading/MutexAcl.cs
+++ b/src/libraries/System.Threading.AccessControl/src/System/Threading/MutexAcl.cs
@@ -34,7 +34,7 @@ namespace System.Threading
                 var secAttrs = new Interop.Kernel32.SECURITY_ATTRIBUTES
                 {
                     nLength = (uint)sizeof(Interop.Kernel32.SECURITY_ATTRIBUTES),
-                    lpSecurityDescriptor = (IntPtr)pSecurityDescriptor
+                    lpSecurityDescriptor = pSecurityDescriptor
                 };
 
                 SafeWaitHandle handle = Interop.Kernel32.CreateMutexEx(

--- a/src/libraries/System.Threading.AccessControl/src/System/Threading/SemaphoreAcl.cs
+++ b/src/libraries/System.Threading.AccessControl/src/System/Threading/SemaphoreAcl.cs
@@ -51,7 +51,7 @@ namespace System.Threading
                 var secAttrs = new Interop.Kernel32.SECURITY_ATTRIBUTES
                 {
                     nLength = (uint)sizeof(Interop.Kernel32.SECURITY_ATTRIBUTES),
-                    lpSecurityDescriptor = (IntPtr)pSecurityDescriptor
+                    lpSecurityDescriptor = pSecurityDescriptor
                 };
 
                 SafeWaitHandle handle = Interop.Kernel32.CreateSemaphoreEx(


### PR DESCRIPTION
Follow-up #82411

We don't need a `SafeLocalAllocHandle` since we own the handle and immediately call `DangerousGetHandle`.

Additionally change type of `Interop+Kernel32+SECURITY_ATTRIBUTES.lpSecurityDescriptor` from `IntPtr` to `void*` which cleans up the code.

cc: @stephentoub