### PR TITLE
.NET 6: enable building on platforms where strict-prototypes is on by default.

### DIFF
--- a/src/libraries/Native/Unix/configure.cmake
+++ b/src/libraries/Native/Unix/configure.cmake
@@ -72,6 +72,12 @@ if(C_SUPPORTS_WUNGUARDED_AVAILABILITY)
   set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -Wunguarded-availability")
 endif()
 
+# Enable building on platforms where strict-prototypes is enabled by default.
+check_c_compiler_flag(-Wno-strict-prototypes COMPILER_SUPPORTS_W_NO_STRICT_PROTOTYPES)
+if(COMPILER_SUPPORTS_W_NO_STRICT_PROTOTYPES)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-strict-prototypes")
+endif()
+
 # in_pktinfo: Find whether this struct exists
 check_include_files(
     "sys/socket.h;linux/in.h"


### PR DESCRIPTION
## Customer Impact

Without this, .NET 6 fails to build on the upcoming Fedora 39 where this warning is defaulting to be an error due to https://fedoraproject.org/wiki/Changes/PortingToModernC#Change_of_meaning_of_()_in_function_declarators

The warnings were fixed in main/7.0 with https://github.com/dotnet/runtime/pull/76463 but suppressing the warning is a more targeted fix for 6.0.

## Testing

Tested on CI and manually.

## Risk

Low. The flag that is set makes the compiler less strict.

@am11 @omajid ptal.