### PR TITLE
Implements correct handling of RequiresAssemblyFiles on properties and events

### DIFF
--- a/src/coreclr/tools/Common/Compiler/PseudoDescExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/PseudoDescExtensions.cs
@@ -12,7 +12,7 @@ namespace ILCompiler
     {
         public static PropertyPseudoDesc GetPropertyForAccessor(this MethodDesc accessor)
         {
-            if (accessor.GetTypicalMethodDefinition() is not EcmaMethod ecmaAccessor)
+            if (!accessor.IsSpecialName || accessor.GetTypicalMethodDefinition() is not EcmaMethod ecmaAccessor)
                 return null;
 
             var type = (EcmaType)ecmaAccessor.OwningType;
@@ -32,7 +32,7 @@ namespace ILCompiler
 
         public static EventPseudoDesc GetEventForAccessor(this MethodDesc accessor)
         {
-            if (accessor.GetTypicalMethodDefinition() is not EcmaMethod ecmaAccessor)
+            if (!accessor.IsSpecialName || accessor.GetTypicalMethodDefinition() is not EcmaMethod ecmaAccessor)
                 return null;
 
             var type = (EcmaType)ecmaAccessor.OwningType;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/DiagnosticUtilities.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/DiagnosticUtilities.cs
@@ -116,10 +116,16 @@ namespace ILCompiler.Dataflow
             if (checkAssociatedSymbol && method.GetPropertyForAccessor() is PropertyPseudoDesc property && TryGetRequiresAttribute(property, requiresAttribute, out _))
                 return true;
 
+            if (checkAssociatedSymbol && method.GetEventForAccessor() is EventPseudoDesc @event && TryGetRequiresAttribute(@event, requiresAttribute, out _))
+                return true;
+
             return false;
         }
 
         internal static bool DoesMethodRequire(this MethodDesc method, string requiresAttribute, [NotNullWhen(returnValue: true)] out CustomAttributeValue<TypeDesc>? attribute)
+            => DoesMethodRequire(method, requiresAttribute, true, out attribute);
+
+        internal static bool DoesMethodRequire(this MethodDesc method, string requiresAttribute, bool checkAssociatedSymbol, [NotNullWhen(returnValue: true)] out CustomAttributeValue<TypeDesc>? attribute)
         {
             attribute = null;
             if (method.IsStaticConstructor)
@@ -132,13 +138,16 @@ namespace ILCompiler.Dataflow
                 !owningType.IsArray && TryGetRequiresAttribute(owningType, requiresAttribute, out attribute))
                 return true;
 
-            if (method.GetPropertyForAccessor() is PropertyPseudoDesc @property
-                && TryGetRequiresAttribute(@property, requiresAttribute, out attribute))
-                return true;
+            if (checkAssociatedSymbol)
+            {
+                if (method.GetPropertyForAccessor() is PropertyPseudoDesc @property
+                    && TryGetRequiresAttribute(@property, requiresAttribute, out attribute))
+                    return true;
 
-            if (method.GetEventForAccessor() is EventPseudoDesc @event
-                && TryGetRequiresAttribute(@event, requiresAttribute, out attribute))
-                return true;
+                if (method.GetEventForAccessor() is EventPseudoDesc @event
+                    && TryGetRequiresAttribute(@event, requiresAttribute, out attribute))
+                    return true;
+            }
 
             return false;
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/DiagnosticUtilities.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/DiagnosticUtilities.cs
@@ -95,16 +95,6 @@ namespace ILCompiler.Dataflow
         internal static bool IsInRequiresScope(this MethodDesc method, string requiresAttribute) =>
             method.IsInRequiresScope(requiresAttribute, true);
 
-        /// <summary>
-        /// True if member of a call is considered to be annotated with the Requires... attribute.
-        /// Doesn't check the associated symbol for overrides and virtual methods because we should warn on mismatched between the property AND the accessors
-        /// </summary>
-        /// <param name="method">
-        /// MethodDesc that is either an overriding member or an overridden/virtual member
-        /// </param>
-        internal static bool IsOverrideInRequiresScope(this MethodDesc method, string requiresAttribute) =>
-            method.IsInRequiresScope(requiresAttribute, false);
-
         private static bool IsInRequiresScope(this MethodDesc method, string requiresAttribute, bool checkAssociatedSymbol)
         {
             if (method.HasCustomAttribute("System.Diagnostics.CodeAnalysis", requiresAttribute) && !method.IsStaticConstructor)
@@ -123,9 +113,6 @@ namespace ILCompiler.Dataflow
         }
 
         internal static bool DoesMethodRequire(this MethodDesc method, string requiresAttribute, [NotNullWhen(returnValue: true)] out CustomAttributeValue<TypeDesc>? attribute)
-            => DoesMethodRequire(method, requiresAttribute, true, out attribute);
-
-        internal static bool DoesMethodRequire(this MethodDesc method, string requiresAttribute, bool checkAssociatedSymbol, [NotNullWhen(returnValue: true)] out CustomAttributeValue<TypeDesc>? attribute)
         {
             attribute = null;
             if (method.IsStaticConstructor)
@@ -138,16 +125,13 @@ namespace ILCompiler.Dataflow
                 !owningType.IsArray && TryGetRequiresAttribute(owningType, requiresAttribute, out attribute))
                 return true;
 
-            if (checkAssociatedSymbol)
-            {
-                if (method.GetPropertyForAccessor() is PropertyPseudoDesc @property
-                    && TryGetRequiresAttribute(@property, requiresAttribute, out attribute))
-                    return true;
+            if (method.GetPropertyForAccessor() is PropertyPseudoDesc @property
+                && TryGetRequiresAttribute(@property, requiresAttribute, out attribute))
+                return true;
 
-                if (method.GetEventForAccessor() is EventPseudoDesc @event
-                    && TryGetRequiresAttribute(@event, requiresAttribute, out attribute))
-                    return true;
-            }
+            if (method.GetEventForAccessor() is EventPseudoDesc @event
+                && TryGetRequiresAttribute(@event, requiresAttribute, out attribute))
+                return true;
 
             return false;
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/DiagnosticUtilities.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/DiagnosticUtilities.cs
@@ -132,6 +132,14 @@ namespace ILCompiler.Dataflow
                 !owningType.IsArray && TryGetRequiresAttribute(owningType, requiresAttribute, out attribute))
                 return true;
 
+            if (method.GetPropertyForAccessor() is PropertyPseudoDesc @property
+                && TryGetRequiresAttribute(@property, requiresAttribute, out attribute))
+                return true;
+
+            if (method.GetEventForAccessor() is EventPseudoDesc @event
+                && TryGetRequiresAttribute(@event, requiresAttribute, out attribute))
+                return true;
+
             return false;
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -797,10 +797,10 @@ namespace ILCompiler
 
         public static bool HasMismatchingAttributes(MethodDesc baseMethod, MethodDesc overridingMethod, string requiresAttributeName)
         {
-            bool baseMethodCreatesRequirement = baseMethod.DoesMethodRequire(requiresAttributeName, checkAssociatedSymbol: false, out _);
-            bool overridingMethodCreatesRequirement = overridingMethod.DoesMethodRequire(requiresAttributeName, checkAssociatedSymbol: false, out _);
-            bool baseMethodFulfillsRequirement = baseMethod.IsOverrideInRequiresScope(requiresAttributeName);
-            bool overridingMethodFulfillsRequirement = overridingMethod.IsOverrideInRequiresScope(requiresAttributeName);
+            bool baseMethodCreatesRequirement = baseMethod.DoesMethodRequire(requiresAttributeName, out _);
+            bool overridingMethodCreatesRequirement = overridingMethod.DoesMethodRequire(requiresAttributeName, out _);
+            bool baseMethodFulfillsRequirement = baseMethod.IsInRequiresScope(requiresAttributeName);
+            bool overridingMethodFulfillsRequirement = overridingMethod.IsInRequiresScope(requiresAttributeName);
             return (baseMethodCreatesRequirement && !overridingMethodFulfillsRequirement) || (overridingMethodCreatesRequirement && !baseMethodFulfillsRequirement);
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -766,11 +766,11 @@ namespace ILCompiler
 
         public override void NoteOverridingMethod(MethodDesc baseMethod, MethodDesc overridingMethod)
         {
-            if (baseMethod == overridingMethod)
-                return;
-
             baseMethod = baseMethod.GetTypicalMethodDefinition();
             overridingMethod = overridingMethod.GetTypicalMethodDefinition();
+
+            if (baseMethod == overridingMethod)
+                return;
 
             bool baseMethodTypeIsInterface = baseMethod.OwningType.IsInterface;
             foreach (var requiresAttribute in _requiresAttributeMismatchNameAndId)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -766,6 +766,9 @@ namespace ILCompiler
 
         public override void NoteOverridingMethod(MethodDesc baseMethod, MethodDesc overridingMethod)
         {
+            if (baseMethod == overridingMethod)
+                return;
+
             baseMethod = baseMethod.GetTypicalMethodDefinition();
             overridingMethod = overridingMethod.GetTypicalMethodDefinition();
 
@@ -794,8 +797,8 @@ namespace ILCompiler
 
         public static bool HasMismatchingAttributes(MethodDesc baseMethod, MethodDesc overridingMethod, string requiresAttributeName)
         {
-            bool baseMethodCreatesRequirement = baseMethod.DoesMethodRequire(requiresAttributeName, out _);
-            bool overridingMethodCreatesRequirement = overridingMethod.DoesMethodRequire(requiresAttributeName, out _);
+            bool baseMethodCreatesRequirement = baseMethod.DoesMethodRequire(requiresAttributeName, checkAssociatedSymbol: false, out _);
+            bool overridingMethodCreatesRequirement = overridingMethod.DoesMethodRequire(requiresAttributeName, checkAssociatedSymbol: false, out _);
             bool baseMethodFulfillsRequirement = baseMethod.IsOverrideInRequiresScope(requiresAttributeName);
             bool overridingMethodFulfillsRequirement = overridingMethod.IsOverrideInRequiresScope(requiresAttributeName);
             return (baseMethodCreatesRequirement && !overridingMethodFulfillsRequirement) || (overridingMethodCreatesRequirement && !baseMethodFulfillsRequirement);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/BasicRequires.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/BasicRequires.cs
@@ -212,13 +212,37 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 		class AssemblyFilesOnly
 		{
-			[RequiresAssemblyFiles("--Requires--")]
+			[RequiresAssemblyFiles ("--Requires--")]
 			static void Requires () { }
+
+			[RequiresAssemblyFiles ("--PropertyRequires--")]
+			static int PropertyRequires { get; set; }
+
+			[ExpectedWarning ("IL3002", "--PropertyRequires--", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
+			[ExpectedWarning ("IL3002", "--PropertyRequires--", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
+			static void TestProperty ()
+			{
+				var a = PropertyRequires;
+				PropertyRequires = 0;
+			}
+
+			[RequiresAssemblyFiles ("--EventRequires--")]
+			static event EventHandler EventRequires;
+
+			[ExpectedWarning ("IL3002", "--EventRequires--", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
+			[ExpectedWarning ("IL3002", "--EventRequires--", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
+			static void TestEvent ()
+			{
+				EventRequires += (object sender, EventArgs e) => throw new NotImplementedException ();
+				EventRequires -= (object sender, EventArgs e) => throw new NotImplementedException ();
+			}
 
 			[ExpectedWarning("IL3002", "--Requires--", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
 			public static void Test()
 			{
 				Requires ();
+				TestProperty ();
+				TestEvent ();
 			}
 		}
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresAttributeMismatch.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresAttributeMismatch.cs
@@ -21,6 +21,17 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 	[ExpectedNoWarnings]
 	class RequiresAttributeMismatch
 	{
+		// General comment about IL3003
+		// Analyzer looks at properties, events and method separately. So mistmatch on property level will be reported
+		// only on the property and not on the accessors. And vice versa.
+		// NativeAOT doesn't really see properties and events, only methods. So it is much easier to handle everything
+		// on the method level. While it's a discrepancy in behavior, it's small and should have no adverse effects
+		// as suppressing the warning on the property level will suppress it for the accessors as well.
+		// So NativeAOT will report all mismatches on the accessors. If the mismatch is on the property
+		// then both accessors will report IL3003 (the attribute on the property is treated as if it was specified
+		// on all accessors, always).
+		// This discrepancy is tracked by https://github.com/dotnet/runtime/issues/83235.
+
 		// Base/Derived and Implementation/Interface differs between ILLink and analyzer https://github.com/dotnet/linker/issues/2533
 		[ExpectedWarning ("IL2026", "BaseClassWithRequires.VirtualPropertyAnnotationInAccesor.get")]
 		[ExpectedWarning ("IL3002", "BaseClassWithRequires.VirtualPropertyAnnotationInAccesor.get", ProducedBy = Tool.NativeAot)]
@@ -34,8 +45,11 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		[ExpectedWarning ("IL2026", "DerivedClassWithRequires.VirtualPropertyAnnotationInAccesor.get", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
 		[ExpectedWarning ("IL3002", "DerivedClassWithRequires.VirtualPropertyAnnotationInAccesor.get", ProducedBy = Tool.NativeAot)]
 		[ExpectedWarning ("IL3050", "DerivedClassWithRequires.VirtualPropertyAnnotationInAccesor.get", ProducedBy = Tool.NativeAot)]
+		[ExpectedWarning ("IL3002", "DerivedClassWithRequires.VirtualPropertyAnnotationInProperty.get", ProducedBy = Tool.NativeAot)]
+		[ExpectedWarning ("IL3002", "DerivedClassWithRequires.VirtualPropertyAnnotationInProperty.set", ProducedBy = Tool.NativeAot)]
 		[ExpectedWarning ("IL2026", "DerivedClassWithAllWarnings.VirtualPropertyAnnotationInAccesor.set", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
 		[ExpectedWarning ("IL3002", "DerivedClassWithAllWarnings.VirtualPropertyAnnotationInAccesor.set", ProducedBy = Tool.NativeAot)]
+		[ExpectedWarning ("IL3002", "DerivedClassWithAllWarnings.VirtualPropertyAnnotationInAccesor.get", ProducedBy = Tool.NativeAot)]
 		[ExpectedWarning ("IL2026", "DerivedClassWithAllWarnings.VirtualPropertyAnnotationInProperty.get", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
 		[ExpectedWarning ("IL3002", "DerivedClassWithAllWarnings.VirtualPropertyAnnotationInProperty.get", ProducedBy = Tool.NativeAot)]
 		[ExpectedWarning ("IL2026", "DerivedClassWithAllWarnings.VirtualPropertyAnnotationInProperty.set", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
@@ -59,6 +73,9 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		[ExpectedWarning ("IL3050", "IBaseWithRequires.PropertyAnnotationInAccesor.get", ProducedBy = Tool.NativeAot)]
 		[ExpectedWarning ("IL2026", "IBaseWithRequires.PropertyAnnotationInPropertyAndAccessor.set")]
 		[ExpectedWarning ("IL3002", "IBaseWithRequires.PropertyAnnotationInPropertyAndAccessor.set", ProducedBy = Tool.NativeAot)]
+		[ExpectedWarning ("IL3002", "IBaseWithRequires.PropertyAnnotationInPropertyAndAccessor.get", ProducedBy = Tool.NativeAot)]
+		[ExpectedWarning ("IL3002", "IBaseWithRequires.PropertyAnnotationInProperty.get", ProducedBy = Tool.NativeAot)]
+		[ExpectedWarning ("IL3002", "IBaseWithRequires.PropertyAnnotationInProperty.set", ProducedBy = Tool.NativeAot)]
 		[ExpectedWarning ("IL2026", "IBaseWithRequires.Method()")]
 		[ExpectedWarning ("IL3002", "IBaseWithRequires.Method()", ProducedBy = Tool.NativeAot)]
 		[ExpectedWarning ("IL3050", "IBaseWithRequires.Method()", ProducedBy = Tool.NativeAot)]
@@ -70,6 +87,9 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		[ExpectedWarning ("IL3050", "ImplementationClassWithRequires.PropertyAnnotationInAccesor.get", ProducedBy = Tool.NativeAot)]
 		[ExpectedWarning ("IL2026", "ImplementationClassWithRequires.PropertyAnnotationInPropertyAndAccessor.get", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
 		[ExpectedWarning ("IL3002", "ImplementationClassWithRequires.PropertyAnnotationInPropertyAndAccessor.get", ProducedBy = Tool.NativeAot)]
+		[ExpectedWarning ("IL3002", "ImplementationClassWithRequires.PropertyAnnotationInPropertyAndAccessor.set", ProducedBy = Tool.NativeAot)]
+		[ExpectedWarning ("IL3002", "ImplementationClassWithRequires.PropertyAnnotationInProperty.get", ProducedBy = Tool.NativeAot)]
+		[ExpectedWarning ("IL3002", "ImplementationClassWithRequires.PropertyAnnotationInProperty.set", ProducedBy = Tool.NativeAot)]
 		[ExpectedWarning ("IL2026", "ImplementationClassWithoutRequires.PropertyAnnotationInPropertyAndAccessor.get", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
 		[ExpectedWarning ("IL3002", "ImplementationClassWithoutRequires.PropertyAnnotationInPropertyAndAccessor.get", ProducedBy = Tool.NativeAot)]
 		[ExpectedWarning ("IL2026", "ImplementationClassWithRequiresInSource.Method()", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
@@ -78,12 +98,23 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		[ExpectedWarning ("IL2026", "ImplementationClassWithRequiresInSource.PropertyAnnotationInAccesor.get", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
 		[ExpectedWarning ("IL3002", "ImplementationClassWithRequiresInSource.PropertyAnnotationInAccesor.get", ProducedBy = Tool.NativeAot)]
 		[ExpectedWarning ("IL3050", "ImplementationClassWithRequiresInSource.PropertyAnnotationInAccesor.get", ProducedBy = Tool.NativeAot)]
+		[ExpectedWarning ("IL3002", "ImplementationClassWithRequiresInSource.PropertyAnnotationInProperty.get", ProducedBy = Tool.NativeAot)]
+		[ExpectedWarning ("IL3002", "ImplementationClassWithRequiresInSource.PropertyAnnotationInProperty.set", ProducedBy = Tool.NativeAot)]
 		[ExpectedWarning ("IL2026", "BaseClassWithRequires.VirtualPropertyAnnotationInPropertyAndAccessor.get")]
 		[ExpectedWarning ("IL3002", "BaseClassWithRequires.VirtualPropertyAnnotationInPropertyAndAccessor.get", ProducedBy = Tool.NativeAot)]
 		[ExpectedWarning ("IL2026", "BaseClassWithRequires.VirtualPropertyAnnotationInPropertyAndAccessor.get")]
 		[ExpectedWarning ("IL3002", "BaseClassWithRequires.VirtualPropertyAnnotationInPropertyAndAccessor.get", ProducedBy = Tool.NativeAot)]
 		[ExpectedWarning ("IL2026", "BaseClassWithRequires.VirtualPropertyAnnotationInPropertyAndAccessor.get")]
 		[ExpectedWarning ("IL3002", "BaseClassWithRequires.VirtualPropertyAnnotationInPropertyAndAccessor.get", ProducedBy = Tool.NativeAot)]
+		[ExpectedWarning ("IL3002", "BaseClassWithRequires.VirtualPropertyAnnotationInPropertyAndAccessor.set", ProducedBy = Tool.NativeAot)]
+		[ExpectedWarning ("IL3002", "BaseClassWithRequires.VirtualPropertyAnnotationInPropertyAndAccessor.set", ProducedBy = Tool.NativeAot)]
+		[ExpectedWarning ("IL3002", "BaseClassWithRequires.VirtualPropertyAnnotationInPropertyAndAccessor.set", ProducedBy = Tool.NativeAot)]
+		[ExpectedWarning ("IL3002", "BaseClassWithRequires.VirtualPropertyAnnotationInProperty.get", ProducedBy = Tool.NativeAot)]
+		[ExpectedWarning ("IL3002", "BaseClassWithRequires.VirtualPropertyAnnotationInProperty.get", ProducedBy = Tool.NativeAot)]
+		[ExpectedWarning ("IL3002", "BaseClassWithRequires.VirtualPropertyAnnotationInProperty.get", ProducedBy = Tool.NativeAot)]
+		[ExpectedWarning ("IL3002", "BaseClassWithRequires.VirtualPropertyAnnotationInProperty.set", ProducedBy = Tool.NativeAot)]
+		[ExpectedWarning ("IL3002", "BaseClassWithRequires.VirtualPropertyAnnotationInProperty.set", ProducedBy = Tool.NativeAot)]
+		[ExpectedWarning ("IL3002", "BaseClassWithRequires.VirtualPropertyAnnotationInProperty.set", ProducedBy = Tool.NativeAot)]
 
 		public static void Main ()
 		{
@@ -101,6 +132,8 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			typeof (ImplementationClassWithoutRequiresInSource).RequiresPublicMethods ();
 			typeof (ImplementationClassWithRequiresInSource).RequiresPublicMethods ();
 			typeof (StaticInterfaceMethods).RequiresPublicMethods ();
+
+			DerivedClassWithRequiresOnRequires.Test ();
 		}
 
 		class BaseClassWithRequires
@@ -167,11 +200,47 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				set { name = value; }
 			}
 
-			// NativeAOT does not look at associated Property/Event to produce warnings
-			// https://github.com/dotnet/runtime/issues/71985
 			[RequiresAssemblyFiles ("Message")]
 			[ExpectedWarning ("IL3003", "DerivedClassWithRequires.VirtualPropertyAnnotationInProperty", "BaseClassWithoutRequires.VirtualPropertyAnnotationInProperty", ProducedBy = Tool.Analyzer)]
-			public override string VirtualPropertyAnnotationInProperty { get; set; }
+			public override string VirtualPropertyAnnotationInProperty {
+				[ExpectedWarning ("IL3003", "DerivedClassWithRequires.VirtualPropertyAnnotationInProperty", "BaseClassWithoutRequires.VirtualPropertyAnnotationInProperty", ProducedBy = Tool.NativeAot)]
+				get;
+				[ExpectedWarning ("IL3003", "DerivedClassWithRequires.VirtualPropertyAnnotationInProperty", "BaseClassWithoutRequires.VirtualPropertyAnnotationInProperty", ProducedBy = Tool.NativeAot)]
+				set;
+			}
+		}
+
+		class DerivedClassWithRequiresOnRequires : BaseClassWithRequires
+		{
+			[RequiresUnreferencedCode ("Message")]
+			[RequiresAssemblyFiles ("Message")]
+			[RequiresDynamicCode ("Message")]
+			public override void VirtualMethod ()
+			{
+			}
+
+			private string name;
+			public override string VirtualPropertyAnnotationInAccesor {
+				[RequiresUnreferencedCode ("Message")]
+				[RequiresAssemblyFiles ("Message")]
+				[RequiresDynamicCode ("Message")]
+				get { return name; }
+				set { name = value; }
+			}
+
+			[RequiresAssemblyFiles ("Message")]
+			public override string VirtualPropertyAnnotationInProperty {
+				get;
+				set;
+			}
+
+			[UnconditionalSuppressMessage ("test", "IL2026")]
+			[UnconditionalSuppressMessage ("test", "IL3002")]
+			[UnconditionalSuppressMessage ("test", "IL3050")]
+			public static void Test()
+			{
+				typeof (DerivedClassWithRequiresOnRequires).RequiresPublicMethods ();
+			}
 		}
 
 		class DerivedClassWithoutRequires : BaseClassWithRequires
@@ -192,18 +261,20 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				set { name = value; }
 			}
 
-			// NativeAOT does not look at associated Property/Event to produce warnings
-			// https://github.com/dotnet/runtime/issues/71985
 			[ExpectedWarning ("IL3003", "DerivedClassWithoutRequires.VirtualPropertyAnnotationInProperty", "BaseClassWithRequires.VirtualPropertyAnnotationInProperty", ProducedBy = Tool.Analyzer)]
-			public override string VirtualPropertyAnnotationInProperty { get; set; }
+			public override string VirtualPropertyAnnotationInProperty {
+				[ExpectedWarning ("IL3003", "DerivedClassWithoutRequires.VirtualPropertyAnnotationInProperty", "BaseClassWithRequires.VirtualPropertyAnnotationInProperty", ProducedBy = Tool.NativeAot)]
+				get;
+				[ExpectedWarning ("IL3003", "DerivedClassWithoutRequires.VirtualPropertyAnnotationInProperty", "BaseClassWithRequires.VirtualPropertyAnnotationInProperty", ProducedBy = Tool.NativeAot)]
+				set;
+			}
 
-			// NativeAOT does not look at associated Property/Event to produce warnings
-			// https://github.com/dotnet/runtime/issues/71985
 			[ExpectedWarning ("IL3003", "DerivedClassWithoutRequires.VirtualPropertyAnnotationInPropertyAndAccessor", "BaseClassWithRequires.VirtualPropertyAnnotationInPropertyAndAccessor", ProducedBy = Tool.Analyzer)]
 			public override string VirtualPropertyAnnotationInPropertyAndAccessor {
 				[ExpectedWarning ("IL2046", "VirtualPropertyAnnotationInPropertyAndAccessor.get", "BaseClassWithRequires.VirtualPropertyAnnotationInPropertyAndAccessor.get")]
 				[ExpectedWarning ("IL3003", "DerivedClassWithoutRequires.VirtualPropertyAnnotationInPropertyAndAccessor.get", "BaseClassWithRequires.VirtualPropertyAnnotationInPropertyAndAccessor.get", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
 				get;
+				[ExpectedWarning ("IL3003", "DerivedClassWithoutRequires.VirtualPropertyAnnotationInPropertyAndAccessor", "BaseClassWithRequires.VirtualPropertyAnnotationInPropertyAndAccessor", ProducedBy = Tool.NativeAot)]
 				set;
 			}
 		}
@@ -219,13 +290,11 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 			private string name;
 
-			// NativeAOT does not look at associated Property/Event to produce warnings
-			// https://github.com/dotnet/runtime/issues/71985
 			[RequiresAssemblyFiles ("Message")]
 			[ExpectedWarning ("IL3003", "DerivedClassWithAllWarnings.VirtualPropertyAnnotationInAccesor", "BaseClassWithRequires.VirtualPropertyAnnotationInAccesor", ProducedBy = Tool.Analyzer)]
 			public override string VirtualPropertyAnnotationInAccesor {
 				[ExpectedWarning ("IL2046", "DerivedClassWithAllWarnings.VirtualPropertyAnnotationInAccesor.get", "BaseClassWithRequires.VirtualPropertyAnnotationInAccesor.get")]
-				[ExpectedWarning ("IL3003", "DerivedClassWithAllWarnings.VirtualPropertyAnnotationInAccesor.get", "BaseClassWithRequires.VirtualPropertyAnnotationInAccesor.get", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
+				[ExpectedWarning ("IL3003", "DerivedClassWithAllWarnings.VirtualPropertyAnnotationInAccesor.get", "BaseClassWithRequires.VirtualPropertyAnnotationInAccesor.get", ProducedBy = Tool.Analyzer)]
 				[ExpectedWarning ("IL3051", "DerivedClassWithAllWarnings.VirtualPropertyAnnotationInAccesor.get", "BaseClassWithRequires.VirtualPropertyAnnotationInAccesor.get", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
 				get { return name; }
 				[RequiresAssemblyFiles ("Message")]
@@ -235,24 +304,20 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				set { name = value; }
 			}
 
-			// NativeAOT does not look at associated Property/Event to produce warnings
-			// https://github.com/dotnet/runtime/issues/71985
 			[ExpectedWarning ("IL3003", "DerivedClassWithAllWarnings.VirtualPropertyAnnotationInProperty", "BaseClassWithRequires.VirtualPropertyAnnotationInProperty", ProducedBy = Tool.Analyzer)]
 			public override string VirtualPropertyAnnotationInProperty {
 				[RequiresAssemblyFiles ("Message")]
 				[RequiresUnreferencedCode ("Message")]
 				[ExpectedWarning ("IL2046", "VirtualPropertyAnnotationInProperty.get", "BaseClassWithRequires.VirtualPropertyAnnotationInProperty.get")]
-				[ExpectedWarning ("IL3003", "DerivedClassWithAllWarnings.VirtualPropertyAnnotationInProperty.get", "BaseClassWithRequires.VirtualPropertyAnnotationInProperty.get", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
+				[ExpectedWarning ("IL3003", "DerivedClassWithAllWarnings.VirtualPropertyAnnotationInProperty.get", "BaseClassWithRequires.VirtualPropertyAnnotationInProperty.get", ProducedBy = Tool.Analyzer)]
 				get;
 				[RequiresAssemblyFiles ("Message")]
 				[RequiresUnreferencedCode ("Message")]
 				[ExpectedWarning ("IL2046", "VirtualPropertyAnnotationInProperty.set", "BaseClassWithRequires.VirtualPropertyAnnotationInProperty.set")]
-				[ExpectedWarning ("IL3003", "DerivedClassWithAllWarnings.VirtualPropertyAnnotationInProperty.set", "BaseClassWithRequires.VirtualPropertyAnnotationInProperty.set", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
+				[ExpectedWarning ("IL3003", "DerivedClassWithAllWarnings.VirtualPropertyAnnotationInProperty.set", "BaseClassWithRequires.VirtualPropertyAnnotationInProperty.set", ProducedBy = Tool.Analyzer)]
 				set;
 			}
 
-			// NativeAOT does not look at associated Property/Event to produce warnings
-			// https://github.com/dotnet/runtime/issues/71985
 			[ExpectedWarning ("IL3003", "DerivedClassWithAllWarnings.VirtualPropertyAnnotationInPropertyAndAccessor", "BaseClassWithRequires.VirtualPropertyAnnotationInPropertyAndAccessor", ProducedBy = Tool.Analyzer)]
 			public override string VirtualPropertyAnnotationInPropertyAndAccessor {
 				[ExpectedWarning ("IL2046", "VirtualPropertyAnnotationInPropertyAndAccessor.get", "BaseClassWithRequires.VirtualPropertyAnnotationInPropertyAndAccessor.get")]
@@ -261,7 +326,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				[RequiresAssemblyFiles ("Message")]
 				[RequiresUnreferencedCode ("Message")]
 				[ExpectedWarning ("IL2046", "VirtualPropertyAnnotationInPropertyAndAccessor.set", "BaseClassWithRequires.VirtualPropertyAnnotationInPropertyAndAccessor.set")]
-				[ExpectedWarning ("IL3003", "DerivedClassWithAllWarnings.VirtualPropertyAnnotationInPropertyAndAccessor.set", "BaseClassWithRequires.VirtualPropertyAnnotationInPropertyAndAccessor.set", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
+				[ExpectedWarning ("IL3003", "DerivedClassWithAllWarnings.VirtualPropertyAnnotationInPropertyAndAccessor.set", "BaseClassWithRequires.VirtualPropertyAnnotationInPropertyAndAccessor.set", ProducedBy = Tool.Analyzer)]
 				set;
 			}
 		}
@@ -328,14 +393,15 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				set { name = value; }
 			}
 
-			// NativeAOT does not look at associated Property/Event to produce warnings
-			// https://github.com/dotnet/runtime/issues/71985
 			[RequiresAssemblyFiles ("Message")]
 			[ExpectedWarning ("IL3003", "ImplementationClassWithRequires.PropertyAnnotationInProperty", "IBaseWithoutRequires.PropertyAnnotationInProperty", ProducedBy = Tool.Analyzer)]
-			public string PropertyAnnotationInProperty { get; set; }
+			public string PropertyAnnotationInProperty {
+				[ExpectedWarning ("IL3003", "ImplementationClassWithRequires.PropertyAnnotationInProperty", "IBaseWithoutRequires.PropertyAnnotationInProperty", ProducedBy = Tool.NativeAot)]
+				get;
+				[ExpectedWarning ("IL3003", "ImplementationClassWithRequires.PropertyAnnotationInProperty", "IBaseWithoutRequires.PropertyAnnotationInProperty", ProducedBy = Tool.NativeAot)]
+				set;
+			}
 
-			// NativeAOT does not look at associated Property/Event to produce warnings
-			// https://github.com/dotnet/runtime/issues/71985
 			[RequiresAssemblyFiles ("Message")]
 			[ExpectedWarning ("IL3003", "ImplementationClassWithRequires.PropertyAnnotationInPropertyAndAccessor", "IBaseWithoutRequires.PropertyAnnotationInPropertyAndAccessor", ProducedBy = Tool.Analyzer)]
 			public string PropertyAnnotationInPropertyAndAccessor {
@@ -344,6 +410,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				[ExpectedWarning ("IL2046", "ImplementationClassWithRequires.PropertyAnnotationInPropertyAndAccessor.get", "IBaseWithoutRequires.PropertyAnnotationInPropertyAndAccessor.get")]
 				[ExpectedWarning ("IL3003", "ImplementationClassWithRequires.PropertyAnnotationInPropertyAndAccessor.get", "IBaseWithoutRequires.PropertyAnnotationInPropertyAndAccessor.get", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
 				get;
+				[ExpectedWarning ("IL3003", "ImplementationClassWithRequires.PropertyAnnotationInPropertyAndAccessor", "IBaseWithoutRequires.PropertyAnnotationInPropertyAndAccessor", ProducedBy = Tool.NativeAot)]
 				set;
 			}
 		}
@@ -376,14 +443,15 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				set { name = value; }
 			}
 
-			// NativeAOT does not look at associated Property/Event to produce warnings
-			// https://github.com/dotnet/runtime/issues/71985
 			[RequiresAssemblyFiles ("Message")]
 			[ExpectedWarning ("IL3003", "ExplicitImplementationClassWithRequires.Mono.Linker.Tests.Cases.RequiresCapability.RequiresAttributeMismatch.IBaseWithoutRequires.PropertyAnnotationInProperty", "IBaseWithoutRequires.PropertyAnnotationInProperty", ProducedBy = Tool.Analyzer)]
-			string IBaseWithoutRequires.PropertyAnnotationInProperty { get; set; }
+			string IBaseWithoutRequires.PropertyAnnotationInProperty {
+				[ExpectedWarning ("IL3003", "ExplicitImplementationClassWithRequires.Mono.Linker.Tests.Cases.RequiresCapability.RequiresAttributeMismatch.IBaseWithoutRequires.PropertyAnnotationInProperty", "IBaseWithoutRequires.PropertyAnnotationInProperty", ProducedBy = Tool.NativeAot)]
+				get;
+				[ExpectedWarning ("IL3003", "ExplicitImplementationClassWithRequires.Mono.Linker.Tests.Cases.RequiresCapability.RequiresAttributeMismatch.IBaseWithoutRequires.PropertyAnnotationInProperty", "IBaseWithoutRequires.PropertyAnnotationInProperty", ProducedBy = Tool.NativeAot)]
+				set;
+			}
 
-			// NativeAOT does not look at associated Property/Event to produce warnings
-			// https://github.com/dotnet/runtime/issues/71985
 			[RequiresAssemblyFiles ("Message")]
 			[ExpectedWarning ("IL3003", "PropertyAnnotationInPropertyAndAccessor", "IBaseWithoutRequires.PropertyAnnotationInPropertyAndAccessor", ProducedBy = Tool.Analyzer)]
 			string IBaseWithoutRequires.PropertyAnnotationInPropertyAndAccessor {
@@ -392,6 +460,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				[ExpectedWarning ("IL2046", "PropertyAnnotationInPropertyAndAccessor.get", "IBaseWithoutRequires.PropertyAnnotationInPropertyAndAccessor.get")]
 				[ExpectedWarning ("IL3003", "PropertyAnnotationInPropertyAndAccessor.get", "IBaseWithoutRequires.PropertyAnnotationInPropertyAndAccessor.get", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
 				get;
+				[ExpectedWarning ("IL3003", "PropertyAnnotationInPropertyAndAccessor", "IBaseWithoutRequires.PropertyAnnotationInPropertyAndAccessor", ProducedBy = Tool.NativeAot)]
 				set;
 			}
 		}
@@ -414,19 +483,20 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				set { name = value; }
 			}
 
-			// NativeAOT does not look at associated Property/Event to produce warnings
-			// https://github.com/dotnet/runtime/issues/71985
 			[ExpectedWarning ("IL3003", "ImplementationClassWithoutRequires.PropertyAnnotationInProperty", "IBaseWithRequires.PropertyAnnotationInProperty", ProducedBy = Tool.Analyzer)]
-			public string PropertyAnnotationInProperty { get; set; }
+			public string PropertyAnnotationInProperty {
+				[ExpectedWarning ("IL3003", "ImplementationClassWithoutRequires.PropertyAnnotationInProperty", "IBaseWithRequires.PropertyAnnotationInProperty", ProducedBy = Tool.NativeAot)]
+				get;
+				[ExpectedWarning ("IL3003", "ImplementationClassWithoutRequires.PropertyAnnotationInProperty", "IBaseWithRequires.PropertyAnnotationInProperty", ProducedBy = Tool.NativeAot)]
+				set;
+			}
 
-			// NativeAOT does not look at associated Property/Event to produce warnings
-			// https://github.com/dotnet/runtime/issues/71985
 			[ExpectedWarning ("IL3003", "ImplementationClassWithoutRequires.PropertyAnnotationInPropertyAndAccessor", "IBaseWithRequires.PropertyAnnotationInPropertyAndAccessor", ProducedBy = Tool.Analyzer)]
 			public string PropertyAnnotationInPropertyAndAccessor {
 				[RequiresAssemblyFiles ("Message")]
 				[RequiresUnreferencedCode ("Message")]
 				[ExpectedWarning ("IL2046", "ImplementationClassWithoutRequires.PropertyAnnotationInPropertyAndAccessor.get", "IBaseWithRequires.PropertyAnnotationInPropertyAndAccessor.get")]
-				[ExpectedWarning ("IL3003", "ImplementationClassWithoutRequires.PropertyAnnotationInPropertyAndAccessor.get", "IBaseWithRequires.PropertyAnnotationInPropertyAndAccessor.get", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
+				[ExpectedWarning ("IL3003", "ImplementationClassWithoutRequires.PropertyAnnotationInPropertyAndAccessor.get", "IBaseWithRequires.PropertyAnnotationInPropertyAndAccessor.get", ProducedBy = Tool.Analyzer)]
 				get;
 				[ExpectedWarning ("IL2046", "ImplementationClassWithoutRequires.PropertyAnnotationInPropertyAndAccessor.set", "IBaseWithRequires.PropertyAnnotationInPropertyAndAccessor.set")]
 				[ExpectedWarning ("IL3003", "ImplementationClassWithoutRequires.PropertyAnnotationInPropertyAndAccessor.set", "IBaseWithRequires.PropertyAnnotationInPropertyAndAccessor.set", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
@@ -456,15 +526,17 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				set { name = value; }
 			}
 
-			// NativeAOT does not look at associated Property/Event to produce warnings
-			// https://github.com/dotnet/runtime/issues/71985
 			[ExpectedWarning ("IL3003", "ExplicitImplementationClassWithoutRequires.Mono.Linker.Tests.Cases.RequiresCapability.RequiresAttributeMismatch.IBaseWithRequires.PropertyAnnotationInProperty", "IBaseWithRequires.PropertyAnnotationInProperty", ProducedBy = Tool.Analyzer)]
-			string IBaseWithRequires.PropertyAnnotationInProperty { get; set; }
+			string IBaseWithRequires.PropertyAnnotationInProperty {
+				[ExpectedWarning ("IL3003", "ExplicitImplementationClassWithoutRequires.Mono.Linker.Tests.Cases.RequiresCapability.RequiresAttributeMismatch.IBaseWithRequires.PropertyAnnotationInProperty", "IBaseWithRequires.PropertyAnnotationInProperty", ProducedBy = Tool.NativeAot)]
+				get;
+				[ExpectedWarning ("IL3003", "ExplicitImplementationClassWithoutRequires.Mono.Linker.Tests.Cases.RequiresCapability.RequiresAttributeMismatch.IBaseWithRequires.PropertyAnnotationInProperty", "IBaseWithRequires.PropertyAnnotationInProperty", ProducedBy = Tool.NativeAot)]
+				set;
+			}
 
-			// NativeAOT does not look at associated Property/Event to produce warnings
-			// https://github.com/dotnet/runtime/issues/71985
 			[ExpectedWarning ("IL3003", "ExplicitImplementationClassWithoutRequires.Mono.Linker.Tests.Cases.RequiresCapability.RequiresAttributeMismatch.IBaseWithRequires.PropertyAnnotationInPropertyAndAccessor", "IBaseWithRequires.PropertyAnnotationInPropertyAndAccessor", ProducedBy = Tool.Analyzer)]
 			string IBaseWithRequires.PropertyAnnotationInPropertyAndAccessor {
+				[ExpectedWarning ("IL3003", "ExplicitImplementationClassWithoutRequires.Mono.Linker.Tests.Cases.RequiresCapability.RequiresAttributeMismatch.IBaseWithRequires.PropertyAnnotationInPropertyAndAccessor", "IBaseWithRequires.PropertyAnnotationInPropertyAndAccessor", ProducedBy = Tool.NativeAot)]
 				get;
 				[ExpectedWarning ("IL2046", "PropertyAnnotationInPropertyAndAccessor.set", "IBaseWithRequires.PropertyAnnotationInPropertyAndAccessor.set")]
 				[ExpectedWarning ("IL3003", "PropertyAnnotationInPropertyAndAccessor.set", "IBaseWithRequires.PropertyAnnotationInPropertyAndAccessor.set", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
@@ -490,10 +562,13 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				set { name = value; }
 			}
 
-			// NativeAOT does not look at associated Property/Event to produce warnings
-			// https://github.com/dotnet/runtime/issues/71985
 			[ExpectedWarning ("IL3003", "ImplementationClassWithoutRequiresInSource.PropertyAnnotationInProperty", "IBaseWithRequiresInReference.PropertyAnnotationInProperty", ProducedBy = Tool.Analyzer)]
-			public string PropertyAnnotationInProperty { get; set; }
+			public string PropertyAnnotationInProperty {
+				[ExpectedWarning ("IL3003", "ImplementationClassWithoutRequiresInSource.PropertyAnnotationInProperty.get", "IBaseWithRequiresInReference.PropertyAnnotationInProperty.get", ProducedBy = Tool.NativeAot)]
+				get;
+				[ExpectedWarning ("IL3003", "ImplementationClassWithoutRequiresInSource.PropertyAnnotationInProperty.set", "IBaseWithRequiresInReference.PropertyAnnotationInProperty.set", ProducedBy = Tool.NativeAot)]
+				set;
+			}
 		}
 
 		class ImplementationClassWithRequiresInSource : ReferenceInterfaces.IBaseWithoutRequiresInReference
@@ -520,11 +595,14 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				set { name = value; }
 			}
 
-			// NativeAOT does not look at associated Property/Event to produce warnings
-			// https://github.com/dotnet/runtime/issues/71985
 			[ExpectedWarning ("IL3003", "ImplementationClassWithRequiresInSource.PropertyAnnotationInProperty", "IBaseWithoutRequiresInReference.PropertyAnnotationInProperty", ProducedBy = Tool.Analyzer)]
 			[RequiresAssemblyFiles ("Message")]
-			public string PropertyAnnotationInProperty { get; set; }
+			public string PropertyAnnotationInProperty {
+				[ExpectedWarning ("IL3003", "ImplementationClassWithRequiresInSource.PropertyAnnotationInProperty", "IBaseWithoutRequiresInReference.PropertyAnnotationInProperty", ProducedBy = Tool.NativeAot)]
+				get;
+				[ExpectedWarning ("IL3003", "ImplementationClassWithRequiresInSource.PropertyAnnotationInProperty", "IBaseWithoutRequiresInReference.PropertyAnnotationInProperty", ProducedBy = Tool.NativeAot)]
+				set;
+			}
 		}
 
 		class StaticInterfaceMethods


### PR DESCRIPTION
The `RequiresAssemblyFiles` attribute can be present on property or event (in which case it applies to all accessors). The analyzer already handles this case, but the NativeAOT compiler didn't. This change implements the correct behavior in NativeAOT as well.

The implementation actually handles all Requires attributes this way now, but the other two are not allowed on properties or event (yet).

Had to add an optimization to the `GetPropertyForAccessor`/`GetEventForAccessor` as these are now called very frequently and they can be really slow.

Fixes https://github.com/dotnet/runtime/issues/71985.