### PR TITLE
[jiterp] Fix stelem_ref not doing a type check

### DIFF
--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -1226,6 +1226,26 @@ mono_jiterp_math_tan (double value)
 }
 
 EMSCRIPTEN_KEEPALIVE int
+mono_jiterp_stelem_ref (
+	MonoArray *o, gint32 aindex, MonoObject *ref
+) {
+	if (!o)
+		return 0;
+	if (aindex >= mono_array_length_internal (o))
+		return 0;
+
+	if (ref) {
+		// FIXME push/pop LMF
+		gboolean isinst = mono_jiterp_isinst (ref, m_class_get_element_class (mono_object_class (o)));
+		if (!isinst)
+			return 0;
+	}
+
+	mono_array_setref_fast ((MonoArray *) o, aindex, ref);
+	return 1;
+}
+
+EMSCRIPTEN_KEEPALIVE int
 mono_jiterp_trace_transfer (
 	int displacement, JiterpreterThunk trace, void *frame, void *pLocals
 ) {

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -173,6 +173,7 @@ export const enum BailoutReason {
     ConditionalBackwardBranch,
     ComplexBranch,
     ArrayLoadFailed,
+    ArrayStoreFailed,
     StringOperationFailed,
     DivideByZero,
     Overflow,
@@ -199,6 +200,7 @@ export const BailoutReasonNames = [
     "ConditionalBackwardBranch",
     "ComplexBranch",
     "ArrayLoadFailed",
+    "ArrayStoreFailed",
     "StringOperationFailed",
     "DivideByZero",
     "Overflow",
@@ -266,6 +268,7 @@ function getTraceImports () {
         importDef("transfer", getRawCwrap("mono_jiterp_trace_transfer")),
         importDef("cmpxchg_i32", getRawCwrap("mono_jiterp_cas_i32")),
         importDef("cmpxchg_i64", getRawCwrap("mono_jiterp_cas_i64")),
+        importDef("stelem_ref", getRawCwrap("mono_jiterp_stelem_ref")),
     ];
 
     if (instrumentedMethodNames.length > 0) {
@@ -555,6 +558,13 @@ function initialize_builder (builder: WasmBuilder) {
             "trace": WasmValtype.i32,
             "frame": WasmValtype.i32,
             "locals": WasmValtype.i32,
+        }, WasmValtype.i32, true
+    );
+    builder.defineType(
+        "stelem_ref", {
+            "o": WasmValtype.i32,
+            "aindex": WasmValtype.i32,
+            "ref": WasmValtype.i32,
         }, WasmValtype.i32, true
     );
 }


### PR DESCRIPTION
Jiterpreter's implementation of stelem_ref wasn't doing a type check. Thankfully in practice I think this is only going to happen in tests and thoroughly broken software, but we still want it to do the type check, so now it does.