### PR TITLE
JIT: stop copying EH tab info into inlinee compiler

### DIFF
--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -341,8 +341,9 @@ inline bool Compiler::jitIsBetweenInclusive(unsigned value, unsigned start, unsi
  */
 inline EHblkDsc* Compiler::ehGetDsc(unsigned regionIndex)
 {
-    assert(regionIndex < compHndBBtabCount);
-    return &compHndBBtab[regionIndex];
+    Compiler* const comp = impInlineRoot();
+    assert(regionIndex < comp->compHndBBtabCount);
+    return &comp->compHndBBtab[regionIndex];
 }
 
 /******************************************************************************************
@@ -366,8 +367,9 @@ inline unsigned Compiler::ehGetEnclosingHndIndex(unsigned regionIndex)
  */
 inline unsigned Compiler::ehGetIndex(EHblkDsc* ehDsc)
 {
-    assert(compHndBBtab <= ehDsc && ehDsc < compHndBBtab + compHndBBtabCount);
-    return (unsigned)(ehDsc - compHndBBtab);
+    Compiler* const comp = impInlineRoot();
+    assert(comp->compHndBBtab <= ehDsc && ehDsc < comp->compHndBBtab + comp->compHndBBtabCount);
+    return (unsigned)(ehDsc - comp->compHndBBtab);
 }
 
 /******************************************************************************************

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -3457,13 +3457,6 @@ void Compiler::fgFindBasicBlocks()
             return;
         }
 
-        noway_assert(info.compXcptnsCount == 0);
-        compHndBBtab = impInlineInfo->InlinerCompiler->compHndBBtab;
-        compHndBBtabAllocCount =
-            impInlineInfo->InlinerCompiler->compHndBBtabAllocCount; // we probably only use the table, not add to it.
-        compHndBBtabCount    = impInlineInfo->InlinerCompiler->compHndBBtabCount;
-        info.compXcptnsCount = impInlineInfo->InlinerCompiler->info.compXcptnsCount;
-
         // Use a spill temp for the return value if there are multiple return blocks,
         // or if the inlinee has GC ref locals.
         if ((info.compRetNativeType != TYP_VOID) && ((fgReturnCount > 1) || impInlineInfo->HasGcRefLocals()))


### PR DESCRIPTION
Having this info show up for inlinees just confuses things -- if the inlinee looks in this table and finds a block reference, it will be to a block that doesn't exist in the inlinee's flow graph.

This has been tripping up profile synthesis, which wants to attribute some flow to EH entries; inlinees don't have any, but currently look like they do.

There is one place in inlinee importation where we might ask about EH properties -- inline pinvoke checks. We're already careful to redirect this query to the call site block, so in the correspnonding lookup we must make sure to answer this via the root compiler's EH tab.

If we ever decide to support inlining of methods with EH we'll have to reconcile all this differently.