### PR TITLE
[wasm][debugger] Avoid creating csproj during compilation time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,5 +363,4 @@ src/coreclr/System.Private.CoreLib/common
 # Temporary artifacts from local libraries stress builds
 .dotnet-daily/
 run-stress-*
-debugger-test-with-colon-in-source-name.csproj
 test:.cs

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestSuite.csproj
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestSuite.csproj
@@ -119,10 +119,6 @@
   <Target Name="CreateProjectWithColonInSourceName"
     Condition="!$([MSBuild]::IsOSPlatform('windows'))">
     <PropertyGroup>
-        <CsprojContent>
-            <Project Sdk="Microsoft.NET.Sdk">
-            </Project>
-        </CsprojContent>
         <CsContent>
             namespace DebuggerTests
             {
@@ -136,10 +132,6 @@
             }
         </CsContent>
     </PropertyGroup>
-    <WriteLinesToFile
-        File="../tests/debugger-test-with-colon-in-source-name/debugger-test-with-colon-in-source-name.csproj"
-        Lines="$(CsprojContent)"
-        Overwrite="true"/>
     <WriteLinesToFile
         File="../tests/debugger-test-with-colon-in-source-name/test:.cs"
         Lines="$(CsContent)"

--- a/src/mono/wasm/debugger/tests/debugger-test-with-colon-in-source-name/debugger-test-with-colon-in-source-name.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test-with-colon-in-source-name/debugger-test-with-colon-in-source-name.csproj
@@ -1,0 +1,1 @@
+<Project Sdk="Microsoft.NET.Sdk"></Project>


### PR DESCRIPTION
Just create the C# file with colon on name on Linux, keep the csproj always there

Trying to fix the error on CI in this PR: https://github.com/dotnet/runtime/pull/82599