### PR TITLE
Include args in hostfxr entry point tracing

### DIFF
--- a/src/native/corehost/fxr/hostfxr.cpp
+++ b/src/native/corehost/fxr/hostfxr.cpp
@@ -241,6 +241,13 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_resolve_sdk2(
     hostfxr_resolve_sdk2_result_fn result)
 {
     trace_hostfxr_entry_point(_X("hostfxr_resolve_sdk2"));
+    trace::info(
+        _X("  exe_dir=%s\n")
+        _X("  working_dir=%s\n")
+        _X("  flags=%d"),
+        exe_dir == nullptr ? _X("<nullptr>") : exe_dir,
+        working_dir == nullptr ? _X("<nullptr>") : working_dir,
+        flags);
 
     if (exe_dir == nullptr)
     {
@@ -315,6 +322,7 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_get_available_sdks(
     hostfxr_get_available_sdks_result_fn result)
 {
     trace_hostfxr_entry_point(_X("hostfxr_get_available_sdks"));
+    trace::info(_X("  exe_dir=%s"), exe_dir == nullptr ? _X("<nullptr>") : exe_dir);
 
     if (exe_dir == nullptr)
     {
@@ -350,6 +358,9 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_get_dotnet_environment_info(
     hostfxr_get_dotnet_environment_info_result_fn result,
     void* result_context)
 {
+    trace_hostfxr_entry_point(_X("hostfxr_get_dotnet_environment_info"));
+    trace::info(_X("  dotnet_root=%s"), dotnet_root == nullptr ? _X("<nullptr>") : dotnet_root);
+
     if (result == nullptr)
     {
         trace::error(_X("hostfxr_get_dotnet_environment_info received an invalid argument: result should not be null."));
@@ -484,6 +495,15 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_get_dotnet_environment_info(
 SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_get_native_search_directories(const int argc, const pal::char_t* argv[], pal::char_t buffer[], int32_t buffer_size, int32_t* required_buffer_size)
 {
     trace_hostfxr_entry_point(_X("hostfxr_get_native_search_directories"));
+    if (trace::is_enabled())
+    {
+        trace::info(_X("  args=["));
+        for (int i = 0; i < argc; ++i)
+        {
+            trace::info(_X("    %s"), argv[i]);
+        }
+        trace::info(_X("  ]"));
+    }
 
     if (buffer_size < 0 || (buffer_size > 0 && buffer == nullptr) || required_buffer_size == nullptr)
     {


### PR DESCRIPTION
Update tracing to print out args passed to hostfxr entry points.