### PR TITLE
Allow certificate bundles for AIA fetching

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCertificateAssetDownloader.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCertificateAssetDownloader.cs
@@ -13,7 +13,7 @@ namespace System.Security.Cryptography.X509Certificates
 {
     internal static class OpenSslCertificateAssetDownloader
     {
-        internal static X509Certificate2? DownloadCertificate(string uri, TimeSpan downloadTimeout)
+        internal static X509Certificate2Collection? DownloadCertificate(string uri, TimeSpan downloadTimeout)
         {
             byte[]? data = DownloadAsset(uri, downloadTimeout);
 
@@ -24,9 +24,15 @@ namespace System.Security.Cryptography.X509Certificates
 
             try
             {
-                X509Certificate2 certificate = new X509Certificate2(data);
-                certificate.ThrowIfInvalid();
-                return certificate;
+                X509Certificate2Collection certificates = new X509Certificate2Collection();
+                certificates.Import(data);
+
+                foreach (X509Certificate2 certificate in certificates)
+                {
+                    certificate.ThrowIfInvalid();
+                }
+
+                return certificates;
             }
             catch (CryptographicException)
             {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainProcessor.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainProcessor.cs
@@ -253,7 +253,7 @@ namespace System.Security.Cryptography.X509Certificates
                         break;
                     }
 
-                    X509Certificate2? downloaded = DownloadCertificate(
+                    X509Certificate2Collection? downloaded = DownloadCertificate(
                         authorityInformationAccess,
                         _downloadTimeout);
 
@@ -267,8 +267,11 @@ namespace System.Security.Cryptography.X509Certificates
 
                     downloadedCerts ??= new List<X509Certificate2>();
 
-                    AddToStackAndUpRef(downloaded.Handle, _untrustedLookup);
-                    downloadedCerts.Add(downloaded);
+                    foreach (X509Certificate2 certificate in downloaded)
+                    {
+                        AddToStackAndUpRef(certificate.Handle, _untrustedLookup);
+                        downloadedCerts.Add(certificate);
+                    }
 
                     Interop.Crypto.X509StoreCtxRebuildChain(storeCtx);
                     statusCode = Interop.Crypto.X509StoreCtxGetError(storeCtx);
@@ -1198,7 +1201,7 @@ namespace System.Security.Cryptography.X509Certificates
             }
         }
 
-        private static X509Certificate2? DownloadCertificate(
+        private static X509Certificate2Collection? DownloadCertificate(
             ReadOnlyMemory<byte> authorityInformationAccess,
             TimeSpan downloadTimeout)
         {


### PR DESCRIPTION
AIA fetching can be be a single certificate, or it can be a "certs-only" CMS message, as defined in RFC5280:

> or a collection of certificates in a BER or DER encoded "certs-only" CMS message as specified in [[RFC2797](https://www.rfc-editor.org/rfc/rfc2797)].

`Import` appears as-permissive as `new X509Certificate2(byte[])` for the single cert case, such as PEM. So I don't believe this is making a different scenario less permissive.

Closes #83366