### PR TITLE
[release/7.0] Remove VersionSuffix from servicing builds

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -38,6 +38,7 @@
     <Product>Microsoft%AE .NET</Product>
     <!-- Use the .NET product branding version for informational version description -->
     <InformationalVersion Condition="'$(InformationalVersion)' == '' and '$(VersionSuffix)' == ''">$(ProductVersion)</InformationalVersion>
+    <InformationalVersion Condition="'$(InformationalVersion)' == '' and '$(PreReleaseVersionLabel)' == 'servicing'">$(ProductVersion)</InformationalVersion>
     <InformationalVersion Condition="'$(InformationalVersion)' == '' and '$(VersionSuffix)' != ''">$(ProductVersion)-$(VersionSuffix)</InformationalVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Backport of #83311.

### Customer Impact
In servicing, we don't append version suffix to the Product Version. This centralized fix is applied to all shipping components alike. Currently, we only omit suffix in some assemblies like `System.Private.CoreLib.dll` but not crossgen2.dll etc.

### Testing

Manual testing using `./build.sh clr+libs+packs -ci -p:OfficialBuildId=22606.5` to make sure that VersionSuffix isn't added to the Product Version of crossgen2; which is reported by `crossgen2 --version`.

### Risk

Low.