### PR TITLE
[mono][aot] Enable direct call transformation for MONO_PATCH_INFO_METHOD

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -6588,12 +6588,10 @@ emit_and_reloc_code (MonoAotCompile *acfg, MonoMethod *method, guint8 *code, gui
 						direct_call_target = symbol;
 						patch_info->type = MONO_PATCH_INFO_NONE;
 					} else if ((m_class_get_image (patch_info->data.method->klass) == acfg->image) && !got_only && is_direct_callable (acfg, method, patch_info)) {
-#if 0
-						// FIXME: Currently not used. It fails as some callees require initialization.
 						MonoCompile *callee_cfg = (MonoCompile *)g_hash_table_lookup (acfg->method_to_cfg, cmethod);
 
-						// Don't compile inflated methods if we're doing dedup
-						if (acfg->aot_opts.dedup && !mono_aot_can_dedup (cmethod)) {
+						// Enable direct call transformation where caller's class requires no initialization
+						if (!m_class_has_static_refs (method->klass)) {
 							char *name = mono_aot_get_mangled_method_name (cmethod);
 							mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_AOT, "DIRECT CALL: %s by %s", name, method ? mono_method_full_name (method, TRUE) : "");
 							g_free (name);
@@ -6603,7 +6601,6 @@ emit_and_reloc_code (MonoAotCompile *acfg, MonoMethod *method, guint8 *code, gui
 							patch_info->type = MONO_PATCH_INFO_NONE;
 							acfg->stats.direct_calls ++;
 						}
-#endif
 					}
 
 					acfg->stats.all_calls ++;

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -6591,7 +6591,7 @@ emit_and_reloc_code (MonoAotCompile *acfg, MonoMethod *method, guint8 *code, gui
 						MonoCompile *callee_cfg = (MonoCompile *)g_hash_table_lookup (acfg->method_to_cfg, cmethod);
 
 						// Enable direct call transformation where caller's class requires no initialization and callee can specialize
-						if (!m_class_has_static_refs (method->klass) && mono_aot_can_specialize (cmethod)) {
+						if (!m_class_has_cctor (method->klass) && mono_aot_can_specialize (cmethod)) {
 							char *name = mono_aot_get_mangled_method_name (cmethod);
 							mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_AOT, "DIRECT CALL: %s by %s", name, method ? mono_method_full_name (method, TRUE) : "");
 							g_free (name);

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -6590,8 +6590,8 @@ emit_and_reloc_code (MonoAotCompile *acfg, MonoMethod *method, guint8 *code, gui
 					} else if ((m_class_get_image (patch_info->data.method->klass) == acfg->image) && !got_only && is_direct_callable (acfg, method, patch_info)) {
 						MonoCompile *callee_cfg = (MonoCompile *)g_hash_table_lookup (acfg->method_to_cfg, cmethod);
 
-						// Enable direct call transformation where caller's class requires no initialization
-						if (!m_class_has_static_refs (method->klass)) {
+						// Enable direct call transformation where caller's class requires no initialization and callee can specialize
+						if (!m_class_has_static_refs (method->klass) && mono_aot_can_specialize (cmethod)) {
 							char *name = mono_aot_get_mangled_method_name (cmethod);
 							mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_AOT, "DIRECT CALL: %s by %s", name, method ? mono_method_full_name (method, TRUE) : "");
 							g_free (name);

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -6287,6 +6287,8 @@ is_direct_callable (MonoAotCompile *acfg, MonoMethod *method, MonoJumpInfo *patc
 			if (direct_callable && !strcmp (callee_cfg->method->name, ".cctor"))
 				direct_callable = FALSE;
 
+			if (direct_callable && (m_class_has_cctor (method->klass) || !mono_aot_can_specialize (callee_cfg->method)))
+				direct_callable = FALSE;
 			//
 			// FIXME: Support inflated methods, it asserts in mini_llvm_init_gshared_method_this () because the method is not in
 			// amodule->extra_methods.
@@ -6589,18 +6591,14 @@ emit_and_reloc_code (MonoAotCompile *acfg, MonoMethod *method, guint8 *code, gui
 						patch_info->type = MONO_PATCH_INFO_NONE;
 					} else if ((m_class_get_image (patch_info->data.method->klass) == acfg->image) && !got_only && is_direct_callable (acfg, method, patch_info)) {
 						MonoCompile *callee_cfg = (MonoCompile *)g_hash_table_lookup (acfg->method_to_cfg, cmethod);
+						char *name = mono_aot_get_mangled_method_name (cmethod);
+						mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_AOT, "DIRECT CALL: %s by %s", name, method ? mono_method_full_name (method, TRUE) : "");
+						g_free (name);
 
-						// Enable direct call transformation where caller's class requires no initialization and callee can specialize
-						if (!m_class_has_cctor (method->klass) && mono_aot_can_specialize (cmethod)) {
-							char *name = mono_aot_get_mangled_method_name (cmethod);
-							mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_AOT, "DIRECT CALL: %s by %s", name, method ? mono_method_full_name (method, TRUE) : "");
-							g_free (name);
-
-							direct_call = TRUE;
-							direct_call_target = callee_cfg->asm_symbol;
-							patch_info->type = MONO_PATCH_INFO_NONE;
-							acfg->stats.direct_calls ++;
-						}
+						direct_call = TRUE;
+						direct_call_target = callee_cfg->asm_symbol;
+						patch_info->type = MONO_PATCH_INFO_NONE;
+						acfg->stats.direct_calls ++;
 					}
 
 					acfg->stats.all_calls ++;


### PR DESCRIPTION
This PR contributes to https://github.com/dotnet/runtime/issues/82224 by enabling direct call transformation for `MONO_PATCH_INFO_METHOD` where caller requires no initialization.