### PR TITLE
[mono][jit] Don't try to do devirt for Delegate.Invoke ().

### DIFF
--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -5816,7 +5816,8 @@ try_prepare_objaddr_callvirt_optimization (MonoCompile *cfg, guchar *next_ip, gu
 	if (!iface_method ||
 		iface_method->is_generic ||
 		iface_method->dynamic || 					// Reflection.Emit-generated methods should have this flag
-		!strcmp (iface_method->name, "GetHashCode")) // the callvirt handler itself optimizes those
+		!strcmp (iface_method->name, "GetHashCode") || // the callvirt handler itself optimizes those
+		(iface_method->iflags & METHOD_IMPL_ATTRIBUTE_RUNTIME))
 		return NULL;
 
 	MonoMethodSignature* iface_method_sig;


### PR DESCRIPTION
The optimized delegate calling code in mini_emit_method_call_full () expects calls to Invoke to stay a virtual call.