### PR TITLE
[wasm] Debugger tests - fix build

### DIFF
--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -110,6 +110,11 @@ jobs:
                       eq(dependencies.evaluate_paths.outputs['DarcDependenciesChanged.Microsoft_NET_Workload_Emscripten_Current_Manifest-8_0_100-preview_3'], true),
                       eq(dependencies.evaluate_paths.outputs['DarcDependenciesChanged.Microsoft_DotNet_Build_Tasks_Workloads'], true),
                       eq(dependencies.evaluate_paths.outputs['DarcDependenciesChanged.System_Runtime_TimeZoneData'], true),
+                      eq(dependencies.evaluate_paths.outputs['DarcDependenciesChanged.Microsoft_Net_Compilers_Toolset'], true),
+                      eq(dependencies.evaluate_paths.outputs['DarcDependenciesChanged.Microsoft_CodeAnalysis'], true),
+                      eq(dependencies.evaluate_paths.outputs['DarcDependenciesChanged.Microsoft_CodeAnalysis_CSharp'], true),
+                      eq(dependencies.evaluate_paths.outputs['DarcDependenciesChanged.Microsoft_CodeAnalysis_Analyzers'], true),
+                      eq(dependencies.evaluate_paths.outputs['DarcDependenciesChanged.Microsoft_CodeAnalysis_NetAnalyzers'], true),
                       eq(dependencies.evaluate_paths.outputs['DarcDependenciesChanged.Microsoft_NET_ILLink_Tasks'], true)) ]
 
       - ${{ each variable in parameters.variables }}:

--- a/src/mono/wasm/debugger/DebuggerTestSuite/TestHarnessProxy.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/TestHarnessProxy.cs
@@ -132,7 +132,7 @@ namespace DebuggerTests
             s_statusTable[id] = status;
             // we have the explicit state now, so we can drop the reference
             // to the proxy
-            s_proxyTable.TryRemove(id, out WeakReference<DebuggerProxyBase> _);
+            s_proxyTable.TryRemove(id, out _);
 
             if (s_exitHandlers.TryRemove(intId, out WeakReference<Action<RunLoopExitState>>? handlerRef)
                 && handlerRef.TryGetTarget(out Action<RunLoopExitState>? handler))


### PR DESCRIPTION
`/workspaces/runtime/src/mono/wasm/debugger/DebuggerTestSuite/TestHarnessProxy.cs(135,44): error CS8601: Possible null reference assignment`

Started being hit with #82479 .
The other instances of this were fixed in #82803 .

- Also, adds a change so all the wasm jobs would get triggered whenever Roslyn is updated.

Fixes https://github.com/dotnet/runtime/issues/82962 .