### PR TITLE
Add additional close statuses in ManagedWebSocket

### DIFF
--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerWebSocketTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerWebSocketTests.cs
@@ -168,6 +168,9 @@ namespace System.Net.Tests
         {
             yield return new object[] { WebSocketCloseStatus.EndpointUnavailable, "", WebSocketCloseStatus.EndpointUnavailable };
             yield return new object[] { WebSocketCloseStatus.MandatoryExtension, "StatusDescription", WebSocketCloseStatus.MandatoryExtension };
+            yield return new object[] { WebSocketCloseStatus.ServiceRestart, "ServiceRestart", WebSocketCloseStatus.ServiceRestart };
+            yield return new object[] { WebSocketCloseStatus.TryAgainLater, "TryAgainLater", WebSocketCloseStatus.TryAgainLater };
+            yield return new object[] { WebSocketCloseStatus.BadGateway, "BadGateway", WebSocketCloseStatus.BadGateway };
         }
 
         [ConditionalTheory(nameof(IsNotWindows7AndIsWindowsImplementation))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/22015", TestPlatforms.AnyUnix)]

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -1059,6 +1059,9 @@ namespace System.Net.WebSockets
                 case WebSocketCloseStatus.NormalClosure:
                 case WebSocketCloseStatus.PolicyViolation:
                 case WebSocketCloseStatus.ProtocolError:
+                case WebSocketCloseStatus.ServiceRestart:
+                case WebSocketCloseStatus.TryAgainLater:
+                case WebSocketCloseStatus.BadGateway:
                     return true;
 
                 default:

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/WebSocketCloseStatus.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/WebSocketCloseStatus.cs
@@ -17,7 +17,10 @@ namespace System.Net.WebSockets
         PolicyViolation = 1008,
         MessageTooBig = 1009,
         MandatoryExtension = 1010,
-        InternalServerError = 1011
+        InternalServerError = 1011,
+        ServiceRestart = 1012,  // indicates that the server / service is restarting.
+        TryAgainLater = 1013,   // indicates that a temporary server condition forced blocking the client's request.
+        BadGateway = 1014       // indicates that the server acting as gateway received an invalid response
         // TLSHandshakeFailed = 1015, // 1015 is reserved and should never be used by user
 
         // 0 - 999 Status codes in the range 0-999 are not used.


### PR DESCRIPTION
Add ServiceRestart (1012), TryAgainLater (1013), and BadGateway (1014) to the list of `WebSocketCloseStatus` values and allow them to be used as valid WebSocket close statuses so we don't reject the close and discard the status description by adding them to the private `IsValueCloseStatus` method switch statement declaring them as valid `true`.

Fixes Issue https://github.com/dotnet/runtime/issues/82602

# Description

The current implementation of `ManagedWebSocket` explicitly declares some `WebSocketCloseStatus` values as "acceptable" reasons to close the socket. For those, the information status decsription is extracted and made available. For all other values, the close status is rejected and the closing information is discarded.

This means that things like `BadGateway` (1014), or `ServiceRestart` (1012),  or `TryAgainLater` (1013)  will be declared invalid by `ManagedWebSocket.IsValidCloseStatus` and thus not handled cleanly even though they could happen after a web socket is completely setup.

# Customer Impact

Lost information and ragged closing of a web socket when a server-side or proxy closes because of any of the previously rejected values:

*  ServiceRestart = 1012  // indicates that the server / service is restarting.
*  TryAgainLater = 1013   // indicates that a temporary server condition forced blocking the client's request.
*  BadGateway = 1014       // indicates that the server acting as gateway received an invalid response

# Regression

No

# Testing

Added test cases for all three to the HttpListenerWebSocketTests.cs file with no regressions found.

# Risk

Changes the public exposed enum of WebSocketCloseStatus.cs adding three new values that were previously not documented.

# Package authoring signed off?

IMPORTANT: If this change touches code that ships in a NuGet package, please make certain that you have added any necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.
