### PR TITLE
Add NT_SIGINFO NOTE to ELF dumps 

### DIFF
--- a/src/coreclr/debug/createdump/crashinfo.cpp
+++ b/src/coreclr/debug/createdump/crashinfo.cpp
@@ -8,16 +8,16 @@ CrashInfo* g_crashInfo;
 
 static bool ModuleInfoCompare(const ModuleInfo* lhs, const ModuleInfo* rhs) { return lhs->BaseAddress() < rhs->BaseAddress(); }
 
-CrashInfo::CrashInfo(pid_t pid, bool gatherFrames, pid_t crashThread, uint32_t signal) :
+CrashInfo::CrashInfo(const CreateDumpOptions& options) :
     m_ref(1),
-    m_pid(pid),
+    m_pid(options.Pid),
     m_ppid(-1),
     m_hdac(nullptr),
     m_pClrDataEnumRegions(nullptr),
     m_pClrDataProcess(nullptr),
-    m_gatherFrames(gatherFrames),
-    m_crashThread(crashThread),
-    m_signal(signal),
+    m_gatherFrames(options.CrashReport),
+    m_crashThread(options.CrashThread),
+    m_signal(options.Signal),
     m_moduleInfos(&ModuleInfoCompare),
     m_mainModule(nullptr)
 {
@@ -27,6 +27,11 @@ CrashInfo::CrashInfo(pid_t pid, bool gatherFrames, pid_t crashThread, uint32_t s
 #else
     m_auxvValues.fill(0);
     m_fd = -1;
+    memset(&m_siginfo, 0, sizeof(m_siginfo));
+    m_siginfo.si_signo = options.Signal;
+    m_siginfo.si_code = options.SignalCode;
+    m_siginfo.si_errno = options.SignalErrno;
+    m_siginfo.si_addr = options.SignalAddress;
 #endif
 }
 
@@ -214,8 +219,6 @@ CrashInfo::GatherCrashInfo(MINIDUMP_TYPE minidumpType)
     {
         return false;
     }
-    // Join all adjacent memory regions
-    CombineMemoryRegions();
     return true;
 }
 

--- a/src/coreclr/debug/createdump/crashinfo.h
+++ b/src/coreclr/debug/createdump/crashinfo.h
@@ -87,6 +87,7 @@ public:
     void CleanupAndResumeProcess();
     bool EnumerateAndSuspendThreads();
     bool GatherCrashInfo(MINIDUMP_TYPE minidumpType);
+    void CombineMemoryRegions();
     bool EnumerateMemoryRegionsWithDAC(MINIDUMP_TYPE minidumpType);
     bool ReadMemory(void* address, void* buffer, size_t size);                          // read memory and add to dump
     bool ReadProcessMemory(void* address, void* buffer, size_t size, size_t* read);     // read raw memory
@@ -149,7 +150,6 @@ private:
     void InsertMemoryRegion(const MemoryRegion& region);
     uint32_t GetMemoryRegionFlags(uint64_t start);
     bool ValidRegion(const MemoryRegion& region);
-    void CombineMemoryRegions();
     void Trace(const char* format, ...);
     void TraceVerbose(const char* format, ...);
 };

--- a/src/coreclr/debug/createdump/crashinfo.h
+++ b/src/coreclr/debug/createdump/crashinfo.h
@@ -56,6 +56,7 @@ private:
 #ifdef __APPLE__
     vm_map_t m_task;                                // the mach task for the process
 #else
+    siginfo_t m_siginfo;                            // signal info (if any)
     bool m_canUseProcVmReadSyscall;
     int m_fd;                                       // /proc/<pid>/mem handle
 #endif
@@ -79,7 +80,7 @@ private:
     void operator=(const CrashInfo&) = delete;
 
 public:
-    CrashInfo(pid_t pid, bool gatherFrames, pid_t crashThread, uint32_t signal);
+    CrashInfo(const CreateDumpOptions& options);
     virtual ~CrashInfo();
 
     bool Initialize();
@@ -116,6 +117,7 @@ public:
 #ifndef __APPLE__
     inline const std::vector<elf_aux_entry>& AuxvEntries() const { return m_auxvEntries; }
     inline size_t GetAuxvSize() const { return m_auxvEntries.size() * sizeof(elf_aux_entry); }
+    inline const siginfo_t* SigInfo() const { return &m_siginfo; }
 #endif
 
     // IUnknown

--- a/src/coreclr/debug/createdump/crashreportwriter.cpp
+++ b/src/coreclr/debug/createdump/crashreportwriter.cpp
@@ -175,17 +175,17 @@ CrashReportWriter::WriteCrashReport()
     }
     CloseArray();               // threads
     CloseObject();              // payload
-#ifdef __APPLE__
     OpenObject("parameters");
     if (exceptionType != nullptr)
     {
         WriteValue("ExceptionType", exceptionType);
     }
+#ifdef __APPLE__
     WriteSysctl("kern.osproductversion", "OSVersion");
     WriteSysctl("hw.model", "SystemModel");
     WriteValue("SystemManufacturer", "apple");
-    CloseObject();              // parameters
 #endif // __APPLE__
+    CloseObject();              // parameters
 }
 
 #ifdef __APPLE__

--- a/src/coreclr/debug/createdump/createdump.h
+++ b/src/coreclr/debug/createdump/createdump.h
@@ -23,6 +23,9 @@ extern bool g_diagnosticsVerbose;
 #define TRACE_VERBOSE(args, ...)
 #endif
 
+// Keep in sync with the definitions in dbgutil.cpp and daccess.h
+#define DACCESS_TABLE_SYMBOL "g_dacTable"
+
 #ifdef HOST_64BIT
 #define PRIA "016"
 #else
@@ -89,6 +92,24 @@ typedef int T_CONTEXT;
 #include <vector>
 #include <array>
 #include <string>
+
+typedef struct
+{
+    const char* DumpPathTemplate;
+    const char* DumpType;
+    MINIDUMP_TYPE MinidumpType;
+    bool CreateDump;
+    bool CrashReport;
+    int Pid;
+    int CrashThread;
+    int Signal;
+#if defined(HOST_UNIX) && !defined(HOST_OSX)
+    int SignalCode;
+    int SignalErrno;
+    void* SignalAddress;
+#endif
+} CreateDumpOptions;
+
 #ifdef HOST_UNIX
 #ifdef __APPLE__
 #include <mach/mach.h>
@@ -108,8 +129,8 @@ typedef int T_CONTEXT;
 #define MAX_LONGPATH   1024
 #endif
 
-bool FormatDumpName(std::string& name, const char* pattern, const char* exename, int pid);
-bool CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP_TYPE minidumpType, bool crashReport, int crashThread, int signal);
+extern bool CreateDump(const CreateDumpOptions& options);
+extern bool FormatDumpName(std::string& name, const char* pattern, const char* exename, int pid);
 
 extern void printf_status(const char* format, ...);
 extern void printf_error(const char* format, ...);

--- a/src/coreclr/debug/createdump/createdumpunix.cpp
+++ b/src/coreclr/debug/createdump/createdumpunix.cpp
@@ -7,9 +7,9 @@
 // The Linux/MacOS create dump code
 //
 bool
-CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP_TYPE minidumpType, bool crashReport, int crashThread, int signal)
+CreateDump(const CreateDumpOptions& options)
 {
-    ReleaseHolder<CrashInfo> crashInfo = new CrashInfo(pid, crashReport, crashThread, signal);
+    ReleaseHolder<CrashInfo> crashInfo = new CrashInfo(options);
     DumpWriter dumpWriter(*crashInfo);
     std::string dumpPath;
     bool result = false;
@@ -19,11 +19,11 @@ CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP
     {
         goto exit;
     }
-    printf_status("Gathering state for process %d %s\n", pid, crashInfo->Name().c_str());
+    printf_status("Gathering state for process %d %s\n", options.Pid, crashInfo->Name().c_str());
 
-    if (signal != 0 || crashThread != 0)
+    if (options.Signal != 0 || options.CrashThread != 0)
     {
-        printf_status("Crashing thread %08x signal %08x\n", crashThread, signal);
+        printf_status("Crashing thread %04x signal %d (%04x)\n", options.CrashThread, options.Signal, options.Signal);
     }
 
     // Suspend all the threads in the target process and build the list of threads
@@ -32,44 +32,50 @@ CreateDump(const char* dumpPathTemplate, int pid, const char* dumpType, MINIDUMP
         goto exit;
     }
     // Gather all the info about the process, threads (registers, etc.) and memory regions
-    if (!crashInfo->GatherCrashInfo(minidumpType))
+    if (!crashInfo->GatherCrashInfo(options.MinidumpType))
     {
         goto exit;
     }
     // Format the dump pattern template now that the process name on MacOS has been obtained
-    if (!FormatDumpName(dumpPath, dumpPathTemplate, crashInfo->Name().c_str(), pid))
+    if (!FormatDumpName(dumpPath, options.DumpPathTemplate, crashInfo->Name().c_str(), options.Pid))
     {
         goto exit;
     }
     // Write the crash report json file if enabled
-    if (crashReport)
+    if (options.CrashReport)
     {
         CrashReportWriter crashReportWriter(*crashInfo);
         crashReportWriter.WriteCrashReport(dumpPath);
     }
-    // Gather all the useful memory regions from the DAC
-    if (!crashInfo->EnumerateMemoryRegionsWithDAC(minidumpType))
+    if (options.CreateDump)
     {
-        goto exit;
-    }
-    printf_status("Writing %s to file %s\n", dumpType, dumpPath.c_str());
+        // Gather all the useful memory regions from the DAC
+        if (!crashInfo->EnumerateMemoryRegionsWithDAC(options.MinidumpType))
+        {
+            goto exit;
+        }
+        // Join all adjacent memory regions
+        crashInfo->CombineMemoryRegions();
+    
+        printf_status("Writing %s to file %s\n", options.DumpType, dumpPath.c_str());
+    
+        // Write the actual dump file
+        if (!dumpWriter.OpenDump(dumpPath.c_str()))
+        {
+            goto exit;
+        }
+        if (!dumpWriter.WriteDump())
+        {
+            printf_error( "Writing dump FAILED\n");
 
-    // Write the actual dump file
-    if (!dumpWriter.OpenDump(dumpPath.c_str()))
-    {
-        goto exit;
-    }
-    if (!dumpWriter.WriteDump())
-    {
-        printf_error( "Writing dump FAILED\n");
-
-        // Delete the partial dump file on error
-        remove(dumpPath.c_str());
-        goto exit;
+            // Delete the partial dump file on error
+            remove(dumpPath.c_str());
+            goto exit;
+        }
     }
     result = true;
 exit:
-    if (kill(pid, 0) == 0)
+    if (kill(options.Pid, 0) == 0)
     {
         printf_status("Target process is alive\n");
     }
@@ -82,7 +88,7 @@ exit:
         }
         else
         {
-            printf_error("kill(%d, 0) FAILED %s (%d)\n", pid, strerror(err), err);
+            printf_error("kill(%d, 0) FAILED %s (%d)\n", options.Pid, strerror(err), err);
         }
     }
     crashInfo->CleanupAndResumeProcess();

--- a/src/coreclr/debug/createdump/dumpwriterelf.cpp
+++ b/src/coreclr/debug/createdump/dumpwriterelf.cpp
@@ -152,7 +152,7 @@ DumpWriter::WriteDump()
     // Write all the thread's state and registers
     for (const ThreadInfo* thread : m_crashInfo.Threads())
     {
-        if (!WriteThread(*thread, SIGABRT)) {
+        if (!WriteThread(*thread)) {
             return false;
         }
     }
@@ -366,13 +366,20 @@ DumpWriter::WriteNTFileInfo()
 }
 
 bool
-DumpWriter::WriteThread(const ThreadInfo& thread, int fatal_signal)
+DumpWriter::WriteThread(const ThreadInfo& thread)
 {
     prstatus_t pr;
     memset(&pr, 0, sizeof(pr));
+    const siginfo_t* siginfo = nullptr;
 
-    pr.pr_info.si_signo = fatal_signal;
-    pr.pr_cursig = fatal_signal;
+    if (m_crashInfo.Signal() != 0 && thread.IsCrashThread())
+    {
+        siginfo = m_crashInfo.SigInfo();
+        pr.pr_info.si_signo = siginfo->si_signo;
+        pr.pr_info.si_code = siginfo->si_code;
+        pr.pr_info.si_errno = siginfo->si_errno;
+        pr.pr_cursig = siginfo->si_signo;
+    }
     pr.pr_pid = thread.Tid();
     pr.pr_ppid = thread.Ppid();
     pr.pr_pgrp = thread.Tgid();
@@ -403,9 +410,8 @@ DumpWriter::WriteThread(const ThreadInfo& thread, int fatal_signal)
         return false;
     }
 
-    nhdr.n_namesz = 6;
-
 #if defined(__i386__)
+    nhdr.n_namesz = 6;
     nhdr.n_descsz = sizeof(user_fpxregs_struct);
     nhdr.n_type = NT_PRXFPREG;
     if (!WriteData(&nhdr, sizeof(nhdr)) ||
@@ -416,6 +422,7 @@ DumpWriter::WriteThread(const ThreadInfo& thread, int fatal_signal)
 #endif
 
 #if defined(__arm__) && defined(__VFP_FP__) && !defined(__SOFTFP__)
+    nhdr.n_namesz = 6;
     nhdr.n_descsz = sizeof(user_vfpregs_struct);
     nhdr.n_type = NT_ARM_VFP;
     if (!WriteData(&nhdr, sizeof(nhdr)) ||
@@ -425,5 +432,19 @@ DumpWriter::WriteThread(const ThreadInfo& thread, int fatal_signal)
     }
 #endif
 
+    if (siginfo != nullptr)
+    {
+        TRACE("Writing NT_SIGINFO tid %04x signo %d (%04x) code %04x errno %04x addr %p\n",
+            thread.Tid(), siginfo->si_signo, siginfo->si_signo, siginfo->si_code, siginfo->si_errno, siginfo->si_addr);
+
+        nhdr.n_namesz = 5;
+        nhdr.n_descsz = sizeof(siginfo_t);
+        nhdr.n_type = NT_SIGINFO;
+        if (!WriteData(&nhdr, sizeof(nhdr)) ||
+            !WriteData("CORE\0SIG", 8) ||
+            !WriteData(siginfo, sizeof(siginfo_t))) {
+            return false;
+        }
+    }
     return true;
 }

--- a/src/coreclr/debug/createdump/dumpwriterelf.h
+++ b/src/coreclr/debug/createdump/dumpwriterelf.h
@@ -29,6 +29,10 @@
 #define NT_FILE		0x46494c45
 #endif
 
+#ifndef NT_SIGINFO	
+#define NT_SIGINFO	0x53494749
+#endif
+
 class DumpWriter
 {
 private:
@@ -52,21 +56,22 @@ private:
     bool WriteAuxv();
     size_t GetNTFileInfoSize(size_t* alignmentBytes = nullptr);
     bool WriteNTFileInfo();
-    bool WriteThread(const ThreadInfo& thread, int fatal_signal);
+    bool WriteThread(const ThreadInfo& thread);
     bool WriteData(const void* buffer, size_t length) { return WriteData(m_fd, buffer, length); }
 
     size_t GetProcessInfoSize() const { return sizeof(Nhdr) + 8 + sizeof(prpsinfo_t); }
     size_t GetAuxvInfoSize() const { return sizeof(Nhdr) + 8 + m_crashInfo.GetAuxvSize(); }
     size_t GetThreadInfoSize() const
     {
-        return m_crashInfo.Threads().size() * ((sizeof(Nhdr) + 8 + sizeof(prstatus_t))
-            + sizeof(Nhdr) + 8 + sizeof(user_fpregs_struct)
+        return (m_crashInfo.Signal() != 0 ? (sizeof(Nhdr) + 8 + sizeof(siginfo_t)) : 0)
+              + (m_crashInfo.Threads().size() * ((sizeof(Nhdr) + 8 + sizeof(prstatus_t))
+              + (sizeof(Nhdr) + 8 + sizeof(user_fpregs_struct))
 #if defined(__i386__)
-            + sizeof(Nhdr) + 8 + sizeof(user_fpxregs_struct)
+              + (sizeof(Nhdr) + 8 + sizeof(user_fpxregs_struct))
 #endif
 #if defined(__arm__) && defined(__VFP_FP__) && !defined(__SOFTFP__)
-            + sizeof(Nhdr) + 8 + sizeof(user_vfpregs_struct)
+              + (sizeof(Nhdr) + 8 + sizeof(user_vfpregs_struct))
 #endif
-        );
+        ));
     }
 };

--- a/src/coreclr/debug/createdump/main.cpp
+++ b/src/coreclr/debug/createdump/main.cpp
@@ -25,6 +25,7 @@ const char* g_help = "createdump [options] pid\n"
 "-v, --verbose - enable verbose diagnostic messages.\n"
 #ifdef HOST_UNIX
 "--crashreport - write crash report file.\n"
+"--crashreportonly - write crash report file only (no dump).\n"
 "--crashthread <id> - the thread id of the crashing thread.\n"
 "--signal <code> - the signal code of the crash.\n"
 #endif
@@ -38,20 +39,27 @@ bool g_diagnosticsVerbose = false;
 //
 int __cdecl main(const int argc, const char* argv[])
 {
-    MINIDUMP_TYPE minidumpType = (MINIDUMP_TYPE)(MiniDumpWithPrivateReadWriteMemory |
-                                                 MiniDumpWithDataSegs |
-                                                 MiniDumpWithHandleData |
-                                                 MiniDumpWithUnloadedModules |
-                                                 MiniDumpWithFullMemoryInfo |
-                                                 MiniDumpWithThreadInfo |
-                                                 MiniDumpWithTokenInformation);
-    const char* dumpType = "minidump with heap";
-    const char* dumpPathTemplate = nullptr;
-    bool crashReport = false;
-    int signal = 0;
-    int crashThread = 0;
+    CreateDumpOptions options;
+    options.MinidumpType = (MINIDUMP_TYPE)(MiniDumpWithPrivateReadWriteMemory |
+                                           MiniDumpWithDataSegs |
+                                           MiniDumpWithHandleData |
+                                           MiniDumpWithUnloadedModules |
+                                           MiniDumpWithFullMemoryInfo |
+                                           MiniDumpWithThreadInfo |
+                                           MiniDumpWithTokenInformation);
+    options.DumpType = "minidump with heap";
+    options.DumpPathTemplate = nullptr;
+    options.CrashReport = false;
+    options.CreateDump = true;
+    options.Signal = 0;
+    options.CrashThread = 0;
+    options.Pid = 0;
+#if defined(HOST_UNIX) && !defined(HOST_OSX)
+    options.SignalCode = 0;
+    options.SignalErrno = 0;
+    options.SignalAddress = nullptr;
+#endif
     int exitCode = 0;
-    int pid = 0;
 
 #ifdef HOST_UNIX
     exitCode = PAL_InitializeDLL();
@@ -70,63 +78,82 @@ int __cdecl main(const int argc, const char* argv[])
         {
             if ((strcmp(*argv, "-f") == 0) || (strcmp(*argv, "--name") == 0))
             {
-                dumpPathTemplate = *++argv;
+                options.DumpPathTemplate = *++argv;
             }
             else if ((strcmp(*argv, "-n") == 0) || (strcmp(*argv, "--normal") == 0))
             {
-                dumpType = "minidump";
-                minidumpType = (MINIDUMP_TYPE)(MiniDumpNormal |
-                                               MiniDumpWithDataSegs |
-                                               MiniDumpWithHandleData |
-                                               MiniDumpWithThreadInfo);
+                options.DumpType = "minidump";
+                options.MinidumpType = (MINIDUMP_TYPE)(MiniDumpNormal |
+                                                       MiniDumpWithDataSegs |
+                                                       MiniDumpWithHandleData |
+                                                       MiniDumpWithThreadInfo);
             }
             else if ((strcmp(*argv, "-h") == 0) || (strcmp(*argv, "--withheap") == 0))
             {
-                dumpType = "minidump with heap";
-                minidumpType = (MINIDUMP_TYPE)(MiniDumpWithPrivateReadWriteMemory |
-                                               MiniDumpWithDataSegs |
-                                               MiniDumpWithHandleData |
-                                               MiniDumpWithUnloadedModules |
-                                               MiniDumpWithFullMemoryInfo |
-                                               MiniDumpWithThreadInfo |
-                                               MiniDumpWithTokenInformation);
+                options.DumpType = "minidump with heap";
+                options.MinidumpType = (MINIDUMP_TYPE)(MiniDumpWithPrivateReadWriteMemory |
+                                                       MiniDumpWithDataSegs |
+                                                       MiniDumpWithHandleData |
+                                                       MiniDumpWithUnloadedModules |
+                                                       MiniDumpWithFullMemoryInfo |
+                                                       MiniDumpWithThreadInfo |
+                                                       MiniDumpWithTokenInformation);
             }
             else if ((strcmp(*argv, "-t") == 0) || (strcmp(*argv, "--triage") == 0))
             {
-                dumpType = "triage minidump";
-                minidumpType = (MINIDUMP_TYPE)(MiniDumpFilterTriage |
-                                               MiniDumpIgnoreInaccessibleMemory |
-                                               MiniDumpWithoutOptionalData |
-                                               MiniDumpWithProcessThreadData |
-                                               MiniDumpFilterModulePaths |
-                                               MiniDumpWithUnloadedModules |
-                                               MiniDumpFilterMemory |
-                                               MiniDumpWithHandleData);
+                options.DumpType = "triage minidump";
+                options.MinidumpType = (MINIDUMP_TYPE)(MiniDumpFilterTriage |
+                                                       MiniDumpIgnoreInaccessibleMemory |
+                                                       MiniDumpWithoutOptionalData |
+                                                       MiniDumpWithProcessThreadData |
+                                                       MiniDumpFilterModulePaths |
+                                                       MiniDumpWithUnloadedModules |
+                                                       MiniDumpFilterMemory |
+                                                       MiniDumpWithHandleData);
             }
             else if ((strcmp(*argv, "-u") == 0) || (strcmp(*argv, "--full") == 0))
             {
-                dumpType = "full dump";
-                minidumpType = (MINIDUMP_TYPE)(MiniDumpWithFullMemory |
-                                               MiniDumpWithDataSegs |
-                                               MiniDumpWithHandleData |
-                                               MiniDumpWithUnloadedModules |
-                                               MiniDumpWithFullMemoryInfo |
-                                               MiniDumpWithThreadInfo |
-                                               MiniDumpWithTokenInformation);
+                options.DumpType = "full dump";
+                options.MinidumpType = (MINIDUMP_TYPE)(MiniDumpWithFullMemory |
+                                                       MiniDumpWithDataSegs |
+                                                       MiniDumpWithHandleData |
+                                                       MiniDumpWithUnloadedModules |
+                                                       MiniDumpWithFullMemoryInfo |
+                                                       MiniDumpWithThreadInfo |
+                                                       MiniDumpWithTokenInformation);
             }
 #ifdef HOST_UNIX
             else if (strcmp(*argv, "--crashreport") == 0)
             {
-                crashReport = true;
+                options.CrashReport = true;
+            }
+            else if (strcmp(*argv, "--crashreportonly") == 0)
+            {
+                options.CrashReport = true;
+                options.CreateDump = false;
             }
             else if (strcmp(*argv, "--crashthread") == 0)
             {
-                crashThread = atoi(*++argv);
+                options.CrashThread = atoi(*++argv);
             }
             else if (strcmp(*argv, "--signal") == 0)
             {
-                signal = atoi(*++argv);
+                options.Signal = atoi(*++argv);
             }
+#ifndef HOST_OSX
+            else if (strcmp(*argv, "--code") == 0)
+            {
+                options.SignalCode = atoi(*++argv);
+            }
+            else if (strcmp(*argv, "--errno") == 0)
+            {
+                options.SignalErrno = atoi(*++argv);
+            }
+            else if (strcmp(*argv, "--address") == 0)
+            {
+                options.SignalAddress = (void*)atoll(*++argv);
+            }
+#endif
 #endif
             else if ((strcmp(*argv, "-d") == 0) || (strcmp(*argv, "--diag") == 0))
             {
@@ -138,17 +165,17 @@ int __cdecl main(const int argc, const char* argv[])
                 g_diagnosticsVerbose = true;
             }
             else {
-                pid = atoi(*argv);
+                options.Pid = atoi(*argv);
             }
             argv++;
         }
     }
 
-    if (pid != 0)
+    if (options.Pid != 0)
     {
         ArrayHolder<char> tmpPath = new char[MAX_LONGPATH];
 
-        if (dumpPathTemplate == nullptr)
+        if (options.DumpPathTemplate == nullptr)
         {
             if (::GetTempPathA(MAX_LONGPATH, tmpPath) == 0)
             {
@@ -161,10 +188,10 @@ int __cdecl main(const int argc, const char* argv[])
                 printf_error("strcat_s failed (%d)\n", exitCode);
                 return exitCode;
             }
-            dumpPathTemplate = tmpPath;
+            options.DumpPathTemplate = tmpPath;
         }
 
-        if (CreateDump(dumpPathTemplate, pid, dumpType, minidumpType, crashReport, crashThread, signal))
+        if (CreateDump(options))
         {
             printf_status("Dump successfully written\n");
         }

--- a/src/coreclr/debug/createdump/threadinfo.cpp
+++ b/src/coreclr/debug/createdump/threadinfo.cpp
@@ -387,3 +387,9 @@ ThreadInfo::GetThreadStack()
         TRACE("Thread %04x null stack pointer\n", m_tid);
     }
 }
+
+bool
+ThreadInfo::IsCrashThread() const
+{
+    return m_tid == m_crashInfo.CrashThread();
+}

--- a/src/coreclr/debug/createdump/threadinfo.h
+++ b/src/coreclr/debug/createdump/threadinfo.h
@@ -136,6 +136,7 @@ public:
     inline const uint64_t GetFramePointer() const { return m_gpRegisters.ARM_fp; }
 #endif
 #endif // __APPLE__
+    bool IsCrashThread() const;
 
 private:
     void UnwindNativeFrames(CONTEXT* pContext);

--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -368,7 +368,7 @@ static void invoke_previous_action(struct sigaction* action, int code, siginfo_t
         if (signalRestarts)
         {
             // This signal mustn't be ignored because it will be restarted.
-            PROCAbort(code);
+            PROCAbort(code, siginfo);
         }
         return;
     }
@@ -383,7 +383,7 @@ static void invoke_previous_action(struct sigaction* action, int code, siginfo_t
         {
             // We can't invoke the original handler because returning from the
             // handler doesn't restart the exception.
-            PROCAbort(code);
+            PROCAbort(code, siginfo);
         }
     }
     else if (IsSaSigInfo(action))
@@ -401,7 +401,7 @@ static void invoke_previous_action(struct sigaction* action, int code, siginfo_t
 
     PROCNotifyProcessShutdown(IsRunningOnAlternateStack(context));
 
-    PROCCreateCrashDumpIfEnabled(code);
+    PROCCreateCrashDumpIfEnabled(code, siginfo);
 }
 
 /*++
@@ -573,13 +573,13 @@ static void sigsegv_handler(int code, siginfo_t *siginfo, void *context)
 
                 if (SwitchStackAndExecuteHandler(code | StackOverflowFlag, siginfo, context, (size_t)handlerStackTop))
                 {
-                    PROCAbort(SIGSEGV);
+                    PROCAbort(SIGSEGV, siginfo);
                 }
             }
             else
             {
                 (void)!write(STDERR_FILENO, StackOverflowMessage, sizeof(StackOverflowMessage) - 1);
-                PROCAbort(SIGSEGV);
+                PROCAbort(SIGSEGV, siginfo);
             }
         }
 
@@ -733,7 +733,7 @@ static void sigterm_handler(int code, siginfo_t *siginfo, void *context)
         char* enable = getenv("COMPlus_EnableDumpOnSigTerm");
         if (enable != nullptr && strcmp(enable, "1") == 0)
         {
-            PROCCreateCrashDumpIfEnabled(code);
+            PROCCreateCrashDumpIfEnabled(code, siginfo);
         }
         // g_pSynchronizationManager shouldn't be null if PAL is initialized.
         _ASSERTE(g_pSynchronizationManager != nullptr);

--- a/src/coreclr/pal/src/include/pal/process.h
+++ b/src/coreclr/pal/src/include/pal/process.h
@@ -151,11 +151,12 @@ Function:
 
 Parameters:
   signal - POSIX signal number
+  siginfo - POSIX signal info
 
   Does not return
 --*/
 PAL_NORETURN
-VOID PROCAbort(int signal = SIGABRT);
+VOID PROCAbort(int signal = SIGABRT, siginfo_t* siginfo = nullptr);
 
 /*++
 Function:
@@ -180,7 +181,7 @@ Parameters:
 
 (no return value)
 --*/
-VOID PROCCreateCrashDumpIfEnabled(int signal);
+VOID PROCCreateCrashDumpIfEnabled(int signal, siginfo_t* siginfo);
 
 /*++
 Function:

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -3107,6 +3107,28 @@ PROCFormatInt(ULONG32 value)
 }
 
 /*++
+Function:
+    PROCFormatInt64
+
+    Helper function to format an ULONG64 as a string.
+
+--*/
+char*
+PROCFormatInt64(ULONG64 value)
+{
+    char* buffer = (char*)InternalMalloc(128);
+    if (buffer != nullptr)
+    {
+        if (sprintf_s(buffer, 128, "%lld", value) == -1)
+        {
+            free(buffer);
+            buffer = nullptr;
+        }
+    }
+    return buffer;
+}
+
+/*++
 Function
   PROCBuildCreateDumpCommandLine
 
@@ -3380,7 +3402,7 @@ Parameters:
 (no return value)
 --*/
 VOID
-PROCCreateCrashDumpIfEnabled(int signal)
+PROCCreateCrashDumpIfEnabled(int signal, siginfo_t* siginfo)
 {
     // If enabled, launch the create minidump utility and wait until it completes
     if (!g_argvCreateDump.empty())
@@ -3388,13 +3410,16 @@ PROCCreateCrashDumpIfEnabled(int signal)
         std::vector<const char*> argv(g_argvCreateDump);
         char* signalArg = nullptr;
         char* crashThreadArg = nullptr;
+        char* signalCodeArg = nullptr;
+        char* signalErrnoArg = nullptr;
+        char* signalAddressArg = nullptr;
 
         if (signal != 0)
         {
             // Remove the terminating nullptr
             argv.pop_back();
 
-            // Add the Windows exception code to the command line
+            // Add the signal number to the command line
             signalArg = PROCFormatInt(signal);
             if (signalArg != nullptr)
             {
@@ -3409,6 +3434,29 @@ PROCCreateCrashDumpIfEnabled(int signal)
                 argv.push_back("--crashthread");
                 argv.push_back(crashThreadArg);
             }
+
+            if (siginfo != nullptr)
+            {
+                signalCodeArg = PROCFormatInt(siginfo->si_code);
+                if (signalCodeArg != nullptr)
+                {
+                    argv.push_back("--code");
+                    argv.push_back(signalCodeArg);
+                }
+                signalErrnoArg = PROCFormatInt(siginfo->si_errno);
+                if (signalErrnoArg != nullptr)
+                {
+                    argv.push_back("--errno");
+                    argv.push_back(signalErrnoArg);
+                }
+                signalAddressArg = PROCFormatInt64((ULONG64)siginfo->si_addr);
+                if (signalAddressArg != nullptr)
+                {
+                    argv.push_back("--address");
+                    argv.push_back(signalAddressArg);
+                }
+            }
+
             argv.push_back(nullptr);
         }
 
@@ -3416,6 +3464,9 @@ PROCCreateCrashDumpIfEnabled(int signal)
 
         free(signalArg);
         free(crashThreadArg);
+        free(signalCodeArg);
+        free(signalErrnoArg);
+        free(signalAddressArg);
     }
 }
 
@@ -3433,12 +3484,12 @@ Parameters:
 --*/
 PAL_NORETURN
 VOID
-PROCAbort(int signal)
+PROCAbort(int signal, siginfo_t* siginfo)
 {
     // Do any shutdown cleanup before aborting or creating a core dump
     PROCNotifyProcessShutdown();
 
-    PROCCreateCrashDumpIfEnabled(signal);
+    PROCCreateCrashDumpIfEnabled(signal, siginfo);
 
     // Restore all signals; the SIGABORT handler to prevent recursion and
     // the others to prevent multiple core dumps from being generated.


### PR DESCRIPTION
# Customer Impact

Linux Watson needs this to better triage ELF dumps. 1st party teams have asked for this.

Issue: https://github.com/dotnet/runtime/issues/40958

This change update createdump which allows windbg/Watson to determine which thread actually crashed (via the .lastevent command). The NT_SIGINFO record has been missing from Linux core dumps causing the wrong thread (startup thread) to be blamed for the crash. This breaks Watson bucketing.

The underlying issue here that we do not put enough data in Linux coredumps: The “crashing thread” isn’t marked as the one of interest.  Without this information, the debugger assumes that the 0th thread (usually the startup thread) is the guilty party.

When an automated debugging service comes along, like Watson/!analyze, they cannot properly triage the bug.  Instead of properly blaming the correct thread (with the correct exception), it will try to blame the non-crashing “crashing thread” (usually just the main function doing nothing, sitting in a wait call).  In effect, this renders all of our Azure Watson bucketing for all of our partner teams and customers useless.

Added "ExceptionType" field to "Parameters" section of the Linux crash report json.

# Testing

All the SOS diagnostics tests pass with these changes.

# Risk

Low.  Createdump/core generation only.
