### PR TITLE
[wasi] provision.ps1: stop on error

### DIFF
--- a/src/mono/wasi/provision.ps1
+++ b/src/mono/wasi/provision.ps1
@@ -9,6 +9,9 @@ param(
      [string]$WasiLocalPath
 )
 
+Set-StrictMode -version 2.0
+$ErrorActionPreference='Stop'
+
 New-Item -Path $WasiSdkPath -ItemType "directory"
 Invoke-WebRequest -Uri $WasiSdkUrl -OutFile ./wasi-sdk-$WasiSdkVersion.0-mingw.tar.gz
 tar --strip-components=1 -xzf ./wasi-sdk-$WasiSdkVersion.0-mingw.tar.gz -C $WasiSdkPath


### PR DESCRIPTION
Stops the script on the first error. For example, if the download fails then it won't continue to untar the non-existent file.

Related - https://github.com/dotnet/runtime/issues/82627