### PR TITLE
[NativeAOT] Cache location of unwind sections

### DIFF
--- a/src/coreclr/nativeaot/Runtime/unix/UnixContext.h
+++ b/src/coreclr/nativeaot/Runtime/unix/UnixContext.h
@@ -11,11 +11,6 @@ void NativeContextToPalContext(const void* context, PAL_LIMITED_CONTEXT* palCont
 // Redirect Unix native context to the PAL_LIMITED_CONTEXT and also set the first two argument registers
 void RedirectNativeContext(void* context, const PAL_LIMITED_CONTEXT* palContext, uintptr_t arg0Reg, uintptr_t arg1Reg);
 
-// Find LSDA and start address for a function at address controlPC
-bool FindProcInfo(uintptr_t controlPC, uintptr_t* startAddress, uintptr_t* endAddress, uintptr_t* lsda); 
-// Virtually unwind stack to the caller of the context specified by the REGDISPLAY
-bool VirtualUnwind(REGDISPLAY* pRegisterSet);
-
 #ifdef HOST_AMD64
 // Get value of a register from the native context. The index is the processor specific
 // register index stored in machine instructions.

--- a/src/coreclr/nativeaot/Runtime/unix/UnixNativeCodeManager.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/UnixNativeCodeManager.cpp
@@ -18,6 +18,7 @@
 #include "gcinfodecoder.cpp"
 
 #include "UnixContext.h"
+#include "UnwindHelpers.h"
 
 #define UBF_FUNC_KIND_MASK      0x03
 #define UBF_FUNC_KIND_ROOT      0x00
@@ -46,10 +47,58 @@ UnixNativeCodeManager::UnixNativeCodeManager(TADDR moduleBase,
       m_pvManagedCodeStartRange(pvManagedCodeStartRange), m_cbManagedCodeRange(cbManagedCodeRange),
       m_pClasslibFunctions(pClasslibFunctions), m_nClasslibFunctions(nClasslibFunctions)
 {
+    libunwind::LocalAddressSpace::sThisAddressSpace.findUnwindSections(
+        (uintptr_t)pvManagedCodeStartRange, m_UnwindInfoSections);
 }
 
 UnixNativeCodeManager::~UnixNativeCodeManager()
 {
+}
+
+// Virtually unwind stack to the caller of the context specified by the REGDISPLAY
+bool UnixNativeCodeManager::VirtualUnwind(REGDISPLAY* pRegisterSet)
+{
+#if _LIBUNWIND_SUPPORT_DWARF_UNWIND
+    uintptr_t pc = pRegisterSet->GetIP();
+    if (pc >= (uintptr_t)m_pvManagedCodeStartRange &&
+        pc < (uintptr_t)m_pvManagedCodeStartRange + m_cbManagedCodeRange)
+    {
+        return UnwindHelpers::StepFrame(pRegisterSet, m_UnwindInfoSections);
+    }
+#endif
+
+    return UnwindHelpers::StepFrame(pRegisterSet);
+}
+
+// Find LSDA and start address for a function at address controlPC
+bool UnixNativeCodeManager::FindProcInfo(uintptr_t controlPC, uintptr_t* startAddress, uintptr_t* endAddress, uintptr_t* lsda)
+{
+    unw_proc_info_t procInfo;
+
+#if _LIBUNWIND_SUPPORT_DWARF_UNWIND
+    if (!UnwindHelpers::GetUnwindProcInfo((PCODE)controlPC, m_UnwindInfoSections, &procInfo))
+    {
+        return false;
+    }
+#else
+    if (!UnwindHelpers::GetUnwindProcInfo((PCODE)controlPC, &procInfo))
+    {
+        return false;
+    }
+#endif
+
+    assert((procInfo.start_ip <= controlPC) && (controlPC < procInfo.end_ip));
+
+#if defined(HOST_ARM)
+    // libunwind fills by reference not by value for ARM
+    *lsda = *((uintptr_t *)procInfo.lsda);
+#else
+    *lsda = procInfo.lsda;
+#endif
+    *startAddress = procInfo.start_ip;
+    *endAddress = procInfo.end_ip;
+
+    return true;
 }
 
 bool UnixNativeCodeManager::FindMethodInfo(PTR_VOID        ControlPC,
@@ -326,7 +375,7 @@ bool UnixNativeCodeManager::UnwindStackFrame(MethodInfo *    pMethodInfo,
         *ppPreviousTransitionFrame = NULL;
     }
 
-    if (!VirtualUnwind(pRegisterSet)) 
+    if (!VirtualUnwind(pRegisterSet))
     {
         return false;
     }
@@ -486,16 +535,20 @@ int UnixNativeCodeManager::TrailingEpilogueInstructionsCount(PTR_VOID pvAddress)
         // is treated as an epilogue.
         //
 
-        size_t startAddress;
-        size_t endAddress;
-        uintptr_t lsda;
-
-        bool result = FindProcInfo((uintptr_t)pvAddress, &startAddress, &endAddress, &lsda);
-        ASSERT(result);
-
-        if (branchTarget < startAddress || branchTarget >= endAddress)
+        if ((uintptr_t)pvAddress >= (uintptr_t)m_pvManagedCodeStartRange &&
+            (uintptr_t)pvAddress < (uintptr_t)m_pvManagedCodeStartRange + m_cbManagedCodeRange)
         {
-            return trailingEpilogueInstructions;
+            size_t startAddress;
+            size_t endAddress;
+            uintptr_t lsda;
+
+            bool result = FindProcInfo((uintptr_t)pvAddress, &startAddress, &endAddress, &lsda);
+            ASSERT(result);
+
+            if (branchTarget < startAddress || branchTarget >= endAddress)
+            {
+                return trailingEpilogueInstructions;
+            }
         }
     }
     else if ((pNextByte[0] == JMP_IND_OP) && (pNextByte[1] == 0x25))

--- a/src/coreclr/nativeaot/Runtime/unix/UnixNativeCodeManager.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/UnixNativeCodeManager.cpp
@@ -47,6 +47,7 @@ UnixNativeCodeManager::UnixNativeCodeManager(TADDR moduleBase,
       m_pvManagedCodeStartRange(pvManagedCodeStartRange), m_cbManagedCodeRange(cbManagedCodeRange),
       m_pClasslibFunctions(pClasslibFunctions), m_nClasslibFunctions(nClasslibFunctions)
 {
+    // Cache the location of unwind sections
     libunwind::LocalAddressSpace::sThisAddressSpace.findUnwindSections(
         (uintptr_t)pvManagedCodeStartRange, m_UnwindInfoSections);
 }
@@ -75,17 +76,10 @@ bool UnixNativeCodeManager::FindProcInfo(uintptr_t controlPC, uintptr_t* startAd
 {
     unw_proc_info_t procInfo;
 
-#if _LIBUNWIND_SUPPORT_DWARF_UNWIND
     if (!UnwindHelpers::GetUnwindProcInfo((PCODE)controlPC, m_UnwindInfoSections, &procInfo))
     {
         return false;
     }
-#else
-    if (!UnwindHelpers::GetUnwindProcInfo((PCODE)controlPC, &procInfo))
-    {
-        return false;
-    }
-#endif
 
     assert((procInfo.start_ip <= controlPC) && (controlPC < procInfo.end_ip));
 

--- a/src/coreclr/nativeaot/Runtime/unix/UnixNativeCodeManager.h
+++ b/src/coreclr/nativeaot/Runtime/unix/UnixNativeCodeManager.h
@@ -3,6 +3,11 @@
 
 #pragma once
 
+// libunwind headers
+#include <libunwind.h>
+#include <external/llvm-libunwind/src/config.h>
+#include <external/llvm-libunwind/src/AddressSpace.hpp>
+
 class UnixNativeCodeManager : public ICodeManager
 {
     TADDR m_moduleBase;
@@ -12,6 +17,13 @@ class UnixNativeCodeManager : public ICodeManager
 
     PTR_PTR_VOID m_pClasslibFunctions;
     uint32_t m_nClasslibFunctions;
+
+#if _LIBUNWIND_SUPPORT_DWARF_UNWIND
+    libunwind::UnwindInfoSections m_UnwindInfoSections;
+#endif
+
+    bool VirtualUnwind(REGDISPLAY* pRegisterSet);
+    bool FindProcInfo(uintptr_t controlPC, uintptr_t* startAddress, uintptr_t* endAddress, uintptr_t* lsda);
 
 public:
     UnixNativeCodeManager(TADDR moduleBase,

--- a/src/coreclr/nativeaot/Runtime/unix/UnixNativeCodeManager.h
+++ b/src/coreclr/nativeaot/Runtime/unix/UnixNativeCodeManager.h
@@ -18,9 +18,7 @@ class UnixNativeCodeManager : public ICodeManager
     PTR_PTR_VOID m_pClasslibFunctions;
     uint32_t m_nClasslibFunctions;
 
-#if _LIBUNWIND_SUPPORT_DWARF_UNWIND
     libunwind::UnwindInfoSections m_UnwindInfoSections;
-#endif
 
     bool VirtualUnwind(REGDISPLAY* pRegisterSet);
     bool FindProcInfo(uintptr_t controlPC, uintptr_t* startAddress, uintptr_t* endAddress, uintptr_t* lsda);

--- a/src/coreclr/nativeaot/Runtime/unix/UnwindHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/UnwindHelpers.cpp
@@ -861,15 +861,15 @@ bool UnwindHelpers::StepFrame(REGDISPLAY *regs, UnwindInfoSections &uwInfoSectio
 bool UnwindHelpers::StepFrame(REGDISPLAY *regs)
 {
     UnwindInfoSections uwInfoSections;
-    uintptr_t ip = regs->GetIP();
-    if (!_addressSpace.findUnwindSections(ip, uwInfoSections))
+    uintptr_t pc = regs->GetIP();
+    if (!_addressSpace.findUnwindSections(pc, uwInfoSections))
     {
         return false;
     }
-    return DoTheStep(ip, uwInfoSections, regs);
+    return DoTheStep(pc, uwInfoSections, regs);
 }
 
-bool UnwindHelpers::GetUnwindProcInfo(PCODE ip, UnwindInfoSections &uwInfoSections, unw_proc_info_t *procInfo)
+bool UnwindHelpers::GetUnwindProcInfo(PCODE pc, UnwindInfoSections &uwInfoSections, unw_proc_info_t *procInfo)
 {
 #if defined(TARGET_AMD64)
     libunwind::UnwindCursor<LocalAddressSpace, Registers_x86_64> uc(_addressSpace);
@@ -888,7 +888,7 @@ bool UnwindHelpers::GetUnwindProcInfo(PCODE ip, UnwindInfoSections &uwInfoSectio
 
 #if _LIBUNWIND_SUPPORT_COMPACT_UNWIND
     // If there is a compact unwind encoding table, look there first.
-    if (uwInfoSections.compact_unwind_section != 0 && uc.getInfoFromCompactEncodingSection(ip, uwInfoSections)) {
+    if (uwInfoSections.compact_unwind_section != 0 && uc.getInfoFromCompactEncodingSection(pc, uwInfoSections)) {
         uc.getInfo(procInfo);
 
 #if defined(TARGET_ARM64)
@@ -909,7 +909,7 @@ bool UnwindHelpers::GetUnwindProcInfo(PCODE ip, UnwindInfoSections &uwInfoSectio
     }
 #endif
 
-    bool retVal = uc.getInfoFromDwarfSection(ip, uwInfoSections, dwarfOffsetHint);
+    bool retVal = uc.getInfoFromDwarfSection(pc, uwInfoSections, dwarfOffsetHint);
     if (!retVal)
     {
         return false;
@@ -917,7 +917,7 @@ bool UnwindHelpers::GetUnwindProcInfo(PCODE ip, UnwindInfoSections &uwInfoSectio
 
 #elif defined(_LIBUNWIND_ARM_EHABI)
     // If there is ARM EHABI unwind info, look there next.
-    if (uwInfoSections.arm_section == 0 || !this->getInfoFromEHABISection(ip, uwInfoSections))
+    if (uwInfoSections.arm_section == 0 || !this->getInfoFromEHABISection(pc, uwInfoSections))
     {
         return false;
     }

--- a/src/coreclr/nativeaot/Runtime/unix/UnwindHelpers.h
+++ b/src/coreclr/nativeaot/Runtime/unix/UnwindHelpers.h
@@ -3,11 +3,19 @@
 
 #include "common.h"
 
+#include <libunwind.h>
+#include <external/llvm-libunwind/src/config.h>
+#include <external/llvm-libunwind/src/AddressSpace.hpp>
+
 // This class is used to encapsulate the internals of our unwinding implementation
 // and any custom versions of libunwind structures that we use for performance
 // reasons.
 class UnwindHelpers
 {
 public:
+    static bool StepFrame(REGDISPLAY *regs, libunwind::UnwindInfoSections &uwInfoSections);
+    static bool GetUnwindProcInfo(PCODE ip, libunwind::UnwindInfoSections &uwInfoSections, unw_proc_info_t *procInfo);
+
     static bool StepFrame(REGDISPLAY *regs);
+    static bool GetUnwindProcInfo(PCODE ip, unw_proc_info_t *procInfo);
 };

--- a/src/coreclr/nativeaot/Runtime/unix/UnwindHelpers.h
+++ b/src/coreclr/nativeaot/Runtime/unix/UnwindHelpers.h
@@ -14,8 +14,6 @@ class UnwindHelpers
 {
 public:
     static bool StepFrame(REGDISPLAY *regs, libunwind::UnwindInfoSections &uwInfoSections);
-    static bool GetUnwindProcInfo(PCODE ip, libunwind::UnwindInfoSections &uwInfoSections, unw_proc_info_t *procInfo);
-
     static bool StepFrame(REGDISPLAY *regs);
-    static bool GetUnwindProcInfo(PCODE ip, unw_proc_info_t *procInfo);
+    static bool GetUnwindProcInfo(PCODE ip, libunwind::UnwindInfoSections &uwInfoSections, unw_proc_info_t *procInfo);
 };


### PR DESCRIPTION
# Abstract

In issue #77568 the exception handling performance was tested on various scenarios. For Linux AOT a bottleneck was identified in the `findUnwindSections` method. Specifically, for multi-threaded scenario there's a significant performance penalty due to the usage of `dl_iterate_phdr` API which internally uses a lock.

A simple observation is that nearly all the frames we try to unwind are the compiled managed code which uses the same unwind table all the time. We can cache the value upfront and avoid all the lookups entirely.

Another side-effect of this is that it also helps the code paths that do thread hijacking during GC, and it potentially avoids some locks in those code paths.

# Implementation

The implementation reshuffles the implementation of the `FindProcInfo` and `VirtualUnwind` methods and moves them into `UnixCodeManager` where the `UnwindInfoSections` value is cached.

The llvm-libunwind API offers two ways to inject the cached information about the unwind sections. It can either be done through custom `AddressSpace` class implementation which has the benefit that high-level C++ API can be reused by simply switching one template parameter. Alternatively, the low-level C++ API can be used directly and the information just passed to it. Since the unwinding code already used the low-level API in most cases I opted to go that route.

# Testing

<details><summary>Test code</summary>
<p>

```
using System.Diagnostics;
using System.Runtime.CompilerServices;

internal class Program
{
    static int exceptionsHandled = 0;

    [MethodImpl(MethodImplOptions.NoInlining)]
    private static void CallMe(int i)
    {
        if (i == 0)
        {
            throw new NotImplementedException();
        }

        CallMe(i - 1);
    }

    [MethodImpl(MethodImplOptions.NoInlining)]
    private static void CatchMe()
    {
        try
        {
            CallMe(100);
        }
        catch (NotImplementedException)
        {
            Interlocked.Increment(ref exceptionsHandled);
        }
    }

    private static void ThreadEntrypoint()
    {
        while (true)
        {
            CatchMe();
        }
    }

    private static void Main(string[] args)
    {
        int savedExceptionsHandled = 0;
        for (int i = 0; i < 10; i++)
        {
            new Thread(ThreadEntrypoint).Start();
        }
        Thread.Sleep(5000);
        savedExceptionsHandled = exceptionsHandled;
        Console.WriteLine($"Exceptions per second: {savedExceptionsHandled / 5}");
        Environment.Exit(0);
    }
}
```

</p>
</details>

The test code was injected into an empty application created with `dotnet new console` and then compiled with `dotnet publish -p:PublishAot=true -r linux-x64 -c Debug`.

My test configuration is a Ryzen 7950X machine with Ubuntu 22.04.2 LTS in Windows Subsystem for Linux. Baseline is .NET 8 Preview 1, where I get ~19500 exceptions per second. With this PR I get around 145000 exceptions per second, or more than **7 times as fast throughput**.

I also briefly tested on MacBook Air M1 in osx-arm64 configuration. The throughput of the PR is about **1.78x faster** than the .NET 8 Preview 1 baseline.

