### PR TITLE
Rename ManagedVirtualMethodTable and adjust indices

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Interop
                 Location interfaceLocation = interfaceData.Syntax.GetLocation();
                 var methods = ImmutableArray.CreateBuilder<(MethodDeclarationSyntax Syntax, IMethodSymbol Symbol, int Index, Diagnostic? Diagnostic)>();
                 int methodVtableOffset = interfaceContext.MethodStartIndex;
-                var i = interfaceContext.MethodStartIndex;
+                var i = methodVtableOffset;
                 foreach (var member in interfaceData.Symbol.GetMembers())
                 {
                     if (member.Kind == SymbolKind.Method && !member.IsStatic)
@@ -682,7 +682,7 @@ namespace Microsoft.Interop
                     FieldDeclaration(VariableDeclaration(VoidStarStarSyntax, SingletonSeparatedList(VariableDeclarator(vtableFieldName))))
                         .AddModifiers(Token(SyntaxKind.PrivateKeyword), Token(SyntaxKind.StaticKeyword)),
                     // public static void* VirtualMethodTableManagedImplementation => _vtable != null ? _vtable : (_vtable = InterfaceImplementation.CreateManagedVirtualMethodTable());
-                    PropertyDeclaration(PointerType(PointerType(PredefinedType(Token(SyntaxKind.VoidKeyword)))), "ManagedVirtualMethodTable")
+                    PropertyDeclaration(VoidStarStarSyntax, "ManagedVirtualMethodTable")
                         .AddModifiers(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword))
                         .WithExpressionBody(
                             ArrowExpressionClause(

--- a/src/libraries/System.Runtime.InteropServices/tests/Ancillary.Interop/IIUnknownInterfaceType.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/Ancillary.Interop/IIUnknownInterfaceType.cs
@@ -6,8 +6,9 @@
 
 namespace System.Runtime.InteropServices.Marshalling
 {
-    public interface IIUnknownInterfaceType : IUnmanagedInterfaceType
+    public unsafe interface IIUnknownInterfaceType
     {
         public abstract static Guid Iid { get; }
+        public abstract static void** ManagedVirtualMethodTable { get; }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/Ancillary.Interop/IUnknownDerivedAttribute.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/Ancillary.Interop/IUnknownDerivedAttribute.cs
@@ -21,6 +21,6 @@ namespace System.Runtime.InteropServices.Marshalling
         public Type Implementation => typeof(TImpl);
 
         /// <inheritdoc />
-        public unsafe void* VirtualMethodTableManagedImplementation => T.VirtualMethodTableManagedImplementation;
+        public unsafe void* VirtualMethodTableManagedImplementation => T.ManagedVirtualMethodTable;
     }
 }


### PR DESCRIPTION
Renames VirtualMethodTableManagedImplementation to ManagedVirtualMethodTable in the ComInterfaceGenerator.

Sets the index of Vtable methods instead of using 0.