### PR TITLE
[release/7.0] Reverting: Set AssemblyName.ProcessorArchitecture for compatibility (#81101)

### DIFF
--- a/src/libraries/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/libraries/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -9,8 +9,8 @@
 
 The System.Reflection.Metadata library is built-in as part of the shared framework in .NET Runtime. The package can be installed when you need to use it in other target frameworks.</PackageDescription>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <ServicingVersion>1</ServicingVersion>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <ServicingVersion>2</ServicingVersion>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.netstandard.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.netstandard.cs
@@ -85,12 +85,6 @@ namespace System.Reflection.Metadata
                     peReader = new PEReader((byte*)safeBuffer.DangerousGetHandle(), (int)safeBuffer.ByteLength);
                     MetadataReader mdReader = peReader.GetMetadataReader(MetadataReaderOptions.None);
                     AssemblyName assemblyName = mdReader.GetAssemblyDefinition().GetAssemblyName();
-
-                    AssemblyFlags aFlags = mdReader.AssemblyTable.GetFlags();
-#pragma warning disable SYSLIB0037 // AssemblyName.ProcessorArchitecture is obsolete
-                    assemblyName.ProcessorArchitecture = CalculateProcArch(peReader, aFlags);
-#pragma warning restore SYSLIB0037
-
                     return assemblyName;
                 }
                 finally
@@ -105,42 +99,6 @@ namespace System.Reflection.Metadata
             {
                 throw new BadImageFormatException(ex.Message);
             }
-        }
-
-        private static ProcessorArchitecture CalculateProcArch(PEReader peReader, AssemblyFlags aFlags)
-        {
-            // 0x70 specifies "reference assembly".
-            // For these, CLR wants to return None as arch so they can be always loaded, regardless of process type.
-            if (((uint)aFlags & 0xF0) == 0x70)
-                return ProcessorArchitecture.None;
-
-            PEHeaders peHeaders = peReader.PEHeaders;
-            switch (peHeaders.CoffHeader.Machine)
-            {
-                case Machine.IA64:
-                    return ProcessorArchitecture.IA64;
-                case Machine.Arm:
-                    return ProcessorArchitecture.Arm;
-                case Machine.Amd64:
-                    return ProcessorArchitecture.Amd64;
-                case Machine.I386:
-                    {
-                        CorFlags flags = peHeaders.CorHeader!.Flags;
-                        if ((flags & CorFlags.ILOnly) != 0 &&
-                            (flags & CorFlags.Requires32Bit) == 0)
-                        {
-                            // platform neutral.
-                            return ProcessorArchitecture.MSIL;
-                        }
-
-                        // requires x86
-                        return ProcessorArchitecture.X86;
-                    }
-            }
-
-            // ProcessorArchitecture is a legacy API and does not cover other Machine kinds.
-            // For example ARM64 is not expressible
-            return ProcessorArchitecture.None;
         }
 
         private static AssemblyNameFlags GetAssemblyNameFlags(AssemblyFlags flags)

--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
@@ -3090,13 +3090,8 @@ namespace System.Reflection.Metadata.Tests
 
             if (PlatformDetection.HasAssemblyFiles)
             {
-                Assembly a = typeof(MetadataReader).Assembly;
-                AssemblyName name = MetadataReader.GetAssemblyName(AssemblyPathHelper.GetAssemblyLocation(a));
-                Assert.Equal(new AssemblyName(a.FullName).ToString(), name.ToString());
-
-#pragma warning disable SYSLIB0037 // AssemblyName.ProcessorArchitecture is obsolete
-                Assert.Equal(ProcessorArchitecture.MSIL, name.ProcessorArchitecture);
-#pragma warning restore SYSLIB0037
+                Assembly a = typeof(MetadataReaderTests).Assembly;
+                Assert.Equal(new AssemblyName(a.FullName).ToString(), MetadataReader.GetAssemblyName(AssemblyPathHelper.GetAssemblyLocation(a)).ToString());
             }
         }
     }


### PR DESCRIPTION
This is a revert of https://github.com/dotnet/runtime/pull/81101

`AssemblyName.ProcessorArchitecture` is unnatural concept in CoreCLR (and thus the property is deprecated).

The attempt to make the behavior closer to the native implementation in #81101 caused more issues than the original minor compat break that it tried to fix.

## Customer Impact

After the original change an application that obtain AssemblyName from assembly files may get ProcessorArchitecture set, which could be now unexpected when the name is subsequently used. 

For example a scenario when an app scans assemblies in a folder used to work prior the original "fix" may now fail with:
```
Loading assembly: LoadAssemblyBug, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
Loading assembly: Microsoft.AspNetCore.Antiforgery, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
Could not load file or assembly 'Microsoft.AspNetCore.Antiforgery, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=AMD64'. The system cannot find the file specified.
```

See: https://github.com/dotnet/runtime/issues/83526

We think that the original fix does not precisely replicate the .NET desktop behavior. However, trying to replicate the exact deprecated API behavior seems very difficult. For instance, the API doesn't support ARM64, so we would have to somehow provide back-compat for a deprecated API even as our product evolves in a way that the original API can't support and we don't want to evolve.

There are also similar issues reported directly by internal teams updating to 7.0.201.

## Testing
We have regression tests for this feature and they were updated as a part of this change. Our understanding of the "modern" API set is quite good, compared to the deprecated set.

## Risk
The change itself has low risk. We are reverting another change.

We also need to acknowledge that the state we are reverting has compat differences with .NET FX and 6.0, which at this point seems preferable.