### PR TITLE
Reduce size of async state machine by a reference field

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -270,6 +270,7 @@ namespace System.Runtime.CompilerServices
 
         /// <summary>A strongly-typed box for Task-based async state machines.</summary>
         /// <typeparam name="TStateMachine">Specifies the type of the state machine.</typeparam>
+        [DebuggerDisplay("{DebuggerDisplay,nq}")]
         private class AsyncStateMachineBox<TStateMachine> : // SOS DumpAsync command depends on this name
             Task<TResult>, IAsyncStateMachineBox
             where TStateMachine : IAsyncStateMachine
@@ -286,15 +287,34 @@ namespace System.Runtime.CompilerServices
                 Unsafe.As<AsyncStateMachineBox<TStateMachine>>(s).StateMachine!.MoveNext();
             }
 
-            /// <summary>A delegate to the <see cref="MoveNext()"/> method.</summary>
-            private Action? _moveNextAction;
             /// <summary>The state machine itself.</summary>
             public TStateMachine? StateMachine; // mutable struct; do not make this readonly. SOS DumpAsync command depends on this name.
             /// <summary>Captured ExecutionContext with which to invoke <see cref="MoveNextAction"/>; may be null.</summary>
             public ExecutionContext? Context;
 
+            /// <summary>Debugger-only display string for the async state machine.</summary>
+            private string DebuggerDisplay
+            {
+                get
+                {
+                    // Ideally we just use the type of the TStateMachine as the "method" name.  However, in certain use in the
+                    // debugger, TStateMachine might actually be a weakly-typed IAsyncStateMachine, in which case we can ToString
+                    // the state machine instance.  But in debug builds the state machine type could also be a class, in which case
+                    // the field could be null, so worst case we just fall back to using "IAsyncStateMachine".
+                    string stateMachineName = typeof(TStateMachine) != typeof(IAsyncStateMachine) ?
+                        typeof(TStateMachine).Name :
+                        StateMachine?.ToString() ??
+                        nameof(IAsyncStateMachine);
+
+                    // Keep the shape of this message in sync with that of the base Task<TResult>.
+                    return IsCompletedSuccessfully && typeof(TResult) != typeof(VoidTaskResult) ?
+                        $"Id = {Id}, Status = {Status}, Method = {stateMachineName}, Result = {m_result}" :
+                        $"Id = {Id}, Status = {Status}, Method = {stateMachineName}";
+                }
+            }
+
             /// <summary>A delegate to the <see cref="MoveNext()"/> method.</summary>
-            public Action MoveNextAction => _moveNextAction ??= new Action(MoveNext);
+            public Action MoveNextAction => (Action)(m_action ??= new Action(MoveNext));
 
             internal sealed override void ExecuteFromThreadPool(Thread threadPoolThread) => MoveNext(threadPoolThread);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
@@ -369,8 +369,6 @@ namespace System.Threading.Tasks
         // internal helper function breaks out logic used by TaskCompletionSource
         internal bool TrySetResult(TResult? result)
         {
-            Debug.Assert(m_action == null, "Task<T>.TrySetResult(): non-null m_action");
-
             bool returnValue = false;
 
             // "Reserve" the completion for this task, while making sure that: (1) No prior reservation

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -124,13 +124,9 @@ namespace System.Threading.Tasks
 
         private int m_taskId; // this task's unique ID. initialized only if it is ever requested
 
-        internal Delegate? m_action;    // The body of the task.  Might be Action<object>, Action<TState> or Action.  Or possibly a Func.
-        // If m_action is set to null it will indicate that we operate in the
-        // "externally triggered completion" mode, which is exclusively meant
-        // for the signalling Task<TResult> (aka. promise). In this mode,
-        // we don't call InnerInvoke() in response to a Wait(), but simply wait on
-        // the completion event which will be set when the Future class calls Finish().
-        // But the event would now be signalled if Cancel() is called
+        // The delegate to invoke for a delegate-backed Task.
+        // This field also may be used by async state machines to cache an Action.
+        internal Delegate? m_action;
 
         internal object? m_stateObject; // A state object that can be optionally supplied, passed to action.
         internal TaskScheduler? m_taskScheduler; // The task scheduler this task runs under.
@@ -3270,8 +3266,6 @@ namespace System.Threading.Tasks
         /// <returns>true if the task was transitioned to ran to completion; false if it was already completed.</returns>
         internal bool TrySetResult()
         {
-            Debug.Assert(m_action == null, "Task<T>.TrySetResult(): non-null m_action");
-
             if (AtomicStateUpdate(
                 (int)TaskStateFlags.CompletionReserved | (int)TaskStateFlags.RanToCompletion,
                 (int)TaskStateFlags.CompletionReserved | (int)TaskStateFlags.RanToCompletion | (int)TaskStateFlags.Faulted | (int)TaskStateFlags.Canceled))
@@ -3298,8 +3292,6 @@ namespace System.Threading.Tasks
         // Called from TaskCompletionSource<T>.SetException(IEnumerable<Exception>).
         internal bool TrySetException(object exceptionObject)
         {
-            Debug.Assert(m_action == null, "Task<T>.TrySetException(): non-null m_action");
-
             // TCS.{Try}SetException() should have checked for this
             Debug.Assert(exceptionObject != null, "Expected non-null exceptionObject argument");
 
@@ -3346,7 +3338,6 @@ namespace System.Threading.Tasks
         // This method is only valid for promise tasks.
         internal bool TrySetCanceled(CancellationToken tokenToRecord, object? cancellationException)
         {
-            Debug.Assert(m_action == null, "Task<T>.TrySetCanceled(): non-null m_action");
             Debug.Assert(
                 cancellationException == null ||
                 cancellationException is OperationCanceledException ||
@@ -6570,7 +6561,6 @@ namespace System.Threading.Tasks
 
                 if (continuationObject is Task continuationTask)
                 {
-                    Debug.Assert(continuationTask.m_action == null);
                     Delegate[]? delegates = continuationTask.GetDelegateContinuationsForDebugger();
                     if (delegates != null)
                         return delegates;


### PR DESCRIPTION
Every async state machine today has a field for an Action.  That field is used to cache an Action that's lazily created to point to its MoveNext method.  It's only needed, however, if the state machine awaits something that's not a known awaiter.

Interestingly, Task itself has a field for storing a delegate, which is only used today when the Task is created to invoke a delegate (e.g. Task.Run, ContinueWith, etc.).  I've considered that a liability, but I just realized we can use that same field for this async method cached Action as well, making it relevant to almost all tasks, and avoiding the need to have an extra field on the state machine box.

As the m_action on a task impacts the DebuggerDisplay rendering, I've also added a DebuggerDisplay to the state machine box type.  We can improve this further in the future, and also add a DebuggerTypeProxy later if desired.