### PR TITLE
[browser] remove custom startup sequence of blazor

### DIFF
--- a/src/mono/wasm/runtime/dotnet-legacy.d.ts
+++ b/src/mono/wasm/runtime/dotnet-legacy.d.ts
@@ -163,10 +163,6 @@ type MONOType = {
      */
     mono_wasm_load_config: (configFilePath: string) => Promise<void>;
     /**
-     * @deprecated Please use runMain instead
-     */
-    mono_load_runtime_and_bcl_args: Function;
-    /**
      * @deprecated Please use [JSImportAttribute] or [JSExportAttribute] for interop instead.
      */
     mono_wasm_new_root_buffer: (capacity: number, name?: string) => WasmRootBuffer;

--- a/src/mono/wasm/runtime/net6-legacy/export-types.ts
+++ b/src/mono/wasm/runtime/net6-legacy/export-types.ts
@@ -111,10 +111,6 @@ export type MONOType = {
      */
     mono_wasm_load_config: (configFilePath: string) => Promise<void>;
     /**
-     * @deprecated Please use runMain instead
-     */
-    mono_load_runtime_and_bcl_args: Function;
-    /**
      * @deprecated Please use [JSImportAttribute] or [JSExportAttribute] for interop instead.
      */
     mono_wasm_new_root_buffer: (capacity: number, name?: string) => WasmRootBuffer;

--- a/src/mono/wasm/runtime/net6-legacy/exports-legacy.ts
+++ b/src/mono/wasm/runtime/net6-legacy/exports-legacy.ts
@@ -8,9 +8,8 @@ import { runtimeHelpers } from "../imports";
 import { mono_wasm_load_bytes_into_heap, setB32, setI8, setI16, setI32, setI52, setU52, setI64Big, setU8, setU16, setU32, setF32, setF64, getB32, getI8, getI16, getI32, getI52, getU52, getI64Big, getU8, getU16, getU32, getF32, getF64 } from "../memory";
 import { mono_wasm_new_root_buffer, mono_wasm_new_root, mono_wasm_new_external_root, mono_wasm_release_roots } from "../roots";
 import { mono_run_main, mono_run_main_and_exit } from "../run";
-import { mono_wasm_setenv, mono_wasm_load_config, mono_load_runtime_and_bcl_args } from "../startup";
+import { mono_wasm_setenv, mono_wasm_load_config } from "../startup";
 import { js_string_to_mono_string, conv_string, js_string_to_mono_string_root, conv_string_root } from "../strings";
-import { MonoConfig, MonoConfigError } from "../types";
 import { mono_array_to_js_array, unbox_mono_obj, unbox_mono_obj_root, mono_array_root_to_js_array } from "./cs-to-js";
 import { js_typed_array_to_array, js_to_mono_obj, js_typed_array_to_array_root, js_to_mono_obj_root } from "./js-to-cs";
 import { mono_bind_static_method, mono_call_assembly_entry_point } from "./method-calls";
@@ -27,7 +26,6 @@ export function export_mono_api(): MONOType {
         mono_wasm_runtime_ready,
         mono_wasm_load_data_archive,
         mono_wasm_load_config,
-        mono_load_runtime_and_bcl_args,
         mono_wasm_new_root_buffer,
         mono_wasm_new_root,
         mono_wasm_new_external_root,
@@ -39,7 +37,7 @@ export function export_mono_api(): MONOType {
         mono_wasm_add_assembly: <any>null,
         mono_wasm_load_runtime,
 
-        config: <MonoConfig | MonoConfigError>runtimeHelpers.config,
+        config: runtimeHelpers.config,
         loaded_files: <string[]>[],
 
         // memory accessors

--- a/src/mono/wasm/runtime/types.ts
+++ b/src/mono/wasm/runtime/types.ts
@@ -140,12 +140,6 @@ export type RunArguments = {
     diagnosticTracing?: boolean,
 }
 
-export type MonoConfigError = {
-    isError: true,
-    message: string,
-    error: any
-}
-
 export interface ResourceRequest {
     name: string, // the name of the asset, including extension.
     behavior: AssetBehaviours, // determines how the asset will be handled once loaded


### PR DESCRIPTION
- remove custom startup sequence of blazor
This was enabled by https://github.com/dotnet/aspnetcore/pull/46532

- remove legacy mono_load_runtime_and_bcl_args
- unused MonoConfigError removal