### PR TITLE
Reduce code duplication in AppendFormat methods with CompositeFormat

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -672,26 +672,13 @@ namespace System
                 }
                 else
                 {
-                    int index = segment.ArgIndex;
-                    switch (index)
+                    handler.AppendFormatted(segment.ArgIndex switch
                     {
-                        case 0:
-                            handler.AppendFormatted(arg0, segment.Alignment, segment.Format);
-                            break;
-
-                        case 1:
-                            handler.AppendFormatted(arg1, segment.Alignment, segment.Format);
-                            break;
-
-                        case 2:
-                            handler.AppendFormatted(arg2, segment.Alignment, segment.Format);
-                            break;
-
-                        default:
-                            Debug.Assert(index > 2);
-                            handler.AppendFormatted(args[index], segment.Alignment, segment.Format);
-                            break;
-                    }
+                        0 => arg0,
+                        1 => arg1,
+                        2 => arg2,
+                        _ => args[segment.ArgIndex],
+                    }, segment.Alignment, segment.Format);
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -1773,26 +1773,13 @@ namespace System.Text
                 }
                 else
                 {
-                    int index = segment.ArgIndex;
-                    switch (index)
+                    handler.AppendFormatted(segment.ArgIndex switch
                     {
-                        case 0:
-                            handler.AppendFormatted(arg0, segment.Alignment, segment.Format);
-                            break;
-
-                        case 1:
-                            handler.AppendFormatted(arg1, segment.Alignment, segment.Format);
-                            break;
-
-                        case 2:
-                            handler.AppendFormatted(arg2, segment.Alignment, segment.Format);
-                            break;
-
-                        default:
-                            Debug.Assert(index > 2);
-                            handler.AppendFormatted(args[index], segment.Alignment, segment.Format);
-                            break;
-                    }
+                        0 => arg0,
+                        1 => arg1,
+                        2 => arg2,
+                        _ => args[segment.ArgIndex],
+                    }, segment.Alignment, segment.Format);
                 }
             }
 


### PR DESCRIPTION
By having one AppendFormatted call site rather than four, we significantly reduce how much asm is generated in these generic methods.