### PR TITLE
Update SDK to preview 1

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "8.0.100-alpha.1.23061.8",
+    "version": "8.0.100-preview.1.23115.2",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "8.0.100-alpha.1.23061.8"
+    "dotnet": "8.0.100-preview.1.23115.2"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23120.1",


### PR DESCRIPTION
Fixes #82583

The slowdowns was being caused by a crash in VBCSCompiler. The process was resilient
to these crashes, but the cached state gets destroyed and the slowness was a
symptom. The crash was when trying to destroy thread statics of dynamic classes
on a collectible module for a thread destroy path. To do this, it checks all
the dynamic entries in the TLM and frees both GC and non-GC statics. The SDK
currently being used doesn't contain #80822 which 0-initializes the entry. 
Without this, we try to free a static that doesn't exist and we crash.