### PR TITLE
Explicitly require `.eh_frame_hdr` section

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -159,8 +159,8 @@ The .NET Foundation licenses this file to you under the MIT license.
       <!-- FreeBSD's inotify is an installed package and not found in default libraries  -->
       <LinkerArg Include="-L/usr/local/lib -linotify" Condition="'$(_targetOS)' == 'freebsd'" />
       <LinkerArg Include="-Wl,-segprot,__THUNKS,rx,rx" Condition="'$(_IsiOSLikePlatform)' == 'true'" />
-
       <LinkerArg Include="@(NativeFramework->'-framework %(Identity)')" Condition="'$(_IsApplePlatform)' == 'true'" />
+      <LinkerArg Include="-Wl,--eh-frame-hdr" Condition="'$(_IsApplePlatform)' != 'true'" />
     </ItemGroup>
 
     <Exec Command="command -v &quot;$(CppLinker)&quot;" IgnoreExitCode="true" StandardOutputImportance="Low">


### PR DESCRIPTION
Currently, `clang` on Alpine Linux by default passes `--eh-frame-hdr` to linker with `-static`, while gcc does not. The defaults depend on how these toolchains were configured and vary by distro..

We depend on `.eh_frame_hdr` section in all combinations:
{clang, gcc} x {bfd, lld, gold, mold} x {shared, static} x {executable, library} x {pie, static, no-pie}

Therefore, we should explicitly specify what is needed (rather than depending on toolchain's defaults). Diffing the clang vs. gcc generated object sections with `readelf -S` revelead this difference.

Fixes https://github.com/dotnet/runtime/issues/83791

ps - ld64 on macOS does not support this option, so omitted Apple-likes.