### PR TITLE
Fix PAX extended attribute reading logic to treat '=' character as valid in the value strings.

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -733,12 +733,6 @@ namespace System.Formats.Tar
             ReadOnlySpan<byte> keySlice = line.Slice(0, equalPos);
             ReadOnlySpan<byte> valueSlice = line.Slice(equalPos + 1);
 
-            // If the value contains an =, it's malformed.
-            if (valueSlice.IndexOf((byte)'=') >= 0)
-            {
-                return false;
-            }
-
             // Return the parsed key and value.
             key = Encoding.UTF8.GetString(keySlice);
             value = Encoding.UTF8.GetString(valueSlice);

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.GlobalExtendedAttributes.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.GlobalExtendedAttributes.Tests.cs
@@ -90,6 +90,8 @@ namespace System.Formats.Tar.Tests
         [InlineData("    key   ", "    value    ")]
         [InlineData("    key spaced   ", "    value spaced    ")]
         [InlineData("many sla/s\\hes", "/////////////\\\\\\///////////")]
+        [InlineData("key", "va=lue")]
+        [InlineData("key", "=")]
         public void GlobalExtendedAttribute_Roundtrips(string key, string value)
         {
             var stream = new MemoryStream();
@@ -104,6 +106,7 @@ namespace System.Formats.Tar.Tests
                 PaxGlobalExtendedAttributesTarEntry entry = Assert.IsType<PaxGlobalExtendedAttributesTarEntry>(reader.GetNextEntry());
                 Assert.Equal(1, entry.GlobalExtendedAttributes.Count);
                 Assert.Equal(KeyValuePair.Create(key, value), entry.GlobalExtendedAttributes.First());
+                Assert.Null(reader.GetNextEntry());
             }
         }
     }

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.GlobalExtendedAttributes.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.GlobalExtendedAttributes.Tests.cs
@@ -84,14 +84,7 @@ namespace System.Formats.Tar.Tests
         }
 
         [Theory]
-        [InlineData("key", "value")]
-        [InlineData("key    ", "value    ")]
-        [InlineData("    key", "    value")]
-        [InlineData("    key   ", "    value    ")]
-        [InlineData("    key spaced   ", "    value spaced    ")]
-        [InlineData("many sla/s\\hes", "/////////////\\\\\\///////////")]
-        [InlineData("key", "va=lue")]
-        [InlineData("key", "=")]
+        [MemberData(nameof(GetPaxExtendedAttributesRoundtripTestData))]
         public void GlobalExtendedAttribute_Roundtrips(string key, string value)
         {
             var stream = new MemoryStream();

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
@@ -333,30 +333,6 @@ namespace System.Formats.Tar.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => reader.GetNextEntry());
         }
 
-        [Theory]
-        [InlineData("key", "value")]
-        [InlineData("key    ", "value    ")]
-        [InlineData("    key", "    value")]
-        [InlineData("    key   ", "    value    ")]
-        [InlineData("    key spaced   ", "    value spaced    ")]
-        [InlineData("many sla/s\\hes", "/////////////\\\\\\///////////")]
-        public void PaxExtendedAttribute_Roundtrips(string key, string value)
-        {
-            var stream = new MemoryStream();
-            using (var writer = new TarWriter(stream, leaveOpen: true))
-            {
-                writer.WriteEntry(new PaxTarEntry(TarEntryType.Directory, "entryName", new Dictionary<string, string>() { { key, value } }));
-            }
-
-            stream.Position = 0;
-            using (var reader = new TarReader(stream))
-            {
-                PaxTarEntry entry = Assert.IsType<PaxTarEntry>(reader.GetNextEntry());
-                Assert.Equal(5, entry.ExtendedAttributes.Count);
-                Assert.Contains(KeyValuePair.Create(key, value), entry.ExtendedAttributes);
-            }
-        }
-
         private static void VerifyDataStreamOfTarUncompressedInternal(string testFolderName, string testCaseName, bool copyData)
         {
             using MemoryStream archiveStream = GetTarMemoryStream(CompressionMethod.Uncompressed, testFolderName, testCaseName);

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.Tests.cs
@@ -100,14 +100,7 @@ namespace System.Formats.Tar.Tests
         }
 
         [Theory]
-        [InlineData("key", "value")]
-        [InlineData("key    ", "value    ")]
-        [InlineData("    key", "    value")]
-        [InlineData("    key   ", "    value    ")]
-        [InlineData("    key spaced   ", "    value spaced    ")]
-        [InlineData("many sla/s\\hes", "/////////////\\\\\\///////////")]
-        [InlineData("key", "va=lue")]
-        [InlineData("key", "=")]
+        [MemberData(nameof(GetPaxExtendedAttributesRoundtripTestData))]
         public void PaxExtendedAttribute_Roundtrips(string key, string value)
         {
             var stream = new MemoryStream();

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.Tests.cs
@@ -98,5 +98,29 @@ namespace System.Formats.Tar.Tests
                 ds.Dispose();
             }
         }
+
+        [Theory]
+        [InlineData("key", "value")]
+        [InlineData("key    ", "value    ")]
+        [InlineData("    key", "    value")]
+        [InlineData("    key   ", "    value    ")]
+        [InlineData("    key spaced   ", "    value spaced    ")]
+        [InlineData("many sla/s\\hes", "/////////////\\\\\\///////////")]
+        public void PaxExtendedAttribute_Roundtrips(string key, string value)
+        {
+            var stream = new MemoryStream();
+            using (var writer = new TarWriter(stream, leaveOpen: true))
+            {
+                writer.WriteEntry(new PaxTarEntry(TarEntryType.Directory, "entryName", new Dictionary<string, string>() { { key, value } }));
+            }
+
+            stream.Position = 0;
+            using (var reader = new TarReader(stream))
+            {
+                PaxTarEntry entry = Assert.IsType<PaxTarEntry>(reader.GetNextEntry());
+                Assert.Equal(5, entry.ExtendedAttributes.Count);
+                Assert.Contains(KeyValuePair.Create(key, value), entry.ExtendedAttributes);
+            }
+        }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.Tests.cs
@@ -106,6 +106,8 @@ namespace System.Formats.Tar.Tests
         [InlineData("    key   ", "    value    ")]
         [InlineData("    key spaced   ", "    value spaced    ")]
         [InlineData("many sla/s\\hes", "/////////////\\\\\\///////////")]
+        [InlineData("key", "va=lue")]
+        [InlineData("key", "=")]
         public void PaxExtendedAttribute_Roundtrips(string key, string value)
         {
             var stream = new MemoryStream();
@@ -120,6 +122,7 @@ namespace System.Formats.Tar.Tests
                 PaxTarEntry entry = Assert.IsType<PaxTarEntry>(reader.GetNextEntry());
                 Assert.Equal(5, entry.ExtendedAttributes.Count);
                 Assert.Contains(KeyValuePair.Create(key, value), entry.ExtendedAttributes);
+                Assert.Null(reader.GetNextEntry());
             }
         }
     }

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.Pax.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.Pax.cs
@@ -133,8 +133,12 @@ namespace System.Formats.Tar.Tests
             yield return new object[] { "    key   ", "    value    " };
             yield return new object[] { "    key spaced   ", "    value spaced    " };
             yield return new object[] { "many sla/s\\hes", "/////////////\\\\\\///////////" };
-            yield return new object[] { "key", "va=lue" };
             yield return new object[] { "key", "=" };
+            yield return new object[] { "key", "=value" };
+            yield return new object[] { "key", "va=lue" };
+            yield return new object[] { "key", "value=" };
+            // real world scenario
+            yield return new object[] { "MSWINDOWS.rawsd", "AQAAgBQAAAAkAAAAAAAAAAAAAAABAgAAAAAABSAAAAAhAgAAAQIAAAAAAAUgAAAAIQIAAA==" };
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.Pax.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.Pax.cs
@@ -124,5 +124,17 @@ namespace System.Formats.Tar.Tests
             VerifyExtendedAttributeTimestamp(pax, PaxEaATime, MinimumTime);
             VerifyExtendedAttributeTimestamp(pax, PaxEaCTime, MinimumTime);
         }
+
+        public static IEnumerable<object[]> GetPaxExtendedAttributesRoundtripTestData()
+        {
+            yield return new object[] { "key", "value" };
+            yield return new object[] { "key    ", "value    " };
+            yield return new object[] { "    key", "    value" };
+            yield return new object[] { "    key   ", "    value    " };
+            yield return new object[] { "    key spaced   ", "    value spaced    " };
+            yield return new object[] { "many sla/s\\hes", "/////////////\\\\\\///////////" };
+            yield return new object[] { "key", "va=lue" };
+            yield return new object[] { "key", "=" };
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/81699

We had logic in TarHeader.Read.cs that was explicitly forbidding the '=' character as part of the body of the value string in an extended attribute key-value pair. It felt natural to have such restriction in place as it is one of the two separators that the spec indicates:

- The '=' character is used to separate a key from a value.
- The '\n' character is used to separate a key-value-pair from another.

But the restriction is not needed: We only need to find the first '=' character to stop reading a key and start reading a value, and after that, we can keep reading any character, including any number of '=' characters, until we detect a '\n' character. Additionally, none of the specs indicated that the '=' is forbidden in values.

This issue was reported by a customer, so we would like to consider a backport to 7.0.