### PR TITLE
Add stub for mini_is_gsharedvt_inst

### DIFF
--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -4530,10 +4530,8 @@ mono_aot_can_dedup (MonoMethod *method)
 		!mini_is_gsharedvt_signature (mono_method_signature_internal (method)) &&
 		!mini_is_gsharedvt_klass (method->klass)) {
 		MonoGenericContext *context = mono_method_get_context (method);
-#ifdef MONO_ARCH_GSHAREDVT_SUPPORTED
 		if (context->method_inst && mini_is_gsharedvt_inst (context->method_inst))
 			return FALSE;
-#endif
 		/* No point in dedup-ing private instances */
 		if ((context->class_inst && inst_is_private (context->class_inst)) ||
 			(context->method_inst && inst_is_private (context->method_inst)))

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -4530,8 +4530,10 @@ mono_aot_can_dedup (MonoMethod *method)
 		!mini_is_gsharedvt_signature (mono_method_signature_internal (method)) &&
 		!mini_is_gsharedvt_klass (method->klass)) {
 		MonoGenericContext *context = mono_method_get_context (method);
+#ifdef MONO_ARCH_GSHAREDVT_SUPPORTED
 		if (context->method_inst && mini_is_gsharedvt_inst (context->method_inst))
 			return FALSE;
+#endif
 		/* No point in dedup-ing private instances */
 		if ((context->class_inst && inst_is_private (context->class_inst)) ||
 			(context->method_inst && inst_is_private (context->method_inst)))

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -4859,4 +4859,10 @@ mini_method_to_shared (MonoMethod *method)
 	return NULL;
 }
 
+gboolean
+mini_is_gsharedvt_inst (MonoGenericInst *inst)
+{
+	return FALSE;
+}
+
 #endif /* !MONO_ARCH_GSHAREDVT_SUPPORTED */


### PR DESCRIPTION
From https://dev.azure.com/dnceng-public/public/_build/results?buildId=185124&view=logs&j=7ea23876-d932-5222-06a0-de72daa3cbf4&t=1c35ec69-2df4-572d-15df-3eb3d5198a04

```sh
  [100%] Building C object mono/profiler/CMakeFiles/mono-profiler-log.dir/log-args.c.o
  [100%] Building C object mono/profiler/CMakeFiles/mono-profiler-log.dir/log.c.o
  libmonosgen-2.0.a(aot-runtime.c.o): In function `mono_aot_can_dedup':
  /__w/1/s/src/mono/mono/mini/aot-runtime.c:4533: undefined reference to `mini_is_gsharedvt_inst'
  clang: error: linker command failed with exit code 1 (use -v to see invocation)
  mono/mini/CMakeFiles/mono-sgen.dir/build.make:195: recipe for target 'mono/mini/mono-sgen' failed
  make[2]: *** [mono/mini/mono-sgen] Error 1
  CMakeFiles/Makefile2:934: recipe for target 'mono/mini/CMakeFiles/mono-sgen.dir/all' failed
  make[1]: *** [mono/mini/CMakeFiles/mono-sgen.dir/all] Error 2
  make[1]: *** Waiting for unfinished jobs....
  [100%] Linking C shared library libmono-profiler-log.so
  [100%] Built target mono-profiler-log
  Makefile:135: recipe for target 'all' failed
  make: *** [all] Error 2
/__w/1/s/src/mono/mono.proj(629,5): error MSB3073: The command "TARGET_BUILD_ARCH=s390x PKG_CONFIG_PATH=/crossrootfs/s390x/usr/lib/s390x-linux-gnu/pkgconfig cmake --build . --target install --config Release --parallel 4" exited with code 2.
##[error]src/mono/mono.proj(629,5): error MSB3073: (NETCORE_ENGINEERING_TELEMETRY=Build) The command "TARGET_BUILD_ARCH=s390x PKG_CONFIG_PATH=/crossrootfs/s390x/usr/lib/s390x-linux-gnu/pkgconfig cmake --build . --target install --config Release --parallel 4" exited with code 2.
```
Regressed in https://github.com/dotnet/runtime/pull/82403.