### PR TITLE
[browser] code cleanup

### DIFF
--- a/src/mono/wasm/runtime/assets.ts
+++ b/src/mono/wasm/runtime/assets.ts
@@ -19,7 +19,6 @@ let actual_instantiated_assets_count = 0;
 let expected_downloaded_assets_count = 0;
 let expected_instantiated_assets_count = 0;
 const loaded_files: { url: string, file: string }[] = [];
-const loaded_assets: { [id: string]: [VoidPtr, number] } = Object.create(null);
 // in order to prevent net::ERR_INSUFFICIENT_RESOURCES if we start downloading too many files at same time
 let parallel_count = 0;
 let throttlingPromise: PromiseAndController<void> | undefined;
@@ -29,6 +28,7 @@ const skipDownloadsByAssetTypes: {
     [k: string]: boolean
 } = {
     "js-module-threads": true,
+    "dotnetwasm": true,
 };
 
 // `response.arrayBuffer()` can't be called twice. Some usecases are calling it on response in the instantiation.
@@ -372,7 +372,6 @@ function _instantiate_asset(asset: AssetEntry, url: string, bytes: Uint8Array) {
         case "heap":
         case "icu":
             offset = mono_wasm_load_bytes_into_heap(bytes);
-            loaded_assets[virtualName] = [offset, bytes.length];
             break;
 
         case "vfs": {

--- a/src/mono/wasm/runtime/es6/dotnet.es6.lib.js
+++ b/src/mono/wasm/runtime/es6/dotnet.es6.lib.js
@@ -97,9 +97,6 @@ let linked_functions = [
     "mono_wasm_invoke_import",
     "mono_wasm_bind_cs_function",
     "mono_wasm_marshal_promise",
-
-    // pal_icushim_static.c
-    "mono_wasm_load_icu_data",
 ];
 
 if (monoWasmThreads) {

--- a/src/mono/wasm/runtime/exports-linker.ts
+++ b/src/mono/wasm/runtime/exports-linker.ts
@@ -5,7 +5,6 @@ import MonoWasmThreads from "consts:monoWasmThreads";
 import WasmEnableLegacyJsInterop from "consts:WasmEnableLegacyJsInterop";
 import { mono_wasm_debugger_log, mono_wasm_add_dbg_command_received, mono_wasm_set_entrypoint_breakpoint, mono_wasm_fire_debugger_agent_message_with_data, mono_wasm_fire_debugger_agent_message_with_data_to_pause } from "./debug";
 import { mono_wasm_release_cs_owned_object } from "./gc-handles";
-import { mono_wasm_load_icu_data } from "./icu";
 import { mono_wasm_bind_cs_function } from "./invoke-cs";
 import { mono_wasm_bind_js_function, mono_wasm_invoke_bound_function, mono_wasm_invoke_import } from "./invoke-js";
 import { mono_interp_tier_prepare_jiterpreter } from "./jiterpreter";
@@ -94,9 +93,6 @@ export function export_linker(): any {
         mono_wasm_invoke_import,
         mono_wasm_bind_cs_function,
         mono_wasm_marshal_promise,
-
-        //  pal_icushim_static.c
-        mono_wasm_load_icu_data,
 
         // threading exports, if threading is enabled
         ...mono_wasm_threads_exports,

--- a/src/mono/wasm/runtime/imports.ts
+++ b/src/mono/wasm/runtime/imports.ts
@@ -51,7 +51,6 @@ export function set_emscripten_entrypoint(
 const initialRuntimeHelpers: Partial<RuntimeHelpers> =
 {
     javaScriptExports: {} as any,
-    mono_wasm_load_runtime_done: false,
     mono_wasm_bindings_is_ready: false,
     maxParallelDownloads: 16,
     enableDownloadRetry: true,

--- a/src/mono/wasm/runtime/pthreads/worker/index.ts
+++ b/src/mono/wasm/runtime/pthreads/worker/index.ts
@@ -69,7 +69,6 @@ export function setupPreloadChannelToMainThread() {
     const mainPort = channel.port2;
     workerPort.addEventListener("message", (event) => {
         const config = JSON.parse(event.data.config) as MonoConfig;
-        console.debug("MONO_WASM: applying mono config from main", event.data.config);
         onMonoConfigReceived(config);
         workerPort.close();
         mainPort.close();

--- a/src/mono/wasm/runtime/types.ts
+++ b/src/mono/wasm/runtime/types.ts
@@ -209,7 +209,6 @@ export type RuntimeHelpers = {
     runtime_interop_exports_class: MonoClass;
 
     _i52_error_scratch_buffer: Int32Ptr;
-    mono_wasm_load_runtime_done: boolean;
     mono_wasm_runtime_is_ready: boolean;
     mono_wasm_bindings_is_ready: boolean;
     mono_wasm_symbols_are_ready: boolean;


### PR DESCRIPTION
Yet another cleanup split from https://github.com/dotnet/runtime/pull/82049

- drop loaded_assets
- drop mono_wasm_load_icu_data from wasm imports
- drop mono_wasm_load_runtime_done
- drop noisy console.debug
- move instantiateWasmPThreadWorkerPool after mono is started
- move replace_linker_placeholders
- move SpecialFolder.CommonApplicationData creation to postRunAsync
- move bindings_init() out to onRuntimeInitializedAsync
- unified body of mono_wasm_before_user_runtime_initialized and _apply_configuration_from_args