### PR TITLE
WIP: [naot] Testing reverse pinvokes

### DIFF
--- a/src/tests/nativeaot/DynamicSymbolTable/CMakeLists.txt
+++ b/src/tests/nativeaot/DynamicSymbolTable/CMakeLists.txt
@@ -1,0 +1,8 @@
+project (NativeLibWithReversePInvokes)
+include_directories(${INC_PLATFORM_DIR})
+
+add_library (NativeLibWithReversePInvokes SHARED NativeLibWithReversePInvokes.cpp)
+target_link_libraries(NativeLibWithReversePInvokes PRIVATE ${LINK_LIBRARIES_ADDITIONAL})
+
+# add the install targets
+install (TARGETS NativeLibWithReversePInvokes DESTINATION bin)

--- a/src/tests/nativeaot/DynamicSymbolTable/CMakeLists.txt
+++ b/src/tests/nativeaot/DynamicSymbolTable/CMakeLists.txt
@@ -5,7 +5,7 @@ if (CLR_CMAKE_TARGET_OSX)
     list(APPEND LINK_LIBRARIES_ADDITIONAL
         "-undefined dynamic_lookup"
     )
-else (CLR_CMAKE_TARGET_WIN32)
+elseif (CLR_CMAKE_TARGET_WIN32)
     list(APPEND LINK_LIBRARIES_ADDITIONAL
         "/FORCE:UNRESOLVED"
     )

--- a/src/tests/nativeaot/DynamicSymbolTable/CMakeLists.txt
+++ b/src/tests/nativeaot/DynamicSymbolTable/CMakeLists.txt
@@ -1,6 +1,16 @@
 project (NativeLibWithReversePInvokes)
 include_directories(${INC_PLATFORM_DIR})
 
+if (CLR_CMAKE_TARGET_OSX)
+    list(APPEND LINK_LIBRARIES_ADDITIONAL
+        "-undefined dynamic_lookup"
+    )
+else (CLR_CMAKE_TARGET_WIN32)
+    list(APPEND LINK_LIBRARIES_ADDITIONAL
+        "/FORCE:UNRESOLVED"
+    )
+endif ()
+
 add_library (NativeLibWithReversePInvokes SHARED NativeLibWithReversePInvokes.cpp)
 target_link_libraries(NativeLibWithReversePInvokes PRIVATE ${LINK_LIBRARIES_ADDITIONAL})
 

--- a/src/tests/nativeaot/DynamicSymbolTable/DynamicSymbolTable.cs
+++ b/src/tests/nativeaot/DynamicSymbolTable/DynamicSymbolTable.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace DynamicSymbolTable
+{
+    unsafe class Program
+    {
+        [UnmanagedCallersOnly(EntryPoint = "ReversePInvokeEntry")]
+        static void ReversePInvokeEntry() => Console.WriteLine($"Hello from {nameof(ReversePInvokeEntry)}");
+
+        static int Main()
+        {
+            IntPtr libHandle;
+            
+            libHandle = NativeLibrary.Load(GetFullNativeLibraryName("NativeLibWithReversePInvokes"));
+            if (libHandle == IntPtr.Zero)
+            {
+                return 1;
+            }
+
+            if (NativeLibrary.TryGetExport(libHandle, "PInvokeEntry", out IntPtr funcHandle))
+            {
+                var PInvokeEntryPtr = (delegate* unmanaged <void>) funcHandle;
+                Console.WriteLine("PInvoke called");
+                PInvokeEntryPtr();
+                Console.WriteLine("PInvoke returned");
+            }
+            else
+            {
+                return 2;
+            }
+
+            return 100;
+        }
+
+        public static string GetFullNativeLibraryName(string baseName)
+        {
+            if (OperatingSystem.IsWindows())
+                return $"{baseName}.dll";
+
+            if (OperatingSystem.IsLinux())
+                return $"lib{baseName}.so";
+
+            if (OperatingSystem.IsMacOS())
+                return $"lib{baseName}.dylib";
+
+            throw new PlatformNotSupportedException();
+        }
+    }
+}

--- a/src/tests/nativeaot/DynamicSymbolTable/DynamicSymbolTable.csproj
+++ b/src/tests/nativeaot/DynamicSymbolTable/DynamicSymbolTable.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IlcExportUnmanagedEntrypoints>true</IlcExportUnmanagedEntrypoints>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="DynamicSymbolTable.cs" />
+    <!-- <LinkerArg Include="-rdynamic" /> -->
+  </ItemGroup>
+  <ItemGroup>
+    <CMakeProjectReference Include="CMakeLists.txt" />
+  </ItemGroup>
+
+</Project>

--- a/src/tests/nativeaot/DynamicSymbolTable/NativeLibWithReversePInvokes.cpp
+++ b/src/tests/nativeaot/DynamicSymbolTable/NativeLibWithReversePInvokes.cpp
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#ifdef TARGET_WINDOWS
+#define DLL_EXPORT extern "C" __declspec(dllexport)
+#else
+#define DLL_EXPORT extern "C" __attribute((visibility("default")))
+#endif
+#include "stdio.h"
+
+extern "C" void ReversePInvokeEntry();
+
+DLL_EXPORT void PInvokeEntry()
+{
+    printf("Hello from PInvokeEntry\n");
+    ReversePInvokeEntry();
+}


### PR DESCRIPTION
This PR is currently just to test some observations on how symbols are exported with NativeAOT executables on different systems.

I suspect that on linux we would need to pass `-rdynamic` when linking the main executable so the exported symbols also get added to the dynamic symbol table.  

I will open an issue and adjust the PR if this turns out to be the truth. 