### PR TITLE
Fix invariant check in DateTimeParse

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
@@ -150,7 +150,7 @@ namespace System.Globalization
 
         private DateTimeFormatFlags formatFlags = DateTimeFormatFlags.NotInitialized;
 
-        internal string CultureName => _name ??= _cultureData.CultureName;
+        private string CultureName => _name ??= _cultureData.CultureName;
 
         private CultureInfo Culture => _cultureInfo ??= CultureInfo.GetCultureInfo(CultureName);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
@@ -3300,7 +3300,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
             result = -1;
             if (str.GetNext())
             {
-                if (dtfi.CultureName == "")
+                if (ReferenceEquals(dtfi, DateTimeFormat.InvariantFormatInfo))
                 {
                     // Invariant data. Do a fast lookup on the known abbreviated month names.
                     ReadOnlySpan<char> span = str.Value.Slice(str.Index);
@@ -3402,7 +3402,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
             result = -1;
             if (str.GetNext())
             {
-                if (dtfi.CultureName == "")
+                if (ReferenceEquals(dtfi, DateTimeFormat.InvariantFormatInfo))
                 {
                     // Invariant data. Do a fast lookup on the known month names.
                     ReadOnlySpan<char> span = str.Value.Slice(str.Index);
@@ -3503,7 +3503,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
             result = -1;
             if (str.GetNext())
             {
-                if (dtfi.CultureName == "")
+                if (ReferenceEquals(dtfi, DateTimeFormat.InvariantFormatInfo))
                 {
                     // Invariant data. Do a fast lookup on the known abbreviated day names.
                     ReadOnlySpan<char> span = str.Value.Slice(str.Index);
@@ -3570,7 +3570,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
             result = -1;
             if (str.GetNext())
             {
-                if (dtfi.CultureName == "")
+                if (ReferenceEquals(dtfi, DateTimeFormat.InvariantFormatInfo))
                 {
                     // Invariant data. Do a fast lookup on the known day names.
                     ReadOnlySpan<char> span = str.Value.Slice(str.Index);

--- a/src/libraries/System.Runtime/tests/System/DateTimeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DateTimeTests.cs
@@ -2626,6 +2626,26 @@ namespace System.Tests
             VerifyDateTime(DateTime.UnixEpoch, 1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
         }
 
+        [Fact]
+        public static void ParseExact_InvariantName_RespectsCustomNames()
+        {
+            var c = new CultureInfo("");
+            c.DateTimeFormat.DayNames = new[] { "A", "B", "C", "D", "E", "F", "G" };
+            c.DateTimeFormat.AbbreviatedDayNames = new[] { "abc", "bcd", "cde", "def", "efg", "fgh", "ghi" };
+            c.DateTimeFormat.MonthNames = new[] { "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "" };
+            c.DateTimeFormat.AbbreviatedMonthNames = new[] { "hij", "ijk", "jkl", "klm", "lmn", "mno", "nop", "opq", "pqr", "qrs", "rst", "stu", "" };
+
+            DateTime expected = new DateTime(2023, 3, 4, 9, 30, 12, DateTimeKind.Utc);
+
+            Assert.Equal(expected, DateTime.ParseExact("Saturday, March 4, 2023 9:30:12 AM", "dddd, MMMM d, yyyy h':'mm':'ss tt", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
+            Assert.Throws<FormatException>(() => DateTime.ParseExact("G, J 4, 2023 9:30:12 AM", "dddd, MMMM d, yyyy h':'mm':'ss tt", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
+            Assert.Equal(expected, DateTime.ParseExact("G, J 4, 2023 9:30:12 AM", "dddd, MMMM d, yyyy h':'mm':'ss tt", c, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
+
+            Assert.Equal(expected, DateTime.ParseExact("Sat, 04 Mar 2023 09:30:12 GMT", "ddd, dd MMM yyyy HH':'mm':'ss 'GMT'", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
+            Assert.Throws<FormatException>(() => DateTime.ParseExact("ghi, 04 jkl 2023 09:30:12 GMT", "ddd, dd MMM yyyy HH':'mm':'ss 'GMT'", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
+            Assert.Equal(expected, DateTime.ParseExact("ghi, 04 jkl 2023 09:30:12 GMT", "ddd, dd MMM yyyy HH':'mm':'ss 'GMT'", c, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
+        }
+
         public enum DateTimeUnits
         {
             Microsecond,


### PR DESCRIPTION
The recently added invariant optimization in DateTimeParse had been checking based on reference equality between the DateTimeFormatInfo and the singleton InvariantFormatInfo.  This was changed to compare the CultureName against "" in order to be more encompassing, but it actually ends up being too encompassing.  Someone can create a culture with the name "", modify its month or date names directly, and those modifications end up getting ignored because the optimization ends up seeing the name is empty.  This switches it back to use reference equality.