### PR TITLE
Switch tests for --additionalprobingpath to mocked components

### DIFF
--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/AdditionalDeps.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/AdditionalDeps.cs
@@ -110,12 +110,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             }
             else
             {
+                // Specifying an additional deps file triggers file existence checking, so execution
+                // should fail when the dependency doesn't exist.
                 result.Should().Fail()
-                    .And.HaveStdErrContaining(
-                        $"Error:{Environment.NewLine}" +
-                        $"  An assembly specified in the application dependencies manifest ({additionalLibName}.deps.json) was not found:" + Environment.NewLine +
-                        $"    package: \'{additionalLibName}\', version: \'1.0.0\'" + Environment.NewLine +
-                        $"    path: \'{additionalLibName}.dll\'");
+                    .And.ErrorWithMissingAssembly($"{additionalLibName}.deps.json", additionalLibName, "1.0.0");
             }
         }
 

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/AdditionalProbingPath.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/AdditionalProbingPath.cs
@@ -1,0 +1,155 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using Microsoft.DotNet.Cli.Build;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Xunit;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
+{
+    public class AdditionalProbingPath : DependencyResolutionBase, IClassFixture<AdditionalProbingPath.SharedTestState>
+    {
+        private readonly SharedTestState sharedState;
+
+        public AdditionalProbingPath(SharedTestState sharedState)
+        {
+            this.sharedState = sharedState;
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CommandLine(bool dependencyExists)
+        {
+            string probePath = dependencyExists ? sharedState.AdditionalProbingPath : sharedState.Location;
+            TestApp app = sharedState.FrameworkReferenceApp;
+            CommandResult result = sharedState.DotNetWithNetCoreApp.Exec(Constants.AdditionalProbingPath.CommandLineArgument, probePath, app.AppDll)
+                .EnableTracingAndCaptureOutputs()
+                .Execute();
+
+            result.Should().HaveUsedAdditionalProbingPath(probePath);
+            if (dependencyExists)
+            {
+                result.Should().Pass()
+                    .And.HaveResolvedAssembly(sharedState.DependencyPath)
+                    .And.HaveResolvedNativeLibraryPath(sharedState.NativeDependencyDirectory);
+            }
+            else
+            {
+                // Specifying additional probing paths triggers file existence checking, so execution
+                // should fail on the first dependency that doesn't exist.
+                result.Should().Fail()
+                    .And.ErrorWithMissingAssembly(Path.GetFileName(app.DepsJson), SharedTestState.DependencyName, SharedTestState.DependencyVersion);
+            }
+        }
+
+        [Fact]
+        public void PlaceholderArchTfm()
+        {
+            // Host should replace |arch| and |tfm| with actual architecture and TFM 
+            string probePath = Path.Combine(sharedState.AdditionalProbingPath, "|arch|", "|tfm|");
+            TestApp app = sharedState.FrameworkReferenceApp;
+            sharedState.DotNetWithNetCoreApp.Exec(Constants.AdditionalProbingPath.CommandLineArgument, probePath, app.AppDll)
+                .EnableTracingAndCaptureOutputs()
+                .Execute()
+                .Should().Pass()
+                .And.HaveUsedAdditionalProbingPath(sharedState.AdditionalProbingPath_ArchTfm)
+                .And.HaveResolvedAssembly(sharedState.DependencyPath_ArchTfm)
+                .And.HaveResolvedNativeLibraryPath(sharedState.NativeDependencyDirectory_ArchTfm);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void RuntimeConfigSetting(bool dependencyExists)
+        {
+            string probePath = dependencyExists ? sharedState.AdditionalProbingPath : sharedState.Location;
+            TestApp app = sharedState.FrameworkReferenceApp.Copy();
+            RuntimeConfig.FromFile(app.RuntimeConfigJson)
+                .WithAdditionalProbingPath(probePath)
+                .Save();
+            CommandResult result = sharedState.DotNetWithNetCoreApp.Exec(app.AppDll)
+                .EnableTracingAndCaptureOutputs()
+                .Execute();
+
+            result.Should().HaveUsedAdditionalProbingPath(probePath);
+            if (dependencyExists)
+            {
+                result.Should().Pass()
+                    .And.HaveResolvedAssembly(sharedState.DependencyPath)
+                    .And.HaveResolvedNativeLibraryPath(sharedState.NativeDependencyDirectory);
+            }
+            else
+            {
+                // Specifying additional probing paths triggers file existence checking, so execution
+                // should fail on the first dependency that doesn't exist.
+                result.Should().Fail()
+                    .And.ErrorWithMissingAssembly(Path.GetFileName(app.DepsJson), SharedTestState.DependencyName, SharedTestState.DependencyVersion);
+            }
+        }
+
+        public class SharedTestState : DependencyResolutionBase.SharedTestStateBase
+        {
+            public DotNetCli DotNetWithNetCoreApp { get; }
+
+            public TestApp FrameworkReferenceApp { get; }
+
+            public const string DependencyName = "Dependency";
+            public const string DependencyVersion = "1.0.0";
+
+            public string DependencyPath { get; }
+            public string NativeDependencyDirectory { get; }
+
+            public string DependencyPath_ArchTfm { get; }
+            public string NativeDependencyDirectory_ArchTfm { get; }
+
+            public string AdditionalProbingPath { get; }
+            public string AdditionalProbingPath_ArchTfm { get; }
+
+            public SharedTestState()
+            {
+                DotNetWithNetCoreApp = DotNet("WithNetCoreApp")
+                    .AddMicrosoftNETCoreAppFrameworkMockCoreClr(RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion)
+                    .Build();
+
+                string nativeDependencyRelPath = $"{RepoDirectoriesProvider.Default.TargetRID}/{Binaries.GetSharedLibraryFileNameForCurrentPlatform("native")}";
+                FrameworkReferenceApp = CreateFrameworkReferenceApp(MicrosoftNETCoreApp, RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion, b => b
+                    .WithProject(DependencyName, DependencyVersion, p => p
+                        .WithAssemblyGroup(null, g => g
+                            .WithAsset($"{DependencyName}.dll", f => f.NotOnDisk()))
+                        .WithNativeLibraryGroup(RepoDirectoriesProvider.Default.TargetRID, g => g
+                            .WithAsset(nativeDependencyRelPath, f => f.NotOnDisk()))));
+                RuntimeConfig.FromFile(FrameworkReferenceApp.RuntimeConfigJson)
+                    .WithTfm(RepoDirectoriesProvider.Default.Tfm)
+                    .Save();
+
+                AdditionalProbingPath = Path.Combine(Location, "probe");
+                (DependencyPath, NativeDependencyDirectory) = AddDependencies(AdditionalProbingPath);
+
+                AdditionalProbingPath_ArchTfm = Path.Combine(AdditionalProbingPath, RepoDirectoriesProvider.Default.BuildArchitecture, RepoDirectoriesProvider.Default.Tfm);
+                (DependencyPath_ArchTfm, NativeDependencyDirectory_ArchTfm) = AddDependencies(AdditionalProbingPath_ArchTfm);
+
+                (string, string) AddDependencies(string probeDir)
+                {
+                    // Probing will look under <library_name>/<library_version>
+                    string dependencyDir = Path.Combine(probeDir, DependencyName, DependencyVersion);
+                    Directory.CreateDirectory(dependencyDir);
+
+                    // Create the assembly dependency
+                    string dependencyPath = Path.Combine(dependencyDir, $"{DependencyName}.dll");
+                    File.WriteAllText(dependencyPath, string.Empty);
+
+                    // Create the native dependency
+                    string nativeDependencyPath = Path.Combine(dependencyDir, nativeDependencyRelPath);
+                    string nativeDependencyDir = Path.GetDirectoryName(nativeDependencyPath);
+                    Directory.CreateDirectory(nativeDependencyDir);
+                    File.WriteAllText(nativeDependencyPath, string.Empty);
+
+                    return (dependencyPath, nativeDependencyDir);
+                }
+            }
+        }
+    }
+}

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/DependencyResolutionCommandResultExtensions.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/DependencyResolutionCommandResultExtensions.cs
@@ -142,9 +142,24 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             return assertion.NotHaveResolvedComponentDependencyContaining(native_search_paths, RelativePathsToAbsoluteAppPaths(path, app));
         }
 
+        public static AndConstraint<CommandResultAssertions> ErrorWithMissingAssembly(this CommandResultAssertions assertion, string depsFileName, string dependencyName, string dependencyVersion)
+        {
+            return assertion.HaveStdErrContaining(
+                $"Error:{Environment.NewLine}" +
+                $"  An assembly specified in the application dependencies manifest ({depsFileName}) was not found:" + Environment.NewLine +
+                $"    package: \'{dependencyName}\', version: \'{dependencyVersion}\'" + Environment.NewLine +
+                $"    path: \'{dependencyName}.dll\'");
+        }
+
         public static AndConstraint<CommandResultAssertions> HaveUsedAdditionalDeps(this CommandResultAssertions assertion, string depsFilePath)
         {
             return assertion.HaveStdErrContaining($"Using specified additional deps.json: '{depsFilePath}'");
+        }
+
+        public static AndConstraint<CommandResultAssertions> HaveUsedAdditionalProbingPath(this CommandResultAssertions assertion, string path)
+        {
+            return assertion.HaveStdErrContaining($"Additional probe dir: {path}")
+                .And.HaveStdErrContaining($"probe type=lookup dir=[{path}]");
         }
 
         public static AndConstraint<CommandResultAssertions> HaveUsedFallbackRid(this CommandResultAssertions assertion, bool usedFallbackRid)

--- a/src/installer/tests/TestUtils/Constants.cs
+++ b/src/installer/tests/TestUtils/Constants.cs
@@ -43,6 +43,12 @@ namespace Microsoft.DotNet.CoreSetup.Test
             public const string CommandLineArgument = "--additional-deps";
         }
 
+        public static class AdditionalProbingPath
+        {
+            public const string CommandLineArgument = "--additionalprobingpath";
+            public const string RuntimeConfigPropertyName = "additionalProbingPaths";
+        }
+
         public static class DepsFile
         {
             public const string CommandLineArgument = "--depsfile";

--- a/src/installer/tests/TestUtils/NetCoreAppBuilder.cs
+++ b/src/installer/tests/TestUtils/NetCoreAppBuilder.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
                     FileUtils.EnsureFileDirectoryExists(absolutePath);
                     File.Copy(SourcePath, absolutePath);
                 }
-                else if (FileOnDiskPath == null || FileOnDiskPath.Length >= 0)
+                else if (FileOnDiskPath == null || FileOnDiskPath.Length > 0)
                 {
                     FileUtils.CreateEmptyFile(absolutePath);
                 }

--- a/src/installer/tests/TestUtils/RepoDirectoriesProvider.cs
+++ b/src/installer/tests/TestUtils/RepoDirectoriesProvider.cs
@@ -15,6 +15,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         public string BuildArchitecture { get; }
         public string TargetRID { get; }
         public string MicrosoftNETCoreAppVersion { get; }
+        public string Tfm { get; }
         public string TestAssetsFolder { get; }
         public string Configuration { get; }
         public string RepoRoot { get; }
@@ -50,6 +51,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             BuildRID = GetTestContextVariable("BUILDRID");
             BuildArchitecture = GetTestContextVariable("BUILD_ARCHITECTURE");
             MicrosoftNETCoreAppVersion = microsoftNETCoreAppVersion ?? GetTestContextVariable("MNA_VERSION");
+            Tfm = GetTestContextVariable("MNA_TFM");
             TestAssetsFolder = GetTestContextVariable("TEST_ASSETS");
 
             Configuration = GetTestContextVariable("BUILD_CONFIGURATION");

--- a/src/installer/tests/TestUtils/RuntimeConfig.cs
+++ b/src/installer/tests/TestUtils/RuntimeConfig.cs
@@ -102,6 +102,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         private readonly List<Framework> _frameworks = new List<Framework>();
         private readonly List<Framework> _includedFrameworks = new List<Framework>();
         private readonly List<Tuple<string, string>> _properties = new List<Tuple<string, string>>();
+        private readonly List<string> _additionalProbingPaths = new List<string>();
 
         /// <summary>
         /// Creates new runtime config - overwrites existing file on Save if any.
@@ -233,6 +234,12 @@ namespace Microsoft.DotNet.CoreSetup.Test
             return this;
         }
 
+        public RuntimeConfig WithAdditionalProbingPath(string path)
+        {
+            _additionalProbingPaths.Add(path);
+            return this;
+        }
+
         public RuntimeConfig WithProperty(string name, string value)
         {
             _properties.Add(new Tuple<string, string>(name, value));
@@ -280,6 +287,13 @@ namespace Microsoft.DotNet.CoreSetup.Test
             if (_tfm is not null)
             {
                 runtimeOptions.Add("tfm", _tfm);
+            }
+
+            if (_additionalProbingPaths.Count > 0)
+            {
+                runtimeOptions.Add(
+                    Constants.AdditionalProbingPath.RuntimeConfigPropertyName,
+                    new JsonArray(_additionalProbingPaths.Select(p => JsonValue.Create(p)).ToArray()));
             }
 
             if (_properties.Count > 0)

--- a/src/installer/tests/TestUtils/TestProjectFixture.cs
+++ b/src/installer/tests/TestUtils/TestProjectFixture.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
             RepoDirProvider = repoDirectoriesProvider;
 
-            Framework = framework ?? RepoDirProvider.GetTestContextVariable("MNA_TFM");
+            Framework = framework ?? RepoDirProvider.Tfm;
 
             SdkDotnet = new DotNetCli(repoDirectoriesProvider.DotnetSDK);
             CurrentRid = repoDirectoriesProvider.TargetRID;


### PR DESCRIPTION
These were testing using `--additionalprobingpath` and they were disabled when we updated to a new SDK which broke some assumptions the tests were making. We really just care that a dependency can be found using specified additional probing paths, so the tests can be switched to use our mock coreclr and depending on the SDK to build/publish a project. This also adds a test case for the runtimeconfig.json setting.

Resolves https://github.com/dotnet/runtime/issues/3654