### PR TITLE
Replace some unnecessary use of CompareInfo

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
@@ -5660,17 +5660,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
         //
         internal bool Match(string str)
         {
-            if (++Index >= Length)
-            {
-                return false;
-            }
-
-            if (str.Length > (Value.Length - Index))
-            {
-                return false;
-            }
-
-            if (m_info.Compare(Value.Slice(Index, str.Length), str, CompareOptions.Ordinal) == 0)
+            if (++Index < Length && Value.Slice(Index).StartsWith(str))
             {
                 // Update the Index to the end of the matching string.
                 // So the following GetNext()/Match() operation will get
@@ -5678,6 +5668,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
                 Index += (str.Length - 1);
                 return true;
             }
+
             return false;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
@@ -71,7 +71,7 @@ namespace System
         {
             if (!char.IsAscii(value))
             {
-                return CompareInfo.Invariant.IndexOf(this, value, CompareOptions.OrdinalIgnoreCase);
+                return Ordinal.IndexOfOrdinalIgnoreCase(this, new ReadOnlySpan<char>(in value));
             }
 
             if (char.IsAsciiLetter(value))

--- a/src/libraries/System.Private.Xml/src/System/Xml/XPath/Internal/StringFunctions.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XPath/Internal/StringFunctions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -133,14 +134,12 @@ namespace MS.Internal.Xml.XPath
             return s1.Length >= s2.Length && string.CompareOrdinal(s1, 0, s2, 0, s2.Length) == 0;
         }
 
-        private static readonly CompareInfo s_compareInfo = CultureInfo.InvariantCulture.CompareInfo;
-
         private bool Contains(XPathNodeIterator nodeIterator)
         {
             Debug.Assert(_argList.Count > 1);
             string s1 = _argList[0].Evaluate(nodeIterator).ToString()!;
             string s2 = _argList[1].Evaluate(nodeIterator).ToString()!;
-            return s_compareInfo.IndexOf(s1, s2, CompareOptions.Ordinal) >= 0;
+            return s1.Contains(s2);
         }
 
         private string SubstringBefore(XPathNodeIterator nodeIterator)
@@ -149,7 +148,7 @@ namespace MS.Internal.Xml.XPath
             string s1 = _argList[0].Evaluate(nodeIterator).ToString()!;
             string s2 = _argList[1].Evaluate(nodeIterator).ToString()!;
             if (s2.Length == 0) { return s2; }
-            int idx = s_compareInfo.IndexOf(s1, s2, CompareOptions.Ordinal);
+            int idx = s1.AsSpan().IndexOf(s2);
             return (idx < 1) ? string.Empty : s1.Substring(0, idx);
         }
 
@@ -159,7 +158,7 @@ namespace MS.Internal.Xml.XPath
             string s1 = _argList[0].Evaluate(nodeIterator).ToString()!;
             string s2 = _argList[1].Evaluate(nodeIterator).ToString()!;
             if (s2.Length == 0) { return s1; }
-            int idx = s_compareInfo.IndexOf(s1, s2, CompareOptions.Ordinal);
+            int idx = s1.AsSpan().IndexOf(s2);
             return (idx < 0) ? string.Empty : s1.Substring(idx + s2.Length);
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XsltFunctions.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XsltFunctions.cs
@@ -21,9 +21,6 @@ namespace System.Xml.Xsl.Runtime
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class XsltFunctions
     {
-        private static readonly CompareInfo s_compareInfo = CultureInfo.InvariantCulture.CompareInfo;
-
-
         //------------------------------------------------
         // Xslt/XPath functions
         //------------------------------------------------
@@ -37,14 +34,14 @@ namespace System.Xml.Xsl.Runtime
         public static bool Contains(string s1, string s2)
         {
             //return collation.IndexOf(s1, s2) >= 0;
-            return s_compareInfo.IndexOf(s1, s2, CompareOptions.Ordinal) >= 0;
+            return s1.Contains(s2);
         }
 
         public static string SubstringBefore(string s1, string s2)
         {
             if (s2.Length == 0) { return s2; }
             //int idx = collation.IndexOf(s1, s2);
-            int idx = s_compareInfo.IndexOf(s1, s2, CompareOptions.Ordinal);
+            int idx = s1.AsSpan().IndexOf(s2);
             return (idx < 1) ? string.Empty : s1.Substring(0, idx);
         }
 
@@ -52,7 +49,7 @@ namespace System.Xml.Xsl.Runtime
         {
             if (s2.Length == 0) { return s1; }
             //int idx = collation.IndexOf(s1, s2);
-            int idx = s_compareInfo.IndexOf(s1, s2, CompareOptions.Ordinal);
+            int idx = s1.AsSpan().IndexOf(s2);
             return (idx < 0) ? string.Empty : s1.Substring(idx + s2.Length);
         }
 


### PR DESCRIPTION
Anywhere we're explicitly passing Ordinal or OrdinalIgnoreCase, the actual culture data is ignored.  We can just use the relevant string/span methods directly.