### PR TITLE
[wasm] Exclude PInvoke with function pointer in TimeZoneTests from wasm compilation

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-unix;$(NetCoreAppCurrent)-browser</TargetFrameworks>
+    <DefineConstants Condition="'$(TargetOS)' == 'browser'">$(DefineConstants);TARGET_BROWSER</DefineConstants> 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn),1718,SYSLIB0013</NoWarn>
     <TestRuntime>true</TestRuntime>

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -3240,6 +3240,8 @@ namespace System.Tests
                 }
 
                 var list = new List<CultureInfo>();
+
+#if !TARGET_BROWSER
                 GCHandle handle = GCHandle.Alloc(list);
                 try
                 {
@@ -3252,10 +3254,12 @@ namespace System.Tests
                 {
                     handle.Free();
                 }
+#endif
 
                 return list.ToArray();
             }
 
+#if !TARGET_BROWSER
             [UnmanagedCallersOnly]
             private static unsafe int EnumUiLanguagesCallback(char* lpUiLanguageString, IntPtr lParam)
             {
@@ -3288,6 +3292,7 @@ namespace System.Tests
 
             [DllImport("Kernel32.dll", CharSet = CharSet.Auto)]
             private static extern unsafe bool EnumUILanguages(delegate* unmanaged<char*, IntPtr, int> lpUILanguageEnumProc, uint dwFlags, IntPtr lParam);
+#endif
         }
     }
 }


### PR DESCRIPTION
It removes this warning. The pinvoke is not used on wasm.

```
C:\helix\work\correlation\build\wasm\WasmApp.Native.targets(297,5): warning WASM0001: Could not get pinvoke, or
callbacks for method 'System.Tests.TimeZoneInfoTests+WindowsUILanguageHelper::EnumUILanguages' because 'Parsing 
function pointer types in signatures is not supported.' [C:\helix\work\workitem\e\publish\ProxyProjectForAOTOnHelix.proj]
```