### PR TITLE
Nullable annotation fixes

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/VersionConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/VersionConverter.cs
@@ -94,7 +94,7 @@ namespace System.ComponentModel
         {
             if (value is string version)
             {
-                return Version.TryParse(version, out Version _);
+                return Version.TryParse(version, out Version? _);
             }
             return value is Version;
         }

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/VersionConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/VersionConverter.cs
@@ -94,7 +94,7 @@ namespace System.ComponentModel
         {
             if (value is string version)
             {
-                return Version.TryParse(version, out Version? _);
+                return Version.TryParse(version, out _);
             }
             return value is Version;
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -494,7 +494,7 @@ namespace System.Net.Http
             {
                 if (entry.Value.CleanCacheAndDisposeIfUnused())
                 {
-                    _pools.TryRemove(entry.Key, out HttpConnectionPool _);
+                    _pools.TryRemove(entry.Key, out HttpConnectionPool? _);
                 }
             }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -494,7 +494,7 @@ namespace System.Net.Http
             {
                 if (entry.Value.CleanCacheAndDisposeIfUnused())
                 {
-                    _pools.TryRemove(entry.Key, out HttpConnectionPool? _);
+                    _pools.TryRemove(entry.Key, out _);
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -891,7 +891,7 @@ namespace System
             string? displayName,
             string? standardDisplayName)
         {
-            bool hasIanaId = TimeZoneInfo.TryConvertIanaIdToWindowsId(id, allocate: false, out string? _);
+            bool hasIanaId = TimeZoneInfo.TryConvertIanaIdToWindowsId(id, allocate: false, out _);
 
             return new TimeZoneInfo(
                 id,
@@ -942,7 +942,7 @@ namespace System
                 adjustmentRules = (AdjustmentRule[])adjustmentRules.Clone();
             }
 
-            bool hasIanaId = TimeZoneInfo.TryConvertIanaIdToWindowsId(id, allocate: false, out string? _);
+            bool hasIanaId = TimeZoneInfo.TryConvertIanaIdToWindowsId(id, allocate: false, out _);
 
             return new TimeZoneInfo(
                 id,

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -891,7 +891,7 @@ namespace System
             string? displayName,
             string? standardDisplayName)
         {
-            bool hasIanaId = TimeZoneInfo.TryConvertIanaIdToWindowsId(id, allocate: false, out string _);
+            bool hasIanaId = TimeZoneInfo.TryConvertIanaIdToWindowsId(id, allocate: false, out string? _);
 
             return new TimeZoneInfo(
                 id,
@@ -942,7 +942,7 @@ namespace System
                 adjustmentRules = (AdjustmentRule[])adjustmentRules.Clone();
             }
 
-            bool hasIanaId = TimeZoneInfo.TryConvertIanaIdToWindowsId(id, allocate: false, out string _);
+            bool hasIanaId = TimeZoneInfo.TryConvertIanaIdToWindowsId(id, allocate: false, out string? _);
 
             return new TimeZoneInfo(
                 id,

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSet.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSet.cs
@@ -650,7 +650,7 @@ namespace System.Runtime.Serialization.DataContracts
         public void ImportSchemaSet(XmlSchemaSet schemaSet, IEnumerable<XmlQualifiedName>? typeNames, bool importXmlDataType)
         {
             SchemaImporter importer = new SchemaImporter(schemaSet, typeNames, null, this, importXmlDataType);
-            importer.Import(out List<XmlQualifiedName>? _);
+            importer.Import(out _);
         }
 
         [RequiresDynamicCode(DataContract.SerializerAOTWarning)]

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSet.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSet.cs
@@ -650,7 +650,7 @@ namespace System.Runtime.Serialization.DataContracts
         public void ImportSchemaSet(XmlSchemaSet schemaSet, IEnumerable<XmlQualifiedName>? typeNames, bool importXmlDataType)
         {
             SchemaImporter importer = new SchemaImporter(schemaSet, typeNames, null, this, importXmlDataType);
-            importer.Import(out List<XmlQualifiedName> _);
+            importer.Import(out List<XmlQualifiedName>? _);
         }
 
         [RequiresDynamicCode(DataContract.SerializerAOTWarning)]

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Parameters/Ecma/EcmaFatMethodParameter.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Parameters/Ecma/EcmaFatMethodParameter.cs
@@ -37,7 +37,7 @@ namespace System.Reflection.TypeLoading.Ecma
 
         protected sealed override IEnumerable<CustomAttributeData> GetTrueCustomAttributes() => Parameter.GetCustomAttributes().ToTrueCustomAttributes(GetEcmaModule());
 
-        public sealed override bool HasDefaultValue => TryGetRawDefaultValue(out object _);
+        public sealed override bool HasDefaultValue => TryGetRawDefaultValue(out object? _);
 
         public sealed override object? RawDefaultValue
         {

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Parameters/Ecma/EcmaFatMethodParameter.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Parameters/Ecma/EcmaFatMethodParameter.cs
@@ -37,7 +37,7 @@ namespace System.Reflection.TypeLoading.Ecma
 
         protected sealed override IEnumerable<CustomAttributeData> GetTrueCustomAttributes() => Parameter.GetCustomAttributes().ToTrueCustomAttributes(GetEcmaModule());
 
-        public sealed override bool HasDefaultValue => TryGetRawDefaultValue(out object? _);
+        public sealed override bool HasDefaultValue => TryGetRawDefaultValue(out _);
 
         public sealed override object? RawDefaultValue
         {


### PR DESCRIPTION
Once runtime merges to a Roslyn toolset that has the fix for [issue 50782](https://github.com/dotnet/roslyn/issues/50782) these annotations will be necessary. Front loading the work here with this change.