### PR TITLE
JIT: Assume allocations succeed

### DIFF
--- a/src/coreclr/inc/unreachable.h
+++ b/src/coreclr/inc/unreachable.h
@@ -9,14 +9,7 @@
 #define __UNREACHABLE_H__
 
 #if defined(_MSC_VER) || defined(_PREFIX_)
-#if defined(TARGET_AMD64)
-// Empty methods that consist of UNREACHABLE() result in a zero-sized declspec(noreturn) method
-// which causes the pdb file to make the next method declspec(noreturn) as well, thus breaking BBT
-// Remove when we get a VC compiler that fixes VSW 449170
-# define __UNREACHABLE() do { DebugBreak(); __assume(0); } while (0)
-#else
-# define __UNREACHABLE() __assume(0)
-#endif
+#define __UNREACHABLE() __assume(0)
 #else
 #define __UNREACHABLE() __builtin_unreachable()
 #endif

--- a/src/coreclr/jit/alloc.h
+++ b/src/coreclr/jit/alloc.h
@@ -235,14 +235,10 @@ public:
 
         void* p = m_arena->allocateMemory(count * sizeof(T));
 
-#if defined(_MSC_VER)
-        // MSVC does not handle the other pattern correctly to recognize this fact.
-        __assume(p != nullptr);
-#elif !defined(DEBUG)
-        if (p == nullptr)
-        {
-            UNREACHABLE();
-        }
+#ifndef DEBUG
+        // Could be in DEBUG too, but COMPILER_ASSUME in debug builds has extra
+        // cruft in it that we'd like to avoid in checked builds.
+        COMPILER_ASSUME(p != nullptr);
 #endif
 
         // Ensure that the allocator returned sizeof(size_t) aligned memory.

--- a/src/coreclr/jit/alloc.h
+++ b/src/coreclr/jit/alloc.h
@@ -235,6 +235,16 @@ public:
 
         void* p = m_arena->allocateMemory(count * sizeof(T));
 
+#if defined(_MSC_VER)
+        // MSVC does not handle the other pattern correctly to recognize this fact.
+        __assume(p != nullptr);
+#elif !defined(DEBUG)
+        if (p == nullptr)
+        {
+            UNREACHABLE();
+        }
+#endif
+
         // Ensure that the allocator returned sizeof(size_t) aligned memory.
         assert((size_t(p) & (sizeof(size_t) - 1)) == 0);
 


### PR DESCRIPTION
We call a NOMEM function when allocations fail that is already marked as no-return, but at least MSVC is not able to pick up on this fact. The result is that all operator new calls end up with an unnecessary null check. This adds an __assume to allow MSVC to recognize that allocations never fail. For other compilers, it uses the preexisting UNREACHABLE() macro, but MSVC was not able to recognize this either.

There was also a workaround for an old VSW bug that I've removed.