### PR TITLE
[jiterp] Inline some performance-sensitive operations into traces

### DIFF
--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -209,22 +209,6 @@ mono_jiterp_try_newobj_inlined (MonoObject **destination, MonoVTable *vtable) {
 }
 
 EMSCRIPTEN_KEEPALIVE int
-mono_jiterp_getitem_span (
-	void **destination, MonoSpanOfVoid *span, int index, size_t element_size
-) {
-	if (!span)
-		return 0;
-
-	const gint32 length = span->_length;
-	if ((index < 0) || (index >= length))
-		return 0;
-
-	unsigned char * pointer = (unsigned char *)span->_reference;
-	*destination = pointer + (index * element_size);
-	return 1;
-}
-
-EMSCRIPTEN_KEEPALIVE int
 mono_jiterp_gettype_ref (
 	MonoObject **destination, MonoObject **source
 ) {
@@ -716,6 +700,7 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 		case MINT_STRLEN:
 		case MINT_GETCHR:
 		case MINT_GETITEM_SPAN:
+		case MINT_GETITEM_LOCALSPAN:
 		case MINT_INTRINS_SPAN_CTOR:
 		case MINT_INTRINS_UNSAFE_BYTE_OFFSET:
 		case MINT_INTRINS_GET_TYPE:

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -195,6 +195,7 @@ mono_jiterp_value_copy (void *dest, void *src, MonoClass *klass) {
 	mono_value_copy_internal(dest, src, klass);
 }
 
+/*
 EMSCRIPTEN_KEEPALIVE int
 mono_jiterp_strlen_ref (MonoString **ppString, int *result) {
 	MonoString *pString = *ppString;
@@ -204,6 +205,7 @@ mono_jiterp_strlen_ref (MonoString **ppString, int *result) {
 	*result = mono_string_length_internal(pString);
 	return 1;
 }
+*/
 
 EMSCRIPTEN_KEEPALIVE int
 mono_jiterp_getchr_ref (MonoString **ppString, int *pIndex, int *result) {
@@ -511,15 +513,32 @@ mono_jiterp_relop_fp (double lhs, double rhs, int opcode) {
 
 #undef JITERP_RELOP
 
+#define JITERP_MEMBER_VT_INITIALIZED 0
+#define JITERP_MEMBER_ARRAY_DATA 1
+#define JITERP_MEMBER_STRING_LENGTH 2
+#define JITERP_MEMBER_STRING_DATA 3
+#define JITERP_MEMBER_IMETHOD 4
+#define JITERP_MEMBER_DATA_ITEMS 5
+
 // we use these helpers at JIT time to figure out where to do memory loads and stores
 EMSCRIPTEN_KEEPALIVE size_t
-mono_jiterp_get_offset_of_vtable_initialized_flag () {
-	return offsetof(MonoVTable, initialized);
-}
-
-EMSCRIPTEN_KEEPALIVE size_t
-mono_jiterp_get_offset_of_array_data () {
-	return MONO_STRUCT_OFFSET (MonoArray, vector);
+mono_jiterp_get_member_offset (int member) {
+	switch (member) {
+		case JITERP_MEMBER_VT_INITIALIZED:
+			return MONO_STRUCT_OFFSET (MonoVTable, initialized);
+		case JITERP_MEMBER_ARRAY_DATA:
+			return MONO_STRUCT_OFFSET (MonoArray, vector);
+		case JITERP_MEMBER_STRING_LENGTH:
+			return MONO_STRUCT_OFFSET (MonoString, length);
+		case JITERP_MEMBER_STRING_DATA:
+			return MONO_STRUCT_OFFSET (MonoString, chars);
+		case JITERP_MEMBER_IMETHOD:
+			return offsetof (InterpFrame, imethod);
+		case JITERP_MEMBER_DATA_ITEMS:
+			return offsetof (InterpMethod, data_items);
+		default:
+			g_assert_not_reached();
+	}
 }
 
 EMSCRIPTEN_KEEPALIVE size_t

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -195,31 +195,6 @@ mono_jiterp_value_copy (void *dest, void *src, MonoClass *klass) {
 	mono_value_copy_internal(dest, src, klass);
 }
 
-/*
-EMSCRIPTEN_KEEPALIVE int
-mono_jiterp_strlen_ref (MonoString **ppString, int *result) {
-	MonoString *pString = *ppString;
-	if (!pString)
-		return 0;
-
-	*result = mono_string_length_internal(pString);
-	return 1;
-}
-*/
-
-EMSCRIPTEN_KEEPALIVE int
-mono_jiterp_getchr_ref (MonoString **ppString, int *pIndex, int *result) {
-	int index = *pIndex;
-	MonoString *pString = *ppString;
-	if (!pString)
-		return 0;
-	if ((index < 0) || (index >= mono_string_length_internal(pString)))
-		return 0;
-
-	*result = mono_string_chars_internal(pString)[index];
-	return 1;
-}
-
 EMSCRIPTEN_KEEPALIVE int
 mono_jiterp_try_newobj_inlined (MonoObject **destination, MonoVTable *vtable) {
 	*destination = 0;
@@ -519,6 +494,7 @@ mono_jiterp_relop_fp (double lhs, double rhs, int opcode) {
 #define JITERP_MEMBER_STRING_DATA 3
 #define JITERP_MEMBER_IMETHOD 4
 #define JITERP_MEMBER_DATA_ITEMS 5
+#define JITERP_MEMBER_RMETHOD 6
 
 // we use these helpers at JIT time to figure out where to do memory loads and stores
 EMSCRIPTEN_KEEPALIVE size_t
@@ -536,6 +512,8 @@ mono_jiterp_get_member_offset (int member) {
 			return offsetof (InterpFrame, imethod);
 		case JITERP_MEMBER_DATA_ITEMS:
 			return offsetof (InterpMethod, data_items);
+		case JITERP_MEMBER_RMETHOD:
+			return offsetof (JiterpEntryDataHeader, rmethod);
 		default:
 			g_assert_not_reached();
 	}

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -495,6 +495,8 @@ mono_jiterp_relop_fp (double lhs, double rhs, int opcode) {
 #define JITERP_MEMBER_IMETHOD 4
 #define JITERP_MEMBER_DATA_ITEMS 5
 #define JITERP_MEMBER_RMETHOD 6
+#define JITERP_MEMBER_SPAN_LENGTH 7
+#define JITERP_MEMBER_SPAN_DATA 8
 
 // we use these helpers at JIT time to figure out where to do memory loads and stores
 EMSCRIPTEN_KEEPALIVE size_t
@@ -514,6 +516,10 @@ mono_jiterp_get_member_offset (int member) {
 			return offsetof (InterpMethod, data_items);
 		case JITERP_MEMBER_RMETHOD:
 			return offsetof (JiterpEntryDataHeader, rmethod);
+		case JITERP_MEMBER_SPAN_LENGTH:
+			return offsetof (MonoSpanOfVoid, _length);
+		case JITERP_MEMBER_SPAN_DATA:
+			return offsetof (MonoSpanOfVoid, _reference);
 		default:
 			g_assert_not_reached();
 	}

--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -102,8 +102,7 @@ const fn_signatures: SigLine[] = [
     // jiterpreter
     [true, "mono_jiterp_get_trace_bailout_count", "number", ["number"]],
     [true, "mono_jiterp_value_copy", "void", ["number", "number", "number"]],
-    [true, "mono_jiterp_get_offset_of_vtable_initialized_flag", "number", []],
-    [true, "mono_jiterp_get_offset_of_array_data", "number", []],
+    [true, "mono_jiterp_get_member_offset", "number", ["number"]],
     [false, "mono_jiterp_encode_leb52", "number", ["number", "number", "number"]],
     [false, "mono_jiterp_encode_leb64_ref", "number", ["number", "number", "number"]],
     [false, "mono_jiterp_encode_leb_signed_boundary", "number", ["number", "number", "number"]],
@@ -243,8 +242,7 @@ export interface t_Cwraps {
 
     mono_jiterp_get_trace_bailout_count(reason: number): number;
     mono_jiterp_value_copy(destination: VoidPtr, source: VoidPtr, klass: MonoClass): void;
-    mono_jiterp_get_offset_of_vtable_initialized_flag(): number;
-    mono_jiterp_get_offset_of_array_data(): number;
+    mono_jiterp_get_member_offset(id: number): number;
     // Returns bytes written (or 0 if writing failed)
     mono_jiterp_encode_leb52(destination: VoidPtr, value: number, valueIsSigned: number): number;
     // Returns bytes written (or 0 if writing failed)

--- a/src/mono/wasm/runtime/jiterpreter-interp-entry.ts
+++ b/src/mono/wasm/runtime/jiterpreter-interp-entry.ts
@@ -13,7 +13,8 @@ import {
     WasmValtype, WasmBuilder, addWasmFunctionPointer,
     _now, elapsedTimes, counters, getRawCwrap, importDef,
     getWasmFunctionTable, recordFailure, getOptions,
-    JiterpreterOptions, shortNameBase
+    JiterpreterOptions, shortNameBase,
+    getMemberOffset, JiterpMember
 } from "./jiterpreter-support";
 
 // Controls miscellaneous diagnostic output.
@@ -39,11 +40,10 @@ typedef struct {
 } JiterpEntryDataHeader;
 */
 
-const // offsetOfStack = 12,
+const
     maxInlineArgs = 16,
     // just allocate a bunch of extra space
-    sizeOfJiterpEntryData = 64,
-    offsetOfRMethod = 0;
+    sizeOfJiterpEntryData = 64;
 
 const maxJitQueueLength = 4,
     queueFlushDelayMs = 10;
@@ -541,7 +541,7 @@ function generate_wasm_body (
 
     // Store the cleaned up rmethod value into the data.rmethod field of the scratch buffer
     builder.appendU8(WasmOpcode.i32_store);
-    builder.appendMemarg(offsetOfRMethod, 0); // data.rmethod
+    builder.appendMemarg(getMemberOffset(JiterpMember.Rmethod), 0); // data.rmethod
 
     // prologue takes data->rmethod and initializes data->context, then returns a value for sp_args
     // prologue also performs thread attach

--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -942,7 +942,8 @@ export const enum JiterpMember {
     StringLength = 2,
     StringData = 3,
     Imethod = 4,
-    DataItems = 5
+    DataItems = 5,
+    Rmethod = 6
 }
 
 const memberOffsets : { [index: number] : number } = {};

--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -943,7 +943,9 @@ export const enum JiterpMember {
     StringData = 3,
     Imethod = 4,
     DataItems = 5,
-    Rmethod = 6
+    Rmethod = 6,
+    SpanLength = 7,
+    SpanData = 8,
 }
 
 const memberOffsets : { [index: number] : number } = {};

--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -936,6 +936,25 @@ export function recordFailure () : void {
     }
 }
 
+export const enum JiterpMember {
+    VtableInitialized = 0,
+    ArrayData = 1,
+    StringLength = 2,
+    StringData = 3,
+    Imethod = 4,
+    DataItems = 5
+}
+
+const memberOffsets : { [index: number] : number } = {};
+
+export function getMemberOffset (member: JiterpMember) {
+    const cached = memberOffsets[member];
+    if (cached === undefined)
+        return memberOffsets[member] = cwraps.mono_jiterp_get_member_offset(<any>member);
+    else
+        return cached;
+}
+
 export function getRawCwrap (name: string): Function {
     const result = (<any>Module)["asm"][name];
     if (typeof (result) !== "function")

--- a/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -244,7 +244,6 @@ function getTraceImports () {
         importDef("array_address", getRawCwrap("mono_jiterp_array_get_element_address_with_size_ref")),
         importDef("entry", getRawCwrap("mono_jiterp_increase_entry_count")),
         importDef("value_copy", getRawCwrap("mono_jiterp_value_copy")),
-        importDef("getspan", getRawCwrap("mono_jiterp_getitem_span")),
         importDef("gettype", getRawCwrap("mono_jiterp_gettype_ref")),
         importDef("cast", getRawCwrap("mono_jiterp_cast_ref")),
         importDef("try_unbox", getRawCwrap("mono_jiterp_try_unbox_ref")),

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -114,10 +114,10 @@ export let countLimitedPrintCounter = 10;
 export const abortCounts : { [key: string] : number } = {};
 export const traceInfo : { [key: string] : TraceInfo } = {};
 
-export const // offsetOfStack = 12,
-    offsetOfImethod = 4,
-    offsetOfDataItems = 20,
+export const
     sizeOfDataItem = 4,
+    sizeOfObjectHeader = 8,
+
     // HACK: Typically we generate ~12 bytes of extra gunk after the function body so we are
     //  subtracting 20 from the maximum size to make sure we don't produce too much
     // Also subtract some more size since the wasm we generate for one opcode could be big
@@ -244,7 +244,7 @@ function getTraceImports () {
         importDef("array_address", getRawCwrap("mono_jiterp_array_get_element_address_with_size_ref")),
         importDef("entry", getRawCwrap("mono_jiterp_increase_entry_count")),
         importDef("value_copy", getRawCwrap("mono_jiterp_value_copy")),
-        importDef("strlen", getRawCwrap("mono_jiterp_strlen_ref")),
+        // importDef("strlen", getRawCwrap("mono_jiterp_strlen_ref")),
         importDef("getchr", getRawCwrap("mono_jiterp_getchr_ref")),
         importDef("getspan", getRawCwrap("mono_jiterp_getitem_span")),
         importDef("gettype", getRawCwrap("mono_jiterp_gettype_ref")),

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -244,8 +244,6 @@ function getTraceImports () {
         importDef("array_address", getRawCwrap("mono_jiterp_array_get_element_address_with_size_ref")),
         importDef("entry", getRawCwrap("mono_jiterp_increase_entry_count")),
         importDef("value_copy", getRawCwrap("mono_jiterp_value_copy")),
-        // importDef("strlen", getRawCwrap("mono_jiterp_strlen_ref")),
-        importDef("getchr", getRawCwrap("mono_jiterp_getchr_ref")),
         importDef("getspan", getRawCwrap("mono_jiterp_getitem_span")),
         importDef("gettype", getRawCwrap("mono_jiterp_gettype_ref")),
         importDef("cast", getRawCwrap("mono_jiterp_cast_ref")),


### PR DESCRIPTION
A few common performance-sensitive operations (getchr, strlen, and getitem_span) currently rely on calling a C helper function to do their work. This PR improves the trace generator to inline the logic for those operations into traces. It may make traces bigger (which is bad) but the work involved in calling the C helper adds overhead and the helper itself is more complex, so this change should pay for itself in terms of performance. This change also allows null check elimination to apply to these opcodes, while the helper would have to always do the null check.

This PR also refactors some of the member offset computations in the jiterpreter to make them less fragile.