### PR TITLE
[browser] partial reversal of PR #82826

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSFunctionBinding.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSFunctionBinding.cs
@@ -142,6 +142,8 @@ namespace System.Runtime.InteropServices.JavaScript
         /// <exception cref="PlatformNotSupportedException">The method is executed on an architecture other than WebAssembly.</exception>
         // JavaScriptExports need to be protected from trimming because they are used from C/JS code which IL linker can't see
         [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, "System.Runtime.InteropServices.JavaScript.JavaScriptExports", "System.Runtime.InteropServices.JavaScript")]
+        // TODO make this DynamicDependency conditional again, see https://github.com/dotnet/runtime/pull/82826
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, "System.Runtime.InteropServices.JavaScript.LegacyExports", "System.Runtime.InteropServices.JavaScript")]
         public static JSFunctionBinding BindJSFunction(string functionName, string moduleName, ReadOnlySpan<JSMarshalerType> signatures)
         {
             if (RuntimeInformation.OSArchitecture != Architecture.Wasm)


### PR DESCRIPTION
There is problem in [Blazor E2E test](https://github.com/dotnet/aspnetcore/pull/47110#issuecomment-1474472215) with protecting the class `System.Runtime.InteropServices.JavaScript.LegacyExports` from trimming.

It seems in some scenario the root file `ILLink.Descriptors.LegacyJsInterop.xml` is not available and the class is trimmed even if we still should have it.

I believe that this PR would be enough revert of the original https://github.com/dotnet/runtime/pull/82826/
We should use it in case that we can't figure out better fix.