### PR TITLE
Rewrite exception handler if retval is a pointer

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ElementsMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ElementsMarshalling.cs
@@ -396,7 +396,7 @@ namespace Microsoft.Interop
         /// This handles the case where the native type of a non-blittable managed type is a pointer,
         /// which are unsupported in generic type parameters.
         /// </summary>
-        private sealed class PointerNativeTypeAssignmentRewriter : CSharpSyntaxRewriter
+        internal sealed class PointerNativeTypeAssignmentRewriter : CSharpSyntaxRewriter
         {
             private readonly string _nativeIdentifier;
             private readonly PointerTypeSyntax _nativeType;

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ElementsMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ElementsMarshalling.cs
@@ -390,47 +390,5 @@ namespace Microsoft.Interop
 
             return EmptyStatement();
         }
-
-        /// <summary>
-        /// Rewrite assignment expressions to the native identifier to cast to IntPtr.
-        /// This handles the case where the native type of a non-blittable managed type is a pointer,
-        /// which are unsupported in generic type parameters.
-        /// </summary>
-        internal sealed class PointerNativeTypeAssignmentRewriter : CSharpSyntaxRewriter
-        {
-            private readonly string _nativeIdentifier;
-            private readonly PointerTypeSyntax _nativeType;
-
-            public PointerNativeTypeAssignmentRewriter(string nativeIdentifier, PointerTypeSyntax nativeType)
-            {
-                _nativeIdentifier = nativeIdentifier;
-                _nativeType = nativeType;
-            }
-
-            public override SyntaxNode VisitAssignmentExpression(AssignmentExpressionSyntax node)
-            {
-                if (node.Left.ToString() == _nativeIdentifier)
-                {
-                    return node.WithRight(
-                        CastExpression(MarshallerHelpers.SystemIntPtrType, node.Right));
-                }
-                if (node.Right.ToString() == _nativeIdentifier)
-                {
-                    return node.WithRight(CastExpression(_nativeType, node.Right));
-                }
-
-                return base.VisitAssignmentExpression(node);
-            }
-
-            public override SyntaxNode? VisitArgument(ArgumentSyntax node)
-            {
-                if (node.Expression.ToString() == _nativeIdentifier)
-                {
-                    return node.WithExpression(
-                        CastExpression(_nativeType, node.Expression));
-                }
-                return base.VisitArgument(node);
-            }
-        }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/PointerNativeTypeAssignmentRewriter.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/PointerNativeTypeAssignmentRewriter.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Microsoft.Interop
+{
+    /// <summary>
+    /// Rewrite assignment expressions to the native identifier to cast to IntPtr.
+    /// This handles the case where the native type of a non-blittable managed type is a pointer,
+    /// which are unsupported in generic type parameters.
+    /// </summary>
+    internal sealed class PointerNativeTypeAssignmentRewriter : CSharpSyntaxRewriter
+    {
+        private readonly string _nativeIdentifier;
+        private readonly PointerTypeSyntax _nativeType;
+
+        public PointerNativeTypeAssignmentRewriter(string nativeIdentifier, PointerTypeSyntax nativeType)
+        {
+            _nativeIdentifier = nativeIdentifier;
+            _nativeType = nativeType;
+        }
+
+        public override SyntaxNode VisitAssignmentExpression(AssignmentExpressionSyntax node)
+        {
+            if (node.Left.ToString() == _nativeIdentifier)
+            {
+                return node.WithRight(
+                    CastExpression(MarshallerHelpers.SystemIntPtrType, node.Right));
+            }
+            if (node.Right.ToString() == _nativeIdentifier)
+            {
+                return node.WithRight(CastExpression(_nativeType, node.Right));
+            }
+
+            return base.VisitAssignmentExpression(node);
+        }
+
+        public override SyntaxNode? VisitArgument(ArgumentSyntax node)
+        {
+            if (node.Expression.ToString() == _nativeIdentifier)
+            {
+                return node.WithExpression(
+                    CastExpression(_nativeType, node.Expression));
+            }
+            return base.VisitArgument(node);
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatelessMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatelessMarshallingStrategy.cs
@@ -82,11 +82,19 @@ namespace Microsoft.Interop
             }
 
             // <nativeIdentifier> = <convertToUnmanaged>;
-            yield return ExpressionStatement(
-                AssignmentExpression(
+            var assignment = AssignmentExpression(
                     SyntaxKind.SimpleAssignmentExpression,
                     IdentifierName(nativeIdentifier),
-                    convertToUnmanaged));
+                    convertToUnmanaged);
+
+
+            if (_unmanagedType is PointerTypeInfo pointer)
+            {
+                var rewriter = new NonBlittableElementsMarshalling.PointerNativeTypeAssignmentRewriter(assignment.Right.ToString(), (PointerTypeSyntax)pointer.Syntax);
+                assignment = (AssignmentExpressionSyntax)rewriter.Visit(assignment);
+
+            }
+            yield return ExpressionStatement(assignment);
         }
 
         public IEnumerable<StatementSyntax> GeneratePinnedMarshalStatements(TypePositionInfo info, StubCodeContext context)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatelessMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatelessMarshallingStrategy.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Interop
 
             if (_unmanagedType is PointerTypeInfo pointer)
             {
-                var rewriter = new NonBlittableElementsMarshalling.PointerNativeTypeAssignmentRewriter(assignment.Right.ToString(), (PointerTypeSyntax)pointer.Syntax);
+                var rewriter = new PointerNativeTypeAssignmentRewriter(assignment.Right.ToString(), (PointerTypeSyntax)pointer.Syntax);
                 assignment = (AssignmentExpressionSyntax)rewriter.Visit(assignment);
 
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/82504

We need to cast the `IntPtr` we assign to `__retVal_native` when it is a pointer type. This uses the `PointerNativeTypeAssignmentRewriter` to do this. I left it as a nested class in `NonBlittableElementsMarshalling`, but let me know if it should be moved out.