### PR TITLE
[mono] Raise inlining length limit in the interpreter from 20 to 30

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -2772,8 +2772,8 @@ interp_icall_op_for_sig (MonoMethodSignature *sig)
 	return op;
 }
 
-/* Same as mono jit */
-#define INLINE_LENGTH_LIMIT 20
+/* larger than mono jit; chosen to ensure that List<T>.get_Item can be inlined */
+#define INLINE_LENGTH_LIMIT 30
 #define INLINE_DEPTH_LIMIT 10
 
 static gboolean


### PR DESCRIPTION
In the past raising the inlining length limit provided some big easy wins on wasm, and it also allows the jiterpreter to work better. Some critical stuff is in this 'over 20 bytes but under 30 bytes' range. For example, V8.Crypto from the dotnet/performance suite is significantly bottlenecked on ListX<T>.get_Item, which just calls List<T>.get_Item.

Previously when I tried this (as part of another PR) it caused one specific obscure test to fail on CI that didn't fail locally, so we'll see if it fails again and I can figure it out...