### PR TITLE
Make string.Substring unroll friendly

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -2101,7 +2101,7 @@ namespace System
             string result = FastAllocateString(length);
 
             Buffer.Memmove(
-                elementCount: (uint)result.Length, // derefing Length now allows JIT to prove 'result' not null below
+                elementCount: (uint)length,
                 destination: ref result._firstChar,
                 source: ref Unsafe.Add(ref _firstChar, (nint)(uint)startIndex /* force zero-extension */));
 


### PR DESCRIPTION
This change makes `string.Substring` unrollable for jit-time constant length, e.g.:
```csharp
string Test(string str, int i) => str.Substring(i, 20);
```
codegen diff: https://www.diffchecker.com/dq8kq40I/


The reason why `str.length` was used is because JIT doesn't know that an internal call `FastAllocateString` always return something non-null so length was re-loaded to do a nullcheck, basically:

![image](https://user-images.githubusercontent.com/523221/226777571-f79eb553-b3f6-4a55-96c0-070d8483aace.png)

1 byte smaller, I doubt it makes any difference here.

PS: we can mark `FastAllocateString` as a jit intrinsics to tell jit it's never null, it'll be like 20 lines of code change and remove a couple of nullchecks here in there in String itself probably.