### PR TITLE
Use output size helpers for cryptographic primitives

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/ECDsaCng.SignVerify.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDsaCng.SignVerify.cs
@@ -20,15 +20,7 @@ namespace System.Security.Cryptography
         {
             ArgumentNullException.ThrowIfNull(hash);
 
-            int estimatedSize = KeySize switch
-            {
-                256 => 64,
-                384 => 96,
-                521 => 132,
-                // If we got here, the range of legal key sizes for ECDsaCng was expanded and someone didn't update this switch.
-                // Since it isn't a fatal error to miscalculate the estimatedSize, don't throw an exception. Just truck along.
-                _ => KeySize / 4,
-            };
+            int estimatedSize = GetMaxSignatureSize(DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
 
             unsafe
             {

--- a/src/libraries/Common/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
@@ -198,7 +198,7 @@ namespace System.Security.Cryptography
         // Now that the padding mode and information have been marshaled to their native counterparts, perform the encryption or decryption.
         private unsafe byte[] EncryptOrDecrypt(SafeNCryptKeyHandle key, ReadOnlySpan<byte> input, AsymmetricPaddingMode paddingMode, void* paddingInfo, bool encrypt)
         {
-            int estimatedSize = KeySize / 8;
+            int estimatedSize = GetMaxOutputSize();
 #if DEBUG
             estimatedSize = 2;  // Make sure the NTE_BUFFER_TOO_SMALL scenario gets exercised.
 #endif

--- a/src/libraries/Common/src/System/Security/Cryptography/RSACng.SignVerify.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSACng.SignVerify.cs
@@ -59,7 +59,7 @@ namespace System.Security.Cryptography
                 {
                     unsafe
                     {
-                        int estimatedSize = KeySize / 8;
+                        int estimatedSize = GetMaxOutputSize();
                         switch (padding.Mode)
                         {
                             case RSASignaturePaddingMode.Pkcs1:


### PR DESCRIPTION
This updates a few places that can use algorithm output size helpers.

Closes #67059 