### PR TITLE
Implement interfaces in the non-generic enumerator base

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Array.Enumerators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.Enumerators.cs
@@ -67,7 +67,7 @@ namespace System
         }
     }
 
-    internal abstract class SZGenericArrayEnumeratorBase
+    internal abstract class SZGenericArrayEnumeratorBase : IDisposable
     {
         protected readonly Array _array;
         protected int _index;
@@ -141,7 +141,7 @@ namespace System
         object? IEnumerator.Current => Current;
     }
 
-    internal abstract class GenericEmptyEnumeratorBase
+    internal abstract class GenericEmptyEnumeratorBase : IDisposable
     {
 #pragma warning disable CA1822 // https://github.com/dotnet/roslyn-analyzers/issues/5911
         public bool MoveNext() => false;

--- a/src/libraries/System.Private.CoreLib/src/System/Array.Enumerators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.Enumerators.cs
@@ -141,7 +141,7 @@ namespace System
         object? IEnumerator.Current => Current;
     }
 
-    internal abstract class GenericEmptyEnumeratorBase : IDisposable
+    internal abstract class GenericEmptyEnumeratorBase : IDisposable, IEnumerator
     {
 #pragma warning disable CA1822 // https://github.com/dotnet/roslyn-analyzers/issues/5911
         public bool MoveNext() => false;


### PR DESCRIPTION
...so that the interface implementation details go to the non-generic dispatch map instead of the individual specialized dispatch maps. Saves 3.5 kB on BasicMinimalApi.

Would be nice if we could do that for `IEnumerable` on `SZGenericArrayEnumeratorBase` but there's no way to express that in C# (we could express that in IL).
