### PR TITLE
Disable adaptive loop alignment for known hot methods

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2454,6 +2454,12 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     opts.compJitUnrollLoopMaxIterationCount = DEFAULT_UNROLL_LOOP_MAX_ITERATION_COUNT;
 #endif
 
+    if (opts.compJitAlignLoopAdaptive && fgHaveSufficientProfileWeights())
+    {
+        JITDUMP("Disable adaptive loop alignment known hot methods")
+        opts.compJitAlignLoopAdaptive = false;
+    }
+
 #ifdef TARGET_XARCH
     if (opts.compJitAlignLoopAdaptive)
     {

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1538,7 +1538,7 @@ class SuperPMIReplayAsmDiffs:
 
         # These vars are force overridden in the SPMI runs for both the base and diff, always.
         replay_vars = {
-            "DOTNET_JitAlignLoops": "0", # disable loop alignment to filter noise
+            "DOTNET_JitAlignLoops": "1", # disable loop alignment to filter noise
             "DOTNET_JitEnableNoWayAssert": "1",
             "DOTNET_JitNoForceFallback": "1",
         }


### PR DESCRIPTION
Should fix perf problems like https://github.com/dotnet/runtime/issues/82442#issuecomment-1444073181

So for methods with sufficient PGO samples (currently it's 1000 invocations with static PGO) we might want to ignore size-aware heuristics and apply large paddings (e.g. 30 bytes) for loops. Let's see if this hits any diffs