### PR TITLE
JIT: Unify arm64 and x64 GT_SELECT handling

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -883,8 +883,7 @@ protected:
     void genCkfinite(GenTree* treeNode);
     void genCodeForCompare(GenTreeOp* tree);
 #ifdef TARGET_ARM64
-    void genCodeForConditionalCompare(GenTreeOp* tree, GenCondition prevCond);
-    void genCodeForContainedCompareChain(GenTree* tree, bool* inchain, GenCondition* prevCond);
+    void genCodeForCCMP(GenTreeCCMP* ccmp);
 #endif
     void genCodeForSelect(GenTreeOp* select);
     void genIntrinsic(GenTreeIntrinsic* treeNode);
@@ -1535,7 +1534,6 @@ public:
 #endif // TARGET_XARCH
 
 #if defined(TARGET_ARM64)
-    static insCflags InsCflagsForCcmp(GenCondition cond);
     static insCond JumpKindToInsCond(emitJumpKind condition);
 #elif defined(TARGET_XARCH)
     static instruction JumpKindToCmov(emitJumpKind condition);

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2696,35 +2696,6 @@ void CodeGen::genCodeForBinary(GenTreeOp* tree)
         return;
     }
 
-    if (tree->isContainedCompareChainSegment(op2))
-    {
-        GenCondition cond;
-        bool         chain = false;
-
-        JITDUMP("Generating compare chain:\n");
-        if (op1->isContained())
-        {
-            // Generate Op1 into flags.
-            genCodeForContainedCompareChain(op1, &chain, &cond);
-            assert(chain);
-        }
-        else
-        {
-            // Op1 is not contained, move it from a register into flags.
-            emit->emitIns_R_I(INS_cmp, emitActualTypeSize(op1), op1->GetRegNum(), 0);
-            cond  = GenCondition::NE;
-            chain = true;
-        }
-        // Gen Op2 into flags.
-        genCodeForContainedCompareChain(op2, &chain, &cond);
-        assert(chain);
-
-        // Move the result from flags into a register.
-        inst_SETCC(cond, tree->TypeGet(), targetReg);
-        genProduceReg(tree);
-        return;
-    }
-
     instruction ins = genGetInsForOper(tree->OperGet(), targetType);
 
     if ((tree->gtFlags & GTF_SET_FLAGS) != 0)
@@ -4606,108 +4577,36 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
 //    tree - a compare node (GT_EQ etc)
 //    cond - the condition of the previous generated compare.
 //
-void CodeGen::genCodeForConditionalCompare(GenTreeOp* tree, GenCondition prevCond)
+void CodeGen::genCodeForCCMP(GenTreeCCMP* ccmp)
 {
     emitter* emit = GetEmitter();
 
-    GenTree*  op1       = tree->gtGetOp1();
-    GenTree*  op2       = tree->gtGetOp2();
-    var_types op1Type   = genActualType(op1->TypeGet());
-    var_types op2Type   = genActualType(op2->TypeGet());
-    emitAttr  cmpSize   = EA_ATTR(genTypeSize(op1Type));
-    regNumber targetReg = tree->GetRegNum();
-    regNumber srcReg1   = op1->GetRegNum();
+    genConsumeOperands(ccmp);
+    GenTree*  op1     = ccmp->gtGetOp1();
+    GenTree*  op2     = ccmp->gtGetOp2();
+    var_types op1Type = genActualType(op1->TypeGet());
+    var_types op2Type = genActualType(op2->TypeGet());
+    emitAttr  cmpSize = emitActualTypeSize(op1Type);
+    regNumber srcReg1 = op1->GetRegNum();
 
     // No float support or swapping op1 and op2 to generate cmp reg, imm.
     assert(!varTypeIsFloating(op2Type));
     assert(!op1->isContainedIntOrIImmed());
 
-    // Should only be called on contained nodes.
-    assert(targetReg == REG_NA);
-
-    // Should not be called for test conditionals (Arm64 does not have a ctst).
-    assert(tree->OperIsCmpCompare());
-
     // For the ccmp flags, invert the condition of the compare.
-    insCflags cflags = InsCflagsForCcmp(GenCondition::FromRelop(tree));
-
     // For the condition, use the previous compare.
-    const GenConditionDesc& prevDesc    = GenConditionDesc::Get(prevCond);
-    insCond                 prevInsCond = JumpKindToInsCond(prevDesc.jumpKind1);
+    const GenConditionDesc& condDesc = GenConditionDesc::Get(ccmp->gtCondition);
+    insCond                 insCond  = JumpKindToInsCond(condDesc.jumpKind1);
 
     if (op2->isContainedIntOrIImmed())
     {
         GenTreeIntConCommon* intConst = op2->AsIntConCommon();
-        emit->emitIns_R_I_FLAGS_COND(INS_ccmp, cmpSize, srcReg1, (int)intConst->IconValue(), cflags, prevInsCond);
+        emit->emitIns_R_I_FLAGS_COND(INS_ccmp, cmpSize, srcReg1, (int)intConst->IconValue(), ccmp->gtFlagsVal, insCond);
     }
     else
     {
         regNumber srcReg2 = op2->GetRegNum();
-        emit->emitIns_R_R_FLAGS_COND(INS_ccmp, cmpSize, srcReg1, srcReg2, cflags, prevInsCond);
-    }
-}
-
-//------------------------------------------------------------------------
-// genCodeForContainedCompareChain: Produce code for a chain of conditional compares.
-//
-// Only generates for contained nodes. Nodes that are not contained are assumed to be
-// generated as part of standard tree generation.
-//
-// Arguments:
-//    tree - the node. Either a compare or a tree of compares connected by ANDs.
-//    inChain - whether a contained chain is in progress.
-//    prevCond - If a chain is in progress, the condition of the previous compare.
-// Return:
-//    The last compare node generated.
-//
-void CodeGen::genCodeForContainedCompareChain(GenTree* tree, bool* inChain, GenCondition* prevCond)
-{
-    assert(tree->isContained());
-
-    if (tree->OperIs(GT_AND))
-    {
-        GenTree* op1 = tree->gtGetOp1();
-        GenTree* op2 = tree->gtGetOp2();
-
-        assert(op2->isContained());
-
-        // If Op1 is contained, generate into flags. Otherwise, move the result into flags.
-        if (op1->isContained())
-        {
-            genCodeForContainedCompareChain(op1, inChain, prevCond);
-            assert(*inChain);
-        }
-        else
-        {
-            emitter* emit = GetEmitter();
-            emit->emitIns_R_I(INS_cmp, emitActualTypeSize(op1), op1->GetRegNum(), 0);
-            *prevCond = GenCondition::NE;
-            *inChain  = true;
-        }
-
-        // Generate Op2 based on Op1.
-        genCodeForContainedCompareChain(op2, inChain, prevCond);
-        assert(*inChain);
-    }
-    else
-    {
-        assert(tree->OperIsCmpCompare());
-
-        // Generate the compare, putting the result in the flags register.
-        if (!*inChain)
-        {
-            // First item in a chain. Use a standard compare.
-            genCodeForCompare(tree->AsOp());
-        }
-        else
-        {
-            // Within the chain. Use a conditional compare (which is
-            // dependent on the previous emitted compare).
-            genCodeForConditionalCompare(tree->AsOp(), *prevCond);
-        }
-
-        *inChain  = true;
-        *prevCond = GenCondition::FromRelop(tree);
+        emit->emitIns_R_R_FLAGS_COND(INS_ccmp, cmpSize, srcReg1, srcReg2, ccmp->gtFlagsVal, insCond);
     }
 }
 
@@ -4719,45 +4618,37 @@ void CodeGen::genCodeForContainedCompareChain(GenTree* tree, bool* inChain, GenC
 //
 void CodeGen::genCodeForSelect(GenTreeOp* tree)
 {
-    assert(tree->OperIs(GT_SELECT));
-    GenTreeConditional* select = tree->AsConditional();
-    emitter*            emit   = GetEmitter();
+    assert(tree->OperIs(GT_SELECT, GT_SELECTCC));
+    GenTree* opcond = nullptr;
+    if (tree->OperIs(GT_SELECT))
+    {
+        opcond = tree->AsConditional()->gtCond;
+        genConsumeRegs(opcond);
+    }
 
-    GenTree*  opcond  = select->gtCond;
-    GenTree*  op1     = select->gtOp1;
-    GenTree*  op2     = select->gtOp2;
-    var_types op1Type = genActualType(op1->TypeGet());
-    var_types op2Type = genActualType(op2->TypeGet());
-    emitAttr  attr    = emitActualTypeSize(select->TypeGet());
+    emitter* emit = GetEmitter();
+
+    GenTree*  op1     = tree->gtOp1;
+    GenTree*  op2     = tree->gtOp2;
+    var_types op1Type = genActualType(op1);
+    var_types op2Type = genActualType(op2);
+    emitAttr  attr    = emitActualTypeSize(tree);
 
     assert(!op1->isUsedFromMemory());
     assert(genTypeSize(op1Type) == genTypeSize(op2Type));
 
-    GenCondition prevCond;
-    genConsumeRegs(opcond);
-    if (opcond->isContained())
-    {
-        // Generate the contained condition.
-        if (opcond->OperIsCompare())
-        {
-            genCodeForCompare(opcond->AsOp());
-            prevCond = GenCondition::FromRelop(opcond);
-        }
-        else
-        {
-            // Condition is a compare chain. Try to contain it.
-            assert(opcond->OperIs(GT_AND));
-            bool chain = false;
-            JITDUMP("Generating compare chain:\n");
-            genCodeForContainedCompareChain(opcond, &chain, &prevCond);
-            assert(chain);
-        }
-    }
-    else
+    GenCondition cond;
+
+    if (opcond != nullptr)
     {
         // Condition has been generated into a register - move it into flags.
         emit->emitIns_R_I(INS_cmp, emitActualTypeSize(opcond), opcond->GetRegNum(), 0);
-        prevCond = GenCondition::NE;
+        cond = GenCondition::NE;
+    }
+    else
+    {
+        assert(tree->OperIs(GT_SELECTCC));
+        cond = tree->AsOpCC()->gtCondition;
     }
 
     assert(!op1->isContained() || op1->IsIntegralConst(0));
@@ -4766,7 +4657,7 @@ void CodeGen::genCodeForSelect(GenTreeOp* tree)
     regNumber               targetReg = tree->GetRegNum();
     regNumber               srcReg1   = op1->IsIntegralConst(0) ? REG_ZR : genConsumeReg(op1);
     regNumber               srcReg2   = op2->IsIntegralConst(0) ? REG_ZR : genConsumeReg(op2);
-    const GenConditionDesc& prevDesc  = GenConditionDesc::Get(prevCond);
+    const GenConditionDesc& prevDesc  = GenConditionDesc::Get(cond);
 
     emit->emitIns_R_R_R_COND(INS_csel, attr, targetReg, srcReg1, srcReg2, JumpKindToInsCond(prevDesc.jumpKind1));
 
@@ -10393,50 +10284,6 @@ void CodeGen::genCodeForCond(GenTreeOp* tree)
     }
 
     genProduceReg(tree);
-}
-
-//------------------------------------------------------------------------
-// InsCflagsForCcmp: Get the Cflags for a required for a CCMP instruction.
-//
-// Consider:
-//   cmp w, x
-//   ccmp y, z, A, COND
-// This is: compare w and x, if this matches condition COND, then compare y and z.
-// Otherwise set flags to A - this should match the case where cmp failed.
-// Given COND, this function returns A.
-//
-// Arguments:
-//    cond - the GenCondition.
-//
-insCflags CodeGen::InsCflagsForCcmp(GenCondition cond)
-{
-    GenCondition inverted = GenCondition::Reverse(cond);
-    switch (inverted.GetCode())
-    {
-        case GenCondition::EQ:
-            return INS_FLAGS_Z;
-        case GenCondition::NE:
-            return INS_FLAGS_NONE;
-        case GenCondition::SGE:
-            return INS_FLAGS_Z;
-        case GenCondition::SGT:
-            return INS_FLAGS_NONE;
-        case GenCondition::SLT:
-            return INS_FLAGS_NC;
-        case GenCondition::SLE:
-            return INS_FLAGS_NZC;
-        case GenCondition::UGE:
-            return INS_FLAGS_C;
-        case GenCondition::UGT:
-            return INS_FLAGS_C;
-        case GenCondition::ULT:
-            return INS_FLAGS_NONE;
-        case GenCondition::ULE:
-            return INS_FLAGS_Z;
-        default:
-            NO_WAY("unexpected condition type");
-            return INS_FLAGS_NONE;
-    }
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -361,11 +361,19 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
         case GT_SELECT:
             genCodeForSelect(treeNode->AsConditional());
             break;
+
+        case GT_SELECTCC:
+            genCodeForSelect(treeNode->AsOp());
+            break;
 #endif
 
 #ifdef TARGET_ARM64
         case GT_JCMP:
             genCodeForJumpCompare(treeNode->AsOp());
+            break;
+
+        case GT_CCMP:
+            genCodeForCCMP(treeNode->AsCCMP());
             break;
 #endif // TARGET_ARM64
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -316,6 +316,7 @@ void GenTree::InitNodeSize()
 #ifdef TARGET_ARM64
     static_assert_no_msg(sizeof(GenTreeCCMP)         <= TREE_NODE_SZ_SMALL);
 #endif
+    static_assert_no_msg(sizeof(GenTreeConditional)  <= TREE_NODE_SZ_SMALL);
     static_assert_no_msg(sizeof(GenTreeCast)         <= TREE_NODE_SZ_LARGE); // *** large node
     static_assert_no_msg(sizeof(GenTreeBox)          <= TREE_NODE_SZ_LARGE); // *** large node
     static_assert_no_msg(sizeof(GenTreeField)        <= TREE_NODE_SZ_LARGE); // *** large node

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -11314,7 +11314,7 @@ void Compiler::gtDispLclVarStructType(unsigned lclNum)
 static const char* InsCflagsToString(insCflags flags)
 {
     const static char* s_table[16] = {"0", "v",  "c",  "cv",  "z",  "zv",  "zc",  "zcv",
-                                       "n", "nv", "nc", "ncv", "nz", "nzv", "nzc", "nzcv"};
+                                      "n", "nv", "nc", "ncv", "nz", "nzv", "nzc", "nzcv"};
     unsigned index = (unsigned)flags;
     assert((0 <= index) && (index < ArrLen(s_table)));
     return s_table[index];

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -11313,43 +11313,11 @@ void Compiler::gtDispLclVarStructType(unsigned lclNum)
 #if defined(DEBUG) && defined(TARGET_ARM64)
 static const char* InsCflagsToString(insCflags flags)
 {
-    switch (flags)
-    {
-        case INS_FLAGS_NONE:
-            return "0";
-        case INS_FLAGS_V:
-            return "v";
-        case INS_FLAGS_C:
-            return "c";
-        case INS_FLAGS_CV:
-            return "cv";
-        case INS_FLAGS_Z:
-            return "z";
-        case INS_FLAGS_ZV:
-            return "zv";
-        case INS_FLAGS_ZC:
-            return "zc";
-        case INS_FLAGS_ZCV:
-            return "zcv";
-        case INS_FLAGS_N:
-            return "n";
-        case INS_FLAGS_NV:
-            return "nv";
-        case INS_FLAGS_NC:
-            return "nc";
-        case INS_FLAGS_NCV:
-            return "ncv";
-        case INS_FLAGS_NZ:
-            return "nz";
-        case INS_FLAGS_NZV:
-            return "nzv";
-        case INS_FLAGS_NZC:
-            return "nzc";
-        case INS_FLAGS_NZCV:
-            return "nzcv";
-        default:
-            return "?";
-    }
+    const static char* s_table[16] = {"0", "v",  "c",  "cv",  "z",  "zv",  "zc",  "zcv",
+                                       "n", "nv", "nc", "ncv", "nz", "nzv", "nzc", "nzcv"};
+    unsigned index = (unsigned)flags;
+    assert((0 <= index) && (index < ArrLen(s_table)));
+    return s_table[index];
 }
 #endif
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1687,7 +1687,15 @@ public:
     {
 #if !defined(TARGET_64BIT)
         if (OperIs(GT_ADD_HI, GT_SUB_HI))
+        {
             return true;
+        }
+#endif
+#if defined(TARGET_ARM64)
+        if (OperIs(GT_CCMP))
+        {
+            return true;
+        }
 #endif
         return OperIs(GT_JCC, GT_SETCC, GT_SELECTCC);
     }

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -894,12 +894,6 @@ public:
         return isContained() && IsCnsIntOrI() && !isUsedFromSpillTemp();
     }
 
-    // Node and its child in isolation form a contained compare chain.
-    bool isContainedCompareChainSegment(GenTree* child) const
-    {
-        return (OperIs(GT_AND) && child->isContained() && (child->OperIs(GT_AND) || child->OperIsCmpCompare()));
-    }
-
     bool isContainedFltOrDblImmed() const
     {
         return isContained() && OperIs(GT_CNS_DBL);
@@ -8549,7 +8543,7 @@ struct GenTreeCC final : public GenTree
 };
 
 // Represents a node with two operands and a condition.
-struct GenTreeOpCC final : public GenTreeOp
+struct GenTreeOpCC : public GenTreeOp
 {
     GenCondition gtCondition;
 
@@ -8565,6 +8559,47 @@ struct GenTreeOpCC final : public GenTreeOp
     }
 #endif // DEBUGGABLE_GENTREE
 };
+
+#ifdef TARGET_ARM64
+enum insCflags : unsigned
+{
+    INS_FLAGS_NONE,
+    INS_FLAGS_V,
+    INS_FLAGS_C,
+    INS_FLAGS_CV,
+
+    INS_FLAGS_Z,
+    INS_FLAGS_ZV,
+    INS_FLAGS_ZC,
+    INS_FLAGS_ZCV,
+
+    INS_FLAGS_N,
+    INS_FLAGS_NV,
+    INS_FLAGS_NC,
+    INS_FLAGS_NCV,
+
+    INS_FLAGS_NZ,
+    INS_FLAGS_NZV,
+    INS_FLAGS_NZC,
+    INS_FLAGS_NZCV,
+};
+
+struct GenTreeCCMP final : public GenTreeOpCC
+{
+    insCflags gtFlagsVal;
+
+    GenTreeCCMP(var_types type, GenCondition condition, GenTree* op1, GenTree* op2, insCflags flagsVal)
+        : GenTreeOpCC(GT_CCMP, type, condition, op1, op2), gtFlagsVal(flagsVal)
+    {
+    }
+
+#if DEBUGGABLE_GENTREE
+    GenTreeCCMP() : GenTreeOpCC()
+    {
+    }
+#endif // DEBUGGABLE_GENTREE
+};
+#endif
 
 //------------------------------------------------------------------------
 // Deferred inline functions of GenTree -- these need the subtypes above to

--- a/src/coreclr/jit/gtlist.h
+++ b/src/coreclr/jit/gtlist.h
@@ -243,7 +243,14 @@ GTNODE(JCC              , GenTreeCC          ,0,GTK_LEAF|GTK_NOVALUE|DBK_NOTHIR)
 // Checks the condition flags and produces 1 if the condition specified by GenTreeCC::gtCondition is true and 0 otherwise.
 GTNODE(SETCC            , GenTreeCC          ,0,GTK_LEAF|DBK_NOTHIR)
 // Variant of SELECT that reuses flags computed by a previous node with the specified condition.
-GTNODE(SELECTCC         , GenTreeCC          ,0,GTK_BINOP|DBK_NOTHIR)
+GTNODE(SELECTCC         , GenTreeOpCC        ,0,GTK_BINOP|DBK_NOTHIR)
+#ifdef TARGET_ARM64
+// The arm64 ccmp instruction. If the specified condition is true, compares two
+// operands and sets the condition flags according to the result. Otherwise
+// sets the condition flags such that they make a specified (assuming to be
+// upcoming) condition false.
+GTNODE(CCMP             , GenTreeCCMP        ,0,GTK_BINOP|GTK_NOVALUE|DBK_NOTHIR)
+#endif
 
 
 //-----------------------------------------------------------------------------

--- a/src/coreclr/jit/gtlist.h
+++ b/src/coreclr/jit/gtlist.h
@@ -247,8 +247,7 @@ GTNODE(SELECTCC         , GenTreeOpCC        ,0,GTK_BINOP|DBK_NOTHIR)
 #ifdef TARGET_ARM64
 // The arm64 ccmp instruction. If the specified condition is true, compares two
 // operands and sets the condition flags according to the result. Otherwise
-// sets the condition flags such that they make a specified (assuming to be
-// upcoming) condition false.
+// sets the condition flags to the specified immediate value.
 GTNODE(CCMP             , GenTreeCCMP        ,0,GTK_BINOP|GTK_NOVALUE|DBK_NOTHIR)
 #endif
 

--- a/src/coreclr/jit/gtstructs.h
+++ b/src/coreclr/jit/gtstructs.h
@@ -113,6 +113,9 @@ GTSTRUCT_1(RuntimeLookup, GT_RUNTIMELOOKUP)
 GTSTRUCT_1(ArrAddr     , GT_ARR_ADDR)
 GTSTRUCT_2(CC          , GT_JCC, GT_SETCC)
 GTSTRUCT_1(OpCC        , GT_SELECTCC)
+#ifdef TARGET_ARM64
+GTSTRUCT_1(CCMP        , GT_CCMP)
+#endif
 #if defined(TARGET_X86)
 GTSTRUCT_1(MultiRegOp  , GT_MUL_LONG)
 #elif defined (TARGET_ARM)

--- a/src/coreclr/jit/instr.h
+++ b/src/coreclr/jit/instr.h
@@ -269,29 +269,6 @@ enum insCond : unsigned
     INS_COND_LE,
 };
 
-enum insCflags : unsigned
-{
-    INS_FLAGS_NONE,
-    INS_FLAGS_V,
-    INS_FLAGS_C,
-    INS_FLAGS_CV,
-
-    INS_FLAGS_Z,
-    INS_FLAGS_ZV,
-    INS_FLAGS_ZC,
-    INS_FLAGS_ZCV,
-
-    INS_FLAGS_N,
-    INS_FLAGS_NV,
-    INS_FLAGS_NC,
-    INS_FLAGS_NCV,
-
-    INS_FLAGS_NZ,
-    INS_FLAGS_NZV,
-    INS_FLAGS_NZC,
-    INS_FLAGS_NZCV,
-};
-
 enum insBarrier : unsigned
 {
     INS_BARRIER_OSHLD =  1,

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -234,6 +234,23 @@ bool Lowering::IsInvariantInRange(GenTree* node, GenTree* endExclusive, GenTree*
     return true;
 }
 
+//------------------------------------------------------------------------
+// IsRangeInvariantInRange: Check if a range of nodes are invariant in the
+// specified range.
+//
+// Arguments:
+//    rangeStart   - The first node.
+//    rangeEnd     - The last node.
+//    endExclusive - The exclusive end of the range to check invariance for.
+//
+// Returns:
+//    True if the range can be evaluated at any point between its current location
+//    and 'endExclusive' without giving a different result; otherwise false.
+//
+// Remarks:
+//    Note that the range is treated as a unit and no pairwise interference
+//    checks between nodes in the range are performed.
+//
 bool Lowering::IsRangeInvariantInRange(GenTree* rangeStart, GenTree* rangeEnd, GenTree* endExclusive) const
 {
     assert((rangeStart != nullptr) && (rangeEnd != nullptr));

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -85,10 +85,9 @@ private:
     void ContainCheckLclHeap(GenTreeOp* node);
     void ContainCheckRet(GenTreeUnOp* ret);
 #ifdef TARGET_ARM64
-    bool IsValidCompareChain(GenTree* child, GenTree* parent);
-    bool ContainCheckCompareChain(GenTree* child, GenTree* parent, GenTree** earliestValid);
-    void ContainCheckCompareChainForAnd(GenTree* tree);
-    void ContainCheckConditionalCompare(GenTreeOp* cmp);
+    GenTree* TryLowerAndToCCMP(GenTree* tree);
+    insCflags FalsifyingFlags(GenCondition cond);
+    void ContainCheckConditionalCompare(GenTreeCCMP* ccmp);
     void ContainCheckNeg(GenTreeOp* neg);
 #endif
     void ContainCheckSelect(GenTreeOp* select);
@@ -504,6 +503,7 @@ private:
 
     bool IsInvariantInRange(GenTree* node, GenTree* endExclusive) const;
     bool IsInvariantInRange(GenTree* node, GenTree* endExclusive, GenTree* ignoreNode) const;
+    bool IsRangeInvariantInRange(GenTree* rangeStart, GenTree* rangeEnd, GenTree* endExclusive) const;
 
     // Checks for memory conflicts in the instructions between childNode and parentNode, and returns true if childNode
     // can be contained.

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -503,7 +503,10 @@ private:
 
     bool IsInvariantInRange(GenTree* node, GenTree* endExclusive) const;
     bool IsInvariantInRange(GenTree* node, GenTree* endExclusive, GenTree* ignoreNode) const;
-    bool IsRangeInvariantInRange(GenTree* rangeStart, GenTree* rangeEnd, GenTree* endExclusive) const;
+    bool IsRangeInvariantInRange(GenTree* rangeStart,
+                                 GenTree* rangeEnd,
+                                 GenTree* endExclusive,
+                                 GenTree* ignoreNode) const;
 
     // Checks for memory conflicts in the instructions between childNode and parentNode, and returns true if childNode
     // can be contained.

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -85,7 +85,7 @@ private:
     void ContainCheckLclHeap(GenTreeOp* node);
     void ContainCheckRet(GenTreeUnOp* ret);
 #ifdef TARGET_ARM64
-    GenTree* TryLowerAndToCCMP(GenTree* tree);
+    GenTree* TryLowerAndToCCMP(GenTreeOp* tree);
     insCflags TruthifyingFlags(GenCondition cond);
     void ContainCheckConditionalCompare(GenTreeCCMP* ccmp);
     void ContainCheckNeg(GenTreeOp* neg);

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -86,7 +86,7 @@ private:
     void ContainCheckRet(GenTreeUnOp* ret);
 #ifdef TARGET_ARM64
     GenTree* TryLowerAndToCCMP(GenTree* tree);
-    insCflags FalsifyingFlags(GenCondition cond);
+    insCflags TruthifyingFlags(GenCondition cond);
     void ContainCheckConditionalCompare(GenTreeCCMP* ccmp);
     void ContainCheckNeg(GenTreeOp* neg);
 #endif

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -482,7 +482,11 @@ GenTree* Lowering::LowerBinaryArithmetic(GenTreeOp* binOp)
 #ifdef TARGET_ARM64
         else
         {
-            ContainCheckCompareChainForAnd(binOp);
+            GenTree* next = TryLowerAndToCCMP(binOp);
+            if (next != nullptr)
+            {
+                return next;
+            }
         }
 #endif
     }
@@ -2266,156 +2270,105 @@ void Lowering::ContainCheckCompare(GenTreeOp* cmp)
 
 #ifdef TARGET_ARM64
 //------------------------------------------------------------------------
-// IsValidCompareChain : Determine if the node contains a valid chain of ANDs and CMPs.
-//
-// Arguments:
-//    child - pointer to the node being checked.
-//    parent - parent node of the child.
-//
-// Return value:
-//    True if a valid chain is found.
-//
-// Notes:
-//    A compare chain is a sequence of CMP nodes connected by AND nodes.
-//    For example:   AND (AND (CMP A B) (CMP C D)) (CMP E F)
-//    The chain can just be a single compare node, however it's parent
-//    must always be an AND or SELECT node.
-//    If a CMP or AND node is contained then it and all it's children are
-//    considered to be in a valid chain.
-//    Chains are built up during the lowering of each successive parent.
-//
-bool Lowering::IsValidCompareChain(GenTree* child, GenTree* parent)
-{
-    assert(parent->OperIs(GT_AND) || parent->OperIs(GT_SELECT));
-
-    if (parent->isContainedCompareChainSegment(child))
-    {
-        // Already have a chain.
-        return true;
-    }
-    else if (child->OperIs(GT_AND))
-    {
-        // Count both sides.
-        return IsValidCompareChain(child->AsOp()->gtGetOp2(), child) &&
-               IsValidCompareChain(child->AsOp()->gtGetOp1(), child);
-    }
-    else if (child->OperIsCmpCompare() && varTypeIsIntegral(child->gtGetOp1()) && varTypeIsIntegral(child->gtGetOp2()))
-    {
-        // Can the child compare be contained.
-        return IsInvariantInRange(child, parent);
-    }
-
-    return false;
-}
-
-//------------------------------------------------------------------------
-// ContainCheckCompareChain : Determine if a chain of ANDs and CMPs can be contained.
-//
-// Arguments:
-//    child - pointer to the node being checked.
-//    parent - parent node of the child.
-//    startOfChain - If found, returns the earliest valid op in the chain.
-//
-// Return value:
-//    True if a valid chain is was contained.
-//
-// Notes:
-//    Assumes the chain was checked via IsValidCompareChain.
-//
-bool Lowering::ContainCheckCompareChain(GenTree* child, GenTree* parent, GenTree** startOfChain)
-{
-    assert(parent->OperIs(GT_AND) || parent->OperIs(GT_SELECT));
-    *startOfChain = nullptr; // Nothing found yet.
-
-    if (parent->isContainedCompareChainSegment(child))
-    {
-        // Already have a contained chain.
-        return true;
-    }
-    // Can the child be contained.
-    else if (IsInvariantInRange(child, parent))
-    {
-        if (child->OperIs(GT_AND))
-        {
-            // If Op2 is not contained, then try to contain it.
-            if (!child->isContainedCompareChainSegment(child->AsOp()->gtGetOp2()))
-            {
-                if (!ContainCheckCompareChain(child->gtGetOp2(), child, startOfChain))
-                {
-                    // Op2 must be contained in order to contain Op1 or the AND.
-                    return false;
-                }
-            }
-
-            // If Op1 is not contained, then try to contain it.
-            if (!child->isContainedCompareChainSegment(child->AsOp()->gtGetOp1()))
-            {
-                if (!ContainCheckCompareChain(child->gtGetOp1(), child, startOfChain))
-                {
-                    return false;
-                }
-            }
-
-            // Contain the AND.
-            child->SetContained();
-            return true;
-        }
-        else if (child->OperIsCmpCompare())
-        {
-            child->AsOp()->SetContained();
-
-            // Ensure the children of the compare are contained correctly.
-            child->AsOp()->gtGetOp1()->ClearContained();
-            child->AsOp()->gtGetOp2()->ClearContained();
-            ContainCheckConditionalCompare(child->AsOp());
-            *startOfChain = child;
-            return true;
-        }
-    }
-
-    return false;
-}
-
-//------------------------------------------------------------------------
-// ContainCheckCompareChainForAnd : Determine if an AND is a containable chain
+// TryLowerAndToCCMP : Lower an and of two conditions into test + CCMP + SETCC nodes.
 //
 // Arguments:
 //    node - pointer to the node
 //
-void Lowering::ContainCheckCompareChainForAnd(GenTree* tree)
+GenTree* Lowering::TryLowerAndToCCMP(GenTree* tree)
 {
     assert(tree->OperIs(GT_AND));
 
     if (!comp->opts.OptimizationEnabled())
     {
-        return;
+        return nullptr;
     }
 
-    // First check there is a valid chain.
-    if (IsValidCompareChain(tree->AsOp()->gtGetOp2(), tree) && IsValidCompareChain(tree->AsOp()->gtGetOp1(), tree))
+    GenTree* op1 = tree->gtGetOp1();
+    GenTree* op2 = tree->gtGetOp2();
+
+    if (!op1->OperIsCompare() && !op1->OperIs(GT_SETCC))
     {
-        GenTree* startOfChain = nullptr;
+        return nullptr;
+    }
 
-        // To ensure ordering at code generation, Op1 and the parent can
-        // only be contained if Op2 is contained.
-        if (ContainCheckCompareChain(tree->AsOp()->gtGetOp2(), tree, &startOfChain))
-        {
-            if (ContainCheckCompareChain(tree->AsOp()->gtGetOp1(), tree, &startOfChain))
-            {
-                // If op1 is the start of a chain, then it'll be generated as a standard compare.
-                if (startOfChain != nullptr)
-                {
-                    // The earliest node in the chain will be generated as a standard compare.
-                    assert(startOfChain->OperIsCmpCompare());
-                    startOfChain->AsOp()->gtGetOp1()->ClearContained();
-                    startOfChain->AsOp()->gtGetOp2()->ClearContained();
-                    ContainCheckCompare(startOfChain->AsOp());
-                }
-            }
-        }
+    if (!op2->OperIsCmpCompare() || !varTypeIsIntegral(op2->gtGetOp1()))
+    {
+        return nullptr;
+    }
 
-        JITDUMP("Lowered `AND` chain:\n");
-        DISPTREE(tree);
+    // We leave checking invariance of op1 to tree to TryLowerConditionToFlagsNode.
+    if (!IsInvariantInRange(op2, tree))
+    {
+        return nullptr;
+    }
+
+    GenCondition cond1;
+    if (!TryLowerConditionToFlagsNode(tree, op1, &cond1))
+    {
+        return nullptr;
+    }
+
+    BlockRange().Remove(op2);
+    BlockRange().InsertBefore(tree, op2);
+
+    GenCondition cond2 = GenCondition::FromRelop(op2);
+    op2->SetOper(GT_CCMP);
+    op2->gtType = TYP_VOID;
+    op2->gtFlags |= GTF_SET_FLAGS;
+
+    op2->gtGetOp1()->ClearContained();
+    op2->gtGetOp2()->ClearContained();
+
+    GenTreeCCMP* ccmp = op2->AsCCMP();
+    ccmp->gtCondition = cond1;
+    // If the first comparison fails, set the condition flags to something that
+    // makes the second one fail.
+    ccmp->gtFlagsVal = FalsifyingFlags(cond2);
+    ContainCheckConditionalCompare(ccmp);
+
+    tree->SetOper(GT_SETCC);
+    tree->AsCC()->gtCondition = cond2;
+
+    return tree->gtNext;
+}
+
+//------------------------------------------------------------------------
+// FalsifyingFlags: Get a flags immediate that falsifies a specified condition.
+//
+// Arguments:
+//    condition - the condition to falsify.
+//
+// Returns:
+//    A flags immediate that makes the specified condition false.
+//
+insCflags Lowering::FalsifyingFlags(GenCondition condition)
+{
+    switch (condition.GetCode())
+    {
+        case GenCondition::EQ:
+            return INS_FLAGS_NONE;
+        case GenCondition::NE:
+            return INS_FLAGS_Z;
+        case GenCondition::SGE:
+            return INS_FLAGS_N;
+        case GenCondition::SGT:
+            return INS_FLAGS_Z;
+        case GenCondition::SLT:
+            return INS_FLAGS_N;
+        case GenCondition::SLE:
+            return INS_FLAGS_NONE;
+        case GenCondition::UGE:
+            return INS_FLAGS_NONE;
+        case GenCondition::UGT:
+            return INS_FLAGS_NONE;
+        case GenCondition::ULT:
+            return INS_FLAGS_C;
+        case GenCondition::ULE:
+            return INS_FLAGS_C;
+        default:
+            NO_WAY("unexpected condition type");
+            return INS_FLAGS_NONE;
     }
 }
 
@@ -2425,9 +2378,8 @@ void Lowering::ContainCheckCompareChainForAnd(GenTree* tree)
 // Arguments:
 //    node - pointer to the node
 //
-void Lowering::ContainCheckConditionalCompare(GenTreeOp* cmp)
+void Lowering::ContainCheckConditionalCompare(GenTreeCCMP* cmp)
 {
-    assert(cmp->OperIsCmpCompare());
     GenTree* op2 = cmp->gtOp2;
 
     if (op2->IsCnsIntOrI() && !op2->AsIntCon()->ImmedValNeedsReloc(comp))
@@ -2454,38 +2406,8 @@ void Lowering::ContainCheckSelect(GenTreeOp* node)
 #ifdef TARGET_ARM
     noway_assert(!"GT_SELECT nodes are not supported on arm32");
 #else
-    if (!comp->opts.OptimizationEnabled())
-    {
-        return;
-    }
-
-    GenTree* cond = node->AsConditional()->gtCond;
-    GenTree* op1  = node->gtOp1;
-    GenTree* op2  = node->gtOp2;
-
-    if (cond->OperIsCompare())
-    {
-        // All compare node types (including TEST_) are containable.
-        if (IsInvariantInRange(cond, node))
-        {
-            cond->AsOp()->SetContained();
-        }
-    }
-    else
-    {
-        // Check for a compare chain and try to contain it.
-        GenTree* startOfChain = nullptr;
-        ContainCheckCompareChain(cond, node, &startOfChain);
-
-        if (startOfChain != nullptr)
-        {
-            // The earliest node in the chain will be generated as a standard compare.
-            assert(startOfChain->OperIsCmpCompare());
-            startOfChain->AsOp()->gtGetOp1()->ClearContained();
-            startOfChain->AsOp()->gtGetOp2()->ClearContained();
-            ContainCheckCompare(startOfChain->AsOp());
-        }
-    }
+    GenTree* op1 = node->gtOp1;
+    GenTree* op2 = node->gtOp2;
 
     if (op1->IsIntegralConst(0))
     {

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -2324,7 +2324,7 @@ GenTree* Lowering::TryLowerAndToCCMP(GenTree* tree)
     ccmp->gtCondition = cond1;
     // If the first comparison fails, set the condition flags to something that
     // makes the second one fail.
-    ccmp->gtFlagsVal = FalsifyingFlags(cond2);
+    ccmp->gtFlagsVal = TruthifyingFlags(GenCondition::Reverse(cond2));
     ContainCheckConditionalCompare(ccmp);
 
     tree->SetOper(GT_SETCC);
@@ -2334,38 +2334,38 @@ GenTree* Lowering::TryLowerAndToCCMP(GenTree* tree)
 }
 
 //------------------------------------------------------------------------
-// FalsifyingFlags: Get a flags immediate that falsifies a specified condition.
+// TruthifyingFlags: Get a flags immediate that will make a specified condition true.
 //
 // Arguments:
-//    condition - the condition to falsify.
+//    condition - the condition.
 //
 // Returns:
-//    A flags immediate that makes the specified condition false.
+//    A flags immediate that, if those flags were set, would cause the specified condition to be true.
 //
-insCflags Lowering::FalsifyingFlags(GenCondition condition)
+insCflags Lowering::TruthifyingFlags(GenCondition condition)
 {
     switch (condition.GetCode())
     {
         case GenCondition::EQ:
-            return INS_FLAGS_NONE;
+            return INS_FLAGS_Z;
         case GenCondition::NE:
-            return INS_FLAGS_Z;
+            return INS_FLAGS_NONE;
         case GenCondition::SGE:
-            return INS_FLAGS_N;
-        case GenCondition::SGT:
             return INS_FLAGS_Z;
+        case GenCondition::SGT:
+            return INS_FLAGS_NONE;
         case GenCondition::SLT:
-            return INS_FLAGS_N;
+            return INS_FLAGS_NC;
         case GenCondition::SLE:
-            return INS_FLAGS_NONE;
+            return INS_FLAGS_NZC;
         case GenCondition::UGE:
-            return INS_FLAGS_NONE;
+            return INS_FLAGS_C;
         case GenCondition::UGT:
-            return INS_FLAGS_NONE;
+            return INS_FLAGS_C;
         case GenCondition::ULT:
-            return INS_FLAGS_C;
+            return INS_FLAGS_NONE;
         case GenCondition::ULE:
-            return INS_FLAGS_C;
+            return INS_FLAGS_Z;
         default:
             NO_WAY("unexpected condition type");
             return INS_FLAGS_NONE;

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -403,6 +403,7 @@ int LinearScan::BuildNode(GenTree* tree)
         case GT_TEST_NE:
         case GT_CMP:
         case GT_TEST:
+        case GT_CCMP:
         case GT_JCMP:
             srcCount = BuildCmp(tree);
             break;
@@ -771,6 +772,10 @@ int LinearScan::BuildNode(GenTree* tree)
         case GT_SELECT:
             assert(dstCount == 1);
             srcCount = BuildSelect(tree->AsConditional());
+            break;
+        case GT_SELECTCC:
+            assert(dstCount == 1);
+            srcCount = BuildSelect(tree->AsOp());
             break;
 
     } // end switch (tree->OperGet())

--- a/src/coreclr/jit/lsraarmarch.cpp
+++ b/src/coreclr/jit/lsraarmarch.cpp
@@ -833,9 +833,14 @@ int LinearScan::BuildCast(GenTreeCast* cast)
 //
 int LinearScan::BuildSelect(GenTreeOp* select)
 {
-    assert(select->OperIs(GT_SELECT));
+    assert(select->OperIs(GT_SELECT, GT_SELECTCC));
 
-    int srcCount = BuildOperandUses(select->AsConditional()->gtCond);
+    int srcCount = 0;
+    if (select->OperIs(GT_SELECT))
+    {
+        srcCount += BuildOperandUses(select->AsConditional()->gtCond);
+    }
+
     srcCount += BuildOperandUses(select->gtOp1);
     srcCount += BuildOperandUses(select->gtOp2);
     BuildDef(select);

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -4108,8 +4108,10 @@ int LinearScan::BuildGCWriteBarrier(GenTree* tree)
 //
 int LinearScan::BuildCmp(GenTree* tree)
 {
-#ifdef TARGET_XARCH
+#if defined(TARGET_XARCH)
     assert(tree->OperIsCompare() || tree->OperIs(GT_CMP, GT_TEST, GT_JCMP, GT_BT));
+#elif defined(TARGET_ARM64)
+    assert(tree->OperIsCompare() || tree->OperIs(GT_CMP, GT_TEST, GT_JCMP, GT_CCMP));
 #else
     assert(tree->OperIsCompare() || tree->OperIs(GT_CMP, GT_TEST, GT_JCMP));
 #endif


### PR DESCRIPTION
This unifies GT_SELECT/GT_SELECTCC handling between arm64 and x64. The arm64 backend no longer uses containment for compare chains; instead, there is a new GT_CCMP node that both produces and consumes flags, and lowering can lower GT_AND(op, relop) down to this node.
To do this, the JIT verifies invariance and reorders the `cmp/ccmps` to happen successively in order. For example, given C# code like:
```csharp
[MethodImpl(MethodImplOptions.NoInlining)]
public static int Foo(int a, int b, int c)
{
    if (a < b & b < c & c < 10)
        return 42;

    return 13;
}
```

we see LIR:
```scala
N001 (  1,  1) [000000] -----------                    t0 =    LCL_VAR   int    V00 arg0         u:1 (last use) $80
N002 (  1,  1) [000001] -----------                    t1 =    LCL_VAR   int    V01 arg1         u:1 $81
                                                            ┌──▌  t0     int    
                                                            ├──▌  t1     int    
N003 (  6,  3) [000002] -----------                    t2 = ▌  LT        int    $100
N004 (  1,  1) [000003] -----------                    t3 =    LCL_VAR   int    V01 arg1         u:1 (last use) $81
N005 (  1,  1) [000004] -----------                    t4 =    LCL_VAR   int    V02 arg2         u:1 $82
                                                            ┌──▌  t3     int    
                                                            ├──▌  t4     int    
N006 (  6,  3) [000005] -----------                    t5 = ▌  LT        int    $101
                                                            ┌──▌  t2     int    
                                                            ├──▌  t5     int    
N007 ( 13,  7) [000006] -----------                    t6 = ▌  AND       int    $102
N008 (  1,  1) [000007] -----------                    t7 =    LCL_VAR   int    V02 arg2         u:1 (last use) $82
N009 (  1,  2) [000008] -----------                    t8 =    CNS_INT   int    10 $44
                                                            ┌──▌  t7     int    
                                                            ├──▌  t8     int    
N010 (  6,  4) [000009] -----------                    t9 = ▌  LT        int    $103
                                                            ┌──▌  t6     int    
                                                            ├──▌  t9     int    
N011 ( 20, 12) [000010] -----------                   t10 = ▌  AND       int    $104
N012 (  1,  2) [000011] -----------                   t11 =    CNS_INT   int    0 $40
                                                            ┌──▌  t10    int    
                                                            ├──▌  t11    int    
N013 ( 22, 15) [000012] J------N---                   t12 = ▌  EQ        int    $105
N014 (  1,  2) [000014] -----------                   t14 =    CNS_INT   int    13 $45
N015 (  1,  2) [000016] -----------                   t16 =    CNS_INT   int    42 $46
                                                            ┌──▌  t12    int    
                                                            ├──▌  t14    int    
                                                            ├──▌  t16    int    
N016 ( 25, 20) [000018] -----------                   t18 = ▌  SELECT    int   
                                                            ┌──▌  t18    int    
N017 ( 26, 21) [000017] -----------                         ▌  RETURN    int    $VN.Void
```

When lowering the first `AND` (`[000006]`), we will notice that its operands are compares, and lower this as:
```diff
 N001 (  1,  1) [000000] -----------                    t0 =    LCL_VAR   int    V00 arg0         u:1 (last use) $80
 N002 (  1,  1) [000001] -----------                    t1 =    LCL_VAR   int    V01 arg1         u:1 $81
-                                                            ┌──▌  t0     int    
-                                                            ├──▌  t1     int    
-N003 (  6,  3) [000002] -----------                    t2 = ▌  LT        int    $100
 N004 (  1,  1) [000003] -----------                    t3 =    LCL_VAR   int    V01 arg1         u:1 (last use) $81
 N005 (  1,  1) [000004] -----------                    t4 =    LCL_VAR   int    V02 arg2         u:1 $82
+                                                            ┌──▌  t0     int    
+                                                            ├──▌  t1     int    
+N003 (  6,  3) [000002] -----------                         ▌  CMP       void  
                                                             ┌──▌  t3     int    
                                                             ├──▌  t4     int    
-N006 (  6,  3) [000005] -----------                    t5 = ▌  LT        int    $101
-                                                            ┌──▌  t2     int    
-                                                            ├──▌  t5     int    
-N007 ( 13,  7) [000006] -----------                    t6 = ▌  AND       int    $102
+N006 (  6,  3) [000005] -----------                         ▌  CCMP      void   cond=SLT flags=z
+N007 ( 13,  7) [000006] -----------                    t6 =    SETCC     int    cond=SLT
 N008 (  1,  1) [000007] -----------                    t7 =    LCL_VAR   int    V02 arg2         u:1 (last use) $82
 N009 (  1,  2) [000008] -----------                    t8 =    CNS_INT   int    10 $44
                                                             ┌──▌  t7     int    

```

I.e. we moved the compare `[000002]` forward and turned it into a `CMP` node, and `[000005]` was then turned into a `CCMP` node.

When we see the second `AND` node (`[000010]`) we do the same thing again: verify invariance and move the entire compare chain forward:

```diff
 N001 (  1,  1) [000000] -----------                    t0 =    LCL_VAR   int
 N002 (  1,  1) [000001] -----------                    t1 =    LCL_VAR   int    V01 arg1         u:1 $81
 N004 (  1,  1) [000003] -----------                    t3 =    LCL_VAR   int    V01 arg1         u:1 (last use) $81
 N005 (  1,  1) [000004] -----------                    t4 =    LCL_VAR   int    V02 arg2         u:1 $82
+N008 (  1,  1) [000007] -----------                    t7 =    LCL_VAR   int    V02 arg2         u:1 (last use) $82
+N009 (  1,  2) [000008] -c---------                    t8 =    CNS_INT   int    10 $44
                                                             ┌──▌  t0     int    
                                                             ├──▌  t1     int    
 N003 (  6,  3) [000002] -----------                         ▌  CMP       void  
                                                             ┌──▌  t3     int    
                                                             ├──▌  t4     int    
 N006 (  6,  3) [000005] -----------                         ▌  CCMP      void   cond=SLT flags=z
-N007 ( 13,  7) [000006] -----------                    t6 =    SETCC     int    cond=SLT
-N008 (  1,  1) [000007] -----------                    t7 =    LCL_VAR   int    V02 arg2         u:1 (last use) $82
-N009 (  1,  2) [000008] -----------                    t8 =    CNS_INT   int    10 $44
                                                             ┌──▌  t7     int    
                                                             ├──▌  t8     int    
-N010 (  6,  4) [000009] -----------                    t9 = ▌  LT        int    $103
-                                                            ┌──▌  t6     int    
-                                                            ├──▌  t9     int    
-N011 ( 20, 12) [000010] -----------                   t10 = ▌  AND       int    $104
+N010 (  6,  4) [000009] -----------                         ▌  CCMP      void   cond=SLT flags=z
+N011 ( 20, 12) [000010] -----------                   t10 =    SETCC     int    cond=SLT
 N012 (  1,  2) [000011] -----------                   t11 =    CNS_INT   int    0 $40
                                                             ┌──▌  t10    int    
                                                             ├──▌  t11    int    
```

When we finally get to the `SELECT` we do the same thing -- move all the conditional compares in front of the `SELECT` and then change it to `SELECTCC`.

cc @a74nh