### PR TITLE
Specify compacting GC in ObjWriter

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -1163,7 +1163,7 @@ namespace ILCompiler.DependencyAnalysis
                     if (logger.IsVerbose)
                         logger.LogMessage($"Freeing up memory");
 
-                    GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive);
+                    GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive, blocking: true, compacting: true);
                 }
 
                 if (logger.IsVerbose)


### PR DESCRIPTION
*Shakes fist

```
[2023/03/15 03:02:43][INFO]   ILC: Memory stats: 2432028672 bytes committed, 8201363456 bytes available
[2023/03/15 03:02:43][INFO]   ILC: Freeing up memory
[2023/03/15 03:02:43][INFO]   ILC: Finalizing output to '/home/helixbot/work/BC8009E1/w/B673099E/e/artifacts/obj/BenchmarkDotNet.Autogenerated/Release/net8.0/linux-x64/native/b5205490-d417-4d0c-89a2-7ce325183843.o'...
[2023/03/15 03:02:43][INFO]   <unknown>:0: error: Undefined temporary symbol
[2023/03/15 03:02:43][INFO] EXEC : error : AggressiveGC requires setting the compacting parameter to true. (Parameter 'compacting') [/home/helixbot/work/BC8009E1/w/B673099E/e/artifacts/bin/MicroBenchmarks/Release/net8.0/b5205490-d417-4d0c-89a2-7ce325183843/BenchmarkDotNet.Autogenerated.csproj]
[2023/03/15 03:02:43][INFO]   System.ArgumentException: AggressiveGC requires setting the compacting parameter to true. (Parameter 'compacting')
[2023/03/15 03:02:43][INFO]      at System.GC.Collect(Int32, GCCollectionMode, Boolean, Boolean) + 0x152
[2023/03/15 03:02:43][INFO]      at ILCompiler.DependencyAnalysis.ObjectWriter.EmitObject(String, IReadOnlyCollection`1, NodeFactory, ObjectWritingOptions, IObjectDumper, Logger) + 0xa06
[2023/03/15 03:02:43][INFO]      at ILCompiler.Compilation.ILCompiler.ICompilation.Compile(String, ObjectDumper) + 0x32
[2023/03/15 03:02:43][INFO]      at ILCompiler.Program.Run() + 0x1aaa
```

Cc @dotnet/ilc-contrib 