### PR TITLE
Enable xunit.analyzers in merged test groups

### DIFF
--- a/src/tests/Common/XUnitWrapperGenerator/ImmutableDictionaryValueComparer.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/ImmutableDictionaryValueComparer.cs
@@ -8,7 +8,7 @@ using System.Text;
 
 namespace XUnitWrapperGenerator;
 
-internal class ImmutableDictionaryValueComparer<TKey, TValue> : IEqualityComparer<ImmutableDictionary<TKey, TValue>>
+internal sealed class ImmutableDictionaryValueComparer<TKey, TValue> : IEqualityComparer<ImmutableDictionary<TKey, TValue>>
     where TKey : notnull
 {
     private readonly IEqualityComparer<TValue> _valueComparer;

--- a/src/tests/Common/XUnitWrapperGenerator/RuntimeTestModes.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/RuntimeTestModes.cs
@@ -27,7 +27,7 @@ namespace Xunit
         ZapDisable = 1 << 5, // DOTNET_ZapDisable is set.
 
         // GCStress3 forces a GC at various locations, typically transitions
-        // to/from the VM from managed code. 
+        // to/from the VM from managed code.
         GCStress3 = 1 << 6,  // DOTNET_GCStress includes mode 0x3.
 
         // GCStressC forces a GC at every JIT-generated code instruction,

--- a/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
@@ -25,7 +25,7 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
                     node.IsKind(SyntaxKind.MethodDeclaration)
                         && node is MethodDeclarationSyntax method
                         && method.AttributeLists.Count > 0,
-                static (context, ct) => (IMethodSymbol)context.SemanticModel.GetDeclaredSymbol(context.Node)!);
+                static (context, ct) => (IMethodSymbol)context.SemanticModel.GetDeclaredSymbol(context.Node, ct)!);
 
         var outOfProcessTests = context.AdditionalTextsProvider.Combine(context.AnalyzerConfigOptionsProvider).SelectMany((data, ct) =>
         {
@@ -141,8 +141,7 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
                 }
                 else
                 {
-                    string consoleType = "System.Console";
-                    context.AddSource("SimpleRunner.g.cs", GenerateStandaloneSimpleTestRunner(methods, aliasMap, consoleType));
+                    context.AddSource("SimpleRunner.g.cs", GenerateStandaloneSimpleTestRunner(methods, aliasMap));
                 }
             });
     }
@@ -373,7 +372,7 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
         return builder.GetCode();
     }
 
-    private static string GenerateStandaloneSimpleTestRunner(ImmutableArray<ITestInfo> testInfos, ImmutableDictionary<string, string> aliasMap, string consoleType)
+    private static string GenerateStandaloneSimpleTestRunner(ImmutableArray<ITestInfo> testInfos, ImmutableDictionary<string, string> aliasMap)
     {
         ITestReporterWrapper reporter = new NoTestReporting();
         CodeBuilder builder = new();
@@ -404,7 +403,7 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
         return builder.GetCode();
     }
 
-    private class ExternallyReferencedTestMethodsVisitor : SymbolVisitor<IEnumerable<IMethodSymbol>>
+    private sealed class ExternallyReferencedTestMethodsVisitor : SymbolVisitor<IEnumerable<IMethodSymbol>>
     {
         public override IEnumerable<IMethodSymbol>? VisitAssembly(IAssemblySymbol symbol)
         {

--- a/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-//
 
 using System;
 using System.Collections.Generic;
@@ -48,7 +47,7 @@ public class TestFilter
             }
             return stringToSearch == Filter;
         }
-            
+
         public override string ToString()
         {
             return $"{Kind}{(Substring ? "~" : "=")}{Filter}";
@@ -67,7 +66,7 @@ public class TestFilter
         }
 
         public bool IsMatch(string fullyQualifiedName, string displayName, string[] traits) => _left.IsMatch(fullyQualifiedName, displayName, traits) && _right.IsMatch(fullyQualifiedName, displayName, traits);
-  
+
         public override string ToString()
         {
             return $"({_left}) && ({_right})";
@@ -86,7 +85,7 @@ public class TestFilter
         }
 
         public bool IsMatch(string fullyQualifiedName, string displayName, string[] traits) => _left.IsMatch(fullyQualifiedName, displayName, traits) || _right.IsMatch(fullyQualifiedName, displayName, traits);
-    
+
         public override string ToString()
         {
             return $"({_left}) || ({_right})";
@@ -103,7 +102,7 @@ public class TestFilter
         }
 
         public bool IsMatch(string fullyQualifiedName, string displayName, string[] traits) => !_inner.IsMatch(fullyQualifiedName, displayName, traits);
-    
+
         public override string ToString()
         {
             return $"!({_inner})";
@@ -118,11 +117,11 @@ public class TestFilter
     // issues.targets file as a split model would be very confusing for developers
     // and test monitors.
     private readonly HashSet<string>? _testExclusionList;
-    private readonly int _stripe = 0;
+    private readonly int _stripe;
     private readonly int _stripeCount = 1;
     private int _shouldRunQuery = -1;
 
-    public TestFilter(string? filterString, HashSet<string>? testExclusionList) : 
+    public TestFilter(string? filterString, HashSet<string>? testExclusionList) :
         this(filterString == null ? Array.Empty<string>() : new string[]{filterString}, testExclusionList)
     {
     }
@@ -135,25 +134,24 @@ public class TestFilter
         {
             if (filterArgs[i].StartsWith("-stripe"))
             {
-                _stripe = Int32.Parse(filterArgs[++i]);
-                _stripeCount = Int32.Parse(filterArgs[++i]);
+                _stripe = int.Parse(filterArgs[++i]);
+                _stripeCount = int.Parse(filterArgs[++i]);
             }
             else
             {
-                if (filterString == null)
-                    filterString = filterArgs[0];
+                filterString ??= filterArgs[0];
             }
         }
 
         var stripeEnvironment = Environment.GetEnvironmentVariable("TEST_HARNESS_STRIPE_TO_EXECUTE");
-        if (!String.IsNullOrEmpty(stripeEnvironment) && stripeEnvironment != ".0.1")
+        if (!string.IsNullOrEmpty(stripeEnvironment) && stripeEnvironment != ".0.1")
         {
             var stripes = stripeEnvironment.Split('.');
             if (stripes.Length == 3)
             {
                 Console.WriteLine($"Test striping enabled via TEST_HARNESS_STRIPE_TO_EXECUTE environment variable set to '{stripeEnvironment}'");
-                _stripe = Int32.Parse(stripes[1]);
-                _stripeCount = Int32.Parse(stripes[2]);
+                _stripe = int.Parse(stripes[1]);
+                _stripeCount = int.Parse(stripes[2]);
             }
         }
 
@@ -161,7 +159,7 @@ public class TestFilter
         {
             if (filterString.IndexOfAny(new[] { '!', '(', ')', '~', '=' }) != -1)
             {
-                throw new ArgumentException("Complex test filter expressions are not supported today. The only filters supported today are the simple form supported in 'dotnet test --filter' (substrings of the test's fully qualified name). If further filtering options are desired, file an issue on dotnet/runtime for support.", nameof(filterString));
+                throw new ArgumentException("Complex test filter expressions are not supported today. The only filters supported today are the simple form supported in 'dotnet test --filter' (substrings of the test's fully qualified name). If further filtering options are desired, file an issue on dotnet/runtime for support.", nameof(filterArgs));
             }
             _filter = new NameClause(TermKind.FullyQualifiedName, filterString, substring: true);
         }
@@ -176,7 +174,7 @@ public class TestFilter
 
     public bool ShouldRunTest(string fullyQualifiedName, string displayName, string[]? traits = null)
     {
-        bool shouldRun = false;
+        bool shouldRun;
         if (_testExclusionList is not null && _testExclusionList.Contains(displayName.Replace("\\", "/")))
         {
             shouldRun = false;
@@ -197,7 +195,7 @@ public class TestFilter
         }
         return false;
     }
-    
+
     public static HashSet<string> LoadTestExclusionList()
     {
         HashSet<string> output = new ();

--- a/src/tests/Common/XUnitWrapperLibrary/TestOutputRecorder.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestOutputRecorder.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-//
 
 using System;
 using System.Collections.Generic;

--- a/src/tests/Common/XUnitWrapperLibrary/TestSummary.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestSummary.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-//
 
 using System;
 using System.IO;
@@ -10,15 +9,15 @@ namespace XUnitWrapperLibrary;
 
 public class TestSummary
 {
-    readonly record struct TestResult
+    public readonly record struct TestResult
     {
-        readonly string Name;
-        readonly string ContainingTypeName;
-        readonly string MethodName;
-        readonly TimeSpan Duration;
-        readonly Exception? Exception;
-        readonly string? SkipReason;
-        readonly string? Output;
+        public readonly string Name;
+        public readonly string ContainingTypeName;
+        public readonly string MethodName;
+        public readonly TimeSpan Duration;
+        public readonly Exception? Exception;
+        public readonly string? SkipReason;
+        public readonly string? Output;
 
         public TestResult(string name,
                           string containingTypeName,
@@ -97,10 +96,10 @@ public class TestSummary
         }
     }
 
-    public int PassedTests { get; private set; } = 0;
-    public int FailedTests { get; private set; } = 0;
-    public int SkippedTests { get; private set; } = 0;
-    public int TotalTests { get; private set; } = 0;
+    public int PassedTests { get; private set; }
+    public int FailedTests { get; private set; }
+    public int SkippedTests { get; private set; }
+    public int TotalTests { get; private set; }
 
     private readonly List<TestResult> _testResults = new();
     private DateTime _testRunStart = DateTime.Now;

--- a/src/tests/Common/test_dependencies/test_dependencies.csproj
+++ b/src/tests/Common/test_dependencies/test_dependencies.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tools.RuntimeClient" Version="$(MicrosoftDiagnosticsToolsRuntimeClientVersion)" />
+    <PackageReference Include="xunit.analyzers" Version="$(XUnitAnalyzersVersion)" />
   </ItemGroup>
 
   <Target Name="Build" DependsOnTargets="$(TraversalBuildDependsOn)" />

--- a/src/tests/JIT/HardwareIntrinsics/Arm/ArmBase/Yield.cs
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/ArmBase/Yield.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace JIT.HardwareIntrinsics.Arm
 {
-    class Program
+    public class Program
     {
         [Fact]
         public static unsafe void Yield()

--- a/src/tests/JIT/HardwareIntrinsics/Directory.Build.props
+++ b/src/tests/JIT/HardwareIntrinsics/Directory.Build.props
@@ -8,4 +8,9 @@
   <ItemGroup>
     <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <RunAnalyzers>true</RunAnalyzers>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/HardwareIntrinsics/General/HwiOp/CompareVectorWithZero.cs
+++ b/src/tests/JIT/HardwareIntrinsics/General/HwiOp/CompareVectorWithZero.cs
@@ -10,7 +10,7 @@ public class CompareVectorWithZero
 {
     [ActiveIssue("https://github.com/dotnet/runtime/pull/65632#issuecomment-1046294324", TestRuntimes.Mono)]
     [Fact]
-    public static void Test()
+    public static void AllTests()
     {
         Test(Vector128.Create(0));
         Test(Vector128.Create(0.0f));
@@ -62,29 +62,29 @@ public class CompareVectorWithZero
     public static T ToVar<T>(T t) => t;
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static void AssertTrue(bool expr)
+    static void AssertTrue(bool expr)
     {
         if (!expr)
             throw new InvalidOperationException();
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static void Test<T>(Vector128<T> v) where T : unmanaged =>
+    static void Test<T>(Vector128<T> v) where T : unmanaged =>
         AssertTrue((v == Vector128<T>.Zero) == 
                    (v == Vector128.Create(ToVar(default(T)))));
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static void Test<T>(Vector64<T> v) where T : unmanaged =>
+    static void Test<T>(Vector64<T> v) where T : unmanaged =>
         AssertTrue((v == Vector64<T>.Zero) == 
                    (v == Vector64.Create(ToVar(default(T)))));
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static void TestReversed<T>(Vector128<T> v) where T : unmanaged =>
+    static void TestReversed<T>(Vector128<T> v) where T : unmanaged =>
         AssertTrue((Vector128<T>.Zero == v) == 
                    (v == Vector128.Create(ToVar(default(T)))));
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static void TestReversed<T>(Vector64<T> v) where T : unmanaged =>
+    static void TestReversed<T>(Vector64<T> v) where T : unmanaged =>
         AssertTrue((Vector64<T>.Zero == v) == 
                    (v == Vector64.Create(ToVar(default(T)))));
 }

--- a/src/tests/JIT/HardwareIntrinsics/General/HwiOp/HwiSideEffects.cs
+++ b/src/tests/JIT/HardwareIntrinsics/General/HwiOp/HwiSideEffects.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 // Tests that side effects induced by the HWI nodes are correctly accounted for.
 
-unsafe class HwiSideEffects
+public unsafe class HwiSideEffects
 {
     [Fact]
     public static void TestProblemWithInterferenceChecks()

--- a/src/tests/JIT/HardwareIntrinsics/General/HwiOp/HwiValueNumbering.cs
+++ b/src/tests/JIT/HardwareIntrinsics/General/HwiOp/HwiValueNumbering.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 // Tests that we value number certain intrinsics correctly.
 //
-unsafe class HwiValueNumbering
+public unsafe class HwiValueNumbering
 {
     [Fact]
     public static void TestProblemWithLoadLow_Sse()
@@ -160,7 +160,7 @@ unsafe class HwiValueNumbering
         if (v1.GetElement(0) == 0)
         {
             var v2 = Avx.MaskLoad(data, Vector128.Create(Mask, 0));
-            Assert.NotEqual(v2.GetElement(0), 0);
+            Assert.NotEqual(0, v2.GetElement(0));
         }
     }
 
@@ -188,10 +188,10 @@ unsafe class HwiValueNumbering
         if (v1.GetElement(0) == 0)
         {
             var v2 = Avx2.MaskLoad(data, Vector128.Create(Mask, 0));
-            Assert.NotEqual(v2.GetElement(0), 0);
+            Assert.NotEqual(0, v2.GetElement(0));
         }
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static void JitUse<T>(T* arg) where T : unmanaged { }
+    static void JitUse<T>(T* arg) where T : unmanaged { }
 }

--- a/src/tests/JIT/HardwareIntrinsics/X86/General/IsSupported.cs
+++ b/src/tests/JIT/HardwareIntrinsics/X86/General/IsSupported.cs
@@ -56,7 +56,7 @@ namespace IntelHardwareIntrinsicTest.General
             {
                 result = false;
             }
-            Assert.Equal(true, result);
+            Assert.True(result);
         }
     }
 }

--- a/src/tests/JIT/HardwareIntrinsics/X86/General/VectorRet.cs
+++ b/src/tests/JIT/HardwareIntrinsics/X86/General/VectorRet.cs
@@ -39,7 +39,7 @@ public partial class Program
     private static Vector256<byte> s_v256i_3;
 
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
-    public static void init()
+    static void init()
     {
         Random random = new Random(100);
 

--- a/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_17073/GitHub_17073.cs
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Regression/GitHub_17073/GitHub_17073.cs
@@ -893,7 +893,7 @@ public class GitHub_17073
         r &= !Avx.IsSupported || Check(true, Test_Avx_TestNotZAndNotC_LogicalNot_Branch_Swap(Vector256.Create(1.0f), Vector256.Create(1.0f)));
         r &= !Avx.IsSupported || Check(true, Test_Avx_TestNotZAndNotC_LogicalNot_Branch_Swap(Vector256.Create(1.0f), Vector256.Create(-1.0f)));
         r &= !Avx.IsSupported || Check(true, Test_Avx_TestNotZAndNotC_LogicalNot_Branch_Swap(Vector256.Create(-1.0f), Vector256.Create(-1.0f)));
-        Assert.Equal(true, r);
+        Assert.True(r);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse41/Multiply.cs
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse41/Multiply.cs
@@ -13,6 +13,7 @@ namespace IntelHardwareIntrinsicTest._Sse41
 {
     public partial class Program
     {
+	[Fact]
         public static unsafe void Multiply()
         {
             int testResult = Pass;

--- a/src/tests/JIT/IL_Conformance/Convert/TestConvertFromIntegral.cs
+++ b/src/tests/JIT/IL_Conformance/Convert/TestConvertFromIntegral.cs
@@ -18,12 +18,12 @@ namespace TestCasts
 {
     public class Program
     {
-        static int failedCount = 0;
+        static int failedCount;
 
-        static readonly bool ExpectException = true;
-        static readonly bool DontExpectException = false;
+        const bool ExpectException = true;
+        const bool DontExpectException = false;
 
-        static readonly bool UnspecifiedBehaviour = true;
+        const bool UnspecifiedBehaviour = true;
 
         static void GenerateTest<F, T>(F from, OpCode fromOpcode, OpCode convOpcode, bool exceptionExpected, T expectedTo, bool undefined = false) where F : struct where T : struct, IEquatable<T>
         {
@@ -31,7 +31,7 @@ namespace TestCasts
             Debug.Assert(!exceptionExpected || !checkResult);
             Debug.Assert(checkResult || expectedTo.Equals(default(T)));
 
-            Type[] args = new Type[] { }; // No args.
+            Type[] args = Array.Empty<Type>(); // No args.
             Type returnType = typeof(T);
             string name = "DynamicConvertFrom" + typeof(F).FullName + "To" + typeof(T).FullName + from.ToString() + "Op" + convOpcode.Name;
             DynamicMethod dm = new DynamicMethod(name, returnType, args);
@@ -53,7 +53,7 @@ namespace TestCasts
 
             try
             {
-                T res = (T)dm.Invoke(null, BindingFlags.Default, null, new object[] { }, null);
+                T res = (T)dm.Invoke(null, BindingFlags.Default, null, Array.Empty<object>(), null);
                 if (exceptionExpected)
                 {
                     failedCount++;

--- a/src/tests/JIT/IL_Conformance/Directory.Build.props
+++ b/src/tests/JIT/IL_Conformance/Directory.Build.props
@@ -6,4 +6,8 @@
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
+
+  <PropertyGroup>
+    <RunAnalyzers>true</RunAnalyzers>
+  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Methodical/Arrays/misc/IndexingSideEffects.cs
+++ b/src/tests/JIT/Methodical/Arrays/misc/IndexingSideEffects.cs
@@ -5,6 +5,8 @@ using System;
 using System.Runtime.CompilerServices;
 using Xunit;
 
+namespace IndexingSideEffects;
+
 public class IndexingSideEffects
 {
     [Fact]
@@ -25,7 +27,7 @@ public class IndexingSideEffects
 
         try
         {
-            TryIndexing(new int[0]);
+            TryIndexing(Array.Empty<int>());
         }
         catch (IndexOutOfRangeException)
         {

--- a/src/tests/JIT/Methodical/Arrays/misc/arrres.cs
+++ b/src/tests/JIT/Methodical/Arrays/misc/arrres.cs
@@ -9,12 +9,12 @@ namespace GCTest_arrres_cs
     public class Test
     {
         private int _indx;
-        public bool m_die = false;
+        public bool m_die;
         private static Test[] s_arr = new Test[50];
 
         public Test(int indx) { _indx = indx; }
 
-        public virtual void CheckValid()
+        internal virtual void CheckValid()
         {
             if (s_arr[_indx] != this)
                 throw new Exception();

--- a/src/tests/JIT/Methodical/Arrays/misc/gcarr.cs
+++ b/src/tests/JIT/Methodical/Arrays/misc/gcarr.cs
@@ -9,7 +9,7 @@ namespace GCTest_gcarr_cs
     public class Test
     {
         private int _magic = 0x12345678;
-        public virtual void CheckValid()
+        internal virtual void CheckValid()
         {
             if (_magic != 0x12345678)
                 throw new Exception();

--- a/src/tests/JIT/Methodical/Directory.Build.props
+++ b/src/tests/JIT/Methodical/Directory.Build.props
@@ -8,4 +8,10 @@
   </PropertyGroup>
 
   <Import Project="..\..\Directory.Build.props" />
+
+  <PropertyGroup>
+    <RunAnalyzers>true</RunAnalyzers>
+    <NoWarn>$(NoWarn);xUnit1013</NoWarn>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Methodical/flowgraph/dev10_bug679008/singleRefField.cs
+++ b/src/tests/JIT/Methodical/flowgraph/dev10_bug679008/singleRefField.cs
@@ -39,13 +39,13 @@ public class Repro
     {
     }
 
-    private Repro[] _preExecutionDelegates = new Repro[0];
+    private Repro[] _preExecutionDelegates = Array.Empty<Repro>();
 
     private int Bug(MB8 mb8, string V_2)
     {
         if (V_2 == null)
         {
-            throw new ArgumentNullException("V_2");
+            throw new ArgumentNullException(nameof(V_2));
         }
         _state = 2;
         int loc0 = 0;

--- a/src/tests/Loader/classloader/TypeGeneratorTests/Directory.Build.props
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/Directory.Build.props
@@ -6,4 +6,8 @@
   </PropertyGroup>
 
   <Import Project="..\..\..\Directory.Build.props" />
+
+  <PropertyGroup>
+    <RunAnalyzers>true</RunAnalyzers>
+  </PropertyGroup>
 </Project>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TestFramework/TestFramework.cs
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TestFramework/TestFramework.cs
@@ -7,6 +7,9 @@ using System.Reflection;
 using System.Collections.Generic;
 using System.IO;
 
+// There are 100000s of uses of TestFramework in the IL files.
+#pragma warning disable CA1050 // Declare types in namespaces
+
 public class TestFramework
 {
     public static void MethodCallTest(string actualResult, string expectedResults, string invocationString)
@@ -57,3 +60,4 @@ public class TestFramework
         if (!success) throw new Exception("Wrong method called");
     }
 }
+#pragma warning restore CA1050

--- a/src/tests/baseservices/threading/Directory.Build.props
+++ b/src/tests/baseservices/threading/Directory.Build.props
@@ -8,4 +8,10 @@
   </PropertyGroup>
 
   <Import Project="..\..\Directory.Build.props" />
+
+  <PropertyGroup>
+    <RunAnalyzers>true</RunAnalyzers>
+    <NoWarn>$(NoWarn);xUnit1013</NoWarn>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Main goal is to enable the rule that all [Fact] methods are in public types.
We'll need a custom rule to check that [Fact] methods are themselves public.
- Add reference in test_dependencies.csproj
- Set RunAnalyzers in Directory.Build.props for merged test groups
- Mostly disable other analyzer rules
- Clean a few warnings - notably enable a few tests in HardwareIntrinsics by making them public