### PR TITLE
Avoid clearing uncommitted mark array

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -8523,14 +8523,9 @@ uint32_t* translate_mark_array (uint32_t* ma)
 
 #ifdef FEATURE_BASICFREEZE
 // end must be page aligned addresses.
-void gc_heap::clear_mark_array (uint8_t* from, uint8_t* end, BOOL read_only/*=FALSE*/)
+void gc_heap::clear_mark_array (uint8_t* from, uint8_t* end)
 {
     assert (gc_can_use_concurrent);
-
-    if (!read_only)
-    {
-        assert (from == align_on_mark_word (from));
-    }
     assert (end == align_on_mark_word (end));
 
     uint8_t* current_lowest_address = background_saved_lowest_address;
@@ -9595,8 +9590,7 @@ void gc_heap::remove_ro_segment (heap_segment* seg)
 #ifdef BACKGROUND_GC
     if (gc_can_use_concurrent)
     {
-        clear_mark_array (align_lower_mark_word (max (heap_segment_mem (seg), lowest_address)),
-                          align_on_card_word (min (heap_segment_allocated (seg), highest_address)));
+        seg_clear_mark_array_bits_soh (seg);
     }
 #endif //BACKGROUND_GC
 
@@ -11084,7 +11078,7 @@ void gc_heap::seg_clear_mark_array_bits_soh (heap_segment* seg)
     uint8_t* range_end = 0;
     if (bgc_mark_array_range (seg, FALSE, &range_beg, &range_end))
     {
-        clear_mark_array (range_beg, align_on_mark_word (range_end), TRUE);
+        clear_mark_array (range_beg, align_on_mark_word (range_end));
     }
 }
 

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -2284,7 +2284,7 @@ private:
 
 #ifdef FEATURE_BASICFREEZE
     PER_HEAP_METHOD void seg_set_mark_array_bits_soh (heap_segment* seg);
-    PER_HEAP_METHOD void clear_mark_array (uint8_t* from, uint8_t* end, BOOL read_only=FALSE);
+    PER_HEAP_METHOD void clear_mark_array (uint8_t* from, uint8_t* end);
     PER_HEAP_METHOD void seg_clear_mark_array_bits_soh (heap_segment* seg);
 #endif // FEATURE_BASICFREEZE
 

--- a/src/tests/GC/API/Frozen/Frozen.cs
+++ b/src/tests/GC/API/Frozen/Frozen.cs
@@ -136,6 +136,13 @@ namespace HelloFrozenSegment
     {
         private static unsafe int Main()
         {
+            // Regression testing for dotnet/runtime #83027
+            Node[] firstArray = new Node[30000000]; 
+            for (int index = 0; index < firstArray.Length; index++)
+            {
+                firstArray[index] = new Node();
+            }
+
             IntPtr methodTable = typeof(Node).TypeHandle.Value;
 
             FrozenSegmentBuilder frozenSegmentBuilder = new FrozenSegmentBuilder(1000);


### PR DESCRIPTION
This PR fixes a bug found in @Feralnex in #83027.

In case a background GC happened and then a frozen segment allocated right next to the regions range is removed, it is possible that the expression `align_lower_mark_word (max (heap_segment_mem (seg), lowest_address)` produce a value less than `highest_address` (because of the `lower` in the `align_lower_mark_word`) and trick the `clear_mark_array` function to believe this frozen segment is in range and therefore attempts to actually clear the mark array that has never been committed.

The fix simply removed that code and reused the `seg_clear_mark_array_bits_soh` function instead.