### PR TITLE
Add cecil dependency to ILLink package

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -963,6 +963,7 @@ extends:
             condition: >-
               or(
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
 
       #

--- a/src/tools/illink/src/linker/Mono.Linker.csproj
+++ b/src/tools/illink/src/linker/Mono.Linker.csproj
@@ -41,7 +41,7 @@
       <PrivateAssets>all</PrivateAssets>
       <ExcludeAssets>contentfiles</ExcludeAssets> <!-- We include our own copy of the ClosedAttribute to work in source build -->
     </PackageReference>
-    <PackageReference Include="Microsoft.DotNet.Cecil" Version="$(MicrosoftDotNetCecilVersion)" PrivateAssets="All" Publish="True" />
+    <PackageReference Include="Microsoft.DotNet.Cecil" Version="$(MicrosoftDotNetCecilVersion)" Publish="True" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tools/illink/src/linker/ref/Mono.Linker.csproj
+++ b/src/tools/illink/src/linker/ref/Mono.Linker.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Cecil" Version="$(MicrosoftDotNetCecilVersion)" PrivateAssets="All" Publish="True" />
+    <PackageReference Include="Microsoft.DotNet.Cecil" Version="$(MicrosoftDotNetCecilVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/82597 by ensuring the Microsoft.DotNet.Cecil dependency shows up in the nuspec. Fixes https://github.com/dotnet/runtime/issues/82611.

The ref project changes aren't strictly necessary since that project isn't used for packaging, but I removed PrivateAssets there for consistency. I removed Publish there because it should never be published in a package from that project.

I think this wasn't caught in https://github.com/dotnet/runtime/pull/82407 because the package validation doesn't run as part of the clr.tools subset - we should fix that.