### PR TITLE
[release/7.0] [browser] fix asset counting after download retry

### DIFF
--- a/src/mono/sample/wasm/browser/Wasm.Browser.Sample.csproj
+++ b/src/mono/sample/wasm/browser/Wasm.Browser.Sample.csproj
@@ -14,5 +14,5 @@
   <PropertyGroup>
     <_SampleProject>Wasm.Browser.Sample.csproj</_SampleProject>
   </PropertyGroup>
-  <Target Name="RunSample" DependsOnTargets="RunSampleWithBrowser" />
+  <Target Name="RunSample" DependsOnTargets="RunSampleWithBrowserAndSimpleServer" />
 </Project>

--- a/src/mono/sample/wasm/browser/main.js
+++ b/src/mono/sample/wasm/browser/main.js
@@ -9,24 +9,26 @@ function sub(a, b) {
 }
 
 let testError = true;
-let testRetry = true;
+let testAbort = true;
 try {
     const { runtimeBuildInfo, setModuleImports, getAssemblyExports, runMain, getConfig } = await dotnet
         .withConsoleForwarding()
         .withElementOnExit()
         .withModuleConfig({
             configSrc: "./mono-config.json",
-            locateFile: (url) => {
-                // we are testing that we can retry loading of the assembly
-                if (testRetry && url.indexOf('System.Private.Uri.dll') != -1) {
-                    testRetry = false;
-                    return url + "?testAbort=true";
+            imports: {
+                fetch: (url, fetchArgs) => {
+                    // we are testing that we can retry loading of the assembly
+                    if (testAbort && url.indexOf('System.Private.Uri.dll') != -1) {
+                        testAbort = false;
+                        return fetch(url + "?testAbort=true", fetchArgs);
+                    }
+                    if (testError && url.indexOf('System.Console.dll') != -1) {
+                        testError = false;
+                        return fetch(url + "?testError=true", fetchArgs);
+                    }
+                    return fetch(url, fetchArgs);
                 }
-                if (testError && url.indexOf('System.Console.dll') != -1) {
-                    testError = false;
-                    return url + "?testError=true";
-                }
-                return url;
             },
             onConfigLoaded: (config) => {
                 // This is called during emscripten `dotnet.wasm` instantiation, after we fetched config.

--- a/src/mono/wasm/runtime/assets.ts
+++ b/src/mono/wasm/runtime/assets.ts
@@ -76,9 +76,11 @@ export async function mono_download_assets(): Promise<void> {
                     asset.pendingDownloadInternal = asset.pendingDownload;
                     const waitForExternalData: () => Promise<AssetWithBuffer> = async () => {
                         const response = await asset.pendingDownloadInternal!.response;
-                        ++actual_downloaded_assets_count;
                         if (!headersOnly) {
                             asset.buffer = await response.arrayBuffer();
+                            ++actual_downloaded_assets_count;
+                        } else {
+                            ++actual_downloaded_assets_count;
                         }
                         return { asset, buffer: asset.buffer };
                     };
@@ -121,6 +123,10 @@ export async function mono_download_assets(): Promise<void> {
                         }
                         if (!skipInstantiateByAssetTypes[asset.behavior]) {
                             expected_instantiated_assets_count--;
+                        }
+                    } else {
+                        if (skipBufferByAssetTypes[asset.behavior]) {
+                            ++actual_downloaded_assets_count;
                         }
                     }
                 }
@@ -197,7 +203,9 @@ async function start_asset_download_with_throttle(asset: AssetEntry, downloadDat
         if (!downloadData || !response) {
             return undefined;
         }
-        return await response.arrayBuffer();
+        const buffer = await response.arrayBuffer();
+        ++actual_downloaded_assets_count;
+        return buffer;
     }
     finally {
         --parallel_count;
@@ -226,7 +234,6 @@ async function start_asset_download_sources(asset: AssetEntryInternal): Promise<
                 }
             }) as any
         };
-        ++actual_downloaded_assets_count;
         return asset.pendingDownloadInternal.response;
     }
     if (asset.pendingDownloadInternal && asset.pendingDownloadInternal.response) {
@@ -262,7 +269,6 @@ async function start_asset_download_sources(asset: AssetEntryInternal): Promise<
             if (!response.ok) {
                 continue;// next source
             }
-            ++actual_downloaded_assets_count;
             return response;
         }
         catch (err) {
@@ -293,7 +299,7 @@ function resolve_path(asset: AssetEntry, sourcePrefix: string): string {
                     : asset.name;
             }
             else if (asset.behavior === "resource") {
-                const path = asset.culture !== "" ? `${asset.culture}/${asset.name}` : asset.name;
+                const path = asset.culture && asset.culture !== "" ? `${asset.culture}/${asset.name}` : asset.name;
                 attemptUrl = assemblyRootFolder
                     ? (assemblyRootFolder + "/" + path)
                     : path;
@@ -420,7 +426,7 @@ function _instantiate_asset(asset: AssetEntry, url: string, bytes: Uint8Array) {
             Module.printErr(`MONO_WASM: Error loading ICU asset ${asset.name}`);
     }
     else if (asset.behavior === "resource") {
-        cwraps.mono_wasm_add_satellite_assembly(virtualName, asset.culture!, offset!, bytes.length);
+        cwraps.mono_wasm_add_satellite_assembly(virtualName, asset.culture || "", offset!, bytes.length);
     }
     ++actual_instantiated_assets_count;
 }
@@ -429,10 +435,10 @@ export async function instantiate_wasm_asset(
     pendingAsset: AssetEntryInternal,
     wasmModuleImports: WebAssembly.Imports,
     successCallback: InstantiateWasmSuccessCallback,
-) {
-    mono_assert(pendingAsset && pendingAsset.pendingDownloadInternal, "Can't load dotnet.wasm");
+): Promise<void> {
+    mono_assert(pendingAsset && pendingAsset.pendingDownloadInternal && pendingAsset.pendingDownloadInternal.response, "Can't load dotnet.wasm");
     const response = await pendingAsset.pendingDownloadInternal.response;
-    const contentType = response.headers ? response.headers.get("Content-Type") : undefined;
+    const contentType = response.headers && response.headers.get ? response.headers.get("Content-Type") : undefined;
     let compiledInstance: WebAssembly.Instance;
     let compiledModule: WebAssembly.Module;
     if (typeof WebAssembly.instantiateStreaming === "function" && contentType === "application/wasm") {

--- a/src/mono/wasm/runtime/assets.ts
+++ b/src/mono/wasm/runtime/assets.ts
@@ -78,10 +78,8 @@ export async function mono_download_assets(): Promise<void> {
                         const response = await asset.pendingDownloadInternal!.response;
                         if (!headersOnly) {
                             asset.buffer = await response.arrayBuffer();
-                            ++actual_downloaded_assets_count;
-                        } else {
-                            ++actual_downloaded_assets_count;
                         }
+                        ++actual_downloaded_assets_count;
                         return { asset, buffer: asset.buffer };
                     };
                     promises_of_assets_with_buffer.push(waitForExternalData());


### PR DESCRIPTION
This is simplified version of the https://github.com/dotnet/runtime/pull/81886/files

Fixes https://github.com/dotnet/runtime/issues/82271

## Customer Impact
Internally detected problem on CI.

The issue is caused by counting download retry multiple times. 
Only when the retry is caused by download fail during `await response.arrayBuffer()` but after HTTP headers are already fetched.
That could be TCP failure and similar issues.


## Testing
Added sample code with test for aborted HTTP stream and HTTP code 500 as well.
Manual testing

## Risk
The download retry logic is complex.
This code path is relevant for WASM application which don’t use blazor (small audience).