### PR TITLE
[wasm] Implement partial backward branch support in the Jiterpreter

### DIFF
--- a/src/mono/mono/mini/interp/interp-internals.h
+++ b/src/mono/mono/mini/interp/interp-internals.h
@@ -173,6 +173,11 @@ struct InterpMethod {
 	unsigned int needs_thread_attach : 1;
 	// If set, this method is MulticastDelegate.Invoke
 	unsigned int is_invoke : 1;
+#if HOST_BROWSER
+	unsigned int contains_traces : 1;
+	guint16 *backward_branch_offsets;
+	guint16 backward_branch_offsets_size, backward_branch_offsets_count;
+#endif
 #if PROFILE_INTERP
 	long calls;
 	long opcounts;

--- a/src/mono/mono/mini/interp/interp-internals.h
+++ b/src/mono/mono/mini/interp/interp-internals.h
@@ -176,7 +176,7 @@ struct InterpMethod {
 #if HOST_BROWSER
 	unsigned int contains_traces : 1;
 	guint16 *backward_branch_offsets;
-	guint16 backward_branch_offsets_size, backward_branch_offsets_count;
+	unsigned int backward_branch_offsets_count;
 #endif
 #if PROFILE_INTERP
 	long calls;

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -693,7 +693,7 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 				if (*inside_branch_block)
 					return TRACE_CONTINUE;
 				else
-					return TRACE_ABORT;
+					return mono_opt_jiterpreter_backward_branches_enabled ? TRACE_CONTINUE : TRACE_ABORT;
 			}
 
 			*inside_branch_block = TRUE;
@@ -731,6 +731,7 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 			(opcode >= MINT_BRFALSE_I4) &&
 			(opcode <= MINT_BLT_UN_I8_IMM_SP)
 		) {
+			// FIXME: Detect negative displacement and abort appropriately
 			*inside_branch_block = TRUE;
 			return TRACE_CONTINUE;
 		}

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -462,46 +462,6 @@ mono_jiterp_relop_fp (double lhs, double rhs, int opcode) {
 
 #undef JITERP_RELOP
 
-#define JITERP_MEMBER_VT_INITIALIZED 0
-#define JITERP_MEMBER_ARRAY_DATA 1
-#define JITERP_MEMBER_STRING_LENGTH 2
-#define JITERP_MEMBER_STRING_DATA 3
-#define JITERP_MEMBER_IMETHOD 4
-#define JITERP_MEMBER_DATA_ITEMS 5
-#define JITERP_MEMBER_RMETHOD 6
-#define JITERP_MEMBER_SPAN_LENGTH 7
-#define JITERP_MEMBER_SPAN_DATA 8
-#define JITERP_MEMBER_ARRAY_LENGTH 9
-
-// we use these helpers at JIT time to figure out where to do memory loads and stores
-EMSCRIPTEN_KEEPALIVE size_t
-mono_jiterp_get_member_offset (int member) {
-	switch (member) {
-		case JITERP_MEMBER_VT_INITIALIZED:
-			return MONO_STRUCT_OFFSET (MonoVTable, initialized);
-		case JITERP_MEMBER_ARRAY_DATA:
-			return MONO_STRUCT_OFFSET (MonoArray, vector);
-		case JITERP_MEMBER_ARRAY_LENGTH:
-			return MONO_STRUCT_OFFSET (MonoArray, max_length);
-		case JITERP_MEMBER_STRING_LENGTH:
-			return MONO_STRUCT_OFFSET (MonoString, length);
-		case JITERP_MEMBER_STRING_DATA:
-			return MONO_STRUCT_OFFSET (MonoString, chars);
-		case JITERP_MEMBER_IMETHOD:
-			return offsetof (InterpFrame, imethod);
-		case JITERP_MEMBER_DATA_ITEMS:
-			return offsetof (InterpMethod, data_items);
-		case JITERP_MEMBER_RMETHOD:
-			return offsetof (JiterpEntryDataHeader, rmethod);
-		case JITERP_MEMBER_SPAN_LENGTH:
-			return offsetof (MonoSpanOfVoid, _length);
-		case JITERP_MEMBER_SPAN_DATA:
-			return offsetof (MonoSpanOfVoid, _reference);
-		default:
-			g_assert_not_reached();
-	}
-}
-
 EMSCRIPTEN_KEEPALIVE size_t
 mono_jiterp_get_size_of_stackval () {
 	return sizeof(stackval);
@@ -941,15 +901,16 @@ trace_info_alloc () {
  *  instruction that would end up there instead and not waste any resources trying to compile it.
  */
 void
-jiterp_insert_entry_points (void *_td)
+jiterp_insert_entry_points (void *_imethod, void *_td)
 {
-	if (!mono_opt_jiterpreter_traces_enabled)
-		return;
+	InterpMethod *imethod = (InterpMethod *)_imethod;
 	TransformData *td = (TransformData *)_td;
-
 	// Insert an entry opcode for the next basic block (call resume and first bb)
 	// FIXME: Should we do this based on relationships between BBs instead of insn sequence?
 	gboolean enter_at_next = TRUE;
+
+	if (!mono_opt_jiterpreter_traces_enabled)
+		return;
 
 	for (InterpBasicBlock *bb = td->entry_bb; bb != NULL; bb = bb->next_bb) {
 		// Enter trace at top of functions
@@ -979,6 +940,7 @@ jiterp_insert_entry_points (void *_td)
 			gint32 trace_index = trace_info_alloc ();
 
 			td->cbb = bb;
+			imethod->contains_traces = TRUE;
 			InterpInst *ins = mono_jiterp_insert_ins (td, NULL, MINT_TIER_PREPARE_JITERPRETER);
 			memcpy(ins->data, &trace_index, sizeof (trace_index));
 
@@ -1259,6 +1221,52 @@ mono_jiterp_trace_transfer (
 	// We got a relative displacement other than 0, so the trace bailed out somewhere or
 	//  branched to another branch target. Time to return (and our caller will return too.)
 	return displacement + relative_displacement;
+}
+
+#define JITERP_MEMBER_VT_INITIALIZED 0
+#define JITERP_MEMBER_ARRAY_DATA 1
+#define JITERP_MEMBER_STRING_LENGTH 2
+#define JITERP_MEMBER_STRING_DATA 3
+#define JITERP_MEMBER_IMETHOD 4
+#define JITERP_MEMBER_DATA_ITEMS 5
+#define JITERP_MEMBER_RMETHOD 6
+#define JITERP_MEMBER_SPAN_LENGTH 7
+#define JITERP_MEMBER_SPAN_DATA 8
+#define JITERP_MEMBER_ARRAY_LENGTH 9
+#define JITERP_MEMBER_BACKWARD_BRANCH_OFFSETS 10
+#define JITERP_MEMBER_BACKWARD_BRANCH_OFFSETS_COUNT 11
+
+// we use these helpers at JIT time to figure out where to do memory loads and stores
+EMSCRIPTEN_KEEPALIVE size_t
+mono_jiterp_get_member_offset (int member) {
+	switch (member) {
+		case JITERP_MEMBER_VT_INITIALIZED:
+			return MONO_STRUCT_OFFSET (MonoVTable, initialized);
+		case JITERP_MEMBER_ARRAY_DATA:
+			return MONO_STRUCT_OFFSET (MonoArray, vector);
+		case JITERP_MEMBER_ARRAY_LENGTH:
+			return MONO_STRUCT_OFFSET (MonoArray, max_length);
+		case JITERP_MEMBER_STRING_LENGTH:
+			return MONO_STRUCT_OFFSET (MonoString, length);
+		case JITERP_MEMBER_STRING_DATA:
+			return MONO_STRUCT_OFFSET (MonoString, chars);
+		case JITERP_MEMBER_IMETHOD:
+			return offsetof (InterpFrame, imethod);
+		case JITERP_MEMBER_DATA_ITEMS:
+			return offsetof (InterpMethod, data_items);
+		case JITERP_MEMBER_BACKWARD_BRANCH_OFFSETS:
+			return offsetof (InterpMethod, backward_branch_offsets);
+		case JITERP_MEMBER_BACKWARD_BRANCH_OFFSETS_COUNT:
+			return offsetof (InterpMethod, backward_branch_offsets_count);
+		case JITERP_MEMBER_RMETHOD:
+			return offsetof (JiterpEntryDataHeader, rmethod);
+		case JITERP_MEMBER_SPAN_LENGTH:
+			return offsetof (MonoSpanOfVoid, _length);
+		case JITERP_MEMBER_SPAN_DATA:
+			return offsetof (MonoSpanOfVoid, _reference);
+		default:
+			g_assert_not_reached();
+	}
 }
 
 // HACK: fix C4206

--- a/src/mono/mono/mini/interp/jiterpreter.h
+++ b/src/mono/mono/mini/interp/jiterpreter.h
@@ -34,7 +34,7 @@ jiterp_preserve_module ();
 
 // HACK: Pass void* so that this header can include safely in files without definition for TransformData
 void
-jiterp_insert_entry_points (void *td);
+jiterp_insert_entry_points (void *imethod, void *td);
 
 // used by the typescript JIT implementation to notify the runtime that it has finished jitting a thunk
 //  for a specific callsite, since it can take a while before it happens

--- a/src/mono/mono/utils/options-def.h
+++ b/src/mono/mono/utils/options-def.h
@@ -108,6 +108,8 @@ DEFINE_BOOL(jiterpreter_dump_traces, "jiterpreter-dump-traces", FALSE, "Dump the
 DEFINE_BOOL(jiterpreter_use_constants, "jiterpreter-use-constants", FALSE, "Use runtime imports for pointer constants")
 // Attempt to eliminate redundant null checks in compiled traces
 DEFINE_BOOL(jiterpreter_eliminate_null_checks, "jiterpreter-eliminate-null-checks", TRUE, "Attempt to eliminate redundant null checks in traces")
+// enables performing backward branches without exiting traces
+DEFINE_BOOL(jiterpreter_backward_branches_enabled, "jiterpreter-backward-branches-enabled", TRUE, "Enable performing backward branches without exiting traces")
 // When compiling a jit_call wrapper, bypass sharedvt wrappers if possible by inlining their
 //  logic into the compiled wrapper and calling the target AOTed function with native call convention
 DEFINE_BOOL(jiterpreter_direct_jit_call, "jiterpreter-direct-jit-calls", TRUE, "Bypass gsharedvt wrappers when compiling JIT call wrappers")

--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -950,6 +950,8 @@ export const enum JiterpMember {
     SpanLength = 7,
     SpanData = 8,
     ArrayLength = 9,
+    BackwardBranchOffsets = 10,
+    BackwardBranchOffsetsCount = 11,
 }
 
 const memberOffsets : { [index: number] : number } = {};
@@ -995,6 +997,8 @@ export type JiterpreterOptions = {
     dumpTraces: boolean;
     // Use runtime imports for pointer constants
     useConstants: boolean;
+    // Enable performing backward branches without exiting traces
+    noExitBackwardBranches: boolean;
     // Unwrap gsharedvt wrappers when compiling jitcalls if possible
     directJitCalls: boolean;
     eliminateNullChecks: boolean;
@@ -1022,6 +1026,7 @@ const optionNames : { [jsName: string] : string } = {
     "dumpTraces": "jiterpreter-dump-traces",
     "useConstants": "jiterpreter-use-constants",
     "eliminateNullChecks": "jiterpreter-eliminate-null-checks",
+    "noExitBackwardBranches": "jiterpreter-backward-branches-enabled",
     "directJitCalls": "jiterpreter-direct-jit-calls",
     "minimumTraceLength": "jiterpreter-minimum-trace-length",
     "minimumTraceHitCount": "jiterpreter-minimum-trace-hit-count",

--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -60,6 +60,7 @@ export class WasmBuilder {
     branchTargets = new Set<MintOpcodePtr>();
     options!: JiterpreterOptions;
     constantSlots: Array<number> = [];
+    backBranchOffsets: Array<MintOpcodePtr> = [];
     nextConstantSlot = 0;
 
     constructor (constantSlotCount: number) {
@@ -91,6 +92,7 @@ export class WasmBuilder {
         this.constantSlots.length = this.options.useConstants ? constantSlotCount : 0;
         for (let i = 0; i < this.constantSlots.length; i++)
             this.constantSlots[i] = 0;
+        this.backBranchOffsets.length = 0;
 
         this.allowNullCheckOptimization = this.options.eliminateNullChecks;
     }

--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -725,6 +725,8 @@ export const counters = {
     failures: 0,
     bytesGenerated: 0,
     nullChecksEliminated: 0,
+    backBranchesEmitted: 0,
+    backBranchesNotEmitted: 0,
 };
 
 export const _now = (globalThis.performance && globalThis.performance.now)

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -59,6 +59,8 @@ export const
     traceBackBranches = false,
     // If we encounter an enter opcode that looks like a loop body and it was already
     //  jitted, we should abort the current trace since it's not worth continuing
+    // Unproductive if we have backward branches enabled because it can stop us from jitting
+    //  nested loops
     abortAtJittedLoopBodies = true,
     // Emit a wasm nop between each managed interpreter opcode
     emitPadding = false,
@@ -928,7 +930,8 @@ export function jiterpreter_dump_stats (b?: boolean, concise?: boolean) {
         return;
 
     console.log(`// jitted ${counters.bytesGenerated} bytes; ${counters.tracesCompiled} traces (${counters.traceCandidates} candidates, ${(counters.tracesCompiled / counters.traceCandidates * 100).toFixed(1)}%); ${counters.jitCallsCompiled} jit_calls (${(counters.directJitCallsCompiled / counters.jitCallsCompiled * 100).toFixed(1)}% direct); ${counters.entryWrappersCompiled} interp_entries`);
-    console.log(`// time: ${elapsedTimes.generation | 0}ms generating, ${elapsedTimes.compilation | 0}ms compiling wasm. ${counters.nullChecksEliminated} null checks eliminated`);
+    const backBranchHitRate = (counters.backBranchesEmitted / (counters.backBranchesEmitted + counters.backBranchesNotEmitted)) * 100;
+    console.log(`// time: ${elapsedTimes.generation | 0}ms generating, ${elapsedTimes.compilation | 0}ms compiling wasm. ${counters.nullChecksEliminated} null checks eliminated. ${counters.backBranchesEmitted} backward branches emitted (${backBranchHitRate.toFixed(1)}%)`);
     if (concise)
         return;
 

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -899,7 +899,9 @@ export function mono_interp_tier_prepare_jiterpreter (
     const imethod = getU32(getMemberOffset(JiterpMember.Imethod) + <any>frame);
     const backBranchCount = getU16(getMemberOffset(JiterpMember.BackwardBranchOffsetsCount) + imethod);
     const pBackBranches = getU32(getMemberOffset(JiterpMember.BackwardBranchOffsets) + imethod);
-    const backwardBranchTable = backBranchCount ? new Uint16Array(Module.HEAPU8.buffer, pBackBranches, backBranchCount) : null;
+    const backwardBranchTable = backBranchCount
+        ? new Uint16Array(Module.HEAPU8.buffer, pBackBranches, backBranchCount)
+        : null;
 
     const fnPtr = generate_wasm(
         frame, methodName, ip, startOfBody, sizeOfBody, methodFullName, backwardBranchTable

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -55,6 +55,8 @@ export const
     nullCheckCaching = true,
     // Print diagnostic information to the console when performing null check optimizations
     traceNullCheckOptimizations = false,
+    // Print diagnostic information when generating backward branches
+    traceBackBranches = false,
     // If we encounter an enter opcode that looks like a loop body and it was already
     //  jitted, we should abort the current trace since it's not worth continuing
     abortAtJittedLoopBodies = true,


### PR DESCRIPTION
This PR adds partial support for backward branches to the jiterpreter.

Due to WASM's quirky approach to constrained control flow and loops, the code it generates is very suboptimal, but it still produces a measurable speed-up (~22sec/iter -> ~20sec/iter for one of the benchmarks that regressed, for example) and is a decent starting point to improve on.

This PR also removes a write barrier from ldelem_ref that didn't need to be there and was *very* expensive. That takes the regressed benchmark down further from ~20sec/iter to ~3sec/iter.

Additional statistics and a runtime option are added to go with the new backward branch support.

More detail on how it works:
1. For any methods that contain a trace entry point, the interpreter maintains a table listing all the bblocks that are targeted by a backwards branch.
2. If a method has one or more backward branch targets in its table, when the jiterpreter generates traces in that method it wraps them in a wasm `loop` instruction so that we can transfer control back to the top.
3. The jiterpreter scans the backward branch table when emitting instructions, and when it hits something it knows is a backwards branch target, it ensures that a branch target block starts there. Each encountered backwards branch target is added to a list.
4. Any time the jiterpreter encounters a backwards branch, if the target is in the list of branch targets we've already encountered, `eip` is updated and control is sent back to the top of the trace by branching to the `loop`. After that, execution will skip over blocks until it reaches the branch target.

Attentive readers will note that this algorithm is inefficient because we have to scan over blocks until we find the branch target - there's only one loop for the entire trace. I tried creating a separate loop for each backwards branch target (which would allow us to jump directly to it) but its interaction with forward branches (which require the ability to jump forward to the end of a control region) made it too hard to get that working, at least initially.

A better implementation of control flow would probably allow direct branching for both forwards and backwards control flow, or at least reduce the cost of the branches from what it is currently. But that implementation would likely require a second pass in the trace compiler and building some sort of CFG on the fly so I haven't started on it yet.