### PR TITLE
Avoid generic virtual methods in enum infrastructure

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
@@ -24,7 +24,6 @@ using System.Globalization;
 using System.Numerics;
 
 using EETypeElementType = Internal.Runtime.EETypeElementType;
-using System.Runtime.InteropServices.ComTypes;
 
 namespace Internal.Reflection.Augments
 {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Numerics;
 
 using EETypeElementType = Internal.Runtime.EETypeElementType;
+using System.Runtime.InteropServices.ComTypes;
 
 namespace Internal.Reflection.Augments
 {
@@ -165,8 +166,7 @@ namespace Internal.Reflection.Augments
 
         public abstract Assembly[] GetLoadedAssemblies();
 
-        public abstract EnumInfo<TUnderlyingValue> GetEnumInfo<TUnderlyingValue>(Type type)
-            where TUnderlyingValue : struct, INumber<TUnderlyingValue>;
+        public abstract EnumInfo GetEnumInfo(Type type, Func<Type, string[], object[], bool, EnumInfo> create);
 
         public abstract DynamicInvokeInfo GetDelegateDynamicInvokeInfo(Type type);
     }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Enum.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Enum.NativeAot.cs
@@ -47,7 +47,15 @@ namespace System
             Debug.Assert(enumType is RuntimeType);
             Debug.Assert(enumType.IsEnum);
 
-            return ReflectionAugments.ReflectionCoreCallbacks.GetEnumInfo<TUnderlyingValue>(enumType);
+            return (EnumInfo<TUnderlyingValue>)ReflectionAugments.ReflectionCoreCallbacks.GetEnumInfo(enumType,
+                static (underlyingType, names, valuesAsObject, isFlags) =>
+                {
+                    // Only after we've sorted, create the underlying array.
+                    var values = new TUnderlyingValue[valuesAsObject.Length];
+                    for (int i = 0; i < valuesAsObject.Length; i++)
+                        values[i] = (TUnderlyingValue)valuesAsObject[i];
+                    return new EnumInfo<TUnderlyingValue>(underlyingType, values, names, isFlags);
+            });
         }
 #pragma warning restore
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
@@ -404,11 +404,11 @@ namespace System.Reflection.Runtime.General
 
         public sealed override Assembly[] GetLoadedAssemblies() => RuntimeAssemblyInfo.GetLoadedAssemblies();
 
-        public sealed override EnumInfo<TUnderlyingValue> GetEnumInfo<TUnderlyingValue>(Type type)
+        public sealed override EnumInfo GetEnumInfo(Type type, Func<Type, string[], object[], bool, EnumInfo> create)
         {
             RuntimeTypeInfo runtimeType = type.CastToRuntimeTypeInfo();
 
-            EnumInfo<TUnderlyingValue>? info = runtimeType.GenericCache as EnumInfo<TUnderlyingValue>;
+            var info = runtimeType.GenericCache as EnumInfo;
             if (info != null)
                 return info;
 
@@ -418,12 +418,8 @@ namespace System.Reflection.Runtime.General
             // That codepath would bring functionality to compare everything that was ever allocated in the program.
             ArraySortHelper<object, string>.IntrospectiveSort(unsortedValues, unsortedNames, EnumUnderlyingTypeComparer.Instance);
 
-            // Only after we've sorted, create the underlying array.
-            var values = new TUnderlyingValue[unsortedValues.Length];
-            for (int i = 0; i < unsortedValues.Length; i++)
-                values[i] = (TUnderlyingValue)unsortedValues[i];
+            info = create(RuntimeAugments.GetEnumUnderlyingType(type.TypeHandle), unsortedNames, unsortedValues, isFlags);
 
-            info = new EnumInfo<TUnderlyingValue>(RuntimeAugments.GetEnumUnderlyingType(runtimeType.TypeHandle), values, unsortedNames, isFlags);
             runtimeType.GenericCache = info;
             return info;
         }

--- a/src/coreclr/nativeaot/System.Private.DisabledReflection/src/Internal/Reflection/ReflectionCoreCallbacksImplementation.cs
+++ b/src/coreclr/nativeaot/System.Private.DisabledReflection/src/Internal/Reflection/ReflectionCoreCallbacksImplementation.cs
@@ -12,12 +12,12 @@ namespace Internal.Reflection
 {
     internal class ReflectionCoreCallbacksImplementation : ReflectionCoreCallbacks
     {
-        public override EnumInfo<TUnderlyingValue> GetEnumInfo<TUnderlyingValue>(Type type) =>
-            new EnumInfo<TUnderlyingValue>(
+        public override EnumInfo GetEnumInfo(Type type, Func<Type, string[], object[], bool, EnumInfo> create) =>
+            create(
                 RuntimeAugments.GetEnumUnderlyingType(type.TypeHandle),
-                values: Array.Empty<TUnderlyingValue>(),
-                names: Array.Empty<string>(),
-                isFlags: false);
+                Array.Empty<string>(),
+                Array.Empty<object>(),
+                false);
 
         public override DynamicInvokeInfo GetDelegateDynamicInvokeInfo(Type type)
             => throw new NotSupportedException(SR.Reflection_Disabled);


### PR DESCRIPTION
After @EgorBo's #83054 it became realistic to remove the type loader from a hello world app. The comparers logic was keeping type loader around no matter what, but comparers are now preinitialized.

This avoidable use of generic virtual methods is another thing keeping the type loader around. As you can see in the commit timestamp, I've been sitting on this change for 2 months.

Cc @dotnet/ilc-contrib 