### PR TITLE
[83871] LINQ Performance

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/AnyAll.cs
+++ b/src/libraries/System.Linq/src/System/Linq/AnyAll.cs
@@ -43,6 +43,29 @@ namespace System.Linq
             return false;
         }
 
+        public static bool Any<TSource>(this TSource[] source, Func<TSource, bool> predicate)
+        {
+            if (source == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            if (predicate == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
+            }
+
+            foreach (TSource element in source)
+            {
+                if (predicate(element))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public static bool All<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
             if (source == null)


### PR DESCRIPTION
#83871 As noted within the issue I created, I observed a rather significant performance between using a `Where.Any` and `Any`. When in reality, it should perform almost the same.

After I created an overload for arrays performance improved (view #83871 for details). It is likely this issue exists in many other areas. 