### PR TITLE
JIT: experimental changes to redundant branch opts

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7142,6 +7142,8 @@ public:
     PhaseStatus optRedundantBranches();
     bool optRedundantRelop(BasicBlock* const block);
     bool optRedundantBranch(BasicBlock* const block);
+    bool optHasIgnorableSideEffects(BasicBlock* const block);
+    bool optSubsumeRelop(BasicBlock* const block, BasicBlock* const domBlock, bool trueReaches);
     bool optJumpThreadDom(BasicBlock* const block, BasicBlock* const domBlock, bool domIsSameRelop);
     bool optJumpThreadPhi(BasicBlock* const block, GenTree* tree, ValueNum treeNormVN);
     bool optJumpThreadCheck(BasicBlock* const block, BasicBlock* const domBlock);

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -990,6 +990,9 @@ public:
     // Returns true iff the VN represents a relop
     bool IsVNRelop(ValueNum vn);
 
+    // Returns true iff the VNFuncApp represents a relop
+    bool IsVNFuncAppRelop(const VNFuncApp& app);
+
     enum class VN_RELATION_KIND
     {
         VRK_Inferred,   // (x ?  y)


### PR DESCRIPTION
Recognize a particular case where a control flow pattern involving two BBJ_COND blocks with relops that test the same VNs can be simplified to a single relop in the dominating block.

As part of this, teach VN about some of the rudiments of boolean simplification (DeMorgan's laws)  and how to simplify some NOT / AND / OR expressions involving relops.

Addresses some of the cases in #81220.