### PR TITLE
Rename cgroup.cpp to cgroupcpu.cpp

### DIFF
--- a/src/coreclr/nativeaot/Runtime/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/CMakeLists.txt
@@ -153,7 +153,7 @@ else()
   )
 
   list(APPEND FULL_RUNTIME_SOURCES
-    unix/cgroup.cpp
+    unix/cgroupcpu.cpp
     unix/HardwareExceptions.cpp
     unix/UnixContext.cpp
     unix/UnixSignals.cpp

--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -344,8 +344,6 @@ void ConfigureSignals()
     signal(SIGPIPE, SIG_IGN);
 }
 
-extern bool GetCpuLimit(uint32_t* val);
-
 void InitializeCurrentProcessCpuCount()
 {
     uint32_t count;

--- a/src/coreclr/nativeaot/Runtime/unix/cgroupcpu.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/cgroupcpu.cpp
@@ -500,11 +500,6 @@ void InitializeCpuCGroup()
     CGroup::Initialize();
 }
 
-void CleanupCpuCGroup()
-{
-    CGroup::Cleanup();
-}
-
 bool GetCpuLimit(uint32_t* val)
 {
     if (val == nullptr)

--- a/src/coreclr/nativeaot/Runtime/unix/cgroupcpu.h
+++ b/src/coreclr/nativeaot/Runtime/unix/cgroupcpu.h
@@ -1,12 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-
 #ifndef __CGROUPCPU_H__
 #define __CGROUPCPU_H__
 
 void InitializeCpuCGroup();
-void CleanupCpuCGroup();
+bool GetCpuLimit(uint32_t* val);
 
 #endif // __CGROUPCPU_H__
-

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
@@ -22,6 +22,8 @@
     <NativeAotSupported Condition="'$(CrossBuild)' == 'true' and '$(TargetOS)' != '$(HostOS)'">false</NativeAotSupported>
     <!-- Can't use NativeAOT in source build yet https://github.com/dotnet/runtime/issues/66859 -->
     <NativeAotSupported Condition="'$(DotNetBuildFromSource)' == 'true'">false</NativeAotSupported>
+    <ObjCopyName Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(CrossBuild)' == 'true' and '$(RuntimeIdentifier)' == 'linux-musl-arm64'">llvm-objcopy-15</ObjCopyName>
+    <ObjCopyName Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(CrossBuild)' == 'true' and '$(RuntimeIdentifier)' == 'linux-arm64'">aarch64-linux-gnu-objcopy</ObjCopyName>
   </PropertyGroup>
 
   <Target Name="PublishCrossgen"
@@ -33,7 +35,7 @@
           DestinationFolder="$(MicrosoftNetCoreAppRuntimePackNativeDir)"
           SkipUnchangedFiles="true" />
 
-<MSBuild Projects="$(RepoRoot)src/coreclr/tools/aot/crossgen2/crossgen2.csproj"
+    <MSBuild Projects="$(RepoRoot)src/coreclr/tools/aot/crossgen2/crossgen2.csproj"
              Targets="Restore"
              Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())
               ;_IsPublishing=true
@@ -48,6 +50,8 @@
               ;RuntimeIdentifier=$(PackageRID)
               ;NativeAotSupported=$(NativeAotSupported)
               ;CoreCLRArtifactsPath=$(CoreCLRArtifactsPath)
+              ;StripSymbols=true
+              ;ObjCopyName=$(ObjCopyName)
               ;R2ROverridePath=$(MSBuildThisFileDirectory)ReadyToRun.targets">
       <Output TaskParameter="TargetOutputs"
               ItemName="_RawCrossgenPublishFiles" />


### PR DESCRIPTION
In this case, two objects (.o) with same name are linked in a static library (`gc/unix/cgroup.cpp` and `nativeaot/Runtime/unix/cgroup.cpp`) and the linkage order of objects is nondeterministic. When such a static library is linked into the final object on macOS (executable or library), and we run `dsymutil` on it to strip its symbols, `dsymutil` does not look past the first object by name and intermittently warns about missing symbols when the linkage order was reversed. That warning turns into error in NativeAOT publishing process.

Simplest fix is to rename the source file to disambiguate the output object filename.

Also refactor the code a bit: instead of using header for InitializeCpuCGroup and extern for GetCpuLimit, use header for both APIs.

Revert #82881
Fix #80934