### PR TITLE
Allow default AsyncFlowControls rather than throwing

### DIFF
--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.MultipleWatchers.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.MultipleWatchers.cs
@@ -79,20 +79,15 @@ namespace System.IO.Tests
 
                 local.Value = 42;
 
-                ExecutionContext.SuppressFlow();
-                try
+                using (ExecutionContext.SuppressFlow())
                 {
                     watcher1.EnableRaisingEvents = true;
                 }
-                finally
-                {
-                    ExecutionContext.RestoreFlow();
-                }
 
-                    File.Create(fileName).Dispose();
-                    tcs1.Task.Wait(WaitForExpectedEventTimeout);
+                File.Create(fileName).Dispose();
+                tcs1.Task.Wait(WaitForExpectedEventTimeout);
 
-                    Assert.Equal(0, tcs1.Task.Result);
+                Assert.Equal(0, tcs1.Task.Result);
            }
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1291,15 +1291,8 @@ namespace System.Net.Http
                     {
                         var thisRef = new WeakReference<HttpConnectionPool>(this);
 
-                        bool restoreFlow = false;
-                        try
+                        using (ExecutionContext.SuppressFlow())
                         {
-                            if (!ExecutionContext.IsFlowSuppressed())
-                            {
-                                ExecutionContext.SuppressFlow();
-                                restoreFlow = true;
-                            }
-
                             _authorityExpireTimer = new Timer(static o =>
                             {
                                 var wr = (WeakReference<HttpConnectionPool>)o!;
@@ -1308,10 +1301,6 @@ namespace System.Net.Http
                                     @this.ExpireAltSvcAuthority();
                                 }
                             }, thisRef, nextAuthorityMaxAge, Timeout.InfiniteTimeSpan);
-                        }
-                        finally
-                        {
-                            if (restoreFlow) ExecutionContext.RestoreFlow();
                         }
                     }
                     else

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -91,16 +91,8 @@ namespace System.Net.Http
                     _cleanPoolTimeout = timerPeriod.TotalSeconds >= MinScavengeSeconds ? timerPeriod : TimeSpan.FromSeconds(MinScavengeSeconds);
                 }
 
-                bool restoreFlow = false;
-                try
+                using (ExecutionContext.SuppressFlow()) // Don't capture the current ExecutionContext and its AsyncLocals onto the timer causing them to live forever
                 {
-                    // Don't capture the current ExecutionContext and its AsyncLocals onto the timer causing them to live forever
-                    if (!ExecutionContext.IsFlowSuppressed())
-                    {
-                        ExecutionContext.SuppressFlow();
-                        restoreFlow = true;
-                    }
-
                     // Create the timer.  Ensure the Timer has a weak reference to this manager; otherwise, it
                     // can introduce a cycle that keeps the HttpConnectionPoolManager rooted by the Timer
                     // implementation until the handler is Disposed (or indefinitely if it's not).
@@ -129,14 +121,6 @@ namespace System.Net.Http
                                 thisRef.HeartBeat();
                             }
                         }, thisRef, heartBeatInterval, heartBeatInterval);
-                    }
-                }
-                finally
-                {
-                    // Restore the current ExecutionContext
-                    if (restoreFlow)
-                    {
-                        ExecutionContext.RestoreFlow();
                     }
                 }
             }
@@ -190,14 +174,7 @@ namespace System.Net.Http
                 return;
             }
 
-            if (!ExecutionContext.IsFlowSuppressed())
-            {
-                using (ExecutionContext.SuppressFlow())
-                {
-                    NetworkChange.NetworkAddressChanged += networkChangedDelegate;
-                }
-            }
-            else
+            using (ExecutionContext.SuppressFlow())
             {
                 NetworkChange.NetworkAddressChanged += networkChangedDelegate;
             }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Unix.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Unix.cs
@@ -104,22 +104,9 @@ namespace System.Net.NetworkInformation
                         if (s_availabilityTimer == null)
                         {
                             // Don't capture the current ExecutionContext and its AsyncLocals onto the timer causing them to live forever
-                            bool restoreFlow = false;
-                            try
+                            using (ExecutionContext.SuppressFlow())
                             {
-                                if (!ExecutionContext.IsFlowSuppressed())
-                                {
-                                    ExecutionContext.SuppressFlow();
-                                    restoreFlow = true;
-                                }
-
                                 s_availabilityTimer = new Timer(s_availabilityTimerFiredCallback, null, Timeout.Infinite, Timeout.Infinite);
-                            }
-                            finally
-                            {
-                                // Restore the current ExecutionContext
-                                if (restoreFlow)
-                                    ExecutionContext.RestoreFlow();
                             }
                         }
 

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ExecutionContextFlowTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ExecutionContextFlowTest.cs
@@ -33,14 +33,9 @@ namespace System.Net.Sockets.Tests
                 };
 
                 asyncLocal.Value = 42;
-                if (suppressContext) ExecutionContext.SuppressFlow();
-                try
+                using (suppressContext ? ExecutionContext.SuppressFlow() : default)
                 {
                     Assert.True(listener.AcceptAsync(saea));
-                }
-                finally
-                {
-                    if (suppressContext) ExecutionContext.RestoreFlow();
                 }
                 asyncLocal.Value = 0;
 
@@ -65,18 +60,13 @@ namespace System.Net.Sockets.Tests
                 var tcs = new TaskCompletionSource<int>();
 
                 asyncLocal.Value = 42;
-                if (suppressContext) ExecutionContext.SuppressFlow();
-                try
+                using (suppressContext ? ExecutionContext.SuppressFlow() : default)
                 {
                     listener.BeginAccept(iar =>
                     {
                         listener.EndAccept(iar).Dispose();
                         tcs.SetResult(asyncLocal.Value);
                     }, null);
-                }
-                finally
-                {
-                    if (suppressContext) ExecutionContext.RestoreFlow();
                 }
                 asyncLocal.Value = 0;
 
@@ -105,14 +95,9 @@ namespace System.Net.Sockets.Tests
 
                 bool pending;
                 asyncLocal.Value = 42;
-                if (suppressContext) ExecutionContext.SuppressFlow();
-                try
+                using (suppressContext ? ExecutionContext.SuppressFlow() : default)
                 {
                     pending = client.ConnectAsync(saea);
-                }
-                finally
-                {
-                    if (suppressContext) ExecutionContext.RestoreFlow();
                 }
                 asyncLocal.Value = 0;
 
@@ -139,18 +124,13 @@ namespace System.Net.Sockets.Tests
 
                 bool pending;
                 asyncLocal.Value = 42;
-                if (suppressContext) ExecutionContext.SuppressFlow();
-                try
+                using (suppressContext ? ExecutionContext.SuppressFlow() : default)
                 {
                     pending = !client.BeginConnect(listener.LocalEndPoint, iar =>
                     {
                         client.EndConnect(iar);
                         tcs.SetResult(asyncLocal.Value);
                     }, null).CompletedSynchronously;
-                }
-                finally
-                {
-                    if (suppressContext) ExecutionContext.RestoreFlow();
                 }
                 asyncLocal.Value = 0;
 
@@ -182,14 +162,9 @@ namespace System.Net.Sockets.Tests
 
                     bool pending;
                     asyncLocal.Value = 42;
-                    if (suppressContext) ExecutionContext.SuppressFlow();
-                    try
+                    using (suppressContext ? ExecutionContext.SuppressFlow() : default)
                     {
                         pending = client.DisconnectAsync(saea);
-                    }
-                    finally
-                    {
-                        if (suppressContext) ExecutionContext.RestoreFlow();
                     }
                     asyncLocal.Value = 0;
 
@@ -220,18 +195,13 @@ namespace System.Net.Sockets.Tests
 
                     bool pending;
                     asyncLocal.Value = 42;
-                    if (suppressContext) ExecutionContext.SuppressFlow();
-                    try
+                    using (suppressContext ? ExecutionContext.SuppressFlow() : default)
                     {
                         pending = !client.BeginDisconnect(reuseSocket: false, iar =>
                         {
                             client.EndDisconnect(iar);
                             tcs.SetResult(asyncLocal.Value);
                         }, null).CompletedSynchronously;
-                    }
-                    finally
-                    {
-                        if (suppressContext) ExecutionContext.RestoreFlow();
                     }
                     asyncLocal.Value = 0;
 
@@ -267,16 +237,11 @@ namespace System.Net.Sockets.Tests
                     saea.RemoteEndPoint = server.LocalEndPoint;
 
                     asyncLocal.Value = 42;
-                    if (suppressContext) ExecutionContext.SuppressFlow();
-                    try
+                    using (suppressContext ? ExecutionContext.SuppressFlow() : default)
                     {
                         Assert.True(receiveFrom ?
                             client.ReceiveFromAsync(saea) :
                             client.ReceiveAsync(saea));
-                    }
-                    finally
-                    {
-                        if (suppressContext) ExecutionContext.RestoreFlow();
                     }
                     asyncLocal.Value = 0;
 
@@ -306,8 +271,7 @@ namespace System.Net.Sockets.Tests
                     var tcs = new TaskCompletionSource<int>();
 
                     asyncLocal.Value = 42;
-                    if (suppressContext) ExecutionContext.SuppressFlow();
-                    try
+                    using (suppressContext ? ExecutionContext.SuppressFlow() : default)
                     {
                         EndPoint ep = server.LocalEndPoint;
                         Assert.False(receiveFrom ?
@@ -321,11 +285,6 @@ namespace System.Net.Sockets.Tests
                                 client.EndReceive(iar);
                                 tcs.SetResult(asyncLocal.Value);
                             }, null).CompletedSynchronously);
-                    }
-                    finally
-                    {
-                        if (suppressContext)
-                            ExecutionContext.RestoreFlow();
                     }
                     asyncLocal.Value = 0;
 
@@ -365,17 +324,12 @@ namespace System.Net.Sockets.Tests
 
                     bool pending;
                     asyncLocal.Value = 42;
-                    if (suppressContext) ExecutionContext.SuppressFlow();
-                    try
+                    using (suppressContext ? ExecutionContext.SuppressFlow() : default)
                     {
                         pending =
                             sendMode == 0 ? client.SendAsync(saea) :
                             sendMode == 1 ? client.SendToAsync(saea) :
                             client.SendPacketsAsync(saea);
-                    }
-                    finally
-                    {
-                        if (suppressContext) ExecutionContext.RestoreFlow();
                     }
                     asyncLocal.Value = 0;
 
@@ -416,8 +370,7 @@ namespace System.Net.Sockets.Tests
 
                     bool pending;
                     asyncLocal.Value = 42;
-                    if (suppressContext) ExecutionContext.SuppressFlow();
-                    try
+                    using (suppressContext ? ExecutionContext.SuppressFlow() : default)
                     {
                         pending = sendTo ?
                             !client.BeginSendTo(buffer, 0, buffer.Length, SocketFlags.None, server.LocalEndPoint, iar =>
@@ -430,10 +383,6 @@ namespace System.Net.Sockets.Tests
                                 client.EndSend(iar);
                                 tcs.SetResult(asyncLocal.Value);
                             }, null).CompletedSynchronously;
-                    }
-                    finally
-                    {
-                        if (suppressContext) ExecutionContext.RestoreFlow();
                     }
                     asyncLocal.Value = 0;
 
@@ -477,18 +426,13 @@ namespace System.Net.Sockets.Tests
 
                     bool pending;
                     asyncLocal.Value = 42;
-                    if (suppressContext) ExecutionContext.SuppressFlow();
-                    try
+                    using (suppressContext ? ExecutionContext.SuppressFlow() : default)
                     {
                         pending = !client.BeginSendFile(filePath, iar =>
                         {
                             client.EndSendFile(iar);
                             tcs.SetResult(asyncLocal.Value);
                         }, null).CompletedSynchronously;
-                    }
-                    finally
-                    {
-                        if (suppressContext) ExecutionContext.RestoreFlow();
                     }
                     asyncLocal.Value = 0;
 

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
@@ -122,27 +122,25 @@ namespace System.Net.Sockets.Tests
                 using (Socket server = await acceptTask)
                 using (var receiveSaea = new SocketAsyncEventArgs())
                 {
-                    if (suppressed)
+                    using (suppressed ? ExecutionContext.SuppressFlow() : default)
                     {
-                        ExecutionContext.SuppressFlow();
+                        var local = new AsyncLocal<int>();
+                        local.Value = 42;
+                        int threadId = Environment.CurrentManagedThreadId;
+
+                        var mres = new ManualResetEventSlim();
+                        receiveSaea.SetBuffer(new byte[1], 0, 1);
+                        receiveSaea.Completed += delegate
+                        {
+                            Assert.NotEqual(threadId, Environment.CurrentManagedThreadId);
+                            Assert.Equal(suppressed ? 0 : 42, local.Value);
+                            mres.Set();
+                        };
+
+                        Assert.True(client.ReceiveAsync(receiveSaea));
+                        server.Send(new byte[1]);
+                        mres.Wait();
                     }
-
-                    var local = new AsyncLocal<int>();
-                    local.Value = 42;
-                    int threadId = Environment.CurrentManagedThreadId;
-
-                    var mres = new ManualResetEventSlim();
-                    receiveSaea.SetBuffer(new byte[1], 0, 1);
-                    receiveSaea.Completed += delegate
-                    {
-                        Assert.NotEqual(threadId, Environment.CurrentManagedThreadId);
-                        Assert.Equal(suppressed ? 0 : 42, local.Value);
-                        mres.Set();
-                    };
-
-                    Assert.True(client.ReceiveAsync(receiveSaea));
-                    server.Send(new byte[1]);
-                    mres.Wait();
                 }
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2422,12 +2422,6 @@
   <data name="InvalidOperation_CannotRestoreUnsuppressedFlow" xml:space="preserve">
     <value>Cannot restore context flow when it is not suppressed.</value>
   </data>
-  <data name="InvalidOperation_CannotSuppressFlowMultipleTimes" xml:space="preserve">
-    <value>Context flow is already suppressed.</value>
-  </data>
-  <data name="InvalidOperation_CannotUseAFCMultiple" xml:space="preserve">
-    <value>AsyncFlowControl object can be used only once to call Undo().</value>
-  </data>
   <data name="InvalidOperation_CannotUseAFCOtherThread" xml:space="preserve">
     <value>AsyncFlowControl object must be used on the thread where it was created.</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
@@ -102,15 +102,14 @@ namespace System.Threading
         {
             Thread currentThread = Thread.CurrentThread;
             ExecutionContext? executionContext = currentThread._executionContext ?? Default;
-            if (executionContext.m_isFlowSuppressed)
+
+            AsyncFlowControl asyncFlowControl = default;
+            if (!executionContext.m_isFlowSuppressed)
             {
-                throw new InvalidOperationException(SR.InvalidOperation_CannotSuppressFlowMultipleTimes);
+                currentThread._executionContext = executionContext.ShallowClone(isFlowSuppressed: true);
+                asyncFlowControl.Initialize(currentThread);
             }
 
-            executionContext = executionContext.ShallowClone(isFlowSuppressed: true);
-            AsyncFlowControl asyncFlowControl = default;
-            currentThread._executionContext = executionContext;
-            asyncFlowControl.Initialize(currentThread);
             return asyncFlowControl;
         }
 
@@ -563,10 +562,11 @@ namespace System.Threading
 
         public void Undo()
         {
-            if (_thread == null)
+            if (_thread is null)
             {
-                throw new InvalidOperationException(SR.InvalidOperation_CannotUseAFCMultiple);
+                return;
             }
+
             if (Thread.CurrentThread != _thread)
             {
                 throw new InvalidOperationException(SR.InvalidOperation_CannotUseAFCOtherThread);

--- a/src/libraries/System.Threading.Tasks.Parallel/tests/ParallelForEachAsyncTests.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/tests/ParallelForEachAsyncTests.cs
@@ -1007,20 +1007,14 @@ namespace System.Threading.Tasks.Tests
             var al = new AsyncLocal<int>();
             al.Value = 42;
 
-            if (!flowContext)
+            Task t;
+            using (!flowContext ? ExecutionContext.SuppressFlow() : default)
             {
-                ExecutionContext.SuppressFlow();
-            }
-
-            Task t = Parallel.ForEachAsync(Iterate(), async (item, cancellationToken) =>
-            {
-                await Task.Yield();
-                Assert.Equal(flowContext ? 42 : 0, al.Value);
-            });
-
-            if (!flowContext)
-            {
-                ExecutionContext.RestoreFlow();
+                t = Parallel.ForEachAsync(Iterate(), async (item, cancellationToken) =>
+                {
+                    await Task.Yield();
+                    Assert.Equal(flowContext ? 42 : 0, al.Value);
+                });
             }
 
             await t;

--- a/src/libraries/System.Threading.Tasks/tests/Task/ExecutionContextFlowTest.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/ExecutionContextFlowTest.cs
@@ -16,16 +16,11 @@ namespace System.Threading.Tasks.Tests
         public void SuppressFlow_TaskCapturesContextAccordingly(bool suppressFlow)
         {
             Assert.False(ExecutionContext.IsFlowSuppressed());
-            if (suppressFlow) ExecutionContext.SuppressFlow();
-            try
+            using (suppressFlow ? ExecutionContext.SuppressFlow() : default)
             {
                 var asyncLocal = new AsyncLocal<int>();
                 Task.Factory.StartNew(() => asyncLocal.Value = 42, CancellationToken.None, TaskCreationOptions.None, new InlineTaskScheduler()).Wait();
                 Assert.Equal(suppressFlow ? 42 : 0, asyncLocal.Value);
-            }
-            finally
-            {
-                if (suppressFlow) ExecutionContext.RestoreFlow();
             }
         }
 

--- a/src/libraries/System.Threading/tests/AsyncLocalTests.cs
+++ b/src/libraries/System.Threading/tests/AsyncLocalTests.cs
@@ -106,15 +106,10 @@ namespace System.Threading.Tests
         [Fact]
         public static async Task CaptureAndRunOnFlowSuppressedContext()
         {
-            ExecutionContext.SuppressFlow();
-            try
+            using (ExecutionContext.SuppressFlow())
             {
                 ExecutionContext ec = ExecutionContext.Capture();
                 Assert.Throws<InvalidOperationException>(() => ExecutionContext.Run(ec, _ => { }, null));
-            }
-            finally
-            {
-                ExecutionContext.RestoreFlow();
             }
         }
 
@@ -598,15 +593,10 @@ namespace System.Threading.Tests
             // Check Running with the contexts captured when setting the locals
             TestCapturedExecutionContexts();
 
-            ExecutionContext.SuppressFlow();
-            try
+            using (ExecutionContext.SuppressFlow())
             {
                 // Re-check restoring, but starting with a suppressed flow
                 TestCapturedExecutionContexts();
-            }
-            finally
-            {
-                ExecutionContext.RestoreFlow();
             }
 
             // -- Local functions --

--- a/src/libraries/System.Threading/tests/ExecutionContextTests.cs
+++ b/src/libraries/System.Threading/tests/ExecutionContextTests.cs
@@ -96,9 +96,18 @@ namespace System.Threading.Tests
                     () => ExecutionContext.SuppressFlow(),
                     () => ExecutionContext.RestoreFlow());
 
+                Assert.False(ExecutionContext.IsFlowSuppressed());
                 Assert.Throws<InvalidOperationException>(() => ExecutionContext.RestoreFlow());
+
+                Assert.False(ExecutionContext.IsFlowSuppressed());
                 asyncFlowControl = ExecutionContext.SuppressFlow();
-                Assert.Throws<InvalidOperationException>(() => ExecutionContext.SuppressFlow());
+                Assert.True(ExecutionContext.IsFlowSuppressed());
+
+                Assert.Equal(default, ExecutionContext.SuppressFlow());
+                Assert.True(ExecutionContext.IsFlowSuppressed());
+
+                ExecutionContext.SuppressFlow().Dispose();
+                Assert.True(ExecutionContext.IsFlowSuppressed());
 
                 ThreadTestHelpers.RunTestInBackgroundThread(() =>
                 {
@@ -109,8 +118,9 @@ namespace System.Threading.Tests
                 });
 
                 asyncFlowControl.Undo();
-                Assert.Throws<InvalidOperationException>(() => asyncFlowControl.Undo());
-                Assert.Throws<InvalidOperationException>(() => asyncFlowControl.Dispose());
+
+                asyncFlowControl.Undo();
+                asyncFlowControl.Dispose();
 
                 // Changing an async local value does not prevent undoing a flow-suppressed execution context. In .NET Core, the
                 // execution context is immutable, so changing an async local value changes the execution context instance,


### PR DESCRIPTION
ExecutionContext.SuppressFlow currently throws an exception if flow is already suppressed.  This makes it complicated to use, as you need to check whether IsFlowSuppressed first and take two different paths based on the result.  If we instead just allow SuppressFlow to return a default AsyncFlowControl rather than throwing, and have AsyncFlowControl's Undo nop rather than throw if it doesn't contain a Thread, we can again make it simple to just always use SuppressFlow without any of the other complications.

@kouvel, thoughts on doing this?  On the one hand, the current exceptions can prevent _some_ misuse.  On the other, it makes using the type much harder.  On balance I think it's better to make a change like that in this PR, but I'd like your insights.