### PR TITLE
Remove double quotes from OwnerCompositeExecutable

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -1400,7 +1400,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                 {
                     int oceOffset = GetOffset(section.RelativeVirtualAddress);
                     string ownerCompositeExecutable = Encoding.UTF8.GetString(Image, oceOffset, section.Size - 1); // exclude the zero terminator
-                    _ownerCompositeExecutable = ownerCompositeExecutable.ToEscapedString();
+                    _ownerCompositeExecutable = ownerCompositeExecutable.ToEscapedString().Replace("\"", ""); // remove double quotes
                     break;
                 }
             }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -1400,7 +1400,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                 {
                     int oceOffset = GetOffset(section.RelativeVirtualAddress);
                     string ownerCompositeExecutable = Encoding.UTF8.GetString(Image, oceOffset, section.Size - 1); // exclude the zero terminator
-                    _ownerCompositeExecutable = ownerCompositeExecutable.ToEscapedString(false);
+                    _ownerCompositeExecutable = ownerCompositeExecutable.ToEscapedString(placeQuotes: false);
                     break;
                 }
             }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -1400,7 +1400,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                 {
                     int oceOffset = GetOffset(section.RelativeVirtualAddress);
                     string ownerCompositeExecutable = Encoding.UTF8.GetString(Image, oceOffset, section.Size - 1); // exclude the zero terminator
-                    _ownerCompositeExecutable = ownerCompositeExecutable.ToEscapedString().Replace("\"", ""); // remove double quotes
+                    _ownerCompositeExecutable = ownerCompositeExecutable.ToEscapedString(false);
                     break;
                 }
             }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/StringExtensions.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/StringExtensions.cs
@@ -16,9 +16,12 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// method in Roslyn .NET compiler; see its
         /// <a href="https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs">sources</a> for reference.
         /// </remarks>
-        public static StringBuilder AppendEscapedString(this StringBuilder builder, string value)
+        public static StringBuilder AppendEscapedString(this StringBuilder builder, string value, bool placeQuotes = true)
         {
-            builder.Append('"');
+            if (placeQuotes)
+            {
+                builder.Append('"');
+            }
 
             for (int i = 0; i < value.Length; i++)
             {
@@ -76,8 +79,10 @@ namespace ILCompiler.Reflection.ReadyToRun
                     builder.Append(escaped);
                 }
             }
-
-            builder.Append('"');
+            if (placeQuotes)
+            {
+                builder.Append('"');
+            }
             return builder;
         }
 
@@ -105,9 +110,9 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <summary>
         /// Returns a C# string literal with the given value.
         /// </summary>
-        public static string ToEscapedString(this string value)
+        public static string ToEscapedString(this string value, bool placeQuotes = true)
         {
-            return new StringBuilder(value.Length + 16).AppendEscapedString(value).ToString();
+            return new StringBuilder(value.Length + 16).AppendEscapedString(value, placeQuotes).ToString();
         }
     }
 }


### PR DESCRIPTION
Just to make it easier to work with, not sure if we should add the quotes back when printing it in TextDumper.cs