### PR TITLE
Improve perf of CharEnumerator

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/CharEnumerator.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/CharEnumerator.cs
@@ -35,22 +35,27 @@ namespace System
 
         public bool MoveNext()
         {
-            if (_index < (_str!.Length - 1))
+            int index = _index + 1;
+            string s = _str!;
+
+            if ((uint)index < (uint)s.Length)
             {
-                _index++;
-                _currentElement = _str[_index];
+                _currentElement = s[index];
+                _index = index;
                 return true;
             }
-            else
-                _index = _str.Length;
+
+            _index = s.Length;
             return false;
         }
 
         public void Dispose()
         {
             if (_str != null)
+            {
                 _index = _str.Length;
-            _str = null;
+                _str = null;
+            }
         }
 
         object? IEnumerator.Current => Current;
@@ -59,10 +64,11 @@ namespace System
         {
             get
             {
-                if (_index == -1)
-                    throw new InvalidOperationException(SR.InvalidOperation_EnumNotStarted);
-                if (_index >= _str!.Length)
-                    throw new InvalidOperationException(SR.InvalidOperation_EnumEnded);
+                if ((uint)_index >= _str!.Length)
+                {
+                    ThrowHelper.ThrowInvalidOperationException_EnumCurrent(_index);
+                }
+
                 return _currentElement;
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/CharEnumerator.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/CharEnumerator.cs
@@ -19,12 +19,15 @@ namespace System
         public bool MoveNext()
         {
             int index = _index + 1;
-            if (index < _str.Length)
+            int length = _str.Length;
+
+            if (index < length)
             {
                 _index = index;
                 return true;
             }
 
+            _index = length;
             return false;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/CharEnumerator.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/CharEnumerator.cs
@@ -1,62 +1,34 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-/*============================================================
-**
-**
-**
-** Purpose: Enumerates the characters on a string.  skips range
-**          checks.
-**
-**
-============================================================*/
-
 using System.Collections;
 using System.Collections.Generic;
 
 namespace System
 {
+    /// <summary>Supports iterating over a <see cref="string"/> object and reading its individual characters.</summary>
     public sealed class CharEnumerator : IEnumerator, IEnumerator<char>, IDisposable, ICloneable
     {
-        private string? _str;
-        private int _index;
-        private char _currentElement;
+        private string _str; // null after disposal
+        private int _index = -1;
 
-        internal CharEnumerator(string str)
-        {
-            _str = str;
-            _index = -1;
-        }
+        internal CharEnumerator(string str) => _str = str;
 
-        public object Clone()
-        {
-            return MemberwiseClone();
-        }
+        public object Clone() => MemberwiseClone();
 
         public bool MoveNext()
         {
             int index = _index + 1;
-            string s = _str!;
-
-            if ((uint)index < (uint)s.Length)
+            if (index < _str.Length)
             {
-                _currentElement = s[index];
                 _index = index;
                 return true;
             }
 
-            _index = s.Length;
             return false;
         }
 
-        public void Dispose()
-        {
-            if (_str != null)
-            {
-                _index = _str.Length;
-                _str = null;
-            }
-        }
+        public void Dispose() => _str = null!;
 
         object? IEnumerator.Current => Current;
 
@@ -64,19 +36,17 @@ namespace System
         {
             get
             {
-                if ((uint)_index >= _str!.Length)
+                int index = _index;
+                string s = _str;
+                if ((uint)index >= (uint)s.Length)
                 {
                     ThrowHelper.ThrowInvalidOperationException_EnumCurrent(_index);
                 }
 
-                return _currentElement;
+                return s[index];
             }
         }
 
-        public void Reset()
-        {
-            _currentElement = (char)0;
-            _index = -1;
-        }
+        public void Reset() => _index = -1;
     }
 }


### PR DESCRIPTION
The C# compiler lowers a foreach over a string to a for loop equivalent, so this is only relevant when the string is used as an `IEnumerable<char>`.

```C#
private string _s = new string('s', 100);

[Benchmark]
public int Iterate()
{
    int sum = 0;
    foreach (char c in (IEnumerable<char>)_s) sum += c;
    return sum;
}
```

|  Method |         Toolchain |     Mean |   Error |  StdDev | Ratio |
|-------- |------------------ |---------:|--------:|--------:|------:|
| Iterate | \main\corerun.exe | 301.4 ns | 2.76 ns | 2.58 ns |  1.00 |
| Iterate |   \pr\corerun.exe | 235.7 ns | 1.13 ns | 1.06 ns |  0.78 |