### PR TITLE
Share some "Compiles" tests with ComInterfaceSourceGenerator

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/Ancillary.Interop/GeneratedComInterfaceAttribute.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/Ancillary.Interop/GeneratedComInterfaceAttribute.cs
@@ -8,14 +8,13 @@ namespace System.Runtime.InteropServices.Marshalling
     [AttributeUsage(AttributeTargets.Interface)]
     public class GeneratedComInterfaceAttribute : Attribute
     {
-        public GeneratedComInterfaceAttribute(Type comWrappersType)
-            => (ComWrappersType) = (comWrappersType);
+        public GeneratedComInterfaceAttribute() { }
 
         public GeneratedComInterfaceAttribute(Type comWrappersType, bool generateManagedObjectWrapper, bool generateComObjectWrapper)
             => (ComWrappersType, GenerateManagedObjectWrapper, GenerateComObjectWrapper)
              = (comWrappersType, generateManagedObjectWrapper, generateComObjectWrapper);
 
-        public Type ComWrappersType { get; }
+        public Type? ComWrappersType { get; } = null;
 
         public bool GenerateManagedObjectWrapper { get; } = true;
 

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/CodeSnippets.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/CodeSnippets.cs
@@ -1,13 +1,75 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Interop;
-using Microsoft.Interop.UnitTests;
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace ComInterfaceGenerator.Unit.Tests
 {
-    internal partial class CodeSnippets
+    internal class CodeSnippets
     {
+        private GeneratorKind Generator { get; }
+
+        public CodeSnippets(GeneratorKind generator)
+        {
+            this.Generator = generator;
+        }
+
+        public enum GeneratorKind
+        {
+            ComInterfaceGenerator,
+            VTableIndexStubGenerator
+        }
+
+        private string VirtualMethodIndex(
+            int index,
+            bool? ImplicitThisParameter = null,
+            MarshalDirection? Direction = null,
+            StringMarshalling? StringMarshalling = null,
+            Type? StringMarshallingCustomType = null,
+            bool? SetLastError = null,
+            ExceptionMarshalling? ExceptionMarshalling = null,
+            Type? ExceptionMarshallingType = null)
+                => Generator switch
+                {
+                    GeneratorKind.ComInterfaceGenerator => "",
+                    GeneratorKind.VTableIndexStubGenerator =>
+                        "[global::System.Runtime.InteropServices.Marshalling.VirtualMethodIndexAttribute("
+                        + index.ToString()
+                        + (ImplicitThisParameter.HasValue ? $", ImplicitThisParameter = {ImplicitThisParameter.Value.ToString().ToLower()}" : "")
+                        + (Direction is not null ? $", Direction = {typeof(MarshalDirection).FullName}.{Direction.Value}" : "")
+                        + (StringMarshalling is not null ? $", StringMarshalling = {typeof(StringMarshalling).FullName}.{StringMarshalling!.Value}" : "")
+                        + (StringMarshallingCustomType is not null ? $", StringMarshallingCustomType = {StringMarshallingCustomType!.FullName}" : "")
+                        + (SetLastError is not null ? $", SetLastError = {SetLastError.Value.ToString().ToLower()}" : "")
+                        + (ExceptionMarshalling is not null ? $", ExceptionMarshalling = {typeof(ExceptionMarshalling).FullName}.{ExceptionMarshalling.Value}" : "")
+                        + (ExceptionMarshallingType is not null ? $", ExceptionMarshallingCustomType = {ExceptionMarshallingType!.FullName}" : "")
+                        + ")]",
+                    _ => throw new NotImplementedException()
+                };
+
+        private string UnmanagedObjectUnwrapper(Type t) => Generator switch
+        {
+            GeneratorKind.VTableIndexStubGenerator => $"[global::System.Runtime.InteropServices.Marshalling.UnmanagedObjectUnwrapperAttribute<{t.FullName!.Replace('+', '.')}>]",
+            GeneratorKind.ComInterfaceGenerator => "",
+            _ => throw new NotImplementedException(),
+        };
+
+        private string GeneratedComInterface => Generator switch
+        {
+            GeneratorKind.VTableIndexStubGenerator => "",
+            GeneratorKind.ComInterfaceGenerator => $"[global::System.Runtime.InteropServices.Marshalling.GeneratedComInterfaceAttribute]",
+            _ => throw new NotImplementedException(),
+        };
+        private string UnmanagedCallConv(Type[]? CallConvs = null)
+        {
+            var arguments = CallConvs?.Length is 0 or null ? "" : "(CallConvs = new[] {" + string.Join(", ", CallConvs!.Select(t => $"typeof({t.FullName})")) + "})";
+            return "[global::System.Runtime.InteropServices.UnmanagedCallConvAttribute"
+                + arguments + "]";
+        }
+
         public static readonly string DisableRuntimeMarshalling = "[assembly:System.Runtime.CompilerServices.DisableRuntimeMarshalling]";
         public static readonly string UsingSystemRuntimeInteropServicesMarshalling = "using System.Runtime.InteropServices.Marshalling;";
         public const string INativeAPI_IUnmanagedInterfaceTypeImpl = $$"""
@@ -29,160 +91,187 @@ sealed class NativeAPI : IUnmanagedVirtualMethodTableProvider, INativeAPI.Native
 }
 ";
 
-        public static readonly string SpecifiedMethodIndexNoExplicitParameters = @"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
+        public string SpecifiedMethodIndexNoExplicitParameters => $$"""
 
-[UnmanagedObjectUnwrapper<UnmanagedObjectUnwrapper.TestUnwrapper>]
-partial interface INativeAPI : IUnmanagedInterfaceType
-{
-    [VirtualMethodIndex(0)]
-    void Method();
-}" + NativeInterfaceUsage() + INativeAPI_IUnmanagedInterfaceTypeImpl;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
 
-        public static readonly string SpecifiedMethodIndexNoExplicitParametersNoImplicitThis = @"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
+            {{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{GeneratedComInterface}}
+            partial interface INativeAPI : IUnmanagedInterfaceType
+            {
+                {{VirtualMethodIndex(0)}}
+                void Method();
+            }
+            """ + NativeInterfaceUsage() + INativeAPI_IUnmanagedInterfaceTypeImpl;
 
-[UnmanagedObjectUnwrapper<UnmanagedObjectUnwrapper.TestUnwrapper>]
-partial interface INativeAPI : IUnmanagedInterfaceType
-{
-    [VirtualMethodIndex(0, ImplicitThisParameter = false)]
-    void Method();
-}" + NativeInterfaceUsage() + INativeAPI_IUnmanagedInterfaceTypeImpl;
+        public string SpecifiedMethodIndexNoExplicitParametersNoImplicitThis => $$"""
 
-        public static readonly string SpecifiedMethodIndexNoExplicitParametersCallConvWithCallingConventions = @"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
 
-[UnmanagedObjectUnwrapper<UnmanagedObjectUnwrapper.TestUnwrapper>]
-partial interface INativeAPI : IUnmanagedInterfaceType
-{
+            {{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{GeneratedComInterface}}
+            partial interface INativeAPI : IUnmanagedInterfaceType
+            {
+                {{VirtualMethodIndex(0, ImplicitThisParameter: false)}}
+                void Method();
 
-    [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
-    [VirtualMethodIndex(0)]
-    void Method();
-    [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl), typeof(CallConvMemberFunction) })]
-    [VirtualMethodIndex(1)]
-    void Method1();
+            }
+            """ + NativeInterfaceUsage() + INativeAPI_IUnmanagedInterfaceTypeImpl;
 
-    [SuppressGCTransition]
-    [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl), typeof(CallConvMemberFunction) })]
-    [VirtualMethodIndex(2)]
-    void Method2();
+        public string SpecifiedMethodIndexNoExplicitParametersCallConvWithCallingConventions => $$"""
 
-    [SuppressGCTransition]
-    [UnmanagedCallConv]
-    [VirtualMethodIndex(3)]
-    void Method3();
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
 
-    [SuppressGCTransition]
-    [VirtualMethodIndex(4)]
-    void Method4();
-}" + NativeInterfaceUsage() + INativeAPI_IUnmanagedInterfaceTypeImpl;
-        public static string BasicParametersAndModifiers(string typeName, string preDeclaration = "") => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
+            {{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{GeneratedComInterface}}
+            partial interface INativeAPI : IUnmanagedInterfaceType
+            {
 
-[assembly:DisableRuntimeMarshalling]
+                {{UnmanagedCallConv(CallConvs: new[] { typeof(CallConvCdecl) })}}
+                {{VirtualMethodIndex(0)}}
+                void Method();
+                {{UnmanagedCallConv(CallConvs: new[] { typeof(CallConvCdecl), typeof(CallConvMemberFunction) })}}
+                {{VirtualMethodIndex(1)}}
+                void Method1();
 
-[UnmanagedObjectUnwrapper<UnmanagedObjectUnwrapper.TestUnwrapper>]
-partial interface INativeAPI : IUnmanagedInterfaceType
-{{
-    [VirtualMethodIndex(0)]
-    {typeName} Method({typeName} value, in {typeName} inValue, ref {typeName} refValue, out {typeName} outValue);
-}}" + NativeInterfaceUsage() + INativeAPI_IUnmanagedInterfaceTypeImpl;
-        public static string BasicParametersAndModifiersManagedToUnmanaged(string typeName, string preDeclaration = "") => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
+                [SuppressGCTransition]
+                {{UnmanagedCallConv(CallConvs: new[] { typeof(CallConvCdecl), typeof(CallConvMemberFunction) })}}
+                {{VirtualMethodIndex(2)}}
+                void Method2();
 
-[assembly:DisableRuntimeMarshalling]
+                [SuppressGCTransition]
+                {{UnmanagedCallConv()}}
+                {{VirtualMethodIndex(3)}}
+                void Method3();
 
-[UnmanagedObjectUnwrapper<UnmanagedObjectUnwrapper.TestUnwrapper>]
-partial interface INativeAPI : IUnmanagedInterfaceType
-{{
-    [VirtualMethodIndex(0, Direction = MarshalDirection.ManagedToUnmanaged)]
-    {typeName} Method({typeName} value, in {typeName} inValue, ref {typeName} refValue, out {typeName} outValue);
-}}" + NativeInterfaceUsage() + INativeAPI_IUnmanagedInterfaceTypeImpl;
-        public static string BasicParametersAndModifiers<T>() => BasicParametersAndModifiers(typeof(T).FullName!);
-        public static string BasicParametersAndModifiersNoRef(string typeName, string preDeclaration = "") => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
+                [SuppressGCTransition]
+                {{VirtualMethodIndex(4)}}
+                void Method4();
+            }
+            """ + NativeInterfaceUsage() + INativeAPI_IUnmanagedInterfaceTypeImpl;
 
-[assembly:DisableRuntimeMarshalling]
+        public string BasicParametersAndModifiers(string typeName, string preDeclaration = "") => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
 
-[UnmanagedObjectUnwrapper<UnmanagedObjectUnwrapper.TestUnwrapper>]
-partial interface INativeAPI : IUnmanagedInterfaceType
-{{
-    [VirtualMethodIndex(0)]
-    {typeName} Method({typeName} value, in {typeName} inValue, out {typeName} outValue);
-}}" + NativeInterfaceUsage() + INativeAPI_IUnmanagedInterfaceTypeImpl;
-        public static string BasicParametersAndModifiersNoImplicitThis(string typeName) => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
+            [assembly:DisableRuntimeMarshalling]
 
-[UnmanagedObjectUnwrapper<UnmanagedObjectUnwrapper.TestUnwrapper>]
-partial interface INativeAPI : IUnmanagedInterfaceType
-{{
-    [VirtualMethodIndex(0, ImplicitThisParameter = false)]
-    {typeName} Method({typeName} value, in {typeName} inValue, ref {typeName} refValue, out {typeName} outValue);
-}}" + NativeInterfaceUsage() + INativeAPI_IUnmanagedInterfaceTypeImpl;
+            {{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{GeneratedComInterface}}
+            partial interface INativeAPI : IUnmanagedInterfaceType
+            {
+                {{VirtualMethodIndex(0)}}
+                {{typeName}} Method({{typeName}} value, in {{typeName}} inValue, ref {{typeName}} refValue, out {{typeName}} outValue);
+            }
+            """ + NativeInterfaceUsage() + INativeAPI_IUnmanagedInterfaceTypeImpl;
 
-        public static string BasicParametersAndModifiersNoImplicitThis<T>() => BasicParametersAndModifiersNoImplicitThis(typeof(T).FullName!);
-        public static string MarshalUsingCollectionCountInfoParametersAndModifiers<T>() => MarshalUsingCollectionCountInfoParametersAndModifiers(typeof(T).ToString());
-        public static string MarshalUsingCollectionCountInfoParametersAndModifiers(string collectionType) => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-[assembly:DisableRuntimeMarshalling]
+        public string BasicParametersAndModifiersManagedToUnmanaged(string typeName, string preDeclaration = "") => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
 
-[UnmanagedObjectUnwrapper<UnmanagedObjectUnwrapper.TestUnwrapper>]
-partial interface INativeAPI : IUnmanagedInterfaceType
-{{
-    [VirtualMethodIndex(0)]
-    [return:MarshalUsing(ConstantElementCount=10)]
-    {collectionType} Method(
-        {collectionType} p,
-        in {collectionType} pIn,
-        int pRefSize,
-        [MarshalUsing(CountElementName = ""pRefSize"")] ref {collectionType} pRef,
-        [MarshalUsing(CountElementName = ""pOutSize"")] out {collectionType} pOut,
-        out int pOutSize);
-}}" + NativeInterfaceUsage() + INativeAPI_IUnmanagedInterfaceTypeImpl;
+            [assembly:DisableRuntimeMarshalling]
 
-        public static string BasicReturnTypeComExceptionHandling(string typeName, string preDeclaration = "") => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
+            {{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{GeneratedComInterface}}
+            partial interface INativeAPI : IUnmanagedInterfaceType
+            {
+                {{VirtualMethodIndex(0, Direction: MarshalDirection.ManagedToUnmanaged)}}
+                {{typeName}} Method({{typeName}} value, in {{typeName}} inValue, ref {{typeName}} refValue, out {{typeName}} outValue);
+            }
+            """ + NativeInterfaceUsage() + INativeAPI_IUnmanagedInterfaceTypeImpl;
+        public string BasicParametersAndModifiers<T>() => BasicParametersAndModifiers(typeof(T).FullName!);
+        public string BasicParametersAndModifiersNoRef(string typeName, string preDeclaration = "") => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
 
-[UnmanagedObjectUnwrapper<UnmanagedObjectUnwrapper.TestUnwrapper>]
-partial interface INativeAPI : IUnmanagedInterfaceType
-{{
-    [VirtualMethodIndex(0, ExceptionMarshalling = ExceptionMarshalling.Com)]
-    {typeName} Method();
-}}" + NativeInterfaceUsage() + INativeAPI_IUnmanagedInterfaceTypeImpl;
+            [assembly:DisableRuntimeMarshalling]
 
-        public static string BasicReturnTypeCustomExceptionHandling(string typeName, string customExceptionType, string preDeclaration = "") => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
+            {{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{GeneratedComInterface}}
+            partial interface INativeAPI : IUnmanagedInterfaceType
+            {
+                {{VirtualMethodIndex(0)}}
+                {{typeName}} Method({{typeName}} value, in {{typeName}} inValue, out {{typeName}} outValue);
+            }
+            """ + NativeInterfaceUsage() + INativeAPI_IUnmanagedInterfaceTypeImpl;
 
-[UnmanagedObjectUnwrapper<UnmanagedObjectUnwrapper.TestUnwrapper>]
-partial interface INativeAPI : IUnmanagedInterfaceType
-{{
-    [VirtualMethodIndex(0, CustomExceptionMarshallingType = typeof({customExceptionType}))]
-    {typeName} Method();
-}}" + NativeInterfaceUsage() + INativeAPI_IUnmanagedInterfaceTypeImpl;
+        public string BasicParametersAndModifiersNoImplicitThis(string typeName) => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+
+            {{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{GeneratedComInterface}}
+            partial interface INativeAPI : IUnmanagedInterfaceType
+            {
+                {{VirtualMethodIndex(0, ImplicitThisParameter: false)}}
+                {{typeName}} Method({{typeName}} value, in {{typeName}} inValue, ref {{typeName}} refValue, out {{typeName}} outValue);
+            }
+            """ + NativeInterfaceUsage() + INativeAPI_IUnmanagedInterfaceTypeImpl;
+
+        public string BasicParametersAndModifiersNoImplicitThis<T>() => BasicParametersAndModifiersNoImplicitThis(typeof(T).FullName!);
+        public string MarshalUsingCollectionCountInfoParametersAndModifiers<T>() => MarshalUsingCollectionCountInfoParametersAndModifiers(typeof(T).ToString());
+        public string MarshalUsingCollectionCountInfoParametersAndModifiers(string collectionType) => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            [assembly:DisableRuntimeMarshalling]
+
+            {{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{GeneratedComInterface}}
+            partial interface INativeAPI : IUnmanagedInterfaceType
+            {
+                {{VirtualMethodIndex(0)}}
+                [return:MarshalUsing(ConstantElementCount=10)]
+                {{collectionType}} Method(
+                    {{collectionType}} p,
+                    in {{collectionType}} pIn,
+                    int pRefSize,
+                    [MarshalUsing(CountElementName = "pRefSize")] ref {{collectionType}} pRef,
+                    [MarshalUsing(CountElementName = "pOutSize")] out {{collectionType}} pOut,
+                    out int pOutSize);
+            }
+            """ + NativeInterfaceUsage() + INativeAPI_IUnmanagedInterfaceTypeImpl;
+
+        public string BasicReturnTypeComExceptionHandling(string typeName, string preDeclaration = "") => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
+
+            {{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{GeneratedComInterface}}
+            partial interface INativeAPI : IUnmanagedInterfaceType
+            {
+                {{VirtualMethodIndex(0, ExceptionMarshalling : ExceptionMarshalling.Com)}}
+                {{typeName}} Method();
+            }
+            """ + NativeInterfaceUsage() + INativeAPI_IUnmanagedInterfaceTypeImpl;
+
+        public string BasicReturnTypeCustomExceptionHandling(string typeName, string customExceptionType, string preDeclaration = "") => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
+
+            {{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{GeneratedComInterface}}
+            partial interface INativeAPI : IUnmanagedInterfaceType
+            {
+                {{VirtualMethodIndex(0, ExceptionMarshallingType : Type.GetType(customExceptionType))}}
+                {{typeName}} Method();
+            }
+            """ + NativeInterfaceUsage() + INativeAPI_IUnmanagedInterfaceTypeImpl;
 
         public class ManagedToUnmanaged : IVirtualMethodIndexSignatureProvider<ManagedToUnmanaged>
         {

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/Compiles.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Interop.UnitTests;
 using Xunit;
 
@@ -18,37 +20,75 @@ namespace ComInterfaceGenerator.Unit.Tests
             [CallerFilePath] string? filePath = null)
             => TestUtils.GetFileLineName(lineNumber, filePath);
 
-        public static IEnumerable<object[]> CodeSnippetsToCompile()
+        public static IEnumerable<object[]> SharedCodeSnippets(int generator)
         {
-            yield return new[] { ID(), CodeSnippets.SpecifiedMethodIndexNoExplicitParameters };
-            yield return new[] { ID(), CodeSnippets.SpecifiedMethodIndexNoExplicitParametersNoImplicitThis };
-            yield return new[] { ID(), CodeSnippets.SpecifiedMethodIndexNoExplicitParametersCallConvWithCallingConventions };
+            var codeSnippets = new CodeSnippets((CodeSnippets.GeneratorKind)generator);
+            yield return new[] { ID(), codeSnippets.SpecifiedMethodIndexNoExplicitParameters };
+            yield return new[] { ID(), codeSnippets.SpecifiedMethodIndexNoExplicitParametersNoImplicitThis };
+            yield return new[] { ID(), codeSnippets.SpecifiedMethodIndexNoExplicitParametersCallConvWithCallingConventions };
 
             // Basic marshalling validation
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiers<byte>() };
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiers<sbyte>() };
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiers<short>() };
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiers<ushort>() };
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiers<int>() };
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiers<uint>() };
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiers<long>() };
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiers<ulong>() };
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiers<float>() };
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiers<double>() };
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiers<IntPtr>() };
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiers<UIntPtr>() };
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiersNoImplicitThis<byte>() };
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiersNoImplicitThis<sbyte>() };
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiersNoImplicitThis<short>() };
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiersNoImplicitThis<ushort>() };
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiersNoImplicitThis<int>() };
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiersNoImplicitThis<uint>() };
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiersNoImplicitThis<long>() };
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiersNoImplicitThis<ulong>() };
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiersNoImplicitThis<float>() };
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiersNoImplicitThis<double>() };
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiersNoImplicitThis<IntPtr>() };
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiersNoImplicitThis<UIntPtr>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiers<byte>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiers<sbyte>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiers<short>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiers<ushort>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiers<int>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiers<uint>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiers<long>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiers<ulong>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiers<float>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiers<double>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiers<IntPtr>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiers<UIntPtr>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiersNoImplicitThis<byte>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiersNoImplicitThis<sbyte>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiersNoImplicitThis<short>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiersNoImplicitThis<ushort>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiersNoImplicitThis<int>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiersNoImplicitThis<uint>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiersNoImplicitThis<long>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiersNoImplicitThis<ulong>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiersNoImplicitThis<float>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiersNoImplicitThis<double>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiersNoImplicitThis<IntPtr>() };
+            yield return new[] { ID(), codeSnippets.BasicParametersAndModifiersNoImplicitThis<UIntPtr>() };
+
+            // SafeHandles
+            if (generator == (int)CodeSnippets.GeneratorKind.VTableIndexStubGenerator)
+                yield return new[] { ID(), codeSnippets.BasicParametersAndModifiersManagedToUnmanaged("Microsoft.Win32.SafeHandles.SafeFileHandle") };
+
+            // Exception Handling
+            // HResult
+            yield return new[] { ID(), codeSnippets.BasicReturnTypeComExceptionHandling("int") };
+            yield return new[] { ID(), codeSnippets.BasicReturnTypeComExceptionHandling("uint") };
+            // NaN
+            yield return new[] { ID(), codeSnippets.BasicReturnTypeComExceptionHandling("float") };
+            yield return new[] { ID(), codeSnippets.BasicReturnTypeComExceptionHandling("double") };
+            // Default Value
+            yield return new[] { ID(), codeSnippets.BasicReturnTypeComExceptionHandling("nint") };
+            // Void
+            yield return new[] { ID(), codeSnippets.BasicReturnTypeComExceptionHandling("void") };
+
+        }
+        public static IEnumerable<object[]> SharedCustomCollectionsSnippets(int generator)
+        {
+            var codeSnippets = new CodeSnippets((CodeSnippets.GeneratorKind)generator);
+            yield return new[] { ID(), codeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<byte[]>() };
+            yield return new[] { ID(), codeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<sbyte[]>() };
+            yield return new[] { ID(), codeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<short[]>() };
+            yield return new[] { ID(), codeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<ushort[]>() };
+            yield return new[] { ID(), codeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<int[]>() };
+            yield return new[] { ID(), codeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<uint[]>() };
+            yield return new[] { ID(), codeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<long[]>() };
+            yield return new[] { ID(), codeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<ulong[]>() };
+            yield return new[] { ID(), codeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<float[]>() };
+            yield return new[] { ID(), codeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<double[]>() };
+            yield return new[] { ID(), codeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<IntPtr[]>() };
+            yield return new[] { ID(), codeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<UIntPtr[]>() };
+
+        }
+        public static IEnumerable<object[]> CodeSnippetsToCompile()
+        {
 
             // Custom type marshalling managed-to-unmanaged
             yield return new[] { ID(), CustomStructMarshallingCodeSnippets<CodeSnippets.ManagedToUnmanaged>.Stateless.ParametersAndModifiers };
@@ -113,21 +153,6 @@ namespace ComInterfaceGenerator.Unit.Tests
             yield return new[] { ID(), CustomStructMarshallingCodeSnippets<CodeSnippets.Bidirectional>.Stateful.MarshalUsingParametersAndModifiers };
             yield return new[] { ID(), CustomStructMarshallingCodeSnippets<CodeSnippets.Bidirectional>.Stateful.RefParameter };
             yield return new[] { ID(), CustomStructMarshallingCodeSnippets<CodeSnippets.Bidirectional>.Stateful.OptionalStackallocParametersAndModifiers };
-
-            // SafeHandles
-            yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiersManagedToUnmanaged("Microsoft.Win32.SafeHandles.SafeFileHandle") };
-
-            // Exception Handling
-            // HResult
-            yield return new[] { ID(), CodeSnippets.BasicReturnTypeComExceptionHandling("int") };
-            yield return new[] { ID(), CodeSnippets.BasicReturnTypeComExceptionHandling("uint") };
-            // NaN
-            yield return new[] { ID(), CodeSnippets.BasicReturnTypeComExceptionHandling("float") };
-            yield return new[] { ID(), CodeSnippets.BasicReturnTypeComExceptionHandling("double") };
-            // Default Value
-            yield return new[] { ID(), CodeSnippets.BasicReturnTypeComExceptionHandling("nint") };
-            // Void
-            yield return new[] { ID(), CodeSnippets.BasicReturnTypeComExceptionHandling("void") }; 
         }
 
         public static IEnumerable<object[]> CustomCollections()
@@ -215,18 +240,6 @@ namespace ComInterfaceGenerator.Unit.Tests
             yield return new[] { ID(), CustomCollectionMarshallingCodeSnippets<CodeSnippets.ManagedToUnmanaged>.Stateful.NonBlittableElementByValue };
             yield return new[] { ID(), CustomCollectionMarshallingCodeSnippets<CodeSnippets.ManagedToUnmanaged>.Stateful.NonBlittableElementNativeToManagedOnlyOutParameter };
             yield return new[] { ID(), CustomCollectionMarshallingCodeSnippets<CodeSnippets.ManagedToUnmanaged>.Stateful.NonBlittableElementNativeToManagedOnlyReturnValue };
-            yield return new[] { ID(), CodeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<byte[]>() };
-            yield return new[] { ID(), CodeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<sbyte[]>() };
-            yield return new[] { ID(), CodeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<short[]>() };
-            yield return new[] { ID(), CodeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<ushort[]>() };
-            yield return new[] { ID(), CodeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<int[]>() };
-            yield return new[] { ID(), CodeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<uint[]>() };
-            yield return new[] { ID(), CodeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<long[]>() };
-            yield return new[] { ID(), CodeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<ulong[]>() };
-            yield return new[] { ID(), CodeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<float[]>() };
-            yield return new[] { ID(), CodeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<double[]>() };
-            yield return new[] { ID(), CodeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<IntPtr[]>() };
-            yield return new[] { ID(), CodeSnippets.MarshalUsingCollectionCountInfoParametersAndModifiers<UIntPtr[]>() };
             yield return new[] { ID(), CustomCollectionMarshallingCodeSnippets<CodeSnippets.Bidirectional>.Stateless.DefaultMarshallerParametersAndModifiers<byte>() };
             yield return new[] { ID(), CustomCollectionMarshallingCodeSnippets<CodeSnippets.Bidirectional>.Stateless.DefaultMarshallerParametersAndModifiers<sbyte>() };
             yield return new[] { ID(), CustomCollectionMarshallingCodeSnippets<CodeSnippets.Bidirectional>.Stateless.DefaultMarshallerParametersAndModifiers<short>() };
@@ -287,6 +300,8 @@ namespace ComInterfaceGenerator.Unit.Tests
         [Theory]
         [MemberData(nameof(CodeSnippetsToCompile))]
         [MemberData(nameof(CustomCollections))]
+        [MemberData(nameof(SharedCodeSnippets), (int)CodeSnippets.GeneratorKind.VTableIndexStubGenerator)]
+        [MemberData(nameof(SharedCustomCollectionsSnippets), (int)CodeSnippets.GeneratorKind.VTableIndexStubGenerator)]
         public async Task ValidateVTableIndexSnippets(string id, string source)
         {
             _ = id;
@@ -299,6 +314,26 @@ namespace ComInterfaceGenerator.Unit.Tests
             Assert.Empty(generatorDiags);
 
             TestUtils.AssertPostSourceGeneratorCompilation(newComp, "CS0105");
+        }
+
+        [Theory]
+        [MemberData(nameof(SharedCodeSnippets), (int)CodeSnippets.GeneratorKind.ComInterfaceGenerator)]
+        // Bug: https://github.com/dotnet/runtime/issues/82504
+        // [MemberData(nameof(SharedCustomCollectionsSnippets), (int)CodeSnippets.GeneratorKind.ComInterfaceGenerator)]
+        public async Task ValidateComInterfaceSnippets(string id, string source)
+        {
+            _ = id;
+            Compilation comp = await TestUtils.CreateCompilation(source);
+            // Allow the Native nested type name to be missing in the pre-source-generator compilation
+            // We allow duplicate usings here since some of the shared snippets add a using for System.Runtime.InteropServices.Marshalling when we already have one in our base snippets.
+            TestUtils.AssertPreSourceGeneratorCompilation(comp, "CS0426", "CS0105");
+
+            var newComp = TestUtils.RunGenerators(comp, out var generatorDiags, new Microsoft.Interop.ComInterfaceGenerator());
+            Assert.Empty(generatorDiags);
+
+            TestUtils.AssertPostSourceGeneratorCompilation(newComp, "CS0105",
+                // ComWrappersUnwrapper is inaccessible due to its protection level
+                "CS0122");
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/GeneratedComInterfaceAnalyzerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/GeneratedComInterfaceAnalyzerTests.cs
@@ -201,7 +201,7 @@ namespace ComInterfaceGenerator.Unit.Tests
                 string snippet =
                     $$$"""
 
-                [GeneratedComInterface(typeof(MyComWrappers))]
+                [GeneratedComInterface]
                 interface IFoo
                 {
                     void Bar() {}
@@ -227,7 +227,7 @@ namespace ComInterfaceGenerator.Unit.Tests
                     $$$"""
 
                 [InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown)]
-                [GeneratedComInterface(typeof(MyComWrappers))]
+                [GeneratedComInterface]
                 interface IFoo
                 {
                     void Bar() {}
@@ -249,7 +249,7 @@ namespace ComInterfaceGenerator.Unit.Tests
                     $$$"""
 
                 [InterfaceTypeAttribute((short)1)]
-                [GeneratedComInterface(typeof(MyComWrappers))]
+                [GeneratedComInterface]
                 interface IFoo
                 {
                     void Bar() {}
@@ -271,7 +271,7 @@ namespace ComInterfaceGenerator.Unit.Tests
                     $$$"""
 
                 [{|#0:InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIDispatch)|}]
-                [GeneratedComInterface(typeof(MyComWrappers))]
+                [GeneratedComInterface]
                 interface IFoo
                 {
                     void Bar() {}
@@ -297,7 +297,7 @@ namespace ComInterfaceGenerator.Unit.Tests
                     $$$"""
 
                 [{|#0:InterfaceTypeAttribute((short)2)|}]
-                [GeneratedComInterface(typeof(MyComWrappers))]
+                [GeneratedComInterface]
                 interface IFoo
                 {
                     void Bar() {}
@@ -323,7 +323,7 @@ namespace ComInterfaceGenerator.Unit.Tests
                     $$$"""
 
                 [{|#0:InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIInspectable)|}]
-                [GeneratedComInterface(typeof(MyComWrappers))]
+                [GeneratedComInterface]
                 interface IFoo
                 {
                     void Bar() {}
@@ -349,7 +349,7 @@ namespace ComInterfaceGenerator.Unit.Tests
                     $$$"""
 
                 [{|#0:InterfaceTypeAttribute((short)3)|}]
-                [GeneratedComInterface(typeof(MyComWrappers))]
+                [GeneratedComInterface]
                 interface IFoo
                 {
                     void Bar() {}
@@ -375,7 +375,7 @@ namespace ComInterfaceGenerator.Unit.Tests
                     $$$"""
 
                 [{|#0:InterfaceTypeAttribute(ComInterfaceType.InterfaceIsDual)|}]
-                [GeneratedComInterface(typeof(MyComWrappers))]
+                [GeneratedComInterface]
                 interface IFoo
                 {
                     void Bar() {}
@@ -401,7 +401,7 @@ namespace ComInterfaceGenerator.Unit.Tests
                     $$$"""
 
                 [{|#0:InterfaceTypeAttribute((short)0)|}]
-                [GeneratedComInterface(typeof(MyComWrappers))]
+                [GeneratedComInterface]
                 interface IFoo
                 {
                     void Bar() {}
@@ -436,7 +436,7 @@ namespace ComInterfaceGenerator.Unit.Tests
                     void Bar() {}
                 }
 
-                [GeneratedComInterface(typeof(MyComWrappers))]
+                [GeneratedComInterface]
                 partial interface IFoo { }
 
                 public unsafe partial class MyComWrappers : GeneratedComWrappersBase
@@ -460,7 +460,7 @@ namespace ComInterfaceGenerator.Unit.Tests
                     void Bar() {}
                 }
 
-                [GeneratedComInterface(typeof(MyComWrappers))]
+                [GeneratedComInterface]
                 partial interface IFoo { }
 
                 public unsafe partial class MyComWrappers : GeneratedComWrappersBase
@@ -484,7 +484,7 @@ namespace ComInterfaceGenerator.Unit.Tests
                     void Bar() {}
                 }
 
-                [GeneratedComInterface(typeof(MyComWrappers))]
+                [GeneratedComInterface]
                 partial interface IFoo { }
 
                 public unsafe partial class MyComWrappers : GeneratedComWrappersBase
@@ -512,7 +512,7 @@ namespace ComInterfaceGenerator.Unit.Tests
                     void Bar() {}
                 }
 
-                [GeneratedComInterface(typeof(MyComWrappers))]
+                [GeneratedComInterface]
                 partial interface IFoo { }
 
                 public unsafe partial class MyComWrappers : GeneratedComWrappersBase
@@ -540,7 +540,7 @@ namespace ComInterfaceGenerator.Unit.Tests
                     void Bar() {}
                 }
 
-                [GeneratedComInterface(typeof(MyComWrappers))]
+                [GeneratedComInterface]
                 partial interface IFoo { }
 
                 public unsafe partial class MyComWrappers : GeneratedComWrappersBase
@@ -568,7 +568,7 @@ namespace ComInterfaceGenerator.Unit.Tests
                     void Bar() {}
                 }
 
-                [GeneratedComInterface(typeof(MyComWrappers))]
+                [GeneratedComInterface]
                 partial interface IFoo { }
 
                 public unsafe partial class MyComWrappers : GeneratedComWrappersBase
@@ -596,7 +596,7 @@ namespace ComInterfaceGenerator.Unit.Tests
                     void Bar() {}
                 }
 
-                [GeneratedComInterface(typeof(MyComWrappers))]
+                [GeneratedComInterface]
                 partial interface IFoo { }
 
                 public unsafe partial class MyComWrappers : GeneratedComWrappersBase
@@ -624,7 +624,7 @@ namespace ComInterfaceGenerator.Unit.Tests
                     void Bar() {}
                 }
 
-                [GeneratedComInterface(typeof(MyComWrappers))]
+                [GeneratedComInterface]
                 partial interface IFoo { }
 
                 public unsafe partial class MyComWrappers : GeneratedComWrappersBase

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/IVirtualMethodIndexSignatureProvider.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/IVirtualMethodIndexSignatureProvider.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Interop;
+using System.Runtime.InteropServices.Marshalling;
 using Microsoft.Interop.UnitTests;
 
 namespace ComInterfaceGenerator.Unit.Tests


### PR DESCRIPTION
This shares a few tests from the `VTableStubGenerator` with the `ComInterfaceGenerator`. To do this, `CodeSnippets` is no longer mostly static methods, and has a field saying which generator the snippets are for. This way, it can leave out `VTableIndexAttribute`s from `ComInterfaceGenerator` snippets and vice versa for `GeneratedComInterfaceAttribute`s.

This PR only moves a few tests to start with. CustomCollection tests are blocked by https://github.com/dotnet/runtime/issues/82504. I'll work on moving the rest of the tests as long as this approach to sharing snippets makes sense to everyone.

Changes in the Analyzer tests are just because the shape of `GeneratedComInterfaceAttribute` changed.