### PR TITLE
Set VSDebugger_ValidateDotnetDebugLibSignatures

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -218,6 +218,9 @@ if ($vs) {
 
   # Put our local dotnet.exe on PATH first so Visual Studio knows which one to use
   $env:PATH=($env:DOTNET_ROOT + ";" + $env:PATH);
+  
+  # Disable .NET runtime signature validation errors which errors for local builds
+  $env:VSDebugger_ValidateDotnetDebugLibSignatures=0;
 
   if ($runtimeConfiguration)
   {


### PR DESCRIPTION
When using the `-vs` switch, disable signature validation. See https://github.com/dotnet/runtime/blob/main/docs/workflow/building/libraries/README.md#debugging for more details