### PR TITLE
[wasm][debugger] Support new feature on browser: instrumentation pause

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -183,6 +183,9 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         protected async Task<bool> OnDebuggerPaused(SessionId sessionId, JObject args, CancellationToken token)
         {
+            if (args?["callFrames"]?.Value<JArray>()?.Count == 0) //new browser version can send pause of type "instrumentation" with an empty callstack
+                return false;
+
             if (args["asyncStackTraceId"] != null)
             {
                 if (!contexts.TryGetValue(sessionId, out ExecutionContext context))


### PR DESCRIPTION
Avoid trying to get callstack[0] when it's empty like in an instrumentation pause

Args that we receive when we get and instrumentation pause:

![image](https://user-images.githubusercontent.com/4503299/222251987-95eba586-3dda-44fa-af4b-0840c7e65487.png)
