### PR TITLE
Fix BeginReceiveMessageFromV4BoundToSpecificV6_NotReceived

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -1432,7 +1432,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.Linux | TestPlatforms.Android | TestPlatforms.OSX | TestPlatforms.MacCatalyst | TestPlatforms.iOS | TestPlatforms.tvOS, "Expected behavior is different on Apple platforms, Linux and Android")]
+        [PlatformSpecific(TestPlatforms.Windows)] // Expected behavior is different on Unix
         public void BeginReceiveMessageFromV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -1449,8 +1449,8 @@ namespace System.Net.Sockets.Tests
         //       an acceptable difference due to the extra state that would otherwise
         //       be necessary to emulate the Winsock behavior.
         [Fact]
-        [PlatformSpecific(TestPlatforms.Linux | TestPlatforms.Android)]  // Read the comment above
-        public void BeginReceiveMessageFromV4BoundToSpecificV6_NotReceived_Linux()
+        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Read the comment above
+        public void BeginReceiveMessageFromV4BoundToSpecificV6_NotReceived_Unix()
         {
             AssertExtensions.Throws<ArgumentException>("remoteEP", () =>
             {

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -1432,8 +1432,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.Linux | TestPlatforms.OSX | TestPlatforms.MacCatalyst | TestPlatforms.iOS | TestPlatforms.tvOS, "Expected behavior is different on Apple platforms and Linux")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/81946", TestPlatforms.Android)]
+        [SkipOnPlatform(TestPlatforms.Linux | TestPlatforms.Android | TestPlatforms.OSX | TestPlatforms.MacCatalyst | TestPlatforms.iOS | TestPlatforms.tvOS, "Expected behavior is different on Apple platforms, Linux and Android")]
         public void BeginReceiveMessageFromV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -1450,7 +1449,7 @@ namespace System.Net.Sockets.Tests
         //       an acceptable difference due to the extra state that would otherwise
         //       be necessary to emulate the Winsock behavior.
         [Fact]
-        [PlatformSpecific(TestPlatforms.Linux)]  // Read the comment above
+        [PlatformSpecific(TestPlatforms.Linux | TestPlatforms.Android)]  // Read the comment above
         public void BeginReceiveMessageFromV4BoundToSpecificV6_NotReceived_Linux()
         {
             AssertExtensions.Throws<ArgumentException>("remoteEP", () =>

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -1432,7 +1432,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)] // Expected behavior is different on Unix
+        [PlatformSpecific(TestPlatforms.Windows)] // // Expected behavior is different on Apple platforms and Linux
         public void BeginReceiveMessageFromV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -1605,7 +1605,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.Windows, "Expected behavior is different on Apple platforms and Linux")]
+        [PlatformSpecific(TestPlatforms.Windows)] // Expected behavior is different on Apple platforms and Linux
         public void ReceiveMessageFromAsyncV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -1449,8 +1449,8 @@ namespace System.Net.Sockets.Tests
         //       an acceptable difference due to the extra state that would otherwise
         //       be necessary to emulate the Winsock behavior.
         [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]  // Read the comment above
-        public void BeginReceiveMessageFromV4BoundToSpecificV6_NotReceived_Unix()
+        [PlatformSpecific(TestPlatforms.Linux | TestPlatforms.Android)] // Read the comment above
+        public void BeginReceiveMessageFromV4BoundToSpecificV6_NotReceived_Linux()
         {
             AssertExtensions.Throws<ArgumentException>("remoteEP", () =>
             {
@@ -1605,8 +1605,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.Linux | TestPlatforms.OSX | TestPlatforms.MacCatalyst | TestPlatforms.iOS | TestPlatforms.tvOS, "Expected behavior is different on Apple platforms and Linux")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/81946", TestPlatforms.Android)]
+        [SkipOnPlatform(TestPlatforms.Windows, "Expected behavior is different on Apple platforms and Linux")]
         public void ReceiveMessageFromAsyncV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -1623,7 +1622,7 @@ namespace System.Net.Sockets.Tests
         //       an acceptable difference due to the extra state that would otherwise
         //       be necessary to emulate the Winsock behavior.
         [Fact]
-        [PlatformSpecific(TestPlatforms.Linux)]  // Read the comment above
+        [PlatformSpecific(TestPlatforms.Linux | TestPlatforms.Android)]  // Read the comment above
         public void ReceiveMessageFromAsyncV4BoundToSpecificV6_NotReceived_Linux()
         {
             AssertExtensions.Throws<ArgumentException>("remoteEP", () =>

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -1432,7 +1432,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)] // // Expected behavior is different on Apple platforms and Linux
+        [PlatformSpecific(TestPlatforms.Windows)] // Expected behavior is different on Apple platforms and Linux
         public void BeginReceiveMessageFromV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>


### PR DESCRIPTION
This should fix #81946 for Android.