### PR TITLE
Remove another reference field from async state machines

### DIFF
--- a/src/libraries/System.Threading.Tasks/tests/System.Runtime.CompilerServices/AsyncTaskMethodBuilderTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/System.Runtime.CompilerServices/AsyncTaskMethodBuilderTests.cs
@@ -662,6 +662,19 @@ namespace System.Threading.Tasks.Tests
             }).Dispose();
         }
 
+        [Fact]
+        public void AsyncTaskMethodBuilder_NullStateEvenAfterSuspend()
+        {
+            Task t = AwaitSomething();
+            Assert.Null(t.AsyncState);
+
+            static async Task AwaitSomething()
+            {
+                Assert.NotNull(ExecutionContext.Capture());
+                await new TaskCompletionSource().Task;
+            }
+        }
+
         #region Helper Methods / Classes
 
         [MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
The async state machine Task-derived type currently adds three fields:
- The StateMachine
- An Action field for caching any delegate created to MoveNext
- The ExecutionContext to flow to the next MoveNext invocation

[The other pending PR](https://github.com/dotnet/runtime/pull/83696) gets rid of the Action field by using the unused Action field from the base Task for that purpose.

This PR gets rid of the ExecutionContext field by using the unused state object field from the base Task for that purpose.  The field is exposed via the public AsyncState property, so this also uses a bit from the state flags field to prevent this state object from being returned from that property.

The combination of removing those two fields shaves 16 bytes off of every `async Task` state machine box on 64-bit.  The only remaining field added by the state machine type is for the state machine itself, which is required.