### PR TITLE
Add references to xunit.*.dll to CLRTest.Crossgen.targets

### DIFF
--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -103,6 +103,7 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
         echo -o:$__OutputFile>>$__ResponseFile
         echo -r:$CORE_ROOT/System.*.dll>>$__ResponseFile
         echo -r:$CORE_ROOT/Microsoft.*.dll>>$__ResponseFile
+        echo -r:$CORE_ROOT/xunit.*.dll>>$__ResponseFile
         echo -r:$CORE_ROOT/mscorlib.dll>>$__ResponseFile
         echo --verify-type-and-field-layout>>$__ResponseFile
         echo --method-layout:random>>$__ResponseFile
@@ -259,6 +260,7 @@ if defined RunCrossGen2 (
     )
     echo -r:!CORE_ROOT!\System.*.dll>>!__ResponseFile!
     echo -r:!CORE_ROOT!\Microsoft.*.dll>>!__ResponseFile!
+    echo -r:!CORE_ROOT!\xunit.*.dll>>!__ResponseFile!
     echo -r:!CORE_ROOT!\mscorlib.dll>>!__ResponseFile!
     echo -r:!CORE_ROOT!\netstandard.dll>>!__ResponseFile!
     echo -O>>!__ResponseFile!


### PR DESCRIPTION
This change fixes the exceptions thrown from Crossgen2 JIT interface when JIT tries to resolve tokens from xunit.assert. As a secondary effect the frequent exception throws ended up hitting the race condition

https://github.com/dotnet/runtime/issues/81884

triggering non-deterministic native CoreCLR runtime failures on arm64. I was reluctant to fix this primary issue until the native runtime bug is understood as otherwise this fix would just cause the issue to stop manifesting without being actually fixed. As the runtime bug has been fixed by now, I am fixing Crossgen2 executions to stop hitting these resolution exceptions.

Thanks

Tomas

Mitigates: #81120, #77820, #81109

/cc @dotnet/crossgen-contrib 