### PR TITLE
Don't spend cycles zeroing constrainedResolvedToken each iteration

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -6401,8 +6401,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
     int  prefixFlags = 0;
     bool explicitTailCall, constraintCall, readonlyCall;
 
-    typeInfo tiRetVal;
-
     unsigned numArgs = info.compArgsCount;
 
     /* Now process all the opcodes in the block */
@@ -6422,17 +6420,18 @@ void Compiler::impImportBlockCode(BasicBlock* block)
         impSpillSpecialSideEff();
     }
 
+    CORINFO_RESOLVED_TOKEN constrainedResolvedToken = {};
+
     while (codeAddr < codeEndp)
     {
 #ifdef FEATURE_READYTORUN
         bool usingReadyToRunHelper = false;
 #endif
         CORINFO_RESOLVED_TOKEN resolvedToken;
-        CORINFO_RESOLVED_TOKEN constrainedResolvedToken = {};
         CORINFO_CALL_INFO      callInfo;
         CORINFO_FIELD_INFO     fieldInfo;
 
-        tiRetVal = typeInfo(); // Default type info
+        typeInfo tiRetVal = typeInfo(); // Default type info
 
         //---------------------------------------------------------------------
 


### PR DESCRIPTION
`CORINFO_RESOLVED_TOKEN` is a large struct that isn't frequently used and when it is, it's always initialized via `CEE_CONSTRAINED`.

Moving it's declaration outside the loop and initializing (zeroing) once up front ends up removing the following assembly that was being executed at the top of every loop:
```asm
xorps xmm0, xmm0
movups xmmword ptr [rbp + 0xF0], xmm0
movups xmmword ptr [rbp + 0x100], xmm0
movups xmmword ptr [rbp + 0x110], xmm0
movups xmmword ptr [rbp + 0x120], xmm0
movups xmmword ptr [rbp + 0x130], xmm0
```

Likewise, moving the declaration of `typeInfo tiRetVal` into the loop helps the compiler move its initialization down to only the paths where its actually used.

A local profile shows that this causes `impImportBlockCode` to change from `106 million cycles` down to `81 million cycles` when running crossgen2 over System.Private.Corelib