### PR TITLE
[browser] fix advanced sample for MT 

### DIFF
--- a/src/mono/sample/wasm/browser-advanced/Wasm.Advanced.Sample.csproj
+++ b/src/mono/sample/wasm/browser-advanced/Wasm.Advanced.Sample.csproj
@@ -6,7 +6,7 @@
     <WasmEnableWebcil>true</WasmEnableWebcil>
     <WasmEmitSymbolMap>true</WasmEmitSymbolMap>
     <EmccEnableAssertions>true</EmccEnableAssertions>
-    <EmccEnvironment>web</EmccEnvironment>
+    <EmccEnvironment>web,worker</EmccEnvironment>
     <!-- add OpenGL emulation -->
     <EmccExtraLDFlags> -s USE_CLOSURE_COMPILER=1 -s LEGACY_GL_EMULATION=1 -lGL -lSDL -lidbfs.js</EmccExtraLDFlags>
     <!-- just to prove we don't do JS eval() -->


### PR DESCRIPTION

```
mcc : error : When building with multithreading enabled and a "-sENVIRONMENT=" 
directive is specified, it must include "worker" as a target! (Try e.g. -sENVIRONMENT=web,worker) 
[/__w/1/s/src/mono/sample/wasm/browser-advanced/Wasm.Advanced.Sample.csproj]
```