### PR TITLE
Reduce duplicity in GVM analysis

### DIFF
--- a/eng/testing/tests.singlefile.targets
+++ b/eng/testing/tests.singlefile.targets
@@ -29,13 +29,10 @@
     <IlcSdkPath>$(CoreCLRAotSdkDir)</IlcSdkPath>
     <IlcFrameworkPath>$(NetCoreAppCurrentTestHostSharedFrameworkPath)</IlcFrameworkPath>
     <IlcFrameworkNativePath>$(NetCoreAppCurrentTestHostSharedFrameworkPath)</IlcFrameworkNativePath>
-    <NoWarn>$(NoWarn);IL1005;IL3002</NoWarn>
+    <NoWarn>$(NoWarn);IL1005;IL3002;IL3003</NoWarn>
     <TrimMode>partial</TrimMode>
     <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
     <SuppressAotAnalysisWarnings>true</SuppressAotAnalysisWarnings>
-
-    <!-- Forced by ILLink targets; we should fix the SDK -->
-    <SelfContained>true</SelfContained>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PublishSingleFile)' == 'true' or '$(TestNativeAot)' == 'true'">

--- a/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
@@ -96,20 +96,6 @@ namespace ILCompiler
         }
 
         /// <summary>
-        /// Gets a value indicating whether this type has any generic virtual methods.
-        /// </summary>
-        public static bool HasGenericVirtualMethods(this TypeDesc type)
-        {
-            foreach (var method in type.GetAllVirtualMethods())
-            {
-                if (method.HasInstantiation)
-                    return true;
-            }
-
-            return false;
-        }
-
-        /// <summary>
         /// Wrapper helper function around the IsCanonicalDefinitionType API on the TypeSystemContext
         /// </summary>
         public static bool IsCanonicalDefinitionType(this TypeDesc type, CanonicalFormKind kind)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CanonicalEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CanonicalEETypeNode.cs
@@ -51,7 +51,7 @@ namespace ILCompiler.DependencyAnalysis
                 dependencyList.Add(factory.NativeLayout.TemplateTypeLayout(_type), "Universal generic types always have template layout");
 
             // Track generic virtual methods that will get added to the GVM tables
-            if (TypeGVMEntriesNode.TypeNeedsGVMTableEntries(_type))
+            if ((_virtualMethodAnalysisFlags & VirtualMethodAnalysisFlags.NeedsGvmEntries) != 0)
             {
                 dependencyList.Add(new DependencyListEntry(factory.TypeGVMEntries(_type.GetTypeDefinition()), "Type with generic virtual methods"));
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -74,6 +74,8 @@ namespace ILCompiler.DependencyAnalysis
         [Flags]
         protected enum VirtualMethodAnalysisFlags
         {
+            None = 0,
+
             NeedsGvmEntries = 0x0001,
             InterestingForDynamicDependencies = 0x0002,
 
@@ -108,7 +110,7 @@ namespace ILCompiler.DependencyAnalysis
 
         private static VirtualMethodAnalysisFlags AnalyzeVirtualMethods(TypeDesc type)
         {
-            VirtualMethodAnalysisFlags result = default;
+            var result = VirtualMethodAnalysisFlags.None;
 
             // Interface EETypes not relevant to virtual method analysis at this time.
             if (type.IsInterface)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -69,6 +69,18 @@ namespace ILCompiler.DependencyAnalysis
         protected bool? _mightHaveInterfaceDispatchMap;
         private bool _hasConditionalDependenciesFromMetadataManager;
 
+        protected readonly VirtualMethodAnalysisFlags _virtualMethodAnalysisFlags;
+
+        [Flags]
+        protected enum VirtualMethodAnalysisFlags
+        {
+            NeedsGvmEntries = 0x0001,
+            InterestingForDynamicDependencies = 0x0002,
+
+            AllFlags = NeedsGvmEntries
+                | InterestingForDynamicDependencies,
+        }
+
         public EETypeNode(NodeFactory factory, TypeDesc type)
         {
             if (type.IsCanonicalDefinitionType(CanonicalFormKind.Any))
@@ -82,6 +94,9 @@ namespace ILCompiler.DependencyAnalysis
             _writableDataNode = factory.Target.SupportsRelativePointers ? new WritableDataNode(this) : null;
             _hasConditionalDependenciesFromMetadataManager = factory.MetadataManager.HasConditionalDependenciesDueToEETypePresence(type);
 
+            if (EmitVirtualSlotsAndInterfaces)
+                _virtualMethodAnalysisFlags = AnalyzeVirtualMethods(type);
+
             factory.TypeSystemContext.EnsureLoadableType(type);
 
             // We don't have a representation for function pointers right now
@@ -89,6 +104,94 @@ namespace ILCompiler.DependencyAnalysis
                 ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, type);
 
             static TypeDesc WithoutParameterizeTypes(TypeDesc t) => t is ParameterizedType pt ? WithoutParameterizeTypes(pt.ParameterType) : t;
+        }
+
+        private static VirtualMethodAnalysisFlags AnalyzeVirtualMethods(TypeDesc type)
+        {
+            VirtualMethodAnalysisFlags result = default;
+
+            // Interface EETypes not relevant to virtual method analysis at this time.
+            if (type.IsInterface)
+                return result;
+
+            DefType defType = type.GetClosestDefType();
+
+            foreach (MethodDesc method in defType.GetAllVirtualMethods())
+            {
+                // First, check if this type has any GVM that overrides a GVM on a parent type. If that's the case, this makes
+                // the current type interesting for GVM analysis (i.e. instantiate its overriding GVMs for existing GVMDependenciesNodes
+                // of the instantiated GVM on the parent types).
+                if (method.HasInstantiation)
+                {
+                    result |= VirtualMethodAnalysisFlags.NeedsGvmEntries;
+
+                    MethodDesc slotDecl = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(method);
+                    if (slotDecl != method)
+                        result |= VirtualMethodAnalysisFlags.InterestingForDynamicDependencies;
+                }
+
+                // Early out if we set all the flags we could have set
+                if ((result & VirtualMethodAnalysisFlags.AllFlags) == VirtualMethodAnalysisFlags.AllFlags)
+                    return result;
+            }
+
+            //
+            // Check if the type implements any interface, where the method implementations could be on
+            // base types.
+            // Example:
+            //      interface IFace {
+            //          void IFaceGVMethod<U>();
+            //      }
+            //      class BaseClass {
+            //          public virtual void IFaceGVMethod<U>() { ... }
+            //      }
+            //      public class DerivedClass : BaseClass, IFace { }
+            //
+            foreach (DefType interfaceImpl in defType.RuntimeInterfaces)
+            {
+                foreach (MethodDesc method in interfaceImpl.GetAllVirtualMethods())
+                {
+                    if (!method.HasInstantiation)
+                        continue;
+
+                    // We found a GVM on one of the implemented interfaces. Find if the type implements this method.
+                    // (Note, do this comparison against the generic definition of the method, not the specific method instantiation
+                    MethodDesc slotDecl = method.Signature.IsStatic ?
+                        defType.ResolveInterfaceMethodToStaticVirtualMethodOnType(method)
+                        : defType.ResolveInterfaceMethodTarget(method);
+                    if (slotDecl != null)
+                    {
+                        // If the type doesn't introduce this interface method implementation (i.e. the same implementation
+                        // already exists in the base type), do not consider this type interesting for GVM analysis just yet.
+                        //
+                        // We need to limit the number of types that are interesting for GVM analysis at all costs since
+                        // these all will be looked at for every unique generic virtual method call in the program.
+                        // Having a long list of interesting types affects the compilation throughput heavily.
+                        if (slotDecl.OwningType == defType ||
+                            defType.BaseType.ResolveInterfaceMethodTarget(method) != slotDecl)
+                        {
+                            result |= VirtualMethodAnalysisFlags.InterestingForDynamicDependencies
+                                | VirtualMethodAnalysisFlags.NeedsGvmEntries;
+                        }
+                    }
+                    else
+                    {
+                        // The method could be implemented by a default interface method
+                        var resolution = defType.ResolveInterfaceMethodToDefaultImplementationOnType(method, out _);
+                        if (resolution == DefaultInterfaceMethodResolution.DefaultImplementation)
+                        {
+                            result |= VirtualMethodAnalysisFlags.InterestingForDynamicDependencies
+                                | VirtualMethodAnalysisFlags.NeedsGvmEntries;
+                        }
+                    }
+
+                    // Early out if we set all the flags we could have set
+                    if ((result & VirtualMethodAnalysisFlags.AllFlags) == VirtualMethodAnalysisFlags.AllFlags)
+                        return result;
+                }
+            }
+
+            return result;
         }
 
         protected bool MightHaveInterfaceDispatchMap(NodeFactory factory)
@@ -135,78 +238,7 @@ namespace ILCompiler.DependencyAnalysis
         protected virtual bool EmitVirtualSlotsAndInterfaces => false;
 
         public override bool InterestingForDynamicDependencyAnalysis
-        {
-            get
-            {
-                if (!EmitVirtualSlotsAndInterfaces)
-                    return false;
-
-                if (_type.IsInterface)
-                    return false;
-
-                if (_type.IsDefType)
-                {
-                    // First, check if this type has any GVM that overrides a GVM on a parent type. If that's the case, this makes
-                    // the current type interesting for GVM analysis (i.e. instantiate its overriding GVMs for existing GVMDependenciesNodes
-                    // of the instantiated GVM on the parent types).
-                    foreach (var method in _type.GetAllVirtualMethods())
-                    {
-                        Debug.Assert(method.IsVirtual);
-
-                        if (method.HasInstantiation)
-                        {
-                            MethodDesc slotDecl = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(method);
-                            if (slotDecl != method)
-                                return true;
-                        }
-                    }
-
-                    // Second, check if this type has any GVMs that implement any GVM on any of the implemented interfaces. This would
-                    // make the current type interesting for dynamic dependency analysis to that we can instantiate its GVMs.
-                    foreach (DefType interfaceImpl in _type.RuntimeInterfaces)
-                    {
-                        foreach (var method in interfaceImpl.GetAllVirtualMethods())
-                        {
-                            Debug.Assert(method.IsVirtual);
-
-                            if (method.HasInstantiation)
-                            {
-                                // We found a GVM on one of the implemented interfaces. Find if the type implements this method.
-                                // (Note, do this comparison against the generic definition of the method, not the specific method instantiation
-                                MethodDesc genericDefinition = method.GetMethodDefinition();
-                                MethodDesc slotDecl = genericDefinition.Signature.IsStatic ?
-                                    _type.ResolveInterfaceMethodToStaticVirtualMethodOnType(genericDefinition)
-                                    : _type.ResolveInterfaceMethodTarget(genericDefinition);
-                                if (slotDecl != null)
-                                {
-                                    // If the type doesn't introduce this interface method implementation (i.e. the same implementation
-                                    // already exists in the base type), do not consider this type interesting for GVM analysis just yet.
-                                    //
-                                    // We need to limit the number of types that are interesting for GVM analysis at all costs since
-                                    // these all will be looked at for every unique generic virtual method call in the program.
-                                    // Having a long list of interesting types affects the compilation throughput heavily.
-                                    if (slotDecl.OwningType == _type ||
-                                        _type.BaseType.ResolveInterfaceMethodTarget(genericDefinition) != slotDecl)
-                                    {
-                                        return true;
-                                    }
-                                }
-                                else
-                                {
-                                    // The method could be implemented by a default interface method
-                                    var resolution = _type.ResolveInterfaceMethodToDefaultImplementationOnType(genericDefinition, out slotDecl);
-                                    if (resolution == DefaultInterfaceMethodResolution.DefaultImplementation)
-                                    {
-                                        return true;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                return false;
-            }
-        }
+            => (_virtualMethodAnalysisFlags & VirtualMethodAnalysisFlags.InterestingForDynamicDependencies) != 0;
 
         internal bool HasOptionalFields
         {
@@ -555,7 +587,7 @@ namespace ILCompiler.DependencyAnalysis
                     dependencies.Add(factory.VTable(intface), "Interface vtable slice");
 
                 // Generated type contains generic virtual methods that will get added to the GVM tables
-                if (TypeGVMEntriesNode.TypeNeedsGVMTableEntries(_type))
+                if ((_virtualMethodAnalysisFlags & VirtualMethodAnalysisFlags.NeedsGvmEntries) != 0)
                 {
                     dependencies.Add(new DependencyListEntry(factory.TypeGVMEntries(_type.GetTypeDefinition()), "Type with generic virtual methods"));
 

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -417,6 +417,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TestNativeAot)' == 'true' and '$(RunDisabledNativeAotTests)' != 'true'">
+    <!-- https://github.com/dotnet/runtime/issues/83167 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Numerics.Vectors\tests\System.Numerics.Vectors.Tests.csproj"
+                       Condition="'$(TargetArchitecture)' == 'arm64'" />
+
     <!-- https://github.com/dotnet/runtime/issues/73431 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.SourceGeneration.Tests\System.Text.Json.SourceGeneration.Roslyn3.11.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.SourceGeneration.Tests\System.Text.Json.SourceGeneration.Roslyn4.4.Tests.csproj" />


### PR DESCRIPTION
There were two very similar pieces of logic in the generic virtual method analysis. First one was deciding whether we need to emit GVM bookkeeping about the type, the second one was deciding whether the type should participate in GVM analysis (the N*M algorithm, "for each type relevant to GVM analysis" * "GVM virtual method called").

Made this into one so that it's in one spot. The interface method resolution is not cheap so this also speeds up the compilation. We should also do this for non-generic virtuals at some point.

I did a test pass with an assert that the analysis came up with the same conclusions to ensure I didn't mess up.

Cc @dotnet/ilc-contrib 