### PR TITLE
Remove calling convention modifiers from cpuid sig

### DIFF
--- a/src/coreclr/vm/cgensys.h
+++ b/src/coreclr/vm/cgensys.h
@@ -97,11 +97,11 @@ inline void GetSpecificCpuInfo(CORINFO_CPU * cpuInfo)
 // MSVC directly defines intrinsics for __cpuid and __cpuidex matching the below signatures
 // We define matching signatures for use on Unix platforms.
 
-extern "C" void __stdcall __cpuid(int cpuInfo[4], int function_id);
-extern "C" void __stdcall __cpuidex(int cpuInfo[4], int function_id, int subFunction_id);
+extern "C" void __cpuid(int cpuInfo[4], int function_id);
+extern "C" void __cpuidex(int cpuInfo[4], int function_id, int subFunction_id);
 #endif // TARGET_UNIX
-extern "C" DWORD __stdcall xmmYmmStateSupport();
-extern "C" DWORD __stdcall avx512StateSupport();
+extern "C" DWORD xmmYmmStateSupport();
+extern "C" DWORD avx512StateSupport();
 #endif
 
 inline bool TargetHasAVXSupport()

--- a/src/coreclr/vm/i386/cgenx86.cpp
+++ b/src/coreclr/vm/i386/cgenx86.cpp
@@ -1084,7 +1084,7 @@ void ResumeAtJit(PCONTEXT pContext, LPVOID oldESP)
 #ifndef TARGET_UNIX
 #pragma warning(push)
 #pragma warning(disable: 4035)
-extern "C" DWORD __stdcall xmmYmmStateSupport()
+extern "C" DWORD xmmYmmStateSupport()
 {
     // No CONTRACT
     STATIC_CONTRACT_NOTHROW;
@@ -1108,7 +1108,7 @@ extern "C" DWORD __stdcall xmmYmmStateSupport()
 
 #pragma warning(push)
 #pragma warning(disable: 4035)
-extern "C" DWORD __stdcall avx512StateSupport()
+extern "C" DWORD avx512StateSupport()
 {
     // No CONTRACT
     STATIC_CONTRACT_NOTHROW;
@@ -1159,7 +1159,7 @@ void __cpuidex(int cpuInfo[4], int function_id, int subFunction_id)
 }
 #endif
 
-extern "C" DWORD __stdcall xmmYmmStateSupport()
+extern "C" DWORD xmmYmmStateSupport()
 {
     DWORD eax;
     __asm("  xgetbv\n" \
@@ -1171,7 +1171,7 @@ extern "C" DWORD __stdcall xmmYmmStateSupport()
     return ((eax & 0x06) == 0x06) ? 1 : 0;
 }
 
-extern "C" DWORD __stdcall avx512StateSupport()
+extern "C" DWORD avx512StateSupport()
 {
     DWORD eax;
     __asm("  xgetbv\n" \


### PR DESCRIPTION
Failure on linux-musl-x86:
> /runtime/src/coreclr/vm/cgensys.h:107:26: error: stdcall calling convention is not supported on builtin function [-Werror,-Wignored-attributes]