### PR TITLE
Constant folding for RuntimeInformation.IsOSPlatform(OSPlatform)

### DIFF
--- a/src/coreclr/jit/importervectorization.cpp
+++ b/src/coreclr/jit/importervectorization.cpp
@@ -732,7 +732,6 @@ GenTree* Compiler::impStringEqualsOrStartsWith(bool startsWith, CORINFO_SIG_INFO
 
     // Create a tree representing string's Length:
     int      strLenOffset = OFFSETOF__CORINFO_String__stringLen;
-    GenTree* lenOffset    = gtNewIconNode(strLenOffset, TYP_I_IMPL);
     GenTree* lenNode      = gtNewArrLen(TYP_INT, varStrLcl, strLenOffset, compCurBB);
     varStrLcl             = gtClone(varStrLcl)->AsLclVar();
 

--- a/src/coreclr/jit/importervectorization.cpp
+++ b/src/coreclr/jit/importervectorization.cpp
@@ -731,10 +731,9 @@ GenTree* Compiler::impStringEqualsOrStartsWith(bool startsWith, CORINFO_SIG_INFO
     GenTreeLclVar* varStrLcl   = gtNewLclvNode(varStrTmp, varStr->TypeGet());
 
     // Create a tree representing string's Length:
-    // TODO-Unroll-CQ: Consider using ARR_LENGTH here, but we'll have to modify QMARK to propagate BBF_HAS_IDX_LEN
     int      strLenOffset = OFFSETOF__CORINFO_String__stringLen;
     GenTree* lenOffset    = gtNewIconNode(strLenOffset, TYP_I_IMPL);
-    GenTree* lenNode      = gtNewIndir(TYP_INT, gtNewOperNode(GT_ADD, TYP_BYREF, varStrLcl, lenOffset));
+    GenTree* lenNode      = gtNewArrLen(TYP_INT, varStrLcl, strLenOffset, compCurBB);
     varStrLcl             = gtClone(varStrLcl)->AsLclVar();
 
     GenTree* unrolled = impExpandHalfConstEquals(varStrLcl, lenNode, needsNullcheck, startsWith, (WCHAR*)str, cnsLength,

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -14544,8 +14544,10 @@ void Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
     // if they are going to be cleared by fgSplitBlockAfterStatement(). We currently only do this only
     // for the GC safe point bit, the logic being that if 'block' was marked gcsafe, then surely
     // remainderBlock will still be GC safe.
-    BasicBlockFlags propagateFlags = block->bbFlags & BBF_GC_SAFE_POINT;
-    BasicBlock*     remainderBlock = fgSplitBlockAfterStatement(block, stmt);
+    BasicBlockFlags propagateFlagsToRemainder = block->bbFlags & BBF_GC_SAFE_POINT;
+    // Conservatively mark all blocks as having IDX_LEN since we don't know where exactly it went
+    BasicBlockFlags propagateFlagsToAll = block->bbFlags & BBF_HAS_IDX_LEN;
+    BasicBlock*     remainderBlock      = fgSplitBlockAfterStatement(block, stmt);
     fgRemoveRefPred(remainderBlock, block); // We're going to put more blocks between block and remainderBlock.
 
     BasicBlock* condBlock = fgNewBBafter(BBJ_COND, block, true);
@@ -14561,13 +14563,16 @@ void Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
         elseBlock->bbFlags |= BBF_IMPORTED;
     }
 
-    remainderBlock->bbFlags |= propagateFlags;
+    remainderBlock->bbFlags |= (propagateFlagsToRemainder | propagateFlagsToAll);
 
     condBlock->inheritWeight(block);
 
     fgAddRefPred(condBlock, block);
     fgAddRefPred(elseBlock, condBlock);
     fgAddRefPred(remainderBlock, elseBlock);
+
+    condBlock->bbFlags |= propagateFlagsToAll;
+    elseBlock->bbFlags |= propagateFlagsToAll;
 
     BasicBlock* thenBlock = nullptr;
     if (hasTrueExpr && hasFalseExpr)
@@ -14585,6 +14590,7 @@ void Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
 
         thenBlock             = fgNewBBafter(BBJ_ALWAYS, condBlock, true);
         thenBlock->bbJumpDest = remainderBlock;
+        thenBlock->bbFlags |= propagateFlagsToAll;
         if ((block->bbFlags & BBF_INTERNAL) == 0)
         {
             thenBlock->bbFlags &= ~BBF_INTERNAL;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -14545,8 +14545,8 @@ void Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
     // for the GC safe point bit, the logic being that if 'block' was marked gcsafe, then surely
     // remainderBlock will still be GC safe.
     BasicBlockFlags propagateFlagsToRemainder = block->bbFlags & BBF_GC_SAFE_POINT;
-    // Conservatively mark all blocks as having IDX_LEN since we don't know where exactly it went
-    BasicBlockFlags propagateFlagsToAll = block->bbFlags & BBF_HAS_IDX_LEN;
+    // Conservatively propagate BBF_COPY_PROPAGATE flags to all blocks
+    BasicBlockFlags propagateFlagsToAll = block->bbFlags & BBF_COPY_PROPAGATE;
     BasicBlock*     remainderBlock      = fgSplitBlockAfterStatement(block, stmt);
     fgRemoveRefPred(remainderBlock, block); // We're going to put more blocks between block and remainderBlock.
 

--- a/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Runtime.Versioning;
 
@@ -115,6 +116,7 @@ namespace System
         /// Indicates whether the current application is running on the specified platform.
         /// </summary>
         /// <param name="platform">Case-insensitive platform name. Examples: Browser, Linux, FreeBSD, Android, iOS, macOS, tvOS, watchOS, Windows.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsOSPlatform(string platform)
         {
             ArgumentNullException.ThrowIfNull(platform);


### PR DESCRIPTION
Partially fixes https://github.com/dotnet/runtime/issues/738 where this API was acknowledged as not JIT friendly which I took personally 😄 This PR is based on previous PRs to make this happen, namely https://github.com/dotnet/runtime/pull/78736 and https://github.com/dotnet/runtime/pull/80431

```csharp
void Test()
{
    if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
    {
        Console.Write("linux!");
    }
}
```
Old codegen (pre .NET 8.0):
```asm
; Assembly listing for method Program:Test():this
       4883EC28             sub      rsp, 40
       FF153E642200         call     [System.Runtime.InteropServices.OSPlatform:get_Linux()]
       488BC8               mov      rcx, rax
       FF153DA22400         call     [System.OperatingSystem:IsOSPlatform(System.String):bool]
       85C0                 test     eax, eax
       7410                 je       SHORT G_M000_IG04
       48B99858453B02020000 mov      rcx, 0x2023B455898
       FF1561802200         call     [System.Console:Write(System.String)]
G_M000_IG04:                
       90                   nop      
       4883C428             add      rsp, 40
       C3                   ret      
; Total bytes of code 45
```
New codegen (I'm on Windows):
```asm
; Assembly listing for method Program:Test():this
       C3                   ret      
; Total bytes of code 1
```

Unfortunately, this only works if the operating system is different from current, otherwise the codegen is:
```asm
; Assembly listing for method Program:Test():this
       4883EC28             sub      rsp, 40
       48B99C94B9CAD6010000 mov      rcx, 0x1D6CAB9949C
       48B82000200020002000 mov      rax, 0x20002000200020
       480B01               or       rax, qword ptr [rcx]
       48B9770069006E006400 mov      rcx, 0x64006E00690077
       4833C8               xor      rcx, rax
       48B8A294B9CAD6010000 mov      rax, 0x1D6CAB994A2
       48BA2000200020002000 mov      rdx, 0x20002000200020
       480B10               or       rdx, qword ptr [rax]
       48B864006F0077007300 mov      rax, 0x730077006F0064
       4833C2               xor      rax, rdx
       480BC8               or       rcx, rax
       7510                 jne      SHORT G_M36831_IG04
       48B90094B9CAD6010000 mov      rcx, 0x1D6CAB99400
       FF1587D47000         call     [System.Console:Write(System.String)]
G_M36831_IG04:              
       90                   nop      
G_M36831_IG05:              
       4883C428             add      rsp, 40
       C3                   ret      
; Total bytes of code 103
```
It happens because of some phase ordering issue in JIT, namely JIT unrolls `string.Equals("Windows", staticReadonlyField)` early in importer and then is unable to fold whatever vectorizer produced -- it can be done actually, but it needs a new JIT-EE API - I might add it separately if it's worth it

Also, this only works for Tier1, so it won't be folded for TC=0/AggressiveOptimization and crossgen/NativeAOT (NativeAOT needs https://github.com/dotnet/runtime/issues/83043 for that)

We recommend users the new APIs we introduced e.g. `OperatingSystem.IsWindows` which don't need any JIT help, but it seems we still have plenty of users of the old API, see https://grep.app/search?q=IsOSPlatform&words=true&filter[lang][0]=C%23

UPD: there are some improvements from using `GT_ARR_LEN` instead of `GT_IND` in `importervectorization.cpp` for string's length. It's needed so VN can fold `GT_ARR_LEN(FROZEN_OBJ)` later.