### PR TITLE
[wasm] Fix dotnet.withRuntimeOptions

### DIFF
--- a/src/mono/wasm/runtime/run-outer.ts
+++ b/src/mono/wasm/runtime/run-outer.ts
@@ -243,10 +243,8 @@ class HostBuilder implements DotnetHostBuilder {
     withRuntimeOptions(runtimeOptions: string[]): DotnetHostBuilder {
         try {
             mono_assert(runtimeOptions && Array.isArray(runtimeOptions), "must be array of strings");
-            const configInternal: MonoConfigInternal = {
-                runtimeOptions: runtimeOptions
-            };
-            Object.assign(this.moduleConfig.config!, configInternal);
+            const configInternal = this.moduleConfig.config as MonoConfigInternal;
+            configInternal.runtimeOptions = [...(configInternal.runtimeOptions || []), ...(runtimeOptions|| [])];
             return this;
         } catch (err) {
             mono_exit(1, err);

--- a/src/mono/wasm/runtime/run-outer.ts
+++ b/src/mono/wasm/runtime/run-outer.ts
@@ -243,7 +243,10 @@ class HostBuilder implements DotnetHostBuilder {
     withRuntimeOptions(runtimeOptions: string[]): DotnetHostBuilder {
         try {
             mono_assert(runtimeOptions && Array.isArray(runtimeOptions), "must be array of strings");
-            Object.assign(this.moduleConfig, { runtimeOptions });
+            const configInternal: MonoConfigInternal = {
+                runtimeOptions: runtimeOptions
+            };
+            Object.assign(this.moduleConfig.config!, configInternal);
             return this;
         } catch (err) {
             mono_exit(1, err);

--- a/src/tests/FunctionalTests/WebAssembly/Browser/RuntimeConfig/main.js
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/RuntimeConfig/main.js
@@ -10,12 +10,17 @@ function wasm_exit(exit_code) {
 }
 
 try {
-    const { getAssemblyExports } = await dotnet.create();
+    const { getAssemblyExports, INTERNAL } = await dotnet.withRuntimeOptions(["--jiterpreter-stats-enabled"]).create();
     const exports = await getAssemblyExports("WebAssembly.Browser.RuntimeConfig.Test.dll");
     const testMeaning = exports.Sample.Test.TestMeaning;
     const ret = testMeaning();
     document.getElementById("out").innerHTML = `${ret}`;
     console.debug(`ret: ${ret}`);
+
+    // Test runtimeOptions were applied
+    if (!INTERNAL.jiterpreter_get_options().enableStats) {
+        throw new Error("RuntimeOptions not propagated")
+    }
 
     let exit_code = ret;
     wasm_exit(exit_code);


### PR DESCRIPTION
The options were assigned to a wrong config object and weren't used in `mono_wasm_set_runtime_options`