### PR TITLE
Allow MemberNotNullAttribute to be applied on constructor.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
@@ -128,7 +128,7 @@ namespace System.Diagnostics.CodeAnalysis
 #endif
 
     /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor, Inherited = false, AllowMultiple = true)]
 #if SYSTEM_PRIVATE_CORELIB
     public
 #else


### PR DESCRIPTION
This allows writing the code where private constructor has half initialization while public one does the rest:

```cs
    class A
    {
        private readonly string _id;
        private readonly string _length;

        [System.Diagnostics.CodeAnalysis.MemberNotNull(nameof(_id))]
        private A()
        {
            _length = "1";
        }

        public A(string id) : this()
        {
            _id = id;
        }
    }
```

An alternative is to suppress initialization check using ` = null!` or to make an additional method which prevents making field readonly.

Alternative 1: No nullable check for `_id`
```cs
    class A
    {
        private readonly string _id = null!;
        private readonly string _length;

        private A()
        {
            _length = "1";
        }

        public A(string id) : this()
        {
            _id = id;
        }
    }
```

Alternative 2: No readonly _id
```cs
    class A
    {
        private readonly string _id;
        private string _length;

        [System.Diagnostics.CodeAnalysis.MemberNotNull(nameof(_length))]
        private void Init()
        {
            _length = "1";
        }

        public A(string id)
        {
            Init();
            _id = id;
        }
    }
```

Alternative 3: Method returning copies for initializations.
```cs
    class A
    {
        private readonly string _id;
        private readonly string _length;

        private (string length, int _) Init()
        {
            return (length: "1", 0);
        }

        public A(string id)
        {
            (_length, _) = Init();
            _id = id;
        }
    }
```