### PR TITLE
Update the Roslyn version our ref-pack generators reference to 4.5.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -67,7 +67,7 @@
       When we are building from source, we care more about reducing pre-built requirements than inner-loop dev experience, so we update this to be the same version
       as MicrosoftCodeAnalysisVersion.
     -->
-    <MicrosoftCodeAnalysisVersion_LatestVS>4.4.0</MicrosoftCodeAnalysisVersion_LatestVS>
+    <MicrosoftCodeAnalysisVersion_LatestVS>4.5.0</MicrosoftCodeAnalysisVersion_LatestVS>
     <MicrosoftCodeAnalysisVersion_LatestVS Condition="'$(DotNetBuildFromSource)' == 'true'">$(MicrosoftCodeAnalysisVersion)</MicrosoftCodeAnalysisVersion_LatestVS>
     <!-- Some of the analyzer dependencies used by ILLink project -->
     <MicrosoftCodeAnalysisCSharpAnalyzerTestingXunitVersion>1.0.1-beta1.21265.1</MicrosoftCodeAnalysisCSharpAnalyzerTestingXunitVersion>


### PR DESCRIPTION
This allows us to use new features like IAttributeOperation.

This also bumps our minimum VS version for local development to 17.5 (our current requirement is 17.4).