### PR TITLE
Fix typo in `IEqualityComparer` comment string

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/IEqualityComparer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/IEqualityComparer.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace System.Collections.Generic
 {
-    // The generic IEqualityComparer interface implements methods to if check two objects are equal
+    // The generic IEqualityComparer interface implements methods to check if two objects are equal
     // and generate Hashcode for an object.
     // It is used in Dictionary class.
     public interface IEqualityComparer<in T>


### PR DESCRIPTION
Noticed a small typo while browsing .NET sources. Here is a fix.