### PR TITLE
[wasm] Fix missing branch target table update in jiterpreter

### DIFF
--- a/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
@@ -2396,6 +2396,7 @@ function emit_branch (
                 // Simple branches are enabled and this is a forward branch. We
                 //  don't need to wrap things in a block here, we can just exit
                 //  the current branch block after updating eip
+                builder.branchTargets.add(destination);
                 builder.ip_const(destination);
                 builder.local("eip", WasmOpcode.set_local);
                 builder.appendU8(WasmOpcode.br);


### PR DESCRIPTION
The jiterpreter was failing to add unconditional branch targets to the branch target table, which could cause branches targeting them to fail and make the trace bail out. This fix appears to provide a significant speed-up, but it's possible it may make some specific scenarios regress.

Any regressions should be fixed once the CFG lands in the future.