### PR TITLE
Fix for issue #78866 and regression test

### DIFF
--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -5838,7 +5838,7 @@ BOOL MethodTable::FindDefaultInterfaceImplementation(
             MethodTable::InterfaceMapIterator it = pMT->IterateInterfaceMapFrom(dwParentInterfaces);
             while (!it.Finished())
             {
-                MethodTable *pCurMT = it.GetInterface(pMT);
+                MethodTable *pCurMT = it.GetInterface(pMT, level);
 
                 MethodDesc *pCurMD = NULL;
                 if (TryGetCandidateImplementation(pCurMT, pInterfaceMD, pInterfaceMT, allowVariance, &pCurMD, level))

--- a/src/tests/Loader/classloader/StaticVirtualMethods/RegressionTests/GitHub_78866.cs
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/RegressionTests/GitHub_78866.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+
+public interface ITestInterfaceEx1<TSelf>
+    where TSelf : ITestInterfaceEx1<TSelf>
+{
+}
+
+public interface ITestInterfaceEx2<TSelf>
+    where TSelf : ITestInterfaceEx2<TSelf>
+{
+    static abstract void Invoke();
+}
+
+public interface ITestInterface<TSelf> : ITestInterfaceEx2<TSelf>, ITestInterfaceEx1<TSelf>
+    where TSelf : ITestInterface<TSelf>
+{
+    static void ITestInterfaceEx2<TSelf>.Invoke()
+    {
+    }
+}
+
+public struct Test : ITestInterface<Test>
+{
+    public Test(object? test)
+    {
+    }
+}
+
+internal class Program
+{
+    public static int Main(string[] args)
+    {
+        new Test(null);
+        return 100;
+    }
+}

--- a/src/tests/Loader/classloader/StaticVirtualMethods/RegressionTests/GitHub_78866.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/RegressionTests/GitHub_78866.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This fix breaks the infinite recursion cycle reported in the above issue by propagating class load level to the interface iterator.

Thanks

Tomas

Fixes: https://github.com/dotnet/runtime/issues/78866