### PR TITLE
Fold canonical templates into canonically equivalent types

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CanonicalEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CanonicalEETypeNode.cs
@@ -29,7 +29,18 @@ namespace ILCompiler.DependencyAnalysis
         public override bool StaticDependenciesAreComputed => true;
         public override bool IsShareable => IsTypeNodeShareable(_type);
         protected override bool EmitVirtualSlotsAndInterfaces => true;
-        public override bool ShouldSkipEmittingObjectNode(NodeFactory factory) => false;
+
+        public override bool ShouldSkipEmittingObjectNode(NodeFactory factory)
+            => factory.MetadataManager.GetTemplateTypeForCanonicalFormType(factory, _type) != _type;
+
+        public override ISymbolNode NodeForLinkage(NodeFactory factory)
+        {
+            TypeDesc template = factory.MetadataManager.GetTemplateTypeForCanonicalFormType(factory, _type);
+            if (template != _type)
+                return factory.ConstructedTypeSymbol(template);
+
+            return this;
+        }
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -20,6 +20,8 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool ShouldSkipEmittingObjectNode(NodeFactory factory) => false;
 
+        public override ISymbolNode NodeForLinkage(NodeFactory factory) => this;
+
         protected override bool EmitVirtualSlotsAndInterfaces => true;
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -114,7 +114,14 @@ namespace ILCompiler.DependencyAnalysis
 
         public virtual ISymbolNode NodeForLinkage(NodeFactory factory)
         {
-            return factory.NecessaryTypeSymbol(_type);
+            if (ConstructedEETypeNode.CreationAllowed(_type))
+            {
+                IEETypeNode constructed = factory.ConstructedTypeSymbol(_type);
+                if (constructed.Marked)
+                    return constructed;
+            }
+
+            return this;
         }
 
         public TypeDesc Type => _type;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NecessaryCanonicalEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NecessaryCanonicalEETypeNode.cs
@@ -20,6 +20,23 @@ namespace ILCompiler.DependencyAnalysis
             Debug.Assert(!type.IsMdArray || factory.Target.Abi == TargetAbi.CppCodegen);
         }
 
+        public override bool ShouldSkipEmittingObjectNode(NodeFactory factory)
+        {
+            if (factory.MetadataManager.GetTemplateTypeForNecessaryCanonicalFormType(factory, _type) != _type)
+                return true;
+
+            return base.ShouldSkipEmittingObjectNode(factory);
+        }
+
+        public override ISymbolNode NodeForLinkage(NodeFactory factory)
+        {
+            TypeDesc template = factory.MetadataManager.GetTemplateTypeForNecessaryCanonicalFormType(factory, _type);
+            if (template != _type)
+                return factory.NecessaryTypeSymbol(template);
+
+            return base.NodeForLinkage(factory);
+        }
+
         protected override ISymbolNode GetBaseTypeNode(NodeFactory factory)
         {
             return _type.BaseType != null ? factory.NecessaryTypeSymbol(_type.BaseType.NormalizeInstantiation()) : null;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -805,6 +805,15 @@ namespace ILCompiler.DependencyAnalysis
         {
             _sb.Clear();
             AppendExternCPrefix(_sb);
+
+            while (target is ISymbolNodeWithLinkage targetWithLinkage)
+            {
+                ISymbolNode newTarget = targetWithLinkage.NodeForLinkage(_nodeFactory);
+                if (target == newTarget)
+                    break;
+                target = newTarget;
+            }
+
             target.AppendMangledName(_nodeFactory.NameMangler, _sb);
 
             SymbolRefFlags flags = 0;


### PR DESCRIPTION
Saves 0.6% for BasicMinimalApi.

The type loader in NativeAOT is a "template type loader" - to load new types, it starts with an existing `MethodTable` and makes a copy of it doing adjustments as necessary.

In .NET Native, we used real `MethodTable`s such as `List<object>`. This had limitations because we sometimes didn't know how a real instantiation should look like - at some point we introduced `CanonALike` templates (`List<CanonAlike>`), mostly due to tooling limitations in rhbind.

In NativeAOT, we use canonical types (`List<__Canon>`). But this is potentially a waste of space because we might be able to use a real type if one exists. This switches us to a "best of both worlds" approach - we still model templates as canonical instantiations, but if at object emission time we find out there's a suitable concrete instantiations, we use that.

Cc @dotnet/ilc-contrib 