### PR TITLE
Fix build with old gcc

### DIFF
--- a/src/coreclr/debug/createdump/crashinfounix.cpp
+++ b/src/coreclr/debug/createdump/crashinfounix.cpp
@@ -349,7 +349,8 @@ CrashInfo::VisitModule(uint64_t baseAddress, std::string& moduleName)
                     m_coreclrPath = GetDirectory(moduleName);
                     m_runtimeBaseAddress = baseAddress;
 
-                    RuntimeInfo runtimeInfo { };
+                    // explicit initialization for old gcc support; instead of just runtimeInfo { }
+                    RuntimeInfo runtimeInfo { .Signature = { }, .Version = 0, .RuntimeModuleIndex = { }, .DacModuleIndex = { }, .DbiModuleIndex = { } };
                     if (ReadMemory((void*)(baseAddress + symbolOffset), &runtimeInfo, sizeof(RuntimeInfo)))
                     {
                         if (strcmp(runtimeInfo.Signature, RUNTIME_INFO_SIGNATURE) == 0)

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -1400,7 +1400,8 @@ void NewCallArg::ValidateTypes()
 //
 bool CallArg::IsArgAddedLate() const
 {
-    switch (m_wellKnownArg)
+    // static_cast to "enum class" for old gcc support
+    switch (static_cast<WellKnownArg>(m_wellKnownArg))
     {
         case WellKnownArg::WrapperDelegateCell:
         case WellKnownArg::VirtualStubCell:

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4645,7 +4645,7 @@ struct NewCallArg
     // The class handle if SignatureType == TYP_STRUCT.
     CORINFO_CLASS_HANDLE SignatureClsHnd = NO_CLASS_HANDLE;
     // The type of well known arg
-    WellKnownArg WellKnownArg = WellKnownArg::None;
+    WellKnownArg WellKnownArg = ::WellKnownArg::None;
 
     NewCallArg WellKnown(::WellKnownArg type) const
     {

--- a/src/native/corehost/hostmisc/trace.cpp
+++ b/src/native/corehost/hostmisc/trace.cpp
@@ -4,6 +4,7 @@
 #include "trace.h"
 #include <mutex>
 #include <thread>
+#include <atomic>
 
 #define TRACE_VERBOSITY_WARN 2
 #define TRACE_VERBOSITY_INFO 3

--- a/src/native/libs/System.Net.Security.Native/pal_gssapi.c
+++ b/src/native/libs/System.Net.Security.Native/pal_gssapi.c
@@ -351,7 +351,7 @@ uint32_t NetSecurityNative_InitSecContextEx(uint32_t* minorStatus,
     }
     else if (packageType == PAL_GSS_KERBEROS)
     {
-        desiredMech = gss_mech_krb5;
+        desiredMech = krbMech;
     }
     else
     {
@@ -631,7 +631,7 @@ static uint32_t AcquireCredWithPassword(uint32_t* minorStatus,
     }
     else if (packageType == PAL_GSS_KERBEROS)
     {
-        desiredMech = gss_mech_krb5;
+        desiredMech = (gss_OID)(unsigned long)gss_mech_krb5;
     }
     else
     {


### PR DESCRIPTION
Fix build with 4.9, lowest gcc version: https://github.com/dotnet/runtime/blob/9b6e755934e89d11787ee653419874882cbebcb9/eng/common/native/init-compiler.sh#L67

Dockerfile used for testing: https://gist.github.com/am11/11b8f526747c5ad12c9a74e7765e14a4.