### PR TITLE
Add runtime file version to RuntimeInfo

### DIFF
--- a/src/coreclr/debug/inc/runtimeinfo.h
+++ b/src/coreclr/debug/inc/runtimeinfo.h
@@ -5,7 +5,8 @@
 
 // The first byte of the index is the count of bytes
 typedef unsigned char SYMBOL_INDEX;
-#define RUNTIME_INFO_SIGNATURE "DotNetRuntimeInfo"
+#define RUNTIME_INFO_SIGNATURE  "DotNetRuntimeInfo"
+#define RUNTIME_INFO_VERSION    2
 
 // Make sure that if you update this structure
 //    - You do so in a in a way that it is backwards compatible. For example, only tail append to this.
@@ -14,10 +15,11 @@ typedef unsigned char SYMBOL_INDEX;
 typedef struct _RuntimeInfo
 {
     const char Signature[18];
-    int Version;
+    const int Version;
     const SYMBOL_INDEX RuntimeModuleIndex[24];
     const SYMBOL_INDEX DacModuleIndex[24];
     const SYMBOL_INDEX DbiModuleIndex[24];
+    const int RuntimeVersion[4];                // major, minor, build, revision
 } RuntimeInfo;
 
 extern RuntimeInfo DotNetRuntimeInfo;

--- a/src/coreclr/debug/runtimeinfo/runtimeinfo.cpp
+++ b/src/coreclr/debug/runtimeinfo/runtimeinfo.cpp
@@ -10,6 +10,7 @@
 
 #include <windows.h>
 #include <runtimeinfo.h>
+#include <runtime_version.h>
 
 // Runtime information public export
 #ifdef HOST_UNIX
@@ -19,7 +20,7 @@ RuntimeInfo DotNetRuntimeInfo = {
     {
         RUNTIME_INFO_SIGNATURE
     },
-    1,
+    RUNTIME_INFO_VERSION,
     {
         #include <runtimemoduleindex.h>
     },
@@ -28,5 +29,8 @@ RuntimeInfo DotNetRuntimeInfo = {
     },
     {
         #include <dbimoduleindex.h>
+    },
+    {
+        RuntimeFileMajorVersion, RuntimeFileMinorVersion, RuntimeFileBuildVersion, RuntimeFileRevisionVersion
     },
 };


### PR DESCRIPTION
The diagnostic tooling needs the runtime file version for single-file applications to:

1) Build the long name DAC on Windows
2) SOS commands and other tooling need the version to adjust for different runtime behavior

/cc: @leculver 