### PR TITLE
Fix warning/error with gcc11 in PalRedhawkUnix.cpp

### DIFF
--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -678,7 +678,9 @@ REDHAWK_PALEXPORT void PalPrintFatalError(const char* message)
 {
     // Write the message using lowest-level OS API available. This is used to print the stack overflow
     // message, so there is not much that can be done here.
-    write(STDERR_FILENO, message, strlen(message));
+    // write() has __attribute__((warn_unused_result)) in glibc, for which gcc 11+ issue `-Wunused-result` even with `(void)write(..)`,
+    // so we use additional NOT(!) operator to force unused-result suppression.
+    (void)!write(STDERR_FILENO, message, strlen(message));
 }
 
 static int W32toUnixAccessControl(uint32_t flProtect)


### PR DESCRIPTION
Otherwise you get:

```
error: ignoring return value of ‘ssize_t write(int, const void*, std::size_t)’ declared with attribute ‘warn_unused_result’ [-Werror=unused-result]
    681 |     write(STDERR_FILENO, message, strlen(message));
        |     ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The same warning was already fixed for `alloca()` in encee.cpp as part of https://github.com/dotnet/runtime/commit/5d6d55977270b3d1549a5c2e454b191487bef5eb#diff-f1018f796e7e06f60f7f4558583ec116f8e394bc90e29177c9dbdbfd29b78ab5R670, applying the same fix here.

Found this while helping a user on Gitter.