### PR TITLE
Simplify IndexOfAnyAsciiByteValues for needles with 0 on X86

### DIFF
--- a/src/libraries/System.Memory/tests/Span/IndexOfAnyValues.cs
+++ b/src/libraries/System.Memory/tests/Span/IndexOfAnyValues.cs
@@ -496,8 +496,8 @@ namespace System.SpanTests
             private static void AssertionFailed<T>(ReadOnlySpan<T> haystack, ReadOnlySpan<T> needle, int expected, int actual, string approach)
                 where T : INumber<T>
             {
-                string readableHaystack = string.Join(", ", haystack.ToString().Select(c => int.CreateChecked(c)));
-                string readableNeedle = string.Join(", ", needle.ToString().Select(c => int.CreateChecked(c)));
+                string readableHaystack = string.Join(", ", haystack.ToArray().Select(c => int.CreateChecked(c)));
+                string readableNeedle = string.Join(", ", needle.ToArray().Select(c => int.CreateChecked(c)));
 
                 Assert.True(false, $"Expected {expected}, got {approach}={actual} for needle='{readableNeedle}', haystack='{readableHaystack}'");
             }

--- a/src/libraries/System.Private.CoreLib/src/System/IndexOfAnyValues/IndexOfAnyAsciiByteValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IndexOfAnyValues/IndexOfAnyAsciiByteValues.cs
@@ -7,17 +7,13 @@ using System.Runtime.Intrinsics;
 
 namespace System.Buffers
 {
-    internal sealed class IndexOfAnyAsciiByteValues<TOptimizations> : IndexOfAnyValues<byte>
-        where TOptimizations : struct, IndexOfAnyAsciiSearcher.IOptimizations
+    internal sealed class IndexOfAnyAsciiByteValues : IndexOfAnyValues<byte>
     {
         private readonly Vector128<byte> _bitmap;
         private readonly BitVector256 _lookup;
 
-        public IndexOfAnyAsciiByteValues(Vector128<byte> bitmap, BitVector256 lookup)
-        {
-            _bitmap = bitmap;
-            _lookup = lookup;
-        }
+        public IndexOfAnyAsciiByteValues(ReadOnlySpan<byte> values) =>
+            IndexOfAnyAsciiSearcher.ComputeBitmap(values, out _bitmap, out _lookup);
 
         internal override byte[] GetValues() => _lookup.GetByteValues();
 
@@ -46,7 +42,7 @@ namespace System.Buffers
             where TNegator : struct, IndexOfAnyAsciiSearcher.INegator
         {
             return IndexOfAnyAsciiSearcher.IsVectorizationSupported && searchSpaceLength >= sizeof(ulong)
-                ? IndexOfAnyAsciiSearcher.IndexOfAnyVectorized<TNegator, TOptimizations>(ref searchSpace, searchSpaceLength, _bitmap)
+                ? IndexOfAnyAsciiSearcher.IndexOfAnyVectorized<TNegator>(ref searchSpace, searchSpaceLength, _bitmap)
                 : IndexOfAnyScalar<TNegator>(ref searchSpace, searchSpaceLength);
         }
 
@@ -55,7 +51,7 @@ namespace System.Buffers
             where TNegator : struct, IndexOfAnyAsciiSearcher.INegator
         {
             return IndexOfAnyAsciiSearcher.IsVectorizationSupported && searchSpaceLength >= sizeof(ulong)
-                ? IndexOfAnyAsciiSearcher.LastIndexOfAnyVectorized<TNegator, TOptimizations>(ref searchSpace, searchSpaceLength, _bitmap)
+                ? IndexOfAnyAsciiSearcher.LastIndexOfAnyVectorized<TNegator>(ref searchSpace, searchSpaceLength, _bitmap)
                 : LastIndexOfAnyScalar<TNegator>(ref searchSpace, searchSpaceLength);
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IndexOfAnyValues/IndexOfAnyValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IndexOfAnyValues/IndexOfAnyValues.cs
@@ -56,11 +56,7 @@ namespace System.Buffers
 
             if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && maxInclusive < 128)
             {
-                IndexOfAnyAsciiSearcher.ComputeBitmap(values, out Vector128<byte> bitmap, out BitVector256 lookup);
-
-                return Ssse3.IsSupported && lookup.Contains(0)
-                    ? new IndexOfAnyAsciiByteValues<IndexOfAnyAsciiSearcher.Ssse3HandleZeroInNeedle>(bitmap, lookup)
-                    : new IndexOfAnyAsciiByteValues<IndexOfAnyAsciiSearcher.Default>(bitmap, lookup);
+                return new IndexOfAnyAsciiByteValues(values);
             }
 
             return new IndexOfAnyByteValues(values);


### PR DESCRIPTION
`IndexOfAnyLookupCore` already discards non-ASCII byte values.
We have to do this special-casing of 0 for char inputs because of how we pack the source on X86, but it's redundant when dealing with byte inputs where we do no such packing.

@stephentoub this will further improve your change in #82789 that hits this case.
For values that contain 0:
|                    Method | Toolchain | Length |     Mean |    Error | Ratio |
|-------------------------- |---------- |------- |---------:|---------:|------:|
|           IndexOfAny_Byte |      main |   1000 | 36.95 ns | 0.127 ns |  1.00 |
|           IndexOfAny_Byte |        pr |   1000 | 30.12 ns | 0.048 ns |  0.81 |
|                           |           |        |          |          |       |
|     IndexOfAnyExcept_Byte |      main |   1000 | 39.75 ns | 0.134 ns |  1.00 |
|     IndexOfAnyExcept_Byte |        pr |   1000 | 32.48 ns | 0.054 ns |  0.82 |
|                           |           |        |          |          |       |
|       LastIndexOfAny_Byte |      main |   1000 | 37.09 ns | 0.088 ns |  1.00 |
|       LastIndexOfAny_Byte |        pr |   1000 | 30.42 ns | 0.062 ns |  0.82 |
|                           |           |        |          |          |       |
| LastIndexOfAnyExcept_Byte |      main |   1000 | 39.67 ns | 0.127 ns |  1.00 |
| LastIndexOfAnyExcept_Byte |        pr |   1000 | 31.98 ns | 0.269 ns |  0.81 |