### PR TITLE
[QUIC] Fix failing parallel tests

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.Quic;
-
 using static Microsoft.Quic.MsQuic;
 
 #if TARGET_WINDOWS

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicPlatformDetectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicPlatformDetectionTests.cs
@@ -38,6 +38,7 @@ namespace System.Net.Quic.Tests
             find.StartInfo.FileName = "find";
             find.StartInfo.Arguments = "/usr/ -iname libmsquic.so*";
             find.StartInfo.RedirectStandardOutput = true;
+            find.StartInfo.RedirectStandardError = true;
             find.Start();
             string output = await find.StandardOutput.ReadToEndAsync();
             _output.WriteLine(output);

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
@@ -203,7 +203,6 @@ namespace System.Net.Quic.Tests
         [InlineData(100, 101)]
         [InlineData(15, 100)]
         [InlineData(10, 1_000)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/82769", typeof(PlatformDetection), nameof(PlatformDetection.IsArmOrArm64Process))]
         [OuterLoop("Higher number of connections slow the test down.")]
         private Task Listener_BacklogLimitRefusesConnection_ParallelClients_ClientThrows_Slow(int backlogLimit, int connectCount)
             => Listener_BacklogLimitRefusesConnection_ParallelClients_ClientThrows_Core(backlogLimit, connectCount);

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
@@ -283,12 +283,6 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
-        public void RemoveThisTest()
-        {
-            Assert.Fail("On purpose.");
-        }
-
-        [Fact]
         public async Task AcceptConnectionAsync_ClientConnects_CancelIgnored()
         {
             await using QuicListener listener = await CreateQuicListener();

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
@@ -283,6 +283,12 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
+        public void RemoveThisTest()
+        {
+            Assert.Fail("On purpose.");
+        }
+
+        [Fact]
         public async Task AcceptConnectionAsync_ClientConnects_CancelIgnored()
         {
             await using QuicListener listener = await CreateQuicListener();

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
@@ -62,6 +62,7 @@ namespace System.Net.Quic.Tests
             if (Interlocked.Exchange(ref s_initMessage, 1) == 0)
             {
                 _output.WriteLine($"MsQuic {(IsSupported ? "supported" : "not supported")} and using '{MsQuicApi.MsQuicLibraryVersion}' version.");
+                Console.WriteLine($"MsQuic {(IsSupported ? "supported" : "not supported")} and using '{MsQuicApi.MsQuicLibraryVersion}' version.");
                 if (IsSupported && !s_queueDelaySet)
                 {
                     _output.WriteLine($"Unable to set MsQuic MaxWorkerQueueDelayUs.");

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
@@ -45,14 +45,17 @@ namespace System.Net.Quic.Tests
         public unsafe QuicTestBase(ITestOutputHelper output)
         {
             _output = output;
-            _output.WriteLine($"Using {MsQuicApi.MsQuicLibraryVersion}");
+            _output.WriteLine($"MsQuic {(IsSupported ? "supported" : "not supported")} and using '{MsQuicApi.MsQuicLibraryVersion}' version.");
 
-            QUIC_SETTINGS settings = default(QUIC_SETTINGS);
-            settings.IsSet.MaxWorkerQueueDelayUs = 1;
-            settings.MaxWorkerQueueDelayUs = (uint)TimeSpan.FromSeconds(2.5).TotalMicroseconds;
-            if (StatusFailed(MsQuicApi.Api.ApiTable->SetParam(null, QUIC_PARAM_GLOBAL_SETTINGS, (uint)sizeof(QUIC_SETTINGS), (byte*)&settings)))
+            if (IsSupported)
             {
-                _output.WriteLine($"Unable to set MsQuic MaxWorkerQueueDelayUs.");
+                QUIC_SETTINGS settings = default(QUIC_SETTINGS);
+                settings.IsSet.MaxWorkerQueueDelayUs = 1;
+                settings.MaxWorkerQueueDelayUs = (uint)TimeSpan.FromSeconds(2.5).TotalMicroseconds;
+                if (StatusFailed(MsQuicApi.Api.ApiTable->SetParam(null, QUIC_PARAM_GLOBAL_SETTINGS, (uint)sizeof(QUIC_SETTINGS), (byte*)&settings)))
+                {
+                    _output.WriteLine($"Unable to set MsQuic MaxWorkerQueueDelayUs.");
+                }
             }
         }
 

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
@@ -42,17 +42,27 @@ namespace System.Net.Quic.Tests
         public const int PassingTestTimeoutMilliseconds = 4 * 60 * 1000;
         public static TimeSpan PassingTestTimeout => TimeSpan.FromMilliseconds(PassingTestTimeoutMilliseconds);
 
-        public unsafe QuicTestBase(ITestOutputHelper output)
-        {
-            _output = output;
-            _output.WriteLine($"MsQuic {(IsSupported ? "supported" : "not supported")} and using '{MsQuicApi.MsQuicLibraryVersion}' version.");
+        private static bool s_queueDelaySet;
+        private static int s_initMessage;
 
+        static unsafe QuicTestBase()
+        {
             if (IsSupported)
             {
                 QUIC_SETTINGS settings = default(QUIC_SETTINGS);
                 settings.IsSet.MaxWorkerQueueDelayUs = 1;
                 settings.MaxWorkerQueueDelayUs = (uint)TimeSpan.FromSeconds(2.5).TotalMicroseconds;
-                if (StatusFailed(MsQuicApi.Api.ApiTable->SetParam(null, QUIC_PARAM_GLOBAL_SETTINGS, (uint)sizeof(QUIC_SETTINGS), (byte*)&settings)))
+                s_queueDelaySet = StatusSucceeded(MsQuicApi.Api.ApiTable->SetParam(null, QUIC_PARAM_GLOBAL_SETTINGS, (uint)sizeof(QUIC_SETTINGS), (byte*)&settings));
+            }
+        }
+
+        public unsafe QuicTestBase(ITestOutputHelper output)
+        {
+            _output = output;
+            if (Interlocked.Exchange(ref s_initMessage, 1) == 0)
+            {
+                _output.WriteLine($"MsQuic {(IsSupported ? "supported" : "not supported")} and using '{MsQuicApi.MsQuicLibraryVersion}' version.");
+                if (IsSupported && !s_queueDelaySet)
                 {
                     _output.WriteLine($"Unable to set MsQuic MaxWorkerQueueDelayUs.");
                 }


### PR DESCRIPTION
Fix failing parallel tests in S.N.Quic with pro-longing the cut-off time for queued operations in MsQuic, only in tests. 
Note that this against MsQuic recommendation, but since both client and server are on the same machine, in the same process, they are both "slow" the same way and this allows them to slowly deal with bursts of parallel requests.

Tested on arm machine where failures of `Listener_BacklogLimitRefusesConnection_ParallelClients_ClientThrows_Slow` were 100% reproducible. After the change, the test runs without any issues.

Fixes #82769