### PR TITLE
[wasm] Migrate jiterpreter LDELEMA1 and LDLEN from C helper to inline in traces

### DIFF
--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -302,19 +302,6 @@ mono_jiterp_cast_ref (
 	return 0;
 }
 
-EMSCRIPTEN_KEEPALIVE void*
-mono_jiterp_array_get_element_address_with_size_ref (MonoArray **array, int size, int index)
-{
-	// HACK: This does not need to be volatile because we know array is visible to
-	//  the GC and this is called from interp traces in gc unsafe mode
-	MonoArray* _array = *array;
-	if (!_array)
-		return NULL;
-	if (index >= mono_array_length_internal(_array))
-		return NULL;
-	return mono_array_addr_with_size_fast (_array, size, index);
-}
-
 EMSCRIPTEN_KEEPALIVE void
 mono_jiterp_localloc (gpointer *destination, gint32 len, InterpFrame *frame)
 {
@@ -484,6 +471,7 @@ mono_jiterp_relop_fp (double lhs, double rhs, int opcode) {
 #define JITERP_MEMBER_RMETHOD 6
 #define JITERP_MEMBER_SPAN_LENGTH 7
 #define JITERP_MEMBER_SPAN_DATA 8
+#define JITERP_MEMBER_ARRAY_LENGTH 9
 
 // we use these helpers at JIT time to figure out where to do memory loads and stores
 EMSCRIPTEN_KEEPALIVE size_t
@@ -493,6 +481,8 @@ mono_jiterp_get_member_offset (int member) {
 			return MONO_STRUCT_OFFSET (MonoVTable, initialized);
 		case JITERP_MEMBER_ARRAY_DATA:
 			return MONO_STRUCT_OFFSET (MonoArray, vector);
+		case JITERP_MEMBER_ARRAY_LENGTH:
+			return MONO_STRUCT_OFFSET (MonoArray, max_length);
 		case JITERP_MEMBER_STRING_LENGTH:
 			return MONO_STRUCT_OFFSET (MonoString, length);
 		case JITERP_MEMBER_STRING_DATA:

--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -949,6 +949,7 @@ export const enum JiterpMember {
     Rmethod = 6,
     SpanLength = 7,
     SpanData = 8,
+    ArrayLength = 9,
 }
 
 const memberOffsets : { [index: number] : number } = {};

--- a/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 

--- a/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
@@ -1138,29 +1139,6 @@ function append_memmove_local_local (builder: WasmBuilder, destLocalOffset: numb
     append_ldloca(builder, destLocalOffset, count, true);
     append_ldloca(builder, sourceLocalOffset, 0);
     append_memmove_dest_src(builder, count);
-}
-
-// Loads the specified i32 value and bails out if it is null. Does not leave it on the stack.
-function append_local_null_check (builder: WasmBuilder, localOffset: number, ip: MintOpcodePtr) {
-    if (knownNotNull.has(localOffset)) {
-        if (nullCheckValidation) {
-            append_ldloc(builder, localOffset, WasmOpcode.i32_load);
-            builder.i32_const(builder.base);
-            builder.callImport("notnull");
-        }
-        // console.log(`skipping null check for ${localOffset}`);
-        counters.nullChecksEliminated++;
-        return;
-    }
-
-    builder.block();
-    append_ldloc(builder, localOffset, WasmOpcode.i32_load);
-    builder.appendU8(WasmOpcode.br_if);
-    builder.appendULeb(0);
-    append_bailout(builder, ip, BailoutReason.NullCheck);
-    builder.endBlock();
-    if (!addressTakenLocals.has(localOffset) && builder.options.eliminateNullChecks)
-        knownNotNull.add(localOffset);
 }
 
 // Loads the specified i32 value and then bails out if it is null, leaving it in the cknull_ptr local.
@@ -2681,6 +2659,11 @@ function append_getelema1 (
     builder: WasmBuilder, ip: MintOpcodePtr,
     objectOffset: number, indexOffset: number, elementSize: number
 ) {
+    // FIXME
+    append_bailout(builder, ip, BailoutReason.ArrayLoadFailed);
+    return;
+    /*
+
     builder.block();
 
     // load index for check
@@ -2715,6 +2698,7 @@ function append_getelema1 (
     builder.appendU8(WasmOpcode.i32_mul);
     builder.appendU8(WasmOpcode.i32_add);
     // append_getelema1 leaves the address on the stack
+    */
 }
 
 function emit_arrayop (builder: WasmBuilder, ip: MintOpcodePtr, opcode: MintOpcode) : boolean {

--- a/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
@@ -2659,11 +2659,6 @@ function append_getelema1 (
     builder: WasmBuilder, ip: MintOpcodePtr,
     objectOffset: number, indexOffset: number, elementSize: number
 ) {
-    // FIXME
-    append_bailout(builder, ip, BailoutReason.ArrayLoadFailed);
-    return;
-    /*
-
     builder.block();
 
     // load index for check
@@ -2690,15 +2685,14 @@ function append_getelema1 (
 
     // We did a null check and bounds check so we can now compute the actual address
     builder.local("cknull_ptr");
-    builder.appendU8(WasmOpcode.i32_load);
-    builder.appendMemarg(getMemberOffset(JiterpMember.ArrayData), 2);
+    builder.i32_const(getMemberOffset(JiterpMember.ArrayData));
+    builder.appendU8(WasmOpcode.i32_add);
 
     builder.local("math_lhs32");
     builder.i32_const(elementSize);
     builder.appendU8(WasmOpcode.i32_mul);
     builder.appendU8(WasmOpcode.i32_add);
     // append_getelema1 leaves the address on the stack
-    */
 }
 
 function emit_arrayop (builder: WasmBuilder, ip: MintOpcodePtr, opcode: MintOpcode) : boolean {

--- a/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
@@ -1231,7 +1231,6 @@ function append_ldloc_cknull (builder: WasmBuilder, localOffset: number, ip: Min
         notNullSince.set(localOffset, <any>ip);
         if (traceNullCheckOptimizations)
             console.log(`(0x${(<any>ip).toString(16)}) cknull_ptr := locals[${localOffset}] (fresh load, fresh null check)`);
-        // FIXME: This breaks the ldelema1 implementation somehow
         cknullOffset = localOffset;
     }
 }
@@ -2008,7 +2007,6 @@ function emit_binop (builder: WasmBuilder, ip: MintOpcodePtr, opcode: MintOpcode
                 // rhs was -1 since the previous br_if didn't execute. Now check lhs.
                 builder.local(lhsVar);
                 // G_MININT32
-                // FIXME: Make sure the leb encoder can actually handle this
                 builder.i32_const(-2147483647-1);
                 builder.appendU8(WasmOpcode.i32_ne);
                 builder.appendU8(WasmOpcode.br_if);
@@ -2644,8 +2642,6 @@ function emit_indirectop (builder: WasmBuilder, ip: MintOpcodePtr, opcode: MintO
     }
 
     append_ldloc_cknull(builder, addressVarIndex, ip, false);
-
-    // FIXME: ldind_offset/stind_offset
 
     if (isLoad) {
         // pre-load pLocals for the store operation

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -245,8 +245,6 @@ function getTraceImports () {
     traceImports = [
         importDef("bailout", getRawCwrap("mono_jiterp_trace_bailout")),
         importDef("copy_pointer", getRawCwrap("mono_wasm_copy_managed_pointer")),
-        importDef("array_length", getRawCwrap("mono_wasm_array_length_ref")),
-        importDef("array_address", getRawCwrap("mono_jiterp_array_get_element_address_with_size_ref")),
         importDef("entry", getRawCwrap("mono_jiterp_increase_entry_count")),
         importDef("value_copy", getRawCwrap("mono_jiterp_value_copy")),
         importDef("gettype", getRawCwrap("mono_jiterp_gettype_ref")),
@@ -360,18 +358,6 @@ function initialize_builder (builder: WasmBuilder) {
             "src": WasmValtype.i32,
             "klass": WasmValtype.i32,
         }, WasmValtype.void, true
-    );
-    builder.defineType(
-        "array_length", {
-            "ppArray": WasmValtype.i32
-        }, WasmValtype.i32, true
-    );
-    builder.defineType(
-        "array_address", {
-            "ppArray": WasmValtype.i32,
-            "elementSize": WasmValtype.i32,
-            "index": WasmValtype.i32
-        }, WasmValtype.i32, true
     );
     builder.defineType(
         "entry", {

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -51,7 +51,7 @@ export const
     nullCheckValidation = false,
     // Cache null-checked pointers in cknull_ptr between instructions. Incredibly fragile
     //  for some reason I have not been able to identify
-    nullCheckCaching = false,
+    nullCheckCaching = true,
     // Print diagnostic information to the console when performing null check optimizations
     traceNullCheckOptimizations = false,
     // If we encounter an enter opcode that looks like a loop body and it was already

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -49,6 +49,9 @@ export const
     //  that will print a diagnostic message if the value is actually null or if
     //  the value does not match the value on the native interpreter stack in memory
     nullCheckValidation = false,
+    // Cache null-checked pointers in cknull_ptr between instructions. Incredibly fragile
+    //  for some reason I have not been able to identify
+    nullCheckCaching = false,
     // Print diagnostic information to the console when performing null check optimizations
     traceNullCheckOptimizations = false,
     // If we encounter an enter opcode that looks like a loop body and it was already
@@ -84,6 +87,7 @@ export const instrumentedMethodNames : Array<string> = [
     // "HashCode"
     // "GetParameterName"
     // "MoveNext"
+    // "MakeSeparatorListAny"
 ];
 
 export class InstrumentedTraceState {

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -49,6 +49,8 @@ export const
     //  that will print a diagnostic message if the value is actually null or if
     //  the value does not match the value on the native interpreter stack in memory
     nullCheckValidation = false,
+    // Print diagnostic information to the console when performing null check optimizations
+    traceNullCheckOptimizations = false,
     // If we encounter an enter opcode that looks like a loop body and it was already
     //  jitted, we should abort the current trace since it's not worth continuing
     abortAtJittedLoopBodies = true,
@@ -80,6 +82,8 @@ export const instrumentedMethodNames : Array<string> = [
     // "InternalInsertNode"
     // "ResolveMethodArguments"
     // "HashCode"
+    // "GetParameterName"
+    // "MoveNext"
 ];
 
 export class InstrumentedTraceState {
@@ -793,7 +797,7 @@ function generate_wasm (
                     console.log(builder.traceBuf[i]);
             }
 
-            console.log(`// MONO_WASM: ${methodFullName || traceName} generated, blob follows //`);
+            console.log(`// MONO_WASM: ${methodFullName || methodName}:${traceOffset.toString(16)} generated, blob follows //`);
             let s = "", j = 0;
             try {
                 // We may have thrown an uncaught exception while inside a block,

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -81,13 +81,6 @@ export const disabledOpcodes : Array<MintOpcode> = [
 // Having any items in this list will add some overhead to the jitting of *all* traces
 // These names can be substrings and instrumentation will happen if the substring is found in the full name
 export const instrumentedMethodNames : Array<string> = [
-    // "System.Collections.Generic.Stack`1<System.Reflection.Emit.LocalBuilder>& System.Collections.Generic.Dictionary`2<System.Type, System.Collections.Generic.Stack`1<System.Reflection.Emit.LocalBuilder>>:FindValue (System.Type)"
-    // "InternalInsertNode"
-    // "ResolveMethodArguments"
-    // "HashCode"
-    // "GetParameterName"
-    // "MoveNext"
-    // "MakeSeparatorListAny"
 ];
 
 export class InstrumentedTraceState {


### PR DESCRIPTION
Many of the regressions we saw once enabling the jiterpreter were benchmarks heavy on array operations, so I think inlining element address and array length will help improve the performance of that code. This also allows the null check optimization to apply to these array operations.

The BCL is already heavy on the use of spans/pointers/ref so I don't expect this to affect it as much, but it might also help with some of the BCL generic containers.

This PR also contains safety improvements to the null check optimizations along with instrumentation improvements.