### PR TITLE
Add tar tests to confirm entries owned by deleted users can still be read or written

### DIFF
--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.File.Base.Unix.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.File.Base.Unix.cs
@@ -102,17 +102,25 @@ namespace System.Formats.Tar.Tests
         {
             using Process p = new Process();
 
-            p.StartInfo.UseShellExecute = false;
             p.StartInfo.FileName = command;
             p.StartInfo.Arguments = arguments;
+
+            p.StartInfo.UseShellExecute = false;
             p.StartInfo.RedirectStandardOutput = true;
             p.StartInfo.RedirectStandardError = true;
 
-            p.Start();
-            p.WaitForExit();
+            string standardError = string.Empty;
+            p.ErrorDataReceived += new DataReceivedEventHandler((sender, e) => { standardError += e.Data; });
 
-            string standardOutput = p.StandardOutput.ReadToEnd();
-            string standardError = p.StandardError.ReadToEnd();
+            string standardOutput = string.Empty;
+            p.OutputDataReceived += new DataReceivedEventHandler((sender, e) => { standardOutput += e.Data; });
+
+            p.Start();
+
+            p.BeginOutputReadLine();
+            p.BeginErrorReadLine();
+
+            p.WaitForExit();
 
             if (p.ExitCode != 0)
             {

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.Unix.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.Unix.cs
@@ -1,8 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.RemoteExecutor;
 using System.IO;
+using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
 namespace System.Formats.Tar.Tests
@@ -172,13 +172,134 @@ namespace System.Formats.Tar.Tests
                     writer.WriteEntry(filePath, fileName); // Should not throw
                 }
                 archive.Seek(0, SeekOrigin.Begin);
-                
+
                 using (TarReader reader = new TarReader(archive, leaveOpen: false))
                 {
                     PosixTarEntry entry = reader.GetNextEntry() as PosixTarEntry;
                     Assert.NotNull(entry);
-                    Assert.Equal(entry.GroupName, string.Empty);
+
+                    Assert.Equal(string.Empty, entry.GroupName);
                     Assert.Equal(groupId, entry.Gid);
+
+                    string extractedPath = Path.Join(root.Path, "extracted.txt");
+                    entry.ExtractToFile(extractedPath, overwrite: false);
+                    Assert.True(File.Exists(extractedPath));
+
+                    Assert.Null(reader.GetNextEntry());
+                }
+            }, f.ToString(), new RemoteInvokeOptions { RunAsSudo = true }).Dispose();
+        }
+
+        [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndPrivilegedProcess))]
+        [InlineData(TarEntryFormat.Ustar)]
+        [InlineData(TarEntryFormat.Pax)]
+        [InlineData(TarEntryFormat.Gnu)]
+        public void CreateEntryFromFileOwnedByNonExistentUser(TarEntryFormat f)
+        {
+            RemoteExecutor.Invoke((string strFormat) =>
+            {
+                using TempDirectory root = new TempDirectory();
+
+                string fileName = "file.txt";
+                string filePath = Path.Join(root.Path, fileName);
+                File.Create(filePath).Dispose();
+
+                string userName = Path.GetRandomFileName()[0..6];
+                int userId = CreateUser(userName);
+
+                try
+                {
+                    SetUserAsOwnerOfFile(userName, filePath);
+                }
+                finally
+                {
+                    DeleteUser(userName);
+                }
+
+                using MemoryStream archive = new MemoryStream();
+                using (TarWriter writer = new TarWriter(archive, Enum.Parse<TarEntryFormat>(strFormat), leaveOpen: true))
+                {
+                    writer.WriteEntry(filePath, fileName); // Should not throw
+                }
+                archive.Seek(0, SeekOrigin.Begin);
+
+                using (TarReader reader = new TarReader(archive, leaveOpen: false))
+                {
+                    PosixTarEntry entry = reader.GetNextEntry() as PosixTarEntry;
+                    Assert.NotNull(entry);
+
+                    Assert.Equal(string.Empty, entry.UserName);
+                    Assert.Equal(userId, entry.Uid);
+
+                    string extractedPath = Path.Join(root.Path, "extracted.txt");
+                    entry.ExtractToFile(extractedPath, overwrite: false);
+                    Assert.True(File.Exists(extractedPath));
+
+                    Assert.Null(reader.GetNextEntry());
+                }
+            }, f.ToString(), new RemoteInvokeOptions { RunAsSudo = true }).Dispose();
+        }
+
+        [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndPrivilegedProcess))]
+        [InlineData(TarEntryFormat.Ustar)]
+        [InlineData(TarEntryFormat.Pax)]
+        [InlineData(TarEntryFormat.Gnu)]
+        public void CreateEntryFromFileOwnedByNonExistentGroupAndUser(TarEntryFormat f)
+        {
+            RemoteExecutor.Invoke((string strFormat) =>
+            {
+                using TempDirectory root = new TempDirectory();
+
+                string fileName = "file.txt";
+                string filePath = Path.Join(root.Path, fileName);
+                File.Create(filePath).Dispose();
+
+                string groupName = Path.GetRandomFileName()[0..6];
+                int groupId = CreateGroup(groupName);
+
+                string userName = Path.GetRandomFileName()[0..6];
+                int userId = CreateUser(userName);
+
+                try
+                {
+                    SetGroupAsOwnerOfFile(groupName, filePath);
+                }
+                finally
+                {
+                    DeleteGroup(groupName);
+                }
+
+                try
+                {
+                    SetUserAsOwnerOfFile(userName, filePath);
+                }
+                finally
+                {
+                    DeleteUser(userName);
+                }
+
+                using MemoryStream archive = new MemoryStream();
+                using (TarWriter writer = new TarWriter(archive, Enum.Parse<TarEntryFormat>(strFormat), leaveOpen: true))
+                {
+                    writer.WriteEntry(filePath, fileName); // Should not throw
+                }
+                archive.Seek(0, SeekOrigin.Begin);
+
+                using (TarReader reader = new TarReader(archive, leaveOpen: false))
+                {
+                    PosixTarEntry entry = reader.GetNextEntry() as PosixTarEntry;
+                    Assert.NotNull(entry);
+
+                    Assert.Equal(string.Empty, entry.GroupName);
+                    Assert.Equal(groupId, entry.Gid);
+
+                    Assert.Equal(string.Empty, entry.UserName);
+                    Assert.Equal(userId, entry.Uid);
+
+                    string extractedPath = Path.Join(root.Path, "extracted.txt");
+                    entry.ExtractToFile(extractedPath, overwrite: false);
+                    Assert.True(File.Exists(extractedPath));
+
                     Assert.Null(reader.GetNextEntry());
                 }
             }, f.ToString(), new RemoteInvokeOptions { RunAsSudo = true }).Dispose();

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.File.Tests.Unix.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.File.Tests.Unix.cs
@@ -1,9 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.RemoteExecutor;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
 namespace System.Formats.Tar.Tests
@@ -149,7 +149,7 @@ namespace System.Formats.Tar.Tests
                 }
             }, format.ToString(), new RemoteInvokeOptions { RunAsSudo = true }).Dispose();
         }
-        
+
         [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndPrivilegedProcess))]
         [InlineData(TarEntryFormat.Ustar)]
         [InlineData(TarEntryFormat.Pax)]
@@ -182,13 +182,134 @@ namespace System.Formats.Tar.Tests
                     await writer.WriteEntryAsync(filePath, fileName); // Should not throw
                 }
                 archive.Seek(0, SeekOrigin.Begin);
-                
+
                 await using (TarReader reader = new TarReader(archive, leaveOpen: false))
                 {
                     PosixTarEntry entry = await reader.GetNextEntryAsync() as PosixTarEntry;
                     Assert.NotNull(entry);
-                    Assert.Equal(entry.GroupName, string.Empty);
+
+                    Assert.Equal(string.Empty, entry.GroupName);
                     Assert.Equal(groupId, entry.Gid);
+
+                    string extractedPath = Path.Join(root.Path, "extracted.txt");
+                    await entry.ExtractToFileAsync(extractedPath, overwrite: false);
+                    Assert.True(File.Exists(extractedPath));
+
+                    Assert.Null(await reader.GetNextEntryAsync());
+                }
+            }, f.ToString(), new RemoteInvokeOptions { RunAsSudo = true }).Dispose();
+        }
+
+        [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndPrivilegedProcess))]
+        [InlineData(TarEntryFormat.Ustar)]
+        [InlineData(TarEntryFormat.Pax)]
+        [InlineData(TarEntryFormat.Gnu)]
+        public void CreateEntryFromFileOwnedByNonExistentUser_Async(TarEntryFormat f)
+        {
+            RemoteExecutor.Invoke(async (string strFormat) =>
+            {
+                using TempDirectory root = new TempDirectory();
+
+                string fileName = "file.txt";
+                string filePath = Path.Join(root.Path, fileName);
+                File.Create(filePath).Dispose();
+
+                string userName = Path.GetRandomFileName()[0..6];
+                int userId = CreateUser(userName);
+
+                try
+                {
+                    SetUserAsOwnerOfFile(userName, filePath);
+                }
+                finally
+                {
+                    DeleteUser(userName);
+                }
+
+                await using MemoryStream archive = new MemoryStream();
+                await using (TarWriter writer = new TarWriter(archive, Enum.Parse<TarEntryFormat>(strFormat), leaveOpen: true))
+                {
+                    await writer.WriteEntryAsync(filePath, fileName); // Should not throw
+                }
+                archive.Seek(0, SeekOrigin.Begin);
+
+                await using (TarReader reader = new TarReader(archive, leaveOpen: false))
+                {
+                    PosixTarEntry entry = await reader.GetNextEntryAsync() as PosixTarEntry;
+                    Assert.NotNull(entry);
+
+                    Assert.Equal(string.Empty, entry.UserName);
+                    Assert.Equal(userId, entry.Uid);
+
+                    string extractedPath = Path.Join(root.Path, "extracted.txt");
+                    await entry.ExtractToFileAsync(extractedPath, overwrite: false);
+                    Assert.True(File.Exists(extractedPath));
+
+                    Assert.Null(await reader.GetNextEntryAsync());
+                }
+            }, f.ToString(), new RemoteInvokeOptions { RunAsSudo = true }).Dispose();
+        }
+
+        [ConditionalTheory(nameof(IsRemoteExecutorSupportedAndPrivilegedProcess))]
+        [InlineData(TarEntryFormat.Ustar)]
+        [InlineData(TarEntryFormat.Pax)]
+        [InlineData(TarEntryFormat.Gnu)]
+        public void CreateEntryFromFileOwnedByNonExistentGroupAndUser_Async(TarEntryFormat f)
+        {
+            RemoteExecutor.Invoke(async (string strFormat) =>
+            {
+                using TempDirectory root = new TempDirectory();
+
+                string fileName = "file.txt";
+                string filePath = Path.Join(root.Path, fileName);
+                File.Create(filePath).Dispose();
+
+                string groupName = Path.GetRandomFileName()[0..6];
+                int groupId = CreateGroup(groupName);
+
+                string userName = Path.GetRandomFileName()[0..6];
+                int userId = CreateUser(userName);
+
+                try
+                {
+                    SetGroupAsOwnerOfFile(groupName, filePath);
+                }
+                finally
+                {
+                    DeleteGroup(groupName);
+                }
+
+                try
+                {
+                    SetUserAsOwnerOfFile(userName, filePath);
+                }
+                finally
+                {
+                    DeleteUser(userName);
+                }
+
+                await using MemoryStream archive = new MemoryStream();
+                await using (TarWriter writer = new TarWriter(archive, Enum.Parse<TarEntryFormat>(strFormat), leaveOpen: true))
+                {
+                    await writer.WriteEntryAsync(filePath, fileName); // Should not throw
+                }
+                archive.Seek(0, SeekOrigin.Begin);
+
+                await using (TarReader reader = new TarReader(archive, leaveOpen: false))
+                {
+                    PosixTarEntry entry = await reader.GetNextEntryAsync() as PosixTarEntry;
+                    Assert.NotNull(entry);
+
+                    Assert.Equal(string.Empty, entry.GroupName);
+                    Assert.Equal(groupId, entry.Gid);
+
+                    Assert.Equal(string.Empty, entry.UserName);
+                    Assert.Equal(userId, entry.Uid);
+
+                    string extractedPath = Path.Join(root.Path, "extracted.txt");
+                    await entry.ExtractToFileAsync(extractedPath, overwrite: false);
+                    Assert.True(File.Exists(extractedPath));
+
                     Assert.Null(await reader.GetNextEntryAsync());
                 }
             }, f.ToString(), new RemoteInvokeOptions { RunAsSudo = true }).Dispose();


### PR DESCRIPTION
I recently fixed a tar bug in Unix where attempting to write an entry into an archive where the groupName didn't exist, we would unexpectedly throw instead of silently continuing. https://github.com/dotnet/runtime/pull/81070

I checked if we had the same issue with userName, and fortunately we don't, because when we do the syscall to try to obtain the userName of a non-existent user, the syscall returns empty string, and we can store that in the entry that we are going to write.

What we were missing were test to verify the userName behavior, so I added them in this PR. I also added tests in which neither the userName or the groupName exist in the system.

I manually ran these tests as `root` in my Ubuntu WSL instance, and they all passed. I did have to add a 250 ms sleep after deleting a user or a group. The tests would intermittently fail because the OS sometimes takes too long to delete the user or the group, causing us to successfully retrieve the values and setting them to the written entry, instead of writing empty string.

I also fixed the logic we use with Process to prevent the deadlock described in the Process docs remarks whenm consuming the standard output: https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.standardoutput?view=net-7.0#remarks