### PR TITLE
[release/7.0] JIT: fix bug in cloning conditions for jagged array (#83414)

### DIFF
--- a/src/coreclr/jit/loopcloning.h
+++ b/src/coreclr/jit/loopcloning.h
@@ -625,12 +625,13 @@ struct LC_Condition
     LC_Expr    op1;
     LC_Expr    op2;
     genTreeOps oper;
+    bool       compareUnsigned;
 
 #ifdef DEBUG
     void Print()
     {
         op1.Print();
-        printf(" %s ", GenTree::OpName(oper));
+        printf(" %s%s ", GenTree::OpName(oper), compareUnsigned ? "U" : "");
         op2.Print();
     }
 #endif
@@ -646,7 +647,8 @@ struct LC_Condition
     LC_Condition()
     {
     }
-    LC_Condition(genTreeOps oper, const LC_Expr& op1, const LC_Expr& op2) : op1(op1), op2(op2), oper(oper)
+    LC_Condition(genTreeOps oper, const LC_Expr& op1, const LC_Expr& op2, bool asUnsigned = false)
+        : op1(op1), op2(op2), oper(oper), compareUnsigned(asUnsigned)
     {
     }
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_83242/Runtime_83242.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_83242/Runtime_83242.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class Runtime_83242
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Map(int i)
+    {
+        if (i == 5) return -1;
+        return i;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void Setup(int[][] a)
+    {
+        for (int i = 0; i < a.Length; i++)
+        {
+            a[i] = new int[5];
+
+            for (int j = 0; j < 5; j++)
+            {
+                a[i][j] = j;
+            }
+        }
+    }
+
+    public static int Main()
+    {
+        int[][] a = new int[11][];
+        int sum = 0;
+        Setup(a);
+        
+        for (int i = 0; i < a.Length; i++)
+        {
+            int ii = Map(i);
+
+            // Need to ensure ii >= 0 is in the cloning
+            // conditions for the following loop
+            
+            for (int j = 0; j < 5; j++)
+            {
+                if (ii >= 0)
+                {
+                    sum += a[ii][j];
+                }
+            }
+        }
+
+        Console.WriteLine($"sum is {sum}\n");
+        return sum;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_83242/Runtime_83242.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_83242/Runtime_83242.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Backport of #83414 to release/7.0, fixes #83242

When checking that an inner array access is in bounds, we must ensure any outer access is fully in bounds too. We were checking that `idx < array.Len` but not that `idx >= 0`.

Use an unsigned compare for this check so we can do both sides with a single instruction.

Fixes #83242.

## Customer Impact

Customer reported access violation when updating their app to run on .NET 7. Because of this bug they are unable to update.

When the JIT clones a loop it has to create a series of checks to decide if it executing the cloned version will be safe, since the clone will bypass bounds checks and the like -- the idea being to get all these checks out of the way before getting into the loop, so there is no need to repeatedly do them inside the loop .
 
These safety checks are ordered because some checks depend on others. For instance, we have to null check a possible array deference before validating the array length is suitable. In this case we were missing one check -- that the array index might be negative, and a subsequent array length check was dependent on that check, so we caused the customer app to AV in the code the added by the JIT to decide which version of the loop to run.
 
In .NET 6 the JIT included that missing check and a whole bunch of other redundant checks. We made a change during .NET 7 to prune away these redundant checks, but we did not realize one of them was not fully redundant and was safeguarding a later check.
 
As far as I know this bug will only surface if the method has a loop over the final dimension of a jagged array. 

For example, the JIT may try and clone the following loop to produce a version with no bounds checks on `a[ii][j]`. 

```C#
for (int j = 0; j < 5; j++)
{
    if (ii >= 0)
    {
        sum += a[ii][j];
    }
}
```
To safely invoke this version the jit must do 5 checks: `(a != null) && (ii >=0) && (ii < a.Length) && (a[ii] != null) && (4 < a[ii].Length)`.  Note some of the latter checks are dependent on the earlier ones.

The bug fixed here is that in current .NET 7 codegen the `(ii >= 0)` check is missing from the above, so the later check of `a[ii]` may cause an out of bounds access, leading to an AV or other unpredictable behavior.

The fix is to logically add in that missing check; however, it turns out there is a well-known way to leverage unsigned compares to check both `ii >= 0` (which we were missing) and `ii < a.Length` (which we were doing) with a single compare, so my fix just modifies the existing `ii < a.Length` check to do an unsigned comparison.

## Testing

Verified the fix on a sample app provided by the customer. From that was able to distill a very simple repro which I've added as a new test case.

## Risk

This is a regression introduced in .NET 7.

Risk is low. Requires a particular pattern of jagged array access in a loop. Small (~20) number of impacted methods seen in SPMI testing; typical change in codegen is to use an unsigned compare rather than a signed compare, so fix is quite surgical.