### PR TITLE
Change LSRA to more efficiently initialize the availableRegs array

### DIFF
--- a/src/coreclr/jit/_typeinfo.h
+++ b/src/coreclr/jit/_typeinfo.h
@@ -40,7 +40,7 @@ namespace
 {
 #endif //  _MSC_VER
 const ti_types g_jit_types_map[] = {
-#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf) verType,
+#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, lsra, tf) verType,
 #include "typelist.h"
 #undef DEF_TP
 };

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -114,25 +114,25 @@ inline bool _our_GetThreadCycles(unsigned __int64* cycleOut)
 #endif // which host OS
 
 const BYTE genTypeSizes[] = {
-#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf) sz,
+#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, lsra, tf) sz,
 #include "typelist.h"
 #undef DEF_TP
 };
 
 const BYTE genTypeAlignments[] = {
-#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf) al,
+#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, lsra, tf) al,
 #include "typelist.h"
 #undef DEF_TP
 };
 
 const BYTE genTypeStSzs[] = {
-#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf) st,
+#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, lsra, tf) st,
 #include "typelist.h"
 #undef DEF_TP
 };
 
 const BYTE genActualTypes[] = {
-#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf) jitType,
+#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, lsra, tf) jitType,
 #include "typelist.h"
 #undef DEF_TP
 };

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -507,13 +507,13 @@ void emitterStats(FILE* fout)
 /*****************************************************************************/
 
 const unsigned short emitTypeSizes[] = {
-#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf) sze,
+#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, lsra, tf) sze,
 #include "typelist.h"
 #undef DEF_TP
 };
 
 const unsigned short emitTypeActSz[] = {
-#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf) asze,
+#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, lsra, tf) asze,
 #include "typelist.h"
 #undef DEF_TP
 };

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -731,7 +731,8 @@ LinearScan::LinearScan(Compiler* theCompiler)
     // Initialize the availableRegs to use for each TYP_*
     CLANG_FORMAT_COMMENT_ANCHOR;
 
-#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, lsra, tf) availableRegs[static_cast<int>(TYP_##tn)] = &lsra;
+#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, lsra, tf)                                              \
+    availableRegs[static_cast<int>(TYP_##tn)] = &lsra;
 #include "typelist.h"
 #undef DEF_TP
 

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -728,34 +728,12 @@ LinearScan::LinearScan(Compiler* theCompiler)
     }
 #endif
 
-    for (unsigned int i = 0; i < TYP_COUNT; i++)
-    {
-        var_types thisType = (var_types)genActualTypes[i];
-        if (thisType == TYP_FLOAT)
-        {
-            availableRegs[i] = &availableFloatRegs;
-        }
-        else if (thisType == TYP_DOUBLE)
-        {
-            availableRegs[i] = &availableDoubleRegs;
-        }
-#ifdef FEATURE_SIMD
-        else if (varTypeIsSIMD(thisType))
-        {
-            availableRegs[i] = &availableDoubleRegs;
-        }
-#ifdef TARGET_XARCH
-        else if (thisType == TYP_MASK)
-        {
-            availableRegs[i] = &availableMaskRegs;
-        }
-#endif // TARGET_XARCH
-#endif // FEATURE_SIMD
-        else
-        {
-            availableRegs[i] = &availableIntRegs;
-        }
-    }
+    // Initialize the availableRegs to use for each TYP_*
+    CLANG_FORMAT_COMMENT_ANCHOR;
+
+#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, lsra, tf) availableRegs[static_cast<int>(TYP_##tn)] = &lsra;
+#include "typelist.h"
+#undef DEF_TP
 
     compiler->rpFrameType           = FT_NOT_SET;
     compiler->rpMustCreateEBPCalled = false;

--- a/src/coreclr/jit/typelist.h
+++ b/src/coreclr/jit/typelist.h
@@ -15,56 +15,57 @@
 #define VTF_I64 0
 #endif
 
-/*  tn  - TYP_name
-    nm  - name string
+/*  tn      - TYP_name
+    nm      - name string
     jitType - The jit compresses types that are 'equivalent', this is the jit type genActualType()
     verType - Used for type checking
-    sz  - size in bytes (genTypeSize(t))
-    sze - size in bytes for the emitter (GC types are encoded) (emitTypeSize(t))
-    asze- size in bytes for the emitter (GC types are encoded) (emitActualTypeSize(t))
-    st  - stack slots (slots are sizeof(int) bytes) (genTypeStSzs())
-    al  - alignment
-    tf  - flags
+    sz      - size in bytes (genTypeSize(t))
+    sze     - size in bytes for the emitter (GC types are encoded) (emitTypeSize(t))
+    asze    - size in bytes for the emitter (GC types are encoded) (emitActualTypeSize(t))
+    st      - stack slots (slots are sizeof(int) bytes) (genTypeStSzs())
+    al      - alignment
+    lsra    - lsra registers to use
+    tf      - flags
 
-DEF_TP(tn      ,nm        , jitType,     verType, sz,sze,asze, st,al, tf     )
+DEF_TP(tn      ,nm        , jitType,     verType, sz,sze,asze, st,al, lsra,                tf     )
 */
 
 // clang-format off
-DEF_TP(UNDEF   ,"<UNDEF>" , TYP_UNDEF,   TI_ERROR, 0,  0,  0,   0, 0, VTF_ANY)
-DEF_TP(VOID    ,"void"    , TYP_VOID,    TI_ERROR, 0,  0,  0,   0, 0, VTF_ANY)
+DEF_TP(UNDEF   ,"<UNDEF>" , TYP_UNDEF,   TI_ERROR, 0,  0,  0,   0, 0, availableIntRegs,    VTF_ANY)
+DEF_TP(VOID    ,"void"    , TYP_VOID,    TI_ERROR, 0,  0,  0,   0, 0, availableIntRegs,    VTF_ANY)
 
-DEF_TP(BOOL    ,"bool"    , TYP_INT,     TI_BYTE,  1,  1,  4,   1, 1, VTF_INT|VTF_UNS)
-DEF_TP(BYTE    ,"byte"    , TYP_INT,     TI_BYTE,  1,  1,  4,   1, 1, VTF_INT)
-DEF_TP(UBYTE   ,"ubyte"   , TYP_INT,     TI_BYTE,  1,  1,  4,   1, 1, VTF_INT|VTF_UNS)
+DEF_TP(BOOL    ,"bool"    , TYP_INT,     TI_BYTE,  1,  1,  4,   1, 1, availableIntRegs,    VTF_INT|VTF_UNS)
+DEF_TP(BYTE    ,"byte"    , TYP_INT,     TI_BYTE,  1,  1,  4,   1, 1, availableIntRegs,    VTF_INT)
+DEF_TP(UBYTE   ,"ubyte"   , TYP_INT,     TI_BYTE,  1,  1,  4,   1, 1, availableIntRegs,    VTF_INT|VTF_UNS)
 
-DEF_TP(SHORT   ,"short"   , TYP_INT,     TI_SHORT, 2,  2,  4,   1, 2, VTF_INT)
-DEF_TP(USHORT  ,"ushort"  , TYP_INT,     TI_SHORT, 2,  2,  4,   1, 2, VTF_INT|VTF_UNS)
+DEF_TP(SHORT   ,"short"   , TYP_INT,     TI_SHORT, 2,  2,  4,   1, 2, availableIntRegs,    VTF_INT)
+DEF_TP(USHORT  ,"ushort"  , TYP_INT,     TI_SHORT, 2,  2,  4,   1, 2, availableIntRegs,    VTF_INT|VTF_UNS)
 
-DEF_TP(INT     ,"int"     , TYP_INT,     TI_INT,   4,  4,  4,   1, 4, VTF_INT|VTF_I32)
-DEF_TP(UINT    ,"uint"    , TYP_INT,     TI_INT,   4,  4,  4,   1, 4, VTF_INT|VTF_UNS|VTF_I32) // Only used in GT_CAST nodes
+DEF_TP(INT     ,"int"     , TYP_INT,     TI_INT,   4,  4,  4,   1, 4, availableIntRegs,    VTF_INT|VTF_I32)
+DEF_TP(UINT    ,"uint"    , TYP_INT,     TI_INT,   4,  4,  4,   1, 4, availableIntRegs,    VTF_INT|VTF_UNS|VTF_I32) // Only used in GT_CAST nodes
 
-DEF_TP(LONG    ,"long"    , TYP_LONG,    TI_LONG,  8,EPS,EPS,   2, 8, VTF_INT|VTF_I64)
-DEF_TP(ULONG   ,"ulong"   , TYP_LONG,    TI_LONG,  8,EPS,EPS,   2, 8, VTF_INT|VTF_UNS|VTF_I64) // Only used in GT_CAST nodes
+DEF_TP(LONG    ,"long"    , TYP_LONG,    TI_LONG,  8,EPS,EPS,   2, 8, availableIntRegs,    VTF_INT|VTF_I64)
+DEF_TP(ULONG   ,"ulong"   , TYP_LONG,    TI_LONG,  8,EPS,EPS,   2, 8, availableIntRegs,    VTF_INT|VTF_UNS|VTF_I64) // Only used in GT_CAST nodes
 
-DEF_TP(FLOAT   ,"float"   , TYP_FLOAT,   TI_FLOAT, 4,  4,  4,   1, 4, VTF_FLT)
-DEF_TP(DOUBLE  ,"double"  , TYP_DOUBLE,  TI_DOUBLE,8,  8,  8,   2, 8, VTF_FLT)
+DEF_TP(FLOAT   ,"float"   , TYP_FLOAT,   TI_FLOAT, 4,  4,  4,   1, 4, availableFloatRegs,  VTF_FLT)
+DEF_TP(DOUBLE  ,"double"  , TYP_DOUBLE,  TI_DOUBLE,8,  8,  8,   2, 8, availableDoubleRegs, VTF_FLT)
 
-DEF_TP(REF     ,"ref"     , TYP_REF,     TI_REF,  PS,GCS,GCS, PST,PS, VTF_ANY|VTF_GCR|VTF_I)
-DEF_TP(BYREF   ,"byref"   , TYP_BYREF,   TI_ERROR,PS,BRS,BRS, PST,PS, VTF_ANY|VTF_BYR|VTF_I)
-DEF_TP(STRUCT  ,"struct"  , TYP_STRUCT,  TI_STRUCT,0,  0,  0,   1, 4, VTF_S)
+DEF_TP(REF     ,"ref"     , TYP_REF,     TI_REF,  PS,GCS,GCS, PST,PS, availableIntRegs,    VTF_ANY|VTF_GCR|VTF_I)
+DEF_TP(BYREF   ,"byref"   , TYP_BYREF,   TI_ERROR,PS,BRS,BRS, PST,PS, availableIntRegs,    VTF_ANY|VTF_BYR|VTF_I)
+DEF_TP(STRUCT  ,"struct"  , TYP_STRUCT,  TI_STRUCT,0,  0,  0,   1, 4, availableIntRegs,    VTF_S)
 
 #ifdef FEATURE_SIMD
-DEF_TP(SIMD8    ,"simd8"  , TYP_SIMD8,   TI_STRUCT, 8, 8,  8,   2, 8, VTF_S|VTF_VEC)
-DEF_TP(SIMD12   ,"simd12" , TYP_SIMD12,  TI_STRUCT,12,16, 16,   4,16, VTF_S|VTF_VEC)
-DEF_TP(SIMD16   ,"simd16" , TYP_SIMD16,  TI_STRUCT,16,16, 16,   4,16, VTF_S|VTF_VEC)
+DEF_TP(SIMD8    ,"simd8"  , TYP_SIMD8,   TI_STRUCT, 8, 8,  8,   2, 8, availableDoubleRegs, VTF_S|VTF_VEC)
+DEF_TP(SIMD12   ,"simd12" , TYP_SIMD12,  TI_STRUCT,12,16, 16,   4,16, availableDoubleRegs, VTF_S|VTF_VEC)
+DEF_TP(SIMD16   ,"simd16" , TYP_SIMD16,  TI_STRUCT,16,16, 16,   4,16, availableDoubleRegs, VTF_S|VTF_VEC)
 #if defined(TARGET_XARCH)
-DEF_TP(SIMD32   ,"simd32" , TYP_SIMD32,  TI_STRUCT,32,32, 32,   8,16, VTF_S|VTF_VEC)
-DEF_TP(SIMD64   ,"simd64" , TYP_SIMD64,  TI_STRUCT,64,64, 64,  16,16, VTF_S|VTF_VEC)
-DEF_TP(MASK     ,"mask"   , TYP_MASK,    TI_STRUCT, 8, 8,  8,   2, 8, VTF_ANY)
+DEF_TP(SIMD32   ,"simd32" , TYP_SIMD32,  TI_STRUCT,32,32, 32,   8,16, availableDoubleRegs, VTF_S|VTF_VEC)
+DEF_TP(SIMD64   ,"simd64" , TYP_SIMD64,  TI_STRUCT,64,64, 64,  16,16, availableDoubleRegs, VTF_S|VTF_VEC)
+DEF_TP(MASK     ,"mask"   , TYP_MASK,    TI_STRUCT, 8, 8,  8,   2, 8, availableMaskRegs,   VTF_ANY)
 #endif // TARGET_XARCH
 #endif // FEATURE_SIMD
 
-DEF_TP(UNKNOWN ,"unknown" ,TYP_UNKNOWN,  TI_ERROR, 0,  0,  0,   0, 0, VTF_ANY)
+DEF_TP(UNKNOWN ,"unknown" ,TYP_UNKNOWN,  TI_ERROR, 0,  0,  0,   0, 0, availableIntRegs,    VTF_ANY)
 // clang-format on
 
 #undef GCS

--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -79,7 +79,7 @@ const signed char       opcodeSizes[] =
 // clang-format on
 
 const BYTE varTypeClassification[] = {
-#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf) tf,
+#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, lsra, tf) tf,
 #include "typelist.h"
 #undef DEF_TP
 };
@@ -105,7 +105,7 @@ extern const BYTE opcodeArgKinds[] = {
 const char* varTypeName(var_types vt)
 {
     static const char* const varTypeNames[] = {
-#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf) nm,
+#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, lsra, tf) nm,
 #include "typelist.h"
 #undef DEF_TP
     };

--- a/src/coreclr/jit/vartypesdef.h
+++ b/src/coreclr/jit/vartypesdef.h
@@ -8,7 +8,7 @@
 
 enum var_types : BYTE
 {
-#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf) TYP_##tn,
+#define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, lsra, tf) TYP_##tn,
 #include "typelist.h"
 #undef DEF_TP
     TYP_COUNT


### PR DESCRIPTION
This was noticed in https://github.com/dotnet/runtime/pull/82731#discussion_r1129794470 and should provide a minor improvement since it will just linearly initialize the data without needing to do any checks.