### PR TITLE
[7.0] Avoid using spanish helix queues

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -144,7 +144,7 @@ jobs:
               - (Windows.10.Amd64.ServerRS5.Open)windows.10.amd64.serverrs5.open@mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-ltsc2019-helix-amd64
           - ${{ if or(ne(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
             - Windows.81.Amd64.Open
-            - Windows.10.Amd64.Server2022.ES.Open
+            - Windows.Amd64.Server2022.Open
             - Windows.11.Amd64.Client.Open
             - ${{ if eq(parameters.jobParameters.testScope, 'outerloop') }}:
               - (Windows.10.Amd64.ServerRS5.Open)windows.10.amd64.serverrs5.open@mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-ltsc2019-helix-amd64
@@ -170,7 +170,7 @@ jobs:
             - Windows.11.Amd64.Client.Open
             - Windows.Amd64.Server2022.Open
           - ${{ if or(ne(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
-            - Windows.10.Amd64.Server2022.ES.Open
+            - Windows.Amd64.Server2022.Open
             - Windows.7.Amd64.Open
 
       # .NETFramework


### PR DESCRIPTION
Manual backport of https://github.com/dotnet/runtime/pull/82578
Fixes the 7.0 portion of https://github.com/dotnet/runtime/issues/83226 

cc @dotnet/area-system-security @dotnet/ncl  this should make a bunch of Networking and Security issues to go away in 7.0.