### PR TITLE
Add CA 2021 into CodeAnalysis config

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -516,6 +516,9 @@ dotnet_diagnostic.CA2019.severity = warning
 # CA2020: Prevent behavioral changes
 dotnet_diagnostic.CA2020.severity = warning
 
+# CA2021: Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+dotnet_diagnostic.CA2021.severity = warning
+
 # CA2100: Review SQL queries for security vulnerabilities
 dotnet_diagnostic.CA2100.severity = none
 

--- a/eng/CodeAnalysis.test.globalconfig
+++ b/eng/CodeAnalysis.test.globalconfig
@@ -513,6 +513,9 @@ dotnet_diagnostic.CA2019.severity = none
 # CA2020: Prevent behavioral changes
 dotnet_diagnostic.CA2020.severity = none
 
+# CA2021: Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+dotnet_diagnostic.CA2021.severity = none
+
 # CA2100: Review SQL queries for security vulnerabilities
 dotnet_diagnostic.CA2100.severity = none
 


### PR DESCRIPTION
CA2021: `Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types` is a new analyzer that [added in January](https://github.com/dotnet/roslyn-analyzers/pull/4328). 

Because it is `Warns` by default it caused build failure [on automation PR that updates analyzer feed](https://github.com/dotnet/runtime/pull/80916)  which caused by [some edge case scenario bug](https://github.com/dotnet/roslyn-analyzers/issues/6457). 

Because the bug could cause a failure in other repos we [lowered the severity of the analyzer](https://github.com/dotnet/roslyn-analyzers/pull/6456) until those bugs get fixed. Now [the fix is ready](https://github.com/dotnet/roslyn-analyzers/pull/6459) for merge which also upgrades the severity into `Warning` back, we need to turn off the analyzer on test projects before merge because it would cause a warning for valid scenarios like: https://github.com/dotnet/runtime/blob/319fcd901db843b06f496ef4af155149c94037b1/src/libraries/System.Linq/tests/CastTests.cs#L31 and https://github.com/dotnet/runtime/blob/319fcd901db843b06f496ef4af155149c94037b1/src/libraries/System.Linq/tests/OfTypeTests.cs#L42-L43