### PR TITLE
[mono][aot] Load AOT module of a container assembly using assembly name

### DIFF
--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -2451,8 +2451,10 @@ load_container_amodule (MonoAssemblyLoadContext *alc)
 	assm->image->alc = alc;
 	assm->aname.name = container_assm_name;
 
+	mono_image_init (assm->image);
 	MonoAotFileInfo* info = (MonoAotFileInfo *)g_hash_table_lookup (static_aot_modules, assm->aname.name);
 	assm->image->guid = (char*)info->assembly_guid;
+	mono_assembly_addref (assm);
 
 	load_aot_module(alc, assm, NULL, error);
 	g_assert (assm->image->aot_module);

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -2439,8 +2439,8 @@ static void
 load_container_amodule (MonoAssemblyLoadContext *alc)
 {
 	// If container_amodule loaded, don't lock the runtime
-    if (!container_assm_name || container_amodule)
-        return;
+	if (!container_assm_name || container_amodule)
+		return;
 
 	mono_loader_lock ();
 	// There might be several threads that passed the first check

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -2446,8 +2446,6 @@ load_container_amodule (MonoAssemblyLoadContext *alc)
 	// There might be several threads that passed the first check
 	// Adding another check to ensure single load of a container assembly due to race condition 
 	if (!container_amodule) {
-        char *local_ref = container_assm_name;
-        container_assm_name = NULL;
 		ERROR_DECL (error);
 
 		// Create a fake MonoAssembly/MonoImage to retrieve its AOT module.
@@ -2456,7 +2454,7 @@ load_container_amodule (MonoAssemblyLoadContext *alc)
 		assm->image = g_new0 (MonoImage, 1);
 		assm->image->dynamic = 0;
 		assm->image->alc = alc;
-		assm->aname.name = local_ref;
+		assm->aname.name = container_assm_name;
 
 		mono_image_init (assm->image);
 		MonoAotFileInfo* info = (MonoAotFileInfo *)g_hash_table_lookup (static_aot_modules, assm->aname.name);
@@ -2465,6 +2463,7 @@ load_container_amodule (MonoAssemblyLoadContext *alc)
 
 		load_aot_module(alc, assm, NULL, error);
 		g_assert (assm->image->aot_module);
+		mono_memory_barrier ();
 		container_amodule = assm->image->aot_module;
 	}
 

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -2439,13 +2439,15 @@ static void
 load_container_amodule (MonoAssemblyLoadContext *alc)
 {
 	// If container_amodule loaded, don't lock the runtime
-	if (container_amodule)
-		return;
+    if (!container_assm_name || container_amodule)
+        return;
 
 	mono_loader_lock ();
 	// There might be several threads that passed the first check
 	// Adding another check to ensure single load of a container assembly due to race condition 
 	if (!container_amodule) {
+        char *local_ref = container_assm_name;
+        container_assm_name = NULL;
 		ERROR_DECL (error);
 
 		// Create a fake MonoAssembly/MonoImage to retrieve its AOT module.
@@ -2454,7 +2456,7 @@ load_container_amodule (MonoAssemblyLoadContext *alc)
 		assm->image = g_new0 (MonoImage, 1);
 		assm->image->dynamic = 0;
 		assm->image->alc = alc;
-		assm->aname.name = container_assm_name;
+		assm->aname.name = local_ref;
 
 		mono_image_init (assm->image);
 		MonoAotFileInfo* info = (MonoAotFileInfo *)g_hash_table_lookup (static_aot_modules, assm->aname.name);

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -2443,13 +2443,16 @@ load_container_amodule (MonoAssemblyLoadContext *alc)
 	if (!container_assm_name || container_amodule)
 		return;
 
+	char *local_ref = container_assm_name;
+	container_assm_name = NULL;
+
 	// Create a fake MonoAssembly/MonoImage to retrieve its AOT module.
 	// Container MonoAssembly/MonoImage shouldn't be used during the runtime.
 	MonoAssembly *assm = g_new0 (MonoAssembly, 1);
 	assm->image = g_new0 (MonoImage, 1);
 	assm->image->dynamic = 0;
 	assm->image->alc = alc;
-	assm->aname.name = container_assm_name;
+	assm->aname.name = local_ref;
 
 	mono_image_init (assm->image);
 	MonoAotFileInfo* info = (MonoAotFileInfo *)g_hash_table_lookup (static_aot_modules, assm->aname.name);
@@ -2458,7 +2461,6 @@ load_container_amodule (MonoAssemblyLoadContext *alc)
 
 	load_aot_module(alc, assm, NULL, error);
 	g_assert (assm->image->aot_module);
-	container_assm_name = NULL;
 	container_amodule = assm->image->aot_module;
 }
 


### PR DESCRIPTION
This PR should fix [loading a container assembly on Mac Catalyst](https://github.com/xamarin/xamarin-macios/pull/17766#issuecomment-1469812054). It loads container AOT module using its name, without an actual assembly in the bundle.

This should simplify the build process as the container assembly might not be required.