### PR TITLE
[wasm] Introduce jiterpreter control flow pass

### DIFF
--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -1281,6 +1281,31 @@ mono_jiterp_get_member_offset (int member) {
 	}
 }
 
+#define JITERP_NUMBER_MODE_U32 0
+#define JITERP_NUMBER_MODE_I32 1
+#define JITERP_NUMBER_MODE_F32 2
+#define JITERP_NUMBER_MODE_F64 3
+
+EMSCRIPTEN_KEEPALIVE void
+mono_jiterp_write_number_unaligned (void *dest, double value, int mode) {
+	switch (mode) {
+		case JITERP_NUMBER_MODE_U32:
+			*((uint32_t *)dest) = (uint32_t)value;
+			return;
+		case JITERP_NUMBER_MODE_I32:
+			*((int32_t *)dest) = (int32_t)value;
+			return;
+		case JITERP_NUMBER_MODE_F32:
+			*((float *)dest) = (float)value;
+			return;
+		case JITERP_NUMBER_MODE_F64:
+			*((double *)dest) = value;
+			return;
+		default:
+			g_assert_not_reached();
+	}
+}
+
 // HACK: fix C4206
 EMSCRIPTEN_KEEPALIVE
 #endif // HOST_BROWSER

--- a/src/mono/mono/utils/options-def.h
+++ b/src/mono/mono/utils/options-def.h
@@ -95,7 +95,7 @@ DEFINE_BOOL(jiterpreter_call_resume_enabled, "jiterpreter-call-resume-enabled", 
 //  stats for options like estimateHeat, but raises overhead.
 DEFINE_BOOL(jiterpreter_disable_heuristic, "jiterpreter-disable-heuristic", FALSE, "Always insert trace entry points for more accurate statistics")
 // Automatically prints stats at app exit or when jiterpreter_dump_stats is called
-DEFINE_BOOL(jiterpreter_stats_enabled, "jiterpreter-stats-enabled", TRUE, "Automatically print jiterpreter statistics")
+DEFINE_BOOL(jiterpreter_stats_enabled, "jiterpreter-stats-enabled", FALSE, "Automatically print jiterpreter statistics")
 // Continue counting hits for traces that fail to compile and use it to estimate
 //  the relative importance of the opcode that caused them to abort
 DEFINE_BOOL(jiterpreter_estimate_heat, "jiterpreter-estimate-heat", FALSE, "Maintain accurate hit count for all trace entry points")

--- a/src/mono/mono/utils/options-def.h
+++ b/src/mono/mono/utils/options-def.h
@@ -109,7 +109,7 @@ DEFINE_BOOL(jiterpreter_use_constants, "jiterpreter-use-constants", FALSE, "Use 
 // Attempt to eliminate redundant null checks in compiled traces
 DEFINE_BOOL(jiterpreter_eliminate_null_checks, "jiterpreter-eliminate-null-checks", TRUE, "Attempt to eliminate redundant null checks in traces")
 // enables performing backward branches without exiting traces
-DEFINE_BOOL(jiterpreter_backward_branches_enabled, "jiterpreter-backward-branches-enabled", FALSE, "Enable performing backward branches without exiting traces")
+DEFINE_BOOL(jiterpreter_backward_branches_enabled, "jiterpreter-backward-branches-enabled", TRUE, "Enable performing backward branches without exiting traces")
 // When compiling a jit_call wrapper, bypass sharedvt wrappers if possible by inlining their
 //  logic into the compiled wrapper and calling the target AOTed function with native call convention
 DEFINE_BOOL(jiterpreter_direct_jit_call, "jiterpreter-direct-jit-calls", TRUE, "Bypass gsharedvt wrappers when compiling JIT call wrappers")

--- a/src/mono/mono/utils/options-def.h
+++ b/src/mono/mono/utils/options-def.h
@@ -95,7 +95,7 @@ DEFINE_BOOL(jiterpreter_call_resume_enabled, "jiterpreter-call-resume-enabled", 
 //  stats for options like estimateHeat, but raises overhead.
 DEFINE_BOOL(jiterpreter_disable_heuristic, "jiterpreter-disable-heuristic", FALSE, "Always insert trace entry points for more accurate statistics")
 // Automatically prints stats at app exit or when jiterpreter_dump_stats is called
-DEFINE_BOOL(jiterpreter_stats_enabled, "jiterpreter-stats-enabled", FALSE, "Automatically print jiterpreter statistics")
+DEFINE_BOOL(jiterpreter_stats_enabled, "jiterpreter-stats-enabled", TRUE, "Automatically print jiterpreter statistics")
 // Continue counting hits for traces that fail to compile and use it to estimate
 //  the relative importance of the opcode that caused them to abort
 DEFINE_BOOL(jiterpreter_estimate_heat, "jiterpreter-estimate-heat", FALSE, "Maintain accurate hit count for all trace entry points")
@@ -109,7 +109,7 @@ DEFINE_BOOL(jiterpreter_use_constants, "jiterpreter-use-constants", FALSE, "Use 
 // Attempt to eliminate redundant null checks in compiled traces
 DEFINE_BOOL(jiterpreter_eliminate_null_checks, "jiterpreter-eliminate-null-checks", TRUE, "Attempt to eliminate redundant null checks in traces")
 // enables performing backward branches without exiting traces
-DEFINE_BOOL(jiterpreter_backward_branches_enabled, "jiterpreter-backward-branches-enabled", TRUE, "Enable performing backward branches without exiting traces")
+DEFINE_BOOL(jiterpreter_backward_branches_enabled, "jiterpreter-backward-branches-enabled", FALSE, "Enable performing backward branches without exiting traces")
 // When compiling a jit_call wrapper, bypass sharedvt wrappers if possible by inlining their
 //  logic into the compiled wrapper and calling the target AOTed function with native call convention
 DEFINE_BOOL(jiterpreter_direct_jit_call, "jiterpreter-direct-jit-calls", TRUE, "Bypass gsharedvt wrappers when compiling JIT call wrappers")

--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -100,6 +100,7 @@ const fn_signatures: SigLine[] = [
     [false, "mono_jiterp_encode_leb52", "number", ["number", "number", "number"]],
     [false, "mono_jiterp_encode_leb64_ref", "number", ["number", "number", "number"]],
     [false, "mono_jiterp_encode_leb_signed_boundary", "number", ["number", "number", "number"]],
+    [false, "mono_jiterp_write_number_unaligned", "void", ["number", "number", "number"]],
     [true, "mono_jiterp_type_is_byref", "number", ["number"]],
     [true, "mono_jiterp_get_size_of_stackval", "number", []],
     [true, "mono_jiterp_parse_option", "number", ["string"]],
@@ -234,6 +235,7 @@ export interface t_Cwraps {
     mono_jiterp_debug_count(): number;
     mono_jiterp_get_trace_hit_count(traceIndex: number): number;
     mono_jiterp_get_polling_required_address(): Int32Ptr;
+    mono_jiterp_write_number_unaligned(destination: VoidPtr, value: number, mode: number): void;
 }
 
 const wrapped_c_functions: t_Cwraps = <any>{};

--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -670,7 +670,7 @@ function generate_wasm (
                 name: traceName,
                 export: true,
                 locals: {
-                    "eip": WasmValtype.i32,
+                    "disp": WasmValtype.i32,
                     "temp_ptr": WasmValtype.i32,
                     "cknull_ptr": WasmValtype.i32,
                     "math_lhs32": WasmValtype.i32,

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -15,7 +15,8 @@ import {
     _now, elapsedTimes, shortNameBase,
     counters, getRawCwrap, importDef,
     JiterpreterOptions, getOptions, recordFailure,
-    JiterpMember, getMemberOffset
+    JiterpMember, getMemberOffset,
+    BailoutReasonNames
 } from "./jiterpreter-support";
 import {
     generate_wasm_body
@@ -164,60 +165,6 @@ struct InterpMethod {
        MonoExceptionClause *clauses; // num_clauses
        void **data_items;
 */
-
-export const enum BailoutReason {
-    Unknown,
-    InterpreterTiering,
-    NullCheck,
-    VtableNotInitialized,
-    Branch,
-    BackwardBranch,
-    ConditionalBranch,
-    ConditionalBackwardBranch,
-    ComplexBranch,
-    ArrayLoadFailed,
-    ArrayStoreFailed,
-    StringOperationFailed,
-    DivideByZero,
-    Overflow,
-    Return,
-    Call,
-    Throw,
-    AllocFailed,
-    SpanOperationFailed,
-    CastFailed,
-    SafepointBranchTaken,
-    UnboxFailed,
-    CallDelegate,
-    Debugging
-}
-
-export const BailoutReasonNames = [
-    "Unknown",
-    "InterpreterTiering",
-    "NullCheck",
-    "VtableNotInitialized",
-    "Branch",
-    "BackwardBranch",
-    "ConditionalBranch",
-    "ConditionalBackwardBranch",
-    "ComplexBranch",
-    "ArrayLoadFailed",
-    "ArrayStoreFailed",
-    "StringOperationFailed",
-    "DivideByZero",
-    "Overflow",
-    "Return",
-    "Call",
-    "Throw",
-    "AllocFailed",
-    "SpanOperationFailed",
-    "CastFailed",
-    "SafepointBranchTaken",
-    "UnboxFailed",
-    "CallDelegate",
-    "Debugging"
-];
 
 export let traceBuilder : WasmBuilder;
 export let traceImports : Array<[string, string, Function]> | undefined;
@@ -743,6 +690,8 @@ function generate_wasm (
                 if (getU16(ip) !== MintOpcode.MINT_TIER_PREPARE_JITERPRETER)
                     throw new Error(`Expected *ip to be MINT_TIER_PREPARE_JITERPRETER but was ${getU16(ip)}`);
 
+                builder.cfg.initialize(startOfBody, backwardBranchTable);
+
                 // TODO: Call generate_wasm_body before generating any of the sections and headers.
                 // This will allow us to do things like dynamically vary the number of locals, in addition
                 //  to using global constants and figuring out how many constant slots we need in advance
@@ -751,7 +700,10 @@ function generate_wasm (
                     frame, traceName, ip, startOfBody, endOfBody,
                     builder, instrumentedTraceId, backwardBranchTable
                 );
+
                 keep = (opcodesProcessed >= mostRecentOptions!.minimumTraceLength);
+
+                return builder.cfg.generate();
             }
         );
 
@@ -769,6 +721,8 @@ function generate_wasm (
 
         compileStarted = _now();
         const buffer = builder.getArrayView();
+        // console.log(`bytes generated: ${buffer.length}`);
+
         if (trace > 0)
             console.log(`${(<any>(builder.base)).toString(16)} ${methodFullName || traceName} generated ${buffer.length} byte(s) of wasm`);
         counters.bytesGenerated += buffer.length;

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -690,7 +690,7 @@ function generate_wasm (
                 if (getU16(ip) !== MintOpcode.MINT_TIER_PREPARE_JITERPRETER)
                     throw new Error(`Expected *ip to be MINT_TIER_PREPARE_JITERPRETER but was ${getU16(ip)}`);
 
-                builder.cfg.initialize(startOfBody, backwardBranchTable);
+                builder.cfg.initialize(startOfBody, backwardBranchTable, !!instrument);
 
                 // TODO: Call generate_wasm_body before generating any of the sections and headers.
                 // This will allow us to do things like dynamically vary the number of locals, in addition


### PR DESCRIPTION
This PR introduces a control flow graph (CFG) pass to the jiterpreter that runs after the initial code generation pass. Things that are currently generated inline like branch target blocks and branches are now recorded in a list of segments, and in a second pass all the segments are stitched together with the necessary webassembly flow control logic inserted inbetween. This allows turning forward branches into direct jumps and turns backward branches into a direct jump paired with a table dispatch. It is theoretically possible to avoid the table dispatch for backward branches, but I'm not smart enough to figure out how to do it in a general way :-)

This should provide large speedups for traces that contain many branch targets, since right now we pay the cost of an eip check for each branch target. The cfg is able to omit all of those checks. For traces containing backward branches the existence of the dispatch table means we still have overhead there, but it's not as bad.

This will probably regress startup time slightly (as visible in the Page Show timing, though I think that is probably noise) due to the second pass and the overhead in tracking segments, but it's possible to optimize that.

Initial browser-bench measurements, compared vs main:

| measurement | cfg | main |
|-:|-:|-:|
|                    AppStart, Page show |    15.6019ms |    15.3393ms |
|                AppStart, Reach managed |   295.5263ms |   296.5789ms |
|         Json, non-ASCII text serialize |     2.2458ms |     3.1807ms |
|       Json, non-ASCII text deserialize |     3.8506ms |     5.7064ms |
|                  Json, small serialize |     0.1135ms |     0.1263ms |
|                Json, small deserialize |     0.1924ms |     0.2150ms |
|                  Json, large serialize |    30.3450ms |    34.3533ms |
|                Json, large deserialize |    51.4950ms |    58.3636ms |
|                    Span, Reverse bytes |     0.0886ms |     0.1198ms |
|                    Span, Reverse chars |     0.1697ms |     0.4297ms |
|                    Span, IndexOf bytes |     0.5563us |     0.8598us |
|                    Span, IndexOf chars |     0.0404ms |     0.0830ms |
|              Span, SequenceEqual bytes |     0.0385ms |     0.1165ms |
|              Span, SequenceEqual chars |     0.0769ms |     0.2322ms |
|                      String, Normalize |     0.9573ms |     1.3945ms |
|                String, Normalize ASCII |     0.0449ms |     0.1718ms |
|               Vector, Create Vector128 |     0.0900us |     0.0878us |
|              Vector, Add 2 Vector128's |     0.1052us |     0.1046us |
|         Vector, Multiply 2 Vector128's |     0.1057us |     0.1054us |
|                Vector, Dot product int |     0.0996us |     0.0983us |
|              Vector, Dot product ulong |     0.0876us |     0.0877us |
|              Vector, Dot product float |     0.1106us |     0.1092us |
|             Vector, Dot product double |     0.0905us |     0.0898us |
|                      Vector, Sum sbyte |     0.1397us |     0.1386us |
|                      Vector, Sum short |     0.1102us |     0.1085us |
|                       Vector, Sum uint |     0.0905us |     0.0891us |
|                     Vector, Sum double |     0.0895us |     0.0883us |
|                      Vector, Min float |     0.1364us |     0.1512us |
|                      Vector, Max float |     0.1378us |     0.1669us |
|                     Vector, Min double |     0.1116us |     0.1179us |
|                     Vector, Max double |     0.1136us |     0.1206us |
|                Vector, Normalize float |     0.4070us |     0.4039us |