### PR TITLE
SequenceReader performance; elide bounds checks and book-keeping

### DIFF
--- a/src/libraries/System.Memory/src/System/Buffers/SequenceReader.Search.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/SequenceReader.Search.cs
@@ -578,7 +578,7 @@ namespace System.Buffers
             {
                 // Advance past all matches in the current span
                 int i;
-                var unread = UnreadSpan; // eat the slice to avoid bounds checks
+                ReadOnlySpan<T> unread = UnreadSpan; // eat the slice to avoid bounds checks
                 for (i = 0; i < unread.Length && unread[i].Equals(value); i++)
                 {
                 }
@@ -610,7 +610,7 @@ namespace System.Buffers
             {
                 // Advance past all matches in the current span
                 int i;
-                var unread = UnreadSpan; // eat the slice to avoid bounds checks
+                ReadOnlySpan<T> unread = UnreadSpan; // eat the slice to avoid bounds checks
                 for (i = 0; i < unread.Length && values.IndexOf(unread[i]) != -1; i++)
                 {
                 }
@@ -642,7 +642,7 @@ namespace System.Buffers
             {
                 // Advance past all matches in the current span
                 int i;
-                var unread = UnreadSpan; // eat the slice to avoid bounds checks
+                ReadOnlySpan<T> unread = UnreadSpan; // eat the slice to avoid bounds checks
                 for (i = 0; i < unread.Length; i++)
                 {
                     ref readonly T value = ref unread[i];
@@ -679,7 +679,7 @@ namespace System.Buffers
             {
                 // Advance past all matches in the current span
                 int i;
-                var unread = UnreadSpan; // eat the slice to avoid bounds checks
+                ReadOnlySpan<T> unread = UnreadSpan; // eat the slice to avoid bounds checks
                 for (i = 0; i < unread.Length; i++)
                 {
                     ref readonly T value = ref unread[i];
@@ -716,7 +716,7 @@ namespace System.Buffers
             {
                 // Advance past all matches in the current span
                 int i;
-                var unread = UnreadSpan; // eat the slice to avoid bounds checks
+                ReadOnlySpan<T> unread = UnreadSpan; // eat the slice to avoid bounds checks
                 for (i = 0; i < unread.Length; i++)
                 {
                     ref readonly T value = ref unread[i];
@@ -752,7 +752,7 @@ namespace System.Buffers
                 _currentSpanIndex = 0;
                 _currentSpan = default;
 
-                var position = _sequence.End;
+                SequencePosition position = _sequence.End;
                 _currentPositionObject = position.GetObject();
                 _currentPositionInteger = position.GetInteger();
                 // and mimic default(Position) for next
@@ -830,7 +830,7 @@ namespace System.Buffers
                 // Need to check the next segment
                 while (true)
                 {
-                    if (!_sequence.TryGetBuffer(position, out var nextSegment, out var nextPosition))
+                    if (!_sequence.TryGetBuffer(position, out ReadOnlyMemory<T> nextSegment, out SequencePosition nextPosition))
                     {
                         // Nothing left
                         return false;

--- a/src/libraries/System.Memory/src/System/Buffers/SequenceReader.Search.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/SequenceReader.Search.cs
@@ -645,7 +645,7 @@ namespace System.Buffers
                 var unread = UnreadSpan; // eat the slice to avoid bounds checks
                 for (i = 0; i < unread.Length; i++)
                 {
-                    T value = unread[i];
+                    ref readonly T value = ref unread[i];
                     if (!value.Equals(value0) && !value.Equals(value1) && !value.Equals(value2) && !value.Equals(value3))
                     {
                         break;
@@ -682,7 +682,7 @@ namespace System.Buffers
                 var unread = UnreadSpan; // eat the slice to avoid bounds checks
                 for (i = 0; i < unread.Length; i++)
                 {
-                    T value = unread[i];
+                    ref readonly T value = ref unread[i];
                     if (!value.Equals(value0) && !value.Equals(value1) && !value.Equals(value2))
                     {
                         break;
@@ -719,7 +719,7 @@ namespace System.Buffers
                 var unread = UnreadSpan; // eat the slice to avoid bounds checks
                 for (i = 0; i < unread.Length; i++)
                 {
-                    T value = unread[i];
+                    ref readonly T value = ref unread[i];
                     if (!value.Equals(value0) && !value.Equals(value1))
                     {
                         break;

--- a/src/libraries/System.Memory/src/System/Buffers/SequenceReader.Search.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/SequenceReader.Search.cs
@@ -813,7 +813,7 @@ namespace System.Buffers
             Debug.Assert(currentSpan.Length < next.Length);
 
             int fullLength = next.Length;
-            SequencePosition position = Position;
+            object? segment = _currentPositionObject;
 
             while (next.StartsWith(currentSpan))
             {
@@ -828,7 +828,7 @@ namespace System.Buffers
                 }
 
                 // Need to check the next segment
-                if (!TryGetNextBuffer(in _sequence, ref position, ref currentSpan))
+                if (!TryGetNextBuffer(in _sequence, ref segment, ref currentSpan))
                 {
                     return false; // no more data
                 }

--- a/src/libraries/System.Memory/src/System/Buffers/SequenceReader.Search.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/SequenceReader.Search.cs
@@ -831,7 +831,7 @@ namespace System.Buffers
                 next = next.Slice(currentSpan.Length);
 
                 // Need to check the next segment
-                if (!TryGetNextBuffer(in _sequence, ref segment, ref currentSpan, out _))
+                if (TryGetNextBuffer(in _sequence, ref segment, ref currentSpan) != TryGetNextBufferResult.SuccessHaveData)
                 {
                     // Nothing left
                     return false;

--- a/src/libraries/System.Memory/src/System/Buffers/SequenceReader.Search.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/SequenceReader.Search.cs
@@ -827,11 +827,16 @@ namespace System.Buffers
                     return true;
                 }
 
+                // move past the values we have validated
+                next = next.Slice(currentSpan.Length);
+
                 // Need to check the next segment
-                if (!TryGetNextBuffer(in _sequence, ref segment, ref currentSpan))
+                if (!TryGetNextBuffer(in _sequence, ref segment, ref currentSpan, out _))
                 {
-                    return false; // no more data
+                    // Nothing left
+                    return false;
                 }
+
                 if (currentSpan.Length > next.Length)
                 {
                     currentSpan = currentSpan.Slice(0, next.Length);

--- a/src/libraries/System.Memory/src/System/Buffers/SequenceReader.Search.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/SequenceReader.Search.cs
@@ -32,7 +32,7 @@ namespace System.Buffers
 
         private bool TryReadToSlow(out ReadOnlySpan<T> span, T delimiter, bool advancePastDelimiter)
         {
-            if (!TryReadToInternal(out ReadOnlySequence<T> sequence, delimiter, advancePastDelimiter, CurrentSpan.Length - CurrentSpanIndex))
+            if (!TryReadToInternal(out ReadOnlySequence<T> sequence, delimiter, advancePastDelimiter, CurrentSpanLength - _currentSpanIndex))
             {
                 span = default;
                 return false;
@@ -198,7 +198,7 @@ namespace System.Buffers
                 Advance(skip);
             ReadOnlySpan<T> remaining = UnreadSpan;
 
-            while (_moreData)
+            while (!End)
             {
                 int index = remaining.IndexOf(delimiter);
                 if (index != -1)
@@ -243,7 +243,7 @@ namespace System.Buffers
             ReadOnlySpan<T> remaining = UnreadSpan;
             bool priorEscape = false;
 
-            while (_moreData)
+            while (!End)
             {
                 int index = remaining.IndexOf(delimiter);
                 if (index != -1)
@@ -344,7 +344,7 @@ namespace System.Buffers
 
         private bool TryReadToAnySlow(out ReadOnlySpan<T> span, scoped ReadOnlySpan<T> delimiters, bool advancePastDelimiter)
         {
-            if (!TryReadToAnyInternal(out ReadOnlySequence<T> sequence, delimiters, advancePastDelimiter, CurrentSpan.Length - CurrentSpanIndex))
+            if (!TryReadToAnyInternal(out ReadOnlySequence<T> sequence, delimiters, advancePastDelimiter, CurrentSpanLength - _currentSpanIndex))
             {
                 span = default;
                 return false;
@@ -578,11 +578,11 @@ namespace System.Buffers
             {
                 // Advance past all matches in the current span
                 int i;
-                for (i = CurrentSpanIndex; i < CurrentSpan.Length && CurrentSpan[i].Equals(value); i++)
+                for (i = _currentSpanIndex; i < CurrentSpanLength && Unsafe.Add(ref CurrentSpanStart, i).Equals(value); i++)
                 {
                 }
 
-                int advanced = i - CurrentSpanIndex;
+                int advanced = i - _currentSpanIndex;
                 if (advanced == 0)
                 {
                     // Didn't advance at all in this span, exit.
@@ -593,7 +593,7 @@ namespace System.Buffers
 
                 // If we're at position 0 after advancing and not at the End,
                 // we're in a new span and should continue the loop.
-            } while (CurrentSpanIndex == 0 && !End);
+            } while (_currentSpanIndex == 0 && !End);
 
             return Consumed - start;
         }
@@ -610,11 +610,11 @@ namespace System.Buffers
             {
                 // Advance past all matches in the current span
                 int i;
-                for (i = CurrentSpanIndex; i < CurrentSpan.Length && values.IndexOf(CurrentSpan[i]) != -1; i++)
+                for (i = _currentSpanIndex; i < CurrentSpanLength && values.IndexOf(Unsafe.Add(ref CurrentSpanStart, i)) != -1; i++)
                 {
                 }
 
-                int advanced = i - CurrentSpanIndex;
+                int advanced = i - _currentSpanIndex;
                 if (advanced == 0)
                 {
                     // Didn't advance at all in this span, exit.
@@ -625,7 +625,7 @@ namespace System.Buffers
 
                 // If we're at position 0 after advancing and not at the End,
                 // we're in a new span and should continue the loop.
-            } while (CurrentSpanIndex == 0 && !End);
+            } while (_currentSpanIndex == 0 && !End);
 
             return Consumed - start;
         }
@@ -642,16 +642,16 @@ namespace System.Buffers
             {
                 // Advance past all matches in the current span
                 int i;
-                for (i = CurrentSpanIndex; i < CurrentSpan.Length; i++)
+                for (i = _currentSpanIndex; i < CurrentSpanLength; i++)
                 {
-                    T value = CurrentSpan[i];
+                    T value = Unsafe.Add(ref CurrentSpanStart, i);
                     if (!value.Equals(value0) && !value.Equals(value1) && !value.Equals(value2) && !value.Equals(value3))
                     {
                         break;
                     }
                 }
 
-                int advanced = i - CurrentSpanIndex;
+                int advanced = i - _currentSpanIndex;
                 if (advanced == 0)
                 {
                     // Didn't advance at all in this span, exit.
@@ -662,7 +662,7 @@ namespace System.Buffers
 
                 // If we're at position 0 after advancing and not at the End,
                 // we're in a new span and should continue the loop.
-            } while (CurrentSpanIndex == 0 && !End);
+            } while (_currentSpanIndex == 0 && !End);
 
             return Consumed - start;
         }
@@ -679,16 +679,16 @@ namespace System.Buffers
             {
                 // Advance past all matches in the current span
                 int i;
-                for (i = CurrentSpanIndex; i < CurrentSpan.Length; i++)
+                for (i = _currentSpanIndex; i < CurrentSpanLength; i++)
                 {
-                    T value = CurrentSpan[i];
+                    T value = Unsafe.Add(ref CurrentSpanStart, i);
                     if (!value.Equals(value0) && !value.Equals(value1) && !value.Equals(value2))
                     {
                         break;
                     }
                 }
 
-                int advanced = i - CurrentSpanIndex;
+                int advanced = i - _currentSpanIndex;
                 if (advanced == 0)
                 {
                     // Didn't advance at all in this span, exit.
@@ -699,7 +699,7 @@ namespace System.Buffers
 
                 // If we're at position 0 after advancing and not at the End,
                 // we're in a new span and should continue the loop.
-            } while (CurrentSpanIndex == 0 && !End);
+            } while (_currentSpanIndex == 0 && !End);
 
             return Consumed - start;
         }
@@ -716,16 +716,16 @@ namespace System.Buffers
             {
                 // Advance past all matches in the current span
                 int i;
-                for (i = CurrentSpanIndex; i < CurrentSpan.Length; i++)
+                for (i = _currentSpanIndex; i < CurrentSpanLength; i++)
                 {
-                    T value = CurrentSpan[i];
+                    T value = Unsafe.Add(ref CurrentSpanStart, i);
                     if (!value.Equals(value0) && !value.Equals(value1))
                     {
                         break;
                     }
                 }
 
-                int advanced = i - CurrentSpanIndex;
+                int advanced = i - _currentSpanIndex;
                 if (advanced == 0)
                 {
                     // Didn't advance at all in this span, exit.
@@ -736,7 +736,7 @@ namespace System.Buffers
 
                 // If we're at position 0 after advancing and not at the End,
                 // we're in a new span and should continue the loop.
-            } while (CurrentSpanIndex == 0 && !End);
+            } while (_currentSpanIndex == 0 && !End);
 
             return Consumed - start;
         }
@@ -746,14 +746,13 @@ namespace System.Buffers
         /// </summary>
         public void AdvanceToEnd()
         {
-            if (_moreData)
+            if (!End)
             {
-                Consumed = Length;
-                CurrentSpan = default;
-                CurrentSpanIndex = 0;
+                _consumedAtStartOfCurrentSpan = Length;
+                WipeCurrentSpan();
+
                 _currentPosition = Sequence.End;
                 _nextPosition = default;
-                _moreData = false;
             }
         }
 
@@ -768,7 +767,7 @@ namespace System.Buffers
             if (End)
                 return false;
 
-            if (CurrentSpan[CurrentSpanIndex].Equals(next))
+            if (Unsafe.Add(ref CurrentSpanStart, _currentSpanIndex).Equals(next))
             {
                 if (advancePast)
                 {

--- a/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
@@ -216,7 +216,7 @@ namespace System.Buffers
             {
                 value = currentSpan[i];
 
-                if (++_currentSpanIndex == currentSpan.Length)
+                if ((_currentSpanIndex = i + 1) == currentSpan.Length)
                 {
                     TryGetNextSpan(); // move ahead eagerly
                 }

--- a/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
@@ -30,7 +30,7 @@ namespace System.Buffers
             var position = sequence.Start;
             _currentPositionObject = position.GetObject();
             _currentPositionInteger = position.GetInteger();
-            sequence.GetFirstSpan(out _currentSpan, out position);
+            sequence.GetFirstSpan(out _currentSpan, next: out position);
             _nextPositionObject = position.GetObject();
             _nextPositionInteger = position.GetInteger();
             _currentSpanIndex = 0;

--- a/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
@@ -91,6 +91,7 @@ namespace System.Buffers
         private ref T CurrentSpanStart => ref Unsafe.AsRef(in current.GetPinnableReference());
         private void SetCurrentSpan(ReadOnlySpan<T> span)
         {
+            _consumedAtStartOfCurrentSpan += CurrentSpanLength; // account for previous
             _currentSpan = span;
             _currentSpanIndex = 0;
         }

--- a/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
@@ -53,10 +53,7 @@ namespace System.Buffers
         /// <summary>
         /// The current position in the <see cref="Sequence"/>.
         /// </summary>
-        public readonly SequencePosition Position
-            => _sequence.GetPosition(_currentSpanIndex, new SequencePosition(_currentPositionObject, _currentPositionInteger));
-        // TODO: by eager-read, we *fully expect* that Position is inside the current span object (or very end for EOF); as such,
-        // we should be able to simplify to: => new SequencePosition(_currentPositionObject, _currentPositionInteger + _currentSpanIndex)
+        public readonly SequencePosition Position => new(_currentPositionObject, _currentPositionInteger + _currentSpanIndex); // since index in same segment, this is valid
 
         /// <summary>
         /// The current segment in the <see cref="Sequence"/> as a span.

--- a/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
@@ -63,13 +63,6 @@ namespace System.Buffers
         /// </summary>
         public readonly ReadOnlySpan<T> CurrentSpan => _currentSpan;
 
-        private void SetCurrentSpan(ReadOnlySpan<T> span)
-        {
-            _consumedAtStartOfCurrentSpan += _currentSpan.Length; // account for previous
-            _currentSpan = span;
-            _currentSpanIndex = 0;
-        }
-
         /// <summary>
         /// The index in the <see cref="CurrentSpan"/>.
         /// </summary>

--- a/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
@@ -265,10 +265,9 @@ namespace System.Buffers
         /// </summary>
         private bool GetNextSpan()
         {
+            _consumedAtStartOfCurrentSpan += _currentSpan.Length; // track consumed length
             if (!_sequence.IsSingleSegment)
             {
-                _consumedAtStartOfCurrentSpan += _currentSpan.Length; // account for previous
-
                 SequencePosition position = new(_nextPositionObject, _nextPositionInteger);
 
                 while (_sequence.TryGetBuffer(position, out var memory, out var next))

--- a/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
@@ -355,8 +355,9 @@ namespace System.Buffers
         {
             AssertValidPosition();
             const long TooBigOrNegative = unchecked((long)0xFFFFFFFF80000000);
-            if ((count & TooBigOrNegative) == 0 && _currentSpan.Length - _currentSpanIndex > (int)count)
+            if ((count & TooBigOrNegative) == 0 & _currentSpan.Length - _currentSpanIndex > (int)count)
             {
+                // ^^^ note & (rather than &&) is intentional; both sides can be safely evaluated
                 _currentSpanIndex += (int)count;
             }
             else

--- a/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
@@ -294,7 +294,6 @@ namespace System.Buffers
         [Conditional("DEBUG")]
         private readonly void AssertValidPosition()
         {
-#if DEBUG
             Debug.Assert(_currentSpanIndex >= 0 && _currentSpanIndex <= _currentSpan.Length, "span index out of range");
             if (_currentSpanIndex == _currentSpan.Length) // should only be at-length for EOF
             {
@@ -302,7 +301,6 @@ namespace System.Buffers
                 object? segment = _currentPositionObject;
                 Debug.Assert(!TryGetNextBuffer(in _sequence, ref segment, ref span), "failed to eagerly read-ahead");
             }
-#endif
         }
 
         private static bool TryGetNextBuffer(in ReadOnlySequence<T> sequence, ref object? @object, ref ReadOnlySpan<T> buffer)

--- a/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
@@ -27,7 +27,7 @@ namespace System.Buffers
         {
             _sequence = sequence;
 
-            var position = sequence.Start;
+            SequencePosition position = sequence.Start;
             _currentPositionObject = position.GetObject();
             _currentPositionInteger = position.GetInteger();
             sequence.GetFirstSpan(out _currentSpan, next: out position);
@@ -172,7 +172,7 @@ namespace System.Buffers
                 SequencePosition position = new(_nextPositionObject, _nextPositionInteger);
 
                 ReadOnlyMemory<T> currentMemory;
-                while (_sequence.TryGetBuffer(position, out currentMemory, out var next))
+                while (_sequence.TryGetBuffer(position, out currentMemory, out SequencePosition next))
                 {
                     position = next;
                     // Skip empty segment
@@ -260,7 +260,7 @@ namespace System.Buffers
         private void ResetReader()
         {
             // preserve the length - it can be relatively expensive to calculate on demand
-            var length = _length;
+            long length = _length;
 
             // reset all state
             this = new(_sequence);
@@ -280,7 +280,7 @@ namespace System.Buffers
             {
                 position = new(_nextPositionObject, _nextPositionInteger);
 
-                while (_sequence.TryGetBuffer(position, out var memory, out var next))
+                while (_sequence.TryGetBuffer(position, out ReadOnlyMemory<T> memory, out SequencePosition next))
                 {
                     if (memory.Length > 0)
                     {
@@ -417,7 +417,7 @@ namespace System.Buffers
             int copied = firstSpan.Length;
 
             SequencePosition position = new(_nextPositionObject, _nextPositionInteger);
-            while (_sequence.TryGetBuffer(position, out var nextSegment, out var next))
+            while (_sequence.TryGetBuffer(position, out ReadOnlyMemory<T> nextSegment, out SequencePosition next))
             {
                 position = next;
                 if (nextSegment.Length > 0)

--- a/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
@@ -337,7 +337,6 @@ namespace System.Buffers
             {
                 while (!ReferenceEquals(segment, endObject) && (@object = segment = segment!.Next) is not null)
                 {
-                    result = TryGetNextBufferResult.FailureAllRemainingSegmentsEmpty; // until we know otherwise
                     buffer = segment!.Memory.Span;
 
                     if (ReferenceEquals(segment, endObject))
@@ -351,6 +350,9 @@ namespace System.Buffers
                         result = TryGetNextBufferResult.SuccessHaveData;
                         break;
                     }
+
+                    // tell the caller that we *had* more segments (and have advanced), even if not useful
+                    result = TryGetNextBufferResult.FailureAllRemainingSegmentsEmpty;
                 }
             }
             return result;
@@ -394,7 +396,7 @@ namespace System.Buffers
             AssertValidPosition();
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)] // avoid what looks like a JIT regression with it inlining this too much from Advance
+        [MethodImpl(MethodImplOptions.NoInlining)] // avoid inlining this too much from Advance
         private void AdvanceToNextSpan(long count)
         {
             AssertValidPosition();

--- a/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
@@ -246,14 +246,13 @@ namespace System.Buffers
             var position = _sequence.Start;
             _currentPositionObject = position.GetObject();
             _currentPositionInteger = position.GetInteger();
-            _consumedAtStartOfCurrentSpan = 0;
-            _sequence.TryGetBuffer(position, out var memory, out var next);
-            _nextPositionObject = next.GetObject();
-            _nextPositionInteger = next.GetInteger();
-            _currentSpan = memory.Span;
+            _sequence.GetFirstSpan(out _currentSpan, out position);
+            _nextPositionObject = position.GetObject();
+            _nextPositionInteger = position.GetInteger();
             _currentSpanIndex = 0;
+            _consumedAtStartOfCurrentSpan = 0;
             if (_currentSpan.IsEmpty && !_sequence.IsSingleSegment)
-            {
+            {   // edge-case; multi-segment with zero-length as first
                 GetNextSpan();
             }
         }

--- a/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
@@ -181,7 +181,7 @@ namespace System.Buffers
                 object? segment = _currentPositionObject;
 
                 ReadOnlySpan<T> currentSpan = default;
-                while (TryGetNextBuffer(in _sequence, ref segment, ref currentSpan, out _))
+                while (TryGetNextBuffer(in _sequence, ref segment, ref currentSpan) == TryGetNextBufferResult.SuccessHaveData)
                 {
                     if (remainingOffset >= currentSpan.Length)
                     {
@@ -282,29 +282,30 @@ namespace System.Buffers
         /// <summary>
         /// Get the next segment with available data, if any.
         /// </summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private bool TryGetNextSpan()
         {
             int lastLength = _currentSpan.Length;
-            if (!TryGetNextBuffer(in _sequence, ref _currentPositionObject, ref _currentSpan, out bool advanced))
+            switch (TryGetNextBuffer(in _sequence, ref _currentPositionObject, ref _currentSpan))
             {
-                if (advanced) // we can still advance while returning false if the later segments are all empty
-                {
+                case TryGetNextBufferResult.SuccessHaveData:
                     _currentPositionInteger = _currentSpanIndex = 0;
                     _consumedAtStartOfCurrentSpan += lastLength; // track consumed length
-                }
-                else
-                {
-                    // make sure we position at the end of the last (current) segment
+                    AssertValidPosition();
+                    return true;
+                case TryGetNextBufferResult.FailureAllRemainingSegmentsEmpty:
+                    // means we advanced, so we still need to reset some things
+                    _currentPositionInteger = _currentSpanIndex = 0;
+                    _consumedAtStartOfCurrentSpan += lastLength; // track consumed length
+                    break;
+                default: // no more segments
+                    // make sure we position at the end of the last (current) segment,
+                    // even if we didn't change segment
                     _currentSpanIndex = lastLength;
-                }
-                AssertValidPosition();
-                return false;
+                    break;
             }
-            Debug.Assert(advanced);
-            _currentPositionInteger = _currentSpanIndex = 0;
-            _consumedAtStartOfCurrentSpan += lastLength; // track consumed length
             AssertValidPosition();
-            return true;
+            return false;
         }
 
         [Conditional("DEBUG")]
@@ -315,21 +316,28 @@ namespace System.Buffers
             {
                 ReadOnlySpan<T> span = default;
                 object? segment = _currentPositionObject;
-                Debug.Assert(!TryGetNextBuffer(in _sequence, ref segment, ref span, out _), "failed to eagerly read-ahead");
+                Debug.Assert(TryGetNextBuffer(in _sequence, ref segment, ref span) == TryGetNextBufferResult.FailureNoMoreSegments, "failed to eagerly read-ahead");
             }
         }
 
-        private static bool TryGetNextBuffer(in ReadOnlySequence<T> sequence, ref object? @object, ref ReadOnlySpan<T> buffer, out bool advanced)
+        private enum TryGetNextBufferResult
+        {
+            SuccessHaveData = 0,
+            FailureNoMoreSegments = 1,
+            FailureAllRemainingSegmentsEmpty = 2,
+        }
+
+        private static TryGetNextBufferResult TryGetNextBuffer(in ReadOnlySequence<T> sequence, ref object? @object, ref ReadOnlySpan<T> buffer)
         {
             SequencePosition end = sequence.End;
             object? endObject = end.GetObject();
-            advanced = false;
+            TryGetNextBufferResult result = TryGetNextBufferResult.FailureNoMoreSegments;
             ReadOnlySequenceSegment<T>? segment = @object as ReadOnlySequenceSegment<T>;
             if (segment is not null)
             {
                 while (!ReferenceEquals(segment, endObject) && (@object = segment = segment!.Next) is not null)
                 {
-                    advanced = true;
+                    result = TryGetNextBufferResult.FailureAllRemainingSegmentsEmpty; // until we know otherwise
                     buffer = segment!.Memory.Span;
 
                     if (ReferenceEquals(segment, endObject))
@@ -340,11 +348,12 @@ namespace System.Buffers
 
                     if (!buffer.IsEmpty) // skip empty segments
                     {
-                        return true;
+                        result = TryGetNextBufferResult.SuccessHaveData;
+                        break;
                     }
                 }
             }
-            return false;
+            return result;
         }
 
         /// <summary>
@@ -385,6 +394,7 @@ namespace System.Buffers
             AssertValidPosition();
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)] // avoid what looks like a JIT regression with it inlining this too much from Advance
         private void AdvanceToNextSpan(long count)
         {
             AssertValidPosition();
@@ -464,7 +474,7 @@ namespace System.Buffers
             int copied = currentSpan.Length;
 
             object? segment = _currentPositionObject;
-            while (TryGetNextBuffer(in _sequence, ref segment, ref currentSpan, out _))
+            while (TryGetNextBuffer(in _sequence, ref segment, ref currentSpan) == TryGetNextBufferResult.SuccessHaveData)
             {
                 int toCopy = Math.Min(currentSpan.Length, destination.Length - copied);
                 currentSpan.Slice(0, toCopy).CopyTo(destination.Slice(copied));

--- a/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/SequenceReader.cs
@@ -246,8 +246,6 @@ namespace System.Buffers
                 return;
             }
 
-            Consumed -= count;
-
             if (_currentSpanIndex >= count)
             {
                 _currentSpanIndex -= (int)count;
@@ -276,7 +274,7 @@ namespace System.Buffers
             this = new(_sequence);
 
             // reinstate the length
-            Unsafe.AsRef(_length) = length;
+            Unsafe.AsRef(in _length) = length;
         }
 
         /// <summary>


### PR DESCRIPTION
context: https://twitter.com/marcgravell/status/1629955240895078405 (read back for @davidfowl mention)

no direct side-by-side benchmark (what's a good way to arrange that here? I'm all ears), but in a proof-of-concept benchmark (see link above), achieved ~0.7 vs existing (note: that number was in-part based on the now removed `ref T` changes)

purpose: improved performance in `SequenceReader`

approach:

- reduced book-keeping by usually only manipulating a single index
- <strike>remove bounds-checking (since we're checking the bounds ourselves) via `Unsafe.Add(ref T, int)`</strike>
- <strike>when possible (net7+) store the current span's `ref T` directly; otherwise, store the `ReadOnlySpan<T>` like before, and use JIT-friendly accessor to expose the same API to the implementation code</strike>
- deconstruct `SequencePosition` for packing purposes
- elide bounds checks in search by slicing for `[0,len)` loop
- simplify position calculation
- in search loop, avoid copying out the `T` value (of unknown size); use the `ref` instead
- don't store/maintain "next" position; refactor next buffer fetch (removes need to retain "next")
- reduce size to 72 bytes from 96 bytes (note: in theory we don't actually need `_currentPositionInteger` (by obtaining the outer span and initializing `_currentSpanIndex` accordingly), but because of padding that wouldn't help unless we were able to split out the `_currentSpan` into `int` plus `ref T` via unsafe add etc, which would allow us to drop to 64 bytes)
- remove bounds checks in tryget/trypeek via hoist/uint check
- use non-short-circuiting `&` in `Advance`, since we expect both sides to pass in the happy path (and both are safe)

[benchmarks are here](https://github.com/mgravell/SequenceReaderBench)

(all payloads are 1024 bytes, split into chunks via `SegmentLength`; if this is negative, it is a vector, rather than a multi-segment)

typical results: https://raw.githubusercontent.com/mgravell/SequenceReaderBench/main/results.md

some similar benchmarks with `ref T` + `int` usage (unsafe, etc) don't show significant improvements in any cases