### PR TITLE
[browser][docs] Update keywords.

### DIFF
--- a/docs/design/features/globalization-icu-wasm.md
+++ b/docs/design/features/globalization-icu-wasm.md
@@ -17,7 +17,7 @@ Only one value for `WasmIcuDataFileName` can be set. It can also be a custom fil
 ## Custom ICU
 
 The easiest way to build ICU is to open https://github.com/dotnet/icu/ it in [Codespaces](docs\workflow\Codespaces.md). See files in https://github.com/dotnet/icu/tree/dotnet/main/icu-filters, and read https://unicode-org.github.io/icu/userguide/icu_data/buildtool.html#locale-slicing. Build your own filter or edit the existing file.
-We advise to edit the filters **only by adding/removing locales** from the `localeFilter/whitelist` to avoid removing important data. We recommend not to remove "en-US" locale from the localeFilter/whitelist because it is used as a fallback. Removing it for when
+We advise to edit the filters **only by adding/removing locales** from the `localeFilter/includelist` to avoid removing important data. We recommend not to remove "en-US" locale from the localeFilter/includelist because it is used as a fallback. Removing it for when
 - `<PredefinedCulturesOnly>true</PredefinedCulturesOnly>`: results in `Encountered infinite recursion while looking for resource in System.Private.Corelib.` exception
 - when predefined cultures only is not set: results in resolving data from ICU's `root.txt` files, e.g. `CultureInfo.DateTimeFormat.GetDayName(DateTime.Today.DayOfWeek)` will return an abbreviated form: `Mon` instead of `Monday`.
 Removing specific feature data might result in an exception that starts with `[CultureData.IcuGetLocaleInfo(LocaleStringData)] Failed`. It means you removed data necessary to extract basic information about the locale.


### PR DESCRIPTION
According to ICU [documentation](https://unicode-org.github.io/icu/userguide/icu_data/buildtool.html#terminology-includelist-excludelist-whitelist-blacklist), we can use whitelist/blacklist interchangibly with includeList/excludelist. In [ICU filters](https://github.com/dotnet/icu/blob/dc5810e9c8628de22eec85a4ec9684c7a875d65c/icu-filters/icudt_wasm.json#L7) we are using the standard form, but we should exchange the keywords in the documentation to fix policheck error.

Our current ICU version: 68.2.