### PR TITLE
Correct documentation comment for IMultiplyOperators returns

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/IMultiplyOperators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/IMultiplyOperators.cs
@@ -13,13 +13,13 @@ namespace System.Numerics
         /// <summary>Multiplies two values together to compute their product.</summary>
         /// <param name="left">The value which <paramref name="right" /> multiplies.</param>
         /// <param name="right">The value which multiplies <paramref name="left" />.</param>
-        /// <returns>The product of <paramref name="left" /> divided-by <paramref name="right" />.</returns>
+        /// <returns>The product of <paramref name="left" /> multiplied-by <paramref name="right" />.</returns>
         static abstract TResult operator *(TSelf left, TOther right);
 
         /// <summary>Multiplies two values together to compute their product.</summary>
         /// <param name="left">The value which <paramref name="right" /> multiplies.</param>
         /// <param name="right">The value which multiplies <paramref name="left" />.</param>
-        /// <returns>The product of <paramref name="left" /> divided-by <paramref name="right" />.</returns>
+        /// <returns>The product of <paramref name="left" /> multiplied-by <paramref name="right" />.</returns>
         /// <exception cref="OverflowException">The product of <paramref name="left" /> multiplied-by <paramref name="right" /> is not representable by <typeparamref name="TResult" />.</exception>
         static virtual TResult operator checked *(TSelf left, TOther right) => left * right;
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NFloat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NFloat.cs
@@ -164,7 +164,7 @@ namespace System.Runtime.InteropServices
         /// <summary>Multiplies two values together to compute their product.</summary>
         /// <param name="left">The value which <paramref name="right" /> multiplies.</param>
         /// <param name="right">The value which multiplies <paramref name="left" />.</param>
-        /// <returns>The product of <paramref name="left" /> divided-by <paramref name="right" />.</returns>
+        /// <returns>The product of <paramref name="left" /> multiplied-by <paramref name="right" />.</returns>
         [NonVersionable]
         public static NFloat operator *(NFloat left, NFloat right) => new NFloat(left._value * right._value);
 


### PR DESCRIPTION
Replaced _divided-by_ with _multiplied-by_ in both IMultiplyOperators.cs and NFloat.cs to fix some copy-paste errors.
Fixes https://github.com/dotnet/runtime/issues/80521