### PR TITLE
[mono][sgen] Remove outdated assertion

### DIFF
--- a/src/mono/mono/sgen/sgen-gc.c
+++ b/src/mono/mono/sgen/sgen-gc.c
@@ -2331,8 +2331,6 @@ major_finish_collection (SgenGrayQueue *gc_thread_gray_queue, const char *reason
 	SGEN_ASSERT (0, sgen_workers_all_done (), "Can't have workers working after joining");
 
 	if (objects_pinned) {
-		g_assert (!sgen_concurrent_collection_in_progress);
-
 		/*
 		 * This is slow, but we just OOM'd.
 		 *


### PR DESCRIPTION
objects_pinned is incremented when we fail to promote an object from nursery due to lack of memory. A long time ago, the concurrent collector was only scanning major objects, while the nursery objects were promoted from a separate nursery collection done also during the finishing pause. This is no longer the case as the finishing concurrent collection directly promotes objects from the nursery, having similar behavior to a normal blocking collection.

Fixes https://github.com/dotnet/runtime/issues/83817