### PR TITLE
disable NTLM tests on RedHat.7

### DIFF
--- a/src/libraries/Common/tests/System/Net/Capability.Security.Unix.cs
+++ b/src/libraries/Common/tests/System/Net/Capability.Security.Unix.cs
@@ -9,7 +9,7 @@ namespace System.Net.Test.Common
         {
             // GSS on Linux does not work with OpenSSL 3.0. Fix was submitted to gss-ntlm but it will take a while to make to
             // all supported distributions. The second part of the check should be removed when it does.
-            return Interop.NetSecurityNative.IsNtlmInstalled() && (!PlatformDetection.IsOpenSslSupported || PlatformDetection.OpenSslVersion.Major < 3);
+            return Interop.NetSecurityNative.IsNtlmInstalled() && (!PlatformDetection.IsOpenSslSupported || PlatformDetection.OpenSslVersion.Major < 3) && !PlatformDetection.IsRedHatFamily7;
         }
     }
 }

--- a/src/libraries/System.Net.Security/tests/UnitTests/NegotiateAuthenticationTests.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/NegotiateAuthenticationTests.cs
@@ -10,6 +10,7 @@ using System.Net.Test.Common;
 using System.Security.Principal;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Net.Security.Tests
@@ -86,6 +87,10 @@ namespace System.Net.Security.Tests
         [ConditionalFact(nameof(IsNtlmUnavailable))]
         public void Package_Unsupported_NTLM()
         {
+            if (PlatformDetection.IsRedHatFamily7)
+            {
+                throw new SkipTestException("https://github.com/dotnet/runtime/issues/83540");
+            }
             NegotiateAuthenticationClientOptions clientOptions = new NegotiateAuthenticationClientOptions { Package = "NTLM", Credential = s_testCredentialRight, TargetName = "HTTP/foo" };
             NegotiateAuthentication negotiateAuthentication = new NegotiateAuthentication(clientOptions);
             NegotiateAuthenticationStatusCode statusCode;


### PR DESCRIPTION
contributes to #83540
It seems like something got broken by OS update