### PR TITLE
Call base.DisposeAsync on DerivedFileStreamStrategy

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/FileStream/DisposeAsync.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/DisposeAsync.cs
@@ -41,22 +41,30 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public async Task DerivedFileStreamDisposeUsedForDisposeAsync()
+        public async Task DerivedFileStreamDisposeAndCloseUsedForDisposeAsync()
         {
-            var fs = new OverridesDisposeFileStream(GetTestFilePath(), FileMode.Create);
+            var fs = new OverridesDisposeAndCloseFileStream(GetTestFilePath(), FileMode.Create);
             Assert.False(fs.DisposeInvoked);
+            Assert.False(fs.CloseInvoked);
             await fs.DisposeAsync();
             Assert.True(fs.DisposeInvoked);
+            Assert.True(fs.CloseInvoked);
         }
 
-        private sealed class OverridesDisposeFileStream : FileStream
+        private sealed class OverridesDisposeAndCloseFileStream : FileStream
         {
+            public bool CloseInvoked;
             public bool DisposeInvoked;
-            public OverridesDisposeFileStream(string path, FileMode mode) : base(path, mode) { }
+            public OverridesDisposeAndCloseFileStream(string path, FileMode mode) : base(path, mode) { }
             protected override void Dispose(bool disposing)
             {
                 DisposeInvoked = true;
                 base.Dispose(disposing);
+            }
+            public override void Close()
+            {
+                CloseInvoked = true;
+                base.Close();
             }
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
@@ -622,6 +622,9 @@ namespace System.IO
         internal ValueTask BaseWriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
             => base.WriteAsync(buffer, cancellationToken);
 
+        internal ValueTask BaseDisposeAsync()
+            => base.DisposeAsync();
+
         internal Task BaseCopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
             => base.CopyToAsync(destination, bufferSize, cancellationToken);
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/DerivedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/DerivedFileStreamStrategy.cs
@@ -146,7 +146,11 @@ namespace System.IO.Strategies
         public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
             => _fileStream.BaseCopyToAsync(destination, bufferSize, cancellationToken);
 
-        public override ValueTask DisposeAsync() => _strategy.DisposeAsync();
+        public override async ValueTask DisposeAsync()
+        {
+            await _strategy.DisposeAsync().ConfigureAwait(false);
+            await _fileStream.BaseDisposeAsync().ConfigureAwait(false);
+        }
 
         protected sealed override void Dispose(bool disposing) => _strategy.DisposeInternal(disposing);
     }


### PR DESCRIPTION
Since we stopped calling base.DisposeAsync (https://github.com/dotnet/runtime/pull/65899) we've been breaking compatibility of types deriving from FileStream where Close was expected to be called. As title suggests, we need to keep calling the base method so Close is properly called.

Fixes https://github.com/dotnet/runtime/issues/82176.