### PR TITLE
[mono] Fix virtual method resolution in mono_delegate_trampoline ().

### DIFF
--- a/src/mono/mono/metadata/object-internals.h
+++ b/src/mono/mono/metadata/object-internals.h
@@ -847,6 +847,7 @@ struct _MonoDelegate {
 	MonoReflectionMethod *method_info;
 	MonoReflectionMethod *original_method_info;
 	MonoObject *data;
+	/* Whenever to resolve the target method using ldvirtftn at call time */
 	MonoBoolean method_is_virtual;
 	MonoBoolean bound;
 };

--- a/src/mono/mono/mini/mini-trampolines.c
+++ b/src/mono/mono/mini/mini-trampolines.c
@@ -1063,18 +1063,11 @@ mono_delegate_trampoline (host_mgreg_t *regs, guint8 *code, gpointer *arg, guint
 			}
 		}
 
-		if (delegate->method_ptr == NULL && tramp_info->method == NULL && delegate->target != NULL && method->flags & METHOD_ATTRIBUTE_VIRTUAL) {
-			/* tramp_info->method == NULL happens when someone asks us to JIT some delegate's
-			 * Invoke method (see compile_special).  In that case if method is virtual, the target
-			 * could be some derived class, so we need to find the correct override.
+		if (delegate->method_is_virtual) {
+			/*
+			 * If the delegate was created by handle_delegate_ctor (virtual==TRUE), the
+			 * ldvirtftn instruction was skipped, so we have to do it now.
 			 */
-			/* FIXME: does it make sense that we get called with tramp_info for the Invoke? */
-			method = mono_object_get_virtual_method_internal (delegate->target, method);
-			enable_caching = FALSE;
-		} else if (delegate->target &&
-			method->flags & METHOD_ATTRIBUTE_VIRTUAL &&
-			method->flags & METHOD_ATTRIBUTE_ABSTRACT &&
-			mono_class_is_abstract (method->klass)) {
 			method = mono_object_get_virtual_method_internal (delegate->target, method);
 			enable_caching = FALSE;
 		}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_83003/Runtime_83003.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_83003/Runtime_83003.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+class Foo
+{
+	public virtual void foo () {
+	}
+}
+
+class Derived : Foo
+{
+	void foo2 (Action a) {
+		a ();
+	}
+
+	public override void foo () {
+		foo2 (base.foo);
+	}
+
+	public static int Main(string[] args) {
+		var d = new Derived ();
+		d.foo ();
+		return 100;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_83003/Runtime_83003.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_83003/Runtime_83003.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Use delegate->method_is_virtual instead of complicated conditions. That flag is set by the code generated in handle_delegate_ctor () if an ldvirtftn instruction was skipped, and thus virtual method resolution needs to be done at call time.

Fixes https://github.com/dotnet/runtime/issues/83003.