### PR TITLE
Private API for RefreshMemoryLimit

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -4,6 +4,7 @@
       <!-- Methods are used to register and unregister frozen segments. They are private and experimental. -->
       <method name="_RegisterFrozenSegment" />
       <method name="_UnregisterFrozenSegment" />
+      <method name="_RefreshMemoryLimit" />
     </type>
     <!-- Accessed via native code. -->
     <type fullname="System.Runtime.InteropServices.ComTypes.IEnumerable" />

--- a/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
@@ -789,5 +789,13 @@ namespace System
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_EnumerateConfigurationValues")]
         internal static unsafe partial void _EnumerateConfigurationValues(void* configurationDictionary, delegate* unmanaged<void*, void*, void*, GCConfigurationType, long, void> callback);
+
+        private static void _RefreshMemoryLimit()
+        {
+            RefreshMemoryLimit();
+        }
+
+        [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_RefreshMemoryLimit")]
+        internal static partial void RefreshMemoryLimit();
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
@@ -792,36 +792,30 @@ namespace System
 
         private static int _RefreshMemoryLimit()
         {
-            ulong specifiedFlags = 0;
-            ulong? heapHardLimit = AppContext.GetData("GCHeapHardLimit") as ulong?; if (heapHardLimit != null) { specifiedFlags |= 1; } else { heapHardLimit = 0; }
-            ulong? heapHardLimitPercent = AppContext.GetData("GCHeapHardLimitPercent") as ulong?; if (heapHardLimitPercent != null) { specifiedFlags |= 2; } else { heapHardLimitPercent = 0; }
-            ulong? heapHardLimitSOH = AppContext.GetData("GCHeapHardLimitSOH") as ulong?; if (heapHardLimitSOH != null) { specifiedFlags |= 4; } else { heapHardLimitSOH = 0; }
-            ulong? heapHardLimitLOH = AppContext.GetData("GCHeapHardLimitLOH") as ulong?; if (heapHardLimitLOH != null) { specifiedFlags |= 8; } else { heapHardLimitLOH = 0; }
-            ulong? heapHardLimitPOH = AppContext.GetData("GCHeapHardLimitPOH") as ulong?; if (heapHardLimitPOH != null) { specifiedFlags |= 16; } else { heapHardLimitPOH = 0; }
-            ulong? heapHardLimitSOHPercent = AppContext.GetData("GCHeapHardLimitSOHPercent") as ulong?; if (heapHardLimitSOHPercent != null) { specifiedFlags |= 32; } else { heapHardLimitSOHPercent = 0; }
-            ulong? heapHardLimitLOHPercent = AppContext.GetData("GCHeapHardLimitLOHPercent") as ulong?; if (heapHardLimitLOHPercent != null) { specifiedFlags |= 64; } else { heapHardLimitLOHPercent = 0; }
-            ulong? heapHardLimitPOHPercent = AppContext.GetData("GCHeapHardLimitPOHPercent") as ulong?; if (heapHardLimitPOHPercent != null) { specifiedFlags |= 128; } else { heapHardLimitPOHPercent = 0; }
-            if (specifiedFlags != 0)
+            ulong heapHardLimit = (AppContext.GetData("GCHeapHardLimit") as ulong?) ?? ulong.MaxValue;
+            ulong heapHardLimitPercent = (AppContext.GetData("GCHeapHardLimitPercent") as ulong?) ?? ulong.MaxValue;
+            ulong heapHardLimitSOH = (AppContext.GetData("GCHeapHardLimitSOH") as ulong?) ?? ulong.MaxValue;
+            ulong heapHardLimitLOH = (AppContext.GetData("GCHeapHardLimitLOH") as ulong?) ?? ulong.MaxValue;
+            ulong heapHardLimitPOH = (AppContext.GetData("GCHeapHardLimitPOH") as ulong?) ?? ulong.MaxValue;
+            ulong heapHardLimitSOHPercent = (AppContext.GetData("GCHeapHardLimitSOHPercent") as ulong?) ?? ulong.MaxValue;
+            ulong heapHardLimitLOHPercent = (AppContext.GetData("GCHeapHardLimitLOHPercent") as ulong?) ?? ulong.MaxValue;
+            ulong heapHardLimitPOHPercent = (AppContext.GetData("GCHeapHardLimitPOHPercent") as ulong?) ?? ulong.MaxValue;
+            GCHeapHardLimitInfo heapHardLimitInfo = new GCHeapHardLimitInfo
             {
-                GCHeapHardLimitInfo heapHardLimitInfo = new GCHeapHardLimitInfo
-                {
-                    HeapHardLimit = heapHardLimit.Value!,
-                    HeapHardLimitPercent = heapHardLimitPercent.Value!,
-                    HeapHardLimitSOH = heapHardLimitSOH.Value!,
-                    HeapHardLimitLOH = heapHardLimitLOH.Value!,
-                    HeapHardLimitPOH = heapHardLimitPOH.Value!,
-                    HeapHardLimitSOHPercent = heapHardLimitSOHPercent.Value!,
-                    HeapHardLimitLOHPercent = heapHardLimitLOHPercent.Value!,
-                    HeapHardLimitPOHPercent = heapHardLimitPOHPercent.Value!,
-                    SpecifiedFlags = specifiedFlags
-                };
-                UpdateHeapHardLimits(heapHardLimitInfo);
-            }
-            return RefreshMemoryLimit();
+                HeapHardLimit = heapHardLimit,
+                HeapHardLimitPercent = heapHardLimitPercent,
+                HeapHardLimitSOH = heapHardLimitSOH,
+                HeapHardLimitLOH = heapHardLimitLOH,
+                HeapHardLimitPOH = heapHardLimitPOH,
+                HeapHardLimitSOHPercent = heapHardLimitSOHPercent,
+                HeapHardLimitLOHPercent = heapHardLimitLOHPercent,
+                HeapHardLimitPOHPercent = heapHardLimitPOHPercent,
+            };
+            return RefreshMemoryLimit(heapHardLimitInfo);
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_RefreshMemoryLimit")]
-        internal static partial int RefreshMemoryLimit();
+        internal static partial int RefreshMemoryLimit(GCHeapHardLimitInfo heapHardLimitInfo);
 
         internal struct GCHeapHardLimitInfo
         {
@@ -833,11 +827,6 @@ namespace System
             internal ulong HeapHardLimitSOHPercent;
             internal ulong HeapHardLimitLOHPercent;
             internal ulong HeapHardLimitPOHPercent;
-            internal ulong SpecifiedFlags;
         }
-
-        [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_UpdateHeapHardLimits")]
-        [SuppressGCTransition]
-        internal static partial int UpdateHeapHardLimits(GCHeapHardLimitInfo heapHardLimitInfo);
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
@@ -790,12 +790,54 @@ namespace System
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_EnumerateConfigurationValues")]
         internal static unsafe partial void _EnumerateConfigurationValues(void* configurationDictionary, delegate* unmanaged<void*, void*, void*, GCConfigurationType, long, void> callback);
 
-        private static void _RefreshMemoryLimit()
+        private static int _RefreshMemoryLimit()
         {
-            RefreshMemoryLimit();
+            ulong specifiedFlags = 0;
+            ulong? heapHardLimit = AppContext.GetData("GCHeapHardLimit") as ulong?; if (heapHardLimit != null) { specifiedFlags |= 1; } else { heapHardLimit = 0; }
+            ulong? heapHardLimitPercent = AppContext.GetData("GCHeapHardLimitPercent") as ulong?; if (heapHardLimitPercent != null) { specifiedFlags |= 2; } else { heapHardLimitPercent = 0; }
+            ulong? heapHardLimitSOH = AppContext.GetData("GCHeapHardLimitSOH") as ulong?; if (heapHardLimitSOH != null) { specifiedFlags |= 4; } else { heapHardLimitSOH = 0; }
+            ulong? heapHardLimitLOH = AppContext.GetData("GCHeapHardLimitLOH") as ulong?; if (heapHardLimitLOH != null) { specifiedFlags |= 8; } else { heapHardLimitLOH = 0; }
+            ulong? heapHardLimitPOH = AppContext.GetData("GCHeapHardLimitPOH") as ulong?; if (heapHardLimitPOH != null) { specifiedFlags |= 16; } else { heapHardLimitPOH = 0; }
+            ulong? heapHardLimitSOHPercent = AppContext.GetData("GCHeapHardLimitSOHPercent") as ulong?; if (heapHardLimitSOHPercent != null) { specifiedFlags |= 32; } else { heapHardLimitSOHPercent = 0; }
+            ulong? heapHardLimitLOHPercent = AppContext.GetData("GCHeapHardLimitLOHPercent") as ulong?; if (heapHardLimitLOHPercent != null) { specifiedFlags |= 64; } else { heapHardLimitLOHPercent = 0; }
+            ulong? heapHardLimitPOHPercent = AppContext.GetData("GCHeapHardLimitPOHPercent") as ulong?; if (heapHardLimitPOHPercent != null) { specifiedFlags |= 128; } else { heapHardLimitPOHPercent = 0; }
+            if (specifiedFlags != 0)
+            {
+                GCHeapHardLimitInfo heapHardLimitInfo = new GCHeapHardLimitInfo
+                {
+                    HeapHardLimit = heapHardLimit.Value!,
+                    HeapHardLimitPercent = heapHardLimitPercent.Value!,
+                    HeapHardLimitSOH = heapHardLimitSOH.Value!,
+                    HeapHardLimitLOH = heapHardLimitLOH.Value!,
+                    HeapHardLimitPOH = heapHardLimitPOH.Value!,
+                    HeapHardLimitSOHPercent = heapHardLimitSOHPercent.Value!,
+                    HeapHardLimitLOHPercent = heapHardLimitLOHPercent.Value!,
+                    HeapHardLimitPOHPercent = heapHardLimitPOHPercent.Value!,
+                    SpecifiedFlags = specifiedFlags
+                };
+                UpdateHeapHardLimits(heapHardLimitInfo);
+            }
+            return RefreshMemoryLimit();
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_RefreshMemoryLimit")]
-        internal static partial void RefreshMemoryLimit();
+        internal static partial int RefreshMemoryLimit();
+
+        internal struct GCHeapHardLimitInfo
+        {
+            internal ulong HeapHardLimit;
+            internal ulong HeapHardLimitPercent;
+            internal ulong HeapHardLimitSOH;
+            internal ulong HeapHardLimitLOH;
+            internal ulong HeapHardLimitPOH;
+            internal ulong HeapHardLimitSOHPercent;
+            internal ulong HeapHardLimitLOHPercent;
+            internal ulong HeapHardLimitPOHPercent;
+            internal ulong SpecifiedFlags;
+        }
+
+        [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_UpdateHeapHardLimits")]
+        [SuppressGCTransition]
+        internal static partial int UpdateHeapHardLimits(GCHeapHardLimitInfo heapHardLimitInfo);
     }
 }

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -3770,7 +3770,7 @@ void region_allocator::print_map (const char* msg)
 
     uint32_t total_regions = (uint32_t)((global_region_end - global_region_start) / region_alignment);
 
-    dprintf (REGIONS_LOG, ("[%s]-----end printing----[%d total, left used %zd (free: %d), right used %zd (free: %d)]\n", heap_type, total_regions, 
+    dprintf (REGIONS_LOG, ("[%s]-----end printing----[%d total, left used %zd (free: %d), right used %zd (free: %d)]\n", heap_type, total_regions,
         (region_map_left_end - region_map_left_start), num_left_used_free_units, (region_map_right_end - region_map_right_start), num_right_used_free_units));
 #endif //_DEBUG
 }
@@ -4049,7 +4049,7 @@ void region_allocator::delete_region_impl (uint8_t* region_start)
         assert (free_index >= region_map_right_start);
         num_right_used_free_units += free_block_size;
     }
-    
+
     if ((current_index != region_map_left_start) && (current_index != region_map_right_start))
     {
         uint32_t previous_val = *(current_index - 1);
@@ -27995,7 +27995,7 @@ uint8_t* gc_heap::loh_allocate_in_condemned (size_t size)
 retry:
     {
         heap_segment* seg = generation_allocation_segment (gen);
-        if (!(loh_size_fit_p (size, generation_allocation_pointer (gen), generation_allocation_limit (gen), 
+        if (!(loh_size_fit_p (size, generation_allocation_pointer (gen), generation_allocation_limit (gen),
                               (generation_allocation_limit (gen) == heap_segment_plan_allocated (seg)))))
         {
             if ((!(loh_pinned_plug_que_empty_p()) &&
@@ -45551,8 +45551,8 @@ HRESULT GCHeap::Initialize()
     gc_heap::enable_special_regions_p = (bool)GCConfig::GetGCEnableSpecialRegions();
     size_t gc_region_size = (size_t)GCConfig::GetGCRegionSize();
 
-    // Constraining the size of region size to be < 2 GB.       
-    if (gc_region_size >= MAX_REGION_SIZE) 
+    // Constraining the size of region size to be < 2 GB.
+    if (gc_region_size >= MAX_REGION_SIZE)
     {
         return CLR_E_GC_BAD_REGION_SIZE;
     }

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -49487,7 +49487,7 @@ int gc_heap::refresh_memory_limit()
 #ifdef MULTIPLE_HEAPS
         for (int h = 0; h < n_heaps; h++)
         {
-            gc_heap* heap = g_heaps [h];
+            gc_heap* heap = g_heaps[h];
 #else
         {
             gc_heap* heap = pGenGCHeap;
@@ -49506,11 +49506,11 @@ int gc_heap::refresh_memory_limit()
                 heap->accumulate_committed_bytes (heap->freeable_uoh_segment, total_committed_per_heap, committed_bookkeeping, (gc_oh_num)oh);
             }
 #if defined(MULTIPLE_HEAPS) && defined(_DEBUG)
-            heap->committed_by_oh_per_heap_refresh [oh] = total_committed_per_heap;
+            heap->committed_by_oh_per_heap_refresh[oh] = total_committed_per_heap;
 #endif //MULTIPLE_HEAPS && _DEBUG
             total_committed_per_oh += total_committed_per_heap;
         }
-        new_committed_by_oh [oh] = total_committed_per_oh;
+        new_committed_by_oh[oh] = total_committed_per_oh;
         total_committed += total_committed_per_oh;
     }
 
@@ -49519,22 +49519,22 @@ int gc_heap::refresh_memory_limit()
 #ifdef MULTIPLE_HEAPS
     for (int h = 0; h < n_heaps; h++)
     {
-        gc_heap* heap = g_heaps [h];
+        gc_heap* heap = g_heaps[h];
 #else
     {
         gc_heap* heap = pGenGCHeap;
 #endif //MULTIPLE_HEAPS
         for (int i = 0; i < count_free_region_kinds; i++)
         {
-            heap_segment* seg = heap->free_regions [i].get_first_free_region();
+            heap_segment* seg = heap->free_regions[i].get_first_free_region();
             heap->accumulate_committed_bytes (seg, committed_free, committed_bookkeeping);
         }
     }
     for (int i = 0; i < count_free_region_kinds; i++)
     {
-        heap_segment* seg = global_regions_to_decommit [i].get_first_free_region();
+        heap_segment* seg = global_regions_to_decommit[i].get_first_free_region();
 #ifdef MULTIPLE_HEAPS
-        gc_heap* heap = g_heaps [0];
+        gc_heap* heap = g_heaps[0];
 #else
         gc_heap* heap = nullptr;
 #endif //MULTIPLE_HEAPS
@@ -49543,14 +49543,14 @@ int gc_heap::refresh_memory_limit()
     {
         heap_segment* seg = global_free_huge_regions.get_first_free_region();
 #ifdef MULTIPLE_HEAPS
-        gc_heap* heap = g_heaps [0];
+        gc_heap* heap = g_heaps[0];
 #else
         gc_heap* heap = pGenGCHeap;
 #endif //MULTIPLE_HEAPS
         heap->accumulate_committed_bytes (seg, committed_free, committed_bookkeeping);
     }
 
-    new_committed_by_oh [recorded_committed_free_bucket] = committed_free;
+    new_committed_by_oh[recorded_committed_free_bucket] = committed_free;
     total_committed += committed_free;
 
     // Accounting for the bytes committed for the book keeping elements
@@ -49564,12 +49564,12 @@ int gc_heap::refresh_memory_limit()
     {
         // In case background GC is disabled - the software write watch table is still there
         // but with size 0
-        assert (commit_sizes [i] >= 0);
-        committed_bookkeeping += commit_sizes [i];
+        assert (commit_sizes[i] >= 0);
+        committed_bookkeeping += commit_sizes[i];
     }
 
     new_current_total_committed_bookkeeping = committed_bookkeeping;
-    new_committed_by_oh [recorded_committed_bookkeeping_bucket] = committed_bookkeeping;
+    new_committed_by_oh[recorded_committed_bookkeeping_bucket] = committed_bookkeeping;
     total_committed += committed_bookkeeping;
     new_current_total_committed = total_committed;
 #endif //USE_REGIONS
@@ -49640,9 +49640,9 @@ int gc_heap::refresh_memory_limit()
         for (int i = 0; i < recorded_committed_bucket_counts; i++)
         {
 #ifdef COMMITTED_BYTES_SHADOW
-            assert (new_committed_by_oh [i] == committed_by_oh [i]);
+            assert (new_committed_by_oh[i] == committed_by_oh[i]);
 #else
-            new_committed_by_oh [i] = committed_by_oh [i];
+            new_committed_by_oh[i] = committed_by_oh[i];
 #endif
         }
 #ifdef MULTIPLE_HEAPS
@@ -49652,9 +49652,9 @@ int gc_heap::refresh_memory_limit()
             for (int oh = soh; oh < total_oh_count; oh++)
             {
 #ifdef COMMITTED_BYTES_SHADOW
-                assert (g_heaps [h]->committed_by_oh_per_heap [oh] == g_heaps [h]->committed_by_oh_per_heap_refresh [oh]);
+                assert (g_heaps[h]->committed_by_oh_per_heap[oh] == g_heaps[h]->committed_by_oh_per_heap_refresh[oh]);
 #else
-                g_heaps [h]->committed_by_oh_per_heap [oh] = g_heaps [h]->committed_by_oh_per_heap_refresh [oh];
+                g_heaps[h]->committed_by_oh_per_heap[oh] = g_heaps[h]->committed_by_oh_per_heap_refresh[oh];
 #endif
             }
         }

--- a/src/coreclr/gc/gcconfig.cpp
+++ b/src/coreclr/gc/gcconfig.cpp
@@ -67,6 +67,18 @@ GC_CONFIGURATION_KEYS
 #undef STRING_CONFIG
 }
 
+void GCConfig::RefreshHeapHardLimitSettings()
+{
+    GCToEEInterface::GetIntConfigValue("GCHeapHardLimit", "System.GC.HeapHardLimit", &s_GCHeapHardLimit); s_UpdatedGCHeapHardLimit = s_GCHeapHardLimit;
+    GCToEEInterface::GetIntConfigValue("GCHeapHardLimitPercent", "System.GC.HeapHardLimitPercent", &s_GCHeapHardLimitPercent); s_UpdatedGCHeapHardLimitPercent = s_GCHeapHardLimitPercent;
+    GCToEEInterface::GetIntConfigValue("GCHeapHardLimitSOH", "System.GC.HeapHardLimitSOH", &s_GCHeapHardLimitSOH); s_UpdatedGCHeapHardLimitSOH = s_GCHeapHardLimitSOH;
+    GCToEEInterface::GetIntConfigValue("GCHeapHardLimitLOH", "System.GC.HeapHardLimitLOH", &s_GCHeapHardLimitLOH); s_UpdatedGCHeapHardLimitLOH = s_GCHeapHardLimitLOH;
+    GCToEEInterface::GetIntConfigValue("GCHeapHardLimitPOH", "System.GC.HeapHardLimitPOH", &s_GCHeapHardLimitPOH); s_UpdatedGCHeapHardLimitPOH = s_GCHeapHardLimitPOH;
+    GCToEEInterface::GetIntConfigValue("GCHeapHardLimitSOHPercent", "System.GC.HeapHardLimitSOHPercent", &s_GCHeapHardLimitSOHPercent); s_UpdatedGCHeapHardLimitSOHPercent = s_GCHeapHardLimitSOHPercent;
+    GCToEEInterface::GetIntConfigValue("GCHeapHardLimitLOHPercent", "System.GC.HeapHardLimitLOHPercent", &s_GCHeapHardLimitLOHPercent); s_UpdatedGCHeapHardLimitLOHPercent = s_GCHeapHardLimitLOHPercent;
+    GCToEEInterface::GetIntConfigValue("GCHeapHardLimitPOHPercent", "System.GC.HeapHardLimitPOHPercent", &s_GCHeapHardLimitPOHPercent); s_UpdatedGCHeapHardLimitPOHPercent = s_GCHeapHardLimitPOHPercent;
+}
+
 void GCConfig::Initialize()
 {
 #define BOOL_CONFIG(name, private_key, public_key, unused_default, unused_doc)                       \

--- a/src/coreclr/gc/gcconfig.h
+++ b/src/coreclr/gc/gcconfig.h
@@ -169,6 +169,8 @@ GC_CONFIGURATION_KEYS
 
 public:
 
+  static void RefreshHeapHardLimitSettings();
+
   static void EnumerateConfigurationValues(void* context, ConfigurationValueFunc configurationValueFunc);
 
 // Flags that may inhabit the number returned for the HeapVerifyLevel config option.

--- a/src/coreclr/gc/gcimpl.h
+++ b/src/coreclr/gc/gcimpl.h
@@ -324,6 +324,8 @@ public:
     virtual void Shutdown();
 
     static void ReportGenerationBounds();
+
+    virtual void RefreshMemoryLimit();
 };
 
 #endif  // GCIMPL_H_

--- a/src/coreclr/gc/gcimpl.h
+++ b/src/coreclr/gc/gcimpl.h
@@ -325,7 +325,7 @@ public:
 
     static void ReportGenerationBounds();
 
-    virtual void RefreshMemoryLimit();
+    virtual int RefreshMemoryLimit();
 };
 
 #endif  // GCIMPL_H_

--- a/src/coreclr/gc/gcinterface.h
+++ b/src/coreclr/gc/gcinterface.h
@@ -472,7 +472,7 @@ typedef enum
      *
      * NOTE: HNDTYPE_WEAK_NATIVE_COM is no longer used in the VM starting .NET 8
      *       but we are keeping it here for backward compatibility purposes"
-     * 
+     *
      */
     HNDTYPE_WEAK_NATIVE_COM   = 9
 } HandleType;
@@ -565,7 +565,7 @@ enum class GCConfigurationType
 {
     Int64,
     StringUtf8,
-    Boolean 
+    Boolean
 };
 
 using ConfigurationValueFunc = void (*)(void* context, void* name, void* publicKey, GCConfigurationType type, int64_t data);

--- a/src/coreclr/gc/gcinterface.h
+++ b/src/coreclr/gc/gcinterface.h
@@ -973,6 +973,9 @@ public:
 
     // Updates given frozen segment
     virtual void UpdateFrozenSegment(segment_handle seg, uint8_t* allocated, uint8_t* committed) PURE_VIRTUAL
+
+    // Refresh the memory limit
+    virtual void RefreshMemoryLimit() PURE_VIRTUAL
 };
 
 #ifdef WRITE_BARRIER_CHECK

--- a/src/coreclr/gc/gcinterface.h
+++ b/src/coreclr/gc/gcinterface.h
@@ -570,6 +570,10 @@ enum class GCConfigurationType
 
 using ConfigurationValueFunc = void (*)(void* context, void* name, void* publicKey, GCConfigurationType type, int64_t data);
 
+const int REFRESH_MEMORY_SUCCEED = 0;
+const int REFRESH_MEMORY_HARD_LIMIT_TOO_LOW = 1;
+const int REFRESH_MEMORY_HARD_LIMIT_INVALID = 2;
+
 // IGCHeap is the interface that the VM will use when interacting with the GC.
 class IGCHeap {
 public:
@@ -975,7 +979,7 @@ public:
     virtual void UpdateFrozenSegment(segment_handle seg, uint8_t* allocated, uint8_t* committed) PURE_VIRTUAL
 
     // Refresh the memory limit
-    virtual void RefreshMemoryLimit() PURE_VIRTUAL
+    virtual int RefreshMemoryLimit() PURE_VIRTUAL
 };
 
 #ifdef WRITE_BARRIER_CHECK

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -18,46 +18,46 @@
 #include "gcrecord.h"
 
 // The per heap and global fields are separated into the following categories -
-// 
+//
 // Used in GC and needs to be maintained, ie, next GC can be using this field so it needs to have the right value.
 // Note that for some fields this doesn't mean the value of the field itself will change (it could remain the same
 // throughout the process lifetime (for example, finalize_queue) but you'll need to pay attention to its content
-// and make sure it's updated correctly through each GC. 
-// 
+// and make sure it's updated correctly through each GC.
+//
 // Some fields are marked as "loosely maintained" in their comments - this means they are really only modified during
 // a single GC *except* they can be resized during a GC so the reinit-ed value will carry over to later GCs.
 // PER_HEAP_FIELD_MAINTAINED
-// 
+//
 // Like PER_HEAP_FIELD_MAINTAINED and also used in the allocator code paths
 // PER_HEAP_FIELD_MAINTAINED_ALLOC
-// 
+//
 // Used only during a single GC so we could fill it with an arbitrary value and shouldn't break anything.
 // Note that for BGC fields, this means it's initialized at the beginning of that BGC. Ephemeral GCs can happen during
 // this single BGC but they do not actually modify these fields.
 // PER_HEAP_FIELD_SINGLE_GC
-// 
+//
 // Like PER_HEAP_FIELD_SINGLE_GC and also used in the allocator code paths
 // PER_HEAP_FIELD_SINGLE_GC_ALLOC
-// 
+//
 // Only used by the allocator code paths
 // PER_HEAP_FIELD_ALLOC
-// 
+//
 // Initialized during the GC init and never changes
 // PER_HEAP_FIELD_INIT_ONLY
-// 
+//
 // Used for diagnostics purpose only
 // PER_HEAP_FIELD_DIAG_ONLY
-// 
+//
 // Corresponding annotation for global fields
 // PER_HEAP_ISOLATED_FIELD_MAINTAINED
 // PER_HEAP_ISOLATED_FIELD_MAINTAINED_ALLOC
 // PER_HEAP_ISOLATED_FIELD_SINGLE_GC
 // PER_HEAP_ISOLATED_FIELD_SINGLE_GC_ALLOC
 // PER_HEAP_ISOLATED_FIELD_INIT_ONLY
-// 
-// If a field does not fit any of the above category, such as fgn_maxgen_percent which is only updated by an API, 
+//
+// If a field does not fit any of the above category, such as fgn_maxgen_percent which is only updated by an API,
 // it will be marked as PER_HEAP_FIELD/PER_HEAP_ISOLATED_FIELD.
-// 
+//
 // A few notes -
 //
 // + within the section of a particular category of fields I use the following policy to list them -
@@ -70,7 +70,7 @@
 //
 // + some of the fields are used by both regions and segments share. When that's the case, the annotation
 // is based on regions. So for segments they may or may not apply (segments code is in maintainence mode only).
-// 
+//
 // + some fields are used by the GC and WB but not by the allocator, in which case I will indicate them as such.
 #ifdef MULTIPLE_HEAPS
 #define PER_HEAP_FIELD
@@ -278,7 +278,7 @@ void GCLogConfig (const char *fmt, ... );
 #define MAX_NUM_BUCKETS (MAX_INDEX_POWER2 - MIN_INDEX_POWER2 + 1)
 
 #ifdef USE_REGIONS
-#define MAX_REGION_SIZE 0x80000000 
+#define MAX_REGION_SIZE 0x80000000
 #endif // USE_REGIONS
 
 #define MAX_NUM_FREE_SPACES 200
@@ -969,7 +969,7 @@ public:
     // When a generation is condemned, these are re-calculated. For older generations these are maintained across GCs as
     // younger generation GCs allocate into this generation's FL.
     //
-    // If we rearrange regions between heaps, we need to adjust these values accordingly. free_list_space can be adjusted 
+    // If we rearrange regions between heaps, we need to adjust these values accordingly. free_list_space can be adjusted
     // when we adjust the FL. However, since we don't actually maintain free_obj_space per region and walking an entire
     // region just to get free_obj_space is not really worth it, we might just have to live with inaccurate value till
     // the next GC that condemns this generation which is okay since this is usually a small value anyway.
@@ -1028,7 +1028,7 @@ struct static_data
 };
 
 // dynamic data is maintained per generation, so we have total_generation_count number of them.
-// 
+//
 // The dynamic data fields are grouped into 3 categories:
 //
 // calculated logical data (like desired_allocation)
@@ -1046,7 +1046,7 @@ public:
 
     //
     // The next group of fields are updated during a GC if that GC condemns this generation.
-    // 
+    //
     // Same as new_allocation but only updated during a GC if the generation is condemned.
     // We should really just get rid of this.
     ptrdiff_t gc_new_allocation;
@@ -3543,7 +3543,7 @@ private:
     PER_HEAP_FIELD_MAINTAINED generation generation_table[total_generation_count];
 
     // These are loosely maintained, ie, could be reinitialized at any GC if needed. All that's
-    // maintained is just the # of elements in mark_stack_array.    
+    // maintained is just the # of elements in mark_stack_array.
     // The content of mark_stack_array is only maintained during a single GC.
     PER_HEAP_FIELD_MAINTAINED size_t mark_stack_array_length;
     PER_HEAP_FIELD_MAINTAINED mark* mark_stack_array;
@@ -3634,7 +3634,7 @@ private:
     PER_HEAP_FIELD_MAINTAINED_ALLOC alloc_list poh_alloc_list[NUM_POH_ALIST - 1];
 
     // Keeps track of the highest address allocated by Alloc
-    // Used in allocator code path. Blocking GCs do use it at the beginning (to update heap_segment_allocated) and 
+    // Used in allocator code path. Blocking GCs do use it at the beginning (to update heap_segment_allocated) and
     // at the end they get initialized for the allocator.
     PER_HEAP_FIELD_MAINTAINED_ALLOC uint8_t* alloc_allocated;
 
@@ -3700,13 +3700,13 @@ private:
 #define vm_heap ((GCHeap*) g_theGCHeap)
 #define heap_number (0)
 #endif //MULTIPLE_HEAPS
-    
+
 #ifdef BACKGROUND_GC
     // We only use this when we need to timeout BGC threads.
     PER_HEAP_FIELD_INIT_ONLY CLRCriticalSection bgc_threads_timeout_cs;
 
     // For regions these are the same as g_gc_lowest_address/g_gc_highest_address
-    // and never change. 
+    // and never change.
     PER_HEAP_FIELD_INIT_ONLY uint8_t* background_saved_lowest_address;
     PER_HEAP_FIELD_INIT_ONLY uint8_t* background_saved_highest_address;
 
@@ -3972,7 +3972,7 @@ private:
 
     // Highest and lowest address for ephemeral generations.
     // For regions these are only used during a GC (init-ed at beginning of mark and
-    // used later in that GC). 
+    // used later in that GC).
     // They could be used for WB but we currently don't use them for that purpose, even
     // thought we do pass them to the WB code.
     //
@@ -4244,7 +4244,7 @@ private:
 
     // For implementation of GCHeap::GetMemoryInfo which is called by
     // the GC.GetGCMemoryInfo API
-    // 
+    //
     // We record the time GC work is done while EE is suspended.
     // suspended_start_ts is what we get right before we call
     // SuspendEE. We omit the time between GC end and RestartEE

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -148,7 +148,7 @@ inline void FATAL_GC_ERROR()
 // + creates some ro segs
 // We can add more mechanisms here.
 //#define STRESS_REGIONS
-#define COMMITTED_BYTES_SHADOW
+//#define COMMITTED_BYTES_SHADOW
 #define MARK_PHASE_PREFETCH
 #endif //USE_REGIONS
 

--- a/src/coreclr/gc/windows/gcenv.windows.cpp
+++ b/src/coreclr/gc/windows/gcenv.windows.cpp
@@ -17,8 +17,6 @@
 
 GCSystemInfo g_SystemInfo;
 
-static size_t g_RestrictedPhysicalMemoryLimit = (size_t)UINTPTR_MAX;
-
 static bool g_SeLockMemoryPrivilegeAcquired = false;
 
 static AffinitySet g_processAffinitySet;
@@ -333,8 +331,7 @@ exit:
         job_physical_memory_limit = 0;
     }
 
-    VolatileStore(&g_RestrictedPhysicalMemoryLimit, job_physical_memory_limit);
-    return g_RestrictedPhysicalMemoryLimit;
+    return job_physical_memory_limit;
 }
 
 // This function checks to see if GetLogicalProcessorInformation API is supported.

--- a/src/coreclr/gc/windows/gcenv.windows.cpp
+++ b/src/coreclr/gc/windows/gcenv.windows.cpp
@@ -252,10 +252,6 @@ static size_t GetRestrictedPhysicalMemoryLimit()
 {
     LIMITED_METHOD_CONTRACT;
 
-    // The limit was cached already
-    if (g_RestrictedPhysicalMemoryLimit != (size_t)UINTPTR_MAX)
-        return g_RestrictedPhysicalMemoryLimit;
-
     size_t job_physical_memory_limit = (size_t)UINTPTR_MAX;
     uint64_t total_virtual = 0;
     uint64_t total_physical = 0;

--- a/src/coreclr/vm/comutilnative.cpp
+++ b/src/coreclr/vm/comutilnative.cpp
@@ -1210,27 +1210,41 @@ void GCInterface::EnumerateConfigurationValues(void* configurationContext, Enume
     pHeap->EnumerateConfigurationValues(configurationContext, callback);
 }
 
-extern "C" void QCALLTYPE GCInterface_RefreshMemoryLimit()
+extern "C" int QCALLTYPE GCInterface_RefreshMemoryLimit()
 {
     QCALL_CONTRACT;
 
+    int result = 0;
+
     BEGIN_QCALL;
-    GCInterface::RefreshMemoryLimit();
+    result = GCInterface::RefreshMemoryLimit();
     END_QCALL;
+
+    return result;
 }
 
-void GCInterface::RefreshMemoryLimit()
+int GCInterface::RefreshMemoryLimit()
 {
     CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_PREEMPTIVE;
-        MODE_ANY;
     }
     CONTRACTL_END;
 
-    GCHeapUtilities::GetGCHeap()->RefreshMemoryLimit();
+    return GCHeapUtilities::GetGCHeap()->RefreshMemoryLimit();
+}
+
+GCHeapHardLimitInfo g_gcHeapHardLimitInfo;
+
+extern "C" void QCALLTYPE GCInterface_UpdateHeapHardLimits(GCHeapHardLimitInfo heapHardLimitInfo)
+{
+    QCALL_CONTRACT_NO_GC_TRANSITION;
+
+    BEGIN_QCALL;
+    g_gcHeapHardLimitInfo = heapHardLimitInfo;
+    END_QCALL;
 }
 
 #ifdef HOST_64BIT

--- a/src/coreclr/vm/comutilnative.cpp
+++ b/src/coreclr/vm/comutilnative.cpp
@@ -1210,6 +1210,29 @@ void GCInterface::EnumerateConfigurationValues(void* configurationContext, Enume
     pHeap->EnumerateConfigurationValues(configurationContext, callback);
 }
 
+extern "C" void QCALLTYPE GCInterface_RefreshMemoryLimit()
+{
+    QCALL_CONTRACT;
+
+    BEGIN_QCALL;
+    GCInterface::RefreshMemoryLimit();
+    END_QCALL;
+}
+
+void GCInterface::RefreshMemoryLimit()
+{
+    CONTRACTL
+    {
+        THROWS;
+        GC_TRIGGERS;
+        MODE_PREEMPTIVE;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
+
+    GCHeapUtilities::GetGCHeap()->RefreshMemoryLimit();
+}
+
 #ifdef HOST_64BIT
 const unsigned MIN_MEMORYPRESSURE_BUDGET = 4 * 1024 * 1024;        // 4 MB
 #else // HOST_64BIT

--- a/src/coreclr/vm/comutilnative.cpp
+++ b/src/coreclr/vm/comutilnative.cpp
@@ -1210,13 +1210,16 @@ void GCInterface::EnumerateConfigurationValues(void* configurationContext, Enume
     pHeap->EnumerateConfigurationValues(configurationContext, callback);
 }
 
-extern "C" int QCALLTYPE GCInterface_RefreshMemoryLimit()
+GCHeapHardLimitInfo g_gcHeapHardLimitInfo;
+
+extern "C" int QCALLTYPE GCInterface_RefreshMemoryLimit(GCHeapHardLimitInfo heapHardLimitInfo)
 {
     QCALL_CONTRACT;
 
     int result = 0;
 
     BEGIN_QCALL;
+    g_gcHeapHardLimitInfo = heapHardLimitInfo;
     result = GCInterface::RefreshMemoryLimit();
     END_QCALL;
 
@@ -1234,17 +1237,6 @@ int GCInterface::RefreshMemoryLimit()
     CONTRACTL_END;
 
     return GCHeapUtilities::GetGCHeap()->RefreshMemoryLimit();
-}
-
-GCHeapHardLimitInfo g_gcHeapHardLimitInfo;
-
-extern "C" void QCALLTYPE GCInterface_UpdateHeapHardLimits(GCHeapHardLimitInfo heapHardLimitInfo)
-{
-    QCALL_CONTRACT_NO_GC_TRANSITION;
-
-    BEGIN_QCALL;
-    g_gcHeapHardLimitInfo = heapHardLimitInfo;
-    END_QCALL;
 }
 
 #ifdef HOST_64BIT

--- a/src/coreclr/vm/comutilnative.h
+++ b/src/coreclr/vm/comutilnative.h
@@ -137,7 +137,6 @@ struct GCHeapHardLimitInfo
     UINT64 heapHardLimitSOHPercent;
     UINT64 heapHardLimitLOHPercent;
     UINT64 heapHardLimitPOHPercent;
-    UINT64 specifiedFlags;
 };
 
 class GCInterface {
@@ -189,7 +188,6 @@ public:
 
     static void EnumerateConfigurationValues(void* configurationContext, EnumerateConfigurationValuesCallback callback);
     static int  RefreshMemoryLimit();
-    static void GCInterface_UpdateHeapHardLimits(GCHeapHardLimitInfo pHeapHardLimitInfo);
 
 private:
     // Out-of-line helper to avoid EH prolog/epilog in functions that otherwise don't throw.
@@ -217,9 +215,7 @@ extern "C" void QCALLTYPE GCInterface_RemoveMemoryPressure(UINT64 bytesAllocated
 
 extern "C" void QCALLTYPE GCInterface_EnumerateConfigurationValues(void* configurationContext, EnumerateConfigurationValuesCallback callback);
 
-extern "C" int  QCALLTYPE GCInterface_RefreshMemoryLimit();
-
-extern "C" void QCALLTYPE GCInterface_UpdateHeapHardLimits(GCHeapHardLimitInfo heapHardLimitInfo);
+extern "C" int  QCALLTYPE GCInterface_RefreshMemoryLimit(GCHeapHardLimitInfo heapHardLimitInfo);
 
 class COMInterlocked
 {

--- a/src/coreclr/vm/comutilnative.h
+++ b/src/coreclr/vm/comutilnative.h
@@ -127,6 +127,19 @@ typedef GCMemoryInfoData * GCMEMORYINFODATAREF;
 
 using EnumerateConfigurationValuesCallback = void (*)(void* context, void* name, void* publicKey, GCConfigurationType type, int64_t data);
 
+struct GCHeapHardLimitInfo
+{
+    UINT64 heapHardLimit;
+    UINT64 heapHardLimitPercent;
+    UINT64 heapHardLimitSOH;
+    UINT64 heapHardLimitLOH;
+    UINT64 heapHardLimitPOH;
+    UINT64 heapHardLimitSOHPercent;
+    UINT64 heapHardLimitLOHPercent;
+    UINT64 heapHardLimitPOHPercent;
+    UINT64 specifiedFlags;
+};
+
 class GCInterface {
 private:
     static INT32    m_gc_counts[3];
@@ -175,7 +188,8 @@ public:
     static void AddMemoryPressure(UINT64 bytesAllocated);
 
     static void EnumerateConfigurationValues(void* configurationContext, EnumerateConfigurationValuesCallback callback);
-    static void RefreshMemoryLimit();
+    static int  RefreshMemoryLimit();
+    static void GCInterface_UpdateHeapHardLimits(GCHeapHardLimitInfo pHeapHardLimitInfo);
 
 private:
     // Out-of-line helper to avoid EH prolog/epilog in functions that otherwise don't throw.
@@ -203,7 +217,9 @@ extern "C" void QCALLTYPE GCInterface_RemoveMemoryPressure(UINT64 bytesAllocated
 
 extern "C" void QCALLTYPE GCInterface_EnumerateConfigurationValues(void* configurationContext, EnumerateConfigurationValuesCallback callback);
 
-extern "C" void QCALLTYPE GCInterface_RefreshMemoryLimit();
+extern "C" int  QCALLTYPE GCInterface_RefreshMemoryLimit();
+
+extern "C" void QCALLTYPE GCInterface_UpdateHeapHardLimits(GCHeapHardLimitInfo heapHardLimitInfo);
 
 class COMInterlocked
 {

--- a/src/coreclr/vm/comutilnative.h
+++ b/src/coreclr/vm/comutilnative.h
@@ -175,6 +175,7 @@ public:
     static void AddMemoryPressure(UINT64 bytesAllocated);
 
     static void EnumerateConfigurationValues(void* configurationContext, EnumerateConfigurationValuesCallback callback);
+    static void RefreshMemoryLimit();
 
 private:
     // Out-of-line helper to avoid EH prolog/epilog in functions that otherwise don't throw.
@@ -201,6 +202,8 @@ extern "C" void QCALLTYPE GCInterface_AddMemoryPressure(UINT64 bytesAllocated);
 extern "C" void QCALLTYPE GCInterface_RemoveMemoryPressure(UINT64 bytesAllocated);
 
 extern "C" void QCALLTYPE GCInterface_EnumerateConfigurationValues(void* configurationContext, EnumerateConfigurationValuesCallback callback);
+
+extern "C" void QCALLTYPE GCInterface_RefreshMemoryLimit();
 
 class COMInterlocked
 {

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -1191,6 +1191,15 @@ bool GCToEEInterface::GetIntConfigValue(const char* privateKey, const char* publ
         return true;
     }
 
+    if ((g_gcHeapHardLimitInfo.specifiedFlags & 1) && strcmp(privateKey, "GCHeapHardLimit") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimit; return true; }
+    if ((g_gcHeapHardLimitInfo.specifiedFlags & 2) && strcmp(privateKey, "GCHeapHardLimitPercent") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimitPercent; return true; }
+    if ((g_gcHeapHardLimitInfo.specifiedFlags & 4) && strcmp(privateKey, "GCHeapHardLimitSOH") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimitSOH; return true; }
+    if ((g_gcHeapHardLimitInfo.specifiedFlags & 8) && strcmp(privateKey, "GCHeapHardLimitLOH") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimitLOH; return true; }
+    if ((g_gcHeapHardLimitInfo.specifiedFlags & 16) && strcmp(privateKey, "GCHeapHardLimitPOH") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimitPOH; return true; }
+    if ((g_gcHeapHardLimitInfo.specifiedFlags & 32) && strcmp(privateKey, "GCHeapHardLimitSOHPercent") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimitSOHPercent; return true; }
+    if ((g_gcHeapHardLimitInfo.specifiedFlags & 64) && strcmp(privateKey, "GCHeapHardLimitLOHPercent") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimitLOHPercent; return true; }
+    if ((g_gcHeapHardLimitInfo.specifiedFlags & 128) && strcmp(privateKey, "GCHeapHardLimitPOHPercent") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimitPOHPercent; return true; }
+
     WCHAR configKey[MaxConfigKeyLength];
     if (MultiByteToWideChar(CP_ACP, 0, privateKey, -1 /* key is null-terminated */, configKey, MaxConfigKeyLength) == 0)
     {

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -1191,14 +1191,14 @@ bool GCToEEInterface::GetIntConfigValue(const char* privateKey, const char* publ
         return true;
     }
 
-    if ((g_gcHeapHardLimitInfo.specifiedFlags & 1) && strcmp(privateKey, "GCHeapHardLimit") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimit; return true; }
-    if ((g_gcHeapHardLimitInfo.specifiedFlags & 2) && strcmp(privateKey, "GCHeapHardLimitPercent") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimitPercent; return true; }
-    if ((g_gcHeapHardLimitInfo.specifiedFlags & 4) && strcmp(privateKey, "GCHeapHardLimitSOH") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimitSOH; return true; }
-    if ((g_gcHeapHardLimitInfo.specifiedFlags & 8) && strcmp(privateKey, "GCHeapHardLimitLOH") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimitLOH; return true; }
-    if ((g_gcHeapHardLimitInfo.specifiedFlags & 16) && strcmp(privateKey, "GCHeapHardLimitPOH") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimitPOH; return true; }
-    if ((g_gcHeapHardLimitInfo.specifiedFlags & 32) && strcmp(privateKey, "GCHeapHardLimitSOHPercent") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimitSOHPercent; return true; }
-    if ((g_gcHeapHardLimitInfo.specifiedFlags & 64) && strcmp(privateKey, "GCHeapHardLimitLOHPercent") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimitLOHPercent; return true; }
-    if ((g_gcHeapHardLimitInfo.specifiedFlags & 128) && strcmp(privateKey, "GCHeapHardLimitPOHPercent") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimitPOHPercent; return true; }
+    if ((g_gcHeapHardLimitInfo.heapHardLimit != UINT64_MAX) && strcmp(privateKey, "GCHeapHardLimit") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimit; return true; }
+    if ((g_gcHeapHardLimitInfo.heapHardLimitPercent != UINT64_MAX) && strcmp(privateKey, "GCHeapHardLimitPercent") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimitPercent; return true; }
+    if ((g_gcHeapHardLimitInfo.heapHardLimitSOH != UINT64_MAX) && strcmp(privateKey, "GCHeapHardLimitSOH") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimitSOH; return true; }
+    if ((g_gcHeapHardLimitInfo.heapHardLimitLOH != UINT64_MAX) && strcmp(privateKey, "GCHeapHardLimitLOH") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimitLOH; return true; }
+    if ((g_gcHeapHardLimitInfo.heapHardLimitPOH != UINT64_MAX) && strcmp(privateKey, "GCHeapHardLimitPOH") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimitPOH; return true; }
+    if ((g_gcHeapHardLimitInfo.heapHardLimitSOHPercent != UINT64_MAX) && strcmp(privateKey, "GCHeapHardLimitSOHPercent") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimitSOHPercent; return true; }
+    if ((g_gcHeapHardLimitInfo.heapHardLimitLOHPercent != UINT64_MAX) && strcmp(privateKey, "GCHeapHardLimitLOHPercent") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimitLOHPercent; return true; }
+    if ((g_gcHeapHardLimitInfo.heapHardLimitPOHPercent != UINT64_MAX) && strcmp(privateKey, "GCHeapHardLimitPOHPercent") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimitPOHPercent; return true; }
 
     WCHAR configKey[MaxConfigKeyLength];
     if (MultiByteToWideChar(CP_ACP, 0, privateKey, -1 /* key is null-terminated */, configKey, MaxConfigKeyLength) == 0)

--- a/src/coreclr/vm/gcenv.ee.standalone.cpp
+++ b/src/coreclr/vm/gcenv.ee.standalone.cpp
@@ -20,6 +20,8 @@
 // Finalizes a weak reference directly.
 extern void FinalizeWeakReference(Object* obj);
 
+extern GCHeapHardLimitInfo g_gcHeapHardLimitInfo;
+
 namespace standalone
 {
 

--- a/src/coreclr/vm/gcenv.ee.static.cpp
+++ b/src/coreclr/vm/gcenv.ee.static.cpp
@@ -20,4 +20,6 @@
 // Finalizes a weak reference directly.
 extern void FinalizeWeakReference(Object* obj);
 
+extern GCHeapHardLimitInfo g_gcHeapHardLimitInfo;
+
 #include "gcenv.ee.cpp"

--- a/src/coreclr/vm/qcallentrypoints.cpp
+++ b/src/coreclr/vm/qcallentrypoints.cpp
@@ -220,6 +220,7 @@ static const Entry s_QCall[] =
     DllImportEntry(GCInterface_UnregisterFrozenSegment)
 #endif
     DllImportEntry(GCInterface_EnumerateConfigurationValues)
+    DllImportEntry(GCInterface_RefreshMemoryLimit)
     DllImportEntry(MarshalNative_Prelink)
     DllImportEntry(MarshalNative_IsBuiltInComSupported)
     DllImportEntry(MarshalNative_GetHINSTANCE)

--- a/src/coreclr/vm/qcallentrypoints.cpp
+++ b/src/coreclr/vm/qcallentrypoints.cpp
@@ -221,6 +221,7 @@ static const Entry s_QCall[] =
 #endif
     DllImportEntry(GCInterface_EnumerateConfigurationValues)
     DllImportEntry(GCInterface_RefreshMemoryLimit)
+    DllImportEntry(GCInterface_UpdateHeapHardLimits)
     DllImportEntry(MarshalNative_Prelink)
     DllImportEntry(MarshalNative_IsBuiltInComSupported)
     DllImportEntry(MarshalNative_GetHINSTANCE)

--- a/src/coreclr/vm/qcallentrypoints.cpp
+++ b/src/coreclr/vm/qcallentrypoints.cpp
@@ -221,7 +221,6 @@ static const Entry s_QCall[] =
 #endif
     DllImportEntry(GCInterface_EnumerateConfigurationValues)
     DllImportEntry(GCInterface_RefreshMemoryLimit)
-    DllImportEntry(GCInterface_UpdateHeapHardLimits)
     DllImportEntry(MarshalNative_Prelink)
     DllImportEntry(MarshalNative_IsBuiltInComSupported)
     DllImportEntry(MarshalNative_GetHINSTANCE)


### PR DESCRIPTION
This PR implements https://github.com/dotnet/runtime/issues/70601 as a private method, we wanted to do that as a private method and get it merged to facilitate testing on a broader scale while not committing to a particular API shape for everyone just yet. For scoping reasons, this is currently only tested for Windows x64, it should work on Windows x86 with a caveat that we will not establish a heap hard limit if we don't already have one. Any other platforms are not tested yet.

Before this change, we detect the physical memory (as well as the additional limits such as job objects) and configure the GC, and then we never change it. Some of these configurations are just some numeric fields on the `gc_heap` class, while some others are structural (e.g. number of heaps, region_range, etc ...). 

This change aims at providing some flexibility on top of that init-once theme above. In particular, we allow the memory limit to change while the process is still running. It would be difficult to make structural changes, but it is relatively easy to just alter some numerical values. This change does just that. It factors out the memory-related settings into a separate function and allows them to be re-computed when the memory limit changes and the GC is notified through the `RefreshMemoryLimit` API call.

The technical challenge is commit accounting. If we happen to have no job object applied on the process and then one is applied later, now we have to set the `heap_hard_limit`, but then how would we know how much we already committed? The bulk of the `refresh_memory_limit` handles that by walking through the `gc_heap` data structure and figuring that out.

To make sure that is correct, a debug-only mode `COMMITTED_BYTES_SHADOW` is introduced. This mode will maintain the committed bytes all the time regardless of the existence of the `heap_hard_limit`, then we can assert the reconstructed value through the heap walking is producing the correct value as if we were tracking it all the time. This committed byte reconstruction and the testing knob will also be useful for other heap restructuring purposes.
