### PR TITLE
Use Environment.SystemDirectory to get system directory

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
@@ -213,11 +213,11 @@ namespace Microsoft.Extensions.Hosting
             // to really be the home for things like appsettings.json, we skip changing the ContentRoot in that case. The non-"default" initial
             // value for ContentRoot is AppContext.BaseDirectory (e.g. the executable path) which probably makes more sense than the system32.
 
-            // In my testing, both Environment.CurrentDirectory and Environment.GetFolderPath(Environment.SpecialFolder.System) return the path without
+            // In my testing, both Environment.CurrentDirectory and Environment.SystemDirectory return the path without
             // any trailing directory separator characters. I'm not even sure the casing can ever be different from these APIs, but I think it makes sense to
             // ignore case for Windows path comparisons given the file system is usually (always?) going to be case insensitive for the system path.
             string cwd = Environment.CurrentDirectory;
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || !string.Equals(cwd, Environment.GetFolderPath(Environment.SpecialFolder.System), StringComparison.OrdinalIgnoreCase))
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || !string.Equals(cwd, Environment.SystemDirectory, StringComparison.OrdinalIgnoreCase))
             {
                 hostConfigBuilder.AddInMemoryCollection(new[]
                 {

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostTests.cs
@@ -55,12 +55,7 @@ namespace Microsoft.Extensions.Hosting.Tests
         {
             using var _ = RemoteExecutor.Invoke(() =>
             {
-                string systemDirectory = Environment.GetFolderPath(Environment.SpecialFolder.System);
-                if (string.IsNullOrEmpty(systemDirectory))
-                {
-                    // Skip the environments (like Nano Server) where Environment.SpecialFolder.System returns empty - https://github.com/dotnet/runtime/issues/21430
-                    return;
-                }
+                string systemDirectory = Environment.SystemDirectory;
 
                 // Test that the path gets normalized before comparison. Use C:\WINDOWS\SYSTEM32\ instead of C:\Windows\system32.
                 systemDirectory = systemDirectory.ToUpper() + "\\";


### PR DESCRIPTION
Environment.SystemDirectory is a lot more efficient than Environment.GetFolderPath(System.Environment.SpecialFolder.System).

Contributes to https://github.com/dotnet/aspnetcore/issues/47269