### PR TITLE
Use SecurityTransforms for RSA+PSS

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
@@ -405,10 +405,10 @@ namespace System.Security.Cryptography
 
                 ThrowIfDisposed();
 
-                bool pssPadding = padding.Mode switch
+                Interop.AppleCrypto.PAL_SignatureAlgorithm signatureAlgorithm = padding.Mode switch
                 {
-                    RSASignaturePaddingMode.Pss => true,
-                    RSASignaturePaddingMode.Pkcs1 => false,
+                    RSASignaturePaddingMode.Pss => Interop.AppleCrypto.PAL_SignatureAlgorithm.RsaPss,
+                    RSASignaturePaddingMode.Pkcs1 => Interop.AppleCrypto.PAL_SignatureAlgorithm.RsaPkcs1,
                     _ => throw new CryptographicException(SR.Cryptography_InvalidPaddingMode)
                 };
 
@@ -421,40 +421,20 @@ namespace System.Security.Cryptography
 
                 int keySize = KeySize;
                 int rsaSize = RsaPaddingProcessor.BytesRequiredForBitCount(keySize);
-
-                if (!pssPadding)
-                {
-                    Interop.AppleCrypto.PAL_HashAlgorithm palAlgId =
+                Interop.AppleCrypto.PAL_HashAlgorithm palAlgId =
                         PalAlgorithmFromAlgorithmName(hashAlgorithm, out int expectedSize);
 
-                    if (hash.Length != expectedSize)
-                    {
-                        // Windows: NTE_BAD_DATA ("Bad Data.")
-                        // OpenSSL: RSA_R_INVALID_MESSAGE_LENGTH ("invalid message length")
-                        throw new CryptographicException(
-                            SR.Format(
-                                SR.Cryptography_BadHashSize_ForAlgorithm,
-                                hash.Length,
-                                expectedSize,
-                                hashAlgorithm.Name));
-                    }
-
-                    if (destination.Length < rsaSize)
-                    {
-                        bytesWritten = 0;
-                        return false;
-                    }
-
-                    return Interop.AppleCrypto.TryCreateSignature(
-                        keys.PrivateKey,
-                        hash,
-                        destination,
-                        palAlgId,
-                        Interop.AppleCrypto.PAL_SignatureAlgorithm.RsaPkcs1,
-                        out bytesWritten);
+                if (hash.Length != expectedSize)
+                {
+                    // Windows: NTE_BAD_DATA ("Bad Data.")
+                    // OpenSSL: RSA_R_INVALID_MESSAGE_LENGTH ("invalid message length")
+                    throw new CryptographicException(
+                        SR.Format(
+                            SR.Cryptography_BadHashSize_ForAlgorithm,
+                            hash.Length,
+                            expectedSize,
+                            hashAlgorithm.Name));
                 }
-
-                Debug.Assert(padding.Mode == RSASignaturePaddingMode.Pss);
 
                 if (destination.Length < rsaSize)
                 {
@@ -462,9 +442,25 @@ namespace System.Security.Cryptography
                     return false;
                 }
 
+                // Apple's PSS implementation does not support PSS+MD5. In that case we will use raw RSA and manually
+                // pad it.
+                if (signatureAlgorithm != Interop.AppleCrypto.PAL_SignatureAlgorithm.RsaPss ||
+                    palAlgId != Interop.AppleCrypto.PAL_HashAlgorithm.Md5)
+                {
+                    return Interop.AppleCrypto.TryCreateSignature(
+                        keys.PrivateKey,
+                        hash,
+                        destination,
+                        palAlgId,
+                        signatureAlgorithm,
+                        out bytesWritten);
+                }
+
+                Debug.Assert(padding.Mode == RSASignaturePaddingMode.Pss && hashAlgorithm == HashAlgorithmName.MD5);
+
                 byte[] rented = CryptoPool.Rent(rsaSize);
                 Span<byte> buf = new Span<byte>(rented, 0, rsaSize);
-                RsaPaddingProcessor.EncodePss(hashAlgorithm, hash, buf, keySize);
+                RsaPaddingProcessor.EncodePss(hashAlgorithm, hash, buf, KeySize);
 
                 try
                 {
@@ -496,19 +492,29 @@ namespace System.Security.Cryptography
 
                 ThrowIfDisposed();
 
-                if (padding == RSASignaturePadding.Pkcs1)
+                Interop.AppleCrypto.PAL_HashAlgorithm palAlgId = PalAlgorithmFromAlgorithmName(hashAlgorithm, out _);
+                Interop.AppleCrypto.PAL_SignatureAlgorithm signatureAlgorithm = padding.Mode switch
                 {
-                    Interop.AppleCrypto.PAL_HashAlgorithm palAlgId =
-                        PalAlgorithmFromAlgorithmName(hashAlgorithm, out _);
+                    RSASignaturePaddingMode.Pss => Interop.AppleCrypto.PAL_SignatureAlgorithm.RsaPss,
+                    RSASignaturePaddingMode.Pkcs1 => Interop.AppleCrypto.PAL_SignatureAlgorithm.RsaPkcs1,
+                    _ => throw new CryptographicException(SR.Cryptography_InvalidPaddingMode)
+                };
+
+                // Apple's native implementation does not support RSA+PSS with MD5. We use raw RSA padding and perform
+                // the padding manually in that circumstance.
+                if (signatureAlgorithm != Interop.AppleCrypto.PAL_SignatureAlgorithm.RsaPss ||
+                    palAlgId != Interop.AppleCrypto.PAL_HashAlgorithm.Md5)
+                {
                     return Interop.AppleCrypto.VerifySignature(
                         GetKeys().PublicKey,
                         hash,
                         signature,
                         palAlgId,
-                        Interop.AppleCrypto.PAL_SignatureAlgorithm.RsaPkcs1);
+                        signatureAlgorithm);
                 }
-                else if (padding.Mode == RSASignaturePaddingMode.Pss)
+                else
                 {
+                    Debug.Assert(padding.Mode == RSASignaturePaddingMode.Pss && hashAlgorithm == HashAlgorithmName.MD5);
                     SafeSecKeyRefHandle publicKey = GetKeys().PublicKey;
 
                     int keySize = KeySize;
@@ -548,8 +554,6 @@ namespace System.Security.Cryptography
                         CryptoPool.Return(rented, clearSize: 0);
                     }
                 }
-
-                throw new CryptographicException(SR.Cryptography_InvalidPaddingMode);
             }
 
             protected override void Dispose(bool disposing)


### PR DESCRIPTION
In #81965 some native code for RSA+PSS was uncommented since the iOS version minimum got bumped to 11. However, we were never actually sending `PAL_SignatureAlgorithm.RsaPss` to the native shim, so it was effectively dead code.

This change allows SecurityTransforms to perform RSA+PSS operations. However, Apple's implementation does not support PSS+MD5. There isn't even an "legacy" identifier to use like we have with PKCSv1.5. In that situation, we will continue to use raw RSA and perform the padding ourselves. Still though, our ethos is to always use the native platform for cryptography when possible, and SHA1+SHA2 for RSA+PSS is the 99% case.

As a bonus, this improves allocations for the non-MD5 algorithms.

|     Method |        Job | Toolchain | SignaturePadding | HashAlgorithmName |        Mean |    Error |   StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------- |----------- |---------- |----------------- |------------------ |------------:|---------:|---------:|------:|-------:|------:|------:|----------:|
|   SignHash | Job-GVNWDB |    branch |              Pss |               MD5 | 1,152.28 us | 1.066 us | 0.945 us |  1.00 |      - |     - |     - |     217 B |
|   SignHash | Job-OVCQWP |      main |              Pss |               MD5 | 1,151.95 us | 0.904 us | 0.755 us |  1.00 |      - |     - |     - |     217 B |
|            |            |           |                  |                   |             |          |          |       |        |       |       |           |
| VerifyHash | Job-GVNWDB |    branch |              Pss |               MD5 |    31.40 us | 0.074 us | 0.065 us |  1.00 |      - |     - |     - |     216 B |
| VerifyHash | Job-OVCQWP |      main |              Pss |               MD5 |    31.41 us | 0.067 us | 0.063 us |  1.00 |      - |     - |     - |     216 B |
|            |            |           |                  |                   |             |          |          |       |        |       |       |           |
|   SignHash | Job-GVNWDB |    branch |              Pss |            SHA256 | 1,152.75 us | 4.020 us | 3.760 us |  1.01 |      - |     - |     - |      65 B |
|   SignHash | Job-OVCQWP |      main |              Pss |            SHA256 | 1,146.19 us | 1.119 us | 0.992 us |  1.00 |      - |     - |     - |     217 B |
|            |            |           |                  |                   |             |          |          |       |        |       |       |           |
| VerifyHash | Job-GVNWDB |    branch |              Pss |            SHA256 |    24.83 us | 0.020 us | 0.017 us |  0.97 |      - |     - |     - |      32 B |
| VerifyHash | Job-OVCQWP |      main |              Pss |            SHA256 |    25.72 us | 0.089 us | 0.069 us |  1.00 | 0.0305 |     - |     - |     216 B |

Closes #82714