### PR TITLE
Enable more intrinsics for Tier0

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -2619,19 +2619,44 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
             case NI_System_Type_op_Equality:
             case NI_System_Type_op_Inequality:
 
-            // Simple cases
+            // These may lead to early dead code elimination
+            case NI_System_Type_get_IsValueType:
+            case NI_System_Type_get_IsEnum:
+            case NI_System_Type_get_IsByRefLike:
+            case NI_System_Type_IsAssignableFrom:
+            case NI_System_Type_IsAssignableTo:
+
+            // Lightweight intrinsics
             case NI_System_String_get_Chars:
             case NI_System_String_get_Length:
             case NI_System_Span_get_Item:
             case NI_System_Span_get_Length:
             case NI_System_ReadOnlySpan_get_Item:
             case NI_System_ReadOnlySpan_get_Length:
+            case NI_System_BitConverter_DoubleToInt64Bits:
+            case NI_System_BitConverter_Int32BitsToSingle:
+            case NI_System_BitConverter_Int64BitsToDouble:
+            case NI_System_BitConverter_SingleToInt32Bits:
+            case NI_System_Buffers_Binary_BinaryPrimitives_ReverseEndianness:
+            case NI_System_Type_GetEnumUnderlyingType:
+
+            // Most atomics are compiled to single instructions
+            case NI_System_Threading_Interlocked_And:
+            case NI_System_Threading_Interlocked_Or:
+            case NI_System_Threading_Interlocked_CompareExchange:
+            case NI_System_Threading_Interlocked_Exchange:
+            case NI_System_Threading_Interlocked_ExchangeAdd:
+            case NI_System_Threading_Interlocked_MemoryBarrier:
+            case NI_System_Threading_Interlocked_ReadMemoryBarrier:
+
                 betterToExpand = true;
                 break;
 
             default:
                 // Unsafe.* are all small enough to prefer expansions.
-                betterToExpand = ni >= NI_SRCS_UNSAFE_START && ni <= NI_SRCS_UNSAFE_END;
+                betterToExpand |= ni >= NI_SRCS_UNSAFE_START && ni <= NI_SRCS_UNSAFE_END;
+                // Same for these
+                betterToExpand |= ni >= NI_PRIMITIVE_START && ni <= NI_PRIMITIVE_END;
                 break;
         }
     }


### PR DESCRIPTION
This PR extends the list of intrinsics we now expand in Tier0 (except explicit minopts and debug-friendly code). The reasons are:
1) Some intrinsics such as `get_IsValueType` lead to early dead code removal in Tier0 - it means we don't waste time resolving tokens inside dead branches
2) Most of them are simpler than `call` and we don't have to call all those expensive VM APIs such as getCallInfo
3) We now never compile some of these methods in JIT separately (and install call counting stubs, etc) e.g. `Interlocked.Add()` function is now never compiled.

Previous round of adding intrinsics in Tier0 demonstrated nice rps/latency wins in TE benchmarks:
![image](https://user-images.githubusercontent.com/523221/222980413-e25f77fd-f729-4535-b110-2338d1639678.png)


Jit-diffs (-f --tier0):
```
PMI CodeSize Diffs for System.Private.CoreLib.dll, framework assemblies [tier0] for  default jit

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 67834276
Total bytes of diff: 67732277
Total bytes of delta: -101999 (-0.15 % of base)
Total relative delta: NaN
    diff is an improvement.
    relative diff is a regression.


Top file improvements (bytes):
      -57370 : System.Private.CoreLib.dasm (-0.76% of base)
      -13499 : System.Text.Json.dasm (-1.07% of base)
       -9422 : System.Data.Common.dasm (-0.57% of base)
       -6040 : System.Collections.Concurrent.dasm (-1.17% of base)
       -4608 : System.Private.Xml.dasm (-0.11% of base)
       -3102 : System.Private.DataContractSerialization.dasm (-0.29% of base)
       -2025 : System.ComponentModel.TypeConverter.dasm (-0.55% of base)
       -1834 : System.Collections.Immutable.dasm (-0.09% of base)
        -774 : FSharp.Core.dasm (-0.08% of base)
        -618 : System.Linq.Parallel.dasm (-0.02% of base)
        -501 : System.Threading.Tasks.Dataflow.dasm (-0.04% of base)
        -488 : System.Collections.dasm (-0.07% of base)
        -296 : System.Threading.Channels.dasm (-0.11% of base)
        -192 : System.Linq.dasm (-0.01% of base)
        -124 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
        -115 : System.Runtime.Caching.dasm (-0.14% of base)
        -112 : System.Private.Xml.Linq.dasm (-0.06% of base)
        -101 : System.Net.Requests.dasm (-0.08% of base)
         -73 : Microsoft.CodeAnalysis.dasm (-0.00% of base)
         -60 : System.Net.Http.dasm (-0.01% of base)

55 total files with Code Size differences (55 improved, 0 regressed), 221 unchanged.

Top method regressions (bytes):
           6 ( 1.49% of base) : System.Collections.Concurrent.dasm - System.Collections.Concurrent.ConcurrentDictionary`2[System.__Canon,System.Nullable`1[int]]:get_Comparer():System.Collections.Generic.IEqualityComparer`1[System.__Canon]:this
           5 ( 6.02% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:TryWriteHalfBigEndian(System.Span`1[ubyte],System.Half):bool
           5 ( 6.58% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:TryWriteInt16BigEndian(System.Span`1[ubyte],short):bool
           5 ( 6.02% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:WriteHalfBigEndian(System.Span`1[ubyte],System.Half)
           5 ( 6.58% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:WriteInt16BigEndian(System.Span`1[ubyte],short)
           5 ( 3.29% of base) : System.Private.CoreLib.dasm - System.Double:System.Numerics.IFloatingPoint<System.Double>.TryWriteExponentBigEndian(System.Span`1[ubyte],byref):bool:this
           5 ( 3.47% of base) : System.Private.CoreLib.dasm - System.Int16:System.Numerics.IBinaryInteger<System.Int16>.TryWriteBigEndian(System.Span`1[ubyte],byref):bool:this
           5 ( 3.16% of base) : System.Private.CoreLib.dasm - System.Runtime.InteropServices.NFloat:System.Numerics.IFloatingPoint<System.Runtime.InteropServices.NFloat>.TryWriteExponentBigEndian(System.Span`1[ubyte],byref):bool:this
           4 ( 5.33% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:TryWriteUInt16BigEndian(System.Span`1[ubyte],ushort):bool
           4 ( 5.33% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:WriteUInt16BigEndian(System.Span`1[ubyte],ushort)
           4 ( 2.63% of base) : System.Private.CoreLib.dasm - System.Half:System.Numerics.IFloatingPoint<System.Half>.TryWriteSignificandBigEndian(System.Span`1[ubyte],byref):bool:this
           4 ( 3.88% of base) : System.Reflection.Metadata.dasm - System.Reflection.BlobUtilities:WriteUInt16BE(ubyte[],int,ushort)
           4 ( 1.13% of base) : System.Private.CoreLib.dasm - System.UInt16:System.Numerics.IBinaryInteger<System.UInt16>.TryReadBigEndian(System.ReadOnlySpan`1[ubyte],bool,byref):bool
           4 ( 2.80% of base) : System.Private.CoreLib.dasm - System.UInt16:System.Numerics.IBinaryInteger<System.UInt16>.TryWriteBigEndian(System.Span`1[ubyte],byref):bool:this
           3 ( 4.35% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:ReadHalfBigEndian(System.ReadOnlySpan`1[ubyte]):System.Half
           3 ( 3.19% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:TryReadHalfBigEndian(System.ReadOnlySpan`1[ubyte],byref):bool
           2 ( 0.39% of base) : System.Private.CoreLib.dasm - System.Int16:System.Numerics.IBinaryInteger<System.Int16>.TryReadBigEndian(System.ReadOnlySpan`1[ubyte],bool,byref):bool
           2 ( 3.03% of base) : System.Private.CoreLib.dasm - System.Text.Unicode.Utf8Utility:ExtractUtf8TwoByteSequenceFromFirstUtf16Char(uint):uint
           1 ( 1.64% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:ReadUInt16BigEndian(System.ReadOnlySpan`1[ubyte]):ushort
           1 ( 1.18% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:TryReadUInt16BigEndian(System.ReadOnlySpan`1[ubyte],byref):bool

Top method improvements (bytes):
       -1396 (-91.72% of base) : System.Private.CoreLib.dasm - System.Enum:TryParse[double](System.ReadOnlySpan`1[ushort],bool,bool,byref):bool
       -1396 (-91.72% of base) : System.Private.CoreLib.dasm - System.Enum:TryParse[int](System.ReadOnlySpan`1[ushort],bool,bool,byref):bool
       -1396 (-91.72% of base) : System.Private.CoreLib.dasm - System.Enum:TryParse[long](System.ReadOnlySpan`1[ushort],bool,bool,byref):bool
       -1396 (-91.72% of base) : System.Private.CoreLib.dasm - System.Enum:TryParse[short](System.ReadOnlySpan`1[ushort],bool,bool,byref):bool
       -1396 (-91.72% of base) : System.Private.CoreLib.dasm - System.Enum:TryParse[System.Numerics.Vector`1[float]](System.ReadOnlySpan`1[ushort],bool,bool,byref):bool
       -1396 (-91.72% of base) : System.Private.CoreLib.dasm - System.Enum:TryParse[ubyte](System.ReadOnlySpan`1[ushort],bool,bool,byref):bool
       -1196 (-91.02% of base) : System.Data.Common.dasm - System.Data.EnumerableRowCollection`1[double]:GetLinqDataView():System.Data.LinqDataView:this
       -1196 (-91.02% of base) : System.Data.Common.dasm - System.Data.EnumerableRowCollection`1[int]:GetLinqDataView():System.Data.LinqDataView:this
       -1196 (-91.02% of base) : System.Data.Common.dasm - System.Data.EnumerableRowCollection`1[long]:GetLinqDataView():System.Data.LinqDataView:this
       -1196 (-91.02% of base) : System.Data.Common.dasm - System.Data.EnumerableRowCollection`1[short]:GetLinqDataView():System.Data.LinqDataView:this
       -1196 (-91.02% of base) : System.Data.Common.dasm - System.Data.EnumerableRowCollection`1[System.Nullable`1[int]]:GetLinqDataView():System.Data.LinqDataView:this
       -1196 (-91.02% of base) : System.Data.Common.dasm - System.Data.EnumerableRowCollection`1[System.Numerics.Vector`1[float]]:GetLinqDataView():System.Data.LinqDataView:this
       -1196 (-91.02% of base) : System.Data.Common.dasm - System.Data.EnumerableRowCollection`1[ubyte]:GetLinqDataView():System.Data.LinqDataView:this
        -887 (-68.28% of base) : System.Private.CoreLib.dasm - System.MemoryExtensions:SequenceEqual[System.__Canon](System.ReadOnlySpan`1[System.__Canon],System.ReadOnlySpan`1[System.__Canon],System.Collections.Generic.IEqualityComparer`1[System.__Canon]):bool
        -702 (-36.11% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2[System.__Canon,System.Nullable`1[int]]:TryInsert(System.__Canon,System.Nullable`1[int],ubyte):bool:this
        -697 (-36.06% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2[System.__Canon,System.__Canon]:TryInsert(System.__Canon,System.__Canon,ubyte):bool:this
        -697 (-35.84% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2[System.__Canon,System.Resources.ResourceLocator]:TryInsert(System.__Canon,System.Resources.ResourceLocator,ubyte):bool:this
        -692 (-36.08% of base) : System.Private.CoreLib.dasm - System.Collections.Generic.Dictionary`2[System.__Canon,long]:TryInsert(System.__Canon,long,ubyte):bool:this
        -681 (-19.29% of base) : System.Collections.Immutable.dasm - System.Collections.Frozen.FrozenDictionary:ChooseImplementationOptimizedForReading[System.__Canon,System.Nullable`1[int]](System.Collections.Generic.Dictionary`2[System.__Canon,System.Nullable`1[int]]):System.Collections.Frozen.FrozenDictionary`2[System.__Canon,System.Nullable`1[int]]
        -655 (-19.58% of base) : System.Collections.Immutable.dasm - System.Collections.Frozen.FrozenSet:ChooseImplementationOptimizedForReading[System.__Canon](System.Collections.Generic.HashSet`1[System.__Canon]):System.Collections.Frozen.FrozenSet`1[System.__Canon]

Top method regressions (percentages):
           5 ( 6.58% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:TryWriteInt16BigEndian(System.Span`1[ubyte],short):bool
           5 ( 6.58% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:WriteInt16BigEndian(System.Span`1[ubyte],short)
           5 ( 6.02% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:TryWriteHalfBigEndian(System.Span`1[ubyte],System.Half):bool
           5 ( 6.02% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:WriteHalfBigEndian(System.Span`1[ubyte],System.Half)
           4 ( 5.33% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:TryWriteUInt16BigEndian(System.Span`1[ubyte],ushort):bool
           4 ( 5.33% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:WriteUInt16BigEndian(System.Span`1[ubyte],ushort)
           3 ( 4.35% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:ReadHalfBigEndian(System.ReadOnlySpan`1[ubyte]):System.Half
           4 ( 3.88% of base) : System.Reflection.Metadata.dasm - System.Reflection.BlobUtilities:WriteUInt16BE(ubyte[],int,ushort)
           5 ( 3.47% of base) : System.Private.CoreLib.dasm - System.Int16:System.Numerics.IBinaryInteger<System.Int16>.TryWriteBigEndian(System.Span`1[ubyte],byref):bool:this
           5 ( 3.29% of base) : System.Private.CoreLib.dasm - System.Double:System.Numerics.IFloatingPoint<System.Double>.TryWriteExponentBigEndian(System.Span`1[ubyte],byref):bool:this
           3 ( 3.19% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:TryReadHalfBigEndian(System.ReadOnlySpan`1[ubyte],byref):bool
           5 ( 3.16% of base) : System.Private.CoreLib.dasm - System.Runtime.InteropServices.NFloat:System.Numerics.IFloatingPoint<System.Runtime.InteropServices.NFloat>.TryWriteExponentBigEndian(System.Span`1[ubyte],byref):bool:this
           2 ( 3.03% of base) : System.Private.CoreLib.dasm - System.Text.Unicode.Utf8Utility:ExtractUtf8TwoByteSequenceFromFirstUtf16Char(uint):uint
           4 ( 2.80% of base) : System.Private.CoreLib.dasm - System.UInt16:System.Numerics.IBinaryInteger<System.UInt16>.TryWriteBigEndian(System.Span`1[ubyte],byref):bool:this
           4 ( 2.63% of base) : System.Private.CoreLib.dasm - System.Half:System.Numerics.IFloatingPoint<System.Half>.TryWriteSignificandBigEndian(System.Span`1[ubyte],byref):bool:this
           1 ( 1.64% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:ReadUInt16BigEndian(System.ReadOnlySpan`1[ubyte]):ushort
           6 ( 1.49% of base) : System.Collections.Concurrent.dasm - System.Collections.Concurrent.ConcurrentDictionary`2[System.__Canon,System.Nullable`1[int]]:get_Comparer():System.Collections.Generic.IEqualityComparer`1[System.__Canon]:this
           1 ( 1.18% of base) : System.Private.CoreLib.dasm - System.Buffers.Binary.BinaryPrimitives:TryReadUInt16BigEndian(System.ReadOnlySpan`1[ubyte],byref):bool
           4 ( 1.13% of base) : System.Private.CoreLib.dasm - System.UInt16:System.Numerics.IBinaryInteger<System.UInt16>.TryReadBigEndian(System.ReadOnlySpan`1[ubyte],bool,byref):bool
           1 ( 0.56% of base) : System.Private.CoreLib.dasm - System.Threading.Tasks.Task:AtomicStateUpdate(int,int,byref):bool:this

Top method improvements (percentages):
       -1396 (-91.72% of base) : System.Private.CoreLib.dasm - System.Enum:TryParse[double](System.ReadOnlySpan`1[ushort],bool,bool,byref):bool
       -1396 (-91.72% of base) : System.Private.CoreLib.dasm - System.Enum:TryParse[int](System.ReadOnlySpan`1[ushort],bool,bool,byref):bool
       -1396 (-91.72% of base) : System.Private.CoreLib.dasm - System.Enum:TryParse[long](System.ReadOnlySpan`1[ushort],bool,bool,byref):bool
       -1396 (-91.72% of base) : System.Private.CoreLib.dasm - System.Enum:TryParse[short](System.ReadOnlySpan`1[ushort],bool,bool,byref):bool
       -1396 (-91.72% of base) : System.Private.CoreLib.dasm - System.Enum:TryParse[System.Numerics.Vector`1[float]](System.ReadOnlySpan`1[ushort],bool,bool,byref):bool
       -1396 (-91.72% of base) : System.Private.CoreLib.dasm - System.Enum:TryParse[ubyte](System.ReadOnlySpan`1[ushort],bool,bool,byref):bool
       -1196 (-91.02% of base) : System.Data.Common.dasm - System.Data.EnumerableRowCollection`1[double]:GetLinqDataView():System.Data.LinqDataView:this
       -1196 (-91.02% of base) : System.Data.Common.dasm - System.Data.EnumerableRowCollection`1[int]:GetLinqDataView():System.Data.LinqDataView:this
       -1196 (-91.02% of base) : System.Data.Common.dasm - System.Data.EnumerableRowCollection`1[long]:GetLinqDataView():System.Data.LinqDataView:this
       -1196 (-91.02% of base) : System.Data.Common.dasm - System.Data.EnumerableRowCollection`1[short]:GetLinqDataView():System.Data.LinqDataView:this
       -1196 (-91.02% of base) : System.Data.Common.dasm - System.Data.EnumerableRowCollection`1[System.Nullable`1[int]]:GetLinqDataView():System.Data.LinqDataView:this
       -1196 (-91.02% of base) : System.Data.Common.dasm - System.Data.EnumerableRowCollection`1[System.Numerics.Vector`1[float]]:GetLinqDataView():System.Data.LinqDataView:this
       -1196 (-91.02% of base) : System.Data.Common.dasm - System.Data.EnumerableRowCollection`1[ubyte]:GetLinqDataView():System.Data.LinqDataView:this
        -361 (-90.25% of base) : System.ComponentModel.TypeConverter.dasm - System.ComponentModel.BindingList`1[System.Numerics.Vector`1[float]]:Initialize():this
        -285 (-87.96% of base) : System.ComponentModel.TypeConverter.dasm - System.ComponentModel.BindingList`1[double]:Initialize():this
        -277 (-87.66% of base) : System.ComponentModel.TypeConverter.dasm - System.ComponentModel.BindingList`1[long]:Initialize():this
        -277 (-87.66% of base) : System.ComponentModel.TypeConverter.dasm - System.ComponentModel.BindingList`1[System.Nullable`1[int]]:Initialize():this
        -275 (-87.58% of base) : System.ComponentModel.TypeConverter.dasm - System.ComponentModel.BindingList`1[int]:Initialize():this
        -275 (-87.58% of base) : System.ComponentModel.TypeConverter.dasm - System.ComponentModel.BindingList`1[short]:Initialize():this
        -275 (-87.58% of base) : System.ComponentModel.TypeConverter.dasm - System.ComponentModel.BindingList`1[ubyte]:Initialize():this

1268 total methods with Code Size differences (1247 improved, 21 regressed), 375945 unchanged.

--------------------------------------------------------------------------------
```
Example of a size "regression": https://www.diffchecker.com/qaKdHKwT/