### PR TITLE
[Codespaces] Fix prebuild by using newer dotnet sdk

### DIFF
--- a/.devcontainer/scripts/onCreateCommand.sh
+++ b/.devcontainer/scripts/onCreateCommand.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+# bump the dotnet sdk version to get msbuild bugfix: https://github.com/dotnet/msbuild/issues/8531
+# TODO: remove once we're on a newer sdk in global.json
+sed -i 's/8.0.100-preview.1.23115.2/8.0.100-preview.3.23159.20/g' global.json || true
+
 opt=$1
 case "$opt" in
 


### PR DESCRIPTION
We need to get this msbuild bugfix to resolve a build error during Codespaces prebuild: https://github.com/dotnet/msbuild/issues/8531

We generally try to avoid bumping to a nightly SDK in global.json since it causes pain for contributors so we bump only in the Codespaces prebuild script.

The only downside is that it'll show global.json as modified in git and you need to avoid staging/committing that diff. I think that is an acceptable downside for the next ~1.5 months.