### PR TITLE
Improve EqualityComparer for NativeAOT

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Collections/Generic/Comparer.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Collections/Generic/Comparer.NativeAot.cs
@@ -29,7 +29,7 @@ namespace System.Collections.Generic
             }
             return new ObjectComparer<T>();
         }
-        
+
         public static Comparer<T> Default { [Intrinsic] get; } = Create();
     }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Collections/Generic/Comparer.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Collections/Generic/Comparer.NativeAot.cs
@@ -12,8 +12,6 @@ namespace System.Collections.Generic
 {
     public abstract partial class Comparer<T> : IComparer, IComparer<T>
     {
-        private static Comparer<T> s_default;
-
         // The AOT compiler can flip this to false under certain circumstances.
         private static bool SupportsGenericIComparableInterfaces => true;
 
@@ -25,23 +23,14 @@ namespace System.Collections.Generic
             // This body serves as a fallback when instantiation-specific implementation is unavailable.
             // If that happens, the compiler ensures we generate data structures to make the fallback work
             // when this method is compiled.
-            Interlocked.CompareExchange(ref s_default,
-                SupportsGenericIComparableInterfaces
-                ? Unsafe.As<Comparer<T>>(ComparerHelpers.GetComparer(typeof(T).TypeHandle))
-                : new ObjectComparer<T>(),
-                null);
-            return s_default;
-        }
-
-        public static Comparer<T> Default
-        {
-            [Intrinsic]
-            get
+            if (SupportsGenericIComparableInterfaces)
             {
-                // Lazy initialization produces smaller code for AOT compilation than initialization in constructor
-                return s_default ?? Create();
+                return Unsafe.As<Comparer<T>>(ComparerHelpers.GetComparer(typeof(T).TypeHandle));
             }
+            return new ObjectComparer<T>();
         }
+        
+        public static Comparer<T> Default { [Intrinsic] get; } = Create();
     }
 
     internal sealed partial class EnumComparer<T> : Comparer<T> where T : struct, Enum

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ComparerIntrinsics.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ComparerIntrinsics.cs
@@ -65,25 +65,7 @@ namespace Internal.IL.Stubs
             ILEmitter emitter = new ILEmitter();
             var codeStream = emitter.NewCodeStream();
 
-            FieldDesc defaultField = owningType.GetKnownField("s_default");
-
-            TypeSystemContext  context = comparerType.Context;
-            TypeDesc objectType = context.GetWellKnownType(WellKnownType.Object);
-            MethodDesc compareExchangeObject = context.SystemModule.
-                GetKnownType("System.Threading", "Interlocked").
-                    GetKnownMethod("CompareExchange",
-                        new MethodSignature(
-                            MethodSignatureFlags.Static,
-                            genericParameterCount: 0,
-                            returnType: objectType,
-                            parameters: new TypeDesc[] { objectType.MakeByRefType(), objectType, objectType }));
-
-            codeStream.Emit(ILOpcode.ldsflda, emitter.NewToken(defaultField));
             codeStream.Emit(ILOpcode.newobj, emitter.NewToken(comparerType.GetParameterlessConstructor()));
-            codeStream.Emit(ILOpcode.ldnull);
-            codeStream.Emit(ILOpcode.call, emitter.NewToken(compareExchangeObject));
-            codeStream.Emit(ILOpcode.pop);
-            codeStream.Emit(ILOpcode.ldsfld, emitter.NewToken(defaultField));
             codeStream.Emit(ILOpcode.ret);
 
             return emitter.Link(methodBeingGenerated);


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/81592

```csharp
static bool Test(int a, int b) =>
    EqualityComparer<int>.Default.Equals(a, b);
```
Old codegen on NativeAOT:
```asm
; Method Program:Bar[int](int,int):bool
       57                   push     rdi
       56                   push     rsi
       4883EC28             sub      rsp, 40
       8BF1                 mov      esi, ecx
       8BFA                 mov      edi, edx
       488B0500000000       mov      rax, qword ptr [(reloc 0x4000000000425988)]
       4883780800           cmp      gword ptr [rax+08H], 0
       7505                 jne      SHORT G_M49161_IG04
       E800000000           call     System.Collections.Generic.EqualityComparer`1[int]:Create()
G_M49161_IG04:              
       33C0                 xor      eax, eax
       3BF7                 cmp      esi, edi
       0F94C0               sete     al
       4883C428             add      rsp, 40
       5E                   pop      rsi
       5F                   pop      rdi
       C3                   ret      
; Total bytes of code: 43
```
New codegen:
```asm
; Method Program:Bar[int](int,int):bool
       33C0                 xor      eax, eax
       3BCA                 cmp      ecx, edx
       0F94C0               sete     al
       C3                   ret      
; Total bytes of code: 8
```
cc @dotnet/ilc-contrib @MichalStrehovsky 