### PR TITLE
Remove VersionSuffix from servicing builds

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -40,6 +40,7 @@
     <Product>Microsoft%AE .NET</Product>
     <!-- Use the .NET product branding version for informational version description -->
     <InformationalVersion Condition="'$(InformationalVersion)' == '' and '$(VersionSuffix)' == ''">$(ProductVersion)</InformationalVersion>
+    <InformationalVersion Condition="'$(InformationalVersion)' == '' and '$(PreReleaseVersionLabel)' == 'servicing'">$(ProductVersion)</InformationalVersion>
     <InformationalVersion Condition="'$(InformationalVersion)' == '' and '$(VersionSuffix)' != ''">$(ProductVersion)-$(VersionSuffix)</InformationalVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
e.g.
```sh
$ ~/.nuget/packages/microsoft.netcore.app.crossgen2.linux-arm64/7.0.2/tools/crossgen2 --version
```

Before:
> 7.0.2-servicing.22606.5+d037e070ebe5c83838443f869d5800752b0fcb13

After:
> 7.0.2+d037e070ebe5c83838443f869d5800752b0fcb13