### PR TITLE
Backport #82480 (fix third argument to TypedArray.fill)

### DIFF
--- a/src/mono/wasm/runtime/memory.ts
+++ b/src/mono/wasm/runtime/memory.ts
@@ -54,10 +54,7 @@ function assert_int_in_range(value: Number, min: Number, max: Number) {
 }
 
 export function _zero_region(byteOffset: VoidPtr, sizeBytes: number): void {
-    if (((<any>byteOffset % 4) === 0) && ((sizeBytes % 4) === 0))
-        Module.HEAP32.fill(0, <any>byteOffset >>> 2, sizeBytes >>> 2);
-    else
-        Module.HEAP8.fill(0, <any>byteOffset, sizeBytes);
+    Module.HEAP8.fill(0, <any>byteOffset, sizeBytes + <any>byteOffset);
 }
 
 export function setB32(offset: MemOffset, value: number | boolean): void {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/82840

## Customer Impact

Customer reported issue where zero'd memory in js interop wasn't actually zero'd

## Testing
Manual testing confirmed this fixes the problem.

## Risk

@shin1m identified that _zero_memory was a no-op due to an incorrect third argument.