### PR TITLE
Refactoring GenTreeVecCon to support TYP_SIMD64

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3192,7 +3192,7 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
             simd8_t value = vnStore->ConstantValue<simd8_t>(vnCns);
 
             GenTreeVecCon* vecCon = gtNewVconNode(tree->TypeGet());
-            vecCon->gtSimd8Val    = value;
+            memcpy(&vecCon->gtSimdVal, &value, sizeof(simd8_t));
 
             conValTree = vecCon;
             break;
@@ -3203,7 +3203,7 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
             simd12_t value = vnStore->ConstantValue<simd12_t>(vnCns);
 
             GenTreeVecCon* vecCon = gtNewVconNode(tree->TypeGet());
-            vecCon->gtSimd12Val   = value;
+            memcpy(&vecCon->gtSimdVal, &value, sizeof(simd12_t));
 
             conValTree = vecCon;
             break;
@@ -3214,7 +3214,7 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
             simd16_t value = vnStore->ConstantValue<simd16_t>(vnCns);
 
             GenTreeVecCon* vecCon = gtNewVconNode(tree->TypeGet());
-            vecCon->gtSimd16Val   = value;
+            memcpy(&vecCon->gtSimdVal, &value, sizeof(simd16_t));
 
             conValTree = vecCon;
             break;
@@ -3222,12 +3222,22 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
 
 #if defined(TARGET_XARCH)
         case TYP_SIMD32:
-        case TYP_SIMD64: // TODO-XArch-AVX512: Fix once GenTreeVecCon supports gtSimd64Val.
         {
             simd32_t value = vnStore->ConstantValue<simd32_t>(vnCns);
 
             GenTreeVecCon* vecCon = gtNewVconNode(tree->TypeGet());
-            vecCon->gtSimd32Val   = value;
+            memcpy(&vecCon->gtSimdVal, &value, sizeof(simd32_t));
+
+            conValTree = vecCon;
+            break;
+        }
+
+        case TYP_SIMD64:
+        {
+            simd64_t value = vnStore->ConstantValue<simd64_t>(vnCns);
+
+            GenTreeVecCon* vecCon = gtNewVconNode(tree->TypeGet());
+            memcpy(&vecCon->gtSimdVal, &value, sizeof(simd64_t));
 
             conValTree = vecCon;
             break;

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2388,16 +2388,16 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
                         // Get a temp integer register to compute long address.
                         regNumber addrReg = tree->GetSingleTempReg();
 
-                        simd8_t              constValue = vecCon->gtSimd8Val;
-                        CORINFO_FIELD_HANDLE hnd        = emit->emitSimd8Const(constValue);
+                        simd8_t constValue;
+                        memcpy(&constValue, &vecCon->gtSimdVal, sizeof(simd8_t));
 
+                        CORINFO_FIELD_HANDLE hnd = emit->emitSimd8Const(constValue);
                         emit->emitIns_R_C(INS_ldr, attr, targetReg, addrReg, hnd, 0);
                     }
                     break;
                 }
 
                 case TYP_SIMD12:
-                case TYP_SIMD16:
                 {
                     if (vecCon->IsAllBitsSet())
                     {
@@ -2413,14 +2413,33 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
                         regNumber addrReg = tree->GetSingleTempReg();
 
                         simd16_t constValue = {};
-
-                        if (vecCon->TypeIs(TYP_SIMD12))
-                            memcpy(&constValue, &vecCon->gtSimd12Val, sizeof(simd12_t));
-                        else
-                            constValue = vecCon->gtSimd16Val;
+                        memcpy(&constValue, &vecCon->gtSimdVal, sizeof(simd12_t));
 
                         CORINFO_FIELD_HANDLE hnd = emit->emitSimd16Const(constValue);
+                        emit->emitIns_R_C(INS_ldr, attr, targetReg, addrReg, hnd, 0);
+                    }
+                    break;
+                }
 
+                case TYP_SIMD16:
+                {
+                    if (vecCon->IsAllBitsSet())
+                    {
+                        emit->emitIns_R_I(INS_mvni, attr, targetReg, 0, INS_OPTS_4S);
+                    }
+                    else if (vecCon->IsZero())
+                    {
+                        emit->emitIns_R_I(INS_movi, attr, targetReg, 0, INS_OPTS_4S);
+                    }
+                    else
+                    {
+                        // Get a temp integer register to compute long address.
+                        regNumber addrReg = tree->GetSingleTempReg();
+
+                        simd16_t constValue;
+                        memcpy(&constValue, &vecCon->gtSimdVal, sizeof(simd16_t));
+
+                        CORINFO_FIELD_HANDLE hnd = emit->emitSimd16Const(constValue);
                         emit->emitIns_R_C(INS_ldr, attr, targetReg, addrReg, hnd, 0);
                     }
                     break;

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -550,34 +550,40 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
 #if defined(FEATURE_SIMD)
                 case TYP_SIMD8:
                 {
-                    simd8_t              constValue = vecCon->gtSimd8Val;
-                    CORINFO_FIELD_HANDLE hnd        = emit->emitSimd8Const(constValue);
+                    simd8_t constValue;
+                    memcpy(&constValue, &vecCon->gtSimdVal, sizeof(simd8_t));
 
+                    CORINFO_FIELD_HANDLE hnd = emit->emitSimd8Const(constValue);
                     emit->emitIns_R_C(ins_Load(targetType), attr, targetReg, hnd, 0);
                     break;
                 }
 
                 case TYP_SIMD12:
-                case TYP_SIMD16:
                 {
                     simd16_t constValue = {};
-
-                    if (vecCon->TypeIs(TYP_SIMD12))
-                        memcpy(&constValue, &vecCon->gtSimd12Val, sizeof(simd12_t));
-                    else
-                        constValue = vecCon->gtSimd16Val;
+                    memcpy(&constValue, &vecCon->gtSimdVal, sizeof(simd12_t));
 
                     CORINFO_FIELD_HANDLE hnd = emit->emitSimd16Const(constValue);
+                    emit->emitIns_R_C(ins_Load(targetType), attr, targetReg, hnd, 0);
+                    break;
+                }
 
+                case TYP_SIMD16:
+                {
+                    simd16_t constValue;
+                    memcpy(&constValue, &vecCon->gtSimdVal, sizeof(simd16_t));
+
+                    CORINFO_FIELD_HANDLE hnd = emit->emitSimd16Const(constValue);
                     emit->emitIns_R_C(ins_Load(targetType), attr, targetReg, hnd, 0);
                     break;
                 }
 
                 case TYP_SIMD32:
                 {
-                    simd32_t             constValue = vecCon->gtSimd32Val;
-                    CORINFO_FIELD_HANDLE hnd        = emit->emitSimd32Const(constValue);
+                    simd32_t constValue;
+                    memcpy(&constValue, &vecCon->gtSimdVal, sizeof(simd32_t));
 
+                    CORINFO_FIELD_HANDLE hnd = emit->emitSimd32Const(constValue);
                     emit->emitIns_R_C(ins_Load(targetType), attr, targetReg, hnd, 0);
                     break;
                 }
@@ -585,11 +591,9 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
                 case TYP_SIMD64:
                 {
                     simd64_t constValue;
-                    // TODO-XArch-AVX512: Fix once GenTreeVecCon supports gtSimd64Val.
-                    constValue.v256[0]       = vecCon->gtSimd32Val;
-                    constValue.v256[1]       = vecCon->gtSimd32Val;
-                    CORINFO_FIELD_HANDLE hnd = emit->emitSimd64Const(constValue);
+                    memcpy(&constValue, &vecCon->gtSimdVal, sizeof(simd64_t));
 
+                    CORINFO_FIELD_HANDLE hnd = emit->emitSimd64Const(constValue);
                     emit->emitIns_R_C(ins_Load(targetType), attr, targetReg, hnd, 0);
                     break;
                 }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -7281,51 +7281,7 @@ GenTree* Compiler::gtNewAllBitsSetConNode(var_types type)
     if (varTypeIsSIMD(type))
     {
         GenTreeVecCon* allBitsSet = gtNewVconNode(type);
-
-        switch (type)
-        {
-#if defined(TARGET_XARCH)
-            case TYP_SIMD64:
-            {
-                allBitsSet->gtSimdVal.i64[7] = -1;
-                allBitsSet->gtSimdVal.i64[6] = -1;
-                allBitsSet->gtSimdVal.i64[5] = -1;
-                allBitsSet->gtSimdVal.i64[4] = -1;
-                FALLTHROUGH;
-            }
-
-            case TYP_SIMD32:
-            {
-                allBitsSet->gtSimdVal.i64[3] = -1;
-                allBitsSet->gtSimdVal.i64[2] = -1;
-                FALLTHROUGH;
-            }
-#endif // TARGET_XARCH
-            case TYP_SIMD16:
-            {
-                allBitsSet->gtSimdVal.i64[1] = -1;
-                allBitsSet->gtSimdVal.i64[0] = -1;
-                break;
-            }
-
-            case TYP_SIMD12:
-            {
-                allBitsSet->gtSimdVal.i32[2] = -1;
-                FALLTHROUGH;
-            }
-
-            case TYP_SIMD8:
-            {
-                allBitsSet->gtSimdVal.i64[0] = -1;
-                break;
-            }
-
-            default:
-            {
-                unreached();
-            }
-        }
-
+        allBitsSet->gtSimdVal     = simd_t::AllBitsSet();
         return allBitsSet;
     }
 #endif // FEATURE_SIMD
@@ -7355,52 +7311,7 @@ GenTree* Compiler::gtNewZeroConNode(var_types type)
     if (varTypeIsSIMD(type))
     {
         GenTreeVecCon* allBitsSet = gtNewVconNode(type);
-
-        switch (type)
-        {
-#if defined(TARGET_XARCH)
-            case TYP_SIMD64:
-            {
-                allBitsSet->gtSimdVal.i64[7] = 0;
-                allBitsSet->gtSimdVal.i64[6] = 0;
-                allBitsSet->gtSimdVal.i64[5] = 0;
-                allBitsSet->gtSimdVal.i64[4] = 0;
-                FALLTHROUGH;
-            }
-
-            case TYP_SIMD32:
-            {
-                allBitsSet->gtSimdVal.i64[3] = 0;
-                allBitsSet->gtSimdVal.i64[2] = 0;
-                FALLTHROUGH;
-            }
-#endif // TARGET_XARCH
-
-            case TYP_SIMD16:
-            {
-                allBitsSet->gtSimdVal.i64[1] = 0;
-                allBitsSet->gtSimdVal.i64[0] = 0;
-                break;
-            }
-
-            case TYP_SIMD12:
-            {
-                allBitsSet->gtSimdVal.i32[2] = 0;
-                FALLTHROUGH;
-            }
-
-            case TYP_SIMD8:
-            {
-                allBitsSet->gtSimdVal.i64[0] = 0;
-                break;
-            }
-
-            default:
-            {
-                unreached();
-            }
-        }
-
+        allBitsSet->gtSimdVal     = simd_t::Zero();
         return allBitsSet;
     }
 #endif // FEATURE_SIMD
@@ -22700,8 +22611,8 @@ GenTree* Compiler::gtNewSimdShuffleNode(var_types   type,
             GenTree* op1Lower = gtNewSimdHWIntrinsicNode(type, op1, NI_Vector256_GetLower, simdBaseJitType, simdSize,
                                                          isSimdAsHWIntrinsic);
 
-            op2                                = gtNewVconNode(TYP_SIMD16);
-            op2->AsVecCon()->gtSimdVal.v128[0] = vecCns.v128[0];
+            op2                          = gtNewVconNode(TYP_SIMD16);
+            op2->AsVecCon()->gtSimd16Val = vecCns.v128[0];
 
             op1Lower = gtNewSimdHWIntrinsicNode(TYP_SIMD16, op1Lower, op2, NI_SSSE3_Shuffle, simdBaseJitType, 16,
                                                 isSimdAsHWIntrinsic);
@@ -22709,8 +22620,8 @@ GenTree* Compiler::gtNewSimdShuffleNode(var_types   type,
             GenTree* op1Upper = gtNewSimdHWIntrinsicNode(type, op1Dup, gtNewIconNode(1), NI_AVX_ExtractVector128,
                                                          simdBaseJitType, simdSize, isSimdAsHWIntrinsic);
 
-            op2                                = gtNewVconNode(TYP_SIMD16);
-            op2->AsVecCon()->gtSimdVal.v128[0] = vecCns.v128[1];
+            op2                          = gtNewVconNode(TYP_SIMD16);
+            op2->AsVecCon()->gtSimd16Val = vecCns.v128[1];
 
             op1Upper = gtNewSimdHWIntrinsicNode(TYP_SIMD16, op1Upper, op2, NI_SSSE3_Shuffle, simdBaseJitType, 16,
                                                 isSimdAsHWIntrinsic);
@@ -22748,8 +22659,8 @@ GenTree* Compiler::gtNewSimdShuffleNode(var_types   type,
         {
             simdBaseJitType = varTypeIsUnsigned(simdBaseType) ? CORINFO_TYPE_UBYTE : CORINFO_TYPE_BYTE;
 
-            op2                                = gtNewVconNode(type);
-            op2->AsVecCon()->gtSimdVal.v128[0] = vecCns.v128[0];
+            op2                          = gtNewVconNode(type);
+            op2->AsVecCon()->gtSimd16Val = vecCns.v128[0];
 
             return gtNewSimdHWIntrinsicNode(type, op1, op2, NI_SSSE3_Shuffle, simdBaseJitType, simdSize,
                                             isSimdAsHWIntrinsic);
@@ -22795,8 +22706,8 @@ GenTree* Compiler::gtNewSimdShuffleNode(var_types   type,
     {
         assert(!compIsaSupportedDebugOnly(InstructionSet_SSSE3));
 
-        op2                                = gtNewVconNode(type);
-        op2->AsVecCon()->gtSimdVal.v128[0] = mskCns.v128[0];
+        op2                          = gtNewVconNode(type);
+        op2->AsVecCon()->gtSimd16Val = mskCns.v128[0];
 
         GenTree* zero = gtNewZeroConNode(type);
         retNode       = gtNewSimdCndSelNode(type, op2, retNode, zero, simdBaseJitType, simdSize, isSimdAsHWIntrinsic);

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -7310,7 +7310,7 @@ GenTree* Compiler::gtNewAllBitsSetConNode(var_types type)
 
             case TYP_SIMD12:
             {
-                allBitsSet->gtSimdVal.i32[3] = -1;
+                allBitsSet->gtSimdVal.i32[2] = -1;
                 FALLTHROUGH;
             }
 
@@ -7385,7 +7385,7 @@ GenTree* Compiler::gtNewZeroConNode(var_types type)
 
             case TYP_SIMD12:
             {
-                allBitsSet->gtSimdVal.i32[3] = 0;
+                allBitsSet->gtSimdVal.i32[2] = 0;
                 FALLTHROUGH;
             }
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -6624,7 +6624,7 @@ struct GenTreeVecCon : public GenTree
 
             case TYP_SIMD12:
             {
-                if (left->gtSimdVal.u32[3] != right->gtSimdVal.u32[3])
+                if (left->gtSimdVal.u32[2] != right->gtSimdVal.u32[2])
                 {
                     return false;
                 }
@@ -9905,7 +9905,13 @@ inline GenTree* GenTree::GetIndirOrArrMetaDataAddr()
 /*****************************************************************************/
 
 const size_t TREE_NODE_SZ_SMALL = sizeof(GenTreeLclFld);
-const size_t TREE_NODE_SZ_LARGE = sizeof(GenTreeCall);
+
+// For some configurations, such as x86 release, GenTreeVecCon is
+// the largest by a small margin due to needing to carry a simd64_t
+// constant value. Otherwise, GenTreeCall is the largest.
+
+const size_t TREE_NODE_SZ_LARGE =
+    (sizeof(GenTreeVecCon) < sizeof(GenTreeCall)) ? sizeof(GenTreeCall) : sizeof(GenTreeVecCon);
 
 enum varRefKinds
 {

--- a/src/coreclr/jit/hwintrinsicarm64.cpp
+++ b/src/coreclr/jit/hwintrinsicarm64.cpp
@@ -458,8 +458,8 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                         GenTreeVecCon* vecCon = op1->AsVecCon();
                         vecCon->gtType        = TYP_SIMD16;
 
-                        vecCon->gtSimd16Val.f32[2] = 0.0f;
-                        vecCon->gtSimd16Val.f32[3] = 0.0f;
+                        vecCon->gtSimdVal.f32[2] = 0.0f;
+                        vecCon->gtSimdVal.f32[3] = 0.0f;
 
                         return vecCon;
                     }
@@ -488,7 +488,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                         GenTreeVecCon* vecCon = op1->AsVecCon();
                         vecCon->gtType        = TYP_SIMD16;
 
-                        vecCon->gtSimd16Val.f32[3] = 0.0f;
+                        vecCon->gtSimdVal.f32[3] = 0.0f;
                         return vecCon;
                     }
 
@@ -712,7 +712,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                         for (uint32_t index = 0; index < sig->numArgs; index++)
                         {
                             cnsVal = static_cast<uint8_t>(impPopStack().val->AsIntConCommon()->IntegralValue());
-                            vecCon->gtSimd16Val.u8[simdLength - 1 - index] = cnsVal;
+                            vecCon->gtSimdVal.u8[simdLength - 1 - index] = cnsVal;
                         }
                         break;
                     }
@@ -725,7 +725,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                         for (uint32_t index = 0; index < sig->numArgs; index++)
                         {
                             cnsVal = static_cast<uint16_t>(impPopStack().val->AsIntConCommon()->IntegralValue());
-                            vecCon->gtSimd16Val.u16[simdLength - 1 - index] = cnsVal;
+                            vecCon->gtSimdVal.u16[simdLength - 1 - index] = cnsVal;
                         }
                         break;
                     }
@@ -738,7 +738,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                         for (uint32_t index = 0; index < sig->numArgs; index++)
                         {
                             cnsVal = static_cast<uint32_t>(impPopStack().val->AsIntConCommon()->IntegralValue());
-                            vecCon->gtSimd16Val.u32[simdLength - 1 - index] = cnsVal;
+                            vecCon->gtSimdVal.u32[simdLength - 1 - index] = cnsVal;
                         }
                         break;
                     }
@@ -751,7 +751,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                         for (uint32_t index = 0; index < sig->numArgs; index++)
                         {
                             cnsVal = static_cast<uint64_t>(impPopStack().val->AsIntConCommon()->IntegralValue());
-                            vecCon->gtSimd16Val.u64[simdLength - 1 - index] = cnsVal;
+                            vecCon->gtSimdVal.u64[simdLength - 1 - index] = cnsVal;
                         }
                         break;
                     }
@@ -763,7 +763,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                         for (uint32_t index = 0; index < sig->numArgs; index++)
                         {
                             cnsVal = static_cast<float>(impPopStack().val->AsDblCon()->DconValue());
-                            vecCon->gtSimd16Val.f32[simdLength - 1 - index] = cnsVal;
+                            vecCon->gtSimdVal.f32[simdLength - 1 - index] = cnsVal;
                         }
                         break;
                     }
@@ -775,7 +775,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                         for (uint32_t index = 0; index < sig->numArgs; index++)
                         {
                             cnsVal = static_cast<double>(impPopStack().val->AsDblCon()->DconValue());
-                            vecCon->gtSimd16Val.f64[simdLength - 1 - index] = cnsVal;
+                            vecCon->gtSimdVal.f64[simdLength - 1 - index] = cnsVal;
                         }
                         break;
                     }
@@ -969,13 +969,13 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                     simdBaseType    = TYP_UBYTE;
                     simdBaseJitType = CORINFO_TYPE_UBYTE;
 
-                    vecCon2->gtSimd16Val.u64[0] = 0x8080808080808080;
-                    vecCon3->gtSimd16Val.u64[0] = 0x00FFFEFDFCFBFAF9;
+                    vecCon2->gtSimdVal.u64[0] = 0x8080808080808080;
+                    vecCon3->gtSimdVal.u64[0] = 0x00FFFEFDFCFBFAF9;
 
                     if (simdSize == 16)
                     {
-                        vecCon2->gtSimd16Val.u64[1] = 0x8080808080808080;
-                        vecCon3->gtSimd16Val.u64[1] = 0x00FFFEFDFCFBFAF9;
+                        vecCon2->gtSimdVal.u64[1] = 0x8080808080808080;
+                        vecCon3->gtSimdVal.u64[1] = 0x00FFFEFDFCFBFAF9;
                     }
                     break;
                 }
@@ -986,13 +986,13 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                     simdBaseType    = TYP_USHORT;
                     simdBaseJitType = CORINFO_TYPE_USHORT;
 
-                    vecCon2->gtSimd16Val.u64[0] = 0x8000800080008000;
-                    vecCon3->gtSimd16Val.u64[0] = 0xFFF4FFF3FFF2FFF1;
+                    vecCon2->gtSimdVal.u64[0] = 0x8000800080008000;
+                    vecCon3->gtSimdVal.u64[0] = 0xFFF4FFF3FFF2FFF1;
 
                     if (simdSize == 16)
                     {
-                        vecCon2->gtSimd16Val.u64[1] = 0x8000800080008000;
-                        vecCon3->gtSimd16Val.u64[1] = 0xFFF8FFF7FFF6FFF5;
+                        vecCon2->gtSimdVal.u64[1] = 0x8000800080008000;
+                        vecCon3->gtSimdVal.u64[1] = 0xFFF8FFF7FFF6FFF5;
                     }
                     break;
                 }
@@ -1004,13 +1004,13 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                     simdBaseType    = TYP_INT;
                     simdBaseJitType = CORINFO_TYPE_INT;
 
-                    vecCon2->gtSimd16Val.u64[0] = 0x8000000080000000;
-                    vecCon3->gtSimd16Val.u64[0] = 0xFFFFFFE2FFFFFFE1;
+                    vecCon2->gtSimdVal.u64[0] = 0x8000000080000000;
+                    vecCon3->gtSimdVal.u64[0] = 0xFFFFFFE2FFFFFFE1;
 
                     if (simdSize == 16)
                     {
-                        vecCon2->gtSimd16Val.u64[1] = 0x8000000080000000;
-                        vecCon3->gtSimd16Val.u64[1] = 0xFFFFFFE4FFFFFFE3;
+                        vecCon2->gtSimdVal.u64[1] = 0x8000000080000000;
+                        vecCon3->gtSimdVal.u64[1] = 0xFFFFFFE4FFFFFFE3;
                     }
                     break;
                 }
@@ -1022,13 +1022,13 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                     simdBaseType    = TYP_LONG;
                     simdBaseJitType = CORINFO_TYPE_LONG;
 
-                    vecCon2->gtSimd16Val.u64[0] = 0x8000000000000000;
-                    vecCon3->gtSimd16Val.u64[0] = 0xFFFFFFFFFFFFFFC1;
+                    vecCon2->gtSimdVal.u64[0] = 0x8000000000000000;
+                    vecCon3->gtSimdVal.u64[0] = 0xFFFFFFFFFFFFFFC1;
 
                     if (simdSize == 16)
                     {
-                        vecCon2->gtSimd16Val.u64[1] = 0x8000000000000000;
-                        vecCon3->gtSimd16Val.u64[1] = 0xFFFFFFFFFFFFFFC2;
+                        vecCon2->gtSimdVal.u64[1] = 0x8000000000000000;
+                        vecCon3->gtSimdVal.u64[1] = 0xFFFFFFFFFFFFFFC2;
                     }
                     break;
                 }

--- a/src/coreclr/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/jit/hwintrinsicxarch.cpp
@@ -667,8 +667,8 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                         GenTreeVecCon* vecCon = op1->AsVecCon();
                         vecCon->gtType        = TYP_SIMD16;
 
-                        vecCon->gtSimd16Val.f32[2] = 0.0f;
-                        vecCon->gtSimd16Val.f32[3] = 0.0f;
+                        vecCon->gtSimdVal.f32[2] = 0.0f;
+                        vecCon->gtSimdVal.f32[3] = 0.0f;
 
                         return vecCon;
                     }
@@ -697,7 +697,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                         GenTreeVecCon* vecCon = op1->AsVecCon();
                         vecCon->gtType        = TYP_SIMD16;
 
-                        vecCon->gtSimd16Val.f32[3] = 0.0f;
+                        vecCon->gtSimdVal.f32[3] = 0.0f;
                         return vecCon;
                     }
 
@@ -942,11 +942,10 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                 }
             }
 
-            // TODO-XArch-AVX512 : Add this path for simd64 once vecCon supports simd64.
-            if (isConstant && (simdSize != 64))
+            if (isConstant)
             {
-                // Some of the below code assumes 16 or 32 byte SIMD types
-                assert((simdSize == 16) || (simdSize == 32));
+                // Some of the below code assumes 16/32/64 byte SIMD types
+                assert((simdSize == 16) || (simdSize == 32) || (simdSize == 64));
 
                 GenTreeVecCon* vecCon = gtNewVconNode(retType);
 
@@ -960,7 +959,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                         for (uint32_t index = 0; index < sig->numArgs; index++)
                         {
                             cnsVal = static_cast<uint8_t>(impPopStack().val->AsIntConCommon()->IntegralValue());
-                            vecCon->gtSimd32Val.u8[simdLength - 1 - index] = cnsVal;
+                            vecCon->gtSimdVal.u8[simdLength - 1 - index] = cnsVal;
                         }
                         break;
                     }
@@ -973,7 +972,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                         for (uint32_t index = 0; index < sig->numArgs; index++)
                         {
                             cnsVal = static_cast<uint16_t>(impPopStack().val->AsIntConCommon()->IntegralValue());
-                            vecCon->gtSimd32Val.u16[simdLength - 1 - index] = cnsVal;
+                            vecCon->gtSimdVal.u16[simdLength - 1 - index] = cnsVal;
                         }
                         break;
                     }
@@ -986,7 +985,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                         for (uint32_t index = 0; index < sig->numArgs; index++)
                         {
                             cnsVal = static_cast<uint32_t>(impPopStack().val->AsIntConCommon()->IntegralValue());
-                            vecCon->gtSimd32Val.u32[simdLength - 1 - index] = cnsVal;
+                            vecCon->gtSimdVal.u32[simdLength - 1 - index] = cnsVal;
                         }
                         break;
                     }
@@ -999,7 +998,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                         for (uint32_t index = 0; index < sig->numArgs; index++)
                         {
                             cnsVal = static_cast<uint64_t>(impPopStack().val->AsIntConCommon()->IntegralValue());
-                            vecCon->gtSimd32Val.u64[simdLength - 1 - index] = cnsVal;
+                            vecCon->gtSimdVal.u64[simdLength - 1 - index] = cnsVal;
                         }
                         break;
                     }
@@ -1011,7 +1010,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                         for (uint32_t index = 0; index < sig->numArgs; index++)
                         {
                             cnsVal = static_cast<float>(impPopStack().val->AsDblCon()->DconValue());
-                            vecCon->gtSimd32Val.f32[simdLength - 1 - index] = cnsVal;
+                            vecCon->gtSimdVal.f32[simdLength - 1 - index] = cnsVal;
                         }
                         break;
                     }
@@ -1023,7 +1022,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                         for (uint32_t index = 0; index < sig->numArgs; index++)
                         {
                             double cnsVal = static_cast<double>(impPopStack().val->AsDblCon()->DconValue());
-                            vecCon->gtSimd32Val.f64[simdLength - 1 - index] = cnsVal;
+                            vecCon->gtSimdVal.f64[simdLength - 1 - index] = cnsVal;
                         }
                         break;
                     }
@@ -1274,7 +1273,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                     case TYP_SHORT:
                     case TYP_USHORT:
                     {
-                        simd32_t simd32Val = {};
+                        simd_t simdVal = {};
 
                         assert((simdSize == 16) || (simdSize == 32) || (simdSize == 64));
                         simdBaseJitType = varTypeIsUnsigned(simdBaseType) ? CORINFO_TYPE_UBYTE : CORINFO_TYPE_BYTE;
@@ -1284,15 +1283,15 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                         //
                         // The most significant bit being set means zero the value
 
-                        simd32Val.u64[0] = 0x0F0D0B0907050301;
-                        simd32Val.u64[1] = 0x8080808080808080;
+                        simdVal.u64[0] = 0x0F0D0B0907050301;
+                        simdVal.u64[1] = 0x8080808080808080;
 
                         if (simdSize == 32)
                         {
                             // Vector256 works on 2x128-bit lanes, so repeat the same indices for the upper lane
 
-                            simd32Val.u64[2] = 0x0F0D0B0907050301;
-                            simd32Val.u64[3] = 0x8080808080808080;
+                            simdVal.u64[2] = 0x0F0D0B0907050301;
+                            simdVal.u64[3] = 0x8080808080808080;
 
                             shuffleIntrinsic  = NI_AVX2_Shuffle;
                             moveMaskIntrinsic = NI_AVX2_MoveMask;
@@ -1307,8 +1306,8 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                             return nullptr;
                         }
 
-                        op2                          = gtNewVconNode(simdType);
-                        op2->AsVecCon()->gtSimd32Val = simd32Val;
+                        op2 = gtNewVconNode(simdType);
+                        memcpy(&op2->AsVecCon()->gtSimdVal, &simdVal, simdSize);
 
                         op1 = impSIMDPopStack(simdType);
                         op1 = gtNewSimdHWIntrinsicNode(simdType, op1, op2, shuffleIntrinsic, simdBaseJitType, simdSize);

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3981,7 +3981,7 @@ GenTree* Compiler::impImportStaticReadOnlyField(CORINFO_FIELD_HANDLE field, CORI
                     if (hwAccelerated)
                     {
                         GenTreeVecCon* vec = gtNewVconNode(simdType);
-                        memcpy(&vec->gtSimd32Val, buffer, totalSize);
+                        memcpy(&vec->gtSimdVal, buffer, totalSize);
                         return vec;
                     }
                 }

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3522,11 +3522,11 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
 
                 if (callJitType == CORINFO_TYPE_FLOAT)
                 {
-                    vecCon->gtSimd16Val.f32[0] = (float)op1->AsDblCon()->DconValue();
+                    vecCon->gtSimdVal.f32[0] = (float)op1->AsDblCon()->DconValue();
                 }
                 else
                 {
-                    vecCon->gtSimd16Val.f64[0] = op1->AsDblCon()->DconValue();
+                    vecCon->gtSimdVal.f64[0] = op1->AsDblCon()->DconValue();
                 }
 
                 op1 = vecCon;

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -772,34 +772,37 @@ CodeGen::OperandDesc CodeGen::genOperandDesc(GenTree* op)
 #if defined(FEATURE_SIMD)
                     case TYP_SIMD8:
                     {
-                        simd8_t constValue = op->AsVecCon()->gtSimd8Val;
+                        simd8_t constValue;
+                        memcpy(&constValue, &op->AsVecCon()->gtSimdVal, sizeof(simd8_t));
                         return OperandDesc(emit->emitSimd8Const(constValue));
                     }
 
                     case TYP_SIMD12:
-                    case TYP_SIMD16:
                     {
                         simd16_t constValue = {};
-
-                        if (op->TypeIs(TYP_SIMD12))
-                            memcpy(&constValue, &op->AsVecCon()->gtSimd12Val, sizeof(simd12_t));
-                        else
-                            constValue = op->AsVecCon()->gtSimd16Val;
-
+                        memcpy(&constValue, &op->AsVecCon()->gtSimdVal, sizeof(simd12_t));
+                        return OperandDesc(emit->emitSimd16Const(constValue));
+                    }
+                    case TYP_SIMD16:
+                    {
+                        simd16_t constValue;
+                        memcpy(&constValue, &op->AsVecCon()->gtSimdVal, sizeof(simd16_t));
                         return OperandDesc(emit->emitSimd16Const(constValue));
                     }
 
 #if defined(TARGET_XARCH)
                     case TYP_SIMD32:
                     {
-                        simd32_t constValue = op->AsVecCon()->gtSimd32Val;
+                        simd32_t constValue;
+                        memcpy(&constValue, &op->AsVecCon()->gtSimdVal, sizeof(simd32_t));
                         return OperandDesc(emit->emitSimd32Const(constValue));
                     }
 
-                    case TYP_SIMD64: // TODO-XArch-AVX512: Fix once GenTreeVecCon supports gtSimd64Val.
+                    case TYP_SIMD64:
                     {
-                        simd32_t constValue = op->AsVecCon()->gtSimd32Val;
-                        return OperandDesc(emit->emitSimd32Const(constValue));
+                        simd64_t constValue;
+                        memcpy(&constValue, &op->AsVecCon()->gtSimdVal, sizeof(simd64_t));
+                        return OperandDesc(emit->emitSimd64Const(constValue));
                     }
 #endif // TARGET_XARCH
 #endif // FEATURE_SIMD

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -1430,7 +1430,7 @@ GenTree* Lowering::LowerHWIntrinsicCreate(GenTreeHWIntrinsic* node)
     CorInfoType    simdBaseJitType = node->GetSimdBaseJitType();
     var_types      simdBaseType    = node->GetSimdBaseType();
     unsigned       simdSize        = node->GetSimdSize();
-    simd32_t       simd32Val       = {};
+    simd_t         simdVal         = {};
 
     if ((simdSize == 8) && (simdType == TYP_DOUBLE))
     {
@@ -1443,7 +1443,7 @@ GenTree* Lowering::LowerHWIntrinsicCreate(GenTreeHWIntrinsic* node)
     assert(varTypeIsArithmetic(simdBaseType));
     assert(simdSize != 0);
 
-    bool   isConstant     = GenTreeVecCon::IsHWIntrinsicCreateConstant<simd32_t>(node, simd32Val);
+    bool   isConstant     = GenTreeVecCon::IsHWIntrinsicCreateConstant<simd_t>(node, simdVal);
     bool   isCreateScalar = (intrinsicId == NI_Vector64_CreateScalar) || (intrinsicId == NI_Vector128_CreateScalar);
     size_t argCnt         = node->GetOperandCount();
 
@@ -1468,7 +1468,7 @@ GenTree* Lowering::LowerHWIntrinsicCreate(GenTreeHWIntrinsic* node)
 
         GenTreeVecCon* vecCon = comp->gtNewVconNode(simdType);
 
-        vecCon->gtSimd32Val = simd32Val;
+        vecCon->gtSimdVal = simdVal;
         BlockRange().InsertBefore(node, vecCon);
 
         LIR::Use use;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -10779,17 +10779,9 @@ GenTree* Compiler::fgOptimizeHWIntrinsic(GenTreeHWIntrinsic* node)
         return node;
     }
 
-#if defined(TARGET_XARCH)
-    // TODO-XArch-AVX512: Enable for simd64 once GenTreeVecCon supports gtSimd64Val.
-    if (node->TypeGet() == TYP_SIMD64)
-    {
-        return node;
-    }
-#endif // TARGET_XARCH
+    simd_t simdVal = {};
 
-    simd32_t simd32Val = {};
-
-    if (GenTreeVecCon::IsHWIntrinsicCreateConstant<simd32_t>(node, simd32Val))
+    if (GenTreeVecCon::IsHWIntrinsicCreateConstant<simd_t>(node, simdVal))
     {
         GenTreeVecCon* vecCon = gtNewVconNode(node->TypeGet());
 
@@ -10798,7 +10790,7 @@ GenTree* Compiler::fgOptimizeHWIntrinsic(GenTreeHWIntrinsic* node)
             DEBUG_DESTROY_NODE(arg);
         }
 
-        vecCon->gtSimd32Val = simd32Val;
+        vecCon->gtSimdVal = simdVal;
         INDEBUG(vecCon->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED);
         return vecCon;
     }

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -2656,7 +2656,7 @@ public:
                 int spillSimdRegInProlog = 1;
 
 #if defined(TARGET_XARCH)
-                // If we have a SIMD32 that is live across a call we have even higher spill costs
+                // If we have a SIMD32/64 that is live across a call we have even higher spill costs
                 //
                 if (candidate->Expr()->TypeIs(TYP_SIMD32, TYP_SIMD64))
                 {

--- a/src/coreclr/jit/simd.h
+++ b/src/coreclr/jit/simd.h
@@ -123,6 +123,7 @@ struct simd16_t
     }
 };
 
+#if defined(TARGET_XARCH)
 struct simd32_t
 {
     union {
@@ -181,6 +182,11 @@ struct simd64_t
         return (v256[0] != other.v256[0]) || (v256[1] != other.v256[1]);
     }
 };
+
+typedef simd64_t simd_t;
+#else
+typedef simd16_t simd_t;
+#endif
 
 template <typename TBase>
 TBase EvaluateUnaryScalarSpecialized(genTreeOps oper, TBase arg0)

--- a/src/coreclr/jit/simd.h
+++ b/src/coreclr/jit/simd.h
@@ -62,7 +62,31 @@ struct simd8_t
 
     bool operator!=(const simd8_t& other) const
     {
-        return (u64[0] != other.u64[0]);
+        return !(*this == other);
+    }
+
+    static simd8_t AllBitsSet()
+    {
+        simd8_t result;
+
+        result.u64[0] = 0xFFFFFFFFFFFFFFFF;
+
+        return result;
+    }
+
+    bool IsAllBitsSet() const
+    {
+        return *this == AllBitsSet();
+    }
+
+    bool IsZero() const
+    {
+        return *this == Zero();
+    }
+
+    static simd8_t Zero()
+    {
+        return {};
     }
 };
 
@@ -92,7 +116,33 @@ struct simd12_t
 
     bool operator!=(const simd12_t& other) const
     {
-        return (u32[0] != other.u32[0]) || (u32[1] != other.u32[1]) || (u32[2] != other.u32[2]);
+        return !(*this == other);
+    }
+
+    static simd12_t AllBitsSet()
+    {
+        simd12_t result;
+
+        result.u32[0] = 0xFFFFFFFF;
+        result.u32[1] = 0xFFFFFFFF;
+        result.u32[2] = 0xFFFFFFFF;
+
+        return result;
+    }
+
+    bool IsAllBitsSet() const
+    {
+        return *this == AllBitsSet();
+    }
+
+    bool IsZero() const
+    {
+        return *this == Zero();
+    }
+
+    static simd12_t Zero()
+    {
+        return {};
     }
 };
 
@@ -114,12 +164,37 @@ struct simd16_t
 
     bool operator==(const simd16_t& other) const
     {
-        return (u64[0] == other.u64[0]) && (u64[1] == other.u64[1]);
+        return (v64[0] == other.v64[0]) && (v64[1] == other.v64[1]);
     }
 
     bool operator!=(const simd16_t& other) const
     {
-        return (u64[0] != other.u64[0]) || (u64[1] != other.u64[1]);
+        return !(*this == other);
+    }
+
+    static simd16_t AllBitsSet()
+    {
+        simd16_t result;
+
+        result.v64[0] = simd8_t::AllBitsSet();
+        result.v64[1] = simd8_t::AllBitsSet();
+
+        return result;
+    }
+
+    bool IsAllBitsSet() const
+    {
+        return *this == AllBitsSet();
+    }
+
+    bool IsZero() const
+    {
+        return *this == Zero();
+    }
+
+    static simd16_t Zero()
+    {
+        return {};
     }
 };
 
@@ -143,14 +218,37 @@ struct simd32_t
 
     bool operator==(const simd32_t& other) const
     {
-        return (u64[0] == other.u64[0]) && (u64[1] == other.u64[1]) && (u64[2] == other.u64[2]) &&
-               (u64[3] == other.u64[3]);
+        return (v128[0] == other.v128[0]) && (v128[1] == other.v128[1]);
     }
 
     bool operator!=(const simd32_t& other) const
     {
-        return (u64[0] != other.u64[0]) || (u64[1] != other.u64[1]) || (u64[2] != other.u64[2]) ||
-               (u64[3] != other.u64[3]);
+        return !(*this == other);
+    }
+
+    static simd32_t AllBitsSet()
+    {
+        simd32_t result;
+
+        result.v128[0] = simd16_t::AllBitsSet();
+        result.v128[1] = simd16_t::AllBitsSet();
+
+        return result;
+    }
+
+    bool IsAllBitsSet() const
+    {
+        return *this == AllBitsSet();
+    }
+
+    bool IsZero() const
+    {
+        return *this == Zero();
+    }
+
+    static simd32_t Zero()
+    {
+        return {};
     }
 };
 
@@ -179,7 +277,32 @@ struct simd64_t
 
     bool operator!=(const simd64_t& other) const
     {
-        return (v256[0] != other.v256[0]) || (v256[1] != other.v256[1]);
+        return !(*this == other);
+    }
+
+    static simd64_t AllBitsSet()
+    {
+        simd64_t result;
+
+        result.v256[0] = simd32_t::AllBitsSet();
+        result.v256[1] = simd32_t::AllBitsSet();
+
+        return result;
+    }
+
+    bool IsAllBitsSet() const
+    {
+        return *this == AllBitsSet();
+    }
+
+    bool IsZero() const
+    {
+        return *this == Zero();
+    }
+
+    static simd64_t Zero()
+    {
+        return {};
     }
 };
 

--- a/src/coreclr/jit/simdashwintrinsic.cpp
+++ b/src/coreclr/jit/simdashwintrinsic.cpp
@@ -815,10 +815,10 @@ GenTree* Compiler::impSimdAsHWIntrinsicSpecial(NamedIntrinsic       intrinsic,
                 {
                     GenTreeVecCon* vecCon = gtNewVconNode(retType);
 
-                    vecCon->gtSimd16Val.f32[0] = 1.0f;
-                    vecCon->gtSimd16Val.f32[1] = 0.0f;
-                    vecCon->gtSimd16Val.f32[2] = 0.0f;
-                    vecCon->gtSimd16Val.f32[3] = 0.0f;
+                    vecCon->gtSimdVal.f32[0] = 1.0f;
+                    vecCon->gtSimdVal.f32[1] = 0.0f;
+                    vecCon->gtSimdVal.f32[2] = 0.0f;
+                    vecCon->gtSimdVal.f32[3] = 0.0f;
 
                     return vecCon;
                 }
@@ -829,10 +829,10 @@ GenTree* Compiler::impSimdAsHWIntrinsicSpecial(NamedIntrinsic       intrinsic,
                 {
                     GenTreeVecCon* vecCon = gtNewVconNode(retType);
 
-                    vecCon->gtSimd16Val.f32[0] = 0.0f;
-                    vecCon->gtSimd16Val.f32[1] = 1.0f;
-                    vecCon->gtSimd16Val.f32[2] = 0.0f;
-                    vecCon->gtSimd16Val.f32[3] = 0.0f;
+                    vecCon->gtSimdVal.f32[0] = 0.0f;
+                    vecCon->gtSimdVal.f32[1] = 1.0f;
+                    vecCon->gtSimdVal.f32[2] = 0.0f;
+                    vecCon->gtSimdVal.f32[3] = 0.0f;
 
                     return vecCon;
                 }
@@ -842,10 +842,10 @@ GenTree* Compiler::impSimdAsHWIntrinsicSpecial(NamedIntrinsic       intrinsic,
                 {
                     GenTreeVecCon* vecCon = gtNewVconNode(retType);
 
-                    vecCon->gtSimd16Val.f32[0] = 0.0f;
-                    vecCon->gtSimd16Val.f32[1] = 0.0f;
-                    vecCon->gtSimd16Val.f32[2] = 1.0f;
-                    vecCon->gtSimd16Val.f32[3] = 0.0f;
+                    vecCon->gtSimdVal.f32[0] = 0.0f;
+                    vecCon->gtSimdVal.f32[1] = 0.0f;
+                    vecCon->gtSimdVal.f32[2] = 1.0f;
+                    vecCon->gtSimdVal.f32[3] = 0.0f;
 
                     return vecCon;
                 }
@@ -855,10 +855,10 @@ GenTree* Compiler::impSimdAsHWIntrinsicSpecial(NamedIntrinsic       intrinsic,
                 {
                     GenTreeVecCon* vecCon = gtNewVconNode(retType);
 
-                    vecCon->gtSimd16Val.f32[0] = 0.0f;
-                    vecCon->gtSimd16Val.f32[1] = 0.0f;
-                    vecCon->gtSimd16Val.f32[2] = 0.0f;
-                    vecCon->gtSimd16Val.f32[3] = 1.0f;
+                    vecCon->gtSimdVal.f32[0] = 0.0f;
+                    vecCon->gtSimdVal.f32[1] = 0.0f;
+                    vecCon->gtSimdVal.f32[2] = 0.0f;
+                    vecCon->gtSimdVal.f32[3] = 1.0f;
 
                     return vecCon;
                 }
@@ -937,10 +937,10 @@ GenTree* Compiler::impSimdAsHWIntrinsicSpecial(NamedIntrinsic       intrinsic,
                 {
                     GenTreeVecCon* vecCon = gtNewVconNode(retType);
 
-                    vecCon->gtSimd16Val.f32[0] = -1.0f;
-                    vecCon->gtSimd16Val.f32[1] = -1.0f;
-                    vecCon->gtSimd16Val.f32[2] = -1.0f;
-                    vecCon->gtSimd16Val.f32[3] = +1.0f;
+                    vecCon->gtSimdVal.f32[0] = -1.0f;
+                    vecCon->gtSimdVal.f32[1] = -1.0f;
+                    vecCon->gtSimdVal.f32[2] = -1.0f;
+                    vecCon->gtSimdVal.f32[3] = +1.0f;
 
                     return gtNewSimdBinOpNode(GT_MUL, retType, op1, vecCon, simdBaseJitType, simdSize,
                                               /* isSimdAsHWIntrinsic */ true);
@@ -966,10 +966,10 @@ GenTree* Compiler::impSimdAsHWIntrinsicSpecial(NamedIntrinsic       intrinsic,
 
                     GenTreeVecCon* vecCon = gtNewVconNode(retType);
 
-                    vecCon->gtSimd16Val.f32[0] = -1.0f;
-                    vecCon->gtSimd16Val.f32[1] = -1.0f;
-                    vecCon->gtSimd16Val.f32[2] = -1.0f;
-                    vecCon->gtSimd16Val.f32[3] = +1.0f;
+                    vecCon->gtSimdVal.f32[0] = -1.0f;
+                    vecCon->gtSimdVal.f32[1] = -1.0f;
+                    vecCon->gtSimdVal.f32[2] = -1.0f;
+                    vecCon->gtSimdVal.f32[3] = +1.0f;
 
                     GenTree* conjugate = gtNewSimdBinOpNode(GT_MUL, retType, op1, vecCon, simdBaseJitType, simdSize,
                                                             /* isSimdAsHWIntrinsic */ true);
@@ -1923,8 +1923,8 @@ GenTree* Compiler::impSimdAsHWIntrinsicSpecial(NamedIntrinsic       intrinsic,
 
                         float cnsVal = 0;
 
-                        vecCon->gtSimd8Val.f32[0] = static_cast<float>(op2->AsDblCon()->DconValue());
-                        vecCon->gtSimd8Val.f32[1] = static_cast<float>(op3->AsDblCon()->DconValue());
+                        vecCon->gtSimdVal.f32[0] = static_cast<float>(op2->AsDblCon()->DconValue());
+                        vecCon->gtSimdVal.f32[1] = static_cast<float>(op3->AsDblCon()->DconValue());
 
                         copyBlkSrc = vecCon;
                     }
@@ -1976,11 +1976,11 @@ GenTree* Compiler::impSimdAsHWIntrinsicSpecial(NamedIntrinsic       intrinsic,
 
                         if (simdSize == 12)
                         {
-                            vecCon->gtSimd12Val.f32[2] = static_cast<float>(op3->AsDblCon()->DconValue());
+                            vecCon->gtSimdVal.f32[2] = static_cast<float>(op3->AsDblCon()->DconValue());
                         }
                         else
                         {
-                            vecCon->gtSimd16Val.f32[3] = static_cast<float>(op3->AsDblCon()->DconValue());
+                            vecCon->gtSimdVal.f32[3] = static_cast<float>(op3->AsDblCon()->DconValue());
                         }
 
                         copyBlkSrc = vecCon;
@@ -2064,9 +2064,9 @@ GenTree* Compiler::impSimdAsHWIntrinsicSpecial(NamedIntrinsic       intrinsic,
 
                         float cnsVal = 0;
 
-                        vecCon->gtSimd12Val.f32[0] = static_cast<float>(op2->AsDblCon()->DconValue());
-                        vecCon->gtSimd12Val.f32[1] = static_cast<float>(op3->AsDblCon()->DconValue());
-                        vecCon->gtSimd12Val.f32[2] = static_cast<float>(op4->AsDblCon()->DconValue());
+                        vecCon->gtSimdVal.f32[0] = static_cast<float>(op2->AsDblCon()->DconValue());
+                        vecCon->gtSimdVal.f32[1] = static_cast<float>(op3->AsDblCon()->DconValue());
+                        vecCon->gtSimdVal.f32[2] = static_cast<float>(op4->AsDblCon()->DconValue());
 
                         copyBlkSrc = vecCon;
                     }
@@ -2106,8 +2106,8 @@ GenTree* Compiler::impSimdAsHWIntrinsicSpecial(NamedIntrinsic       intrinsic,
                         GenTreeVecCon* vecCon = op2->AsVecCon();
                         vecCon->gtType        = simdType;
 
-                        vecCon->gtSimd16Val.f32[2] = static_cast<float>(op3->AsDblCon()->DconValue());
-                        vecCon->gtSimd16Val.f32[3] = static_cast<float>(op4->AsDblCon()->DconValue());
+                        vecCon->gtSimdVal.f32[2] = static_cast<float>(op3->AsDblCon()->DconValue());
+                        vecCon->gtSimdVal.f32[3] = static_cast<float>(op4->AsDblCon()->DconValue());
 
                         copyBlkSrc = vecCon;
                     }
@@ -2191,10 +2191,10 @@ GenTree* Compiler::impSimdAsHWIntrinsicSpecial(NamedIntrinsic       intrinsic,
 
                         float cnsVal = 0;
 
-                        vecCon->gtSimd16Val.f32[0] = static_cast<float>(op2->AsDblCon()->DconValue());
-                        vecCon->gtSimd16Val.f32[1] = static_cast<float>(op3->AsDblCon()->DconValue());
-                        vecCon->gtSimd16Val.f32[2] = static_cast<float>(op4->AsDblCon()->DconValue());
-                        vecCon->gtSimd16Val.f32[3] = static_cast<float>(op5->AsDblCon()->DconValue());
+                        vecCon->gtSimdVal.f32[0] = static_cast<float>(op2->AsDblCon()->DconValue());
+                        vecCon->gtSimdVal.f32[1] = static_cast<float>(op3->AsDblCon()->DconValue());
+                        vecCon->gtSimdVal.f32[2] = static_cast<float>(op4->AsDblCon()->DconValue());
+                        vecCon->gtSimdVal.f32[3] = static_cast<float>(op5->AsDblCon()->DconValue());
 
                         copyBlkSrc = vecCon;
                     }

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -444,8 +444,10 @@ ValueNumStore::ValueNumStore(Compiler* comp, CompAllocator alloc)
     , m_simd8CnsMap(nullptr)
     , m_simd12CnsMap(nullptr)
     , m_simd16CnsMap(nullptr)
+#if defined(TARGET_XARCH)
     , m_simd32CnsMap(nullptr)
     , m_simd64CnsMap(nullptr)
+#endif // TARGET_XARCH
 #endif // FEATURE_SIMD
     , m_VNFunc0Map(nullptr)
     , m_VNFunc1Map(nullptr)
@@ -2049,10 +2051,7 @@ ValueNum ValueNumStore::VNAllBitsForType(var_types typ)
         case TYP_SIMD8:
         {
             simd8_t cnsVal;
-
-            cnsVal.u32[0] = 0xFFFFFFFF;
-            cnsVal.u32[1] = 0xFFFFFFFF;
-
+            cnsVal.u64[0] = 0xFFFFFFFFFFFFFFFF;
             return VNForSimd8Con(cnsVal);
         }
 
@@ -2060,9 +2059,8 @@ ValueNum ValueNumStore::VNAllBitsForType(var_types typ)
         {
             simd12_t cnsVal;
 
-            cnsVal.u32[0] = 0xFFFFFFFF;
-            cnsVal.u32[1] = 0xFFFFFFFF;
-            cnsVal.u32[2] = 0xFFFFFFFF;
+            cnsVal.u64[0] = 0xFFFFFFFFFFFFFFFF;
+            cnsVal.u32[3] = 0xFFFFFFFF;
 
             return VNForSimd12Con(cnsVal);
         }
@@ -2071,10 +2069,8 @@ ValueNum ValueNumStore::VNAllBitsForType(var_types typ)
         {
             simd16_t cnsVal;
 
-            cnsVal.u32[0] = 0xFFFFFFFF;
-            cnsVal.u32[1] = 0xFFFFFFFF;
-            cnsVal.u32[2] = 0xFFFFFFFF;
-            cnsVal.u32[3] = 0xFFFFFFFF;
+            cnsVal.u64[0] = 0xFFFFFFFFFFFFFFFF;
+            cnsVal.u64[1] = 0xFFFFFFFFFFFFFFFF;
 
             return VNForSimd16Con(cnsVal);
         }
@@ -2084,17 +2080,29 @@ ValueNum ValueNumStore::VNAllBitsForType(var_types typ)
         {
             simd32_t cnsVal;
 
-            cnsVal.u32[0] = 0xFFFFFFFF;
-            cnsVal.u32[1] = 0xFFFFFFFF;
-            cnsVal.u32[2] = 0xFFFFFFFF;
-            cnsVal.u32[3] = 0xFFFFFFFF;
-
-            cnsVal.u32[4] = 0xFFFFFFFF;
-            cnsVal.u32[5] = 0xFFFFFFFF;
-            cnsVal.u32[6] = 0xFFFFFFFF;
-            cnsVal.u32[7] = 0xFFFFFFFF;
+            cnsVal.u64[0] = 0xFFFFFFFFFFFFFFFF;
+            cnsVal.u64[1] = 0xFFFFFFFFFFFFFFFF;
+            cnsVal.u64[2] = 0xFFFFFFFFFFFFFFFF;
+            cnsVal.u64[3] = 0xFFFFFFFFFFFFFFFF;
 
             return VNForSimd32Con(cnsVal);
+        }
+
+        case TYP_SIMD64:
+        {
+            simd64_t cnsVal;
+
+            cnsVal.u64[0] = 0xFFFFFFFFFFFFFFFF;
+            cnsVal.u64[1] = 0xFFFFFFFFFFFFFFFF;
+            cnsVal.u64[2] = 0xFFFFFFFFFFFFFFFF;
+            cnsVal.u64[3] = 0xFFFFFFFFFFFFFFFF;
+
+            cnsVal.u64[4] = 0xFFFFFFFFFFFFFFFF;
+            cnsVal.u64[5] = 0xFFFFFFFFFFFFFFFF;
+            cnsVal.u64[6] = 0xFFFFFFFFFFFFFFFF;
+            cnsVal.u64[7] = 0xFFFFFFFFFFFFFFFF;
+
+            return VNForSimd64Con(cnsVal);
         }
 #endif // TARGET_XARCH
 #endif // FEATURE_SIMD
@@ -2111,8 +2119,8 @@ ValueNum ValueNumStore::VNOneForSimdType(var_types simdType, var_types simdBaseT
 {
     assert(varTypeIsSIMD(simdType));
 
-    simd32_t simd32Val = {};
-    int      simdSize  = genTypeSize(simdType);
+    simd_t simdVal  = {};
+    int    simdSize = genTypeSize(simdType);
 
     switch (simdBaseType)
     {
@@ -2121,7 +2129,7 @@ ValueNum ValueNumStore::VNOneForSimdType(var_types simdType, var_types simdBaseT
         {
             for (int i = 0; i < simdSize; i++)
             {
-                simd32Val.u8[i] = 1;
+                simdVal.u8[i] = 1;
             }
             break;
         }
@@ -2131,7 +2139,7 @@ ValueNum ValueNumStore::VNOneForSimdType(var_types simdType, var_types simdBaseT
         {
             for (int i = 0; i < (simdSize / 2); i++)
             {
-                simd32Val.u16[i] = 1;
+                simdVal.u16[i] = 1;
             }
             break;
         }
@@ -2141,7 +2149,7 @@ ValueNum ValueNumStore::VNOneForSimdType(var_types simdType, var_types simdBaseT
         {
             for (int i = 0; i < (simdSize / 4); i++)
             {
-                simd32Val.u32[i] = 1;
+                simdVal.u32[i] = 1;
             }
             break;
         }
@@ -2151,7 +2159,7 @@ ValueNum ValueNumStore::VNOneForSimdType(var_types simdType, var_types simdBaseT
         {
             for (int i = 0; i < (simdSize / 8); i++)
             {
-                simd32Val.u64[i] = 1;
+                simdVal.u64[i] = 1;
             }
             break;
         }
@@ -2160,7 +2168,7 @@ ValueNum ValueNumStore::VNOneForSimdType(var_types simdType, var_types simdBaseT
         {
             for (int i = 0; i < (simdSize / 4); i++)
             {
-                simd32Val.f32[i] = 1.0f;
+                simdVal.f32[i] = 1.0f;
             }
             break;
         }
@@ -2169,7 +2177,7 @@ ValueNum ValueNumStore::VNOneForSimdType(var_types simdType, var_types simdBaseT
         {
             for (int i = 0; i < (simdSize / 8); i++)
             {
-                simd32Val.f64[i] = 1.0;
+                simdVal.f64[i] = 1.0;
             }
             break;
         }
@@ -2184,27 +2192,38 @@ ValueNum ValueNumStore::VNOneForSimdType(var_types simdType, var_types simdBaseT
     {
         case TYP_SIMD8:
         {
-            return VNForSimd8Con(simd32Val.v64[0]);
+            simd8_t simd8Val;
+            memcpy(&simd8Val, &simdVal, sizeof(simd8_t));
+            return VNForSimd8Con(simd8Val);
         }
 
         case TYP_SIMD12:
         {
-            assert(simdBaseType == TYP_FLOAT);
-
             simd12_t simd12Val;
-            memcpy(&simd12Val, &simd32Val.f32, sizeof(simd12_t));
+            memcpy(&simd12Val, &simdVal, sizeof(simd12_t));
             return VNForSimd12Con(simd12Val);
         }
 
         case TYP_SIMD16:
         {
-            return VNForSimd16Con(simd32Val.v128[0]);
+            simd16_t simd16Val;
+            memcpy(&simd16Val, &simdVal, sizeof(simd16_t));
+            return VNForSimd16Con(simd16Val);
         }
 
 #if defined(TARGET_XARCH)
         case TYP_SIMD32:
         {
+            simd32_t simd32Val;
+            memcpy(&simd32Val, &simdVal, sizeof(simd32_t));
             return VNForSimd32Con(simd32Val);
+        }
+
+        case TYP_SIMD64:
+        {
+            simd64_t simd64Val;
+            memcpy(&simd64Val, &simdVal, sizeof(simd64_t));
+            return VNForSimd64Con(simd64Val);
         }
 #endif // TARGET_XARCH
 
@@ -6424,6 +6443,18 @@ simd32_t GetConstantSimd32(ValueNumStore* vns, var_types baseType, ValueNum argV
 
     return BroadcastConstantToSimd<simd32_t>(vns, baseType, argVN);
 }
+
+simd64_t GetConstantSimd64(ValueNumStore* vns, var_types baseType, ValueNum argVN)
+{
+    assert(vns->IsVNConstant(argVN));
+
+    if (vns->TypeOfVN(argVN) == TYP_SIMD64)
+    {
+        return vns->GetConstantSimd64(argVN);
+    }
+
+    return BroadcastConstantToSimd<simd64_t>(vns, baseType, argVN);
+}
 #endif // TARGET_XARCH
 
 ValueNum EvaluateUnarySimd(
@@ -6466,6 +6497,15 @@ ValueNum EvaluateUnarySimd(
             simd32_t result = {};
             EvaluateUnarySimd<simd32_t>(oper, scalar, baseType, &result, arg0);
             return vns->VNForSimd32Con(result);
+        }
+
+        case TYP_SIMD64:
+        {
+            simd64_t arg0 = GetConstantSimd64(vns, baseType, arg0VN);
+
+            simd64_t result = {};
+            EvaluateUnarySimd<simd64_t>(oper, scalar, baseType, &result, arg0);
+            return vns->VNForSimd64Con(result);
         }
 #endif // TARGET_XARCH
 
@@ -6525,6 +6565,16 @@ ValueNum EvaluateBinarySimd(ValueNumStore* vns,
             simd32_t result = {};
             EvaluateBinarySimd<simd32_t>(oper, scalar, baseType, &result, arg0, arg1);
             return vns->VNForSimd32Con(result);
+        }
+
+        case TYP_SIMD64:
+        {
+            simd64_t arg0 = GetConstantSimd64(vns, baseType, arg0VN);
+            simd64_t arg1 = GetConstantSimd64(vns, baseType, arg1VN);
+
+            simd64_t result = {};
+            EvaluateBinarySimd<simd64_t>(oper, scalar, baseType, &result, arg0, arg1);
+            return vns->VNForSimd64Con(result);
         }
 #endif // TARGET_XARCH
 
@@ -6630,6 +6680,11 @@ ValueNum EvaluateSimdGetElement(ValueNumStore* vns, var_types type, var_types ba
         case TYP_SIMD32:
         {
             return EvaluateSimdGetElement<simd32_t>(vns, baseType, vns->GetConstantSimd32(arg0VN), arg1);
+        }
+
+        case TYP_SIMD64:
+        {
+            return EvaluateSimdGetElement<simd64_t>(vns, baseType, vns->GetConstantSimd64(arg0VN), arg1);
         }
 #endif // TARGET_XARCH
 
@@ -9689,22 +9744,50 @@ void Compiler::fgValueNumberTreeConst(GenTree* tree)
 
 #ifdef FEATURE_SIMD
         case TYP_SIMD8:
-            tree->gtVNPair.SetBoth(vnStore->VNForSimd8Con(tree->AsVecCon()->gtSimd8Val));
+        {
+            simd8_t simd8Val;
+            memcpy(&simd8Val, &tree->AsVecCon()->gtSimdVal, sizeof(simd8_t));
+
+            tree->gtVNPair.SetBoth(vnStore->VNForSimd8Con(simd8Val));
             break;
+        }
 
         case TYP_SIMD12:
-            tree->gtVNPair.SetBoth(vnStore->VNForSimd12Con(tree->AsVecCon()->gtSimd12Val));
+        {
+            simd12_t simd12Val;
+            memcpy(&simd12Val, &tree->AsVecCon()->gtSimdVal, sizeof(simd12_t));
+
+            tree->gtVNPair.SetBoth(vnStore->VNForSimd12Con(simd12Val));
             break;
+        }
 
         case TYP_SIMD16:
-            tree->gtVNPair.SetBoth(vnStore->VNForSimd16Con(tree->AsVecCon()->gtSimd16Val));
+        {
+            simd16_t simd16Val;
+            memcpy(&simd16Val, &tree->AsVecCon()->gtSimdVal, sizeof(simd16_t));
+
+            tree->gtVNPair.SetBoth(vnStore->VNForSimd16Con(simd16Val));
             break;
+        }
 
 #if defined(TARGET_XARCH)
         case TYP_SIMD32:
-        case TYP_SIMD64: // TODO-XArch-AVX512: Fix once GenTreeVecCon supports gtSimd64Val.
-            tree->gtVNPair.SetBoth(vnStore->VNForSimd32Con(tree->AsVecCon()->gtSimd32Val));
+        {
+            simd32_t simd32Val;
+            memcpy(&simd32Val, &tree->AsVecCon()->gtSimdVal, sizeof(simd32_t));
+
+            tree->gtVNPair.SetBoth(vnStore->VNForSimd32Con(simd32Val));
             break;
+        }
+
+        case TYP_SIMD64:
+        {
+            simd64_t simd64Val;
+            memcpy(&simd64Val, &tree->AsVecCon()->gtSimdVal, sizeof(simd64_t));
+
+            tree->gtVNPair.SetBoth(vnStore->VNForSimd64Con(simd64Val));
+            break;
+        }
 #endif // TARGET_XARCH
 #endif // FEATURE_SIMD
 
@@ -10151,6 +10234,12 @@ bool Compiler::fgValueNumberConstLoad(GenTreeIndir* tree)
                     {
                         READ_VALUE(simd32_t);
                         tree->gtVNPair.SetBoth(vnStore->VNForSimd32Con(val));
+                        return true;
+                    }
+                    case TYP_SIMD64:
+                    {
+                        READ_VALUE(simd64_t);
+                        tree->gtVNPair.SetBoth(vnStore->VNForSimd64Con(val));
                         return true;
                     }
 #endif // TARGET_XARCH

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -2060,7 +2060,7 @@ ValueNum ValueNumStore::VNAllBitsForType(var_types typ)
             simd12_t cnsVal;
 
             cnsVal.u64[0] = 0xFFFFFFFFFFFFFFFF;
-            cnsVal.u32[3] = 0xFFFFFFFF;
+            cnsVal.u32[2] = 0xFFFFFFFF;
 
             return VNForSimd12Con(cnsVal);
         }
@@ -10136,7 +10136,7 @@ bool Compiler::fgValueNumberConstLoad(GenTreeIndir* tree)
     {
         CORINFO_FIELD_HANDLE fieldHandle    = fieldSeq->GetFieldHandle();
         int                  size           = (int)genTypeSize(tree->TypeGet());
-        const int            maxElementSize = 32; // SIMD32
+        const int            maxElementSize = sizeof(simd_t);
         if ((fieldHandle != nullptr) && (size > 0) && (size <= maxElementSize) && ((size_t)byteOffset < INT_MAX))
         {
             uint8_t buffer[maxElementSize] = {0};

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -1959,28 +1959,28 @@ ValueNum ValueNumStore::VNZeroForType(var_types typ)
 #ifdef FEATURE_SIMD
         case TYP_SIMD8:
         {
-            return VNForSimd8Con({});
+            return VNForSimd8Con(simd8_t::Zero());
         }
 
         case TYP_SIMD12:
         {
-            return VNForSimd12Con({});
+            return VNForSimd12Con(simd12_t::Zero());
         }
 
         case TYP_SIMD16:
         {
-            return VNForSimd16Con({});
+            return VNForSimd16Con(simd16_t::Zero());
         }
 
 #if defined(TARGET_XARCH)
         case TYP_SIMD32:
         {
-            return VNForSimd32Con({});
+            return VNForSimd32Con(simd32_t::Zero());
         }
 
         case TYP_SIMD64:
         {
-            return VNForSimd64Con({});
+            return VNForSimd64Con(simd64_t::Zero());
         }
 #endif // TARGET_XARCH
 #endif // FEATURE_SIMD
@@ -2050,59 +2050,28 @@ ValueNum ValueNumStore::VNAllBitsForType(var_types typ)
 #ifdef FEATURE_SIMD
         case TYP_SIMD8:
         {
-            simd8_t cnsVal;
-            cnsVal.u64[0] = 0xFFFFFFFFFFFFFFFF;
-            return VNForSimd8Con(cnsVal);
+            return VNForSimd8Con(simd8_t::AllBitsSet());
         }
 
         case TYP_SIMD12:
         {
-            simd12_t cnsVal;
-
-            cnsVal.u64[0] = 0xFFFFFFFFFFFFFFFF;
-            cnsVal.u32[2] = 0xFFFFFFFF;
-
-            return VNForSimd12Con(cnsVal);
+            return VNForSimd12Con(simd12_t::AllBitsSet());
         }
 
         case TYP_SIMD16:
         {
-            simd16_t cnsVal;
-
-            cnsVal.u64[0] = 0xFFFFFFFFFFFFFFFF;
-            cnsVal.u64[1] = 0xFFFFFFFFFFFFFFFF;
-
-            return VNForSimd16Con(cnsVal);
+            return VNForSimd16Con(simd16_t::AllBitsSet());
         }
 
 #if defined(TARGET_XARCH)
         case TYP_SIMD32:
         {
-            simd32_t cnsVal;
-
-            cnsVal.u64[0] = 0xFFFFFFFFFFFFFFFF;
-            cnsVal.u64[1] = 0xFFFFFFFFFFFFFFFF;
-            cnsVal.u64[2] = 0xFFFFFFFFFFFFFFFF;
-            cnsVal.u64[3] = 0xFFFFFFFFFFFFFFFF;
-
-            return VNForSimd32Con(cnsVal);
+            return VNForSimd32Con(simd32_t::AllBitsSet());
         }
 
         case TYP_SIMD64:
         {
-            simd64_t cnsVal;
-
-            cnsVal.u64[0] = 0xFFFFFFFFFFFFFFFF;
-            cnsVal.u64[1] = 0xFFFFFFFFFFFFFFFF;
-            cnsVal.u64[2] = 0xFFFFFFFFFFFFFFFF;
-            cnsVal.u64[3] = 0xFFFFFFFFFFFFFFFF;
-
-            cnsVal.u64[4] = 0xFFFFFFFFFFFFFFFF;
-            cnsVal.u64[5] = 0xFFFFFFFFFFFFFFFF;
-            cnsVal.u64[6] = 0xFFFFFFFFFFFFFFFF;
-            cnsVal.u64[7] = 0xFFFFFFFFFFFFFFFF;
-
-            return VNForSimd64Con(cnsVal);
+            return VNForSimd64Con(simd64_t::AllBitsSet());
         }
 #endif // TARGET_XARCH
 #endif // FEATURE_SIMD

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -1611,6 +1611,7 @@ private:
         return m_simd16CnsMap;
     }
 
+#if defined(TARGET_XARCH)
     struct Simd32PrimitiveKeyFuncs : public JitKeyFuncsDefEquals<simd32_t>
     {
         static bool Equals(simd32_t x, simd32_t y)
@@ -1688,7 +1689,7 @@ private:
         }
         return m_simd64CnsMap;
     }
-
+#endif // TARGET_XARCH
 #endif // FEATURE_SIMD
 
     template <size_t NumArgs>


### PR DESCRIPTION
The initial support for TYP_SIMD64 was added in https://github.com/dotnet/runtime/pull/80960, but complete support for it wasn't achieved due to various complications that were found at the time.

This ensures that `simd32_t` and `simd64_t` are xarch only, so it doesn't pessimize other architectures and correspondingly updates the general support for `GenTreeVecCon` to support TYP_SIMD64 on xarch.