### PR TITLE
Enable DwarfDump AOT test in Release

### DIFF
--- a/src/tests/nativeaot/SmokeTests/DwarfDump/DwarfDump.csproj
+++ b/src/tests/nativeaot/SmokeTests/DwarfDump/DwarfDump.csproj
@@ -4,8 +4,8 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
-    <!-- Test checks symbols, so don't run in non-debug builds. -->
-    <CLRTestTargetUnsupported Condition="'$(Configuration)' != 'Debug' or '$(TargetOS)' != 'linux'">true</CLRTestTargetUnsupported>
+    <!-- Currently only tracking DWARF info on Linux -->
+    <CLRTestTargetUnsupported Condition="'$(TargetOS)' != 'linux'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
+++ b/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
@@ -50,8 +50,13 @@ public class Program
         });
 
         // Just count the number of warnings and errors. There are so many right now that it's not worth enumerating the list
+#if DEBUG
         const int MinWarnings = 17000;
         const int MaxWarnings = 18500;
+#else
+        const int MinWarnings = 12000;
+        const int MaxWarnings = 13000;
+#endif
         int count = 0;
         string line;
         while ((line = proc.StandardOutput.ReadLine()) != null)


### PR DESCRIPTION
There are some reports (#82802) that debugging might be particularly bad in Release.