### PR TITLE
[browser] Fixed the 3rd argument for TypedArray.fill()

### DIFF
--- a/src/mono/wasm/runtime/memory.ts
+++ b/src/mono/wasm/runtime/memory.ts
@@ -54,7 +54,7 @@ function assert_int_in_range(value: Number, min: Number, max: Number) {
 }
 
 export function _zero_region(byteOffset: VoidPtr, sizeBytes: number): void {
-    Module.HEAP8.fill(0, <any>byteOffset, sizeBytes);
+    Module.HEAP8.fill(0, <any>byteOffset, <any>byteOffset + sizeBytes);
 }
 
 export function setB32(offset: MemOffset, value: number | boolean): void {


### PR DESCRIPTION
According to
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill
, `TypedArray.fill()` expects `end` as the 3rd argument.