### PR TITLE
Trim away netframework targets in source-build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -106,6 +106,7 @@
     <NetFrameworkMinimum>net462</NetFrameworkMinimum>
     <NetFrameworkToolCurrent>net472</NetFrameworkToolCurrent>
     <!-- Don't build for NETFramework during source-build. -->
+    <NetFrameworkMinimum Condition="'$(DotNetBuildFromSource)' == 'true'" />
     <NetFrameworkToolCurrent Condition="'$(DotNetBuildFromSource)' == 'true'" />
 
     <TargetFrameworkForNETFrameworkTasks>$(NetFrameworkToolCurrent)</TargetFrameworkForNETFrameworkTasks>

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -43,6 +43,8 @@
       <InnerBuildArgs Condition="'$(ContinuousIntegrationBuild)' != ''">$(InnerBuildArgs) /p:ContinuousIntegrationBuild=$(ContinuousIntegrationBuild)</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) /p:AdditionalRuntimeIdentifierParent=$(BaseOS)</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(SourceBuildUseMonoRuntime)' == 'true'">$(InnerBuildArgs) /p:PrimaryRuntimeFlavor=Mono /p:RuntimeFlavor=Mono</InnerBuildArgs>
+      <!-- Unset NetFrameworkMinimum property, to disable netfx projects. -->
+      <InnerBuildArgs>$(InnerBuildArgs) /p:NetFrameworkMinimum=</InnerBuildArgs>
     </PropertyGroup>
   </Target>
 

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -43,8 +43,6 @@
       <InnerBuildArgs Condition="'$(ContinuousIntegrationBuild)' != ''">$(InnerBuildArgs) /p:ContinuousIntegrationBuild=$(ContinuousIntegrationBuild)</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) /p:AdditionalRuntimeIdentifierParent=$(BaseOS)</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(SourceBuildUseMonoRuntime)' == 'true'">$(InnerBuildArgs) /p:PrimaryRuntimeFlavor=Mono /p:RuntimeFlavor=Mono</InnerBuildArgs>
-      <!-- Unset NetFrameworkMinimum property, to disable netfx projects. -->
-      <InnerBuildArgs>$(InnerBuildArgs) /p:NetFrameworkMinimum=</InnerBuildArgs>
     </PropertyGroup>
   </Target>
 

--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -60,7 +60,7 @@
           Condition="'$(IncludeDesignerMarker)' != 'false'" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(AddNETFrameworkAssemblyReferenceToPackage)' == 'true'">
+  <ItemGroup Condition="'$(AddNETFrameworkAssemblyReferenceToPackage)' == 'true' and '$(NetFrameworkMinimum)' != ''">
     <_FrameworkAssemblyReferences Include="$(MSBuildProjectName)"
                                   TargetFramework="$(NetFrameworkMinimum)" />
   </ItemGroup>
@@ -80,7 +80,7 @@
         <None Include="$(PlaceholderFile)"
               Pack="true"
               PackagePath="$(BuildOutputTargetFolder)\$(NetFrameworkMinimum)\"
-              Condition="'$(AddNETFrameworkPlaceholderFileToPackage)' == 'true'" />
+              Condition="'$(AddNETFrameworkPlaceholderFileToPackage)' == 'true' and '$(NetFrameworkMinimum)' != ''" />
         <None Include="$(PlaceholderFile)"
               Pack="true"
               PackagePath="$(BuildOutputTargetFolder)\MonoAndroid10\;
@@ -104,7 +104,7 @@
                                        ($(TargetFrameworks.Contains('$(NetCoreAppMinimum)')) or $(TargetFrameworks.Contains('$(NetCoreAppPrevious)')) or $(TargetFrameworks.Contains('$(NetCoreAppCurrent)')))" />
     <NETStandardCompatError Include="net461"
                             Supported="$(NetFrameworkMinimum)"
-                            Condition="$(TargetFrameworks.Contains('netstandard2.0')) and
+                            Condition="'$(NetFrameworkMinimum)' != '' and $(TargetFrameworks.Contains('netstandard2.0')) and
                                        ($(TargetFrameworks.Contains('$(NetFrameworkMinimum)')) or $(TargetFrameworks.Contains('net47')) or $(TargetFrameworks.Contains('net48')))" />
   </ItemGroup>
 


### PR DESCRIPTION
﻿### Summary of the changes

This is part of the source-build work to enable trimming of net4* targets. Parent repos (`installer` and `sdk`) have been updated, so the next step is to update dependencies, like `runtime`.

Here's how this is consumed: https://github.com/dotnet/arcade/pull/12785

Top-level tracking issue: https://github.com/dotnet/source-build/issues/3014

This essentially just avoids building net4* TFMs when building Linux source build.

Fixes: https://github.com/dotnet/runtime/issues/74950