### PR TITLE
When the aggressive GCCollectionMode is specified, make sure the compacting parameter is set appropriately

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
@@ -185,7 +185,8 @@ namespace System
 
         public static void Collect(int generation, GCCollectionMode mode, bool blocking)
         {
-            Collect(generation, mode, blocking, false);
+            bool aggressive = generation == 2 && mode == GCCollectionMode.Aggressive;
+            Collect(generation, mode, blocking, compacting: aggressive);
         }
 
         public static void Collect(int generation, GCCollectionMode mode, bool blocking, bool compacting)

--- a/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
@@ -185,7 +185,7 @@ namespace System
 
         public static void Collect(int generation, GCCollectionMode mode, bool blocking)
         {
-            bool aggressive = generation == 2 && mode == GCCollectionMode.Aggressive;
+            bool aggressive = generation == MaxGeneration && mode == GCCollectionMode.Aggressive;
             Collect(generation, mode, blocking, compacting: aggressive);
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/GC.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/GC.NativeAot.cs
@@ -114,7 +114,8 @@ namespace System
 
         public static void Collect(int generation, GCCollectionMode mode, bool blocking)
         {
-            Collect(generation, mode, blocking, false);
+            bool aggressive = generation == MaxGeneration && mode == GCCollectionMode.Aggressive;
+            Collect(generation, mode, blocking, compacting: aggressive);
         }
 
         public static void Collect(int generation, GCCollectionMode mode, bool blocking, bool compacting)

--- a/src/tests/GC/API/GC/Collect_Aggressive_MultipleParameters.cs
+++ b/src/tests/GC/API/GC/Collect_Aggressive_MultipleParameters.cs
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+public class AggressiveCollect_MultipleParameters
+{
+    public static int Main()
+    {
+        long before = CreateGarbage();
+        GC.Collect(2, GCCollectionMode.Aggressive, blocking: true, compacting: true);
+
+        // Positive Test Case. 
+        long after = GC.GetGCMemoryInfo().TotalCommittedBytes;
+        long reclaimed = before - after;
+        long reclaimedAtLeast = 2000 * 4000;
+        if (reclaimed < reclaimedAtLeast)
+        {
+            // If we reach this case, the aggressive GC is not releasing as much memory as
+            // we wished, something is wrong.
+            throw new ArgumentException("Test for Collect_Aggressive_MultipleParameters failed: ArgumentException.");
+        }
+        else
+        {
+            // Doing some extra allocation (and also trigger GC indirectly) here
+            // should be just fine.
+            for (int i = 0; i < 10; i++)
+            {
+                CreateGarbage();
+            }
+        }
+
+        before = CreateGarbage();
+
+        // Negative Test Cases.
+        try
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                CreateGarbage();
+            }
+
+            GC.Collect(2, GCCollectionMode.Aggressive, blocking: false, compacting: false);
+        }
+        catch (ArgumentException ex)
+        {
+            // Should throw an exception.
+        }
+
+        catch (Exception ex)
+        {
+            throw new Exception("Test for Collect_Aggressive_MultipleParameters failed.");
+        }
+
+        // If we got this far, we have successfully executed all the tests. 
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static long CreateGarbage()
+    {
+        byte[][] smallGarbage = new byte[2000][];
+
+        // This will force us to use more than one region in the small object heap
+        for (int i = 0; i < 2000; i++)
+        {
+            // It will roughly span one page
+            smallGarbage[i] = new byte[4000];
+        }
+
+        // This will force us to use more than one region in the large object heap
+        byte[] largeGarbage = new byte[33 * 1024 * 1024];
+
+        // This will force us to use more than one region in the pin object heap
+        byte[] pinnedGarbage = GC.AllocateArray<byte>(33 * 1024 * 1024, /* pinned = */true);
+
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+        long committed = GC.GetGCMemoryInfo().TotalCommittedBytes;
+
+        GC.KeepAlive(smallGarbage);
+        GC.KeepAlive(largeGarbage);
+        GC.KeepAlive(pinnedGarbage);
+
+        return committed;
+    }
+}

--- a/src/tests/GC/API/GC/Collect_Aggressive_MultipleParameters.csproj
+++ b/src/tests/GC/API/GC/Collect_Aggressive_MultipleParameters.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <!-- Consider enable it for Mono whenever the implementation is ready -->
+    <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' != 'coreclr'">true</CLRTestTargetUnsupported>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>PdbOnly</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Collect_Aggressive_MultipleParameters.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
- If Generation specified as 2 and the GCCollectionMode is Aggressive, then compaction must be true.
- Added a unit test for this case. 