### PR TITLE
Shortcut some generic lookups

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunGenericHelperNode.cs
@@ -25,6 +25,14 @@ namespace ILCompiler.DependencyAnalysis
         {
             // INVARIANT: must not trash context register
 
+            // If this is the "not actually a lookup" lookup (see the constructor for details), just return context.
+            if (lookup == null)
+            {
+                if (result != context)
+                    encoder.EmitMOV(result, context);
+                return;
+            }
+
             // Find the generic dictionary slot
             int dictionarySlot = 0;
             if (!relocsOnly)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunGenericHelperNode.cs
@@ -25,14 +25,6 @@ namespace ILCompiler.DependencyAnalysis
         {
             // INVARIANT: must not trash context register
 
-            // If this is the "not actually a lookup" lookup (see the constructor for details), just return context.
-            if (lookup == null)
-            {
-                if (result != context)
-                    encoder.EmitMOV(result, context);
-                return;
-            }
-
             // Find the generic dictionary slot
             int dictionarySlot = 0;
             if (!relocsOnly)
@@ -69,10 +61,19 @@ namespace ILCompiler.DependencyAnalysis
 
         protected sealed override void EmitCode(NodeFactory factory, ref ARMEmitter encoder, bool relocsOnly)
         {
+            Register contextRegister = GetContextRegister(ref encoder);
+
+            // If this is the "not actually a lookup" lookup (see the constructor for details), just return context.
+            if (_lookupSignature == null)
+            {
+                if (contextRegister != encoder.TargetRegister.Result)
+                    encoder.EmitMOV(encoder.TargetRegister.Result, contextRegister);
+                encoder.EmitRET();
+                return;
+            }
+
             // First load the generic context into the context register.
             EmitLoadGenericContext(factory, ref encoder, relocsOnly);
-
-            Register contextRegister = GetContextRegister(ref encoder);
 
             switch (_id)
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunGenericHelperNode.cs
@@ -25,6 +25,14 @@ namespace ILCompiler.DependencyAnalysis
         {
             // INVARIANT: must not trash context register
 
+            // If this is the "not actually a lookup" lookup (see the constructor for details), just return context.
+            if (lookup == null)
+            {
+                if (result != context)
+                    encoder.EmitMOV(result, context);
+                return;
+            }
+
             // Find the generic dictionary slot
             int dictionarySlot = 0;
             if (!relocsOnly)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunGenericHelperNode.cs
@@ -25,14 +25,6 @@ namespace ILCompiler.DependencyAnalysis
         {
             // INVARIANT: must not trash context register
 
-            // If this is the "not actually a lookup" lookup (see the constructor for details), just return context.
-            if (lookup == null)
-            {
-                if (result != context)
-                    encoder.EmitMOV(result, context);
-                return;
-            }
-
             // Find the generic dictionary slot
             int dictionarySlot = 0;
             if (!relocsOnly)
@@ -80,10 +72,19 @@ namespace ILCompiler.DependencyAnalysis
 
         protected sealed override void EmitCode(NodeFactory factory, ref ARM64Emitter encoder, bool relocsOnly)
         {
+            Register contextRegister = GetContextRegister(ref encoder);
+
+            // If this is the "not actually a lookup" lookup (see the constructor for details), just return context.
+            if (_lookupSignature == null)
+            {
+                if (contextRegister != encoder.TargetRegister.Result)
+                    encoder.EmitMOV(encoder.TargetRegister.Result, contextRegister);
+                encoder.EmitRET();
+                return;
+            }
+
             // First load the generic context into the context register.
             EmitLoadGenericContext(factory, ref encoder, relocsOnly);
-
-            Register contextRegister = GetContextRegister(ref encoder);
 
             switch (_id)
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_LoongArch64/LoongArch64ReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_LoongArch64/LoongArch64ReadyToRunGenericHelperNode.cs
@@ -25,6 +25,14 @@ namespace ILCompiler.DependencyAnalysis
         {
             // INVARIANT: must not trash context register
 
+            // If this is the "not actually a lookup" lookup (see the constructor for details), just return context.
+            if (lookup == null)
+            {
+                if (result != context)
+                    encoder.EmitMOV(result, context);
+                return;
+            }
+
             // Find the generic dictionary slot
             int dictionarySlot = 0;
             if (!relocsOnly)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
@@ -25,6 +25,14 @@ namespace ILCompiler.DependencyAnalysis
         {
             // INVARIANT: must not trash context register
 
+            // If this is the "not actually a lookup" lookup (see the constructor for details), just return context.
+            if (lookup == null)
+            {
+                if (result != context)
+                    encoder.EmitMOV(result, context);
+                return;
+            }
+
             // Find the generic dictionary slot
             int dictionarySlot = 0;
             if (!relocsOnly)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
@@ -25,14 +25,6 @@ namespace ILCompiler.DependencyAnalysis
         {
             // INVARIANT: must not trash context register
 
-            // If this is the "not actually a lookup" lookup (see the constructor for details), just return context.
-            if (lookup == null)
-            {
-                if (result != context)
-                    encoder.EmitMOV(result, context);
-                return;
-            }
-
             // Find the generic dictionary slot
             int dictionarySlot = 0;
             if (!relocsOnly)
@@ -83,10 +75,19 @@ namespace ILCompiler.DependencyAnalysis
 
         protected sealed override void EmitCode(NodeFactory factory, ref X64Emitter encoder, bool relocsOnly)
         {
+            Register contextRegister = GetContextRegister(ref encoder);
+
+            // If this is the "not actually a lookup" lookup (see the constructor for details), just return context.
+            if (_lookupSignature == null)
+            {
+                if (contextRegister != encoder.TargetRegister.Result)
+                    encoder.EmitMOV(encoder.TargetRegister.Result, contextRegister);
+                encoder.EmitRET();
+                return;
+            }
+
             // First load the generic context into the context register.
             EmitLoadGenericContext(factory, ref encoder, relocsOnly);
-
-            Register contextRegister = GetContextRegister(ref encoder);
 
             switch (_id)
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/GenericDictionaryLookup.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/GenericDictionaryLookup.cs
@@ -17,6 +17,7 @@ namespace ILCompiler
     {
         private const short UseHelperOffset = -1;
         private const short UseNullOffset = -2;
+        private const short UseIdentityOffset = -3;
 
         private readonly object _helperObject;
 
@@ -83,6 +84,10 @@ namespace ILCompiler
             get
             {
                 Debug.Assert(!UseHelper && !UseNull);
+
+                if (_offset1 == UseIdentityOffset)
+                    return 0;
+
                 return ContextSource == GenericContextSource.MethodParameter ? 1 : 2;
             }
         }
@@ -138,6 +143,11 @@ namespace ILCompiler
         public static GenericDictionaryLookup CreateNullLookup(GenericContextSource contextSource)
         {
             return new GenericDictionaryLookup(contextSource, UseNullOffset, 0, null, false);
+        }
+
+        public static GenericDictionaryLookup CreateIdentityLookup(GenericContextSource contextSource)
+        {
+            return new GenericDictionaryLookup(contextSource, UseIdentityOffset, 0, null, false);
         }
     }
 

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -276,17 +276,17 @@ namespace Internal.JitInterface
                         lookup.runtimeLookup.helper = CorInfoHelpFunc.CORINFO_HELP_RUNTIMEHANDLE_CLASS;
                     }
 
+                    // There might be one more zero indirection if IndirectLastOffset is true.
                     lookup.runtimeLookup.indirections = (ushort)(genericLookup.NumberOfIndirections + (genericLookup.IndirectLastOffset ? 1 : 0));
-                    lookup.runtimeLookup.offset0 = (IntPtr)genericLookup[0];
+                    if (genericLookup.NumberOfIndirections > 0)
+                    {
+                        lookup.runtimeLookup.offset0 = genericLookup[0];
+                        lookup.runtimeLookup.offset1 = IntPtr.Zero; // might be looked at if IndirectLastOffset and this is last
+                    }
                     if (genericLookup.NumberOfIndirections > 1)
                     {
-                        lookup.runtimeLookup.offset1 = (IntPtr)genericLookup[1];
-                        if (genericLookup.IndirectLastOffset)
-                            lookup.runtimeLookup.offset2 = IntPtr.Zero;
-                    }
-                    else if (genericLookup.IndirectLastOffset)
-                    {
-                        lookup.runtimeLookup.offset1 = IntPtr.Zero;
+                        lookup.runtimeLookup.offset1 = genericLookup[1];
+                        lookup.runtimeLookup.offset2 = IntPtr.Zero; // might be looked at if IndirectLastOffset and this is last
                     }
                     lookup.runtimeLookup.sizeOffset = CORINFO.CORINFO_NO_SIZE_CHECK;
                     lookup.runtimeLookup.testForFixup = false; // TODO: this will be needed in true multifile


### PR DESCRIPTION
If the thing we want to look up is the same thing that defines the current context, skip the lookup and use the generic context as-is. For example:

```csharp
class Gen<T>
{
    static void Method1(...) => Method2(...);
    static void Method2(...) => ...;
}
```

Since `Method1` is calling `Method2`, we need to pass the generic context so that we know what the `T` is. We could either generate it as a dictionary lookup for `TypeHandle` of `Gen<!0>`, or we can realize that the current generic context is already the `TypeHandle` of `Gen<!0>` and we can use it as-is.

Cc @dotnet/ilc-contrib 