### PR TITLE
[release/7.0] Fix encoding problem when publishing

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,7 +9,7 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-emsdk -->
-    <add key="darc-pub-dotnet-emsdk-2a1a284" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-2a1a284c/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-emsdk-7fa7119" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-7fa7119c/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-emsdk -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <!--

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -48,13 +48,13 @@
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>5618b2d243ccdeb5c7e50a298b33b13036b4351b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.net6.Manifest-7.0.100" Version="7.0.4">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.net6.Manifest-7.0.100" Version="7.0.5">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>2a1a284cb9e62959ed261bba6cfc678612fc4559</Sha>
+      <Sha>7fa7119c1cdf1290aabb2391c3eee6ed42f8851d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.net7.Manifest-7.0.100" Version="7.0.4">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.net7.Manifest-7.0.100" Version="7.0.5">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>2a1a284cb9e62959ed261bba6cfc678612fc4559</Sha>
+      <Sha>7fa7119c1cdf1290aabb2391c3eee6ed42f8851d</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -22,8 +22,8 @@
     <UsingToolIbcOptimization>false</UsingToolIbcOptimization>
     <UsingToolXliff>false</UsingToolXliff>
     <LastReleasedStableAssemblyVersion>$(AssemblyVersion)</LastReleasedStableAssemblyVersion>
-    <MicrosoftNETWorkloadEmscriptennet6Manifest70100Version>7.0.4</MicrosoftNETWorkloadEmscriptennet6Manifest70100Version>
-    <MicrosoftNETWorkloadEmscriptennet7Manifest70100Version>7.0.4</MicrosoftNETWorkloadEmscriptennet7Manifest70100Version>
+    <MicrosoftNETWorkloadEmscriptennet6Manifest70100Version>7.0.5</MicrosoftNETWorkloadEmscriptennet6Manifest70100Version>
+    <MicrosoftNETWorkloadEmscriptennet7Manifest70100Version>7.0.5</MicrosoftNETWorkloadEmscriptennet7Manifest70100Version>
   </PropertyGroup>
   <ItemGroup>
     <!-- The bands we want to produce workload manifests for -->

--- a/src/tasks/Common/Utils.cs
+++ b/src/tasks/Common/Utils.cs
@@ -64,6 +64,9 @@ internal static class Utils
             using StreamWriter sw = new(file);
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
+                // set encoding to UTF-8 -> full Unicode support is needed for usernames -
+                // `command` contains tmp dir path with the username
+                sw.WriteLine(@"%SystemRoot%\System32\chcp.com 65001>nul");
                 sw.WriteLine("setlocal");
                 sw.WriteLine("set errorlevel=dummy");
                 sw.WriteLine("set errorlevel=");
@@ -185,29 +188,6 @@ internal static class Utils
 
         logger.LogMessage(debugMessageImportance, $"{msgPrefix}Exit code: {process.ExitCode}");
         return (process.ExitCode, outputBuilder.ToString().Trim('\r', '\n'));
-    }
-
-    internal static string CreateTemporaryBatchFile(string command)
-    {
-        string extn = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".cmd" : ".sh";
-        string file = Path.Combine(Path.GetTempPath(), $"tmp{Guid.NewGuid():N}{extn}");
-
-        using StreamWriter sw = new(file);
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-                sw.WriteLine("setlocal");
-                sw.WriteLine("set errorlevel=dummy");
-                sw.WriteLine("set errorlevel=");
-        }
-        else
-        {
-            // Use sh rather than bash, as not all 'nix systems necessarily have Bash installed
-            sw.WriteLine("#!/bin/sh");
-        }
-
-        sw.WriteLine(command);
-
-        return file;
     }
 
     public static bool CopyIfDifferent(string src, string dst, bool useHash)

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BlazorWasmBuildPublishTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BlazorWasmBuildPublishTests.cs
@@ -26,7 +26,7 @@ namespace Wasm.Build.Tests
         [InlineData("Release")]
         public void DefaultTemplate_WithoutWorkload(string config)
         {
-            string id = $"blz_no_workload_{config}";
+            string id = $"blz_no_workload_{config}{s_unicodeChar}";
             CreateBlazorWasmTemplateProject(id);
 
             // Build

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildPublishTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildPublishTests.cs
@@ -25,7 +25,7 @@ namespace Wasm.Build.Tests
         [BuildAndRun(host: RunHost.Chrome, aot: false, config: "Debug")]
         public void BuildThenPublishNoAOT(BuildArgs buildArgs, RunHost host, string id)
         {
-            string projectName = $"build_publish_{buildArgs.Config}";
+            string projectName = $"build_publish_{buildArgs.Config}_{s_unicodeChar}";
 
             buildArgs = buildArgs with { ProjectName = projectName };
             buildArgs = ExpandBuildArgs(buildArgs);

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
@@ -29,7 +29,7 @@ namespace Wasm.Build.Tests
     {
         public const string DefaultTargetFramework = "net7.0";
         public static readonly string NuGetConfigFileNameForDefaultFramework = $"nuget7.config";
-        protected static readonly char s_unicodeChar = '煉';
+        protected static readonly char s_unicodeChar = '\u7149';
         protected static readonly bool s_skipProjectCleanup;
         protected static readonly string s_xharnessRunnerCommand;
         protected string? _projectDir;

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
@@ -29,6 +29,7 @@ namespace Wasm.Build.Tests
     {
         public const string DefaultTargetFramework = "net7.0";
         public static readonly string NuGetConfigFileNameForDefaultFramework = $"nuget7.config";
+        protected static readonly char s_unicodeChar = '煉';
         protected static readonly bool s_skipProjectCleanup;
         protected static readonly string s_xharnessRunnerCommand;
         protected string? _projectDir;


### PR DESCRIPTION
Backport of #82833 to release/7.0

Fixes https://github.com/dotnet/runtime/issues/78953.


## Customer Impact

Customers had a problem with publishing applications that were located in a path with Unicode chars. It was because Windows’s scripts do not support UTF-8 by default. Now we added that feature + tests.

## Testing

The PR introduced changes in WasmBuildTests and they are passing.

## Risk

Low, it broadens the accepted range of codes for Windows to `UTF-8`.