### PR TITLE
Use windows.vs2022.amd64.open for stress tests

### DIFF
--- a/eng/docker/build-docker-sdk.ps1
+++ b/eng/docker/build-docker-sdk.ps1
@@ -28,6 +28,7 @@ if ($buildWindowsContainers)
     exit $LASTEXITCODE
   }
 
+  $dockerFileName="libraries-sdk.windows.Dockerfile"
   $dockerFile="$dockerFilePrefix.windows.Dockerfile"
   
   # Collect the following artifacts to folder, that will be used as build context for the container,
@@ -49,8 +50,10 @@ if ($buildWindowsContainers)
                      -Destination $dockerContext\microsoft.netcore.app.runtime.win-x64
   Copy-Item -Recurse -Path $binArtifacts\testhost `
                      -Destination $dockerContext\testhost
-  Copy-Item -Recurse -Path $REPO_ROOT_DIR\eng\targetingpacks.targets `
+  Copy-Item          -Path $REPO_ROOT_DIR\eng\targetingpacks.targets `
                      -Destination $dockerContext\targetingpacks.targets
+  Copy-Item          -Path $dockerFile 
+                     -Destination $dockerContext\$dockerFileName
   
   # In case of non-CI builds, testhost may already contain Microsoft.AspNetCore.App (see build-local.ps1 in HttpStress):
   $testHostAspNetCorePath="$dockerContext\testhost\net$dotNetVersion-windows-$configuration-x64/shared/Microsoft.AspNetCore.App"
@@ -60,7 +63,7 @@ if ($buildWindowsContainers)
   
   docker build --tag $imageName `
     --build-arg CONFIGURATION=$configuration `
-    --file $dockerFile `
+    --file $dockerContext\$dockerFileName `
     $dockerContext
 }
 else

--- a/eng/docker/build-docker-sdk.ps1
+++ b/eng/docker/build-docker-sdk.ps1
@@ -52,7 +52,7 @@ if ($buildWindowsContainers)
                      -Destination $dockerContext\testhost
   Copy-Item          -Path $REPO_ROOT_DIR\eng\targetingpacks.targets `
                      -Destination $dockerContext\targetingpacks.targets
-  Copy-Item          -Path $dockerFile 
+  Copy-Item          -Path $dockerFile `
                      -Destination $dockerContext\$dockerFileName
   
   # In case of non-CI builds, testhost may already contain Microsoft.AspNetCore.App (see build-local.ps1 in HttpStress):

--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -103,7 +103,7 @@ extends:
           DUMPS_SHARE_MOUNT_ROOT: "C:/dumps-share"
         pool:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals 1es-windows-2022-open
+          demands: ImageOverride -equals windows.vs2022.amd64.open
 
         steps:
         - checkout: self

--- a/eng/pipelines/libraries/stress/ssl.yml
+++ b/eng/pipelines/libraries/stress/ssl.yml
@@ -61,7 +61,7 @@ extends:
         timeoutInMinutes: 120
         pool:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals 1es-windows-2022-open
+          demands: ImageOverride -equals windows.vs2022.amd64.open
 
         steps:
         - checkout: self


### PR DESCRIPTION
This is an attempt to fix #82528.