### PR TITLE
Support sites with invalid IDN in SslStream

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/SspiCli/SecuritySafeHandles.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/SecuritySafeHandles.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Security.Authentication.ExtendedProtection;
 using System.Security.Cryptography.X509Certificates;
@@ -334,9 +333,6 @@ namespace System.Net.Security
     internal abstract partial class SafeDeleteContext : SafeHandle
     {
 #endif
-        private const string dummyStr = " ";
-        private static readonly IdnMapping s_idnMapping = new IdnMapping();
-
         protected SafeFreeCredentials? _EffectiveCredential;
 
         //-------------------------------------------------------------------
@@ -453,18 +449,12 @@ namespace System.Net.Security
                             }
                         }
 
-                        if (targetName == null || targetName.Length == 0)
-                        {
-                            targetName = dummyStr;
-                        }
-
-                        string punyCode = s_idnMapping.GetAscii(targetName);
-                        fixed (char* namePtr = punyCode)
+                        fixed (char* namePtr = targetName)
                         {
                             errorCode = MustRunInitializeSecurityContext(
                                             ref inCredentials,
                                             isContextAbsent,
-                                            (byte*)(((object)targetName == (object)dummyStr) ? null : namePtr),
+                                            (byte*)namePtr,
                                             inFlags,
                                             endianness,
                                             &inSecurityBufferDescriptor,
@@ -514,7 +504,7 @@ namespace System.Net.Security
                                 errorCode = MustRunInitializeSecurityContext(
                                              ref inCredentials,
                                              isContextAbsent,
-                                             (byte*)(((object)targetName == (object)dummyStr) ? null : namePtr),
+                                             (byte*)namePtr,
                                              inFlags,
                                              endianness,
                                              &inSecurityBufferDescriptor,

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
@@ -262,45 +262,6 @@ namespace System.Net.Security.Tests
             return true;
         }
 
-        [Theory]
-        [InlineData("www-.volal.cz")]
-        [InlineData("www-.colorhexa.com")]
-        [InlineData("xn--www-7m0a.thegratuit.com")]
-        public async Task SslStream_InvalidTargetName_HandshakeOk(string name)
-        {
-            //using CancellationTokenSource cts = new CancellationTokenSource();
-            //cts.CancelAfter(TestConfiguration.PassingTestTimeout);
-
-            (SslStream client, SslStream server) = TestHelper.GetConnectedSslStreams();
-            using (client)
-            using (server)
-            {
-                using X509Certificate2 serverCertificate = Configuration.Certificates.GetServerCertificate();
-                using X509Certificate2 clientCertificate = Configuration.Certificates.GetClientCertificate();
-
-
-                SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions()
-                {
-                    TargetHost = name,
-                    CertificateChainPolicy = new X509ChainPolicy() { VerificationFlags = X509VerificationFlags.IgnoreInvalidName }
-
-                };
-                clientOptions.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true;
-
-                SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions() { ServerCertificate = serverCertificate };
-                serverOptions.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true;
-                //serverOptions.CertificateChainPolicy = new X509ChainPolicy() { VerificationFlags = X509VerificationFlags.IgnoreInvalidName };
-
-                await TestConfiguration.WhenAllOrAnyFailedWithTimeout(
-                                client.AuthenticateAsClientAsync(clientOptions, default),
-                                server.AuthenticateAsServerAsync(serverOptions, default));
-
-                Console.WriteLine("Server get '{0}' SNI ", server.TargetHostName );
-                await TestHelper.PingPong(client, server, default);
-                Assert.Null(server.RemoteCertificate);
-            }
-        }
-
         private bool ClientSideRemoteServerCertificateValidation(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
         {
             SslPolicyErrors expectedSslPolicyErrors = SslPolicyErrors.None;

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
@@ -236,6 +236,7 @@ namespace System.Net.Security.Tests
         [InlineData("www-.volal.cz")]
         [InlineData("www-.colorhexa.com")]
         [InlineData("xn--www-7m0a.thegratuit.com")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/68206", TestPlatforms.Android)]
         public async Task SslStream_SafeInvalidIdn_Success(string name)
         {
             (SslStream client, SslStream server) = TestHelper.GetConnectedSslStreams();

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
@@ -202,6 +202,87 @@ namespace System.Net.Security.Tests
             Assert.Equal(string.Empty, server.TargetHostName);
         }
 
+        [Theory]
+        [InlineData("\u00E1b\u00E7d\u00EB.com")]
+        [InlineData("\u05D1\u05F1.com")]
+        [InlineData("\u30B6\u30C7\u30D8.com")]
+        public async Task SslStream_ValidIdn_Success(string name)
+        {
+            (SslStream client, SslStream server) = TestHelper.GetConnectedSslStreams();
+            using (client)
+            using (server)
+            {
+                using X509Certificate2 serverCertificate = Configuration.Certificates.GetServerCertificate();
+                using X509Certificate2 clientCertificate = Configuration.Certificates.GetClientCertificate();
+
+                SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions() { ServerCertificate = serverCertificate };
+                SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions()
+                {
+                    TargetHost = name,
+                    CertificateChainPolicy = new X509ChainPolicy() { VerificationFlags = X509VerificationFlags.IgnoreInvalidName },
+                    RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true
+                };
+
+                await TestConfiguration.WhenAllOrAnyFailedWithTimeout(
+                                client.AuthenticateAsClientAsync(clientOptions, default),
+                                server.AuthenticateAsServerAsync(serverOptions, default));
+
+                await TestHelper.PingPong(client, server, default);
+                Assert.Equal(name, server.TargetHostName);
+            }
+        }
+
+        [Theory]
+        [InlineData("www-.volal.cz")]
+        [InlineData("www-.colorhexa.com")]
+        [InlineData("xn--www-7m0a.thegratuit.com")]
+        public async Task SslStream_SafeInvalidIdn_Success(string name)
+        {
+            (SslStream client, SslStream server) = TestHelper.GetConnectedSslStreams();
+            using (client)
+            using (server)
+            {
+                using X509Certificate2 serverCertificate = Configuration.Certificates.GetServerCertificate();
+                using X509Certificate2 clientCertificate = Configuration.Certificates.GetClientCertificate();
+
+                SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions() { ServerCertificate = serverCertificate };
+                SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions()
+                {
+                    TargetHost = name,
+                    CertificateChainPolicy = new X509ChainPolicy() { VerificationFlags = X509VerificationFlags.IgnoreInvalidName },
+                    RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true
+                };
+
+                await TestConfiguration.WhenAllOrAnyFailedWithTimeout(
+                                client.AuthenticateAsClientAsync(clientOptions, default),
+                                server.AuthenticateAsServerAsync(serverOptions, default));
+
+                await TestHelper.PingPong(client, server, default);
+                Assert.Equal(name, server.TargetHostName);
+            }
+        }
+
+        [Theory]
+        [InlineData("\u0000\u00E7d\u00EB.com")]
+        public async Task SslStream_UnsafeInvalidIdn_Throws(string name)
+        {
+            (SslStream client, SslStream server) = TestHelper.GetConnectedSslStreams();
+            using (client)
+            using (server)
+            {
+                using X509Certificate2 serverCertificate = Configuration.Certificates.GetServerCertificate();
+
+                SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions()
+                {
+                    TargetHost = name,
+                    CertificateChainPolicy = new X509ChainPolicy() { VerificationFlags = X509VerificationFlags.IgnoreInvalidName },
+                    RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true
+                };
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.AuthenticateAsClientAsync(clientOptions, default));
+            }
+        }
+
         private static Func<Task> WithAggregateExceptionUnwrapping(Func<Task> a)
         {
             return async () => {


### PR DESCRIPTION
fixes  #82464

This is attempt to allow TLS handshake on site with invalid IDN to match browsers and other HTTP/TLS implementations. 

Since this is somewhat corner case the change is focusing on allowing the handshake go through via setting policy to ignore name. It does not try to verify that the problematic names would for example match wildcard certificates. It would be up to the caller to verify certificates as most browsers would also show warning and not proceed automatically. 

Handling has been centralize to `SslAuthenticationOptions` and eliminated code scattered in PAL. 

I'm not sure how this impacts Android @simonrozsival. I would think that doing the puny code before calling Java should be just fine since that is what should go out on wire.  