### PR TITLE
Try reducing memory pressure during object writing

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -1156,10 +1156,14 @@ namespace ILCompiler.DependencyAnalysis
                 // Free up as much memory as possible so that we don't get OOM killed.
                 // This is potentially a waste of time. We're about to end the process and let the
                 // OS "garbage collect" the entire address space.
-                // https://github.com/dotnet/runtime/issues/83180
                 var gcMemoryInfo = GC.GetGCMemoryInfo();
                 if (gcMemoryInfo.TotalCommittedBytes > gcMemoryInfo.TotalAvailableMemoryBytes / 2)
-                    GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive));
+                {
+                    if (logger.IsVerbose)
+                        logger.LogMessage($"Freeing up memory");
+
+                    GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive);
+                }
 
                 objectWriter.EmitDebugModuleInfo();
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -1153,7 +1153,10 @@ namespace ILCompiler.DependencyAnalysis
                     logger.LogMessage($"Emitting debug information");
 
                 // Native side of the object writer is going to do more native memory allocations.
-                // Free up as much memory as possible.
+                // Free up as much memory as possible so that we don't get OOM killed.
+                // This is potentially a waste of time. We're about to end the process and let the
+                // OS "garbage collect" the entire address space.
+                // https://github.com/dotnet/runtime/issues/83180
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
                 GC.Collect();

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -1150,7 +1150,13 @@ namespace ILCompiler.DependencyAnalysis
                 }
 
                 if (logger.IsVerbose)
-                    logger.LogMessage($"Finalizing output to '{objectFilePath}'...");
+                    logger.LogMessage($"Emitting debug information");
+
+                // Native side of the object writer is going to do more native memory allocations.
+                // Free up as much memory as possible.
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
 
                 objectWriter.EmitDebugModuleInfo();
 
@@ -1158,6 +1164,9 @@ namespace ILCompiler.DependencyAnalysis
             }
             finally
             {
+                if (logger.IsVerbose)
+                    logger.LogMessage($"Finalizing output to '{objectFilePath}'...");
+            
                 objectWriter.Dispose();
 
                 if (!succeeded)
@@ -1173,6 +1182,9 @@ namespace ILCompiler.DependencyAnalysis
                     }
                 }
             }
+            
+            if (logger.IsVerbose)
+                logger.LogMessage($"Done writing object file");
         }
 
         [DllImport(NativeObjectWriterFileName)]

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -1157,9 +1157,7 @@ namespace ILCompiler.DependencyAnalysis
                 // This is potentially a waste of time. We're about to end the process and let the
                 // OS "garbage collect" the entire address space.
                 // https://github.com/dotnet/runtime/issues/83180
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                GC.Collect();
+                GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive););
 
                 objectWriter.EmitDebugModuleInfo();
 
@@ -1169,7 +1167,6 @@ namespace ILCompiler.DependencyAnalysis
             {
                 if (logger.IsVerbose)
                     logger.LogMessage($"Finalizing output to '{objectFilePath}'...");
-            
                 objectWriter.Dispose();
 
                 if (!succeeded)
@@ -1185,7 +1182,6 @@ namespace ILCompiler.DependencyAnalysis
                     }
                 }
             }
-            
             if (logger.IsVerbose)
                 logger.LogMessage($"Done writing object file");
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -1157,7 +1157,9 @@ namespace ILCompiler.DependencyAnalysis
                 // This is potentially a waste of time. We're about to end the process and let the
                 // OS "garbage collect" the entire address space.
                 // https://github.com/dotnet/runtime/issues/83180
-                GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive););
+                var gcMemoryInfo = GC.GetGCMemoryInfo();
+                if (gcMemoryInfo.TotalCommittedBytes > gcMemoryInfo.TotalAvailableMemoryBytes / 2)
+                    GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive));
 
                 objectWriter.EmitDebugModuleInfo();
 
@@ -1167,6 +1169,7 @@ namespace ILCompiler.DependencyAnalysis
             {
                 if (logger.IsVerbose)
                     logger.LogMessage($"Finalizing output to '{objectFilePath}'...");
+
                 objectWriter.Dispose();
 
                 if (!succeeded)
@@ -1182,6 +1185,7 @@ namespace ILCompiler.DependencyAnalysis
                     }
                 }
             }
+
             if (logger.IsVerbose)
                 logger.LogMessage($"Done writing object file");
         }


### PR DESCRIPTION
This is likely going to be a compile time regression, because we're close to finishing the compilation and the managed memory is going to be freed by the ultimate garbage collector: process termination.

But it looks like we're getting OOM-killed for larger apps around here. The native object writer is going to allocate more native memory without giving the managed GC see there's memory pressure. We might be able to tune this with `GC.AddMemoryPressure` once we have some sort of estimate of native memory used by the native object writer.

Hoping to unblock https://github.com/dotnet/performance/pull/2919.

Cc @dotnet/ilc-contrib @markples 