### PR TITLE
Make open method resolver pay for play

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/OpenMethodResolver.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/OpenMethodResolver.cs
@@ -45,9 +45,6 @@ namespace Internal.Runtime.CompilerServices
             _handle = handle;
             _readerGCHandle = readerGCHandle;
             _nonVirtualOpenInvokeCodePointer = IntPtr.Zero;
-            
-            if (s_lazyGvmLookupForSlot == IntPtr.Zero)
-                s_lazyGvmLookupForSlot = &TypeLoaderExports.GVMLookupForSlot;
         }
 
         public unsafe OpenMethodResolver(RuntimeTypeHandle declaringTypeOfSlot, RuntimeMethodHandle gvmSlot, GCHandle readerGCHandle, int handle)
@@ -70,9 +67,6 @@ namespace Internal.Runtime.CompilerServices
             _declaringType = declaringType.ToEETypePtr();
             _handle = handle;
             _readerGCHandle = readerGCHandle;
-
-            if (s_lazyGvmLookupForSlot == IntPtr.Zero)
-                s_lazyGvmLookupForSlot = &TypeLoaderExports.GVMLookupForSlot;
         }
 
         public OpenMethodResolver(RuntimeTypeHandle declaringType, IntPtr codePointer, GCHandle readerGCHandle, int handle, short resolveType)
@@ -88,9 +82,6 @@ namespace Internal.Runtime.CompilerServices
                 _nonVirtualOpenInvokeCodePointer = RuntimeAugments.TypeLoaderCallbacks.ConvertUnboxingFunctionPointerToUnderlyingNonUnboxingPointer(codePointer, declaringType);
             else
                 throw new NotSupportedException();
-
-            if (s_lazyGvmLookupForSlot == IntPtr.Zero)
-                s_lazyGvmLookupForSlot = &TypeLoaderExports.GVMLookupForSlot;
         }
 
         public short ResolverType

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/OpenMethodResolver.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/OpenMethodResolver.cs
@@ -22,6 +22,7 @@ namespace Internal.Runtime.CompilerServices
     [ReflectionBlocked]
     public unsafe struct OpenMethodResolver : IEquatable<OpenMethodResolver>
     {
+        // Lazy initialized to point to the type loader method when the first `GVMResolve` resolver is created
         private static delegate*<object, RuntimeMethodHandle, nint> s_lazyGvmLookupForSlot;
 
         public const short DispatchResolve = 0;
@@ -44,7 +45,9 @@ namespace Internal.Runtime.CompilerServices
             _handle = handle;
             _readerGCHandle = readerGCHandle;
             _nonVirtualOpenInvokeCodePointer = IntPtr.Zero;
-            s_lazyGvmLookupForSlot = &TypeLoaderExports.GVMLookupForSlot;
+            
+            if (s_lazyGvmLookupForSlot == IntPtr.Zero)
+                s_lazyGvmLookupForSlot = &TypeLoaderExports.GVMLookupForSlot;
         }
 
         public unsafe OpenMethodResolver(RuntimeTypeHandle declaringTypeOfSlot, RuntimeMethodHandle gvmSlot, GCHandle readerGCHandle, int handle)
@@ -55,7 +58,9 @@ namespace Internal.Runtime.CompilerServices
             _handle = handle;
             _readerGCHandle = readerGCHandle;
             _nonVirtualOpenInvokeCodePointer = IntPtr.Zero;
-            s_lazyGvmLookupForSlot = &TypeLoaderExports.GVMLookupForSlot;
+
+            if (s_lazyGvmLookupForSlot == IntPtr.Zero)
+                s_lazyGvmLookupForSlot = &TypeLoaderExports.GVMLookupForSlot;
         }
 
         public OpenMethodResolver(RuntimeTypeHandle declaringType, IntPtr codePointer, GCHandle readerGCHandle, int handle)
@@ -65,7 +70,9 @@ namespace Internal.Runtime.CompilerServices
             _declaringType = declaringType.ToEETypePtr();
             _handle = handle;
             _readerGCHandle = readerGCHandle;
-            s_lazyGvmLookupForSlot = &TypeLoaderExports.GVMLookupForSlot;
+
+            if (s_lazyGvmLookupForSlot == IntPtr.Zero)
+                s_lazyGvmLookupForSlot = &TypeLoaderExports.GVMLookupForSlot;
         }
 
         public OpenMethodResolver(RuntimeTypeHandle declaringType, IntPtr codePointer, GCHandle readerGCHandle, int handle, short resolveType)
@@ -81,7 +88,9 @@ namespace Internal.Runtime.CompilerServices
                 _nonVirtualOpenInvokeCodePointer = RuntimeAugments.TypeLoaderCallbacks.ConvertUnboxingFunctionPointerToUnderlyingNonUnboxingPointer(codePointer, declaringType);
             else
                 throw new NotSupportedException();
-            s_lazyGvmLookupForSlot = &TypeLoaderExports.GVMLookupForSlot;
+
+            if (s_lazyGvmLookupForSlot == IntPtr.Zero)
+                s_lazyGvmLookupForSlot = &TypeLoaderExports.GVMLookupForSlot;
         }
 
         public short ResolverType

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/OpenMethodResolver.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/OpenMethodResolver.cs
@@ -20,10 +20,10 @@ namespace Internal.Runtime.CompilerServices
     // 3) Use the ResolveMethod function to do the virtual lookup. This function takes advantage of
     //    a lockless cache so the resolution is very fast for repeated lookups.
     [ReflectionBlocked]
-    public unsafe struct OpenMethodResolver : IEquatable<OpenMethodResolver>
+    public struct OpenMethodResolver : IEquatable<OpenMethodResolver>
     {
         // Lazy initialized to point to the type loader method when the first `GVMResolve` resolver is created
-        private static delegate*<object, RuntimeMethodHandle, nint> s_lazyGvmLookupForSlot;
+        private static unsafe delegate*<object, RuntimeMethodHandle, nint> s_lazyGvmLookupForSlot;
 
         public const short DispatchResolve = 0;
         public const short GVMResolve = 1;
@@ -56,7 +56,7 @@ namespace Internal.Runtime.CompilerServices
             _readerGCHandle = readerGCHandle;
             _nonVirtualOpenInvokeCodePointer = IntPtr.Zero;
 
-            if (s_lazyGvmLookupForSlot == IntPtr.Zero)
+            if (s_lazyGvmLookupForSlot == null)
                 s_lazyGvmLookupForSlot = &TypeLoaderExports.GVMLookupForSlot;
         }
 


### PR DESCRIPTION
Resolver is called into from delegate thunks, so we can't get rid of it, but to construct a resolver one needs to do some reflection first. Make the resolution logic statically depend on resolver being constructed.

cc @dotnet/ilc-contrib 