### PR TITLE
JIT: tolerate malformed IL when counting block successors

### DIFF
--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -1151,6 +1151,13 @@ unsigned BasicBlock::NumSucc(Compiler* comp)
 
         case BBJ_EHFINALLYRET:
         {
+            // We may call this method before we realize we have invalid IL. Tolerate.
+            //
+            if (!hasHndIndex())
+            {
+                return 0;
+            }
+
             // The first block of the handler is labelled with the catch type.
             BasicBlock* hndBeg = comp->fgFirstBlockOfHandler(this);
             if (hndBeg->bbCatchTyp == BBCT_FINALLY)


### PR DESCRIPTION
If we run synthesis, we may now invoke `BasicBlock::NumSucc` before we've detected some cases of invalid IL, In particular an endfinally that is not within a finally (this gets detected during importation).

Tolerate this by reporting that an endfinally with no handler index has no successors.

Fixes #83674.