### PR TITLE
Avoid locking on every ValidationAttributeStore lookup.

### DIFF
--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttributeStore.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttributeStore.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -19,7 +20,7 @@ namespace System.ComponentModel.DataAnnotations
     /// </remarks>
     internal sealed class ValidationAttributeStore
     {
-        private readonly Dictionary<Type, TypeStoreItem> _typeStoreItems = new Dictionary<Type, TypeStoreItem>();
+        private readonly ConcurrentDictionary<Type, TypeStoreItem> _typeStoreItems = new();
 
         /// <summary>
         ///     Gets the singleton <see cref="ValidationAttributeStore" />
@@ -118,16 +119,14 @@ namespace System.ComponentModel.DataAnnotations
         {
             Debug.Assert(type != null);
 
-            lock (_typeStoreItems)
-            {
-                if (!_typeStoreItems.TryGetValue(type, out TypeStoreItem? item))
-                {
-                    AttributeCollection attributes = TypeDescriptor.GetAttributes(type);
-                    item = new TypeStoreItem(type, attributes);
-                    _typeStoreItems[type] = item;
-                }
+            return _typeStoreItems.GetOrAdd(type, AddTypeStoreItem);
 
-                return item;
+            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2067:UnrecognizedReflectionPattern",
+                Justification = "The parameter in the parent method has already been marked DynamicallyAccessedMemberTypes.All.")]
+            static TypeStoreItem AddTypeStoreItem(Type type)
+            {
+                AttributeCollection attributes = TypeDescriptor.GetAttributes(type);
+                return new TypeStoreItem(type, attributes);
             }
         }
 


### PR DESCRIPTION
The `ValidationAttributeStore` implementation uses a regular dictionary as a global cache that needs to lock on every lookup operation. This PR replaces it with a ConcurrentDictionary.