### PR TITLE
Improve incremental handling in regex generator

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Parser.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Parser.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -19,7 +20,7 @@ namespace System.Text.RegularExpressions.Generator
         private const string GeneratedRegexAttributeName = "System.Text.RegularExpressions.GeneratedRegexAttribute";
 
         // Returns null if nothing to do, Diagnostic if there's an error to report, or RegexType if the type was analyzed successfully.
-        private static object? GetSemanticTargetForGeneration(
+        private static object? GetRegexMethodDataOrFailureDiagnostic(
             GeneratorAttributeSyntaxContext context, CancellationToken cancellationToken)
         {
             var methodSyntax = (MethodDeclarationSyntax)context.TargetNode;
@@ -27,9 +28,8 @@ namespace System.Text.RegularExpressions.Generator
 
             Compilation compilation = sm.Compilation;
             INamedTypeSymbol? regexSymbol = compilation.GetBestTypeByMetadataName(RegexName);
-            INamedTypeSymbol? generatedRegexAttributeSymbol = compilation.GetBestTypeByMetadataName(GeneratedRegexAttributeName);
 
-            if (regexSymbol is null || generatedRegexAttributeSymbol is null)
+            if (regexSymbol is null)
             {
                 // Required types aren't available
                 return null;
@@ -47,69 +47,49 @@ namespace System.Text.RegularExpressions.Generator
                 return null;
             }
 
-            ImmutableArray<AttributeData>? boundAttributes = regexMethodSymbol.GetAttributes();
-            if (boundAttributes is null || boundAttributes.Value.Length == 0)
+            ImmutableArray<AttributeData> boundAttributes = context.Attributes;
+            if (boundAttributes.Length != 1)
             {
-                return null;
+                return Diagnostic.Create(DiagnosticDescriptors.MultipleGeneratedRegexAttributes, methodSyntax.GetLocation());
+            }
+            AttributeData generatedRegexAttr = boundAttributes[0];
+
+            if (generatedRegexAttr.ConstructorArguments.Any(ca => ca.Kind == TypedConstantKind.Error))
+            {
+                return Diagnostic.Create(DiagnosticDescriptors.InvalidGeneratedRegexAttribute, methodSyntax.GetLocation());
             }
 
-            bool attributeFound = false;
-            string? pattern = null;
+            ImmutableArray<TypedConstant> items = generatedRegexAttr.ConstructorArguments;
+            if (items.Length is 0 or > 4)
+            {
+                return Diagnostic.Create(DiagnosticDescriptors.InvalidGeneratedRegexAttribute, methodSyntax.GetLocation());
+            }
+
+            string? pattern = items[0].Value as string;
             int? options = null;
             int? matchTimeout = null;
             string? cultureName = string.Empty;
-            foreach (AttributeData attributeData in boundAttributes)
+            if (items.Length >= 2)
             {
-                if (!SymbolEqualityComparer.Default.Equals(attributeData.AttributeClass, generatedRegexAttributeSymbol))
+                options = items[1].Value as int?;
+                if (items.Length == 4)
                 {
-                    continue;
+                    matchTimeout = items[2].Value as int?;
+                    cultureName = items[3].Value as string;
                 }
-
-                if (attributeData.ConstructorArguments.Any(ca => ca.Kind == TypedConstantKind.Error))
+                // If there are 3 parameters, we need to check if the third argument is
+                // int matchTimeoutMilliseconds, or string cultureName.
+                else if (items.Length == 3)
                 {
-                    return Diagnostic.Create(DiagnosticDescriptors.InvalidGeneratedRegexAttribute, methodSyntax.GetLocation());
-                }
-
-                if (pattern is not null)
-                {
-                    return Diagnostic.Create(DiagnosticDescriptors.MultipleGeneratedRegexAttributes, methodSyntax.GetLocation());
-                }
-
-                ImmutableArray<TypedConstant> items = attributeData.ConstructorArguments;
-                if (items.Length == 0 || items.Length > 4)
-                {
-                    return Diagnostic.Create(DiagnosticDescriptors.InvalidGeneratedRegexAttribute, methodSyntax.GetLocation());
-                }
-
-                attributeFound = true;
-                pattern = items[0].Value as string;
-                if (items.Length >= 2)
-                {
-                    options = items[1].Value as int?;
-                    if (items.Length == 4)
+                    if (items[2].Type?.SpecialType == SpecialType.System_Int32)
                     {
                         matchTimeout = items[2].Value as int?;
-                        cultureName = items[3].Value as string;
                     }
-                    // If there are 3 parameters, we need to check if the third argument is
-                    // int matchTimeoutMilliseconds, or string cultureName.
-                    else if (items.Length == 3)
+                    else
                     {
-                        if (items[2].Type?.SpecialType == SpecialType.System_Int32)
-                        {
-                            matchTimeout = items[2].Value as int?;
-                        }
-                        else
-                        {
-                            cultureName = items[2].Value as string;
-                        }
+                        cultureName = items[2].Value as string;
                     }
                 }
-            }
-
-            if (!attributeFound)
-            {
-                return null;
             }
 
             if (pattern is null || cultureName is null)
@@ -128,7 +108,7 @@ namespace System.Text.RegularExpressions.Generator
 
             RegexOptions regexOptions = options is not null ? (RegexOptions)options : RegexOptions.None;
 
-            // If  RegexOptions.IgnoreCase was specified or the inline ignore case option `(?i)` is present in the pattern, then we will (in priority order):
+            // If RegexOptions.IgnoreCase was specified or the inline ignore case option `(?i)` is present in the pattern, then we will (in priority order):
             // - If a culture name was passed in:
             //   - If RegexOptions.CultureInvariant was also passed in, then we emit a diagnostic due to the explicit conflict.
             //   - We try to initialize a culture using the passed in culture name to be used for case-sensitive comparisons. If
@@ -195,7 +175,7 @@ namespace System.Text.RegularExpressions.Generator
                 ns ?? string.Empty,
                 $"{typeDec.Identifier}{typeDec.TypeParameterList}");
 
-            var regexMethod = new RegexPatternAndSyntax(
+            var result = new RegexPatternAndSyntax(
                 regexType,
                 GetComparableLocation(methodSyntax),
                 regexMethodSymbol.Name,
@@ -219,7 +199,7 @@ namespace System.Text.RegularExpressions.Generator
                 parent = parent.Parent as TypeDeclarationSyntax;
             }
 
-            return regexMethod;
+            return result;
 
             static bool IsAllowedKind(SyntaxKind kind) =>
                 kind == SyntaxKind.ClassDeclaration ||
@@ -228,6 +208,9 @@ namespace System.Text.RegularExpressions.Generator
                 kind == SyntaxKind.RecordStructDeclaration ||
                 kind == SyntaxKind.InterfaceDeclaration;
 
+
+            // Get a Location object that doesn't store a reference to the compilation.
+            // That allows it to compare equally across compilations.
             static Location GetComparableLocation(MethodDeclarationSyntax method)
             {
                 var location = method.GetLocation();
@@ -235,9 +218,10 @@ namespace System.Text.RegularExpressions.Generator
             }
         }
 
+        /// <summary>Data about a regex directly from the GeneratedRegex attribute.</summary>
         internal sealed record RegexPatternAndSyntax(RegexType DeclaringType, Location DiagnosticLocation, string MethodName, string Modifiers, string Pattern, RegexOptions Options, int? MatchTimeout, CultureInfo Culture);
 
-        /// <summary>A regex method.</summary>
+        /// <summary>Data about a regex, including a fully parsed RegexTree and subsequent analysis.</summary>
         internal sealed record RegexMethod(RegexType DeclaringType, Location DiagnosticLocation, string MethodName, string Modifiers, string Pattern, RegexOptions Options, int? MatchTimeout, RegexTree Tree, AnalysisResults Analysis)
         {
             public string? GeneratedName { get; set; }

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
@@ -57,33 +57,43 @@ namespace System.Text.RegularExpressions.Generator
                 context.SyntaxProvider
 
                 // Find all MethodDeclarationSyntax nodes attributed with GeneratedRegex and gather the required information.
+                // The predicate will be run once for every attributed node in the same file that's being modified.
+                // The transform will be run once for every attributed node in the compilation.
+                // Thus, both should do the minimal amount of work required and get out.  This should also have extracted
+                // everything from the target necessary to do all subsequent analysis and should return an object that's
+                // meaningfully comparable and that doesn't reference anything from the compilation: we want to ensure
+                // that any successful cached results are idempotent for the input such that they don't trigger downstream work
+                // if there are no changes.
                 .ForAttributeWithMetadataName(
                     GeneratedRegexAttributeName,
                     (node, _) => node is MethodDeclarationSyntax,
-                    GetSemanticTargetForGeneration)
+                    GetRegexMethodDataOrFailureDiagnostic)
+
+                // Filter out any parsing errors that resulted in null objects being returned.
                 .Where(static m => m is not null)
 
-                // Generate the tree and analysis from the pattern
+                // The input here will either be a Diagnostic (in the case of something erroneous detected in GetRegexMethodDataOrFailureDiagnostic)
+                // or it will be a RegexPatternAndSyntax containing all of the successfully parsed data from the attribute/method.
                 .Select((methodOrDiagnostic, _) =>
                 {
-                    if (methodOrDiagnostic is not RegexPatternAndSyntax method)
+                    if (methodOrDiagnostic is RegexPatternAndSyntax method)
                     {
-                        return methodOrDiagnostic;
+                        try
+                        {
+                            RegexTree regexTree = RegexParser.Parse(method.Pattern, method.Options | RegexOptions.Compiled, method.Culture); // make sure Compiled is included to get all optimizations applied to it
+                            AnalysisResults analysis = RegexTreeAnalyzer.Analyze(regexTree);
+                            return new RegexMethod(method.DeclaringType, method.DiagnosticLocation, method.MethodName, method.Modifiers, method.Pattern, method.Options, method.MatchTimeout, regexTree, analysis);
+                        }
+                        catch (Exception e)
+                        {
+                            return Diagnostic.Create(DiagnosticDescriptors.InvalidRegexArguments, method.DiagnosticLocation, e.Message);
+                        }
                     }
 
-                    try
-                    {
-                        RegexTree regexTree = RegexParser.Parse(method.Pattern, method.Options | RegexOptions.Compiled, method.Culture); // make sure Compiled is included to get all optimizations applied to it
-                        AnalysisResults analysis = RegexTreeAnalyzer.Analyze(regexTree);
-                        return new RegexMethod(method.DeclaringType, method.DiagnosticLocation, method.MethodName, method.Modifiers, method.Pattern, method.Options, method.MatchTimeout, regexTree, analysis);
-                    }
-                    catch (Exception e)
-                    {
-                        return Diagnostic.Create(DiagnosticDescriptors.InvalidRegexArguments, method.DiagnosticLocation, e.Message);
-                    }
+                    return methodOrDiagnostic;
                 })
 
-                // Incorporate the compilation data, as it impacts code generation.
+                // Now incorporate the compilation data, as it impacts code generation.
                 .Combine(compilationDataProvider)
 
                 // Generate the RunnerFactory for each regex, if possible.  This is where the bulk of the implementation occurs.
@@ -113,6 +123,8 @@ namespace System.Text.RegularExpressions.Generator
                     writer.Indent -= 2;
                     return (regexMethod, sw.ToString(), requiredHelpers, methodOrDiagnosticAndCompilationData.Right);
                 })
+
+                // Combine all of the generated text outputs into a single batch. We then generate a single source output from that batch.
                 .Collect();
 
             // When there something to output, take all the generated strings and concatenate them to output,


### PR DESCRIPTION
I noticed that the regex generator wasn't being as incremental as was intended.  One issue that had previously been pointed out was that the data returned from the initial pipeline stage included a SyntaxNode, which caused comparison of the cached result against a new compilation to fail.  Another issue @chsienki found was that the initial stage was doing the regex parsing and including the parsed regex tree in the result, but that doesn't define anything other than reference equality, so it was also prohibiting reuse of the cached result.  On top of that, even if the caching worked, the regex parsing and analysis is relatively expensive, and it would end up being done on every recompilation regardless of whether the result could be cached.

Chris fixed the location issue by creating a new Location with the relevant file path/span from the original but without referencing the syntax tree.  And he fixed the parsing by moving that logic out into a subsequent stage.

We also cleaned up the parsing routine, which no longer needed to find the GeneratedRegexAttribute on its own, as it's now handed into the method in the context supplied by ForAttributeWithMetadataName.