### PR TITLE
fix failing ConnectWithRevocation_ServerCertWithoutContext_NoStapleOcsp failures

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -163,7 +163,7 @@ namespace System.Net.Security
                 if (certificateWithKey != null && certificateWithKey.HasPrivateKey)
                 {
                     // given cert is X509Certificate2 with key. We can use it directly.
-                    CertificateContext = SslStreamCertificateContext.Create(certificateWithKey, null);
+                    CertificateContext = SslStreamCertificateContext.Create(certificateWithKey, additionalCertificates: null, offline: false, trust: null, noOcspFetch: true);
                 }
                 else
                 {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -123,16 +123,9 @@ namespace System.Net.Security.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Linux)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/70981", typeof(PlatformDetection), nameof(PlatformDetection.IsDebian10))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/70981", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public Task ConnectWithRevocation_ServerCertWithoutContext_NoStapledOcsp()
         {
-            // Offline will only work if
-            // a) the revocation has been checked recently enough that it is cached, or
-            // b) the server stapled the response
-            //
-            // At high load, the server's background fetch might not have completed before
-            // this test runs.
+            // When using specific certificate, OCSP is disabled e.g. when SslStreamCertificateContext is passed in explicitly.
             return ConnectWithRevocation_WithCallback_Core(X509RevocationMode.Offline, offlineContext: null);
         }
 


### PR DESCRIPTION
There was mismatch between the test and product. When context is created from certificate internally, the code defaults to OCSP processing 
https://github.com/dotnet/runtime/blob/4eca676a57f0d818b94c0ff002d3fef03b14cb60/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.cs#L21-L24

(negative false -> oof ;( )

So the server would provide OCSP response and based on the timing the test would succeed or fail.

I was thinking about deleting the test but I decided to keep it and modify the behavior instead. 
This would IMHO preserve legacy behavior. When single certificate is used it would act as it always did - e.g. no OCSP. 

When  `SslStreamCertificateContext` is created and provided by user we would take is as intention to reuse it over time and we would handle TLS resume & OCSP. This is currently recommended use as it also offers other performance benefits. 

fixes #70981