### PR TITLE
Revert "ActiveIssue for BuildInvalidSignatureTwice on mono interpreter."

### DIFF
--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/ChainTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/ChainTests.cs
@@ -953,7 +953,6 @@ tHP28fj0LUop/QFojSZPsaPAW6JvoQ0t4hd6WoyX6z7FsA==
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/82837", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter))]
         public static void BuildInvalidSignatureTwice()
         {
             byte[] bytes = (byte[])TestData.MsCertificate.Clone();


### PR DESCRIPTION
I believe this test failure was fixed by #82890. Prior to that fix, I saw a bunch of odd failures in S.S.Cryptography/tests with `/p:MonoForceInterpreter=true`, including this test. After applying the fix, I got several green runs of S.S.Cryptography's tests.

Reverts dotnet/runtime#82864

Closes #82837.