### PR TITLE
[7.0] Fix intellisense xml file selection from 'net' or 'dotnet-plat-ext' 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -91,7 +91,7 @@
     <IbcOptimizationDataDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'ibc'))</IbcOptimizationDataDir>
     <MibcOptimizationDataDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'mibc'))</MibcOptimizationDataDir>
     <XmlDocDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'docs'))</XmlDocDir>
-    <XmlDocFileRoot>$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'microsoft.private.intellisense', '$(MicrosoftPrivateIntellisenseVersion)', 'IntellisenseFiles', 'net'))</XmlDocFileRoot>
+    <XmlDocFileRoot>$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'microsoft.private.intellisense', '$(MicrosoftPrivateIntellisenseVersion)', 'IntellisenseFiles'))</XmlDocFileRoot>
     <DocsDir>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'docs'))</DocsDir>
     <ManPagesDir>$([MSBuild]::NormalizeDirectory('$(DocsDir)', 'manpages'))</ManPagesDir>
 

--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -24,7 +24,10 @@
                                        '$(BuildAllConfigurations)' == 'true' and
                                        '$(DotNetBuildFromSource)' == 'true'">true</GeneratePackageOnBuild>
     <!-- Search for the documentation file in the intellisense package and otherwise pick up the generated one. -->
-    <LibIntellisenseDocumentationFilePath>$(XmlDocFileRoot)1033\$(AssemblyName).xml</LibIntellisenseDocumentationFilePath>
+    <IntellisenseNetFile>$([MSBuild]::NormalizePath('$(XmlDocFileRoot)', 'net', '1033', '$(AssemblyName).xml'))</IntellisenseNetFile>
+    <LibIntellisenseDocumentationFilePath Condition="Exists(IntellisenseNetFile)">$(IntellisenseNetFile)</LibIntellisenseDocumentationFilePath>
+    <IntellisenseDotNetPlatExtFile Condition="'$(LibIntellisenseDocumentationFilePath)' == ''">$([MSBuild]::NormalizePath('$(XmlDocFileRoot)', 'dotnet-plat-ext', '1033', '$(AssemblyName).xml'))</IntellisenseDotNetPlatExtFile>
+    <LibIntellisenseDocumentationFilePath Condition="'$(LibIntellisenseDocumentationFilePath)' == '' and Exists($(IntellisenseDotNetPlatExtFile))">$(IntellisenseDotNetPlatExtFile)</LibIntellisenseDocumentationFilePath>
     <UseIntellisenseDocumentationFile Condition="'$(UseIntellisenseDocumentationFile)' == '' and Exists('$(LibIntellisenseDocumentationFilePath)')">true</UseIntellisenseDocumentationFile>
   </PropertyGroup>
 

--- a/eng/restore/docs.targets
+++ b/eng/restore/docs.targets
@@ -9,7 +9,7 @@
           AfterTargets="Restore">
 
     <ItemGroup>
-      <DocFile Include="$(XmlDocFileRoot)**\*.xml"/>
+      <DocFile Include="$(XmlDocFileRoot)\net\**\*.xml;$(XmlDocFileRoot)\dotnet-plat-ext\**\*.xml"/>
       <DocFile>
         <!-- trim off slash since it differs by platform and we need to do a string compare -->
         <LCID>$([System.String]::new('%(RecursiveDir)').TrimEnd('\/'))</LCID>
@@ -35,7 +35,7 @@
     </ItemGroup>
 
     <Error Condition="'%(DocFile.Culture)' == 'unknown'" Text="Unknown language folder '%(LCID)' for doc files '@(DocFile)'" />
-    
+
     <Copy SourceFiles="@(DocFile)"
           DestinationFiles="$(XmlDocDir)\%(SubFolder)%(FileName)%(Extension)"
           SkipUnchangedFiles="true"


### PR DESCRIPTION
Addresses the 7.0 bug of https://github.com/dotnet/runtime/issues/82214

There are two places in 7.0 where the intellisense xml files are analyzed and/or copied.

- In packaging.targets, we decide if we want to include in the assembly package either the built xml or the one that comes from the internal intellisense nupkg. If we decide to use the latter, we were missing logic that would find the right xml file in either the 'net' or the 'dotnet-plat-ext' folder of the extracted nupkg. Instead, we were only looking inside 'net', and assemblies like System.IO.Ports were not getting anything included in its nupkg.

- In docs.targets, we were only copying to artifacts/bin/docs the files that were found in the 'net' folder of the internal intellisense nupkg. We need to also copy the files from 'dotnet-plat-ext', so that assemblies like System.IO.Ports get the right documentation shipped.

cc @krwq