### PR TITLE
[7.0] Fix superpmi_collect-setup.py helix images to use floating versions instead

### DIFF
--- a/src/coreclr/scripts/superpmi_collect_setup.py
+++ b/src/coreclr/scripts/superpmi_collect_setup.py
@@ -403,9 +403,9 @@ def main(main_args):
         helix_queue = "Windows.10.Arm64" if arch == "arm64" else "Windows.10.Amd64.X86.Rt"
     elif platform_name == "linux":
         if arch == "arm":
-            helix_queue = "(Ubuntu.1804.Arm32)Ubuntu.1804.Armarch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-20230201170255-8b7d579"
+            helix_queue = "(Ubuntu.1804.Arm32)Ubuntu.1804.Armarch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7"
         elif arch == "arm64":
-            helix_queue = "(Ubuntu.1804.Arm64)Ubuntu.1804.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-20230201170341-8b7d579"
+            helix_queue = "(Ubuntu.1804.Arm64)Ubuntu.1804.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8"
         else:
             helix_queue = "Ubuntu.1804.Amd64"
     elif platform_name == "osx":

--- a/src/coreclr/scripts/superpmi_collect_setup.py
+++ b/src/coreclr/scripts/superpmi_collect_setup.py
@@ -22,12 +22,12 @@
 # 4.  Lastly, it sets the pipeline variables.
 #
 # Below are the helix queues it sets depending on the OS/architecture:
-# | Arch  | windows                 | Linux                                                                                                                                | macOS          |
-# |-------|-------------------------|--------------------------------------------------------------------------------------------------------------------------------------|----------------|
-# | x86   | Windows.10.Amd64.X86.Rt |                                                                                                                                      | -              |
-# | x64   | Windows.10.Amd64.X86.Rt | Ubuntu.1804.Amd64                                                                                                                    | OSX.1014.Amd64 |
-# | arm   | -                       | (Ubuntu.1804.Arm32)Ubuntu.1804.Armarch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-20230201170255-8b7d579 | -              |
-# | arm64 | Windows.10.Arm64        | (Ubuntu.1804.Arm64)Ubuntu.1804.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-20230201170341-8b7d579 | OSX.1100.ARM64 |
+# | Arch  | windows                 | Linux                                                                                                         | macOS          |
+# |-------|-------------------------|---------------------------------------------------------------------------------------------------------------|----------------|
+# | x86   | Windows.10.Amd64.X86.Rt |                                                                                                               | -              |
+# | x64   | Windows.10.Amd64.X86.Rt | Ubuntu.1804.Amd64                                                                                             | OSX.1014.Amd64 |
+# | arm   | -                       | (Ubuntu.1804.Arm32)Ubuntu.1804.Armarch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7 | -              |
+# | arm64 | Windows.10.Arm64        | (Ubuntu.1804.Arm64)Ubuntu.1804.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8 | OSX.1100.ARM64 |
 #
 ################################################################################
 ################################################################################


### PR DESCRIPTION
Per the suggestions here: https://github.com/dotnet/runtime/pull/81712#discussion_r1127829613

cc @sbomer @MattGal @mthalman 