### PR TITLE
Make WindowsServiceLifetime gracefully stop

### DIFF
--- a/eng/testing/xunit/xunit.targets
+++ b/eng/testing/xunit/xunit.targets
@@ -6,6 +6,11 @@
                       Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <AutoGenerateBindingRedirects Condition="'$(AutoGenerateBindingRedirects)' == ''">true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType Condition="'$(GenerateBindingRedirectsOutputType)' == ''">true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
+
   <!-- Run target (F5) support. -->
   <PropertyGroup>
     <RunWorkingDirectory Condition="'$(RunWorkingDirectory)' == ''">$(OutDir)</RunWorkingDirectory>

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.QueryServiceStatusEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.QueryServiceStatusEx.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Advapi32
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct SERVICE_STATUS_PROCESS
+        {
+            public int dwServiceType;
+            public int dwCurrentState;
+            public int dwControlsAccepted;
+            public int dwWin32ExitCode;
+            public int dwServiceSpecificExitCode;
+            public int dwCheckPoint;
+            public int dwWaitHint;
+            public int dwProcessId;
+            public int dwServiceFlags;
+        }
+
+        private const int SC_STATUS_PROCESS_INFO = 0;
+
+        [LibraryImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static unsafe partial bool QueryServiceStatusEx(SafeServiceHandle serviceHandle, int InfoLevel, SERVICE_STATUS_PROCESS* pStatus, int cbBufSize, out int pcbBytesNeeded);
+
+        internal static unsafe bool QueryServiceStatusEx(SafeServiceHandle serviceHandle, SERVICE_STATUS_PROCESS* pStatus) => QueryServiceStatusEx(serviceHandle, SC_STATUS_PROCESS_INFO, pStatus, sizeof(SERVICE_STATUS_PROCESS), out int unused);
+    }
+}

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.QueryServiceStatusEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.QueryServiceStatusEx.cs
@@ -29,6 +29,6 @@ internal static partial class Interop
         [return: MarshalAs(UnmanagedType.Bool)]
         private static unsafe partial bool QueryServiceStatusEx(SafeServiceHandle serviceHandle, int InfoLevel, SERVICE_STATUS_PROCESS* pStatus, int cbBufSize, out int pcbBytesNeeded);
 
-        internal static unsafe bool QueryServiceStatusEx(SafeServiceHandle serviceHandle, SERVICE_STATUS_PROCESS* pStatus) => QueryServiceStatusEx(serviceHandle, SC_STATUS_PROCESS_INFO, pStatus, sizeof(SERVICE_STATUS_PROCESS), out int unused);
+        internal static unsafe bool QueryServiceStatusEx(SafeServiceHandle serviceHandle, SERVICE_STATUS_PROCESS* pStatus) => QueryServiceStatusEx(serviceHandle, SC_STATUS_PROCESS_INFO, pStatus, sizeof(SERVICE_STATUS_PROCESS), out _);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Interop.Errors.cs
+++ b/src/libraries/Common/src/Interop/Windows/Interop.Errors.cs
@@ -64,6 +64,8 @@ internal static partial class Interop
         internal const int ERROR_IO_PENDING = 0x3E5;
         internal const int ERROR_NO_TOKEN = 0x3f0;
         internal const int ERROR_SERVICE_DOES_NOT_EXIST = 0x424;
+        internal const int ERROR_EXCEPTION_IN_SERVICE = 0x428;
+        internal const int ERROR_PROCESS_ABORTED = 0x42B;
         internal const int ERROR_NO_UNICODE_TRANSLATION = 0x459;
         internal const int ERROR_DLL_INIT_FAILED = 0x45A;
         internal const int ERROR_COUNTER_TIMEOUT = 0x461;

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceLifetime.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
                 await Task.Run(Stop, cancellationToken).ConfigureAwait(false);
             }
 
-            // When the underlying service is stopped this will cause the ServiceBase.Run method to complete and return, which completes _serviceStopRequested.
+            // When the underlying service is stopped this will cause the ServiceBase.Run method to complete and return, which completes _serviceDispatcherStopped.
             await _serviceDispatcherStopped.Task.ConfigureAwait(false);
         }
 

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceLifetime.cs
@@ -100,9 +100,11 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
 
         public async Task StopAsync(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (!_serviceStopped)
             {
-                await Task.Run(Stop, CancellationToken.None).ConfigureAwait(false);
+                await Task.Run(Stop, cancellationToken).ConfigureAwait(false);
             }
 
             // When the underlying service is stopped this will cause the ServiceBase.Run method to complete and return, which completes _serviceStopped.

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/Microsoft.Extensions.Hosting.WindowsServices.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/Microsoft.Extensions.Hosting.WindowsServices.Tests.csproj
@@ -4,10 +4,41 @@
     <!-- Use "$(NetCoreAppCurrent)-windows" to avoid PlatformNotSupportedExceptions from ServiceController. -->
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetFrameworkMinimum)</TargetFrameworks> 
     <EnableDefaultItems>true</EnableDefaultItems>
+    <EnableLibraryImportGenerator>true</EnableLibraryImportGenerator>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\src\Microsoft.Extensions.Hosting.WindowsServices.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="$(LibrariesProjectRoot)System.ServiceProcess.ServiceController\src\Microsoft\Win32\SafeHandles\SafeServiceHandle.cs"
+             Link="Microsoft\Win32\SafeHandles\SafeServiceHandle.cs" />
+    <Compile Include="$(CommonPath)DisableRuntimeMarshalling.cs"
+             Link="Common\DisableRuntimeMarshalling.cs"
+             Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs"
+             Link="Common\Interop\Windows\Interop.Libraries.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ServiceProcessOptions.cs"
+             Link="Common\Interop\Windows\Interop.ServiceProcessOptions.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CloseServiceHandle.cs"
+             Link="Common\Interop\Windows\Interop.CloseServiceHandle.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CreateService.cs"
+             Link="Common\Interop\Windows\Interop.CreateService.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.DeleteService.cs"
+             Link="Common\Interop\Windows\Interop.DeleteService.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.OpenService.cs"
+             Link="Common\Interop\Windows\Interop.OpenService.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.OpenSCManager.cs"
+             Link="Common\Interop\Windows\Interop.OpenSCManager.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.QueryServiceStatus.cs"
+             Link="Common\Interop\Windows\Interop.QueryServiceStatus.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.QueryServiceStatusEx.cs"
+             Link="Common\Interop\Windows\Interop.QueryServiceStatusEx.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.SERVICE_STATUS.cs"
+             Link="Common\Interop\Windows\Interop.SERVICE_STATUS.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/Microsoft.Extensions.Hosting.WindowsServices.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/Microsoft.Extensions.Hosting.WindowsServices.Tests.csproj
@@ -19,6 +19,8 @@
     <Compile Include="$(CommonPath)DisableRuntimeMarshalling.cs"
              Link="Common\DisableRuntimeMarshalling.cs"
              Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs"
+             Link="Common\Interop\Windows\Interop.Errors.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs"
              Link="Common\Interop\Windows\Interop.Libraries.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ServiceProcessOptions.cs"

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/UseWindowsServiceTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/UseWindowsServiceTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.IO;
 using System.Reflection;
 using System.ServiceProcess;
 using Microsoft.Extensions.DependencyInjection;
@@ -28,6 +27,26 @@ namespace Microsoft.Extensions.Hosting
 
             var lifetime = host.Services.GetRequiredService<IHostLifetime>();
             Assert.IsType<ConsoleLifetime>(lifetime);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPrivilegedProcess))]
+        public void CanCreateService()
+        {
+            using var serviceTester = WindowsServiceTester.Create(nameof(CanCreateService), () =>
+            {
+                using IHost host = new HostBuilder()
+                    .UseWindowsService()
+                    .Build();
+                host.Run();
+            });
+
+            serviceTester.Start();
+            serviceTester.WaitForStatus(ServiceControllerStatus.Running);
+            serviceTester.Stop();
+            serviceTester.WaitForStatus(ServiceControllerStatus.Stopped);
+
+            var status = serviceTester.QueryServiceStatus();
+            Assert.Equal(0, status.win32ExitCode);
         }
 
         [Fact]
@@ -66,7 +85,7 @@ namespace Microsoft.Extensions.Hosting
             var builder = new HostApplicationBuilder(new HostApplicationBuilderSettings
             {
                 ApplicationName = appName,
-            }); 
+            });
 
             // Emulate calling builder.Services.AddWindowsService() from inside a Windows service.
             AddWindowsServiceLifetime(builder.Services);
@@ -82,7 +101,7 @@ namespace Microsoft.Extensions.Hosting
         [Fact]
         public void ServiceCollectionExtensionMethodCanBeCalledOnDefaultConfiguration()
         {
-            var builder = new HostApplicationBuilder(); 
+            var builder = new HostApplicationBuilder();
 
             // Emulate calling builder.Services.AddWindowsService() from inside a Windows service.
             AddWindowsServiceLifetime(builder.Services);

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/UseWindowsServiceTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/UseWindowsServiceTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Extensions.Hosting
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPrivilegedProcess))]
         public void CanCreateService()
         {
-            using var serviceTester = WindowsServiceTester.Create(nameof(CanCreateService), () =>
+            using var serviceTester = WindowsServiceTester.Create(() =>
             {
                 using IHost host = new HostBuilder()
                     .UseWindowsService()

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/WindowsServiceLifetimeTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/WindowsServiceLifetimeTests.cs
@@ -1,0 +1,127 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.ServiceProcess;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting.WindowsServices;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Microsoft.Extensions.Hosting
+{
+    public class WindowsServiceLifetimeTests
+    {
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPrivilegedProcess))]
+        public void ServiceSequenceIsCorrect()
+        {
+            using var serviceTester = WindowsServiceTester.Create(nameof(ServiceSequenceIsCorrect), () =>
+            {
+                SimpleServiceLogger.InitializeForTestCase(nameof(ServiceSequenceIsCorrect));
+                using IHost host = new HostBuilder()
+                    .ConfigureServices(services =>
+                    {
+                        services.AddHostedService<SimpleBackgroundService>();
+                        services.AddSingleton<IHostLifetime, SimpleWindowsServiceLifetime>();
+                    })
+                    .Build();
+
+                var applicationLifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+                applicationLifetime.ApplicationStarted.Register(() => SimpleServiceLogger.Log($"lifetime started"));
+                applicationLifetime.ApplicationStopping.Register(() => SimpleServiceLogger.Log($"lifetime stopping"));
+                applicationLifetime.ApplicationStopped.Register(() => SimpleServiceLogger.Log($"lifetime stopped"));
+
+                SimpleServiceLogger.Log("host.Run()");
+                host.Run();
+                SimpleServiceLogger.Log("host.Run() complete");
+            });
+
+            SimpleServiceLogger.DeleteLog(nameof(ServiceSequenceIsCorrect));
+
+            serviceTester.Start();
+            serviceTester.WaitForStatus(ServiceControllerStatus.Running);
+
+            var statusEx = serviceTester.QueryServiceStatusEx();
+            var serviceProcess = Process.GetProcessById(statusEx.dwProcessId);
+
+            serviceTester.Stop();
+            serviceTester.WaitForStatus(ServiceControllerStatus.Stopped);
+            
+            serviceProcess.WaitForExit();
+
+            var status = serviceTester.QueryServiceStatus();
+            Assert.Equal(0, status.win32ExitCode);
+
+            var logText = SimpleServiceLogger.ReadLog(nameof(ServiceSequenceIsCorrect));
+            Assert.Equal("""
+                host.Run()
+                WindowsServiceLifetime.OnStart
+                BackgroundService.StartAsync
+                lifetime started
+                WindowsServiceLifetime.OnStop
+                lifetime stopping
+                BackgroundService.StopAsync
+                lifetime stopped
+                host.Run() complete
+
+                """, logText);
+
+        }
+
+        public class SimpleWindowsServiceLifetime : WindowsServiceLifetime
+        {
+            public SimpleWindowsServiceLifetime(IHostEnvironment environment, IHostApplicationLifetime applicationLifetime, ILoggerFactory loggerFactory, IOptions<HostOptions> optionsAccessor) :
+                base(environment, applicationLifetime, loggerFactory, optionsAccessor)
+            { }
+
+            protected override void OnStart(string[] args)
+            {
+                SimpleServiceLogger.Log("WindowsServiceLifetime.OnStart");
+                base.OnStart(args);
+            }
+
+            protected override void OnStop()
+            {
+                SimpleServiceLogger.Log("WindowsServiceLifetime.OnStop");
+                base.OnStop();
+            }
+        }
+
+        public class SimpleBackgroundService : BackgroundService
+        {
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+            protected override async Task ExecuteAsync(CancellationToken stoppingToken) => SimpleServiceLogger.Log("BackgroundService.ExecuteAsync");
+            public override async Task StartAsync(CancellationToken stoppingToken) => SimpleServiceLogger.Log("BackgroundService.StartAsync");
+            public override async Task StopAsync(CancellationToken stoppingToken) => SimpleServiceLogger.Log("BackgroundService.StopAsync");
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+        }
+
+        static class SimpleServiceLogger
+        {
+            static string _fileName;
+
+            public static void InitializeForTestCase(string testCaseName)
+            {
+                Assert.Null(_fileName);
+                _fileName = GetLogForTestCase(testCaseName);
+            }
+
+            private static string GetLogForTestCase(string testCaseName) => Path.Combine(AppContext.BaseDirectory, $"{testCaseName}.log");
+            public static void DeleteLog(string testCaseName) => File.Delete(GetLogForTestCase(testCaseName));
+            public static string ReadLog(string testCaseName) => File.ReadAllText(GetLogForTestCase(testCaseName));
+            public static void Log(string message)
+            {
+                Assert.NotNull(_fileName);
+                lock (_fileName)
+                {
+                    File.AppendAllText(_fileName, message + Environment.NewLine);
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/WindowsServiceLifetimeTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/WindowsServiceLifetimeTests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Extensions.Hosting
 
             serviceTester.WaitForStatus(ServiceControllerStatus.Stopped);
             var status = serviceTester.QueryServiceStatus();
-            Assert.Equal(1064, status.win32ExitCode);
+            Assert.Equal(Interop.Errors.ERROR_EXCEPTION_IN_SERVICE, status.win32ExitCode);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPrivilegedProcess))]
@@ -100,7 +100,7 @@ namespace Microsoft.Extensions.Hosting
 
             serviceTester.WaitForStatus(ServiceControllerStatus.Stopped);
             var status = serviceTester.QueryServiceStatus();
-            Assert.Equal(1067, status.win32ExitCode);
+            Assert.Equal(Interop.Errors.ERROR_PROCESS_ABORTED, status.win32ExitCode);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPrivilegedProcess))]
@@ -123,7 +123,7 @@ namespace Microsoft.Extensions.Hosting
 
             serviceTester.WaitForStatus(ServiceControllerStatus.Stopped);
             var status = serviceTester.QueryServiceStatus();
-            Assert.Equal(1067, status.win32ExitCode);
+            Assert.Equal(Interop.Errors.ERROR_PROCESS_ABORTED, status.win32ExitCode);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPrivilegedProcess))]

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/WindowsServiceTester.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/WindowsServiceTester.cs
@@ -1,0 +1,107 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.ComponentModel;
+using System.ServiceProcess;
+using Microsoft.DotNet.RemoteExecutor;
+using Microsoft.Win32.SafeHandles;
+
+namespace Microsoft.Extensions.Hosting
+{
+    public class WindowsServiceTester : ServiceController
+    {
+        private WindowsServiceTester(SafeServiceHandle handle, string serviceName) : base(serviceName)
+        {
+            _handle = handle;
+        }
+
+        private SafeServiceHandle _handle;
+
+        public static WindowsServiceTester Create(string serviceName, Action serviceMain)
+        {
+            // create remote executor commandline arguments
+            string commandLine;
+            using (var remoteExecutorHandle = RemoteExecutor.Invoke(serviceMain, new RemoteInvokeOptions() { Start = false }))
+            {
+                var startInfo = remoteExecutorHandle.Process.StartInfo;
+                remoteExecutorHandle.Process.Dispose();
+                remoteExecutorHandle.Process = null;
+                commandLine = startInfo.FileName + " " + startInfo.Arguments;
+            }
+
+            // install the service
+            using (var serviceManagerHandle = new SafeServiceHandle(Interop.Advapi32.OpenSCManager(null, null, Interop.Advapi32.ServiceControllerOptions.SC_MANAGER_ALL)))
+            {
+                if (serviceManagerHandle.IsInvalid)
+                {
+                    throw new InvalidOperationException("Cannot open Service Control Manager");
+                }
+
+                // delete existing service if it exists
+                using (var existingServiceHandle = new SafeServiceHandle(Interop.Advapi32.OpenService(serviceManagerHandle, serviceName, Interop.Advapi32.ServiceAccessOptions.ACCESS_TYPE_ALL)))
+                {
+                    if (!existingServiceHandle.IsInvalid)
+                    {
+                        Interop.Advapi32.DeleteService(existingServiceHandle);
+                    }
+                }
+
+                var serviceHandle = new SafeServiceHandle(
+                    Interop.Advapi32.CreateService(serviceManagerHandle,
+                    serviceName,
+                    $"{nameof(WindowsServiceTester)} test service",
+                    Interop.Advapi32.ServiceAccessOptions.ACCESS_TYPE_ALL,
+                    Interop.Advapi32.ServiceTypeOptions.SERVICE_WIN32_OWN_PROCESS,
+                    (int)ServiceStartMode.Manual,
+                    Interop.Advapi32.ServiceStartErrorModes.ERROR_CONTROL_NORMAL,
+                    commandLine,
+                    loadOrderGroup: null,
+                    pTagId: IntPtr.Zero,
+                    dependencies: null,
+                    servicesStartName: null,
+                    password: null));
+
+                if (serviceHandle.IsInvalid)
+                {
+                    throw new Win32Exception("Could not create service");
+                }
+
+                return new WindowsServiceTester(serviceHandle, serviceName);
+            }
+        }
+
+        internal unsafe Interop.Advapi32.SERVICE_STATUS QueryServiceStatus()
+        {
+            Interop.Advapi32.SERVICE_STATUS status = default;
+            bool success = Interop.Advapi32.QueryServiceStatus(_handle, &status);
+            if (!success)
+            {
+                throw new Win32Exception();
+            }
+            return status;
+        }
+        internal unsafe Interop.Advapi32.SERVICE_STATUS_PROCESS QueryServiceStatusEx()
+        {
+            Interop.Advapi32.SERVICE_STATUS_PROCESS status = default;
+            bool success = Interop.Advapi32.QueryServiceStatusEx(_handle, &status);
+            if (!success)
+            {
+                throw new Win32Exception();
+            }
+            return status;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!_handle.IsInvalid)
+            {
+                // delete the temporary test service
+                Interop.Advapi32.DeleteService(_handle);
+                _handle.Close();
+                _handle = null;
+            }
+        }
+
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/WindowsServiceTester.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/WindowsServiceTester.cs
@@ -9,6 +9,7 @@ using System.ServiceProcess;
 using System.Threading.Tasks;
 using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Win32.SafeHandles;
+using Xunit;
 
 namespace Microsoft.Extensions.Hosting
 {
@@ -45,6 +46,18 @@ namespace Microsoft.Extensions.Hosting
             }
             catch (ArgumentException)
             { }
+        }
+
+        public TimeSpan WaitForStatusTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+        public new void WaitForStatus(ServiceControllerStatus desiredStatus) =>
+            WaitForStatus(desiredStatus, WaitForStatusTimeout);
+
+        public new void WaitForStatus(ServiceControllerStatus desiredStatus, TimeSpan timeout)
+        {
+            base.WaitForStatus(desiredStatus, timeout);
+
+            Assert.Equal(Status, desiredStatus);
         }
 
         // the following overloads are necessary to ensure the compiler will produce the correct signature from a lambda.

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/WindowsServiceTester.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/WindowsServiceTester.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Extensions.Hosting
             {
                 if (serviceManagerHandle.IsInvalid)
                 {
-                    throw new InvalidOperationException("Cannot open Service Control Manager");
+                    throw new InvalidOperationException();
                 }
 
                 // delete existing service if it exists
@@ -87,7 +87,7 @@ namespace Microsoft.Extensions.Hosting
 
                 if (serviceHandle.IsInvalid)
                 {
-                    throw new Win32Exception("Could not create service");
+                    throw new Win32Exception();
                 }
 
                 return new WindowsServiceTester(serviceHandle, remoteInvokeHandle, serviceName);

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/WindowsServiceTester.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/tests/WindowsServiceTester.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Extensions.Hosting
                 var serviceHandle = new SafeServiceHandle(
                     Interop.Advapi32.CreateService(serviceManagerHandle,
                     serviceName,
-                    $"{nameof(WindowsServiceTester)} test service",
+                    $"{nameof(WindowsServiceTester)} {serviceName} test service",
                     Interop.Advapi32.ServiceAccessOptions.ACCESS_TYPE_ALL,
                     Interop.Advapi32.ServiceTypeOptions.SERVICE_WIN32_OWN_PROCESS,
                     (int)ServiceStartMode.Manual,

--- a/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
@@ -647,6 +647,12 @@ namespace System.ServiceProcess
 
         public void Stop()
         {
+            if (_status.currentState == ServiceControlStatus.STATE_STOPPED || _status.currentState == default)
+            {
+                // nothing to do if the service is already stopped or never started
+                return;
+            }
+
             DeferredStop();
         }
 

--- a/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
@@ -31,6 +31,7 @@ namespace System.ServiceProcess
         private bool _commandPropsFrozen;  // set to true once we've use the Can... properties.
         private bool _disposed;
         private bool _initialized;
+        private object _stopLock = new object();
         private EventLog? _eventLog;
 
         /// <summary>
@@ -501,27 +502,34 @@ namespace System.ServiceProcess
         // This is a problem when multiple services are hosted in a single process.
         private unsafe void DeferredStop()
         {
-            fixed (SERVICE_STATUS* pStatus = &_status)
+            lock(_stopLock)
             {
-                int previousState = _status.currentState;
+                // never call SetServiceStatus again after STATE_STOPPED is set.
+                if (_status.currentState != ServiceControlStatus.STATE_STOPPED)
+                {
+                    fixed (SERVICE_STATUS* pStatus = &_status)
+                    {
+                        int previousState = _status.currentState;
 
-                _status.checkPoint = 0;
-                _status.waitHint = 0;
-                _status.currentState = ServiceControlStatus.STATE_STOP_PENDING;
-                SetServiceStatus(_statusHandle, pStatus);
-                try
-                {
-                    OnStop();
-                    WriteLogEntry(SR.StopSuccessful);
-                    _status.currentState = ServiceControlStatus.STATE_STOPPED;
-                    SetServiceStatus(_statusHandle, pStatus);
-                }
-                catch (Exception e)
-                {
-                    _status.currentState = previousState;
-                    SetServiceStatus(_statusHandle, pStatus);
-                    WriteLogEntry(SR.Format(SR.StopFailed, e), EventLogEntryType.Error);
-                    throw;
+                        _status.checkPoint = 0;
+                        _status.waitHint = 0;
+                        _status.currentState = ServiceControlStatus.STATE_STOP_PENDING;
+                        SetServiceStatus(_statusHandle, pStatus);
+                        try
+                        {
+                            OnStop();
+                            WriteLogEntry(SR.StopSuccessful);
+                            _status.currentState = ServiceControlStatus.STATE_STOPPED;
+                            SetServiceStatus(_statusHandle, pStatus);
+                        }
+                        catch (Exception e)
+                        {
+                            _status.currentState = previousState;
+                            SetServiceStatus(_statusHandle, pStatus);
+                            WriteLogEntry(SR.Format(SR.StopFailed, e), EventLogEntryType.Error);
+                            throw;
+                        }
+                    }
                 }
             }
         }
@@ -533,14 +541,17 @@ namespace System.ServiceProcess
                 OnShutdown();
                 WriteLogEntry(SR.ShutdownOK);
 
-                if (_status.currentState == ServiceControlStatus.STATE_PAUSED || _status.currentState == ServiceControlStatus.STATE_RUNNING)
+                lock(_stopLock)
                 {
-                    fixed (SERVICE_STATUS* pStatus = &_status)
+                    if (_status.currentState == ServiceControlStatus.STATE_PAUSED || _status.currentState == ServiceControlStatus.STATE_RUNNING)
                     {
-                        _status.checkPoint = 0;
-                        _status.waitHint = 0;
-                        _status.currentState = ServiceControlStatus.STATE_STOPPED;
-                        SetServiceStatus(_statusHandle, pStatus);
+                        fixed (SERVICE_STATUS* pStatus = &_status)
+                        {
+                            _status.checkPoint = 0;
+                            _status.waitHint = 0;
+                            _status.currentState = ServiceControlStatus.STATE_STOPPED;
+                            SetServiceStatus(_statusHandle, pStatus);
+                        }
                     }
                 }
             }
@@ -647,12 +658,6 @@ namespace System.ServiceProcess
 
         public void Stop()
         {
-            if (_status.currentState == ServiceControlStatus.STATE_STOPPED || _status.currentState == default)
-            {
-                // nothing to do if the service is already stopped or never started
-                return;
-            }
-
             DeferredStop();
         }
 
@@ -660,7 +665,7 @@ namespace System.ServiceProcess
         {
             if (!_initialized)
             {
-                //Cannot register the service with NT service manatger if the object has been disposed, since finalization has been suppressed.
+                //Cannot register the service with NT service manager if the object has been disposed, since finalization has been suppressed.
                 if (_disposed)
                     throw new ObjectDisposedException(GetType().Name);
 
@@ -929,8 +934,14 @@ namespace System.ServiceProcess
                 {
                     string errorMessage = new Win32Exception().Message;
                     WriteLogEntry(SR.Format(SR.StartFailed, errorMessage), EventLogEntryType.Error);
-                    _status.currentState = ServiceControlStatus.STATE_STOPPED;
-                    SetServiceStatus(_statusHandle, pStatus);
+                    lock (_stopLock)
+                    {
+                        if (_status.currentState != ServiceControlStatus.STATE_STOPPED)
+                        {
+                            _status.currentState = ServiceControlStatus.STATE_STOPPED;
+                            SetServiceStatus(_statusHandle, pStatus);
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
WindowsServiceLifetime was not waiting for ServiceBase to stop the service.  As a result we would sometimes end the process before notifying service control manager that the service had stopped -- resulting in an error in the eventlog and sometimes a service restart.

We also were permitting multiple calls to Stop to occur - through SCM callbacks, and through public API.  We must not call SetServiceStatus again once the service is marked as stopped.

Fixes: #62579 