### PR TITLE
[wasm] Partially revert #82604

### DIFF
--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -988,7 +988,8 @@ jiterp_insert_entry_points (void *_imethod, void *_td)
 			// We failed to start a trace at a backwards branch target, but that might just mean
 			//  that the loop body starts with one or two unsupported opcodes, so it may be
 			//  worthwhile to try again later
-			enter_at_next = TRUE;
+			// FIXME: This caused a bunch of regressions
+			// enter_at_next = TRUE;
 		}
 
 		// Increase the instruction counter. If we inserted an entry point at the top of this bb,

--- a/src/mono/mono/utils/options-def.h
+++ b/src/mono/mono/utils/options-def.h
@@ -116,7 +116,7 @@ DEFINE_BOOL(jiterpreter_direct_jit_call, "jiterpreter-direct-jit-calls", TRUE, "
 // any trace that doesn't have at least this many meaningful (non-nop) opcodes in it will be rejected
 DEFINE_INT(jiterpreter_minimum_trace_length, "jiterpreter-minimum-trace-length", 10, "Reject traces shorter than this number of meaningful opcodes")
 // ensure that we don't create trace entry points too close together
-DEFINE_INT(jiterpreter_minimum_distance_between_traces, "jiterpreter-minimum-distance-between-traces", 6, "Don't insert entry points closer together than this")
+DEFINE_INT(jiterpreter_minimum_distance_between_traces, "jiterpreter-minimum-distance-between-traces", 4, "Don't insert entry points closer together than this")
 // once a trace entry point is inserted, we only actually JIT code for it once it's been hit this many times
 DEFINE_INT(jiterpreter_minimum_trace_hit_count, "jiterpreter-minimum-trace-hit-count", 5000, "JIT trace entry points once they are hit this many times")
 // After a do_jit_call call site is hit this many times, we will queue it to be jitted


### PR DESCRIPTION
#82604 produced more regressions than it did improvements, so this PR relaxes one of its changes and disables the more suspect one temporarily. In the future the heuristic will be significantly revised, and the actual overhead of various parts of traces is going to change once the CFG is added, so it's not worthwhile to invest a bunch of time into tuning the parameters right now. Once things are more stable we will hopefully be able to identify the right parameter values by doing a bunch of benchmark runs.

In my local testing Perf_Enumerable (one of the main regression sets from https://github.com/dotnet/perf-autofiling-issues/issues/13759 ) is largely improved by this PR, so this should minimize most of the regressions.