### PR TITLE
[release/6.0][wasm][debugger] Support new feature on browser: instrumentation pause 

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -147,6 +147,9 @@ namespace Microsoft.WebAssembly.Diagnostics
                         if (!contexts.TryGetValue(sessionId, out ExecutionContext context))
                             return false;
 
+                        if (args?["callFrames"]?.Value<JArray>()?.Count == 0)
+                            return false;
+
                         if (!context.IsRuntimeReady)
                         {
                             string reason = args?["reason"]?.Value<string>();


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/82852 to release/6.0

## Customer Impact

It will not be possible to debug Blazor apps because newer Chrome/Edge versions started sending us instrumentation breakpoints pause and the Debugger.Paused message has the callFrames property with len = 0. 
Then BrowserDebugProxy crashes and the customer cannot debug the app at all.

## Testing

Manual testing

## Risk

Low. We are just checking if the len of the callFrames property is 0 and returning false because we don't care about this kind of pause.

IMPORTANT: Is this backport for a servicing release? If so and this change touches code that ships in a NuGet package, please make certain that you have added any necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.
