### PR TITLE
[release/7.0] Do not use ALC name for AssemblyName in DispatchProxy

### DIFF
--- a/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
@@ -117,19 +117,9 @@ namespace System.Reflection
             [RequiresDynamicCode("Defining a dynamic assembly requires generating code at runtime")]
             public ProxyAssembly(AssemblyLoadContext alc)
             {
-                string name;
-                if (alc == AssemblyLoadContext.Default)
-                {
-                    name = "ProxyBuilder";
-                }
-                else
-                {
-                    string? alcName = alc.Name;
-                    name = string.IsNullOrEmpty(alcName) ? $"DispatchProxyTypes.{alc.GetHashCode()}" : $"DispatchProxyTypes.{alcName}";
-                }
                 AssemblyBuilderAccess builderAccess =
                     alc.IsCollectible ? AssemblyBuilderAccess.RunAndCollect : AssemblyBuilderAccess.Run;
-                _ab = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(name), builderAccess);
+                _ab = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("ProxyBuilder"), builderAccess);
                 _mb = _ab.DefineDynamicModule("testmod");
             }
 

--- a/src/libraries/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
@@ -681,5 +681,24 @@ namespace DispatchProxyTests
                     .MakeGenericMethod(typeof(IDisposable), type)
                     .Invoke(null, null);
         }
+
+        [Fact]
+        public static void Test_Multiple_AssemblyLoadContextsWithBadName()
+        {
+            if (typeof(DispatchProxyTests).Assembly.Location == "")
+                return;
+
+            Assembly assembly = Assembly.LoadFile(typeof(DispatchProxyTests).Assembly.Location);
+            Type type = assembly.GetType(typeof(DispatchProxyTests).FullName);
+            MethodInfo method = type.GetMethod(nameof(Demo), BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.True((bool)method.Invoke(null, null));
+        }
+
+        internal static bool Demo()
+        {
+            TestType_IHelloService proxy = DispatchProxy.Create<TestType_IHelloService, InternalInvokeProxy>();
+            proxy.Hello("Hello");
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Backport of #82754 to release/7.0
Issue https://github.com/dotnet/runtime/issues/80387

## Description 
DispatchProxy uses Reflection.Emit internally and used to use only one `AssemblyBuilder` for all proxy types. In .NET 7 that fixed with https://github.com/dotnet/runtime/pull/62095, now it creates a separate `AssemblyBuilder`, for each `AssemblyLoadContext` of the proxy type and also uses the ALC name for creating `AssemblyName`

In some cases, ALC name [could include a path](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Reflection/Assembly.cs#L273) and because of the special characters in the path `AssemblyName` constructor and throws:` The given assembly name was invalid`

## Customer Impact

The regression causing failures for customers when they upgrade from .NET previous versions to 7.0. For now, two customers indirectly impacted by this regression: 
1. Originally reported in MSBuild repo: [DispatchProxy.Create reads AssemblyLoadContext.Name but treats it as an assembly name](https://github.com/dotnet/runtime/issues/80387) - this has a workaround that [mentioned in the issue](https://github.com/dotnet/runtime/issues/80387#issuecomment-1376288611)
2. Originally reported in WPF/Winforms repo: [Executing a SOAP rating service request in a .NET 7 COM-enabled assembly fails with 'The given assembly name was invalid'](https://github.com/dotnet/runtime/issues/82640) - @jkotas investigated and found the same root cause, I don't think there is a workaround for this issue.

## Testing

- [x] Unit test added with the fix
- [x] Manually tested with the repro attached in the issue https://github.com/dotnet/runtime/issues/80387. The repro in [other issue](https://github.com/dotnet/runtime/issues/82640) has build issues, so could not validate.

## Risk

Very low, the fix is simple, in this PR we are just using the same name for each ALC, there were no specific need to pass the `ALC` name to the `AssemblyName`. Do not expect there is a code dependency on this name as this change was introduced just in 7.0.

Passing the ALC name could be useful for debugging purposes, [we will fix that later appropriately as suggested](https://github.com/dotnet/runtime/pull/82807#discussion_r1125160686) this fix has a lower risk for porting into 7.0.

CC @ericstj @jeffhandley 