### PR TITLE
Implement `FlipBit`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -945,12 +945,15 @@ namespace System.Numerics
         }
 
         /// <summary>
-        /// Toggle specific bit in the given value
+        /// Flip the bit at a specific position in a given value.
+        /// Similar in behavior to the x86 instruction BTC (Bit Test and Complement).
         /// </summary>
+        /// <param name="value">The value.</param>
+        /// <param name="index">The zero-based index of the bit to flip.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static uint ToggleBit(uint value, int bitPos)
+        internal static uint FlipBit(uint value, int index)
         {
-            return value ^ (1u << bitPos);
+            return value ^ (1u << index);
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -949,7 +949,9 @@ namespace System.Numerics
         /// Similar in behavior to the x86 instruction BTC (Bit Test and Complement).
         /// </summary>
         /// <param name="value">The value.</param>
-        /// <param name="index">The zero-based index of the bit to flip.</param>
+        /// <param name="index">The zero-based index of the bit to flip.
+        /// Any value outside the range [0..31] is treated as congruent mod 32.</param>
+        /// <returns>The new value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static uint FlipBit(uint value, int index)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -945,13 +945,12 @@ namespace System.Numerics
         }
 
         /// <summary>
-        /// Reset specific bit in the given value
+        /// Toggle specific bit in the given value
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static uint ResetBit(uint value, int bitPos)
+        internal static uint ToggleBit(uint value, int bitPos)
         {
-            // TODO: Recognize BTR on x86 and LSL+BIC on ARM
-            return value & ~(uint)(1 << bitPos);
+            return value ^ (1u << bitPos);
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -261,16 +261,16 @@ namespace System
                         do
                         {
                             // unlike IndexOf, here we use LZCNT to process matches starting from the end
-                            int bitPos = 31 - BitOperations.LeadingZeroCount(mask);
+                            int highestSetBitIndex = 31 - BitOperations.LeadingZeroCount(mask);
                             if (valueLength == 2 || // we already matched two bytes
                                 SequenceEqual(
-                                    ref Unsafe.Add(ref searchSpace, offset + bitPos),
+                                    ref Unsafe.Add(ref searchSpace, offset + highestSetBitIndex),
                                     ref value, (nuint)(uint)valueLength)) // The (nuint)-cast is necessary to pick the correct overload
                             {
-                                return bitPos + offset;
+                                return highestSetBitIndex + offset;
                             }
                             // Clear the highest set bit.
-                            mask = BitOperations.ToggleBit(mask, bitPos);
+                            mask = BitOperations.FlipBit(mask, highestSetBitIndex);
                         } while (mask != 0);
                     }
 
@@ -310,16 +310,16 @@ namespace System
                         do
                         {
                             // unlike IndexOf, here we use LZCNT to process matches starting from the end
-                            int bitPos = 31 - BitOperations.LeadingZeroCount(mask);
+                            int highestSetBitIndex = 31 - BitOperations.LeadingZeroCount(mask);
                             if (valueLength == 2 || // we already matched two bytes
                                 SequenceEqual(
-                                    ref Unsafe.Add(ref searchSpace, offset + bitPos),
+                                    ref Unsafe.Add(ref searchSpace, offset + highestSetBitIndex),
                                     ref value, (nuint)(uint)valueLength)) // The (nuint)-cast is necessary to pick the correct overload
                             {
-                                return bitPos + offset;
+                                return highestSetBitIndex + offset;
                             }
                             // Clear the highest set bit.
-                            mask = BitOperations.ToggleBit(mask, bitPos);
+                            mask = BitOperations.FlipBit(mask, highestSetBitIndex);
                         } while (mask != 0);
                     }
 

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -270,7 +270,7 @@ namespace System
                                 return bitPos + offset;
                             }
                             // Clear the highest set bit.
-                            mask = BitOperations.ResetBit(mask, bitPos);
+                            mask = BitOperations.ToggleBit(mask, bitPos);
                         } while (mask != 0);
                     }
 
@@ -319,7 +319,7 @@ namespace System
                                 return bitPos + offset;
                             }
                             // Clear the highest set bit.
-                            mask = BitOperations.ResetBit(mask, bitPos);
+                            mask = BitOperations.ToggleBit(mask, bitPos);
                         } while (mask != 0);
                     }
 


### PR DESCRIPTION
Change code in `System.SpanHelper` to use an efficient implementation of `FlipBit` instead of `ResetBit`, as the bit is known is be set. 

> ```diff
>   mov eax, 1          ; 0 LAT; 0.25 TP; 5 bytes
>   shlx eax, eax, edx  ; 1 LAT; 0.50 TP; 5 bytes
> - andn eax, eax, ecx  ; 1 LAT; 0.50 TP; 5 bytes
> + xor eax, ecx        ; 1 LAT; 0.25 TP; 2 bytes
> ```

Removed internal `ResetBit` for now since it is unused. In regard to the the TODO comment, there is an existing issue for XARCH (#81512) and the pattern is already recognized on ARM64.
