### PR TITLE
[browser] Calculate hash for runtime assets

### DIFF
--- a/src/mono/sample/wasm/browser-advanced/Wasm.Advanced.Sample.csproj
+++ b/src/mono/sample/wasm/browser-advanced/Wasm.Advanced.Sample.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <EnableAggressiveTrimming>true</EnableAggressiveTrimming>
     <PublishTrimmed>true</PublishTrimmed>
+    <WasmEnableWebcil>true</WasmEnableWebcil>
     <!-- add OpenGL emulation -->
     <EmccExtraLDFlags> -s USE_CLOSURE_COMPILER=1 -s LEGACY_GL_EMULATION=1 -lGL -lSDL -lidbfs.js</EmccExtraLDFlags>
     <!-- just to prove we don't do JS eval() -->

--- a/src/mono/sample/wasm/browser-advanced/index.html
+++ b/src/mono/sample/wasm/browser-advanced/index.html
@@ -12,7 +12,7 @@
   <link rel="preload" href="./mono-config.json" as="fetch" crossorigin="anonymous">
   <link rel="prefetch" href="./dotnet.wasm" as="fetch" crossorigin="anonymous">
   <link rel="prefetch" href="./icudt.dat" as="fetch" crossorigin="anonymous">
-  <link rel="prefetch" href="./managed/System.Private.CoreLib.dll" as="fetch" crossorigin="anonymous">
+  <link rel="prefetch" href="./managed/System.Private.CoreLib.webcil" as="fetch" crossorigin="anonymous">
 </head>
 
 <body>

--- a/src/mono/wasm/runtime/assets.ts
+++ b/src/mono/wasm/runtime/assets.ts
@@ -74,7 +74,7 @@ export function get_preferred_icu_asset(): string | null {
     return OTHERS;
 }
 
-export function shouldLoadIcuAsset(asset : AssetEntryInternal, preferredIcuAsset: string | null) : boolean{
+export function shouldLoadIcuAsset(asset: AssetEntryInternal, preferredIcuAsset: string | null): boolean {
     return !(asset.behavior == "icu" && asset.name != preferredIcuAsset);
 }
 
@@ -293,6 +293,14 @@ async function start_asset_download_sources(asset: AssetEntryInternal): Promise<
             return response;
         }
         catch (err) {
+            if (!response) {
+                response = {
+                    ok: false,
+                    url: attemptUrl,
+                    status: 0,
+                    statusText: "" + err,
+                } as any;
+            }
             continue; //next source
         }
     }

--- a/src/mono/wasm/runtime/dotnet.d.ts
+++ b/src/mono/wasm/runtime/dotnet.d.ts
@@ -132,6 +132,10 @@ type MonoConfig = {
      * initial number of workers to add to the emscripten pthread pool
      */
     pthreadPoolSize?: number;
+    /**
+     * hash of assets
+     */
+    assetsHash?: string;
 };
 interface ResourceRequest {
     name: string;

--- a/src/mono/wasm/runtime/types.ts
+++ b/src/mono/wasm/runtime/types.ts
@@ -119,6 +119,10 @@ export type MonoConfig = {
      * initial number of workers to add to the emscripten pthread pool
      */
     pthreadPoolSize?: number,
+    /**
+     * hash of assets
+     */
+    assetsHash?: string,
 };
 
 export type MonoConfigInternal = MonoConfig & {

--- a/src/tasks/AndroidAppBuilder/AndroidAppBuilder.csproj
+++ b/src/tasks/AndroidAppBuilder/AndroidAppBuilder.csproj
@@ -5,7 +5,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <Nullable>enable</Nullable>
-    <NoWarn>$(NoWarn),CA1050</NoWarn>
+    <NoWarn>$(NoWarn),CA1050,CA1850</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="Templates\*.*" />

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.csproj
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.csproj
@@ -5,7 +5,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <Nullable>enable</Nullable>
-    <NoWarn>$(NoWarn),CA1050</NoWarn>
+    <NoWarn>$(NoWarn),CA1050,CA1850</NoWarn>
 
     <!-- Ignore nullable warnings on net4* -->
     <NoWarn Condition="$(TargetFramework.StartsWith('net4'))">$(NoWarn),CS8604,CS8602</NoWarn>

--- a/src/tasks/AppleAppBuilder/AppleAppBuilder.csproj
+++ b/src/tasks/AppleAppBuilder/AppleAppBuilder.csproj
@@ -5,7 +5,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <Nullable>enable</Nullable>
-    <NoWarn>$(NoWarn),CA1050</NoWarn>
+    <NoWarn>$(NoWarn),CA1050,CA1850</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="Templates\*.*" />

--- a/src/tasks/Common/Utils.cs
+++ b/src/tasks/Common/Utils.cs
@@ -3,9 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Reflection.PortableExecutable;
+using System.Reflection.Metadata;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Build.Framework;
@@ -237,6 +240,32 @@ internal static class Utils
         return Convert.ToBase64String(hash);
     }
 
+    public static string ComputeIntegrity(string filepath)
+    {
+        using var stream = File.OpenRead(filepath);
+        using HashAlgorithm hashAlgorithm = SHA256.Create();
+
+        byte[] hash = hashAlgorithm.ComputeHash(stream);
+        return "sha256-" + Convert.ToBase64String(hash);
+    }
+
+    public static string ComputeIntegrity(byte[] bytes)
+    {
+        using HashAlgorithm hashAlgorithm = SHA256.Create();
+
+        byte[] hash = hashAlgorithm.ComputeHash(bytes);
+        return "sha256-" + Convert.ToBase64String(hash);
+    }
+
+    public static string ComputeTextIntegrity(string str)
+    {
+        using HashAlgorithm hashAlgorithm = SHA256.Create();
+
+        var bytes = Encoding.UTF8.GetBytes(str);
+        byte[] hash = hashAlgorithm.ComputeHash(bytes);
+        return "sha256-" + Convert.ToBase64String(hash);
+    }
+
 #if NETCOREAPP
     public static void DirectoryCopy(string sourceDir, string destDir, Func<string, bool>? predicate=null)
     {
@@ -258,4 +287,44 @@ internal static class Utils
         }
     }
 #endif
+
+    public static bool IsManagedAssembly(string filePath)
+    {
+        if (!File.Exists(filePath))
+            return false;
+
+        // Try to read CLI metadata from the PE file.
+        using FileStream fileStream = File.OpenRead(filePath);
+        using PEReader peReader = new(fileStream, PEStreamOptions.Default);
+        return IsManagedAssembly(peReader);
+    }
+
+    public static bool IsManagedAssembly(byte[] bytes)
+    {
+        using var peReader = new PEReader(ImmutableArray.Create(bytes));
+        return IsManagedAssembly(peReader);
+    }
+
+    private static bool IsManagedAssembly(PEReader peReader)
+    {
+        try
+        {
+            if (!peReader.HasMetadata)
+            {
+                return false; // File does not have CLI metadata.
+            }
+
+            // Check that file has an assembly manifest.
+            MetadataReader reader = peReader.GetMetadataReader();
+            return reader.IsAssembly;
+        }
+        catch (BadImageFormatException)
+        {
+            return false;
+        }
+        catch (FileNotFoundException)
+        {
+            return false;
+        }
+    }
 }

--- a/src/tasks/MonoTargetsTasks/MonoTargetsTasks.csproj
+++ b/src/tasks/MonoTargetsTasks/MonoTargetsTasks.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>$(TargetFrameworkForNETCoreTasks);$(TargetFrameworkForNETFrameworkTasks)</TargetFrameworks>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <Nullable>enable</Nullable>
-    <NoWarn>$(NoWarn),CA1050</NoWarn>
+    <NoWarn>$(NoWarn),CA1050,CA1850</NoWarn>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkForNETCoreTasks)'">
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />

--- a/src/tasks/TestExclusionListTasks/TestExclusionListTasks.csproj
+++ b/src/tasks/TestExclusionListTasks/TestExclusionListTasks.csproj
@@ -5,7 +5,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <Nullable>enable</Nullable>
-    <NoWarn>$(NoWarn),CA1050</NoWarn>
+    <NoWarn>$(NoWarn),CA1050,CA1850</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tasks/WasmAppBuilder/ManagedToNativeGenerator.cs
+++ b/src/tasks/WasmAppBuilder/ManagedToNativeGenerator.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using System.Reflection.PortableExecutable;
 using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -128,7 +127,7 @@ public class ManagedToNativeGenerator : Task
 
             try
             {
-                if (!IsManagedAssembly(asmPath))
+                if (!Utils.IsManagedAssembly(asmPath))
                 {
                     Log.LogMessage(MessageImportance.Low, $"Skipping unmanaged {asmPath}.");
                     continue;
@@ -145,15 +144,4 @@ public class ManagedToNativeGenerator : Task
 
         return managedAssemblies;
     }
-
-    private static bool IsManagedAssembly(string filePath)
-    {
-        if (!File.Exists(filePath))
-            return false;
-
-        using FileStream fileStream = File.OpenRead(filePath);
-        using PEReader reader = new(fileStream, PEStreamOptions.Default);
-        return reader.HasMetadata;
-    }
-
 }

--- a/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
@@ -4,14 +4,20 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using System.Numerics;
+using System.Security.Cryptography;
+using System.Reflection.PortableExecutable;
+using System.Reflection.Metadata;
 
 namespace Microsoft.WebAssembly.Build.Tasks;
 
@@ -37,6 +43,8 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
     // </summary>
     public ITaskItem[]? ExtraConfig { get; set; }
 
+    private static SHA256 HashAlgorithm = SHA256.Create();
+
     private sealed class WasmAppConfig
     {
         [JsonPropertyName("mainAssemblyName")]
@@ -51,46 +59,49 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
         public List<string> RemoteSources { get; set; } = new List<string>();
         [JsonExtensionData]
         public Dictionary<string, object?> Extra { get; set; } = new();
+        [JsonPropertyName("assetsHash")]
+        public string AssetsHash { get; set; } = "none";
     }
 
     private class AssetEntry
     {
-        protected AssetEntry (string name, string behavior)
+        protected AssetEntry (string name, string hash, string behavior)
         {
             Name = name;
             Behavior = behavior;
+            Hash = hash;
         }
         [JsonPropertyName("behavior")]
         public string Behavior { get; init; }
         [JsonPropertyName("name")]
         public string Name { get; init; }
-        // TODO [JsonPropertyName("hash")]
-        // TODO public string? Hash { get; set; }
+        [JsonPropertyName("hash")]
+        public string? Hash { get; set; }
     }
 
     private sealed class WasmEntry : AssetEntry
     {
-        public WasmEntry(string name) : base(name, "dotnetwasm") { }
+        public WasmEntry(string name, string hash) : base(name, hash, "dotnetwasm") { }
     }
 
     private sealed class ThreadsWorkerEntry : AssetEntry
     {
-        public ThreadsWorkerEntry(string name) : base(name, "js-module-threads") { }
+        public ThreadsWorkerEntry(string name, string hash) : base(name, hash, "js-module-threads") { }
     }
 
     private sealed class AssemblyEntry : AssetEntry
     {
-        public AssemblyEntry(string name) : base(name, "assembly") {}
+        public AssemblyEntry(string name, string hash) : base(name, hash, "assembly") {}
     }
 
     private sealed class PdbEntry : AssetEntry
     {
-        public PdbEntry(string name) : base(name, "pdb") {}
+        public PdbEntry(string name, string hash) : base(name, hash, "pdb") {}
     }
 
     private sealed class SatelliteAssemblyEntry : AssetEntry
     {
-        public SatelliteAssemblyEntry(string name, string culture) : base(name, "resource")
+        public SatelliteAssemblyEntry(string name, string hash, string culture) : base(name, hash, "resource")
         {
             CultureName = culture;
         }
@@ -101,14 +112,14 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
 
     private sealed class VfsEntry : AssetEntry
     {
-        public VfsEntry(string name) : base(name, "vfs") {}
+        public VfsEntry(string name, string hash) : base(name, hash, "vfs") {}
         [JsonPropertyName("virtualPath")]
         public string? VirtualPath { get; set; }
     }
 
     private sealed class IcuData : AssetEntry
     {
-        public IcuData(string name) : base(name, "icu") {}
+        public IcuData(string name, string hash) : base(name, hash, "icu") {}
         [JsonPropertyName("loadRemote")]
         public bool LoadRemote { get; set; }
     }
@@ -183,11 +194,19 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
 
         foreach (ITaskItem item in NativeAssets)
         {
-            string dest = Path.Combine(AppDir!, Path.GetFileName(item.ItemSpec));
+            var name = Path.GetFileName(item.ItemSpec);
+            var dest = Path.Combine(AppDir!, name);
             if (!FileCopyChecked(item.ItemSpec, dest, "NativeAssets"))
                 return false;
+            if (name == "dotnet.wasm")
+            {
+                config.Assets.Add(new WasmEntry (name, GetFileHash(item.ItemSpec)) );
+            }
+            else if (IncludeThreadsWorker && name == "dotnet.worker.js")
+            {
+                config.Assets.Add(new ThreadsWorkerEntry (name, GetFileHash(item.ItemSpec)));
+            }
         }
-
 
         string packageJsonPath = Path.Combine(AppDir, "package.json");
         if (!File.Exists(packageJsonPath))
@@ -199,14 +218,24 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
         foreach (var assembly in _assemblies)
         {
             string assemblyPath = assembly;
-            if (UseWebcil)
-                assemblyPath = Path.ChangeExtension(assemblyPath, ".webcil");
-            config.Assets.Add(new AssemblyEntry(Path.GetFileName(assemblyPath)));
-            if (DebugLevel != 0) {
-                var pdb = assembly;
-                pdb = Path.ChangeExtension(pdb, ".pdb");
-                if (File.Exists(pdb))
-                    config.Assets.Add(new PdbEntry(Path.GetFileName(pdb)));
+            var bytes = File.ReadAllBytes(assemblyPath);
+            if (!IsAssembly(bytes))
+            {
+                Log.LogWarning("Skipping non-assembly file: " + assemblyPath);
+            }
+            else
+            {
+                if (UseWebcil)
+                    assemblyPath = Path.ChangeExtension(assemblyPath, ".webcil");
+
+                config.Assets.Add(new AssemblyEntry(Path.GetFileName(assemblyPath), GetFileHash(bytes)));
+                if (DebugLevel != 0)
+                {
+                    var pdb = assembly;
+                    pdb = Path.ChangeExtension(pdb, ".pdb");
+                    if (File.Exists(pdb))
+                        config.Assets.Add(new PdbEntry(Path.GetFileName(pdb), GetFileHash(pdb)));
+                }
             }
         }
 
@@ -228,12 +257,13 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
                 else
                     Log.LogMessage(MessageImportance.Low, $"Skipped generating {finalWebcil} as the contents are unchanged.");
                 _fileWrites.Add(finalWebcil);
-                config.Assets.Add(new SatelliteAssemblyEntry(Path.GetFileName(finalWebcil), args.culture));
+                config.Assets.Add(new SatelliteAssemblyEntry(Path.GetFileName(finalWebcil), GetFileHash(finalWebcil), args.culture));
             }
             else
             {
-                FileCopyChecked(args.fullPath, Path.Combine(directory, name), "SatelliteAssemblies");
-                config.Assets.Add(new SatelliteAssemblyEntry(name, args.culture));
+                var satellitePath = Path.Combine(directory, name);
+                FileCopyChecked(args.fullPath, satellitePath, "SatelliteAssemblies");
+                config.Assets.Add(new SatelliteAssemblyEntry(name, GetFileHash(satellitePath), args.culture));
             }
         });
 
@@ -271,10 +301,10 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
                 targetPathTable[targetPath] = item.ItemSpec;
 
                 var generatedFileName = $"{i++}_{Path.GetFileName(item.ItemSpec)}";
+                var vfsPath = Path.Combine(supportFilesDir, generatedFileName);
+                FileCopyChecked(item.ItemSpec, vfsPath, "FilesToIncludeInFileSystem");
 
-                FileCopyChecked(item.ItemSpec, Path.Combine(supportFilesDir, generatedFileName), "FilesToIncludeInFileSystem");
-
-                var asset = new VfsEntry ($"supportFiles/{generatedFileName}") {
+                var asset = new VfsEntry ($"supportFiles/{generatedFileName}", GetFileHash(vfsPath)) {
                     VirtualPath = targetPath
                 };
                 config.Assets.Add(asset);
@@ -291,14 +321,10 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
                     Log.LogError($"Expected the file defined as ICU resource: {idfn} to exist but it does not.");
                     return false;
                 }
-                config.Assets.Add(new IcuData(Path.GetFileName(idfn)) { LoadRemote = loadRemote });
+                config.Assets.Add(new IcuData(Path.GetFileName(idfn), GetFileHash(idfn)) { LoadRemote = loadRemote });
             }
         }
 
-
-        config.Assets.Add(new WasmEntry ("dotnet.wasm") );
-        if (IncludeThreadsWorker)
-            config.Assets.Add(new ThreadsWorkerEntry ("dotnet.worker.js") );
 
         if (RemoteSources?.Length > 0)
         {
@@ -328,6 +354,16 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
         string tmpMonoConfigPath = Path.GetTempFileName();
         using (var sw = File.CreateText(tmpMonoConfigPath))
         {
+            HashAlgorithm.Initialize();
+            var sb = new StringBuilder();
+            foreach(AssetEntry asset in config.Assets)
+            {
+                sb.Append(asset.Hash);
+            }
+            var bytesToHash = Encoding.UTF8.GetBytes(sb.ToString());
+            var hashBytes = HashAlgorithm.ComputeHash(bytesToHash);
+            config.AssetsHash = "sha256-" + Convert.ToBase64String(hashBytes);
+
             var json = JsonSerializer.Serialize (config, new JsonSerializerOptions { WriteIndented = true });
             sw.Write(json);
         }
@@ -408,4 +444,43 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
             return false;
         }
     }
+
+    public static bool IsAssembly(byte[] bytes)
+    {
+        try
+        {
+            // Try to read CLI metadata from the PE file.
+            using var peReader = new PEReader(ImmutableArray.Create(bytes));
+
+            if (!peReader.HasMetadata)
+            {
+                return false; // File does not have CLI metadata.
+            }
+
+            // Check that file has an assembly manifest.
+            MetadataReader reader = peReader.GetMetadataReader();
+            return reader.IsAssembly;
+        }
+        catch (BadImageFormatException)
+        {
+            return false;
+        }
+        catch (FileNotFoundException)
+        {
+            return false;
+        }
+    }
+
+    public static string GetFileHash(string filePath)
+    {
+        return GetFileHash(File.ReadAllBytes(filePath));
+    }
+
+    public static string GetFileHash(byte[] bytes)
+    {
+        HashAlgorithm.Initialize();
+        var hashBytes = HashAlgorithm.ComputeHash(bytes);
+        return "sha256-" + Convert.ToBase64String(hashBytes);
+    }
+
 }

--- a/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
@@ -219,6 +219,7 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
         {
             string assemblyPath = assembly;
             var bytes = File.ReadAllBytes(assemblyPath);
+            // for the is IL IsAssembly check we need to read the bytes from the original DLL
             if (!IsAssembly(bytes))
             {
                 Log.LogWarning("Skipping non-assembly file: " + assemblyPath);
@@ -226,7 +227,11 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
             else
             {
                 if (UseWebcil)
-                    assemblyPath = Path.ChangeExtension(assemblyPath, ".webcil");
+                {
+                    assemblyPath = Path.Combine(asmRootPath, Path.ChangeExtension(Path.GetFileName(assembly), ".webcil"));
+                    // For the hash, read the bytes from the webcil file, not the dll file.
+                    bytes = File.ReadAllBytes(assemblyPath);
+                }
 
                 config.Assets.Add(new AssemblyEntry(Path.GetFileName(assemblyPath), GetFileHash(bytes)));
                 if (DebugLevel != 0)

--- a/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
@@ -215,7 +215,7 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
             // for the is IL IsAssembly check we need to read the bytes from the original DLL
             if (!Utils.IsManagedAssembly(bytes))
             {
-                Log.LogWarning("Skipping non-assembly file: " + assemblyPath);
+                Log.LogMessage(MessageImportance.Low, "Skipping non-assembly file: " + assemblyPath);
             }
             else
             {

--- a/src/tasks/WasmAppBuilder/WasmAppBuilder.csproj
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilder.csproj
@@ -5,6 +5,7 @@
     <NoWarn>$(NoWarn),CA1050</NoWarn>
     <!-- Ignore nullable warnings on net4* -->
     <NoWarn Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">$(NoWarn),CS8604,CS8602</NoWarn>
+    <NoWarn Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) != '.NETFramework'">$(NoWarn),CA1850</NoWarn>
     <EnableSingleFileAnalyzer>false</EnableSingleFileAnalyzer>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/tasks/WorkloadBuildTasks/WorkloadBuildTasks.csproj
+++ b/src/tasks/WorkloadBuildTasks/WorkloadBuildTasks.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>$(TargetFrameworkForNETCoreTasks)</TargetFramework>
     <Nullable>enable</Nullable>
-    <NoWarn>$(NoWarn),CA1050</NoWarn>
+    <NoWarn>$(NoWarn),CA1050,CA1850</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Common\Utils.cs" />


### PR DESCRIPTION
- calculate SHA256 hash and use in to check integrity of the download
- calculate SHA256 of all assets (to be used later for memory snapshot)
- skip non-IL assemblies and issue message for it. Fixes https://github.com/dotnet/runtime/issues/82888