### PR TITLE
Only call base.DisposeAsync on classes derived from FileStream

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/FileStream/Dispose.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/Dispose.cs
@@ -213,6 +213,14 @@ namespace System.IO.Tests
             }
         }
 
+        [Fact]
+        public void DerivedFileStream_PropertiesDontThrow_OnDispose()
+        {
+            var fs = new DerivedFileStreamAccesingPropertiesOnDispose(GetTestFilePath(), FileMode.Create);
+            fs.Dispose();
+            fs.VerifyAfterDispose();
+        }
+
         public class DerivedFileStreamWithFinalizer : FileStream
         {
             public static int DisposeTrueCalled = 0;
@@ -286,6 +294,54 @@ namespace System.IO.Tests
                 }
 
                 base.Dispose(disposing);
+            }
+        }
+
+        public sealed class DerivedFileStreamAccesingPropertiesOnDispose : FileStream
+        {
+            private readonly string _name;
+            private bool _disposed;
+
+            public DerivedFileStreamAccesingPropertiesOnDispose(string path, FileMode mode) : base(path, mode, FileAccess.ReadWrite)
+            {
+                _name = path;
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (!_disposed)
+                {
+                    Assert.Equal(_name, Name);
+                    Assert.False(IsAsync);
+                    Assert.True(CanRead);
+                    Assert.True(CanSeek);
+                    Assert.True(CanWrite);
+                    Assert.False(CanTimeout);
+                    Assert.Equal(0, Length);
+                    Assert.Equal(0, Position);
+#pragma warning disable CS0618 // Type or member is obsolete
+                    Assert.NotEqual(nint.Zero, Handle);
+#pragma warning restore CS0618 // Type or member is obsolete
+                    Assert.NotNull(SafeFileHandle);
+                    _disposed = true;
+                }
+
+                base.Dispose(disposing);
+            }
+
+            public void VerifyAfterDispose()
+            {
+                Assert.True(_disposed, "This method must be called only after the object has been disposed.");
+                Assert.Throws<ObjectDisposedException>(() => Length);
+                Assert.Throws<ObjectDisposedException>(() => Position);
+#pragma warning disable CS0618 // Type or member is obsolete
+                Assert.Throws<ObjectDisposedException>(() => Handle);
+#pragma warning restore CS0618 // Type or member is obsolete
+                Assert.Throws<ObjectDisposedException>(() => SafeFileHandle);
+                Assert.False(CanRead);
+                Assert.False(CanSeek);
+                Assert.False(CanWrite);
+                Assert.False(CanTimeout);
             }
         }
 

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/Dispose.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/Dispose.cs
@@ -216,7 +216,7 @@ namespace System.IO.Tests
         [Fact]
         public void DerivedFileStream_PropertiesDontThrow_OnDispose()
         {
-            var fs = new DerivedFileStreamAccesingPropertiesOnDispose(GetTestFilePath(), FileMode.Create);
+            var fs = new DerivedFileStreamAccessingPropertiesOnDispose(GetTestFilePath(), FileMode.Create);
             fs.Dispose();
             fs.VerifyAfterDispose();
         }
@@ -297,12 +297,12 @@ namespace System.IO.Tests
             }
         }
 
-        public sealed class DerivedFileStreamAccesingPropertiesOnDispose : FileStream
+        public sealed class DerivedFileStreamAccessingPropertiesOnDispose : FileStream
         {
             private readonly string _name;
             private bool _disposed;
 
-            public DerivedFileStreamAccesingPropertiesOnDispose(string path, FileMode mode) : base(path, mode, FileAccess.ReadWrite)
+            public DerivedFileStreamAccessingPropertiesOnDispose(string path, FileMode mode) : base(path, mode, FileAccess.ReadWrite)
             {
                 _name = path;
             }

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/DisposeAsync.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/DisposeAsync.cs
@@ -41,22 +41,38 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public async Task DerivedFileStreamDisposeUsedForDisposeAsync()
+        public async Task DerivedFileStreamDisposeAndCloseUsedForDisposeAsync()
         {
-            var fs = new OverridesDisposeFileStream(GetTestFilePath(), FileMode.Create);
+            var fs = new DerivedFileStream(GetTestFilePath(), FileMode.Create);
             Assert.False(fs.DisposeInvoked);
+            Assert.False(fs.CloseInvoked);
             await fs.DisposeAsync();
             Assert.True(fs.DisposeInvoked);
+            Assert.True(fs.CloseInvoked);
         }
 
-        private sealed class OverridesDisposeFileStream : FileStream
+        [Fact]
+        public async Task DerivedFileStream_PropertiesDontThrow_OnDisposeAsync()
         {
+            var fs = new FileStream_Dispose.DerivedFileStreamAccesingPropertiesOnDispose(GetTestFilePath(), FileMode.Create);
+            await fs.DisposeAsync();
+            fs.VerifyAfterDispose();
+        }
+
+        private sealed class DerivedFileStream : FileStream
+        {
+            public bool CloseInvoked;
             public bool DisposeInvoked;
-            public OverridesDisposeFileStream(string path, FileMode mode) : base(path, mode) { }
+            public DerivedFileStream(string path, FileMode mode) : base(path, mode) { }
             protected override void Dispose(bool disposing)
             {
                 DisposeInvoked = true;
                 base.Dispose(disposing);
+            }
+            public override void Close()
+            {
+                CloseInvoked = true;
+                base.Close();
             }
         }
     }

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/DisposeAsync.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/DisposeAsync.cs
@@ -54,7 +54,7 @@ namespace System.IO.Tests
         [Fact]
         public async Task DerivedFileStream_PropertiesDontThrow_OnDisposeAsync()
         {
-            var fs = new FileStream_Dispose.DerivedFileStreamAccesingPropertiesOnDispose(GetTestFilePath(), FileMode.Create);
+            var fs = new FileStream_Dispose.DerivedFileStreamAccessingPropertiesOnDispose(GetTestFilePath(), FileMode.Create);
             await fs.DisposeAsync();
             fs.VerifyAfterDispose();
         }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/DerivedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/DerivedFileStreamStrategy.cs
@@ -21,6 +21,7 @@ namespace System.IO.Strategies
         {
             _fileStream = fileStream;
             _strategy = strategy;
+            IsDerived = true;
         }
 
         public override bool CanRead => _strategy.CanRead;
@@ -146,7 +147,7 @@ namespace System.IO.Strategies
         public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
             => _fileStream.BaseCopyToAsync(destination, bufferSize, cancellationToken);
 
-        public override ValueTask DisposeAsync() => _strategy.DisposeAsync();
+        public override ValueTask DisposeAsync() => _fileStream.BaseDisposeAsync();
 
         protected sealed override void Dispose(bool disposing) => _strategy.DisposeInternal(disposing);
     }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamStrategy.cs
@@ -9,6 +9,8 @@ namespace System.IO.Strategies
     {
         internal abstract bool IsAsync { get; }
 
+        internal bool IsDerived { get; init; }
+
         internal abstract string Name { get; }
 
         internal abstract SafeFileHandle SafeFileHandle { get; }


### PR DESCRIPTION
Regression introduced on https://github.com/dotnet/runtime/pull/65899.

Fixes https://github.com/dotnet/runtime/issues/82176.
Fixes https://github.com/dotnet/runtime/issues/82186.

