### PR TITLE
[Test] Remove dotnet7 feeds from NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -16,9 +16,6 @@
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
-    <!-- TODO: Remove dotnet7 feeds when dependencies publish into dotnet8 feeds: https://github.com/dotnet/runtime/issues/63375. -->
-    <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
-    <add key="dotnet7-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7-transport/nuget/v3/index.json" />
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <add key="dotnet8-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-transport/nuget/v3/index.json" />
   </packageSources>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/63375

If all dependencies are getting published to dotnet8 and dotnet8-transport now, we should be able to remove these lines.