### PR TITLE
Update SourceBuild image to be our Centos 8 Stream image.

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -102,12 +102,6 @@ jobs:
         ${{ if notin(parameters.osGroup, 'ios', 'tvos', 'maccatalyst')}}:
           value: ''
 
-      - name: _sclEnableCommand
-        ${{ if eq(parameters.isSourceBuild, true) }}:
-          value: scl enable llvm-toolset-7.0 --
-        ${{ if ne(parameters.isSourceBuild, true) }}:
-          value: ''
-
       - name: _monoAotBuildshCommand
         value: ''
 
@@ -166,7 +160,7 @@ jobs:
       - template: /eng/common/templates/steps/source-build.yml
         parameters:
           platform:
-            buildScript: $(_sclEnableCommand) $(Build.SourcesDirectory)$(dir)build$(scriptExt)
+            buildScript: $(Build.SourcesDirectory)$(dir)build$(scriptExt)
             nonPortable: ${{ parameters.isNonPortableSourceBuild }}
             targetRID: ${{ parameters.targetRid }}
             runtimeOS: linux
@@ -194,7 +188,7 @@ jobs:
         - task: CodeQL3000Init@0
           displayName: Initialize CodeQL (manually-injected)
 
-      - script: $(_sclEnableCommand) $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch ${{ parameters.archType }} $(_osParameter) ${{ parameters.buildArgs }} $(_officialBuildParameter) $(_crossBuildPropertyArg) $(_cxx11Parameter) $(_buildDarwinFrameworksParameter) $(_overrideTestScriptWindowsCmdParameter)
+      - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch ${{ parameters.archType }} $(_osParameter) ${{ parameters.buildArgs }} $(_officialBuildParameter) $(_crossBuildPropertyArg) $(_cxx11Parameter) $(_buildDarwinFrameworksParameter) $(_overrideTestScriptWindowsCmdParameter)
         displayName: Build product
         ${{ if eq(parameters.useContinueOnErrorDuringBuild, true) }}:
           continueOnError: ${{ parameters.shouldContinueOnError }}

--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -44,8 +44,10 @@ resources:
       env:
         ROOTFS_DIR: /crossrootfs/x86
 
+    # CentOS 8 Stream is the closest image to RHEL8, which has the oldest toolsets we support building against
+    # for our source-build partners.
     - container: SourceBuild_linux_x64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-source-build
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8
 
     - container: linux_s390x
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-s390x


### PR DESCRIPTION
It's close enough to a plain RHEL8 install that it will serve our purposes for validating our source-build min requirements. It technically can go ahead of RHEL8 (as the Stream distros are ahread releases, not behind ones like CentOS used to be), but I don't think that's enough of a concern as we don't have a good base distro to use otherwise as we can't use RHEL8 directly due to licensing rules.

Closes https://github.com/dotnet/dotnet-buildtools-prereqs-docker/issues/719 as we don't need to update that source-build image if we aren't building for it.