### PR TITLE
use ROSpan in SslStreamCertificateContext

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -262,7 +262,7 @@ internal static partial class Interop
             }
         }
 
-        internal static bool AddExtraChainCertificates(SafeSslHandle ssl, X509Certificate2[] chain)
+        internal static bool AddExtraChainCertificates(SafeSslHandle ssl, ReadOnlySpan<X509Certificate2> chain)
         {
             // send pre-computed list of intermediates.
             for (int i = 0; i < chain.Length; i++)

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
@@ -35,7 +35,7 @@ internal static partial class Interop
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetCaching")]
         internal static unsafe partial int SslCtxSetCaching(SafeSslContextHandle ctx, int mode, int cacheSize, int contextIdLength, Span<byte> contextId, delegate* unmanaged<IntPtr, IntPtr, int> neewSessionCallback, delegate* unmanaged<IntPtr, IntPtr, void> removeSessionCallback);
 
-        internal static bool AddExtraChainCertificates(SafeSslContextHandle ctx, X509Certificate2[] chain)
+        internal static bool AddExtraChainCertificates(SafeSslContextHandle ctx, ReadOnlySpan<X509Certificate2> chain)
         {
             // send pre-computed list of intermediates.
             for (int i = 0; i < chain.Length; i++)

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
@@ -69,7 +69,7 @@ internal static class MsQuicConfiguration
             }
         }
 
-        return Create(options, flags, certificate, intermediates: null, authenticationOptions.ApplicationProtocols, authenticationOptions.CipherSuitesPolicy, authenticationOptions.EncryptionPolicy);
+        return Create(options, flags, certificate, ReadOnlySpan<X509Certificate2>.Empty, authenticationOptions.ApplicationProtocols, authenticationOptions.CipherSuitesPolicy, authenticationOptions.EncryptionPolicy);
     }
 
     public static MsQuicSafeHandle Create(QuicServerConnectionOptions options, string? targetHost)
@@ -85,7 +85,7 @@ internal static class MsQuicConfiguration
         }
 
         X509Certificate? certificate = null;
-        ReadOnlySpan<X509Certificate2> intermediates = ReadOnlySpan<X509Certificate2>.Empty;
+        ReadOnlySpan<X509Certificate2> intermediates = default;
         if (authenticationOptions.ServerCertificateContext is not null)
         {
             certificate = authenticationOptions.ServerCertificateContext.Certificate;
@@ -175,9 +175,9 @@ internal static class MsQuicConfiguration
                 {
                     X509Certificate2Collection collection = new X509Certificate2Collection();
                     collection.Add(certificate);
-                    foreach (X509Certificate2 ca in intermediates)
+                    foreach (X509Certificate2 intermediate in intermediates)
                     {
-                        collection.Add(ca);
+                        collection.Add(intermediate);
                     }
                     certificateData = collection.Export(X509ContentType.Pkcs12)!;
                 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
@@ -85,7 +85,7 @@ internal static class MsQuicConfiguration
         }
 
         X509Certificate? certificate = null;
-        X509Certificate[]? intermediates = null;
+        ReadOnlySpan<X509Certificate2> intermediates = ReadOnlySpan<X509Certificate2>.Empty;
         if (authenticationOptions.ServerCertificateContext is not null)
         {
             certificate = authenticationOptions.ServerCertificateContext.Certificate;
@@ -101,7 +101,7 @@ internal static class MsQuicConfiguration
         return Create(options, flags, certificate, intermediates, authenticationOptions.ApplicationProtocols, authenticationOptions.CipherSuitesPolicy, authenticationOptions.EncryptionPolicy);
     }
 
-    private static unsafe MsQuicSafeHandle Create(QuicConnectionOptions options, QUIC_CREDENTIAL_FLAGS flags, X509Certificate? certificate, X509Certificate[]? intermediates, List<SslApplicationProtocol>? alpnProtocols, CipherSuitesPolicy? cipherSuitesPolicy, EncryptionPolicy encryptionPolicy)
+    private static unsafe MsQuicSafeHandle Create(QuicConnectionOptions options, QUIC_CREDENTIAL_FLAGS flags, X509Certificate? certificate, ReadOnlySpan<X509Certificate2> intermediates, List<SslApplicationProtocol>? alpnProtocols, CipherSuitesPolicy? cipherSuitesPolicy, EncryptionPolicy encryptionPolicy)
     {
         // Validate options and SSL parameters.
         if (alpnProtocols is null || alpnProtocols.Count <= 0)
@@ -171,11 +171,14 @@ internal static class MsQuicConfiguration
 
                 byte[] certificateData;
 
-                if (intermediates?.Length > 0)
+                if (intermediates.Length > 0)
                 {
                     X509Certificate2Collection collection = new X509Certificate2Collection();
                     collection.Add(certificate);
-                    collection.AddRange(intermediates);
+                    foreach (X509Certificate2 ca in intermediates)
+                    {
+                        collection.Add(ca);
+                    }
                     certificateData = collection.Export(X509ContentType.Pkcs12)!;
                 }
                 else

--- a/src/libraries/System.Net.Security/src/CompatibilitySuppressions.xml
+++ b/src/libraries/System.Net.Security/src/CompatibilitySuppressions.xml
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
@@ -8,13 +9,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>F:System.Net.Security.SslStreamCertificateContext.IntermediateCertificates</Target>
+    <Target>M:System.Net.Security.SslClientHelloInfo.#ctor(System.String,System.Security.Authentication.SslProtocols)</Target>
     <Left>ref/net8.0/System.Net.Security.dll</Left>
     <Right>runtimes/android/lib/net8.0/System.Net.Security.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:System.Net.Security.SslClientHelloInfo.#ctor(System.String,System.Security.Authentication.SslProtocols)</Target>
+    <Target>M:System.Net.Security.SslStreamCertificateContext.get_IntermediateCertificates</Target>
     <Left>ref/net8.0/System.Net.Security.dll</Left>
     <Right>runtimes/android/lib/net8.0/System.Net.Security.dll</Right>
   </Suppression>
@@ -26,13 +27,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>F:System.Net.Security.SslStreamCertificateContext.IntermediateCertificates</Target>
+    <Target>M:System.Net.Security.SslClientHelloInfo.#ctor(System.String,System.Security.Authentication.SslProtocols)</Target>
     <Left>ref/net8.0/System.Net.Security.dll</Left>
     <Right>runtimes/freebsd/lib/net8.0/System.Net.Security.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:System.Net.Security.SslClientHelloInfo.#ctor(System.String,System.Security.Authentication.SslProtocols)</Target>
+    <Target>M:System.Net.Security.SslStreamCertificateContext.get_IntermediateCertificates</Target>
     <Left>ref/net8.0/System.Net.Security.dll</Left>
     <Right>runtimes/freebsd/lib/net8.0/System.Net.Security.dll</Right>
   </Suppression>
@@ -44,13 +45,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>F:System.Net.Security.SslStreamCertificateContext.IntermediateCertificates</Target>
+    <Target>M:System.Net.Security.SslClientHelloInfo.#ctor(System.String,System.Security.Authentication.SslProtocols)</Target>
     <Left>ref/net8.0/System.Net.Security.dll</Left>
     <Right>runtimes/ios/lib/net8.0/System.Net.Security.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:System.Net.Security.SslClientHelloInfo.#ctor(System.String,System.Security.Authentication.SslProtocols)</Target>
+    <Target>M:System.Net.Security.SslStreamCertificateContext.get_IntermediateCertificates</Target>
     <Left>ref/net8.0/System.Net.Security.dll</Left>
     <Right>runtimes/ios/lib/net8.0/System.Net.Security.dll</Right>
   </Suppression>
@@ -62,13 +63,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>F:System.Net.Security.SslStreamCertificateContext.IntermediateCertificates</Target>
+    <Target>M:System.Net.Security.SslClientHelloInfo.#ctor(System.String,System.Security.Authentication.SslProtocols)</Target>
     <Left>ref/net8.0/System.Net.Security.dll</Left>
     <Right>runtimes/linux/lib/net8.0/System.Net.Security.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:System.Net.Security.SslClientHelloInfo.#ctor(System.String,System.Security.Authentication.SslProtocols)</Target>
+    <Target>M:System.Net.Security.SslStreamCertificateContext.get_IntermediateCertificates</Target>
     <Left>ref/net8.0/System.Net.Security.dll</Left>
     <Right>runtimes/linux/lib/net8.0/System.Net.Security.dll</Right>
   </Suppression>
@@ -80,13 +81,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>F:System.Net.Security.SslStreamCertificateContext.IntermediateCertificates</Target>
+    <Target>M:System.Net.Security.SslClientHelloInfo.#ctor(System.String,System.Security.Authentication.SslProtocols)</Target>
     <Left>ref/net8.0/System.Net.Security.dll</Left>
     <Right>runtimes/osx/lib/net8.0/System.Net.Security.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:System.Net.Security.SslClientHelloInfo.#ctor(System.String,System.Security.Authentication.SslProtocols)</Target>
+    <Target>M:System.Net.Security.SslStreamCertificateContext.get_IntermediateCertificates</Target>
     <Left>ref/net8.0/System.Net.Security.dll</Left>
     <Right>runtimes/osx/lib/net8.0/System.Net.Security.dll</Right>
   </Suppression>
@@ -98,13 +99,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>F:System.Net.Security.SslStreamCertificateContext.IntermediateCertificates</Target>
+    <Target>M:System.Net.Security.SslClientHelloInfo.#ctor(System.String,System.Security.Authentication.SslProtocols)</Target>
     <Left>ref/net8.0/System.Net.Security.dll</Left>
     <Right>runtimes/tvos/lib/net8.0/System.Net.Security.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:System.Net.Security.SslClientHelloInfo.#ctor(System.String,System.Security.Authentication.SslProtocols)</Target>
+    <Target>M:System.Net.Security.SslStreamCertificateContext.get_IntermediateCertificates</Target>
     <Left>ref/net8.0/System.Net.Security.dll</Left>
     <Right>runtimes/tvos/lib/net8.0/System.Net.Security.dll</Right>
   </Suppression>
@@ -116,13 +117,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>F:System.Net.Security.SslStreamCertificateContext.IntermediateCertificates</Target>
+    <Target>M:System.Net.Security.SslClientHelloInfo.#ctor(System.String,System.Security.Authentication.SslProtocols)</Target>
     <Left>ref/net8.0/System.Net.Security.dll</Left>
     <Right>runtimes/win/lib/net8.0/System.Net.Security.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:System.Net.Security.SslClientHelloInfo.#ctor(System.String,System.Security.Authentication.SslProtocols)</Target>
+    <Target>M:System.Net.Security.SslStreamCertificateContext.get_IntermediateCertificates</Target>
     <Left>ref/net8.0/System.Net.Security.dll</Left>
     <Right>runtimes/win/lib/net8.0/System.Net.Security.dll</Right>
   </Suppression>

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
@@ -727,11 +727,7 @@ namespace System.Net.Security
                     // effectively disable caching as it would lead to creating new credentials for each connection. We attempt to recover by creating
                     // a temporary certificate context (which builds a new chain with hopefully more recent chain).
                     //
-                    certificateContext = SslStreamCertificateContext.Create(
-                        certificateContext.Certificate,
-                        new X509Certificate2Collection(certificateContext.IntermediateCertificates),
-                        trust: certificateContext.Trust);
-
+                    certificateContext = certificateContext.Duplicate();
                     cred._expiry = GetExpiryTimestamp(certificateContext);
                 }
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Android.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Android.cs
@@ -11,8 +11,8 @@ namespace System.Net.Security
 
         private SslStreamCertificateContext(X509Certificate2 target, X509Certificate2[] intermediates, SslCertificateTrust? trust)
         {
+            _intermediateCertificates = intermediates;
             Certificate = target;
-            IntermediateCertificates = intermediates;
             Trust = trust;
         }
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
@@ -31,8 +31,8 @@ namespace System.Net.Security
 
         private SslStreamCertificateContext(X509Certificate2 target, X509Certificate2[] intermediates, SslCertificateTrust? trust)
         {
+            _intermediateCertificates = intermediates;
             Certificate = target;
-            IntermediateCertificates = intermediates;
             Trust = trust;
             SslContexts = new ConcurrentDictionary<SslProtocols, SafeSslContextHandle>();
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.OSX.cs
@@ -12,8 +12,8 @@ namespace System.Net.Security
 
         private SslStreamCertificateContext(X509Certificate2 target, X509Certificate2[] intermediates, SslCertificateTrust? trust)
         {
+            _intermediateCertificates = intermediates;
             Certificate = target;
-            IntermediateCertificates = intermediates;
             Trust = trust;
         }
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Windows.cs
@@ -101,8 +101,8 @@ namespace System.Net.Security
                 }
             }
 
+            _intermediateCertificates = intermediates;
             Certificate = target;
-            IntermediateCertificates = intermediates;
             Trust = trust;
         }
     }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.cs
@@ -9,7 +9,9 @@ namespace System.Net.Security
     public partial class SslStreamCertificateContext
     {
         public readonly X509Certificate2 Certificate;
-        public readonly X509Certificate2[] IntermediateCertificates;
+        public ReadOnlySpan<X509Certificate2> IntermediateCertificates => _intermediateCertificates;
+
+        private readonly X509Certificate2[] _intermediateCertificates;
         internal readonly SslCertificateTrust? Trust;
 
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -131,7 +133,7 @@ namespace System.Net.Security
 
         internal SslStreamCertificateContext Duplicate()
         {
-            return new SslStreamCertificateContext(new X509Certificate2(Certificate), IntermediateCertificates, Trust);
+            return new SslStreamCertificateContext(new X509Certificate2(Certificate), _intermediateCertificates, Trust);
         }
     }
 }


### PR DESCRIPTION
contributes to #67552 and #72226.
If we want to make it public, we should probably make the intermediate certificates immutable.
This change does it to make sure it would work OK.
Since the API is not really public I would probably move forward as preparation. 
