### PR TITLE
Enable mono runtime to handle SIGTERM like CoreCLR

### DIFF
--- a/src/mono/mono/metadata/gc.c
+++ b/src/mono/mono/metadata/gc.c
@@ -43,6 +43,7 @@
 #include <mono/utils/mono-os-wait.h>
 #include <mono/utils/mono-lazy-init.h>
 #include <mono/utils/mono-threads-wasm.h>
+#include <mono/metadata/runtime.h>
 #ifndef HOST_WIN32
 #include <pthread.h>
 #endif
@@ -62,6 +63,8 @@ typedef struct DomainFinalizationReq {
 static gboolean gc_disabled;
 
 static gboolean finalizing_root_domain;
+
+extern volatile gboolean term_signaled;
 
 gboolean mono_log_finalizers;
 gboolean mono_do_not_finalize;
@@ -879,6 +882,17 @@ finalizer_thread (gpointer unused)
 	mono_hazard_pointer_install_free_queue_size_callback (hazard_free_queue_is_too_big);
 
 	while (!finished) {
+
+		/* Just in case we've received a SIGTERM */
+		if (term_signaled) {
+			int ec = mono_environment_exitcode_get();
+			mono_runtime_try_shutdown();
+			if (ec == 0)
+				exit(128+SIGTERM);
+			else
+				exit(ec);
+		}
+
 		/* Wait to be notified that there's at least one
 		 * finaliser to run
 		 */


### PR DESCRIPTION
Provide fix for https://github.com/dotnet/runtime/issues/81093 - "Mono does not emit ProcessExit event on SIGTERM"

	* src/mono/mono/mini/mini-posix.c
	  - Add signal handler for SIGTERM
	  - SIGTERM handler will set a global variable that may be monitored by the GC finalizer thread

	* src/mono/mono/metadata/gc.c
	  - Monitor for sigterm and kick off the shutdown process when encountered by calling mono_runtime_try_shutdown().
	  - Exit with either the user set exitcode (System.Environment.ExitCode) or SIGTERM + 128.