### PR TITLE
Fix ilc package name for linux-musl

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
@@ -2,7 +2,8 @@
 
   <PropertyGroup Condition="'$(RuntimeIdentifier)' != '' and '$(NETCoreSdkPortableRuntimeIdentifier)' != ''">
     <!-- Define the name of the runtime specific compiler package to import -->
-    <_targetOS>$(NETCoreSdkPortableRuntimeIdentifier.SubString(0, $(NETCoreSdkPortableRuntimeIdentifier.IndexOf('-'))))</_targetOS>
+    <_targetOSPkg>$(NETCoreSdkPortableRuntimeIdentifier.SubString(0, $(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))))</_targetOSPkg>
+    <_targetOS>$(_targetOSPkg.SubString(0, $(_targetOSPkg.IndexOf('-'))))</_targetOS>
     <_indexOfPeriod>$(_targetOS.IndexOf('.'))</_indexOfPeriod>
     <_targetOS Condition="'$(_indexOfPeriod)' &gt; -1">$(_targetOS.SubString(0, $(_indexOfPeriod)))</_targetOS>
     <_targetOS Condition="$(_targetOS.StartsWith('win'))">win</_targetOS>
@@ -16,7 +17,7 @@
     <IlcHostArch Condition="'$(OS)' == 'Windows_NT' and '$(IlcHostArch)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant)</IlcHostArch>
     <!-- Default to host that matches SDK architecture on non-Windows -->
     <IlcHostArch Condition="'$(IlcHostArch)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant)</IlcHostArch>
-    <IlcHostPackageName>runtime.$(_targetOS)-$(IlcHostArch).Microsoft.DotNet.ILCompiler</IlcHostPackageName>
+    <IlcHostPackageName>runtime.$(_targetOSPkg)-$(IlcHostArch).Microsoft.DotNet.ILCompiler</IlcHostPackageName>
 
     <IlcCalledViaPackage>true</IlcCalledViaPackage>
   </PropertyGroup>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
@@ -3,7 +3,9 @@
   <PropertyGroup Condition="'$(RuntimeIdentifier)' != '' and '$(NETCoreSdkPortableRuntimeIdentifier)' != ''">
     <!-- Define the name of the runtime specific compiler package to import -->
     <_targetOSPkg>$(NETCoreSdkPortableRuntimeIdentifier.SubString(0, $(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))))</_targetOSPkg>
-    <_targetOS>$(_targetOSPkg.SubString(0, $(_targetOSPkg.IndexOf('-'))))</_targetOS>
+    <_indexOfHyphen>$(_targetOSPkg.IndexOf('-'))</_indexOfHyphen>
+    <_targetOS Condition="'$(_indexOfHyphen)' &gt; -1">$(_targetOSPkg.SubString(0, $(_indexOfHyphen)))</_targetOS>
+    <_targetOS Condition="'$(_indexOfHyphen)' == -1">$(_targetOSPkg)</_targetOS>
     <_indexOfPeriod>$(_targetOS.IndexOf('.'))</_indexOfPeriod>
     <_targetOS Condition="'$(_indexOfPeriod)' &gt; -1">$(_targetOS.SubString(0, $(_indexOfPeriod)))</_targetOS>
     <_targetOS Condition="$(_targetOS.StartsWith('win'))">win</_targetOS>


### PR DESCRIPTION
ilc doesn't differentiate between linux and linux-musl, but their runtime package names are different.