### PR TITLE
[workload] Fix using empty RuntimeIdentifier in LibraryBuilder AutoImport.props

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Runtime.LibraryBuilder.Sdk/Sdk/AutoImport.props
+++ b/src/mono/nuget/Microsoft.NET.Runtime.LibraryBuilder.Sdk/Sdk/AutoImport.props
@@ -1,7 +1,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <PropertyGroup>
-    <TargetOS>$(RuntimeIdentifier.Substring(0, $(RuntimeIdentifier.IndexOf('-'))))</TargetOS>
+    <TargetOS Condition="'$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier.Substring(0, $(RuntimeIdentifier.IndexOf('-'))))</TargetOS>
 
     <TargetsAppleMobile Condition="'$(TargetOS)' == 'ios' or '$(TargetOS)' == 'iossimulator' or '$(TargetOS)' == 'maccatalyst' or '$(TargetOS)' == 'tvos' or '$(TargetOS)' == 'tvossimulator'">true</TargetsAppleMobile>
     <TargetsAndroid Condition="'$(TargetOS)' == 'android'">true</TargetsAndroid>

--- a/src/mono/nuget/Microsoft.NET.Runtime.LibraryBuilder.Sdk/Sdk/AutoImport.props
+++ b/src/mono/nuget/Microsoft.NET.Runtime.LibraryBuilder.Sdk/Sdk/AutoImport.props
@@ -1,7 +1,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Project>
   <PropertyGroup>
-    <TargetOS Condition="'$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier.Substring(0, $(RuntimeIdentifier.IndexOf('-'))))</TargetOS>
+    <TargetOS Condition="'$(RuntimeIdentifier)' != '' and $(RuntimeIdentifier.Contains('-'))">$(RuntimeIdentifier.Substring(0, $(RuntimeIdentifier.IndexOf('-'))))</TargetOS>
 
     <TargetsAppleMobile Condition="'$(TargetOS)' == 'ios' or '$(TargetOS)' == 'iossimulator' or '$(TargetOS)' == 'maccatalyst' or '$(TargetOS)' == 'tvos' or '$(TargetOS)' == 'tvossimulator'">true</TargetsAppleMobile>
     <TargetsAndroid Condition="'$(TargetOS)' == 'android'">true</TargetsAndroid>


### PR DESCRIPTION
When `mobile-librarybuilder-experimental` is installed, the LibraryBuilder SDK AutoImport.props activates and it incorrectly tries to IndexOf RuntimeIdentifier even when it's an empty string. This can lead to annoying error messages popping up even when not using the workload.

The fix is to add a condition only when RuntimeIdentifier has a value.