### PR TITLE
Enable mono runtime to handle SIGTERM like CoreCLR #82806

### DIFF
--- a/src/libraries/System.Runtime/tests/System/ExitCodeTests.Unix.cs
+++ b/src/libraries/System.Runtime/tests/System/ExitCodeTests.Unix.cs
@@ -16,7 +16,6 @@ namespace System.Tests
         private static extern int kill(int pid, int sig);
 
         [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/31656", TestRuntimes.Mono)]
         [InlineData(null)]
         [InlineData(0)]
         [InlineData(42)]

--- a/src/mono/mono/metadata/gc.c
+++ b/src/mono/mono/metadata/gc.c
@@ -24,6 +24,7 @@
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/metadata-internals.h>
 #include <mono/metadata/threads-types.h>
+#include <mono/metadata/runtime.h>
 #include <mono/sgen/sgen-conf.h>
 #include <mono/sgen/sgen-gc.h>
 #include <mono/utils/mono-logger-internals.h>
@@ -62,6 +63,8 @@ typedef struct DomainFinalizationReq {
 static gboolean gc_disabled;
 
 static gboolean finalizing_root_domain;
+
+extern volatile gboolean term_signaled;
 
 gboolean mono_log_finalizers;
 gboolean mono_do_not_finalize;
@@ -879,6 +882,17 @@ finalizer_thread (gpointer unused)
 	mono_hazard_pointer_install_free_queue_size_callback (hazard_free_queue_is_too_big);
 
 	while (!finished) {
+
+		/* Just in case we've received a SIGTERM */
+		if (term_signaled) {
+			int ec = mono_environment_exitcode_get();
+			mono_runtime_try_shutdown();
+			if (ec == 0)
+				exit(128+SIGTERM);
+			else
+				exit(ec);
+		}
+
 		/* Wait to be notified that there's at least one
 		 * finaliser to run
 		 */

--- a/src/mono/mono/metadata/gc.c
+++ b/src/mono/mono/metadata/gc.c
@@ -885,12 +885,8 @@ finalizer_thread (gpointer unused)
 
 		/* Just in case we've received a SIGTERM */
 		if (term_signaled) {
-			int ec = mono_environment_exitcode_get();
 			mono_runtime_try_shutdown();
-			if (ec == 0)
-				exit(128+SIGTERM);
-			else
-				exit(ec);
+			exit(mono_environment_exitcode_get());
 		}
 
 		/* Wait to be notified that there's at least one

--- a/src/mono/mono/metadata/gc.c
+++ b/src/mono/mono/metadata/gc.c
@@ -64,7 +64,7 @@ static gboolean gc_disabled;
 
 static gboolean finalizing_root_domain;
 
-extern volatile gboolean term_signaled;
+extern gboolean mono_term_signaled;
 
 gboolean mono_log_finalizers;
 gboolean mono_do_not_finalize;
@@ -883,12 +883,6 @@ finalizer_thread (gpointer unused)
 
 	while (!finished) {
 
-		/* Just in case we've received a SIGTERM */
-		if (term_signaled) {
-			mono_runtime_try_shutdown();
-			exit(mono_environment_exitcode_get());
-		}
-
 		/* Wait to be notified that there's at least one
 		 * finaliser to run
 		 */
@@ -901,6 +895,12 @@ finalizer_thread (gpointer unused)
 			mono_coop_sem_wait (&finalizer_sem, MONO_SEM_FLAGS_ALERTABLE);
 		}
 		wait = TRUE;
+
+		/* Just in case we've received a SIGTERM */
+		if (mono_term_signaled) {
+			mono_runtime_try_shutdown();
+			exit(mono_environment_exitcode_get());
+		}
 
 		mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NONE);
 

--- a/src/mono/mono/mini/mini-posix.c
+++ b/src/mono/mono/mini/mini-posix.c
@@ -390,6 +390,8 @@ mono_runtime_posix_install_handlers (void)
 	sigaddset (&signal_set, SIGFPE);
 	add_signal_handler (SIGQUIT, sigquit_signal_handler, SA_RESTART);
 	sigaddset (&signal_set, SIGQUIT);
+	add_signal_handler (SIGTERM, mono_sigterm_signal_handler, SA_RESTART);
+	sigaddset (&signal_set, SIGTERM);
 	add_signal_handler (SIGILL, mono_crashing_signal_handler, 0);
 	sigaddset (&signal_set, SIGILL);
 	add_signal_handler (SIGBUS, mono_sigsegv_signal_handler, 0);

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -3631,9 +3631,9 @@ MONO_SIG_HANDLER_FUNC (, mono_crashing_signal_handler)
 
 MONO_SIG_HANDLER_FUNC (, mono_sigterm_signal_handler)
 {
-	term_signaled = TRUE;
-
 	mono_environment_exitcode_set(128+SIGTERM);	/* Set default exit code */
+
+	term_signaled = TRUE;
 
 	mono_gc_finalize_notify ();			
 

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -118,6 +118,7 @@ const char *mono_build_date;
 gboolean mono_do_signal_chaining;
 gboolean mono_do_crash_chaining;
 int mini_verbose = 0;
+gboolean term_signaled = FALSE;
 
 /*
  * This flag controls whenever the runtime uses LLVM for JIT compilation, and whenever
@@ -3626,6 +3627,15 @@ MONO_SIG_HANDLER_FUNC (, mono_crashing_signal_handler)
 		mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
 		return;
 	}
+}
+
+MONO_SIG_HANDLER_FUNC (, mono_sigterm_signal_handler)
+{
+	term_signaled = TRUE;
+
+	mono_gc_finalize_notify ();
+
+	mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
 }
 
 #if defined(MONO_ARCH_USE_SIGACTION) || defined(HOST_WIN32)

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -3633,7 +3633,9 @@ MONO_SIG_HANDLER_FUNC (, mono_sigterm_signal_handler)
 {
 	term_signaled = TRUE;
 
-	mono_gc_finalize_notify ();
+	mono_environment_exitcode_set(128+SIGTERM);	/* Set default exit code */
+
+	mono_gc_finalize_notify ();			
 
 	mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
 }

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -118,7 +118,7 @@ const char *mono_build_date;
 gboolean mono_do_signal_chaining;
 gboolean mono_do_crash_chaining;
 int mini_verbose = 0;
-gboolean term_signaled = FALSE;
+gboolean mono_term_signaled = FALSE;
 
 /*
  * This flag controls whenever the runtime uses LLVM for JIT compilation, and whenever
@@ -3633,7 +3633,7 @@ MONO_SIG_HANDLER_FUNC (, mono_sigterm_signal_handler)
 {
 	mono_environment_exitcode_set(128+SIGTERM);	/* Set default exit code */
 
-	term_signaled = TRUE;
+	mono_term_signaled = TRUE;
 
 	mono_gc_finalize_notify ();			
 

--- a/src/mono/mono/mini/mini-runtime.h
+++ b/src/mono/mono/mini/mini-runtime.h
@@ -671,6 +671,7 @@ void MONO_SIG_HANDLER_SIGNATURE (mono_sigfpe_signal_handler) ;
 void MONO_SIG_HANDLER_SIGNATURE (mono_crashing_signal_handler) ;
 void MONO_SIG_HANDLER_SIGNATURE (mono_sigsegv_signal_handler);
 void MONO_SIG_HANDLER_SIGNATURE (mono_sigint_signal_handler) ;
+void MONO_SIG_HANDLER_SIGNATURE (mono_sigterm_signal_handler) ;
 gboolean MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal);
 
 #if defined (HOST_WASM)

--- a/src/mono/mono/mini/mini-windows.c
+++ b/src/mono/mono/mini/mini-windows.c
@@ -189,7 +189,7 @@ mono_runtime_install_handlers (void)
 	win32_seh_set_handler(SIGFPE, mono_sigfpe_signal_handler);
 	win32_seh_set_handler(SIGILL, mono_crashing_signal_handler);
 	win32_seh_set_handler(SIGSEGV, mono_sigsegv_signal_handler);
-	win32_seh_set_handler(SIGSEGV, mono_sigterm_signal_handler);
+	win32_seh_set_handler(SIGTERM, mono_sigterm_signal_handler);
 	if (mini_debug_options.handle_sigint)
 		win32_seh_set_handler(SIGINT, mono_sigint_signal_handler);
 #endif

--- a/src/mono/mono/mini/mini-windows.c
+++ b/src/mono/mono/mini/mini-windows.c
@@ -189,6 +189,7 @@ mono_runtime_install_handlers (void)
 	win32_seh_set_handler(SIGFPE, mono_sigfpe_signal_handler);
 	win32_seh_set_handler(SIGILL, mono_crashing_signal_handler);
 	win32_seh_set_handler(SIGSEGV, mono_sigsegv_signal_handler);
+	win32_seh_set_handler(SIGSEGV, mono_sigterm_signal_handler);
 	if (mini_debug_options.handle_sigint)
 		win32_seh_set_handler(SIGINT, mono_sigint_signal_handler);
 #endif


### PR DESCRIPTION
Provide fix for #81093 - "Mono does not emit ProcessExit event on SIGTERM"

* src/mono/mono/mini/mini-posix.c
  - Add signal handler for SIGTERM

* src/mono/mono/mini/mini-windows.c
  - Add signal handler for SIGTERM

* src/mono/mono/mini/mini-runtime.c
  - Add mono_sigterm_signal_handler to process SIGTERM that will set a global variable to be monitored by the GC finalizer thread

* src/mono/mono/mini/mini-runtime.h
  - Define prototype for mono_sigterm_signal_handler()

* src/mono/mono/metadata/gc.c
  - Monitor for sigterm and kick off the shutdown process when encountered by calling mono_runtime_try_shutdown().
  - Exit with either the user set exitcode (System.Environment.ExitCode) or SIGTERM + 128.