### PR TITLE
Handle custom modifiers on parameter constraints

### DIFF
--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/Ecma/EcmaGenericParameterType.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/Ecma/EcmaGenericParameterType.cs
@@ -50,6 +50,16 @@ namespace System.Reflection.TypeLoading.Ecma
             foreach (GenericParameterConstraintHandle h in handles)
             {
                 RoType constraint = h.GetGenericParameterConstraint(reader).Type.ResolveTypeDefRefOrSpec(GetEcmaModule(), typeContext);
+
+                // A constraint can have modifiers such as 'System.Runtime.InteropServices.UnmanagedType' which here is a 'System.ValueType'
+                // modified type with a modreq for 'UnmanagedType' which would be obtainable through 'GetRequiredCustomModifiers()'.
+                // However, for backwards compat, just return the unmodified type ('ValueType' in this case). This also prevents modified types from
+                // "leaking" into an unmodified type hierarchy.
+                if (constraint is RoModifiedType)
+                {
+                    constraint = (RoType)constraint.UnderlyingSystemType;
+                }
+
                 constraints[index++] = constraint;
             }
             return constraints;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/83679.

Addresses an edge case where a custom modifier is used for a parameter constraint which caused a "modified" type to leak into the "unmodified" type universe which is not prepared for it (calling `BaseType` or `Equals()` for example throws on a modified type).