### PR TITLE
[iOS] Add gss framework back into sample linker args

### DIFF
--- a/src/mono/msbuild/apple/build/AppleApp.targets
+++ b/src/mono/msbuild/apple/build/AppleApp.targets
@@ -36,7 +36,7 @@
 
     <!-- common linker arguments for app and library builds -->
     <ItemGroup>
-      <_CommonLinkerArgs Condition="'$(_IsLibraryMode)' == 'true' and '$(TargetOS)' != 'tvos'" Include="-framework GSS" />
+      <_CommonLinkerArgs Condition="'$(_IsLibraryMode)' == 'true' and '$(TargetOS)' != 'tvos' and '$(TargetOS)' != 'tvossimulator'" Include="-framework GSS" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/src/mono/msbuild/apple/build/AppleApp.targets
+++ b/src/mono/msbuild/apple/build/AppleApp.targets
@@ -36,7 +36,7 @@
 
     <!-- common linker arguments for app and library builds -->
     <ItemGroup>
-      <_CommonLinkerArgs Condition="'$(TargetOS)' != 'tvos'" Include="-framework GSS" />
+      <_CommonLinkerArgs Condition="'$(_IsLibraryMode)' == 'true' and '$(TargetOS)' != 'tvos'" Include="-framework GSS" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/src/tasks/AppleAppBuilder/Xcode.cs
+++ b/src/tasks/AppleAppBuilder/Xcode.cs
@@ -400,11 +400,19 @@ internal sealed class Xcode
             toLink += $"    {asmLinkFile}{Environment.NewLine}";
         }
 
+        string frameworks = "";
+        if ((Target == TargetNames.iOS) || (Target == TargetNames.iOSsim) || (Target == TargetNames.MacCatalyst))
+        {
+            frameworks = "\"-framework GSS\"";
+        }
+
         string appLinkerArgs = "";
         foreach(string linkerArg in extraLinkerArgs)
         {
             appLinkerArgs += $"    \"{linkerArg}\"{Environment.NewLine}";
         }
+
+        appLinkerArgs += $"    {frameworks}{Environment.NewLine}";
 
         cmakeLists = cmakeLists.Replace("%NativeLibrariesToLink%", toLink);
         cmakeLists = cmakeLists.Replace("%APP_LINKER_ARGS%", appLinkerArgs);


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/81919 introduced a regression where the gss framework was omitted from the sample build. This change adds it back in.

Fixes https://github.com/dotnet/performance/issues/2924