### PR TITLE
Add osx-arm64 to official RIDs in ILCompiler NuGet

### DIFF
--- a/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/ILCompilerRIDs.props
+++ b/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/ILCompilerRIDs.props
@@ -7,6 +7,7 @@
     <OfficialBuildRID Include="linux-musl-x64" Platform="x64" />
     <OfficialBuildRID Include="linux-x64" Platform="x64" />
     <OfficialBuildRID Include="osx-x64" Platform="x64" />
+    <OfficialBuildRID Include="osx-arm64" Platform="arm64" />
     <OfficialBuildRID Include="win-arm64" Platform="arm64" />
     <OfficialBuildRID Include="win-x64" Platform="x64" />
     <OfficialBuildRID Include="freebsd-x64" Platform="x64" />


### PR DESCRIPTION
Contributes to #82542

When cross-compiling from osx-x64 to osx-arm64 the target runtime package was not restored correctly. This can be [explicitly fixed in the SDK](https://github.com/dotnet/sdk/pull/30818). However, the reason why the opposite (osx-arm64 -> osx-x64) works is because the Microsoft.DotNet.ILCompiler dependency pulls the correct runtime package. The osx-arm64 dependency was missing though, and thus the runtime package was never restored.

[More details](https://github.com/dotnet/sdk/pull/30818#discussion_r1116260347)