### PR TITLE
Add exceptions to TAR extended attribute constructors to disallow '=' and '\n' characters in keys and values.

### DIFF
--- a/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
+++ b/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
@@ -264,4 +264,10 @@
   <data name="TarSizeFieldTooLargeForEntryFormat" xml:space="preserve">
     <value>The value of the size field for the current entry of format '{0}' is greater than the format allows.</value>
   </data>
+  <data name="TarExtAttrDisallowedKeyChar" xml:space="preserve">
+    <value>The extended attribute key '{0}' contains a disallowed '{1}' character.</value>
+  </data>
+  <data name="TarExtAttrDisallowedValueChar" xml:space="preserve">
+    <value>The value of the extended attribute key '{0}' contains a disallowed '{1}' character.</value>
+  </data>
 </root>

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
@@ -125,7 +125,7 @@ namespace System.Formats.Tar
                 {
                     throw new ArgumentException(SR.Format(SR.TarExtAttrDisallowedKeyChar, kvp.Key, kvp.Key[index] == '\n' ? "\\n" : kvp.Key[index]));
                 }
-                if (kvp.Value.IndexOf('\n') != -1)
+                if (kvp.Value.Contains('\n'))
                 {
                     throw new ArgumentException(SR.Format(SR.TarExtAttrDisallowedValueChar, kvp.Key, "\\n"));
                 }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
@@ -113,9 +113,13 @@ namespace System.Formats.Tar
         internal void InitializeExtendedAttributesWithExisting(IEnumerable<KeyValuePair<string, string>> existing)
         {
             Debug.Assert(_ea == null);
-            _ea = new Dictionary<string, string>(existing);
-            foreach (KeyValuePair<string, string> kvp in _ea)
+            Debug.Assert(existing != null);
+
+            using IEnumerator<KeyValuePair<string, string>> enumerator = existing.GetEnumerator();
+            while (enumerator.MoveNext())
             {
+                KeyValuePair<string, string> kvp = enumerator.Current;
+
                 int index = kvp.Key.IndexOfAny(new char[] { '=', '\n' });
                 if (index >= 0)
                 {
@@ -125,6 +129,10 @@ namespace System.Formats.Tar
                 {
                     throw new ArgumentException(SR.Format(SR.TarExtAttrDisallowedValueChar, kvp.Key, "\\n"));
                 }
+
+                _ea ??= new Dictionary<string, string>();
+
+                _ea.Add(kvp.Key, kvp.Value);
             }
         }
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
@@ -113,6 +113,21 @@ namespace System.Formats.Tar
         internal void InitializeExtendedAttributesWithExisting(IEnumerable<KeyValuePair<string, string>> existing)
         {
             Debug.Assert(_ea == null);
+            foreach (KeyValuePair<string, string> kvp in existing)
+            {
+                if (kvp.Key.IndexOf('=') != -1)
+                {
+                    throw new ArgumentException(SR.Format(SR.TarExtAttrDisallowedKeyChar, kvp.Key, '='));
+                }
+                if (kvp.Key.IndexOf('\n') != -1)
+                {
+                    throw new ArgumentException(SR.Format(SR.TarExtAttrDisallowedKeyChar, kvp.Key, "\\n"));
+                }
+                if (kvp.Value.IndexOf('\n') != -1)
+                {
+                    throw new ArgumentException(SR.Format(SR.TarExtAttrDisallowedValueChar, kvp.Key, "\\n"));
+                }
+            }
             _ea = new Dictionary<string, string>(existing);
         }
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
@@ -113,22 +113,19 @@ namespace System.Formats.Tar
         internal void InitializeExtendedAttributesWithExisting(IEnumerable<KeyValuePair<string, string>> existing)
         {
             Debug.Assert(_ea == null);
-            foreach (KeyValuePair<string, string> kvp in existing)
+            _ea = new Dictionary<string, string>(existing);
+            foreach (KeyValuePair<string, string> kvp in _ea)
             {
-                if (kvp.Key.IndexOf('=') != -1)
+                int index = kvp.Key.IndexOfAny(new char[] { '=', '\n' });
+                if (index >= 0)
                 {
-                    throw new ArgumentException(SR.Format(SR.TarExtAttrDisallowedKeyChar, kvp.Key, '='));
-                }
-                if (kvp.Key.IndexOf('\n') != -1)
-                {
-                    throw new ArgumentException(SR.Format(SR.TarExtAttrDisallowedKeyChar, kvp.Key, "\\n"));
+                    throw new ArgumentException(SR.Format(SR.TarExtAttrDisallowedKeyChar, kvp.Key, kvp.Key[index] == '\n' ? "\\n" : kvp.Key[index]));
                 }
                 if (kvp.Value.IndexOf('\n') != -1)
                 {
                     throw new ArgumentException(SR.Format(SR.TarExtAttrDisallowedValueChar, kvp.Key, "\\n"));
                 }
             }
-            _ea = new Dictionary<string, string>(existing);
         }
 
         private static string GetMagicForFormat(TarEntryFormat format) => format switch

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/PaxTarEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/PaxTarEntry.Tests.cs
@@ -1,8 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.IO;
-using System.Linq;
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.Formats.Tar.Tests
@@ -34,6 +33,28 @@ namespace System.Formats.Tar.Tests
             // The user should not be creating these entries manually in pax
             Assert.Throws<ArgumentException>(() => new PaxTarEntry(TarEntryType.ExtendedAttributes, InitialEntryName));
             Assert.Throws<ArgumentException>(() => new PaxTarEntry(TarEntryType.GlobalExtendedAttributes, InitialEntryName));
+        }
+
+
+        [Theory]
+        [InlineData("\n", "value")]
+        [InlineData("=", "value")]
+        [InlineData("key", "\n")]
+        [InlineData("\nkey", "value")]
+        [InlineData("k\ney", "value")]
+        [InlineData("key\n", "value")]
+        [InlineData("=key", "value")]
+        [InlineData("ke=y", "value")]
+        [InlineData("key=", "value")]
+        [InlineData("key", "\nvalue")]
+        [InlineData("key", "val\nue")]
+        [InlineData("key", "value\n")]
+        public void Disallowed_ExtendedAttributes_SeparatorCharacters(string key, string value)
+        {
+            Dictionary<string, string> extendedAttribute = new Dictionary<string, string>() { { key, value } };
+
+            Assert.Throws<ArgumentException>(() => new PaxTarEntry(TarEntryType.RegularFile, InitialEntryName, extendedAttribute));
+            Assert.Throws < ArgumentException>(() => new PaxGlobalExtendedAttributesTarEntry(extendedAttribute));
         }
 
         [Fact]

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/PaxTarEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/PaxTarEntry.Tests.cs
@@ -49,12 +49,14 @@ namespace System.Formats.Tar.Tests
         [InlineData("key", "\nvalue")]
         [InlineData("key", "val\nue")]
         [InlineData("key", "value\n")]
+        [InlineData("key=", "value\n")]
+        [InlineData("key\n", "value\n")]
         public void Disallowed_ExtendedAttributes_SeparatorCharacters(string key, string value)
         {
             Dictionary<string, string> extendedAttribute = new Dictionary<string, string>() { { key, value } };
 
             Assert.Throws<ArgumentException>(() => new PaxTarEntry(TarEntryType.RegularFile, InitialEntryName, extendedAttribute));
-            Assert.Throws < ArgumentException>(() => new PaxGlobalExtendedAttributesTarEntry(extendedAttribute));
+            Assert.Throws<ArgumentException>(() => new PaxGlobalExtendedAttributesTarEntry(extendedAttribute));
         }
 
         [Fact]


### PR DESCRIPTION
Follow up of https://github.com/dotnet/runtime/pull/82810 
Related to https://github.com/dotnet/runtime/issues/81699

This change adds exceptions that prevent creating a PAX entry with extended attributes that contain:

- An '=' character in a key.
- A '\n' character in either a key or a value.

The TAR spec indicates that the '=' character is used to divide a key from a value, and the '\n' character is used to divide a key-value-pair from another.

Since the keys and values are strings, the user could easily pass one of these characters where they shouldn't, and without proper internal detection, we end up writing them in the extended attributes. This prevents a roundtrip to properly read the extended attribute entries, and we either fail silently (the extended attributes show up as empty) or show corrupt data.