### PR TITLE
[class] DIMs in the vtable of abstract classes may be overridden

### DIFF
--- a/src/mono/mono/metadata/class-setup-vtable.c
+++ b/src/mono/mono/metadata/class-setup-vtable.c
@@ -1918,7 +1918,7 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 				}
 
 				if (vtable [im_slot] == NULL) {
-					if (!(im->flags & METHOD_ATTRIBUTE_ABSTRACT) & !mono_class_is_abstract(klass)) {
+					if (!(im->flags & METHOD_ATTRIBUTE_ABSTRACT) && !mono_class_is_abstract(klass)) {
 						TRACE_INTERFACE_VTABLE (printf ("    Using default iface method %s.\n", mono_method_full_name (im, 1)));
 						vtable [im_slot] = im;
 					}

--- a/src/mono/mono/metadata/class-setup-vtable.c
+++ b/src/mono/mono/metadata/class-setup-vtable.c
@@ -1918,7 +1918,7 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 				}
 
 				if (vtable [im_slot] == NULL) {
-					if (!(im->flags & METHOD_ATTRIBUTE_ABSTRACT)) {
+					if (!(im->flags & METHOD_ATTRIBUTE_ABSTRACT) & !mono_class_is_abstract(klass)) {
 						TRACE_INTERFACE_VTABLE (printf ("    Using default iface method %s.\n", mono_method_full_name (im, 1)));
 						vtable [im_slot] = im;
 					}

--- a/src/mono/mono/metadata/class-setup-vtable.c
+++ b/src/mono/mono/metadata/class-setup-vtable.c
@@ -1877,7 +1877,8 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 						flags |= MONO_ITF_OVERRIDE_EXPLICITLY_IMPLEMENTED;
 					if (interface_is_explicitly_implemented_by_class && variant_itf)
 						flags |= MONO_ITF_OVERRIDE_VARIANT_ITF;
-					if (vtable [im_slot] == NULL)
+					// if the slot is emtpy, or it's filled with a DIM, treat it as empty
+					if (vtable [im_slot] == NULL || m_class_is_interface (vtable [im_slot]->klass))
 						flags |= MONO_ITF_OVERRIDE_SLOT_EMPTY;
 					if (check_interface_method_override (klass, im, cm, flags)) {
 						TRACE_INTERFACE_VTABLE (printf ("[check ok]: ASSIGNING\n"));
@@ -1918,7 +1919,7 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 				}
 
 				if (vtable [im_slot] == NULL) {
-					if (!(im->flags & METHOD_ATTRIBUTE_ABSTRACT) && !mono_class_is_abstract(klass)) {
+					if (!(im->flags & METHOD_ATTRIBUTE_ABSTRACT)) {
 						TRACE_INTERFACE_VTABLE (printf ("    Using default iface method %s.\n", mono_method_full_name (im, 1)));
 						vtable [im_slot] = im;
 					}

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -2686,14 +2686,7 @@ set_interface_map_data_method_object (MonoMethod *method, MonoClass *iclass, int
 
 	MonoMethod* foundMethod = m_class_get_vtable (klass) [i + ioffset];
 
-	if (!foundMethod) {
-		/* abstract classes might have null vtable entries if an interface method
-		 * is not implemented by the class.
-		 */
-		g_assert (mono_class_is_abstract (klass));
-		MONO_HANDLE_ARRAY_SETREF (targets, i, NULL_HANDLE);
-		goto leave;
-	}
+	g_assert (foundMethod);
 
 	if (mono_class_has_dim_conflicts (klass) && mono_class_is_interface (foundMethod->klass)) {
 		GSList* conflicts = mono_class_get_dim_conflicts (klass);

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -2686,6 +2686,15 @@ set_interface_map_data_method_object (MonoMethod *method, MonoClass *iclass, int
 
 	MonoMethod* foundMethod = m_class_get_vtable (klass) [i + ioffset];
 
+	if (!foundMethod) {
+		/* abstract classes might have null vtable entries if an interface method
+		 * is not implemented by the class.
+		 */
+		g_assert (mono_class_is_abstract (klass));
+		MONO_HANDLE_ARRAY_SETREF (targets, i, NULL_HANDLE);
+		goto leave;
+	}
+
 	if (mono_class_has_dim_conflicts (klass) && mono_class_is_interface (foundMethod->klass)) {
 		GSList* conflicts = mono_class_get_dim_conflicts (klass);
 		GSList* l;

--- a/src/mono/sample/HelloWorld/Program.cs
+++ b/src/mono/sample/HelloWorld/Program.cs
@@ -3,6 +3,37 @@
 
 using System;
 
+interface IDefault
+{
+    public void Method1()
+    {
+        Console.WriteLine("Interface Method1");
+    }
+
+    public object Method2()
+    {
+        Console.WriteLine("Interface Method2");
+        return null;
+    }
+}
+
+abstract class ClassA : IDefault
+{
+    virtual public void Method1()
+    {
+        Console.WriteLine("ClassA Method 1");
+    }
+}
+
+class ClassB : ClassA
+{
+    public virtual object Method2()
+    {
+        Console.WriteLine("ClassB Method2");
+        return null;
+    }
+}
+
 namespace HelloWorld
 {
     internal class Program
@@ -14,6 +45,12 @@ namespace HelloWorld
             Console.WriteLine(typeof(object).Assembly.FullName);
             Console.WriteLine(System.Reflection.Assembly.GetEntryAssembly ());
             Console.WriteLine(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);
+
+            IDefault c = new ClassB();
+
+            c.Method1();
+            c.Method2();
+            
         }
     }
 }

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github81882.cs
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github81882.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+
+using Xunit;
+
+namespace LeaveAbstractMethodsNulInVTable
+{
+    interface IDefault
+    {
+        public string Method1() => "Interface Method1";
+
+        public string Method2() => "Interface Method2";
+    }
+
+    abstract class ClassA : IDefault
+    {
+        virtual public string Method1() => "ClassA Method1";
+    }
+
+    class ClassB : ClassA
+    {
+        virtual public string Method2() => "ClassB Method2";
+    }
+
+    public class Program
+    {
+        public static int Main()
+        {
+            IDefault c = new ClassB();
+
+            string s1 = c.Method1();
+            Assert.Equal("ClassA Method1", s1);
+
+            string s2 = c.Method2();
+            Assert.Equal("ClassB Method2", s2);
+
+            return 100;
+        }
+    }
+
+}

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github81882.csproj
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github81882.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
pretend the slot is empty in abstract classes and allow concrete subclasses classes to fill it in.

Related to https://github.com/dotnet/runtime/issues/81882