### PR TITLE
[wasm] Various jiterpreter optimizations; implement CALL_HANDLER; don't abort for some icalls

### DIFF
--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -513,12 +513,11 @@ mono_jiterp_type_get_raw_value_size (MonoType *type) {
 }
 
 // we use these helpers to record when a trace bails out (in countBailouts mode)
-EMSCRIPTEN_KEEPALIVE void*
-mono_jiterp_trace_bailout (void* rip, int reason)
+EMSCRIPTEN_KEEPALIVE void
+mono_jiterp_trace_bailout (int reason)
 {
 	if (reason < 256)
 		jiterp_trace_bailout_counts[reason]++;
-	return rip;
 }
 
 EMSCRIPTEN_KEEPALIVE double
@@ -702,6 +701,8 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 		case MINT_BR_S:
 		case MINT_LEAVE:
 		case MINT_LEAVE_S:
+		case MINT_CALL_HANDLER:
+		case MINT_CALL_HANDLER_S:
 			// Detect backwards branches
 			if (ins->info.target_bb->il_offset <= ins->il_offset) {
 				if (*inside_branch_block)
@@ -713,6 +714,12 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 			*inside_branch_block = TRUE;
 			return TRACE_CONTINUE;
 
+		case MINT_ICALL_V_P:
+		case MINT_ICALL_V_V:
+		case MINT_ICALL_P_P:
+		case MINT_ICALL_P_V:
+		case MINT_ICALL_PP_V:
+		case MINT_ICALL_PP_P:
 		case MINT_MONO_RETHROW:
 		case MINT_THROW:
 			if (*inside_branch_block)
@@ -724,8 +731,6 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 		case MINT_LEAVE_S_CHECK:
 			return TRACE_ABORT;
 
-		case MINT_CALL_HANDLER:
-		case MINT_CALL_HANDLER_S:
 		case MINT_ENDFINALLY:
 		case MINT_RETHROW:
 		case MINT_PROF_EXIT:
@@ -1249,6 +1254,7 @@ mono_jiterp_trace_transfer (
 #define JITERP_MEMBER_ARRAY_LENGTH 9
 #define JITERP_MEMBER_BACKWARD_BRANCH_OFFSETS 10
 #define JITERP_MEMBER_BACKWARD_BRANCH_OFFSETS_COUNT 11
+#define JITERP_MEMBER_CLAUSE_DATA_OFFSETS 12
 
 // we use these helpers at JIT time to figure out where to do memory loads and stores
 EMSCRIPTEN_KEEPALIVE size_t
@@ -1272,6 +1278,8 @@ mono_jiterp_get_member_offset (int member) {
 			return offsetof (InterpMethod, backward_branch_offsets);
 		case JITERP_MEMBER_BACKWARD_BRANCH_OFFSETS_COUNT:
 			return offsetof (InterpMethod, backward_branch_offsets_count);
+		case JITERP_MEMBER_CLAUSE_DATA_OFFSETS:
+			return offsetof (InterpMethod, clause_data_offsets);
 		case JITERP_MEMBER_RMETHOD:
 			return offsetof (JiterpEntryDataHeader, rmethod);
 		case JITERP_MEMBER_SPAN_LENGTH:

--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -94,6 +94,7 @@ const fn_signatures: SigLine[] = [
     [true, "mono_wasm_get_f64_unaligned", "number", ["number"]],
 
     // jiterpreter
+    [true, "mono_jiterp_trace_bailout", "void", ["number"]],
     [true, "mono_jiterp_get_trace_bailout_count", "number", ["number"]],
     [true, "mono_jiterp_value_copy", "void", ["number", "number", "number"]],
     [true, "mono_jiterp_get_member_offset", "number", ["number"]],
@@ -204,6 +205,7 @@ export interface t_Cwraps {
     mono_wasm_get_f32_unaligned(source: VoidPtr): number;
     mono_wasm_get_f64_unaligned(source: VoidPtr): number;
 
+    mono_jiterp_trace_bailout(reason: number): void;
     mono_jiterp_get_trace_bailout_count(reason: number): number;
     mono_jiterp_value_copy(destination: VoidPtr, source: VoidPtr, klass: MonoClass): void;
     mono_jiterp_get_member_offset(id: number): number;

--- a/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
@@ -114,6 +114,14 @@ function get_imethod_data (frame: NativePointer, index: number) {
     return getU32_unaligned(dataOffset);
 }
 
+function get_imethod_clause_data_offset (frame: NativePointer, index: number) {
+    // FIXME: Encoding this data directly into the trace will prevent trace reuse
+    const iMethod = getU32_unaligned(<any>frame + getMemberOffset(JiterpMember.Imethod));
+    const pData = getU32_unaligned(iMethod + getMemberOffset(JiterpMember.ClauseDataOffsets));
+    const dataOffset = pData + (index * sizeOfDataItem);
+    return getU32_unaligned(dataOffset);
+}
+
 function is_backward_branch_target (
     ip: MintOpcodePtr, startOfBody: MintOpcodePtr,
     backwardBranchTable: Uint16Array | null
@@ -306,7 +314,9 @@ export function generate_wasm_body (
             case MintOpcode.MINT_BRTRUE_I8_S:
             case MintOpcode.MINT_LEAVE_S:
             case MintOpcode.MINT_BR_S:
-                if (!emit_branch(builder, ip, opcode))
+            case MintOpcode.MINT_CALL_HANDLER:
+            case MintOpcode.MINT_CALL_HANDLER_S:
+                if (!emit_branch(builder, ip, frame, opcode))
                     ip = abort;
                 break;
 
@@ -847,6 +857,22 @@ export function generate_wasm_body (
                 }
                 break;
 
+            // TODO: Verify that this isn't worse
+            case MintOpcode.MINT_ICALL_V_P:
+            case MintOpcode.MINT_ICALL_V_V:
+            case MintOpcode.MINT_ICALL_P_P:
+            case MintOpcode.MINT_ICALL_P_V:
+            case MintOpcode.MINT_ICALL_PP_V:
+            case MintOpcode.MINT_ICALL_PP_P:
+                // See comments for MINT_CALL
+                if (builder.branchTargets.size > 0) {
+                    append_bailout(builder, ip, BailoutReason.Icall);
+                    isLowValueOpcode = true;
+                } else {
+                    ip = abort;
+                }
+                break;
+
             // Unlike regular rethrow which will only appear in catch blocks,
             //  MONO_RETHROW appears to show up in other places, so it's worth conditional bailout
             case MintOpcode.MINT_MONO_RETHROW:
@@ -1079,7 +1105,7 @@ export function generate_wasm_body (
                     if (!emit_unop(builder, ip, opcode))
                         ip = abort;
                 } else if (relopbranchTable[opcode]) {
-                    if (!emit_relop_branch(builder, ip, opcode))
+                    if (!emit_relop_branch(builder, ip, frame, opcode))
                         ip = abort;
                 } else if (
                     // instance ldfld/stfld
@@ -1180,7 +1206,7 @@ export function generate_wasm_body (
                 builder.appendU8(WasmOpcode.nop);
         } else {
             if (instrumentedTraceId)
-                console.log(`instrumented trace ${traceName} aborted for opcode ${opname} @${_ip}`);
+                console.log(`instrumented trace ${traceName} aborted for opcode ${opname} @${(<any>_ip).toString(16)}`);
             record_abort(traceIp, _ip, traceName, opcode);
         }
     }
@@ -1591,7 +1617,7 @@ function emit_fieldop (
 
             if (!notNull) {
                 builder.appendU8(WasmOpcode.br_if);
-                builder.appendLeb(0);
+                builder.appendULeb(0);
                 append_bailout(builder, ip, BailoutReason.NullCheck);
                 builder.endBlock();
             } else {
@@ -2295,9 +2321,28 @@ function emit_unop (builder: WasmBuilder, ip: MintOpcodePtr, opcode: MintOpcode)
     return true;
 }
 
+function append_call_handler_store_ret_ip (
+    builder: WasmBuilder, ip: MintOpcodePtr,
+    frame: NativePointer, opcode: MintOpcode
+) {
+    const shortOffset = (opcode === MintOpcode.MINT_CALL_HANDLER_S),
+        retIp = shortOffset ? <any>ip + (3 * 2) : <any>ip + (4 * 2),
+        clauseIndex = getU16(retIp - 2),
+        clauseDataOffset = get_imethod_clause_data_offset(frame, clauseIndex);
+
+    // note: locals here is unsigned char *, not stackval *, so clauseDataOffset is in bytes
+    // *(const guint16**)(locals + frame->imethod->clause_data_offsets [clause_index]) = ret_ip;
+    builder.local("pLocals");
+    builder.ptr_const(retIp);
+    builder.appendU8(WasmOpcode.i32_store);
+    builder.appendMemarg(clauseDataOffset, 0); // FIXME: 32-bit alignment?
+
+    // console.log(`call_handler clauseDataOffset=0x${clauseDataOffset.toString(16)} retIp=0x${retIp.toString(16)}`);
+}
+
 function emit_branch (
     builder: WasmBuilder, ip: MintOpcodePtr,
-    opcode: MintOpcode, displacement?: number
+    frame: NativePointer, opcode: MintOpcode, displacement?: number
 ) : boolean {
     const info = OpcodeInfo[opcode];
     const isSafepoint = (opcode >= MintOpcode.MINT_BRFALSE_I4_SP) &&
@@ -2313,11 +2358,20 @@ function emit_branch (
     switch (opcode) {
         case MintOpcode.MINT_LEAVE:
         case MintOpcode.MINT_LEAVE_S:
+        case MintOpcode.MINT_CALL_HANDLER:
+        case MintOpcode.MINT_CALL_HANDLER_S:
         case MintOpcode.MINT_BR:
         case MintOpcode.MINT_BR_S: {
-            displacement = ((opcode === MintOpcode.MINT_LEAVE) || (opcode === MintOpcode.MINT_BR))
+            const isCallHandler = (opcode === MintOpcode.MINT_CALL_HANDLER) ||
+                (opcode === MintOpcode.MINT_CALL_HANDLER_S);
+            displacement = (
+                (opcode === MintOpcode.MINT_LEAVE) ||
+                (opcode === MintOpcode.MINT_BR) ||
+                (opcode === MintOpcode.MINT_CALL_HANDLER)
+            )
                 ? getArgI32(ip, 1)
                 : getArgI16(ip, 1);
+
             if (traceBranchDisplacements)
                 console.log(`br.s @${ip} displacement=${displacement}`);
             const destination = <any>ip + (displacement * 2);
@@ -2329,6 +2383,8 @@ function emit_branch (
                     // append_safepoint(builder, ip);
                     if (traceBackBranches)
                         console.log(`performing backward branch to 0x${destination.toString(16)}`);
+                    if (isCallHandler)
+                        append_call_handler_store_ret_ip(builder, ip, frame, opcode);
                     builder.cfg.branch(destination, true, false);
                     counters.backBranchesEmitted++;
                     return true;
@@ -2345,6 +2401,8 @@ function emit_branch (
                 //  don't need to wrap things in a block here, we can just exit
                 //  the current branch block after updating eip
                 builder.branchTargets.add(destination);
+                if (isCallHandler)
+                    append_call_handler_store_ret_ip(builder, ip, frame, opcode);
                 builder.cfg.branch(destination, false, false);
                 return true;
             }
@@ -2437,7 +2495,10 @@ function emit_branch (
     return true;
 }
 
-function emit_relop_branch (builder: WasmBuilder, ip: MintOpcodePtr, opcode: MintOpcode) : boolean {
+function emit_relop_branch (
+    builder: WasmBuilder, ip: MintOpcodePtr,
+    frame: NativePointer, opcode: MintOpcode
+) : boolean {
     const relopBranchInfo = relopbranchTable[opcode];
     if (!relopBranchInfo)
         return false;
@@ -2494,7 +2555,7 @@ function emit_relop_branch (builder: WasmBuilder, ip: MintOpcodePtr, opcode: Min
         builder.callImport("relop_fp");
     }
 
-    return emit_branch(builder, ip, opcode, displacement);
+    return emit_branch(builder, ip, frame, opcode, displacement);
 }
 
 const mathIntrinsicTable : { [opcode: number] : [isUnary: boolean, isF32: boolean, opcodeOrFuncName: WasmOpcode | string] } = {
@@ -2814,7 +2875,7 @@ function append_getelema1 (
     builder.appendU8(WasmOpcode.i32_lt_u);
     // bailout unless (index < array.length)
     builder.appendU8(WasmOpcode.br_if);
-    builder.appendLeb(0);
+    builder.appendULeb(0);
     append_bailout(builder, ip, BailoutReason.ArrayLoadFailed);
     builder.endBlock();
 
@@ -2874,7 +2935,7 @@ function emit_arrayop (builder: WasmBuilder, frame: NativePointer, ip: MintOpcod
             append_ldloc(builder, getArgU16(ip, 3), WasmOpcode.i32_load);
             builder.callImport("stelem_ref");
             builder.appendU8(WasmOpcode.br_if);
-            builder.appendLeb(0);
+            builder.appendULeb(0);
             append_bailout(builder, ip, BailoutReason.ArrayStoreFailed);
             builder.endBlock();
             return true;


### PR DESCRIPTION
This PR is primarily aimed at reducing time spent compiling traces (which should provide small improvements to startup time), since the cfg added overhead.

* Track bailouts on a per-trace basis when bailout counting is enabled. This makes it easier to understand which traces have the worst performance problems. This does make bailout counting more expensive, but it was already expensive. (This probably needs more improvement to be truly useful, but it was helpful already.)
* Don't abort trace compiles for simple icalls, since in my testing many of them are in rarely-taken branches. They become bailouts instead.
* Implement CALL_HANDLER and CALL_HANDLER_S, since upon closer inspection they turned out to basically be a slightly more complex version of BR.
* Unify the implementation of compressed names to simplify things.
* When defining an import you now pass the actual function (or function pointer) instead of manually providing it when instantiating the module.
* Introduce persistent imported functions (similar to persistent types), which reduces the amount of time defining imports before compiling a trace.
* Don't call into C in order to emit single-byte unsigned LEB values (appendULeb is one of the hottest parts of the trace compiler).
* Various small optimizations to remove temporary JS allocations.
* Improve message formatting in the branch trace messages (off by default)