### PR TITLE
use PlatformSpecific attribute to supress platform specific Quic tests

### DIFF
--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicPlatformDetectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicPlatformDetectionTests.cs
@@ -63,7 +63,7 @@ namespace System.Net.Quic.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/82154", typeof(PlatformDetection), nameof(PlatformDetection.IsRaspbian10), nameof(PlatformDetection.IsArmv6Process), nameof(PlatformDetection.IsInContainer))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/82154", typeof(PlatformDetection), nameof(PlatformDetection.IsUbuntu2004), nameof(PlatformDetection.IsPpc64leProcess))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/82154", typeof(PlatformDetection), nameof(PlatformDetection.IsUbuntu2004), nameof(PlatformDetection.IsS390xProcess))]
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsInHelix))]
         [PlatformSpecific(TestPlatforms.Linux)]
         public void SupportedLinuxPlatforms_IsSupportedIsTrue()
         {

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicPlatformDetectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicPlatformDetectionTests.cs
@@ -23,7 +23,8 @@ namespace System.Net.Quic.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/73290", typeof(PlatformDetection), nameof(PlatformDetection.IsSingleFile))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/82885", typeof(PlatformDetection), nameof(PlatformDetection.IsArm64Process))]
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows), nameof(PlatformDetection.SupportsTls13))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.SupportsTls13))]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void SupportedWindowsPlatforms_IsSupportedIsTrue()
         {
             Assert.True(QuicListener.IsSupported);
@@ -31,7 +32,8 @@ namespace System.Net.Quic.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/81901", typeof(PlatformDetection), nameof(PlatformDetection.IsAlpine314), nameof(PlatformDetection.IsInContainer))]
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Linux)]
         public async Task SupportedLinuxPlatformsWithMsQuic_IsSupportedIsTrue()
         {
             using Process find = new Process();
@@ -61,7 +63,8 @@ namespace System.Net.Quic.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/82154", typeof(PlatformDetection), nameof(PlatformDetection.IsRaspbian10), nameof(PlatformDetection.IsArmv6Process), nameof(PlatformDetection.IsInContainer))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/82154", typeof(PlatformDetection), nameof(PlatformDetection.IsUbuntu2004), nameof(PlatformDetection.IsPpc64leProcess))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/82154", typeof(PlatformDetection), nameof(PlatformDetection.IsUbuntu2004), nameof(PlatformDetection.IsS390xProcess))]
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsLinux), nameof(PlatformDetection.IsInHelix))]
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Linux)]
         public void SupportedLinuxPlatforms_IsSupportedIsTrue()
         {
             _output.WriteLine($"Running on {PlatformDetection.GetDistroVersionString()}");


### PR DESCRIPTION
Using ConditionalFact creates noise on platforms where given test would never run.
```
   ===========================================================================================================
  ~/github/wfurt-runtime2/artifacts/bin/System.Net.Quic.Functional.Tests/Debug/net8.0-osx ~/github/wfurt-runtime2/src/libraries/System.Net.Quic/tests/FunctionalTests
    Discovering: System.Net.Quic.Functional.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Net.Quic.Functional.Tests (found 4 of 122 test cases)
    Starting:    System.Net.Quic.Functional.Tests (parallel test collections = on, max threads = 16)
      System.Net.Quic.Tests.MsQuicPlatformDetectionTests.SupportedLinuxPlatformsWithMsQuic_IsSupportedIsTrue [SKIP]
        Condition(s) not met: "IsLinux"
      System.Net.Quic.Tests.MsQuicPlatformDetectionTests.SupportedWindowsPlatforms_IsSupportedIsTrue [SKIP]
        Condition(s) not met: "IsWindows", "SupportsTls13"
      System.Net.Quic.Tests.MsQuicPlatformDetectionTests.SupportedLinuxPlatforms_IsSupportedIsTrue [SKIP]
        Condition(s) not met: "IsLinux", "IsInHelix"
    Finished:    System.Net.Quic.Functional.Tests
  === TEST EXECUTION SUMMARY ===
     System.Net.Quic.Functional.Tests  Total: 4, Errors: 0, Failed: 0, Skipped: 3, Time: 3.639s
  ~/github/wfurt-runtime2/src/libraries/System.Net.Quic/tests/FunctionalTests
```

The `PlatformSpecific` attributes allows to silently suppress tests that are not even candidates
```
  ~/github/wfurt-runtime2/artifacts/bin/System.Net.Quic.Functional.Tests/Debug/net8.0-osx ~/github/wfurt-runtime2/src/libraries/System.Net.Quic/tests/FunctionalTests
    Discovering: System.Net.Quic.Functional.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Net.Quic.Functional.Tests (found 1 of 122 test case)
    Starting:    System.Net.Quic.Functional.Tests (parallel test collections = on, max threads = 16)
    Finished:    System.Net.Quic.Functional.Tests
  === TEST EXECUTION SUMMARY ===
     System.Net.Quic.Functional.Tests  Total: 1, Errors: 0, Failed: 0, Skipped: 0, Time: 2.981s
```

so we have less noise and possibly less entries in test database.