### PR TITLE
Substitute out geopolitical term in TimeZoneInfo

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.NonAndroid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.NonAndroid.cs
@@ -134,7 +134,7 @@ namespace System
             {
                 if (!string.IsNullOrEmpty(zoneTabFileLine) && zoneTabFileLine[0] != '#')
                 {
-                    // the format of the line is "country-code \t coordinates \t TimeZone Id \t comments"
+                    // the format of the line is "ISO 3166 territory code \t coordinates \t TimeZone Id \t comments"
 
                     int firstTabIndex = zoneTabFileLine.IndexOf('\t');
                     if (firstTabIndex >= 0)


### PR DESCRIPTION
PoliCheck classified the term as geopolitical. Replaced with term referred to in https://www.unix.com/man-page/freebsd/8/tzsetup/.