### PR TITLE
[wasm] Boost hit count for outer back branch targets; improve conditional execution detection

### DIFF
--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -721,7 +721,6 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 					return mono_opt_jiterpreter_backward_branches_enabled ? TRACE_CONTINUE : TRACE_ABORT;
 			}
 
-			*inside_branch_block = TRUE;
 			return TRACE_CONTINUE;
 
 		case MINT_ICALL_V_P:

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -1414,6 +1414,31 @@ mono_jiterp_get_rejected_trace_count ()
 	return traces_rejected;
 }
 
+EMSCRIPTEN_KEEPALIVE void
+mono_jiterp_boost_back_branch_target (guint16 *ip) {
+	if (*ip != MINT_TIER_PREPARE_JITERPRETER) {
+		// g_print ("Failed to boost back branch target %d because it was %s\n", ip,  mono_interp_opname(*ip));
+		return;
+	}
+
+	guint32 trace_index = READ32 (ip + 1);
+	if (!trace_index)
+		return;
+
+	TraceInfo *trace_info = trace_info_get (trace_index);
+	// We need to make sure we don't boost the hit count too high, because if we do
+	//  it will increment past the compile threshold and never compile
+	int limit = mono_opt_jiterpreter_minimum_trace_hit_count - 1,
+		old_hit_count = trace_info->hit_count;
+	trace_info->hit_count = MIN (limit, trace_info->hit_count + mono_opt_jiterpreter_back_branch_boost);
+	/*
+	if (trace_info->hit_count > old_hit_count)
+		g_print ("Boosted entry point #%d at %d to %d\n", trace_index, ip, trace_info->hit_count);
+	else
+		g_print ("Entry point #%d at %d was already maxed out\n", trace_index, ip, trace_info->hit_count);
+	*/
+}
+
 // HACK: fix C4206
 EMSCRIPTEN_KEEPALIVE
 #endif // HOST_BROWSER

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -1428,8 +1428,7 @@ mono_jiterp_boost_back_branch_target (guint16 *ip) {
 	TraceInfo *trace_info = trace_info_get (trace_index);
 	// We need to make sure we don't boost the hit count too high, because if we do
 	//  it will increment past the compile threshold and never compile
-	int limit = mono_opt_jiterpreter_minimum_trace_hit_count - 1,
-		old_hit_count = trace_info->hit_count;
+	int limit = mono_opt_jiterpreter_minimum_trace_hit_count - 1;
 	trace_info->hit_count = MIN (limit, trace_info->hit_count + mono_opt_jiterpreter_back_branch_boost);
 	/*
 	if (trace_info->hit_count > old_hit_count)

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -721,6 +721,10 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 					return mono_opt_jiterpreter_backward_branches_enabled ? TRACE_CONTINUE : TRACE_ABORT;
 			}
 
+			// NOTE: This is technically incorrect - we are not conditionally executing code. However
+			//  the instructions *following* this may not be executed since we might skip over them.
+			*inside_branch_block = TRUE;
+
 			return TRACE_CONTINUE;
 
 		case MINT_ICALL_V_P:

--- a/src/mono/mono/utils/options-def.h
+++ b/src/mono/mono/utils/options-def.h
@@ -129,6 +129,9 @@ DEFINE_INT(jiterpreter_trace_monitoring_long_distance, "jiterpreter-trace-monito
 DEFINE_INT(jiterpreter_trace_monitoring_max_average_penalty, "jiterpreter-trace-monitoring-max-average-penalty", 75, "If the average penalty value for a trace is above this value it will be rejected")
 // 0 = no monitoring, 1 = log when rejecting a trace, 2 = log when accepting or rejecting a trace, 3 = log every recorded bailout
 DEFINE_INT(jiterpreter_trace_monitoring_log, "jiterpreter-trace-monitoring-log", 0, "Logging detail level for trace monitoring")
+// if a trace fails to back branch outside of itself, and there is a prepare point at the branch target, boost
+//  the hit count of that prepare point so it will JIT much sooner
+DEFINE_INT(jiterpreter_back_branch_boost, "jiterpreter-back-branch-boost", 4900, "Boost the hit count of prepare points targeted by a failed backward branch")
 // After a do_jit_call call site is hit this many times, we will queue it to be jitted
 DEFINE_INT(jiterpreter_jit_call_trampoline_hit_count, "jiterpreter-jit-call-hit-count", 1000, "Queue specialized do_jit_call trampoline for JIT after this many hits")
 // After a do_jit_call call site is hit this many times without being jitted, we will flush the JIT queue

--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -122,6 +122,7 @@ const fn_signatures: SigLine[] = [
     [true, "mono_jiterp_get_trace_hit_count", "number", ["number"]],
     [true, "mono_jiterp_get_polling_required_address", "number", []],
     [true, "mono_jiterp_get_rejected_trace_count", "number", []],
+    [true, "mono_jiterp_boost_back_branch_target", "void", ["number"]],
     ...legacy_interop_cwraps
 ];
 
@@ -240,6 +241,7 @@ export interface t_Cwraps {
     mono_jiterp_get_polling_required_address(): Int32Ptr;
     mono_jiterp_write_number_unaligned(destination: VoidPtr, value: number, mode: number): void;
     mono_jiterp_get_rejected_trace_count(): number;
+    mono_jiterp_boost_back_branch_target(destination: number): void;
 }
 
 const wrapped_c_functions: t_Cwraps = <any>{};

--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -1611,6 +1611,7 @@ export type JiterpreterOptions = {
     monitoringShortDistance: number;
     monitoringLongDistance: number;
     monitoringMaxAveragePenalty: number;
+    backBranchBoost: number;
     jitCallHitCount: number;
     jitCallFlushThreshold: number;
     interpEntryHitCount: number;
@@ -1641,6 +1642,7 @@ const optionNames : { [jsName: string] : string } = {
     "monitoringShortDistance": "jiterpreter-trace-monitoring-short-distance",
     "monitoringLongDistance": "jiterpreter-trace-monitoring-long-distance",
     "monitoringMaxAveragePenalty": "jiterpreter-trace-monitoring-max-average-penalty",
+    "backBranchBoost": "jiterpreter-back-branch-boost",
     "jitCallHitCount": "jiterpreter-jit-call-hit-count",
     "jitCallFlushThreshold": "jiterpreter-jit-call-queue-flush-threshold",
     "interpEntryHitCount": "jiterpreter-interp-entry-hit-count",

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -56,7 +56,8 @@ export const
     // Print diagnostic information to the console when performing null check optimizations
     traceNullCheckOptimizations = false,
     // Print diagnostic information when generating backward branches
-    traceBackBranches = false,
+    // 1 = failures only, 2 = full detail
+    traceBackBranches = 0,
     // If we encounter an enter opcode that looks like a loop body and it was already
     //  jitted, we should abort the current trace since it's not worth continuing
     // Unproductive if we have backward branches enabled because it can stop us from jitting


### PR DESCRIPTION
When we jit compile a trace and it tries to back branch outside of itself, this will cause a bailout. In cases with nested loops the outer target's hit count may take a long time to reach the compile threshold, but ideally we would compile a trace starting at that outer target so that we can spend more time inside of traces. This could happen for a less-frequently-called method that has millions of internal loop iterations, for example - like `Benchstone.BenchF.FFT`. In local test runs this appears to improve that benchmark's performance a bit and the bailout counts indicate that it goes down from millions of back-branch bailouts to tens of thousands, so it seems to work there.

This may increase startup time and memory usage a bit because we compile traces sooner, but it should balance out since the new traces will usually perform better. Adding the monitoring phase will help cull any cases where the new traces are slower.

Also, the jiterpreter's original logic only cared whether we were in a branch block when deciding whether a ret or call would execute, but any instruction after a branch instruction is conditionally executed. Improving this heuristic should fix some spurious compile aborts in certain functions (this affected a couple of the FFT benchmarks, for example)

EDIT: No merge because I want to delay this until after P3.