### PR TITLE
Don't run non-wasm test lanes for jiterpreter-only changes

### DIFF
--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -23,6 +23,7 @@ parameters:
         src/mono/sample/wasm/*
         src/mono/wasi/*
         src/mono/wasm/*
+        src/mono/mono/mini/interp/jiterpreter*
         src/tasks/WasmAppBuilder/*
         src/tasks/WasmBuildTasks/*
         src/tasks/WorkloadBuildTasks/*

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -8,15 +8,18 @@
 #endif
 #include "config.h"
 
+void jiterp_preserve_module (void);
+
+// NOTE: All code in this file needs to be guarded with HOST_BROWSER, since
+//  we don't run non-wasm tests for changes to this file!
+
+#if HOST_BROWSER
+
 #if 0
 #define jiterp_assert(b) g_assert(b)
 #else
 #define jiterp_assert(b)
 #endif
-
-void jiterp_preserve_module (void);
-
-#if HOST_BROWSER
 
 #include <emscripten.h>
 
@@ -1248,7 +1251,7 @@ mono_jiterp_trace_transfer (
 
 // HACK: fix C4206
 EMSCRIPTEN_KEEPALIVE
-#endif
+#endif // HOST_BROWSER
 
 void jiterp_preserve_module () {
 }


### PR DESCRIPTION
Because jiterpreter.c/h are in the interp directory right now all lanes run for changes to those files. They are guarded with HOST_BROWSER though, so that's not necessary.