### PR TITLE
Fix System.Management wminet_utils.dll lookup code for arm64

### DIFF
--- a/src/libraries/System.Management/src/System/Management/ManagementScope.cs
+++ b/src/libraries/System.Management/src/System/Management/ManagementScope.cs
@@ -290,8 +290,10 @@ namespace System.Management
         static WmiNetUtilsHelper()
         {
             RegistryKey netFrameworkSubKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\.NETFramework\");
-            string netFrameworkInstallRoot = (string)netFrameworkSubKey?.GetValue("InstallRoot");
-
+            string netFrameworkInstallRoot = (string)netFrameworkSubKey?.GetValue(RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ?
+                "InstallRootArm64" :
+                "InstallRoot");
+            
             if (netFrameworkInstallRoot == null)
             {
                 // In some Windows versions, like Nano Server, the .NET Framework is not installed by default.

--- a/src/libraries/System.Management/src/System/Management/ManagementScope.cs
+++ b/src/libraries/System.Management/src/System/Management/ManagementScope.cs
@@ -293,7 +293,7 @@ namespace System.Management
             string netFrameworkInstallRoot = (string)netFrameworkSubKey?.GetValue(RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ?
                 "InstallRootArm64" :
                 "InstallRoot");
-            
+
             if (netFrameworkInstallRoot == null)
             {
                 // In some Windows versions, like Nano Server, the .NET Framework is not installed by default.

--- a/src/libraries/System.Management/tests/WmiTestHelper.cs
+++ b/src/libraries/System.Management/tests/WmiTestHelper.cs
@@ -11,7 +11,7 @@ namespace System.Management.Tests
         private static readonly bool s_isElevated = AdminHelpers.IsProcessElevated();
         private static readonly bool s_isWmiSupported =
                                             PlatformDetection.IsWindows &&
-                                            PlatformDetection.IsNotArmNorArm64Process &&
+                                            PlatformDetection.IsNotArmProcess &&
                                             PlatformDetection.IsNotWindowsNanoServer &&
                                             PlatformDetection.IsNotWindowsIoTCore &&
                                             !PlatformDetection.IsInAppContainer;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/81400

It's highly unlikely that there will be another side by side .NET Framework installation and as we were already using `CompatSwitches.DotNetVersion` as the folder probe path, we follow that approach for arm64 as well.