### PR TITLE
[release/7.0] Port #82470 (disable EventPipe stack collection with environment variable) to 7.0

### DIFF
--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -690,6 +690,7 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_EventPipeRundown, W("EventPipeRundown"), 1, "E
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_EventPipeCircularMB, W("EventPipeCircularMB"), 1024, "The EventPipe circular buffer size in megabytes.")
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_EventPipeProcNumbers, W("EventPipeProcNumbers"), 0, "Enable/disable capturing processor numbers in EventPipe event headers")
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_EventPipeOutputStreaming, W("EventPipeOutputStreaming"), 0, "Enable/disable streaming for trace file set in COMPlus_EventPipeOutputPath.  Non-zero values enable streaming.")
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_EventPipeEnableStackwalk, W("EventPipeEnableStackwalk"), 1, "Set to 0 to disable collecting stacks for EventPipe events.")
 
 #ifdef FEATURE_AUTO_TRACE
 RETAIL_CONFIG_DWORD_INFO_EX(INTERNAL_AutoTrace_N_Tracers, W("AutoTrace_N_Tracers"), 0, "", CLRConfig::LookupOptions::ParseIntegerAsBase10)

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -1670,6 +1670,15 @@ ep_rt_config_value_get_use_portable_thread_pool (void)
 	return ThreadpoolMgr::UsePortableThreadPool ();
 }
 
+static
+inline
+bool
+ep_rt_config_value_get_enable_stackwalk (void)
+{
+	STATIC_CONTRACT_NOTHROW;
+	return CLRConfig::GetConfigValue(CLRConfig::INTERNAL_EventPipeEnableStackwalk) != 0;
+}
+
 /*
  * EventPipeSampleProfiler.
  */

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -1026,6 +1026,21 @@ ep_rt_config_value_get_rundown (void)
 	return value_uint32_t;
 }
 
+static
+inline
+bool
+ep_rt_config_value_get_enable_stackwalk (void)
+{
+	uint32_t value_uint32_t = 1;
+	gchar *value = g_getenv ("DOTNET_EventPipeEnableStackwalk");
+	if (!value)
+		value = g_getenv ("COMPlus_EventPipeEnableStackwalk");
+	if (value)
+		value_uint32_t = (uint32_t)atoi (value);
+	g_free (value);
+	return value_uint32_t != 0;
+}
+
 /*
  * EventPipeSampleProfiler.
  */

--- a/src/native/eventpipe/ep-buffer-manager.c
+++ b/src/native/eventpipe/ep-buffer-manager.c
@@ -971,7 +971,7 @@ ep_buffer_manager_write_event (
 		event_thread = thread;
 
 	current_stack_contents = ep_stack_contents_init (&stack_contents);
-	if (stack == NULL && ep_event_get_need_stack (ep_event) && !ep_session_get_rundown_enabled (session)) {
+	if (stack == NULL && ep_session_get_enable_stackwalk (session) && ep_event_get_need_stack (ep_event) && !ep_session_get_rundown_enabled (session)) {
 		ep_walk_managed_stack_for_current_thread (current_stack_contents);
 		stack = current_stack_contents;
 	}

--- a/src/native/eventpipe/ep-rt.h
+++ b/src/native/eventpipe/ep-rt.h
@@ -406,6 +406,7 @@ static
 bool
 ep_rt_config_value_get_use_portable_thread_pool (void);
 
+static
 inline
 bool
 ep_rt_config_value_get_enable_stackwalk (void);

--- a/src/native/eventpipe/ep-rt.h
+++ b/src/native/eventpipe/ep-rt.h
@@ -406,6 +406,10 @@ static
 bool
 ep_rt_config_value_get_use_portable_thread_pool (void);
 
+inline
+bool
+ep_rt_config_value_get_enable_stackwalk (void);
+
 /*
  * EventPipeSampleProfiler.
  */

--- a/src/native/eventpipe/ep-session.c
+++ b/src/native/eventpipe/ep-session.c
@@ -206,6 +206,7 @@ ep_session_alloc (
 	instance->session_start_time = ep_system_timestamp_get ();
 	instance->session_start_timestamp = ep_perf_timestamp_get ();
 	instance->paused = false;
+	instance->enable_stackwalk = ep_rt_config_value_get_enable_stackwalk ();
 
 ep_on_exit:
 	ep_requires_lock_held ();

--- a/src/native/eventpipe/ep-session.h
+++ b/src/native/eventpipe/ep-session.h
@@ -59,6 +59,8 @@ struct _EventPipeSession_Internal {
 	// we expect to remove it in the future once that limitation is resolved other scenarios are discouraged from using this given that
 	// we plan to make it go away
 	bool paused;
+	// Set via environment variable to enable or disable stack collection globally
+	bool enable_stackwalk;
 };
 
 #if !defined(EP_INLINE_GETTER_SETTER) && !defined(EP_IMPL_SESSION_GETTER_SETTER)
@@ -75,6 +77,7 @@ EP_DEFINE_GETTER(EventPipeSession *, session, bool, rundown_requested)
 EP_DEFINE_GETTER(EventPipeSession *, session, ep_timestamp_t, session_start_time)
 EP_DEFINE_GETTER(EventPipeSession *, session, ep_timestamp_t, session_start_timestamp)
 EP_DEFINE_GETTER(EventPipeSession *, session, EventPipeFile *, file)
+EP_DEFINE_GETTER(EventPipeSession *, session, bool, enable_stackwalk)
 
 EventPipeSession *
 ep_session_alloc (


### PR DESCRIPTION
 Port of #82470. We have an internal partner who is blocked from moving to EventPipe on Linux due to the performance hit of collecting stacks when firing events.

## Customer Impact
Currently in EventPipe the provider defines whether or not to collect stack for each event. Stack collection is very expensive when compared to firing an event, and when an app starts emitting enough events it can cause a significant slowdown. Some scenarios do not care about the event stacks and want to fire many events, this will let them turn off stack collection globally.

## Testing
Manual testing by the dev team and partner validation

## Risk
Low. This feature is opt in, turning off stack collection may break some diagnostics scenarios but the user has to intentionally disable stack collection. The default of the runtime remains unchanged.