### PR TITLE
[wasm] Avoid unnecessary relinking when publishing a blazor project for AOT

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "microsoft.dotnet.xharness.cli": {
-      "version": "1.0.0-prerelease.23117.1",
+      "version": "1.0.0-prerelease.23151.1",
       "commands": [
         "xharness"
       ]

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -284,17 +284,17 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>252018c3d3fffdb592413cf61d5b80cf751e0a59</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="1.0.0-prerelease.23117.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Common" Version="1.0.0-prerelease.23151.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>8d789cbeecb6c89bf470fdc7727a8f501724fc8a</Sha>
+      <Sha>05d4d5fc8634fa68ec53a9a3b31271797f4a0c7c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.23117.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.23151.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>8d789cbeecb6c89bf470fdc7727a8f501724fc8a</Sha>
+      <Sha>05d4d5fc8634fa68ec53a9a3b31271797f4a0c7c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="1.0.0-prerelease.23117.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="1.0.0-prerelease.23151.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>8d789cbeecb6c89bf470fdc7727a8f501724fc8a</Sha>
+      <Sha>05d4d5fc8634fa68ec53a9a3b31271797f4a0c7c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.PackageTesting" Version="8.0.0-beta.23123.2">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -185,9 +185,9 @@
     <!-- Testing -->
     <MicrosoftNETCoreCoreDisToolsVersion>1.1.0</MicrosoftNETCoreCoreDisToolsVersion>
     <MicrosoftNETTestSdkVersion>17.4.0-preview-20220707-01</MicrosoftNETTestSdkVersion>
-    <MicrosoftDotNetXHarnessTestRunnersCommonVersion>1.0.0-prerelease.23117.1</MicrosoftDotNetXHarnessTestRunnersCommonVersion>
-    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>1.0.0-prerelease.23117.1</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.23117.1</MicrosoftDotNetXHarnessCLIVersion>
+    <MicrosoftDotNetXHarnessTestRunnersCommonVersion>1.0.0-prerelease.23151.1</MicrosoftDotNetXHarnessTestRunnersCommonVersion>
+    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>1.0.0-prerelease.23151.1</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.23151.1</MicrosoftDotNetXHarnessCLIVersion>
     <MicrosoftDotNetHotReloadUtilsGeneratorBuildToolVersion>1.1.0-alpha.0.23113.1</MicrosoftDotNetHotReloadUtilsGeneratorBuildToolVersion>
     <XUnitVersion>2.4.2</XUnitVersion>
     <XUnitAnalyzersVersion>1.0.0</XUnitAnalyzersVersion>

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
@@ -228,11 +228,7 @@ public class BuildPublishTests : BuildTestBase
         string id = $"blazor_{config}_{Path.GetRandomFileName()}";
         string projectFile = CreateWasmTemplateProject(id, "blazorwasm");
 
-        new DotNetCommand(s_buildEnv, _testOutput)
-                .WithWorkingDirectory(_projectDir!)
-                .Execute($"build -c {config} -bl:{Path.Combine(s_buildEnv.LogRootPath, $"{id}.binlog")}")
-                .EnsureSuccessful();
-
+        BlazorBuild(new BlazorBuildOptions(id, config, NativeFilesType.FromRuntimePack));
         await BlazorRunForBuildWithDotnetRun(config);
     }
 
@@ -248,11 +244,7 @@ public class BuildPublishTests : BuildTestBase
         if (aot)
             AddItemsPropertiesToProject(projectFile, "<RunAOTCompilation>true</RunAOTCompilation>");
 
-        new DotNetCommand(s_buildEnv, _testOutput)
-                .WithWorkingDirectory(_projectDir!)
-                .Execute($"publish -c {config} -bl:{Path.Combine(s_buildEnv.LogRootPath, $"{id}.binlog")}")
-                .EnsureSuccessful();
-
+        BlazorPublish(new BlazorBuildOptions(id, config, aot ? NativeFilesType.AOT : NativeFilesType.Relinked));
         await BlazorRunForPublishWithWebServer(config);
     }
 

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
@@ -52,11 +52,11 @@ public class BuildPublishTests : BuildTestBase
         if (config == "Release")
         {
             // relinking in publish for Release config
-            BlazorPublish(new BlazorBuildOptions(id, config, NativeFilesType.Relinked));
+            BlazorPublish(new BlazorBuildOptions(id, config, NativeFilesType.Relinked, ExpectRelinkDirWhenPublishing: true));
         }
         else
         {
-            BlazorPublish(new BlazorBuildOptions(id, config, NativeFilesType.FromRuntimePack));
+            BlazorPublish(new BlazorBuildOptions(id, config, NativeFilesType.FromRuntimePack, ExpectRelinkDirWhenPublishing: true));
         }
     }
 
@@ -121,7 +121,7 @@ public class BuildPublishTests : BuildTestBase
         BlazorBuild(new BlazorBuildOptions(id, config, NativeFilesType.Relinked));
         CheckNativeFileLinked(forPublish: false);
 
-        BlazorPublish(new BlazorBuildOptions(id, config, NativeFilesType.Relinked));
+        BlazorPublish(new BlazorBuildOptions(id, config, NativeFilesType.Relinked, ExpectRelinkDirWhenPublishing: true));
         CheckNativeFileLinked(forPublish: true);
 
         await BlazorRun(config, async (page) =>
@@ -181,7 +181,7 @@ public class BuildPublishTests : BuildTestBase
         BlazorBuild(new BlazorBuildOptions(id, config, NativeFilesType.FromRuntimePack));
 
         // will relink
-        BlazorPublish(new BlazorBuildOptions(id, config, NativeFilesType.Relinked));
+        BlazorPublish(new BlazorBuildOptions(id, config, NativeFilesType.Relinked, ExpectRelinkDirWhenPublishing: true));
 
         // publish/wwwroot/_framework/blazor.boot.json
         string frameworkDir = FindBlazorBinFrameworkDir(config, forPublish: true);

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
@@ -232,6 +232,7 @@ public class BuildPublishTests : BuildTestBase
         await BlazorRunForBuildWithDotnetRun(config);
     }
 
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/82481")]
     [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
     [InlineData("Debug", false)]
     [InlineData("Debug", true)]

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
@@ -32,11 +32,11 @@ public class BuildPublishTests : BuildTestBase
         CreateBlazorWasmTemplateProject(id);
 
         // Build
-        BuildInternal(id, config, publish: false);
+        BlazorBuildInternal(id, config, publish: false);
         AssertBlazorBootJson(config, isPublish: false);
 
         // Publish
-        BuildInternal(id, config, publish: true);
+        BlazorBuildInternal(id, config, publish: true);
         AssertBlazorBootJson(config, isPublish: true);
     }
 

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/MiscTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/MiscTests.cs
@@ -35,7 +35,7 @@ public class MiscTests : BuildTestBase
         AddItemsPropertiesToProject(projectFile, extraProperties: extraProperties);
 
         // build with -p:DeployOnBuild=true, and that will trigger a publish
-        (CommandResult res, _) = BuildInternal(id, config, publish: false, setWasmDevel: false, "-p:DeployOnBuild=true");
+        (CommandResult res, _) = BlazorBuildInternal(id, config, publish: false, setWasmDevel: false, "-p:DeployOnBuild=true");
 
         var expectedFileType = nativeRelink ? NativeFilesType.Relinked : NativeFilesType.AOT;
 

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/MiscTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/MiscTests.cs
@@ -83,7 +83,7 @@ public class MiscTests : BuildTestBase
         BlazorBuild(new BlazorBuildOptions(id, config, NativeFilesType.FromRuntimePack));
 
         // will aot
-        BlazorPublish(new BlazorBuildOptions(id, config, NativeFilesType.AOT));
+        BlazorPublish(new BlazorBuildOptions(id, config, NativeFilesType.AOT, ExpectRelinkDirWhenPublishing: true));
 
         // build again
         BlazorBuild(new BlazorBuildOptions(id, config, NativeFilesType.FromRuntimePack));

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/NativeRefTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/NativeRefTests.cs
@@ -32,7 +32,7 @@ public class NativeRefTests : BuildTestBase
 
         BlazorBuild(new BlazorBuildOptions(id, config, NativeFilesType.Relinked));
 
-        BlazorPublish(new BlazorBuildOptions(id, config, NativeFilesType.AOT));
+        BlazorPublish(new BlazorBuildOptions(id, config, NativeFilesType.AOT, ExpectRelinkDirWhenPublishing: true));
 
         // will relink
         BlazorBuild(new BlazorBuildOptions(id, config, NativeFilesType.Relinked));
@@ -53,10 +53,10 @@ public class NativeRefTests : BuildTestBase
 
         BlazorBuild(new BlazorBuildOptions(id, config, NativeFilesType.Relinked));
 
-        BlazorPublish(new BlazorBuildOptions(id, config, NativeFilesType.AOT), "-p:RunAOTCompilation=true");
+        BlazorPublish(new BlazorBuildOptions(id, config, NativeFilesType.AOT, ExpectRelinkDirWhenPublishing: true), "-p:RunAOTCompilation=true");
 
         // no aot!
-        BlazorPublish(new BlazorBuildOptions(id, config, NativeFilesType.Relinked));
+        BlazorPublish(new BlazorBuildOptions(id, config, NativeFilesType.Relinked, ExpectRelinkDirWhenPublishing: true));
     }
 }
 

--- a/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
@@ -77,7 +77,7 @@ internal class BrowserRunner : IAsyncDisposable
             throw new Exception($"Process ended before the url was found");
         }
         if (!urlAvailable.Task.IsCompleted)
-            throw new Exception("Timed out waiting for the app host url");
+            throw new Exception("Timed out waiting for the web server url");
 
         var url = new Uri(urlAvailable.Task.Result);
         Playwright = await Microsoft.Playwright.Playwright.CreateAsync();

--- a/src/mono/wasm/Wasm.Build.Tests/BuildPublishTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildPublishTests.cs
@@ -41,7 +41,6 @@ namespace Wasm.Build.Tests
                         Publish: false
                         ));
 
-
             Run();
 
             if (!_buildContext.TryGetBuildFor(buildArgs, out BuildProduct? product))

--- a/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
@@ -575,12 +575,12 @@ namespace Wasm.Build.Tests
 
             }
 
-            if (!options.ExpectRelinkDirWhenPublishing)
-            {
-                // Check that we linked only for publish
-                string objBuildDir = Path.Combine(_projectDir!, "obj", options.Config, options.TargetFramework, "wasm", "for-build");
+            string objBuildDir = Path.Combine(_projectDir!, "obj", options.Config, options.TargetFramework, "wasm", "for-build");
+            // Check that we linked only for publish
+            if (options.ExpectRelinkDirWhenPublishing)
+                Assert.True(Directory.Exists(objBuildDir), $"Could not find expected {objBuildDir}, which gets created when relinking during Build. This is liokely a test authoring error");
+            else
                 Assert.False(Directory.Exists(objBuildDir), $"Found unexpected {objBuildDir}, which gets created when relinking during Build");
-            }
 
             return res;
         }

--- a/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
@@ -544,7 +544,7 @@ namespace Wasm.Build.Tests
             if (options.WarnAsError)
                 extraArgs = extraArgs.Append("/warnaserror").ToArray();
 
-            var res = BuildInternal(options.Id, options.Config, publish: false, setWasmDevel: false, extraArgs);
+            var res = BlazorBuildInternal(options.Id, options.Config, publish: false, setWasmDevel: false, extraArgs);
             _testOutput.WriteLine($"BlazorBuild, options.tfm: {options.TargetFramework}");
             AssertDotNetNativeFiles(options.ExpectedFileType, options.Config, forPublish: false, targetFramework: options.TargetFramework);
             AssertBlazorBundle(options.Config,
@@ -557,7 +557,7 @@ namespace Wasm.Build.Tests
 
         protected (CommandResult, string) BlazorPublish(BlazorBuildOptions options, params string[] extraArgs)
         {
-            var res = BuildInternal(options.Id, options.Config, publish: true, setWasmDevel: false, extraArgs);
+            var res = BlazorBuildInternal(options.Id, options.Config, publish: true, setWasmDevel: false, extraArgs);
             AssertDotNetNativeFiles(options.ExpectedFileType, options.Config, forPublish: true, targetFramework: options.TargetFramework);
             AssertBlazorBundle(options.Config,
                                isPublish: true,
@@ -576,7 +576,7 @@ namespace Wasm.Build.Tests
             return res;
         }
 
-        protected (CommandResult, string) BuildInternal(string id, string config, bool publish=false, bool setWasmDevel=true, params string[] extraArgs)
+        protected (CommandResult, string) BlazorBuildInternal(string id, string config, bool publish=false, bool setWasmDevel=true, params string[] extraArgs)
         {
             string label = publish ? "publish" : "build";
             _testOutput.WriteLine($"{Environment.NewLine}** {label} **{Environment.NewLine}");

--- a/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
@@ -572,7 +572,16 @@ namespace Wasm.Build.Tests
 
                 // make sure this assembly gets skipped
                 Assert.DoesNotContain("Microsoft.JSInterop.WebAssembly.dll -> Microsoft.JSInterop.WebAssembly.dll.bc", res.Item1.Output);
+
             }
+
+            if (!options.ExpectRelinkDirWhenPublishing)
+            {
+                // Check that we linked only for publish
+                string objBuildDir = Path.Combine(_projectDir!, "obj", options.Config, options.TargetFramework, "wasm", "for-build");
+                Assert.False(Directory.Exists(objBuildDir), $"Found unexpected {objBuildDir}, which gets created when relinking during Build");
+            }
+
             return res;
         }
 
@@ -1211,7 +1220,8 @@ namespace Wasm.Build.Tests
         string Config,
         NativeFilesType ExpectedFileType,
         string TargetFramework = BuildTestBase.DefaultTargetFrameworkForBlazor,
-        bool WarnAsError = true
+        bool WarnAsError = true,
+        bool ExpectRelinkDirWhenPublishing=false
     );
 
     public enum GlobalizationMode

--- a/src/mono/wasm/Wasm.Build.Tests/CleanTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/CleanTests.cs
@@ -73,7 +73,7 @@ public class CleanTests : NativeRebuildTestsBase
         AddItemsPropertiesToProject(projectFile, extraProperties: extraProperties);
 
         bool relink = firstBuildNative;
-        BuildInternal(id, config, publish: false,
+        BlazorBuildInternal(id, config, publish: false,
                         extraArgs: relink ? "-p:WasmBuildNative=true" : string.Empty);
 
         string relinkDir = Path.Combine(_projectDir!, "obj", config, DefaultTargetFrameworkForBlazor, "wasm", "for-build");
@@ -81,7 +81,7 @@ public class CleanTests : NativeRebuildTestsBase
             Assert.True(Directory.Exists(relinkDir), $"Could not find expected relink dir: {relinkDir}");
 
         relink = !firstBuildNative;
-        BuildInternal(id, config, publish: false,
+        BlazorBuildInternal(id, config, publish: false,
                         extraArgs: relink ? "-p:WasmBuildNative=true" : string.Empty);
 
         if (relink)

--- a/src/mono/wasm/Wasm.Build.Tests/WasmNativeDefaultsTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WasmNativeDefaultsTests.cs
@@ -63,7 +63,9 @@ namespace Wasm.Build.Tests
                                                         dotnetWasmFromRuntimePack: !publishValue,
                                                         extraItems: nativeRefItem);
 
-            Assert.Contains($"** WasmBuildNative: '{buildValue.ToString().ToLower()}', WasmBuildingForNestedPublish: ''", output);
+            // for build
+            Assert.DoesNotContain($"** WasmBuildNative: '{buildValue.ToString().ToLower()}', WasmBuildingForNestedPublish: ''", output);
+            // for publish
             Assert.Contains($"** WasmBuildNative: '{publishValue.ToString().ToLower()}', WasmBuildingForNestedPublish: 'true'", output);
             Assert.Contains("Stopping the build", output);
         }

--- a/src/mono/wasm/Wasm.Build.Tests/WasmNativeDefaultsTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WasmNativeDefaultsTests.cs
@@ -40,7 +40,9 @@ namespace Wasm.Build.Tests
         {
             string output = CheckWasmNativeDefaultValue("native_defaults_publish", config, extraProperties, aot, dotnetWasmFromRuntimePack: !publishValue);
 
-            Assert.Contains($"** WasmBuildNative: '{buildValue.ToString().ToLower()}', WasmBuildingForNestedPublish: ''", output);
+            // for build
+            Assert.DoesNotContain($"** WasmBuildNative: '{buildValue.ToString().ToLower()}', WasmBuildingForNestedPublish: ''", output);
+            // for publish
             Assert.Contains($"** WasmBuildNative: '{publishValue.ToString().ToLower()}', WasmBuildingForNestedPublish: 'true'", output);
             Assert.Contains("Stopping the build", output);
         }

--- a/src/mono/wasm/Wasm.Build.Tests/WasmTemplateTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WasmTemplateTests.cs
@@ -418,21 +418,6 @@ namespace Wasm.Build.Tests
             Assert.Contains("args[2] = z", res.Output);
         }
 
-        [ConditionalFact(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
-        public async Task BlazorRunTest()
-        {
-            string config = "Debug";
-            string id = $"blazor_{config}_{Path.GetRandomFileName()}";
-            string projectFile = CreateWasmTemplateProject(id, "blazorwasm");
-
-            new DotNetCommand(s_buildEnv, _testOutput)
-                    .WithWorkingDirectory(_projectDir!)
-                    .Execute($"build -c {config} -bl:{Path.Combine(s_buildEnv.LogRootPath, $"{id}.binlog")}")
-                    .EnsureSuccessful();
-
-            await BlazorRun(config);
-        }
-
         [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
         [InlineData("", BuildTestBase.DefaultTargetFramework)]
         // [ActiveIssue("https://github.com/dotnet/runtime/issues/79313")]

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -108,7 +108,8 @@
     <_WasmNestedPublishAppPreTarget Condition="'$(DisableAutoWasmPublishApp)' != 'true'">Publish</_WasmNestedPublishAppPreTarget>
 
     <EnableDefaultWasmAssembliesToBundle Condition="'$(EnableDefaultWasmAssembliesToBundle)' == ''">true</EnableDefaultWasmAssembliesToBundle>
-    <WasmBuildOnlyAfterPublish Condition="'$(WasmBuildOnlyAfterPublish)' == '' and '$(DeployOnBuild)' == 'true'">true</WasmBuildOnlyAfterPublish>
+    <!-- VS uses DeployOnBuild, and sdk sets _IsPublishing -->
+    <WasmBuildOnlyAfterPublish Condition="'$(WasmBuildOnlyAfterPublish)' == '' and ('$(DeployOnBuild)' == 'true' or '$(_IsPublishing)' == 'true')">true</WasmBuildOnlyAfterPublish>
     <WasmGenerateAppBundle Condition="'$(WasmGenerateAppBundle)' == '' and '$(OutputType)' != 'Library'">true</WasmGenerateAppBundle>
     <WasmGenerateAppBundle Condition="'$(WasmGenerateAppBundle)' == ''">false</WasmGenerateAppBundle>
     <UseAppHost>false</UseAppHost>
@@ -172,7 +173,7 @@
     <!-- Use a unique property, so the already run wasm targets can also run -->
     <MSBuild Projects="$(MSBuildProjectFile)"
              Targets="WasmNestedPublishApp"
-             Properties="_WasmInNestedPublish_UniqueProperty_XYZ=true;;WasmBuildingForNestedPublish=true;DeployOnBuild=">
+             Properties="_WasmInNestedPublish_UniqueProperty_XYZ=true;;WasmBuildingForNestedPublish=true;DeployOnBuild=;_IsPublishing=">
       <Output TaskParameter="TargetOutputs" ItemName="WasmNestedPublishAppResultItems" />
     </MSBuild>
 


### PR DESCRIPTION
`Publish` target triggers `Build` target to run. When publishing, we don't want
to run relinking step during the `Build`, as it will be run for `Publish`
anyway. Earlier there wasn't a good way to differentiate the two cases of
`build` target - `dotnet build`, and `dotnet publish`, but now the sdk sets
`$(_IsPublishing)=true`, which can be used here.

- VS uses `$(DeployOnBuild)`, and that is still supported

- And add tests to run blazor+AOT