### PR TITLE
Slightly improve struct zeroing & copying

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -3349,31 +3349,30 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
                                ? YMM_REGSIZE_BYTES
                                : XMM_REGSIZE_BYTES;
 
-        while (size >= regSize)
+        do
         {
-            for (; size >= regSize; size -= regSize, srcOffset += regSize, dstOffset += regSize)
+            if (srcLclNum != BAD_VAR_NUM)
             {
-                if (srcLclNum != BAD_VAR_NUM)
-                {
-                    emit->emitIns_R_S(simdMov, EA_ATTR(regSize), tempReg, srcLclNum, srcOffset);
-                }
-                else
-                {
-                    emit->emitIns_R_ARX(simdMov, EA_ATTR(regSize), tempReg, srcAddrBaseReg, srcAddrIndexReg,
-                                        srcAddrIndexScale, srcOffset);
-                }
-
-                if (dstLclNum != BAD_VAR_NUM)
-                {
-                    emit->emitIns_S_R(simdMov, EA_ATTR(regSize), tempReg, dstLclNum, dstOffset);
-                }
-                else
-                {
-                    emit->emitIns_ARX_R(simdMov, EA_ATTR(regSize), tempReg, dstAddrBaseReg, dstAddrIndexReg,
-                                        dstAddrIndexScale, dstOffset);
-                }
+                emit->emitIns_R_S(simdMov, EA_ATTR(regSize), tempReg, srcLclNum, srcOffset);
             }
-        }
+            else
+            {
+                emit->emitIns_R_ARX(simdMov, EA_ATTR(regSize), tempReg, srcAddrBaseReg, srcAddrIndexReg,
+                                    srcAddrIndexScale, srcOffset);
+            }
+
+            if (dstLclNum != BAD_VAR_NUM)
+            {
+                emit->emitIns_S_R(simdMov, EA_ATTR(regSize), tempReg, dstLclNum, dstOffset);
+            }
+            else
+            {
+                emit->emitIns_ARX_R(simdMov, EA_ATTR(regSize), tempReg, dstAddrBaseReg, dstAddrIndexReg,
+                                    dstAddrIndexScale, dstOffset);
+            }
+            dstOffset += regSize;
+            size -= regSize;
+        } while (size >= regSize);
 
         // Handle the remainder by overlapping with previosly processed data
         if ((size > 0) && (size < regSize) && (regSize >= XMM_REGSIZE_BYTES))

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -3370,6 +3370,7 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
                 emit->emitIns_ARX_R(simdMov, EA_ATTR(regSize), tempReg, dstAddrBaseReg, dstAddrIndexReg,
                                     dstAddrIndexScale, dstOffset);
             }
+            srcOffset += regSize;
             dstOffset += regSize;
             size -= regSize;
         } while (size >= regSize);
@@ -3389,9 +3390,11 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
                     regSize = XMM_REGSIZE_BYTES;
                 }
 
+                assert(srcOffset >= (int)regSize);
                 assert(dstOffset >= (int)regSize);
 
                 // Rewind dstOffset so we can fit a vector for the while remainder
+                srcOffset -= (regSize - size);
                 dstOffset -= (regSize - size);
 
                 if (srcLclNum != BAD_VAR_NUM)


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/83277

Currently, when we need to perform unrolled memset/memcpy (BLK) we do a loop of SIMD and then handle the remainder using scalar loads/stores. This PR slightly improves this logic by using wide stores/loads + overlapping with previously processed data.

```csharp
struct MyStruct
{
    public fixed byte Data[30]; // and other sizes
}

// unrolled memset
MyStruct InitMemory() => new MyStruct();

// unrolled memcpy
MyStruct CopyMemory(MyStruct val) => val;
```
Codegen diff (base vs PR) for `InitMemory()` and `CopyMemory()`:
```diff
; Assembly listing for method InitMemory()
G_M46073_IG01:	
       sub      rsp, 56	
       vzeroupper 	
       mov      rax, 0xD1FFAB1E	
       mov      qword ptr [rsp+30H], rax	
G_M46073_IG02:	
       xor      eax, eax	
       vxorps   xmm0, xmm0	
       vmovdqu  xmmword ptr [rdx], xmm0	
-      mov      qword ptr [rdx+10H], rax	
-      mov      qword ptr [rdx+16H], rax	
+      vmovdqu  xmmword ptr [rdx+0EH], xmm0
       mov      rax, rdx	
       mov      rcx, 0xD1FFAB1E	
       cmp      qword ptr [rsp+30H], rcx	
       je       SHORT G_M46073_IG03	
       call     CORINFO_HELP_FAIL_FAST	
G_M46073_IG03:	
       nop      	
G_M46073_IG04:	
       add      rsp, 56	
       ret      	
-; Total bytes of code 71
+; Total bytes of code 68


; Assembly listing for method CopyMemory()
G_M3723_IG01:
       sub      rsp, 56
       vzeroupper 
       mov      rax, 0xD1FFAB1E
       mov      qword ptr [rsp+30H], rax
G_M3723_IG02:
       vmovdqu  xmm0, xmmword ptr [rdx]
       vmovdqu  xmmword ptr [rcx], xmm0
-      mov      rax, qword ptr [rdx+10H]
-      mov      qword ptr [rcx+10H], rax
-      mov      rax, qword ptr [rdx+16H]
-      mov      qword ptr [rcx+16H], rax
+      vmovdqu  xmm0, xmmword ptr [rdx+0EH]
+      vmovdqu  xmmword ptr [rcx+0EH], xmm0
       mov      rax, rcx
       mov      rcx, 0xD1FFAB1E
       cmp      qword ptr [rsp+30H], rcx
       je       SHORT G_M3723_IG03
       call     CORINFO_HELP_FAIL_FAST
G_M3723_IG03:
       nop      
G_M3723_IG04:
       add      rsp, 56
       ret      
-; Total bytes of code 77
+; Total bytes of code 71
```
