### PR TITLE
Add assert.xunit subtree and make it AOT-safe

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,219 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+insert_final_newline = true
+end_of_line = lf
+
+# Visual Studio demands 2-spaced project files
+# Tabs are not legal whitespace for YAML files
+[*.{csproj,json,props,targets,xslt,yaml,yml}]
+indent_style = space
+indent_size = 2
+
+[*.cs]
+# Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
+
+# this. and Me. preferences
+dotnet_style_qualification_for_field = false
+dotnet_style_qualification_for_property = false
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_event = false
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members
+
+# Expression-level preferences
+dotnet_style_coalesce_expression = true
+dotnet_style_collection_initializer = true
+dotnet_style_explicit_tuple_names = true
+dotnet_style_namespace_match_folder = false
+dotnet_style_null_propagation = true
+dotnet_style_object_initializer = true
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_style_prefer_auto_properties = true
+dotnet_style_prefer_compound_assignment = true
+dotnet_style_prefer_conditional_expression_over_assignment = true
+dotnet_style_prefer_conditional_expression_over_return = true
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+dotnet_style_prefer_inferred_tuple_names = true
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+dotnet_style_prefer_simplified_boolean_expressions = true
+dotnet_style_prefer_simplified_interpolation = true
+
+# Field preferences
+dotnet_style_readonly_field = true
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = none
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental = true
+dotnet_style_allow_statement_immediately_after_block_experimental = true
+
+#### C# Coding Conventions ####
+
+# var preferences
+csharp_style_var_elsewhere = true
+csharp_style_var_for_built_in_types = true
+csharp_style_var_when_type_is_apparent = true
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors = true
+csharp_style_expression_bodied_constructors = false
+csharp_style_expression_bodied_indexers = true
+csharp_style_expression_bodied_lambdas = true
+csharp_style_expression_bodied_local_functions = false
+csharp_style_expression_bodied_methods = false
+csharp_style_expression_bodied_operators = false
+csharp_style_expression_bodied_properties = true
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true
+csharp_style_pattern_matching_over_is_with_cast_check = true
+csharp_style_prefer_not_pattern = true
+csharp_style_prefer_pattern_matching = true
+csharp_style_prefer_switch_expression = true
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true
+
+# Modifier preferences
+csharp_prefer_static_local_function = true
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+
+# Code-block preferences
+csharp_prefer_braces = false
+csharp_prefer_simple_using_statement = true
+csharp_style_namespace_declarations = block_scoped
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression = true
+csharp_style_deconstructed_variable_declaration = true
+csharp_style_implicit_object_creation_when_type_is_apparent = true
+csharp_style_inlined_variable_declaration = true
+csharp_style_pattern_local_over_anonymous_function = true
+csharp_style_prefer_index_operator = true
+csharp_style_prefer_null_check_over_type_check = true
+csharp_style_prefer_range_operator = true
+csharp_style_throw_expression = true
+csharp_style_unused_value_assignment_preference = discard_variable
+csharp_style_unused_value_expression_statement_preference = discard_variable
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:warning
+
+# New line preferences
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true
+csharp_style_allow_embedded_statements_on_same_line_experimental = true
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_switch_labels = true
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers =
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers =
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers =
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix =
+dotnet_naming_style.pascal_case.required_suffix =
+dotnet_naming_style.pascal_case.word_separator =
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix =
+dotnet_naming_style.begins_with_i.word_separator =
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+#### Roslyn diagnostics ####
+
+dotnet_diagnostic.IDE1006.severity = none

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto eol=lf
+*.cs text diff=csharp
+*.csproj text merge=union
+*.resx text merge=union
+*.sln text eol=crlf merge=union
+*.vbproj text merge=union

--- a/Assert.cs
+++ b/Assert.cs
@@ -1,0 +1,46 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.ComponentModel;
+
+namespace Xunit
+{
+	/// <summary>
+	/// Contains various static methods that are used to verify that conditions are met during the
+	/// process of running tests.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Assert"/> class.
+		/// </summary>
+		protected Assert() { }
+
+		/// <summary>Do not call this method.</summary>
+		[Obsolete("This is an override of Object.Equals(). Call Assert.Equal() instead.", true)]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public new static bool Equals(
+			object a,
+			object b)
+		{
+			throw new InvalidOperationException("Assert.Equals should not be used");
+		}
+
+		/// <summary>Do not call this method.</summary>
+		[Obsolete("This is an override of Object.ReferenceEquals(). Call Assert.Same() instead.", true)]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public new static bool ReferenceEquals(
+			object a,
+			object b)
+		{
+			throw new InvalidOperationException("Assert.ReferenceEquals should not be used");
+		}
+	}
+}

--- a/BooleanAsserts.cs
+++ b/BooleanAsserts.cs
@@ -1,0 +1,146 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using Xunit.Sdk;
+
+#if XUNIT_NULLABLE
+using System.Diagnostics.CodeAnalysis;
+#endif
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		/// <summary>
+		/// Verifies that the condition is false.
+		/// </summary>
+		/// <param name="condition">The condition to be tested</param>
+		/// <exception cref="FalseException">Thrown if the condition is not false</exception>
+#if XUNIT_NULLABLE
+		public static void False([DoesNotReturnIf(parameterValue: true)] bool condition)
+#else
+		public static void False(bool condition)
+#endif
+		{
+			False((bool?)condition, null);
+		}
+
+		/// <summary>
+		/// Verifies that the condition is false.
+		/// </summary>
+		/// <param name="condition">The condition to be tested</param>
+		/// <exception cref="FalseException">Thrown if the condition is not false</exception>
+#if XUNIT_NULLABLE
+		public static void False([DoesNotReturnIf(parameterValue: true)] bool? condition)
+#else
+		public static void False(bool? condition)
+#endif
+		{
+			False(condition, null);
+		}
+
+		/// <summary>
+		/// Verifies that the condition is false.
+		/// </summary>
+		/// <param name="condition">The condition to be tested</param>
+		/// <param name="userMessage">The message to show when the condition is not false</param>
+		/// <exception cref="FalseException">Thrown if the condition is not false</exception>
+		public static void False(
+#if XUNIT_NULLABLE
+			[DoesNotReturnIf(parameterValue: true)] bool condition,
+			string? userMessage) =>
+#else
+			bool condition,
+			string userMessage) =>
+#endif
+				False((bool?)condition, userMessage);
+
+		/// <summary>
+		/// Verifies that the condition is false.
+		/// </summary>
+		/// <param name="condition">The condition to be tested</param>
+		/// <param name="userMessage">The message to show when the condition is not false</param>
+		/// <exception cref="FalseException">Thrown if the condition is not false</exception>
+		public static void False(
+#if XUNIT_NULLABLE
+			[DoesNotReturnIf(parameterValue: true)] bool? condition,
+			string? userMessage)
+#else
+			bool? condition,
+			string userMessage)
+#endif
+		{
+			if (!condition.HasValue || condition.GetValueOrDefault())
+				throw new FalseException(userMessage, condition);
+		}
+
+		/// <summary>
+		/// Verifies that an expression is true.
+		/// </summary>
+		/// <param name="condition">The condition to be inspected</param>
+		/// <exception cref="TrueException">Thrown when the condition is false</exception>
+#if XUNIT_NULLABLE
+		public static void True([DoesNotReturnIf(parameterValue: false)] bool condition)
+#else
+		public static void True(bool condition)
+#endif
+		{
+			True((bool?)condition, null);
+		}
+
+		/// <summary>
+		/// Verifies that an expression is true.
+		/// </summary>
+		/// <param name="condition">The condition to be inspected</param>
+		/// <exception cref="TrueException">Thrown when the condition is false</exception>
+#if XUNIT_NULLABLE
+		public static void True([DoesNotReturnIf(parameterValue: false)] bool? condition)
+#else
+		public static void True(bool? condition)
+#endif
+		{
+			True(condition, null);
+		}
+
+		/// <summary>
+		/// Verifies that an expression is true.
+		/// </summary>
+		/// <param name="condition">The condition to be inspected</param>
+		/// <param name="userMessage">The message to be shown when the condition is false</param>
+		/// <exception cref="TrueException">Thrown when the condition is false</exception>
+		public static void True(
+#if XUNIT_NULLABLE
+			[DoesNotReturnIf(parameterValue: false)] bool condition,
+			string? userMessage) =>
+#else
+			bool condition,
+			string userMessage) =>
+#endif
+				True((bool?)condition, userMessage);
+
+		/// <summary>
+		/// Verifies that an expression is true.
+		/// </summary>
+		/// <param name="condition">The condition to be inspected</param>
+		/// <param name="userMessage">The message to be shown when the condition is false</param>
+		/// <exception cref="TrueException">Thrown when the condition is false</exception>
+		public static void True(
+#if XUNIT_NULLABLE
+			[DoesNotReturnIf(parameterValue: false)] bool? condition,
+			string? userMessage)
+#else
+			bool? condition,
+			string userMessage)
+#endif
+		{
+			if (!condition.HasValue || !condition.GetValueOrDefault())
+				throw new TrueException(userMessage, condition);
+		}
+	}
+}

--- a/CollectionAsserts.cs
+++ b/CollectionAsserts.cs
@@ -1,0 +1,631 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Sdk;
+
+#if XUNIT_VALUETASK
+using System.Threading.Tasks;
+#endif
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		/// <summary>
+		/// Verifies that all items in the collection pass when executed against
+		/// action.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="collection">The collection</param>
+		/// <param name="action">The action to test each item against</param>
+		/// <exception cref="AllException">Thrown when the collection contains at least one non-matching element</exception>
+		public static void All<T>(
+			IEnumerable<T> collection,
+			Action<T> action)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+			GuardArgumentNotNull(nameof(action), action);
+
+			All(collection, (item, index) => action(item));
+		}
+
+		/// <summary>
+		/// Verifies that all items in the collection pass when executed against
+		/// action. The item index is provided to the action, in addition to the item.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="collection">The collection</param>
+		/// <param name="action">The action to test each item against</param>
+		/// <exception cref="AllException">Thrown when the collection contains at least one non-matching element</exception>
+		public static void All<T>(
+			IEnumerable<T> collection,
+			Action<T, int> action)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+			GuardArgumentNotNull(nameof(action), action);
+
+#if XUNIT_NULLABLE
+			var errors = new Stack<Tuple<int, object?, Exception>>();
+#else
+			var errors = new Stack<Tuple<int, object, Exception>>();
+#endif
+			var idx = 0;
+
+			foreach (var item in collection)
+			{
+				try
+				{
+					action(item, idx);
+				}
+				catch (Exception ex)
+				{
+#if XUNIT_NULLABLE
+					errors.Push(new Tuple<int, object?, Exception>(idx, item, ex));
+#else
+					errors.Push(new Tuple<int, object, Exception>(idx, item, ex));
+#endif
+				}
+
+				++idx;
+			}
+
+			if (errors.Count > 0)
+				throw new AllException(idx, errors.ToArray());
+		}
+
+#if XUNIT_VALUETASK
+		/// <summary>
+		/// Verifies that all items in the collection pass when executed against
+		/// action.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="collection">The collection</param>
+		/// <param name="action">The action to test each item against</param>
+		/// <exception cref="AllException">Thrown when the collection contains at least one non-matching element</exception>
+		public static async ValueTask AllAsync<T>(
+			IEnumerable<T> collection,
+			Func<T, ValueTask> action)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+			GuardArgumentNotNull(nameof(action), action);
+
+			await AllAsync(collection, async (item, index) => await action(item));
+		}
+
+		/// <summary>
+		/// Verifies that all items in the collection pass when executed against
+		/// action. The item index is provided to the action, in addition to the item.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="collection">The collection</param>
+		/// <param name="action">The action to test each item against</param>
+		/// <exception cref="AllException">Thrown when the collection contains at least one non-matching element</exception>
+		public static async ValueTask AllAsync<T>(
+			IEnumerable<T> collection,
+			Func<T, int, ValueTask> action)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+			GuardArgumentNotNull(nameof(action), action);
+
+#if XUNIT_NULLABLE
+			var errors = new Stack<Tuple<int, object?, Exception>>();
+#else
+			var errors = new Stack<Tuple<int, object, Exception>>();
+#endif
+			var idx = 0;
+
+			foreach (var item in collection)
+			{
+				try
+				{
+					await action(item, idx);
+				}
+				catch (Exception ex)
+				{
+#if XUNIT_NULLABLE
+					errors.Push(new Tuple<int, object?, Exception>(idx, item, ex));
+#else
+					errors.Push(new Tuple<int, object, Exception>(idx, item, ex));
+#endif
+				}
+
+				++idx;
+			}
+
+			if (errors.Count > 0)
+				throw new AllException(idx, errors.ToArray());
+		}
+#endif
+
+		/// <summary>
+		/// Verifies that a collection contains exactly a given number of elements, which meet
+		/// the criteria provided by the element inspectors.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="collection">The collection to be inspected</param>
+		/// <param name="elementInspectors">The element inspectors, which inspect each element in turn. The
+		/// total number of element inspectors must exactly match the number of elements in the collection.</param>
+		public static void Collection<T>(
+			IEnumerable<T> collection,
+			params Action<T>[] elementInspectors)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+			GuardArgumentNotNull(nameof(elementInspectors), elementInspectors);
+
+			var elements = collection.ToArray();
+			var expectedCount = elementInspectors.Length;
+			var actualCount = elements.Length;
+
+			if (expectedCount != actualCount)
+				throw new CollectionException(collection, expectedCount, actualCount);
+
+			for (var idx = 0; idx < actualCount; idx++)
+			{
+				try
+				{
+					elementInspectors[idx](elements[idx]);
+				}
+				catch (Exception ex)
+				{
+					throw new CollectionException(collection, expectedCount, actualCount, idx, ex);
+				}
+			}
+		}
+
+#if XUNIT_VALUETASK
+		/// <summary>
+		/// Verifies that a collection contains exactly a given number of elements, which meet
+		/// the criteria provided by the element inspectors.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="collection">The collection to be inspected</param>
+		/// <param name="elementInspectors">The element inspectors, which inspect each element in turn. The
+		/// total number of element inspectors must exactly match the number of elements in the collection.</param>
+		public static async ValueTask CollectionAsync<T>(
+			IEnumerable<T> collection,
+			params Func<T, ValueTask>[] elementInspectors)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+			GuardArgumentNotNull(nameof(elementInspectors), elementInspectors);
+
+			var elements = collection.ToArray();
+			var expectedCount = elementInspectors.Length;
+			var actualCount = elements.Length;
+
+			if (expectedCount != actualCount)
+				throw new CollectionException(collection, expectedCount, actualCount);
+
+			for (var idx = 0; idx < actualCount; idx++)
+				try
+				{
+					await elementInspectors[idx](elements[idx]);
+				}
+				catch (Exception ex)
+				{
+					throw new CollectionException(collection, expectedCount, actualCount, idx, ex);
+				}
+		}
+#endif
+
+		/// <summary>
+		/// Verifies that a collection contains a given object.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="expected">The object expected to be in the collection</param>
+		/// <param name="collection">The collection to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the collection</exception>
+		public static void Contains<T>(
+			T expected,
+			IEnumerable<T> collection)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+
+			// If an equality comparer is not explicitly provided, call into ICollection<T>.Contains or
+			// IReadOnlyCollection<T>.Contains which may use the collection's equality comparer for types
+			// like HashSet and Dictionary. HashSet and Dictionary are normally handled explicitly, but
+			// the developer may end up in the IEnumerable<> override because the variable is not an explicit
+			// enough type.
+			var readWriteCollection = collection as ICollection<T>;
+			if (readWriteCollection != null)
+			{
+				if (readWriteCollection.Contains(expected))
+					return;
+			}
+			else
+			{
+				var readOnlyCollection = collection as IReadOnlyCollection<T>;
+				if (readOnlyCollection != null && readOnlyCollection.Contains(expected))
+					return;
+			}
+
+			Contains(expected, collection, GetEqualityComparer<T>());
+		}
+
+		/// <summary>
+		/// Verifies that a collection contains a given object, using an equality comparer.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="expected">The object expected to be in the collection</param>
+		/// <param name="collection">The collection to be inspected</param>
+		/// <param name="comparer">The comparer used to equate objects in the collection with the expected object</param>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the collection</exception>
+		public static void Contains<T>(
+			T expected,
+			IEnumerable<T> collection,
+			IEqualityComparer<T> comparer)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+			GuardArgumentNotNull(nameof(comparer), comparer);
+
+			if (collection.Contains(expected, comparer))
+				return;
+
+			throw new ContainsException(expected, collection);
+		}
+
+		/// <summary>
+		/// Verifies that a collection contains a given object.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="collection">The collection to be inspected</param>
+		/// <param name="filter">The filter used to find the item you're ensuring the collection contains</param>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the collection</exception>
+		public static void Contains<T>(
+			IEnumerable<T> collection,
+			Predicate<T> filter)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+			GuardArgumentNotNull(nameof(filter), filter);
+
+			foreach (var item in collection)
+				if (filter(item))
+					return;
+
+			throw new ContainsException("(filter expression)", collection);
+		}
+
+		/// <summary>
+		/// Verifies that a collection contains each object only once.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be compared</typeparam>
+		/// <param name="collection">The collection to be inspected</param>
+		/// <exception cref="ContainsDuplicateException">Thrown when an object is present inside the container more than once</exception>
+		public static void Distinct<T>(IEnumerable<T> collection) =>
+			Distinct<T>(collection, EqualityComparer<T>.Default);
+
+		/// <summary>
+		/// Verifies that a collection contains each object only once.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be compared</typeparam>
+		/// <param name="collection">The collection to be inspected</param>
+		/// <param name="comparer">The comparer used to equate objects in the collection with the expected object</param>
+		/// <exception cref="ContainsDuplicateException">Thrown when an object is present inside the container more than once</exception>
+		public static void Distinct<T>(
+			IEnumerable<T> collection,
+			IEqualityComparer<T> comparer)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+			GuardArgumentNotNull(nameof(comparer), comparer);
+
+			var set = new HashSet<T>(comparer);
+
+			foreach (var x in collection)
+				if (!set.Add(x))
+					throw new ContainsDuplicateException(x, collection);
+		}
+
+		/// <summary>
+		/// Verifies that a collection does not contain a given object.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be compared</typeparam>
+		/// <param name="expected">The object that is expected not to be in the collection</param>
+		/// <param name="collection">The collection to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the object is present inside the container</exception>
+		public static void DoesNotContain<T>(
+			T expected,
+			IEnumerable<T> collection)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+
+			// If an equality comparer is not explicitly provided, call into ICollection<T>.Contains or
+			// IReadOnlyCollection<T>.Contains which may use the collection's equality comparer for types
+			// like HashSet and Dictionary. HashSet and Dictionary are normally handled explicitly, but
+			// the developer may end up in the IEnumerable<> override because the variable is not an explicit
+			// enough type.
+			var readWriteCollection = collection as ICollection<T>;
+			if (readWriteCollection != null)
+			{
+				if (readWriteCollection.Contains(expected))
+					throw new DoesNotContainException(expected, collection);
+			}
+			else
+			{
+				var readOnlyCollection = collection as IReadOnlyCollection<T>;
+				if (readOnlyCollection != null && readOnlyCollection.Contains(expected))
+					throw new DoesNotContainException(expected, collection);
+			}
+
+			DoesNotContain(expected, collection, GetEqualityComparer<T>());
+		}
+
+		/// <summary>
+		/// Verifies that a collection does not contain a given object, using an equality comparer.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be compared</typeparam>
+		/// <param name="expected">The object that is expected not to be in the collection</param>
+		/// <param name="collection">The collection to be inspected</param>
+		/// <param name="comparer">The comparer used to equate objects in the collection with the expected object</param>
+		/// <exception cref="DoesNotContainException">Thrown when the object is present inside the container</exception>
+		public static void DoesNotContain<T>(
+			T expected,
+			IEnumerable<T> collection,
+			IEqualityComparer<T> comparer)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+			GuardArgumentNotNull(nameof(comparer), comparer);
+
+			if (!collection.Contains(expected, comparer))
+				return;
+
+			throw new DoesNotContainException(expected, collection);
+		}
+
+		/// <summary>
+		/// Verifies that a collection does not contain a given object.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be compared</typeparam>
+		/// <param name="collection">The collection to be inspected</param>
+		/// <param name="filter">The filter used to find the item you're ensuring the collection does not contain</param>
+		/// <exception cref="DoesNotContainException">Thrown when the object is present inside the container</exception>
+		public static void DoesNotContain<T>(
+			IEnumerable<T> collection,
+			Predicate<T> filter)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+			GuardArgumentNotNull(nameof(filter), filter);
+
+			foreach (var item in collection)
+				if (filter(item))
+					throw new DoesNotContainException("(filter expression)", collection);
+		}
+
+		/// <summary>
+		/// Verifies that a collection is empty.
+		/// </summary>
+		/// <param name="collection">The collection to be inspected</param>
+		/// <exception cref="ArgumentNullException">Thrown when the collection is null</exception>
+		/// <exception cref="EmptyException">Thrown when the collection is not empty</exception>
+		public static void Empty(IEnumerable collection)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+
+			var enumerator = collection.GetEnumerator();
+			try
+			{
+				if (enumerator.MoveNext())
+					throw new EmptyException(collection);
+			}
+			finally
+			{
+				(enumerator as IDisposable)?.Dispose();
+			}
+		}
+
+		/// <summary>
+		/// Verifies that two sequences are equivalent, using a default comparer.
+		/// </summary>
+		/// <typeparam name="T">The type of the objects to be compared</typeparam>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The value to be compared against</param>
+		/// <exception cref="EqualException">Thrown when the objects are not equal</exception>
+		public static void Equal<T>(
+#if XUNIT_NULLABLE
+			IEnumerable<T>? expected,
+			IEnumerable<T>? actual) =>
+#else
+			IEnumerable<T> expected,
+			IEnumerable<T> actual) =>
+#endif
+				Equal(expected, actual, GetEqualityComparer<IEnumerable<T>>());
+
+		/// <summary>
+		/// Verifies that two sequences are equivalent, using a custom equatable comparer.
+		/// </summary>
+		/// <typeparam name="T">The type of the objects to be compared</typeparam>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The value to be compared against</param>
+		/// <param name="comparer">The comparer used to compare the two objects</param>
+		/// <exception cref="EqualException">Thrown when the objects are not equal</exception>
+		public static void Equal<T>(
+#if XUNIT_NULLABLE
+			IEnumerable<T>? expected,
+			IEnumerable<T>? actual,
+#else
+			IEnumerable<T> expected,
+			IEnumerable<T> actual,
+#endif
+			IEqualityComparer<T> comparer) =>
+				Equal(expected, actual, GetEqualityComparer<IEnumerable<T>>(new AssertEqualityComparerAdapter<T>(comparer)));
+
+		/// <summary>
+		/// Verifies that a collection is not empty.
+		/// </summary>
+		/// <param name="collection">The collection to be inspected</param>
+		/// <exception cref="ArgumentNullException">Thrown when a null collection is passed</exception>
+		/// <exception cref="NotEmptyException">Thrown when the collection is empty</exception>
+		public static void NotEmpty(IEnumerable collection)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+
+			var enumerator = collection.GetEnumerator();
+			try
+			{
+				if (!enumerator.MoveNext())
+					throw new NotEmptyException();
+			}
+			finally
+			{
+				(enumerator as IDisposable)?.Dispose();
+			}
+		}
+
+		/// <summary>
+		/// Verifies that two sequences are not equivalent, using a default comparer.
+		/// </summary>
+		/// <typeparam name="T">The type of the objects to be compared</typeparam>
+		/// <param name="expected">The expected object</param>
+		/// <param name="actual">The actual object</param>
+		/// <exception cref="NotEqualException">Thrown when the objects are equal</exception>
+		public static void NotEqual<T>(
+#if XUNIT_NULLABLE
+			IEnumerable<T>? expected,
+			IEnumerable<T>? actual) =>
+#else
+			IEnumerable<T> expected,
+			IEnumerable<T> actual) =>
+#endif
+				NotEqual(expected, actual, GetEqualityComparer<IEnumerable<T>>());
+
+		/// <summary>
+		/// Verifies that two sequences are not equivalent, using a custom equality comparer.
+		/// </summary>
+		/// <typeparam name="T">The type of the objects to be compared</typeparam>
+		/// <param name="expected">The expected object</param>
+		/// <param name="actual">The actual object</param>
+		/// <param name="comparer">The comparer used to compare the two objects</param>
+		/// <exception cref="NotEqualException">Thrown when the objects are equal</exception>
+		public static void NotEqual<T>(
+#if XUNIT_NULLABLE
+			IEnumerable<T>? expected,
+			IEnumerable<T>? actual,
+#else
+			IEnumerable<T> expected,
+			IEnumerable<T> actual,
+#endif
+			IEqualityComparer<T> comparer) =>
+				NotEqual(expected, actual, GetEqualityComparer<IEnumerable<T>>(new AssertEqualityComparerAdapter<T>(comparer)));
+
+		/// <summary>
+		/// Verifies that the given collection contains only a single
+		/// element of the given type.
+		/// </summary>
+		/// <param name="collection">The collection.</param>
+		/// <returns>The single item in the collection.</returns>
+		/// <exception cref="SingleException">Thrown when the collection does not contain
+		/// exactly one element.</exception>
+#if XUNIT_NULLABLE
+		public static object? Single(IEnumerable collection)
+#else
+		public static object Single(IEnumerable collection)
+#endif
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+
+			return Single(collection.Cast<object>());
+		}
+
+		/// <summary>
+		/// Verifies that the given collection contains only a single
+		/// element of the given value. The collection may or may not
+		/// contain other values.
+		/// </summary>
+		/// <param name="collection">The collection.</param>
+		/// <param name="expected">The value to find in the collection.</param>
+		/// <returns>The single item in the collection.</returns>
+		/// <exception cref="SingleException">Thrown when the collection does not contain
+		/// exactly one element.</exception>
+		public static void Single(
+			IEnumerable collection,
+#if XUNIT_NULLABLE
+			object? expected)
+#else
+			object expected)
+#endif
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+
+			GetSingleResult(collection.Cast<object>(), item => object.Equals(item, expected), ArgumentFormatter.Format(expected));
+		}
+
+		/// <summary>
+		/// Verifies that the given collection contains only a single
+		/// element of the given type.
+		/// </summary>
+		/// <typeparam name="T">The collection type.</typeparam>
+		/// <param name="collection">The collection.</param>
+		/// <returns>The single item in the collection.</returns>
+		/// <exception cref="SingleException">Thrown when the collection does not contain
+		/// exactly one element.</exception>
+		public static T Single<T>(IEnumerable<T> collection)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+
+			return GetSingleResult(collection, null, null);
+		}
+
+		/// <summary>
+		/// Verifies that the given collection contains only a single
+		/// element of the given type which matches the given predicate. The
+		/// collection may or may not contain other values which do not
+		/// match the given predicate.
+		/// </summary>
+		/// <typeparam name="T">The collection type.</typeparam>
+		/// <param name="collection">The collection.</param>
+		/// <param name="predicate">The item matching predicate.</param>
+		/// <returns>The single item in the filtered collection.</returns>
+		/// <exception cref="SingleException">Thrown when the filtered collection does
+		/// not contain exactly one element.</exception>
+		public static T Single<T>(
+			IEnumerable<T> collection,
+			Predicate<T> predicate)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+			GuardArgumentNotNull(nameof(predicate), predicate);
+
+			return GetSingleResult(collection, predicate, "(filter expression)");
+		}
+
+		static T GetSingleResult<T>(
+			IEnumerable<T> collection,
+#if XUNIT_NULLABLE
+			Predicate<T>? predicate,
+			string? expectedArgument)
+#else
+			Predicate<T> predicate,
+			string expectedArgument)
+#endif
+		{
+			var count = 0;
+			var result = default(T);
+
+			foreach (var item in collection)
+				if (predicate == null || predicate(item))
+					if (++count == 1)
+						result = item;
+
+			switch (count)
+			{
+				case 0:
+					throw SingleException.Empty(expectedArgument);
+				case 1:
+#if XUNIT_NULLABLE
+					return result!;
+#else
+					return result;
+#endif
+				default:
+					throw SingleException.MoreThanOne(count, expectedArgument);
+			}
+		}
+	}
+}

--- a/Comparers.cs
+++ b/Comparers.cs
@@ -1,0 +1,31 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		static IComparer<T> GetComparer<T>()
+			where T : IComparable =>
+				new AssertComparer<T>();
+
+#if XUNIT_NULLABLE
+		static IEqualityComparer<T?> GetEqualityComparer<T>(IEqualityComparer? innerComparer = null) =>
+			new AssertEqualityComparer<T?>(innerComparer);
+#else
+		static IEqualityComparer<T> GetEqualityComparer<T>(IEqualityComparer innerComparer = null) =>
+			new AssertEqualityComparer<T>(innerComparer);
+#endif
+	}
+}

--- a/DictionaryAsserts.cs
+++ b/DictionaryAsserts.cs
@@ -1,0 +1,235 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Xunit.Sdk;
+
+#if XUNIT_IMMUTABLE_COLLECTIONS
+using System.Collections.Immutable;
+#endif
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		/// <summary>
+		/// Verifies that a dictionary contains a given key.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys of the object to be verified.</typeparam>
+		/// <typeparam name="TValue">The type of the values of the object to be verified.</typeparam>
+		/// <param name="expected">The object expected to be in the collection.</param>
+		/// <param name="collection">The collection to be inspected.</param>
+		/// <returns>The value associated with <paramref name="expected"/>.</returns>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the collection</exception>
+		public static TValue Contains<TKey, TValue>(
+			TKey expected,
+			IDictionary<TKey, TValue> collection)
+#if XUNIT_NULLABLE
+				where TKey : notnull
+#endif
+		{
+			GuardArgumentNotNull(nameof(expected), expected);
+			GuardArgumentNotNull(nameof(collection), collection);
+
+			var value = default(TValue);
+			if (!collection.TryGetValue(expected, out value))
+				throw new ContainsException(expected, collection.Keys);
+
+			return value;
+		}
+
+		/// <summary>
+		/// Verifies that a read-only dictionary contains a given key.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys of the object to be verified.</typeparam>
+		/// <typeparam name="TValue">The type of the values of the object to be verified.</typeparam>
+		/// <param name="expected">The object expected to be in the collection.</param>
+		/// <param name="collection">The collection to be inspected.</param>
+		/// <returns>The value associated with <paramref name="expected"/>.</returns>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the collection</exception>
+		public static TValue Contains<TKey, TValue>(
+			TKey expected,
+			IReadOnlyDictionary<TKey, TValue> collection)
+#if XUNIT_NULLABLE
+				where TKey : notnull
+#endif
+		{
+			GuardArgumentNotNull(nameof(expected), expected);
+			GuardArgumentNotNull(nameof(collection), collection);
+
+			var value = default(TValue);
+			if (!collection.TryGetValue(expected, out value))
+				throw new ContainsException(expected, collection.Keys);
+
+			return value;
+		}
+
+		/// <summary>
+		/// Verifies that a dictionary contains a given key.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys of the object to be verified.</typeparam>
+		/// <typeparam name="TValue">The type of the values of the object to be verified.</typeparam>
+		/// <param name="expected">The object expected to be in the collection.</param>
+		/// <param name="collection">The collection to be inspected.</param>
+		/// <returns>The value associated with <paramref name="expected"/>.</returns>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the collection</exception>
+		public static TValue Contains<TKey, TValue>(
+			TKey expected,
+			Dictionary<TKey, TValue> collection)
+#if XUNIT_NULLABLE
+				where TKey : notnull
+#endif
+		{
+			return Contains(expected, (IReadOnlyDictionary<TKey, TValue>)collection);
+		}
+
+		/// <summary>
+		/// Verifies that a dictionary contains a given key.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys of the object to be verified.</typeparam>
+		/// <typeparam name="TValue">The type of the values of the object to be verified.</typeparam>
+		/// <param name="expected">The object expected to be in the collection.</param>
+		/// <param name="collection">The collection to be inspected.</param>
+		/// <returns>The value associated with <paramref name="expected"/>.</returns>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the collection</exception>
+		public static TValue Contains<TKey, TValue>(
+			TKey expected,
+			ReadOnlyDictionary<TKey, TValue> collection)
+#if XUNIT_NULLABLE
+				where TKey : notnull
+#endif
+		{
+			return Contains(expected, (IReadOnlyDictionary<TKey, TValue>)collection);
+		}
+
+#if XUNIT_IMMUTABLE_COLLECTIONS
+		/// <summary>
+		/// Verifies that a dictionary contains a given key.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys of the object to be verified.</typeparam>
+		/// <typeparam name="TValue">The type of the values of the object to be verified.</typeparam>
+		/// <param name="expected">The object expected to be in the collection.</param>
+		/// <param name="collection">The collection to be inspected.</param>
+		/// <returns>The value associated with <paramref name="expected"/>.</returns>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the collection</exception>
+		public static TValue Contains<TKey, TValue>(
+			TKey expected,
+			ImmutableDictionary<TKey, TValue> collection)
+#if XUNIT_NULLABLE
+				where TKey : notnull
+#endif
+		{
+			return Contains(expected, (IReadOnlyDictionary<TKey, TValue>)collection);
+		}
+#endif
+
+		/// <summary>
+		/// Verifies that a dictionary does not contain a given key.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys of the object to be verified.</typeparam>
+		/// <typeparam name="TValue">The type of the values of the object to be verified.</typeparam>
+		/// <param name="expected">The object expected to be in the collection.</param>
+		/// <param name="collection">The collection to be inspected.</param>
+		/// <exception cref="DoesNotContainException">Thrown when the object is present in the collection</exception>
+		public static void DoesNotContain<TKey, TValue>(
+			TKey expected,
+			IDictionary<TKey, TValue> collection)
+#if XUNIT_NULLABLE
+				where TKey : notnull
+#endif
+		{
+			GuardArgumentNotNull(nameof(expected), expected);
+			GuardArgumentNotNull(nameof(collection), collection);
+
+			// Do not forward to DoesNotContain(expected, collection.Keys) as we want the default SDK behavior
+			if (collection.ContainsKey(expected))
+				throw new DoesNotContainException(expected, collection.Keys);
+		}
+
+		/// <summary>
+		/// Verifies that a dictionary does not contain a given key.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys of the object to be verified.</typeparam>
+		/// <typeparam name="TValue">The type of the values of the object to be verified.</typeparam>
+		/// <param name="expected">The object expected to be in the collection.</param>
+		/// <param name="collection">The collection to be inspected.</param>
+		/// <exception cref="DoesNotContainException">Thrown when the object is present in the collection</exception>
+		public static void DoesNotContain<TKey, TValue>(
+			TKey expected,
+			IReadOnlyDictionary<TKey, TValue> collection)
+#if XUNIT_NULLABLE
+				where TKey : notnull
+#endif
+		{
+			GuardArgumentNotNull(nameof(expected), expected);
+			GuardArgumentNotNull(nameof(collection), collection);
+
+			// Do not forward to DoesNotContain(expected, collection.Keys) as we want the default SDK behavior
+			if (collection.ContainsKey(expected))
+				throw new DoesNotContainException(expected, collection.Keys);
+		}
+
+		/// <summary>
+		/// Verifies that a dictionary does not contain a given key.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys of the object to be verified.</typeparam>
+		/// <typeparam name="TValue">The type of the values of the object to be verified.</typeparam>
+		/// <param name="expected">The object expected to be in the collection.</param>
+		/// <param name="collection">The collection to be inspected.</param>
+		/// <exception cref="DoesNotContainException">Thrown when the object is present in the collection</exception>
+		public static void DoesNotContain<TKey, TValue>(
+			TKey expected,
+			Dictionary<TKey, TValue> collection)
+#if XUNIT_NULLABLE
+				where TKey : notnull
+#endif
+		{
+			DoesNotContain(expected, (IDictionary<TKey, TValue>)collection);
+		}
+
+		/// <summary>
+		/// Verifies that a dictionary does not contain a given key.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys of the object to be verified.</typeparam>
+		/// <typeparam name="TValue">The type of the values of the object to be verified.</typeparam>
+		/// <param name="expected">The object expected to be in the collection.</param>
+		/// <param name="collection">The collection to be inspected.</param>
+		/// <exception cref="DoesNotContainException">Thrown when the object is present in the collection</exception>
+		public static void DoesNotContain<TKey, TValue>(
+			TKey expected,
+			ReadOnlyDictionary<TKey, TValue> collection)
+#if XUNIT_NULLABLE
+				where TKey : notnull
+#endif
+		{
+			DoesNotContain(expected, (IReadOnlyDictionary<TKey, TValue>)collection);
+		}
+
+#if XUNIT_IMMUTABLE_COLLECTIONS
+		/// <summary>
+		/// Verifies that a dictionary does not contain a given key.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys of the object to be verified.</typeparam>
+		/// <typeparam name="TValue">The type of the values of the object to be verified.</typeparam>
+		/// <param name="expected">The object expected to be in the collection.</param>
+		/// <param name="collection">The collection to be inspected.</param>
+		/// <exception cref="DoesNotContainException">Thrown when the object is present in the collection</exception>
+		public static void DoesNotContain<TKey, TValue>(
+			TKey expected,
+			ImmutableDictionary<TKey, TValue> collection)
+#if XUNIT_NULLABLE
+				where TKey : notnull
+#endif
+		{
+			DoesNotContain(expected, (IReadOnlyDictionary<TKey, TValue>)collection);
+		}
+#endif
+	}
+}

--- a/EqualityAsserts.cs
+++ b/EqualityAsserts.cs
@@ -1,0 +1,467 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Xunit.Sdk;
+
+#if XUNIT_NULLABLE
+using System.Diagnostics.CodeAnalysis;
+#endif
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+#if XUNIT_SPAN
+		/// <summary>
+		/// Verifies that two arrays of un-managed type T are equal, using Span&lt;T&gt;.SequenceEqual.
+		/// </summary>
+		/// <typeparam name="T">The type of items whose arrays are to be compared</typeparam>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The value to be compared against</param>
+		/// <exception cref="EqualException">Thrown when the arrays are not equal</exception>
+		/// <remarks>
+		/// If Span&lt;T&gt;.SequenceEqual fails, a call to Assert.Equal(object, object) is made,
+		/// to provide a more meaningful error message.
+		/// </remarks>
+		public static void Equal<T>(
+#if XUNIT_NULLABLE
+			[AllowNull] T[] expected,
+			[AllowNull] T[] actual)
+				where T : unmanaged, IEquatable<T>
+#else
+			T[] expected,
+			T[] actual)
+				where T : IEquatable<T>
+#endif
+		{
+			if (expected == null && actual == null)
+				return;
+
+			// Call into Equal<object> so we get proper formatting of the sequence
+			if (expected == null || actual == null || !expected.AsSpan().SequenceEqual(actual))
+				Equal<object>(expected, actual);
+		}
+#endif
+
+		/// <summary>
+		/// Verifies that two objects are equal, using a default comparer.
+		/// </summary>
+		/// <typeparam name="T">The type of the objects to be compared</typeparam>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The value to be compared against</param>
+		/// <exception cref="EqualException">Thrown when the objects are not equal</exception>
+		public static void Equal<T>(
+#if XUNIT_NULLABLE
+			[AllowNull] T expected,
+			[AllowNull] T actual) =>
+#else
+			T expected,
+			T actual) =>
+#endif
+				Equal(expected, actual, GetEqualityComparer<T>());
+
+		/// <summary>
+		/// Verifies that two objects are equal, using a custom equatable comparer.
+		/// </summary>
+		/// <typeparam name="T">The type of the objects to be compared</typeparam>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The value to be compared against</param>
+		/// <param name="comparer">The comparer used to compare the two objects</param>
+		/// <exception cref="EqualException">Thrown when the objects are not equal</exception>
+		public static void Equal<T>(
+#if XUNIT_NULLABLE
+			[AllowNull] T expected,
+			[AllowNull] T actual,
+#else
+			T expected,
+			T actual,
+#endif
+			IEqualityComparer<T> comparer)
+		{
+			GuardArgumentNotNull(nameof(comparer), comparer);
+
+			var expectedAsIEnum = expected as IEnumerable;
+			var actualAsIEnum = actual as IEnumerable;
+			var aec = comparer as AssertEqualityComparer<T>;
+
+			// if we got an AssertEqualityComparer<T> we can invoke it to get the mismatched index.
+			if (aec != null)
+			{
+				int? mismatchedIndex;
+
+				if (!aec.Equals(expected, actual, out mismatchedIndex))
+				{
+					if (mismatchedIndex.HasValue)
+						throw EqualException.FromEnumerable(expectedAsIEnum, actualAsIEnum, mismatchedIndex.Value);
+					else
+						throw new EqualException(expected, actual);
+				}
+			}
+			else if (!comparer.Equals(expected, actual))
+				throw new EqualException(expected, actual);
+		}
+
+		/// <summary>
+		/// Verifies that two <see cref="double"/> values are equal, within the number of decimal
+		/// places given by <paramref name="precision"/>. The values are rounded before comparison.
+		/// </summary>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The value to be compared against</param>
+		/// <param name="precision">The number of decimal places (valid values: 0-15)</param>
+		/// <exception cref="EqualException">Thrown when the values are not equal</exception>
+		public static void Equal(
+			double expected,
+			double actual,
+			int precision)
+		{
+			var expectedRounded = Math.Round(expected, precision);
+			var actualRounded = Math.Round(actual, precision);
+
+			if (!object.Equals(expectedRounded, actualRounded))
+				throw new EqualException($"{expectedRounded} (rounded from {expected})", $"{actualRounded} (rounded from {actual})");
+		}
+
+		/// <summary>
+		/// Verifies that two <see cref="double"/> values are equal, within the number of decimal
+		/// places given by <paramref name="precision"/>. The values are rounded before comparison.
+		/// The rounding method to use is given by <paramref name="rounding" />
+		/// </summary>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The value to be compared against</param>
+		/// <param name="precision">The number of decimal places (valid values: 0-15)</param>
+		/// <param name="rounding">Rounding method to use to process a number that is midway between two numbers</param>
+		public static void Equal(
+			double expected,
+			double actual,
+			int precision,
+			MidpointRounding rounding)
+		{
+			var expectedRounded = Math.Round(expected, precision, rounding);
+			var actualRounded = Math.Round(actual, precision, rounding);
+
+			if (!object.Equals(expectedRounded, actualRounded))
+				throw new EqualException($"{expectedRounded} (rounded from {expected})", $"{actualRounded} (rounded from {actual})");
+		}
+
+		/// <summary>
+		/// Verifies that two <see cref="double"/> values are equal, within the tolerance given by
+		/// <paramref name="tolerance"/> (positive or negative).
+		/// </summary>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The value to be compared against</param>
+		/// <param name="tolerance">The allowed difference between values</param>
+		/// <exception cref="ArgumentException">Thrown when supplied tolerance is invalid</exception>"
+		/// <exception cref="EqualException">Thrown when the values are not equal</exception>
+		public static void Equal(
+			double expected,
+			double actual,
+			double tolerance)
+		{
+			if (double.IsNaN(tolerance) || double.IsNegativeInfinity(tolerance) || tolerance < 0.0)
+				throw new ArgumentException("Tolerance must be greater than or equal to zero", nameof(tolerance));
+
+			if (!(object.Equals(expected, actual) || Math.Abs(expected - actual) <= tolerance))
+				throw new EqualException($"{expected:G17}", $"{actual:G17}");
+		}
+
+		/// <summary>
+		/// Verifies that two <see cref="float"/> values are equal, within the number of decimal
+		/// places given by <paramref name="precision"/>. The values are rounded before comparison.
+		/// </summary>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The value to be compared against</param>
+		/// <param name="precision">The number of decimal places (valid values: 0-15)</param>
+		/// <exception cref="EqualException">Thrown when the values are not equal</exception>
+		public static void Equal(
+			float expected,
+			float actual,
+			int precision) =>
+				Equal((double)expected, (double)actual, precision);
+
+		/// <summary>
+		/// Verifies that two <see cref="float"/> values are equal, within the number of decimal
+		/// places given by <paramref name="precision"/>. The values are rounded before comparison.
+		/// The rounding method to use is given by <paramref name="rounding" />
+		/// </summary>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The value to be compared against</param>
+		/// <param name="precision">The number of decimal places (valid values: 0-15)</param>
+		/// <param name="rounding">Rounding method to use to process a number that is midway between two numbers</param>
+		public static void Equal(
+			float expected,
+			float actual,
+			int precision,
+			MidpointRounding rounding) =>
+				Equal((double)expected, (double)actual, precision, rounding);
+
+		/// <summary>
+		/// Verifies that two <see cref="float"/> values are equal, within the tolerance given by
+		/// <paramref name="tolerance"/> (positive or negative).
+		/// </summary>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The value to be compared against</param>
+		/// <param name="tolerance">The allowed difference between values</param>
+		/// <exception cref="ArgumentException">Thrown when supplied tolerance is invalid</exception>"
+		/// <exception cref="EqualException">Thrown when the values are not equal</exception>
+		public static void Equal(
+			float expected,
+			float actual,
+			float tolerance)
+		{
+			if (float.IsNaN(tolerance) || float.IsNegativeInfinity(tolerance) || tolerance < 0.0)
+				throw new ArgumentException("Tolerance must be greater than or equal to zero", nameof(tolerance));
+
+			if (!(object.Equals(expected, actual) || Math.Abs(expected - actual) <= tolerance))
+				throw new EqualException($"{expected:G9}", $"{actual:G9}");
+		}
+
+		/// <summary>
+		/// Verifies that two <see cref="decimal"/> values are equal, within the number of decimal
+		/// places given by <paramref name="precision"/>. The values are rounded before comparison.
+		/// </summary>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The value to be compared against</param>
+		/// <param name="precision">The number of decimal places (valid values: 0-28)</param>
+		/// <exception cref="EqualException">Thrown when the values are not equal</exception>
+		public static void Equal(
+			decimal expected,
+			decimal actual,
+			int precision)
+		{
+			var expectedRounded = Math.Round(expected, precision);
+			var actualRounded = Math.Round(actual, precision);
+
+			if (expectedRounded != actualRounded)
+				throw new EqualException($"{expectedRounded} (rounded from {expected})", $"{actualRounded} (rounded from {actual})");
+		}
+
+		/// <summary>
+		/// Verifies that two <see cref="DateTime"/> values are equal.
+		/// </summary>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The value to be compared against</param>
+		/// <exception cref="EqualException">Thrown when the values are not equal</exception>
+		public static void Equal(
+			DateTime expected,
+			DateTime actual) =>
+				Equal(expected, actual, TimeSpan.Zero);
+
+		/// <summary>
+		/// Verifies that two <see cref="DateTime"/> values are equal, within the precision
+		/// given by <paramref name="precision"/>.
+		/// </summary>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The value to be compared against</param>
+		/// <param name="precision">The allowed difference in time where the two dates are considered equal</param>
+		/// <exception cref="EqualException">Thrown when the values are not within the given precision</exception>
+		public static void Equal(
+			DateTime expected,
+			DateTime actual,
+			TimeSpan precision)
+		{
+			var difference = (expected - actual).Duration();
+
+			if (difference > precision)
+			{
+				var actualValue =
+					precision == TimeSpan.Zero
+						? actual.ToString()
+						: $"{actual} (difference {difference} is larger than {precision})";
+
+				throw new EqualException(expected.ToString(), actualValue);
+			}
+		}
+
+		/// <summary>
+		/// Verifies that two <see cref="DateTimeOffset"/> values are equal.
+		/// </summary>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The value to be compared against</param>
+		/// <exception cref="EqualException">Thrown when the values are not equal</exception>
+		public static void Equal(
+			DateTimeOffset expected,
+			DateTimeOffset actual) =>
+				Equal(expected, actual, TimeSpan.Zero);
+
+		/// <summary>
+		/// Verifies that two <see cref="DateTimeOffset"/> values are equal, within the precision
+		/// given by <paramref name="precision"/>.
+		/// </summary>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The value to be compared against</param>
+		/// <param name="precision">The allowed difference in time where the two dates are considered equal</param>
+		/// <exception cref="EqualException">Thrown when the values are not within the given precision</exception>
+		public static void Equal(
+			DateTimeOffset expected,
+			DateTimeOffset actual,
+			TimeSpan precision)
+		{
+			var difference = (expected - actual).Duration();
+
+			if (difference > precision)
+			{
+				var actualValue =
+					precision == TimeSpan.Zero
+						? actual.ToString()
+						: $"{actual} (difference {difference} is larger than {precision})";
+
+				throw new EqualException(expected.ToString(), actualValue);
+			}
+		}
+
+		/// <summary>
+		/// Verifies that two objects are strictly equal, using the type's default comparer.
+		/// </summary>
+		/// <typeparam name="T">The type of the objects to be compared</typeparam>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The value to be compared against</param>
+		/// <exception cref="EqualException">Thrown when the objects are not equal</exception>
+		public static void StrictEqual<T>(
+#if XUNIT_NULLABLE
+			[AllowNull] T expected,
+			[AllowNull] T actual) =>
+				Equal(expected, actual, EqualityComparer<T?>.Default);
+#else
+			T expected,
+			T actual) =>
+				Equal(expected, actual, EqualityComparer<T>.Default);
+#endif
+
+#if XUNIT_SPAN
+		/// <summary>
+		/// Verifies that two arrays of un-managed type T are not equal, using Span&lt;T&gt;.SequenceEqual.
+		/// </summary>
+		/// <typeparam name="T">The type of items whose arrays are to be compared</typeparam>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The value to be compared against</param>
+		/// <exception cref="NotEqualException">Thrown when the arrays are equal</exception>
+		public static void NotEqual<T>(
+#if XUNIT_NULLABLE
+			[AllowNull] T[] expected,
+			[AllowNull] T[] actual)
+				where T : unmanaged, IEquatable<T>
+#else
+			T[] expected,
+			T[] actual)
+				where T : IEquatable<T>
+#endif
+		{
+			// Call into NotEqual<object> so we get proper formatting of the sequence
+			if (expected == null && actual == null)
+				NotEqual<object>(expected, actual);
+			if (expected == null || actual == null)
+				return;
+			if (expected.AsSpan().SequenceEqual(actual))
+				NotEqual<object>(expected, actual);
+		}
+#endif
+
+		/// <summary>
+		/// Verifies that two objects are not equal, using a default comparer.
+		/// </summary>
+		/// <typeparam name="T">The type of the objects to be compared</typeparam>
+		/// <param name="expected">The expected object</param>
+		/// <param name="actual">The actual object</param>
+		/// <exception cref="NotEqualException">Thrown when the objects are equal</exception>
+		public static void NotEqual<T>(
+#if XUNIT_NULLABLE
+			[AllowNull] T expected,
+			[AllowNull] T actual) =>
+#else
+			T expected,
+			T actual) =>
+#endif
+				NotEqual(expected, actual, GetEqualityComparer<T>());
+
+		/// <summary>
+		/// Verifies that two objects are not equal, using a custom equality comparer.
+		/// </summary>
+		/// <typeparam name="T">The type of the objects to be compared</typeparam>
+		/// <param name="expected">The expected object</param>
+		/// <param name="actual">The actual object</param>
+		/// <param name="comparer">The comparer used to examine the objects</param>
+		/// <exception cref="NotEqualException">Thrown when the objects are equal</exception>
+		public static void NotEqual<T>(
+#if XUNIT_NULLABLE
+			[AllowNull] T expected,
+			[AllowNull] T actual,
+#else
+			T expected,
+			T actual,
+#endif
+			IEqualityComparer<T> comparer)
+		{
+			GuardArgumentNotNull(nameof(comparer), comparer);
+
+			if (comparer.Equals(expected, actual))
+				throw new NotEqualException(ArgumentFormatter.Format(expected), ArgumentFormatter.Format(actual));
+		}
+
+		/// <summary>
+		/// Verifies that two <see cref="double"/> values are not equal, within the number of decimal
+		/// places given by <paramref name="precision"/>.
+		/// </summary>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The value to be compared against</param>
+		/// <param name="precision">The number of decimal places (valid values: 0-15)</param>
+		/// <exception cref="EqualException">Thrown when the values are equal</exception>
+		public static void NotEqual(
+			double expected,
+			double actual,
+			int precision)
+		{
+			var expectedRounded = Math.Round(expected, precision);
+			var actualRounded = Math.Round(actual, precision);
+
+			if (object.Equals(expectedRounded, actualRounded))
+				throw new NotEqualException($"{expectedRounded} (rounded from {expected})", $"{actualRounded} (rounded from {actual})");
+		}
+
+		/// <summary>
+		/// Verifies that two <see cref="decimal"/> values are not equal, within the number of decimal
+		/// places given by <paramref name="precision"/>.
+		/// </summary>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The value to be compared against</param>
+		/// <param name="precision">The number of decimal places (valid values: 0-28)</param>
+		/// <exception cref="EqualException">Thrown when the values are equal</exception>
+		public static void NotEqual(
+			decimal expected,
+			decimal actual,
+			int precision)
+		{
+			var expectedRounded = Math.Round(expected, precision);
+			var actualRounded = Math.Round(actual, precision);
+
+			if (expectedRounded == actualRounded)
+				throw new NotEqualException($"{expectedRounded} (rounded from {expected})", $"{actualRounded} (rounded from {actual})");
+		}
+
+		/// <summary>
+		/// Verifies that two objects are strictly not equal, using the type's default comparer.
+		/// </summary>
+		/// <typeparam name="T">The type of the objects to be compared</typeparam>
+		/// <param name="expected">The expected object</param>
+		/// <param name="actual">The actual object</param>
+		/// <exception cref="NotEqualException">Thrown when the objects are equal</exception>
+		public static void NotStrictEqual<T>(
+#if XUNIT_NULLABLE
+			[AllowNull] T expected,
+			[AllowNull] T actual) =>
+				NotEqual(expected, actual, EqualityComparer<T?>.Default);
+#else
+			T expected,
+			T actual) =>
+				NotEqual(expected, actual, EqualityComparer<T>.Default);
+#endif
+	}
+}

--- a/EquivalenceAsserts.cs
+++ b/EquivalenceAsserts.cs
@@ -1,0 +1,44 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using Xunit.Internal;
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		/// <summary>
+		/// Verifies that two objects are equivalent, using a default comparer. This comparison is done
+		/// without regard to type, and only inspects public property and field values for individual
+		/// equality. Deep equivalence tests (meaning, property or fields which are themselves complex
+		/// types) are supported. With strict mode off, object comparison allows <paramref name="actual"/>
+		/// to have extra public members that aren't part of <paramref name="expected"/>, and collection
+		/// comparison allows <paramref name="actual"/> to have more data in it than is present in
+		/// <paramref name="expected"/>; with strict mode on, those rules are tightened to require exact
+		/// member list (for objects) or data (for collections).
+		/// </summary>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The actual value</param>
+		/// <param name="strict">A flag which enables strict comparison mode</param>
+		public static void Equivalent(
+#if XUNIT_NULLABLE
+			object? expected,
+			object? actual,
+#else
+			object expected,
+			object actual,
+#endif
+			bool strict = false)
+		{
+			var ex = AssertHelper.VerifyEquivalence(expected, actual, strict);
+			if (ex != null)
+				throw ex;
+		}
+	}
+}

--- a/EventAsserts.cs
+++ b/EventAsserts.cs
@@ -1,0 +1,202 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.Threading.Tasks;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		/// <summary>
+		/// Verifies that a event with the exact event args is raised.
+		/// </summary>
+		/// <typeparam name="T">The type of the event arguments to expect</typeparam>
+		/// <param name="attach">Code to attach the event handler</param>
+		/// <param name="detach">Code to detach the event handler</param>
+		/// <param name="testCode">A delegate to the code to be tested</param>
+		/// <returns>The event sender and arguments wrapped in an object</returns>
+		/// <exception cref="RaisesException">Thrown when the expected event was not raised.</exception>
+		public static RaisedEvent<T> Raises<T>(
+			Action<EventHandler<T>> attach,
+			Action<EventHandler<T>> detach,
+			Action testCode)
+		{
+			var raisedEvent = RaisesInternal(attach, detach, testCode);
+
+			if (raisedEvent == null)
+				throw new RaisesException(typeof(T));
+
+			if (raisedEvent.Arguments != null && !raisedEvent.Arguments.GetType().Equals(typeof(T)))
+				throw new RaisesException(typeof(T), raisedEvent.Arguments.GetType());
+
+			return raisedEvent;
+		}
+
+		/// <summary>
+		/// Verifies that an event with the exact or a derived event args is raised.
+		/// </summary>
+		/// <typeparam name="T">The type of the event arguments to expect</typeparam>
+		/// <param name="attach">Code to attach the event handler</param>
+		/// <param name="detach">Code to detach the event handler</param>
+		/// <param name="testCode">A delegate to the code to be tested</param>
+		/// <returns>The event sender and arguments wrapped in an object</returns>
+		/// <exception cref="RaisesException">Thrown when the expected event was not raised.</exception>
+		public static RaisedEvent<T> RaisesAny<T>(
+			Action<EventHandler<T>> attach,
+			Action<EventHandler<T>> detach,
+			Action testCode)
+		{
+			var raisedEvent = RaisesInternal(attach, detach, testCode);
+
+			if (raisedEvent == null)
+				throw new RaisesException(typeof(T));
+
+			return raisedEvent;
+		}
+
+		/// <summary>
+		/// Verifies that a event with the exact event args (and not a derived type) is raised.
+		/// </summary>
+		/// <typeparam name="T">The type of the event arguments to expect</typeparam>
+		/// <param name="attach">Code to attach the event handler</param>
+		/// <param name="detach">Code to detach the event handler</param>
+		/// <param name="testCode">A delegate to the code to be tested</param>
+		/// <returns>The event sender and arguments wrapped in an object</returns>
+		/// <exception cref="RaisesException">Thrown when the expected event was not raised.</exception>
+		public static async Task<RaisedEvent<T>> RaisesAsync<T>(
+			Action<EventHandler<T>> attach,
+			Action<EventHandler<T>> detach,
+			Func<Task> testCode)
+		{
+			var raisedEvent = await RaisesAsyncInternal(attach, detach, testCode);
+
+			if (raisedEvent == null)
+				throw new RaisesException(typeof(T));
+
+			if (raisedEvent.Arguments != null && !raisedEvent.Arguments.GetType().Equals(typeof(T)))
+				throw new RaisesException(typeof(T), raisedEvent.Arguments.GetType());
+
+			return raisedEvent;
+		}
+
+		/// <summary>
+		/// Verifies that an event with the exact or a derived event args is raised.
+		/// </summary>
+		/// <typeparam name="T">The type of the event arguments to expect</typeparam>
+		/// <param name="attach">Code to attach the event handler</param>
+		/// <param name="detach">Code to detach the event handler</param>
+		/// <param name="testCode">A delegate to the code to be tested</param>
+		/// <returns>The event sender and arguments wrapped in an object</returns>
+		/// <exception cref="RaisesException">Thrown when the expected event was not raised.</exception>
+		public static async Task<RaisedEvent<T>> RaisesAnyAsync<T>(
+			Action<EventHandler<T>> attach,
+			Action<EventHandler<T>> detach,
+			Func<Task> testCode)
+		{
+			var raisedEvent = await RaisesAsyncInternal(attach, detach, testCode);
+
+			if (raisedEvent == null)
+				throw new RaisesException(typeof(T));
+
+			return raisedEvent;
+		}
+
+#if XUNIT_NULLABLE
+		static RaisedEvent<T>? RaisesInternal<T>(
+#else
+		static RaisedEvent<T> RaisesInternal<T>(
+#endif
+			Action<EventHandler<T>> attach,
+			Action<EventHandler<T>> detach,
+			Action testCode)
+		{
+			GuardArgumentNotNull(nameof(attach), attach);
+			GuardArgumentNotNull(nameof(detach), detach);
+			GuardArgumentNotNull(nameof(testCode), testCode);
+
+#if XUNIT_NULLABLE
+			RaisedEvent<T>? raisedEvent = null;
+			void handler(object? s, T args) => raisedEvent = new RaisedEvent<T>(s, args);
+#else
+			RaisedEvent<T> raisedEvent = null;
+			EventHandler<T> handler = (object s, T args) => raisedEvent = new RaisedEvent<T>(s, args);
+#endif
+			attach(handler);
+			testCode();
+			detach(handler);
+			return raisedEvent;
+		}
+
+#if XUNIT_NULLABLE
+		static async Task<RaisedEvent<T>?> RaisesAsyncInternal<T>(
+#else
+		static async Task<RaisedEvent<T>> RaisesAsyncInternal<T>(
+#endif
+			Action<EventHandler<T>> attach,
+			Action<EventHandler<T>> detach,
+			Func<Task> testCode)
+		{
+			GuardArgumentNotNull(nameof(attach), attach);
+			GuardArgumentNotNull(nameof(detach), detach);
+			GuardArgumentNotNull(nameof(testCode), testCode);
+
+#if XUNIT_NULLABLE
+			RaisedEvent<T>? raisedEvent = null;
+			void handler(object? s, T args) => raisedEvent = new RaisedEvent<T>(s, args);
+#else
+			RaisedEvent<T> raisedEvent = null;
+			EventHandler<T> handler = (object s, T args) => raisedEvent = new RaisedEvent<T>(s, args);
+#endif
+			attach(handler);
+			await testCode();
+			detach(handler);
+			return raisedEvent;
+		}
+
+		/// <summary>
+		/// Represents a raised event after the fact.
+		/// </summary>
+		/// <typeparam name="T">The type of the event arguments.</typeparam>
+		public class RaisedEvent<T>
+		{
+			/// <summary>
+			/// The sender of the event.
+			/// </summary>
+#if XUNIT_NULLABLE
+			public object? Sender { get; }
+#else
+			public object Sender { get; }
+#endif
+
+			/// <summary>
+			/// The event arguments.
+			/// </summary>
+			public T Arguments { get; }
+
+			/// <summary>
+			/// Creates a new instance of the <see cref="RaisedEvent{T}" /> class.
+			/// </summary>
+			/// <param name="sender">The sender of the event.</param>
+			/// <param name="args">The event arguments</param>
+			public RaisedEvent(
+#if XUNIT_NULLABLE
+				object? sender,
+#else
+				object sender,
+#endif
+				T args)
+			{
+				Sender = sender;
+				Arguments = args;
+			}
+		}
+	}
+}

--- a/ExceptionAsserts.cs
+++ b/ExceptionAsserts.cs
@@ -1,0 +1,380 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.ComponentModel;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		/// <summary>
+		/// Verifies that the exact exception is thrown (and not a derived exception type).
+		/// </summary>
+		/// <typeparam name="T">The type of the exception expected to be thrown</typeparam>
+		/// <param name="testCode">A delegate to the code to be tested</param>
+		/// <returns>The exception that was thrown, when successful</returns>
+		/// <exception cref="ThrowsException">Thrown when an exception was not thrown, or when an exception of the incorrect type is thrown</exception>
+		public static T Throws<T>(Action testCode)
+			where T : Exception =>
+				(T)Throws(typeof(T), RecordException(testCode));
+
+		/// <summary>
+		/// Verifies that the exact exception is thrown (and not a derived exception type).
+		/// Generally used to test property accessors.
+		/// </summary>
+		/// <typeparam name="T">The type of the exception expected to be thrown</typeparam>
+		/// <param name="testCode">A delegate to the code to be tested</param>
+		/// <returns>The exception that was thrown, when successful</returns>
+		/// <exception cref="ThrowsException">Thrown when an exception was not thrown, or when an exception of the incorrect type is thrown</exception>
+#if XUNIT_NULLABLE
+		public static T Throws<T>(Func<object?> testCode)
+#else
+		public static T Throws<T>(Func<object> testCode)
+#endif
+			where T : Exception =>
+				(T)Throws(typeof(T), RecordException(testCode));
+
+		/// <summary/>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("You must call Assert.ThrowsAsync<T> (and await the result) when testing async code.", true)]
+		public static T Throws<T>(Func<Task> testCode)
+			where T : Exception
+		{
+			throw new NotImplementedException();
+		}
+
+#if XUNIT_VALUETASK
+		/// <summary/>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("You must call Assert.ThrowsAsync<T> (and await the result) when testing async code.", true)]
+		public static T Throws<T>(Func<ValueTask> testCode)
+			where T : Exception
+		{
+			throw new NotImplementedException();
+		}
+#endif
+
+		/// <summary>
+		/// Verifies that the exact exception is thrown (and not a derived exception type).
+		/// </summary>
+		/// <typeparam name="T">The type of the exception expected to be thrown</typeparam>
+		/// <param name="testCode">A delegate to the task to be tested</param>
+		/// <returns>The exception that was thrown, when successful</returns>
+		/// <exception cref="ThrowsException">Thrown when an exception was not thrown, or when an exception of the incorrect type is thrown</exception>
+		public static async Task<T> ThrowsAsync<T>(Func<Task> testCode)
+			where T : Exception =>
+				(T)Throws(typeof(T), await RecordExceptionAsync(testCode));
+
+#if XUNIT_VALUETASK
+		/// <summary>
+		/// Verifies that the exact exception is thrown (and not a derived exception type).
+		/// </summary>
+		/// <typeparam name="T">The type of the exception expected to be thrown</typeparam>
+		/// <param name="testCode">A delegate to the task to be tested</param>
+		/// <returns>The exception that was thrown, when successful</returns>
+		/// <exception cref="ThrowsException">Thrown when an exception was not thrown, or when an exception of the incorrect type is thrown</exception>
+		public static async ValueTask<T> ThrowsAsync<T>(Func<ValueTask> testCode)
+			where T : Exception =>
+				(T)Throws(typeof(T), await RecordExceptionAsync(testCode));
+#endif
+
+		/// <summary>
+		/// Verifies that the exact exception or a derived exception type is thrown.
+		/// </summary>
+		/// <typeparam name="T">The type of the exception expected to be thrown</typeparam>
+		/// <param name="testCode">A delegate to the code to be tested</param>
+		/// <returns>The exception that was thrown, when successful</returns>
+		/// <exception cref="ThrowsException">Thrown when an exception was not thrown, or when an exception of the incorrect type is thrown</exception>
+		public static T ThrowsAny<T>(Action testCode)
+			where T : Exception =>
+				(T)ThrowsAny(typeof(T), RecordException(testCode));
+
+		/// <summary>
+		/// Verifies that the exact exception or a derived exception type is thrown.
+		/// Generally used to test property accessors.
+		/// </summary>
+		/// <typeparam name="T">The type of the exception expected to be thrown</typeparam>
+		/// <param name="testCode">A delegate to the code to be tested</param>
+		/// <returns>The exception that was thrown, when successful</returns>
+		/// <exception cref="ThrowsException">Thrown when an exception was not thrown, or when an exception of the incorrect type is thrown</exception>
+#if XUNIT_NULLABLE
+		public static T ThrowsAny<T>(Func<object?> testCode)
+#else
+		public static T ThrowsAny<T>(Func<object> testCode)
+#endif
+			where T : Exception =>
+				(T)ThrowsAny(typeof(T), RecordException(testCode));
+
+		/// <summary>
+		/// Verifies that the exact exception or a derived exception type is thrown.
+		/// </summary>
+		/// <typeparam name="T">The type of the exception expected to be thrown</typeparam>
+		/// <param name="testCode">A delegate to the task to be tested</param>
+		/// <returns>The exception that was thrown, when successful</returns>
+		/// <exception cref="ThrowsException">Thrown when an exception was not thrown, or when an exception of the incorrect type is thrown</exception>
+		public static async Task<T> ThrowsAnyAsync<T>(Func<Task> testCode)
+			where T : Exception =>
+				(T)ThrowsAny(typeof(T), await RecordExceptionAsync(testCode));
+
+#if XUNIT_VALUETASK
+		/// <summary>
+		/// Verifies that the exact exception or a derived exception type is thrown.
+		/// </summary>
+		/// <typeparam name="T">The type of the exception expected to be thrown</typeparam>
+		/// <param name="testCode">A delegate to the task to be tested</param>
+		/// <returns>The exception that was thrown, when successful</returns>
+		/// <exception cref="ThrowsException">Thrown when an exception was not thrown, or when an exception of the incorrect type is thrown</exception>
+		public static async ValueTask<T> ThrowsAnyAsync<T>(Func<ValueTask> testCode)
+			where T : Exception =>
+				(T)ThrowsAny(typeof(T), await RecordExceptionAsync(testCode));
+#endif
+
+		/// <summary>
+		/// Verifies that the exact exception is thrown (and not a derived exception type).
+		/// </summary>
+		/// <param name="exceptionType">The type of the exception expected to be thrown</param>
+		/// <param name="testCode">A delegate to the code to be tested</param>
+		/// <returns>The exception that was thrown, when successful</returns>
+		/// <exception cref="ThrowsException">Thrown when an exception was not thrown, or when an exception of the incorrect type is thrown</exception>
+		public static Exception Throws(
+			Type exceptionType,
+			Action testCode) =>
+				Throws(exceptionType, RecordException(testCode));
+
+		/// <summary>
+		/// Verifies that the exact exception is thrown (and not a derived exception type).
+		/// Generally used to test property accessors.
+		/// </summary>
+		/// <param name="exceptionType">The type of the exception expected to be thrown</param>
+		/// <param name="testCode">A delegate to the code to be tested</param>
+		/// <returns>The exception that was thrown, when successful</returns>
+		/// <exception cref="ThrowsException">Thrown when an exception was not thrown, or when an exception of the incorrect type is thrown</exception>
+		public static Exception Throws(
+			Type exceptionType,
+#if XUNIT_NULLABLE
+			Func<object?> testCode) =>
+#else
+			Func<object> testCode) =>
+#endif
+				Throws(exceptionType, RecordException(testCode));
+
+		/// <summary/>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("You must call Assert.ThrowsAsync (and await the result) when testing async code.", true)]
+		public static Exception Throws(
+			string paramName,
+			Func<Task> testCode)
+		{
+			throw new NotImplementedException();
+		}
+
+#if XUNIT_VALUETASK
+		/// <summary/>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("You must call Assert.ThrowsAsync (and await the result) when testing async code.", true)]
+		public static Exception Throws(
+			string paramName,
+			Func<ValueTask> testCode)
+		{
+			throw new NotImplementedException();
+		}
+#endif
+
+		/// <summary>
+		/// Verifies that the exact exception is thrown (and not a derived exception type).
+		/// </summary>
+		/// <param name="exceptionType">The type of the exception expected to be thrown</param>
+		/// <param name="testCode">A delegate to the task to be tested</param>
+		/// <returns>The exception that was thrown, when successful</returns>
+		/// <exception cref="ThrowsException">Thrown when an exception was not thrown, or when an exception of the incorrect type is thrown</exception>
+		public static async Task<Exception> ThrowsAsync(
+			Type exceptionType,
+			Func<Task> testCode) =>
+				Throws(exceptionType, await RecordExceptionAsync(testCode));
+
+#if XUNIT_VALUETASK
+		/// <summary>
+		/// Verifies that the exact exception is thrown (and not a derived exception type).
+		/// </summary>
+		/// <param name="exceptionType">The type of the exception expected to be thrown</param>
+		/// <param name="testCode">A delegate to the task to be tested</param>
+		/// <returns>The exception that was thrown, when successful</returns>
+		/// <exception cref="ThrowsException">Thrown when an exception was not thrown, or when an exception of the incorrect type is thrown</exception>
+		public static async ValueTask<Exception> ThrowsAsync(
+			Type exceptionType,
+			Func<ValueTask> testCode) =>
+				Throws(exceptionType, await RecordExceptionAsync(testCode));
+#endif
+
+		static Exception Throws(
+			Type exceptionType,
+#if XUNIT_NULLABLE
+			Exception? exception)
+#else
+			Exception exception)
+#endif
+		{
+			GuardArgumentNotNull(nameof(exceptionType), exceptionType);
+
+			if (exception == null)
+				throw new ThrowsException(exceptionType);
+
+			if (!exceptionType.Equals(exception.GetType()))
+				throw new ThrowsException(exceptionType, exception);
+
+			return exception;
+		}
+
+		static Exception ThrowsAny(
+			Type exceptionType,
+#if XUNIT_NULLABLE
+			Exception? exception)
+#else
+			Exception exception)
+#endif
+		{
+			GuardArgumentNotNull(nameof(exceptionType), exceptionType);
+
+			if (exception == null)
+				throw new ThrowsException(exceptionType);
+
+			if (!exceptionType.GetTypeInfo().IsAssignableFrom(exception.GetType().GetTypeInfo()))
+				throw new ThrowsException(exceptionType, exception);
+
+			return exception;
+		}
+
+		/// <summary>
+		/// Verifies that the exact exception is thrown (and not a derived exception type), where the exception
+		/// derives from <see cref="ArgumentException"/> and has the given parameter name.
+		/// </summary>
+		/// <param name="paramName">The parameter name that is expected to be in the exception</param>
+		/// <param name="testCode">A delegate to the code to be tested</param>
+		/// <returns>The exception that was thrown, when successful</returns>
+		/// <exception cref="ThrowsException">Thrown when an exception was not thrown, or when an exception of the incorrect type is thrown</exception>
+		public static T Throws<T>(
+#if XUNIT_NULLABLE
+			string? paramName,
+#else
+			string paramName,
+#endif
+			Action testCode)
+				where T : ArgumentException
+		{
+			var ex = Throws<T>(testCode);
+			Equal(paramName, ex.ParamName);
+			return ex;
+		}
+
+		/// <summary>
+		/// Verifies that the exact exception is thrown (and not a derived exception type), where the exception
+		/// derives from <see cref="ArgumentException"/> and has the given parameter name.
+		/// </summary>
+		/// <param name="paramName">The parameter name that is expected to be in the exception</param>
+		/// <param name="testCode">A delegate to the code to be tested</param>
+		/// <returns>The exception that was thrown, when successful</returns>
+		/// <exception cref="ThrowsException">Thrown when an exception was not thrown, or when an exception of the incorrect type is thrown</exception>
+		public static T Throws<T>(
+#if XUNIT_NULLABLE
+			string? paramName,
+			Func<object?> testCode)
+#else
+			string paramName,
+			Func<object> testCode)
+#endif
+				where T : ArgumentException
+		{
+			var ex = Throws<T>(testCode);
+			Equal(paramName, ex.ParamName);
+			return ex;
+		}
+
+		/// <summary/>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("You must call Assert.ThrowsAsync<T> (and await the result) when testing async code.", true)]
+		public static T Throws<T>(
+#if XUNIT_NULLABLE
+			string? paramName,
+#else
+			string paramName,
+#endif
+			Func<Task> testCode)
+				where T : ArgumentException
+		{
+			throw new NotImplementedException();
+		}
+
+#if XUNIT_VALUETASK
+		/// <summary/>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("You must call Assert.ThrowsAsync<T> (and await the result) when testing async code.", true)]
+		public static T Throws<T>(
+#if XUNIT_NULLABLE
+			string? paramName,
+#else
+			string paramName,
+#endif
+			Func<ValueTask> testCode)
+				where T : ArgumentException
+		{
+			throw new NotImplementedException();
+		}
+#endif
+
+		/// <summary>
+		/// Verifies that the exact exception is thrown (and not a derived exception type), where the exception
+		/// derives from <see cref="ArgumentException"/> and has the given parameter name.
+		/// </summary>
+		/// <param name="paramName">The parameter name that is expected to be in the exception</param>
+		/// <param name="testCode">A delegate to the task to be tested</param>
+		/// <returns>The exception that was thrown, when successful</returns>
+		/// <exception cref="ThrowsException">Thrown when an exception was not thrown, or when an exception of the incorrect type is thrown</exception>
+		public static async Task<T> ThrowsAsync<T>(
+#if XUNIT_NULLABLE
+			string? paramName,
+#else
+			string paramName,
+#endif
+			Func<Task> testCode)
+				where T : ArgumentException
+		{
+			var ex = await ThrowsAsync<T>(testCode);
+			Equal(paramName, ex.ParamName);
+			return ex;
+		}
+
+#if XUNIT_VALUETASK
+		/// <summary>
+		/// Verifies that the exact exception is thrown (and not a derived exception type), where the exception
+		/// derives from <see cref="ArgumentException"/> and has the given parameter name.
+		/// </summary>
+		/// <param name="paramName">The parameter name that is expected to be in the exception</param>
+		/// <param name="testCode">A delegate to the task to be tested</param>
+		/// <returns>The exception that was thrown, when successful</returns>
+		/// <exception cref="ThrowsException">Thrown when an exception was not thrown, or when an exception of the incorrect type is thrown</exception>
+		public static async ValueTask<T> ThrowsAsync<T>(
+#if XUNIT_NULLABLE
+			string? paramName,
+#else
+			string paramName,
+#endif
+			Func<ValueTask> testCode)
+				where T : ArgumentException
+		{
+			var ex = await ThrowsAsync<T>(testCode);
+			Equal(paramName, ex.ParamName);
+			return ex;
+		}
+#endif
+	}
+}

--- a/FailAsserts.cs
+++ b/FailAsserts.cs
@@ -1,0 +1,34 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using Xunit.Sdk;
+
+#if XUNIT_NULLABLE
+using System.Diagnostics.CodeAnalysis;
+#endif
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		/// <summary>
+		/// Indicates that the test should immediately fail.
+		/// </summary>
+		/// <param name="message">The failure message</param>
+#if XUNIT_NULLABLE
+		[DoesNotReturn]
+#endif
+		public static void Fail(string message)
+		{
+			GuardArgumentNotNull(nameof(message), message);
+
+			throw new FailException(message);
+		}
+	}
+}

--- a/Guards.cs
+++ b/Guards.cs
@@ -1,0 +1,33 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+
+#if XUNIT_NULLABLE
+using System.Diagnostics.CodeAnalysis;
+#endif
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		/// <summary/>
+		internal static void GuardArgumentNotNull(
+			string argName,
+#if XUNIT_NULLABLE
+			[NotNull] object? argValue)
+#else
+			object argValue)
+#endif
+		{
+			if (argValue == null)
+				throw new ArgumentNullException(argName);
+		}
+	}
+}

--- a/IdentityAsserts.cs
+++ b/IdentityAsserts.cs
@@ -1,0 +1,54 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using Xunit.Sdk;
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		/// <summary>
+		/// Verifies that two objects are not the same instance.
+		/// </summary>
+		/// <param name="expected">The expected object instance</param>
+		/// <param name="actual">The actual object instance</param>
+		/// <exception cref="NotSameException">Thrown when the objects are the same instance</exception>
+		public static void NotSame(
+#if XUNIT_NULLABLE
+			object? expected,
+			object? actual)
+#else
+			object expected,
+			object actual)
+#endif
+		{
+			if (object.ReferenceEquals(expected, actual))
+				throw new NotSameException();
+		}
+
+		/// <summary>
+		/// Verifies that two objects are the same instance.
+		/// </summary>
+		/// <param name="expected">The expected object instance</param>
+		/// <param name="actual">The actual object instance</param>
+		/// <exception cref="SameException">Thrown when the objects are not the same instance</exception>
+		public static void Same(
+#if XUNIT_NULLABLE
+			object? expected,
+			object? actual)
+#else
+			object expected,
+			object actual)
+#endif
+		{
+			if (!object.ReferenceEquals(expected, actual))
+				throw new SameException(expected, actual);
+		}
+	}
+}

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,14 @@
+Copyright (c) .NET Foundation and Contributors
+All Rights Reserved
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/MemoryAsserts.cs
+++ b/MemoryAsserts.cs
@@ -1,0 +1,712 @@
+#if XUNIT_SPAN
+
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		// NOTE: there is an implicit conversion operator on Memory<T> to ReadOnlyMemory<T> - however, I have found that the compiler sometimes struggles
+		// with identifying the proper methods to use, thus I have overloaded quite a few of the assertions in terms of supplying both
+		// Memory and ReadOnlyMemory based methods
+
+		// NOTE: we could consider StartsWith<T> and EndsWith<T> with both arguments as ReadOnlyMemory<T>, and use the Memory extension methods on Span to check difference
+		// BUT: the current Exceptions for startswith and endswith are only built for string types, so those would need a change (or new non-string versions created).
+
+		// NOTE: Memory and ReadonlyMemory, even when null, are coerced into empty arrays of the specified type when a value is grabbed. Thus some of the code below
+		// for null scenarios looks odd, but is safe and correct.
+
+		/// <summary>
+		/// Verifies that a Memory contains a given sub-Memory, using the default <see cref="StringComparison.CurrentCulture"/> comparison type.
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-Memory is not present inside the Memory</exception>
+		public static void Contains(
+			Memory<char> expectedSubMemory,
+			Memory<char> actualMemory) =>
+				Contains((ReadOnlyMemory<char>)expectedSubMemory, (ReadOnlyMemory<char>)actualMemory, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a Memory contains a given sub-Memory, using the default <see cref="StringComparison.CurrentCulture"/> comparison type.
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-Memory is not present inside the Memory</exception>
+		public static void Contains(
+			Memory<char> expectedSubMemory,
+			ReadOnlyMemory<char> actualMemory) =>
+				Contains((ReadOnlyMemory<char>)expectedSubMemory, actualMemory, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a Memory contains a given sub-Memory, using the default <see cref="StringComparison.CurrentCulture"/> comparison type.
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-Memory is not present inside the Memory</exception>
+		public static void Contains(
+			ReadOnlyMemory<char> expectedSubMemory,
+			Memory<char> actualMemory) =>
+				Contains(expectedSubMemory, (ReadOnlyMemory<char>)actualMemory, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a Memory contains a given sub-Memory, using the default <see cref="StringComparison.CurrentCulture"/> comparison type.
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-Memory is not present inside the Memory</exception>
+		public static void Contains(
+			ReadOnlyMemory<char> expectedSubMemory,
+			ReadOnlyMemory<char> actualMemory) =>
+				Contains(expectedSubMemory, actualMemory, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a Memory contains a given sub-Memory, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="ContainsException">Thrown when the sub-Memory is not present inside the Memory</exception>
+		public static void Contains(
+			Memory<char> expectedSubMemory,
+			Memory<char> actualMemory,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				Contains((ReadOnlyMemory<char>)expectedSubMemory, (ReadOnlyMemory<char>)actualMemory, comparisonType);
+
+		/// <summary>
+		/// Verifies that a Memory contains a given sub-Memory, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="ContainsException">Thrown when the sub-Memory is not present inside the Memory</exception>
+		public static void Contains(
+			Memory<char> expectedSubMemory,
+			ReadOnlyMemory<char> actualMemory,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				Contains((ReadOnlyMemory<char>)expectedSubMemory, actualMemory, comparisonType);
+
+		/// <summary>
+		/// Verifies that a Memory contains a given sub-Memory, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="ContainsException">Thrown when the sub-Memory is not present inside the Memory</exception>
+		public static void Contains(
+			ReadOnlyMemory<char> expectedSubMemory,
+			Memory<char> actualMemory,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				Contains(expectedSubMemory, (ReadOnlyMemory<char>)actualMemory, comparisonType);
+
+		/// <summary>
+		/// Verifies that a Memory contains a given sub-Memory, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="ContainsException">Thrown when the sub-Memory is not present inside the Memory</exception>
+		public static void Contains(
+			ReadOnlyMemory<char> expectedSubMemory,
+			ReadOnlyMemory<char> actualMemory,
+			StringComparison comparisonType = StringComparison.CurrentCulture)
+		{
+			GuardArgumentNotNull(nameof(expectedSubMemory), expectedSubMemory);
+
+			Contains(expectedSubMemory.Span, actualMemory.Span, comparisonType);
+		}
+
+		/// <summary>
+		/// Verifies that a Memory contains a given sub-Memory
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-Memory is not present inside the Memory</exception>
+		public static void Contains<T>(
+			Memory<T> expectedSubMemory,
+			Memory<T> actualMemory)
+				where T : IEquatable<T> =>
+					Contains((ReadOnlyMemory<T>)expectedSubMemory, (ReadOnlyMemory<T>)actualMemory);
+
+		/// <summary>
+		/// Verifies that a Memory contains a given sub-Memory
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-Memory is not present inside the Memory</exception>
+		public static void Contains<T>(
+			Memory<T> expectedSubMemory,
+			ReadOnlyMemory<T> actualMemory)
+				where T : IEquatable<T> =>
+					Contains((ReadOnlyMemory<T>)expectedSubMemory, actualMemory);
+
+		/// <summary>
+		/// Verifies that a Memory contains a given sub-Memory
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-Memory is not present inside the Memory</exception>
+		public static void Contains<T>(
+			ReadOnlyMemory<T> expectedSubMemory,
+			Memory<T> actualMemory)
+				where T : IEquatable<T> =>
+					Contains(expectedSubMemory, (ReadOnlyMemory<T>)actualMemory);
+
+		/// <summary>
+		/// Verifies that a Memory contains a given sub-Memory
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-Memory is not present inside the Memory</exception>
+		public static void Contains<T>(
+			ReadOnlyMemory<T> expectedSubMemory,
+			ReadOnlyMemory<T> actualMemory)
+				where T : IEquatable<T>
+		{
+			GuardArgumentNotNull(nameof(expectedSubMemory), expectedSubMemory);
+
+			if (actualMemory.Span.IndexOf(expectedSubMemory.Span) < 0)
+				throw new ContainsException(expectedSubMemory, actualMemory);
+		}
+
+		/// <summary>
+		/// Verifies that a Memory does not contain a given sub-Memory, using the default <see cref="StringComparison.CurrentCulture"/> comparison type.
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected not to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-Memory is present inside the Memory</exception>
+		public static void DoesNotContain(
+			Memory<char> expectedSubMemory,
+			Memory<char> actualMemory) =>
+				DoesNotContain((ReadOnlyMemory<char>)expectedSubMemory, (ReadOnlyMemory<char>)actualMemory, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a Memory does not contain a given sub-Memory, using the default <see cref="StringComparison.CurrentCulture"/> comparison type.
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected not to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-Memory is present inside the Memory</exception>
+		public static void DoesNotContain(
+			Memory<char> expectedSubMemory,
+			ReadOnlyMemory<char> actualMemory) =>
+				DoesNotContain((ReadOnlyMemory<char>)expectedSubMemory, actualMemory, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a Memory does not contain a given sub-Memory, using the default <see cref="StringComparison.CurrentCulture"/> comparison type.
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected not to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-Memory is present inside the Memory</exception>
+		public static void DoesNotContain(
+			ReadOnlyMemory<char> expectedSubMemory,
+			Memory<char> actualMemory) =>
+				DoesNotContain(expectedSubMemory, (ReadOnlyMemory<char>)actualMemory, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a Memory does not contain a given sub-Memory, using the default <see cref="StringComparison.CurrentCulture"/> comparison type.
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected not to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-Memory is present inside the Memory</exception>
+		public static void DoesNotContain(
+			ReadOnlyMemory<char> expectedSubMemory,
+			ReadOnlyMemory<char> actualMemory) =>
+				DoesNotContain(expectedSubMemory, actualMemory, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a Memory does not contain a given sub-Memory, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected not to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-Memory is present inside the Memory</exception>
+		public static void DoesNotContain(
+			Memory<char> expectedSubMemory,
+			Memory<char> actualMemory,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				DoesNotContain((ReadOnlyMemory<char>)expectedSubMemory, (ReadOnlyMemory<char>)actualMemory, comparisonType);
+
+		/// <summary>
+		/// Verifies that a Memory does not contain a given sub-Memory, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected not to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-Memory is present inside the Memory</exception>
+		public static void DoesNotContain(
+			Memory<char> expectedSubMemory,
+			ReadOnlyMemory<char> actualMemory,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				DoesNotContain((ReadOnlyMemory<char>)expectedSubMemory, actualMemory, comparisonType);
+
+		/// <summary>
+		/// Verifies that a Memory does not contain a given sub-Memory, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected not to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-Memory is present inside the Memory</exception>
+		public static void DoesNotContain(
+			ReadOnlyMemory<char> expectedSubMemory,
+			Memory<char> actualMemory,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				DoesNotContain(expectedSubMemory, (ReadOnlyMemory<char>)actualMemory, comparisonType);
+
+		/// <summary>
+		/// Verifies that a Memory does not contain a given sub-Memory, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected not to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-Memory is present inside the Memory</exception>
+		public static void DoesNotContain(
+			ReadOnlyMemory<char> expectedSubMemory,
+			ReadOnlyMemory<char> actualMemory,
+			StringComparison comparisonType = StringComparison.CurrentCulture)
+		{
+			GuardArgumentNotNull(nameof(expectedSubMemory), expectedSubMemory);
+
+			DoesNotContain(expectedSubMemory.Span, actualMemory.Span, comparisonType);
+		}
+
+		/// <summary>
+		/// Verifies that a Memory does not contain a given sub-Memory
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected not to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-Memory is present inside the Memory</exception>
+		public static void DoesNotContain<T>(
+			Memory<T> expectedSubMemory,
+			Memory<T> actualMemory)
+				where T : IEquatable<T> =>
+					DoesNotContain((ReadOnlyMemory<T>)expectedSubMemory, (ReadOnlyMemory<T>)actualMemory);
+
+		/// <summary>
+		/// Verifies that a Memory does not contain a given sub-Memory
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected not to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-Memory is present inside the Memory</exception>
+		public static void DoesNotContain<T>(
+			Memory<T> expectedSubMemory,
+			ReadOnlyMemory<T> actualMemory)
+				where T : IEquatable<T> =>
+					DoesNotContain((ReadOnlyMemory<T>)expectedSubMemory, actualMemory);
+
+		/// <summary>
+		/// Verifies that a Memory does not contain a given sub-Memory
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected not to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-Memory is present inside the Memory</exception>
+		public static void DoesNotContain<T>(
+			ReadOnlyMemory<T> expectedSubMemory,
+			Memory<T> actualMemory)
+				where T : IEquatable<T> =>
+					DoesNotContain(expectedSubMemory, (ReadOnlyMemory<T>)actualMemory);
+
+		/// <summary>
+		/// Verifies that a Memory does not contain a given sub-Memory
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected not to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-Memory is present inside the Memory</exception>
+		public static void DoesNotContain<T>(
+			ReadOnlyMemory<T> expectedSubMemory,
+			ReadOnlyMemory<T> actualMemory)
+				where T : IEquatable<T>
+		{
+			GuardArgumentNotNull(nameof(expectedSubMemory), expectedSubMemory);
+
+			if (actualMemory.Span.IndexOf(expectedSubMemory.Span) > -1)
+				throw new DoesNotContainException(expectedSubMemory, actualMemory);
+		}
+
+		/// <summary>
+		/// Verifies that a Memory starts with a given sub-Memory, using the default <see cref="StringComparison.CurrentCulture"/> comparison type.
+		/// </summary>
+		/// <param name="expectedStartMemory">The sub-Memory expected to be at the start of the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="StartsWithException">Thrown when the Memory does not start with the expected subMemory</exception>
+		public static void StartsWith(
+			Memory<char> expectedStartMemory,
+			Memory<char> actualMemory) =>
+				StartsWith((ReadOnlyMemory<char>)expectedStartMemory, (ReadOnlyMemory<char>)actualMemory, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a Memory starts with a given sub-Memory, using the default <see cref="StringComparison.CurrentCulture"/> comparison type.
+		/// </summary>
+		/// <param name="expectedStartMemory">The sub-Memory expected to be at the start of the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="StartsWithException">Thrown when the Memory does not start with the expected subMemory</exception>
+		public static void StartsWith(
+			Memory<char> expectedStartMemory,
+			ReadOnlyMemory<char> actualMemory) =>
+				StartsWith((ReadOnlyMemory<char>)expectedStartMemory, actualMemory, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a Memory starts with a given sub-Memory, using the default <see cref="StringComparison.CurrentCulture"/> comparison type.
+		/// </summary>
+		/// <param name="expectedStartMemory">The sub-Memory expected to be at the start of the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="StartsWithException">Thrown when the Memory does not start with the expected subMemory</exception>
+		public static void StartsWith(
+			ReadOnlyMemory<char> expectedStartMemory,
+			Memory<char> actualMemory) =>
+				StartsWith(expectedStartMemory, (ReadOnlyMemory<char>)actualMemory, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a Memory starts with a given sub-Memory, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedStartMemory">The sub-Memory expected to be at the start of the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="StartsWithException">Thrown when the Memory does not start with the expected subMemory</exception>
+		public static void StartsWith(
+			ReadOnlyMemory<char> expectedStartMemory,
+			ReadOnlyMemory<char> actualMemory) =>
+				StartsWith(expectedStartMemory, actualMemory, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a Memory starts with a given sub-Memory, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedStartMemory">The sub-Memory expected to be at the start of the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="StartsWithException">Thrown when the Memory does not start with the expected subMemory</exception>
+		public static void StartsWith(
+			Memory<char> expectedStartMemory,
+			Memory<char> actualMemory,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				StartsWith((ReadOnlyMemory<char>)expectedStartMemory, (ReadOnlyMemory<char>)actualMemory, comparisonType);
+
+		/// <summary>
+		/// Verifies that a Memory starts with a given sub-Memory, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedStartMemory">The sub-Memory expected to be at the start of the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="StartsWithException">Thrown when the Memory does not start with the expected subMemory</exception>
+		public static void StartsWith(
+			Memory<char> expectedStartMemory,
+			ReadOnlyMemory<char> actualMemory,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				StartsWith((ReadOnlyMemory<char>)expectedStartMemory, actualMemory, comparisonType);
+
+		/// <summary>
+		/// Verifies that a Memory starts with a given sub-Memory, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedStartMemory">The sub-Memory expected to be at the start of the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="StartsWithException">Thrown when the Memory does not start with the expected subMemory</exception>
+		public static void StartsWith(
+			ReadOnlyMemory<char> expectedStartMemory,
+			Memory<char> actualMemory,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				StartsWith(expectedStartMemory, (ReadOnlyMemory<char>)actualMemory, comparisonType);
+
+		/// <summary>
+		/// Verifies that a Memory starts with a given sub-Memory, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedStartMemory">The sub-Memory expected to be at the start of the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="StartsWithException">Thrown when the Memory does not start with the expected subMemory</exception>
+		public static void StartsWith(
+			ReadOnlyMemory<char> expectedStartMemory,
+			ReadOnlyMemory<char> actualMemory,
+			StringComparison comparisonType = StringComparison.CurrentCulture)
+		{
+			GuardArgumentNotNull(nameof(expectedStartMemory), expectedStartMemory);
+
+			StartsWith(expectedStartMemory.Span, actualMemory.Span, comparisonType);
+		}
+
+		/// <summary>
+		/// Verifies that a Memory ends with a given sub-Memory, using the default <see cref="StringComparison.CurrentCulture"/> comparison type.
+		/// </summary>
+		/// <param name="expectedEndMemory">The sub-Memory expected to be at the end of the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="EndsWithException">Thrown when the Memory does not end with the expected subMemory</exception>
+		public static void EndsWith(
+			Memory<char> expectedEndMemory,
+			Memory<char> actualMemory) =>
+				EndsWith((ReadOnlyMemory<char>)expectedEndMemory, (ReadOnlyMemory<char>)actualMemory, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a Memory ends with a given sub-Memory, using the default <see cref="StringComparison.CurrentCulture"/> comparison type.
+		/// </summary>
+		/// <param name="expectedEndMemory">The sub-Memory expected to be at the end of the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="EndsWithException">Thrown when the Memory does not end with the expected subMemory</exception>
+		public static void EndsWith(
+			Memory<char> expectedEndMemory,
+			ReadOnlyMemory<char> actualMemory) =>
+				EndsWith((ReadOnlyMemory<char>)expectedEndMemory, actualMemory, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a Memory ends with a given sub-Memory, using the default <see cref="StringComparison.CurrentCulture"/> comparison type.
+		/// </summary>
+		/// <param name="expectedEndMemory">The sub-Memory expected to be at the end of the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="EndsWithException">Thrown when the Memory does not end with the expected subMemory</exception>
+		public static void EndsWith(
+			ReadOnlyMemory<char> expectedEndMemory,
+			Memory<char> actualMemory) =>
+				EndsWith(expectedEndMemory, (ReadOnlyMemory<char>)actualMemory, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a Memory ends with a given sub-Memory, using the default <see cref="StringComparison.CurrentCulture"/> comparison type.
+		/// </summary>
+		/// <param name="expectedEndMemory">The sub-Memory expected to be at the end of the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="EndsWithException">Thrown when the Memory does not end with the expected subMemory</exception>
+		public static void EndsWith(
+			ReadOnlyMemory<char> expectedEndMemory,
+			ReadOnlyMemory<char> actualMemory) =>
+				EndsWith(expectedEndMemory, actualMemory, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a Memory ends with a given sub-Memory, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedEndMemory">The sub-Memory expected to be at the end of the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="EndsWithException">Thrown when the Memory does not end with the expected subMemory</exception>
+		public static void EndsWith(
+			Memory<char> expectedEndMemory,
+			Memory<char> actualMemory,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				EndsWith((ReadOnlyMemory<char>)expectedEndMemory, (ReadOnlyMemory<char>)actualMemory, comparisonType);
+
+		/// <summary>
+		/// Verifies that a Memory ends with a given sub-Memory, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedEndMemory">The sub-Memory expected to be at the end of the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="EndsWithException">Thrown when the Memory does not end with the expected subMemory</exception>
+		public static void EndsWith(
+			Memory<char> expectedEndMemory,
+			ReadOnlyMemory<char> actualMemory,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				EndsWith((ReadOnlyMemory<char>)expectedEndMemory, actualMemory, comparisonType);
+
+		/// <summary>
+		/// Verifies that a Memory ends with a given sub-Memory, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedEndMemory">The sub-Memory expected to be at the end of the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="EndsWithException">Thrown when the Memory does not end with the expected subMemory</exception>
+		public static void EndsWith(
+			ReadOnlyMemory<char> expectedEndMemory,
+			Memory<char> actualMemory,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				EndsWith(expectedEndMemory, (ReadOnlyMemory<char>)actualMemory, comparisonType);
+
+		/// <summary>
+		/// Verifies that a Memory ends with a given sub-Memory, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedEndMemory">The sub-Memory expected to be at the end of the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="EndsWithException">Thrown when the Memory does not end with the expected subMemory</exception>
+		public static void EndsWith(
+			ReadOnlyMemory<char> expectedEndMemory,
+			ReadOnlyMemory<char> actualMemory,
+			StringComparison comparisonType = StringComparison.CurrentCulture)
+		{
+			GuardArgumentNotNull(nameof(expectedEndMemory), expectedEndMemory);
+
+			EndsWith(expectedEndMemory.Span, actualMemory.Span, comparisonType);
+		}
+
+		/// <summary>
+		/// Verifies that two Memory values are equivalent.
+		/// </summary>
+		/// <param name="expectedMemory">The expected Memory value.</param>
+		/// <param name="actualMemory">The actual Memory value.</param>
+		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+		public static void Equal(
+			Memory<char> expectedMemory,
+			Memory<char> actualMemory) =>
+				Equal((ReadOnlyMemory<char>)expectedMemory, (ReadOnlyMemory<char>)actualMemory, false, false, false);
+
+		/// <summary>
+		/// Verifies that two Memory values are equivalent.
+		/// </summary>
+		/// <param name="expectedMemory">The expected Memory value.</param>
+		/// <param name="actualMemory">The actual Memory value.</param>
+		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+		public static void Equal(
+			Memory<char> expectedMemory,
+			ReadOnlyMemory<char> actualMemory) =>
+				Equal((ReadOnlyMemory<char>)expectedMemory, actualMemory, false, false, false);
+
+		/// <summary>
+		/// Verifies that two Memory values are equivalent.
+		/// </summary>
+		/// <param name="expectedMemory">The expected Memory value.</param>
+		/// <param name="actualMemory">The actual Memory value.</param>
+		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+		public static void Equal(
+			ReadOnlyMemory<char> expectedMemory,
+			Memory<char> actualMemory) =>
+				Equal(expectedMemory, (ReadOnlyMemory<char>)actualMemory, false, false, false);
+
+		/// <summary>
+		/// Verifies that two Memory values are equivalent.
+		/// </summary>
+		/// <param name="expectedMemory">The expected Memory value.</param>
+		/// <param name="actualMemory">The actual Memory value.</param>
+		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+		public static void Equal(
+			ReadOnlyMemory<char> expectedMemory,
+			ReadOnlyMemory<char> actualMemory) =>
+				Equal(expectedMemory, actualMemory, false, false, false);
+
+		/// <summary>
+		/// Verifies that two Memory values are equivalent.
+		/// </summary>
+		/// <param name="expectedMemory">The expected Memory value.</param>
+		/// <param name="actualMemory">The actual Memory value.</param>
+		/// <param name="ignoreCase">If set to <c>true</c>, ignores cases differences. The invariant culture is used.</param>
+		/// <param name="ignoreLineEndingDifferences">If set to <c>true</c>, treats \r\n, \r, and \n as equivalent.</param>
+		/// <param name="ignoreWhiteSpaceDifferences">If set to <c>true</c>, treats spaces and tabs (in any non-zero quantity) as equivalent.</param>
+		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+		public static void Equal(
+			Memory<char> expectedMemory,
+			Memory<char> actualMemory,
+			bool ignoreCase = false,
+			bool ignoreLineEndingDifferences = false,
+			bool ignoreWhiteSpaceDifferences = false) =>
+				Equal((ReadOnlyMemory<char>)expectedMemory, (ReadOnlyMemory<char>)actualMemory, ignoreCase, ignoreLineEndingDifferences, ignoreWhiteSpaceDifferences);
+
+		/// <summary>
+		/// Verifies that two Memory values are equivalent.
+		/// </summary>
+		/// <param name="expectedMemory">The expected Memory value.</param>
+		/// <param name="actualMemory">The actual Memory value.</param>
+		/// <param name="ignoreCase">If set to <c>true</c>, ignores cases differences. The invariant culture is used.</param>
+		/// <param name="ignoreLineEndingDifferences">If set to <c>true</c>, treats \r\n, \r, and \n as equivalent.</param>
+		/// <param name="ignoreWhiteSpaceDifferences">If set to <c>true</c>, treats spaces and tabs (in any non-zero quantity) as equivalent.</param>
+		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+		public static void Equal(
+			Memory<char> expectedMemory,
+			ReadOnlyMemory<char> actualMemory,
+			bool ignoreCase = false,
+			bool ignoreLineEndingDifferences = false,
+			bool ignoreWhiteSpaceDifferences = false) =>
+				Equal((ReadOnlyMemory<char>)expectedMemory, actualMemory, ignoreCase, ignoreLineEndingDifferences, ignoreWhiteSpaceDifferences);
+
+		/// <summary>
+		/// Verifies that two Memory values are equivalent.
+		/// </summary>
+		/// <param name="expectedMemory">The expected Memory value.</param>
+		/// <param name="actualMemory">The actual Memory value.</param>
+		/// <param name="ignoreCase">If set to <c>true</c>, ignores cases differences. The invariant culture is used.</param>
+		/// <param name="ignoreLineEndingDifferences">If set to <c>true</c>, treats \r\n, \r, and \n as equivalent.</param>
+		/// <param name="ignoreWhiteSpaceDifferences">If set to <c>true</c>, treats spaces and tabs (in any non-zero quantity) as equivalent.</param>
+		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+		public static void Equal(
+			ReadOnlyMemory<char> expectedMemory,
+			Memory<char> actualMemory,
+			bool ignoreCase = false,
+			bool ignoreLineEndingDifferences = false,
+			bool ignoreWhiteSpaceDifferences = false) =>
+				Equal(expectedMemory, (ReadOnlyMemory<char>)actualMemory, ignoreCase, ignoreLineEndingDifferences, ignoreWhiteSpaceDifferences);
+
+		/// <summary>
+		/// Verifies that two Memory values are equivalent.
+		/// </summary>
+		/// <param name="expectedMemory">The expected Memory value.</param>
+		/// <param name="actualMemory">The actual Memory value.</param>
+		/// <param name="ignoreCase">If set to <c>true</c>, ignores cases differences. The invariant culture is used.</param>
+		/// <param name="ignoreLineEndingDifferences">If set to <c>true</c>, treats \r\n, \r, and \n as equivalent.</param>
+		/// <param name="ignoreWhiteSpaceDifferences">If set to <c>true</c>, treats spaces and tabs (in any non-zero quantity) as equivalent.</param>
+		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+		public static void Equal(
+			ReadOnlyMemory<char> expectedMemory,
+			ReadOnlyMemory<char> actualMemory,
+			bool ignoreCase = false,
+			bool ignoreLineEndingDifferences = false,
+			bool ignoreWhiteSpaceDifferences = false)
+		{
+			GuardArgumentNotNull(nameof(expectedMemory), expectedMemory);
+
+			Equal(
+				expectedMemory.Span,
+				actualMemory.Span,
+				ignoreCase,
+				ignoreLineEndingDifferences,
+				ignoreWhiteSpaceDifferences
+			);
+		}
+
+		/// <summary>
+		/// Verifies that two Memory values are equivalent.
+		/// </summary>
+		/// <param name="expectedMemory">The expected Memory value.</param>
+		/// <param name="actualMemory">The actual Memory value.</param>
+		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+		public static void Equal<T>(
+			Memory<T> expectedMemory,
+			Memory<T> actualMemory)
+				where T : IEquatable<T> =>
+					Equal((ReadOnlyMemory<T>)expectedMemory, (ReadOnlyMemory<T>)actualMemory);
+
+		/// <summary>
+		/// Verifies that two Memory values are equivalent.
+		/// </summary>
+		/// <param name="expectedMemory">The expected Memory value.</param>
+		/// <param name="actualMemory">The actual Memory value.</param>
+		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+		public static void Equal<T>(
+			Memory<T> expectedMemory,
+			ReadOnlyMemory<T> actualMemory)
+				where T : IEquatable<T> =>
+					Equal((ReadOnlyMemory<T>)expectedMemory, actualMemory);
+
+		/// <summary>
+		/// Verifies that two Memory values are equivalent.
+		/// </summary>
+		/// <param name="expectedMemory">The expected Memory value.</param>
+		/// <param name="actualMemory">The actual Memory value.</param>
+		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+		public static void Equal<T>(
+			ReadOnlyMemory<T> expectedMemory,
+			Memory<T> actualMemory)
+				where T : IEquatable<T> =>
+					Equal(expectedMemory, (ReadOnlyMemory<T>)actualMemory);
+
+		/// <summary>
+		/// Verifies that two Memory values are equivalent.
+		/// </summary>
+		/// <param name="expectedMemory">The expected Memory value.</param>
+		/// <param name="actualMemory">The actual Memory value.</param>
+		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+		public static void Equal<T>(
+			ReadOnlyMemory<T> expectedMemory,
+			ReadOnlyMemory<T> actualMemory)
+				where T : IEquatable<T>
+		{
+			GuardArgumentNotNull(nameof(expectedMemory), expectedMemory);
+
+			if (!expectedMemory.Span.SequenceEqual(actualMemory.Span))
+				Equal<object>(expectedMemory.Span.ToArray(), actualMemory.Span.ToArray());
+		}
+	}
+}
+
+#endif

--- a/MultipleAsserts.cs
+++ b/MultipleAsserts.cs
@@ -1,0 +1,49 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.ExceptionServices;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		/// <summary>
+		/// Runs multiple checks, collecting the exceptions from each one, and then bundles all failures
+		/// up into a single assertion failure.
+		/// </summary>
+		/// <param name="checks">The individual assertions to run, as actions.</param>
+		public static void Multiple(params Action[] checks)
+		{
+			if (checks == null || checks.Length == 0)
+				return;
+
+			var exceptions = new List<Exception>();
+
+			foreach (var check in checks)
+				try
+				{
+					check();
+				}
+				catch (Exception ex)
+				{
+					exceptions.Add(ex);
+				}
+
+			if (exceptions.Count == 0)
+				return;
+			if (exceptions.Count == 1)
+				ExceptionDispatchInfo.Capture(exceptions[0]).Throw();
+
+			throw new MultipleException(exceptions);
+		}
+	}
+}

--- a/NullAsserts.cs
+++ b/NullAsserts.cs
@@ -1,0 +1,50 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using Xunit.Sdk;
+
+#if XUNIT_NULLABLE
+using System.Diagnostics.CodeAnalysis;
+#endif
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		/// <summary>
+		/// Verifies that an object reference is not null.
+		/// </summary>
+		/// <param name="object">The object to be validated</param>
+		/// <exception cref="NotNullException">Thrown when the object reference is null</exception>
+#if XUNIT_NULLABLE
+		public static void NotNull([NotNull] object? @object)
+#else
+		public static void NotNull(object @object)
+#endif
+		{
+			if (@object == null)
+				throw new NotNullException();
+		}
+
+		/// <summary>
+		/// Verifies that an object reference is null.
+		/// </summary>
+		/// <param name="object">The object to be inspected</param>
+		/// <exception cref="NullException">Thrown when the object reference is not null</exception>
+#if XUNIT_NULLABLE
+		public static void Null([MaybeNull] object? @object)
+#else
+		public static void Null(object @object)
+#endif
+		{
+			if (@object != null)
+				throw new NullException(@object);
+		}
+	}
+}

--- a/PropertyAsserts.cs
+++ b/PropertyAsserts.cs
@@ -1,0 +1,100 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		/// <summary>
+		/// Verifies that the provided object raised <see cref="INotifyPropertyChanged.PropertyChanged"/>
+		/// as a result of executing the given test code.
+		/// </summary>
+		/// <param name="object">The object which should raise the notification</param>
+		/// <param name="propertyName">The property name for which the notification should be raised</param>
+		/// <param name="testCode">The test code which should cause the notification to be raised</param>
+		/// <exception cref="PropertyChangedException">Thrown when the notification is not raised</exception>
+		public static void PropertyChanged(
+			INotifyPropertyChanged @object,
+			string propertyName,
+			Action testCode)
+		{
+			GuardArgumentNotNull(nameof(@object), @object);
+			GuardArgumentNotNull(nameof(propertyName), propertyName);
+			GuardArgumentNotNull(nameof(testCode), testCode);
+
+			var propertyChangeHappened = false;
+
+			PropertyChangedEventHandler handler = (sender, args) => propertyChangeHappened |= string.IsNullOrEmpty(args.PropertyName) || propertyName.Equals(args.PropertyName, StringComparison.OrdinalIgnoreCase);
+
+			@object.PropertyChanged += handler;
+
+			try
+			{
+				testCode();
+				if (!propertyChangeHappened)
+					throw new PropertyChangedException(propertyName);
+			}
+			finally
+			{
+				@object.PropertyChanged -= handler;
+			}
+		}
+
+		/// <summary/>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("You must call Assert.PropertyChangedAsync (and await the result) when testing async code.", true)]
+		public static void PropertyChanged(
+			INotifyPropertyChanged @object,
+			string propertyName,
+			Func<Task> testCode)
+		{
+			throw new NotImplementedException();
+		}
+
+		/// <summary>
+		/// Verifies that the provided object raised <see cref="INotifyPropertyChanged.PropertyChanged"/>
+		/// as a result of executing the given test code.
+		/// </summary>
+		/// <param name="object">The object which should raise the notification</param>
+		/// <param name="propertyName">The property name for which the notification should be raised</param>
+		/// <param name="testCode">The test code which should cause the notification to be raised</param>
+		/// <exception cref="PropertyChangedException">Thrown when the notification is not raised</exception>
+		public static async Task PropertyChangedAsync(
+			INotifyPropertyChanged @object,
+			string propertyName,
+			Func<Task> testCode)
+		{
+			GuardArgumentNotNull(nameof(@object), @object);
+			GuardArgumentNotNull(nameof(propertyName), propertyName);
+			GuardArgumentNotNull(nameof(testCode), testCode);
+
+			var propertyChangeHappened = false;
+
+			PropertyChangedEventHandler handler = (sender, args) => propertyChangeHappened |= string.IsNullOrEmpty(args.PropertyName) || propertyName.Equals(args.PropertyName, StringComparison.OrdinalIgnoreCase);
+
+			@object.PropertyChanged += handler;
+
+			try
+			{
+				await testCode();
+				if (!propertyChangeHappened)
+					throw new PropertyChangedException(propertyName);
+			}
+			finally
+			{
+				@object.PropertyChanged -= handler;
+			}
+		}
+	}
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,104 @@
+# About This Project
+
+This project contains the xUnit.net assertion library source code, intended to be used as a Git submodule. Code here is built with a target-framework of `netstandard1.1`, and must support both `net452` and `netcoreapp1.0`. The code must be buildable by a minimum of C# 6.0. These constraints are supported by the [suggested contribution workflow](#suggested-contribution-workflow), which makes it trivial to know when you've used unavailable features.
+
+> _**Note:** If your PR requires a newer target framework or a newer C# language to build, please start a discussion in the related issue(s) before starting any work. PRs that arbitrarily use newer target frameworks and/or newer C# language features will need to be fixed; you may be asked to fix them, or we may fix them for you, or we may decline the PR (at our discretion)._
+
+To open an issue for this project, please visit the [core xUnit.net project issue tracker](https://github.com/xunit/xunit/issues).
+
+## Annotations
+
+Whether you are using this repository via Git submodule or via the [source-based NuGet package](https://www.nuget.org/packages/xunit.assert.source), the following pre-processor directives can be used to influence the code contained in this repository:
+
+### `XUNIT_IMMUTABLE_COLLECTIONS` (min: C# 6.0, xUnit.net v2)
+
+There are assertions that target immutable collections. If you are using a target framework that is compatible with [`System.Collections.Immutable`](https://www.nuget.org/packages/System.Collections.Immutable), you should define `XUNIT_IMMUTABLE_COLLECTIONS` to enable the additional versions of those assertions that will consume immutable collections.
+
+### `XUNIT_NULLABLE` (min: C# 9.0, xUnit.net v2)
+
+Projects that consume this repository as source, which wish to use nullable reference type annotations should define the `XUNIT_NULLABLE` compilation symbol to opt-in to the relevant nullability analysis annotations on method signatures.
+
+### `XUNIT_SKIP` (min: C# 10.0, xUnit.net v3)
+
+The Skip family of assertions (like `Assert.Skip`) require xUnit.net v3. Define this to enable the Skip assertions.
+
+> _**Note**: If you enable try to use it from xUnit.net v2, the test will show up as failed rather than skipped. Runtime support in the core library is required to make this feature work properly, which is why it's not supported for v2._
+
+### `XUNIT_SPAN` (min: C# 6.0, xUnit.net v2)
+
+There are optimized versions of `Assert.Equal` for arrays which use `Span<T>`- and/or `Memory<T>`-based comparison options. If you are using a target framework that supports `Span<T>` and `Memory<T>`, you should define `XUNIT_SPAN` to enable these new assertions.
+
+### `XUNIT_VALUETASK` (min: C# 6.0, xUnit.net v2)
+
+Any asynchronous assertion API (like `Assert.ThrowsAsync`) is available with versions that consume `Task` or `Task<T>`. If you are using a target framework and compiler that support `ValueTask<T>`, you should define `XUNIT_VALUETASK` to enable additional versions of those assertions that will consume `ValueTask` and/or `ValueTask<T>`.
+
+### `XUNIT_VISIBILITY_INTERNAL`
+
+By default, the `Assert` class has `public` visibility. This is appropriate for the default usage (as a shipped library). If your consumption of `Assert` via source is intended to be local to a single library, you should define `XUNIT_VISIBILITY_INTERNAL` to move the visibility of the `Assert` class to `internal`.
+
+## Suggested Contribution Workflow
+
+The pull request workflow for the assertion library is more complex than a typical single-repository project. The source code for the assertions live in this repository, and the source code for the unit tests live in the main repository: [`xunit/xunit`](https://github.com/xunit/xunit).
+
+This workflow makes it easier to work in your branches as well as ensuring that your PR build has a higher chance of succeeding.
+
+You will need a fork of both `xunit/assert.xunit` (this repository) and `xunit/xunit` (the main repository for xUnit.net). You will also need a local clone of `xunit/xunit`, which is where you will be doing all your work. _You do not need a clone of your `xunit/assert.xunit` fork, because we use Git submodules to bring both repositories together into a single folder._
+
+### Before you start working
+
+1. In a command prompt, from the root of the repository, run:
+
+   * `git submodule update --init` to ensure the Git submodule in `/src/xunit.v3.assert/Asserts` is initialized.
+   * `git switch main`
+   * `git pull origin --ff-only` to ensure that `main` is up to date.
+   * `git remote add fork https://github.com/yourusername/assert.xunit` to point to your fork (update the URL as appropriate).
+   * `git fetch fork` to ensure that your `fork` remote is working.
+   * `git switch -c my-branch-name` to create a new branch for `xunit/xunit`.
+
+   _Replace `my-branch-name` with whatever branch name you want. We suggest you put the general feature and the `xunit/xunit` issue number into the name, to help you track the work if you're planning to help with multiple issues. An example branch name might be something like `add-support-for-IAsyncEnumerable-2367`._
+
+1. In a command prompt, from `/src/xunit.v3.assert/Asserts`, run:
+
+   * `git switch main`
+   * `git pull origin --ff-only` to ensure that `main` is up to date.
+   * `git remote add fork https://github.com/yourusername/assert.xunit` to point to your fork (update the URL as appropriate).
+   * `git fetch fork` to ensure that your `fork` remote is working.
+   * `git switch -c my-branch-name` to create a new branch for `xunit/assert.xunit`.
+
+   _You may use the same branch name that you used above, as these branches are in two different repositories; identical names won't conflict, and may help you keep your work straight if you are working on multiple issues._
+
+### Create the code and test
+
+Open the solution in Visual Studio (or your preferred editor/IDE), and create your changes. The assertion changes will live in `/src/xunit.v3.assert/Asserts` and the tests will live in `/src/xunit.v3.assert.tests/Asserts`. In Visual Studio, the two projects you'll be working in are named `xunit.v3.assert` and `xunit.v3.assert.tests`. (You will see several `xunit.v3.assert.*` projects which ensure that the code you're writing correctly compiles in all the supported scenarios.)
+
+When the changes are complete, you can run `./build` from the root of the repository to run the full test suite that would normally be run by a PR.
+
+### When you're ready to submit the pull requests
+
+1. In a command prompt, from `/src/xunit.v3.assert/Asserts`, run:
+
+   * `git add -A`
+   * `git commit`
+   * `git push fork my-branch-name`
+
+   _This pushes the branch up to your fork for you to create the PR for `xunit/assert.xunit`. The push message will give you a link (something like `https://github.com/yourusername/assert.xunit/pull/new/my-new-branch`) to start the PR process. You may do that now. We do this folder first, because we need for the source to be pushed to get a commit reference for the next step._
+
+1. In a command prompt, from the root of the repository, run the same three commands:
+
+   * `git add -A`
+   * `git commit`
+   * `git push fork my-branch-name`
+
+   _Just like the previous steps did, this pushes up your branch for the PR for `xunit/xunit`. Only do this after you have pushed your PR-ready changes for `xunit/assert.xunit`. You may now start the PR process for `xunit/xunit` as well, and it will include the reference to the new assertion code that you've already pushed._
+
+A maintainer will review and merge your PRs, and automatically create equivalent updates to the `v2` branch so that your assertion changes will be made available for any potential future xUnit.net v2.x releases.
+
+_Please remember that all PRs require associated unit tests. You may be asked to write the tests if you create a PR without them. If you're not sure how to test the code in question, please feel free to open the PR and then mention that in the PR description, and someone will help you with this._
+
+# About xUnit.net
+
+[<img align="right" width="100px" src="https://raw.githubusercontent.com/xunit/media/main/dotnet-foundation.svg" />](https://dotnetfoundation.org/projects/project-detail/xunit)
+
+xUnit.net is a free, open source, community-focused unit testing tool for the .NET Framework. Written by the original inventor of NUnit v2, xUnit.net is the latest technology for unit testing C#, F#, VB.NET and other .NET languages. xUnit.net works with ReSharper, CodeRush, TestDriven.NET and Xamarin. It is part of the [.NET Foundation](https://www.dotnetfoundation.org/), and operates under their [code of conduct](http://www.dotnetfoundation.org/code-of-conduct). It is licensed under [Apache 2](https://opensource.org/licenses/Apache-2.0) (an OSI approved license).
+
+For project documentation, please visit the [xUnit.net project home](https://xunit.net/).

--- a/RangeAsserts.cs
+++ b/RangeAsserts.cs
@@ -1,0 +1,90 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.Collections.Generic;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		/// <summary>
+		/// Verifies that a value is within a given range.
+		/// </summary>
+		/// <typeparam name="T">The type of the value to be compared</typeparam>
+		/// <param name="actual">The actual value to be evaluated</param>
+		/// <param name="low">The (inclusive) low value of the range</param>
+		/// <param name="high">The (inclusive) high value of the range</param>
+		/// <exception cref="InRangeException">Thrown when the value is not in the given range</exception>
+		public static void InRange<T>(
+			T actual,
+			T low,
+			T high)
+				where T : IComparable =>
+					InRange(actual, low, high, GetComparer<T>());
+
+		/// <summary>
+		/// Verifies that a value is within a given range, using a comparer.
+		/// </summary>
+		/// <typeparam name="T">The type of the value to be compared</typeparam>
+		/// <param name="actual">The actual value to be evaluated</param>
+		/// <param name="low">The (inclusive) low value of the range</param>
+		/// <param name="high">The (inclusive) high value of the range</param>
+		/// <param name="comparer">The comparer used to evaluate the value's range</param>
+		/// <exception cref="InRangeException">Thrown when the value is not in the given range</exception>
+		public static void InRange<T>(
+			T actual,
+			T low,
+			T high,
+			IComparer<T> comparer)
+		{
+			GuardArgumentNotNull(nameof(comparer), comparer);
+
+			if (comparer.Compare(low, actual) > 0 || comparer.Compare(actual, high) > 0)
+				throw new InRangeException(actual, low, high);
+		}
+
+		/// <summary>
+		/// Verifies that a value is not within a given range, using the default comparer.
+		/// </summary>
+		/// <typeparam name="T">The type of the value to be compared</typeparam>
+		/// <param name="actual">The actual value to be evaluated</param>
+		/// <param name="low">The (inclusive) low value of the range</param>
+		/// <param name="high">The (inclusive) high value of the range</param>
+		/// <exception cref="NotInRangeException">Thrown when the value is in the given range</exception>
+		public static void NotInRange<T>(
+			T actual,
+			T low,
+			T high)
+				where T : IComparable =>
+					NotInRange(actual, low, high, GetComparer<T>());
+
+		/// <summary>
+		/// Verifies that a value is not within a given range, using a comparer.
+		/// </summary>
+		/// <typeparam name="T">The type of the value to be compared</typeparam>
+		/// <param name="actual">The actual value to be evaluated</param>
+		/// <param name="low">The (inclusive) low value of the range</param>
+		/// <param name="high">The (inclusive) high value of the range</param>
+		/// <param name="comparer">The comparer used to evaluate the value's range</param>
+		/// <exception cref="NotInRangeException">Thrown when the value is in the given range</exception>
+		public static void NotInRange<T>(
+			T actual,
+			T low,
+			T high,
+			IComparer<T> comparer)
+		{
+			GuardArgumentNotNull(nameof(comparer), comparer);
+
+			if (comparer.Compare(low, actual) <= 0 && comparer.Compare(actual, high) <= 0)
+				throw new NotInRangeException(actual, low, high);
+		}
+	}
+}

--- a/Record.cs
+++ b/Record.cs
@@ -1,0 +1,173 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		/// <summary>
+		/// Records any exception which is thrown by the given code.
+		/// </summary>
+		/// <param name="testCode">The code which may thrown an exception.</param>
+		/// <returns>Returns the exception that was thrown by the code; null, otherwise.</returns>
+#if XUNIT_NULLABLE
+		protected static Exception? RecordException(Action testCode)
+#else
+		protected static Exception RecordException(Action testCode)
+#endif
+		{
+			GuardArgumentNotNull(nameof(testCode), testCode);
+
+			try
+			{
+				testCode();
+				return null;
+			}
+			catch (Exception ex)
+			{
+				return ex;
+			}
+		}
+
+		/// <summary>
+		/// Records any exception which is thrown by the given code that has
+		/// a return value. Generally used for testing property accessors.
+		/// </summary>
+		/// <param name="testCode">The code which may thrown an exception.</param>
+		/// <returns>Returns the exception that was thrown by the code; null, otherwise.</returns>
+#if XUNIT_NULLABLE
+		protected static Exception? RecordException(Func<object?> testCode)
+#else
+		protected static Exception RecordException(Func<object> testCode)
+#endif
+		{
+			GuardArgumentNotNull(nameof(testCode), testCode);
+			var task = default(Task);
+
+			try
+			{
+				task = testCode() as Task;
+			}
+			catch (Exception ex)
+			{
+				return ex;
+			}
+
+			if (task != null)
+				throw new InvalidOperationException("You must call Assert.ThrowsAsync, Assert.DoesNotThrowAsync, or Record.ExceptionAsync when testing async code.");
+
+			return null;
+		}
+
+		/// <summary/>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("You must call Assert.RecordExceptionAsync (and await the result) when testing async code.", true)]
+		protected static Exception RecordException(Func<Task> testCode)
+		{
+			throw new NotImplementedException();
+		}
+
+#if XUNIT_VALUETASK
+		/// <summary/>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("You must call Assert.RecordExceptionAsync (and await the result) when testing async code.", true)]
+		protected static Exception RecordException(Func<ValueTask> testCode)
+		{
+			throw new NotImplementedException();
+		}
+
+		/// <summary/>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("You must call Assert.RecordExceptionAsync (and await the result) when testing async code.", true)]
+		protected static Exception RecordException<T>(Func<ValueTask<T>> testCode)
+		{
+			throw new NotImplementedException();
+		}
+#endif
+
+		/// <summary>
+		/// Records any exception which is thrown by the given task.
+		/// </summary>
+		/// <param name="testCode">The task which may thrown an exception.</param>
+		/// <returns>Returns the exception that was thrown by the code; null, otherwise.</returns>
+#if XUNIT_NULLABLE
+		protected static async Task<Exception?> RecordExceptionAsync(Func<Task> testCode)
+#else
+		protected static async Task<Exception> RecordExceptionAsync(Func<Task> testCode)
+#endif
+		{
+			GuardArgumentNotNull(nameof(testCode), testCode);
+
+			try
+			{
+				await testCode();
+				return null;
+			}
+			catch (Exception ex)
+			{
+				return ex;
+			}
+		}
+
+#if XUNIT_VALUETASK
+		/// <summary>
+		/// Records any exception which is thrown by the given task.
+		/// </summary>
+		/// <param name="testCode">The task which may thrown an exception.</param>
+		/// <returns>Returns the exception that was thrown by the code; null, otherwise.</returns>
+#if XUNIT_NULLABLE
+		protected static async ValueTask<Exception?> RecordExceptionAsync(Func<ValueTask> testCode)
+#else
+		protected static async ValueTask<Exception> RecordExceptionAsync(Func<ValueTask> testCode)
+#endif
+		{
+			GuardArgumentNotNull(nameof(testCode), testCode);
+
+			try
+			{
+				await testCode();
+				return null;
+			}
+			catch (Exception ex)
+			{
+				return ex;
+			}
+		}
+
+		/// <summary>
+		/// Records any exception which is thrown by the given task.
+		/// </summary>
+		/// <param name="testCode">The task which may thrown an exception.</param>
+		/// <typeparam name="T">The type of the ValueTask return value.</typeparam>
+		/// <returns>Returns the exception that was thrown by the code; null, otherwise.</returns>
+#if XUNIT_NULLABLE
+		protected static async ValueTask<Exception?> RecordExceptionAsync<T>(Func<ValueTask<T>> testCode)
+#else
+		protected static async ValueTask<Exception> RecordExceptionAsync<T>(Func<ValueTask<T>> testCode)
+#endif
+		{
+			GuardArgumentNotNull(nameof(testCode), testCode);
+
+			try
+			{
+				await testCode();
+				return null;
+			}
+			catch (Exception ex)
+			{
+				return ex;
+			}
+		}
+#endif
+	}
+}

--- a/Sdk/ArgumentFormatter.cs
+++ b/Sdk/ArgumentFormatter.cs
@@ -1,0 +1,484 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Formats arguments for display in theories.
+	/// </summary>
+	static class ArgumentFormatter
+	{
+		const int MAX_DEPTH = 3;
+		const int MAX_ENUMERABLE_LENGTH = 5;
+		const int MAX_OBJECT_PARAMETER_COUNT = 5;
+		const int MAX_STRING_LENGTH = 50;
+
+		static readonly object[] EmptyObjects = new object[0];
+		static readonly Type[] EmptyTypes = new Type[0];
+
+		// List of system types => C# type names
+		static readonly Dictionary<TypeInfo, string> TypeMappings = new Dictionary<TypeInfo, string>
+		{
+			{ typeof(bool).GetTypeInfo(), "bool" },
+			{ typeof(byte).GetTypeInfo(), "byte" },
+			{ typeof(sbyte).GetTypeInfo(), "sbyte" },
+			{ typeof(char).GetTypeInfo(), "char" },
+			{ typeof(decimal).GetTypeInfo(), "decimal" },
+			{ typeof(double).GetTypeInfo(), "double" },
+			{ typeof(float).GetTypeInfo(), "float" },
+			{ typeof(int).GetTypeInfo(), "int" },
+			{ typeof(uint).GetTypeInfo(), "uint" },
+			{ typeof(long).GetTypeInfo(), "long" },
+			{ typeof(ulong).GetTypeInfo(), "ulong" },
+			{ typeof(object).GetTypeInfo(), "object" },
+			{ typeof(short).GetTypeInfo(), "short" },
+			{ typeof(ushort).GetTypeInfo(), "ushort" },
+			{ typeof(string).GetTypeInfo(), "string" },
+		};
+
+		/// <summary>
+		/// Format the value for presentation.
+		/// </summary>
+		/// <param name="value">The value to be formatted.</param>
+		/// <param name="pointerPosition">The position where the difference starts</param>
+		/// <param name="errorIndex"></param>
+		/// <returns>The formatted value.</returns>
+		public static string Format(
+#if XUNIT_NULLABLE
+			object? value,
+#else
+			object value,
+#endif
+			out int? pointerPosition,
+			int? errorIndex = null)
+		{
+			return Format(value, 1, out pointerPosition, errorIndex);
+		}
+
+		/// <summary>
+		/// Format the value for presentation.
+		/// </summary>
+		/// <param name="value">The value to be formatted.</param>
+		/// <param name="errorIndex"></param>
+		/// <returns>The formatted value.</returns>
+		public static string Format(
+#if XUNIT_NULLABLE
+			object? value,
+#else
+			object value,
+#endif
+			int? errorIndex = null)
+		{
+			int? _;
+
+			return Format(value, 1, out _, errorIndex);
+		}
+
+		static string FormatInner(
+#if XUNIT_NULLABLE
+			object? value,
+#else
+			object value,
+#endif
+			int depth)
+		{
+			int? _;
+
+			return Format(value, depth, out _, null);
+		}
+
+		static string Format(
+#if XUNIT_NULLABLE
+			object? value,
+#else
+			object value,
+#endif
+			int depth,
+			out int? pointerPostion,
+			int? errorIndex = null)
+		{
+			pointerPostion = null;
+
+			if (value == null)
+				return "null";
+
+			var valueAsType = value as Type;
+			if (valueAsType != null)
+				return $"typeof({FormatTypeName(valueAsType)})";
+
+			try
+			{
+				if (value.GetType().GetTypeInfo().IsEnum)
+					return value.ToString()?.Replace(", ", " | ") ?? "null";
+
+				if (value is char)
+				{
+					var charValue = (char)value;
+
+					if (charValue == '\'')
+						return @"'\''";
+
+					// Take care of all of the escape sequences
+#if XUNIT_NULLABLE
+					string? escapeSequence;
+#else
+					string escapeSequence;
+#endif
+					if (TryGetEscapeSequence(charValue, out escapeSequence))
+						return $"'{escapeSequence}'";
+
+					if (char.IsLetterOrDigit(charValue) || char.IsPunctuation(charValue) || char.IsSymbol(charValue) || charValue == ' ')
+						return $"'{charValue}'";
+
+					// Fallback to hex
+					return $"0x{(int)charValue:x4}";
+				}
+
+				if (value is DateTime || value is DateTimeOffset)
+					return $"{value:o}";
+
+				var stringParameter = value as string;
+				if (stringParameter != null)
+				{
+					stringParameter = EscapeString(stringParameter);
+					stringParameter = stringParameter.Replace(@"""", @"\"""); // escape double quotes
+					if (stringParameter.Length > MAX_STRING_LENGTH)
+					{
+						var displayed = stringParameter.Substring(0, MAX_STRING_LENGTH);
+						return $"\"{displayed}\"...";
+					}
+
+					return $"\"{stringParameter}\"";
+				}
+
+				try
+				{
+					var enumerable = value as IEnumerable;
+					if (enumerable != null)
+						return FormatEnumerable(enumerable.Cast<object>(), depth, errorIndex, out pointerPostion);
+				}
+				catch
+				{
+					// Sometimes enumerables cannot be enumerated when being, and instead thrown an exception.
+					// This could be, for example, because they require state that is not provided by Xunit.
+					// In these cases, just continue formatting.
+				}
+
+				if (value is float)
+					return $"{value:G9}";
+
+				if (value is double)
+					return $"{value:G17}";
+
+				var type = value.GetType();
+				var typeInfo = type.GetTypeInfo();
+				if (typeInfo.IsValueType)
+				{
+					if (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
+					{
+						var k = typeInfo.GetDeclaredProperty("Key")?.GetValue(value, null);
+						var v = typeInfo.GetDeclaredProperty("Value")?.GetValue(value, null);
+
+						return $"[{Format(k)}] = {Format(v)}";
+					}
+
+					return Convert.ToString(value, CultureInfo.CurrentCulture) ?? "null";
+				}
+
+				var task = value as Task;
+				if (task != null)
+				{
+					var typeParameters = typeInfo.GenericTypeArguments;
+					var typeName = typeParameters.Length == 0 ? "Task" : $"Task<{string.Join(",", typeParameters.Select(FormatTypeName))}>";
+					return $"{typeName} {{ Status = {task.Status} }}";
+				}
+
+				var toString = type.GetRuntimeMethod("ToString", EmptyTypes);
+
+				if (toString != null && toString.DeclaringType != typeof(object))
+#if XUNIT_NULLABLE
+					return ((string?)toString.Invoke(value, EmptyObjects)) ?? "null";
+#else
+					return ((string)toString.Invoke(value, EmptyObjects)) ?? "null";
+#endif
+
+				return FormatComplexValue(value, depth, type);
+			}
+			catch (Exception ex)
+			{
+				// Sometimes an exception is thrown when formatting an argument, such as in ToString.
+				// In these cases, we don't want xunit to crash, as tests may have passed despite this.
+				return $"{ex.GetType().Name} was thrown formatting an object of type \"{value.GetType()}\"";
+			}
+		}
+
+		static string FormatComplexValue(
+			object value,
+			int depth,
+			Type type)
+		{
+			if (depth == MAX_DEPTH)
+				return $"{type.Name} {{ ... }}";
+
+			var fields =
+				type
+					.GetRuntimeFields()
+					.Where(f => f.IsPublic && !f.IsStatic)
+					.Select(f => new { name = f.Name, value = WrapAndGetFormattedValue(() => f.GetValue(value), depth) });
+
+			var properties =
+				type
+					.GetRuntimeProperties()
+					.Where(p => p.GetMethod != null && p.GetMethod.IsPublic && !p.GetMethod.IsStatic)
+					.Select(p => new { name = p.Name, value = WrapAndGetFormattedValue(() => p.GetValue(value), depth) });
+
+			var parameters =
+				fields
+					.Concat(properties)
+					.OrderBy(p => p.name)
+					.Take(MAX_OBJECT_PARAMETER_COUNT + 1)
+					.ToList();
+
+			if (parameters.Count == 0)
+				return $"{type.Name} {{ }}";
+
+			var formattedParameters = string.Join(", ", parameters.Take(MAX_OBJECT_PARAMETER_COUNT).Select(p => $"{p.name} = {p.value}"));
+
+			if (parameters.Count > MAX_OBJECT_PARAMETER_COUNT)
+				formattedParameters += ", ...";
+
+			return $"{type.Name} {{ {formattedParameters} }}";
+		}
+
+		static string FormatEnumerable(
+			IEnumerable<object> enumerableValues,
+			int depth,
+			int? neededIndex,
+			out int? pointerPostion)
+		{
+			pointerPostion = null;
+
+			if (depth == MAX_DEPTH)
+				return "[...]";
+
+			var printedValues = string.Empty;
+
+			if (neededIndex.HasValue)
+			{
+				var enumeratedValues = enumerableValues.ToList();
+
+				var half = (int)Math.Floor(MAX_ENUMERABLE_LENGTH / 2m);
+				var startIndex = Math.Max(0, neededIndex.Value - half);
+				var endIndex = Math.Min(enumeratedValues.Count, startIndex + MAX_ENUMERABLE_LENGTH);
+				startIndex = Math.Max(0, endIndex - MAX_ENUMERABLE_LENGTH);
+
+				var leftCount = neededIndex.Value - startIndex;
+
+				if (startIndex != 0)
+					printedValues += "..., ";
+
+				var leftValues = enumeratedValues.Skip(startIndex).Take(leftCount).ToList();
+				var rightValues = enumeratedValues.Skip(startIndex + leftCount).Take(MAX_ENUMERABLE_LENGTH - leftCount + 1).ToList();
+
+				// Values to the left of the difference
+				if (leftValues.Count > 0)
+				{
+					printedValues += string.Join(", ", leftValues.Select(x => FormatInner(x, depth + 1)));
+
+					if (rightValues.Count > 0)
+						printedValues += ", ";
+				}
+
+				pointerPostion = printedValues.Length + 1;
+
+				// Difference value and values to the right
+				printedValues += string.Join(", ", rightValues.Take(MAX_ENUMERABLE_LENGTH - leftCount).Select(x => FormatInner(x, depth + 1)));
+				if (leftValues.Count + rightValues.Count > MAX_ENUMERABLE_LENGTH)
+					printedValues += ", ...";
+			}
+			else
+			{
+				var values = enumerableValues.Take(MAX_ENUMERABLE_LENGTH + 1).ToList();
+				printedValues += string.Join(", ", values.Take(MAX_ENUMERABLE_LENGTH).Select(x => FormatInner(x, depth + 1)));
+				if (values.Count > MAX_ENUMERABLE_LENGTH)
+					printedValues += ", ...";
+			}
+
+			return $"[{printedValues}]";
+		}
+
+		static bool IsSZArrayType(this TypeInfo typeInfo)
+		{
+#if NETCOREAPP2_0_OR_GREATER
+			return typeInfo.IsSZArray;
+#elif XUNIT_NULLABLE
+			return typeInfo == typeInfo.GetElementType()!.MakeArrayType().GetTypeInfo();
+#else
+			return typeInfo == typeInfo.GetElementType().MakeArrayType().GetTypeInfo();
+#endif
+		}
+
+		static string FormatTypeName(Type type)
+		{
+			var typeInfo = type.GetTypeInfo();
+			var arraySuffix = "";
+
+			// Deconstruct and re-construct array
+			while (typeInfo.IsArray)
+			{
+				if (typeInfo.IsSZArrayType())
+					arraySuffix += "[]";
+				else
+				{
+					var rank = typeInfo.GetArrayRank();
+					if (rank == 1)
+						arraySuffix += "[*]";
+					else
+						arraySuffix += $"[{new string(',', rank - 1)}]";
+				}
+
+#if XUNIT_NULLABLE
+				typeInfo = typeInfo.GetElementType()!.GetTypeInfo();
+#else
+				typeInfo = typeInfo.GetElementType().GetTypeInfo();
+#endif
+			}
+
+			// Map C# built-in type names
+#if XUNIT_NULLABLE
+			string? result;
+#else
+			string result;
+#endif
+			if (TypeMappings.TryGetValue(typeInfo, out result))
+				return result + arraySuffix;
+
+			// Strip off generic suffix
+			var name = typeInfo.FullName;
+
+			// catch special case of generic parameters not being bound to a specific type:
+			if (name == null)
+				return typeInfo.Name;
+
+			var tickIdx = name.IndexOf('`');
+			if (tickIdx > 0)
+				name = name.Substring(0, tickIdx);
+
+			if (typeInfo.IsGenericTypeDefinition)
+				name = $"{name}<{new string(',', typeInfo.GenericTypeParameters.Length - 1)}>";
+			else if (typeInfo.IsGenericType)
+			{
+				if (typeInfo.GetGenericTypeDefinition() == typeof(Nullable<>))
+					name = FormatTypeName(typeInfo.GenericTypeArguments[0]) + "?";
+				else
+					name = $"{name}<{string.Join(", ", typeInfo.GenericTypeArguments.Select(FormatTypeName))}>";
+			}
+
+			return name + arraySuffix;
+		}
+
+		static string WrapAndGetFormattedValue(
+#if XUNIT_NULLABLE
+			Func<object?> getter,
+#else
+			Func<object> getter,
+#endif
+			int depth)
+		{
+			try
+			{
+				return FormatInner(getter(), depth + 1);
+			}
+			catch (Exception ex)
+			{
+				return $"(throws {UnwrapException(ex)?.GetType().Name})";
+			}
+		}
+
+		static Exception UnwrapException(Exception ex)
+		{
+			while (true)
+			{
+				var tiex = ex as TargetInvocationException;
+				if (tiex == null || tiex.InnerException == null)
+					return ex;
+
+				ex = tiex.InnerException;
+			}
+		}
+
+		internal static string EscapeString(string s)
+		{
+			var builder = new StringBuilder(s.Length);
+			for (var i = 0; i < s.Length; i++)
+			{
+				var ch = s[i];
+#if XUNIT_NULLABLE
+				string? escapeSequence;
+#else
+				string escapeSequence;
+#endif
+				if (TryGetEscapeSequence(ch, out escapeSequence))
+					builder.Append(escapeSequence);
+				else if (ch < 32) // C0 control char
+					builder.AppendFormat(@"\x{0}", (+ch).ToString("x2"));
+				else if (char.IsSurrogatePair(s, i)) // should handle the case of ch being the last one
+				{
+					// For valid surrogates, append like normal
+					builder.Append(ch);
+					builder.Append(s[++i]);
+				}
+				// Check for stray surrogates/other invalid chars
+				else if (char.IsSurrogate(ch) || ch == '\uFFFE' || ch == '\uFFFF')
+				{
+					builder.AppendFormat(@"\x{0}", (+ch).ToString("x4"));
+				}
+				else
+					builder.Append(ch); // Append the char like normal
+			}
+			return builder.ToString();
+		}
+
+		static bool TryGetEscapeSequence(
+			char ch,
+#if XUNIT_NULLABLE
+			out string? value)
+#else
+			out string value)
+#endif
+		{
+			value = null;
+
+			if (ch == '\t') // tab
+				value = @"\t";
+			if (ch == '\n') // newline
+				value = @"\n";
+			if (ch == '\v') // vertical tab
+				value = @"\v";
+			if (ch == '\a') // alert
+				value = @"\a";
+			if (ch == '\r') // carriage return
+				value = @"\r";
+			if (ch == '\f') // formfeed
+				value = @"\f";
+			if (ch == '\b') // backspace
+				value = @"\b";
+			if (ch == '\0') // null char
+				value = @"\0";
+			if (ch == '\\') // backslash
+				value = @"\\";
+
+			return value != null;
+		}
+	}
+}

--- a/Sdk/AssertComparer.cs
+++ b/Sdk/AssertComparer.cs
@@ -1,0 +1,52 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.Collections.Generic;
+
+#if XUNIT_NULLABLE
+using System.Diagnostics.CodeAnalysis;
+#endif
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Default implementation of <see cref="IComparer{T}"/> used by the xUnit.net range assertions.
+	/// </summary>
+	/// <typeparam name="T">The type that is being compared.</typeparam>
+	class AssertComparer<T> : IComparer<T>
+		where T : IComparable
+	{
+		/// <inheritdoc/>
+		public int Compare(
+#if XUNIT_NULLABLE
+			[AllowNull] T x,
+			[AllowNull] T y)
+#else
+			T x,
+			T y)
+#endif
+		{
+			// Null?
+			if (x == null && y == null)
+				return 0;
+			if (x == null)
+				return -1;
+			if (y == null)
+				return 1;
+
+			// Same type?
+			if (x.GetType() != y.GetType())
+				return -1;
+
+			// Implements IComparable<T>?
+			var comparable1 = x as IComparable<T>;
+			if (comparable1 != null)
+				return comparable1.CompareTo(y);
+
+			// Implements IComparable
+			return x.CompareTo(y);
+		}
+	}
+}

--- a/Sdk/AssertEqualityComparer.cs
+++ b/Sdk/AssertEqualityComparer.cs
@@ -1,0 +1,431 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+#if XUNIT_NULLABLE
+using System.Diagnostics.CodeAnalysis;
+#endif
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Default implementation of <see cref="IEqualityComparer{T}"/> used by the xUnit.net equality assertions.
+	/// </summary>
+	/// <typeparam name="T">The type that is being compared.</typeparam>
+	class AssertEqualityComparer<T> : IEqualityComparer<T>
+	{
+		static readonly IEqualityComparer DefaultInnerComparer = new AssertEqualityComparerAdapter<object>(new AssertEqualityComparer<object>());
+		static readonly TypeInfo NullableTypeInfo = typeof(Nullable<>).GetTypeInfo();
+
+		readonly Func<IEqualityComparer> innerComparerFactory;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="AssertEqualityComparer{T}" /> class.
+		/// </summary>
+		/// <param name="innerComparer">The inner comparer to be used when the compared objects are enumerable.</param>
+#if XUNIT_NULLABLE
+		public AssertEqualityComparer(IEqualityComparer? innerComparer = null)
+#else
+		public AssertEqualityComparer(IEqualityComparer innerComparer = null)
+#endif
+		{
+			// Use a thunk to delay evaluation of DefaultInnerComparer
+			innerComparerFactory = () => innerComparer ?? DefaultInnerComparer;
+		}
+
+		/// <inheritdoc/>
+		public bool Equals(
+#if XUNIT_NULLABLE
+			[AllowNull] T x,
+			[AllowNull] T y)
+#else
+			T x,
+			T y)
+#endif
+		{
+			int? _;
+
+			return Equals(x, y, out _);
+		}
+
+		/// <inheritdoc/>
+		public bool Equals(
+#if XUNIT_NULLABLE
+			[AllowNull] T x,
+			[AllowNull] T y,
+#else
+			T x,
+			T y,
+#endif
+			out int? mismatchIndex)
+		{
+			mismatchIndex = null;
+			var typeInfo = typeof(T).GetTypeInfo();
+
+			// Null?
+			if (x == null && y == null)
+				return true;
+			if (x == null || y == null)
+				return false;
+
+			// Implements IEquatable<T>?
+			var equatable = x as IEquatable<T>;
+			if (equatable != null)
+				return equatable.Equals(y);
+
+			// Implements IComparable<T>?
+			var comparableGeneric = x as IComparable<T>;
+			if (comparableGeneric != null)
+			{
+				try
+				{
+					return comparableGeneric.CompareTo(y) == 0;
+				}
+				catch
+				{
+					// Some implementations of IComparable<T>.CompareTo throw exceptions in
+					// certain situations, such as if x can't compare against y.
+					// If this happens, just swallow up the exception and continue comparing.
+				}
+			}
+
+			// Implements IComparable?
+			var comparable = x as IComparable;
+			if (comparable != null)
+			{
+				try
+				{
+					return comparable.CompareTo(y) == 0;
+				}
+				catch
+				{
+					// Some implementations of IComparable.CompareTo throw exceptions in
+					// certain situations, such as if x can't compare against y.
+					// If this happens, just swallow up the exception and continue comparing.
+				}
+			}
+
+			// Dictionaries?
+			var dictionariesEqual = CheckIfDictionariesAreEqual(x, y);
+			if (dictionariesEqual.HasValue)
+				return dictionariesEqual.GetValueOrDefault();
+
+			// Sets?
+			var setsEqual = CheckIfSetsAreEqual(x, y, typeInfo);
+			if (setsEqual.HasValue)
+				return setsEqual.GetValueOrDefault();
+
+			// Enumerable?
+			var enumerablesEqual = CheckIfEnumerablesAreEqual(x, y, out mismatchIndex);
+			if (enumerablesEqual.HasValue)
+			{
+				if (!enumerablesEqual.GetValueOrDefault())
+				{
+					return false;
+				}
+
+				// Array.GetEnumerator() flattens out the array, ignoring array ranks and lengths
+				var xArray = x as Array;
+				var yArray = y as Array;
+				if (xArray != null && yArray != null)
+				{
+					// new object[2,1] != new object[2]
+					if (xArray.Rank != yArray.Rank)
+						return false;
+
+					// new object[2,1] != new object[1,2]
+					for (var i = 0; i < xArray.Rank; i++)
+						if (xArray.GetLength(i) != yArray.GetLength(i))
+							return false;
+				}
+
+				return true;
+			}
+
+			// Implements IStructuralEquatable?
+			var structuralEquatable = x as IStructuralEquatable;
+			if (structuralEquatable != null && structuralEquatable.Equals(y, new TypeErasedEqualityComparer(innerComparerFactory())))
+				return true;
+
+			// Implements IEquatable<typeof(y)>?
+			var iequatableY = typeof(IEquatable<>).MakeGenericType(y.GetType()).GetTypeInfo();
+			if (iequatableY.IsAssignableFrom(x.GetType().GetTypeInfo()))
+			{
+				var equalsMethod = iequatableY.GetDeclaredMethod(nameof(IEquatable<T>.Equals));
+				if (equalsMethod == null)
+					return false;
+
+#if XUNIT_NULLABLE
+				return equalsMethod.Invoke(x, new object[] { y }) is true;
+#else
+				return (bool)equalsMethod.Invoke(x, new object[] { y });
+#endif
+			}
+
+			// Implements IComparable<typeof(y)>?
+			var icomparableY = typeof(IComparable<>).MakeGenericType(y.GetType()).GetTypeInfo();
+			if (icomparableY.IsAssignableFrom(x.GetType().GetTypeInfo()))
+			{
+				var compareToMethod = icomparableY.GetDeclaredMethod(nameof(IComparable<T>.CompareTo));
+				if (compareToMethod == null)
+					return false;
+
+				try
+				{
+#if XUNIT_NULLABLE
+					return compareToMethod.Invoke(x, new object[] { y }) is 0;
+#else
+					return (int)compareToMethod.Invoke(x, new object[] { y }) == 0;
+#endif
+				}
+				catch
+				{
+					// Some implementations of IComparable.CompareTo throw exceptions in
+					// certain situations, such as if x can't compare against y.
+					// If this happens, just swallow up the exception and continue comparing.
+				}
+			}
+
+			// Last case, rely on object.Equals
+			return object.Equals(x, y);
+		}
+
+		bool? CheckIfEnumerablesAreEqual(
+#if XUNIT_NULLABLE
+			[AllowNull] T x,
+			[AllowNull] T y,
+#else
+			T x,
+			T y,
+#endif
+			out int? mismatchIndex)
+		{
+			mismatchIndex = null;
+
+			var enumerableX = x as IEnumerable;
+			var enumerableY = y as IEnumerable;
+
+			if (enumerableX == null || enumerableY == null)
+				return null;
+
+			var enumeratorX = default(IEnumerator);
+			var enumeratorY = default(IEnumerator);
+
+			try
+			{
+				enumeratorX = enumerableX.GetEnumerator();
+				enumeratorY = enumerableY.GetEnumerator();
+				var equalityComparer = innerComparerFactory();
+
+				mismatchIndex = 0;
+
+				while (true)
+				{
+					var hasNextX = enumeratorX.MoveNext();
+					var hasNextY = enumeratorY.MoveNext();
+
+					if (!hasNextX || !hasNextY)
+					{
+						if (hasNextX == hasNextY)
+						{
+							mismatchIndex = null;
+							return true;
+						}
+
+						return false;
+					}
+
+					if (!equalityComparer.Equals(enumeratorX.Current, enumeratorY.Current))
+						return false;
+
+					mismatchIndex++;
+				}
+			}
+			finally
+			{
+				var asDisposable = enumeratorX as IDisposable;
+				if (asDisposable != null)
+					asDisposable.Dispose();
+				asDisposable = enumeratorY as IDisposable;
+				if (asDisposable != null)
+					asDisposable.Dispose();
+			}
+		}
+
+		bool? CheckIfDictionariesAreEqual(
+#if XUNIT_NULLABLE
+			[AllowNull] T x,
+			[AllowNull] T y)
+#else
+			T x,
+			T y)
+#endif
+		{
+			var dictionaryX = x as IDictionary;
+			var dictionaryY = y as IDictionary;
+
+			if (dictionaryX == null || dictionaryY == null)
+				return null;
+
+			if (dictionaryX.Count != dictionaryY.Count)
+				return false;
+
+			var equalityComparer = innerComparerFactory();
+			var dictionaryYKeys = new HashSet<object>(dictionaryY.Keys.Cast<object>());
+
+			foreach (var key in dictionaryX.Keys.Cast<object>())
+			{
+				if (!dictionaryYKeys.Contains(key))
+					return false;
+
+				var valueX = dictionaryX[key];
+				var valueY = dictionaryY[key];
+
+				if (!equalityComparer.Equals(valueX, valueY))
+					return false;
+
+				dictionaryYKeys.Remove(key);
+			}
+
+			return dictionaryYKeys.Count == 0;
+		}
+
+#if XUNIT_NULLABLE
+		static MethodInfo? s_compareTypedSetsMethod;
+#else
+		static MethodInfo s_compareTypedSetsMethod;
+#endif
+
+		bool? CheckIfSetsAreEqual(
+#if XUNIT_NULLABLE
+			[AllowNull] T x,
+			[AllowNull] T y,
+#else
+			T x,
+			T y,
+#endif
+			TypeInfo typeInfo)
+		{
+			if (!IsSet(typeInfo))
+				return null;
+
+			var enumX = x as IEnumerable;
+			var enumY = y as IEnumerable;
+			if (enumX == null || enumY == null)
+				return null;
+
+			Type elementType;
+			if (typeof(T).GenericTypeArguments.Length != 1)
+				elementType = typeof(object);
+			else
+				elementType = typeof(T).GenericTypeArguments[0];
+
+			if (s_compareTypedSetsMethod == null)
+			{
+				s_compareTypedSetsMethod = GetType().GetTypeInfo().GetDeclaredMethod(nameof(CompareTypedSets));
+				if (s_compareTypedSetsMethod == null)
+					return false;
+			}
+
+			var method = s_compareTypedSetsMethod.MakeGenericMethod(new Type[] { elementType });
+#if XUNIT_NULLABLE
+			return method.Invoke(this, new object[] { enumX, enumY }) is true;
+#else
+			return (bool)method.Invoke(this, new object[] { enumX, enumY });
+#endif
+		}
+
+		bool CompareTypedSets<R>(
+			IEnumerable enumX,
+			IEnumerable enumY)
+		{
+			var setX = new HashSet<R>(enumX.Cast<R>());
+			var setY = new HashSet<R>(enumY.Cast<R>());
+
+			return setX.SetEquals(setY);
+		}
+
+		bool IsSet(TypeInfo typeInfo) =>
+			typeInfo
+				.ImplementedInterfaces
+				.Select(i => i.GetTypeInfo())
+				.Where(ti => ti.IsGenericType)
+				.Select(ti => ti.GetGenericTypeDefinition())
+				.Contains(typeof(ISet<>).GetGenericTypeDefinition());
+
+		/// <inheritdoc/>
+		public int GetHashCode(T obj)
+		{
+			throw new NotImplementedException();
+		}
+
+		private class TypeErasedEqualityComparer : IEqualityComparer
+		{
+			readonly IEqualityComparer innerComparer;
+
+			public TypeErasedEqualityComparer(IEqualityComparer innerComparer)
+			{
+				this.innerComparer = innerComparer;
+			}
+
+#if XUNIT_NULLABLE
+			static MethodInfo? s_equalsMethod;
+#else
+			static MethodInfo s_equalsMethod;
+#endif
+
+			public new bool Equals(
+#if XUNIT_NULLABLE
+				object? x,
+				object? y)
+#else
+				object x,
+				object y)
+#endif
+			{
+				if (x == null)
+					return y == null;
+				if (y == null)
+					return false;
+
+				// Delegate checking of whether two objects are equal to AssertEqualityComparer.
+				// To get the best result out of AssertEqualityComparer, we attempt to specialize the
+				// comparer for the objects that we are checking.
+				// If the objects are the same, great! If not, assume they are objects.
+				// This is more naive than the C# compiler which tries to see if they share any interfaces
+				// etc. but that's likely overkill here as AssertEqualityComparer<object> is smart enough.
+				Type objectType = x.GetType() == y.GetType() ? x.GetType() : typeof(object);
+
+				// Lazily initialize and cache the EqualsGeneric<U> method.
+				if (s_equalsMethod == null)
+				{
+					s_equalsMethod = typeof(TypeErasedEqualityComparer).GetTypeInfo().GetDeclaredMethod(nameof(EqualsGeneric));
+					if (s_equalsMethod == null)
+						return false;
+				}
+
+#if XUNIT_NULLABLE
+				return s_equalsMethod.MakeGenericMethod(objectType).Invoke(this, new object[] { x, y }) is true;
+#else
+				return (bool)s_equalsMethod.MakeGenericMethod(objectType).Invoke(this, new object[] { x, y });
+#endif
+			}
+
+			bool EqualsGeneric<U>(
+				U x,
+				U y) =>
+					new AssertEqualityComparer<U>(innerComparer: innerComparer).Equals(x, y);
+
+			public int GetHashCode(object obj)
+			{
+				throw new NotImplementedException();
+			}
+		}
+	}
+}

--- a/Sdk/AssertEqualityComparerAdapter.cs
+++ b/Sdk/AssertEqualityComparerAdapter.cs
@@ -1,0 +1,49 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// A class that wraps <see cref="IEqualityComparer{T}"/> to create <see cref="IEqualityComparer"/>.
+	/// </summary>
+	/// <typeparam name="T">The type that is being compared.</typeparam>
+	class AssertEqualityComparerAdapter<T> : IEqualityComparer
+	{
+		readonly IEqualityComparer<T> innerComparer;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="AssertEqualityComparerAdapter{T}"/> class.
+		/// </summary>
+		/// <param name="innerComparer">The comparer that is being adapted.</param>
+		public AssertEqualityComparerAdapter(IEqualityComparer<T> innerComparer)
+		{
+			if (innerComparer == null)
+				throw new ArgumentNullException(nameof(innerComparer));
+
+			this.innerComparer = innerComparer;
+		}
+
+		/// <inheritdoc/>
+		public new bool Equals(
+#if XUNIT_NULLABLE
+			object? x,
+			object? y) =>
+				innerComparer.Equals((T?)x, (T?)y);
+#else
+			object x,
+			object y) =>
+				innerComparer.Equals((T)x, (T)y);
+#endif
+
+		/// <inheritdoc/>
+		public int GetHashCode(object obj)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/Sdk/AssertHelper.cs
+++ b/Sdk/AssertHelper.cs
@@ -1,0 +1,234 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit.Sdk;
+
+#if XUNIT_NULLABLE
+using System.Diagnostics.CodeAnalysis;
+#endif
+
+namespace Xunit.Internal
+{
+	internal static class AssertHelper
+	{
+#if XUNIT_NULLABLE
+		static ConcurrentDictionary<Type, Dictionary<string, Func<object?, object?>>> gettersByType = new ConcurrentDictionary<Type, Dictionary<string, Func<object?, object?>>>();
+#else
+		static ConcurrentDictionary<Type, Dictionary<string, Func<object, object>>> gettersByType = new ConcurrentDictionary<Type, Dictionary<string, Func<object, object>>>();
+#endif
+
+#if XUNIT_NULLABLE
+		static Dictionary<string, Func<object?, object?>> GetGettersForType(Type type) =>
+#else
+		static Dictionary<string, Func<object, object>> GetGettersForType(Type type) =>
+#endif
+			gettersByType.GetOrAdd(type, _type =>
+			{
+				var fieldGetters =
+					_type
+						.GetRuntimeFields()
+						.Where(f => f.IsPublic && !f.IsStatic)
+#if XUNIT_NULLABLE
+						.Select(f => new { name = f.Name, getter = (Func<object?, object?>)f.GetValue });
+#else
+						.Select(f => new { name = f.Name, getter = (Func<object, object>)f.GetValue });
+#endif
+
+				var propertyGetters =
+					_type
+						.GetRuntimeProperties()
+						.Where(p => p.CanRead && p.GetMethod != null && p.GetMethod.IsPublic && !p.GetMethod.IsStatic && p.GetIndexParameters().Length == 0)
+#if XUNIT_NULLABLE
+						.Select(p => new { name = p.Name, getter = (Func<object?, object?>)p.GetValue });
+#else
+						.Select(p => new { name = p.Name, getter = (Func<object, object>)p.GetValue });
+#endif
+
+				return
+					fieldGetters
+						.Concat(propertyGetters)
+						.ToDictionary(g => g.name, g => g.getter);
+			});
+
+#if XUNIT_NULLABLE
+		public static EquivalentException? VerifyEquivalence(
+			object? expected,
+			object? actual,
+#else
+		public static EquivalentException VerifyEquivalence(
+			object expected,
+			object actual,
+#endif
+			bool strict)
+		{
+			return VerifyEquivalence(expected, actual, strict, string.Empty, new HashSet<object>(), new HashSet<object>());
+		}
+
+#if XUNIT_NULLABLE
+		static EquivalentException? VerifyEquivalence(
+			object? expected,
+			object? actual,
+#else
+		public static EquivalentException VerifyEquivalence(
+			object expected,
+			object actual,
+#endif
+			bool strict,
+			string prefix,
+			HashSet<object> expectedRefs,
+			HashSet<object> actualRefs)
+		{
+			// Check for null equivalence
+			if (expected == null)
+				return
+					actual == null
+						? null
+						: EquivalentException.ForMemberValueMismatch(expected, actual, prefix);
+
+			if (actual == null)
+				return EquivalentException.ForMemberValueMismatch(expected, actual, prefix);
+
+			// Check for identical references
+			if (object.ReferenceEquals(expected, actual))
+				return null;
+
+			// Prevent circular references
+			if (expectedRefs.Contains(expected))
+				return EquivalentException.ForCircularReference($"{nameof(expected)}.{prefix}");
+
+			if (actualRefs.Contains(actual))
+				return EquivalentException.ForCircularReference($"{nameof(actual)}.{prefix}");
+
+			expectedRefs.Add(expected);
+			actualRefs.Add(actual);
+
+			try
+			{
+				var expectedType = expected.GetType();
+				var expectedTypeInfo = expectedType.GetTypeInfo();
+
+				// Primitive types, enums and strings should just fall back to their Equals implementation
+				if (expectedTypeInfo.IsPrimitive || expectedTypeInfo.IsEnum || expectedType == typeof(string))
+					return
+						expected.Equals(actual)
+							? null
+							: EquivalentException.ForMemberValueMismatch(expected, actual, prefix);
+
+				// IComparable value types should fall back to their CompareTo implementation
+				if (expectedTypeInfo.IsValueType)
+				{
+					var expectedComparable = expected as IComparable;
+					if (expectedComparable != null)
+						return
+							expectedComparable.CompareTo(actual) == 0
+								? null
+								: EquivalentException.ForMemberValueMismatch(expected, actual, prefix);
+				}
+
+				// Enumerables? Check equivalence of individual members
+				var enumerableExpected = expected as IEnumerable;
+				var enumerableActual = actual as IEnumerable;
+				if (enumerableExpected != null && enumerableActual != null)
+					return VerifyEquivalenceEnumerable(enumerableExpected, enumerableActual, strict, prefix, expectedRefs, actualRefs);
+
+				return VerifyEquivalenceReference(expected, actual, strict, prefix, expectedRefs, actualRefs);
+			}
+			finally
+			{
+				expectedRefs.Remove(expected);
+				actualRefs.Remove(actual);
+			}
+		}
+
+#if XUNIT_NULLABLE
+		static EquivalentException? VerifyEquivalenceEnumerable(
+#else
+		static EquivalentException VerifyEquivalenceEnumerable(
+#endif
+			IEnumerable expected,
+			IEnumerable actual,
+			bool strict,
+			string prefix,
+			HashSet<object> expectedRefs,
+			HashSet<object> actualRefs)
+		{
+#if XUNIT_NULLABLE
+			var expectedValues = expected.Cast<object?>().ToList();
+			var actualValues = actual.Cast<object?>().ToList();
+#else
+			var expectedValues = expected.Cast<object>().ToList();
+			var actualValues = actual.Cast<object>().ToList();
+#endif
+			var actualOriginalValues = actualValues.ToList();
+
+			// Walk the list of expected values, and look for actual values that are equivalent
+			foreach (var expectedValue in expectedValues)
+			{
+				var actualIdx = 0;
+				for (; actualIdx < actualValues.Count; ++actualIdx)
+					if (VerifyEquivalence(expectedValue, actualValues[actualIdx], strict, "", expectedRefs, actualRefs) == null)
+						break;
+
+				if (actualIdx == actualValues.Count)
+					return EquivalentException.ForMissingCollectionValue(expectedValue, actualOriginalValues, prefix);
+
+				actualValues.RemoveAt(actualIdx);
+			}
+
+			if (strict && actualValues.Count != 0)
+				return EquivalentException.ForExtraCollectionValue(expectedValues, actualOriginalValues, actualValues, prefix);
+
+			return null;
+		}
+
+#if XUNIT_NULLABLE
+		static EquivalentException? VerifyEquivalenceReference(
+#else
+		static EquivalentException VerifyEquivalenceReference(
+#endif
+			object expected,
+			object actual,
+			bool strict,
+			string prefix,
+			HashSet<object> expectedRefs,
+			HashSet<object> actualRefs)
+		{
+			var prefixDot = prefix == string.Empty ? string.Empty : prefix + ".";
+
+			// Enumerate over public instance fields and properties and validate equivalence
+			var expectedGetters = GetGettersForType(expected.GetType());
+			var actualGetters = GetGettersForType(actual.GetType());
+
+			if (strict && expectedGetters.Count != actualGetters.Count)
+				return EquivalentException.ForMemberListMismatch(expectedGetters.Keys, actualGetters.Keys, prefixDot);
+
+			foreach (var kvp in expectedGetters)
+			{
+#if XUNIT_NULLABLE
+				Func<object?, object?>? actualGetter;
+#else
+				Func<object, object> actualGetter;
+#endif
+
+				if (!actualGetters.TryGetValue(kvp.Key, out actualGetter))
+					return EquivalentException.ForMemberListMismatch(expectedGetters.Keys, actualGetters.Keys, prefixDot);
+
+				var expectedMemberValue = kvp.Value(expected);
+				var actualMemberValue = actualGetter(actual);
+
+				var ex = VerifyEquivalence(expectedMemberValue, actualMemberValue, strict, prefixDot + kvp.Key, expectedRefs, actualRefs);
+				if (ex != null)
+					return ex;
+			}
+
+			return null;
+		}
+	}
+}

--- a/Sdk/DynamicSkipToken.cs
+++ b/Sdk/DynamicSkipToken.cs
@@ -1,0 +1,18 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+namespace Xunit.Sdk
+{
+	static class DynamicSkipToken
+	{
+		/// <summary>
+		/// The contract for exceptions which indicate that something should be skipped rather than
+		/// failed is that exception message should start with this, and that any text following this
+		/// will be treated as the skip reason (for example,
+		/// "$XunitDynamicSkip$This code can only run on Linux") will result in a skipped test with
+		/// the reason of "This code can only run on Linux".
+		/// </summary>
+		public const string Value = "$XunitDynamicSkip$";
+	}
+}

--- a/Sdk/Exceptions/AllException.cs
+++ b/Sdk/Exceptions/AllException.cs
@@ -1,0 +1,70 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when an All assertion has one or more items fail an assertion.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class AllException : XunitException
+	{
+#if XUNIT_NULLABLE
+		readonly IReadOnlyList<Tuple<int, object?, Exception>> errors;
+#else
+		readonly IReadOnlyList<Tuple<int, object, Exception>> errors;
+#endif
+		readonly int totalItems;
+
+		/// <summary>
+		/// Creates a new instance of the <see cref="AllException"/> class.
+		/// </summary>
+		/// <param name="totalItems">The total number of items that were in the collection.</param>
+		/// <param name="errors">The list of errors that occurred during the test pass.</param>
+		public AllException(
+#if XUNIT_NULLABLE
+			int totalItems,
+			Tuple<int, object?, Exception>[] errors) :
+#else
+			int totalItems,
+			Tuple<int, object, Exception>[] errors) :
+#endif
+				base("Assert.All() Failure")
+		{
+			this.errors = errors;
+			this.totalItems = totalItems;
+		}
+
+		/// <summary>
+		/// The errors that occurred during execution of the test.
+		/// </summary>
+		public IReadOnlyList<Exception> Failures =>
+			errors.Select(t => t.Item3).ToList();
+
+		/// <inheritdoc/>
+		public override string Message
+		{
+			get
+			{
+				var formattedErrors = errors.Select(error =>
+				{
+					var indexString = $"[{error.Item1}]: ";
+					var spaces = Environment.NewLine + "".PadRight(indexString.Length);
+
+					return $"{indexString}Item: {error.Item2?.ToString()?.Replace(Environment.NewLine, spaces)}{spaces}{error.Item3.ToString().Replace(Environment.NewLine, spaces)}";
+				});
+
+				return $"{base.Message}: {errors.Count} out of {totalItems} items in the collection did not pass.{Environment.NewLine}{string.Join(Environment.NewLine, formattedErrors)}";
+			}
+		}
+	}
+}

--- a/Sdk/Exceptions/AssertActualExpectedException.cs
+++ b/Sdk/Exceptions/AssertActualExpectedException.cs
@@ -1,0 +1,173 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.Collections;
+using System.Linq;
+using System.Reflection;
+
+#if XUNIT_NULLABLE
+using System.Diagnostics.CodeAnalysis;
+#endif
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Base class for exceptions that have actual and expected values
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class AssertActualExpectedException : XunitException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see href="AssertActualExpectedException"/> class.
+		/// </summary>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The actual value</param>
+		/// <param name="userMessage">The user message to be shown</param>
+		/// <param name="expectedTitle">The title to use for the expected value (defaults to "Expected")</param>
+		/// <param name="actualTitle">The title to use for the actual value (defaults to "Actual")</param>
+		public AssertActualExpectedException(
+#if XUNIT_NULLABLE
+			object? expected,
+			object? actual,
+			string? userMessage,
+			string? expectedTitle = null,
+			string? actualTitle = null) :
+#else
+			object expected,
+			object actual,
+			string userMessage,
+			string expectedTitle = null,
+			string actualTitle = null) :
+#endif
+				this(expected, actual, userMessage, expectedTitle, actualTitle, null)
+		{ }
+
+		/// <summary>
+		/// Creates a new instance of the <see href="AssertActualExpectedException"/> class.
+		/// </summary>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The actual value</param>
+		/// <param name="userMessage">The user message to be shown</param>
+		/// <param name="expectedTitle">The title to use for the expected value (defaults to "Expected")</param>
+		/// <param name="actualTitle">The title to use for the actual value (defaults to "Actual")</param>
+		/// <param name="innerException">The inner exception.</param>
+		public AssertActualExpectedException(
+#if XUNIT_NULLABLE
+			object? expected,
+			object? actual,
+			string? userMessage,
+			string? expectedTitle,
+			string? actualTitle,
+			Exception? innerException) :
+#else
+			object expected,
+			object actual,
+			string userMessage,
+			string expectedTitle,
+			string actualTitle,
+			Exception innerException) :
+#endif
+				base(userMessage, innerException)
+		{
+			Actual = ConvertToString(actual);
+			ActualTitle = actualTitle ?? "Actual";
+			Expected = ConvertToString(expected);
+			ExpectedTitle = expectedTitle ?? "Expected";
+
+			if (actual != null &&
+				expected != null &&
+				Actual == Expected &&
+				actual.GetType() != expected.GetType())
+			{
+				Actual += $" ({actual.GetType().FullName})";
+				Expected += $" ({expected.GetType().FullName})";
+			}
+		}
+
+		/// <summary>
+		/// Gets the actual value.
+		/// </summary>
+#if XUNIT_NULLABLE
+		public string? Actual { get; }
+#else
+		public string Actual { get; }
+#endif
+
+		/// <summary>
+		/// Gets the title used for the actual value.
+		/// </summary>
+		public string ActualTitle { get; }
+
+		/// <summary>
+		/// Gets the expected value.
+		/// </summary>
+#if XUNIT_NULLABLE
+		public string? Expected { get; }
+#else
+		public string Expected { get; }
+#endif
+
+		/// <summary>
+		/// Gets the title used for the expected value.
+		/// </summary>
+		public string ExpectedTitle { get; }
+
+		/// <summary>
+		/// Gets a message that describes the current exception. Includes the expected and actual values.
+		/// </summary>
+		/// <returns>The error message that explains the reason for the exception, or an empty string("").</returns>
+		/// <filterpriority>1</filterpriority>
+		public override string Message
+		{
+			get
+			{
+				var titleLength = Math.Max(ExpectedTitle.Length, ActualTitle.Length) + 2;  // + the colon and space
+				var formattedExpectedTitle = (ExpectedTitle + ":").PadRight(titleLength);
+				var formattedActualTitle = (ActualTitle + ":").PadRight(titleLength);
+				var indentedNewLine = Environment.NewLine + " ".PadRight(titleLength);
+
+				return $"{base.Message}{Environment.NewLine}{formattedExpectedTitle}{Expected?.Replace(Environment.NewLine, indentedNewLine) ?? "(null)"}{Environment.NewLine}{formattedActualTitle}{Actual?.Replace(Environment.NewLine, indentedNewLine) ?? "(null)"}";
+			}
+		}
+
+		static string ConvertToSimpleTypeName(TypeInfo typeInfo)
+		{
+			if (!typeInfo.IsGenericType)
+				return typeInfo.Name;
+
+			var simpleNames = typeInfo.GenericTypeArguments.Select(type => ConvertToSimpleTypeName(type.GetTypeInfo()));
+			var backTickIdx = typeInfo.Name.IndexOf('`');
+			if (backTickIdx < 0)
+				backTickIdx = typeInfo.Name.Length;  // F# doesn't use backticks for generic type names
+
+			return $"{typeInfo.Name.Substring(0, backTickIdx)}<{string.Join(", ", simpleNames)}>";
+		}
+
+#if XUNIT_NULLABLE
+		[return: NotNullIfNotNull("value")]
+		static string? ConvertToString(object? value)
+#else
+		static string ConvertToString(object value)
+#endif
+		{
+			if (value == null)
+				return null;
+
+			var stringValue = value as string;
+			if (stringValue != null)
+				return stringValue;
+
+			var formattedValue = ArgumentFormatter.Format(value);
+			if (value is IEnumerable)
+				formattedValue = $"{ConvertToSimpleTypeName(value.GetType().GetTypeInfo())} {formattedValue}";
+
+			return formattedValue;
+		}
+	}
+}

--- a/Sdk/Exceptions/AssertCollectionCountException.cs
+++ b/Sdk/Exceptions/AssertCollectionCountException.cs
@@ -1,0 +1,28 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when the collection did not contain exactly the given number element.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class AssertCollectionCountException : XunitException
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="AssertCollectionCountException"/> class.
+		/// </summary>
+		/// <param name="expectedCount">The expected number of items in the collection.</param>
+		/// <param name="actualCount">The actual number of items in the collection.</param>
+		public AssertCollectionCountException(
+			int expectedCount,
+			int actualCount) :
+				base($"The collection contained {actualCount} matching element(s) instead of {expectedCount}.")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/CollectionException.cs
+++ b/Sdk/Exceptions/CollectionException.cs
@@ -1,0 +1,131 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.Linq;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when Assert.Collection fails.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class CollectionException : XunitException
+	{
+#if XUNIT_NULLABLE
+		readonly string? innerException;
+		readonly string? innerStackTrace;
+#else
+		readonly string innerException;
+		readonly string innerStackTrace;
+#endif
+
+		/// <summary>
+		/// Creates a new instance of the <see cref="CollectionException"/> class.
+		/// </summary>
+		/// <param name="collection">The collection that failed the test.</param>
+		/// <param name="expectedCount">The expected number of items in the collection.</param>
+		/// <param name="actualCount">The actual number of items in the collection.</param>
+		/// <param name="indexFailurePoint">The index of the position where the first comparison failure occurred.</param>
+		/// <param name="innerException">The exception that was thrown during the comparison failure.</param>
+		public CollectionException(
+#if XUNIT_NULLABLE
+			object? collection,
+			int expectedCount,
+			int actualCount,
+			int indexFailurePoint = -1,
+			Exception? innerException = null) :
+#else
+			object collection,
+			int expectedCount,
+			int actualCount,
+			int indexFailurePoint = -1,
+			Exception innerException = null) :
+#endif
+				base("Assert.Collection() Failure")
+		{
+			Collection = collection;
+			ExpectedCount = expectedCount;
+			ActualCount = actualCount;
+			IndexFailurePoint = indexFailurePoint;
+			this.innerException = FormatInnerException(innerException);
+			innerStackTrace = innerException == null ? null : innerException.StackTrace;
+		}
+
+		/// <summary>
+		/// The collection that failed the test.
+		/// </summary>
+#if XUNIT_NULLABLE
+		public object? Collection { get; set; }
+#else
+		public object Collection { get; set; }
+#endif
+
+		/// <summary>
+		/// The actual number of items in the collection.
+		/// </summary>
+		public int ActualCount { get; set; }
+
+		/// <summary>
+		/// The expected number of items in the collection.
+		/// </summary>
+		public int ExpectedCount { get; set; }
+
+		/// <summary>
+		/// The index of the position where the first comparison failure occurred, or -1 if
+		/// comparisions did not occur (because the actual and expected counts differed).
+		/// </summary>
+		public int IndexFailurePoint { get; set; }
+
+		/// <inheritdoc/>
+		public override string Message
+		{
+			get
+			{
+				if (IndexFailurePoint >= 0)
+					return $"{base.Message}{Environment.NewLine}Collection: {ArgumentFormatter.Format(Collection)}{Environment.NewLine}Error during comparison of item at index {IndexFailurePoint}{Environment.NewLine}Inner exception: {innerException}";
+
+				return $"{base.Message}{Environment.NewLine}Collection: {ArgumentFormatter.Format(Collection)}{Environment.NewLine}Expected item count: {ExpectedCount}{Environment.NewLine}Actual item count:   {ActualCount}";
+			}
+		}
+
+		/// <inheritdoc/>
+#if XUNIT_NULLABLE
+		public override string? StackTrace
+#else
+		public override string StackTrace
+#endif
+		{
+			get
+			{
+				if (innerStackTrace == null)
+					return base.StackTrace;
+
+				return innerStackTrace + Environment.NewLine + base.StackTrace;
+			}
+		}
+
+#if XUNIT_NULLABLE
+		static string? FormatInnerException(Exception? innerException)
+#else
+		static string FormatInnerException(Exception innerException)
+#endif
+		{
+			if (innerException == null)
+				return null;
+
+			var lines =
+				innerException
+					.Message
+					.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+					.Select((value, idx) => idx > 0 ? "        " + value : value);
+
+			return string.Join(Environment.NewLine, lines);
+		}
+	}
+}

--- a/Sdk/Exceptions/ContainsDuplicateException.cs
+++ b/Sdk/Exceptions/ContainsDuplicateException.cs
@@ -1,0 +1,59 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System.Collections;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when <see cref="Assert.Distinct{T}(System.Collections.Generic.IEnumerable{T})" />
+	/// or <see cref="Assert.Distinct{T}(System.Collections.Generic.IEnumerable{T}, System.Collections.Generic.IEqualityComparer{T})" />
+	/// finds a duplicate entry in the collection
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class ContainsDuplicateException : XunitException
+	{
+
+		/// <summary>
+		/// Creates a new instance of the <see cref="ContainsDuplicateException"/> class.
+		/// </summary>
+		/// <param name="duplicateObject">The object that was present twice in the collection.</param>
+		/// <param name="collection">The collection that was checked for duplicate entries.</param>
+		public ContainsDuplicateException(
+#if XUNIT_NULLABLE
+			object? duplicateObject,
+			IEnumerable collection) :
+#else
+			object duplicateObject,
+			IEnumerable collection) :
+#endif
+				base("Assert.Distinct() Failure")
+		{
+			DuplicateObject = duplicateObject;
+			Collection = collection;
+		}
+
+		/// <summary>
+		/// Gets the collection that was checked for duplicate entries.
+		/// </summary>
+		public IEnumerable Collection { get; }
+
+		/// <summary>
+		/// Gets the object that was present more than once in the collection.
+		/// </summary>
+#if XUNIT_NULLABLE
+		public object? DuplicateObject { get; }
+#else
+		public object DuplicateObject { get; }
+#endif
+
+		/// <inheritdoc/>
+		public override string Message =>
+			$"{base.Message}: The item {ArgumentFormatter.Format(DuplicateObject)} occurs multiple times in {ArgumentFormatter.Format(Collection)}.";
+	}
+}

--- a/Sdk/Exceptions/ContainsException.cs
+++ b/Sdk/Exceptions/ContainsException.cs
@@ -1,0 +1,33 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when a collection unexpectedly does not contain the expected value.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class ContainsException : AssertActualExpectedException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="ContainsException"/> class.
+		/// </summary>
+		/// <param name="expected">The expected object value</param>
+		/// <param name="actual">The actual value</param>
+		public ContainsException(
+#if XUNIT_NULLABLE
+			object? expected,
+			object? actual) :
+#else
+			object expected,
+			object actual) :
+#endif
+				base(expected, actual, "Assert.Contains() Failure", "Not found", "In value")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/DoesNotContainException.cs
+++ b/Sdk/Exceptions/DoesNotContainException.cs
@@ -1,0 +1,33 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when a collection unexpectedly contains the expected value.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class DoesNotContainException : AssertActualExpectedException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="DoesNotContainException"/> class.
+		/// </summary>
+		/// <param name="expected">The expected object value</param>
+		/// <param name="actual">The actual value</param>
+		public DoesNotContainException(
+#if XUNIT_NULLABLE
+			object? expected,
+			object? actual) :
+#else
+			object expected,
+			object actual) :
+#endif
+				base(expected, actual, "Assert.DoesNotContain() Failure", "Found", "In value")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/DoesNotMatchException.cs
+++ b/Sdk/Exceptions/DoesNotMatchException.cs
@@ -1,0 +1,35 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when a string unexpectedly matches a regular expression.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class DoesNotMatchException : XunitException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="DoesNotMatchException"/> class.
+		/// </summary>
+		/// <param name="expectedRegexPattern">The regular expression pattern expected not to match</param>
+		/// <param name="actual">The actual value</param>
+		public DoesNotMatchException(
+#if XUNIT_NULLABLE
+			string expectedRegexPattern,
+			object? actual) :
+#else
+			string expectedRegexPattern,
+			object actual) :
+#endif
+				base($"Assert.DoesNotMatch() Failure:{Environment.NewLine}Regex: {expectedRegexPattern}{Environment.NewLine}Value: {actual}")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/EmptyException.cs
+++ b/Sdk/Exceptions/EmptyException.cs
@@ -1,0 +1,27 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System.Collections;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when a collection is unexpectedly not empty.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class EmptyException : AssertActualExpectedException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="EmptyException"/> class.
+		/// </summary>
+		/// <param name="collection">The collection that was not empty</param>
+		public EmptyException(IEnumerable collection) :
+			base("<empty>", ArgumentFormatter.Format(collection), "Assert.Empty() Failure")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/EndsWithException.cs
+++ b/Sdk/Exceptions/EndsWithException.cs
@@ -1,0 +1,67 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when a string does not end with the expected value.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class EndsWithException : XunitException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="EndsWithException"/> class.
+		/// </summary>
+		/// <param name="expected">The expected value that should've ended <paramref name="actual"/></param>
+		/// <param name="actual">The actual value</param>
+		public EndsWithException(
+#if XUNIT_NULLABLE
+			string? expected,
+			string? actual) :
+#else
+			string expected,
+			string actual) :
+#endif
+				base($"Assert.EndsWith() Failure:{Environment.NewLine}Expected: {ShortenExpected(expected, actual) ?? "(null)"}{Environment.NewLine}Actual:   {ShortenActual(expected, actual) ?? "(null)"}")
+		{ }
+
+#if XUNIT_NULLABLE
+		static string? ShortenExpected(
+			string? expected,
+			string? actual)
+#else
+		static string ShortenExpected(
+			string expected,
+			string actual)
+#endif
+		{
+			if (expected == null || actual == null || actual.Length <= expected.Length)
+				return expected;
+
+			return "   " + expected;
+		}
+
+#if XUNIT_NULLABLE
+		static string? ShortenActual(
+			string? expected,
+			string? actual)
+#else
+		static string ShortenActual(
+			string expected,
+			string actual)
+#endif
+		{
+			if (expected == null || actual == null || actual.Length <= expected.Length)
+				return actual;
+
+			return "···" + actual.Substring(actual.Length - expected.Length);
+		}
+	}
+}

--- a/Sdk/Exceptions/EqualException.cs
+++ b/Sdk/Exceptions/EqualException.cs
@@ -1,0 +1,316 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when two values are unexpectedly not equal.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class EqualException : AssertActualExpectedException
+	{
+		static readonly Dictionary<char, string> Encodings = new Dictionary<char, string>
+		{
+			{ '\r', "\\r" },
+			{ '\n', "\\n" },
+			{ '\t', "\\t" },
+			{ '\0', "\\0" }
+		};
+
+#if XUNIT_NULLABLE
+		string? message;
+#else
+		string message;
+#endif
+
+		/// <summary>
+		/// Creates a new instance of the <see cref="EqualException"/> class.
+		/// </summary>
+		/// <param name="expected">The expected object value</param>
+		/// <param name="actual">The actual object value</param>
+		public EqualException(
+#if XUNIT_NULLABLE
+			object? expected,
+			object? actual) :
+#else
+			object expected,
+			object actual) :
+#endif
+				base(expected, actual, "Assert.Equal() Failure")
+		{
+			ActualIndex = -1;
+			ExpectedIndex = -1;
+		}
+
+		/// <summary>
+		/// Creates a new instance of the <see cref="EqualException"/> class for string comparisons.
+		/// </summary>
+		/// <param name="expected">The expected string value</param>
+		/// <param name="actual">The actual string value</param>
+		/// <param name="expectedIndex">The first index in the expected string where the strings differ</param>
+		/// <param name="actualIndex">The first index in the actual string where the strings differ</param>
+		public EqualException(
+#if XUNIT_NULLABLE
+			string? expected,
+			string? actual,
+			int expectedIndex,
+			int actualIndex) :
+#else
+			string expected,
+			string actual,
+			int expectedIndex,
+			int actualIndex) :
+#endif
+				this(expected, actual, expectedIndex, actualIndex, null)
+		{ }
+
+		EqualException(
+#if XUNIT_NULLABLE
+			string? expected,
+			string? actual,
+			int expectedIndex,
+			int actualIndex,
+			int? pointerPosition) :
+#else
+			string expected,
+			string actual,
+			int expectedIndex,
+			int actualIndex,
+			int? pointerPosition) :
+#endif
+				base(expected, actual, "Assert.Equal() Failure")
+		{
+			ActualIndex = actualIndex;
+			ExpectedIndex = expectedIndex;
+			PointerPosition = pointerPosition;
+		}
+
+		EqualException(
+#if XUNIT_NULLABLE
+			string? expected,
+			string? actual,
+			int expectedIndex,
+			int actualIndex,
+			string? expectedType,
+			string? actualType,
+			int? pointerPosition) :
+#else
+			string expected,
+			string actual,
+			int expectedIndex,
+			int actualIndex,
+			string expectedType,
+			string actualType,
+			int? pointerPosition) :
+#endif
+				this(expected, actual, expectedIndex, actualIndex, pointerPosition)
+		{
+			ActualType = actualType;
+			ExpectedType = expectedType;
+		}
+
+		/// <summary>
+		/// Gets the index into the actual value where the values first differed.
+		/// Returns -1 if the difference index points were not provided.
+		/// </summary>
+		public int ActualIndex { get; }
+
+		/// <summary>
+		/// Gets the index into the expected value where the values first differed.
+		/// Returns -1 if the difference index points were not provided.
+		/// </summary>
+		public int ExpectedIndex { get; }
+
+		/// <summary>
+		/// Gets the type of the actual value of the first values differed.
+		/// Returns null if the type was not provided.
+		/// </summary>
+#if XUNIT_NULLABLE
+		public string? ActualType { get; }
+#else
+		public string ActualType { get; }
+#endif
+
+		/// <summary>
+		/// Gets the type of the expected value of the first values differed.
+		/// Returns null if the type was not provided.
+		/// </summary>
+#if XUNIT_NULLABLE
+		public string? ExpectedType { get; }
+#else
+		public string ExpectedType { get; }
+#endif
+
+		/// <inheritdoc/>
+		public override string Message
+		{
+			get
+			{
+				if (message == null)
+					message = CreateMessage();
+
+				return message;
+			}
+		}
+
+		/// <summary>
+		/// Gets the index of the difference between the IEnumerables when converted to a string.
+		/// </summary>
+		public int? PointerPosition { get; private set; }
+
+		string CreateMessage()
+		{
+			if (ExpectedIndex == -1)
+				return base.Message;
+
+			var undefinedType = string.IsNullOrEmpty(ActualType) || string.IsNullOrEmpty(ExpectedType);
+
+			var actualTypeMessage = undefinedType || ExpectedType == ActualType ? string.Empty : ActualType;
+			var expectedTypeMessage = undefinedType || ExpectedType == ActualType ? string.Empty : ExpectedType;
+
+			var printedExpected = ShortenAndEncode(Expected, expectedTypeMessage, PointerPosition ?? ExpectedIndex, '↓', ExpectedIndex);
+			var printedActual = ShortenAndEncode(Actual, actualTypeMessage, PointerPosition ?? ActualIndex, '↑', ActualIndex);
+
+			var sb = new StringBuilder();
+			sb.Append(UserMessage);
+
+			if (!string.IsNullOrWhiteSpace(printedExpected.Item2))
+				sb.AppendFormat(
+					CultureInfo.CurrentCulture,
+					"{0}          {1}",
+					Environment.NewLine,
+					printedExpected.Item2
+				);
+
+			sb.AppendFormat(
+				CultureInfo.CurrentCulture,
+				"{0}Expected: {1}{0}Actual:   {2}",
+				Environment.NewLine,
+				printedExpected.Item1,
+				printedActual.Item1
+			);
+
+			if (!string.IsNullOrWhiteSpace(printedActual.Item2))
+				sb.AppendFormat(
+					CultureInfo.CurrentCulture,
+					"{0}          {1}",
+					Environment.NewLine,
+					printedActual.Item2
+				);
+
+			return sb.ToString();
+		}
+
+		/// <summary>
+		/// Creates a new instance of the <see cref="EqualException"/> class for IEnumerable comparisons.
+		/// </summary>
+		/// <param name="expected">The expected object value</param>
+		/// <param name="actual">The actual object value</param>
+		/// <param name="mismatchIndex">The first index in the expected IEnumerable where the strings differ</param>
+		public static EqualException FromEnumerable(
+#if XUNIT_NULLABLE
+			IEnumerable? expected,
+			IEnumerable? actual,
+#else
+			IEnumerable expected,
+			IEnumerable actual,
+#endif
+			int mismatchIndex)
+		{
+			int? pointerPositionExpected;
+			int? pointerPositionActual;
+
+			var expectedText = ArgumentFormatter.Format(expected, out pointerPositionExpected, mismatchIndex);
+			var actualText = ArgumentFormatter.Format(actual, out pointerPositionActual, mismatchIndex);
+			var pointerPosition = (pointerPositionExpected ?? -1) > (pointerPositionActual ?? -1) ? pointerPositionExpected : pointerPositionActual;
+
+			var expectedEnumerable = expected?.Cast<object>();
+			var actualEnumerable = actual?.Cast<object>();
+
+			var expectedType = mismatchIndex < expectedEnumerable?.Count() ? expectedEnumerable.ElementAt(mismatchIndex)?.GetType().FullName : string.Empty;
+			var actualType = mismatchIndex < actualEnumerable?.Count() ? actualEnumerable.ElementAt(mismatchIndex)?.GetType().FullName : string.Empty;
+
+			return new EqualException(expectedText, actualText, mismatchIndex, mismatchIndex, expectedType, actualType, pointerPosition);
+		}
+
+
+		static Tuple<string, string> ShortenAndEncode(
+#if XUNIT_NULLABLE
+			string? value,
+			string? type,
+#else
+			string value,
+			string type,
+#endif
+			int position,
+			char pointer,
+			int? index = null)
+		{
+			if (value == null)
+				return Tuple.Create("(null)", "");
+
+			index = index ?? position;
+
+			var start = Math.Max(position - 20, 0);
+			var end = Math.Min(position + 41, value.Length);
+			var printedValue = new StringBuilder(100);
+			var printedPointer = new StringBuilder(100);
+
+			if (start > 0)
+			{
+				printedValue.Append("···");
+				printedPointer.Append("   ");
+			}
+
+			for (var idx = start; idx < end; ++idx)
+			{
+				var c = value[idx];
+				var paddingLength = 1;
+
+#if XUNIT_NULLABLE
+				string? encoding;
+#else
+				string encoding;
+#endif
+
+				if (Encodings.TryGetValue(c, out encoding))
+				{
+					printedValue.Append(encoding);
+					paddingLength = encoding.Length;
+				}
+				else
+					printedValue.Append(c);
+
+				if (idx < position)
+					printedPointer.Append(' ', paddingLength);
+				else if (idx == position)
+				{
+					if (string.IsNullOrEmpty(type))
+						printedPointer.AppendFormat("{0} (pos {1})", pointer, index);
+					else
+						printedPointer.AppendFormat("{0} (pos {1}, type {2})", pointer, index, type);
+				}
+			}
+
+			if (value.Length == position)
+				printedPointer.AppendFormat("{0} (pos {1})", pointer, index);
+
+			if (end < value.Length)
+				printedValue.Append("···");
+
+			return Tuple.Create(printedValue.ToString(), printedPointer.ToString());
+		}
+	}
+}

--- a/Sdk/Exceptions/EquivalentException.cs
+++ b/Sdk/Exceptions/EquivalentException.cs
@@ -1,0 +1,162 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when two values are unexpectedly not equal.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class EquivalentException : AssertActualExpectedException
+	{
+#if XUNIT_NULLABLE
+		readonly string? message;
+#else
+		readonly string message;
+#endif
+
+		EquivalentException(string message) :
+			base(null, null, null)
+		{
+			this.message = message;
+		}
+
+		EquivalentException(
+#if XUNIT_NULLABLE
+			object? expected,
+			object? actual,
+			string messageSuffix,
+			string? expectedTitle = null,
+			string? actualTitle = null) :
+#else
+			object expected,
+			object actual,
+			string messageSuffix,
+			string expectedTitle = null,
+			string actualTitle = null) :
+#endif
+				base(expected, actual, "Assert.Equivalent() Failure" + messageSuffix, expectedTitle, actualTitle)
+		{ }
+
+		/// <inheritdoc/>
+		public override string Message =>
+			message ?? base.Message;
+
+		static string FormatMemberNameList(
+			IEnumerable<string> memberNames,
+			string prefix) =>
+				"[" + string.Join(", ", memberNames.Select(k => $"\"{prefix}{k}\"")) + "]";
+
+		/// <summary>
+		/// Creates a new instance of <see cref="EquivalentException"/> which shows a message that indicates
+		/// a circular reference was discovered.
+		/// </summary>
+		/// <param name="memberName">The name of the member that caused the circular reference</param>
+		public static EquivalentException ForCircularReference(string memberName) =>
+			new EquivalentException($"Assert.Equivalent() Failure: Circular reference found in '{memberName}'");
+
+		/// <summary>
+		/// Creates a new instance of <see cref="EquivalentException"/> which shows a message that indicates
+		/// that the list of available members does not match.
+		/// </summary>
+		/// <param name="expectedMemberNames">The expected member names</param>
+		/// <param name="actualMemberNames">The actual member names</param>
+		/// <param name="prefix">The prefix to be applied to the member names (may be an empty string for a
+		/// top-level object, or a name in "member." format used as a prefix to show the member name list)</param>
+		public static EquivalentException ForMemberListMismatch(
+			IEnumerable<string> expectedMemberNames,
+			IEnumerable<string> actualMemberNames,
+			string prefix)
+		{
+			return new EquivalentException(
+				FormatMemberNameList(expectedMemberNames, prefix),
+				FormatMemberNameList(actualMemberNames, prefix),
+				": Mismatched member list"
+			);
+		}
+
+		/// <summary>
+		/// Creates a new instance of <see cref="EquivalentException"/> which shows a message that indicates
+		/// that the fault comes from an individual value mismatch one of the members.
+		/// </summary>
+		/// <param name="expected">The expected member value</param>
+		/// <param name="actual">The actual member value</param>
+		/// <param name="memberName">The name of the mismatched member (may be an empty string for a
+		/// top-level object)</param>
+		public static EquivalentException ForMemberValueMismatch(
+#if XUNIT_NULLABLE
+			object? expected,
+			object? actual,
+#else
+			object expected,
+			object actual,
+#endif
+			string memberName) =>
+				new EquivalentException(
+					expected,
+					actual,
+					memberName == string.Empty ? string.Empty : $": Mismatched value on member '{memberName}'"
+				);
+
+		/// <summary>
+		/// Creates a new instance of <see cref="EquivalentException"/> which shows a message that indicates
+		/// a value was missing from the <paramref name="actual"/> collection.
+		/// </summary>
+		/// <param name="expected">The object that was expected to be found in <paramref name="actual"/> collection.</param>
+		/// <param name="actual">The actual collection which was missing the object.</param>
+		/// <param name="memberName">The name of the member that was being inspected (may be an empty
+		/// string for a top-level collection)</param>
+		public static EquivalentException ForMissingCollectionValue(
+#if XUNIT_NULLABLE
+			object? expected,
+			IEnumerable<object?> actual,
+#else
+			object expected,
+			IEnumerable<object> actual,
+#endif
+			string memberName) =>
+				new EquivalentException(
+					expected,
+					ArgumentFormatter.Format(actual),
+					$": Collection value not found{(memberName == string.Empty ? string.Empty : $" in member '{memberName}'")}",
+					actualTitle: "In"
+				);
+
+		/// <summary>
+		/// Creates a new instance of <see cref="EquivalentException"/> which shows a message that indicates
+		/// that <paramref name="actual"/> contained one or more values that were not specified
+		/// in <paramref name="expected"/>.
+		/// </summary>
+		/// <param name="expected">The values expected to be found in the <paramref name="actual"/>
+		/// collection.</param>
+		/// <param name="actual">The actual collection values.</param>
+		/// <param name="actualLeftovers">The values from <paramref name="actual"/> that did not have
+		/// matching <paramref name="expected"/> values</param>
+		/// <param name="memberName">The name of the member that was being inspected (may be an empty
+		/// string for a top-level collection)</param>
+		public static EquivalentException ForExtraCollectionValue(
+#if XUNIT_NULLABLE
+			IEnumerable<object?> expected,
+			IEnumerable<object?> actual,
+			IEnumerable<object?> actualLeftovers,
+#else
+			IEnumerable<object> expected,
+			IEnumerable<object> actual,
+			IEnumerable<object> actualLeftovers,
+#endif
+			string memberName) =>
+				new EquivalentException(
+					ArgumentFormatter.Format(expected),
+					$"{ArgumentFormatter.Format(actualLeftovers)} left over from {ArgumentFormatter.Format(actual)}",
+					$": Extra values found{(memberName == string.Empty ? string.Empty : $" in member '{memberName}'")}"
+				);
+	}
+}

--- a/Sdk/Exceptions/FailException.cs
+++ b/Sdk/Exceptions/FailException.cs
@@ -1,0 +1,25 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when the user calls <see cref="Assert"/>.<see cref="Assert.Fail(string)"/>.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class FailException : XunitException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="FailException"/> class.
+		/// </summary>
+		/// <param name="message">The user's failure message.</param>
+		public FailException(string message) :
+			base($"Assert.Fail(): {message}")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/FalseException.cs
+++ b/Sdk/Exceptions/FalseException.cs
@@ -1,0 +1,32 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when a value is unexpectedly true.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class FalseException : AssertActualExpectedException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="FalseException"/> class.
+		/// </summary>
+		/// <param name="userMessage">The user message to be display, or <c>null</c> for the default message</param>
+		/// <param name="value">The actual value</param>
+		public FalseException(
+#if XUNIT_NULLABLE
+			string? userMessage,
+#else
+			string userMessage,
+#endif
+			bool? value) :
+				base("False", value?.ToString() ?? "(null)", userMessage ?? "Assert.False() Failure")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/InRangeException.cs
+++ b/Sdk/Exceptions/InRangeException.cs
@@ -1,0 +1,74 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when a value is unexpectedly not in the given range.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class InRangeException : XunitException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="InRangeException"/> class.
+		/// </summary>
+		/// <param name="actual">The actual object value</param>
+		/// <param name="low">The low value of the range</param>
+		/// <param name="high">The high value of the range</param>
+		public InRangeException(
+#if XUNIT_NULLABLE
+			object? actual,
+			object? low,
+			object? high) :
+#else
+			object actual,
+			object low,
+			object high) :
+#endif
+				base("Assert.InRange() Failure")
+		{
+			Low = low?.ToString();
+			High = high?.ToString();
+			Actual = actual?.ToString();
+		}
+
+		/// <summary>
+		/// Gets the actual object value
+		/// </summary>
+#if XUNIT_NULLABLE
+		public string? Actual { get; }
+#else
+		public string Actual { get; }
+#endif
+
+		/// <summary>
+		/// Gets the high value of the range
+		/// </summary>
+#if XUNIT_NULLABLE
+		public string? High { get; }
+#else
+		public string High { get; }
+#endif
+
+		/// <summary>
+		/// Gets the low value of the range
+		/// </summary>
+#if XUNIT_NULLABLE
+		public string? Low { get; }
+#else
+		public string Low { get; }
+#endif
+
+		/// <summary>
+		/// Gets a message that describes the current exception.
+		/// </summary>
+		/// <returns>The error message that explains the reason for the exception, or an empty string("").</returns>
+		public override string Message =>
+			$"{base.Message}\r\nRange:  ({Low} - {High})\r\nActual: {Actual ?? "(null)"}";
+	}
+}

--- a/Sdk/Exceptions/IsAssignableFromException.cs
+++ b/Sdk/Exceptions/IsAssignableFromException.cs
@@ -1,0 +1,34 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when the value is unexpectedly not of the given type or a derived type.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class IsAssignableFromException : AssertActualExpectedException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="IsTypeException"/> class.
+		/// </summary>
+		/// <param name="expected">The expected type</param>
+		/// <param name="actual">The actual object value</param>
+		public IsAssignableFromException(
+			Type expected,
+#if XUNIT_NULLABLE
+			object? actual) :
+#else
+			object actual) :
+#endif
+				base(expected, actual?.GetType(), "Assert.IsAssignableFrom() Failure")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/IsNotTypeException.cs
+++ b/Sdk/Exceptions/IsNotTypeException.cs
@@ -1,0 +1,34 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when the value is unexpectedly of the exact given type.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class IsNotTypeException : AssertActualExpectedException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="IsNotTypeException"/> class.
+		/// </summary>
+		/// <param name="expected">The expected type</param>
+		/// <param name="actual">The actual object value</param>
+		public IsNotTypeException(
+			Type expected,
+#if XUNIT_NULLABLE
+			object? actual) :
+#else
+			object actual) :
+#endif
+				base(expected, actual?.GetType(), "Assert.IsNotType() Failure")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/IsTypeException.cs
+++ b/Sdk/Exceptions/IsTypeException.cs
@@ -1,0 +1,33 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when the value is unexpectedly not of the exact given type.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class IsTypeException : AssertActualExpectedException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="IsTypeException"/> class.
+		/// </summary>
+		/// <param name="expectedTypeName">The expected type name</param>
+		/// <param name="actualTypeName">The actual type name</param>
+		public IsTypeException(
+#if XUNIT_NULLABLE
+			string? expectedTypeName,
+			string? actualTypeName) :
+#else
+			string expectedTypeName,
+			string actualTypeName) :
+#endif
+				base(expectedTypeName, actualTypeName, "Assert.IsType() Failure")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/MatchesException.cs
+++ b/Sdk/Exceptions/MatchesException.cs
@@ -1,0 +1,35 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when a string does not match a regular expression.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class MatchesException : XunitException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="MatchesException"/> class.
+		/// </summary>
+		/// <param name="expectedRegexPattern">The expected regular expression pattern</param>
+		/// <param name="actual">The actual value</param>
+		public MatchesException(
+#if XUNIT_NULLABLE
+			string? expectedRegexPattern,
+			object? actual) :
+#else
+			string expectedRegexPattern,
+			object actual) :
+#endif
+				base($"Assert.Matches() Failure:{Environment.NewLine}Regex: {expectedRegexPattern}{Environment.NewLine}Value: {actual}")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/MultipleException.cs
+++ b/Sdk/Exceptions/MultipleException.cs
@@ -1,0 +1,46 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when multiple assertions failed via <see cref="Assert.Multiple"/>.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class MultipleException : XunitException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="MultipleException"/> class.
+		/// </summary>
+		public MultipleException(IEnumerable<Exception> innerExceptions) :
+			base("Multiple failures were encountered:")
+		{
+			if (innerExceptions == null)
+				throw new ArgumentNullException(nameof(innerExceptions));
+
+			InnerExceptions = innerExceptions.ToList();
+		}
+
+		/// <summary>
+		/// Gets the list of inner exceptions that were thrown.
+		/// </summary>
+		public IReadOnlyCollection<Exception> InnerExceptions { get; }
+
+		/// <inheritdoc/>
+#if XUNIT_NULLABLE
+		public override string? StackTrace =>
+#else
+		public override string StackTrace =>
+#endif
+			"Inner stack traces:";
+	}
+}

--- a/Sdk/Exceptions/NotEmptyException.cs
+++ b/Sdk/Exceptions/NotEmptyException.cs
@@ -1,0 +1,24 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when a collection is unexpectedly empty.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class NotEmptyException : XunitException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="NotEmptyException"/> class.
+		/// </summary>
+		public NotEmptyException() :
+			base("Assert.NotEmpty() Failure")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/NotEqualException.cs
+++ b/Sdk/Exceptions/NotEqualException.cs
@@ -1,0 +1,31 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when two values are unexpectedly equal.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class NotEqualException : AssertActualExpectedException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="NotEqualException"/> class.
+		/// </summary>
+		public NotEqualException(
+#if XUNIT_NULLABLE
+			string? expected,
+			string? actual) :
+#else
+			string expected,
+			string actual) :
+#endif
+				base($"Not {expected ?? "(null)"}", actual ?? "(null)", "Assert.NotEqual() Failure")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/NotInRangeException.cs
+++ b/Sdk/Exceptions/NotInRangeException.cs
@@ -1,0 +1,76 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when a value is unexpectedly in the given range.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class NotInRangeException : XunitException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="NotInRangeException"/> class.
+		/// </summary>
+		/// <param name="actual">The actual object value</param>
+		/// <param name="low">The low value of the range</param>
+		/// <param name="high">The high value of the range</param>
+		public NotInRangeException(
+#if XUNIT_NULLABLE
+			object? actual,
+			object? low,
+			object? high) :
+#else
+			object actual,
+			object low,
+			object high) :
+#endif
+				base("Assert.NotInRange() Failure")
+		{
+			Low = low?.ToString();
+			High = high?.ToString();
+			Actual = actual?.ToString();
+		}
+
+		/// <summary>
+		/// Gets the actual object value
+		/// </summary>
+#if XUNIT_NULLABLE
+		public string? Actual { get; }
+#else
+		public string Actual { get; }
+#endif
+
+		/// <summary>
+		/// Gets the high value of the range
+		/// </summary>
+#if XUNIT_NULLABLE
+		public string? High { get; }
+#else
+		public string High { get; }
+#endif
+
+		/// <summary>
+		/// Gets the low value of the range
+		/// </summary>
+#if XUNIT_NULLABLE
+		public string? Low { get; }
+#else
+		public string Low { get; }
+#endif
+
+		/// <summary>
+		/// Gets a message that describes the current exception.
+		/// </summary>
+		/// <returns>The error message that explains the reason for the exception, or an empty string("").</returns>
+		public override string Message =>
+			$"{base.Message}{Environment.NewLine}Range:  ({Low} - {High}){Environment.NewLine}Actual: {Actual ?? "(null)"}";
+	}
+}

--- a/Sdk/Exceptions/NotNullException.cs
+++ b/Sdk/Exceptions/NotNullException.cs
@@ -1,0 +1,24 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when an object is unexpectedly null.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class NotNullException : XunitException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="NotNullException"/> class.
+		/// </summary>
+		public NotNullException() :
+			base("Assert.NotNull() Failure")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/NotSameException.cs
+++ b/Sdk/Exceptions/NotSameException.cs
@@ -1,0 +1,24 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when two values are unexpected the same instance.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class NotSameException : XunitException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="NotSameException"/> class.
+		/// </summary>
+		public NotSameException() :
+			base("Assert.NotSame() Failure")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/NullException.cs
+++ b/Sdk/Exceptions/NullException.cs
@@ -1,0 +1,25 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when an object reference is unexpectedly not null.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class NullException : AssertActualExpectedException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="NullException"/> class.
+		/// </summary>
+		/// <param name="actual">The actual non-<c>null</c> value</param>
+		public NullException(object actual) :
+			base(null, actual, "Assert.Null() Failure")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/ParameterCountMismatchException.cs
+++ b/Sdk/Exceptions/ParameterCountMismatchException.cs
@@ -1,0 +1,20 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception to be thrown from theory execution when the number of
+	/// parameter values does not the test method signature.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class ParameterCountMismatchException : Exception
+	{ }
+}

--- a/Sdk/Exceptions/ProperSubsetException.cs
+++ b/Sdk/Exceptions/ProperSubsetException.cs
@@ -1,0 +1,36 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System.Collections;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when a set is not a proper subset of another set.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class ProperSubsetException : AssertActualExpectedException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="ProperSubsetException"/> class.
+		/// </summary>
+		/// <param name="expected">The expected value</param>
+		/// <param name="actual">The actual value</param>
+#if XUNIT_NULLABLE
+		public ProperSubsetException(
+			IEnumerable expected,
+			IEnumerable? actual) :
+#else
+		public ProperSubsetException(
+			IEnumerable expected,
+			IEnumerable actual) :
+#endif
+				base(expected, actual, "Assert.ProperSubset() Failure")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/ProperSupersetException.cs
+++ b/Sdk/Exceptions/ProperSupersetException.cs
@@ -1,0 +1,30 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System.Collections;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when a set is not a proper superset of another set.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class ProperSupersetException : AssertActualExpectedException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="ProperSupersetException"/> class.
+		/// </summary>
+#if XUNIT_NULLABLE
+		public ProperSupersetException(IEnumerable expected, IEnumerable? actual)
+#else
+		public ProperSupersetException(IEnumerable expected, IEnumerable actual)
+#endif
+			: base(expected, actual, "Assert.ProperSuperset() Failure")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/PropertyChangedException.cs
+++ b/Sdk/Exceptions/PropertyChangedException.cs
@@ -1,0 +1,26 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when code unexpectedly fails change a property.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class PropertyChangedException : XunitException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="PropertyChangedException"/> class. Call this constructor
+		/// when no exception was thrown.
+		/// </summary>
+		/// <param name="propertyName">The name of the property that was expected to be changed.</param>
+		public PropertyChangedException(string propertyName) :
+			base($"Assert.PropertyChanged failure: Property {propertyName} was not set")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/RaisesException.cs
+++ b/Sdk/Exceptions/RaisesException.cs
@@ -1,0 +1,93 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when code unexpectedly fails to raise an event.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class RaisesException : XunitException
+	{
+#if XUNIT_NULLABLE
+		readonly string? stackTrace = null;
+#else
+		readonly string stackTrace = null;
+#endif
+
+		/// <summary>
+		/// Creates a new instance of the <see cref="RaisesException" /> class. Call this constructor
+		/// when no event was raised.
+		/// </summary>
+		/// <param name="expected">The type of the event args that was expected</param>
+		public RaisesException(Type expected)
+			: base("(No event was raised)")
+		{
+			Expected = ConvertToSimpleTypeName(expected.GetTypeInfo());
+			Actual = "(No event was raised)";
+		}
+
+		/// <summary>
+		/// Creates a new instance of the <see cref="RaisesException" /> class. Call this constructor
+		/// when an
+		/// </summary>
+		/// <param name="expected"></param>
+		/// <param name="actual"></param>
+		public RaisesException(Type expected, Type actual)
+			: base("(Raised event did not match expected event)")
+		{
+			Expected = ConvertToSimpleTypeName(expected.GetTypeInfo());
+			Actual = ConvertToSimpleTypeName(actual.GetTypeInfo());
+		}
+
+		/// <summary>
+		/// Gets the actual value.
+		/// </summary>
+		public string Actual { get; }
+
+		/// <summary>
+		/// Gets the expected value.
+		/// </summary>
+		public string Expected { get; }
+
+		/// <summary>
+		/// Gets a message that describes the current exception. Includes the expected and actual values.
+		/// </summary>
+		/// <returns>The error message that explains the reason for the exception, or an empty string("").</returns>
+		/// <filterpriority>1</filterpriority>
+		public override string Message =>
+			$"{base.Message}{Environment.NewLine}{Expected ?? "(null)"}{Environment.NewLine}{Actual ?? "(null)"}";
+
+		/// <summary>
+		/// Gets a string representation of the frames on the call stack at the time the current exception was thrown.
+		/// </summary>
+		/// <returns>A string that describes the contents of the call stack, with the most recent method call appearing first.</returns>
+#if XUNIT_NULLABLE
+		public override string? StackTrace => stackTrace ?? base.StackTrace;
+#else
+		public override string StackTrace => stackTrace ?? base.StackTrace;
+#endif
+
+		static string ConvertToSimpleTypeName(TypeInfo typeInfo)
+		{
+			if (!typeInfo.IsGenericType)
+				return typeInfo.Name;
+
+			var simpleNames = typeInfo.GenericTypeArguments.Select(type => ConvertToSimpleTypeName(type.GetTypeInfo()));
+			var backTickIdx = typeInfo.Name.IndexOf('`');
+			if (backTickIdx < 0)
+				backTickIdx = typeInfo.Name.Length;  // F# doesn't use backticks for generic type names
+
+			return $"{typeInfo.Name.Substring(0, backTickIdx)}<{string.Join(", ", simpleNames)}>";
+		}
+	}
+}

--- a/Sdk/Exceptions/SameException.cs
+++ b/Sdk/Exceptions/SameException.cs
@@ -1,0 +1,30 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when two object references are unexpectedly not the same instance.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class SameException : AssertActualExpectedException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="SameException"/> class.
+		/// </summary>
+		/// <param name="expected">The expected object reference</param>
+		/// <param name="actual">The actual object reference</param>
+#if XUNIT_NULLABLE
+		public SameException(object? expected, object? actual)
+#else
+		public SameException(object expected, object actual)
+#endif
+			: base(expected, actual, "Assert.Same() Failure")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/SingleException.cs
+++ b/Sdk/Exceptions/SingleException.cs
@@ -1,0 +1,44 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when the collection did not contain exactly one element.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class SingleException : XunitException
+	{
+		SingleException(string errorMessage)
+			: base(errorMessage)
+		{ }
+
+		/// <summary>
+		/// Creates an instance of <see cref="SingleException"/> for when the collection didn't contain any of the expected value.
+		/// </summary>
+#if XUNIT_NULLABLE
+		public static Exception Empty(string? expected) =>
+#else
+		public static Exception Empty(string expected) =>
+#endif
+			new SingleException($"The collection was expected to contain a single element{(expected == null ? "" : " matching " + expected)}, but it {(expected == null ? "was empty." : "contained no matching elements.")}");
+
+		/// <summary>
+		/// Creates an instance of <see cref="SingleException"/> for when the collection had too many of the expected items.
+		/// </summary>
+		/// <returns></returns>
+#if XUNIT_NULLABLE
+		public static Exception MoreThanOne(int count, string? expected) =>
+#else
+		public static Exception MoreThanOne(int count, string expected) =>
+#endif
+			new SingleException($"The collection was expected to contain a single element{(expected == null ? "" : " matching " + expected)}, but it contained {count}{(expected == null ? "" : " matching")} elements.");
+	}
+}

--- a/Sdk/Exceptions/SkipException.cs
+++ b/Sdk/Exceptions/SkipException.cs
@@ -1,0 +1,26 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when a test should be skipped.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class SkipException : XunitException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="SkipException"/> class. This is a special
+		/// exception that, when thrown, will cause xUnit.net to mark your test as skipped
+		/// rather than failed.
+		/// </summary>
+		public SkipException(string message)
+			: base($"{DynamicSkipToken.Value}{message}")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/StartsWithException.cs
+++ b/Sdk/Exceptions/StartsWithException.cs
@@ -1,0 +1,48 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when a string does not start with the expected value.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class StartsWithException : XunitException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="StartsWithException"/> class.
+		/// </summary>
+		/// <param name="expected">The expected string value</param>
+		/// <param name="actual">The actual value</param>
+#if XUNIT_NULLABLE
+		public StartsWithException(
+			string? expected,
+			string? actual) :
+#else
+		public StartsWithException(
+			string expected,
+			string actual) :
+#endif
+				base($"Assert.StartsWith() Failure:{Environment.NewLine}Expected: {expected ?? "(null)"}{Environment.NewLine}Actual:   {ShortenActual(expected, actual) ?? "(null)"}")
+		{ }
+
+#if XUNIT_NULLABLE
+		static string? ShortenActual(string? expected, string? actual)
+#else
+		static string ShortenActual(string expected, string actual)
+#endif
+		{
+			if (expected == null || actual == null || actual.Length <= expected.Length)
+				return actual;
+
+			return actual.Substring(0, expected.Length) + "...";
+		}
+	}
+}

--- a/Sdk/Exceptions/SubsetException.cs
+++ b/Sdk/Exceptions/SubsetException.cs
@@ -1,0 +1,30 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System.Collections;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when a set is not a subset of another set.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class SubsetException : AssertActualExpectedException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="SubsetException"/> class.
+		/// </summary>
+#if XUNIT_NULLABLE
+		public SubsetException(IEnumerable expected, IEnumerable? actual)
+#else
+		public SubsetException(IEnumerable expected, IEnumerable actual)
+#endif
+			: base(expected, actual, "Assert.Subset() Failure")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/SupersetException.cs
+++ b/Sdk/Exceptions/SupersetException.cs
@@ -1,0 +1,30 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System.Collections;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when a set is not a superset of another set.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class SupersetException : AssertActualExpectedException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="SupersetException"/> class.
+		/// </summary>
+#if XUNIT_NULLABLE
+		public SupersetException(IEnumerable expected, IEnumerable? actual)
+#else
+		public SupersetException(IEnumerable expected, IEnumerable actual)
+#endif
+			: base(expected, actual, "Assert.Superset() Failure")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/ThrowsException.cs
+++ b/Sdk/Exceptions/ThrowsException.cs
@@ -1,0 +1,78 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when code unexpectedly fails to throw an exception.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class ThrowsException : AssertActualExpectedException
+	{
+#if XUNIT_NULLABLE
+		readonly string? stackTrace = null;
+#else
+		readonly string stackTrace = null;
+#endif
+
+		/// <summary>
+		/// Creates a new instance of the <see cref="ThrowsException"/> class. Call this constructor
+		/// when no exception was thrown.
+		/// </summary>
+		/// <param name="expectedType">The type of the exception that was expected</param>
+		public ThrowsException(Type expectedType)
+			: this(expectedType, "(No exception was thrown)", null, null, null)
+		{ }
+
+		/// <summary>
+		/// Creates a new instance of the <see cref="ThrowsException"/> class. Call this constructor
+		/// when an exception of the wrong type was thrown.
+		/// </summary>
+		/// <param name="expectedType">The type of the exception that was expected</param>
+		/// <param name="actual">The actual exception that was thrown</param>
+		public ThrowsException(Type expectedType, Exception actual)
+#if XUNIT_NULLABLE
+			: this(expectedType, ArgumentFormatter.Format(actual.GetType())!, actual.Message, actual.StackTrace, actual)
+#else
+			: this(expectedType, ArgumentFormatter.Format(actual.GetType()), actual.Message, actual.StackTrace, actual)
+#endif
+		{ }
+
+		/// <summary>
+		/// THIS CONSTRUCTOR IS FOR UNIT TESTING PURPOSES ONLY.
+		/// </summary>
+#if XUNIT_NULLABLE
+		protected ThrowsException(Type expected, string actual, string? actualMessage, string? stackTrace, Exception? innerException)
+#else
+		protected ThrowsException(Type expected, string actual, string actualMessage, string stackTrace, Exception innerException)
+#endif
+			: base(
+				expected,
+				actual + (actualMessage == null ? "" : ": " + actualMessage),
+				"Assert.Throws() Failure",
+				null,
+				null,
+				innerException
+			)
+		{
+			this.stackTrace = stackTrace;
+		}
+
+		/// <summary>
+		/// Gets a string representation of the frames on the call stack at the time the current exception was thrown.
+		/// </summary>
+		/// <returns>A string that describes the contents of the call stack, with the most recent method call appearing first.</returns>
+#if XUNIT_NULLABLE
+		public override string? StackTrace => stackTrace ?? base.StackTrace;
+#else
+		public override string StackTrace => stackTrace ?? base.StackTrace;
+#endif
+	}
+}

--- a/Sdk/Exceptions/TrueException.cs
+++ b/Sdk/Exceptions/TrueException.cs
@@ -1,0 +1,32 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when a value is unexpectedly false.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class TrueException : AssertActualExpectedException
+	{
+		/// <summary>
+		/// Creates a new instance of the <see cref="TrueException"/> class.
+		/// </summary>
+		/// <param name="userMessage">The user message to be displayed, or null for the default message</param>
+		/// <param name="value">The actual value</param>
+		public TrueException(
+#if XUNIT_NULLABLE
+			string? userMessage,
+#else
+			string userMessage,
+#endif
+			bool? value) :
+				base("True", value?.ToString() ?? "(null)", userMessage ?? "Assert.True() Failure")
+		{ }
+	}
+}

--- a/Sdk/Exceptions/XunitException.cs
+++ b/Sdk/Exceptions/XunitException.cs
@@ -1,0 +1,119 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// The base assert exception class
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	class XunitException : Exception, IAssertionException
+	{
+#if XUNIT_NULLABLE
+		readonly string? stackTrace;
+#else
+		readonly string stackTrace;
+#endif
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="XunitException"/> class.
+		/// </summary>
+		public XunitException()
+		{ }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="XunitException"/> class.
+		/// </summary>
+		/// <param name="userMessage">The user message to be displayed</param>
+#if XUNIT_NULLABLE
+		public XunitException(string? userMessage) :
+			this(userMessage, (Exception?)null)
+#else
+		public XunitException(string userMessage) :
+			this(userMessage, (Exception)null)
+#endif
+		{ }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="XunitException"/> class.
+		/// </summary>
+		/// <param name="userMessage">The user message to be displayed</param>
+		/// <param name="innerException">The inner exception</param>
+		public XunitException(
+#if XUNIT_NULLABLE
+			string? userMessage,
+			Exception? innerException) :
+#else
+			string userMessage,
+			Exception innerException) :
+#endif
+				base(userMessage, innerException)
+		{
+			UserMessage = userMessage;
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="XunitException"/> class.
+		/// </summary>
+		/// <param name="userMessage">The user message to be displayed</param>
+		/// <param name="stackTrace">The stack trace to be displayed</param>
+		protected XunitException(
+#if XUNIT_NULLABLE
+			string? userMessage,
+			string? stackTrace) :
+#else
+			string userMessage,
+			string stackTrace) :
+#endif
+				this(userMessage)
+		{
+			this.stackTrace = stackTrace;
+		}
+
+		/// <summary>
+		/// Gets a string representation of the frames on the call stack at the time the current exception was thrown.
+		/// </summary>
+		/// <returns>A string that describes the contents of the call stack, with the most recent method call appearing first.</returns>
+#if XUNIT_NULLABLE
+		public override string? StackTrace =>
+#else
+		public override string StackTrace =>
+#endif
+			stackTrace ?? base.StackTrace;
+
+		/// <summary>
+		/// Gets the user message
+		/// </summary>
+#if XUNIT_NULLABLE
+		public string? UserMessage { get; protected set; }
+#else
+		public string UserMessage { get; protected set; }
+#endif
+
+		/// <inheritdoc/>
+		public override string ToString()
+		{
+			var className = GetType().ToString();
+			var message = Message;
+			string result;
+
+			if (message == null || message.Length <= 0)
+				result = className;
+			else
+				result = $"{className}: {message}";
+
+			var stackTrace = StackTrace;
+			if (stackTrace != null)
+				result = $"{result}{Environment.NewLine}{stackTrace}";
+
+			return result;
+		}
+	}
+}

--- a/Sdk/IAssertionException.cs
+++ b/Sdk/IAssertionException.cs
@@ -1,0 +1,13 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// This is a marker interface implemented by all built-in assertion exceptions so that
+	/// test failures can be marked with <see cref="F:Xunit.v3.FailureCause.Assertion"/>.
+	/// </summary>
+	public interface IAssertionException
+	{ }
+}

--- a/SetAsserts.cs
+++ b/SetAsserts.cs
@@ -1,0 +1,231 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System.Collections.Generic;
+using Xunit.Sdk;
+
+#if XUNIT_IMMUTABLE_COLLECTIONS
+using System.Collections.Immutable;
+#endif
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		/// <summary>
+		/// Verifies that the set contains the given object.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="expected">The object expected to be in the set</param>
+		/// <param name="set">The set to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the set</exception>
+		public static void Contains<T>(
+			T expected,
+			ISet<T> set)
+		{
+			GuardArgumentNotNull(nameof(set), set);
+
+			// Do not forward to DoesNotContain(expected, set.Keys) as we want the default SDK behavior
+			if (!set.Contains(expected))
+				throw new ContainsException(expected, set);
+		}
+
+#if NET5_0_OR_GREATER
+		/// <summary>
+		/// Verifies that the read-only set contains the given object.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="expected">The object expected to be in the set</param>
+		/// <param name="set">The set to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the set</exception>
+		public static void Contains<T>(
+			T expected,
+			IReadOnlySet<T> set)
+		{
+			GuardArgumentNotNull(nameof(set), set);
+
+			// Do not forward to DoesNotContain(expected, set.Keys) as we want the default SDK behavior
+			if (!set.Contains(expected))
+				throw new ContainsException(expected, set);
+		}
+#endif
+
+		/// <summary>
+		/// Verifies that the hashset contains the given object.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="expected">The object expected to be in the set</param>
+		/// <param name="set">The set to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the set</exception>
+		public static void Contains<T>(
+			T expected,
+			HashSet<T> set) =>
+				Contains(expected, (ISet<T>)set);
+
+#if XUNIT_IMMUTABLE_COLLECTIONS
+		/// <summary>
+		/// Verifies that the immutable hashset contains the given object.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="expected">The object expected to be in the set</param>
+		/// <param name="set">The set to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the set</exception>
+		public static void Contains<T>(
+			T expected,
+			ImmutableHashSet<T> set) =>
+				Contains(expected, (ISet<T>)set);
+#endif
+
+		/// <summary>
+		/// Verifies that the set does not contain the given item.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be compared</typeparam>
+		/// <param name="expected">The object that is expected not to be in the set</param>
+		/// <param name="set">The set to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the object is present inside the set</exception>
+		public static void DoesNotContain<T>(
+			T expected,
+			ISet<T> set)
+		{
+			GuardArgumentNotNull(nameof(set), set);
+
+			if (set.Contains(expected))
+				throw new DoesNotContainException(expected, set);
+		}
+
+#if NET5_0_OR_GREATER
+		/// <summary>
+		/// Verifies that the read-only set does not contain the given item.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be compared</typeparam>
+		/// <param name="expected">The object that is expected not to be in the set</param>
+		/// <param name="set">The set to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the object is present inside the container</exception>
+		public static void DoesNotContain<T>(
+			T expected,
+			IReadOnlySet<T> set)
+		{
+			GuardArgumentNotNull(nameof(set), set);
+
+			if (set.Contains(expected))
+				throw new DoesNotContainException(expected, set);
+		}
+#endif
+
+		/// <summary>
+		/// Verifies that the hashset does not contain the given item.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="expected">The object expected to be in the set</param>
+		/// <param name="set">The set to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the set</exception>
+		public static void DoesNotContain<T>(
+			T expected,
+			HashSet<T> set) =>
+				DoesNotContain(expected, (ISet<T>)set);
+
+#if XUNIT_IMMUTABLE_COLLECTIONS
+		/// <summary>
+		/// Verifies that the immutable hashset does not contain the given item.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="expected">The object expected to be in the set</param>
+		/// <param name="set">The set to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the set</exception>
+		public static void DoesNotContain<T>(
+			T expected,
+			ImmutableHashSet<T> set) =>
+				DoesNotContain(expected, (ISet<T>)set);
+#endif
+
+		/// <summary>
+		/// Verifies that a set is a proper subset of another set.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="expectedSuperset">The expected superset</param>
+		/// <param name="actual">The set expected to be a proper subset</param>
+		/// <exception cref="ContainsException">Thrown when the actual set is not a proper subset of the expected set</exception>
+		public static void ProperSubset<T>(
+			ISet<T> expectedSuperset,
+#if XUNIT_NULLABLE
+			ISet<T>? actual)
+#else
+			ISet<T> actual)
+#endif
+		{
+			GuardArgumentNotNull(nameof(expectedSuperset), expectedSuperset);
+
+			if (actual == null || !actual.IsProperSubsetOf(expectedSuperset))
+				throw new ProperSubsetException(expectedSuperset, actual);
+		}
+
+		/// <summary>
+		/// Verifies that a set is a proper superset of another set.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="expectedSubset">The expected subset</param>
+		/// <param name="actual">The set expected to be a proper superset</param>
+		/// <exception cref="ContainsException">Thrown when the actual set is not a proper superset of the expected set</exception>
+		public static void ProperSuperset<T>(
+			ISet<T> expectedSubset,
+#if XUNIT_NULLABLE
+			ISet<T>? actual)
+#else
+			ISet<T> actual)
+#endif
+		{
+			GuardArgumentNotNull(nameof(expectedSubset), expectedSubset);
+
+			if (actual == null || !actual.IsProperSupersetOf(expectedSubset))
+				throw new ProperSupersetException(expectedSubset, actual);
+		}
+
+		/// <summary>
+		/// Verifies that a set is a subset of another set.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="expectedSuperset">The expected superset</param>
+		/// <param name="actual">The set expected to be a subset</param>
+		/// <exception cref="ContainsException">Thrown when the actual set is not a subset of the expected set</exception>
+		public static void Subset<T>(
+			ISet<T> expectedSuperset,
+#if XUNIT_NULLABLE
+			ISet<T>? actual)
+#else
+			ISet<T> actual)
+#endif
+		{
+			GuardArgumentNotNull(nameof(expectedSuperset), expectedSuperset);
+
+			if (actual == null || !actual.IsSubsetOf(expectedSuperset))
+				throw new SubsetException(expectedSuperset, actual);
+		}
+
+		/// <summary>
+		/// Verifies that a set is a superset of another set.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="expectedSubset">The expected subset</param>
+		/// <param name="actual">The set expected to be a superset</param>
+		/// <exception cref="ContainsException">Thrown when the actual set is not a superset of the expected set</exception>
+		public static void Superset<T>(
+			ISet<T> expectedSubset,
+#if XUNIT_NULLABLE
+			ISet<T>? actual)
+#else
+			ISet<T> actual)
+#endif
+		{
+			GuardArgumentNotNull(nameof(expectedSubset), expectedSubset);
+
+			if (actual == null || !actual.IsSupersetOf(expectedSubset))
+				throw new SupersetException(expectedSubset, actual);
+		}
+	}
+}

--- a/SkipAsserts.cs
+++ b/SkipAsserts.cs
@@ -1,0 +1,79 @@
+#if XUNIT_SKIP
+
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using Xunit.Sdk;
+
+#if XUNIT_NULLABLE
+using System.Diagnostics.CodeAnalysis;
+#endif
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		/// <summary>
+		/// Skips the current test. Used when determining whether a test should be skipped
+		/// happens at runtime rather than at discovery time.
+		/// </summary>
+		/// <param name="reason">The message to indicate why the test was skipped</param>
+#if XUNIT_NULLABLE
+		[DoesNotReturn]
+#endif
+		public static void Skip(string reason)
+		{
+			GuardArgumentNotNull(nameof(reason), reason);
+
+			throw new SkipException(reason);
+		}
+
+		/// <summary>
+		/// Will skip the current test unless <paramref name="condition"/> evaluates to <c>true</c>.
+		/// </summary>
+		/// <param name="condition">When <c>true</c>, the test will continue to run; when <c>false</c>,
+		/// the test will be skipped</param>
+		/// <param name="reason">The message to indicate why the test was skipped</param>
+		public static void SkipUnless(
+#if XUNIT_NULLABLE
+			[DoesNotReturnIf(false)] bool condition,
+#else
+			bool condition,
+#endif
+			string reason)
+		{
+			GuardArgumentNotNull(nameof(reason), reason);
+
+			if (!condition)
+				throw new SkipException(reason);
+		}
+
+		/// <summary>
+		/// Will skip the current test when <paramref name="condition"/> evaluates to <c>true</c>.
+		/// </summary>
+		/// <param name="condition">When <c>true</c>, the test will be skipped; when <c>false</c>,
+		/// the test will continue to run</param>
+		/// <param name="reason">The message to indicate why the test was skipped</param>
+		public static void SkipWhen(
+#if XUNIT_NULLABLE
+			[DoesNotReturnIf(true)] bool condition,
+#else
+			bool condition,
+#endif
+			string reason)
+		{
+			GuardArgumentNotNull(nameof(reason), reason);
+
+			if (condition)
+				throw new SkipException(reason);
+		}
+	}
+}
+
+#endif

--- a/SpanAsserts.cs
+++ b/SpanAsserts.cs
@@ -1,0 +1,806 @@
+#if XUNIT_SPAN
+
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.Globalization;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		// NOTE: ref struct types (Span, ReadOnlySpan) are not Nullable, and thus there is no XUNIT_NULLABLE usage currently in this class
+		// This also means that null spans are identical to empty spans, (both in essence point to a 0 sized array of whatever type)
+
+		// NOTE: we could consider StartsWith<T> and EndsWith<T> and use the Span extension methods to check difference, but, the current
+		// Exceptions for StartsWith and EndsWith are only built for string types, so those would need a change (or new non-string versions created).
+
+		// NOTE: there is an implicit conversion operator on Span<T> to ReadOnlySpan<T> - however, I have found that the compiler sometimes struggles
+		// with identifying the proper methods to use, thus I have overloaded quite a few of the assertions in terms of supplying both
+		// Span and ReadOnlySpan based methods
+
+		/// <summary>
+		/// Verifies that a span contains a given sub-span, using the default <see cref="StringComparison.CurrentCulture"/> comparison type.
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-span is not present inside the span</exception>
+		public static void Contains(
+			Span<char> expectedSubSpan,
+			Span<char> actualSpan) =>
+				Contains((ReadOnlySpan<char>)expectedSubSpan, (ReadOnlySpan<char>)actualSpan, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a span contains a given sub-span, using the default <see cref="StringComparison.CurrentCulture"/> comparison type.
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-span is not present inside the span</exception>
+		public static void Contains(
+			Span<char> expectedSubSpan,
+			ReadOnlySpan<char> actualSpan) =>
+				Contains((ReadOnlySpan<char>)expectedSubSpan, actualSpan, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a span contains a given sub-span, using the default <see cref="StringComparison.CurrentCulture"/> comparison type.
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-span is not present inside the span</exception>
+		public static void Contains(
+			ReadOnlySpan<char> expectedSubSpan,
+			Span<char> actualSpan) =>
+				Contains(expectedSubSpan, (ReadOnlySpan<char>)actualSpan, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a span contains a given sub-span, using the default <see cref="StringComparison.CurrentCulture"/> comparison type.
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-span is not present inside the span</exception>
+		public static void Contains(
+			ReadOnlySpan<char> expectedSubSpan,
+			ReadOnlySpan<char> actualSpan) =>
+				Contains(expectedSubSpan, actualSpan, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a span contains a given sub-span, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="ContainsException">Thrown when the sub-span is not present inside the span</exception>
+		public static void Contains(
+			Span<char> expectedSubSpan,
+			Span<char> actualSpan,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				Contains((ReadOnlySpan<char>)expectedSubSpan, (ReadOnlySpan<char>)actualSpan, comparisonType);
+
+		/// <summary>
+		/// Verifies that a span contains a given sub-span, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="ContainsException">Thrown when the sub-span is not present inside the span</exception>
+		public static void Contains(
+			Span<char> expectedSubSpan,
+			ReadOnlySpan<char> actualSpan,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				Contains((ReadOnlySpan<char>)expectedSubSpan, actualSpan, comparisonType);
+
+		/// <summary>
+		/// Verifies that a span contains a given sub-span, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="ContainsException">Thrown when the sub-span is not present inside the span</exception>
+		public static void Contains(
+			ReadOnlySpan<char> expectedSubSpan,
+			Span<char> actualSpan,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				Contains(expectedSubSpan, (ReadOnlySpan<char>)actualSpan, comparisonType);
+
+		/// <summary>
+		/// Verifies that a span contains a given sub-span, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="ContainsException">Thrown when the sub-span is not present inside the span</exception>
+		public static void Contains(
+			ReadOnlySpan<char> expectedSubSpan,
+			ReadOnlySpan<char> actualSpan,
+			StringComparison comparisonType = StringComparison.CurrentCulture)
+		{
+			if (actualSpan.IndexOf(expectedSubSpan, comparisonType) < 0)
+				throw new ContainsException(expectedSubSpan.ToString(), actualSpan.ToString());
+		}
+
+		/// <summary>
+		/// Verifies that a span contains a given sub-span
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-span is not present inside the span</exception>
+		public static void Contains<T>(
+			Span<T> expectedSubSpan,
+			Span<T> actualSpan)
+				where T : IEquatable<T> =>
+					Contains((ReadOnlySpan<T>)expectedSubSpan, (ReadOnlySpan<T>)actualSpan);
+
+		/// <summary>
+		/// Verifies that a span contains a given sub-span
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-span is not present inside the span</exception>
+		public static void Contains<T>(
+			Span<T> expectedSubSpan,
+			ReadOnlySpan<T> actualSpan)
+				where T : IEquatable<T> =>
+					Contains((ReadOnlySpan<T>)expectedSubSpan, actualSpan);
+
+		/// <summary>
+		/// Verifies that a span contains a given sub-span
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-span is not present inside the span</exception>
+		public static void Contains<T>(
+			ReadOnlySpan<T> expectedSubSpan,
+			Span<T> actualSpan)
+				where T : IEquatable<T> =>
+					Contains(expectedSubSpan, (ReadOnlySpan<T>)actualSpan);
+
+		/// <summary>
+		/// Verifies that a span contains a given sub-span
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-span is not present inside the span</exception>
+		public static void Contains<T>(
+			ReadOnlySpan<T> expectedSubSpan,
+			ReadOnlySpan<T> actualSpan)
+				where T : IEquatable<T>
+		{
+			if (actualSpan.IndexOf(expectedSubSpan) < 0)
+				throw new ContainsException(expectedSubSpan.ToArray(), actualSpan.ToArray());
+		}
+
+		/// <summary>
+		/// Verifies that a span does not contain a given sub-span, using the default <see cref="StringComparison.CurrentCulture"/> comparison type.
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected not to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-span is present inside the span</exception>
+		public static void DoesNotContain(
+			Span<char> expectedSubSpan,
+			Span<char> actualSpan) =>
+				DoesNotContain((ReadOnlySpan<char>)expectedSubSpan, (ReadOnlySpan<char>)actualSpan, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a span does not contain a given sub-span, using the default <see cref="StringComparison.CurrentCulture"/> comparison type.
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected not to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-span is present inside the span</exception>
+		public static void DoesNotContain(
+			Span<char> expectedSubSpan,
+			ReadOnlySpan<char> actualSpan) =>
+				DoesNotContain((ReadOnlySpan<char>)expectedSubSpan, actualSpan, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a span does not contain a given sub-span, using the default <see cref="StringComparison.CurrentCulture"/> comparison type.
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected not to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-span is present inside the span</exception>
+		public static void DoesNotContain(
+			ReadOnlySpan<char> expectedSubSpan,
+			Span<char> actualSpan) =>
+				DoesNotContain(expectedSubSpan, (ReadOnlySpan<char>)actualSpan, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a span does not contain a given sub-span, using the default <see cref="StringComparison.CurrentCulture"/> comparison type.
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected not to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-span is present inside the span</exception>
+		public static void DoesNotContain(
+			ReadOnlySpan<char> expectedSubSpan,
+			ReadOnlySpan<char> actualSpan) =>
+				DoesNotContain((ReadOnlySpan<char>)expectedSubSpan, (ReadOnlySpan<char>)actualSpan, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a span does not contain a given sub-span, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected not to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-span is present inside the span</exception>
+		public static void DoesNotContain(
+			Span<char> expectedSubSpan,
+			Span<char> actualSpan,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				DoesNotContain((ReadOnlySpan<char>)expectedSubSpan, (ReadOnlySpan<char>)actualSpan, comparisonType);
+
+		/// <summary>
+		/// Verifies that a span does not contain a given sub-span, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected not to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-span is present inside the span</exception>
+		public static void DoesNotContain(
+			Span<char> expectedSubSpan,
+			ReadOnlySpan<char> actualSpan,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				DoesNotContain((ReadOnlySpan<char>)expectedSubSpan, actualSpan, comparisonType);
+
+		/// <summary>
+		/// Verifies that a span does not contain a given sub-span, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected not to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-span is present inside the span</exception>
+		public static void DoesNotContain(
+			ReadOnlySpan<char> expectedSubSpan,
+			Span<char> actualSpan,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				DoesNotContain(expectedSubSpan, (ReadOnlySpan<char>)actualSpan, comparisonType);
+
+		/// <summary>
+		/// Verifies that a span does not contain a given sub-span, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected not to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-span is present inside the span</exception>
+		public static void DoesNotContain(
+			ReadOnlySpan<char> expectedSubSpan,
+			ReadOnlySpan<char> actualSpan,
+			StringComparison comparisonType = StringComparison.CurrentCulture)
+		{
+			if (actualSpan.IndexOf(expectedSubSpan, comparisonType) > -1)
+				throw new DoesNotContainException(expectedSubSpan.ToString(), actualSpan.ToString());
+		}
+
+		/// <summary>
+		/// Verifies that a span does not contain a given sub-span
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected not to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-span is present inside the span</exception>
+		public static void DoesNotContain<T>(
+			Span<T> expectedSubSpan,
+			Span<T> actualSpan)
+				where T : IEquatable<T> =>
+					DoesNotContain((ReadOnlySpan<T>)expectedSubSpan, (ReadOnlySpan<T>)actualSpan);
+
+		/// <summary>
+		/// Verifies that a span does not contain a given sub-span
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected not to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-span is present inside the span</exception>
+		public static void DoesNotContain<T>(
+			Span<T> expectedSubSpan,
+			ReadOnlySpan<T> actualSpan)
+				where T : IEquatable<T> =>
+					DoesNotContain((ReadOnlySpan<T>)expectedSubSpan, actualSpan);
+
+		/// <summary>
+		/// Verifies that a span does not contain a given sub-span
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected not to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-span is present inside the span</exception>
+		public static void DoesNotContain<T>(
+			ReadOnlySpan<T> expectedSubSpan,
+			Span<T> actualSpan)
+				where T : IEquatable<T> =>
+					DoesNotContain(expectedSubSpan, (ReadOnlySpan<T>)actualSpan);
+
+		/// <summary>
+		/// Verifies that a span does not contain a given sub-span
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected not to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-span is present inside the span</exception>
+		public static void DoesNotContain<T>(
+			ReadOnlySpan<T> expectedSubSpan,
+			ReadOnlySpan<T> actualSpan)
+				where T : IEquatable<T>
+		{
+			if (actualSpan.IndexOf(expectedSubSpan) > -1)
+				throw new DoesNotContainException(expectedSubSpan.ToArray(), actualSpan.ToArray());
+		}
+
+		/// <summary>
+		/// Verifies that a span starts with a given sub-span, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedStartSpan">The sub-span expected to be at the start of the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="StartsWithException">Thrown when the span does not start with the expected subspan</exception>
+		public static void StartsWith(
+			Span<char> expectedStartSpan,
+			Span<char> actualSpan) =>
+				StartsWith((ReadOnlySpan<char>)expectedStartSpan, (ReadOnlySpan<char>)actualSpan, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a span starts with a given sub-span, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedStartSpan">The sub-span expected to be at the start of the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="StartsWithException">Thrown when the span does not start with the expected subspan</exception>
+		public static void StartsWith(
+			Span<char> expectedStartSpan,
+			ReadOnlySpan<char> actualSpan) =>
+				StartsWith((ReadOnlySpan<char>)expectedStartSpan, actualSpan, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a span starts with a given sub-span, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedStartSpan">The sub-span expected to be at the start of the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="StartsWithException">Thrown when the span does not start with the expected subspan</exception>
+		public static void StartsWith(
+			ReadOnlySpan<char> expectedStartSpan,
+			Span<char> actualSpan) =>
+				StartsWith(expectedStartSpan, (ReadOnlySpan<char>)actualSpan, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a span starts with a given sub-span, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedStartSpan">The sub-span expected to be at the start of the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="StartsWithException">Thrown when the span does not start with the expected subspan</exception>
+		public static void StartsWith(
+			ReadOnlySpan<char> expectedStartSpan,
+			ReadOnlySpan<char> actualSpan) =>
+				StartsWith(expectedStartSpan, actualSpan, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a span starts with a given sub-span, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedStartSpan">The sub-span expected to be at the start of the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="StartsWithException">Thrown when the span does not start with the expected subspan</exception>
+		public static void StartsWith(
+			Span<char> expectedStartSpan,
+			Span<char> actualSpan,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				StartsWith((ReadOnlySpan<char>)expectedStartSpan, (ReadOnlySpan<char>)actualSpan, comparisonType);
+
+		/// <summary>
+		/// Verifies that a span starts with a given sub-span, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedStartSpan">The sub-span expected to be at the start of the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="StartsWithException">Thrown when the span does not start with the expected subspan</exception>
+		public static void StartsWith(
+			Span<char> expectedStartSpan,
+			ReadOnlySpan<char> actualSpan,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				StartsWith((ReadOnlySpan<char>)expectedStartSpan, actualSpan, comparisonType);
+
+		/// <summary>
+		/// Verifies that a span starts with a given sub-span, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedStartSpan">The sub-span expected to be at the start of the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="StartsWithException">Thrown when the span does not start with the expected subspan</exception>
+		public static void StartsWith(
+			ReadOnlySpan<char> expectedStartSpan,
+			Span<char> actualSpan,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				StartsWith(expectedStartSpan, (ReadOnlySpan<char>)actualSpan, comparisonType);
+
+		/// <summary>
+		/// Verifies that a span starts with a given sub-span, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedStartSpan">The sub-span expected to be at the start of the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="StartsWithException">Thrown when the span does not start with the expected subspan</exception>
+		public static void StartsWith(
+			ReadOnlySpan<char> expectedStartSpan,
+			ReadOnlySpan<char> actualSpan,
+			StringComparison comparisonType = StringComparison.CurrentCulture)
+		{
+			if (!actualSpan.StartsWith(expectedStartSpan, comparisonType))
+				throw new StartsWithException(expectedStartSpan.ToString(), actualSpan.ToString());
+		}
+
+		/// <summary>
+		/// Verifies that a span ends with a given sub-span, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedEndSpan">The sub-span expected to be at the end of the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="EndsWithException">Thrown when the span does not end with the expected subspan</exception>
+		public static void EndsWith(
+			Span<char> expectedEndSpan,
+			Span<char> actualSpan) =>
+				EndsWith((ReadOnlySpan<char>)expectedEndSpan, (ReadOnlySpan<char>)actualSpan, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a span ends with a given sub-span, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedEndSpan">The sub-span expected to be at the end of the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="EndsWithException">Thrown when the span does not end with the expected subspan</exception>
+		public static void EndsWith(
+			Span<char> expectedEndSpan,
+			ReadOnlySpan<char> actualSpan) =>
+				EndsWith((ReadOnlySpan<char>)expectedEndSpan, actualSpan, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a span ends with a given sub-span, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedEndSpan">The sub-span expected to be at the end of the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="EndsWithException">Thrown when the span does not end with the expected subspan</exception>
+		public static void EndsWith(
+			ReadOnlySpan<char> expectedEndSpan,
+			Span<char> actualSpan) =>
+				EndsWith(expectedEndSpan, (ReadOnlySpan<char>)actualSpan, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a span ends with a given sub-span, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedEndSpan">The sub-span expected to be at the end of the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="EndsWithException">Thrown when the span does not end with the expected subspan</exception>
+		public static void EndsWith(
+			ReadOnlySpan<char> expectedEndSpan,
+			ReadOnlySpan<char> actualSpan) =>
+				EndsWith(expectedEndSpan, actualSpan, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a span ends with a given sub-span, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedEndSpan">The sub-span expected to be at the end of the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="EndsWithException">Thrown when the span does not end with the expected subspan</exception>
+		public static void EndsWith(
+			Span<char> expectedEndSpan,
+			Span<char> actualSpan,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				EndsWith((ReadOnlySpan<char>)expectedEndSpan, (ReadOnlySpan<char>)actualSpan, comparisonType);
+
+		/// <summary>
+		/// Verifies that a span ends with a given sub-span, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedEndSpan">The sub-span expected to be at the end of the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="EndsWithException">Thrown when the span does not end with the expected subspan</exception>
+		public static void EndsWith(
+			Span<char> expectedEndSpan,
+			ReadOnlySpan<char> actualSpan,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				EndsWith((ReadOnlySpan<char>)expectedEndSpan, actualSpan, comparisonType);
+
+		/// <summary>
+		/// Verifies that a span ends with a given sub-span, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedEndSpan">The sub-span expected to be at the end of the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="EndsWithException">Thrown when the span does not end with the expected subspan</exception>
+		public static void EndsWith(
+			ReadOnlySpan<char> expectedEndSpan,
+			Span<char> actualSpan,
+			StringComparison comparisonType = StringComparison.CurrentCulture) =>
+				EndsWith(expectedEndSpan, (ReadOnlySpan<char>)actualSpan, comparisonType);
+
+		/// <summary>
+		/// Verifies that a span ends with a given sub-span, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedEndSpan">The sub-span expected to be at the end of the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="EndsWithException">Thrown when the span does not end with the expected subspan</exception>
+		public static void EndsWith(
+			ReadOnlySpan<char> expectedEndSpan,
+			ReadOnlySpan<char> actualSpan,
+			StringComparison comparisonType = StringComparison.CurrentCulture)
+		{
+			if (!actualSpan.EndsWith(expectedEndSpan, comparisonType))
+				throw new EndsWithException(expectedEndSpan.ToString(), actualSpan.ToString());
+		}
+
+		/// <summary>
+		/// Verifies that two spans are equivalent.
+		/// </summary>
+		/// <param name="expectedSpan">The expected span value.</param>
+		/// <param name="actualSpan">The actual span value.</param>
+		/// <exception cref="EqualException">Thrown when the spans are not equivalent.</exception>
+		public static void Equal(
+			Span<char> expectedSpan,
+			Span<char> actualSpan) =>
+				Equal((ReadOnlySpan<char>)expectedSpan, (ReadOnlySpan<char>)actualSpan, false, false, false, false);
+
+		/// <summary>
+		/// Verifies that two spans are equivalent.
+		/// </summary>
+		/// <param name="expectedSpan">The expected span value.</param>
+		/// <param name="actualSpan">The actual span value.</param>
+		/// <exception cref="EqualException">Thrown when the spans are not equivalent.</exception>
+		public static void Equal(
+			Span<char> expectedSpan,
+			ReadOnlySpan<char> actualSpan) =>
+				Equal((ReadOnlySpan<char>)expectedSpan, actualSpan, false, false, false, false);
+
+		/// <summary>
+		/// Verifies that two spans are equivalent.
+		/// </summary>
+		/// <param name="expectedSpan">The expected span value.</param>
+		/// <param name="actualSpan">The actual span value.</param>
+		/// <exception cref="EqualException">Thrown when the spans are not equivalent.</exception>
+		public static void Equal(
+			ReadOnlySpan<char> expectedSpan,
+			Span<char> actualSpan) =>
+				Equal(expectedSpan, (ReadOnlySpan<char>)actualSpan, false, false, false, false);
+
+		/// <summary>
+		/// Verifies that two spans are equivalent.
+		/// </summary>
+		/// <param name="expectedSpan">The expected span value.</param>
+		/// <param name="actualSpan">The actual span value.</param>
+		/// <exception cref="EqualException">Thrown when the spans are not equivalent.</exception>
+		public static void Equal(
+			ReadOnlySpan<char> expectedSpan,
+			ReadOnlySpan<char> actualSpan) =>
+				Equal(expectedSpan, actualSpan, false, false, false, false);
+
+		/// <summary>
+		/// Verifies that two spans are equivalent.
+		/// </summary>
+		/// <param name="expectedSpan">The expected span value.</param>
+		/// <param name="actualSpan">The actual span value.</param>
+		/// <param name="ignoreCase">If set to <c>true</c>, ignores cases differences. The invariant culture is used.</param>
+		/// <param name="ignoreLineEndingDifferences">If set to <c>true</c>, treats \r\n, \r, and \n as equivalent.</param>
+		/// <param name="ignoreWhiteSpaceDifferences">If set to <c>true</c>, treats spaces and tabs (in any non-zero quantity) as equivalent.</param>
+		/// <param name="ignoreAllWhiteSpace">If set to <c>true</c>, ignores all white space differences during comparison.</param>
+		/// <exception cref="EqualException">Thrown when the spans are not equivalent.</exception>
+		public static void Equal(
+			Span<char> expectedSpan,
+			Span<char> actualSpan,
+			bool ignoreCase = false,
+			bool ignoreLineEndingDifferences = false,
+			bool ignoreWhiteSpaceDifferences = false,
+			bool ignoreAllWhiteSpace = false) =>
+				Equal((ReadOnlySpan<char>)expectedSpan, (ReadOnlySpan<char>)actualSpan, ignoreCase, ignoreLineEndingDifferences, ignoreWhiteSpaceDifferences, ignoreAllWhiteSpace);
+
+		/// <summary>
+		/// Verifies that two spans are equivalent.
+		/// </summary>
+		/// <param name="expectedSpan">The expected span value.</param>
+		/// <param name="actualSpan">The actual span value.</param>
+		/// <param name="ignoreCase">If set to <c>true</c>, ignores cases differences. The invariant culture is used.</param>
+		/// <param name="ignoreLineEndingDifferences">If set to <c>true</c>, treats \r\n, \r, and \n as equivalent.</param>
+		/// <param name="ignoreWhiteSpaceDifferences">If set to <c>true</c>, treats spaces and tabs (in any non-zero quantity) as equivalent.</param>
+		/// <param name="ignoreAllWhiteSpace">If set to <c>true</c>, ignores all white space differences during comparison.</param>
+		/// <exception cref="EqualException">Thrown when the spans are not equivalent.</exception>
+		public static void Equal(
+			Span<char> expectedSpan,
+			ReadOnlySpan<char> actualSpan,
+			bool ignoreCase = false,
+			bool ignoreLineEndingDifferences = false,
+			bool ignoreWhiteSpaceDifferences = false,
+			bool ignoreAllWhiteSpace = false) =>
+				Equal((ReadOnlySpan<char>)expectedSpan, actualSpan, ignoreCase, ignoreLineEndingDifferences, ignoreWhiteSpaceDifferences, ignoreAllWhiteSpace);
+
+		/// <summary>
+		/// Verifies that two spans are equivalent.
+		/// </summary>
+		/// <param name="expectedSpan">The expected span value.</param>
+		/// <param name="actualSpan">The actual span value.</param>
+		/// <param name="ignoreCase">If set to <c>true</c>, ignores cases differences. The invariant culture is used.</param>
+		/// <param name="ignoreLineEndingDifferences">If set to <c>true</c>, treats \r\n, \r, and \n as equivalent.</param>
+		/// <param name="ignoreWhiteSpaceDifferences">If set to <c>true</c>, treats spaces and tabs (in any non-zero quantity) as equivalent.</param>
+		/// <param name="ignoreAllWhiteSpace">If set to <c>true</c>, removes all whitespaces and tabs before comparing.</param>
+		/// <exception cref="EqualException">Thrown when the spans are not equivalent.</exception>
+		public static void Equal(
+			ReadOnlySpan<char> expectedSpan,
+			Span<char> actualSpan,
+			bool ignoreCase = false,
+			bool ignoreLineEndingDifferences = false,
+			bool ignoreWhiteSpaceDifferences = false,
+			bool ignoreAllWhiteSpace = false) =>
+				Equal(expectedSpan, (ReadOnlySpan<char>)actualSpan, ignoreCase, ignoreLineEndingDifferences, ignoreWhiteSpaceDifferences, ignoreAllWhiteSpace);
+
+		/// <summary>
+		/// Verifies that two spans are equivalent.
+		/// </summary>
+		/// <param name="expectedSpan">The expected span value.</param>
+		/// <param name="actualSpan">The actual span value.</param>
+		/// <param name="ignoreCase">If set to <c>true</c>, ignores cases differences. The invariant culture is used.</param>
+		/// <param name="ignoreLineEndingDifferences">If set to <c>true</c>, treats \r\n, \r, and \n as equivalent.</param>
+		/// <param name="ignoreWhiteSpaceDifferences">If set to <c>true</c>, treats spaces and tabs (in any non-zero quantity) as equivalent.</param>
+		/// <param name="ignoreAllWhiteSpace">If set to <c>true</c>, ignores all white space differences during comparison.</param>
+		/// <exception cref="EqualException">Thrown when the spans are not equivalent.</exception>
+		public static void Equal(
+			ReadOnlySpan<char> expectedSpan,
+			ReadOnlySpan<char> actualSpan,
+			bool ignoreCase = false,
+			bool ignoreLineEndingDifferences = false,
+			bool ignoreWhiteSpaceDifferences = false,
+			bool ignoreAllWhiteSpace = false)
+		{
+			// Walk the string, keeping separate indices since we can skip variable amounts of
+			// data based on ignoreLineEndingDifferences and ignoreWhiteSpaceDifferences.
+			var expectedIndex = 0;
+			var actualIndex = 0;
+			var expectedLength = expectedSpan.Length;
+			var actualLength = actualSpan.Length;
+
+			// Block used to fix edge case of Equal("", " ") when ignoreAllWhiteSpace enabled.
+			if (ignoreAllWhiteSpace)
+			{
+				if (expectedLength == 0 && SkipWhitespace(actualSpan, 0) == actualLength)
+					return;
+				if (actualLength == 0 && SkipWhitespace(expectedSpan, 0) == expectedLength)
+					return;
+			}
+
+			while (expectedIndex < expectedLength && actualIndex < actualLength)
+			{
+				var expectedChar = expectedSpan[expectedIndex];
+				var actualChar = actualSpan[actualIndex];
+
+				if (ignoreLineEndingDifferences && IsLineEnding(expectedChar) && IsLineEnding(actualChar))
+				{
+					expectedIndex = SkipLineEnding(expectedSpan, expectedIndex);
+					actualIndex = SkipLineEnding(actualSpan, actualIndex);
+				}
+				else if (ignoreAllWhiteSpace && (IsWhiteSpace(expectedChar) || IsWhiteSpace(actualChar)))
+				{
+					expectedIndex = SkipWhitespace(expectedSpan, expectedIndex);
+					actualIndex = SkipWhitespace(actualSpan, actualIndex);
+				}
+				else if (ignoreWhiteSpaceDifferences && IsWhiteSpace(expectedChar) && IsWhiteSpace(actualChar))
+				{
+					expectedIndex = SkipWhitespace(expectedSpan, expectedIndex);
+					actualIndex = SkipWhitespace(actualSpan, actualIndex);
+				}
+				else
+				{
+					if (ignoreCase)
+					{
+						expectedChar = char.ToUpperInvariant(expectedChar);
+						actualChar = char.ToUpperInvariant(actualChar);
+					}
+
+					if (expectedChar != actualChar)
+						break;
+
+					expectedIndex++;
+					actualIndex++;
+				}
+			}
+
+			if (expectedIndex < expectedLength || actualIndex < actualLength)
+				throw new EqualException(expectedSpan.ToString(), actualSpan.ToString(), expectedIndex, actualIndex);
+		}
+
+		/// <summary>
+		/// Verifies that two spans are equivalent.
+		/// </summary>
+		/// <param name="expectedSpan">The expected span value.</param>
+		/// <param name="actualSpan">The actual span value.</param>
+		/// <exception cref="EqualException">Thrown when the spans are not equivalent.</exception>
+		public static void Equal<T>(
+			Span<T> expectedSpan,
+			Span<T> actualSpan)
+				where T : IEquatable<T> =>
+					Equal((ReadOnlySpan<T>)expectedSpan, (ReadOnlySpan<T>)actualSpan);
+
+		/// <summary>
+		/// Verifies that two spans are equivalent.
+		/// </summary>
+		/// <param name="expectedSpan">The expected span value.</param>
+		/// <param name="actualSpan">The actual span value.</param>
+		/// <exception cref="EqualException">Thrown when the spans are not equivalent.</exception>
+		public static void Equal<T>(
+			Span<T> expectedSpan,
+			ReadOnlySpan<T> actualSpan)
+				where T : IEquatable<T> =>
+					Equal((ReadOnlySpan<T>)expectedSpan, actualSpan);
+
+		/// <summary>
+		/// Verifies that two spans are equivalent.
+		/// </summary>
+		/// <param name="expectedSpan">The expected span value.</param>
+		/// <param name="actualSpan">The actual span value.</param>
+		/// <exception cref="EqualException">Thrown when the spans are not equivalent.</exception>
+		public static void Equal<T>(
+			ReadOnlySpan<T> expectedSpan,
+			Span<T> actualSpan)
+				where T : IEquatable<T> =>
+					Equal(expectedSpan, (ReadOnlySpan<T>)actualSpan);
+
+		/// <summary>
+		/// Verifies that two spans are equivalent.
+		/// </summary>
+		/// <param name="expectedSpan">The expected span value.</param>
+		/// <param name="actualSpan">The actual span value.</param>
+		/// <exception cref="EqualException">Thrown when the spans are not equivalent.</exception>
+		public static void Equal<T>(
+			ReadOnlySpan<T> expectedSpan,
+			ReadOnlySpan<T> actualSpan)
+				where T : IEquatable<T>
+		{
+			if (!expectedSpan.SequenceEqual(actualSpan))
+				Equal<object>(expectedSpan.ToArray(), actualSpan.ToArray());
+		}
+
+		// ReadOnlySpan<char> helper methods
+
+		static bool IsLineEnding(char c) =>
+			c == '\r' || c == '\n';
+
+		static bool IsWhiteSpace(char c)
+		{
+			const char mongolianVowelSeparator = '\u180E';
+			const char zeroWidthSpace = '\u200B';
+			const char zeroWidthNoBreakSpace = '\uFEFF';
+			const char tabulation = '\u0009';
+
+			var unicodeCategory = CharUnicodeInfo.GetUnicodeCategory(c);
+
+			return
+				unicodeCategory == UnicodeCategory.SpaceSeparator ||
+				c == mongolianVowelSeparator ||
+				c == zeroWidthSpace ||
+				c == zeroWidthNoBreakSpace ||
+				c == tabulation;
+		}
+
+		static int SkipLineEnding(
+			ReadOnlySpan<char> value,
+			int index)
+		{
+			if (value[index] == '\r')
+				++index;
+
+			if (index < value.Length && value[index] == '\n')
+				++index;
+
+			return index;
+		}
+
+		static int SkipWhitespace(
+			ReadOnlySpan<char> value,
+			int index)
+		{
+			while (index < value.Length)
+			{
+				if (IsWhiteSpace(value[index]))
+					index++;
+				else
+					return index;
+			}
+
+			return index;
+		}
+	}
+}
+
+#endif

--- a/StringAsserts.cs
+++ b/StringAsserts.cs
@@ -1,0 +1,405 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.Text.RegularExpressions;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		/// <summary>
+		/// Verifies that a string contains a given sub-string, using the current culture.
+		/// </summary>
+		/// <param name="expectedSubstring">The sub-string expected to be in the string</param>
+		/// <param name="actualString">The string to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-string is not present inside the string</exception>
+		public static void Contains(
+			string expectedSubstring,
+#if XUNIT_NULLABLE
+			string? actualString) =>
+#else
+			string actualString) =>
+#endif
+				Contains(expectedSubstring, actualString, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a string contains a given sub-string, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedSubstring">The sub-string expected to be in the string</param>
+		/// <param name="actualString">The string to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="ContainsException">Thrown when the sub-string is not present inside the string</exception>
+		public static void Contains(
+			string expectedSubstring,
+#if XUNIT_NULLABLE
+			string? actualString,
+#else
+			string actualString,
+#endif
+			StringComparison comparisonType)
+		{
+			GuardArgumentNotNull(nameof(expectedSubstring), expectedSubstring);
+
+			if (actualString == null || actualString.IndexOf(expectedSubstring, comparisonType) < 0)
+				throw new ContainsException(expectedSubstring, actualString);
+		}
+
+		/// <summary>
+		/// Verifies that a string does not contain a given sub-string, using the current culture.
+		/// </summary>
+		/// <param name="expectedSubstring">The sub-string which is expected not to be in the string</param>
+		/// <param name="actualString">The string to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-string is present inside the string</exception>
+		public static void DoesNotContain(
+			string expectedSubstring,
+#if XUNIT_NULLABLE
+			string? actualString) =>
+#else
+			string actualString) =>
+#endif
+				DoesNotContain(expectedSubstring, actualString, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a string does not contain a given sub-string, using the current culture.
+		/// </summary>
+		/// <param name="expectedSubstring">The sub-string which is expected not to be in the string</param>
+		/// <param name="actualString">The string to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-string is present inside the given string</exception>
+		public static void DoesNotContain(
+			string expectedSubstring,
+#if XUNIT_NULLABLE
+			string? actualString,
+#else
+			string actualString,
+#endif
+			StringComparison comparisonType)
+		{
+			GuardArgumentNotNull(nameof(expectedSubstring), expectedSubstring);
+
+			if (actualString != null && actualString.IndexOf(expectedSubstring, comparisonType) >= 0)
+				throw new DoesNotContainException(expectedSubstring, actualString);
+		}
+
+		/// <summary>
+		/// Verifies that a string starts with a given string, using the current culture.
+		/// </summary>
+		/// <param name="expectedStartString">The string expected to be at the start of the string</param>
+		/// <param name="actualString">The string to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the string does not start with the expected string</exception>
+		public static void StartsWith(
+#if XUNIT_NULLABLE
+			string? expectedStartString,
+			string? actualString) =>
+#else
+			string expectedStartString,
+			string actualString) =>
+#endif
+				StartsWith(expectedStartString, actualString, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a string starts with a given string, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedStartString">The string expected to be at the start of the string</param>
+		/// <param name="actualString">The string to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="ContainsException">Thrown when the string does not start with the expected string</exception>
+		public static void StartsWith(
+#if XUNIT_NULLABLE
+			string? expectedStartString,
+			string? actualString,
+#else
+			string expectedStartString,
+			string actualString,
+#endif
+			StringComparison comparisonType)
+		{
+			if (expectedStartString == null || actualString == null || !actualString.StartsWith(expectedStartString, comparisonType))
+				throw new StartsWithException(expectedStartString, actualString);
+		}
+
+		/// <summary>
+		/// Verifies that a string ends with a given string, using the current culture.
+		/// </summary>
+		/// <param name="expectedEndString">The string expected to be at the end of the string</param>
+		/// <param name="actualString">The string to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the string does not end with the expected string</exception>
+		public static void EndsWith(
+#if XUNIT_NULLABLE
+			string? expectedEndString,
+			string? actualString) =>
+#else
+			string expectedEndString,
+			string actualString) =>
+#endif
+				EndsWith(expectedEndString, actualString, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a string ends with a given string, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedEndString">The string expected to be at the end of the string</param>
+		/// <param name="actualString">The string to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="ContainsException">Thrown when the string does not end with the expected string</exception>
+		public static void EndsWith(
+#if XUNIT_NULLABLE
+			string? expectedEndString,
+			string? actualString,
+#else
+			string expectedEndString,
+			string actualString,
+#endif
+			StringComparison comparisonType)
+		{
+			if (expectedEndString == null || actualString == null || !actualString.EndsWith(expectedEndString, comparisonType))
+				throw new EndsWithException(expectedEndString, actualString);
+		}
+
+		/// <summary>
+		/// Verifies that a string matches a regular expression.
+		/// </summary>
+		/// <param name="expectedRegexPattern">The regex pattern expected to match</param>
+		/// <param name="actualString">The string to be inspected</param>
+		/// <exception cref="MatchesException">Thrown when the string does not match the regex pattern</exception>
+		public static void Matches(
+			string expectedRegexPattern,
+#if XUNIT_NULLABLE
+			string? actualString)
+#else
+			string actualString)
+#endif
+		{
+			GuardArgumentNotNull(nameof(expectedRegexPattern), expectedRegexPattern);
+
+			if (actualString == null || !Regex.IsMatch(actualString, expectedRegexPattern))
+				throw new MatchesException(expectedRegexPattern, actualString);
+		}
+
+		/// <summary>
+		/// Verifies that a string matches a regular expression.
+		/// </summary>
+		/// <param name="expectedRegex">The regex expected to match</param>
+		/// <param name="actualString">The string to be inspected</param>
+		/// <exception cref="MatchesException">Thrown when the string does not match the regex</exception>
+		public static void Matches(
+			Regex expectedRegex,
+#if XUNIT_NULLABLE
+			string? actualString)
+#else
+			string actualString)
+#endif
+		{
+			GuardArgumentNotNull(nameof(expectedRegex), expectedRegex);
+
+			if (actualString == null || !expectedRegex.IsMatch(actualString))
+				throw new MatchesException(expectedRegex.ToString(), actualString);
+		}
+
+		/// <summary>
+		/// Verifies that a string does not match a regular expression.
+		/// </summary>
+		/// <param name="expectedRegexPattern">The regex pattern expected not to match</param>
+		/// <param name="actualString">The string to be inspected</param>
+		/// <exception cref="DoesNotMatchException">Thrown when the string matches the regex pattern</exception>
+		public static void DoesNotMatch(
+			string expectedRegexPattern,
+#if XUNIT_NULLABLE
+			string? actualString)
+#else
+			string actualString)
+#endif
+		{
+			GuardArgumentNotNull(nameof(expectedRegexPattern), expectedRegexPattern);
+
+			if (actualString != null && Regex.IsMatch(actualString, expectedRegexPattern))
+				throw new DoesNotMatchException(expectedRegexPattern, actualString);
+		}
+
+		/// <summary>
+		/// Verifies that a string does not match a regular expression.
+		/// </summary>
+		/// <param name="expectedRegex">The regex expected not to match</param>
+		/// <param name="actualString">The string to be inspected</param>
+		/// <exception cref="DoesNotMatchException">Thrown when the string matches the regex</exception>
+		public static void DoesNotMatch(
+			Regex expectedRegex,
+#if XUNIT_NULLABLE
+			string? actualString)
+#else
+			string actualString)
+#endif
+		{
+			GuardArgumentNotNull(nameof(expectedRegex), expectedRegex);
+
+			if (actualString != null && expectedRegex.IsMatch(actualString))
+				throw new DoesNotMatchException(expectedRegex.ToString(), actualString);
+		}
+
+		/// <summary>
+		/// Verifies that two strings are equivalent.
+		/// </summary>
+		/// <param name="expected">The expected string value.</param>
+		/// <param name="actual">The actual string value.</param>
+		/// <exception cref="EqualException">Thrown when the strings are not equivalent.</exception>
+		public static void Equal(
+#if XUNIT_NULLABLE
+			string? expected,
+			string? actual) =>
+#else
+			string expected,
+			string actual) =>
+#endif
+				Equal(expected, actual, false, false, false);
+
+		/// <summary>
+		/// Verifies that two strings are equivalent.
+		/// </summary>
+		/// <param name="expected">The expected string value.</param>
+		/// <param name="actual">The actual string value.</param>
+		/// <param name="ignoreCase">If set to <c>true</c>, ignores cases differences. The invariant culture is used.</param>
+		/// <param name="ignoreLineEndingDifferences">If set to <c>true</c>, treats \r\n, \r, and \n as equivalent.</param>
+		/// <param name="ignoreWhiteSpaceDifferences">If set to <c>true</c>, treats spaces and tabs (in any non-zero quantity) as equivalent.</param>
+		/// <param name="ignoreAllWhiteSpace">If set to <c>true</c>, ignores all white space differences during comparison.</param>
+		/// <exception cref="EqualException">Thrown when the strings are not equivalent.</exception>
+		public static void Equal(
+#if XUNIT_NULLABLE
+			string? expected,
+			string? actual,
+#else
+			string expected,
+			string actual,
+#endif
+			bool ignoreCase = false,
+			bool ignoreLineEndingDifferences = false,
+			bool ignoreWhiteSpaceDifferences = false,
+			bool ignoreAllWhiteSpace = false)
+		{
+#if XUNIT_SPAN
+			if (expected == null && actual == null)
+				return;
+			if (expected == null || actual == null)
+				throw new EqualException(expected, actual, -1, -1);
+
+			Equal(expected.AsSpan(), actual.AsSpan(), ignoreCase, ignoreLineEndingDifferences, ignoreWhiteSpaceDifferences, ignoreAllWhiteSpace);
+#else
+			// Start out assuming the one of the values is null
+			int expectedIndex = -1;
+			int actualIndex = -1;
+			int expectedLength = 0;
+			int actualLength = 0;
+
+			if (expected == null)
+			{
+				if (actual == null)
+					return;
+			}
+			else if (actual != null)
+			{
+				// Walk the string, keeping separate indices since we can skip variable amounts of
+				// data based on ignoreLineEndingDifferences and ignoreWhiteSpaceDifferences.
+				expectedIndex = 0;
+				actualIndex = 0;
+				expectedLength = expected.Length;
+				actualLength = actual.Length;
+
+				// Block used to fix edge case of Equal("", " ") when ignoreAllWhiteSpace enabled.
+				if (ignoreAllWhiteSpace)
+				{
+					if (expectedLength == 0 && SkipWhitespace(actual, 0) == actualLength)
+						return;
+					if (actualLength == 0 && SkipWhitespace(expected, 0) == expectedLength)
+						return;
+				}
+
+				while (expectedIndex < expectedLength && actualIndex < actualLength)
+				{
+					char expectedChar = expected[expectedIndex];
+					char actualChar = actual[actualIndex];
+
+					if (ignoreLineEndingDifferences && IsLineEnding(expectedChar) && IsLineEnding(actualChar))
+					{
+						expectedIndex = SkipLineEnding(expected, expectedIndex);
+						actualIndex = SkipLineEnding(actual, actualIndex);
+					}
+					else if (ignoreAllWhiteSpace && (IsWhiteSpace(expectedChar) || IsWhiteSpace(actualChar)))
+					{
+						expectedIndex = SkipWhitespace(expected, expectedIndex);
+						actualIndex = SkipWhitespace(actual, actualIndex);
+					}
+					else if (ignoreWhiteSpaceDifferences && IsWhiteSpace(expectedChar) && IsWhiteSpace(actualChar))
+					{
+						expectedIndex = SkipWhitespace(expected, expectedIndex);
+						actualIndex = SkipWhitespace(actual, actualIndex);
+					}
+					else
+					{
+						if (ignoreCase)
+						{
+							expectedChar = Char.ToUpperInvariant(expectedChar);
+							actualChar = Char.ToUpperInvariant(actualChar);
+						}
+
+						if (expectedChar != actualChar)
+							break;
+
+						expectedIndex++;
+						actualIndex++;
+					}
+				}
+			}
+
+			if (expectedIndex < expectedLength || actualIndex < actualLength)
+				throw new EqualException(expected, actual, expectedIndex, actualIndex);
+#endif
+		}
+
+#if !XUNIT_SPAN
+		static bool IsLineEnding(char c) =>
+			c == '\r' || c == '\n';
+
+		static bool IsWhiteSpace(char c) =>
+			c == ' ' || c == '\t';
+
+		static int SkipLineEnding(
+			string value,
+			int index)
+		{
+			if (value[index] == '\r')
+				++index;
+			if (index < value.Length && value[index] == '\n')
+				++index;
+
+			return index;
+		}
+
+		static int SkipWhitespace(
+			string value,
+			int index)
+		{
+			while (index < value.Length)
+			{
+				switch (value[index])
+				{
+					case ' ':
+					case '\t':
+						index++;
+						break;
+
+					default:
+						return index;
+				}
+			}
+
+			return index;
+		}
+#endif
+	}
+}

--- a/TypeAsserts.cs
+++ b/TypeAsserts.cs
@@ -1,0 +1,144 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.Reflection;
+using Xunit.Sdk;
+
+#if XUNIT_NULLABLE
+using System.Diagnostics.CodeAnalysis;
+#endif
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		/// <summary>
+		/// Verifies that an object is of the given type or a derived type.
+		/// </summary>
+		/// <typeparam name="T">The type the object should be</typeparam>
+		/// <param name="object">The object to be evaluated</param>
+		/// <returns>The object, casted to type T when successful</returns>
+		/// <exception cref="IsAssignableFromException">Thrown when the object is not the given type</exception>
+#if XUNIT_NULLABLE
+		public static T IsAssignableFrom<T>(object? @object)
+#else
+		public static T IsAssignableFrom<T>(object @object)
+#endif
+		{
+			IsAssignableFrom(typeof(T), @object);
+			return (T)@object;
+		}
+
+		/// <summary>
+		/// Verifies that an object is of the given type or a derived type.
+		/// </summary>
+		/// <param name="expectedType">The type the object should be</param>
+		/// <param name="object">The object to be evaluated</param>
+		/// <exception cref="IsAssignableFromException">Thrown when the object is not the given type</exception>
+		public static void IsAssignableFrom(
+			Type expectedType,
+#if XUNIT_NULLABLE
+			[NotNull] object? @object)
+#else
+			object @object)
+#endif
+		{
+			GuardArgumentNotNull(nameof(expectedType), expectedType);
+
+			if (@object == null || !expectedType.GetTypeInfo().IsAssignableFrom(@object.GetType().GetTypeInfo()))
+				throw new IsAssignableFromException(expectedType, @object);
+		}
+
+		/// <summary>
+		/// Verifies that an object is not exactly the given type.
+		/// </summary>
+		/// <typeparam name="T">The type the object should not be</typeparam>
+		/// <param name="object">The object to be evaluated</param>
+		/// <exception cref="IsNotTypeException">Thrown when the object is the given type</exception>
+#if XUNIT_NULLABLE
+		public static void IsNotType<T>(object? @object) =>
+#else
+		public static void IsNotType<T>(object @object) =>
+#endif
+			IsNotType(typeof(T), @object);
+
+		/// <summary>
+		/// Verifies that an object is not exactly the given type.
+		/// </summary>
+		/// <param name="expectedType">The type the object should not be</param>
+		/// <param name="object">The object to be evaluated</param>
+		/// <exception cref="IsNotTypeException">Thrown when the object is the given type</exception>
+		public static void IsNotType(
+			Type expectedType,
+#if XUNIT_NULLABLE
+			object? @object)
+#else
+			object @object)
+#endif
+		{
+			GuardArgumentNotNull(nameof(expectedType), expectedType);
+
+			if (@object != null && expectedType.Equals(@object.GetType()))
+				throw new IsNotTypeException(expectedType, @object);
+		}
+
+		/// <summary>
+		/// Verifies that an object is exactly the given type (and not a derived type).
+		/// </summary>
+		/// <typeparam name="T">The type the object should be</typeparam>
+		/// <param name="object">The object to be evaluated</param>
+		/// <returns>The object, casted to type T when successful</returns>
+		/// <exception cref="IsTypeException">Thrown when the object is not the given type</exception>
+#if XUNIT_NULLABLE
+		public static T IsType<T>([NotNull] object? @object)
+#else
+		public static T IsType<T>(object @object)
+#endif
+		{
+			IsType(typeof(T), @object);
+			return (T)@object;
+		}
+
+		/// <summary>
+		/// Verifies that an object is exactly the given type (and not a derived type).
+		/// </summary>
+		/// <param name="expectedType">The type the object should be</param>
+		/// <param name="object">The object to be evaluated</param>
+		/// <exception cref="IsTypeException">Thrown when the object is not the given type</exception>
+		public static void IsType(
+			Type expectedType,
+#if XUNIT_NULLABLE
+			[NotNull] object? @object)
+#else
+			object @object)
+#endif
+		{
+			GuardArgumentNotNull(nameof(expectedType), expectedType);
+
+			if (@object == null)
+				throw new IsTypeException(expectedType.FullName, null);
+
+			var actualType = @object.GetType();
+			if (expectedType != actualType)
+			{
+				var expectedTypeName = expectedType.FullName;
+				var actualTypeName = actualType.FullName;
+
+				if (expectedTypeName == actualTypeName)
+				{
+					expectedTypeName += $" ({expectedType.GetTypeInfo().Assembly.GetName().FullName})";
+					actualTypeName += $" ({actualType.GetTypeInfo().Assembly.GetName().FullName})";
+				}
+
+				throw new IsTypeException(expectedTypeName, actualTypeName);
+			}
+		}
+	}
+}

--- a/eng/testing/xunit/xunit.props
+++ b/eng/testing/xunit/xunit.props
@@ -8,8 +8,13 @@
   <ItemGroup>
     <PackageReference Condition="'$(IncludeRemoteExecutor)' == 'true'" Include="Microsoft.DotNet.RemoteExecutor" Version="$(MicrosoftDotNetRemoteExecutorVersion)" />
 
-    <!-- Excluding xunit.core/build as it enables deps file generation. -->
-    <PackageReference Include="xunit" Version="$(XUnitVersion)" ExcludeAssets="build" />
+    <!-- Excluding xunit.core/build as it enables deps file generation -->
+    <PackageReference Include="xunit.core" Version="$(XUnitVersion)" ExcludeAssets="build" />
+
+    <!-- Use dotnet/runtime fork of assert.xunit if netcore, otherwise use xunit.assert package. -->
+    <ProjectReference Include="$(RepoRoot)src/tests/Common/xunit/assert.xunit/DXUnit.Assert.csproj" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'"/>
+    <PackageReference Include="xunit.assert" Version="$(XUnitVersion)" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
+
     <PackageReference Include="xunit.analyzers" Version="$(XUnitAnalyzersVersion)" ExcludeAssets="build" />
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsVersion)" />
 

--- a/src/libraries/Common/tests/StreamConformanceTests/StreamConformanceTests.csproj
+++ b/src/libraries/Common/tests/StreamConformanceTests/StreamConformanceTests.csproj
@@ -16,8 +16,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsVersion)" />
-    <PackageReference Include="xunit.core" Version="$(XUnitVersion)" ExcludeAssets="build" />
-    <PackageReference Include="xunit.assert" Version="$(XUnitVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)TestUtilities\TestUtilities.csproj" />

--- a/src/libraries/Common/tests/TestUtilities/TestUtilities.csproj
+++ b/src/libraries/Common/tests/TestUtilities/TestUtilities.csproj
@@ -107,7 +107,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsVersion)" />
     <PackageReference Include="xunit.core" Version="$(XUnitVersion)" ExcludeAssets="build" />
-    <PackageReference Include="xunit.assert" Version="$(XUnitVersion)" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Use dotnet/runtime fork of assert.xunit if netcore, otherwise use xunit.assert package. -->
+    <ProjectReference Include="$(RepoRoot)src/tests/Common/xunit/assert.xunit/DXUnit.Assert.csproj" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'"/>
+    <PackageReference Include="xunit.assert" Version="$(XUnitVersion)" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <!-- Upgrade the NetStandard.Library transitive xunit dependency to avoid 1.x NS dependencies. -->

--- a/src/tests/Common/xunit/Directory.Build.props
+++ b/src/tests/Common/xunit/Directory.Build.props
@@ -1,0 +1,4 @@
+<Project>
+  <!-- ignore coreclr-specific props -->
+  <Import Project="..\..\..\..\Directory.Build.props" />
+</Project>

--- a/src/tests/Common/xunit/Directory.Build.targets
+++ b/src/tests/Common/xunit/Directory.Build.targets
@@ -1,0 +1,5 @@
+<Project>
+  <!-- ignore coreclr-specific targets -->
+  <Import Project="..\..\..\..\Directory.Build.targets" />
+
+</Project>

--- a/src/tests/Common/xunit/assert.xunit/Comparers.cs
+++ b/src/tests/Common/xunit/assert.xunit/Comparers.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Xunit.Sdk;
 
 namespace Xunit

--- a/src/tests/Common/xunit/assert.xunit/DXUnit.Assert.csproj
+++ b/src/tests/Common/xunit/assert.xunit/DXUnit.Assert.csproj
@@ -1,8 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
-</Project>

--- a/src/tests/Common/xunit/assert.xunit/DXUnit.Assert.csproj
+++ b/src/tests/Common/xunit/assert.xunit/DXUnit.Assert.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- dotnet/runtime fork of xunit.assert, with modifications for AOT-compatibilty -->
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFrameworks>$(NetCoreAppMinimum)</TargetFrameworks>
+    <DefineConstants>$(DefineConstants);XUNIT_NULLABLE</DefineConstants>
+
+    <!-- Baselining warnings -->
+    <NoWarn>$(NoWarn);SA1400;CA1852;CA1859;CA2007;SA1121;CA2249;CA1845;CA1822;CA1823;IDE0020;IDE0054;IDE0031;IDE0059;CA1510;CA1805;CA1825;IDE0036;IDE0074</NoWarn>
+  </PropertyGroup>
+
+</Project>

--- a/src/tests/Common/xunit/assert.xunit/DXUnit.Assert.csproj
+++ b/src/tests/Common/xunit/assert.xunit/DXUnit.Assert.csproj
@@ -2,8 +2,12 @@
   <!-- dotnet/runtime fork of xunit.assert, with modifications for AOT-compatibilty -->
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>$(NetCoreAppMinimum)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum)</TargetFrameworks>
     <DefineConstants>$(DefineConstants);XUNIT_NULLABLE</DefineConstants>
+
+    <IsTrimmable>true</IsTrimmable>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
 
     <!-- Baselining warnings -->
     <NoWarn>$(NoWarn);SA1400;CA1852;CA1859;CA2007;SA1121;CA2249;CA1845;CA1822;CA1823;IDE0020;IDE0054;IDE0031;IDE0059;CA1510;CA1805;CA1825;IDE0036;IDE0074</NoWarn>

--- a/src/tests/Common/xunit/assert.xunit/Sdk/ArgumentFormatter.cs
+++ b/src/tests/Common/xunit/assert.xunit/Sdk/ArgumentFormatter.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -225,6 +226,11 @@ namespace Xunit.Sdk
 		static string FormatComplexValue(
 			object value,
 			int depth,
+			[DynamicallyAccessedMembers(
+				DynamicallyAccessedMemberTypes.PublicProperties
+				| DynamicallyAccessedMemberTypes.NonPublicProperties
+				| DynamicallyAccessedMemberTypes.PublicFields
+				| DynamicallyAccessedMemberTypes.NonPublicFields)]
 			Type type)
 		{
 			if (depth == MAX_DEPTH)

--- a/src/tests/Common/xunit/assert.xunit/Sdk/AssertHelper.cs
+++ b/src/tests/Common/xunit/assert.xunit/Sdk/AssertHelper.cs
@@ -24,12 +24,15 @@ namespace Xunit.Internal
 		static ConcurrentDictionary<Type, Dictionary<string, Func<object, object>>> gettersByType = new ConcurrentDictionary<Type, Dictionary<string, Func<object, object>>>();
 #endif
 
-#if XUNIT_NULLABLE
-		static Dictionary<string, Func<object?, object?>> GetGettersForType(Type type) =>
-#else
-		static Dictionary<string, Func<object, object>> GetGettersForType(Type type) =>
-#endif
-			gettersByType.GetOrAdd(type, _type =>
+		static Dictionary<string, Func<object?, object?>> GetGettersForType(
+			Type type) =>
+			gettersByType.GetOrAdd(type,
+			([DynamicallyAccessedMembers(
+				DynamicallyAccessedMemberTypes.PublicProperties
+				| DynamicallyAccessedMemberTypes.NonPublicProperties
+				| DynamicallyAccessedMemberTypes.PublicFields
+				| DynamicallyAccessedMemberTypes.NonPublicFields)]
+			Type _type) =>
 			{
 				var fieldGetters =
 					_type


### PR DESCRIPTION
Adds a subtree from https://github.com/xunit/assert.xunit and modifies it to make it AOT-safe. This assert clone is used in the libraries tests for AOT-compatibility.

Recommended to review commit-by-commit

Contributes to https://github.com/dotnet/runtime/issues/79316