### PR TITLE
Force ASM compiler to target the same triple as C, in WASI build

### DIFF
--- a/src/mono/mono/utils/CMakeLists.txt
+++ b/src/mono/mono/utils/CMakeLists.txt
@@ -16,6 +16,7 @@ if(HOST_WIN32 AND HOST_AMD64)
     list(APPEND utils_win32_sources win64.asm)
 elseif(HOST_WASI)
     set (CMAKE_ASM_COMPILER_VERSION "${CMAKE_C_COMPILER_VERSION}")
+    set (CMAKE_ASM_COMPILER_TARGET "${CMAKE_C_COMPILER_TARGET}")
     enable_language(ASM)
 endif()
 


### PR DESCRIPTION
The upstream WASI SDK sets a default compiler triple of `--target=wasm32-wasi`. We don't, because we're compiling our for-WASI-use version of Clang as part of our more general LLVM, and as such, the default compiler triple is the LLVM default (i.e. linux-x64 on x64 Linux, etc).

In one place, we compile an Assembly file using Clang by setting CMAKE_ASM_COMPILER_VERSION = CMAKE_ASM_COMPILER_VERSION - but whilst CMAKE_C_COMPILER_TARGET is overridden to always be wasm32-wasi in the wasi-sdk.cmake toolchain file, the toolchain file does not set CMAKE_ASM_COMPILER_TARGET (and thus, when compiling Assembly, our Clang default to linux-x64 etc, not wasm32-wasi). Therefore, force the issue here in our CMakeLists.txt, so we use the correct compiler target.