### PR TITLE
Ensure that the new Vector512 related ISAs are covered by ILLink Substitutions

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.NoX86Intrinsics.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.NoX86Intrinsics.xml
@@ -3,6 +3,9 @@
     <type fullname="System.Runtime.Intrinsics.Vector256">
       <method signature="System.Boolean get_IsHardwareAccelerated()" body="stub" value="false" />
     </type>
+    <type fullname="System.Runtime.Intrinsics.Vector512">
+      <method signature="System.Boolean get_IsHardwareAccelerated()" body="stub" value="false" />
+    </type>
     <type fullname="System.Runtime.Intrinsics.X86.Aes">
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
     </type>
@@ -19,6 +22,42 @@
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
     </type>
     <type fullname="System.Runtime.Intrinsics.X86.Avx2/X64">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.X86.Avx512BW">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.X86.Avx512BW/VL">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.X86.Avx512BW/X64">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.X86.Avx512CD">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.X86.Avx512CD/VL">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.X86.Avx512CD/X64">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.X86.Avx512DQ">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.X86.Avx512DQ/VL">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.X86.Avx512DQ/X64">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.X86.Avx512F">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.X86.Avx512F/VL">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.X86.Avx512F/X64">
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
     </type>
     <type fullname="System.Runtime.Intrinsics.X86.AvxVnni">
@@ -111,6 +150,5 @@
     <type fullname="System.Runtime.Intrinsics.X86.X86Serialize/X64">
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
     </type>
-
   </assembly>
 </linker>

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -2422,6 +2422,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Aes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Avx.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Avx2.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Avx512BW.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Avx512CD.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Avx512DQ.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Avx512F.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\AvxVnni.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Bmi1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Bmi2.cs" />
@@ -2442,6 +2446,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Aes.PlatformNotSupported.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Avx.PlatformNotSupported.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Avx2.PlatformNotSupported.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Avx512BW.PlatformNotSupported.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Avx512CD.PlatformNotSupported.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Avx512DQ.PlatformNotSupported.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Avx512F.PlatformNotSupported.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\AvxVnni.PlatformNotSupported.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Bmi1.PlatformNotSupported.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Bmi2.PlatformNotSupported.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512BW.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512BW.PlatformNotSupported.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+
+namespace System.Runtime.Intrinsics.X86
+{
+    /// <summary>This class provides access to X86 AVX512BW hardware instructions via intrinsics</summary>
+    [CLSCompliant(false)]
+    public abstract class Avx512BW : Avx512F
+    {
+        internal Avx512BW() { }
+
+        public static new bool IsSupported { [Intrinsic] get { return false; } }
+
+        public new abstract class VL : Avx512F.VL
+        {
+            internal VL() { }
+
+            public static new bool IsSupported { [Intrinsic] get { return false; } }
+        }
+
+        public new abstract class X64 : Avx512F.X64
+        {
+            internal X64() { }
+
+            public static new bool IsSupported { [Intrinsic] get { return false; } }
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512BW.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512BW.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace System.Runtime.Intrinsics.X86
+{
+    /// <summary>This class provides access to X86 AVX512BW hardware instructions via intrinsics</summary>
+    [Intrinsic]
+    [CLSCompliant(false)]
+    public abstract class Avx512BW : Avx512F
+    {
+        internal Avx512BW() { }
+
+        public static new bool IsSupported { get => IsSupported; }
+
+        [Intrinsic]
+        public new abstract class VL : Avx512F.VL
+        {
+            internal VL() { }
+
+            public static new bool IsSupported { get => IsSupported; }
+        }
+
+        [Intrinsic]
+        public new abstract class X64 : Avx512F.X64
+        {
+            internal X64() { }
+
+            public static new bool IsSupported { get => IsSupported; }
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512CD.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512CD.PlatformNotSupported.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+
+namespace System.Runtime.Intrinsics.X86
+{
+    /// <summary>This class provides access to X86 AVX512CD hardware instructions via intrinsics</summary>
+    [CLSCompliant(false)]
+    public abstract class Avx512CD : Avx512F
+    {
+        internal Avx512CD() { }
+
+        public static new bool IsSupported { [Intrinsic] get { return false; } }
+
+        public new abstract class VL : Avx512F.VL
+        {
+            internal VL() { }
+
+            public static new bool IsSupported { [Intrinsic] get { return false; } }
+        }
+
+        public new abstract class X64 : Avx512F.X64
+        {
+            internal X64() { }
+
+            public static new bool IsSupported { [Intrinsic] get { return false; } }
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512CD.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512CD.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace System.Runtime.Intrinsics.X86
+{
+    /// <summary>This class provides access to X86 AVX512CD hardware instructions via intrinsics</summary>
+    [Intrinsic]
+    [CLSCompliant(false)]
+    public abstract class Avx512CD : Avx512F
+    {
+        internal Avx512CD() { }
+
+        public static new bool IsSupported { get => IsSupported; }
+
+        [Intrinsic]
+        public new abstract class VL : Avx512F.VL
+        {
+            internal VL() { }
+
+            public static new bool IsSupported { get => IsSupported; }
+        }
+
+        [Intrinsic]
+        public new abstract class X64 : Avx512F.X64
+        {
+            internal X64() { }
+
+            public static new bool IsSupported { get => IsSupported; }
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512DQ.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512DQ.PlatformNotSupported.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+
+namespace System.Runtime.Intrinsics.X86
+{
+    /// <summary>This class provides access to X86 AVX512DQ hardware instructions via intrinsics</summary>
+    [CLSCompliant(false)]
+    public abstract class Avx512DQ : Avx512F
+    {
+        internal Avx512DQ() { }
+
+        public static new bool IsSupported { [Intrinsic] get { return false; } }
+
+        public new abstract class VL : Avx512F.VL
+        {
+            internal VL() { }
+
+            public static new bool IsSupported { [Intrinsic] get { return false; } }
+        }
+
+        public new abstract class X64 : Avx512F.X64
+        {
+            internal X64() { }
+
+            public static new bool IsSupported { [Intrinsic] get { return false; } }
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512DQ.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512DQ.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace System.Runtime.Intrinsics.X86
+{
+    /// <summary>This class provides access to X86 AVX512DQ hardware instructions via intrinsics</summary>
+    [Intrinsic]
+    [CLSCompliant(false)]
+    public abstract class Avx512DQ : Avx512F
+    {
+        internal Avx512DQ() { }
+
+        public static new bool IsSupported { get => IsSupported; }
+
+        [Intrinsic]
+        public new abstract class VL : Avx512F.VL
+        {
+            internal VL() { }
+
+            public static new bool IsSupported { get => IsSupported; }
+        }
+
+        [Intrinsic]
+        public new abstract class X64 : Avx512F.X64
+        {
+            internal X64() { }
+
+            public static new bool IsSupported { get => IsSupported; }
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512F.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512F.PlatformNotSupported.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+
+namespace System.Runtime.Intrinsics.X86
+{
+    /// <summary>This class provides access to X86 AVX512F hardware instructions via intrinsics</summary>
+    [CLSCompliant(false)]
+    public abstract class Avx512F : Avx2
+    {
+        internal Avx512F() { }
+
+        public static new bool IsSupported { [Intrinsic] get { return false; } }
+
+        public abstract class VL
+        {
+            internal VL() { }
+
+            public static bool IsSupported { [Intrinsic] get { return false; } }
+        }
+
+        public new abstract class X64 : Avx2.X64
+        {
+            internal X64() { }
+
+            public static new bool IsSupported { [Intrinsic] get { return false; } }
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512F.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512F.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace System.Runtime.Intrinsics.X86
+{
+    /// <summary>This class provides access to X86 AVX512F hardware instructions via intrinsics</summary>
+    [Intrinsic]
+    [CLSCompliant(false)]
+    public abstract class Avx512F : Avx2
+    {
+        internal Avx512F() { }
+
+        public static new bool IsSupported { get => IsSupported; }
+
+        [Intrinsic]
+        public abstract class VL
+        {
+            internal VL() { }
+
+            public static bool IsSupported { get => IsSupported; }
+        }
+
+        [Intrinsic]
+        public new abstract class X64 : Avx2.X64
+        {
+            internal X64() { }
+
+            public static new bool IsSupported { get => IsSupported; }
+        }
+    }
+}

--- a/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
+++ b/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
@@ -4374,6 +4374,70 @@ namespace System.Runtime.Intrinsics.X86
         }
     }
     [System.CLSCompliantAttribute(false)]
+    public abstract partial class Avx512BW : System.Runtime.Intrinsics.X86.Avx512F
+    {
+        internal Avx512BW() { }
+        public static new bool IsSupported { get { throw null; } }
+        public new abstract partial class VL : System.Runtime.Intrinsics.X86.Avx512F.VL
+        {
+            internal VL() { }
+            public static new bool IsSupported { get { throw null; } }
+        }
+        public new abstract partial class X64 : System.Runtime.Intrinsics.X86.Avx512F.X64
+        {
+            internal X64() { }
+            public static new bool IsSupported { get { throw null; } }
+        }
+    }
+    [System.CLSCompliantAttribute(false)]
+    public abstract partial class Avx512CD : System.Runtime.Intrinsics.X86.Avx512F
+    {
+        internal Avx512CD() { }
+        public static new bool IsSupported { get { throw null; } }
+        public new abstract partial class VL : System.Runtime.Intrinsics.X86.Avx512F.VL
+        {
+            internal VL() { }
+            public static new bool IsSupported { get { throw null; } }
+        }
+        public new abstract partial class X64 : System.Runtime.Intrinsics.X86.Avx512F.X64
+        {
+            internal X64() { }
+            public static new bool IsSupported { get { throw null; } }
+        }
+    }
+    [System.CLSCompliantAttribute(false)]
+    public abstract partial class Avx512DQ : System.Runtime.Intrinsics.X86.Avx512F
+    {
+        internal Avx512DQ() { }
+        public static new bool IsSupported { get { throw null; } }
+        public new abstract partial class VL : System.Runtime.Intrinsics.X86.Avx512F.VL
+        {
+            internal VL() { }
+            public static new bool IsSupported { get { throw null; } }
+        }
+        public new abstract partial class X64 : System.Runtime.Intrinsics.X86.Avx512F.X64
+        {
+            internal X64() { }
+            public static new bool IsSupported { get { throw null; } }
+        }
+    }
+    [System.CLSCompliantAttribute(false)]
+    public abstract partial class Avx512F : System.Runtime.Intrinsics.X86.Avx2
+    {
+        internal Avx512F() { }
+        public static new bool IsSupported { get { throw null; } }
+        public abstract partial class VL
+        {
+            internal VL() { }
+            public static bool IsSupported { get { throw null; } }
+        }
+        public new abstract partial class X64 : System.Runtime.Intrinsics.X86.Avx2.X64
+        {
+            internal X64() { }
+            public static new bool IsSupported { get { throw null; } }
+        }
+    }
+    [System.CLSCompliantAttribute(false)]
     [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("AvxVnni is in preview.")]
     public abstract class AvxVnni : System.Runtime.Intrinsics.X86.Avx2
     {
@@ -5210,7 +5274,7 @@ namespace System.Runtime.Intrinsics.X86
             public static new bool IsSupported { get { throw null; } }
         }
     }
-    
+
     [System.CLSCompliantAttribute(false)]
     public abstract partial class X86Base
     {


### PR DESCRIPTION
Now that the foundational PRs are in, they'll be several people iterating on adding Vector512 related intrinsics concurrently.

Having these classes defined up front helps reduce merge conflicts and other issues that would otherwise arise.

This makes progress towards https://github.com/dotnet/runtime/issues/73604, https://github.com/dotnet/runtime/issues/74813, and https://github.com/dotnet/runtime/issues/76579