### PR TITLE
Allow multiple EventCounters sessions and make sure EventListeners always send a Disable command

### DIFF
--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestCallbacks.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestCallbacks.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
+using System.Diagnostics.Tracing;
+#endif
+using System.Reflection;
+
+namespace BasicEventSourceTests
+{
+    public class TestsEventSourceCallbacks
+    {
+        /// <summary>
+        /// Validates that the EventProvider AppDomain.ProcessExit handler does not keep the EventProvider instance
+        /// alive.
+        /// </summary>
+        [Fact]
+        public void Test_EventSource_Lifetime()
+        {
+            using (var source = new CallbacksTestEventSource())
+            {
+                bool isDisabledInDelegate = false;
+                source.EventCommandExecuted += (sender, args) =>
+                {
+                    if (args.Command == EventCommand.Disable)
+                    {
+                        EventSource eventSource = (EventSource)sender;
+                        isDisabledInDelegate = !eventSource.IsEnabled();
+                    }
+                };
+
+                using (var listener = new CallbacksEventListener())
+                {
+                    source.Event();
+                }
+
+                if (!source._isDisabledInCallback)
+                {
+                    Assert.Fail("EventSource was still enabled in OnEventCommand callback");
+                }
+
+                if (!isDisabledInDelegate)
+                {
+                    Assert.Fail("EventSource was still enabled in EventCommandExecuted delegate");
+                }
+            }
+        }
+
+        private class CallbacksEventListener : EventListener
+        {
+            protected override void OnEventSourceCreated(EventSource eventSource)
+            {
+                base.OnEventSourceCreated(eventSource);
+
+                if (eventSource.Name.Equals("TestsEventSourceCallbacks.CallbacksTestEventSource"))
+                {
+                    EnableEvents(eventSource, EventLevel.Verbose);
+                }
+            }
+        }
+
+        [EventSource(Name = "TestsEventSourceCallbacks.CallbacksTestEventSource")]
+        private class CallbacksTestEventSource : EventSource
+        {
+            internal bool _isDisabledInCallback;
+
+            [Event(1)]
+            public void Event()
+            {
+                WriteEvent(1);
+            }
+
+            [NonEvent]
+            protected override void OnEventCommand(EventCommandEventArgs command)
+            {
+                base.OnEventCommand(command);
+
+                _isDisabledInCallback = !IsEnabled();
+            }
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -79,6 +79,12 @@ namespace System.Diagnostics.Tracing
                     // Should only be enable or disable
                     Debug.Assert(false);
                 }
+
+                // Sanity checks. It is possible that an EventSource could be enabled without the counter group being enabled,
+                // so we can't assert that. But we know if the counter group is enabled the EventSource must be.
+                Debug.Assert((s_counterGroupEnabledList == null && _refCount == 0)
+                                || (s_counterGroupEnabledList!.Contains(this) && _refCount > 0 && _eventSource.IsEnabled())
+                                || (!s_counterGroupEnabledList!.Contains(this) && _refCount == 0));
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -53,9 +53,7 @@ namespace System.Diagnostics.Tracing
                 if (e.Command == EventCommand.Enable)
                 {
                     Debug.Assert(e.Arguments != null);
-                    Debug.Assert(_refCount >= 0);
 
-                    ++_refCount;
                     float intervalValue = 1.0f;
                     if (e.Arguments.TryGetValue("EventCounterIntervalSec", out string? valueStr)
                         && float.TryParse(valueStr, out float value))
@@ -63,7 +61,18 @@ namespace System.Diagnostics.Tracing
                         intervalValue = value;
                     }
 
-                    EnableTimer(intervalValue);
+                    if (intervalValue > 0)
+                    {
+                        Debug.Assert(_refCount >= 0);
+                        ++_refCount;
+                        EnableTimer(intervalValue);
+                    }
+                    else
+                    {
+                        Debug.Assert(_refCount >= 1);
+                        --_refCount;
+                        DisableTimer();
+                    }
                 }
                 else if (e.Command == EventCommand.Disable)
                 {
@@ -140,11 +149,7 @@ namespace System.Diagnostics.Tracing
         private void EnableTimer(float pollingIntervalInSeconds)
         {
             Debug.Assert(Monitor.IsEntered(s_counterGroupLock));
-            if (pollingIntervalInSeconds <= 0)
-            {
-                DisableTimer();
-            }
-            else if (_pollingIntervalInMilliseconds == 0 || pollingIntervalInSeconds * 1000 < _pollingIntervalInMilliseconds)
+            if (pollingIntervalInSeconds * 1000 < _pollingIntervalInMilliseconds)
             {
                 _pollingIntervalInMilliseconds = (int)(pollingIntervalInSeconds * 1000);
                 ResetCounters(); // Reset statistics for counters before we start the thread.

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -149,7 +149,7 @@ namespace System.Diagnostics.Tracing
         private void EnableTimer(float pollingIntervalInSeconds)
         {
             Debug.Assert(Monitor.IsEntered(s_counterGroupLock));
-            if (pollingIntervalInSeconds * 1000 < _pollingIntervalInMilliseconds)
+            if (_pollingIntervalInMilliseconds == 0 || pollingIntervalInSeconds * 1000 < _pollingIntervalInMilliseconds)
             {
                 _pollingIntervalInMilliseconds = (int)(pollingIntervalInSeconds * 1000);
                 ResetCounters(); // Reset statistics for counters before we start the thread.

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -56,11 +56,16 @@ namespace System.Diagnostics.Tracing
                 {
                     Debug.Assert(e.Arguments != null);
 
-                    if (e.Arguments.TryGetValue("EventCounterIntervalSec", out string? valueStr)
-                        && float.TryParse(valueStr, out float value))
+                    string? valueStr = null;
+                    float value = 0.0f;
+                    if (!e.Arguments.TryGetValue("EventCounterIntervalSec", out valueStr)
+                        || !float.TryParse(valueStr, out value))
                     {
-                        intervalValue = value;
+                        // Command is Enable but no EventCounterIntervalSec arg so ignore
+                        return;
                     }
+
+                    intervalValue = value;
                 }
 
                 if ((e.Command == EventCommand.Disable && !_eventSource.IsEnabled()) || intervalValue <= 0)
@@ -74,6 +79,7 @@ namespace System.Diagnostics.Tracing
 
                 Debug.Assert((s_counterGroupEnabledList == null && !_eventSource.IsEnabled())
                                 || (_eventSource.IsEnabled() && s_counterGroupEnabledList!.Contains(this))
+                                || (intervalValue <= 0 && !s_counterGroupEnabledList!.Contains(this))
                                 || (!_eventSource.IsEnabled() && !s_counterGroupEnabledList!.Contains(this)));
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -2629,9 +2629,6 @@ namespace System.Diagnostics.Tracing
                         m_eventSourceEnabled = true;
                     }
 
-                    this.OnEventCommand(commandArgs);
-                    this.m_eventCommandExecuted?.Invoke(this, commandArgs);
-
                     if (!commandArgs.enable)
                     {
                         // If we are disabling, maybe we can turn on 'quick checks' to filter
@@ -2663,6 +2660,9 @@ namespace System.Diagnostics.Tracing
                             m_eventSourceEnabled = false;
                         }
                     }
+
+                    this.OnEventCommand(commandArgs);
+                    this.m_eventCommandExecuted?.Invoke(this, commandArgs);
                 }
                 else
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -4286,9 +4286,9 @@ namespace System.Diagnostics.Tracing
             // eventSource.m_Dispatchers could have mutated
             foreach (WeakReference<EventSource> eventSourceRef in s_EventSources)
             {
-                if (eventSourceRef.TryGetTarget(out EventSource? eventSource))
+                if (eventSourceRef.TryGetTarget(out EventSource? eventSource)
+                    && eventSource.m_Dispatchers != null)
                 {
-                    Debug.Assert(eventSource.m_Dispatchers != null);
                     // Is the first output dispatcher the dispatcher we are removing?
                     if (eventSource.m_Dispatchers.m_Listener == listenerToRemove)
                     {

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -4264,7 +4264,8 @@ namespace System.Diagnostics.Tracing
             Debug.Assert(s_EventSources != null);
 
             // First pass to call DisableEvents
-            foreach (WeakReference<EventSource> eventSourceRef in s_EventSources)
+            WeakReference<EventSource>[] eventSourcesSnapshot = s_EventSources.ToArray();
+            foreach (WeakReference<EventSource> eventSourceRef in eventSourcesSnapshot)
             {
                 if (eventSourceRef.TryGetTarget(out EventSource? eventSource))
                 {

--- a/src/tests/tracing/eventcounter/gh53564.cs
+++ b/src/tests/tracing/eventcounter/gh53564.cs
@@ -33,7 +33,6 @@ namespace gh53564Tests
                 // first set interval to 1 seconds
                 refreshInterval["EventCounterIntervalSec"] = "1";
                 EnableEvents(source, EventLevel.Informational, (EventKeywords)(-1), refreshInterval);
-                DisableEvents(source);
 
                 // wait a moment to get some events
                 Thread.Sleep(TimeSpan.FromSeconds(3));
@@ -42,7 +41,6 @@ namespace gh53564Tests
                 Console.WriteLine($"[{DateTime.UtcNow:hh:mm:ss.fff}] OnEventSourceCreated :: Setting interval to 0");
                 refreshInterval["EventCounterIntervalSec"] = "0";
                 EnableEvents(source, EventLevel.Informational, (EventKeywords)(-1), refreshInterval);
-                DisableEvents(source);
                 setToZeroTimestamp = DateTime.UtcNow + TimeSpan.FromSeconds(1); // Stash timestamp 1 second after setting to 0
                 setToZero.Set();
 
@@ -51,7 +49,6 @@ namespace gh53564Tests
                 Console.WriteLine($"[{DateTime.UtcNow:hh:mm:ss.fff}] OnEventSourceCreated :: Setting interval to 1");
                 refreshInterval["EventCounterIntervalSec"] = "1";
                 EnableEvents(source, EventLevel.Informational, (EventKeywords)(-1), refreshInterval);
-                DisableEvents(source);
             }
         }
 

--- a/src/tests/tracing/eventcounter/gh53564.cs
+++ b/src/tests/tracing/eventcounter/gh53564.cs
@@ -33,6 +33,7 @@ namespace gh53564Tests
                 // first set interval to 1 seconds
                 refreshInterval["EventCounterIntervalSec"] = "1";
                 EnableEvents(source, EventLevel.Informational, (EventKeywords)(-1), refreshInterval);
+                DisableEvents(source);
 
                 // wait a moment to get some events
                 Thread.Sleep(TimeSpan.FromSeconds(3));
@@ -41,6 +42,7 @@ namespace gh53564Tests
                 Console.WriteLine($"[{DateTime.UtcNow:hh:mm:ss.fff}] OnEventSourceCreated :: Setting interval to 0");
                 refreshInterval["EventCounterIntervalSec"] = "0";
                 EnableEvents(source, EventLevel.Informational, (EventKeywords)(-1), refreshInterval);
+                DisableEvents(source);
                 setToZeroTimestamp = DateTime.UtcNow + TimeSpan.FromSeconds(1); // Stash timestamp 1 second after setting to 0
                 setToZero.Set();
 
@@ -49,6 +51,7 @@ namespace gh53564Tests
                 Console.WriteLine($"[{DateTime.UtcNow:hh:mm:ss.fff}] OnEventSourceCreated :: Setting interval to 1");
                 refreshInterval["EventCounterIntervalSec"] = "1";
                 EnableEvents(source, EventLevel.Informational, (EventKeywords)(-1), refreshInterval);
+                DisableEvents(source);
             }
         }
 

--- a/src/tests/tracing/eventlistener/eventlistenerenabledisable.cs
+++ b/src/tests/tracing/eventlistener/eventlistenerenabledisable.cs
@@ -1,0 +1,103 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Diagnostics.Tracing;
+using System.Threading;
+using Tracing.Tests.Common;
+
+namespace Tracing.Tests
+{
+    [EventSource(Name = "Tracing.Tests.EnableDisableEventSource")]
+    class EnableDisableEventSource : EventSource
+    {
+        internal int _enables;
+        internal int _disables;
+
+        public EnableDisableEventSource() : base(true) { }
+
+        [Event(1)]
+        internal void TestEvent() { this.WriteEvent(1); }
+
+        [NonEvent]
+        protected override OnEventCommand(EventCommandEventArgs command)
+        {
+            base.OnEventCommand(command);
+
+            if (command.Command == EventCommand.Enable)
+            {
+                Interlocked.Increment(ref _enables);
+            }
+            else if (command.Command == EventCommand.Disable)
+            {
+                Interlocked.Increment(ref _disables);
+            }
+            else
+            {
+                throw new Exception($"Saw unexpected command {command.Command} in OnEventCommand");
+            }
+        }
+    }
+    
+    internal sealed class EnableDisableListener : EventListener
+    {
+        private EventSource? _target;
+
+        protected override void OnEventSourceCreated(EventSource source)
+        {
+            if (source.Name.Equals("Tracing.Tests.EnableDisableEventSource"))
+            {
+                _target = source;
+                EnableEvents(_target, EventLevel.Verbose);
+            }
+        }
+
+        public void Disable()
+        {
+            DisableEvents(_target);
+        }
+
+        public bool Dispose(bool disableEvents)
+        {
+            if (disableEvents)
+            {
+                Disable();
+            }
+
+            base.Dispose();
+        }
+    }
+
+    class EventPipeSmoke
+    {
+        private static int messageIterations = 100;
+        private static readonly DateTime ThePast = DateTime.UtcNow;
+
+        static int Main()
+        {
+            bool pass = false;
+            using(var source = new EnableDisableEventSource()
+            {
+                using (var listener1 = new EnableDisableListener())
+                using (var listener2 = new EnableDisableListener())
+                {
+                    var listener3 = new EnableDisableListener();
+                    source.TestEvent();
+                    listener3.Dispose(true);
+
+                    listener2.Disable();
+                    listener1.Disable();
+                }
+
+                if (source._enables == 3 && source._disables == 3)
+                {
+                    return 100;
+                }
+
+                Console.WriteLine($"Unexpected enable/disable count _enables={source._enables} _disables={source._disables}");
+                return -1;
+            }
+        }
+    }
+}

--- a/src/tests/tracing/eventlistener/eventlistenerenabledisable.cs
+++ b/src/tests/tracing/eventlistener/eventlistenerenabledisable.cs
@@ -70,11 +70,8 @@ namespace Tracing.Tests
         }
     }
 
-    class EventPipeSmoke
+    class EventListenerEnableDisableTest
     {
-        private static int messageIterations = 100;
-        private static readonly DateTime ThePast = DateTime.UtcNow;
-
         static int Main()
         {
             bool pass = false;

--- a/src/tests/tracing/eventlistener/eventlistenerenabledisable.csproj
+++ b/src/tests/tracing/eventlistener/eventlistenerenabledisable.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="eventlistenerenabledisable.cs" />
+    <ProjectReference Include="../common/common.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This PR does two things
1. Refcounts CountGroup so multiple sessions can enable and disable counters. Previously if any session disabled counters it would disable them globally
2. Adds a check in EventListener.Dispose that will call DisableEvents if the user hasn't already

Fixes #61353 