### PR TITLE
Ignore the property with JsonIgnore when generating source code

### DIFF
--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -667,6 +667,19 @@ namespace {@namespace}
 
                 List<PropertyGenerationSpec> properties = typeGenerationSpec.PropertyGenSpecList!;
 
+                if (typeGenerationSpec.CtorParamGenSpecArray != null)
+                {
+                    properties = properties
+                        .Where(prop => prop.DefaultIgnoreCondition != JsonIgnoreCondition.Always ||
+                                       typeGenerationSpec.CtorParamGenSpecArray.Any(
+                                           ctorPara => prop.ClrName.Equals(ctorPara.ParameterInfo.Name, StringComparison.OrdinalIgnoreCase)))
+                        .ToList();
+                }
+                else
+                {
+                    properties = properties.Where(prop => prop.DefaultIgnoreCondition != JsonIgnoreCondition.Always).ToList();
+                }
+
                 int propCount = properties.Count;
 
                 string propertyArrayInstantiationValue = propCount == 0

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -788,8 +788,10 @@ private static {JsonPropertyInfoTypeRef}[] {propInitMethodName}({JsonSerializerO
                         .Where(properties => properties.DefaultIgnoreCondition != JsonIgnoreCondition.Always)
                         .Select(properties => properties.ClrName),
                     StringComparer.OrdinalIgnoreCase);
+
                 var ctorNames = new HashSet<string>(
-                    typeGenerationSpec.CtorParamGenSpecArray?.Select(ctorPara => ctorPara.ParameterInfo.Name!) ?? Array.Empty<string>(),
+                    typeGenerationSpec.CtorParamGenSpecArray?
+                        .Select(ctorPara => ctorPara.ParameterInfo.Name!) ?? Array.Empty<string>(),
                     StringComparer.OrdinalIgnoreCase);
 
                 foreach (PropertyGenerationSpec propertyGenerationSpec in typeGenerationSpec.PropertyGenSpecList!)
@@ -817,7 +819,6 @@ private static {JsonPropertyInfoTypeRef}[] {propInitMethodName}({JsonSerializerO
 
                 return properties;
             }
-
 
             private
 #if !DEBUG


### PR DESCRIPTION
Ignore the property with JsonIgnore attribute when generating property info.
- If the property is bind with parameter in constructor, we keep generating the property info.
- If type has JsonExtensionData, we keep generating the property info.
- If JsonIgnore property has same name with other members, we keep generating the property info.