### PR TITLE
Update usage of AllowEmptyTelemetry based on changes to the task in the SDK

### DIFF
--- a/src/tasks/Crossgen2Tasks/Microsoft.NET.CrossGen.targets
+++ b/src/tasks/Crossgen2Tasks/Microsoft.NET.CrossGen.targets
@@ -346,7 +346,13 @@ Copyright (c) .NET Foundation. All rights reserved.
                             _CreateR2RImages;
                             _CreateR2RSymbols">
 
-    <AllowEmptyTelemetry EventName="ReadyToRun" EventData="PublishReadyToRunUseCrossgen2=$(PublishReadyToRunUseCrossgen2);Crossgen2PackVersion=%(ResolvedCrossgen2Pack.NuGetPackageVersion);CompileListCount=@(_ReadyToRunCompileList->Count());FailedCount=@(_ReadyToRunCompilationFailures->Count())" />
+    <ItemGroup>
+       <_R2RCrossgenTelemetry Include="PublishReadyToRunUseCrossgen2" Value="$(PublishReadyToRunUseCrossgen2)" />
+       <_R2RCrossgenTelemetry Include="Crossgen2PackVersion" Value="%(ResolvedCrossgen2Pack.NuGetPackageVersion)" />
+       <_R2RCrossgenTelemetry Include="CompileListCount" Value="@(_ReadyToRunCompileList->Count())" />
+       <_R2RCrossgenTelemetry Include="FailedCount" Value="@(_ReadyToRunCompilationFailures->Count())" />
+    </ItemGroup>
+    <AllowEmptyTelemetry EventName="ReadyToRun" EventData="@(_R2RCrossgenTelemetry)" />
 
     <NETSdkError Condition="'@(_ReadyToRunCompilationFailures)' != ''" ResourceName="ReadyToRunCompilationFailed" />
 


### PR DESCRIPTION
In https://github.com/dotnet/sdk/pull/30269 the API of the AllowEmptyTelemetry task changed to allow for more granular hashing of the collected telemetry properties. This change was against a servicing branch and flowed into SDK main. Sometime after that change, these targets moved from SDK to Runtime, and so the change was lost.

This re-applies the change to Runtime main to address breaks seen in source-build.

Is there a layering concern here with consuming an SDK-delivered Task? Is the crossgen telemetry still relevant and should we still be collecting it?