### PR TITLE
Add getNN_unaligned memory.ts APIs for potentially unaligned pointers

### DIFF
--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -89,6 +89,9 @@ const fn_signatures: SigLine[] = [
     [true, "mono_wasm_method_get_full_name", "number", ["number"]],
     [true, "mono_wasm_gc_lock", "void", []],
     [true, "mono_wasm_gc_unlock", "void", []],
+    [true, "mono_wasm_get_i32_unaligned", "number", ["number"]],
+    [true, "mono_wasm_get_f32_unaligned", "number", ["number"]],
+    [true, "mono_wasm_get_f64_unaligned", "number", ["number"]],
 
     // jiterpreter
     [true, "mono_jiterp_get_trace_bailout_count", "number", ["number"]],
@@ -196,6 +199,9 @@ export interface t_Cwraps {
     mono_wasm_method_get_full_name(method: MonoMethod): CharPtr;
     mono_wasm_gc_lock(): void;
     mono_wasm_gc_unlock(): void;
+    mono_wasm_get_i32_unaligned(source: VoidPtr): number;
+    mono_wasm_get_f32_unaligned(source: VoidPtr): number;
+    mono_wasm_get_f64_unaligned(source: VoidPtr): number;
 
     mono_jiterp_get_trace_bailout_count(reason: number): number;
     mono_jiterp_value_copy(destination: VoidPtr, source: VoidPtr, klass: MonoClass): void;

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -1401,3 +1401,15 @@ EMSCRIPTEN_KEEPALIVE const char * mono_wasm_method_get_full_name (MonoMethod *me
 EMSCRIPTEN_KEEPALIVE const char * mono_wasm_method_get_name (MonoMethod *method) {
 	return mono_method_get_name(method);
 }
+
+EMSCRIPTEN_KEEPALIVE float mono_wasm_get_f32_unaligned (const float *src) {
+	return *src;
+}
+
+EMSCRIPTEN_KEEPALIVE double mono_wasm_get_f64_unaligned (const double *src) {
+	return *src;
+}
+
+EMSCRIPTEN_KEEPALIVE int32_t mono_wasm_get_i32_unaligned (const int32_t *src) {
+	return *src;
+}

--- a/src/mono/wasm/runtime/jiterpreter-interp-entry.ts
+++ b/src/mono/wasm/runtime/jiterpreter-interp-entry.ts
@@ -5,7 +5,7 @@ import { mono_assert, MonoMethod, MonoType } from "./types";
 import { NativePointer } from "./types/emscripten";
 import { Module } from "./imports";
 import {
-    getU32, _zero_region
+    getU32_unaligned, _zero_region
 } from "./memory";
 import { WasmOpcode } from "./jiterpreter-opcodes";
 import cwraps from "./cwraps";
@@ -106,7 +106,7 @@ class TrampolineInfo {
         this.name = name;
         this.paramTypes = new Array(argumentCount);
         for (let i = 0; i < argumentCount; i++)
-            this.paramTypes[i] = <any>getU32(<any>pParamTypes + (i * 4));
+            this.paramTypes[i] = <any>getU32_unaligned(<any>pParamTypes + (i * 4));
         this.defaultImplementation = defaultImplementation;
         this.result = 0;
         let subName = name;

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -5,7 +5,7 @@ import { mono_assert, MonoMethod } from "./types";
 import { NativePointer } from "./types/emscripten";
 import { Module } from "./imports";
 import {
-    getU16, getU32
+    getU16, getU32_unaligned
 } from "./memory";
 import { WasmOpcode } from "./jiterpreter-opcodes";
 import { MintOpcode, OpcodeInfo } from "./mintops";
@@ -950,9 +950,9 @@ export function mono_interp_tier_prepare_jiterpreter (
     const methodName = Module.UTF8ToString(cwraps.mono_wasm_method_get_name(method));
     info.name = methodFullName || methodName;
 
-    const imethod = getU32(getMemberOffset(JiterpMember.Imethod) + <any>frame);
-    const backBranchCount = getU32(getMemberOffset(JiterpMember.BackwardBranchOffsetsCount) + imethod);
-    const pBackBranches = getU32(getMemberOffset(JiterpMember.BackwardBranchOffsets) + imethod);
+    const imethod = getU32_unaligned(getMemberOffset(JiterpMember.Imethod) + <any>frame);
+    const backBranchCount = getU32_unaligned(getMemberOffset(JiterpMember.BackwardBranchOffsetsCount) + imethod);
+    const pBackBranches = getU32_unaligned(getMemberOffset(JiterpMember.BackwardBranchOffsets) + imethod);
     let backwardBranchTable = backBranchCount
         ? new Uint16Array(Module.HEAPU8.buffer, pBackBranches, backBranchCount)
         : null;

--- a/src/mono/wasm/runtime/marshal.ts
+++ b/src/mono/wasm/runtime/marshal.ts
@@ -3,7 +3,7 @@
 
 import { js_owned_gc_handle_symbol, teardown_managed_proxy } from "./gc-handles";
 import { Module, runtimeHelpers } from "./imports";
-import { getF32, getF64, getI16, getI32, getI64Big, getU16, getU32, getU8, setF32, setF64, setI16, setI32, setI64Big, setU16, setU32, setU8 } from "./memory";
+import { getF32, getF64_unaligned, getI16, getI32, getI64Big, getU16, getU32, getU8, setF32, setF64, setI16, setI32, setI64Big, setU16, setU32, setU8 } from "./memory";
 import { mono_wasm_new_external_root } from "./roots";
 import { mono_assert, GCHandle, JSHandle, MonoObject, MonoString, GCHandleNull, JSMarshalerArguments, JSFunctionSignature, JSMarshalerType, JSMarshalerArgument, MarshalerToJs, MarshalerToCs, WasmRoot } from "./types";
 import { CharPtr, TypedArray, VoidPtr } from "./types/emscripten";
@@ -23,8 +23,8 @@ export const imported_js_function_symbol = Symbol.for("wasm imported_js_function
  *      arg1: { jsType: JsTypeFlags, type:MarshalerType, restype:MarshalerType, arg1type:MarshalerType, arg2type:MarshalerType, arg3type:MarshalerType}
  *      arg2: { jsType: JsTypeFlags, type:MarshalerType, restype:MarshalerType, arg1type:MarshalerType, arg2type:MarshalerType, arg3type:MarshalerType}
  *      ...
- *      ] 
- * 
+ *      ]
+ *
  * Layout of the call stack frame buffers is array of JSMarshalerArgument
  * JSMarshalerArguments is pointer to [
  *      exc:  {type:MarshalerType, handle: IntPtr, data: Int64|Ref*|Void* },
@@ -171,7 +171,7 @@ export function get_arg_intptr(arg: JSMarshalerArgument): number {
 export function get_arg_i52(arg: JSMarshalerArgument): number {
     mono_assert(arg, "Null arg");
     // we know that the range check and conversion from Int64 was be done on C# side
-    return getF64(<any>arg);
+    return getF64_unaligned(<any>arg);
 }
 
 export function get_arg_i64_big(arg: JSMarshalerArgument): bigint {
@@ -181,7 +181,7 @@ export function get_arg_i64_big(arg: JSMarshalerArgument): bigint {
 
 export function get_arg_date(arg: JSMarshalerArgument): Date {
     mono_assert(arg, "Null arg");
-    const unixTime = getF64(<any>arg);
+    const unixTime = getF64_unaligned(<any>arg);
     const date = new Date(unixTime);
     return date;
 }
@@ -193,7 +193,7 @@ export function get_arg_f32(arg: JSMarshalerArgument): number {
 
 export function get_arg_f64(arg: JSMarshalerArgument): number {
     mono_assert(arg, "Null arg");
-    return getF64(<any>arg);
+    return getF64_unaligned(<any>arg);
 }
 
 export function set_arg_b8(arg: JSMarshalerArgument, value: boolean): void {

--- a/src/mono/wasm/runtime/marshal.ts
+++ b/src/mono/wasm/runtime/marshal.ts
@@ -3,7 +3,7 @@
 
 import { js_owned_gc_handle_symbol, teardown_managed_proxy } from "./gc-handles";
 import { Module, runtimeHelpers } from "./imports";
-import { getF32, getF64_unaligned, getI16, getI32, getI64Big, getU16, getU32, getU8, setF32, setF64, setI16, setI32, setI64Big, setU16, setU32, setU8 } from "./memory";
+import { getF32, getF64, getI16, getI32, getI64Big, getU16, getU32, getU8, setF32, setF64, setI16, setI32, setI64Big, setU16, setU32, setU8 } from "./memory";
 import { mono_wasm_new_external_root } from "./roots";
 import { mono_assert, GCHandle, JSHandle, MonoObject, MonoString, GCHandleNull, JSMarshalerArguments, JSFunctionSignature, JSMarshalerType, JSMarshalerArgument, MarshalerToJs, MarshalerToCs, WasmRoot } from "./types";
 import { CharPtr, TypedArray, VoidPtr } from "./types/emscripten";
@@ -23,8 +23,8 @@ export const imported_js_function_symbol = Symbol.for("wasm imported_js_function
  *      arg1: { jsType: JsTypeFlags, type:MarshalerType, restype:MarshalerType, arg1type:MarshalerType, arg2type:MarshalerType, arg3type:MarshalerType}
  *      arg2: { jsType: JsTypeFlags, type:MarshalerType, restype:MarshalerType, arg1type:MarshalerType, arg2type:MarshalerType, arg3type:MarshalerType}
  *      ...
- *      ]
- *
+ *      ] 
+ * 
  * Layout of the call stack frame buffers is array of JSMarshalerArgument
  * JSMarshalerArguments is pointer to [
  *      exc:  {type:MarshalerType, handle: IntPtr, data: Int64|Ref*|Void* },
@@ -171,7 +171,7 @@ export function get_arg_intptr(arg: JSMarshalerArgument): number {
 export function get_arg_i52(arg: JSMarshalerArgument): number {
     mono_assert(arg, "Null arg");
     // we know that the range check and conversion from Int64 was be done on C# side
-    return getF64_unaligned(<any>arg);
+    return getF64(<any>arg);
 }
 
 export function get_arg_i64_big(arg: JSMarshalerArgument): bigint {
@@ -181,7 +181,7 @@ export function get_arg_i64_big(arg: JSMarshalerArgument): bigint {
 
 export function get_arg_date(arg: JSMarshalerArgument): Date {
     mono_assert(arg, "Null arg");
-    const unixTime = getF64_unaligned(<any>arg);
+    const unixTime = getF64(<any>arg);
     const date = new Date(unixTime);
     return date;
 }
@@ -193,7 +193,7 @@ export function get_arg_f32(arg: JSMarshalerArgument): number {
 
 export function get_arg_f64(arg: JSMarshalerArgument): number {
     mono_assert(arg, "Null arg");
-    return getF64_unaligned(<any>arg);
+    return getF64(<any>arg);
 }
 
 export function set_arg_b8(arg: JSMarshalerArgument, value: boolean): void {

--- a/src/mono/wasm/runtime/memory.ts
+++ b/src/mono/wasm/runtime/memory.ts
@@ -170,6 +170,22 @@ export function getU32(offset: MemOffset): number {
     return Module.HEAPU32[<any>offset >>> 2];
 }
 
+export function getI32_unaligned(offset: MemOffset): number {
+    return cwraps.mono_wasm_get_i32_unaligned(<any>offset);
+}
+
+export function getU32_unaligned(offset: MemOffset): number {
+    return cwraps.mono_wasm_get_i32_unaligned(<any>offset) >>> 0;
+}
+
+export function getF32_unaligned(offset: MemOffset): number {
+    return cwraps.mono_wasm_get_f32_unaligned(<any>offset);
+}
+
+export function getF64_unaligned(offset: MemOffset): number {
+    return cwraps.mono_wasm_get_f64_unaligned(<any>offset);
+}
+
 export function getI8(offset: MemOffset): number {
     return Module.HEAP8[<any>offset];
 }
@@ -226,8 +242,8 @@ export function afterUpdateGlobalBufferAndViews(buffer: ArrayBufferLike): void {
 }
 
 export function getCU64(offset: MemOffset): cuint64.CUInt64 {
-    const lo = getU32(offset);
-    const hi = getU32(<any>offset + 4);
+    const lo = getU32_unaligned(offset);
+    const hi = getU32_unaligned(<any>offset + 4);
     return cuint64.pack32(lo, hi);
 }
 

--- a/src/mono/wasm/runtime/memory.ts
+++ b/src/mono/wasm/runtime/memory.ts
@@ -5,7 +5,6 @@ import monoWasmThreads from "consts:monoWasmThreads";
 import { Module, runtimeHelpers } from "./imports";
 import { mono_assert, MemOffset, NumberOrPointer } from "./types";
 import { VoidPtr, CharPtr } from "./types/emscripten";
-import * as cuint64 from "./cuint64";
 import cwraps, { I52Error } from "./cwraps";
 
 const alloca_stack: Array<VoidPtr> = [];
@@ -239,18 +238,6 @@ export function afterUpdateGlobalBufferAndViews(buffer: ArrayBufferLike): void {
         min_int64_big = BigInt("-9223372036854775808");
         HEAPI64 = new BigInt64Array(buffer);
     }
-}
-
-export function getCU64(offset: MemOffset): cuint64.CUInt64 {
-    const lo = getU32_unaligned(offset);
-    const hi = getU32_unaligned(<any>offset + 4);
-    return cuint64.pack32(lo, hi);
-}
-
-export function setCU64(offset: MemOffset, value: cuint64.CUInt64): void {
-    const [lo, hi] = cuint64.unpack32(value);
-    setU32_unchecked(offset, lo);
-    setU32_unchecked(<any>offset + 4, hi);
 }
 
 /// Allocates a new buffer of the given size on the Emscripten stack and passes a pointer to it to the callback.


### PR DESCRIPTION
The existing getNN helpers in our memory API require the pointer to be aligned and don't enforce it. For most allocations we can expect alignment, but when accessing members of structs or elements of arrays, it's not necessarily a safe assumption. Similarly for 8-byte values it's possible the allocation was only 4-byte aligned or struct elements were packed densely.

In the interpreter we know for a fact that this is an issue since opcodes are 2 bytes and the opcode stream has 4-byte and 8-byte values packed into it unaligned.

I updated various places in the TS that looked to me like they could potentially be dealing with unaligned addresses (thankfully not too many).