### PR TITLE
Extend mstat format with information that maps to dependency nodes

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/MetadataEmitter/TypeSystemMetadataEmitter.cs
+++ b/src/coreclr/tools/Common/TypeSystem/MetadataEmitter/TypeSystemMetadataEmitter.cs
@@ -85,16 +85,20 @@ namespace Internal.TypeSystem
         }
 
         private static readonly Guid s_guid = new Guid("97F4DBD4-F6D1-4FAD-91B3-1001F92068E5");
-        private static readonly BlobContentId s_contentId = new BlobContentId(s_guid, 0x04030201);
+        protected static readonly BlobContentId s_contentId = new BlobContentId(s_guid, 0x04030201);
 
         public MetadataBuilder Builder => _metadataBuilder;
 
-        public void SerializeToStream(Stream peStream)
+        protected virtual ManagedPEBuilder CreateManagedPEBuilder(BlobBuilder ilBuilder)
         {
             var peHeaderBuilder = new PEHeaderBuilder();
-            var peBuilder = new ManagedPEBuilder(peHeaderBuilder, new MetadataRootBuilder(_metadataBuilder), _ilBuilder,
+            return new ManagedPEBuilder(peHeaderBuilder, new MetadataRootBuilder(_metadataBuilder), ilBuilder,
                 deterministicIdProvider: content => s_contentId);
+        }
 
+        public void SerializeToStream(Stream peStream)
+        {
+            var peBuilder = CreateManagedPEBuilder(_ilBuilder);
             var peBlob = new BlobBuilder();
             var contentId = peBuilder.Serialize(peBlob);
             new BlobWriter(_mvidFixup).WriteGuid(contentId.Guid);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/IObjectDumper.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/IObjectDumper.cs
@@ -7,6 +7,6 @@ namespace ILCompiler.DependencyAnalysis
 {
     public interface IObjectDumper
     {
-        void DumpObjectNode(NameMangler mangler, ObjectNode node, ObjectData objectData);
+        void DumpObjectNode(NodeFactory factory, ObjectNode node, ObjectData objectData);
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -992,7 +992,7 @@ namespace ILCompiler.DependencyAnalysis
 
                     ObjectData nodeContents = node.GetData(factory);
 
-                    dumper?.DumpObjectNode(factory.NameMangler, node, nodeContents);
+                    dumper?.DumpObjectNode(factory, node, nodeContents);
 
 #if DEBUG
                     foreach (ISymbolNode definedSymbol in nodeContents.DefinedSymbols)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MstatObjectDumper.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MstatObjectDumper.cs
@@ -2,43 +2,47 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
 
-using Internal.Text;
 using Internal.TypeSystem;
 
 using ILCompiler.DependencyAnalysis;
+using ILCompiler.DependencyAnalysisFramework;
 
 using ObjectData = ILCompiler.DependencyAnalysis.ObjectNode.ObjectData;
 using AssemblyName = System.Reflection.AssemblyName;
-using System.Collections.Generic;
 
 namespace ILCompiler
 {
     public class MstatObjectDumper : ObjectDumper
     {
-        private const int VersionMajor = 1;
-        private const int VersionMinor = 1;
+        private const int VersionMajor = 2;
+        private const int VersionMinor = 0;
 
         private readonly string _fileName;
-        private readonly TypeSystemMetadataEmitter _emitter;
+        private readonly MstatEmitter _emitter;
 
         private readonly InstructionEncoder _types = new InstructionEncoder(new BlobBuilder());
 
-        private Dictionary<MethodDesc, (string MangledName, int Size, int GcInfoSize)> _methods = new();
+        private readonly BlobBuilder _mangledNames = new BlobBuilder();
+
+        private List<(MethodDesc Method, string MangledName, int Size, int GcInfoSize)> _methods = new();
         private Dictionary<MethodDesc, int> _methodEhInfo = new();
         private Dictionary<string, int> _blobs = new();
-
-        private Utf8StringBuilder _utf8StringBuilder = new Utf8StringBuilder();
 
         public MstatObjectDumper(string fileName, TypeSystemContext context)
         {
             _fileName = fileName;
             var asmName = new AssemblyName(Path.GetFileName(fileName));
             asmName.Version = new Version(VersionMajor, VersionMinor);
-            _emitter = new TypeSystemMetadataEmitter(asmName, context);
+            _emitter = new MstatEmitter(asmName, context);
             _emitter.AllowUseOfAddGlobalMethod();
         }
 
@@ -46,24 +50,23 @@ namespace ILCompiler
         {
         }
 
-        protected override void DumpObjectNode(NameMangler mangler, ObjectNode node, ObjectData objectData)
+        protected override void DumpObjectNode(NodeFactory factory, ObjectNode node, ObjectData objectData)
         {
-            string mangledName = null;
-            if (node is ISymbolNode symbol)
-            {
-                _utf8StringBuilder.Clear();
-                symbol.AppendMangledName(mangler, _utf8StringBuilder);
-                mangledName = _utf8StringBuilder.ToString();
-            }
-
             switch (node)
             {
                 case EETypeNode eeType:
-                    SerializeSimpleEntry(_types, eeType.Type, objectData);
+                    _types.OpCode(ILOpCode.Ldtoken);
+                    _types.Token(_emitter.EmitMetadataHandleForTypeSystemEntity(eeType.Type));
+                    _types.LoadConstantI4(objectData.Data.Length);
+                    _types.LoadConstantI4(AppendMangledName(DependencyNodeCore<NodeFactory>.GetNodeName(node, factory)));
                     break;
                 case IMethodBodyNode methodBody:
                     var codeInfo = (INodeWithCodeInfo)node;
-                    _methods.Add(methodBody.Method, (mangledName, objectData.Data.Length, codeInfo.GCInfo.Length));
+                    _methods.Add((
+                        methodBody.Method,
+                        DependencyNodeCore<NodeFactory>.GetNodeName(node, factory),
+                        objectData.Data.Length,
+                        codeInfo.GCInfo.Length));
                     break;
                 case MethodExceptionHandlingInfoNode ehInfoNode:
                     _methodEhInfo.Add(ehInfoNode.Method, objectData.Data.Length);
@@ -77,13 +80,11 @@ namespace ILCompiler
             }
         }
 
-        private void SerializeSimpleEntry(InstructionEncoder encoder, TypeSystemEntity entity, ObjectData blob)
+        private int AppendMangledName(string mangledName)
         {
-            encoder.OpCode(ILOpCode.Ldtoken);
-            encoder.Token(_emitter.EmitMetadataHandleForTypeSystemEntity(entity));
-            // Would like to do this but mangled names are very long and go over the 16 MB string limit quickly.
-            // encoder.LoadString(_emitter.GetUserStringHandle(mangledName));
-            encoder.LoadConstantI4(blob.Data.Length);
+            int index = _mangledNames.Count;
+            _mangledNames.WriteSerializedString(mangledName);
+            return index;
         }
 
         internal override void End()
@@ -92,12 +93,11 @@ namespace ILCompiler
             foreach (var m in _methods)
             {
                 methods.OpCode(ILOpCode.Ldtoken);
-                methods.Token(_emitter.EmitMetadataHandleForTypeSystemEntity(m.Key));
-                // Would like to do this but mangled names are very long and go over the 16 MB string limit quickly.
-                // methods.LoadString(_emitter.GetUserStringHandle(m.Value.MangledName));
-                methods.LoadConstantI4(m.Value.Size);
-                methods.LoadConstantI4(m.Value.GcInfoSize);
-                methods.LoadConstantI4(_methodEhInfo.GetValueOrDefault(m.Key));
+                methods.Token(_emitter.EmitMetadataHandleForTypeSystemEntity(m.Method));
+                methods.LoadConstantI4(m.Size);
+                methods.LoadConstantI4(m.GcInfoSize);
+                methods.LoadConstantI4(_methodEhInfo.GetValueOrDefault(m.Method));
+                methods.LoadConstantI4(AppendMangledName(m.MangledName));
             }
 
             var blobs = new InstructionEncoder(new BlobBuilder());
@@ -111,8 +111,60 @@ namespace ILCompiler
             _emitter.AddGlobalMethod("Types", _types, 0);
             _emitter.AddGlobalMethod("Blobs", blobs, 0);
 
-            using (var fs = File.OpenWrite(_fileName))
+            _emitter.AddPESection(".names", _mangledNames);
+
+            using (var fs = File.Create(_fileName))
                 _emitter.SerializeToStream(fs);
+        }
+
+        private class MstatEmitter : TypeSystemMetadataEmitter
+        {
+            private readonly List<(string Name, BlobBuilder Content)> _customSections = new();
+
+            public MstatEmitter(AssemblyName assemblyName, TypeSystemContext context, AssemblyFlags flags = default(AssemblyFlags), byte[] publicKeyArray = null)
+                : base(assemblyName, context, flags, publicKeyArray)
+            {
+            }
+
+            public void AddPESection(string name, BlobBuilder content)
+            {
+                _customSections.Add((name, content));
+            }
+
+            protected override ManagedPEBuilder CreateManagedPEBuilder(BlobBuilder ilBuilder)
+            {
+                return new MstatPEBuilder(this, ilBuilder);
+            }
+
+            private class MstatPEBuilder : ManagedPEBuilder
+            {
+                private readonly MstatEmitter _emitter;
+
+                public MstatPEBuilder(
+                    MstatEmitter emitter,
+                    BlobBuilder ilStream)
+                    : base(PEHeaderBuilder.CreateLibraryHeader(), new MetadataRootBuilder(emitter.Builder), ilStream, deterministicIdProvider: content => s_contentId)
+                {
+                    _emitter = emitter;
+                }
+
+                protected override ImmutableArray<Section> CreateSections()
+                {
+                    ImmutableArray<Section> result = base.CreateSections();
+                    return result.AddRange(_emitter._customSections.Select(s => new Section(s.Name, SectionCharacteristics.MemRead)));
+                }
+
+                protected override BlobBuilder SerializeSection(string name, SectionLocation location)
+                {
+                    foreach (var section in _emitter._customSections)
+                    {
+                        if (section.Name == name)
+                            return section.Content;
+                    }
+
+                    return base.SerializeSection(name, location);
+                }
+            }
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MstatObjectDumper.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MstatObjectDumper.cs
@@ -117,7 +117,7 @@ namespace ILCompiler
                 _emitter.SerializeToStream(fs);
         }
 
-        private class MstatEmitter : TypeSystemMetadataEmitter
+        private sealed class MstatEmitter : TypeSystemMetadataEmitter
         {
             private readonly List<(string Name, BlobBuilder Content)> _customSections = new();
 
@@ -136,7 +136,7 @@ namespace ILCompiler
                 return new MstatPEBuilder(this, ilBuilder);
             }
 
-            private class MstatPEBuilder : ManagedPEBuilder
+            private sealed class MstatPEBuilder : ManagedPEBuilder
             {
                 private readonly MstatEmitter _emitter;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectDumper.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectDumper.cs
@@ -13,8 +13,8 @@ namespace ILCompiler
     {
         internal abstract void Begin();
         internal abstract void End();
-        void IObjectDumper.DumpObjectNode(NameMangler mangler, ObjectNode node, ObjectData objectData) => DumpObjectNode(mangler, node, objectData);
-        protected abstract void DumpObjectNode(NameMangler mangler, ObjectNode node, ObjectData objectData);
+        void IObjectDumper.DumpObjectNode(NodeFactory factory, ObjectNode node, ObjectData objectData) => DumpObjectNode(factory, node, objectData);
+        protected abstract void DumpObjectNode(NodeFactory factory, ObjectNode node, ObjectData objectData);
 
         protected static string GetObjectNodeName(ObjectNode node)
         {
@@ -53,10 +53,10 @@ namespace ILCompiler
 
             public ComposedObjectDumper(ObjectDumper[] dumpers) => _dumpers = dumpers;
 
-            protected override void DumpObjectNode(NameMangler mangler, ObjectNode node, ObjectData objectData)
+            protected override void DumpObjectNode(NodeFactory factory, ObjectNode node, ObjectData objectData)
             {
                 foreach (var d in _dumpers)
-                    d.DumpObjectNode(mangler, node, objectData);
+                    d.DumpObjectNode(factory, node, objectData);
             }
             internal override void Begin()
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/XmlObjectDumper.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/XmlObjectDumper.cs
@@ -38,7 +38,7 @@ namespace ILCompiler
             _writer.WriteStartElement("ObjectNodes");
         }
 
-        protected override void DumpObjectNode(NameMangler mangler, ObjectNode node, ObjectData objectData)
+        protected override void DumpObjectNode(NodeFactory nodeFactory, ObjectNode node, ObjectData objectData)
         {
             string name = null;
 
@@ -48,7 +48,7 @@ namespace ILCompiler
             if (symbolNode != null)
             {
                 Utf8StringBuilder sb = new Utf8StringBuilder();
-                symbolNode.AppendMangledName(mangler, sb);
+                symbolNode.AppendMangledName(nodeFactory.NameMangler, sb);
                 name = sb.ToString();
                 _writer.WriteAttributeString("Name", name);
             }

--- a/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/DependencyNodeCore.cs
+++ b/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/DependencyNodeCore.cs
@@ -153,5 +153,8 @@ namespace ILCompiler.DependencyAnalysisFramework
         {
             return GetName(context);
         }
+
+        public static string GetNodeName(DependencyNodeCore<DependencyContextType> node, DependencyContextType context)
+            => node.GetName(context);
     }
 }


### PR DESCRIPTION
This will allow crossreferencing MSTAT with DGML files. The ultimate goal is to allow folding information from DGML into MSTAT (so that we don't need two files) but... baby steps.

This is a breaking change to the file format. I don't anticipate a breaking change after this. The DGML folding would be backwards compatible. I considered making it non-breaking, but I think it's just better to bite the bullet now. To fix existing readers, just skip over the new entry. Like in this diff: https://gist.github.com/MichalStrehovsky/2c7cb3d623c7f8901541914dab04238d/revisions

This adds an extra instruction encoding the name into each entry of the Method and Types stream.

We avoid the problem in #75328 (where the strings ran over the 16 MB total length limit) by generating the textual strings into a separate PE section. The record contains an integer index into this section.

If you would like to read it, it's not possible with Cecil, but the superior metadata reader in S.R.Metadata comes to the rescue. This is the ~diff you'd want to apply (and make a similar adjustment for methods): https://gist.github.com/MichalStrehovsky/195967f3a117663b6340cd828a52dfc7/revisions. If you're worried about duplicate loading, I'd suggest creating a memory mapped view of the file and sharing the same view between Cecil and S.R.Metadata. S.R.Metadata is pretty much no overhead on it's own.

Cc @dotnet/ilc-contrib @Suchiman @kant2002 @ShreyasJejurkar @eerhardt @amcasey