### PR TITLE
[runtime/6.0] [mono] Raise soft RLIMIT_NOFILE on Linux

### DIFF
--- a/src/mono/mono/mini/driver.c
+++ b/src/mono/mono/mini/driver.c
@@ -69,7 +69,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <locale.h>
-#if TARGET_OSX
+#ifdef HAVE_SYS_RESOURCE_H
 #   include <sys/resource.h>
 #endif
 
@@ -1940,23 +1940,28 @@ switch_gc (char* argv[], const char* target_gc)
 #endif
 }
 
-#ifdef TARGET_OSX
-
-/*
- * tries to increase the minimum number of files, if the number is below 1024
- */
 static void
-darwin_change_default_file_handles ()
+increase_descriptor_limit (void)
 {
+#if defined(HAVE_GETRLIMIT) && !defined(DONT_SET_RLIMIT_NOFILE)
 	struct rlimit limit;
 	
-	if (getrlimit (RLIMIT_NOFILE, &limit) == 0){
-		if (limit.rlim_cur < 1024){
-			limit.rlim_cur = MAX(1024,limit.rlim_cur);
-			setrlimit (RLIMIT_NOFILE, &limit);
-		}
+	if (getrlimit (RLIMIT_NOFILE, &limit) == 0) {
+		// Set our soft limit for file descriptors to be the same
+		// as the max limit.
+		limit.rlim_cur = limit.rlim_max;
+#ifdef __APPLE__
+		// Based on compatibility note in setrlimit(2) manpage for OSX,
+		// trim the limit to OPEN_MAX.
+		if (limit.rlim_cur > OPEN_MAX)
+			limit.rlim_cur = OPEN_MAX;
+#endif
+		setrlimit (RLIMIT_NOFILE, &limit);
 	}
+#endif
 }
+
+#ifdef TARGET_OSX
 
 static void
 switch_arch (char* argv[], const char* target_arch)
@@ -2113,9 +2118,7 @@ mono_main (int argc, char* argv[])
 
 	setlocale (LC_ALL, "");
 
-#if TARGET_OSX
-	darwin_change_default_file_handles ();
-#endif
+	increase_descriptor_limit ();
 
 	if (g_hasenv ("MONO_NO_SMP"))
 		mono_set_use_smp (FALSE);


### PR DESCRIPTION
Manual backport of https://github.com/dotnet/runtime/pull/82429.

Replace darwin_change_default_file_handles by a new routine increase_descriptor_limit, which mirrors the logic in the CoreCLR INIT_IncreaseDescriptorLimit routine.

Fixes https://github.com/dotnet/runtime/issues/82428.

## Customer Impact

Running `dotnet restore` using the Mono runtime (e.g. on the s390x architecture) would under certain circumstances abort with a "Too many open files" error message.  The details are documented in https://github.com/NuGet/Home/issues/12410.

It turned out that Mono does not raise the limit for open files like CoreCLR does. This change fixes that to align with CoreCLR.

## Testing
Manual testing confirmed this fixes the problem.

## Risk
Low, we're aligning the Mono behavior with CoreCLR and the affected codepath is only used on Desktop so doesn't impact the mobile/wasm workloads.