### PR TITLE
Move throw out of inlined CompositeFormat helper

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/CompositeFormat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/CompositeFormat.cs
@@ -112,7 +112,7 @@ namespace System.Text
         {
             if (numArgs < _argsRequired)
             {
-                throw new FormatException(SR.Format_IndexOutOfRange);
+                ThrowHelper.ThrowFormatIndexOutOfRange();
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -1568,7 +1568,7 @@ namespace System.Text
 
                 if ((uint)index >= (uint)args.Length)
                 {
-                    throw new FormatException(SR.Format_IndexOutOfRange);
+                    ThrowHelper.ThrowFormatIndexOutOfRange();
                 }
                 object? arg = args[index];
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/ValueStringBuilder.AppendFormat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ValueStringBuilder.AppendFormat.cs
@@ -64,7 +64,7 @@ namespace System.Text
                     // This wasn't an escape, so it must be an opening brace.
                     if (brace != '{')
                     {
-                        ThrowFormatInvalidString();
+                        ThrowHelper.ThrowFormatInvalidString();
                     }
 
                     // Proceed to parse the hole.
@@ -87,7 +87,7 @@ namespace System.Text
                 int index = ch - '0';
                 if ((uint)index >= 10u)
                 {
-                    ThrowFormatInvalidString();
+                    ThrowHelper.ThrowFormatInvalidString();
                 }
 
                 // Common case is a single digit index followed by a closing brace.  If it's not a closing brace,
@@ -134,7 +134,7 @@ namespace System.Text
                         width = ch - '0';
                         if ((uint)width >= 10u)
                         {
-                            ThrowFormatInvalidString();
+                            ThrowHelper.ThrowFormatInvalidString();
                         }
                         ch = MoveNext(format, ref pos);
                         while (char.IsAsciiDigit(ch) && width < WidthLimit)
@@ -157,7 +157,7 @@ namespace System.Text
                         if (ch != ':')
                         {
                             // Unexpected character
-                            ThrowFormatInvalidString();
+                            ThrowHelper.ThrowFormatInvalidString();
                         }
 
                         // Search for the closing brace; everything in between is the format,
@@ -176,7 +176,7 @@ namespace System.Text
                             if (ch == '{')
                             {
                                 // Braces inside the argument hole are not supported
-                                ThrowFormatInvalidString();
+                                ThrowHelper.ThrowFormatInvalidString();
                             }
                         }
 
@@ -193,7 +193,7 @@ namespace System.Text
 
                 if ((uint)index >= (uint)args.Length)
                 {
-                    throw new FormatException(SR.Format_IndexOutOfRange);
+                    ThrowHelper.ThrowFormatIndexOutOfRange();
                 }
                 object? arg = args[index];
 
@@ -269,12 +269,10 @@ namespace System.Text
                 pos++;
                 if ((uint)pos >= (uint)format.Length)
                 {
-                    ThrowFormatInvalidString();
+                    ThrowHelper.ThrowFormatInvalidString();
                 }
                 return format[pos];
             }
         }
-
-        private static void ThrowFormatInvalidString() => throw new FormatException(SR.Format_InvalidString);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
@@ -569,6 +569,12 @@ namespace System
             throw new FormatException(SR.Format_InvalidString);
         }
 
+        [DoesNotReturn]
+        internal static void ThrowFormatIndexOutOfRange()
+        {
+            throw new FormatException(SR.Format_IndexOutOfRange);
+        }
+
         private static Exception GetArraySegmentCtorValidationFailedException(Array? array, int offset, int count)
         {
             if (array == null)


### PR DESCRIPTION
Either this helper isn't getting inlined because of the throw, or it's getting inlined and increasing the size of all call sites where it is.

In doing this I noticed we had a duplicate throw helper for another FormatException in string formatted, so deduped.