### PR TITLE
[LoongArch64] delete the unused code for comparing.

### DIFF
--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -4355,8 +4355,7 @@ void CodeGen::genCodeForJumpCompare(GenTreeOp* tree)
     int cond = ((int)tree->gtFlags >> 25) & 0xf; // GenCondition::Code.
     assert((((int)tree->gtFlags >> 25) & GenCondition::Float) == 0);
 
-    bool IsUnsigned = (((cond & GenCondition::OperMask) > 1) && ((cond & GenCondition::Unsigned) != 0));
-    assert(((tree->gtFlags & GTF_UNSIGNED) != 0) == IsUnsigned);
+    bool IsUnsigned = (cond & GenCondition::Unsigned) != 0;
 
     emitAttr  cmpSize = EA_ATTR(genTypeSize(op1Type));
     regNumber regOp1  = op1->GetRegNum();
@@ -5076,7 +5075,6 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
         case GT_LE:
         case GT_GE:
         case GT_GT:
-        case GT_CMP:
             genConsumeOperands(treeNode->AsOp());
             genCodeForCompare(treeNode->AsOp());
             break;

--- a/src/coreclr/jit/lowerloongarch64.cpp
+++ b/src/coreclr/jit/lowerloongarch64.cpp
@@ -186,11 +186,6 @@ GenTree* Lowering::LowerJTrue(GenTreeOp* jtrue)
     jtrue->gtFlags &= ~(GTF_JCMP_TST | GTF_JCMP_EQ | GTF_JCMP_MASK);
     jtrue->gtFlags |= (GenTreeFlags)(cond.GetCode() << 25);
 
-    if ((cond.GetCode() == GenCondition::EQ) || (cond.GetCode() == GenCondition::NE))
-    {
-        jtrue->gtFlags &= ~GTF_UNSIGNED;
-    }
-
     if (cmpOp2->IsCnsIntOrI())
     {
         cmpOp2->SetContained();


### PR DESCRIPTION
This PR is part of the issue https://github.com/dotnet/runtime/issues/69705 to amend the LA's port.
