### PR TITLE
better link to open new issues in other repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Also see info about related [Microsoft .NET Core and ASP.NET Core Bug Bounty Pro
 
 This repo should contain issues that are tied to the runtime, the class libraries and frameworks, the installation of the `dotnet` binary (sometimes known as the `muxer`) and installation of the .NET runtime and libraries.
 
-For other issues, please file them to their appropriate sibling repos. Their respective links are described in the [config issue template doc](/.github/ISSUE_TEMPLATE/config.yml).
+For other issues, please file them to their appropriate sibling repos. We have links to many of them on [our new issue page](https://github.com/dotnet/runtime/issues/new/choose).
 
 ## Useful Links
 


### PR DESCRIPTION
linking to the actual page that has links to open issues in other repos, not the template.