### PR TITLE
JIT: Remove JTRUE(relop) invariant in the backend

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -1610,6 +1610,7 @@ public:
 
     void genCodeForJcc(GenTreeCC* tree);
     void genCodeForSetcc(GenTreeCC* setcc);
+    void genCodeForJTrue(GenTreeOp* jtrue);
 #endif // !TARGET_LOONGARCH64
 };
 

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -1275,6 +1275,22 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
 }
 
 //------------------------------------------------------------------------
+// genCodeForJTrue: Produce code for a GT_JTRUE node.
+//
+// Arguments:
+//    tree - the node
+//
+void CodeGen::genCodeForJTrue(GenTreeOp* jtrue)
+{
+    assert(compiler->compCurBB->bbJumpKind == BBJ_COND);
+
+    GenTree*  op  = jtrue->gtGetOp1();
+    regNumber reg = genConsumeReg(op);
+    inst_RV_RV(INS_tst, reg, reg, genActualType(op));
+    inst_JMP(EJ_ne, compiler->compCurBB->bbJumpDest);
+}
+
+//------------------------------------------------------------------------
 // genCodeForReturnTrap: Produce code for a GT_RETURNTRAP node.
 //
 // Arguments:

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -1278,7 +1278,7 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
 // genCodeForJTrue: Produce code for a GT_JTRUE node.
 //
 // Arguments:
-//    tree - the node
+//    jtrue - the node
 //
 void CodeGen::genCodeForJTrue(GenTreeOp* jtrue)
 {

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -4565,6 +4565,21 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
 }
 
 //------------------------------------------------------------------------
+// genCodeForJTrue: Produce code for a GT_JTRUE node.
+//
+// Arguments:
+//    tree - the node
+//
+void CodeGen::genCodeForJTrue(GenTreeOp* jtrue)
+{
+    assert(compiler->compCurBB->bbJumpKind == BBJ_COND);
+
+    GenTree*  op  = jtrue->gtGetOp1();
+    regNumber reg = genConsumeReg(op);
+    GetEmitter()->emitIns_J_R(INS_cbnz, emitActualTypeSize(op), compiler->compCurBB->bbJumpDest, reg);
+}
+
+//------------------------------------------------------------------------
 // genCodeForConditionalCompare: Produce code for a compare that's dependent on a previous compare.
 //
 // Arguments:

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -4568,7 +4568,7 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
 // genCodeForJTrue: Produce code for a GT_JTRUE node.
 //
 // Arguments:
-//    tree - the node
+//    jtrue - the node
 //
 void CodeGen::genCodeForJTrue(GenTreeOp* jtrue)
 {

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -377,6 +377,10 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
             break;
 #endif // TARGET_ARM64
 
+        case GT_JTRUE:
+            genCodeForJTrue(treeNode->AsOp());
+            break;
+
         case GT_JCC:
             genCodeForJcc(treeNode->AsCC());
             break;

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -1305,6 +1305,22 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
 }
 
 //------------------------------------------------------------------------
+// genCodeForJTrue: Produce code for a GT_JTRUE node.
+//
+// Arguments:
+//    tree - the node
+//
+void CodeGen::genCodeForJTrue(GenTreeOp* jtrue)
+{
+    assert(compiler->compCurBB->bbJumpKind == BBJ_COND);
+
+    GenTree*  op  = jtrue->gtGetOp1();
+    regNumber reg = genConsumeReg(op);
+    inst_RV_RV(INS_test, reg, reg, genActualType(op));
+    inst_JMP(EJ_jne, compiler->compCurBB->bbJumpDest);
+}
+
+//------------------------------------------------------------------------
 // JumpKindToCmov:
 //   Convert an emitJumpKind to the corresponding cmov instruction.
 //
@@ -1834,6 +1850,10 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
         case GT_BT:
             genConsumeOperands(treeNode->AsOp());
             genCodeForCompare(treeNode->AsOp());
+            break;
+
+        case GT_JTRUE:
+            genCodeForJTrue(treeNode->AsOp());
             break;
 
         case GT_JCC:

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -1308,7 +1308,7 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
 // genCodeForJTrue: Produce code for a GT_JTRUE node.
 //
 // Arguments:
-//    tree - the node
+//    jtrue - the node
 //
 void CodeGen::genCodeForJTrue(GenTreeOp* jtrue)
 {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -12740,8 +12740,9 @@ void Compiler::gtDispRange(LIR::ReadOnlyRange const& range)
 //
 void Compiler::gtDispTreeRange(LIR::Range& containingRange, GenTree* tree)
 {
-    bool unused;
-    gtDispRange(containingRange.GetTreeRange(tree, &unused));
+    bool     closed;
+    unsigned sideEffects;
+    gtDispRange(containingRange.GetTreeRangeWithFlags(tree, &closed, &sideEffects));
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/lir.cpp
+++ b/src/coreclr/jit/lir.cpp
@@ -1131,9 +1131,9 @@ bool LIR::Range::TryGetUse(GenTree* node, Use* use)
 }
 
 //------------------------------------------------------------------------
-// LIR::Range::GetTreeRange: Computes the subrange that includes all nodes
-//                           in the dataflow trees rooted at a particular
-//                           set of nodes.
+// LIR::Range::GetMarkedRange:
+//   Computes the subrange that includes all nodes in the dataflow trees rooted
+//   at a particular set of nodes.
 //
 // This method logically uses the following algorithm to compute the
 // range:

--- a/src/coreclr/jit/lir.cpp
+++ b/src/coreclr/jit/lir.cpp
@@ -1195,7 +1195,8 @@ LIR::ReadOnlyRange LIR::Range::GetMarkedRange(unsigned  markCount,
     assert(sideEffects != nullptr);
 
 #ifndef DEBUG
-    // The treatment of flags definitions is on a best-effort basis; it should be used debug purposes only.
+    // The treatment of flags definitions is on a best-effort basis; it should
+    // be used for debug purposes only.
     static_assert_no_msg(!markFlagsOperands);
 #endif
 
@@ -1310,6 +1311,7 @@ LIR::ReadOnlyRange LIR::Range::GetTreeRange(GenTree* root, bool* isClosed, unsig
     return GetMarkedRange(markCount, root, isClosed, sideEffects);
 }
 
+#ifdef DEBUG
 //------------------------------------------------------------------------
 // LIR::Range::GetTreeRangeWithFlags:
 // Computes the subrange that includes all nodes in the dataflow tree rooted at
@@ -1335,6 +1337,7 @@ LIR::ReadOnlyRange LIR::Range::GetTreeRangeWithFlags(GenTree* root, bool* isClos
 
     return GetMarkedRange<true>(markCount, root, isClosed, sideEffects);
 }
+#endif
 
 //------------------------------------------------------------------------
 // LIR::Range::GetTreeRange: Computes the subrange that includes all nodes

--- a/src/coreclr/jit/lir.cpp
+++ b/src/coreclr/jit/lir.cpp
@@ -1164,6 +1164,15 @@ bool LIR::Range::TryGetUse(GenTree* node, Use* use)
 // occurring before uses).
 //
 // Arguments:
+//    markCount         - The number of marks initially set on nodes before the
+//                        start node.
+//    start             - The node to start looking backwards from.
+//    isClosed          - [out] Set to true if the returned range contains only
+//                        nodes in the dataflow tree and false otherwise.
+//    sideEffects       - [out] Combined side effect flags for all nodes in the
+//                        returned range.
+//
+// Template arguments:
 //    markFlagsOperands - Whether the dataflow algorithm should also try to
 //                        mark operands that are defining flags. For example,
 //                        GT_JCC implicitly consumes the flags defined by the
@@ -1173,12 +1182,6 @@ bool LIR::Range::TryGetUse(GenTree* node, Use* use)
 //                        range.
 //                        This works on a best-effort basis; the user should not
 //                        rely on all flags defs to be found.
-//    root              - The root of the dataflow tree.
-//    isClosed          - An output parameter that is set to true if the returned
-//                        range contains only nodes in the dataflow tree and false
-//                        otherwise.
-//
-// Type arguments:
 //
 // Returns:
 //    The computed subrange.

--- a/src/coreclr/jit/lir.h
+++ b/src/coreclr/jit/lir.h
@@ -291,6 +291,7 @@ public:
 
         ReadOnlyRange GetTreeRange(GenTree* root, bool* isClosed) const;
         ReadOnlyRange GetTreeRange(GenTree* root, bool* isClosed, unsigned* sideEffects) const;
+        ReadOnlyRange GetTreeRangeWithFlags(GenTree* root, bool* isClosed, unsigned* sideEffects) const;
         ReadOnlyRange GetRangeOfOperandTrees(GenTree* root, bool* isClosed, unsigned* sideEffects) const;
 
 #ifdef DEBUG
@@ -306,6 +307,8 @@ public:
     static Range SeqTree(Compiler* compiler, GenTree* tree);
 
     static void InsertBeforeTerminator(BasicBlock* block, LIR::Range&& range);
+
+    static GenTree* EarliestNode(GenTree* node1, GenTree* node2);
 };
 
 inline void GenTree::SetUnusedValue()

--- a/src/coreclr/jit/lir.h
+++ b/src/coreclr/jit/lir.h
@@ -248,6 +248,7 @@ public:
         Range(const Range& other) = delete;
         Range& operator=(const Range& other) = delete;
 
+        template <bool markFlagsOperands = false>
         ReadOnlyRange GetMarkedRange(unsigned markCount, GenTree* start, bool* isClosed, unsigned* sideEffects) const;
 
         void FinishInsertBefore(GenTree* insertionPoint, GenTree* first, GenTree* last);
@@ -291,7 +292,9 @@ public:
 
         ReadOnlyRange GetTreeRange(GenTree* root, bool* isClosed) const;
         ReadOnlyRange GetTreeRange(GenTree* root, bool* isClosed, unsigned* sideEffects) const;
+#ifdef DEBUG
         ReadOnlyRange GetTreeRangeWithFlags(GenTree* root, bool* isClosed, unsigned* sideEffects) const;
+#endif
         ReadOnlyRange GetRangeOfOperandTrees(GenTree* root, bool* isClosed, unsigned* sideEffects) const;
 
 #ifdef DEBUG
@@ -307,8 +310,6 @@ public:
     static Range SeqTree(Compiler* compiler, GenTree* tree);
 
     static void InsertBeforeTerminator(BasicBlock* block, LIR::Range&& range);
-
-    static GenTree* EarliestNode(GenTree* node1, GenTree* node2);
 };
 
 inline void GenTree::SetUnusedValue()

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3357,6 +3357,10 @@ GenTree* Lowering::LowerJTrue(GenTreeOp* jtrue)
 {
     GenTree* cond = jtrue->gtGetOp1();
 
+    JITDUMP("Lowering JTRUE:\n");
+    DISPTREERANGE(BlockRange(), jtrue);
+    JITDUMP("\n");
+
 #if defined(TARGET_ARM64)
     if (cond->OperIsCompare() && cond->gtGetOp2()->IsCnsIntOrI())
     {
@@ -3389,6 +3393,7 @@ GenTree* Lowering::LowerJTrue(GenTreeOp* jtrue)
             relopOp2->SetContained();
 
             BlockRange().Remove(cond);
+            JITDUMP("Lowered to JCMP\n");
             return nullptr;
         }
     }
@@ -3400,6 +3405,10 @@ GenTree* Lowering::LowerJTrue(GenTreeOp* jtrue)
         jtrue->SetOper(GT_JCC);
         jtrue->AsCC()->gtCondition = condCode;
     }
+
+    JITDUMP("Result:\n");
+    DISPTREERANGE(BlockRange(), jtrue);
+    JITDUMP("\n");
 
     return nullptr;
 }
@@ -3448,6 +3457,10 @@ GenTree* Lowering::LowerSelect(GenTreeConditional* select)
         }
     }
 
+    JITDUMP("Lowering select:\n");
+    DISPTREERANGE(BlockRange(), select);
+    JITDUMP("\n");
+
     // Do not transform GT_SELECT with GTF_SET_FLAGS into GT_SELECTCC; this
     // node is used by decomposition on x86.
     // TODO-CQ: If we allowed multiple nodes to consume the same CPU flags then
@@ -3460,6 +3473,9 @@ GenTree* Lowering::LowerSelect(GenTreeConditional* select)
         GenTreeOpCC* newSelect = select->AsOpCC();
         newSelect->gtCondition = selectCond;
         ContainCheckSelect(newSelect);
+        JITDUMP("Converted to SELECTCC:\n");
+        DISPTREERANGE(BlockRange(), newSelect);
+        JITDUMP("\n");
         return newSelect->gtNext;
     }
 

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3059,10 +3059,11 @@ GenTree* Lowering::OptimizeConstCompare(GenTree* cmp)
 {
     assert(cmp->gtGetOp2()->IsIntegralConst());
 
+    GenTree*       op1 = cmp->gtGetOp1();
+    GenTreeIntCon* op2 = cmp->gtGetOp2()->AsIntCon();
+
 #if defined(TARGET_XARCH) || defined(TARGET_ARM64)
-    GenTree*       op1      = cmp->gtGetOp1();
-    GenTreeIntCon* op2      = cmp->gtGetOp2()->AsIntCon();
-    ssize_t        op2Value = op2->IconValue();
+    ssize_t op2Value = op2->IconValue();
 
 #ifdef TARGET_XARCH
     var_types op1Type = op1->TypeGet();
@@ -3265,6 +3266,26 @@ GenTree* Lowering::OptimizeConstCompare(GenTree* cmp)
 #endif // TARGET_XARCH
 #endif // defined(TARGET_XARCH) || defined(TARGET_ARM64)
 
+    // Optimize EQ/NE(relop/SETCC, 0) into (maybe reversed) cond.
+    if (op2->IsIntegralConst(0) && (op1->OperIsCompare() || op1->OperIs(GT_SETCC)))
+    {
+        LIR::Use use;
+        if (BlockRange().TryGetUse(cmp, &use))
+        {
+            if (cmp->OperIs(GT_EQ))
+            {
+                GenTree* reversed = comp->gtReverseCond(op1);
+                assert(reversed == op1);
+            }
+
+            GenTree* next = cmp->gtNext;
+            use.ReplaceWith(op1);
+            BlockRange().Remove(cmp->gtGetOp2());
+            BlockRange().Remove(cmp);
+            return next;
+        }
+    }
+
     return cmp;
 }
 
@@ -3314,10 +3335,12 @@ GenTree* Lowering::LowerCompare(GenTree* cmp)
         }
     }
 #endif // TARGET_XARCH
+
     ContainCheckCompare(cmp->AsOp());
     return cmp->gtNext;
 }
 
+#ifndef TARGET_LOONGARCH64
 //------------------------------------------------------------------------
 // Lowering::LowerJTrue: Lowers a JTRUE node.
 //
@@ -3333,98 +3356,55 @@ GenTree* Lowering::LowerCompare(GenTree* cmp)
 //
 GenTree* Lowering::LowerJTrue(GenTreeOp* jtrue)
 {
-    assert(jtrue->gtGetOp1()->OperIsCompare());
-    assert(jtrue->gtGetOp1()->gtNext == jtrue);
-    GenTreeOp* relop = jtrue->gtGetOp1()->AsOp();
-
-    GenTree* relopOp1 = relop->gtGetOp1();
-    GenTree* relopOp2 = relop->gtGetOp2();
+    GenTree* cond = jtrue->gtGetOp1();
 
 #if defined(TARGET_ARM64)
-    if (relopOp2->IsCnsIntOrI())
+    if (cond->OperIsCompare() && cond->gtGetOp2()->IsCnsIntOrI())
     {
-        bool         useJCMP = false;
-        GenTreeFlags flags   = GTF_EMPTY;
+        GenTree*     relopOp1 = cond->gtGetOp1();
+        GenTree*     relopOp2 = cond->gtGetOp2();
+        bool         useJCMP  = false;
+        GenTreeFlags flags    = GTF_EMPTY;
 
-        if (relop->OperIs(GT_EQ, GT_NE) && relopOp2->IsIntegralConst(0))
+        if (cond->OperIs(GT_EQ, GT_NE) && relopOp2->IsIntegralConst(0))
         {
             // Codegen will use cbz or cbnz in codegen which do not affect the flag register
-            flags   = relop->OperIs(GT_EQ) ? GTF_JCMP_EQ : GTF_EMPTY;
+            flags   = cond->OperIs(GT_EQ) ? GTF_JCMP_EQ : GTF_EMPTY;
             useJCMP = true;
         }
-        else if (relop->OperIs(GT_TEST_EQ, GT_TEST_NE) && isPow2(relopOp2->AsIntCon()->IconValue()))
+        else if (cond->OperIs(GT_TEST_EQ, GT_TEST_NE) && isPow2(relopOp2->AsIntCon()->IconValue()))
         {
             // Codegen will use tbz or tbnz in codegen which do not affect the flag register
-            flags   = GTF_JCMP_TST | (relop->OperIs(GT_TEST_EQ) ? GTF_JCMP_EQ : GTF_EMPTY);
+            flags   = GTF_JCMP_TST | (cond->OperIs(GT_TEST_EQ) ? GTF_JCMP_EQ : GTF_EMPTY);
             useJCMP = true;
         }
 
         if (useJCMP)
         {
-            relop->SetOper(GT_JCMP);
-            relop->gtFlags &= ~(GTF_JCMP_TST | GTF_JCMP_EQ);
-            relop->gtFlags |= flags;
-            relop->gtType = TYP_VOID;
+            jtrue->SetOper(GT_JCMP);
+            jtrue->gtFlags &= ~(GTF_JCMP_TST | GTF_JCMP_EQ);
+            jtrue->gtOp1 = relopOp1;
+            jtrue->gtOp2 = relopOp2;
+            jtrue->gtFlags |= flags;
 
             relopOp2->SetContained();
 
-            BlockRange().Remove(jtrue);
-
-            assert(relop->gtNext == nullptr);
+            BlockRange().Remove(cond);
             return nullptr;
         }
     }
 #endif // TARGET_ARM64
 
-    assert(relop->OperIsCompare());
-    assert(relop->gtNext == jtrue);
-    assert(jtrue->gtNext == nullptr);
-
-#if defined(TARGET_LOONGARCH64)
-    GenCondition cond = GenCondition::FromRelop(relop);
-    // for LA64's integer compare and condition-branch instructions,
-    // it's very similar to the IL instructions.
-    if (!varTypeIsFloating(relopOp1->TypeGet()))
+    GenCondition condCode;
+    if (TryLowerConditionToFlagsNode(jtrue, cond, &condCode))
     {
-        relop->SetOper(GT_JCMP);
-        relop->gtType = TYP_VOID;
-
-        relop->gtFlags &= ~(GTF_JCMP_TST | GTF_JCMP_EQ | GTF_JCMP_MASK);
-        relop->gtFlags |= (GenTreeFlags)(cond.GetCode() << 25);
-
-        if ((cond.GetCode() == GenCondition::EQ) || (cond.GetCode() == GenCondition::NE))
-        {
-            relop->gtFlags &= ~GTF_UNSIGNED;
-        }
-
-        if (relopOp2->IsCnsIntOrI())
-        {
-            relopOp2->SetContained();
-        }
-
-        BlockRange().Remove(jtrue);
-
-        assert(relop->gtNext == nullptr);
-        return nullptr;
+        jtrue->SetOperRaw(GT_JCC);
+        jtrue->AsCC()->gtCondition = condCode;
     }
-    else
-    {
-        // But the LA64's float compare and condition-branch instructions,
-        // it has the condition flags indicating the comparing results.
-        relop->gtType = TYP_VOID;
-        relop->gtFlags |= GTF_SET_FLAGS;
-        assert(relop->OperIs(GT_EQ, GT_NE, GT_LT, GT_LE, GT_GE, GT_GT));
-    }
-#else
-    GenCondition cond;
-    bool         lowered = TryLowerConditionToFlagsNode(jtrue, relop, &cond);
-    assert(lowered); // Should succeed since relop is right before jtrue
-#endif // TARGET_LOONGARCH64
 
-    jtrue->SetOperRaw(GT_JCC);
-    jtrue->AsCC()->gtCondition = cond;
     return nullptr;
 }
+#endif
 
 //----------------------------------------------------------------------------------------------
 // LowerSelect: Lower a GT_SELECT node.
@@ -3489,14 +3469,14 @@ GenTree* Lowering::LowerSelect(GenTreeConditional* select)
 }
 
 //----------------------------------------------------------------------------------------------
-// TryLowerCompareToFlagsNode: Given a node 'parent' that is able to consume
+// TryLowerConditionToFlagsNode: Given a node 'parent' that is able to consume
 // conditions from CPU flags, try to transform 'condition' into a node that
 // produces CPU flags, and reorder it to happen right before 'parent'.
 //
 // Arguments:
-//     parent - The parent node that can consume from CPU flags.
-//     relop  - The relop that can be transformed into something that produces CPU flags.
-//     cond   - The condition that makes the compare true.
+//     parent    - The parent node that can consume from CPU flags.
+//     condition - The condition that to try to transform into something that produces CPU flags.
+//     code      - [out] The condition code that makes the condition true.
 //
 // Return Value:
 //     True if relop was transformed and is now right before 'parent'; otherwise false.

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3335,7 +3335,6 @@ GenTree* Lowering::LowerCompare(GenTree* cmp)
         }
     }
 #endif // TARGET_XARCH
-
     ContainCheckCompare(cmp->AsOp());
     return cmp->gtNext;
 }
@@ -3398,7 +3397,7 @@ GenTree* Lowering::LowerJTrue(GenTreeOp* jtrue)
     GenCondition condCode;
     if (TryLowerConditionToFlagsNode(jtrue, cond, &condCode))
     {
-        jtrue->SetOperRaw(GT_JCC);
+        jtrue->SetOper(GT_JCC);
         jtrue->AsCC()->gtCondition = condCode;
     }
 
@@ -3457,7 +3456,7 @@ GenTree* Lowering::LowerSelect(GenTreeConditional* select)
     GenCondition selectCond;
     if (((select->gtFlags & GTF_SET_FLAGS) == 0) && TryLowerConditionToFlagsNode(select, cond, &selectCond))
     {
-        select->SetOperRaw(GT_SELECTCC);
+        select->SetOper(GT_SELECTCC);
         GenTreeOpCC* newSelect = select->AsOpCC();
         newSelect->gtCondition = selectCond;
         ContainCheckSelect(newSelect);

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -135,8 +135,9 @@ private:
     GenTree* OptimizeConstCompare(GenTree* cmp);
     GenTree* LowerCompare(GenTree* cmp);
     GenTree* LowerJTrue(GenTreeOp* jtrue);
+    bool TryLowerJTrueToJCMP(GenTreeOp* jtrue);
     GenTree* LowerSelect(GenTreeConditional* cond);
-    bool TryLowerConditionToFlagsNode(GenTree* parent, GenTree* condition, GenCondition* cond);
+    bool TryLowerConditionToFlagsNode(GenTree* parent, GenTree* condition, GenCondition* code);
     GenTreeCC* LowerNodeCC(GenTree* node, GenCondition condition);
     void LowerJmpMethod(GenTree* jmp);
     void LowerRet(GenTreeUnOp* ret);

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -135,7 +135,6 @@ private:
     GenTree* OptimizeConstCompare(GenTree* cmp);
     GenTree* LowerCompare(GenTree* cmp);
     GenTree* LowerJTrue(GenTreeOp* jtrue);
-    bool TryLowerJTrueToJCMP(GenTreeOp* jtrue);
     GenTree* LowerSelect(GenTreeConditional* cond);
     bool TryLowerConditionToFlagsNode(GenTree* parent, GenTree* condition, GenCondition* code);
     GenTreeCC* LowerNodeCC(GenTree* node, GenCondition condition);

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -2306,20 +2306,9 @@ GenTree* Lowering::TryLowerAndToCCMP(GenTreeOp* tree)
         return nullptr;
     }
 
-#ifdef DEBUG
-    if (comp->verbose)
-    {
-        bool               isClosed;
-        unsigned           sideEffects;
-        LIR::ReadOnlyRange op1Range  = BlockRange().GetTreeRangeWithFlags(op1, &isClosed, &sideEffects);
-        LIR::ReadOnlyRange op2Range  = BlockRange().GetTreeRangeWithFlags(op2, &isClosed, &sideEffects);
-        GenTree*           firstNode = LIR::EarliestNode(op1Range.FirstNode(), op2Range.FirstNode());
-
-        JITDUMP("[%06u] is a candidate for CCMP:\n", Compiler::dspTreeID(tree));
-        comp->gtDispRange(LIR::ReadOnlyRange(firstNode, tree));
-        JITDUMP("\n");
-    }
-#endif
+    JITDUMP("[%06u] is a candidate for CCMP:\n", Compiler::dspTreeID(tree));
+    DISPTREERANGE(BlockRange(), tree);
+    JITDUMP("\n");
 
     // We leave checking invariance of op1 to tree to TryLowerConditionToFlagsNode.
     if (!IsInvariantInRange(op2, tree))
@@ -2356,17 +2345,9 @@ GenTree* Lowering::TryLowerAndToCCMP(GenTreeOp* tree)
     tree->SetOper(GT_SETCC);
     tree->AsCC()->gtCondition = cond2;
 
-#ifdef DEBUG
-    if (comp->verbose)
-    {
-        printf("Conversion was legal. Result:\n");
-        bool               isClosed;
-        unsigned           sideEffects;
-        LIR::ReadOnlyRange range = BlockRange().GetTreeRangeWithFlags(tree, &isClosed, &sideEffects);
-        comp->gtDispRange(range);
-        JITDUMP("\n");
-    }
-#endif
+    JITDUMP("Conversion was legal. Result:\n");
+    DISPTREERANGE(BlockRange(), tree);
+    JITDUMP("\n");
 
     return tree->gtNext;
 }

--- a/src/coreclr/jit/lowerloongarch64.cpp
+++ b/src/coreclr/jit/lowerloongarch64.cpp
@@ -125,6 +125,81 @@ GenTree* Lowering::LowerMul(GenTreeOp* mul)
 }
 
 //------------------------------------------------------------------------
+// Lowering::LowerJTrue: Lowers a JTRUE node.
+//
+// Arguments:
+//    jtrue - the JTRUE node
+//
+// Return Value:
+//    The next node to lower (usually nullptr).
+//
+GenTree* Lowering::LowerJTrue(GenTreeOp* jtrue)
+{
+    GenTree*     op = jtrue->gtGetOp1();
+    GenCondition cond;
+    GenTree*     cmpOp1;
+    GenTree*     cmpOp2;
+
+    if (op->OperIsCompare())
+    {
+        // We do not expect any other relops on LA64
+        assert(op->OperIs(GT_EQ, GT_NE, GT_LT, GT_LE, GT_GE, GT_GT));
+
+        cond = GenCondition::FromRelop(op);
+
+        cmpOp1 = op->gtGetOp1();
+        cmpOp2 = op->gtGetOp2();
+
+        // LA64's float compare and condition-branch instructions, have
+        // condition flags indicating the comparing results.
+        if (varTypeIsFloating(cmpOp1))
+        {
+            op->gtType = TYP_VOID;
+            op->gtFlags |= GTF_SET_FLAGS;
+            assert(op->OperIs(GT_EQ, GT_NE, GT_LT, GT_LE, GT_GE, GT_GT));
+            jtrue->SetOper(GT_JCC);
+            jtrue->AsCC()->gtCondition = cond;
+            return nullptr;
+        }
+
+        // We will fall through and turn this into a JCMP(op1, op2, kind), but need to remove the relop here.
+        BlockRange().Remove(op);
+    }
+    else
+    {
+        cond = GenCondition(GenCondition::NE);
+
+        cmpOp1 = op;
+        cmpOp2 = comp->gtNewZeroConNode(cmpOp1->TypeGet());
+
+        BlockRange().InsertBefore(jtrue, cmpOp2);
+
+        // Fall through and turn this into a JCMP(op1, 0, NE).
+    }
+
+    // for LA64's integer compare and condition-branch instructions,
+    // it's very similar to the IL instructions.
+    jtrue->SetOper(GT_JCMP);
+    jtrue->gtOp1 = cmpOp1;
+    jtrue->gtOp2 = cmpOp2;
+
+    jtrue->gtFlags &= ~(GTF_JCMP_TST | GTF_JCMP_EQ | GTF_JCMP_MASK);
+    jtrue->gtFlags |= (GenTreeFlags)(cond.GetCode() << 25);
+
+    if ((cond.GetCode() == GenCondition::EQ) || (cond.GetCode() == GenCondition::NE))
+    {
+        jtrue->gtFlags &= ~GTF_UNSIGNED;
+    }
+
+    if (cmpOp2->IsCnsIntOrI())
+    {
+        cmpOp2->SetContained();
+    }
+
+    return jtrue->gtNext;
+}
+
+//------------------------------------------------------------------------
 // LowerBinaryArithmetic: lowers the given binary arithmetic node.
 //
 // Arguments:

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -7750,6 +7750,7 @@ void LinearScan::handleOutgoingCriticalEdges(BasicBlock* block)
         }
     }
 
+    LclVarDsc* terminatorNodeLclVarDsc = nullptr;
     // Next, if this blocks ends with a switch table, or for Arm64, ends with JCMP instruction,
     // make sure to not copy into the registers that are consumed at the end of this block.
     //
@@ -7782,10 +7783,8 @@ void LinearScan::handleOutgoingCriticalEdges(BasicBlock* block)
             consumedRegs |= genRegMask(srcOp1->GetRegNum());
         }
     }
-
-#if defined(TARGET_ARM64) || defined(TARGET_LOONGARCH64)
-    // Next, if this blocks ends with a JCMP, we have to make sure:
-    // 1. Not to copy into the register that JCMP uses
+    // Next, if this blocks ends with a JCMP/JTRUE, we have to make sure:
+    // 1. Not to copy into the register that JCMP/JTRUE uses
     //    e.g. JCMP w21, BRANCH
     // 2. Not to copy into the source of JCMP's operand before it is consumed
     //    e.g. Should not use w0 since it will contain wrong value after resolution
@@ -7794,34 +7793,37 @@ void LinearScan::handleOutgoingCriticalEdges(BasicBlock* block)
     //          mov w21, w0
     //          JCMP w21, BRANCH
     // 3. Not to modify the local variable it must consume
-
     // Note: GT_COPY has special handling in codegen and its generation is merged with the
     // node that consumes its result. So both, the input and output regs of GT_COPY must be
     // excluded from the set available for resolution.
-    LclVarDsc* jcmpLocalVarDsc = nullptr;
-    if (block->bbJumpKind == BBJ_COND)
+    else if (block->bbJumpKind == BBJ_COND)
     {
         GenTree* lastNode = LIR::AsRange(block).LastNode();
 
-        if (lastNode->OperIs(GT_JCMP))
+        if (lastNode->OperIs(GT_JTRUE, GT_JCMP))
         {
-            GenTree* op1 = lastNode->gtGetOp1();
-            consumedRegs |= genRegMask(op1->GetRegNum());
+            GenTree* op = lastNode->gtGetOp1();
+            consumedRegs |= genRegMask(op->GetRegNum());
 
-            if (op1->OperIs(GT_COPY))
+            if (op->OperIs(GT_COPY))
             {
-                GenTree* srcOp1 = op1->gtGetOp1();
-                consumedRegs |= genRegMask(srcOp1->GetRegNum());
+                GenTree* srcOp = op->gtGetOp1();
+                consumedRegs |= genRegMask(srcOp->GetRegNum());
             }
 
-            if (op1->IsLocal())
+            if (op->IsLocal())
             {
-                GenTreeLclVarCommon* lcl = op1->AsLclVarCommon();
-                jcmpLocalVarDsc          = &compiler->lvaTable[lcl->GetLclNum()];
+                GenTreeLclVarCommon* lcl = op->AsLclVarCommon();
+                terminatorNodeLclVarDsc  = &compiler->lvaTable[lcl->GetLclNum()];
             }
+
+#ifndef TARGET_LOONGARCH64
+            // TODO-LOONGARCH64: Take into account that on LA64, the second
+            // operand of a JCMP can be in a register too.
+            assert(!lastNode->OperIs(GT_JCMP) || lastNode->gtGetOp2()->isContained());
+#endif
         }
     }
-#endif // defined(TARGET_ARM64) || defined(TARGET_LOONGARCH64)
 
     VarToRegMap sameVarToRegMap = sharedCriticalVarToRegMap;
     regMaskTP   sameWriteRegs   = RBM_NONE;
@@ -7898,7 +7900,8 @@ void LinearScan::handleOutgoingCriticalEdges(BasicBlock* block)
             }
 
 #if defined(TARGET_ARM64) || defined(TARGET_LOONGARCH64)
-            if (jcmpLocalVarDsc && (jcmpLocalVarDsc->lvVarIndex == outResolutionSetVarIndex))
+            if ((terminatorNodeLclVarDsc != nullptr) &&
+                (terminatorNodeLclVarDsc->lvVarIndex == outResolutionSetVarIndex))
             {
                 sameToReg = REG_NA;
             }

--- a/src/coreclr/jit/lsraarm.cpp
+++ b/src/coreclr/jit/lsraarm.cpp
@@ -769,6 +769,11 @@ int LinearScan::BuildNode(GenTree* tree)
             srcCount = BuildSimple(tree);
             break;
 
+        case GT_JTRUE:
+            BuildOperandUses(tree->gtGetOp1(), RBM_NONE);
+            srcCount = 1;
+            break;
+
         case GT_INDEX_ADDR:
             dstCount = 1;
             buildInternalIntRegisterDefForNode(tree);

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -408,6 +408,11 @@ int LinearScan::BuildNode(GenTree* tree)
             srcCount = BuildCmp(tree);
             break;
 
+        case GT_JTRUE:
+            BuildOperandUses(tree->gtGetOp1(), RBM_NONE);
+            srcCount = 1;
+            break;
+
         case GT_CKFINITE:
             srcCount = 1;
             assert(dstCount == 1);

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -228,6 +228,11 @@ int LinearScan::BuildNode(GenTree* tree)
             srcCount = BuildOperandUses(tree->gtGetOp1());
             break;
 
+        case GT_JTRUE:
+            BuildOperandUses(tree->gtGetOp1(), RBM_NONE);
+            srcCount = 1;
+            break;
+
         case GT_JCC:
             srcCount = 0;
             assert(dstCount == 0);


### PR DESCRIPTION
Today the backend (and much of the JIT) allows only JTRUE with a relop
operand, and it is always assumed that this relop appears right before
JTRUE in linear order. This change adds support for JTRUE nodes with
arbitrary integral operands from lowering and onwards. The operand is
also allowed to appear at arbitrary locations in LIR.

With this, we can now enable an optimization that turns
EQ/NE(relop/SETCC, 0) into just a (potentially) reversed condition. This
improves codegen for some cases with SELECTCC and gives us a simple way
to allow for compare chains that feed conditional branches in the
future.

Not so many diffs are expected, but they should come with #79283.

Currently based on top of #82610.

Example diffs:
```csharp
[MethodImpl(MethodImplOptions.NoInlining)]
public static int Foo(int a, int b, int c)
{
    if (a < b & b < c & c < 10)
        return a * 42 + b;

    return 13;
}
```
```diff
         6B01001F          cmp     w0, w1
         7A42B024          ccmp    w1, w2, z, lt
         7A4AB844          ccmp    w2, #10, z, lt
-        9A9FA7E2          cset    x2, lt
-        340000A2          cbz     w2, G_M35561_IG05
-						;; size=20 bbWeight=1 PerfScore 3.00
-G_M35561_IG03:              ;; offset=001CH
+        540000AA          bge     G_M35561_IG05
+						;; size=16 bbWeight=1 PerfScore 2.50
+G_M35561_IG03:              ;; offset=0018H
         52800542          mov     w2, #42
         1B020400          madd    w0, w0, w2, w1
 						;; size=8 bbWeight=0.50 PerfScore 1.25
 
```

```csharp
[MethodImpl(MethodImplOptions.NoInlining)]
public static int Foo(int a, int b, int c)
{
    if (a < b & b < c & c < 10)
        return 42;

    return 13;
}
```

```diff
G_M35561_IG01:              ;; offset=0000H
         910003FD          mov     fp, sp
 						;; size=8 bbWeight=1 PerfScore 1.50
 G_M35561_IG02:              ;; offset=0008H
+        528001A3          mov     w3, #13
+        52800544          mov     w4, #42
         6B01001F          cmp     w0, w1
         7A42B024          ccmp    w1, w2, z, lt
         7A4AB844          ccmp    w2, #10, z, lt
-        9A9FA7E0          cset    x0, lt
-        528001A1          mov     w1, #13
-        52800542          mov     w2, #42
-        7100001F          cmp     w0, #0
-        1A820020          csel    w0, w1, w2, eq
-						;; size=32 bbWeight=1 PerfScore 4.00
-G_M35561_IG03:              ;; offset=0028H
+        1A84A060          csel    w0, w3, w4, ge
+						;; size=24 bbWeight=1 PerfScore 3.00
+G_M35561_IG03:              ;; offset=0020H
         A8C17BFD          ldp     fp, lr, [sp], #0x10
         D65F03C0          ret     lr
 						;; size=8 bbWeight=1 PerfScore 2.00

```