### PR TITLE
[mono] permission denied when reading a jitdump file

### DIFF
--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -2099,7 +2099,7 @@ mono_enable_jit_dump (void)
 
 		g_snprintf (name, sizeof (name), "/tmp/jit-%d.dump", perf_dump_pid);
 		unlink (name);
-		perf_dump_file = fopen (name, "w");
+		perf_dump_file = fopen (name, "w+");
 
 		add_file_header_info (&header);
 		if (perf_dump_file) {


### PR DESCRIPTION
when using the `--jitdump` flag for the mono runtime, the strace shows an -EACESS error when `mmap()` tries to read the particular jitdump file.

```
1610126 openat(AT_FDCWD, "/tmp/jit-1610126.dump", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 5 
1610126 fstat(5, {st_mode=S_IFREG|0644, st_size=0, ...}) = 0
1610126 mmap(NULL, 40, PROT_READ|PROT_EXEC, MAP_PRIVATE, 5, 0) = -1 EACCES (Permission denied)
```

Fix: change the permissions when opening the jitdump file

After the fix:
```
1610807 openat(AT_FDCWD, "/tmp/jit-1610807.dump", O_RDWR|O_CREAT|O_TRUNC, 0666) = 3
1610807 fstat(3, {st_mode=S_IFREG|0644, st_size=0, ...}) = 0
1610807 mmap(NULL, 40, PROT_READ|PROT_EXEC, MAP_PRIVATE, 3, 0) = 0x3ff9f880000
```


