### PR TITLE
[browser] cleanup before memory snapshot

### DIFF
--- a/src/mono/wasm/runtime/dotnet.d.ts
+++ b/src/mono/wasm/runtime/dotnet.d.ts
@@ -58,14 +58,10 @@ declare interface EmscriptenModule {
     FS_createPath(parent: string, path: string, canRead?: boolean, canWrite?: boolean): string;
     FS_createDataFile(parent: string, name: string, data: TypedArray, canRead: boolean, canWrite: boolean, canOwn?: boolean): string;
     FS_readFile(filename: string, opts: any): any;
-    removeRunDependency(id: string): void;
-    addRunDependency(id: string): void;
     addFunction(fn: Function, signature: string): number;
-    getWasmTableEntry(index: number): any;
     stackSave(): VoidPtr;
     stackRestore(stack: VoidPtr): void;
     stackAlloc(size: number): VoidPtr;
-    ready: Promise<unknown>;
     instantiateWasm?: InstantiateWasmCallBack;
     preInit?: (() => any)[] | (() => any);
     preRun?: (() => any)[] | (() => any);

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -8,7 +8,7 @@ import BuildConfiguration from "consts:configuration";
 import WasmEnableLegacyJsInterop from "consts:WasmEnableLegacyJsInterop";
 
 import { ENVIRONMENT_IS_PTHREAD, exportedRuntimeAPI, moduleExports, set_emscripten_entrypoint, set_imports_exports } from "./imports";
-import { DotnetModule, is_nullish, EarlyImports, EarlyExports, EarlyReplacements, RuntimeAPI, CreateDotnetRuntimeType } from "./types";
+import { is_nullish, EarlyImports, EarlyExports, EarlyReplacements, RuntimeAPI, CreateDotnetRuntimeType, DotnetModuleInternal } from "./types";
 import { configure_emscripten_startup, mono_wasm_pthread_worker_init } from "./startup";
 
 import { create_weak_ref } from "./weak-ref";
@@ -37,7 +37,7 @@ function initializeImportsAndExports(
     replacements: EarlyReplacements,
     callbackAPI: any
 ): RuntimeAPI {
-    const module = exports.module as DotnetModule;
+    const module = exports.module as DotnetModuleInternal;
     const globalThisAny = globalThis as any;
 
     // we want to have same instance of MONO, BINDING and Module in dotnet iife

--- a/src/mono/wasm/runtime/icu.ts
+++ b/src/mono/wasm/runtime/icu.ts
@@ -50,3 +50,29 @@ export function mono_wasm_globalization_init(): void {
     }
 }
 
+export function get_preferred_icu_asset(): string | null {
+    if (!runtimeHelpers.config.assets)
+        return null;
+
+    // By setting <WasmIcuDataFileName> user can define what ICU source file they want to load.
+    // There is no need to check application's culture when <WasmIcuDataFileName> is set.
+    // If it was not set, then we have 3 "icu" assets in config and we should choose
+    // only one for loading, the one that matches the application's locale.
+    const icuAssets = runtimeHelpers.config.assets.filter(a => a["behavior"] == "icu");
+    if (icuAssets.length === 1)
+        return icuAssets[0].name;
+
+    // reads the browsers locale / the OS's locale
+    const preferredCulture = ENVIRONMENT_IS_WEB ? navigator.language : Intl.DateTimeFormat().resolvedOptions().locale;
+    const prefix = preferredCulture.split("-")[0];
+    const CJK = "icudt_CJK.dat";
+    const EFIGS = "icudt_EFIGS.dat";
+    const OTHERS = "icudt_no_CJK.dat";
+
+    // not all "fr-*", "it-*", "de-*", "es-*" are in EFIGS, only the one that is mostly used
+    if (prefix == "en" || ["fr", "fr-FR", "it", "it-IT", "de", "de-DE", "es", "es-ES"].includes(preferredCulture))
+        return EFIGS;
+    if (["zh", "ko", "ja"].includes(prefix))
+        return CJK;
+    return OTHERS;
+}

--- a/src/mono/wasm/runtime/imports.ts
+++ b/src/mono/wasm/runtime/imports.ts
@@ -29,6 +29,7 @@ export function set_imports_exports(
 ): void {
     INTERNAL = exports.internal;
     IMPORTS = exports.marshaled_imports;
+    Module = exports.module;
 
     ENVIRONMENT_IS_NODE = imports.isNode;
     ENVIRONMENT_IS_SHELL = imports.isShell;

--- a/src/mono/wasm/runtime/imports.ts
+++ b/src/mono/wasm/runtime/imports.ts
@@ -10,6 +10,7 @@ import type { EmscriptenModule } from "./types/emscripten";
 
 // these are our public API (except internal)
 export let Module: EmscriptenModule & DotnetModule;
+export let anyModule: any = undefined;
 export let INTERNAL: any;
 export let IMPORTS: any;
 
@@ -29,7 +30,7 @@ export function set_imports_exports(
 ): void {
     INTERNAL = exports.internal;
     IMPORTS = exports.marshaled_imports;
-    Module = exports.module;
+    anyModule = Module = exports.module;
 
     ENVIRONMENT_IS_NODE = imports.isNode;
     ENVIRONMENT_IS_SHELL = imports.isShell;

--- a/src/mono/wasm/runtime/imports.ts
+++ b/src/mono/wasm/runtime/imports.ts
@@ -6,11 +6,10 @@
 /// <reference path="./types/node.d.ts" />
 
 import type { CreateDotnetRuntimeType, DotnetModule, RuntimeAPI, EarlyExports, EarlyImports, ModuleAPI, RuntimeHelpers } from "./types";
-import type { EmscriptenModule } from "./types/emscripten";
+import type { EmscriptenModule, EmscriptenModuleInternal } from "./types/emscripten";
 
 // these are our public API (except internal)
-export let Module: EmscriptenModule & DotnetModule;
-export let anyModule: any = undefined;
+export let Module: EmscriptenModule & DotnetModule & EmscriptenModuleInternal;
 export let INTERNAL: any;
 export let IMPORTS: any;
 
@@ -30,7 +29,6 @@ export function set_imports_exports(
 ): void {
     INTERNAL = exports.internal;
     IMPORTS = exports.marshaled_imports;
-    anyModule = Module = exports.module;
 
     ENVIRONMENT_IS_NODE = imports.isNode;
     ENVIRONMENT_IS_SHELL = imports.isShell;

--- a/src/mono/wasm/runtime/managed-exports.ts
+++ b/src/mono/wasm/runtime/managed-exports.ts
@@ -3,7 +3,7 @@
 
 import { GCHandle, MarshalerToCs, MarshalerToJs, MonoMethod, mono_assert } from "./types";
 import cwraps from "./cwraps";
-import { runtimeHelpers, ENVIRONMENT_IS_PTHREAD, anyModule } from "./imports";
+import { runtimeHelpers, ENVIRONMENT_IS_PTHREAD, Module } from "./imports";
 import { alloc_stack_frame, get_arg, get_arg_gc_handle, MarshalerType, set_arg_type, set_gc_handle } from "./marshal";
 import { invoke_method_and_handle_exception } from "./invoke-cs";
 import { marshal_array_to_cs_impl, marshal_exception_to_cs, marshal_intptr_to_cs } from "./marshal-to-cs";
@@ -37,7 +37,7 @@ export function init_managed_exports(): void {
     mono_assert(get_managed_stack_trace_method, "Can't find GetManagedStackTrace method");
 
     runtimeHelpers.javaScriptExports.call_entry_point = (entry_point: MonoMethod, program_args?: string[]) => {
-        const sp = anyModule.stackSave();
+        const sp = Module.stackSave();
         try {
             const args = alloc_stack_frame(4);
             const res = get_arg(args, 1);
@@ -55,12 +55,12 @@ export function init_managed_exports(): void {
             }
             return promise;
         } finally {
-            anyModule.stackRestore(sp);
+            Module.stackRestore(sp);
         }
     };
     runtimeHelpers.javaScriptExports.release_js_owned_object_by_gc_handle = (gc_handle: GCHandle) => {
         mono_assert(gc_handle, "Must be valid gc_handle");
-        const sp = anyModule.stackSave();
+        const sp = Module.stackSave();
         try {
             const args = alloc_stack_frame(3);
             const arg1 = get_arg(args, 2);
@@ -68,22 +68,22 @@ export function init_managed_exports(): void {
             set_gc_handle(arg1, gc_handle);
             invoke_method_and_handle_exception(release_js_owned_object_by_gc_handle_method, args);
         } finally {
-            anyModule.stackRestore(sp);
+            Module.stackRestore(sp);
         }
     };
     runtimeHelpers.javaScriptExports.create_task_callback = () => {
-        const sp = anyModule.stackSave();
+        const sp = Module.stackSave();
         try {
             const args = alloc_stack_frame(2);
             invoke_method_and_handle_exception(create_task_callback_method, args);
             const res = get_arg(args, 1);
             return get_arg_gc_handle(res);
         } finally {
-            anyModule.stackRestore(sp);
+            Module.stackRestore(sp);
         }
     };
     runtimeHelpers.javaScriptExports.complete_task = (holder_gc_handle: GCHandle, error?: any, data?: any, res_converter?: MarshalerToCs) => {
-        const sp = anyModule.stackSave();
+        const sp = Module.stackSave();
         try {
             const args = alloc_stack_frame(5);
             const arg1 = get_arg(args, 2);
@@ -100,11 +100,11 @@ export function init_managed_exports(): void {
             }
             invoke_method_and_handle_exception(complete_task_method, args);
         } finally {
-            anyModule.stackRestore(sp);
+            Module.stackRestore(sp);
         }
     };
     runtimeHelpers.javaScriptExports.call_delegate = (callback_gc_handle: GCHandle, arg1_js: any, arg2_js: any, arg3_js: any, res_converter?: MarshalerToJs, arg1_converter?: MarshalerToCs, arg2_converter?: MarshalerToCs, arg3_converter?: MarshalerToCs) => {
-        const sp = anyModule.stackSave();
+        const sp = Module.stackSave();
         try {
             const args = alloc_stack_frame(6);
 
@@ -133,11 +133,11 @@ export function init_managed_exports(): void {
                 return res_converter(res);
             }
         } finally {
-            anyModule.stackRestore(sp);
+            Module.stackRestore(sp);
         }
     };
     runtimeHelpers.javaScriptExports.get_managed_stack_trace = (exception_gc_handle: GCHandle) => {
-        const sp = anyModule.stackSave();
+        const sp = Module.stackSave();
         try {
             const args = alloc_stack_frame(3);
 
@@ -149,18 +149,18 @@ export function init_managed_exports(): void {
             const res = get_arg(args, 1);
             return marshal_string_to_js(res);
         } finally {
-            anyModule.stackRestore(sp);
+            Module.stackRestore(sp);
         }
     };
 
     if (install_sync_context) {
         runtimeHelpers.javaScriptExports.install_synchronization_context = () => {
-            const sp = anyModule.stackSave();
+            const sp = Module.stackSave();
             try {
                 const args = alloc_stack_frame(2);
                 invoke_method_and_handle_exception(install_sync_context, args);
             } finally {
-                anyModule.stackRestore(sp);
+                Module.stackRestore(sp);
             }
         };
 

--- a/src/mono/wasm/runtime/managed-exports.ts
+++ b/src/mono/wasm/runtime/managed-exports.ts
@@ -3,14 +3,13 @@
 
 import { GCHandle, MarshalerToCs, MarshalerToJs, MonoMethod, mono_assert } from "./types";
 import cwraps from "./cwraps";
-import { Module, runtimeHelpers, ENVIRONMENT_IS_PTHREAD } from "./imports";
+import { runtimeHelpers, ENVIRONMENT_IS_PTHREAD, anyModule } from "./imports";
 import { alloc_stack_frame, get_arg, get_arg_gc_handle, MarshalerType, set_arg_type, set_gc_handle } from "./marshal";
 import { invoke_method_and_handle_exception } from "./invoke-cs";
 import { marshal_array_to_cs_impl, marshal_exception_to_cs, marshal_intptr_to_cs } from "./marshal-to-cs";
 import { marshal_int32_to_js, marshal_string_to_js, marshal_task_to_js } from "./marshal-to-js";
 
 export function init_managed_exports(): void {
-    const anyModule = Module as any;
     const exports_fqn_asm = "System.Runtime.InteropServices.JavaScript";
     runtimeHelpers.runtime_interop_module = cwraps.mono_wasm_assembly_load(exports_fqn_asm);
     if (!runtimeHelpers.runtime_interop_module)

--- a/src/mono/wasm/runtime/marshal.ts
+++ b/src/mono/wasm/runtime/marshal.ts
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { js_owned_gc_handle_symbol, teardown_managed_proxy } from "./gc-handles";
-import { Module, runtimeHelpers } from "./imports";
+import { anyModule, Module, runtimeHelpers } from "./imports";
 import { getF32, getF64, getI16, getI32, getI64Big, getU16, getU32, getU8, setF32, setF64, setI16, setI32, setI64Big, setU16, setU32, setU8 } from "./memory";
 import { mono_wasm_new_external_root } from "./roots";
 import { mono_assert, GCHandle, JSHandle, MonoObject, MonoString, GCHandleNull, JSMarshalerArguments, JSFunctionSignature, JSMarshalerType, JSMarshalerArgument, MarshalerToJs, MarshalerToCs, WasmRoot } from "./types";
@@ -41,7 +41,6 @@ export const JSMarshalerTypeSize = 32;
 export const JSMarshalerSignatureHeaderSize = 4 + 4; // without Exception and Result
 
 export function alloc_stack_frame(size: number): JSMarshalerArguments {
-    const anyModule = Module as any;
     const args = anyModule.stackAlloc(JavaScriptMarshalerArgSize * size);
     mono_assert(args && (<any>args) % 8 == 0, "Arg alignment");
     const exc = get_arg(args, 0);

--- a/src/mono/wasm/runtime/marshal.ts
+++ b/src/mono/wasm/runtime/marshal.ts
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { js_owned_gc_handle_symbol, teardown_managed_proxy } from "./gc-handles";
-import { anyModule, Module, runtimeHelpers } from "./imports";
+import { Module, runtimeHelpers } from "./imports";
 import { getF32, getF64, getI16, getI32, getI64Big, getU16, getU32, getU8, setF32, setF64, setI16, setI32, setI64Big, setU16, setU32, setU8 } from "./memory";
 import { mono_wasm_new_external_root } from "./roots";
 import { mono_assert, GCHandle, JSHandle, MonoObject, MonoString, GCHandleNull, JSMarshalerArguments, JSFunctionSignature, JSMarshalerType, JSMarshalerArgument, MarshalerToJs, MarshalerToCs, WasmRoot } from "./types";
@@ -41,7 +41,7 @@ export const JSMarshalerTypeSize = 32;
 export const JSMarshalerSignatureHeaderSize = 4 + 4; // without Exception and Result
 
 export function alloc_stack_frame(size: number): JSMarshalerArguments {
-    const args = anyModule.stackAlloc(JavaScriptMarshalerArgSize * size);
+    const args = Module.stackAlloc(JavaScriptMarshalerArgSize * size) as any;
     mono_assert(args && (<any>args) % 8 == 0, "Arg alignment");
     const exc = get_arg(args, 0);
     set_arg_type(exc, MarshalerType.None);

--- a/src/mono/wasm/runtime/polyfills.ts
+++ b/src/mono/wasm/runtime/polyfills.ts
@@ -3,7 +3,7 @@
 
 import BuildConfiguration from "consts:configuration";
 import MonoWasmThreads from "consts:monoWasmThreads";
-import { ENVIRONMENT_IS_NODE, ENVIRONMENT_IS_SHELL, ENVIRONMENT_IS_WEB, ENVIRONMENT_IS_WORKER, INTERNAL, Module, runtimeHelpers } from "./imports";
+import { anyModule, ENVIRONMENT_IS_NODE, ENVIRONMENT_IS_SHELL, ENVIRONMENT_IS_WEB, ENVIRONMENT_IS_WORKER, INTERNAL, Module, runtimeHelpers } from "./imports";
 import { afterUpdateGlobalBufferAndViews } from "./memory";
 import { replaceEmscriptenPThreadLibrary } from "./pthreads/shared/emscripten-replacements";
 import { DotnetModuleConfigImports, EarlyReplacements } from "./types";
@@ -13,7 +13,6 @@ let node_fs: any | undefined = undefined;
 let node_url: any | undefined = undefined;
 
 export function init_polyfills(replacements: EarlyReplacements): void {
-    const anyModule = Module as any;
 
     // performance.now() is used by emscripten and doesn't work in JSC
     if (typeof globalThis.performance === "undefined") {
@@ -177,7 +176,7 @@ export function init_polyfills(replacements: EarlyReplacements): void {
 
     // memory
     const originalUpdateGlobalBufferAndViews = replacements.updateGlobalBufferAndViews;
-    replacements.updateGlobalBufferAndViews = (buffer: ArrayBufferLike) => {
+    runtimeHelpers.updateGlobalBufferAndViews = replacements.updateGlobalBufferAndViews = (buffer: ArrayBufferLike) => {
         originalUpdateGlobalBufferAndViews(buffer);
         afterUpdateGlobalBufferAndViews(buffer);
     };

--- a/src/mono/wasm/runtime/polyfills.ts
+++ b/src/mono/wasm/runtime/polyfills.ts
@@ -3,7 +3,7 @@
 
 import BuildConfiguration from "consts:configuration";
 import MonoWasmThreads from "consts:monoWasmThreads";
-import { anyModule, ENVIRONMENT_IS_NODE, ENVIRONMENT_IS_SHELL, ENVIRONMENT_IS_WEB, ENVIRONMENT_IS_WORKER, INTERNAL, Module, runtimeHelpers } from "./imports";
+import { ENVIRONMENT_IS_NODE, ENVIRONMENT_IS_SHELL, ENVIRONMENT_IS_WEB, ENVIRONMENT_IS_WORKER, INTERNAL, Module, runtimeHelpers } from "./imports";
 import { afterUpdateGlobalBufferAndViews } from "./memory";
 import { replaceEmscriptenPThreadLibrary } from "./pthreads/shared/emscripten-replacements";
 import { DotnetModuleConfigImports, EarlyReplacements } from "./types";
@@ -122,7 +122,7 @@ export function init_polyfills(replacements: EarlyReplacements): void {
     }
 
     // require replacement
-    const imports = anyModule.imports = (Module.imports || {}) as DotnetModuleConfigImports;
+    const imports = Module.imports = (Module.imports || {}) as DotnetModuleConfigImports;
     const requireWrapper = (wrappedRequire: Function) => (name: string) => {
         const resolved = (<any>Module.imports)[name];
         if (resolved) {
@@ -145,20 +145,20 @@ export function init_polyfills(replacements: EarlyReplacements): void {
 
     // script location
     runtimeHelpers.scriptDirectory = replacements.scriptDirectory = detectScriptDirectory(replacements);
-    anyModule.mainScriptUrlOrBlob = replacements.scriptUrl;// this is needed by worker threads
+    Module.mainScriptUrlOrBlob = replacements.scriptUrl;// this is needed by worker threads
     if (BuildConfiguration === "Debug") {
         console.debug(`MONO_WASM: starting script ${replacements.scriptUrl}`);
         console.debug(`MONO_WASM: starting in ${runtimeHelpers.scriptDirectory}`);
     }
-    if (anyModule.__locateFile === anyModule.locateFile) {
+    if (Module.__locateFile === Module.locateFile) {
         // above it's our early version from dotnet.es6.pre.js, we could replace it with better
-        anyModule.locateFile = runtimeHelpers.locateFile = (path) => {
+        Module.locateFile = runtimeHelpers.locateFile = (path) => {
             if (isPathAbsolute(path)) return path;
             return runtimeHelpers.scriptDirectory + path;
         };
     } else {
         // we use what was given to us
-        runtimeHelpers.locateFile = anyModule.locateFile;
+        runtimeHelpers.locateFile = Module.locateFile!;
     }
 
     // prefer fetch_like over global fetch for assets

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -5,10 +5,10 @@ import BuildConfiguration from "consts:configuration";
 import MonoWasmThreads from "consts:monoWasmThreads";
 import WasmEnableLegacyJsInterop from "consts:WasmEnableLegacyJsInterop";
 import { CharPtrNull, DotnetModule, RuntimeAPI, MonoConfig, MonoConfigInternal } from "./types";
-import { ENVIRONMENT_IS_NODE, ENVIRONMENT_IS_SHELL, INTERNAL, Module, runtimeHelpers } from "./imports";
+import { anyModule, ENVIRONMENT_IS_NODE, ENVIRONMENT_IS_SHELL, INTERNAL, Module, runtimeHelpers } from "./imports";
 import cwraps, { init_c_exports } from "./cwraps";
 import { mono_wasm_raise_debug_event, mono_wasm_runtime_ready } from "./debug";
-import { mono_wasm_globalization_init } from "./icu";
+import { get_preferred_icu_asset, mono_wasm_globalization_init } from "./icu";
 import { toBase64StringImpl } from "./base64";
 import { mono_wasm_init_aot_profiler, mono_wasm_init_browser_profiler } from "./profiler";
 import { mono_on_abort, mono_exit } from "./run";
@@ -125,7 +125,6 @@ async function instantiateWasmWorker(
     // wait for the config to arrive by message from the main thread
     await afterConfigLoaded.promise;
 
-    const anyModule = Module as any;
     normalizeConfig();
     replace_linker_placeholders(imports, export_linker());
 
@@ -295,7 +294,6 @@ export function abort_startup(reason: any, should_exit: boolean): void {
     }
 }
 
-// runs in both blazor and non-blazor
 function mono_wasm_pre_init_essential(isWorker: boolean): void {
     if (!isWorker)
         Module.addRunDependency("mono_wasm_pre_init_essential");
@@ -318,7 +316,6 @@ function mono_wasm_pre_init_essential(isWorker: boolean): void {
         Module.removeRunDependency("mono_wasm_pre_init_essential");
 }
 
-// runs in both blazor and non-blazor
 async function mono_wasm_pre_init_essential_async(): Promise<void> {
     if (runtimeHelpers.diagnosticTracing) console.debug("MONO_WASM: mono_wasm_pre_init_essential_async");
     Module.addRunDependency("mono_wasm_pre_init_essential_async");
@@ -333,7 +330,6 @@ async function mono_wasm_pre_init_essential_async(): Promise<void> {
     Module.removeRunDependency("mono_wasm_pre_init_essential_async");
 }
 
-// runs just in non-blazor
 async function mono_wasm_pre_init_full(): Promise<void> {
     if (runtimeHelpers.diagnosticTracing) console.debug("MONO_WASM: mono_wasm_pre_init_full");
     Module.addRunDependency("mono_wasm_pre_init_full");
@@ -343,7 +339,6 @@ async function mono_wasm_pre_init_full(): Promise<void> {
     Module.removeRunDependency("mono_wasm_pre_init_full");
 }
 
-// runs just in non-blazor
 async function mono_wasm_before_user_runtime_initialized(): Promise<void> {
     if (runtimeHelpers.diagnosticTracing) console.debug("MONO_WASM: mono_wasm_before_user_runtime_initialized");
 
@@ -365,7 +360,6 @@ async function mono_wasm_before_user_runtime_initialized(): Promise<void> {
     }
 }
 
-// runs in both blazor and non-blazor
 async function mono_wasm_after_user_runtime_initialized(): Promise<void> {
     if (runtimeHelpers.diagnosticTracing) console.debug("MONO_WASM: mono_wasm_after_user_runtime_initialized");
     try {
@@ -385,10 +379,6 @@ async function mono_wasm_after_user_runtime_initialized(): Promise<void> {
                     console.warn(`MONO_WASM: The exported symbol ${exportName} could not be found in the emscripten module`);
                 }
             }
-        }
-        // for Blazor, init diagnostics after their "onRuntimeInitalized" sets env variables, but before their postRun callback (which calls mono_wasm_load_runtime)
-        if (MonoWasmThreads) {
-            await mono_wasm_init_diagnostics();
         }
 
         if (runtimeHelpers.diagnosticTracing) console.debug("MONO_WASM: Initializing mono runtime");
@@ -484,15 +474,7 @@ async function instantiate_wasm_module(
     Module.removeRunDependency("instantiate_wasm_module");
 }
 
-// runs just in non-blazor
 async function _apply_configuration_from_args() {
-    try {
-        const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
-        if (tz) mono_wasm_setenv("TZ", tz);
-    } catch {
-        console.info("MONO_WASM: failed to detect timezone, will fallback to UTC");
-    }
-
     // create /usr/share folder which is SpecialFolder.CommonApplicationData
     Module["FS_createPath"]("/", "usr", true, true);
     Module["FS_createPath"]("/", "usr/share", true, true);
@@ -514,7 +496,7 @@ async function _apply_configuration_from_args() {
     if (config.browserProfilerOptions)
         mono_wasm_init_browser_profiler(config.browserProfilerOptions);
 
-    // for non-Blazor, init diagnostics after environment variables are set
+    // init diagnostics after environment variables are set
     if (MonoWasmThreads) {
         await mono_wasm_init_diagnostics();
     }
@@ -536,7 +518,6 @@ export function mono_wasm_load_runtime(unused?: string, debugLevel?: number): vo
         }
         cwraps.mono_wasm_load_runtime(unused || "unused", debugLevel);
         endMeasure(mark, MeasuredBlock.loadRuntime);
-        runtimeHelpers.waitForDebugger = config.waitForDebugger;
 
         if (!runtimeHelpers.mono_wasm_bindings_is_ready) bindings_init();
     } catch (err: any) {
@@ -552,10 +533,10 @@ export function mono_wasm_load_runtime(unused?: string, debugLevel?: number): vo
 }
 
 export function bindings_init(): void {
-    if (runtimeHelpers.diagnosticTracing) console.debug("MONO_WASM: bindings_init");
     if (runtimeHelpers.mono_wasm_bindings_is_ready) {
         return;
     }
+    if (runtimeHelpers.diagnosticTracing) console.debug("MONO_WASM: bindings_init");
     runtimeHelpers.mono_wasm_bindings_is_ready = true;
     try {
         const mark = startMeasure();
@@ -588,7 +569,7 @@ export async function mono_wasm_load_config(configFilePath?: string): Promise<vo
     configLoaded = true;
     if (!configFilePath) {
         normalizeConfig();
-        afterConfigLoaded.promise_control.resolve(runtimeHelpers.config);
+        afterConfigLoaded.promise_control.resolve(config);
         return;
     }
     if (runtimeHelpers.diagnosticTracing) console.debug("MONO_WASM: mono_wasm_load_config");
@@ -609,7 +590,7 @@ export async function mono_wasm_load_config(configFilePath?: string): Promise<vo
 
         if (Module.onConfigLoaded) {
             try {
-                await Module.onConfigLoaded(<MonoConfig>runtimeHelpers.config);
+                await Module.onConfigLoaded(<MonoConfig>config);
                 normalizeConfig();
             }
             catch (err: any) {
@@ -617,7 +598,7 @@ export async function mono_wasm_load_config(configFilePath?: string): Promise<vo
                 throw err;
             }
         }
-        afterConfigLoaded.promise_control.resolve(runtimeHelpers.config);
+        afterConfigLoaded.promise_control.resolve(config);
     } catch (err) {
         const errMessage = `Failed to load config file ${configFilePath} ${err}`;
         abort_startup(errMessage, true);
@@ -640,13 +621,23 @@ function normalizeConfig() {
     if (config.diagnosticTracing === undefined && BuildConfiguration === "Debug") {
         config.diagnosticTracing = true;
     }
-    runtimeHelpers.diagnosticTracing = !!runtimeHelpers.config.diagnosticTracing;
+    runtimeHelpers.diagnosticTracing = !!config.diagnosticTracing;
 
     runtimeHelpers.enablePerfMeasure = !!config.browserProfilerOptions
         && globalThis.performance
         && typeof globalThis.performance.measure === "function";
-}
+    runtimeHelpers.preferredIcuAsset = get_preferred_icu_asset();
 
+    if (runtimeHelpers.timezone === undefined && config.environmentVariables["TZ"] === undefined) {
+        try {
+            runtimeHelpers.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || null;
+            if (runtimeHelpers.timezone) config.environmentVariables["TZ"] = runtimeHelpers.timezone;
+        } catch {
+            console.info("MONO_WASM: failed to detect timezone, will fallback to UTC");
+        }
+    }
+    runtimeHelpers.waitForDebugger = config.waitForDebugger;
+}
 
 export function mono_wasm_asm_loaded(assembly_name: CharPtr, assembly_ptr: number, assembly_len: number, pdb_ptr: number, pdb_len: number): void {
     // Only trigger this codepath for assemblies loaded after app is ready

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -4,8 +4,8 @@
 import BuildConfiguration from "consts:configuration";
 import MonoWasmThreads from "consts:monoWasmThreads";
 import WasmEnableLegacyJsInterop from "consts:WasmEnableLegacyJsInterop";
-import { CharPtrNull, DotnetModule, RuntimeAPI, MonoConfig, MonoConfigInternal } from "./types";
-import { anyModule, ENVIRONMENT_IS_NODE, ENVIRONMENT_IS_SHELL, INTERNAL, Module, runtimeHelpers } from "./imports";
+import { CharPtrNull, DotnetModule, RuntimeAPI, MonoConfig, MonoConfigInternal, DotnetModuleInternal } from "./types";
+import { ENVIRONMENT_IS_NODE, ENVIRONMENT_IS_SHELL, INTERNAL, Module, runtimeHelpers } from "./imports";
 import cwraps, { init_c_exports } from "./cwraps";
 import { mono_wasm_raise_debug_event, mono_wasm_runtime_ready } from "./debug";
 import { get_preferred_icu_asset, mono_wasm_globalization_init } from "./icu";
@@ -50,7 +50,7 @@ const MONO_PTHREAD_POOL_SIZE = 4;
 
 // we are making emscripten startup async friendly
 // emscripten is executing the events without awaiting it and so we need to block progress via PromiseControllers above
-export function configure_emscripten_startup(module: DotnetModule, exportedAPI: RuntimeAPI): void {
+export function configure_emscripten_startup(module: DotnetModuleInternal, exportedAPI: RuntimeAPI): void {
     const mark = startMeasure();
     // these all could be overridden on DotnetModuleConfig, we are chaing them to async below, as opposed to emscripten
     // when user set configSrc or config, we are running our default startup sequence.
@@ -130,9 +130,9 @@ async function instantiateWasmWorker(
 
     // Instantiate from the module posted from the main thread.
     // We can just use sync instantiation in the worker.
-    const instance = new WebAssembly.Instance(anyModule.wasmModule, imports);
+    const instance = new WebAssembly.Instance(Module.wasmModule!, imports);
     successCallback(instance, undefined);
-    anyModule.wasmModule = null;
+    Module.wasmModule = null;
 }
 
 function preInit(userPreInit: (() => void)[]) {

--- a/src/mono/wasm/runtime/types.ts
+++ b/src/mono/wasm/runtime/types.ts
@@ -229,6 +229,9 @@ export type RuntimeHelpers = {
     locateFile: (path: string, prefix?: string) => string,
     javaScriptExports: JavaScriptExports,
     loadedFiles: string[],
+    preferredIcuAsset: string | null,
+    timezone: string | null,
+    updateGlobalBufferAndViews: (buffer: ArrayBufferLike) => void
 }
 
 export type GlobalizationMode =

--- a/src/mono/wasm/runtime/types.ts
+++ b/src/mono/wasm/runtime/types.ts
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { DotnetHostBuilder } from "./run-outer";
-import { CharPtr, EmscriptenModule, ManagedPointer, NativePointer, VoidPtr, Int32Ptr } from "./types/emscripten";
+import { CharPtr, EmscriptenModule, ManagedPointer, NativePointer, VoidPtr, Int32Ptr, EmscriptenModuleInternal } from "./types/emscripten";
 
 export type GCHandle = {
     __brand: "GCHandle"
@@ -250,6 +250,7 @@ export type BrowserProfilerOptions = {
 
 // how we extended emscripten Module
 export type DotnetModule = EmscriptenModule & DotnetModuleConfig;
+export type DotnetModuleInternal = EmscriptenModule & DotnetModuleConfig & EmscriptenModuleInternal;
 
 export type DotnetModuleConfig = {
     disableDotnet6Compatibility?: boolean,

--- a/src/mono/wasm/runtime/types/emscripten.ts
+++ b/src/mono/wasm/runtime/types/emscripten.ts
@@ -50,16 +50,12 @@ export declare interface EmscriptenModule {
     FS_createPath(parent: string, path: string, canRead?: boolean, canWrite?: boolean): string;
     FS_createDataFile(parent: string, name: string, data: TypedArray, canRead: boolean, canWrite: boolean, canOwn?: boolean): string;
     FS_readFile(filename: string, opts: any): any;
-    removeRunDependency(id: string): void;
-    addRunDependency(id: string): void;
     addFunction(fn: Function, signature: string): number;
-    getWasmTableEntry(index: number): any;
     stackSave(): VoidPtr;
     stackRestore(stack: VoidPtr): void;
     stackAlloc(size: number): VoidPtr;
 
 
-    ready: Promise<unknown>;
     instantiateWasm?: InstantiateWasmCallBack;
     preInit?: (() => any)[] | (() => any);
     preRun?: (() => any)[] | (() => any);
@@ -67,6 +63,18 @@ export declare interface EmscriptenModule {
     postRun?: (() => any)[] | (() => any);
     onAbort?: { (error: any): void };
 }
+
+export declare interface EmscriptenModuleInternal {
+    __locateFile?: (path: string, prefix?: string) => string;
+    locateFile?: (path: string, prefix?: string) => string;
+    mainScriptUrlOrBlob?: string;
+    wasmModule: WebAssembly.Instance | null;
+    ready: Promise<unknown>;
+    getWasmTableEntry(index: number): any;
+    removeRunDependency(id: string): void;
+    addRunDependency(id: string): void;
+}
+
 
 export type InstantiateWasmSuccessCallback = (instance: WebAssembly.Instance, module: WebAssembly.Module | undefined) => void;
 export type InstantiateWasmCallBack = (imports: WebAssembly.Imports, successCallback: InstantiateWasmSuccessCallback) => any;


### PR DESCRIPTION
Split from https://github.com/dotnet/runtime/pull/82049

- moved get_preferred_icu_asset
- moved TZ detection
- moved runtimeHelpers.waitForDebugger
- replaced `anyModule` with `EmscriptenModuleInternal` type
- added runtimeHelpers.updateGlobalBufferAndViews
- removed obsolete comments about blazor startup sequence
- removed duplicate calls mono_wasm_init_diagnostics (also previously blazor startup path)