### PR TITLE
[mono][interp] Correctly track livness of vars used with MINT_MOV_8_*

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -10579,6 +10579,16 @@ interp_alloc_offsets (TransformData *td)
 					end_active_var (td, &av, var);
 				}
 			}
+			if (opcode >= MINT_MOV_8_2 && opcode <= MINT_MOV_8_4) {
+				// These opcodes have multiple dvars, which overcomplicate things, so they are
+				// marked as having no svars/dvars, for now. Special case it.
+				int num_pairs = 2 + opcode - MINT_MOV_8_2;
+				for (int i = 0; i < num_pairs; i++) {
+					int var = ins->data [2 * i + 1];
+					if (!(td->locals [var].flags & INTERP_LOCAL_FLAG_GLOBAL) && td->locals [var].live_end == ins_index)
+						end_active_var (td, &av, var);
+				}
+			}
 
 			if (is_call)
 				end_active_call (td, &ac, ins);


### PR DESCRIPTION
These instructions are defined as having no svars/dvars, even though they have multiple svars/dvars. We were failing to remove svars used by these instructions from the set of active vars, leading to vars remaining alive until the end of the basic block. This could lead to the consuming of the entire stack space available for interp vars.

Fixes https://github.com/dotnet/runtime/issues/83260