### PR TITLE
Fix trim warning in ComponentActivator

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComponentActivator.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComponentActivator.cs
@@ -140,26 +140,29 @@ namespace Internal.Runtime.InteropServices
 
             [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
                 Justification = "The same feature switch applies to GetFunctionPointer and this function. We rely on the warning from GetFunctionPointer.")]
-            static void LoadAssemblyLocal(string assemblyPath)
+            static void LoadAssemblyLocal(string assemblyPath) => LoadAssemblyImpl(assemblyPath);
+        }
+
+        [RequiresUnreferencedCode(TrimIncompatibleWarningMessage, Url = "https://aka.ms/dotnet-illink/nativehost")]
+        private static void LoadAssemblyImpl(string assemblyPath)
+        {
+            lock(s_loadedInDefaultContext)
             {
-                lock(s_loadedInDefaultContext)
-                {
-                    if (s_loadedInDefaultContext.Contains(assemblyPath))
-                        return;
+                if (s_loadedInDefaultContext.Contains(assemblyPath))
+                    return;
 
-                    var resolver = new AssemblyDependencyResolver(assemblyPath);
-                    AssemblyLoadContext.Default.Resolving +=
-                        (context, assemblyName) =>
-                        {
-                            string? assemblyPath = resolver.ResolveAssemblyToPath(assemblyName);
-                            return assemblyPath != null
-                                ? context.LoadFromAssemblyPath(assemblyPath)
-                                : null;
-                        };
+                var resolver = new AssemblyDependencyResolver(assemblyPath);
+                AssemblyLoadContext.Default.Resolving +=
+                    (context, assemblyName) =>
+                    {
+                        string? assemblyPath = resolver.ResolveAssemblyToPath(assemblyName);
+                        return assemblyPath != null
+                            ? context.LoadFromAssemblyPath(assemblyPath)
+                            : null;
+                    };
 
-                    AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
-                    s_loadedInDefaultContext.Add(assemblyPath);
-                }
+                AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
+                s_loadedInDefaultContext.Add(assemblyPath);
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComponentActivator.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComponentActivator.cs
@@ -144,6 +144,11 @@ namespace Internal.Runtime.InteropServices
         }
 
         [RequiresUnreferencedCode(TrimIncompatibleWarningMessage, Url = "https://aka.ms/dotnet-illink/nativehost")]
+        [UnsupportedOSPlatform("android")]
+        [UnsupportedOSPlatform("browser")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("maccatalyst")]
+        [UnsupportedOSPlatform("tvos")]
         private static void LoadAssemblyImpl(string assemblyPath)
         {
             lock(s_loadedInDefaultContext)


### PR DESCRIPTION
Refactor `CompononentActivator.LoadAssembly` to avoid trim warnings. The suppression on the local function doesn't get applied to the lambda inside it.

See https://github.com/dotnet/sdk/pull/30919#issuecomment-1453368422