### PR TITLE
Add MemoryExtensions.TryWriteUtf8

### DIFF
--- a/src/libraries/System.Memory/ref/System.Memory.cs
+++ b/src/libraries/System.Memory/ref/System.Memory.cs
@@ -382,6 +382,8 @@ namespace System
         public static bool TryWrite<TArg0, TArg1, TArg2>(this System.Span<char> destination, System.IFormatProvider? provider, System.Text.CompositeFormat format, out int charsWritten, TArg0 arg0, TArg1 arg1, TArg2 arg2) { throw null; }
         public static bool TryWrite(this Span<char> destination, System.IFormatProvider? provider, System.Text.CompositeFormat format, out int charsWritten, params object?[] args) { throw null; }
         public static bool TryWrite(this Span<char> destination, System.IFormatProvider? provider, System.Text.CompositeFormat format, out int charsWritten, System.ReadOnlySpan<object?> args) { throw null; }
+        public static bool TryWriteUtf8(this System.Span<byte> destination, [System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute("destination")] ref System.MemoryExtensions.TryWriteUtf8InterpolatedStringHandler handler, out int bytesWritten) { throw null; }
+        public static bool TryWriteUtf8(this System.Span<byte> destination, IFormatProvider? provider, [System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute("destination", "provider")] ref System.MemoryExtensions.TryWriteUtf8InterpolatedStringHandler handler, out int bytesWritten) { throw null; }
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         [System.Runtime.CompilerServices.InterpolatedStringHandlerAttribute]
         public ref struct TryWriteInterpolatedStringHandler
@@ -393,6 +395,27 @@ namespace System
             public bool AppendLiteral(string value) { throw null; }
             public bool AppendFormatted(scoped System.ReadOnlySpan<char> value) { throw null; }
             public bool AppendFormatted(scoped System.ReadOnlySpan<char> value, int alignment = 0, string? format = null) { throw null; }
+            public bool AppendFormatted<T>(T value) { throw null; }
+            public bool AppendFormatted<T>(T value, string? format) { throw null; }
+            public bool AppendFormatted<T>(T value, int alignment) { throw null; }
+            public bool AppendFormatted<T>(T value, int alignment, string? format) { throw null; }
+            public bool AppendFormatted(object? value, int alignment = 0, string? format = null) { throw null; }
+            public bool AppendFormatted(string? value) { throw null; }
+            public bool AppendFormatted(string? value, int alignment = 0, string? format = null) { throw null; }
+        }
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.Runtime.CompilerServices.InterpolatedStringHandlerAttribute]
+        public ref struct TryWriteUtf8InterpolatedStringHandler
+        {
+            private readonly object _dummy;
+            private readonly int _dummyPrimitive;
+            public TryWriteUtf8InterpolatedStringHandler(int literalLength, int formattedCount, System.Span<byte> destination, out bool shouldAppend) { throw null; }
+            public TryWriteUtf8InterpolatedStringHandler(int literalLength, int formattedCount, System.Span<byte> destination, IFormatProvider? provider, out bool shouldAppend) { throw null; }
+            public bool AppendLiteral(string value) { throw null; }
+            public bool AppendFormatted(scoped System.ReadOnlySpan<char> value) { throw null; }
+            public bool AppendFormatted(scoped System.ReadOnlySpan<char> value, int alignment = 0, string? format = null) { throw null; }
+            public bool AppendFormatted(scoped System.ReadOnlySpan<byte> utf8Value) { throw null; }
+            public bool AppendFormatted(scoped System.ReadOnlySpan<byte> utf8Value, int alignment = 0, string? format = null) { throw null; }
             public bool AppendFormatted<T>(T value) { throw null; }
             public bool AppendFormatted<T>(T value, string? format) { throw null; }
             public bool AppendFormatted<T>(T value, int alignment) { throw null; }

--- a/src/libraries/System.Memory/tests/Span/TryWrite.cs
+++ b/src/libraries/System.Memory/tests/Span/TryWrite.cs
@@ -529,7 +529,7 @@ namespace System.SpanTests
             Assert.Equal(expected, tss.ToStringState.ToStringMode);
         }
 
-        private sealed class SpanFormattableStringWrapper : IFormattable, ISpanFormattable, IHasToStringState
+        internal sealed class SpanFormattableStringWrapper : IFormattable, ISpanFormattable, IHasToStringState
         {
             private readonly string _value;
             public ToStringState ToStringState { get; } = new ToStringState();
@@ -576,7 +576,7 @@ namespace System.SpanTests
             }
         }
 
-        private struct SpanFormattableInt32Wrapper : IFormattable, ISpanFormattable, IHasToStringState
+        internal struct SpanFormattableInt32Wrapper : IFormattable, ISpanFormattable, IHasToStringState
         {
             private readonly int _value;
             public ToStringState ToStringState { get; }
@@ -613,7 +613,7 @@ namespace System.SpanTests
             }
         }
 
-        private sealed class FormattableStringWrapper : IFormattable, IHasToStringState
+        internal sealed class FormattableStringWrapper : IFormattable, IHasToStringState
         {
             private readonly string _value;
             public ToStringState ToStringState { get; } = new ToStringState();
@@ -637,7 +637,7 @@ namespace System.SpanTests
             }
         }
 
-        private struct FormattableInt32Wrapper : IFormattable, IHasToStringState
+        internal struct FormattableInt32Wrapper : IFormattable, IHasToStringState
         {
             private readonly int _value;
             public ToStringState ToStringState { get; }
@@ -665,19 +665,19 @@ namespace System.SpanTests
             }
         }
 
-        private sealed class ToStringState
+        internal sealed class ToStringState
         {
             public string LastFormat { get; set; }
             public IFormatProvider LastProvider { get; set; }
             public ToStringMode ToStringMode { get; set; }
         }
 
-        private interface IHasToStringState
+        internal interface IHasToStringState
         {
             ToStringState ToStringState { get; }
         }
 
-        private enum ToStringMode
+        internal enum ToStringMode
         {
             ObjectToString,
             IFormattableToString,
@@ -685,7 +685,7 @@ namespace System.SpanTests
             ICustomFormatterFormat,
         }
 
-        private sealed class StringWrapper
+        internal sealed class StringWrapper
         {
             private readonly string _value;
 
@@ -694,7 +694,7 @@ namespace System.SpanTests
             public override string ToString() => _value;
         }
 
-        private sealed class ConcatFormatter : IFormatProvider, ICustomFormatter
+        internal sealed class ConcatFormatter : IFormatProvider, ICustomFormatter
         {
             public object GetFormat(Type formatType) => formatType == typeof(ICustomFormatter) ? this : null;
 
@@ -714,7 +714,7 @@ namespace System.SpanTests
             }
         }
 
-        private sealed class ConstFormatter : IFormatProvider, ICustomFormatter
+        internal sealed class ConstFormatter : IFormatProvider, ICustomFormatter
         {
             private readonly string _value;
 

--- a/src/libraries/System.Memory/tests/Span/TryWriteUtf8.cs
+++ b/src/libraries/System.Memory/tests/Span/TryWriteUtf8.cs
@@ -1,0 +1,609 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers.Text;
+using System.Globalization;
+using System.Text;
+using Xunit;
+
+namespace System.SpanTests
+{
+    public class TryWriteUtf8Tests
+    {
+        private byte[] _largeBuffer = new byte[4096];
+
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(1, 1)]
+        [InlineData(42, 84)]
+        [InlineData(-1, 0)]
+        [InlineData(-1, -1)]
+        [InlineData(-16, 1)]
+        public void LengthAndHoleArguments_Valid(int literalLength, int formattedCount)
+        {
+            bool shouldAppend;
+
+            new MemoryExtensions.TryWriteUtf8InterpolatedStringHandler(literalLength, formattedCount, new byte[Math.Max(0, literalLength)], out shouldAppend);
+            Assert.True(shouldAppend);
+
+            new MemoryExtensions.TryWriteUtf8InterpolatedStringHandler(literalLength, formattedCount, new byte[1 + Math.Max(0, literalLength)], out shouldAppend);
+            Assert.True(shouldAppend);
+
+            if (literalLength > 0)
+            {
+                new MemoryExtensions.TryWriteUtf8InterpolatedStringHandler(literalLength, formattedCount, new byte[literalLength - 1], out shouldAppend);
+                Assert.False(shouldAppend);
+            }
+
+            foreach (IFormatProvider provider in new IFormatProvider[] { null, new TryWriteTests.ConcatFormatter(), CultureInfo.InvariantCulture, CultureInfo.CurrentCulture, new CultureInfo("en-US"), new CultureInfo("fr-FR") })
+            {
+                new MemoryExtensions.TryWriteUtf8InterpolatedStringHandler(literalLength, formattedCount, new byte[Math.Max(0, literalLength)], out shouldAppend);
+                Assert.True(shouldAppend);
+
+                new MemoryExtensions.TryWriteUtf8InterpolatedStringHandler(literalLength, formattedCount, new byte[1 + Math.Max(0, literalLength)], out shouldAppend);
+                Assert.True(shouldAppend);
+
+                if (literalLength > 0)
+                {
+                    new MemoryExtensions.TryWriteUtf8InterpolatedStringHandler(literalLength, formattedCount, new byte[literalLength - 1], out shouldAppend);
+                    Assert.False(shouldAppend);
+                }
+            }
+        }
+
+        [Fact]
+        public void AppendLiteral()
+        {
+            var expected = new StringBuilder();
+            MemoryExtensions.TryWriteUtf8InterpolatedStringHandler actual = new MemoryExtensions.TryWriteUtf8InterpolatedStringHandler(0, 0, _largeBuffer, out _);
+
+            foreach (string s in new[] { "", "a", "bc", "def", "this is a long string", "!" })
+            {
+                expected.Append(s);
+                actual.AppendLiteral(s);
+            }
+
+            Assert.True(MemoryExtensions.TryWriteUtf8(_largeBuffer, ref actual, out int bytesWritten));
+            Assert.Equal(expected.ToString(), Encoding.UTF8.GetString(_largeBuffer.AsSpan(0, bytesWritten)));
+        }
+
+        [Fact]
+        public void AppendFormatted_ReadOnlySpanChar()
+        {
+            var expected = new StringBuilder();
+            MemoryExtensions.TryWriteUtf8InterpolatedStringHandler actual = new MemoryExtensions.TryWriteUtf8InterpolatedStringHandler(0, 0, _largeBuffer, out _);
+
+            foreach (string s in new[] { "", "a", "bc", "def", "this is a longer string", "!" })
+            {
+                // span
+                expected.Append(s);
+                actual.AppendFormatted((ReadOnlySpan<char>)s);
+
+                // span, format
+                expected.AppendFormat("{0:X2}", s);
+                actual.AppendFormatted((ReadOnlySpan<char>)s, format: "X2");
+
+                foreach (int alignment in new[] { 0, 3, -3 })
+                {
+                    // span, alignment
+                    expected.AppendFormat("{0," + alignment.ToString(CultureInfo.InvariantCulture) + "}", s);
+                    actual.AppendFormatted((ReadOnlySpan<char>)s, alignment);
+
+                    // span, alignment, format
+                    expected.AppendFormat("{0," + alignment.ToString(CultureInfo.InvariantCulture) + ":X2}", s);
+                    actual.AppendFormatted((ReadOnlySpan<char>)s, alignment, "X2");
+                }
+            }
+
+            Assert.True(MemoryExtensions.TryWriteUtf8(_largeBuffer, ref actual, out int bytesWritten));
+            Assert.Equal(expected.ToString(), Encoding.UTF8.GetString(_largeBuffer.AsSpan(0, bytesWritten)));
+        }
+
+        [Fact]
+        public void AppendFormatted_ReadOnlySpanByte()
+        {
+            var expected = new StringBuilder();
+            MemoryExtensions.TryWriteUtf8InterpolatedStringHandler actual = new MemoryExtensions.TryWriteUtf8InterpolatedStringHandler(0, 0, _largeBuffer, out _);
+
+            foreach (string s in new[] { "", "a", "bc", "def", "this is a longer string", "!" })
+            {
+                ReadOnlySpan<byte> utf8 = Encoding.UTF8.GetBytes(s);
+
+                // span
+                expected.Append(s);
+                actual.AppendFormatted(utf8);
+
+                // span, format
+                expected.AppendFormat("{0:X2}", s);
+                actual.AppendFormatted(utf8, format: "X2");
+
+                foreach (int alignment in new[] { 0, 3, -3 })
+                {
+                    // span, alignment
+                    expected.AppendFormat("{0," + alignment.ToString(CultureInfo.InvariantCulture) + "}", s);
+                    actual.AppendFormatted(utf8, alignment);
+
+                    // span, alignment, format
+                    expected.AppendFormat("{0," + alignment.ToString(CultureInfo.InvariantCulture) + ":X2}", s);
+                    actual.AppendFormatted(utf8, alignment, "X2");
+                }
+            }
+
+            Assert.True(MemoryExtensions.TryWriteUtf8(_largeBuffer, ref actual, out int bytesWritten));
+            Assert.Equal(expected.ToString(), Encoding.UTF8.GetString(_largeBuffer.AsSpan(0, bytesWritten)));
+        }
+
+        [Fact]
+        public void AppendFormatted_String()
+        {
+            var expected = new StringBuilder();
+            MemoryExtensions.TryWriteUtf8InterpolatedStringHandler actual = new MemoryExtensions.TryWriteUtf8InterpolatedStringHandler(0, 0, _largeBuffer, out _);
+
+            foreach (string s in new[] { null, "", "a", "bc", "def", "this is a longer string", "!" })
+            {
+                // string
+                expected.AppendFormat("{0}", s);
+                actual.AppendFormatted(s);
+
+                // string, format
+                expected.AppendFormat("{0:X2}", s);
+                actual.AppendFormatted(s, "X2");
+
+                foreach (int alignment in new[] { 0, 3, -3 })
+                {
+                    // string, alignment
+                    expected.AppendFormat("{0," + alignment.ToString(CultureInfo.InvariantCulture) + "}", s);
+                    actual.AppendFormatted(s, alignment);
+
+                    // string, alignment, format
+                    expected.AppendFormat("{0," + alignment.ToString(CultureInfo.InvariantCulture) + ":X2}", s);
+                    actual.AppendFormatted(s, alignment, "X2");
+                }
+            }
+
+            Assert.True(MemoryExtensions.TryWriteUtf8(_largeBuffer, ref actual, out int bytesWritten));
+            Assert.Equal(expected.ToString(), Encoding.UTF8.GetString(_largeBuffer.AsSpan(0, bytesWritten)));
+        }
+
+        [Fact]
+        public void AppendFormatted_String_ICustomFormatter()
+        {
+            var provider = new TryWriteTests.ConcatFormatter();
+
+            var expected = new StringBuilder();
+            MemoryExtensions.TryWriteUtf8InterpolatedStringHandler actual = new MemoryExtensions.TryWriteUtf8InterpolatedStringHandler(0, 0, _largeBuffer, provider, out _);
+
+            foreach (string s in new[] { null, "", "a" })
+            {
+                // string
+                expected.AppendFormat(provider, "{0}", s);
+                actual.AppendFormatted(s);
+
+                // string, format
+                expected.AppendFormat(provider, "{0:X2}", s);
+                actual.AppendFormatted(s, "X2");
+
+                // string, alignment
+                expected.AppendFormat(provider, "{0,3}", s);
+                actual.AppendFormatted(s, 3);
+
+                // string, alignment, format
+                expected.AppendFormat(provider, "{0,-3:X2}", s);
+                actual.AppendFormatted(s, -3, "X2");
+            }
+
+            Assert.True(MemoryExtensions.TryWriteUtf8(_largeBuffer, ref actual, out int bytesWritten));
+            Assert.Equal(expected.ToString(), Encoding.UTF8.GetString(_largeBuffer.AsSpan(0, bytesWritten)));
+        }
+
+        [Fact]
+        public void AppendFormatted_ReferenceTypes()
+        {
+            var expected = new StringBuilder();
+            MemoryExtensions.TryWriteUtf8InterpolatedStringHandler actual = new MemoryExtensions.TryWriteUtf8InterpolatedStringHandler(0, 0, _largeBuffer, out _);
+
+            foreach (string rawInput in new[] { null, "", "a", "bc", "def", "this is a longer string", "!" })
+            {
+                foreach (object o in new object[]
+                {
+                    rawInput, // raw string directly; ToString will return itself
+                    new TryWriteTests.StringWrapper(rawInput), // wrapper object that returns string from ToString
+                    new TryWriteTests.FormattableStringWrapper(rawInput), // IFormattable wrapper around string
+                    new TryWriteTests.SpanFormattableStringWrapper(rawInput) // ISpanFormattable wrapper around string
+                })
+                {
+                    // object
+                    expected.AppendFormat("{0}", o);
+                    actual.AppendFormatted(o);
+                    if (o is TryWriteTests.IHasToStringState tss1)
+                    {
+                        Assert.True(string.IsNullOrEmpty(tss1.ToStringState.LastFormat));
+                        AssertModeMatchesType(tss1);
+                    }
+
+                    // object, format
+                    expected.AppendFormat("{0:X2}", o);
+                    actual.AppendFormatted(o, "X2");
+                    if (o is TryWriteTests.IHasToStringState tss2)
+                    {
+                        Assert.Equal("X2", tss2.ToStringState.LastFormat);
+                        AssertModeMatchesType(tss2);
+                    }
+
+                    foreach (int alignment in new[] { 0, 3, -3 })
+                    {
+                        // object, alignment
+                        expected.AppendFormat("{0," + alignment.ToString(CultureInfo.InvariantCulture) + "}", o);
+                        actual.AppendFormatted(o, alignment);
+                        if (o is TryWriteTests.IHasToStringState tss3)
+                        {
+                            Assert.True(string.IsNullOrEmpty(tss3.ToStringState.LastFormat));
+                            AssertModeMatchesType(tss3);
+                        }
+
+                        // object, alignment, format
+                        expected.AppendFormat("{0," + alignment.ToString(CultureInfo.InvariantCulture) + ":X2}", o);
+                        actual.AppendFormatted(o, alignment, "X2");
+                        if (o is TryWriteTests.IHasToStringState tss4)
+                        {
+                            Assert.Equal("X2", tss4.ToStringState.LastFormat);
+                            AssertModeMatchesType(tss4);
+                        }
+                    }
+                }
+            }
+
+            Assert.True(MemoryExtensions.TryWriteUtf8(_largeBuffer, ref actual, out int bytesWritten));
+            Assert.Equal(expected.ToString(), Encoding.UTF8.GetString(_largeBuffer.AsSpan(0, bytesWritten)));
+        }
+
+        [Fact]
+        public void AppendFormatted_ReferenceTypes_CreateProviderFlowed()
+        {
+            var provider = new CultureInfo("en-US");
+            MemoryExtensions.TryWriteUtf8InterpolatedStringHandler handler = new MemoryExtensions.TryWriteUtf8InterpolatedStringHandler(1, 2, _largeBuffer, provider, out _);
+
+            foreach (TryWriteTests.IHasToStringState tss in new TryWriteTests.IHasToStringState[] { new TryWriteTests.FormattableStringWrapper("hello"), new  TryWriteTests.SpanFormattableStringWrapper("hello") })
+            {
+                handler.AppendFormatted(tss);
+                Assert.Same(provider, tss.ToStringState.LastProvider);
+
+                handler.AppendFormatted(tss, 1);
+                Assert.Same(provider, tss.ToStringState.LastProvider);
+
+                handler.AppendFormatted(tss, "X2");
+                Assert.Same(provider, tss.ToStringState.LastProvider);
+
+                handler.AppendFormatted(tss, 1, "X2");
+                Assert.Same(provider, tss.ToStringState.LastProvider);
+            }
+        }
+
+        [Fact]
+        public void AppendFormatted_ReferenceTypes_ICustomFormatter()
+        {
+            var provider = new TryWriteTests.ConcatFormatter();
+
+            var expected = new StringBuilder();
+            MemoryExtensions.TryWriteUtf8InterpolatedStringHandler actual = new MemoryExtensions.TryWriteUtf8InterpolatedStringHandler(0, 0, _largeBuffer, provider, out _);
+
+            foreach (string s in new[] { null, "", "a" })
+            {
+                foreach (TryWriteTests.IHasToStringState tss in new TryWriteTests.IHasToStringState[] { new TryWriteTests.FormattableStringWrapper(s), new  TryWriteTests.SpanFormattableStringWrapper(s) })
+                {
+                    void AssertTss(TryWriteTests.IHasToStringState tss, string format)
+                    {
+                        Assert.Equal(format, tss.ToStringState.LastFormat);
+                        Assert.Same(provider, tss.ToStringState.LastProvider);
+                        Assert.Equal(TryWriteTests.ToStringMode.ICustomFormatterFormat, tss.ToStringState.ToStringMode);
+                    }
+
+                    // object
+                    expected.AppendFormat(provider, "{0}", tss);
+                    actual.AppendFormatted(tss);
+                    AssertTss(tss, null);
+
+                    // object, format
+                    expected.AppendFormat(provider, "{0:X2}", tss);
+                    actual.AppendFormatted(tss, "X2");
+                    AssertTss(tss, "X2");
+
+                    // object, alignment
+                    expected.AppendFormat(provider, "{0,3}", tss);
+                    actual.AppendFormatted(tss, 3);
+                    AssertTss(tss, null);
+
+                    // object, alignment, format
+                    expected.AppendFormat(provider, "{0,-3:X2}", tss);
+                    actual.AppendFormatted(tss, -3, "X2");
+                    AssertTss(tss, "X2");
+                }
+            }
+
+            Assert.True(MemoryExtensions.TryWriteUtf8(_largeBuffer, ref actual, out int bytesWritten));
+            Assert.Equal(expected.ToString(), Encoding.UTF8.GetString(_largeBuffer.AsSpan(0, bytesWritten)));
+        }
+
+        [Fact]
+        public void AppendFormatted_ValueTypes()
+        {
+            void Test<T>(T t)
+            {
+                var expected = new StringBuilder();
+                MemoryExtensions.TryWriteUtf8InterpolatedStringHandler actual = new MemoryExtensions.TryWriteUtf8InterpolatedStringHandler(0, 0, _largeBuffer, out _);
+
+                // struct
+                expected.AppendFormat("{0}", t);
+                actual.AppendFormatted(t);
+                Assert.True(string.IsNullOrEmpty(((TryWriteTests.IHasToStringState)t).ToStringState.LastFormat));
+                AssertModeMatchesType(((TryWriteTests.IHasToStringState)t));
+
+                // struct, format
+                expected.AppendFormat("{0:X2}", t);
+                actual.AppendFormatted(t, "X2");
+                Assert.Equal("X2", ((TryWriteTests.IHasToStringState)t).ToStringState.LastFormat);
+                AssertModeMatchesType(((TryWriteTests.IHasToStringState)t));
+
+                foreach (int alignment in new[] { 0, 3, -3 })
+                {
+                    // struct, alignment
+                    expected.AppendFormat("{0," + alignment.ToString(CultureInfo.InvariantCulture) + "}", t);
+                    actual.AppendFormatted(t, alignment);
+                    Assert.True(string.IsNullOrEmpty(((TryWriteTests.IHasToStringState)t).ToStringState.LastFormat));
+                    AssertModeMatchesType(((TryWriteTests.IHasToStringState)t));
+
+                    // struct, alignment, format
+                    expected.AppendFormat("{0," + alignment.ToString(CultureInfo.InvariantCulture) + ":X2}", t);
+                    actual.AppendFormatted(t, alignment, "X2");
+                    Assert.Equal("X2", ((TryWriteTests.IHasToStringState)t).ToStringState.LastFormat);
+                    AssertModeMatchesType(((TryWriteTests.IHasToStringState)t));
+                }
+
+                Assert.True(MemoryExtensions.TryWriteUtf8(_largeBuffer, ref actual, out int bytesWritten));
+                Assert.Equal(expected.ToString(), Encoding.UTF8.GetString(_largeBuffer.AsSpan(0, bytesWritten)));
+            }
+
+            Test(new TryWriteTests.FormattableInt32Wrapper(42));
+            Test(new TryWriteTests.SpanFormattableInt32Wrapper(84));
+            Test((TryWriteTests.FormattableInt32Wrapper?)new TryWriteTests.FormattableInt32Wrapper(42));
+            Test((TryWriteTests.SpanFormattableInt32Wrapper?)new TryWriteTests.SpanFormattableInt32Wrapper(84));
+        }
+
+        [Fact]
+        public void AppendFormatted_ValueTypes_CreateProviderFlowed()
+        {
+            void Test<T>(T t)
+            {
+                var provider = new CultureInfo("en-US");
+                MemoryExtensions.TryWriteUtf8InterpolatedStringHandler handler = new MemoryExtensions.TryWriteUtf8InterpolatedStringHandler(1, 2, _largeBuffer, provider, out _);
+
+                handler.AppendFormatted(t);
+                Assert.Same(provider, ((TryWriteTests.IHasToStringState)t).ToStringState.LastProvider);
+
+                handler.AppendFormatted(t, 1);
+                Assert.Same(provider, ((TryWriteTests.IHasToStringState)t).ToStringState.LastProvider);
+
+                handler.AppendFormatted(t, "X2");
+                Assert.Same(provider, ((TryWriteTests.IHasToStringState)t).ToStringState.LastProvider);
+
+                handler.AppendFormatted(t, 1, "X2");
+                Assert.Same(provider, ((TryWriteTests.IHasToStringState)t).ToStringState.LastProvider);
+            }
+
+            Test(new TryWriteTests.FormattableInt32Wrapper(42));
+            Test(new TryWriteTests.SpanFormattableInt32Wrapper(84));
+            Test((TryWriteTests.FormattableInt32Wrapper?)new TryWriteTests.FormattableInt32Wrapper(42));
+            Test((TryWriteTests.SpanFormattableInt32Wrapper?)new TryWriteTests.SpanFormattableInt32Wrapper(84));
+        }
+
+        [Fact]
+        public void AppendFormatted_ValueTypes_ICustomFormatter()
+        {
+            var provider = new TryWriteTests.ConcatFormatter();
+
+            void Test<T>(T t)
+            {
+                void AssertTss(T tss, string format)
+                {
+                    Assert.Equal(format, ((TryWriteTests.IHasToStringState)tss).ToStringState.LastFormat);
+                    Assert.Same(provider, ((TryWriteTests.IHasToStringState)tss).ToStringState.LastProvider);
+                    Assert.Equal(TryWriteTests.ToStringMode.ICustomFormatterFormat, ((TryWriteTests.IHasToStringState)tss).ToStringState.ToStringMode);
+                }
+
+                var expected = new StringBuilder();
+                MemoryExtensions.TryWriteUtf8InterpolatedStringHandler actual = new MemoryExtensions.TryWriteUtf8InterpolatedStringHandler(0, 0, _largeBuffer, provider, out _);
+
+                // struct
+                expected.AppendFormat(provider, "{0}", t);
+                actual.AppendFormatted(t);
+                AssertTss(t, null);
+
+                // struct, format
+                expected.AppendFormat(provider, "{0:X2}", t);
+                actual.AppendFormatted(t, "X2");
+                AssertTss(t, "X2");
+
+                // struct, alignment
+                expected.AppendFormat(provider, "{0,3}", t);
+                actual.AppendFormatted(t, 3);
+                AssertTss(t, null);
+
+                // struct, alignment, format
+                expected.AppendFormat(provider, "{0,-3:X2}", t);
+                actual.AppendFormatted(t, -3, "X2");
+                AssertTss(t, "X2");
+
+                Assert.True(MemoryExtensions.TryWriteUtf8(_largeBuffer, ref actual, out int bytesWritten));
+                Assert.Equal(expected.ToString(), Encoding.UTF8.GetString(_largeBuffer.AsSpan(0, bytesWritten)));
+            }
+
+            Test(new TryWriteTests.FormattableInt32Wrapper(42));
+            Test(new TryWriteTests.SpanFormattableInt32Wrapper(84));
+            Test((TryWriteTests.FormattableInt32Wrapper?)new TryWriteTests.FormattableInt32Wrapper(42));
+            Test((TryWriteTests.SpanFormattableInt32Wrapper?)new TryWriteTests.SpanFormattableInt32Wrapper(84));
+        }
+
+        [Fact]
+        public void AppendFormatted_EmptyBuffer_ZeroLengthWritesSuccessful()
+        {
+            var buffer = new byte[100];
+
+            MemoryExtensions.TryWriteUtf8InterpolatedStringHandler b = new MemoryExtensions.TryWriteUtf8InterpolatedStringHandler(0, 0, buffer.AsSpan(0, 0), out bool shouldAppend);
+            Assert.True(shouldAppend);
+
+            Assert.True(b.AppendLiteral(""));
+            Assert.True(b.AppendFormatted((object)"", alignment: 0, format: "X2"));
+            Assert.True(b.AppendFormatted((string?)null));
+            Assert.True(b.AppendFormatted(""));
+            Assert.True(b.AppendFormatted("", alignment: 0, format: "X2"));
+            Assert.True(b.AppendFormatted<string>(""));
+            Assert.True(b.AppendFormatted<string>("", alignment: 0));
+            Assert.True(b.AppendFormatted<string>("", format: "X2"));
+            Assert.True(b.AppendFormatted<string>("", alignment: 0, format: "X2"));
+            Assert.True(b.AppendFormatted("".AsSpan()));
+            Assert.True(b.AppendFormatted("".AsSpan(), alignment: 0, format: "X2"));
+
+            Assert.True(MemoryExtensions.TryWriteUtf8(buffer.AsSpan(0, 0), ref b, out int bytesWritten));
+            Assert.Equal(0, bytesWritten);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(100)]
+        public void AppendFormatted_BufferTooSmall(int bufferLength)
+        {
+            var buffer = new byte[bufferLength];
+
+            for (int i = 0; i <= 29; i++)
+            {
+                MemoryExtensions.TryWriteUtf8InterpolatedStringHandler b = new MemoryExtensions.TryWriteUtf8InterpolatedStringHandler(0, 0, buffer, out bool shouldAppend);
+                Assert.True(shouldAppend);
+
+                Assert.True(b.AppendLiteral(new string('s', bufferLength)));
+
+                bool result = i switch
+                {
+                    0 => b.AppendLiteral(" "),
+                    1 => b.AppendFormatted((object)" ", alignment: 0, format: "X2"),
+                    2 => b.AppendFormatted(" "),
+                    3 => b.AppendFormatted(" ", alignment: 0, format: "X2"),
+                    4 => b.AppendFormatted<string>(" "),
+                    5 => b.AppendFormatted<string>(" ", alignment: 0),
+                    6 => b.AppendFormatted<string>(" ", format: "X2"),
+                    7 => b.AppendFormatted<string>(" ", alignment: 0, format: "X2"),
+                    8 => b.AppendFormatted(" ".AsSpan()),
+                    9 => b.AppendFormatted(" ".AsSpan(), alignment: 0, format: "X2"),
+                    10 => b.AppendFormatted(new TryWriteTests.FormattableStringWrapper(" ")),
+                    11 => b.AppendFormatted(new TryWriteTests.FormattableStringWrapper(" "), alignment: 0),
+                    12 => b.AppendFormatted(new TryWriteTests.FormattableStringWrapper(" "), format: "X2"),
+                    13 => b.AppendFormatted(new TryWriteTests.FormattableStringWrapper(" "), alignment: 0, format: "X2"),
+                    14 => b.AppendFormatted(new  TryWriteTests.SpanFormattableStringWrapper(" ")),
+                    15 => b.AppendFormatted(new  TryWriteTests.SpanFormattableStringWrapper(" "), alignment: 0),
+                    16 => b.AppendFormatted(new  TryWriteTests.SpanFormattableStringWrapper(" "), format: "X2"),
+                    17 => b.AppendFormatted(new  TryWriteTests.SpanFormattableStringWrapper(" "), alignment: 0, format: "X2"),
+                    18 => b.AppendFormatted(new TryWriteTests.FormattableInt32Wrapper(1)),
+                    19 => b.AppendFormatted(new TryWriteTests.FormattableInt32Wrapper(1), alignment: 0),
+                    20 => b.AppendFormatted(new TryWriteTests.FormattableInt32Wrapper(1), format: "X2"),
+                    21 => b.AppendFormatted(new TryWriteTests.FormattableInt32Wrapper(1), alignment: 0, format: "X2"),
+                    22 => b.AppendFormatted(new TryWriteTests.SpanFormattableInt32Wrapper(1)),
+                    23 => b.AppendFormatted(new TryWriteTests.SpanFormattableInt32Wrapper(1), alignment: 0),
+                    24 => b.AppendFormatted(new TryWriteTests.SpanFormattableInt32Wrapper(1), format: "X2"),
+                    25 => b.AppendFormatted(new TryWriteTests.SpanFormattableInt32Wrapper(1), alignment: 0, format: "X2"),
+                    26 => b.AppendFormatted<string>("", alignment: 1),
+                    27 => b.AppendFormatted<string>("", alignment: -1),
+                    28 => b.AppendFormatted<string>(" ", alignment: 1, format: "X2"),
+                    29 => b.AppendFormatted<string>(" ", alignment: -1, format: "X2"),
+                    _ => throw new Exception(),
+                };
+                Assert.False(result);
+
+                Assert.False(MemoryExtensions.TryWriteUtf8(buffer.AsSpan(0, 0), ref b, out int bytesWritten));
+                Assert.Equal(0, bytesWritten);
+            }
+        }
+        [Fact]
+        public void AppendFormatted_BufferTooSmall_CustomFormatter()
+        {
+            var buffer = new byte[100];
+            var provider = new TryWriteTests.ConstFormatter(" ");
+
+            {
+                MemoryExtensions.TryWriteUtf8InterpolatedStringHandler b = new MemoryExtensions.TryWriteUtf8InterpolatedStringHandler(0, 0, buffer.AsSpan(0, 0), provider, out bool shouldAppend);
+                Assert.True(shouldAppend);
+
+                // don't use custom formatter
+                Assert.True(b.AppendLiteral(""));
+                Assert.True(b.AppendFormatted("".AsSpan()));
+                Assert.True(b.AppendFormatted("".AsSpan(), alignment: 0, format: "X2"));
+
+                // do use custom formatter
+                Assert.False(b.AppendFormatted((object)"", alignment: 0, format: "X2"));
+                Assert.False(b.AppendFormatted((string?)null));
+                Assert.False(b.AppendFormatted(""));
+                Assert.False(b.AppendFormatted("", alignment: 0, format: "X2"));
+                Assert.False(b.AppendFormatted<string>(""));
+                Assert.False(b.AppendFormatted<string>("", alignment: 0));
+                Assert.False(b.AppendFormatted<string>("", format: "X2"));
+                Assert.False(b.AppendFormatted<string>("", alignment: 0, format: "X2"));
+
+                Assert.False(MemoryExtensions.TryWriteUtf8(buffer.AsSpan(0, 0), ref b, out int bytesWritten));
+                Assert.Equal(0, bytesWritten);
+            }
+        }
+
+        private static void AssertModeMatchesType<T>(T tss) where T : TryWriteTests.IHasToStringState
+        {
+            TryWriteTests.ToStringMode expected =
+                tss is ISpanFormattable ? TryWriteTests.ToStringMode.ISpanFormattableTryFormat :
+                tss is IFormattable ? TryWriteTests.ToStringMode.IFormattableToString :
+                TryWriteTests.ToStringMode.ObjectToString;
+            Assert.Equal(expected, tss.ToStringState.ToStringMode);
+        }
+
+        private struct Utf8SpanFormattableInt32Wrapper : IUtf8SpanFormattable, TryWriteTests.IHasToStringState
+        {
+            private readonly int _value;
+            public TryWriteTests.ToStringState ToStringState { get; }
+
+            public Utf8SpanFormattableInt32Wrapper(int value)
+            {
+                ToStringState = new TryWriteTests.ToStringState();
+                _value = value;
+            }
+
+            public bool TryFormat(Span<byte> destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider provider)
+            {
+                ToStringState.LastFormat = format.ToString();
+                ToStringState.LastProvider = provider;
+                ToStringState.ToStringMode = TryWriteTests.ToStringMode.ISpanFormattableTryFormat;
+
+                // TODO: Replace with Int32's IUtf8SpanFormattable.TryFormat
+                ReadOnlySpan<byte> src = Encoding.UTF8.GetBytes(_value.ToString(format.ToString(), provider)).AsSpan();
+                if (src.TryCopyTo(destination))
+                {
+                    bytesWritten = src.Length;
+                    return true;
+                }
+
+                bytesWritten = 0;
+                return false;
+            }
+
+            public string ToString(string format, IFormatProvider formatProvider)
+            {
+                ToStringState.LastFormat = format;
+                ToStringState.LastProvider = formatProvider;
+                ToStringState.ToStringMode = TryWriteTests.ToStringMode.IFormattableToString;
+                return _value.ToString(format, formatProvider);
+            }
+
+            public override string ToString()
+            {
+                ToStringState.LastFormat = null;
+                ToStringState.LastProvider = null;
+                ToStringState.ToStringMode = TryWriteTests.ToStringMode.ObjectToString;
+                return _value.ToString();
+            }
+        }
+    }
+}

--- a/src/libraries/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/libraries/System.Memory/tests/System.Memory.Tests.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Span\ToArray.cs" />
     <Compile Include="Span\ToString.cs" />
     <Compile Include="Span\TryWrite.cs" />
+    <Compile Include="Span\TryWriteUtf8.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ReadOnlyBuffer\ReadOnlySequenceTests.Common.char.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -515,6 +515,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\IObserver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IProgress.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\ISpanFormattable.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IUtf8SpanFormattable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Lazy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\LazyOfTTMetadata.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\LoaderOptimization.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/IUtf8SpanFormattable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IUtf8SpanFormattable.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System
+{
+    /// <summary>Provides functionality to format the string representation of an object into a span as UTF8.</summary>
+    public interface IUtf8SpanFormattable
+    {
+        /// <summary>Tries to format the value of the current instance as UTF8 into the provided span of bytes.</summary>
+        /// <param name="destination">When this method returns, this instance's value formatted as a span of bytes.</param>
+        /// <param name="bytesWritten">When this method returns, the number of bytes that were written in <paramref name="destination"/>.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string that defines the acceptable format for <paramref name="destination"/>.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for <paramref name="destination"/>.</param>
+        /// <returns><see langword="true"/> if the formatting was successful; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// An implementation of this interface should produce the same string of characters as an implementation of <see cref="IFormattable.ToString"/> or <see cref="ISpanFormattable.TryFormat"/>
+        /// on the same type. TryFormat should return false only if there is not enough space in the destination buffer; any other failures should throw an exception.
+        /// </remarks>
+        bool TryFormat(Span<byte> destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider);
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -10,6 +10,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Text;
+using System.Text.Unicode;
 
 #pragma warning disable 8500 // sizeof of managed types
 
@@ -3815,6 +3816,36 @@ namespace System
             // is the same as the non-provider overload.
             TryWrite(destination, ref handler, out charsWritten);
 
+        /// <summary>Writes the specified interpolated string to the UTF8 byte span.</summary>
+        /// <param name="destination">The span to which the interpolated string should be formatted.</param>
+        /// <param name="handler">The interpolated string.</param>
+        /// <param name="bytesWritten">The number of characters written to the span.</param>
+        /// <returns>true if the entire interpolated string could be formatted successfully; otherwise, false.</returns>
+        public static bool TryWriteUtf8(this Span<byte> destination, [InterpolatedStringHandlerArgument(nameof(destination))] ref TryWriteUtf8InterpolatedStringHandler handler, out int bytesWritten)
+        {
+            // The span argument isn't used directly in the method; rather, it'll be used by the compiler to create the handler.
+            // We could validate here that span == handler._destination, but that doesn't seem necessary.
+            if (handler._success)
+            {
+                bytesWritten = handler._pos;
+                return true;
+            }
+
+            bytesWritten = 0;
+            return false;
+        }
+
+        /// <summary>Writes the specified interpolated string to the UTF8 byte span.</summary>
+        /// <param name="destination">The span to which the interpolated string should be formatted.</param>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="handler">The interpolated string.</param>
+        /// <param name="bytesWritten">The number of characters written to the span.</param>
+        /// <returns>true if the entire interpolated string could be formatted successfully; otherwise, false.</returns>
+        public static bool TryWriteUtf8(this Span<byte> destination, IFormatProvider? provider, [InterpolatedStringHandlerArgument(nameof(destination), nameof(provider))] ref TryWriteUtf8InterpolatedStringHandler handler, out int bytesWritten) =>
+            // The provider is passed to the handler by the compiler, so the actual implementation of the method
+            // is the same as the non-provider overload.
+            TryWriteUtf8(destination, ref handler, out bytesWritten);
+
         /// <summary>
         /// Writes the <see cref="CompositeFormat"/> string to the character span, substituting the format item or items
         /// with the string representation of the corresponding arguments.
@@ -4429,6 +4460,392 @@ namespace System
                     {
                         _destination.Slice(startingPos, charsWritten).CopyTo(_destination.Slice(startingPos + paddingNeeded));
                         _destination.Slice(startingPos, paddingNeeded).Fill(' ');
+                    }
+
+                    _pos += paddingNeeded;
+                    return true;
+                }
+
+                return Fail();
+            }
+
+            /// <summary>Marks formatting as having failed and returns false.</summary>
+            private bool Fail()
+            {
+                _success = false;
+                return false;
+            }
+        }
+
+        /// <summary>Provides a handler used by the language compiler to format interpolated strings into UTF8 byte spans.</summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [InterpolatedStringHandler]
+        public ref struct TryWriteUtf8InterpolatedStringHandler
+        {
+            /// <summary>The destination UTF8 buffer.</summary>
+            private readonly Span<byte> _destination;
+            /// <summary>Optional provider to pass to IFormattable.ToString, ISpanFormattable.TryFormat, and IUtf8SpanFormattable.TryFormat calls.</summary>
+            private readonly IFormatProvider? _provider;
+            /// <summary>The number of bytes written to <see cref="_destination"/>.</summary>
+            internal int _pos;
+            /// <summary>true if all formatting operations have succeeded; otherwise, false.</summary>
+            internal bool _success;
+            /// <summary>Whether <see cref="_provider"/> provides an ICustomFormatter.</summary>
+            private readonly bool _hasCustomFormatter;
+
+            /// <summary>Creates a handler used to write an interpolated string into a UTF8 <see cref="Span{Byte}"/>.</summary>
+            /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the interpolated string.</param>
+            /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+            /// <param name="destination">The destination buffer.</param>
+            /// <param name="shouldAppend">Upon return, true if the destination may be long enough to support the formatting, or false if it won't be.</param>
+            /// <remarks>This is intended to be called only by compiler-generated code. Arguments are not validated as they'd otherwise be for members intended to be used directly.</remarks>
+            public TryWriteUtf8InterpolatedStringHandler(int literalLength, int formattedCount, Span<byte> destination, out bool shouldAppend)
+            {
+                _destination = destination;
+                _provider = null;
+                _pos = 0;
+                _success = shouldAppend = destination.Length >= literalLength; // UTF8 encoding never produces fewer bytes than input characters
+                _hasCustomFormatter = false;
+            }
+
+            /// <summary>Creates a handler used to write an interpolated string into a UTF8 <see cref="Span{Byte}"/>.</summary>
+            /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the interpolated string.</param>
+            /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+            /// <param name="destination">The destination buffer.</param>
+            /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+            /// <param name="shouldAppend">Upon return, true if the destination may be long enough to support the formatting, or false if it won't be.</param>
+            /// <remarks>This is intended to be called only by compiler-generated code. Arguments are not validated as they'd otherwise be for members intended to be used directly.</remarks>
+            public TryWriteUtf8InterpolatedStringHandler(int literalLength, int formattedCount, Span<byte> destination, IFormatProvider? provider, out bool shouldAppend)
+            {
+                _destination = destination;
+                _provider = provider;
+                _pos = 0;
+                _success = shouldAppend = destination.Length >= literalLength; // UTF8 encoding never produces fewer bytes than input characters
+                _hasCustomFormatter = provider is not null && DefaultInterpolatedStringHandler.HasCustomFormatter(provider);
+            }
+
+            /// <summary>Writes the specified string to the handler.</summary>
+            /// <param name="value">The string to write.</param>
+            /// <returns>true if the value could be formatted to the span; otherwise, false.</returns>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public bool AppendLiteral(string value) => AppendFormatted(value.AsSpan());
+
+            // TODO https://github.com/dotnet/csharplang/issues/7072:
+            // Add this if/when C# supports u8 literals with string interpolation.
+            // If that happens prior to this type being released, the above AppendLiteral(string)
+            // should also be removed.
+            //public bool AppendLiteral(ReadOnlySpan<byte> value) => AppendFormatted(value);
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public bool AppendFormatted<T>(T value)
+            {
+                // This method could delegate to AppendFormatted with a null format, but explicitly passing
+                // default as the format to TryFormat helps to improve code quality in some cases when TryFormat is inlined,
+                // e.g. for Int32 it enables the JIT to eliminate code in the inlined method based on a length check on the format.
+
+                // If there's a custom formatter, always use it.
+                if (_hasCustomFormatter)
+                {
+                    return AppendCustomFormatter(value, format: null);
+                }
+
+                // If the value can format itself directly into our buffer, do so.
+                if (value is IUtf8SpanFormattable)
+                {
+                    if (((IUtf8SpanFormattable)value).TryFormat(_destination.Slice(_pos), out int bytesWritten, format: default, _provider))
+                    {
+                        _pos += bytesWritten;
+                        return true;
+                    }
+
+                    return Fail();
+                }
+
+                string? s;
+                if (value is IFormattable)
+                {
+                    // If the value can format itself directly into a UTF16 buffer, do so, then transcode.
+                    if (value is ISpanFormattable)
+                    {
+                        return AppendSpanFormattable(value, format: null);
+                    }
+
+                    // If the value can ToString with the format / provider, get the resulting string, then append that.
+                    s = ((IFormattable)value).ToString(null, _provider);
+                }
+                else
+                {
+                    // Fall back to a normal ToString and append that.
+                    s = value?.ToString();
+                }
+
+                return AppendFormatted(s.AsSpan());
+            }
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="format">The format string.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public bool AppendFormatted<T>(T value, string? format)
+            {
+                // If there's a custom formatter, always use it.
+                if (_hasCustomFormatter)
+                {
+                    return AppendCustomFormatter(value, format);
+                }
+
+                // If the value can format itself directly into our buffer, do so.
+                if (value is IUtf8SpanFormattable)
+                {
+                    if (((IUtf8SpanFormattable)value).TryFormat(_destination.Slice(_pos), out int bytesWritten, format, _provider))
+                    {
+                        _pos += bytesWritten;
+                        return true;
+                    }
+
+                    return Fail();
+                }
+
+                string? s;
+                if (value is IFormattable)
+                {
+                    // If the value can format itself directly into a UTF16 buffer, do so, then transcode.
+                    if (value is ISpanFormattable)
+                    {
+                        return AppendSpanFormattable(value, format);
+                    }
+
+                    // If the value can ToString with the format / provider, get the resulting string, then append that.
+                    s = ((IFormattable)value).ToString(format, _provider);
+                }
+                else
+                {
+                    // Fall back to a normal ToString and append that.
+                    s = value?.ToString();
+                }
+
+                return AppendFormatted(s.AsSpan());
+            }
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public bool AppendFormatted<T>(T value, int alignment)
+            {
+                int startingPos = _pos;
+                if (AppendFormatted(value))
+                {
+                    return alignment == 0 || TryAppendOrInsertAlignmentIfNeeded(startingPos, alignment);
+                }
+
+                return Fail();
+            }
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="format">The format string.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public bool AppendFormatted<T>(T value, int alignment, string? format)
+            {
+                int startingPos = _pos;
+                if (AppendFormatted(value, format))
+                {
+                    return alignment == 0 || TryAppendOrInsertAlignmentIfNeeded(startingPos, alignment);
+                }
+
+                return Fail();
+            }
+
+            /// <summary>Writes the specified character span to the handler.</summary>
+            /// <param name="value">The span to write.</param>
+            public bool AppendFormatted(scoped ReadOnlySpan<char> value)
+            {
+                switch (Utf8.FromUtf16(value, _destination.Slice(_pos), out _, out int bytesWritten))
+                {
+                    case OperationStatus.Done:
+                        _pos += bytesWritten;
+                        return true;
+
+                    case OperationStatus.DestinationTooSmall:
+                        break;
+
+                    default:
+                        ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.value);
+                        break;
+                }
+
+                return Fail();
+            }
+
+            /// <summary>Writes the specified string of chars to the handler.</summary>
+            /// <param name="value">The span to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="format">The format string.</param>
+            public bool AppendFormatted(scoped ReadOnlySpan<char> value, int alignment = 0, string? format = null)
+            {
+                int startingPos = _pos;
+                if (AppendFormatted(value))
+                {
+                    return alignment == 0 || TryAppendOrInsertAlignmentIfNeeded(startingPos, alignment);
+                }
+
+                return Fail();
+            }
+
+            /// <summary>Writes the specified span of UTF8 bytes to the handler.</summary>
+            /// <param name="utf8Value">The span to write.</param>
+            public bool AppendFormatted(scoped ReadOnlySpan<byte> utf8Value)
+            {
+                if (utf8Value.TryCopyTo(_destination.Slice(_pos)))
+                {
+                    _pos += utf8Value.Length;
+                    return true;
+                }
+
+                return Fail();
+            }
+
+            /// <summary>Writes the specified span of UTF8 bytes to the handler.</summary>
+            /// <param name="utf8Value">The span to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="format">The format string.</param>
+            public bool AppendFormatted(scoped ReadOnlySpan<byte> utf8Value, int alignment = 0, string? format = null)
+            {
+                int startingPos = _pos;
+                if (AppendFormatted(utf8Value))
+                {
+                    return alignment == 0 || TryAppendOrInsertAlignmentIfNeeded(startingPos, alignment);
+                }
+
+                return Fail();
+            }
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            public bool AppendFormatted(string? value) =>
+                _hasCustomFormatter ? AppendCustomFormatter(value, format: null)  :
+                AppendFormatted(value.AsSpan());
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="format">The format string.</param>
+            public bool AppendFormatted(string? value, int alignment = 0, string? format = null) =>
+                // Format is meaningless for strings and doesn't make sense for someone to specify.  We have the overload
+                // simply to disambiguate between ROS and object, just in case someone does specify a format, as
+                // string is implicitly convertible to both. Just delegate to the T-based implementation.
+                AppendFormatted<string?>(value, alignment, format);
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="format">The format string.</param>
+            public bool AppendFormatted(object? value, int alignment = 0, string? format = null) =>
+                // This overload is expected to be used rarely, only if either a) something strongly typed as object is
+                // formatted with both an alignment and a format, or b) the compiler is unable to target type to T. It
+                // exists purely to help make cases from (b) compile. Just delegate to the T-based implementation.
+                AppendFormatted<object?>(value, alignment, format);
+
+            /// <summary>Formats the value using the custom formatter from the provider.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="format">The format string.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            private bool AppendCustomFormatter<T>(T value, string? format)
+            {
+                // This case is very rare, but we need to handle it prior to the other checks in case
+                // a provider was used that supplied an ICustomFormatter which wanted to intercept the particular value.
+                // We do the cast here rather than in the ctor, even though this could be executed multiple times per
+                // formatting, to make the cast pay for play.
+                Debug.Assert(_hasCustomFormatter);
+                Debug.Assert(_provider is not null);
+
+                ICustomFormatter? formatter = (ICustomFormatter?)_provider.GetFormat(typeof(ICustomFormatter));
+                Debug.Assert(formatter is not null, "An incorrectly written provider said it implemented ICustomFormatter, and then didn't");
+
+                if (formatter is not null &&
+                    formatter.Format(format, value, _provider) is string customFormatted)
+                {
+                    return AppendFormatted(customFormatted.AsSpan());
+                }
+
+                return true;
+            }
+
+            /// <summary>Writes the specified ISpanFormattable to the handler.</summary>
+            /// <param name="value">The value to write. It must be an ISpanFormattable but isn't constrained because the caller doesn't have a cosntraint.</param>
+            /// <param name="format">The format string.</param>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private bool AppendSpanFormattable<T>(T value, string? format)
+            {
+                Debug.Assert(value is ISpanFormattable);
+
+                Span<char> utf16 = stackalloc char[256];
+                return ((ISpanFormattable)value).TryFormat(utf16, out int charsWritten, format, _provider) ?
+                    AppendFormatted(utf16.Slice(0, charsWritten)) :
+                    GrowAndAppendFormatted(ref this, value, utf16.Length, out charsWritten, format);
+
+                [MethodImpl(MethodImplOptions.NoInlining)]
+                static bool GrowAndAppendFormatted(scoped ref TryWriteUtf8InterpolatedStringHandler thisRef, T value, int length, out int charsWritten, string? format)
+                {
+                    Debug.Assert(value is ISpanFormattable);
+
+                    while (true)
+                    {
+                        length *= 2;
+                        char[] array = ArrayPool<char>.Shared.Rent(length);
+                        try
+                        {
+                            if (((ISpanFormattable)value).TryFormat(array, out charsWritten, format, thisRef._provider))
+                            {
+                                return thisRef.AppendFormatted(array.AsSpan(0, charsWritten));
+                            }
+                        }
+                        finally
+                        {
+                            ArrayPool<char>.Shared.Return(array);
+                        }
+                    }
+                }
+            }
+
+            /// <summary>Handles adding any padding required for aligning a formatted value in an interpolation expression.</summary>
+            /// <param name="startingPos">The position at which the written value started.</param>
+            /// <param name="alignment">Non-zero minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            private bool TryAppendOrInsertAlignmentIfNeeded(int startingPos, int alignment)
+            {
+                Debug.Assert(startingPos >= 0 && startingPos <= _pos);
+                Debug.Assert(alignment != 0);
+
+                int bytesWritten = _pos - startingPos;
+
+                bool leftAlign = false;
+                if (alignment < 0)
+                {
+                    leftAlign = true;
+                    alignment = -alignment;
+                }
+
+                int paddingNeeded = alignment - bytesWritten;
+                if (paddingNeeded <= 0)
+                {
+                    return true;
+                }
+
+                if (paddingNeeded <= _destination.Length - _pos)
+                {
+                    if (leftAlign)
+                    {
+                        _destination.Slice(_pos, paddingNeeded).Fill((byte)' ');
+                    }
+                    else
+                    {
+                        _destination.Slice(startingPos, bytesWritten).CopyTo(_destination.Slice(startingPos + paddingNeeded));
+                        _destination.Slice(startingPos, paddingNeeded).Fill((byte)' ');
                     }
 
                     _pos += paddingNeeded;

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -3850,6 +3850,10 @@ namespace System
         static abstract TSelf Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider);
         static abstract bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, [System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out TSelf result);
     }
+    public partial interface IUtf8SpanFormattable
+    {
+        bool TryFormat(System.Span<byte> destination, out int bytesWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider);
+    }
     public partial class Lazy<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]T>
     {
         public Lazy() { }


### PR DESCRIPTION
Initial implementation of MemoryExtensions.TryWriteUtf8. The performance of this won't be great at present, but will improve as our cores types add implementation of IUtf8SpanFormattable. For tests, I copy/pasted the tests we had for TryWrite and searched/replaced to make them work for TryWriteUtf8.

Fixes https://github.com/dotnet/runtime/issues/79376
Contributes to https://github.com/dotnet/runtime/issues/81500