### PR TITLE
move fence to the right place

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -16826,7 +16826,8 @@ found_fit:
     // (see also: object.cpp/Object::ValidateInner)
     // Make sure it will see cleaned up state to prevent triggering occasional verification failures.
     // And make sure the write happens before updating "allocated"
-    VolatileStore(((void**)allocated - 1), (void*)0);     //clear the sync block
+    ((void**)allocated)[-1] = 0;    // clear the sync block
+    VOLATILE_MEMORY_BARRIER();
 #endif //VERIFY_HEAP && _DEBUG
 
     uint8_t* old_alloc;


### PR DESCRIPTION
fixes #82414

we need to make sure the clearing of the syncblock and the increase of the alloc_allocated not reordered. the comment had the right idea but the implementation was incorrect. the fence should be between these 2 operations, not before the 1st one. 