### PR TITLE
get transport MsQuic for Windows arm64

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -222,7 +222,7 @@
     <MicrosoftNETCoreRuntimeICUTransportVersion>8.0.0-preview.3.23151.1</MicrosoftNETCoreRuntimeICUTransportVersion>
     <!-- MsQuic -->
     <MicrosoftNativeQuicMsQuicVersion>2.1.7</MicrosoftNativeQuicMsQuicVersion>
-    <SystemNetMsQuicTransportVersion>8.0.0-alpha.1.23153.1</SystemNetMsQuicTransportVersion>
+    <SystemNetMsQuicTransportVersion>8.0.0-alpha.1.23156.1</SystemNetMsQuicTransportVersion>
     <!-- Mono LLVM -->
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>14.0.0-alpha.1.23124.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>14.0.0-alpha.1.23124.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicPlatformDetectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicPlatformDetectionTests.cs
@@ -22,7 +22,6 @@ namespace System.Net.Quic.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/73290", typeof(PlatformDetection), nameof(PlatformDetection.IsSingleFile))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/82885", typeof(PlatformDetection), nameof(PlatformDetection.IsArm64Process))]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.SupportsTls13))]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void SupportedWindowsPlatforms_IsSupportedIsTrue()


### PR DESCRIPTION
floats in https://github.com/dotnet/msquic/pull/131
reverts #82902
fixes #82885