### PR TITLE
[iOS][maccatalyst] Disable MacCatalyst and Simulator CI runs

### DIFF
--- a/eng/pipelines/runtime-extra-platforms.yml
+++ b/eng/pipelines/runtime-extra-platforms.yml
@@ -66,11 +66,14 @@ extends:
           isRollingBuild: ${{ variables.isRollingBuild }}
 
       # Add iOS/tvOS simulator jobs
-      - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
-        parameters:
-          isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
-          isiOSLikeSimulatorOnlyBuild: ${{ variables.isiOSLikeSimulatorOnlyBuild }}
-          isRollingBuild: ${{ variables.isRollingBuild }}
+      #
+      # Disabled pending queue backup investigation 
+      #
+      #- template: /eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
+      #  parameters:
+      #    isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
+      #    isiOSLikeSimulatorOnlyBuild: ${{ variables.isiOSLikeSimulatorOnlyBuild }}
+      #    isRollingBuild: ${{ variables.isRollingBuild }}
 
       # Add Android jobs
       - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
@@ -87,11 +90,14 @@ extends:
           isRollingBuild: ${{ variables.isRollingBuild }}
 
       # Add Mac Catalyst jobs
-      - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-maccatalyst.yml
-        parameters:
-          isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
-          isMacCatalystOnlyBuild: ${{ variables.isMacCatalystOnlyBuild }}
-          isRollingBuild: ${{ variables.isRollingBuild }}
+      #
+      # Disabled pending queue backup investigation 
+      #
+      #- template: /eng/pipelines/extra-platforms/runtime-extra-platforms-maccatalyst.yml
+      #  parameters:
+      #    isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
+      #    isMacCatalystOnlyBuild: ${{ variables.isMacCatalystOnlyBuild }}
+      #    isRollingBuild: ${{ variables.isRollingBuild }}
 
       # Add Linux Bionic jobs
       - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-linuxbionic.yml

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -564,43 +564,46 @@ extends:
       # MacCatalyst interp - requires AOT Compilation and Interp flags
       # Build the whole product using Mono and run libraries tests
       #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-          buildConfig: Release
-          runtimeFlavor: mono
-          platforms:
-          - maccatalyst_x64
-          - ${{ if eq(variables['isRollingBuild'], true) }}:
-            - maccatalyst_arm64
-          variables:
-            # map dependencies variables to local variables
-            - name: librariesContainsChange
-              value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-            - name: monoContainsChange
-              value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'] ]
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: AllSubsets_Mono
-            buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true /p:DevTeamProvisioning=adhoc /p:RunAOTCompilation=true /p:MonoForceInterpreter=true /p:BuildDarwinFrameworks=true
-            timeoutInMinutes: 180
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-            # extra steps, run tests
-            extraStepsTemplate: /eng/pipelines/libraries/helix.yml
-            extraStepsParameters:
-              creator: dotnet-bot
-              testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-              condition: >-
-                or(
-                  eq(variables['librariesContainsChange'], true),
-                  eq(variables['monoContainsChange'], true),
-                  eq(variables['isRollingBuild'], true))
+      #
+      # Disabled pending queue backup investigation 
+      #
+      #- template: /eng/pipelines/common/platform-matrix.yml
+      #  parameters:
+      #    jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+      #    buildConfig: Release
+      #    runtimeFlavor: mono
+      #    platforms:
+      #    - maccatalyst_x64
+      #    - ${{ if eq(variables['isRollingBuild'], true) }}:
+      #      - maccatalyst_arm64
+      #    variables:
+      #      # map dependencies variables to local variables
+      #      - name: librariesContainsChange
+      #        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+      #      - name: monoContainsChange
+      #        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'] ]
+      #    jobParameters:
+      #      testGroup: innerloop
+      #      nameSuffix: AllSubsets_Mono
+      #      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true /p:DevTeamProvisioning=adhoc /p:RunAOTCompilation=true /p:MonoForceInterpreter=true /p:BuildDarwinFrameworks=true
+      #      timeoutInMinutes: 180
+      #      condition: >-
+      #        or(
+      #          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+      #          eq(variables['isRollingBuild'], true))
+      #      # extra steps, run tests
+      #      extraStepsTemplate: /eng/pipelines/libraries/helix.yml
+      #      extraStepsParameters:
+      #        creator: dotnet-bot
+      #        testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+      #        condition: >-
+      #          or(
+      #            eq(variables['librariesContainsChange'], true),
+      #            eq(variables['monoContainsChange'], true),
+      #            eq(variables['isRollingBuild'], true))
 
       #
       # Build Mono and Installer on LLVMJIT mode


### PR DESCRIPTION
The work items for these configurations are failing at a high rate and causing numerous retries. Disabling temporarily to see if that helps queue traffic stabilize.