### PR TITLE
Reimplement DacStackReferenceWalker and DacHandleWalker

### DIFF
--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -7634,8 +7634,8 @@ void DacHandleWalker::WalkHandles()
 
     DacHandleWalkerParam param(&mList);
     
-    dac_handle_table_map *map = g_gcDacGlobals->handle_table_map;
-    while (SUCCEEDED(param.Result) && map)
+    
+    for (dac_handle_table_map *map = g_gcDacGlobals->handle_table_map; SUCCEEDED(param.Result) && map; map = map->pNext)
     {
         for (int i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE && SUCCEEDED(param.Result); ++i)
         {
@@ -7672,8 +7672,6 @@ void DacHandleWalker::WalkHandles()
                     }
                 }
             }
-
-            map = map->pNext;
         }
     }
 }

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -7808,7 +7808,10 @@ void DacStackReferenceWalker::GCEnumCallbackDbi(LPVOID hCallback, OBJECTREF *pOb
         data.pObject = pObject->GetAddr() | 1;
 
     data.dwType = CorReferenceStack;
-    data.i64ExtraData = 0;
+    if (!dsc->resolvePointers && (flags & GC_CALL_INTERIOR))
+        data.i64ExtraData = GC_CALL_INTERIOR;
+    else
+        data.i64ExtraData = 0;
 
     pList->Add(data);
 }
@@ -7839,7 +7842,7 @@ void DacStackReferenceWalker::GCReportCallbackDbi(PTR_PTR_Object ppObj, ScanCont
     data.vmDomain.SetDacTargetPtr(AppDomain::GetCurrentDomain().GetAddr());
     data.objHnd.SetDacTargetPtr(obj);
     data.dwType = CorReferenceStack;
-    if (!dsc->resolvePointers)
+    if (!dsc->resolvePointers && (flags & GC_CALL_INTERIOR))
         data.i64ExtraData = GC_CALL_INTERIOR;
     else
         data.i64ExtraData = 0;

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -7726,7 +7726,7 @@ HRESULT DacHandleWalker::Next(ULONG count, DacGcReference roots[], ULONG *pFetch
 
         #if defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS) || defined(FEATURE_OBJCMARSHAL)
             case HNDTYPE_REFCOUNTED:
-                GetRefCountedHandleInfo((OBJECTREF)handle.Handle, handle.Type, &refCnt, NULL, NULL, NULL);
+                GetRefCountedHandleInfo((OBJECTREF)CLRDATA_ADDRESS_TO_TADDR(handle.Handle), handle.Type, &refCnt, NULL, NULL, NULL);
                 roots[i].i64ExtraData = refCnt;
                 roots[i].dwType = (DWORD)(roots[i].i64ExtraData ? CorHandleStrongRefCount : CorHandleWeakRefCount);
                 break;
@@ -7734,7 +7734,7 @@ HRESULT DacHandleWalker::Next(ULONG count, DacGcReference roots[], ULONG *pFetch
 
             case HNDTYPE_DEPENDENT:
                 roots[i].dwType = (DWORD)CorHandleStrongDependent;
-                roots[i].i64ExtraData = GetDependentHandleSecondary(handle.Handle).GetAddr();
+                roots[i].i64ExtraData = GetDependentHandleSecondary(CLRDATA_ADDRESS_TO_TADDR(handle.Handle)).GetAddr();
                 break;
 
             case HNDTYPE_ASYNCPINNED:

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -7618,7 +7618,7 @@ HRESULT DacRefWalker::Next(ULONG celt, DacGcReference roots[], ULONG *pceltFetch
     {
         hr = mHandleWalker->Next(celt, roots, &total);
 
-        if (hr == S_FALSE || FAILED(hr))
+        if (total == 0 || FAILED(hr))
         {
             delete mHandleWalker;
             mHandleWalker = NULL;

--- a/src/coreclr/debug/daccess/dacdbiimpl.h
+++ b/src/coreclr/debug/daccess/dacdbiimpl.h
@@ -1176,7 +1176,7 @@ protected:
 class DacRefWalker
 {
 public:
-    DacRefWalker(ClrDataAccess *dac, BOOL walkStacks, BOOL walkFQ, UINT32 handleMask);
+    DacRefWalker(ClrDataAccess *dac, BOOL walkStacks, BOOL walkFQ, UINT32 handleMask, BOOL resolvePointers);
     ~DacRefWalker();
 
     HRESULT Init();
@@ -1194,6 +1194,7 @@ private:
 
     // Stacks
     DacStackReferenceWalker *mStackWalker;
+    BOOL mResolvePointers;
 
     // Handles
     DacHandleWalker *mHandleWalker;

--- a/src/coreclr/debug/daccess/dacimpl.h
+++ b/src/coreclr/debug/daccess/dacimpl.h
@@ -1939,7 +1939,7 @@ class DacReferenceList
 
         const T& Get(unsigned int index) const
         {
-            assert(index < _count);
+            _ASSERTE(index < _count);
             return _array[index];
         }
 
@@ -1962,29 +1962,23 @@ class DacStackReferenceWalker : public DefaultCOMImpl<ISOSStackRefEnum, IID_ISOS
     struct DacScanContext : public ScanContext
     {
         DacStackReferenceWalker *pWalker;
-        DacReferenceList<SOSStackRefData> *pSOSList;
-        void *pDbiData;
+        DacReferenceList<SOSStackRefData> *pList;
         Frame *pFrame;
         TADDR sp, pc;
         bool stop;
         bool resolvePointers;
         GCEnumCallback pEnumFunc;
 
-        DacScanContext(DacStackReferenceWalker *walker, DacReferenceList<SOSStackRefData> *sos, void *dbi, bool resolveInteriorPointers)
-            : pWalker(walker), pSOSList(sos), pDbiData(dbi), pFrame(0), sp(0), pc(0), stop(false), resolvePointers(resolveInteriorPointers), pEnumFunc(0)
+        DacScanContext(DacStackReferenceWalker *walker, DacReferenceList<SOSStackRefData> *list, bool resolveInteriorPointers)
+            : pWalker(walker), pList(list), pFrame(0), sp(0), pc(0), stop(false), resolvePointers(resolveInteriorPointers), pEnumFunc(0)
         {
-            assert(walker);
-            assert(sos || dbi);
+            _ASSERTE(pWalker);
+            _ASSERTE(pList);
         }
     };
 
 public:
-    DacStackReferenceWalker(ClrDataAccess *dac, DWORD osThreadID, bool resolveInteriorPointers, void *dbiData = 0);
-    virtual ~DacStackReferenceWalker()
-    {
-        if (mDbiData)
-            CleanupDbiData();
-    }
+    DacStackReferenceWalker(ClrDataAccess *dac, DWORD osThreadID, bool resolveInteriorPointers);
 
     HRESULT Init();
 
@@ -2006,16 +2000,12 @@ public:
 
 private:
     static StackWalkAction Callback(CrawlFrame *pCF, VOID *pData);
-    static void GCEnumCallbackSOS(LPVOID hCallback, OBJECTREF *pObject, uint32_t flags, DacSlotLocation loc);
-    static void GCReportCallbackSOS(PTR_PTR_Object ppObj, ScanContext *sc, uint32_t flags);
-    static void GCEnumCallbackDbi(LPVOID hCallback, OBJECTREF *pObject, uint32_t flags, DacSlotLocation loc);
-    static void GCReportCallbackDbi(PTR_PTR_Object ppObj, ScanContext *sc, uint32_t flags);
-    unsigned int GetDbiCount();
+    static void GCEnumCallback(LPVOID hCallback, OBJECTREF *pObject, uint32_t flags, DacSlotLocation loc);
+    static void GCReportCallback(PTR_PTR_Object ppObj, ScanContext *sc, uint32_t flags);
 
     CLRDATA_ADDRESS ReadPointer(TADDR addr);
 
     void WalkStack();
-    void CleanupDbiData();
 
 private:
     // Dac variables required for entering/leaving the dac.
@@ -2023,8 +2013,7 @@ private:
     ULONG32 m_instanceAge;
 
     // Storage
-    DacReferenceList<SOSStackRefData> mSOSData;
-    void* mDbiData;
+    DacReferenceList<SOSStackRefData> mList;
 
     // Operational variables
     Thread *mThread;
@@ -2052,7 +2041,7 @@ class DacHandleWalker : public DefaultCOMImpl<ISOSHandleEnum, IID_ISOSHandleEnum
         DacHandleWalkerParam(DacReferenceList<SOSHandleData> *list)
             : List(list), Result(S_OK), AppDomain(0), Type(0)
         {
-            assert(list);
+            _ASSERTE(list);
         }
     };
 

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -617,7 +617,7 @@ ClrDataAccess::GetStackReferences(DWORD osThreadID, ISOSStackRefEnum **ppEnum)
 
     SOSDacEnter();
 
-    DacStackReferenceWalker *walker = new (nothrow) DacStackReferenceWalker(this, osThreadID);
+    DacStackReferenceWalker *walker = new (nothrow) DacStackReferenceWalker(this, osThreadID, true, false);
 
     if (walker == NULL)
     {

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -617,7 +617,7 @@ ClrDataAccess::GetStackReferences(DWORD osThreadID, ISOSStackRefEnum **ppEnum)
 
     SOSDacEnter();
 
-    DacStackReferenceWalker *walker = new (nothrow) DacStackReferenceWalker(this, osThreadID, true, false);
+    DacStackReferenceWalker *walker = new (nothrow) DacStackReferenceWalker(this, osThreadID, false);
 
     if (walker == NULL)
     {


### PR DESCRIPTION
Added a flag to not resolve interior pointers to the start of the object. This allows the debugger to shoulder that burden instead of the dac doing this work. This greatly speeds up stack root walking.

Greatly simplified the logic here:

- The old logic will store the pointer passed to `::Next` past the call, and while this doesn't strictly corrupt memory, it's tricky to call this code correctly.
- Eliminated all of the complicated pointer math to fill the DBI vs SOS data structures.  We now instead just produce the SOS data structure and then convert those data structures to DBI ones on demand.