### PR TITLE
Fix Mono default interface methods with protected virtual class methods

### DIFF
--- a/src/mono/mono/metadata/class-setup-vtable.c
+++ b/src/mono/mono/metadata/class-setup-vtable.c
@@ -514,7 +514,7 @@ check_interface_method_override (MonoClass *klass, MonoMethod *im, MonoMethod *c
 	gboolean variant_itf = (flags & MONO_ITF_OVERRIDE_VARIANT_ITF) != 0;
 	MonoMethodSignature *cmsig, *imsig;
 	if (strcmp (im->name, cm->name) == 0) {
-		if (! (cm->flags & METHOD_ATTRIBUTE_PUBLIC)) {
+		if ((cm->flags & METHOD_ATTRIBUTE_MEMBER_ACCESS_MASK) != METHOD_ATTRIBUTE_PUBLIC) {
 			TRACE_INTERFACE_VTABLE (printf ("[PUBLIC CHECK FAILED]"));
 			return FALSE;
 		}

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github82577.cs
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github82577.cs
@@ -1,0 +1,38 @@
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+
+class Program
+{
+    static int Main()
+    {
+       int ret;
+       ret = (new TestClass() as ITestInterface).PublicInterfaceProtectedVirtualClass();
+       if (ret != 100) return ret;
+
+       ret = (new TestClass() as ITestInterface).PublicInterfaceProtectedClass();
+       if (ret != 100) return ret;
+
+       ret = (new TestClass() as ITestInterface).PublicInterfacePublicClass();
+       if (ret != 100) return ret;
+
+       return ret;
+    }
+}
+
+public interface ITestInterface
+{
+    public int PublicInterfaceProtectedVirtualClass()=> 100;
+    public int PublicInterfaceProtectedClass()=> 100;
+    public int PublicInterfacePublicClass()=> 3;
+}
+
+public class TestClass : ITestInterface
+{
+    protected virtual int PublicInterfaceProtectedVirtualClass()=> 1;
+    protected int PublicInterfaceProtectedClass()=> 2;
+    public int PublicInterfacePublicClass()=> 100;
+}
+
+

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github82577.csproj
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github82577.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixing the METHOD_ATTRIBUTE_PUBLIC flag check on the class method for check_interface_method_override.