### PR TITLE
[NativeAOT] simpler ObjectHasComponentSize

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/EETypePtr.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/EETypePtr.cs
@@ -231,14 +231,6 @@ namespace System
             }
         }
 
-        internal bool IsAbstract
-        {
-            get
-            {
-                return _value->IsAbstract;
-            }
-        }
-
         internal bool IsByRefLike
         {
             get
@@ -315,14 +307,6 @@ namespace System
 
                 EETypePtr baseEEType = new EETypePtr(_value->NonArrayBaseType);
                 return baseEEType;
-            }
-        }
-
-        internal ushort ComponentSize
-        {
-            get
-            {
-                return _value->ComponentSize;
             }
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
@@ -350,6 +350,7 @@ namespace System.Runtime.CompilerServices
             if (mt->IsNullable)
             {
                 mt = mt->NullableType;
+                return GetUninitializedObject(Type.GetTypeFromEETypePtr(new EETypePtr(mt)));
             }
 
             // Triggering the .cctor here is slightly different than desktop/CoreCLR, which

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
@@ -285,7 +285,7 @@ namespace System.Runtime.CompilerServices
             Justification = "We keep class constructors of all types with an MethodTable")]
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:UnrecognizedReflectionPattern",
             Justification = "Constructed MethodTable of a Nullable forces a constructed MethodTable of the element type")]
-        public static object GetUninitializedObject(
+        public static unsafe object GetUninitializedObject(
             // This API doesn't call any constructors, but the type needs to be seen as constructed.
             // A type is seen as constructed if a constructor is kept.
             // This obviously won't cover a type with no constructor. Reference types with no
@@ -319,37 +319,37 @@ namespace System.Runtime.CompilerServices
                 throw new NotSupportedException(SR.NotSupported_ManagedActivation);
             }
 
-            EETypePtr eeTypePtr = type.TypeHandle.ToEETypePtr();
+            MethodTable* mt = type.TypeHandle.ToMethodTable();
 
-            if (eeTypePtr.ElementType == Internal.Runtime.EETypeElementType.Void)
+            if (mt->ElementType == Internal.Runtime.EETypeElementType.Void)
             {
                 throw new ArgumentException(SR.Argument_InvalidValue);
             }
 
             // Don't allow strings (we already checked for arrays above)
-            if (eeTypePtr.ComponentSize != 0)
+            if (mt->HasComponentSize)
             {
                 throw new ArgumentException(SR.Argument_NoUninitializedStrings);
             }
 
-            if (RuntimeImports.AreTypesAssignable(eeTypePtr, EETypePtr.EETypePtrOf<Delegate>()))
+            if (RuntimeImports.AreTypesAssignable(mt, MethodTable.Of<Delegate>()))
             {
                 throw new MemberAccessException();
             }
 
-            if (eeTypePtr.IsAbstract)
+            if (mt->IsAbstract)
             {
                 throw new MemberAccessException(SR.Acc_CreateAbst);
             }
 
-            if (eeTypePtr.IsByRefLike)
+            if (mt->IsByRefLike)
             {
                 throw new NotSupportedException(SR.NotSupported_ByRefLike);
             }
 
-            if (eeTypePtr.IsNullable)
+            if (mt->IsNullable)
             {
-                return GetUninitializedObject(Type.GetTypeFromEETypePtr(eeTypePtr.NullableType));
+                mt = mt->NullableType;
             }
 
             // Triggering the .cctor here is slightly different than desktop/CoreCLR, which
@@ -357,7 +357,7 @@ namespace System.Runtime.CompilerServices
             // in MethodTable just for this API to behave slightly differently.
             RunClassConstructor(type.TypeHandle);
 
-            return RuntimeImports.RhNewObject(eeTypePtr);
+            return RuntimeImports.RhNewObject(mt);
         }
     }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
@@ -242,10 +242,9 @@ namespace System.Runtime.CompilerServices
         // Returns true iff the object has a component size;
         // i.e., is variable length like System.String or Array.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool ObjectHasComponentSize(object obj)
+        internal static unsafe bool ObjectHasComponentSize(object obj)
         {
-            Debug.Assert(obj != null);
-            return obj.GetEETypePtr().ComponentSize != 0;
+            return GetMethodTable(obj)->HasComponentSize;
         }
 
         public static void PrepareMethod(RuntimeMethodHandle method)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -305,7 +305,7 @@ namespace System.Runtime
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhTypeCast_AreTypesAssignable")]
-        private static extern unsafe bool AreTypesAssignable(MethodTable* pSourceType, MethodTable* pTargetType);
+        internal static extern unsafe bool AreTypesAssignable(MethodTable* pSourceType, MethodTable* pTargetType);
 
         internal static unsafe bool AreTypesAssignable(EETypePtr pSourceType, EETypePtr pTargetType)
             => AreTypesAssignable(pSourceType.ToPointer(), pTargetType.ToPointer());
@@ -351,7 +351,7 @@ namespace System.Runtime
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhNewObject")]
-        private static extern unsafe object RhNewObject(MethodTable* pEEType);
+        internal static extern unsafe object RhNewObject(MethodTable* pEEType);
 
         internal static unsafe object RhNewObject(EETypePtr pEEType)
             => RhNewObject(pEEType.ToPointer());

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeTypeHandle.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeTypeHandle.cs
@@ -118,6 +118,12 @@ namespace System
             return new EETypePtr(_value);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal MethodTable* ToMethodTable()
+        {
+            return (MethodTable*)_value;
+        }
+
         internal bool IsNull
         {
             get


### PR DESCRIPTION

I keep seeing entries like ` BasicMinimalApi!S_P_CoreLib_Internal_Runtime_MethodTable__get_ComponentSize` in profiles. But `MethodTable.ComponentSize` is a simple one-liner that should be inlineable. 

I expected that #83351, besides code reuse, will also take care of this, but there is more.

Turns out things like `Memory<T>.Span` [call `ObjectHasComponentSize` ](https://github.com/dotnet/runtime/blob/55a09408141e4c97b866b7f36910d033d2f1f05d/src/libraries/System.Private.CoreLib/src/System/Memory.cs#L293) to detect if the underlying object is an array and NativeAOT implementation does `EETypePtr.ComponentSize != 0`, and that calls `MethodTable.ComponentSize`. The roundabout way might be difficult to inline. 

`MethodTable.HasComponentSize` is just a sign check for the flags word, so here is a simpler implementation.

I've also switched a few other places that use `EETypePtr.ComponentSize`