### PR TITLE
Add additional close statuses in ManagedWebSocket

### DIFF
--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -1059,6 +1059,9 @@ namespace System.Net.WebSockets
                 case WebSocketCloseStatus.NormalClosure:
                 case WebSocketCloseStatus.PolicyViolation:
                 case WebSocketCloseStatus.ProtocolError:
+                case (WebSocketCloseStatus)1012: // ServiceRestart
+                case (WebSocketCloseStatus)1013: // TryAgainLater
+                case (WebSocketCloseStatus)1014: // BadGateway
                     return true;
 
                 default:

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/WebSocketCloseStatus.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/WebSocketCloseStatus.cs
@@ -18,6 +18,10 @@ namespace System.Net.WebSockets
         MessageTooBig = 1009,
         MandatoryExtension = 1010,
         InternalServerError = 1011
+        //non-RFC IANA registered status codes that we allow as valid closing status
+        // ServiceRestart = 1012,  // indicates that the server / service is restarting.
+        // TryAgainLater = 1013,   // indicates that a temporary server condition forced blocking the client's request.
+        // BadGateway = 1014       // indicates that the server acting as gateway received an invalid response
         // TLSHandshakeFailed = 1015, // 1015 is reserved and should never be used by user
 
         // 0 - 999 Status codes in the range 0-999 are not used.

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/WebSocketCloseStatus.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/WebSocketCloseStatus.cs
@@ -18,7 +18,7 @@ namespace System.Net.WebSockets
         MessageTooBig = 1009,
         MandatoryExtension = 1010,
         InternalServerError = 1011
-        //non-RFC IANA registered status codes that we allow as valid closing status
+        // non-RFC IANA registered status codes that we allow as valid closing status
         // ServiceRestart = 1012,  // indicates that the server / service is restarting.
         // TryAgainLater = 1013,   // indicates that a temporary server condition forced blocking the client's request.
         // BadGateway = 1014       // indicates that the server acting as gateway received an invalid response

--- a/src/libraries/System.Net.WebSockets/tests/System.Net.WebSockets.Tests.csproj
+++ b/src/libraries/System.Net.WebSockets/tests/System.Net.WebSockets.Tests.csproj
@@ -6,6 +6,7 @@
     <RdXmlFile Include="default.rd.xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="WebSocketCloseTests.cs" />
     <Compile Include="WebSocketTests.cs" />
     <Compile Include="WebSocketExceptionTests.cs" />
     <Compile Include="WebSocketReceiveResultTests.cs" />

--- a/src/libraries/System.Net.WebSockets/tests/WebSocketCloseTests.cs
+++ b/src/libraries/System.Net.WebSockets/tests/WebSocketCloseTests.cs
@@ -43,7 +43,7 @@ namespace System.Net.WebSockets.Tests
         public void WebSocketReceiveResult_WebSocketCloseStatus_Roundtrip(WebSocketCloseStatus closeStatus)
         {
             string closeStatusDescription = "closeStatus " + closeStatus.ToString();
-            WebSocketReceiveResult wsrr = new WebSocketReceiveResult(42, WebSocketMessageType.Close, true, closeStatus, closeStatusDescription);
+            WebSocketReceiveResult wsrr = new WebSocketReceiveResult(42, WebSocketMessageType.Close, endOfMessage: true, closeStatus, closeStatusDescription);
             Assert.Equal(42, wsrr.Count);
             Assert.Equal(closeStatus, wsrr.CloseStatus);
             Assert.Equal(closeStatusDescription, wsrr.CloseStatusDescription);
@@ -57,8 +57,8 @@ namespace System.Net.WebSockets.Tests
             WebSocketTestStream stream = new();
             Encoding encoding = Encoding.UTF8;
 
-            using (WebSocket server = WebSocket.CreateFromStream(stream, isServer: true, null, TimeSpan.FromSeconds(3)))
-            using (WebSocket client = WebSocket.CreateFromStream(stream.Remote, isServer: false, null, TimeSpan.FromSeconds(3)))
+            using (WebSocket server = WebSocket.CreateFromStream(stream, isServer: true, subProtocol: null, TimeSpan.FromSeconds(3)))
+            using (WebSocket client = WebSocket.CreateFromStream(stream.Remote, isServer: false, subProtocol: null, TimeSpan.FromSeconds(3)))
             {
                 Assert.NotNull(server);
                 Assert.NotNull(client);
@@ -66,7 +66,7 @@ namespace System.Net.WebSockets.Tests
                 // send something
                 string hello = "Testing " + closeStatus.ToString();
                 byte[] sendBytes = encoding.GetBytes(hello);
-                await server.SendAsync(sendBytes.AsMemory(), WebSocketMessageType.Text, WebSocketMessageFlags.DisableCompression, CancellationToken);
+                await server.SendAsync(sendBytes.AsMemory(), WebSocketMessageType.Text, WebSocketMessageFlags.None, CancellationToken);
 
                 // and then server-side close with the test status
                 string closeStatusDescription = "CloseStatus " + closeStatus.ToString();
@@ -82,7 +82,7 @@ namespace System.Net.WebSockets.Tests
                 WebSocketReceiveResult closing = await client.ReceiveAsync(new ArraySegment<byte>(receiveBuffer), CancellationToken);
                 Assert.Equal(WebSocketMessageType.Close, closing.MessageType);
                 Assert.Equal(closeStatus, closing.CloseStatus);
-                Assert.Equal(serverMessage, closing.CloseStatusDescription);
+                Assert.Equal(closeStatusDescription, closing.CloseStatusDescription);
             }
         }
     }

--- a/src/libraries/System.Net.WebSockets/tests/WebSocketCloseTests.cs
+++ b/src/libraries/System.Net.WebSockets/tests/WebSocketCloseTests.cs
@@ -42,11 +42,11 @@ namespace System.Net.WebSockets.Tests
         [MemberData(nameof(CloseStatuses))]
         public void WebSocketReceiveResult_WebSocketCloseStatus_Roundtrip(WebSocketCloseStatus closeStatus)
         {
-            string serverMessage = "closeStatus " + closeStatus.ToString();
-            WebSocketReceiveResult wsrr = new WebSocketReceiveResult(42, WebSocketMessageType.Close, true, closeStatus, serverMessage);
+            string closeStatusDescription = "closeStatus " + closeStatus.ToString();
+            WebSocketReceiveResult wsrr = new WebSocketReceiveResult(42, WebSocketMessageType.Close, true, closeStatus, closeStatusDescription);
             Assert.Equal(42, wsrr.Count);
             Assert.Equal(closeStatus, wsrr.CloseStatus);
-            Assert.Equal(serverMessage, wsrr.CloseStatusDescription);
+            Assert.Equal(closeStatusDescription, wsrr.CloseStatusDescription);
         }
 
         [Theory]

--- a/src/libraries/System.Net.WebSockets/tests/WebSocketCloseTests.cs
+++ b/src/libraries/System.Net.WebSockets/tests/WebSocketCloseTests.cs
@@ -69,8 +69,8 @@ namespace System.Net.WebSockets.Tests
                 await server.SendAsync(sendBytes.AsMemory(), WebSocketMessageType.Text, WebSocketMessageFlags.DisableCompression, CancellationToken);
 
                 // and then server-side close with the test status
-                string serverMessage = "CloseStatus " + closeStatus.ToString();
-                await server.CloseOutputAsync(closeStatus, serverMessage, CancellationToken);
+                string closeStatusDescription = "CloseStatus " + closeStatus.ToString();
+                await server.CloseOutputAsync(closeStatus, closeStatusDescription, CancellationToken);
 
                 // get the hello from the client (after the close message was sent)
                 WebSocketReceiveResult result = await client.ReceiveAsync(new ArraySegment<byte>(receiveBuffer), CancellationToken);

--- a/src/libraries/System.Net.WebSockets/tests/WebSocketCloseTests.cs
+++ b/src/libraries/System.Net.WebSockets/tests/WebSocketCloseTests.cs
@@ -1,0 +1,94 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.WebSockets.Tests
+{
+    public class WebSocketCloseTests
+    {
+        private readonly CancellationTokenSource? _cancellation;
+
+        public WebSocketCloseTests()
+        {
+            if (!Debugger.IsAttached)
+            {
+                _cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            }
+        }
+
+        public CancellationToken CancellationToken => _cancellation?.Token ?? default;
+
+        public static object[][] ClosesData = {
+            new object[] { WebSocketCloseStatus.EndpointUnavailable },
+            new object[] { WebSocketCloseStatus.InternalServerError },
+            new object[] { WebSocketCloseStatus.InvalidMessageType},
+            new object[] { WebSocketCloseStatus.InvalidPayloadData },
+            new object[] { WebSocketCloseStatus.MandatoryExtension },
+            new object[] { WebSocketCloseStatus.MessageTooBig },
+            new object[] { WebSocketCloseStatus.NormalClosure },
+            new object[] { WebSocketCloseStatus.PolicyViolation },
+            new object[] { WebSocketCloseStatus.ProtocolError },
+            new object[] { (WebSocketCloseStatus)1012 },  // ServiceRestart indicates that the server / service is restarting.
+            new object[] { (WebSocketCloseStatus)1013 },  // TryAgainLater indicates that a temporary server condition forced blocking the client's request.
+            new object[] { (WebSocketCloseStatus)1014 },  // BadGateway indicates that the server acting as gateway received an invalid response
+        };
+
+        [Theory]
+        [MemberData(nameof(ClosesData))]
+        public void WebSocketReceiveResult_WebSocketCloseStatus_Roundtrip(WebSocketCloseStatus closeStatus)
+        {
+            string closeStatusDescription = "closeStatus " + closeStatus.ToString();
+            WebSocketReceiveResult wsrr = new WebSocketReceiveResult(42, WebSocketMessageType.Close, true, closeStatus, closeStatusDescription);
+            Assert.Equal(42, wsrr.Count);
+            Assert.Equal(closeStatus, wsrr.CloseStatus);
+            Assert.Equal(closeStatusDescription, wsrr.CloseStatusDescription);
+        }
+
+        [Theory]
+        [MemberData(nameof(ClosesData))]
+        public async Task ReceivesClose(WebSocketCloseStatus closeStatus)
+        {
+            WebSocketTestStream stream = new();
+            using (WebSocket server = WebSocket.CreateFromStream(stream, true, null, TimeSpan.FromSeconds(3)))
+            using (WebSocket client = WebSocket.CreateFromStream(stream.Remote, false, null, TimeSpan.FromSeconds(3)))
+            {
+                Assert.NotNull(server);
+                Assert.NotNull(client);
+
+                string closeStatusDescription = "closeStatus " + closeStatus.ToString();
+                await SendTextAsync(closeStatusDescription, server);
+                var response = await ReceiveAsync(client);
+                Assert.Equal(closeStatusDescription, response);
+
+                string closed = "Closed";
+                await SendTextAsync(closed, server);
+                await server.CloseOutputAsync(closeStatus, closeStatusDescription, CancellationToken);
+
+                var received = await ReceiveAsync(client);
+                Assert.Equal(closed, received);
+            }
+        }
+
+        private async Task<string> ReceiveAsync(WebSocket client)
+        {
+            var buffer = new byte[1024];
+            ValueWebSocketReceiveResult result = await client.ReceiveAsync(buffer.AsMemory(), CancellationToken);
+
+            Assert.True(result.EndOfMessage);
+            Assert.Equal(WebSocketMessageType.Text, result.MessageType);
+            return Encoding.UTF8.GetString(buffer.AsSpan(0, result.Count));
+        }
+
+        private ValueTask SendTextAsync(string text, WebSocket websocket)
+        {
+            WebSocketMessageFlags flags = WebSocketMessageFlags.EndOfMessage | WebSocketMessageFlags.DisableCompression;
+            byte[] bytes = Encoding.UTF8.GetBytes(text);
+            return websocket.SendAsync(bytes.AsMemory(), WebSocketMessageType.Text, flags, CancellationToken);
+        }
+    }
+}

--- a/src/libraries/System.Net.WebSockets/tests/WebSocketCloseTests.cs
+++ b/src/libraries/System.Net.WebSockets/tests/WebSocketCloseTests.cs
@@ -23,7 +23,7 @@ namespace System.Net.WebSockets.Tests
 
         public CancellationToken CancellationToken => _cancellation?.Token ?? default;
 
-        public static object[][] ClosesData = {
+        public static object[][] CloseStatuses = {
             new object[] { WebSocketCloseStatus.EndpointUnavailable },
             new object[] { WebSocketCloseStatus.InternalServerError },
             new object[] { WebSocketCloseStatus.InvalidMessageType},

--- a/src/libraries/System.Net.WebSockets/tests/WebSocketCloseTests.cs
+++ b/src/libraries/System.Net.WebSockets/tests/WebSocketCloseTests.cs
@@ -51,7 +51,7 @@ namespace System.Net.WebSockets.Tests
 
         [Theory]
         [MemberData(nameof(ClosesData))]
-        public async Task ReceivesClose(WebSocketCloseStatus closeStatus)
+        public async Task ReceiveAsync_ValidCloseStatus_Success(WebSocketCloseStatus closeStatus)
         {
             WebSocketTestStream stream = new();
             using (WebSocket server = WebSocket.CreateFromStream(stream, true, null, TimeSpan.FromSeconds(3)))

--- a/src/libraries/System.Net.WebSockets/tests/WebSocketCloseTests.cs
+++ b/src/libraries/System.Net.WebSockets/tests/WebSocketCloseTests.cs
@@ -57,8 +57,8 @@ namespace System.Net.WebSockets.Tests
             WebSocketTestStream stream = new();
             Encoding encoding = Encoding.UTF8;
 
-            using (WebSocket server = WebSocket.CreateFromStream(stream, true, null, TimeSpan.FromSeconds(3)))
-            using (WebSocket client = WebSocket.CreateFromStream(stream.Remote, false, null, TimeSpan.FromSeconds(3)))
+            using (WebSocket server = WebSocket.CreateFromStream(stream, isServer: true, null, TimeSpan.FromSeconds(3)))
+            using (WebSocket client = WebSocket.CreateFromStream(stream.Remote, isServer: false, null, TimeSpan.FromSeconds(3)))
             {
                 Assert.NotNull(server);
                 Assert.NotNull(client);


### PR DESCRIPTION
Add ServiceRestart (1012), TryAgainLater (1013), and BadGateway (1014) to the list of `WebSocketCloseStatus` values and allow them to be used as valid WebSocket close statuses so we don't reject the close and discard the status description by adding them to the private `IsValueCloseStatus` method switch statement declaring them as valid `true`.

Fixes https://github.com/dotnet/runtime/issues/82602

# Description

The current implementation of `ManagedWebSocket` explicitly declares some `WebSocketCloseStatus` values as "acceptable" reasons to close the socket. For those, the information status description is extracted and made available. For all other values, the close status is rejected and the closing information is discarded.

This means that things like `BadGateway` (1014), or `ServiceRestart` (1012),  or `TryAgainLater` (1013)  will be declared invalid by `ManagedWebSocket.IsValidCloseStatus` and thus not handled cleanly even though they could happen after a web socket is completely setup. These codes are documented [here](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code) as valid server-initiated close reasons.

# Customer Impact

Lost information and ragged closing of a web socket when a server-side or proxy closes because of any of the previously rejected values:

*  ServiceRestart = 1012  // indicates that the server / service is restarting.
*  TryAgainLater = 1013   // indicates that a temporary server condition forced blocking the client's request.
*  BadGateway = 1014       // indicates that the server acting as gateway received an invalid response

This codes are documented [here](https://kapeli.com/cheat_sheets/WebSocket_Status_Codes.docset/Contents/Resources/Documents/index) and [here as IANA registered](https://netty.io/4.1/api/io/netty/handler/codec/http/websocketx/WebSocketCloseStatus.html) and in the [Mozilla docs](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code) 

# Regression

No

# Testing

Added test cases for all three to new WebSocketCloseTests.cs file with no regressions in current tests.

# Risk

This **does not** change the public enum of `WebSocketCloseStatus` as we don't want to invoke public review and the values are not mentioned in the RFC.

# Package authoring signed off?

N/A
