### PR TITLE
Adjust Test Watcher Timeout for Test Collections

### DIFF
--- a/src/native/watchdog/watchdog.cpp
+++ b/src/native/watchdog/watchdog.cpp
@@ -35,8 +35,11 @@ int main(const int argc, const char *argv[])
         return EXIT_FAILURE;
     }
 
-    const long timeout_ms = strtol(argv[1], nullptr, 10);
-    int exit_code = run_timed_process(timeout_ms, argc-2, &argv[2]);
+    // Due to how Helix test environment variables are set, we have to receive
+    // the raw timeout value in minutes. Then we convert it to milliseconds when
+    // calling run_timed_process().
+    const long timeout_mins = strtol(argv[1], nullptr, 10);
+    int exit_code = run_timed_process(timeout_mins * 60000L, argc-2, &argv[2]);
 
     printf("App Exit Code: %d\n", exit_code);
     return exit_code;

--- a/src/tests/Common/CLRTest.Execute.Bash.targets
+++ b/src/tests/Common/CLRTest.Execute.Bash.targets
@@ -555,6 +555,13 @@ if [[ ! -z "$__TestCollectionTimeoutMins" ]]%3B then
     _WatcherTimeoutMins=$__TestCollectionTimeoutMins
 fi
 
+# The watcher needs a bit of time to start up, capture dumps, clean up, and so on.
+# Because of this, we pass a smaller timeout than the test collection one.
+# For simplicity purposes, we will assume there are no work items with just
+# a one-minute max timeout.
+if (( $_WatcherTimeoutMins > 1 ))%3B then
+    _WatcherTimeoutMins="%24((_WatcherTimeoutMins-1))"
+fi
 
 # The __TestEnv variable may be used to specify a script to source before the test.
 if [ -n "$__TestEnv" ]%3B then

--- a/src/tests/Common/CLRTest.Execute.Bash.targets
+++ b/src/tests/Common/CLRTest.Execute.Bash.targets
@@ -290,7 +290,7 @@ fi
       </PropertyGroup>
       <PropertyGroup>
       <CLRTestRunFile Condition="'$(CLRTestIsHosted)'=='true'">"$CORE_ROOT/corerun" $(CoreRunArgs)  ${__DotEnvArg}</CLRTestRunFile>
-      <WatcherRunFile>"$CORE_ROOT/watchdog" $_WatcherTimeoutMilliseconds</WatcherRunFile>
+      <WatcherRunFile>"$CORE_ROOT/watchdog" $_WatcherTimeoutMins</WatcherRunFile>
 
       <!-- Note that this overwrites CLRTestBashPreCommands rather than adding to it. -->
       <CLRTestBashPreCommands Condition="'$(CLRTestKind)' == 'BuildAndRun' and '$(TargetArchitecture)' == 'wasm'"><![CDATA[
@@ -549,10 +549,10 @@ ReleaseLock()
 cd "$%28dirname "${BASH_SOURCE[0]}")"
 LockFile="lock"
 _RunWithWatcher=0
-_WatcherTimeoutMilliseconds=600000
+_WatcherTimeoutMins=10
 
-if [[ ! -z "$__TestTimeout" ]]%3B then
-    _WatcherTimeoutMilliseconds=$__TestTimeout
+if [[ ! -z "$__TestCollectionTimeoutMins" ]]%3B then
+    _WatcherTimeoutMins=$__TestCollectionTimeoutMins
 fi
 
 

--- a/src/tests/Common/CLRTest.Execute.Batch.targets
+++ b/src/tests/Common/CLRTest.Execute.Batch.targets
@@ -439,10 +439,10 @@ set "lockFolder=%~dp0\lock"
 pushd %~dp0
 set "scriptPath=%~dp0"
 set /A _RunWithWatcher=0
-set _WatcherTimeoutMins=10
+set /A _WatcherTimeoutMins=10
 
 IF NOT "%__TestCollectionTimeoutMins%"=="" (
-    set _WatcherTimeoutMins=%__TestCollectionTimeoutMins%
+    set /A _WatcherTimeoutMins=%__TestCollectionTimeoutMins%
 )
 
 REM The watcher needs a bit of time to start up, capture dumps, clean up, and so on.
@@ -450,7 +450,7 @@ REM Because of this, we pass a smaller timeout than the test collection one.
 REM For simplicity purposes, we will assume there are no work items with just
 REM a one-minute max timeout.
 IF %_WatcherTimeoutMins% GTR 1 (
-    _WatcherTimeoutMins-=1
+    set /A _WatcherTimeoutMins-=1
 )
 
 $(BatchCLRTestArgPrep)

--- a/src/tests/Common/CLRTest.Execute.Batch.targets
+++ b/src/tests/Common/CLRTest.Execute.Batch.targets
@@ -298,7 +298,7 @@ if defined DoLink (
       </PropertyGroup>
       <PropertyGroup>
       <CLRTestRunFile Condition="'$(CLRTestIsHosted)'=='true'">"%CORE_ROOT%\corerun.exe" $(CoreRunArgs) %__DotEnvArg%</CLRTestRunFile>
-      <WatcherRunFile>"%CORE_ROOT%\watchdog.exe" %_WatcherTimeoutMilliseconds%</WatcherRunFile>
+      <WatcherRunFile>"%CORE_ROOT%\watchdog.exe" %_WatcherTimeoutMins%</WatcherRunFile>
 
       <BatchCopyCoreShimLocalCmds Condition="'$(CLRTestScriptLocalCoreShim)' == 'true'"><![CDATA[
 REM Local CoreShim requested - see MSBuild property 'CLRTestScriptLocalCoreShim'
@@ -439,10 +439,10 @@ set "lockFolder=%~dp0\lock"
 pushd %~dp0
 set "scriptPath=%~dp0"
 set /A _RunWithWatcher=0
-set _WatcherTimeoutMilliseconds=600000
+set _WatcherTimeoutMins=10
 
-IF NOT "%__TestTimeout%"=="" (
-    set _WatcherTimeoutMilliseconds=%__TestTimeout%
+IF NOT "%__TestCollectionTimeoutMins%"=="" (
+    set _WatcherTimeoutMins=%__TestCollectionTimeoutMins%
 )
 
 $(BatchCLRTestArgPrep)

--- a/src/tests/Common/CLRTest.Execute.Batch.targets
+++ b/src/tests/Common/CLRTest.Execute.Batch.targets
@@ -445,6 +445,14 @@ IF NOT "%__TestCollectionTimeoutMins%"=="" (
     set _WatcherTimeoutMins=%__TestCollectionTimeoutMins%
 )
 
+REM The watcher needs a bit of time to start up, capture dumps, clean up, and so on.
+REM Because of this, we pass a smaller timeout than the test collection one.
+REM For simplicity purposes, we will assume there are no work items with just
+REM a one-minute max timeout.
+IF %_WatcherTimeoutMins% GTR 1 (
+    _WatcherTimeoutMins-=1
+)
+
 $(BatchCLRTestArgPrep)
 $(BatchCLRTestExitCodePrep)
 

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -626,6 +626,7 @@
     <HelixPreCommand Include="set CLRCustomTestLauncher=%HELIX_CORRELATION_PAYLOAD%\nativeaottest.cmd" Condition=" '$(NativeAotTest)' == 'true' " />
     <HelixPreCommand Include="set __TestEnv=%HELIX_WORKITEM_PAYLOAD%\$(TestEnvFileName)" />
     <HelixPreCommand Include="set __TestTimeout=$(TimeoutPerTestInMilliseconds)" Condition=" '$(TimeoutPerTestInMilliseconds)' != '' " />
+    <HelixPreCommand Include="set __TestCollectionTimeoutMins=$(TimeoutPerTestCollectionInMinutes)" Condition=" '$(TimeoutPerTestCollectionInMinutes)' != '' " />
     <HelixPreCommand Include="set __CollectDumps=1" />
     <HelixPreCommand Include="set __CrashDumpFolder=%HELIX_DUMP_FOLDER%" />
     <HelixPreCommand Include="set __TestArchitecture=$(TargetArchitecture)" />
@@ -676,6 +677,7 @@
     <HelixPreCommand Include="export CLRCustomTestLauncher=$HELIX_CORRELATION_PAYLOAD/nativeaottest.sh" Condition=" '$(NativeAotTest)' == 'true' " />
     <HelixPreCommand Include="export __TestEnv=$HELIX_WORKITEM_PAYLOAD/$(TestEnvFileName)" />
     <HelixPreCommand Include="export __TestTimeout=$(TimeoutPerTestInMilliseconds)" Condition=" '$(TimeoutPerTestInMilliseconds)' != '' " />
+    <HelixPreCommand Include="export __TestCollectionTimeoutMins=$(TimeoutPerTestCollectionInMinutes)" Condition=" '$(TimeoutPerTestCollectionInMinutes)' != '' " />
     <HelixPreCommand Include="export __CollectDumps=1" />
     <HelixPreCommand Include="export __CrashDumpFolder=$HELIX_DUMP_FOLDER" />
     <HelixPreCommand Include="set __TestArchitecture=$(TargetArchitecture)" />


### PR DESCRIPTION
Addresses issue #83654. This PR introduces a new environment variable, `__TestCollectionTimeoutMins`, which is used by the watcher in favor of `__TestTimeout`. This is to have it be able to measure running time more appropriately in test collections work items.