### PR TITLE
Support WindowStyle without UseShellExecute

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ProcessOptions.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ProcessOptions.cs
@@ -39,6 +39,7 @@ internal static partial class Interop
 
         internal static partial class StartupInfoOptions
         {
+            internal const int STARTF_USESHOWWINDOW = 0x00000001;
             internal const int STARTF_USESTDHANDLES = 0x00000100;
             internal const int CREATE_UNICODE_ENVIRONMENT = 0x00000400;
             internal const int CREATE_NO_WINDOW = 0x08000000;

--- a/src/libraries/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/libraries/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -266,9 +266,6 @@
   <data name="RemoteMachinesNotSupported" xml:space="preserve">
     <value>Access to processes on remote machines is not supported on this platform.</value>
   </data>
-  <data name="CantSetWindowStyleWithCreateNoWindow" xml:space="preserve">
-    <value>ProcessStartInfo.WindowStyle that is not Normal and ProcessStartInfo.CreateNoWindow cannot both be set. Use only one of them.</value>
-  </data>
   <data name="CantSetDuplicatePassword" xml:space="preserve">
     <value>ProcessStartInfo.Password and ProcessStartInfo.PasswordInClearText cannot both be set. Use only one of them.</value>
   </data>

--- a/src/libraries/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/libraries/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -266,6 +266,9 @@
   <data name="RemoteMachinesNotSupported" xml:space="preserve">
     <value>Access to processes on remote machines is not supported on this platform.</value>
   </data>
+  <data name="CantSetWindowStyleWithCreateNoWindow" xml:space="preserve">
+    <value>ProcessStartInfo.WindowStyle that is not Normal and ProcessStartInfo.CreateNoWindow cannot both be set. Use only one of them.</value>
+  </data>
   <data name="CantSetDuplicatePassword" xml:space="preserve">
     <value>ProcessStartInfo.Password and ProcessStartInfo.PasswordInClearText cannot both be set. Use only one of them.</value>
   </data>

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Win32.cs
@@ -69,13 +69,7 @@ namespace System.Diagnostics
                 else
                     shellExecuteInfo.fMask |= Interop.Shell32.SEE_MASK_FLAG_NO_UI;
 
-                shellExecuteInfo.nShow = startInfo.WindowStyle switch
-                {
-                    ProcessWindowStyle.Hidden => Interop.Shell32.SW_HIDE,
-                    ProcessWindowStyle.Minimized => Interop.Shell32.SW_SHOWMINIMIZED,
-                    ProcessWindowStyle.Maximized => Interop.Shell32.SW_SHOWMAXIMIZED,
-                    _ => Interop.Shell32.SW_SHOWNORMAL,
-                };
+                shellExecuteInfo.nShow = GetShowWindowFromWindowStyle(startInfo.WindowStyle);
                 ShellExecuteHelper executeHelper = new ShellExecuteHelper(&shellExecuteInfo);
                 if (!executeHelper.ShellExecuteOnSTAThread())
                 {
@@ -108,6 +102,14 @@ namespace System.Diagnostics
 
             return false;
         }
+
+        private static int GetShowWindowFromWindowStyle(ProcessWindowStyle windowStyle) => windowStyle switch
+        {
+            ProcessWindowStyle.Hidden => Interop.Shell32.SW_HIDE,
+            ProcessWindowStyle.Minimized => Interop.Shell32.SW_SHOWMINIMIZED,
+            ProcessWindowStyle.Maximized => Interop.Shell32.SW_SHOWMAXIMIZED,
+            _ => Interop.Shell32.SW_SHOWNORMAL,
+        };
 
         private static int GetShellError(IntPtr error)
         {

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -495,6 +495,22 @@ namespace System.Diagnostics
                         startupInfo.dwFlags = Interop.Advapi32.StartupInfoOptions.STARTF_USESTDHANDLES;
                     }
 
+                    if (startInfo.WindowStyle != ProcessWindowStyle.Normal)
+                    {
+                        if (startInfo.CreateNoWindow)
+                        {
+                            throw new ArgumentException(SR.CantSetWindowStyleWithCreateNoWindow);
+                        }
+
+                        startupInfo.wShowWindow = startInfo.WindowStyle switch
+                        {
+                            ProcessWindowStyle.Minimized => (short)Interop.Shell32.SW_SHOWMINIMIZED,
+                            ProcessWindowStyle.Maximized => (short)Interop.Shell32.SW_SHOWMAXIMIZED,
+                            _ => (short)Interop.Shell32.SW_HIDE,
+                        };
+                        startupInfo.dwFlags |= Interop.Advapi32.StartupInfoOptions.STARTF_USESHOWWINDOW;
+                    }
+
                     // set up the creation flags parameter
                     int creationFlags = 0;
                     if (startInfo.CreateNoWindow) creationFlags |= Interop.Advapi32.StartupInfoOptions.CREATE_NO_WINDOW;

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -497,11 +497,6 @@ namespace System.Diagnostics
 
                     if (startInfo.WindowStyle != ProcessWindowStyle.Normal)
                     {
-                        if (startInfo.CreateNoWindow)
-                        {
-                            throw new ArgumentException(SR.CantSetWindowStyleWithCreateNoWindow);
-                        }
-
                         startupInfo.wShowWindow = startInfo.WindowStyle switch
                         {
                             ProcessWindowStyle.Minimized => (short)Interop.Shell32.SW_SHOWMINIMIZED,

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -497,12 +497,7 @@ namespace System.Diagnostics
 
                     if (startInfo.WindowStyle != ProcessWindowStyle.Normal)
                     {
-                        startupInfo.wShowWindow = startInfo.WindowStyle switch
-                        {
-                            ProcessWindowStyle.Minimized => (short)Interop.Shell32.SW_SHOWMINIMIZED,
-                            ProcessWindowStyle.Maximized => (short)Interop.Shell32.SW_SHOWMAXIMIZED,
-                            _ => (short)Interop.Shell32.SW_HIDE,
-                        };
+                        startupInfo.wShowWindow = (short)GetShowWindowFromWindowStyle(startInfo.WindowStyle);
                         startupInfo.dwFlags |= Interop.Advapi32.StartupInfoOptions.STARTF_USESHOWWINDOW;
                     }
 

--- a/src/libraries/System.Diagnostics.Process/tests/Interop.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/Interop.cs
@@ -24,6 +24,29 @@ internal static partial class Interop
     }
 
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct STARTUPINFO
+    {
+        public int cb;
+        public IntPtr lpReserved;
+        public IntPtr lpDesktop;
+        public IntPtr lpTitle;
+        public int dwX;
+        public int dwY;
+        public int dwXSize;
+        public int dwYSize;
+        public int dwXCountChars;
+        public int dwYCountChars;
+        public int dwFillAttribute;
+        public int dwFlags;
+        public short wShowWindow;
+        public short cbReserved2;
+        public IntPtr lpReserved2;
+        public IntPtr hStdInput;
+        public IntPtr hStdOutput;
+        public IntPtr hStdError;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     internal struct USER_INFO_1
     {
         public string usri1_name;
@@ -57,6 +80,9 @@ internal static partial class Interop
 
     [DllImport("kernel32.dll")]
     public static extern int GetProcessId(SafeProcessHandle nativeHandle);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+    public static extern void GetStartupInfoW(out STARTUPINFO lpStartupInfo);
 
     [DllImport("kernel32.dll")]
     internal static extern int GetConsoleCP();

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.Windows.cs
@@ -110,16 +110,5 @@ namespace System.Diagnostics.Tests
             Assert.True(p.WaitForExit(WaitInMS));
             Assert.Equal(RemoteExecutor.SuccessExitCode, p.ExitCode);
         }
-
-        [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        public void TestUseCreateNoWindowAndWindowStyle_NotSupported()
-        {
-            Process p = CreateProcessLong();
-            p.StartInfo.CreateNoWindow  = true;
-            p.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
-
-            Assert.Throws<ArgumentException>(() => p.Start());
-        }
     }
 }

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.Windows.cs
@@ -69,7 +69,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [ConditionalTheory(nameof(IsAdmin_IsNotNano_RemoteExecutorIsSupported))]
         [PlatformSpecific(TestPlatforms.Windows)]
         [InlineData(ProcessWindowStyle.Normal, true)]
         [InlineData(ProcessWindowStyle.Normal, false)]


### PR DESCRIPTION
Supports specifying a custom ProcessStartInfo.WindowStyle without having to use UseShellExecute.

Fix #81681