### PR TITLE
Enable CS1591 in System.Formats.Cbor

### DIFF
--- a/src/libraries/System.Formats.Cbor/src/System.Formats.Cbor.csproj
+++ b/src/libraries/System.Formats.Cbor/src/System.Formats.Cbor.csproj
@@ -9,6 +9,7 @@
 Commonly Used Types:
 System.Formats.Cbor.CborReader
 System.Formats.Cbor.CborWriter</PackageDescription>
+    <SkipArcadeNoWarnCS1591>false</SkipArcadeNoWarnCS1591>
   </PropertyGroup>
 
   <ItemGroup>
@@ -42,7 +43,7 @@ System.Formats.Cbor.CborWriter</PackageDescription>
     <Compile Include="System\Formats\Cbor\Reader\CborReader.Simple.netcoreapp.cs" />
     <Compile Include="System\Formats\Cbor\Writer\CborWriter.Simple.netcoreapp.cs" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <Compile Include="System\Formats\Cbor\CborHelpers.netstandard.cs" />
     <Compile Include="System\Formats\Cbor\HalfHelpers.netstandard.cs" />


### PR DESCRIPTION
Partially addresses: https://github.com/dotnet/runtime/issues/49120

CS1591 is the rule that makes triple slash comments mandatory in public APIs.

It was globally suppressed in Arcade, which wasn't ideal, but we introduced a property in https://github.com/dotnet/arcade/pull/12188 to allow using the rule in specific assemblies.

We enabled the `SkipArcadeNoWarnCS1591` property by default in the runtime repo with PR: https://github.com/dotnet/runtime/pull/79134

And now we can use it in the assembly that can successfully generate its own triple slash xml as source of truth.

I manually tested that the rule works by:
- Building the assembly. It succeeds, all public APIs are documented as expected.
- Removing an existing triple slash line from a public API, then building. It fails with the expected error message.