### PR TITLE
[release/7.0][mono] Use unsigned char when computing UTF8 string hashes

### DIFF
--- a/src/mono/mono/eglib/ghashtable.c
+++ b/src/mono/mono/eglib/ghashtable.c
@@ -673,7 +673,7 @@ guint
 g_str_hash (gconstpointer v1)
 {
 	guint hash = 0;
-	char *p = (char *) v1;
+	unsigned char *p = (unsigned char *) v1;
 
 	while (*p++)
 		hash = (hash << 5) - (hash + *p);

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -5519,7 +5519,8 @@ guint
 mono_metadata_str_hash (gconstpointer v1)
 {
 	/* Same as g_str_hash () in glib */
-	char *p = (char *) v1;
+	/* note: signed/unsigned char matters - we feed UTF-8 to this function, so the high bit will give diferent results if we don't match. */
+	unsigned char *p = (unsigned char *) v1;
 	guint hash = *p;
 
 	while (*p++) {

--- a/src/tests/Loader/classloader/regressions/GitHub_82187/GitHub_82187.csproj
+++ b/src/tests/Loader/classloader/regressions/GitHub_82187/GitHub_82187.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="repro.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/classloader/regressions/GitHub_82187/repro.cs
+++ b/src/tests/Loader/classloader/regressions/GitHub_82187/repro.cs
@@ -1,0 +1,31 @@
+using System;
+
+/* Regression test for https://github.com/dotnet/runtime/issues/78638
+ * and https://github.com/dotnet/runtime/issues/82187 ensure AOT
+ * cross-compiler and AOT runtime use the same name hashing for names
+ * that include UTF-8 continuation bytes.
+ */
+
+[MySpecial(typeof(MeineTüre))]
+public class Program
+{
+    public static int Main()
+    {
+        var attr = (MySpecialAttribute)Attribute.GetCustomAttribute(typeof (Program), typeof(MySpecialAttribute), false);
+        if (attr == null)
+            return 101;
+        if (attr.Type == null)
+            return 102;
+        if (attr.Type.FullName != "MeineTüre")
+            return 103;
+        return 100;
+    }
+}
+
+public class MySpecialAttribute : Attribute
+{
+    public Type Type {get; private set; }
+    public MySpecialAttribute(Type t) { Type = t; }
+}
+
+public class MeineTüre {}


### PR DESCRIPTION
Backport of #83273 to release/7.0

Resolves #82187 
Resolves #78638

The corresponding 6.0 PR is #83303 

## Customer Impact

Resolves crashes in Release builds of Android apps that include classes with non-ASCII names that use AOT compilation.

## Testing

Manual testing.  New regression test.

## Risk

Low. For code that uses ASCII names the hash code computation is unchanged.
