### PR TITLE
Switch tests for --depsfile to mocked components

### DIFF
--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/DependencyResolutionBase.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/DependencyResolutionBase.cs
@@ -12,10 +12,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
 
         public abstract class SharedTestStateBase : TestArtifact
         {
-            protected string BuiltDotnetPath { get; }
-
-            public RepoDirectoriesProvider RepoDirectories { get; }
-
             private static string GetBaseDir(string name)
             {
                 string baseDir = Path.Combine(TestArtifactsPath, name);
@@ -25,20 +21,18 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             public SharedTestStateBase()
                 : base(GetBaseDir("dependencyResolution"))
             {
-                BuiltDotnetPath = Path.Combine(TestArtifactsPath, "sharedFrameworkPublish");
-                RepoDirectories = new RepoDirectoriesProvider(builtDotnet: BuiltDotnetPath);
             }
 
             public DotNetBuilder DotNet(string name)
             {
-                return new DotNetBuilder(Location, BuiltDotnetPath, name);
+                return new DotNetBuilder(Location, RepoDirectoriesProvider.Default.BuiltDotnet, name);
             }
 
-            public TestApp CreateFrameworkReferenceApp(string fxName, string fxVersion)
+            public TestApp CreateFrameworkReferenceApp(string fxName, string fxVersion, Action<NetCoreAppBuilder> customizer = null)
             {
                 // Prepare the app mock - we're not going to run anything really, so we just need the basic files
                 TestApp testApp = CreateTestApp(Location, "FrameworkReferenceApp");
-                testApp.PopulateFrameworkDependent(fxName, fxVersion);
+                testApp.PopulateFrameworkDependent(fxName, fxVersion, customizer);
                 return testApp;
             }
 

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/DepsFile.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/DepsFile.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using Microsoft.DotNet.Cli.Build;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Xunit;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
+{
+    public class DepsFile : DependencyResolutionBase, IClassFixture<DepsFile.SharedTestState>
+    {
+        private readonly SharedTestState sharedState;
+
+        public DepsFile(SharedTestState sharedState)
+        {
+            this.sharedState = sharedState;
+        }
+
+        [Fact]
+        public void NoDepsJson()
+        {
+            // Without .deps.json, all assemblies in the app's directory are added to the TPA
+            // and the app's directory is added to the native library search path
+            TestApp app = sharedState.FrameworkReferenceApp;
+            sharedState.DotNetWithNetCoreApp.Exec(app.AppDll)
+                .EnableTracingAndCaptureOutputs()
+                .Execute()
+                .Should().Pass()
+                .And.HaveResolvedAssembly(Path.Combine(app.Location, $"{SharedTestState.DependencyName}.dll"))
+                .And.HaveResolvedNativeLibraryPath(app.Location);
+        }
+
+        [Fact]
+        public void SeparateDepsJson()
+        {
+            // For framework-dependent apps, the probing directories are:
+            // - The directory where the .deps.json is
+            // - Any framework directory
+            // Dependency should resolve relative to the .deps.json directory without checking for file existence
+            string dependencyPath = Path.Combine(Path.GetDirectoryName(sharedState.DepsJsonPath), $"{SharedTestState.DependencyName}.dll");
+            sharedState.DotNetWithNetCoreApp.Exec("exec", Constants.DepsFile.CommandLineArgument, sharedState.DepsJsonPath, sharedState.FrameworkReferenceApp.AppDll)
+                .EnableTracingAndCaptureOutputs()
+                .Execute()
+                .Should().Pass()
+                .And.HaveResolvedAssembly(dependencyPath);
+        }
+
+        public class SharedTestState : DependencyResolutionBase.SharedTestStateBase
+        {
+            public DotNetCli DotNetWithNetCoreApp { get; }
+
+            public TestApp FrameworkReferenceApp { get; }
+
+            public const string DependencyName = "Dependency";
+
+            public string DepsJsonPath { get; }
+
+            public SharedTestState()
+            {
+                DotNetWithNetCoreApp = DotNet("WithNetCoreApp")
+                    .AddMicrosoftNETCoreAppFrameworkMockCoreClr(RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion)
+                    .Build();
+
+                FrameworkReferenceApp = CreateFrameworkReferenceApp(MicrosoftNETCoreApp, RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion, b => b
+                    .WithProject(DependencyName, "1.0.0", p => p
+                        .WithAssemblyGroup(null, g => g.WithAsset($"{DependencyName}.dll"))));
+
+                var depsDir = Path.Combine(Location, "deps");
+                Directory.CreateDirectory(depsDir);
+                DepsJsonPath = Path.Combine(depsDir, Path.GetFileName(FrameworkReferenceApp.DepsJson));
+                File.Move(FrameworkReferenceApp.DepsJson, DepsJsonPath);
+            }
+        }
+    }
+}

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/PerAssemblyVersionResolutionMultipleFrameworks.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/PerAssemblyVersionResolutionMultipleFrameworks.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
                     HighWare,
                     "1.1.1",
                     runtimeConfig => runtimeConfig.WithFramework(MicrosoftNETCoreApp, "4.0.0"),
-                    path => NetCoreAppBuilder.ForNETCoreApp(HighWare, RepoDirectories.TargetRID)
+                    path => NetCoreAppBuilder.ForNETCoreApp(HighWare, RepoDirectoriesProvider.Default.TargetRID)
                         .WithProject(HighWare, "1.1.1", p => p
                             .WithAssemblyGroup(null, g => g
                             .WithAsset(TestAssemblyWithNoVersions + ".dll")

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/RidAssetResolution.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/RidAssetResolution.cs
@@ -228,7 +228,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             protected void UseFallbacksFromBuiltDotNet(NetCoreAppBuilder builder)
             {
                 IReadOnlyList<RuntimeFallbacks> fallbacks;
-                string depsJson = Path.Combine(new DotNetCli(BuiltDotnetPath).GreatestVersionSharedFxPath, $"{Constants.MicrosoftNETCoreApp}.deps.json");
+                string depsJson = Path.Combine(new DotNetCli(RepoDirectoriesProvider.Default.BuiltDotnet).GreatestVersionSharedFxPath, $"{Constants.MicrosoftNETCoreApp}.deps.json");
                 using (FileStream fileStream = File.Open(depsJson, FileMode.Open))
                 using (DependencyContextJsonReader reader = new DependencyContextJsonReader())
                 {

--- a/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
@@ -84,25 +84,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
         // https://github.com/dotnet/runtime/issues/3654
         [Fact(Skip = "The 3.0 SDK copies NuGet references to the output by default now for executable projects, so this no longer fails.")]
-        public void Muxer_Exec_activation_of_Build_Output_Portable_DLL_with_DepsJson_Local_and_RuntimeConfig_Remote_Without_AdditionalProbingPath_Fails()
-        {
-            var fixture = sharedTestState.PortableAppFixture_Built
-                .Copy();
-
-            var runtimeConfig = MoveRuntimeConfigToSubdirectory(fixture);
-
-            var dotnet = fixture.BuiltDotnet;
-            var appDll = fixture.TestProject.AppDll;
-
-            dotnet.Exec("exec", "--runtimeconfig", runtimeConfig, appDll)
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .Execute(expectedToFail: true)
-                .Should().Fail();
-        }
-
-        // https://github.com/dotnet/runtime/issues/3654
-        [Fact(Skip = "The 3.0 SDK copies NuGet references to the output by default now for executable projects, so this no longer fails.")]
         public void Muxer_Exec_activation_of_Build_Output_Portable_DLL_with_DepsJson_Local_and_RuntimeConfig_Remote_With_AdditionalProbingPath_Succeeds()
         {
             var fixture = sharedTestState.PortableAppFixture_Built
@@ -157,34 +138,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         }
 
         [Fact]
-        public void Muxer_Exec_activation_of_Build_Output_Portable_DLL_with_DepsJson_Remote_and_RuntimeConfig_Local_Succeeds()
-        {
-            var fixture = sharedTestState.PortableAppFixture_Built
-                .Copy();
-
-            // Move the .deps.json to a subdirectory, note that in this case we have to move all of the app's dependencies
-            // along with it - in this case Newtonsoft.Json.dll
-            // For framework dependent apps (dotnet build produces those) the probing directories are:
-            // - The directory where the .deps.json is
-            // - Any framework directory
-            var depsJson = MoveDepsJsonToSubdirectory(fixture);
-            File.Move(
-                Path.Combine(Path.GetDirectoryName(fixture.TestProject.AppDll), "Newtonsoft.Json.dll"),
-                Path.Combine(Path.GetDirectoryName(depsJson), "Newtonsoft.Json.dll"));
-
-            var dotnet = fixture.BuiltDotnet;
-            var appDll = fixture.TestProject.AppDll;
-
-            dotnet.Exec("exec", "--depsfile", depsJson, appDll)
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .Execute()
-                .Should().Pass()
-                .And.HaveStdOutContaining("Hello World");
-
-        }
-
-        [Fact]
         public void Muxer_activation_of_Publish_Output_Portable_DLL_with_DepsJson_and_RuntimeConfig_Local_Succeeds()
         {
             var fixture = sharedTestState.PortableAppFixture_Published
@@ -226,24 +179,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World");
-        }
-
-        [Fact]
-        public void Muxer_Exec_activation_of_Publish_Output_Portable_DLL_with_DepsJson_Remote_and_RuntimeConfig_Local_Fails()
-        {
-            var fixture = sharedTestState.PortableAppFixture_Published
-                .Copy();
-
-            var depsJson = MoveDepsJsonToSubdirectory(fixture);
-
-            var dotnet = fixture.BuiltDotnet;
-            var appDll = fixture.TestProject.AppDll;
-
-            dotnet.Exec("exec", "--depsfile", depsJson, appDll)
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .Execute(expectedToFail: true)
-                .Should().Fail();
         }
 
         [Fact]
@@ -637,25 +572,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                     .Should().Fail()
                     .And.NotHaveStdErrContaining("Showing error dialog for application");
             }
-        }
-
-        private string MoveDepsJsonToSubdirectory(TestProjectFixture testProjectFixture)
-        {
-            var subdirectory = Path.Combine(testProjectFixture.TestProject.ProjectDirectory, "d");
-            if (!Directory.Exists(subdirectory))
-            {
-                Directory.CreateDirectory(subdirectory);
-            }
-
-            var destDepsJson = Path.Combine(subdirectory, Path.GetFileName(testProjectFixture.TestProject.DepsJson));
-
-            if (File.Exists(destDepsJson))
-            {
-                File.Delete(destDepsJson);
-            }
-            File.Move(testProjectFixture.TestProject.DepsJson, destDepsJson);
-
-            return destDepsJson;
         }
 
         private string MoveRuntimeConfigToSubdirectory(TestProjectFixture testProjectFixture)

--- a/src/installer/tests/TestUtils/Constants.cs
+++ b/src/installer/tests/TestUtils/Constants.cs
@@ -43,6 +43,11 @@ namespace Microsoft.DotNet.CoreSetup.Test
             public const string CommandLineArgument = "--additional-deps";
         }
 
+        public static class DepsFile
+        {
+            public const string CommandLineArgument = "--depsfile";
+        }
+
         public static class RollForwardToPreRelease
         {
             public const string EnvironmentVariable = "DOTNET_ROLL_FORWARD_TO_PRERELEASE";


### PR DESCRIPTION
These were testing using `--depsfile` to point at a .deps.json in a different location. They would built/run an actual app with a dependency on Newtonsoft.Json and check that dependency could/could not be found. We really just care how a dependency is resolved based on the passed deps.json, so the tests can be switched to use our mock coreclr (and avoid issues like we hit in https://github.com/dotnet/runtime/pull/82599#issuecomment-1447297414)

This removes one of the pieces we have that had the host test assets using Newtonsoft.Json. I think the remaining ones are the `--additionalprobingpath` tests (should be moveable to mock coreclr) and startup hook tests (can use a different dependency or be [moved to runtime tests](https://github.com/dotnet/runtime/issues/77805)).