### PR TITLE
Do not generate Equals/GetHashCode support for async state machines

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.ValueTypeMethods.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.ValueTypeMethods.cs
@@ -76,16 +76,18 @@ namespace ILCompiler
                 return false;
 
             // Heuristic: async state machines don't need equality/hashcode.
-            _iAsyncStateMachineType ??= SystemModule.GetType("System.Runtime.CompilerServices", "IAsyncStateMachine");
-            if (valueType.HasCustomAttribute("System.Runtime.CompilerServices", "CompilerGeneratedAttribute")
-                && valueType.ContainingType != null
-                && Array.IndexOf(valueType.RuntimeInterfaces, _iAsyncStateMachineType) >= 0)
-            {
+            if (IsAsyncStateMachineType(valueType))
                 return false;
-            }
-
 
             return !_typeStateHashtable.GetOrCreateValue(valueType).CanCompareValueTypeBits;
+        }
+
+        public bool IsAsyncStateMachineType(MetadataType type)
+        {
+            Debug.Assert(type.IsValueType);
+            _iAsyncStateMachineType ??= SystemModule.GetType("System.Runtime.CompilerServices", "IAsyncStateMachine", throwIfNotFound: false);
+            return type.HasCustomAttribute("System.Runtime.CompilerServices", "CompilerGeneratedAttribute")
+                && Array.IndexOf(type.RuntimeInterfaces, _iAsyncStateMachineType) >= 0;
         }
 
         private sealed class TypeState

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 
 using Internal.IL;
+using Internal.IL.Stubs;
 using Internal.Runtime;
 using Internal.Text;
 using Internal.TypeSystem;
@@ -945,6 +946,9 @@ namespace ILCompiler.DependencyAnalysis
             if (_type.IsInterface)
                 return;
 
+            bool isAsyncStateMachineValueType = implType.IsValueType
+                && factory.TypeSystemContext.IsAsyncStateMachineType((MetadataType)implType);
+
             // Actual vtable slots follow
             IReadOnlyList<MethodDesc> virtualSlots = declVTable.Slots;
 
@@ -967,7 +971,21 @@ namespace ILCompiler.DependencyAnalysis
                 if (declMethod.CanMethodBeInSealedVTable() && !declType.IsArrayTypeWithoutGenericInterfaces())
                     continue;
 
-                if (!implMethod.IsAbstract)
+                bool shouldEmitImpl = !implMethod.IsAbstract;
+
+                // We do a size optimization that removes support for built-in ValueType Equals/GetHashCode
+                // Null out the vtable slot associated with built-in support to catch if it ever becomes illegal.
+                // We also null out Equals/GetHashCode - that's just a marginal size/startup optimization.
+                if (isAsyncStateMachineValueType)
+                {
+                    if ((declType.IsObject && declMethod.Name is "Equals" or "GetHashCode" && implMethod.OwningType.IsWellKnownType(WellKnownType.ValueType))
+                        || (declType.IsWellKnownType(WellKnownType.ValueType) && declMethod.Name == ValueTypeGetFieldHelperMethodOverride.MetadataName))
+                    {
+                        shouldEmitImpl = false;
+                    }
+                }
+
+                if (shouldEmitImpl)
                 {
                     MethodDesc canonImplMethod = implMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
 


### PR DESCRIPTION
Saves 0.63% on BasicMinimalApi.

This logic controls whether we inject the `__GetFieldHelper` override for the type (see https://github.com/dotnet/corert/pull/5436). Suggestions for better ways of detecting async state machines are welcome!

Context: #83323

Cc @dotnet/ilc-contrib 