### PR TITLE
Reduce cost of async waiting on SemaphoreSlim with cancellation/timeout

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -735,15 +735,16 @@ namespace System.Threading
 
         // TODO https://github.com/dotnet/runtime/issues/22144: Replace with official nothrow await solution once available.
         /// <summary>Awaiter used to await a task.ConfigureAwait(false) but without throwing any exceptions for faulted or canceled tasks.</summary>
-        private readonly struct ConfiguredNoThrowAwaiter<T> : ICriticalNotifyCompletion
+        private readonly struct ConfiguredNoThrowAwaiter<T> : ICriticalNotifyCompletion, IStateMachineBoxAwareAwaiter
         {
             private readonly Task<T> _task;
             public ConfiguredNoThrowAwaiter(Task<T> task) => _task = task;
             public ConfiguredNoThrowAwaiter<T> GetAwaiter() => this;
             public bool IsCompleted => _task.IsCompleted;
             public void GetResult() => _task.MarkExceptionsAsHandled();
-            public void UnsafeOnCompleted(Action continuation) => _task.ConfigureAwait(false).GetAwaiter().UnsafeOnCompleted(continuation);
-            public void OnCompleted(Action continuation) => _task.ConfigureAwait(false).GetAwaiter().OnCompleted(continuation);
+            public void OnCompleted(Action continuation) => TaskAwaiter.OnCompletedInternal(_task, continuation, continueOnCapturedContext: false, flowExecutionContext: true);
+            public void UnsafeOnCompleted(Action continuation) => TaskAwaiter.OnCompletedInternal(_task, continuation, continueOnCapturedContext: false, flowExecutionContext: false);
+            public void AwaitUnsafeOnCompleted(IAsyncStateMachineBox box) => TaskAwaiter.UnsafeOnCompletedInternal(_task, box, continueOnCapturedContext: false);
         }
 
         /// <summary>


### PR DESCRIPTION
If a WaitAsync on a SemaphoreSlim is unable to synchronously acquire the semaphore, it calls an async method that handles the waiting.  That method awaits with a custom awaiter that avoids throwing in the case of cancellation or timeout.  However, in using a custom awaiter, we get knocked off the highest-perf path that can avoid allocating an Action.  This change puts it back onto the golden path by having the awaiter implement our internal interface that lets it backchannel with the async method builders. Eventually we want this awaiter to be available publicly as well, and it'll end up benefiting more than just semaphores.

|    Method |         Toolchain |     Mean | Ratio | Allocated | Alloc Ratio |
|---------- |------------------ |---------:|------:|----------:|------------:|
| WaitAsync | \main\corerun.exe | 57.39 us |  1.00 |  43.84 KB |        1.00 |
| WaitAsync |   \pr\corerun.exe | 52.43 us |  0.91 |  37.58 KB |        0.86 |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Threading;
using System.Threading.Tasks;

[MemoryDiagnoser]
public partial class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    private CancellationToken _token = new CancellationTokenSource().Token;
    private SemaphoreSlim _sem = new SemaphoreSlim(0);
    private Task[] _tasks = new Task[100];

    [Benchmark]
    public Task WaitAsync()
    {
        for (int i = 0; i < _tasks.Length; i++)
        {
            _tasks[i] = _sem.WaitAsync(_token);
        }
        _sem.Release(_tasks.Length);
        return Task.WhenAll(_tasks);
    }
}
```