### PR TITLE
[browser] disable memorySnapshot for WS test

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
+++ b/src/libraries/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
@@ -7,6 +7,9 @@
     <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
     <!--Remove once this is fixed, https://github.com/dotnet/runtime/issues/71506 -->
     <IlcTrimMetadata>false</IlcTrimMetadata>
+
+    <!-- this test project is too slow with extra start of another runtime -->
+    <WasmXHarnessMonoArgs>$(WasmXHarnessMonoArgs) --no-memory-snapshot</WasmXHarnessMonoArgs>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetOS)' == 'browser'">

--- a/src/mono/wasm/test-main.js
+++ b/src/mono/wasm/test-main.js
@@ -269,7 +269,9 @@ function configureRuntime(dotnet, runArgs, INTERNAL) {
         }
     }
     if (is_browser) {
-        if (runArgs.memorySnapshot) dotnet.withStartupMemoryCache(true)
+        if (runArgs.memorySnapshot) {
+            dotnet.withStartupMemoryCache(true);
+        }
         dotnet.withEnvironmentVariable("IsWebSocketSupported", "true");
     }
     if (runArgs.runtimeArgs.length > 0) {

--- a/src/mono/wasm/test-main.js
+++ b/src/mono/wasm/test-main.js
@@ -92,6 +92,7 @@ function initRunArgs(runArgs) {
     runArgs.configSrc = runArgs.configSrc === undefined ? './mono-config.json' : runArgs.configSrc;
     // default'ing to true for tests, unless debugging
     runArgs.forwardConsole = runArgs.forwardConsole === undefined ? !runArgs.debugging : runArgs.forwardConsole;
+    runArgs.memorySnapshot = runArgs.memorySnapshot === undefined ? true : runArgs.memorySnapshot;
 
     return runArgs;
 }
@@ -123,6 +124,8 @@ function processArguments(incomingArguments, runArgs) {
             runArgs.debugging = true;
         } else if (currentArg == "--no-forward-console") {
             runArgs.forwardConsole = false;
+        } else if (currentArg == "--no-memory-snapshot") {
+            runArgs.memorySnapshot = false;
         } else if (currentArg.startsWith("--fetch-random-delay=")) {
             const arg = currentArg.substring("--fetch-random-delay=".length);
             if (is_browser) {
@@ -266,9 +269,8 @@ function configureRuntime(dotnet, runArgs, INTERNAL) {
         }
     }
     if (is_browser) {
-        dotnet
-            .withStartupMemoryCache(true)
-            .withEnvironmentVariable("IsWebSocketSupported", "true");
+        if (runArgs.memorySnapshot) dotnet.withStartupMemoryCache(true)
+        dotnet.withEnvironmentVariable("IsWebSocketSupported", "true");
     }
     if (runArgs.runtimeArgs.length > 0) {
         dotnet.withRuntimeOptions(runArgs.runtimeArgs);
@@ -314,7 +316,7 @@ async function run() {
         const runArgs = await getArgs();
         console.log("Application arguments: " + runArgs.applicationArguments.join(' '));
 
-        if (is_browser) {
+        if (is_browser && runArgs.memorySnapshot) {
             const dryOk = await dry_run(runArgs);
             if (!dryOk) {
                 mono_exit(1, "Failed during dry run");


### PR DESCRIPTION
Perphaps it could fix the timeout 
[Log](https://helixre107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-pull-83524-merge-da225e1956f84ddd91/WasmTestOnBrowser-System.Net.WebSockets.Client.Tests/1/console.c0689440.log?helixlogtype=result)