### PR TITLE
Fix Wrong Date Format in Test Logs

### DIFF
--- a/src/tests/Common/XUnitWrapperLibrary/TestSummary.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestSummary.cs
@@ -174,7 +174,7 @@ public class TestSummary
 <assembly
     name=""{assemblyName}""
     test-framework=""XUnitWrapperGenerator-generated-runner""
-    run-date=""{_testRunStart.ToString("yyy-mm-dd")}""
+    run-date=""{_testRunStart.ToString("yyyy-MM-dd")}""
     run-time=""{_testRunStart.ToString("hh:mm:ss")}""
     time=""{totalRunSeconds}""
     total=""{_testResults.Count}""


### PR DESCRIPTION
As I was working on Merge-on-Red, I noticed the date format for the test logs is wrong. It was printing _Year-Minutes-Day_ instead of _Year-Month-Day._ This PR fixes it.