### PR TITLE
Update Microsoft.Build.* SDKs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -450,7 +450,6 @@
 
   <PropertyGroup>
     <CustomBeforeNoTargets>$(RepositoryEngineeringDir)NoTargetsSdk.BeforeTargets.targets</CustomBeforeNoTargets>
-    <CustomAfterNoTargets>$(RepositoryEngineeringDir)NoTargetsSdk.AfterTargets.targets</CustomAfterNoTargets>
     <CustomAfterTraversalTargets>$(RepositoryEngineeringDir)TraversalSdk.AfterTargets.targets</CustomAfterTraversalTargets>
   </PropertyGroup>
 </Project>

--- a/eng/NoTargetsSdk.AfterTargets.targets
+++ b/eng/NoTargetsSdk.AfterTargets.targets
@@ -1,7 +1,0 @@
-<Project>
-
-  <!-- Reset the following target to avoid copying references to an output directory.
-       TODO: Remove when https://github.com/microsoft/MSBuildSdks/pull/395 is merged. -->
-  <Target Name="CopyFilesToOutputDirectory" />
-
-</Project>

--- a/eng/NoTargetsSdk.BeforeTargets.targets
+++ b/eng/NoTargetsSdk.BeforeTargets.targets
@@ -1,6 +1,8 @@
 <Project>
 
   <PropertyGroup>
+    <!-- NoTargets SDK shouldn't copy files into the intermediate/output directory. -->
+    <SkipCopyFilesMarkedCopyLocal>true</SkipCopyFilesMarkedCopyLocal>
     <!-- NoTargets SDK needs a TFM set. Set a default if the project doesn't multi target. -->
     <TargetFramework Condition="'$(TargetFramework)' == '' and '$(TargetFrameworks)' == ''">$(NetCoreAppCurrent)</TargetFramework>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -11,8 +11,8 @@
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23172.2",
     "Microsoft.DotNet.Helix.Sdk": "8.0.0-beta.23172.2",
     "Microsoft.DotNet.SharedFramework.Sdk": "8.0.0-beta.23172.2",
-    "Microsoft.Build.NoTargets": "3.5.0",
-    "Microsoft.Build.Traversal": "3.1.6",
+    "Microsoft.Build.NoTargets": "3.7.0",
+    "Microsoft.Build.Traversal": "3.4.0",
     "Microsoft.NET.Sdk.IL": "8.0.0-preview.3.23162.2"
   }
 }


### PR DESCRIPTION
Avoids net45 prebuilds in Traversal projects: https://github.com/microsoft/MSBuildSdks/pull/430

@MichaelSimons @NikolaMilosavljevic this fixes the microsoft.netframework.referenceassemblies.net45 prebuild for the entire stack (as long as repos update to the newer version of Traversal). That said, I'm not sure how many repos actually use that msbuild sdk.