### PR TITLE
[loader] Does find_method_in_class really see null method entries?

### DIFF
--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -491,9 +491,11 @@ find_method_in_class (MonoClass *klass, const char *name, const char *qname, con
 		MonoMethod *m = klass_methods [i];
 		MonoMethodSignature *msig;
 
-		/* We must cope with failing to load some of the types. */
-		if (!m)
-			continue;
+		/* When do we ever see NULL here? */
+		g_assertf(m != NULL, "Found null method %d when looking for '%s' in '%s.%s' on behalf of '%s.%s'",
+			  i, fqname ? fqname : qname ? qname : name,
+			  m_class_get_name_space (klass), m_class_get_name (klass),
+			  m_class_get_name_space (from_class), m_class_get_name (from_class));
 
 		if (!((fqname && !strcmp (m->name, fqname)) ||
 		      (qname && !strcmp (m->name, qname)) ||


### PR DESCRIPTION
For hot reload it would be nice to rewrite this part of `find_method_in_class` using the `mono_class_get_methods` iterator.  But the iterator contract is to return `NULL` when we're done iterating.  So we might be changing something here.

Does modern code ever see `NULL` at this point?  Apparently not.  Assert that that is the case.

