### PR TITLE
[wasm] Improve jiterpreter trace entry point selection heuristic

### DIFF
--- a/src/mono/mono/utils/options-def.h
+++ b/src/mono/mono/utils/options-def.h
@@ -115,6 +115,8 @@ DEFINE_BOOL(jiterpreter_backward_branches_enabled, "jiterpreter-backward-branche
 DEFINE_BOOL(jiterpreter_direct_jit_call, "jiterpreter-direct-jit-calls", TRUE, "Bypass gsharedvt wrappers when compiling JIT call wrappers")
 // any trace that doesn't have at least this many meaningful (non-nop) opcodes in it will be rejected
 DEFINE_INT(jiterpreter_minimum_trace_length, "jiterpreter-minimum-trace-length", 10, "Reject traces shorter than this number of meaningful opcodes")
+// ensure that we don't create trace entry points too close together
+DEFINE_INT(jiterpreter_minimum_distance_between_traces, "jiterpreter-minimum-distance-between-traces", 6, "Don't insert entry points closer together than this")
 // once a trace entry point is inserted, we only actually JIT code for it once it's been hit this many times
 DEFINE_INT(jiterpreter_minimum_trace_hit_count, "jiterpreter-minimum-trace-hit-count", 5000, "JIT trace entry points once they are hit this many times")
 // After a do_jit_call call site is hit this many times, we will queue it to be jitted

--- a/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
@@ -203,7 +203,7 @@ export function generate_wasm_body (
                 //  because a backward branch might target a point in the middle of the trace
                 (isFirstInstruction && backwardBranchTable),
             needsFallthroughEipUpdate = needsEipCheck && !isFirstInstruction;
-        let isDeadOpcode = false,
+        let isLowValueOpcode = false,
             skipDregInvalidation = false;
 
         // We record the offset of each backward branch we encounter, so that later branch
@@ -317,7 +317,7 @@ export function generate_wasm_body (
             }
 
             case MintOpcode.MINT_TIER_ENTER_JITERPRETER:
-                isDeadOpcode = true;
+                isLowValueOpcode = true;
                 // If we hit an enter opcode and we're not currently in a branch block
                 //  or the enter opcode is the first opcode in a branch block, this likely
                 //  indicates that we've reached a loop body that was already jitted before
@@ -363,7 +363,7 @@ export function generate_wasm_body (
             case MintOpcode.MINT_SDB_BREAKPOINT:
             case MintOpcode.MINT_SDB_INTR_LOC:
             case MintOpcode.MINT_SDB_SEQ_POINT:
-                isDeadOpcode = true;
+                isLowValueOpcode = true;
                 break;
 
             case MintOpcode.MINT_SAFEPOINT:
@@ -792,6 +792,7 @@ export function generate_wasm_body (
                     //  to abort the entire trace if we have branch support enabled - the call
                     //  might be infrequently hit and as a result it's worth it to keep going.
                     append_bailout(builder, ip, BailoutReason.Call);
+                    isLowValueOpcode = true;
                 } else {
                     // We're in a block that executes unconditionally, and no branches have been
                     //  executed before now so the trace will always need to bail out into the
@@ -815,6 +816,7 @@ export function generate_wasm_body (
                             ? BailoutReason.CallDelegate
                             : BailoutReason.Call
                     );
+                    isLowValueOpcode = true;
                 } else {
                     ip = abort;
                 }
@@ -828,6 +830,7 @@ export function generate_wasm_body (
                 // Otherwise, it may be in a branch that is unlikely to execute
                 if (builder.branchTargets.size > 0) {
                     append_bailout(builder, ip, BailoutReason.Throw);
+                    isLowValueOpcode = true;
                 } else {
                     ip = abort;
                 }
@@ -1031,9 +1034,10 @@ export function generate_wasm_body (
                         (opcode <= MintOpcode.MINT_RET_I8_IMM)
                     )
                 ) {
-                    if ((builder.branchTargets.size > 0) || trapTraceErrors || builder.options.countBailouts)
+                    if ((builder.branchTargets.size > 0) || trapTraceErrors || builder.options.countBailouts) {
                         append_bailout(builder, ip, BailoutReason.Return);
-                    else
+                        isLowValueOpcode = true;
+                    } else
                         ip = abort;
                 } else if (
                     (opcode >= MintOpcode.MINT_LDC_I4_M1) &&
@@ -1102,9 +1106,10 @@ export function generate_wasm_body (
                     //  types can be handled by emit_branch or emit_relop_branch,
                     //  to only perform a conditional bailout
                     // complex safepoint branches, just generate a bailout
-                    if (builder.branchTargets.size > 0)
+                    if (builder.branchTargets.size > 0) {
                         append_bailout(builder, ip, BailoutReason.ComplexBranch);
-                    else
+                        isLowValueOpcode = true;
+                    } else
                         ip = abort;
                 } else {
                     ip = abort;
@@ -1147,7 +1152,7 @@ export function generate_wasm_body (
                 builder.traceBuf.push(stmtText);
             }
 
-            if (!isDeadOpcode)
+            if (!isLowValueOpcode)
                 result++;
 
             ip += <any>(info[1] * 2);


### PR DESCRIPTION
This PR adjusts the jiterpreter's heuristic that decides where it's best to put entry points:
* Adds a requirement that entry points be at least a certain distance apart, since in some cases we can end up with trace entry points right next to each other, which isn't very useful and adds overhead. (Backwards branch targets are exempted from this so loops will still JIT properly).
* If we fail to create a trace exactly located at a backwards branch target, continue trying at blocks afterward. This should help in the rare case where the body of a loop begins with an unsupported instruction.
* When considering how long a trace actually is, we treat conditional aborts (like calls and throws) separately from ignored and supported instructions, so they don't count towards the overall size of the trace. These instructions aren't actually doing any useful work and if executed the trace will exit, so it's better not to consider them when deciding whether a trace is worth compiling.

This PR also manually inlines trace entry logic, because performance in benchmarks reduced mysteriously once I outlined it even though the function was MONO_ALWAYS_INLINE.

This PR may erase some of the benchmark gains from the jiterpreter, but in my testing with these current tuning values, S.R.T isn't much slower than before (if at all) and it measurably reduces the number of traces compiled while increasing the success rate of the heuristic, which should mean we spend less time executing jiterpreter nops (a source of slowdown) and short traces (also bad). The two raytracer tests and browser-bench also didn't show any measurable regressions.