### PR TITLE
[release/7.0][wasm][debugger] Support new feature on browser: instrumentation pause

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -175,6 +175,9 @@ namespace Microsoft.WebAssembly.Diagnostics
                         if (!contexts.ContainsKey(sessionId))
                             return false;
 
+                        if (args?["callFrames"]?.Value<JArray>()?.Count == 0)
+                            return false;
+
                         //TODO figure out how to stich out more frames and, in particular what happens when real wasm is on the stack
                         string top_func = args?["callFrames"]?[0]?["functionName"]?.Value<string>();
                         switch (top_func) {


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/82852 to release/7.0

## Customer Impact

It will not be possible to debug Blazor apps because newer Chrome/Edge versions started sending us instrumentation breakpoints pause and the Debugger.Paused message has the callFrames property with len = 0. 
Then BrowserDebugProxy crashes and the customer cannot debug the app at all.

## Testing

Manual testing

## Risk

Low. We are just checking if the len of the callFrames property is 0 and returning false because we don't care about this kind of pause.

IMPORTANT: Is this backport for a servicing release? If so and this change touches code that ships in a NuGet package, please make certain that you have added any necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.
