### PR TITLE
Permit trailing data when parsing an X.509 certificate by DER content

### DIFF
--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertTests.cs
@@ -571,6 +571,22 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
+        [Fact]
+        public static void CertificateWithTrailingDataCanBeRead()
+        {
+            byte[] certData = new byte[TestData.MsCertificate.Length + 100];
+            TestData.MsCertificate.AsSpan().CopyTo(certData);
+            certData.AsSpan(TestData.MsCertificate.Length).Fill(0xFF);
+
+            using (X509Certificate2 cert = new X509Certificate2(certData))
+            {
+                Assert.Equal("CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US", cert.Subject);
+                Assert.Equal("CN=Microsoft Code Signing PCA, O=Microsoft Corporation, L=Redmond, S=Washington, C=US", cert.Issuer);
+
+                Assert.Equal(TestData.MsCertificate, cert.RawData);
+            }
+        }
+
         [ConditionalFact(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctional))]
         [OuterLoop("Hardware backed key generation takes several seconds.")]
         public static void CreateCertificate_MicrosoftPlatformCryptoProvider_EcdsaKey()


### PR DESCRIPTION
The managed X.509 decoder did not permit trailing data after the DER contents of the certificate. In #82682 it was reported that the Windows and Unix implementations permit this, so we should update the managed PAL to do the same.

n.b. I generally liked the managed PAL's behavior here. We can't make Windows and Unix more strict without possibly breaking someone, but we can make the managed implementation more relaxed.

Fixes #82682