### PR TITLE
Fixes #82871 Add an additional constructor for StackTrace

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs
@@ -126,6 +126,15 @@ namespace System.Diagnostics
         }
 
         /// <summary>
+        /// Constructs a "fake" stack trace
+        /// </summary>
+        public StackTrace(StackFrame[] frames)
+        {
+            _stackFrames = frames;
+            _numOfFrames = frames.Length;
+        }
+
+        /// <summary>
         /// Property to get the number of frames in the stack trace
         /// </summary>
         public virtual int FrameCount => _numOfFrames;


### PR DESCRIPTION
Fixes dotnet/runtime#82871