### PR TITLE
Fix build failure in pal_ssl

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
@@ -1051,7 +1051,7 @@ int32_t CryptoNative_SslSetAlpnProtos(SSL* ssl, const uint8_t* protos, uint32_t 
     }
     else
 #else
-    (void)ctx;
+    (void)ssl;
     (void)protos;
     (void)protos_len;
 #endif


### PR DESCRIPTION
Hit this on Alpine Linux while trying to compile a statically linked executable with NativeAOT. 