### PR TITLE
Exclude a source-gen test project from NativeAOT

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -451,6 +451,7 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.SourceGeneration.Unit.Tests\System.Text.Json.SourceGeneration.Roslyn4.4.Unit.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\FunctionalTests\System.Text.RegularExpressions.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices.JavaScript\tests\JSImportGenerator.UnitTest\JSImportGenerator.Unit.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration.Binder\tests\SourceGenerationTests\Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests.csproj" />
 
     <!-- Depends on DNNE. Not particularly interesting because it tests marshalling-less p/invoke only. Low priority -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices\tests\LibraryImportGenerator.Tests\LibraryImportGenerator.Tests.csproj" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -452,6 +452,7 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\FunctionalTests\System.Text.RegularExpressions.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices.JavaScript\tests\JSImportGenerator.UnitTest\JSImportGenerator.Unit.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration.Binder\tests\SourceGenerationTests\Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration.Binder\tests\UnitTests\Microsoft.Extensions.Configuration.Binder.Tests.csproj" />
 
     <!-- Depends on DNNE. Not particularly interesting because it tests marshalling-less p/invoke only. Low priority -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices\tests\LibraryImportGenerator.Tests\LibraryImportGenerator.Tests.csproj" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -452,7 +452,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\FunctionalTests\System.Text.RegularExpressions.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices.JavaScript\tests\JSImportGenerator.UnitTest\JSImportGenerator.Unit.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration.Binder\tests\SourceGenerationTests\Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration.Binder\tests\UnitTests\Microsoft.Extensions.Configuration.Binder.Tests.csproj" />
 
     <!-- Depends on DNNE. Not particularly interesting because it tests marshalling-less p/invoke only. Low priority -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices\tests\LibraryImportGenerator.Tests\LibraryImportGenerator.Tests.csproj" />
@@ -465,7 +464,7 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ServiceModel.Syndication\tests\System.ServiceModel.Syndication.Tests.csproj" />
 
     <!-- Not supported with trimming. Low priority -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration.Binder\tests\Microsoft.Extensions.Configuration.Binder.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration.Binder\tests\UnitTests\Microsoft.Extensions.Configuration.Binder.Tests.csproj" />
 
     <!-- Built-in COM. Low priority -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Speech\tests\System.Speech.Tests.csproj" />


### PR DESCRIPTION
This one is failing in CI https://dev.azure.com/dnceng-public/public/_build/results?buildId=216092&view=logs&jobId=abdbb26b-d534-5e94-28a6-1260271ac680&j=abdbb26b-d534-5e94-28a6-1260271ac680&t=dbc42842-7b02-597d-a661-290954514df7

```
  Generating native code
EXEC : error : Failed to load assembly 'SQLitePCLRaw.core' [/__w/1/s/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests.csproj::TargetFramework=net8.0]
##[error]EXEC(0,0): error : (NETCORE_ENGINEERING_TELEMETRY=Build) Failed to load assembly 'SQLitePCLRaw.core'
  Internal.TypeSystem.TypeSystemException+FileNotFoundException: Failed to load assembly 'SQLitePCLRaw.core'
     at Internal.TypeSystem.ThrowHelper.ThrowFileNotFoundException(ExceptionStringID, String) + 0x30
     at Internal.TypeSystem.ResolutionFailure.Throw() + 0x100
     at Internal.TypeSystem.Ecma.EcmaModule.GetObject(EntityHandle, NotFoundBehavior) + 0x9b
     at Internal.TypeSystem.Ecma.EcmaSignatureParser.ResolveHandle(EntityHandle) + 0x1e
     at Internal.TypeSystem.Ecma.EcmaSignatureParser.ParseTypeImpl(SignatureTypeCode) + 0x79
     at Internal.TypeSystem.Ecma.EcmaSignatureParser.ParseType(SignatureTypeCode) + 0x47
     at Internal.TypeSystem.Ecma.EcmaSignatureParser.ParseType() + 0x4f
     at Internal.TypeSystem.Ecma.EcmaSignatureParser.ParseFieldSignature() + 0x3b
     at Internal.TypeSystem.Ecma.EcmaField.InitializeFieldType() + 0x10b
     at Internal.TypeSystem.MetadataFieldLayoutAlgorithm.ComputeInstanceLayout(DefType, InstanceLayoutKind) + 0x14a
     at Internal.TypeSystem.DefType.ComputeInstanceLayout(InstanceLayoutKind) + 0x60
     at ILCompiler.CompilerTypeSystemContext.EnsureLoadableTypeUncached(TypeDesc) + 0x450
     at Internal.TypeSystem.LockFreeReaderHashtable`2.CreateValueAndEnsureValueIsInTable(TKey) + 0x14
     at ILCompiler.DependencyAnalysis.EETypeNode..ctor(NodeFactory, TypeDesc) + 0x14f
     at ILCompiler.DependencyAnalysis.NodeFactory.CreateNecessaryTypeNode(TypeDesc) + 0xf4
     at Internal.TypeSystem.LockFreeReaderHashtable`2.CreateValueAndEnsureValueIsInTable(TKey) + 0x14
     at ILCompiler.DependencyAnalysis.NodeFactory.NecessaryTypeSymbol(TypeDesc) + 0x9d
     at ILCompiler.DependencyAnalysis.GenericCompositionNode.GetDehydratableData(NodeFactory, Boolean) + 0x1e2
     at ILCompiler.DependencyAnalysis.DehydratableObjectNode.GetData(NodeFactory, Boolean) + 0x2e
     at ILCompiler.DependencyAnalysis.ObjectNode.GetStaticDependencies(NodeFactory) + 0x39
     at ILCompiler.Program.Run() + 0x16f4
     at ILCompiler.ILCompilerRootCommand.<>c__DisplayClass206_0.<.ctor>b__0(InvocationContext context) + 0x201
/__w/1/s/artifacts/bin/coreclr/linux.x64.Release/build/Microsoft.NETCore.Native.targets(268,5): error MSB3073: The command ""/__w/1/s/artifacts/bin/coreclr/linux.x64.Release/ilc-published/ilc" @"/__w/1/s/artifacts/obj/Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests/Release/net8.0/native/Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests.ilc.rsp"" exited with code 1. [/__w/1/s/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests.csproj::TargetFramework=net8.0]
##[error]artifacts/bin/coreclr/linux.x64.Release/build/Microsoft.NETCore.Native.targets(268,5): error MSB3073: (NETCORE_ENGINEERING_TELEMETRY=Build) The command ""/__w/1/s/artifacts/bin/coreclr/linux.x64.Release/ilc-published/ilc" @"/__w/1/s/artifacts/obj/Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests/Release/net8.0/native/Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests.ilc.rsp"" exited with code 1.
```