### PR TITLE
[wasi] Fix `Invariant.Tests` failures

### DIFF
--- a/eng/testing/tests.wasi.targets
+++ b/eng/testing/tests.wasi.targets
@@ -44,8 +44,8 @@
     <_XHarnessArgs Condition="'$(WasmXHarnessArgsCli)' != ''"      >$(_XHarnessArgs) $(WasmXHarnessArgsCli)</_XHarnessArgs>
 
     <!-- There two flavors of WasmXHarnessArgs and WasmXHarnessMonoArgs, one is MSBuild property and the other is environment variable -->
-    <RunScriptCommand Condition="'$(OS)' != 'Windows_NT'">$HARNESS_RUNNER $(_XHarnessArgs) %24XHARNESS_ARGS %24WasmXHarnessArgs -- $(WasmXHarnessMonoArgs) %24WasmXHarnessMonoArgs $(_AppArgs) %24WasmTestAppArgs</RunScriptCommand>
-    <RunScriptCommand Condition="'$(OS)' == 'Windows_NT'">%HARNESS_RUNNER% $(_XHarnessArgs) %XHARNESS_ARGS% %WasmXHarnessArgs%  -- $(WasmXHarnessMonoArgs) %WasmXHarnessMonoArgs% $(_AppArgs) %WasmTestAppArgs%</RunScriptCommand>
+    <RunScriptCommand Condition="'$(OS)' != 'Windows_NT'">$HARNESS_RUNNER $(_XHarnessArgs) %24XHARNESS_ARGS %24WasmXHarnessArgs -- $(WasmXHarnessMonoArgs) %24WasmXHarnessMonoArgs $(_AppArgs) $(InvariantGlobalization) %24WasmTestAppArgs</RunScriptCommand>
+    <RunScriptCommand Condition="'$(OS)' == 'Windows_NT'">%HARNESS_RUNNER% $(_XHarnessArgs) %XHARNESS_ARGS% %WasmXHarnessArgs%  -- $(WasmXHarnessMonoArgs) %WasmXHarnessMonoArgs% $(_AppArgs) $(InvariantGlobalization) %WasmTestAppArgs%</RunScriptCommand>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(BuildAOTTestsOnHelix)' == 'true'">

--- a/src/mono/wasi/build/WasiApp.targets
+++ b/src/mono/wasi/build/WasiApp.targets
@@ -363,8 +363,8 @@
   <Target Name="_GenerateRunWasmtimeScript">
     <PropertyGroup>
       <WasmRunWasmtimeScriptPath Condition="'$(WasmRunWasmtimeScriptPath)' == ''">$(WasmAppDir)run-wasmtime.sh</WasmRunWasmtimeScriptPath>
-      <_ScriptContent Condition="'$(WasmSingleFileBundle)' == 'true'">wasmtime run $([System.IO.Path]::GetFileNameWithoutExtension($(WasmMainAssemblyFileName))).wasm $*</_ScriptContent>
-      <_ScriptContent Condition="'$(WasmSingleFileBundle)' != 'true'">wasmtime run --dir . dotnet.wasm $([System.IO.Path]::GetFileNameWithoutExtension($(WasmMainAssemblyFileName))) $*</_ScriptContent>
+      <_ScriptContent Condition="'$(WasmSingleFileBundle)' == 'true'">wasmtime run $([System.IO.Path]::GetFileNameWithoutExtension($(WasmMainAssemblyFileName))).wasm $(InvariantGlobalization) $*</_ScriptContent>
+      <_ScriptContent Condition="'$(WasmSingleFileBundle)' != 'true'">wasmtime run --dir . dotnet.wasm $([System.IO.Path]::GetFileNameWithoutExtension($(WasmMainAssemblyFileName))) $(InvariantGlobalization) $*</_ScriptContent>
     </PropertyGroup>
 
     <Error Condition="'$(WasmMainAssemblyFileName)' == ''" Text="%24(WasmMainAssemblyFileName) property needs to be set for generating $(WasmRunWasmtimeScriptPath)." />

--- a/src/mono/wasi/build/WasiApp.targets
+++ b/src/mono/wasi/build/WasiApp.targets
@@ -363,8 +363,8 @@
   <Target Name="_GenerateRunWasmtimeScript">
     <PropertyGroup>
       <WasmRunWasmtimeScriptPath Condition="'$(WasmRunWasmtimeScriptPath)' == ''">$(WasmAppDir)run-wasmtime.sh</WasmRunWasmtimeScriptPath>
-      <_ScriptContent Condition="'$(WasmSingleFileBundle)' == 'true'">wasmtime run $([System.IO.Path]::GetFileNameWithoutExtension($(WasmMainAssemblyFileName))).wasm $(InvariantGlobalization) $*</_ScriptContent>
-      <_ScriptContent Condition="'$(WasmSingleFileBundle)' != 'true'">wasmtime run --dir . dotnet.wasm $([System.IO.Path]::GetFileNameWithoutExtension($(WasmMainAssemblyFileName))) $(InvariantGlobalization) $*</_ScriptContent>
+      <_ScriptContent Condition="'$(WasmSingleFileBundle)' == 'true'">wasmtime run $([System.IO.Path]::GetFileNameWithoutExtension($(WasmMainAssemblyFileName))).wasm $*</_ScriptContent>
+      <_ScriptContent Condition="'$(WasmSingleFileBundle)' != 'true'">wasmtime run --dir . dotnet.wasm $([System.IO.Path]::GetFileNameWithoutExtension($(WasmMainAssemblyFileName))) $*</_ScriptContent>
     </PropertyGroup>
 
     <Error Condition="'$(WasmMainAssemblyFileName)' == ''" Text="%24(WasmMainAssemblyFileName) property needs to be set for generating $(WasmRunWasmtimeScriptPath)." />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/82567. 
1) I am not sure if it's good to touch `unused` parameter and why we have it at all
2) Will we call the `main` function of drive.c from different places so that 3rd arg might not be `InvariantGlobalization`?
3) Any suggestions how to clean it up are welcome.