### PR TITLE
[metadata] make mono_method_get_param_names external only

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -8850,7 +8850,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 
 		/* Emit parameter names */
 		names = g_new (char *, sig->param_count);
-		mono_method_get_param_names_nternal (method, (const char **) names);
+		mono_method_get_param_names_internal (method, (const char **) names);
 		for (guint16 i = 0; i < sig->param_count; ++i)
 			buffer_add_string (buf, names [i]);
 		g_free (names);

--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -8850,7 +8850,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 
 		/* Emit parameter names */
 		names = g_new (char *, sig->param_count);
-		mono_method_get_param_names (method, (const char **) names);
+		mono_method_get_param_names_nternal (method, (const char **) names);
 		for (guint16 i = 0; i < sig->param_count; ++i)
 			buffer_add_string (buf, names [i]);
 		g_free (names);

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -1433,6 +1433,9 @@ mono_method_has_no_body (MonoMethod *method);
 MONO_COMPONENT_API MonoMethodHeader*
 mono_method_get_header_internal (MonoMethod *method, MonoError *error);
 
+MONO_COMPONENT_API void
+mono_method_get_param_names_internal (MonoMethod *method, char **names, MonoError *error);
+
 MonoType*
 mono_class_find_enum_basetype (MonoClass *klass, MonoError *error);
 

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -1434,7 +1434,7 @@ MONO_COMPONENT_API MonoMethodHeader*
 mono_method_get_header_internal (MonoMethod *method, MonoError *error);
 
 MONO_COMPONENT_API void
-mono_method_get_param_names_internal (MonoMethod *method, char **names, MonoError *error);
+mono_method_get_param_names_internal (MonoMethod *method, const char **names);
 
 MonoType*
 mono_class_find_enum_basetype (MonoClass *klass, MonoError *error);

--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -1414,15 +1414,14 @@ mono_method_get_param_names (MonoMethod *method, const char **names)
 {
 	MONO_ENTER_GC_UNSAFE;
 	mono_method_get_param_names_internal (method, names);
-	mono_error_assert_ok (error);
 	MONO_EXIT_GC_UNSAFE;
 }
 
 /**
- * mono_method_get_param_names:
+ * mono_method_get_param_names_internal:
  */
 void
-mono_method_get_param_names_internal (MonoMethod *method, const char **names, MonoError *error)
+mono_method_get_param_names_internal (MonoMethod *method, const char **names)
 {
 	int i, lastp;
 	MonoClass *klass;

--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -1412,6 +1412,18 @@ mono_free_method  (MonoMethod *method)
 void
 mono_method_get_param_names (MonoMethod *method, const char **names)
 {
+	MONO_ENTER_GC_UNSAFE;
+	mono_method_get_param_names_internal (method, names);
+	mono_error_assert_ok (error);
+	MONO_EXIT_GC_UNSAFE;
+}
+
+/**
+ * mono_method_get_param_names:
+ */
+void
+mono_method_get_param_names_internal (MonoMethod *method, const char **names, MonoError *error)
+{
 	int i, lastp;
 	MonoClass *klass;
 	MonoTableInfo *paramt;

--- a/src/mono/mono/metadata/reflection.c
+++ b/src/mono/mono/metadata/reflection.c
@@ -1087,7 +1087,7 @@ param_objects_construct (MonoClass *refclass, MonoMethodSignature **addr_of_sig,
 	MonoReflectionMethodHandle member = mono_method_get_object_handle (method, refclass, error);
 	goto_if_nok (error, leave);
 	names = g_new (char *, sig->param_count);
-	mono_method_get_param_names (method, (const char **) names);
+	mono_method_get_param_names_internal (method, (const char **) names);
 
 	mspecs = g_new (MonoMarshalSpec*, sig->param_count + 1);
 	mono_method_get_marshal_info (method, mspecs);

--- a/src/mono/mono/mini/debug-mini.c
+++ b/src/mono/mono/mini/debug-mini.c
@@ -673,7 +673,7 @@ mono_debug_print_vars (gpointer ip, gboolean only_arguments)
 	if (only_arguments) {
 		char **names;
 		names = g_new (char *, jit->num_params);
-		mono_method_get_param_names (jinfo_get_method (ji), (const char **) names);
+		mono_method_get_param_names_internal (jinfo_get_method (ji), (const char **) names);
 		if (jit->this_var)
 			print_var_info (jit->this_var, 0, "this", "Arg");
 		for (guint32 i = 0; i < jit->num_params; ++i) {

--- a/src/mono/mono/mini/dwarfwriter.c
+++ b/src/mono/mono/mini/dwarfwriter.c
@@ -1805,7 +1805,7 @@ mono_dwarf_writer_emit_method (MonoDwarfWriter *w, MonoCompile *cfg, MonoMethod 
 
 	/* Subprogram */
 	names = g_new0 (char *, sig->param_count);
-	mono_method_get_param_names (method, (const char **) names);
+	mono_method_get_param_names_internal (method, (const char **) names);
 
 	emit_uleb128 (w, ABBREV_SUBPROGRAM);
 	/* DW_AT_name */

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -3900,7 +3900,7 @@ emit_entry_bb (EmitContext *ctx, LLVMBuilderRef builder)
 	}
 
 	names = g_new (char *, sig->param_count);
-	mono_method_get_param_names (cfg->method, (const char **) names);
+	mono_method_get_param_names_internal (cfg->method, (const char **) names);
 
 	for (int i = 0; i < sig->param_count; ++i) {
 		LLVMArgInfo *ainfo = &linfo->args [i + sig->hasthis];
@@ -12209,7 +12209,7 @@ emit_method_inner (EmitContext *ctx)
 		LLVMSetValueName (LLVMGetParam (method, linfo->dummy_arg_pindex), "dummy_arg");
 
 	names = g_new (char *, sig->param_count);
-	mono_method_get_param_names (cfg->method, (const char **) names);
+	mono_method_get_param_names_internal (cfg->method, (const char **) names);
 
 	/* Set parameter names/attributes */
 	for (int i = 0; i < sig->param_count; ++i) {

--- a/src/native/public/mono/metadata/details/loader-functions.h
+++ b/src/native/public/mono/metadata/details/loader-functions.h
@@ -44,7 +44,7 @@ MONO_API_FUNCTION(MONO_RT_EXTERNAL_ONLY void, mono_dllmap_insert, (MonoImage *as
 
 MONO_API_FUNCTION(MONO_RT_EXTERNAL_ONLY void*, mono_lookup_pinvoke_call, (MonoMethod *method, const char **exc_class, const char **exc_arg))
 
-MONO_API_FUNCTION(void, mono_method_get_param_names, (MonoMethod *method, const char **names))
+MONO_API_FUNCTION(MONO_RT_EXTERNAL_ONLY void, mono_method_get_param_names, (MonoMethod *method, const char **names))
 
 MONO_API_FUNCTION(uint32_t, mono_method_get_param_token, (MonoMethod *method, int idx))
 


### PR DESCRIPTION
Add GC Unsafe transitions.

Change the runtime to use mono_method_get_param_names_internal.

Fixes https://github.com/dotnet/runtime/issues/83178