### PR TITLE
Using canonical All-pointers GC desc in more scenarios.

### DIFF
--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -398,11 +398,14 @@ namespace Internal.Runtime.TypeLoader
                 if (cbGCDesc != 0)
                 {
                     pEEType->ContainsGCPointers = true;
-                    if (state.IsArrayOfReferenceTypes)
+                    if (state.IsArrayOfReferenceTypes || IsAllGCPointers(gcBitfield))
                     {
                         IntPtr* gcDescStart = (IntPtr*)((byte*)pEEType - cbGCDesc);
+                        // Series size
                         gcDescStart[0] = new IntPtr(-baseSize);
+                        // Series offset
                         gcDescStart[1] = new IntPtr(baseSize - sizeof(IntPtr));
+                        // NumSeries
                         gcDescStart[2] = new IntPtr(1);
                     }
                     else
@@ -443,9 +446,9 @@ namespace Internal.Runtime.TypeLoader
             var gcBitfield = state.InstanceGCLayout;
             if (isArray)
             {
-                if (state.IsArrayOfReferenceTypes)
+                if (state.IsArrayOfReferenceTypes || IsAllGCPointers(gcBitfield))
                 {
-                    // Reference type arrays have a GC desc the size of 3 pointers
+                    // For efficiency this is special cased and encoded as one serie
                     return 3 * sizeof(IntPtr);
                 }
                 else
@@ -470,6 +473,20 @@ namespace Internal.Runtime.TypeLoader
             {
                 return 0;
             }
+        }
+
+        private static bool IsAllGCPointers(LowLevelList<bool> bitfield)
+        {
+            int count = bitfield.Count;
+            Debug.Assert(count > 0);
+
+            for (int i = 0; i < count; i++)
+            {
+                if (!bitfield[i])
+                    return false;
+            }
+
+            return true;
         }
 
         private static unsafe int CreateArrayGCDesc(LowLevelList<bool> bitfield, int rank, bool isSzArray, void* gcdesc)

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -446,7 +446,8 @@ namespace Internal.Runtime.TypeLoader
             var gcBitfield = state.InstanceGCLayout;
             if (isArray)
             {
-                if (state.IsArrayOfReferenceTypes || IsAllGCPointers(gcBitfield))
+                if (state.IsArrayOfReferenceTypes ||
+                    (gcBitfield != null && IsAllGCPointers(gcBitfield)))
                 {
                     // For efficiency this is special cased and encoded as one serie
                     return 3 * sizeof(IntPtr);

--- a/src/coreclr/tools/Common/Internal/Runtime/GCDescEncoder.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/GCDescEncoder.cs
@@ -23,7 +23,7 @@ namespace Internal.Runtime
                 TypeDesc elementType = ((ArrayType)type).ElementType;
                 if (elementType.IsGCPointer)
                 {
-                    // For efficiency this is special cased and encoded as one serie.
+                    // For efficiency this is special cased and encoded as one serie
                     return 3 * type.Context.Target.PointerSize;
                 }
                 else if (elementType.IsDefType)
@@ -34,7 +34,7 @@ namespace Internal.Runtime
                         GCPointerMap pointerMap = GCPointerMap.FromInstanceLayout(defType);
                         if (pointerMap.IsAllGCPointers)
                         {
-                            // For efficiency this is special cased and encoded as one serie.
+                            // For efficiency this is special cased and encoded as one serie
                             return 3 * type.Context.Target.PointerSize;
                         }
                         else
@@ -51,9 +51,18 @@ namespace Internal.Runtime
                 var defType = (MetadataType)type;
                 if (defType.ContainsGCPointers)
                 {
-                    int numSeries = GCPointerMap.FromInstanceLayout(defType).NumSeries;
-                    Debug.Assert(numSeries > 0);
-                    return (numSeries * 2 + 1) * type.Context.Target.PointerSize;
+                    GCPointerMap pointerMap = GCPointerMap.FromInstanceLayout(defType);
+                    if (pointerMap.IsAllGCPointers)
+                    {
+                        // For efficiency this is special cased and encoded as one serie
+                        return 3 * type.Context.Target.PointerSize;
+                    }
+                    else
+                    {
+                        int numSeries = pointerMap.NumSeries;
+                        Debug.Assert(numSeries > 0);
+                        return (numSeries * 2 + 1) * type.Context.Target.PointerSize;
+                    }
                 }
             }
 
@@ -69,18 +78,18 @@ namespace Internal.Runtime
             {
                 TypeDesc elementType = ((ArrayType)type).ElementType;
 
-                // 2 means m_pEEType and _numComponents. Syncblock is sort of appended at the end of the object layout in this case.
-                int baseSize = 2 * builder.TargetPointerSize;
+                // 2 means m_pEEType and _numComponents.
+                int offsetToData = 2 * builder.TargetPointerSize;
 
                 if (type.IsMdArray)
                 {
                     // Multi-dim arrays include upper and lower bounds for each rank
-                    baseSize += 2 * sizeof(int) * ((ArrayType)type).Rank;
+                    offsetToData += 2 * sizeof(int) * ((ArrayType)type).Rank;
                 }
 
                 if (elementType.IsGCPointer)
                 {
-                    EncodeAllGCPointersArrayGCDesc(ref builder, baseSize);
+                    EncodeAllGCPointersGCDesc(ref builder, offsetToData);
                 }
                 else if (elementType.IsDefType)
                 {
@@ -90,11 +99,11 @@ namespace Internal.Runtime
                         GCPointerMap pointerMap = GCPointerMap.FromInstanceLayout(elementDefType);
                         if (pointerMap.IsAllGCPointers)
                         {
-                            EncodeAllGCPointersArrayGCDesc(ref builder, baseSize);
+                            EncodeAllGCPointersGCDesc(ref builder, offsetToData);
                         }
                         else
                         {
-                            EncodeArrayGCDesc(ref builder, pointerMap, baseSize);
+                            EncodeArrayGCDesc(ref builder, pointerMap, offsetToData);
                         }
                     }
                 }
@@ -104,13 +113,22 @@ namespace Internal.Runtime
                 var defType = (MetadataType)type;
                 if (defType.ContainsGCPointers)
                 {
-                    // Computing the layout for the boxed version if this is a value type.
-                    int offs = defType.IsValueType ? builder.TargetPointerSize : 0;
+                    GCPointerMap pointerMap = GCPointerMap.FromInstanceLayout(defType);
+                    if (pointerMap.IsAllGCPointers)
+                    {
+                        int offsetToData = builder.TargetPointerSize;
+                        EncodeAllGCPointersGCDesc(ref builder, offsetToData);
+                    }
+                    else
+                    {
+                        // Pointer map for value types is for the unboxed version, so need to add an offset
+                        int offs = defType.IsValueType ? builder.TargetPointerSize : 0;
 
-                    // Include syncblock
-                    int objectSize = defType.InstanceByteCount.AsInt + offs + builder.TargetPointerSize;
+                        // Include syncblock
+                        int objectSize = defType.InstanceByteCount.AsInt + offs + builder.TargetPointerSize;
 
-                    EncodeStandardGCDesc(ref builder, GCPointerMap.FromInstanceLayout(defType), objectSize, offs);
+                        EncodeStandardGCDesc(ref builder, GCPointerMap.FromInstanceLayout(defType), objectSize, offs);
+                    }
                 }
             }
 
@@ -150,22 +168,22 @@ namespace Internal.Runtime
         }
 
         // Arrays of all GC references are encoded as special kind of GC desc for efficiency
-        private static void EncodeAllGCPointersArrayGCDesc<T>(ref T builder, int baseSize)
+        private static void EncodeAllGCPointersGCDesc<T>(ref T builder, int offsetToData)
             where T : struct, ITargetBinaryWriter
         {
-            // Construct the gc info as if this array contains exactly one pointer
+            // Construct the gc info as if this instance contains exactly one pointer
             // - the encoding trick where the size of the series is measured as a difference from
-            // total object size will make this work for arbitrary array lengths
+            // total object size will make this work for arbitrary instance lengths
 
             // Series size
-            builder.EmitNaturalInt(-(baseSize + builder.TargetPointerSize));
+            builder.EmitNaturalInt(-(offsetToData + builder.TargetPointerSize));
             // Series offset
-            builder.EmitNaturalInt(baseSize);
+            builder.EmitNaturalInt(offsetToData);
             // NumSeries
             builder.EmitNaturalInt(1);
         }
 
-        private static void EncodeArrayGCDesc<T>(ref T builder, GCPointerMap map, int baseSize)
+        private static void EncodeArrayGCDesc<T>(ref T builder, GCPointerMap map, int ofsetToData)
             where T : struct, ITargetBinaryWriter
         {
             // NOTE: This format cannot properly represent element types with sizes >= 64k bytes.
@@ -212,7 +230,7 @@ namespace Internal.Runtime
             }
 
             Debug.Assert(numSeries > 0);
-            builder.EmitNaturalInt(baseSize + leadingNonPointerCount * pointerSize);
+            builder.EmitNaturalInt(ofsetToData + leadingNonPointerCount * pointerSize);
             builder.EmitNaturalInt(-numSeries);
         }
     }

--- a/src/coreclr/vm/array.cpp
+++ b/src/coreclr/vm/array.cpp
@@ -584,16 +584,14 @@ MethodTable* Module::CreateArrayMethodTable(TypeHandle elemTypeHnd, CorElementTy
     }
 
     // Set up GC information
-    if (CorTypeInfo::IsObjRef(elemType))
+    if (CorTypeInfo::IsObjRef(elemType) || pMT->IsAllGCPointers())
     {
-        CGCDescSeries  *pSeries;
-
         pMT->SetContainsPointers();
 
         // This array is all GC Pointers
         CGCDesc::GetCGCDescFromMT(pMT)->Init( pMT, 1 );
 
-        pSeries = CGCDesc::GetCGCDescFromMT(pMT)->GetHighestSeries();
+        CGCDescSeries* pSeries = CGCDesc::GetCGCDescFromMT(pMT)->GetHighestSeries();
 
         pSeries->SetSeriesOffset(ArrayBase::GetDataPtrOffset(pMT));
         // For arrays, the size is the negative of the BaseSize (the GC always adds the total

--- a/src/coreclr/vm/array.cpp
+++ b/src/coreclr/vm/array.cpp
@@ -585,7 +585,7 @@ MethodTable* Module::CreateArrayMethodTable(TypeHandle elemTypeHnd, CorElementTy
 
     // Set up GC information
     if (CorTypeInfo::IsObjRef(elemType) ||
-        (elemType == ELEMENT_TYPE_VALUETYPE) && pElemMT->IsAllGCPointers())
+        ((elemType == ELEMENT_TYPE_VALUETYPE) && pElemMT->IsAllGCPointers()))
     {
         pMT->SetContainsPointers();
 

--- a/src/coreclr/vm/array.cpp
+++ b/src/coreclr/vm/array.cpp
@@ -584,59 +584,65 @@ MethodTable* Module::CreateArrayMethodTable(TypeHandle elemTypeHnd, CorElementTy
     }
 
     // Set up GC information
-    if (elemType == ELEMENT_TYPE_VALUETYPE || elemType == ELEMENT_TYPE_VOID)
+    if (CorTypeInfo::IsObjRef(elemType))
+    {
+        CGCDescSeries  *pSeries;
+
+        pMT->SetContainsPointers();
+
+        // This array is all GC Pointers
+        CGCDesc::GetCGCDescFromMT(pMT)->Init( pMT, 1 );
+
+        pSeries = CGCDesc::GetCGCDescFromMT(pMT)->GetHighestSeries();
+
+        pSeries->SetSeriesOffset(ArrayBase::GetDataPtrOffset(pMT));
+        // For arrays, the size is the negative of the BaseSize (the GC always adds the total
+        // size of the object, so what you end up with is the size of the data portion of the array)
+        pSeries->SetSeriesSize(-(SSIZE_T)(pMT->GetBaseSize()));
+    }
+    else if (elemType == ELEMENT_TYPE_VALUETYPE)
     {
         // If it's an array of value classes, there is a different format for the GCDesc if it contains pointers
         if (pElemMT->ContainsPointers())
         {
-            CGCDescSeries  *pSeries;
-
-            // There must be only one series for value classes
-            CGCDescSeries  *pByValueSeries = CGCDesc::GetCGCDescFromMT(pElemMT)->GetHighestSeries();
-
             pMT->SetContainsPointers();
+
+            CGCDescSeries* pElemSeries = CGCDesc::GetCGCDescFromMT(pElemMT)->GetHighestSeries();
 
             // negative series has a special meaning, indicating a different form of GCDesc
             SSIZE_T nSeries = (SSIZE_T) CGCDesc::GetCGCDescFromMT(pElemMT)->GetNumSeries();
             CGCDesc::GetCGCDescFromMT(pMT)->InitValueClassSeries(pMT, nSeries);
 
-            pSeries = CGCDesc::GetCGCDescFromMT(pMT)->GetHighestSeries();
+            CGCDescSeries* pSeries = CGCDesc::GetCGCDescFromMT(pMT)->GetHighestSeries();
 
-            // sort by offset
-            SSIZE_T AllocSizeSeries;
-            if (!ClrSafeInt<SSIZE_T>::multiply(sizeof(CGCDescSeries*), nSeries, AllocSizeSeries))
-                COMPlusThrowOM();
-            CGCDescSeries** sortedSeries = (CGCDescSeries**) _alloca(AllocSizeSeries);
-            int index;
-            for (index = 0; index < nSeries; index++)
-                sortedSeries[index] = &pByValueSeries[-index];
-
-            // section sort
-            for (int i = 0; i < nSeries; i++) {
-                for (int j = i+1; j < nSeries; j++)
-                    if (sortedSeries[j]->GetSeriesOffset() < sortedSeries[i]->GetSeriesOffset())
-                    {
-                        CGCDescSeries* temp = sortedSeries[i];
-                        sortedSeries[i] = sortedSeries[j];
-                        sortedSeries[j] = temp;
-                    }
+#if _DEBUG
+            // GC series must be sorted by the offset
+            // we will validate that here just in case.
+            size_t prevOffset = pElemSeries[0].GetSeriesOffset();
+            for (int index = 1; index < nSeries; index++)
+            {
+                size_t offset = pElemSeries[-index].GetSeriesOffset();
+                _ASSERTE((offset - prevOffset) > 0);
+                prevOffset = offset;
             }
+#endif // _DEBUG
 
             // Offset of the first pointer in the array
             // This equals the offset of the first pointer if this were an array of entirely pointers, plus the offset of the
             // first pointer in the value class
             pSeries->SetSeriesOffset(ArrayBase::GetDataPtrOffset(pMT)
-                + (sortedSeries[0]->GetSeriesOffset()) - OBJECT_SIZE);
-            for (index = 0; index < nSeries; index ++)
+                + (pElemSeries[0].GetSeriesOffset()) - OBJECT_SIZE);
+
+            for (int index = 0; index < nSeries; index ++)
             {
-                size_t numPtrsInBytes = sortedSeries[index]->GetSeriesSize()
+                size_t numPtrsInBytes = pElemSeries[-index].GetSeriesSize()
                     + pElemMT->GetBaseSize();
                 size_t currentOffset;
                 size_t skip;
-                currentOffset = sortedSeries[index]->GetSeriesOffset()+numPtrsInBytes;
+                currentOffset = pElemSeries[-index].GetSeriesOffset()+numPtrsInBytes;
                 if (index != nSeries-1)
                 {
-                    skip = sortedSeries[index+1]->GetSeriesOffset()-currentOffset;
+                    skip = pElemSeries[-(index+1)].GetSeriesOffset()-currentOffset;
                 }
                 else if (index == 0)
                 {
@@ -644,7 +650,7 @@ MethodTable* Module::CreateArrayMethodTable(TypeHandle elemTypeHnd, CorElementTy
                 }
                 else
                 {
-                    skip = sortedSeries[0]->GetSeriesOffset() + pElemMT->GetBaseSize()
+                    skip = pElemSeries[0].GetSeriesOffset() + pElemMT->GetBaseSize()
                          - OBJECT_BASESIZE - currentOffset;
                 }
 
@@ -664,22 +670,6 @@ MethodTable* Module::CreateArrayMethodTable(TypeHandle elemTypeHnd, CorElementTy
                 val_item->set_val_serie_item (NumPtrs, (unsigned short)skip);
             }
         }
-    }
-    else if (CorTypeInfo::IsObjRef(elemType))
-    {
-        CGCDescSeries  *pSeries;
-
-        pMT->SetContainsPointers();
-
-        // This array is all GC Pointers
-        CGCDesc::GetCGCDescFromMT(pMT)->Init( pMT, 1 );
-
-        pSeries = CGCDesc::GetCGCDescFromMT(pMT)->GetHighestSeries();
-
-        pSeries->SetSeriesOffset(ArrayBase::GetDataPtrOffset(pMT));
-        // For arrays, the size is the negative of the BaseSize (the GC always adds the total
-        // size of the object, so what you end up with is the size of the data portion of the array)
-        pSeries->SetSeriesSize(-(SSIZE_T)(pMT->GetBaseSize()));
     }
 
     // If we get here we are assuming that there was no truncation. If this is not the case then

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -1772,8 +1772,8 @@ BOOL MethodTable::IsAllGCPointers()
 
         int offsetToData = IsArray() ? ArrayBase::GetDataPtrOffset(this) : sizeof(size_t);
         CGCDescSeries* pSeries = pDesc->GetHighestSeries();
-        return pSeries->GetSeriesOffset() == offsetToData &&
-            (SSIZE_T)pSeries->GetSeriesSize() == -(SSIZE_T)(offsetToData + sizeof(size_t));
+        return ((int)pSeries->GetSeriesOffset() == offsetToData) &&
+            ((SSIZE_T)pSeries->GetSeriesSize() == -(SSIZE_T)(offsetToData + sizeof(size_t)));
     }
 
     return false;

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -1766,10 +1766,14 @@ BOOL MethodTable::IsAllGCPointers()
     if (this->ContainsPointers())
     {
         // check for canonical GC encoding for all-pointer types
-        CGCDescSeries* pSeries = CGCDesc::GetCGCDescFromMT(this)->GetHighestSeries();
-        return pSeries->GetSeriesCount() == 1 &&
-            pSeries->GetSeriesOffset() == this->GetBaseSize() - sizeof(size_t) &&
-            pSeries->GetSeriesSize() - this->GetBaseSize() == 0;
+        CGCDesc* pDesc = CGCDesc::GetCGCDescFromMT(this);
+        if (pDesc->GetNumSeries() != 1)
+            return false;
+
+        int offsetToData = IsArray() ? ArrayBase::GetDataPtrOffset(this) : sizeof(size_t);
+        CGCDescSeries* pSeries = pDesc->GetHighestSeries();
+        return pSeries->GetSeriesOffset() == offsetToData &&
+            (SSIZE_T)pSeries->GetSeriesSize() == -(SSIZE_T)(offsetToData + sizeof(size_t));
     }
 
     return false;

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -1761,6 +1761,21 @@ BOOL MethodTable::CanShareVtableChunksFrom(MethodTable *pTargetMT, Module *pCurr
     return pTargetMT->GetLoaderModule() == pCurrentLoaderModule;
 }
 
+BOOL MethodTable::IsAllGCPointers()
+{
+    if (this->ContainsPointers())
+    {
+        // check for canonical GC encoding for all-pointer types
+        CGCDescSeries* pSeries = CGCDesc::GetCGCDescFromMT(this)->GetHighestSeries();
+        return pSeries->GetSeriesCount() == 1 &&
+            pSeries->GetSeriesOffset() == this->GetBaseSize() - sizeof(size_t) &&
+            pSeries->GetSeriesSize() - this->GetBaseSize() == 0;
+    }
+
+    return false;
+}
+
+
 #ifdef _DEBUG
 
 void

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -1582,6 +1582,7 @@ public:
         LIMITED_METHOD_CONTRACT;
         return GetFlag(enum_flag_ContainsPointers);
     }
+
     BOOL            Collectible()
     {
         LIMITED_METHOD_CONTRACT;
@@ -1591,6 +1592,7 @@ public:
         return FALSE;
 #endif
     }
+
     BOOL            ContainsPointersOrCollectible()
     {
         LIMITED_METHOD_CONTRACT;
@@ -1601,6 +1603,8 @@ public:
     NOINLINE BYTE *GetLoaderAllocatorObjectForGC();
 
     BOOL            IsNotTightlyPacked();
+
+    BOOL            IsAllGCPointers();
 
     void SetContainsPointers()
     {

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -1863,8 +1863,8 @@ MethodTableBuilder::BuildMethodTableThrowing(
         // Perform relevant GC calculations for value classes
         HandleGCForValueClasses(pByValueClassCache);
 
-        // GC reqires the series to be sorted.
-        // TODO: fix it so that we emit them in the correct order in the first place.
+    // GC reqires the series to be sorted.
+    // TODO: fix it so that we emit them in the correct order in the first place.
     if (pMT->ContainsPointers())
     {
         CGCDesc* gcDesc = CGCDesc::GetCGCDescFromMT(pMT);
@@ -8042,6 +8042,8 @@ VOID    MethodTableBuilder::PlaceInstanceFields(MethodTable ** pByValueClassCach
         FieldDesc *pFieldDescList = GetHalfBakedClass()->GetFieldDescList();
         DWORD   dwCumulativeInstanceFieldPos;
 
+        bool isAllGCPointers = true;
+
         // Instance fields start right after the parent
         if (HasParent())
         {
@@ -8057,6 +8059,11 @@ VOID    MethodTableBuilder::PlaceInstanceFields(MethodTable ** pByValueClassCach
             else
             {
                 dwCumulativeInstanceFieldPos = pParentMT->GetNumInstanceFieldBytes();
+            }
+
+            if (pParentMT->GetNumInstanceFields() != 0 && !pParentMT->IsAllGCPointers())
+            {
+                isAllGCPointers = false;
             }
         }
         else
@@ -8300,6 +8307,11 @@ VOID    MethodTableBuilder::PlaceInstanceFields(MethodTable ** pByValueClassCach
                     // Add pointer series for by-value classes
                     dwNumGCPointerSeries += (DWORD)CGCDesc::GetCGCDescFromMT(pByValueMT)->GetNumSeries();
                 }
+
+                if (!pByValueMT->ContainsPointers() || !pByValueMT->IsAllGCPointers())
+                {
+                    isAllGCPointers = false;
+                }
             }
             else
             {
@@ -8307,6 +8319,11 @@ VOID    MethodTableBuilder::PlaceInstanceFields(MethodTable ** pByValueClassCach
                 // This does not account for types that are marked IsAlign8Candidate due to 8-byte fields
                 // but that is explicitly handled when we calculate the final alignment for the type.
                 largestAlignmentRequirement = max(largestAlignmentRequirement, TARGET_POINTER_SIZE);
+
+                if (!pFieldDescList[i].IsObjRef())
+                {
+                    isAllGCPointers = false;
+                }
             }
         }
 
@@ -8315,14 +8332,17 @@ VOID    MethodTableBuilder::PlaceInstanceFields(MethodTable ** pByValueClassCach
 
         if (IsValueClass())
         {
-                 // Like C++ we enforce that there can be no 0 length structures.
-                // Thus for a value class with no fields, we 'pad' the length to be 1
+            // Like C++ we enforce that there can be no 0 length structures.
+            // Thus for a value class with no fields, we 'pad' the length to be 1
             if (dwNumInstanceFieldBytes == 0)
+            {
                 dwNumInstanceFieldBytes = 1;
+                isAllGCPointers = false;
+            }
 
-                // The JITs like to copy full machine words,
-                //  so if the size is bigger than a void* round it up to minAlign
-                // and if the size is smaller than void* round it up to next power of two
+            // The JITs like to copy full machine words,
+            //  so if the size is bigger than a void* round it up to minAlign
+            // and if the size is smaller than void* round it up to next power of two
             unsigned minAlign;
 
 #ifdef FEATURE_64BIT_ALIGNMENT
@@ -8370,6 +8390,13 @@ VOID    MethodTableBuilder::PlaceInstanceFields(MethodTable ** pByValueClassCach
             {
                 dwNumGCPointerSeries *= bmtFP->NumInlineArrayElements;
             }
+        }
+
+        bmtFP->fIsAllGCPointers = isAllGCPointers && dwNumGCPointerSeries;
+        if (bmtFP->fIsAllGCPointers)
+        {
+            // we can use optimized form of GCDesc taking one serie
+            dwNumGCPointerSeries = 1;
         }
 
         bmtFP->NumInstanceFieldBytes = dwNumInstanceFieldBytes;
@@ -9023,6 +9050,10 @@ void MethodTableBuilder::FindPointerSeriesExplicit(UINT instanceSliceSize,
 
     bmtFP->NumGCPointerSeries = bmtParent->NumParentPointerSeries + bmtGCSeries->numSeries;
 
+    // since the GC series are computed from a ref map,
+    // in most cases where optimized GCDesc could be used, that is what we will compute anyways,
+    // so we will not try optimizing this case.
+    bmtFP->fIsAllGCPointers = false;
 }
 
 //*******************************************************************************
@@ -11536,8 +11567,27 @@ VOID MethodTableBuilder::HandleGCForValueClasses(MethodTable ** pByValueClassCac
 
         pMT->SetContainsPointers();
 
-        // Copy the pointer series map from the parent
         CGCDesc::Init( (PVOID) pMT, bmtFP->NumGCPointerSeries );
+
+        // special case when all instance fields are objects - we can encode that as one serie.
+        if (bmtFP->fIsAllGCPointers)
+        {
+            _ASSERTE(bmtFP->NumGCPointerSeries == 1);
+
+            CGCDescSeries* pSeries = CGCDesc::GetCGCDescFromMT(pMT)->GetHighestSeries();
+
+            // the data is right after the method table ptr
+            int offsetToData = TARGET_POINTER_SIZE;
+
+            // Set the size as the negative of the BaseSize (the GC always adds the total
+            // size of the object, so what you end up with is the size of the data portion of the instance)
+            pSeries->SetSeriesSize(-(SSIZE_T)(offsetToData + TARGET_POINTER_SIZE));
+            pSeries->SetSeriesOffset(offsetToData);
+
+            return;
+        }
+
+        // Copy the pointer series map from the parent
         if (bmtParent->NumParentPointerSeries != 0)
         {
             size_t ParentGCSize = CGCDesc::ComputeSize(bmtParent->NumParentPointerSeries);
@@ -11554,7 +11604,7 @@ VOID MethodTableBuilder::HandleGCForValueClasses(MethodTable ** pByValueClassCac
             repeat = bmtFP->NumInlineArrayElements;
         }
 
-        // Build the pointer series map for this pointers in this instance
+        // Build the pointer series map for pointers in this instance
         pSeries = ((CGCDesc*)pMT)->GetLowestSeries();
         if (bmtFP->NumInstanceGCPointerFields)
         {
@@ -11579,7 +11629,6 @@ VOID MethodTableBuilder::HandleGCForValueClasses(MethodTable ** pByValueClassCac
 
                     // if we have an inline array, we will have only one formal instance field,
                     // but will have to replicate the layout "repeat" times.
-                    // otherwise every field will be matched with 1 serie.
                     for (DWORD r = 0; r < repeat; r++)
                     {
                         // The by value class may have more than one pointer series

--- a/src/coreclr/vm/methodtablebuilder.h
+++ b/src/coreclr/vm/methodtablebuilder.h
@@ -2012,6 +2012,7 @@ private:
         DWORD NumInstanceFieldBytes;
         DWORD NumInlineArrayElements;
 
+        bool  fIsAllGCPointers;
         bool  fIsByRefLikeType;
         bool  fHasFixedAddressValueTypes;
         bool  fHasSelfReferencingStaticValueTypeField_WithRVA;

--- a/src/tests/Loader/classloader/InlineArray/InlineArrayValid.cs
+++ b/src/tests/Loader/classloader/InlineArray/InlineArrayValid.cs
@@ -368,6 +368,7 @@ unsafe class Validate
     // ====================== GCDescOpt ==========================================================
 
     [Fact]
+    [SkipOnMono("CoreCLR and NativeAOT-specific implementation details.")]
     public static void GCDescOpt()
     {
         Console.WriteLine($"{nameof(GCDescOpt)}...");

--- a/src/tests/Loader/classloader/InlineArray/InlineArrayValid.cs
+++ b/src/tests/Loader/classloader/InlineArray/InlineArrayValid.cs
@@ -364,4 +364,23 @@ unsafe class Validate
 
         BoxedMethodArg(arr);
     }
+
+    // ====================== GCDescOpt ==========================================================
+
+    [Fact]
+    public static void GCDescOpt()
+    {
+        Console.WriteLine($"{nameof(GCDescOpt)}...");
+
+        MyArray<object>[] arr = new MyArray<object>[5];
+
+        fixed (void* arrPtr = arr)
+        {
+            nint* mtPtr = (nint*)arrPtr - 2;
+            nint* gcSeriesPtr = (nint*)*mtPtr - 1;
+
+            // optimized gc info should have exactly 1 gc series.
+            Assert.Equal(1, *gcSeriesPtr);
+        }
+    }
 }


### PR DESCRIPTION
Re: https://github.com/dotnet/runtime/pull/82744#discussion_r1125188177
Fixes: [#83111](https://github.com/dotnet/runtime/issues/83111)

Turns out NativeAOT already emits optimized GC descs. That just follows from the implementation that builds complete pointer maps and scans them for series. Array-of-all-pointer-structs cases were not considered on some code paths though.

In the most general case CoreClr builds GC descs by appending GC descs of constituent parts - the base class and struct fields. It does use the compact "all-pointers" form, but only for object arrays.
With this change we detect most of the cases of all-pointers instances and use a compact 1-serie GC desc.

This is not a 100% match of the optimal GC descs produced by NativeAOT. 
For example NativeAOT will naturally coalesce adjacent all-pointers structs in the middle of an instance into one contiguous GC serie. NativeAOT has more time and more motivation for this (the number of statically required method tables could be a lot higher than what is actually used at run time and using more compact forms reduces size).  
For the JIT scenario, handling "all-pointers" seems good enough and also what we can do cheaply and allocation-free at JIT time.