### PR TITLE
pal_console.c: cast TIOCSWINSZ to int when `HAVE_IOCTL_WITH_INT_REQUEST`

### DIFF
--- a/src/native/libs/System.Native/pal_console.c
+++ b/src/native/libs/System.Native/pal_console.c
@@ -43,7 +43,9 @@ int32_t SystemNative_SetWindowSize(WinSize* windowSize)
 {
     assert(windowSize != NULL);
 
-#if HAVE_IOCTL && HAVE_TIOCSWINSZ
+#if HAVE_IOCTL_WITH_INT_REQUEST && HAVE_TIOCSWINSZ
+    return ioctl(STDOUT_FILENO, (int)TIOCSWINSZ, windowSize);
+#elif HAVE_IOCTL && HAVE_TIOCSWINSZ
     return ioctl(STDOUT_FILENO, TIOCSWINSZ, windowSize);
 #else
     // Not supported on e.g. Android. Also, prevent a compiler error because windowSize is unused


### PR DESCRIPTION
Adds missing cast to int when `HAVE_IOCTL_WITH_INT_REQUEST`

Related to https://github.com/dotnet/runtime/pull/82173

Per @am11:
```
On some Unix-likes, such as linux with musl-libc and illumos, the second argument of ioctl is
int request instead of unsigned long request.
```

/cc: @Sapana-Khemkar 