### PR TITLE
Do not use ALC name for AssemblyName

### DIFF
--- a/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
@@ -118,19 +118,9 @@ namespace System.Reflection
             [RequiresDynamicCode("Defining a dynamic assembly requires generating code at runtime")]
             public ProxyAssembly(AssemblyLoadContext alc)
             {
-                string name;
-                if (alc == AssemblyLoadContext.Default)
-                {
-                    name = "ProxyBuilder";
-                }
-                else
-                {
-                    string? alcName = alc.Name;
-                    name = string.IsNullOrEmpty(alcName) ? $"DispatchProxyTypes.{alc.GetHashCode()}" : $"DispatchProxyTypes.{alcName}";
-                }
                 AssemblyBuilderAccess builderAccess =
                     alc.IsCollectible ? AssemblyBuilderAccess.RunAndCollect : AssemblyBuilderAccess.Run;
-                _ab = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(name), builderAccess);
+                _ab = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("ProxyBuilder"), builderAccess);
                 _mb = _ab.DefineDynamicModule("testmod");
             }
 

--- a/src/libraries/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
@@ -811,6 +811,25 @@ namespace DispatchProxyTests
             }
         }
 
+        [Fact]
+        public static void Test_Multiple_AssemblyLoadContextsWithBadName()
+        {
+            if (typeof(DispatchProxyTests).Assembly.Location == "")
+                return;
+
+            Assembly assembly = Assembly.LoadFile(typeof(DispatchProxyTests).Assembly.Location);
+            Type type = assembly.GetType(typeof(DispatchProxyTests).FullName);
+            MethodInfo method = type.GetMethod(nameof(Demo), BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.True((bool)method.Invoke(null, null));
+        }
+
+        internal static bool Demo()
+        {
+            TestType_IHelloService proxy = DispatchProxy.Create<TestType_IHelloService, InternalInvokeProxy>();
+            proxy.Hello("Hello");
+            return true;
+        }
+
         private static TInterface CreateHelper<TInterface, TProxy>(bool useGenericCreate) where TProxy : DispatchProxy
         {
             if (useGenericCreate)


### PR DESCRIPTION
DispatchProxy uses Reflection.Emit internally and used to use only one `AssemblyBuilder` for all proxy types.

In .NET 7 that fixed with https://github.com/dotnet/runtime/pull/62095, now it creates a separate `AssemblyBuilder`, for each `AssemblyLoadContext` of the proxy type and also used the ALC name for creating `AssemblyName`

In some cases, ALC name could include a path: https://github.com/dotnet/runtime/blob/ccbcb7f8cf2c07184e2a8399a430ce9e1a885c12/src/libraries/System.Private.CoreLib/src/System/Reflection/Assembly.cs#L273 and special characters used for the path is not valid name for `AssemblyName` constructor and throws.

With this PR we are just using the same name for each ALC, we might want to pass the AssemblyLoadContext.Name as @KalleOlaviNiemitalo [suggested](https://github.com/dotnet/runtime/issues/80387#issuecomment-1428370220) for debugging purpose, but ALC info probably should be passed/solved appropriately with https://github.com/dotnet/runtime/issues/62234 instead, or if needed we can update accordingly later.

See more details from https://github.com/dotnet/runtime/issues/80387