### PR TITLE
Swap order of OnError in FileSystemWatcher.ReadDirectoryChangesCallback on Windows

### DIFF
--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
@@ -218,8 +218,8 @@ namespace System.IO
                     const int ERROR_OPERATION_ABORTED = 995;
                     if (errorCode != ERROR_OPERATION_ABORTED)
                     {
-                        OnError(new ErrorEventArgs(new Win32Exception((int)errorCode)));
                         EnableRaisingEvents = false;
+                        OnError(new ErrorEventArgs(new Win32Exception((int)errorCode)));
                     }
                     return;
                 }


### PR DESCRIPTION
If the directory watching encounters a failure error code other than abort, the Windows implementation raises the Error event and sets EnableRaisingEvents to false. However, because it does so in that order, the Error event handler may or may not see the FSW's EnableRaisingEvents as false, based on whether there's a SynchronizingObject that results in the callback being queued.  By swapping the order to always disable first, we can ensure consistency regardless of SynchronizingObject, which also means the Error handler can choose based on the error to set EnableRaisingEvents to true again if it desires.

I haven't added a test as I haven't found a reliable way to get the enumeration to error out, and we don't have any tests today that hit that error path.

Closes https://github.com/dotnet/runtime/issues/81226