### PR TITLE
Fix DBI loading problem on Linux

### DIFF
--- a/src/coreclr/dlls/mscordbi/CMakeLists.txt
+++ b/src/coreclr/dlls/mscordbi/CMakeLists.txt
@@ -100,6 +100,17 @@ elseif(CLR_CMAKE_HOST_UNIX)
         mscordaccore
     )
 
+    # Before llvm 16, lld was setting `--undefined-version` by default. The default was
+    # flipped to `--no-undefined-version` in lld 16, so we will explicitly set it to
+    # `--undefined-version` for our use-case.
+    include(CheckLinkerFlag OPTIONAL)
+    if(COMMAND check_linker_flag)
+        check_linker_flag(CXX -Wl,--undefined-version LINKER_SUPPORTS_UNDEFINED_VERSION)
+        if (LINKER_SUPPORTS_UNDEFINED_VERSION)
+            add_linker_flag(-Wl,--undefined-version)
+        endif(LINKER_SUPPORTS_UNDEFINED_VERSION)
+    endif(COMMAND check_linker_flag)
+
     # COREDBI_LIBRARIES is mentioned twice because ld is one pass linker and will not find symbols
     # if they are defined after they are used. Having all libs twice makes sure that ld will actually
     # find all symbols.

--- a/src/coreclr/dlls/mscordbi/CMakeLists.txt
+++ b/src/coreclr/dlls/mscordbi/CMakeLists.txt
@@ -100,7 +100,10 @@ elseif(CLR_CMAKE_HOST_UNIX)
         mscordaccore
     )
 
-    target_link_libraries(mscordbi ${COREDBI_LIBRARIES})
+    # COREDBI_LIBRARIES is mentioned twice because ld is one pass linker and will not find symbols
+    # if they are defined after they are used. Having all libs twice makes sure that ld will actually
+    # find all symbols.
+    target_link_libraries(mscordbi ${COREDBI_LIBRARIES} ${COREDBI_LIBRARIES})
 
     add_dependencies(mscordbi mscordaccore)
 

--- a/src/coreclr/dlls/mscordbi/mscordbi.cpp
+++ b/src/coreclr/dlls/mscordbi/mscordbi.cpp
@@ -32,18 +32,3 @@ BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
 	// Defer to the main debugging code.
     return DbgDllMain(hInstance, dwReason, lpReserved);
 }
-
-#if defined(TARGET_LINUX) && !defined(HOST_WINDOWS)
-PALIMPORT HINSTANCE PALAPI DAC_PAL_RegisterModule(IN LPCSTR lpLibFileName);
-PALIMPORT VOID PALAPI DAC_PAL_UnregisterModule(IN HINSTANCE hInstance);
-
-HINSTANCE PALAPI PAL_RegisterModule(IN LPCSTR lpLibFileName)
-{
-     return DAC_PAL_RegisterModule(lpLibFileName);
-}
-
-VOID PALAPI PAL_UnregisterModule(IN HINSTANCE hInstance)
-{
-    DAC_PAL_UnregisterModule(hInstance);
-}
-#endif


### PR DESCRIPTION
Part of PR https://github.com/dotnet/runtime/pull/81573 needed to be undone to build libmscordbi.so without any undefined symbols from the DAC. The DAC_PAL_RegisterModule, etc. stubs I recommended didn't work and DBI could not be loaded by SOS (and I assume other debuggers) because of missing exports.

The double pass at the libraries from the `target_link_libraries(mscordbi ${COREDBI_LIBRARIES} ${COREDBI_LIBRARIES})` cmake file needed to be restored. The stubs were not needed after that.

Before the changes:
```
~/diagnostics/.dotnet-test/shared/Microsoft.NETCore.App/8.0.0-preview.2.23116.1$ ldd -r libmscordbi.so
        linux-vdso.so.1 (0x00007ffe54bee000)
        libmscordaccore.so => /home/mikem/diagnostics/.dotnet-test/shared/Microsoft.NETCore.App/8.0.0-preview.2.23116.1/./libmscordaccore.so (0x00007fc29f686000)
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fc29f499000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fc29f34a000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fc29f32f000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fc29f13d000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fc29faa0000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fc29f118000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fc29f10e000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fc29f108000)
undefined symbol: _Z22DAC_PAL_RegisterModulePKc (./libmscordbi.so)
undefined symbol: _Z24DAC_PAL_UnregisterModulePv        (./libmscordbi.so)
```
When I build the latest main I locally I get even more undefines before this fix:
```
        linux-vdso.so.1 (0x00007ffef5dfe000)
        libmscordaccore.so => /home/mikem/runtime/artifacts/bin/coreclr/linux.x64.Release/sharedFramework/./libmscordaccore.so (0x00007f4f1bb77000)
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f4f1b98a000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f4f1b83b000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f4f1b820000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f4f1b62e000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f4f1bf73000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f4f1b609000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f4f1b5ff000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f4f1b5f9000)
undefined symbol: _ZN14UTSemReadWrite11UnlockWriteEv    (./libmscordbi.so)
undefined symbol: _ZN14UTSemReadWriteC1Ev       (./libmscordbi.so)
undefined symbol: _ZNK9PEDecoder14CheckCorHeaderEv      (./libmscordbi.so)
undefined symbol: _Z17SplitPathInteriorPKDsPS0_PmS1_S2_S1_S2_S1_S2_     (./libmscordbi.so)
undefined symbol: _ZN14UTSemReadWrite8LockReadEv        (./libmscordbi.so)
undefined symbol: _ZNK9PEDecoder11GetMetadataEPj        (./libmscordbi.so)
undefined symbol: DAC_PAL_UnregisterModule      (./libmscordbi.so)
undefined symbol: _ZN14UTSemReadWrite9LockWriteEv       (./libmscordbi.so)
undefined symbol: _ZN8MDFormat15VerifySignatureEP16STORAGESIGNATUREj    (./libmscordbi.so)
undefined symbol: DAC_PAL_RegisterModule        (./libmscordbi.so)
undefined symbol: _ZN14UTSemReadWrite4InitEv    (./libmscordbi.so)
undefined symbol: _ZNK9PEDecoder14CheckNTHeadersEv      (./libmscordbi.so)
undefined symbol: _Z19_FillMDDefaultValuehPKvjP15_MDDefaultValue        (./libmscordbi.so)
undefined symbol: _ZN8MDFormat14GetFirstStreamEP13STORAGEHEADERPKv      (./libmscordbi.so)
undefined symbol: _ZNK9PEDecoder10GetRvaDataEj8IsNullOK (./libmscordbi.so)
undefined symbol: _ZNK9PEDecoder12HasNTHeadersEv        (./libmscordbi.so)
undefined symbol: _ZN14UTSemReadWrite10UnlockReadEv     (./libmscordbi.so)
undefined symbol: _ZN14UTSemReadWriteD1Ev       (./libmscordbi.so)
undefined symbol: _ZNK9PEDecoder20FindReadyToRunHeaderEv        (./libmscordbi.so)
```