### PR TITLE
JIT: Fold unreachable cases for switch in importer.

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -8003,16 +8003,16 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 #ifdef DEBUG
                 if (verbose)
                 {
-                    printf("\n---- CEE_SWITCH start in " FMT_BB " (PC=%03u) of '%s'", block->bbNum, block->bbCodeOffs,
+                    printf("\nStarting CEE_SWITCH in " FMT_BB " (PC=%03u) of '%s'", block->bbNum, block->bbCodeOffs,
                            info.compFullName);
                 }
 #endif
                 /* Pop the switch value off the stack */
-                op1 = impPopStack().val;
+                op1 = gtFoldExpr(impPopStack().val);
                 assertImp(genActualTypeIsIntOrI(op1->TypeGet()));
 
                 // Fold Switch for GT_CNS_INT
-                if ((op1->gtOper == GT_CNS_INT) && !compIsForImportOnly())
+                if (opts.OptimizationEnabled() && (op1->gtOper == GT_CNS_INT) && !compIsForImportOnly())
                 {
                     // Find the jump target
                     size_t       switchVal = (size_t)op1->AsIntCon()->gtIconVal;

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -8000,13 +8000,83 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 goto COND_JUMP;
 
             case CEE_SWITCH:
+#ifdef DEBUG
+                if (verbose)
+                {
+                    printf("\n---- CEE_SWITCH start in " FMT_BB " (PC=%03u) of '%s'", block->bbNum, block->bbCodeOffs,
+                           info.compFullName);
+                }
+#endif
                 /* Pop the switch value off the stack */
                 op1 = impPopStack().val;
                 assertImp(genActualTypeIsIntOrI(op1->TypeGet()));
 
-                /* We can create a switch node */
+                // Fold Switch for GT_CNS_INT
+                if ((op1->gtOper == GT_CNS_INT) && !compIsForImportOnly())
+                {
+                    // Find the jump target
+                    size_t       switchVal = (size_t)op1->AsIntCon()->gtIconVal;
+                    unsigned     jumpCnt   = block->bbJumpSwt->bbsCount;
+                    BasicBlock** jumpTab   = block->bbJumpSwt->bbsDstTab;
+                    bool         foundVal  = false;
 
-                op1 = gtNewOperNode(GT_SWITCH, TYP_VOID, op1);
+                    for (unsigned val = 0; val < jumpCnt; val++, jumpTab++)
+                    {
+                        BasicBlock* curJump = *jumpTab;
+
+                        assert(curJump->countOfInEdges() > 0);
+
+                        // If val matches switchVal or we are at the last entry and
+                        // we never found the switch value then set the new jump dest
+
+                        if ((val == switchVal) || (!foundVal && (val == jumpCnt - 1)))
+                        {
+                            if (curJump != block->bbNext)
+                            {
+                                // transform the basic block into a BBJ_ALWAYS
+                                block->bbJumpKind = BBJ_ALWAYS;
+                                block->bbJumpDest = curJump;
+                            }
+                            else
+                            {
+                                // transform the basic block into a BBJ_NONE
+                                block->bbJumpKind = BBJ_NONE;
+                            }
+                            foundVal = true;
+                        }
+                        else
+                        {
+                            // Remove 'block' from the predecessor list of 'curJump'
+                            fgRemoveRefPred(curJump, block);
+                        }
+                    }
+
+                    assert(foundVal);
+
+#ifdef DEBUG
+                    if (verbose)
+                    {
+                        printf("\nSwitch folded at " FMT_BB "\n", block->bbNum);
+                        printf(FMT_BB " becomes a %s", block->bbNum,
+                               block->bbJumpKind == BBJ_ALWAYS ? "BBJ_ALWAYS" : "BBJ_NONE");
+                        if (block->bbJumpKind == BBJ_ALWAYS)
+                        {
+                            printf(" to " FMT_BB, block->bbJumpDest->bbNum);
+                        }
+                        printf("\n");
+                        fgDispBasicBlocks(true);
+                    }
+#endif
+
+                    // Create a NOP node
+                    op1 = gtNewNothingNode();
+                }
+                else
+                {
+                    // We can create a switch node
+
+                    op1 = gtNewOperNode(GT_SWITCH, TYP_VOID, op1);
+                }
 
                 val = (int)getU4LittleEndian(codeAddr);
                 codeAddr += 4 + val * 4; // skip over the switch-table

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -8000,13 +8000,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 goto COND_JUMP;
 
             case CEE_SWITCH:
-#ifdef DEBUG
-                if (verbose)
-                {
-                    printf("\nStarting CEE_SWITCH in " FMT_BB " (PC=%03u) of '%s'", block->bbNum, block->bbCodeOffs,
-                           info.compFullName);
-                }
-#endif
                 /* Pop the switch value off the stack */
                 op1 = gtFoldExpr(impPopStack().val);
                 assertImp(genActualTypeIsIntOrI(op1->TypeGet()));
@@ -8064,7 +8057,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                             printf(" to " FMT_BB, block->bbJumpDest->bbNum);
                         }
                         printf("\n");
-                        fgDispBasicBlocks(true);
                     }
 #endif
 


### PR DESCRIPTION
This PR folds unreachable cases in Switch early in `Import` phase when switch value is GT_CNT_INT. 
Fixes https://github.com/dotnet/runtime/issues/65368.

Below trees show the optimization example for the below scenario:
```
static void Foo() => Bar(3);

static void Bar(int i)
{
    switch (i)
    {
        case 0:
            Console.WriteLine();
            break;
        case 1:
            Console.WriteLine();
            break;
        case 2:
            Console.WriteLine();
            break;
        case 3:
            Console.WriteLine();
            break;
        case 4:
            Console.WriteLine();
            break;
        case 5:
            // no-op
            break;
    }
}
```

- Trees before Switch folding:
```
*************** Inline @[000003] Finishing PHASE Profile incorporation
Trees after Profile incorporation

-----------------------------------------------------------------------------------------------------------------------------------------
BBnum BBid ref try hnd preds           weight    lp [IL range]     [jump]      [EH region]         [flags]
-----------------------------------------------------------------------------------------------------------------------------------------
BB03 [0002]  1                             1       [000..01E)-> BB05,BB06,BB07,BB08,BB09,BB10,BB04[def] (switch)                     
BB04 [0003]  1       BB03                  1       [01E..01F)        (return)                     
BB05 [0004]  1       BB03                  1       [01F..025)        (return)                     
BB06 [0005]  1       BB03                  1       [025..02B)        (return)                     
BB07 [0006]  1       BB03                  1       [02B..031)        (return)                     
BB08 [0007]  1       BB03                  1       [031..037)        (return)                     
BB09 [0008]  1       BB03                  1       [037..03C)                                     
BB10 [0009]  2       BB03,BB09             1       [03C..03D)        (return)                     
-----------------------------------------------------------------------------------------------------------------------------------------
```

- After Importation, BB03 always jumps to BB08 and other basic blocks are folded away:
```
*************** Inline @[000003] Finishing PHASE Importation
Trees after Importation

-----------------------------------------------------------------------------------------------------------------------------------------
BBnum BBid ref try hnd preds           weight    lp [IL range]     [jump]      [EH region]         [flags]
-----------------------------------------------------------------------------------------------------------------------------------------
BB03 [0002]  1                             1       [000..01E)-> BB08 (always)                     i 
BB04 [0003]  0                             1       [01E..01F)        (return)                     
BB05 [0004]  0                             1       [01F..025)        (return)                     
BB06 [0005]  0                             1       [025..02B)        (return)                     
BB07 [0006]  0                             1       [02B..031)        (return)                     
BB08 [0007]  1       BB03                  1       [031..037)        (return)                     i 
BB09 [0008]  0                             1       [037..03C)                                     
BB10 [0009]  1       BB09                  1       [03C..03D)        (return)                     
-----------------------------------------------------------------------------------------------------------------------------------------
```

```
*************** Before renumbering the basic blocks

-----------------------------------------------------------------------------------------------------------------------------------------
BBnum BBid ref try hnd preds           weight    lp [IL range]     [jump]      [EH region]         [flags]
-----------------------------------------------------------------------------------------------------------------------------------------
BB03 [0002]  1                             1       [000..01E)-> BB08 (always)                     i 
BB08 [0007]  1       BB03                  1       [031..037)        (return)                     i 
-----------------------------------------------------------------------------------------------------------------------------------------

***************  Exception Handling table is empty
Renumber BB08 to BB04
```

```
*************** Inline @[000003] Finishing PHASE Post-import
Trees after Post-import

-----------------------------------------------------------------------------------------------------------------------------------------
BBnum BBid ref try hnd preds           weight    lp [IL range]     [jump]      [EH region]         [flags]
-----------------------------------------------------------------------------------------------------------------------------------------
BB03 [0002]  1                             1       [000..01E)-> BB04 (always)                     i 
BB04 [0007]  1       BB03                  1       [031..037)        (return)                     i 
-----------------------------------------------------------------------------------------------------------------------------------------

------------ BB03 [000..01E) -> BB04 (always), preds={} succs={BB04}

***** BB03
STMT00003 ( 0x000[E-] ... ??? ) <- INL01 @ 0x000[E-] <- INLRT @ 0x000[E-]
               [000006] -----------                         *  NOP       void  

------------ BB04 [031..037) (return), preds={BB03} succs={}

***** BB04
STMT00004 ( 0x031[E-] ... ??? ) <- INL01 @ 0x000[E-] <- INLRT @ 0x000[E-]
               [000007] --C-G------                         *  CALL      void   System.Console:WriteLine()
```
