### PR TITLE
Read StartDiskNumber as uint32

### DIFF
--- a/src/libraries/System.IO.Compression/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.Compression/src/Resources/Strings.resx
@@ -233,9 +233,6 @@
   <data name="FieldTooBigOffsetToZip64EOCD" xml:space="preserve">
     <value>Offset to Zip64 End Of Central Directory record cannot be held in an Int64.</value>
   </data>
-  <data name="FieldTooBigStartDiskNumber" xml:space="preserve">
-    <value>Start Disk Number cannot be held in an Int64.</value>
-  </data>
   <data name="FieldTooBigUncompressedSize" xml:space="preserve">
     <value>Uncompressed Size cannot be held in an Int64.</value>
   </data>

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -18,7 +18,7 @@ namespace System.IO.Compression
     {
         private ZipArchive _archive;
         private readonly bool _originallyInArchive;
-        private readonly int _diskNumberStart;
+        private readonly uint _diskNumberStart;
         private readonly ZipVersionMadeByPlatform _versionMadeByPlatform;
         private ZipVersionNeededValues _versionMadeBySpecification;
         internal ZipVersionNeededValues _versionToExtract;

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -96,7 +96,7 @@ namespace System.IO.Compression
         private long? _uncompressedSize;
         private long? _compressedSize;
         private long? _localHeaderOffset;
-        private int? _startDiskNumber;
+        private uint? _startDiskNumber;
 
         public ushort TotalSize => (ushort)(_size + 4);
 
@@ -115,7 +115,7 @@ namespace System.IO.Compression
             get { return _localHeaderOffset; }
             set { _localHeaderOffset = value; UpdateSize(); }
         }
-        public int? StartDiskNumber => _startDiskNumber;
+        public uint? StartDiskNumber => _startDiskNumber;
 
         private void UpdateSize()
         {
@@ -242,7 +242,7 @@ namespace System.IO.Compression
 
                 if (readStartDiskNumber)
                 {
-                    zip64Block._startDiskNumber = reader.ReadInt32();
+                    zip64Block._startDiskNumber = reader.ReadUInt32();
                 }
                 else if (readAllFields)
                 {
@@ -253,7 +253,6 @@ namespace System.IO.Compression
                 if (zip64Block._uncompressedSize < 0) throw new InvalidDataException(SR.FieldTooBigUncompressedSize);
                 if (zip64Block._compressedSize < 0) throw new InvalidDataException(SR.FieldTooBigCompressedSize);
                 if (zip64Block._localHeaderOffset < 0) throw new InvalidDataException(SR.FieldTooBigLocalHeaderOffset);
-                if (zip64Block._startDiskNumber < 0) throw new InvalidDataException(SR.FieldTooBigStartDiskNumber);
 
                 return true;
             }
@@ -480,7 +479,7 @@ namespace System.IO.Compression
         public ushort FilenameLength;
         public ushort ExtraFieldLength;
         public ushort FileCommentLength;
-        public int DiskNumberStart;
+        public uint DiskNumberStart;
         public ushort InternalFileAttributes;
         public uint ExternalFileAttributes;
         public long RelativeOffsetOfLocalHeader;


### PR DESCRIPTION
- The startDiskNumber field has been changed according to the zip specification. 
- Added test with the archive where the value of startDiskNumber greater than int.MaxValue.

Fix #31825