### PR TITLE
Add switch for trim out ConfigurationManager support

### DIFF
--- a/src/libraries/System.Configuration.ConfigurationManager/src/ILLink/ILLink.Substitutions.xml
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/ILLink/ILLink.Substitutions.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<linker>
+  <assembly fullname="System.Configuration.ConfigurationManager">
+    <type fullname="System.Configuration.ConfigurationManager">
+      <method signature="System.Boolean get_DisableConfigurationManager()" body="stub" value="true" feature="Switch.System.Configuration.ConfigurationManager.DisableConfigurationManager" featurevalue="true" />
+    </type>
+  </assembly>
+</linker>

--- a/src/libraries/System.Configuration.ConfigurationManager/src/Resources/Strings.resx
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/Resources/Strings.resx
@@ -694,4 +694,7 @@
   <data name="TL_InitializeData_NotSpecified" xml:space="preserve">
     <value>initializeData needs to be valid for this TraceListener.</value>
   </data>
+  <data name="ConfigurationManagerDisabled" xml:space="preserve">
+    <value>Working with ConfigurationManager is disabled.</value>
+  </data>
 </root>

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System.Configuration.ConfigurationManager.csproj
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System.Configuration.ConfigurationManager.csproj
@@ -13,8 +13,6 @@
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>
     <IsPartialFacadeAssembly Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">true</IsPartialFacadeAssembly>
-    <!-- ILLinker settings -->
-    <ILLinkDirectory>$(MSBuildThisFileDirectory)ILLink\</ILLinkDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System.Configuration.ConfigurationManager.csproj
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System.Configuration.ConfigurationManager.csproj
@@ -13,7 +13,13 @@
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>
     <IsPartialFacadeAssembly Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">true</IsPartialFacadeAssembly>
+    <!-- ILLinker settings -->
+    <ILLinkDirectory>$(MSBuildThisFileDirectory)ILLink\</ILLinkDirectory>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ILLinkSubstitutionsXmls Include="$(ILLinkDirectory)ILLink.Substitutions.xml" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <Compile Include="System\Configuration\DictionarySectionHandler.cs" />

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationManager.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationManager.cs
@@ -145,6 +145,9 @@ namespace System.Configuration
 
         public static object GetSection(string sectionName)
         {
+            if (DisableConfigurationManager)
+                throw new ArgumentException(SR.ConfigurationManagerDisabled);
+
             // Avoid unintended AV's by ensuring sectionName is not empty.
             // For compatibility, we cannot throw an InvalidArgumentException.
             if (string.IsNullOrEmpty(sectionName)) return null;
@@ -157,6 +160,9 @@ namespace System.Configuration
 
         public static void RefreshSection(string sectionName)
         {
+            if (DisableConfigurationManager)
+                throw new ArgumentException(SR.ConfigurationManagerDisabled);
+
             // Avoid unintended AV's by ensuring sectionName is not empty.
             // For consistency with GetSection, we should not throw an InvalidArgumentException.
             if (string.IsNullOrEmpty(sectionName)) return;
@@ -201,6 +207,9 @@ namespace System.Configuration
         private static Configuration OpenExeConfigurationImpl(ConfigurationFileMap fileMap, bool isMachine,
             ConfigurationUserLevel userLevel, string exePath, bool preLoad = false)
         {
+            if (DisableConfigurationManager)
+                throw new ArgumentException(SR.ConfigurationManagerDisabled);
+
             // exePath must be specified if not running inside ClientConfigurationSystem
             if (!isMachine &&
                 (((fileMap == null) && (exePath == null)) ||
@@ -241,6 +250,15 @@ namespace System.Configuration
             // Load child section groups.
             foreach (ConfigurationSectionGroup childSectionGroup in sectionGroup.SectionGroups)
                 PreloadConfigurationSectionGroup(childSectionGroup);
+        }
+
+        private static bool s_disableConfigurationManager;
+        private static bool DisableConfigurationManager
+        {
+            get
+            {
+                return AppContext.TryGetSwitch(@"Switch.System.Configuration.ConfigurationManager.DisableConfigurationManager", out s_disableConfigurationManager) ? s_disableConfigurationManager : false;
+            }
         }
 
         private enum InitState

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationManager.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationManager.cs
@@ -257,7 +257,7 @@ namespace System.Configuration
         {
             get
             {
-                return AppContext.TryGetSwitch(@"Switch.System.Configuration.ConfigurationManager.DisableConfigurationManager", out s_disableConfigurationManager) ? s_disableConfigurationManager : false;
+                return AppContext.TryGetSwitch(@"System.Configuration.ConfigurationManager.DisableConfigurationManager", out s_disableConfigurationManager) ? s_disableConfigurationManager : false;
             }
         }
 

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationManager.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationManager.cs
@@ -146,7 +146,7 @@ namespace System.Configuration
         public static object GetSection(string sectionName)
         {
             if (DisableConfigurationManager)
-                throw new ArgumentException(SR.ConfigurationManagerDisabled);
+                return null;
 
             // Avoid unintended AV's by ensuring sectionName is not empty.
             // For compatibility, we cannot throw an InvalidArgumentException.
@@ -161,7 +161,7 @@ namespace System.Configuration
         public static void RefreshSection(string sectionName)
         {
             if (DisableConfigurationManager)
-                throw new ArgumentException(SR.ConfigurationManagerDisabled);
+                return;
 
             // Avoid unintended AV's by ensuring sectionName is not empty.
             // For consistency with GetSection, we should not throw an InvalidArgumentException.


### PR DESCRIPTION
With this change you can shave 900Kb out of 25.8Mb from sample SqlClient app from here https://github.com/dotnet/SqlClient/issues/1941#issuecomment-1454973332

Other example is that usage of `System.Runtime.Caching.MemoryCache` as shown in https://learn.microsoft.com/en-us/dotnet/api/system.runtime.caching.memorycache

Applying configuration switch reduce app size by 5.2Mb (from 7.8Mb to 2.6Mb)

Most likely modern applications which are first to use NativeAOT would not need this functionality because they use other means for configuration, so would be great to have this disabled.

Low drop in size in SqlClient coming from fact that there other large dependencies which keep Xml related code around.

Discovered as part of https://github.com/dotnet/SqlClient/issues/1942