### PR TITLE
Track down analyzer failure 2

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -324,17 +324,17 @@
       <Uri>https://github.com/dotnet/runtime-assets</Uri>
       <Sha>3a8fb28f12af0c2c0b9eace35afafd689437c39e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.6.0-1.23073.4">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.6.0-2.23120.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>6acaa7b7c0efea8ea292ca26888c0346fbf8b0c1</Sha>
+      <Sha>4190056e0126f206c64439275fbf43a54dd31067</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis" Version="4.6.0-1.23073.4">
+    <Dependency Name="Microsoft.CodeAnalysis" Version="4.6.0-2.23120.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>6acaa7b7c0efea8ea292ca26888c0346fbf8b0c1</Sha>
+      <Sha>4190056e0126f206c64439275fbf43a54dd31067</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.6.0-1.23073.4">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.6.0-2.23120.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>6acaa7b7c0efea8ea292ca26888c0346fbf8b0c1</Sha>
+      <Sha>4190056e0126f206c64439275fbf43a54dd31067</Sha>
     </Dependency>
     <Dependency Name="Microsoft.CodeAnalysis.Analyzers" Version="3.3.5-beta1.23124.1">
       <Uri>https://github.com/dotnet/roslyn-analyzers</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -40,9 +40,9 @@
       Any tools that contribute to the design-time experience should use the MicrosoftCodeAnalysisVersion_LatestVS property above to ensure
       they do not break the local dev experience.
     -->
-    <MicrosoftCodeAnalysisCSharpVersion>4.6.0-1.23073.4</MicrosoftCodeAnalysisCSharpVersion>
-    <MicrosoftCodeAnalysisVersion>4.6.0-1.23073.4</MicrosoftCodeAnalysisVersion>
-    <MicrosoftNetCompilersToolsetVersion>4.6.0-1.23073.4</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftCodeAnalysisCSharpVersion>4.6.0-2.23120.1</MicrosoftCodeAnalysisCSharpVersion>
+    <MicrosoftCodeAnalysisVersion>4.6.0-2.23120.1</MicrosoftCodeAnalysisVersion>
+    <MicrosoftNetCompilersToolsetVersion>4.6.0-2.23120.1</MicrosoftNetCompilersToolsetVersion>
   </PropertyGroup>
   <!--
     For source generator support we need to target multiple versions of Roslyn in order to be able to run on older versions of Roslyn.


### PR DESCRIPTION
Testing the theory that our analyzer load failure is related to #80822 as we switched to collectable assemblies. The curent global.json has a runtime which has the fix for collectable assemblies. 

Related #82467