### PR TITLE
[wasm] Disable jiterpreter null check optimization for mid-method traces

### DIFF
--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -35,6 +35,7 @@ export class WasmBuilder {
     stackSize!: number;
     inSection!: boolean;
     inFunction!: boolean;
+    allowNullCheckOptimization!: boolean;
     locals = new Map<string, [WasmValtype, number]>();
 
     permanentFunctionTypeCount = 0;
@@ -90,6 +91,8 @@ export class WasmBuilder {
         this.constantSlots.length = this.options.useConstants ? constantSlotCount : 0;
         for (let i = 0; i < this.constantSlots.length; i++)
             this.constantSlots[i] = 0;
+
+        this.allowNullCheckOptimization = this.options.eliminateNullChecks;
     }
 
     push () {

--- a/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
@@ -1165,7 +1165,7 @@ function append_local_null_check (builder: WasmBuilder, localOffset: number, ip:
 
 // Loads the specified i32 value and then bails out if it is null, leaving it in the cknull_ptr local.
 function append_ldloc_cknull (builder: WasmBuilder, localOffset: number, ip: MintOpcodePtr, leaveOnStack: boolean) {
-    if (knownNotNull.has(localOffset)) {
+    if (builder.allowNullCheckOptimization && knownNotNull.has(localOffset)) {
         counters.nullChecksEliminated++;
         if (cknullOffset === localOffset) {
             // console.log(`cknull_ptr already contains ${localOffset}`);
@@ -1196,7 +1196,10 @@ function append_ldloc_cknull (builder: WasmBuilder, localOffset: number, ip: Min
     if (leaveOnStack)
         builder.local("cknull_ptr");
 
-    if (!addressTakenLocals.has(localOffset) && builder.options.eliminateNullChecks) {
+    if (
+        !addressTakenLocals.has(localOffset) &&
+        builder.allowNullCheckOptimization
+    ) {
         knownNotNull.add(localOffset);
         cknullOffset = localOffset;
     }

--- a/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
@@ -1180,7 +1180,9 @@ function append_ldloc_cknull (builder: WasmBuilder, localOffset: number, ip: Min
 
         if (nullCheckValidation) {
             builder.local("cknull_ptr");
+            append_ldloc(builder, localOffset, WasmOpcode.i32_load);
             builder.i32_const(builder.base);
+            builder.i32_const(ip);
             builder.callImport("notnull");
         }
         return;
@@ -1201,6 +1203,7 @@ function append_ldloc_cknull (builder: WasmBuilder, localOffset: number, ip: Min
         builder.allowNullCheckOptimization
     ) {
         knownNotNull.add(localOffset);
+        // FIXME: This breaks the ldelema1 implementation somehow
         cknullOffset = localOffset;
     }
 }


### PR DESCRIPTION
When compiling a trace in the middle of a method, the null check optimization is currently not safe to apply since we don't know whether ldloca has happened earlier in the execution of the method. This PR disables it for those traces and improves our instrumentation a bit.