### PR TITLE
Fix host tests clean-up of test artifact parent directories

### DIFF
--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/DependencyResolutionBase.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/DependencyResolutionBase.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             }
 
             public SharedTestStateBase()
-                : base(GetBaseDir("dependencyResolution"), "dependencyResolution")
+                : base(GetBaseDir("dependencyResolution"))
             {
                 BuiltDotnetPath = Path.Combine(TestArtifactsPath, "sharedFrameworkPublish");
                 RepoDirectories = new RepoDirectoriesProvider(builtDotnet: BuiltDotnetPath);

--- a/src/installer/tests/HostActivation.Tests/SDKLookup.cs
+++ b/src/installer/tests/HostActivation.Tests/SDKLookup.cs
@@ -22,8 +22,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         {
             SharedState = sharedState;
 
-            string exeDotNetPath = SharedFramework.CalculateUniqueTestDirectory(sharedState.BaseDir);
-            ExecutableDotNetBuilder = new DotNetBuilder(exeDotNetPath, sharedState.BuiltDotNet.BinPath, "exe");
+            string exeDotNetPath = SharedFramework.CalculateUniqueTestDirectory(Path.Combine(sharedState.BaseDir, "exe"));
+            ExecutableDotNetBuilder = new DotNetBuilder(exeDotNetPath, sharedState.BuiltDotNet.BinPath, null);
             ExecutableDotNet = ExecutableDotNetBuilder
                 .AddMicrosoftNETCoreAppFrameworkMockHostPolicy("9999.0.0")
                 .Build();

--- a/src/installer/tests/TestUtils/SharedFramework.cs
+++ b/src/installer/tests/TestUtils/SharedFramework.cs
@@ -15,9 +15,8 @@ namespace Microsoft.DotNet.CoreSetup.Test
     {
         private static readonly Mutex id_mutex = new Mutex();
 
-        // MultilevelDirectory is %TEST_ARTIFACTS%\dotnetMultilevelSharedFxLookup\id.
-        // We must locate the first non existing id.
-        public static string CalculateUniqueTestDirectory(string baseDir)
+        // Locate the first non-existent directory of the form <basePath>-<count>
+        public static string CalculateUniqueTestDirectory(string basePath)
         {
             id_mutex.WaitOne();
 
@@ -26,7 +25,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
             do
             {
-                dir = Path.Combine(baseDir, count.ToString());
+                dir = $"{basePath}-{count}";
                 count++;
             } while (Directory.Exists(dir));
 

--- a/src/installer/tests/TestUtils/TestApp.cs
+++ b/src/installer/tests/TestUtils/TestApp.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             LoadAssets();
         }
 
-        public TestApp(TestApp source)
+        private TestApp(TestApp source)
             : base(source)
         {
             AssemblyName = source.AssemblyName;
@@ -34,8 +34,11 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         public static TestApp CreateEmpty(string name)
         {
-            string location = GetNewTestArtifactPath(name);
-            return new TestApp(location);
+            var (location, parentPath) = GetNewTestArtifactPath(name);
+            return new TestApp(location)
+            {
+                DirectoryToDelete = parentPath
+            };
         }
 
         public TestApp Copy()


### PR DESCRIPTION
The host tests leave behind a lot of empty directories that held tests assets. I've found this kind of annoying every time I need to investigate / update tests - finally spent the time to dig into it.

They create various test directories of the form:
- `random_name/nice_name`
  - Generated by `TestArtifact.GetNewTestArtifactPath`
  - We delete `nice_name`, but not `random_name`
- `nice_name/id`
  - Generated by `SharedFramework.CalculateUniqueTestDirectory`
  - We delete `id`, but not `nice_name`

This change updates:
- `TestArtifact`/`TestApp` to delete the parent directory if it creates a new path
- `CalculateUniqueTestDirectory` to make directories of the form `nice_name-id` instead of subfolders

We can probably also reconcile the two ways of creating unique test directories, but I was just targeting the left-behind folders in this change.