### PR TITLE
Remove unused code for PBKDF2 on Android

### DIFF
--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Evp.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Evp.cs
@@ -37,40 +37,6 @@ internal static partial class Interop
         [LibraryImport(Libraries.AndroidCryptoNative, EntryPoint = "CryptoNative_GetMaxMdSize")]
         private static partial int GetMaxMdSize();
 
-        [LibraryImport(Libraries.AndroidCryptoNative, EntryPoint = "CryptoNative_Pbkdf2")]
-        private static unsafe partial int Pbkdf2(
-            byte* pPassword,
-            int passwordLength,
-            byte* pSalt,
-            int saltLength,
-            int iterations,
-            IntPtr digestEvp,
-            byte* pDestination,
-            int destinationLength);
-
-        internal static unsafe int Pbkdf2(
-            ReadOnlySpan<byte> password,
-            ReadOnlySpan<byte> salt,
-            int iterations,
-            IntPtr digestEvp,
-            Span<byte> destination)
-        {
-            fixed (byte* pPassword = password)
-            fixed (byte* pSalt = salt)
-            fixed (byte* pDestination = destination)
-            {
-                return Pbkdf2(
-                    pPassword,
-                    password.Length,
-                    pSalt,
-                    salt.Length,
-                    iterations,
-                    digestEvp,
-                    pDestination,
-                    destination.Length);
-            }
-        }
-
         internal static readonly int EVP_MAX_MD_SIZE = GetMaxMdSize();
     }
 }


### PR DESCRIPTION
While working on something else, I noticed that we had some code for calling in to the android native shims for PBKDF2... but android doesn't use native code for PBKDF2. It uses a managed implementation. So this `LibraryImport` wasn't importing anything real.