### PR TITLE
JIT: Expand handling of non-value commas in gtSplitTree

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -16437,7 +16437,7 @@ bool Compiler::gtSplitTree(
             }
 
             Statement* stmt = nullptr;
-            if (!(*use)->IsValue() || (*use)->OperIs(GT_ASG) || (user == nullptr) ||
+            if (!(*use)->IsValue() || (*use)->gtEffectiveVal()->OperIs(GT_ASG) || (user == nullptr) ||
                 (user->OperIs(GT_COMMA) && (user->gtGetOp1() == *use)))
             {
                 GenTree* sideEffects = nullptr;


### PR DESCRIPTION
We can have a 'value'-typed COMMA whose RHS operand is actually an assignment. gtSplitTree would create illegal IR for this case.

For example:

```scala
N018 ( 38, 33) [000327] -ACXGO----- arg1 setup              ├──▌  COMMA     simd32
N011 ( 28, 25) [000328] -ACXGO-----                         │  ├──▌  COMMA     void
N008 ( 24, 22) [000320] -ACXG---R--                         │  │  ├──▌  ASG       byref
N007 (  3,  2) [000319] D------N---                         │  │  │  ├──▌  LCL_VAR   byref  V50 tmp45
N006 ( 20, 19) [000126] --CXG------                         │  │  │  └──▌  CALL help byref  CORINFO_HELP_UNBOX
N004 (  3,  2) [000124] ----------- arg1 in rsi             │  │  │     ├──▌  LCL_VAR   ref    V02 loc1
N005 (  3, 10) [000125] H---------- arg0 in rdi             │  │  │     └──▌  CNS_INT(h) long   0x7f6e4bb0e500 class
N010 (  4,  3) [000322] ---X-O-----                         │  │  └──▌  NULLCHECK byte
N009 (  3,  2) [000321] -----------                         │  │     └──▌  LCL_VAR   byref  V50 tmp45
N017 ( 10,  8) [000331] -A-XGO--R--                         │  └──▌  ASG       simd32 (copy)
N016 (  3,  2) [000330] D------N---                         │     ├──▌  LCL_VAR   simd32 V51 tmp46
N015 (  6,  5) [000329] ---XGO-N---                         │     └──▌  IND       simd32
N014 (  4,  3) [000326] -----O-N---                         │        └──▌  ADD       byref
N012 (  3,  2) [000324] -----O-----                         │           ├──▌  LCL_VAR   byref  V50 tmp45
N013 (  1,  1) [000325] -----------                         │           └──▌  CNS_INT   long   32
```

gtSplitTree would believe that [000327] was a value and would create the following IR shape:

```scala
N016 ( 14, 11) [000428] -A-XGO--R--                         ▌  ASG       simd32 (copy)
N015 (  3,  2) [000427] D------N---                         ├──▌  LCL_VAR   simd32 V76 tmp71
N014 ( 10,  8) [000331] -A-XGO-NR--                         └──▌  ASG       simd32 (copy)
N013 (  3,  2) [000330] D------N---                            ├──▌  LCL_VAR   simd32 V51 tmp46
N012 (  6,  5) [000329] ---XGO-N---                            └──▌  IND       simd32
N011 (  4,  3) [000326] -----O-N---                               └──▌  ADD       byref
N009 (  3,  2) [000324] -----O-----                                  ├──▌  LCL_VAR   byref  V50 tmp45
N010 (  1,  1) [000325] -----------                                  └──▌  CNS_INT   long   32
```

Fix #83576