### PR TITLE
Trim managed debugging support code

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -249,7 +249,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Include="--feature:System.Linq.Expressions.CanCreateArbitraryDelegates=false" />
 
       <!-- The managed debugging support in libraries is unused - trim it -->
-      <IlcArg Include="--feature:System.Diagnostics.Debugger.IsSupported=false" />
+      <IlcArg Condition="'$(IlcKeepManagedDebuggerSupport)' != 'true'" Include="--feature:System.Diagnostics.Debugger.IsSupported=false" />
     </ItemGroup>
 
     <MakeDir Directories="$(NativeIntermediateOutputPath)" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -247,6 +247,9 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Include="--feature:System.Linq.Expressions.CanCompileToIL=false" />
       <IlcArg Include="--feature:System.Linq.Expressions.CanEmitObjectArrayDelegate=false" />
       <IlcArg Include="--feature:System.Linq.Expressions.CanCreateArbitraryDelegates=false" />
+
+      <!-- The managed debugging support in libraries is unused - trim it -->
+      <IlcArg Include="--feature:System.Diagnostics.Debugger.IsSupported=false" />
     </ItemGroup>
 
     <MakeDir Directories="$(NativeIntermediateOutputPath)" />

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
@@ -1091,7 +1091,7 @@ namespace System.Collections.Immutable.Tests
             Assert.Equal(builder, items);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDebuggerTypeProxyAttributeSupported))]
         public static void TestDebuggerAttributes_Null()
         {
             Type proxyType = DebuggerAttributes.GetProxyType(ImmutableArray.CreateBuilder<string>(4));

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableDictionaryBuilderTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableDictionaryBuilderTest.cs
@@ -268,7 +268,7 @@ namespace System.Collections.Immutable.Tests
             Assert.Equal(builder, items);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDebuggerTypeProxyAttributeSupported))]
         public static void TestDebuggerAttributes_Null()
         {
             Type proxyType = DebuggerAttributes.GetProxyType(ImmutableHashSet.Create<string>());

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableDictionaryTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableDictionaryTest.cs
@@ -363,7 +363,7 @@ namespace System.Collections.Immutable.Tests
             Assert.Equal(dict, items);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDebuggerTypeProxyAttributeSupported))]
         public static void TestDebuggerAttributes_Null()
         {
             Type proxyType = DebuggerAttributes.GetProxyType(ImmutableHashSet.Create<string>());

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableHashSetTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableHashSetTest.cs
@@ -182,7 +182,7 @@ namespace System.Collections.Immutable.Tests
             Assert.Equal(set, items);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDebuggerTypeProxyAttributeSupported))]
         public static void TestDebuggerAttributes_Null()
         {
             Type proxyType = DebuggerAttributes.GetProxyType(ImmutableHashSet.Create<string>());

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableListBuilderTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableListBuilderTest.cs
@@ -416,7 +416,7 @@ namespace System.Collections.Immutable.Tests
             Assert.Equal(builder, items);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDebuggerTypeProxyAttributeSupported))]
         public static void TestDebuggerAttributes_Null()
         {
             Type proxyType = DebuggerAttributes.GetProxyType(ImmutableList.CreateBuilder<string>());

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableSortedSetBuilderTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableSortedSetBuilderTest.cs
@@ -393,7 +393,7 @@ namespace System.Collections.Immutable.Tests
             Assert.Equal(builder, items);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDebuggerTypeProxyAttributeSupported))]
         public static void TestDebuggerAttributes_Null()
         {
             Type proxyType = DebuggerAttributes.GetProxyType(ImmutableSortedSet.CreateBuilder<int>());

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableSortedSetTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableSortedSetTest.cs
@@ -370,7 +370,7 @@ namespace System.Collections.Immutable.Tests
             Assert.Equal(set, items);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDebuggerTypeProxyAttributeSupported))]
         public static void TestDebuggerAttributes_Null()
         {
             Type proxyType = DebuggerAttributes.GetProxyType(ImmutableSortedSet.Create("1", "2", "3"));

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableStackTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableStackTest.cs
@@ -264,7 +264,7 @@ namespace System.Collections.Immutable.Tests
             Assert.Equal(stack, items);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDebuggerTypeProxyAttributeSupported))]
         public static void TestDebuggerAttributes_Null()
         {
             Type proxyType = DebuggerAttributes.GetProxyType(ImmutableStack.Create<string>("1", "2", "3"));

--- a/src/libraries/System.Collections.NonGeneric/tests/ArrayListTests.cs
+++ b/src/libraries/System.Collections.NonGeneric/tests/ArrayListTests.cs
@@ -78,7 +78,7 @@ namespace System.Collections.Tests
             AssertExtensions.Throws<ArgumentNullException>("c", () => new ArrayList(null)); // Collection is null
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDebuggerTypeProxyAttributeSupported))]
         public static void DebuggerAttribute()
         {
             DebuggerAttributes.ValidateDebuggerDisplayReferences(new ArrayList());

--- a/src/libraries/System.Collections.NonGeneric/tests/HashtableTests.cs
+++ b/src/libraries/System.Collections.NonGeneric/tests/HashtableTests.cs
@@ -349,7 +349,7 @@ namespace System.Collections.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("loadFactor", () => new Hashtable(100, float.NegativeInfinity, null)); // Load factor is infinity
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDebuggerTypeProxyAttributeSupported))]
         public void DebuggerAttribute()
         {
             DebuggerAttributes.ValidateDebuggerDisplayReferences(new Hashtable());

--- a/src/libraries/System.Collections.NonGeneric/tests/QueueTests.cs
+++ b/src/libraries/System.Collections.NonGeneric/tests/QueueTests.cs
@@ -109,7 +109,7 @@ namespace System.Collections.Tests
             Assert.Equal(testQueue.ToArray(), items);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDebuggerTypeProxyAttributeSupported))]
         public static void DebuggerAttribute_NullQueue_ThrowsArgumentNullException()
         {
             bool threwNull = false;

--- a/src/libraries/System.Collections.NonGeneric/tests/SortedListTests.cs
+++ b/src/libraries/System.Collections.NonGeneric/tests/SortedListTests.cs
@@ -218,7 +218,7 @@ namespace System.Collections.Tests
             Assert.Equal("Count = 0", DebuggerAttributes.ValidateDebuggerDisplayReferences(new SortedList()));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDebuggerTypeProxyAttributeSupported))]
         public void DebuggerAttribute_NormalList()
         {
             var list = new SortedList() { { "a", 1 }, { "b", 2 } };
@@ -228,7 +228,7 @@ namespace System.Collections.Tests
             Assert.Equal(list.Count, items.Length);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDebuggerTypeProxyAttributeSupported))]
         public void DebuggerAttribute_SynchronizedList()
         {
             var list = SortedList.Synchronized(new SortedList() { { "a", 1 }, { "b", 2 } });
@@ -238,7 +238,7 @@ namespace System.Collections.Tests
             Assert.Equal(list.Count, items.Length);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDebuggerTypeProxyAttributeSupported))]
         public void DebuggerAttribute_NullSortedList_ThrowsArgumentNullException()
         {
             bool threwNull = false;

--- a/src/libraries/System.Collections.NonGeneric/tests/StackTests.cs
+++ b/src/libraries/System.Collections.NonGeneric/tests/StackTests.cs
@@ -87,7 +87,7 @@ namespace System.Collections.Tests
             Assert.Equal(stack.ToArray(), items);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDebuggerTypeProxyAttributeSupported))]
         public static void DebuggerAttribute_NullStack_ThrowsArgumentNullException()
         {
             bool threwNull = false;

--- a/src/libraries/System.Reflection/tests/AssemblyTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyTests.cs
@@ -21,7 +21,6 @@ StringAttr("hello", name = "StringAttrSimple"),
 EnumAttr(PublicEnum.Case1, name = "EnumAttrSimple"),
 TypeAttr(typeof(object), name = "TypeAttrSimple")]
 [assembly: CompilationRelaxations(8)]
-[assembly: Debuggable((DebuggableAttribute.DebuggingModes)263)]
 [assembly: CLSCompliant(false)]
 [assembly: TypeForwardedTo(typeof(string))]
 [assembly: TypeForwardedTo(typeof(TypeInForwardedAssembly))]
@@ -60,7 +59,6 @@ namespace System.Reflection.Tests
         [InlineData(typeof(AssemblyDescriptionAttribute))]
         [InlineData(typeof(AssemblyCompanyAttribute))]
         [InlineData(typeof(CLSCompliantAttribute))]
-        [InlineData(typeof(DebuggableAttribute))]
         [InlineData(typeof(Attr))]
         public void CustomAttributes(Type type)
         {
@@ -857,7 +855,6 @@ namespace System.Reflection.Tests
         [InlineData(typeof(AssemblyDescriptionAttribute))]
         [InlineData(typeof(AssemblyCompanyAttribute))]
         [InlineData(typeof(CLSCompliantAttribute))]
-        [InlineData(typeof(DebuggableAttribute))]
         [InlineData(typeof(Attr))]
         public void GetCustomAttributesData(Type attrType)
         {

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -7,6 +7,9 @@
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <!-- Disable nullability public only feature for NullabilityInfoContextTests -->
     <Features>$(Features.Replace('nullablePublicOnly', '')</Features>
+
+    <!-- The test is looking for debugger attributes we would have stripped with NativeAOT -->
+    <IlcKeepManagedDebuggerSupport>true</IlcKeepManagedDebuggerSupport>
   </PropertyGroup>
 
   <!-- 


### PR DESCRIPTION
Saves 1.1% on BasicMinimalApi.

NativeAOT is not debugged with a managed debugger that would be able to use these. It's also questionable whether a possible future managed debugger would be using this (versus debugging with IL that gets embedded in debugging symbols like .NET Native does).

Cc @dotnet/ilc-contrib  @eerhardt @vitek-karas - sending this for discussion. This doesn't feel 100% right to do this way (I don't like hardcoding the string), but I also don't think we would want to flip `<DebuggerSupport>false</DebuggerSupport>` because that one affects symbol stripping as well - we don't want that (although NativeAOT doesn't currently respect that part - maybe it should).