### PR TITLE
[wasm] Fix threading startup after emscripten bump

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -115,7 +115,6 @@ jobs:
       # Always run for runtime-wasm because browser testing is not on runtime
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
       scenarios:
-        - normal
         - WasmTestOnBrowser
 
   # Library tests with full threading

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -112,6 +112,8 @@ jobs:
       shouldRunSmokeOnly: true
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
+      # Always run for runtime-wasm because browser testing is not on runtime
+      alwaysRun: ${{ parameters.isWasmOnlyBuild }}
       scenarios:
         - normal
         - WasmTestOnBrowser

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -101,6 +101,21 @@ jobs:
         - WasmTestOnBrowser
         - WasmTestOnNodeJS
 
+  # Smoke tests only with full threading
+  - template: /eng/pipelines/common/templates/wasm-library-tests.yml
+    parameters:
+      platforms:
+        - browser_wasm
+        #- browser_wasm_win
+      nameSuffix: _Threading_Smoke
+      extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:_WasmPThreadPoolSize=8
+      shouldRunSmokeOnly: true
+      isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
+      isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
+      scenarios:
+        - normal
+        - WasmTestOnBrowser
+
   # Library tests with full threading
   - template: /eng/pipelines/common/templates/wasm-library-tests.yml
     parameters:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -488,6 +488,8 @@ extends:
           extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:_WasmPThreadPoolSize=8
           shouldRunSmokeOnly: true
           alwaysRun: ${{ variables.isRollingBuild }}
+          scenarios:
+            - normal
 
       - template: /eng/pipelines/common/templates/wasm-build-only.yml
         parameters:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -479,13 +479,14 @@ extends:
             - browser_wasm
           alwaysRun: ${{ variables.isRollingBuild }}
 
-      # BUILD ONLY - Wasm Threading Legs
-      - template: /eng/pipelines/common/templates/wasm-build-only.yml
+      # Build and Smoke Tests only - Wasm Threading Legs
+      - template: /eng/pipelines/common/templates/wasm-library-tests.yml
         parameters:
           platforms:
             - browser_wasm
-          nameSuffix: _Threading
-          extraBuildArgs: /p:MonoWasmBuildVariant=multithread
+          nameSuffix: _Threading_Smoke
+          extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:_WasmPThreadPoolSize=8
+          shouldRunSmokeOnly: true
           alwaysRun: ${{ variables.isRollingBuild }}
 
       - template: /eng/pipelines/common/templates/wasm-build-only.yml
@@ -495,6 +496,8 @@ extends:
           nameSuffix: _Threading_PerfTracing
           extraBuildArgs: /p:MonoWasmBuildVariant=perftrace
           alwaysRun: ${{ variables.isRollingBuild }}
+          scenarios:
+            - normal
 
       # WASI/WASM
 

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -498,8 +498,6 @@ extends:
           nameSuffix: _Threading_PerfTracing
           extraBuildArgs: /p:MonoWasmBuildVariant=perftrace
           alwaysRun: ${{ variables.isRollingBuild }}
-          scenarios:
-            - normal
 
       # WASI/WASM
 

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -489,7 +489,7 @@ extends:
           shouldRunSmokeOnly: true
           alwaysRun: ${{ variables.isRollingBuild }}
           scenarios:
-            - normal
+            - WasmTestOnBrowser
 
       - template: /eng/pipelines/common/templates/wasm-build-only.yml
         parameters:

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -50,6 +50,7 @@
   <!-- Samples that require a multi-threaded runtime -->
   <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(MonoWasmBuildVariant)' != 'multithread'" >
     <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-threads\Wasm.Browser.Threads.Sample.csproj" />
+    <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-threads-minimal\Wasm.Browser.Threads.Minimal.Sample.csproj" />
   </ItemGroup>
 
   <!-- Samples that require a perf-tracing wasm runtime -->

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -565,9 +565,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(MonoWasmBuildVariant)' == 'multithread'">
-      <!-- Don't want the default smoke tests - just verify that threading works -->
-      <SmokeTestProject Remove="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests.csproj" />
-      <SmokeTestProject Include="$(MonoProjectRoot)sample\wasm\browser-threads-minimal\Wasm.Browser.Threads.Minimal.Sample.csproj" />
+    <!-- Don't want the default smoke tests - just verify that threading works -->
+    <SmokeTestProject Remove="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests.csproj" />
+    <SmokeTestProject Include="$(MonoProjectRoot)sample\wasm\browser-threads-minimal\Wasm.Browser.Threads.Minimal.Sample.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -566,7 +566,7 @@
 
   <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(MonoWasmBuildVariant)' == 'multithread'">
     <!-- Don't want the default smoke tests - just verify that threading works -->
-    <SmokeTestProject Remove="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests.csproj" />
+    <SmokeTestProject Remove="@(SmokeTestProject)" />
     <SmokeTestProject Include="$(MonoProjectRoot)sample\wasm\browser-threads-minimal\Wasm.Browser.Threads.Minimal.Sample.csproj" />
   </ItemGroup>
 

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -564,6 +564,12 @@
     <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices\tests\System.Runtime.InteropServices.UnitTests\System.Runtime.InteropServices.Tests.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(MonoWasmBuildVariant)' == 'multithread'">
+      <!-- Don't want the default smoke tests - just verify that threading works -->
+      <SmokeTestProject Remove="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests.csproj" />
+      <SmokeTestProject Include="$(MonoProjectRoot)sample\wasm\browser-threads-minimal\Wasm.Browser.Threads.Minimal.Sample.csproj" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Condition="'$(RunSmokeTestsOnly)' == 'true'"
                       Include="@(SmokeTestProject)" />

--- a/src/mono/sample/wasm/browser-threads-minimal/Makefile
+++ b/src/mono/sample/wasm/browser-threads-minimal/Makefile
@@ -1,0 +1,13 @@
+TOP=../../../../..
+
+include ../wasm.mk
+
+override MSBUILD_ARGS+=/p:WasmEnableThreads=true
+
+ifneq ($(AOT),)
+override MSBUILD_ARGS+=/p:RunAOTCompilation=true
+endif
+
+PROJECT_NAME=Wasm.Browser.Threads.Minimal.Sample.csproj
+
+run: run-browser

--- a/src/mono/sample/wasm/browser-threads-minimal/Program.cs
+++ b/src/mono/sample/wasm/browser-threads-minimal/Program.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices.JavaScript;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
+namespace Sample
+{
+    public partial class Test
+    {
+        public static int Main(string[] args)
+        {
+            Console.WriteLine("Hello, World!");
+            return 0;
+        }
+
+        [JSExport]
+        public static async Task<int> RunBackgroundThreadCompute()
+        {
+            var tcs = new TaskCompletionSource<int>();
+            var t = new Thread(() => {
+                var n = CountingCollatzTest();
+                tcs.SetResult(n);
+            });
+            t.Start();
+            return await tcs.Task;
+        }
+
+        [JSExport]
+        public static async Task<int> RunBackgroundLongRunningTaskCompute()
+        {
+            var factory = new TaskFactory();
+            var t = factory.StartNew<int> (() => {
+                var n = CountingCollatzTest();
+                return n;
+            }, TaskCreationOptions.LongRunning);
+            return await t;
+        }
+
+        public static int CountingCollatzTest()
+        {
+            const int limit = 5000;
+            const int maxInput = 500_000;
+            int bigly = 0;
+            int hugely = 0;
+            int maxSteps = 0;
+            for (int n = 1; n < maxInput; n++) {
+                int steps = CountingCollatz ((long)n, limit);
+                if (steps > maxSteps)
+                    maxSteps = steps;
+                if (steps > 120)
+                    bigly++;
+                if (steps >= limit)
+                    hugely++;
+            }
+
+            Console.WriteLine ($"Bigly: {bigly}, Hugely: {hugely}, maxSteps: {maxSteps}");
+
+            if (bigly == 241677 && hugely == 0 && maxSteps == 448)
+                return 524;
+            else
+                return 0;
+        }
+
+
+        private static int CountingCollatz (long n, int limit)
+        {
+            int steps = 0;
+            while (n > 1) {
+                n = Collatz1 (n);
+                steps++;
+                if (steps >= limit)
+                    break;
+            }
+            return steps;
+        }
+
+        private static long Collatz1 (long n)
+        {
+            if (n <= 0)
+                throw new Exception("Unexpected non-positive input");
+            if (n % 2 == 0)
+                return n / 2;
+            else
+                return 3 * n + 1;
+        }
+    }
+}

--- a/src/mono/sample/wasm/browser-threads-minimal/Wasm.Browser.Threads.Minimal.Sample.csproj
+++ b/src/mono/sample/wasm/browser-threads-minimal/Wasm.Browser.Threads.Minimal.Sample.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\DefaultBrowserSample.targets" />
+  <PropertyGroup>
+    <WasmEnableThreads>true</WasmEnableThreads>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <WasmExtraFilesToDeploy Include="main.js" />
+  </ItemGroup>
+
+  <!-- set the condition to false and you will get a CA1416 error about the call to Thread.Start from a browser-wasm project -->
+  <ItemGroup Condition="true">
+    <!-- TODO: some .props file that automates this.  Unfortunately just adding a ProjectReference to Microsoft.NET.WebAssembly.Threading.proj doesn't work - it ends up bundling the ref assemblies into the publish directory and breaking the app. -->
+    <!-- it's a reference assembly, but the project system doesn't know that - include it during compilation, but don't publish it -->
+    <ProjectReference Include="$(LibrariesProjectRoot)\System.Threading.Thread.WebAssembly.Threading\ref\System.Threading.Thread.WebAssembly.Threading.csproj" IncludeAssets="compile" PrivateAssets="none" ExcludeAssets="runtime" Private="false" />
+    <ProjectReference Include="$(LibrariesProjectRoot)\System.Threading.ThreadPool.WebAssembly.Threading\ref\System.Threading.ThreadPool.WebAssembly.Threading.csproj" IncludeAssets="compile" PrivateAssets="none" ExcludeAssets="runtime" Private="false" />
+    <ProjectReference Include="$(LibrariesProjectRoot)\System.Diagnostics.Tracing.WebAssembly.PerfTracing\ref\System.Diagnostics.Tracing.WebAssembly.PerfTracing.csproj" IncludeAssets="compile" PrivateAssets="none" ExcludeAssets="runtime" Private="false" />
+  </ItemGroup>
+
+</Project>

--- a/src/mono/sample/wasm/browser-threads-minimal/index.html
+++ b/src/mono/sample/wasm/browser-threads-minimal/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<!--  Licensed to the .NET Foundation under one or more agreements. -->
+<!-- The .NET Foundation licenses this file to you under the MIT license. -->
+<html>
+
+<head>
+    <title>Wasm Browser Smoke Test Threading Sample</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script type='module' src="./main.js"></script>
+</head>
+
+<body>
+    <h3 id="header">Wasm Browser Smoke Test Threading Sample</h3>
+    This calculation will take a long time: <span id="out"></span>
+</body>
+
+</html>

--- a/src/mono/sample/wasm/browser-threads-minimal/main.js
+++ b/src/mono/sample/wasm/browser-threads-minimal/main.js
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+import { dotnet, exit } from './dotnet.js'
+
+const assemblyName = "Wasm.Browser.Threads.Minimal.Sample.dll";
+
+
+try {
+    const { setModuleImports, getAssemblyExports, runMain } = await dotnet
+        .withEnvironmentVariable("MONO_LOG_LEVEL", "debug")
+        .withElementOnExit()
+        .withExitCodeLogging()
+        .create();
+
+    const exports = await getAssemblyExports(assemblyName);
+
+    const r1 = await exports.Sample.Test.RunBackgroundThreadCompute();
+    if (r1 !== 524) {
+        const msg = `Unexpected result ${r1} from RunBackgroundThreadCompute()`;
+        document.getElementById("out").innerHTML = msg;
+        throw new Error(msg);
+    }
+    const r2 = await exports.Sample.Test.RunBackgroundLongRunningTaskCompute();
+    if (r2 !== 524) {
+        const msg = `Unexpected result ${r2} from RunBackgorundLongRunningTaskCompute()`;
+        document.getElementById("out").innerHTML = msg;
+        throw new Error(msg);
+    }
+
+    let exit_code = await runMain(assemblyName, []);
+    exit(exit_code);
+} catch (err) {
+    exit(2, err);
+}

--- a/src/mono/wasm/runtime/pthreads/browser/index.ts
+++ b/src/mono/wasm/runtime/pthreads/browser/index.ts
@@ -139,13 +139,7 @@ export async function instantiateWasmPThreadWorkerPool(): Promise<void> {
     // this is largely copied from emscripten's "receiveInstance" in "createWasm" in "src/preamble.js"
     const workers = Internals.getUnusedWorkerPool();
     if (workers.length > 0) {
-        const allLoaded = createPromiseController<void>();
-        let leftToLoad = workers.length;
-        workers.forEach((w) => {
-            Internals.loadWasmModuleToWorker(w, function () {
-                if (!--leftToLoad) allLoaded.promise_control.resolve();
-            });
-        });
-        await allLoaded.promise;
+        const promises = workers.map(Internals.loadWasmModuleToWorker);
+        await Promise.all(promises);
     }
 }

--- a/src/mono/wasm/runtime/pthreads/shared/emscripten-internals.ts
+++ b/src/mono/wasm/runtime/pthreads/shared/emscripten-internals.ts
@@ -16,7 +16,7 @@ interface PThreadLibrary {
     unusedWorkers: Worker[];
     pthreads: PThreadInfoMap;
     allocateUnusedWorker: () => void;
-    loadWasmModuleToWorker: (worker: Worker, onFinishedLoading?: (worker: Worker) => void) => void;
+    loadWasmModuleToWorker: (worker: Worker) => Promise<Worker>;
 }
 
 interface EmscriptenPThreadInfo {
@@ -67,8 +67,8 @@ const Internals = {
     getUnusedWorkerPool: (): Worker[] => {
         return Internals.modulePThread.unusedWorkers;
     },
-    loadWasmModuleToWorker: (worker: Worker, onFinishedLoading: () => void): void => {
-        Internals.modulePThread.loadWasmModuleToWorker(worker, onFinishedLoading);
+    loadWasmModuleToWorker: (worker: Worker): Promise<Worker> => {
+        return Internals.modulePThread.loadWasmModuleToWorker(worker);
     }
 };
 

--- a/src/mono/wasm/runtime/pthreads/shared/emscripten-replacements.ts
+++ b/src/mono/wasm/runtime/pthreads/shared/emscripten-replacements.ts
@@ -8,7 +8,7 @@ import { afterThreadInitTLS } from "../worker";
 import Internals from "./emscripten-internals";
 import { resolve_asset_path } from "../../assets";
 import { mono_assert } from "../../types";
-import { runtimeHelpers }  from "../../imports";
+import { runtimeHelpers } from "../../imports";
 
 /** @module emscripten-replacements Replacements for individual functions in the emscripten PThreads library.
  * These have a hard dependency on the version of Emscripten that we are using and may need to be kept in sync with
@@ -18,9 +18,10 @@ import { runtimeHelpers }  from "../../imports";
 export function replaceEmscriptenPThreadLibrary(replacements: PThreadReplacements): void {
     if (MonoWasmThreads) {
         const originalLoadWasmModuleToWorker = replacements.loadWasmModuleToWorker;
-        replacements.loadWasmModuleToWorker = (worker: Worker, onFinishedLoading?: (worker: Worker) => void): void => {
-            originalLoadWasmModuleToWorker(worker, onFinishedLoading);
+        replacements.loadWasmModuleToWorker = (worker: Worker): Promise<Worker> => {
+            const p = originalLoadWasmModuleToWorker(worker);
             afterLoadWasmModuleToWorker(worker);
+            return p;
         };
         const originalThreadInitTLS = replacements.threadInitTLS;
         replacements.threadInitTLS = (): void => {

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -180,7 +180,6 @@ async function preInitWorkerAsync() {
         mono_wasm_pre_init_essential(true);
         await init_polyfills_async();
         afterPreInit.promise_control.resolve();
-        console.debug("MONO_WASM: worker preInitWorkerAsync done");
         endMeasure(mark, MeasuredBlock.preInitWorker);
     } catch (err) {
         _print_error("MONO_WASM: user preInitWorker() failed", err);
@@ -312,7 +311,7 @@ function mono_wasm_pre_init_essential(isWorker: boolean): void {
     if (!isWorker)
         Module.addRunDependency("mono_wasm_pre_init_essential");
 
-    if (runtimeHelpers.diagnosticTracing || isWorker) console.debug("MONO_WASM: mono_wasm_pre_init_essential");
+    if (runtimeHelpers.diagnosticTracing) console.debug("MONO_WASM: mono_wasm_pre_init_essential");
 
     // init_polyfills() is already called from export.ts
     init_c_exports();
@@ -328,8 +327,6 @@ function mono_wasm_pre_init_essential(isWorker: boolean): void {
     // sending postMessage twice will break instantiateWasmPThreadWorkerPool on the main thread.
     if (!isWorker)
         Module.removeRunDependency("mono_wasm_pre_init_essential");
-    else
-        console.debug("MONO_WASM: worker finished pre_init_essential");
 }
 
 async function mono_wasm_pre_init_essential_async(): Promise<void> {
@@ -685,8 +682,6 @@ export async function mono_wasm_pthread_worker_init(module: DotnetModule, export
     module.preInit = [() => preInitWorkerAsync()];
     module.instantiateWasm = instantiateWasmWorker;
 
-    console.debug("MONO_WASM: worker awaiting afterPreInit");
     await afterPreInit.promise;
-    console.debug("MONO_WASM: worker afterPreInit done - mono_wasm_pthread_worker_init returning");
     return exportedAPI.Module;
 }

--- a/src/mono/wasm/runtime/types.ts
+++ b/src/mono/wasm/runtime/types.ts
@@ -170,13 +170,13 @@ export interface AssetEntry extends ResourceRequest {
     /**
      * If true, an attempt will be made to load the asset from each location in MonoConfig.remoteSources.
      */
-    loadRemote?: boolean, //
+    loadRemote?: boolean, // 
     /**
      * If true, the runtime startup would not fail if the asset download was not successful.
      */
     isOptional?: boolean
     /**
-     * If provided, runtime doesn't have to fetch the data.
+     * If provided, runtime doesn't have to fetch the data. 
      * Runtime would set the buffer to null after instantiation to free the memory.
      */
     buffer?: ArrayBuffer
@@ -377,8 +377,7 @@ export interface ExitStatusError {
     new(status: number): any;
 }
 export type PThreadReplacements = {
-    loadWasmModuleToWorker(worker: Worker): Promise<Worker>,
-    // loadWasmModuleToAllWorkers(onMaybeReady?: () => void): void, // FIXME: replace?
+    loadWasmModuleToWorker: (worker: Worker, onFinishedLoading?: (worker: Worker) => void) => void,
     threadInitTLS: () => void,
     allocateUnusedWorker: () => void,
 }

--- a/src/mono/wasm/runtime/types.ts
+++ b/src/mono/wasm/runtime/types.ts
@@ -170,13 +170,13 @@ export interface AssetEntry extends ResourceRequest {
     /**
      * If true, an attempt will be made to load the asset from each location in MonoConfig.remoteSources.
      */
-    loadRemote?: boolean, // 
+    loadRemote?: boolean, //
     /**
      * If true, the runtime startup would not fail if the asset download was not successful.
      */
     isOptional?: boolean
     /**
-     * If provided, runtime doesn't have to fetch the data. 
+     * If provided, runtime doesn't have to fetch the data.
      * Runtime would set the buffer to null after instantiation to free the memory.
      */
     buffer?: ArrayBuffer
@@ -377,7 +377,8 @@ export interface ExitStatusError {
     new(status: number): any;
 }
 export type PThreadReplacements = {
-    loadWasmModuleToWorker: (worker: Worker, onFinishedLoading?: (worker: Worker) => void) => void,
+    loadWasmModuleToWorker(worker: Worker): Promise<Worker>,
+    // loadWasmModuleToAllWorkers(onMaybeReady?: () => void): void, // FIXME: replace?
     threadInitTLS: () => void,
     allocateUnusedWorker: () => void,
 }

--- a/src/mono/wasm/runtime/types.ts
+++ b/src/mono/wasm/runtime/types.ts
@@ -377,7 +377,7 @@ export interface ExitStatusError {
     new(status: number): any;
 }
 export type PThreadReplacements = {
-    loadWasmModuleToWorker: (worker: Worker, onFinishedLoading?: (worker: Worker) => void) => void,
+    loadWasmModuleToWorker(worker: Worker): Promise<Worker>,
     threadInitTLS: () => void,
     allocateUnusedWorker: () => void,
 }


### PR DESCRIPTION
Upstream `loadWasmModuleToWorker` changed type.

---

Also: run threading smoke tests on every PR and on rolling builds.

Threading smoke test  is a new sample that just creates a thread to do some background math 

