### PR TITLE
Smaller static constructor context

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.cs
@@ -52,13 +52,13 @@ namespace System.Runtime.CompilerServices
         public static unsafe void EnsureClassConstructorRun(StaticClassConstructionContext* pContext)
         {
             IntPtr pfnCctor = pContext->cctorMethodAddress;
-            NoisyLog("EnsureClassConstructorRun, cctor={0}, thread={1}", pfnCctor, CurrentManagedThreadId);
+            NoisyLog("EnsureClassConstructorRun, context={0}, thread={1}", (IntPtr)pContext, CurrentManagedThreadId);
 
             // If we were called from MRT, this check is redundant but harmless. This is in case someone within classlib
             // (cough, Reflection) needs to call this explicitly.
-            if (pContext->initialized == 1)
+            if (pfnCctor == 0)
             {
-                NoisyLog("Cctor already run, cctor={0}, thread={1}", pfnCctor, CurrentManagedThreadId);
+                NoisyLog("Cctor already run, context={0}, thread={1}", (IntPtr)pContext, CurrentManagedThreadId);
                 return;
             }
 
@@ -68,22 +68,22 @@ namespace System.Runtime.CompilerServices
             try
             {
                 Lock cctorLock = cctors[cctorIndex].Lock;
-                if (DeadlockAwareAcquire(cctor, pfnCctor))
+                if (DeadlockAwareAcquire(cctor, pContext))
                 {
                     int currentManagedThreadId = CurrentManagedThreadId;
                     try
                     {
-                        NoisyLog("Acquired cctor lock, cctor={0}, thread={1}", pfnCctor, currentManagedThreadId);
+                        NoisyLog("Acquired cctor lock, context={0}, thread={1}", (IntPtr)pContext, currentManagedThreadId);
 
                         cctors[cctorIndex].HoldingThread = currentManagedThreadId;
-                        if (pContext->initialized == 0)  // Check again in case some thread raced us while we were acquiring the lock.
+                        if (pContext->cctorMethodAddress != 0)  // Check again in case some thread raced us while we were acquiring the lock.
                         {
                             TypeInitializationException priorException = cctors[cctorIndex].Exception;
                             if (priorException != null)
                                 throw priorException;
                             try
                             {
-                                NoisyLog("Calling cctor, cctor={0}, thread={1}", pfnCctor, currentManagedThreadId);
+                                NoisyLog("Calling cctor, context={0}, thread={1}", (IntPtr)pContext, currentManagedThreadId);
 
                                 ((delegate*<void>)pfnCctor)();
 
@@ -94,9 +94,9 @@ namespace System.Runtime.CompilerServices
                                 // still see uninitialized static fields on the class.
                                 Interlocked.MemoryBarrier();
 
-                                NoisyLog("Set type inited, cctor={0}, thread={1}", pfnCctor, currentManagedThreadId);
+                                NoisyLog("Set type inited, context={0}, thread={1}", (IntPtr)pContext, currentManagedThreadId);
 
-                                pContext->initialized = 1;
+                                pContext->cctorMethodAddress = 0;
                             }
                             catch (Exception e)
                             {
@@ -109,7 +109,7 @@ namespace System.Runtime.CompilerServices
                     finally
                     {
                         cctors[cctorIndex].HoldingThread = ManagedThreadIdNone;
-                        NoisyLog("Releasing cctor lock, cctor={0}, thread={1}", pfnCctor, currentManagedThreadId);
+                        NoisyLog("Releasing cctor lock, context={0}, thread={1}", (IntPtr)pContext, currentManagedThreadId);
 
                         cctorLock.Release();
                     }
@@ -124,7 +124,7 @@ namespace System.Runtime.CompilerServices
             {
                 Cctor.Release(cctor);
             }
-            NoisyLog("EnsureClassConstructorRun complete, cctor={0}, thread={1}", pfnCctor, CurrentManagedThreadId);
+            NoisyLog("EnsureClassConstructorRun complete, context={0}, thread={1}", (IntPtr)pContext, CurrentManagedThreadId);
         }
 
         //=========================================================================================================
@@ -132,7 +132,7 @@ namespace System.Runtime.CompilerServices
         //   true   - lock acquired.
         //   false  - deadlock detected. Lock not acquired.
         //=========================================================================================================
-        private static bool DeadlockAwareAcquire(CctorHandle cctor, IntPtr pfnCctor)
+        private static unsafe bool DeadlockAwareAcquire(CctorHandle cctor, StaticClassConstructionContext* pContext)
         {
             const int WaitIntervalSeedInMS = 1;      // seed with 1ms and double every time through the loop
             const int WaitIntervalLimitInMS = WaitIntervalSeedInMS << 7; // limit of 128ms
@@ -181,8 +181,8 @@ namespace System.Runtime.CompilerServices
                             if (holdingThread == currentManagedThreadId)
                             {
                                 // Deadlock detected.  We will break the guarantee and return without running the .cctor.
-                                DebugLog("A class constructor was skipped due to class constructor cycle. cctor={0}, thread={1}",
-                                    pfnCctor, currentManagedThreadId);
+                                DebugLog("A class constructor was skipped due to class constructor cycle. context={0}, thread={1}",
+                                    (IntPtr)pContext, currentManagedThreadId);
 
                                 // We are maintaining an invariant that the BlockingRecords never show a cycle because,
                                 // before we add a record, we first check for a cycle.  As a result, once we've said
@@ -223,7 +223,7 @@ namespace System.Runtime.CompilerServices
                         // respect to other updates to the BlockingRecords.
                         if (unmarkCookie == -1)
                         {
-                            NoisyLog("Mark thread blocked, cctor={0}, thread={1}", pfnCctor, currentManagedThreadId);
+                            NoisyLog("Mark thread blocked, context={0}, thread={1}", (IntPtr)pContext, currentManagedThreadId);
 
                             unmarkCookie = BlockingRecord.MarkThreadAsBlocked(currentManagedThreadId, cctor);
                         }
@@ -241,7 +241,7 @@ namespace System.Runtime.CompilerServices
             {
                 if (unmarkCookie != -1)
                 {
-                    NoisyLog("Unmark thread blocked, cctor={0}, thread={1}", pfnCctor, currentManagedThreadId);
+                    NoisyLog("Unmark thread blocked, context={0}, thread={1}", (IntPtr)pContext, currentManagedThreadId);
                     BlockingRecord.UnmarkThreadAsBlocked(unmarkCookie);
                 }
             }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/StaticClassConstructionContext.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/StaticClassConstructionContext.cs
@@ -8,23 +8,14 @@ using System.Runtime.InteropServices;
 namespace System.Runtime.CompilerServices
 {
     // This structure is used to pass context about a type's static class construction state from the runtime
-    // to the classlibrary via the CheckStaticClassConstruction callback. The runtime knows about the first
-    // two fields (cctorMethodAddress and initialized) and thus these must remain the first two fields in the
-    // same order and at the same offset (hence the sequential layout attribute). It is permissable for the
-    // classlibrary to add its own fields after these for its own use however. These must not contain GC
+    // to the classlibrary via the CheckStaticClassConstruction callback. It is permissable for the
+    // classlibrary to add its own fields after these for its own use. These must not contain GC
     // references and will be zero initialized.
     [CLSCompliant(false)]
     [StructLayout(LayoutKind.Sequential)]
     public struct StaticClassConstructionContext
     {
-        // Pointer to the code for the static class constructor method. This is initialized by the
-        // binder/runtime.
-        public IntPtr cctorMethodAddress;
-
-        // Initialization state of the class. This is initialized to 0. Every time managed code checks the
-        // cctor state the runtime will call the classlibrary's CheckStaticClassConstruction with this context
-        // structure unless initialized == 1. This check is specific to allow the classlibrary to store more
-        // than a binary state for each cctor if it so desires.
-        public volatile int initialized;
+        // Pointer to the code for the static class constructor method. Set to 0 once the cctor has run.
+        public volatile IntPtr cctorMethodAddress;
     }
 }

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -53,7 +53,7 @@ namespace Internal.Runtime.TypeLoader
         /// The StaticClassConstructionContext for a type is encoded in the negative space
         /// of the NonGCStatic fields of a type.
         /// </summary>
-        public static readonly unsafe int ClassConstructorOffset = -sizeof(System.Runtime.CompilerServices.StaticClassConstructionContext);
+        public static unsafe int ClassConstructorOffset => -sizeof(System.Runtime.CompilerServices.StaticClassConstructionContext);
 
         private LowLevelList<TypeDesc> _typesThatNeedTypeHandles = new LowLevelList<TypeDesc>();
 

--- a/src/coreclr/nativeaot/Test.CoreLib/src/System/Runtime/CompilerServices/StaticClassConstructionContext.cs
+++ b/src/coreclr/nativeaot/Test.CoreLib/src/System/Runtime/CompilerServices/StaticClassConstructionContext.cs
@@ -6,22 +6,13 @@ using System.Runtime.InteropServices;
 namespace System.Runtime.CompilerServices
 {
     // This structure is used to pass context about a type's static class construction state from the runtime
-    // to the classlibrary via the CheckStaticClassConstruction callback. The runtime knows about the first
-    // two fields (cctorMethodAddress and initialized) and thus these must remain the first two fields in the
-    // same order and at the same offset (hence the sequential layout attribute). It is permissable for the
-    // classlibrary to add its own fields after these for its own use however. These must not contain GC
+    // to the classlibrary via the CheckStaticClassConstruction callback. It is permissable for the
+    // classlibrary to add its own fields after these for its own use. These must not contain GC
     // references and will be zero initialized.
     [StructLayout(LayoutKind.Sequential)]
     public struct StaticClassConstructionContext
     {
-        // Pointer to the code for the static class constructor method. This is initialized by the
-        // binder/runtime.
-        public IntPtr cctorMethodAddress;
-
-        // Initialization state of the class. This is initialized to 0. Every time managed code checks the
-        // cctor state the runtime will call the classlibrary's CheckStaticClassConstruction with this context
-        // structure unless initialized == 1. This check is specific to allow the classlibrary to store more
-        // than a binary state for each cctor if it so desires.
-        public volatile int initialized;
+        // Pointer to the code for the static class constructor method. Set to 0 .
+        public volatile IntPtr cctorMethodAddress;
     }
 }

--- a/src/coreclr/nativeaot/Test.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/Test.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -100,6 +100,10 @@ namespace System.Runtime
         internal static extern int InterlockedCompareExchange(ref int location1, int value, int comparand);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "RhpLockCmpXchg64")]
+        internal static extern long InterlockedCompareExchange(ref long location1, long value, long comparand);
+
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhpMemoryBarrier")]
         internal static extern void MemoryBarrier();
 

--- a/src/coreclr/nativeaot/Test.CoreLib/src/System/Threading/Interlocked.cs
+++ b/src/coreclr/nativeaot/Test.CoreLib/src/System/Threading/Interlocked.cs
@@ -9,7 +9,23 @@ namespace System.Threading
     public static class Interlocked
     {
         [Intrinsic]
+        public static IntPtr CompareExchange(ref IntPtr location1, IntPtr value, IntPtr comparand)
+        {
+#if TARGET_64BIT
+            return (IntPtr)Interlocked.CompareExchange(ref Unsafe.As<IntPtr, long>(ref location1), (long)value, (long)comparand);
+#else
+            return (IntPtr)Interlocked.CompareExchange(ref Unsafe.As<IntPtr, int>(ref location1), (int)value, (int)comparand);
+#endif
+        }
+
+        [Intrinsic]
         public static int CompareExchange(ref int location1, int value, int comparand)
+        {
+            return RuntimeImports.InterlockedCompareExchange(ref location1, value, comparand);
+        }
+
+        [Intrinsic]
+        public static long CompareExchange(ref long location1, long value, long comparand)
         {
             return RuntimeImports.InterlockedCompareExchange(ref location1, value, comparand);
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
@@ -103,7 +103,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             // TODO: Assert that StaticClassConstructionContext type has the expected size
             //       (need to make it a well known type?)
-            return target.PointerSize * 2;
+            return target.PointerSize;
         }
 
         private static int GetClassConstructorContextStorageSize(TargetDetails target, MetadataType type)
@@ -172,26 +172,15 @@ namespace ILCompiler.DependencyAnalysis
                 // cctor context as already executed.
                 if (!HasLazyStaticConstructor)
                 {
-                    // Pointer to the cctor: we don't care - emit as zero
+                    // Pointer to the cctor: Zero means initialized
                     builder.EmitZeroPointer();
-
-                    // Constructor executed
-                    // TODO-NICE: introduce a named constant and also use it in the runner in CoreLib
-                    builder.EmitInt(1);
                 }
                 else
                 {
                     // Emit pointer to the cctor
                     MethodDesc cctorMethod = _type.GetStaticConstructor();
                     builder.EmitPointerReloc(factory.ExactCallableAddress(cctorMethod));
-
-                    // Constructor didn't execute
-                    builder.EmitInt(0);
                 }
-
-                // Emit padding if needed
-                if (builder.TargetPointerSize == 8)
-                    builder.EmitInt(0);
             }
             else
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunGenericHelperNode.cs
@@ -82,12 +82,12 @@ namespace ILCompiler.DependencyAnalysis
                         {
                             // We need to trigger the cctor before returning the base. It is stored at the beginning of the non-GC statics region.
                             int cctorContextSize = NonGCStaticsNode.GetClassConstructorContextSize(factory.Target);
-                            encoder.EmitLDR(encoder.TargetRegister.Arg1, encoder.TargetRegister.Arg0, ((short)(factory.Target.PointerSize - cctorContextSize)));
-                            encoder.EmitCMP(encoder.TargetRegister.Arg1, ((byte)1));
+                            encoder.EmitLDR(encoder.TargetRegister.Arg1, encoder.TargetRegister.Arg0, (short)-cctorContextSize);
+                            encoder.EmitCMP(encoder.TargetRegister.Arg1, 0);
                             encoder.EmitRETIfEqual();
 
                             encoder.EmitMOV(encoder.TargetRegister.Arg1, encoder.TargetRegister.Result);
-                            encoder.EmitSUB(encoder.TargetRegister.Arg0, ((byte)(cctorContextSize)));
+                            encoder.EmitSUB(encoder.TargetRegister.Arg0, (byte)cctorContextSize);
                             encoder.EmitJMP(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnNonGCStaticBase));
                         }
                     }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunHelperNode.cs
@@ -55,8 +55,8 @@ namespace ILCompiler.DependencyAnalysis
                             // We need to trigger the cctor before returning the base. It is stored at the beginning of the non-GC statics region.
                             encoder.EmitMOV(encoder.TargetRegister.Arg2, factory.TypeNonGCStaticsSymbol(target));
                             encoder.EmitLDR(encoder.TargetRegister.Arg3, encoder.TargetRegister.Arg2,
-                                            ((short)(factory.Target.PointerSize - NonGCStaticsNode.GetClassConstructorContextSize(factory.Target))));
-                            encoder.EmitCMP(encoder.TargetRegister.Arg3, 1);
+                                            (short)-NonGCStaticsNode.GetClassConstructorContextSize(factory.Target));
+                            encoder.EmitCMP(encoder.TargetRegister.Arg3, 0);
                             encoder.EmitRETIfEqual();
 
                             encoder.EmitMOV(encoder.TargetRegister.Arg1, encoder.TargetRegister.Result);
@@ -108,8 +108,8 @@ namespace ILCompiler.DependencyAnalysis
                             // We need to trigger the cctor before returning the base. It is stored at the beginning of the non-GC statics region.
                             encoder.EmitMOV(encoder.TargetRegister.Arg2, factory.TypeNonGCStaticsSymbol(target));
                             encoder.EmitLDR(encoder.TargetRegister.Arg3, encoder.TargetRegister.Arg2,
-                                            ((short)(factory.Target.PointerSize - NonGCStaticsNode.GetClassConstructorContextSize(factory.Target))));
-                            encoder.EmitCMP(encoder.TargetRegister.Arg3, 1);
+                                            (short)-NonGCStaticsNode.GetClassConstructorContextSize(factory.Target));
+                            encoder.EmitCMP(encoder.TargetRegister.Arg3, 0);
                             encoder.EmitRETIfEqual();
 
                             encoder.EmitMOV(encoder.TargetRegister.Arg1, encoder.TargetRegister.Result);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunGenericHelperNode.cs
@@ -93,8 +93,8 @@ namespace ILCompiler.DependencyAnalysis
                         {
                             // We need to trigger the cctor before returning the base. It is stored at the beginning of the non-GC statics region.
                             encoder.EmitSUB(encoder.TargetRegister.Arg3, encoder.TargetRegister.Arg0, NonGCStaticsNode.GetClassConstructorContextSize(factory.Target));
-                            encoder.EmitLDR(encoder.TargetRegister.Arg2, encoder.TargetRegister.Arg3, (short)factory.Target.PointerSize);
-                            encoder.EmitCMP(encoder.TargetRegister.Arg2, 1);
+                            encoder.EmitLDR(encoder.TargetRegister.Arg2, encoder.TargetRegister.Arg3);
+                            encoder.EmitCMP(encoder.TargetRegister.Arg2, 0);
                             encoder.EmitRETIfEqual();
 
                             encoder.EmitMOV(encoder.TargetRegister.Arg1, encoder.TargetRegister.Result);
@@ -125,8 +125,8 @@ namespace ILCompiler.DependencyAnalysis
                             EmitDictionaryLookup(factory, ref encoder, encoder.TargetRegister.Arg1, encoder.TargetRegister.Arg2, nonGcRegionLookup, relocsOnly);
 
                             encoder.EmitSUB(encoder.TargetRegister.Arg2, NonGCStaticsNode.GetClassConstructorContextSize(factory.Target));
-                            encoder.EmitLDR(encoder.TargetRegister.Arg3, encoder.TargetRegister.Arg2, (short)factory.Target.PointerSize);
-                            encoder.EmitCMP(encoder.TargetRegister.Arg3, 1);
+                            encoder.EmitLDR(encoder.TargetRegister.Arg3, encoder.TargetRegister.Arg2);
+                            encoder.EmitCMP(encoder.TargetRegister.Arg3, 0);
                             encoder.EmitRETIfEqual();
 
                             encoder.EmitMOV(encoder.TargetRegister.Arg1, encoder.TargetRegister.Result);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunHelperNode.cs
@@ -56,8 +56,8 @@ namespace ILCompiler.DependencyAnalysis
                         {
                             // We need to trigger the cctor before returning the base. It is stored at the beginning of the non-GC statics region.
                             encoder.EmitSUB(encoder.TargetRegister.Arg3, encoder.TargetRegister.Result, NonGCStaticsNode.GetClassConstructorContextSize(factory.Target));
-                            encoder.EmitLDR(encoder.TargetRegister.Arg2, encoder.TargetRegister.Arg3, (short)factory.Target.PointerSize);
-                            encoder.EmitCMP(encoder.TargetRegister.Arg2, 1);
+                            encoder.EmitLDR(encoder.TargetRegister.Arg2, encoder.TargetRegister.Arg3);
+                            encoder.EmitCMP(encoder.TargetRegister.Arg2, 0);
                             encoder.EmitRETIfEqual();
 
                             encoder.EmitMOV(encoder.TargetRegister.Arg1, encoder.TargetRegister.Result);
@@ -90,8 +90,8 @@ namespace ILCompiler.DependencyAnalysis
                             encoder.EmitMOV(encoder.TargetRegister.Arg2, factory.TypeNonGCStaticsSymbol(target));
                             encoder.EmitSUB(encoder.TargetRegister.Arg2, NonGCStaticsNode.GetClassConstructorContextSize(factory.Target));
 
-                            encoder.EmitLDR(encoder.TargetRegister.Arg3, encoder.TargetRegister.Arg2, (short)factory.Target.PointerSize);
-                            encoder.EmitCMP(encoder.TargetRegister.Arg3, 1);
+                            encoder.EmitLDR(encoder.TargetRegister.Arg3, encoder.TargetRegister.Arg2);
+                            encoder.EmitCMP(encoder.TargetRegister.Arg3, 0);
                             encoder.EmitJE(factory.HelperEntrypoint(HelperEntrypoint.GetThreadStaticBaseForType));
 
                             encoder.EmitJMP(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnThreadStaticBase));
@@ -115,8 +115,8 @@ namespace ILCompiler.DependencyAnalysis
                             // We need to trigger the cctor before returning the base. It is stored at the beginning of the non-GC statics region.
                             encoder.EmitMOV(encoder.TargetRegister.Arg2, factory.TypeNonGCStaticsSymbol(target));
                             encoder.EmitSUB(encoder.TargetRegister.Arg2, NonGCStaticsNode.GetClassConstructorContextSize(factory.Target));
-                            encoder.EmitLDR(encoder.TargetRegister.Arg3, encoder.TargetRegister.Arg2, (short)factory.Target.PointerSize);
-                            encoder.EmitCMP(encoder.TargetRegister.Arg3, 1);
+                            encoder.EmitLDR(encoder.TargetRegister.Arg3, encoder.TargetRegister.Arg2);
+                            encoder.EmitCMP(encoder.TargetRegister.Arg3, 0);
                             encoder.EmitRETIfEqual();
 
                             encoder.EmitMOV(encoder.TargetRegister.Arg1, encoder.TargetRegister.Result);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_LoongArch64/LoongArch64ReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_LoongArch64/LoongArch64ReadyToRunGenericHelperNode.cs
@@ -82,8 +82,8 @@ namespace ILCompiler.DependencyAnalysis
                         {
                             // We need to trigger the cctor before returning the base. It is stored at the beginning of the non-GC statics region.
                             encoder.EmitADD(encoder.TargetRegister.Arg3, encoder.TargetRegister.Arg0, -NonGCStaticsNode.GetClassConstructorContextSize(factory.Target));
-                            encoder.EmitLD(encoder.TargetRegister.Arg2, encoder.TargetRegister.Arg3, factory.Target.PointerSize);
-                            encoder.EmitXOR(encoder.TargetRegister.IntraProcedureCallScratch1, encoder.TargetRegister.Arg2, 1);
+                            encoder.EmitLD(encoder.TargetRegister.Arg2, encoder.TargetRegister.Arg3, 0);
+                            encoder.EmitXOR(encoder.TargetRegister.IntraProcedureCallScratch1, encoder.TargetRegister.Arg2, 0);
                             encoder.EmitRETIfEqual(Register.R21);
 
                             encoder.EmitMOV(encoder.TargetRegister.Arg1, encoder.TargetRegister.Result);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_LoongArch64/LoongArch64ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_LoongArch64/LoongArch64ReadyToRunHelperNode.cs
@@ -90,8 +90,8 @@ namespace ILCompiler.DependencyAnalysis
                             encoder.EmitMOV(encoder.TargetRegister.Arg2, factory.TypeNonGCStaticsSymbol(target));
                             encoder.EmitADD(encoder.TargetRegister.Arg2, encoder.TargetRegister.Arg2, -NonGCStaticsNode.GetClassConstructorContextSize(factory.Target));
 
-                            encoder.EmitLD(encoder.TargetRegister.Arg3, encoder.TargetRegister.Arg2, factory.Target.PointerSize);
-                            encoder.EmitXOR(encoder.TargetRegister.IntraProcedureCallScratch1, encoder.TargetRegister.Arg3, 1);
+                            encoder.EmitLD(encoder.TargetRegister.Arg3, encoder.TargetRegister.Arg2, 0);
+                            encoder.EmitXOR(encoder.TargetRegister.IntraProcedureCallScratch1, encoder.TargetRegister.Arg3, 0);
                             encoder.EmitJE(encoder.TargetRegister.IntraProcedureCallScratch1, factory.HelperEntrypoint(HelperEntrypoint.GetThreadStaticBaseForType));
 
                             encoder.EmitJMP(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnThreadStaticBase));
@@ -115,8 +115,8 @@ namespace ILCompiler.DependencyAnalysis
                             // We need to trigger the cctor before returning the base. It is stored at the beginning of the non-GC statics region.
                             encoder.EmitMOV(encoder.TargetRegister.Arg2, factory.TypeNonGCStaticsSymbol(target));
                             encoder.EmitADD(encoder.TargetRegister.Arg2, encoder.TargetRegister.Arg2, -NonGCStaticsNode.GetClassConstructorContextSize(factory.Target));
-                            encoder.EmitLD(encoder.TargetRegister.Arg3, encoder.TargetRegister.Arg2, factory.Target.PointerSize);
-                            encoder.EmitXOR(encoder.TargetRegister.IntraProcedureCallScratch1, encoder.TargetRegister.Arg3, 1);
+                            encoder.EmitLD(encoder.TargetRegister.Arg3, encoder.TargetRegister.Arg2, 0);
+                            encoder.EmitXOR(encoder.TargetRegister.IntraProcedureCallScratch1, encoder.TargetRegister.Arg3, 0);
                             encoder.EmitRETIfEqual(Register.R21);
 
                             encoder.EmitMOV(encoder.TargetRegister.Arg1, encoder.TargetRegister.Result);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
@@ -98,8 +98,8 @@ namespace ILCompiler.DependencyAnalysis
 
                             // We need to trigger the cctor before returning the base. It is stored at the beginning of the non-GC statics region.
                             int cctorContextSize = NonGCStaticsNode.GetClassConstructorContextSize(factory.Target);
-                            AddrMode initialized = new AddrMode(encoder.TargetRegister.Arg0, null, factory.Target.PointerSize - cctorContextSize, 0, AddrModeSize.Int32);
-                            encoder.EmitCMP(ref initialized, 1);
+                            AddrMode initialized = new AddrMode(encoder.TargetRegister.Arg0, null, -cctorContextSize, 0, AddrModeSize.Int64);
+                            encoder.EmitCMP(ref initialized, 0);
                             encoder.EmitRETIfEqual();
 
                             AddrMode loadCctor = new AddrMode(encoder.TargetRegister.Arg0, null, -cctorContextSize, 0, AddrModeSize.Int64);
@@ -132,8 +132,8 @@ namespace ILCompiler.DependencyAnalysis
                             EmitDictionaryLookup(factory, ref encoder, encoder.TargetRegister.Arg0, encoder.TargetRegister.Arg0, nonGcRegionLookup, relocsOnly);
 
                             int cctorContextSize = NonGCStaticsNode.GetClassConstructorContextSize(factory.Target);
-                            AddrMode initialized = new AddrMode(encoder.TargetRegister.Arg0, null, factory.Target.PointerSize - cctorContextSize, 0, AddrModeSize.Int32);
-                            encoder.EmitCMP(ref initialized, 1);
+                            AddrMode initialized = new AddrMode(encoder.TargetRegister.Arg0, null, -cctorContextSize, 0, AddrModeSize.Int64);
+                            encoder.EmitCMP(ref initialized, 0);
                             encoder.EmitRETIfEqual();
 
                             encoder.EmitMOV(encoder.TargetRegister.Arg1, encoder.TargetRegister.Result);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -58,8 +58,8 @@ namespace ILCompiler.DependencyAnalysis
                             // We need to trigger the cctor before returning the base. It is stored at the beginning of the non-GC statics region.
                             encoder.EmitLEAQ(encoder.TargetRegister.Arg0, factory.TypeNonGCStaticsSymbol(target), -NonGCStaticsNode.GetClassConstructorContextSize(factory.Target));
 
-                            AddrMode initialized = new AddrMode(encoder.TargetRegister.Arg0, null, factory.Target.PointerSize, 0, AddrModeSize.Int32);
-                            encoder.EmitCMP(ref initialized, 1);
+                            AddrMode initialized = new AddrMode(encoder.TargetRegister.Arg0, null, 0, 0, AddrModeSize.Int64);
+                            encoder.EmitCMP(ref initialized, 0);
                             encoder.EmitRETIfEqual();
 
                             encoder.EmitMOV(encoder.TargetRegister.Arg1, encoder.TargetRegister.Result);
@@ -92,8 +92,8 @@ namespace ILCompiler.DependencyAnalysis
                         {
                             encoder.EmitLEAQ(encoder.TargetRegister.Arg2, factory.TypeNonGCStaticsSymbol(target), - NonGCStaticsNode.GetClassConstructorContextSize(factory.Target));
 
-                            AddrMode initialized = new AddrMode(encoder.TargetRegister.Arg2, null, factory.Target.PointerSize, 0, AddrModeSize.Int32);
-                            encoder.EmitCMP(ref initialized, 1);
+                            AddrMode initialized = new AddrMode(encoder.TargetRegister.Arg2, null, 0, 0, AddrModeSize.Int64);
+                            encoder.EmitCMP(ref initialized, 0);
                             encoder.EmitJE(factory.ExternSymbol("RhpGetThreadStaticBaseForType"));
 
                             encoder.EmitJMP(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnThreadStaticBase));
@@ -118,8 +118,8 @@ namespace ILCompiler.DependencyAnalysis
                             // We need to trigger the cctor before returning the base. It is stored at the beginning of the non-GC statics region.
                             encoder.EmitLEAQ(encoder.TargetRegister.Arg0, factory.TypeNonGCStaticsSymbol(target), -NonGCStaticsNode.GetClassConstructorContextSize(factory.Target));
 
-                            AddrMode initialized = new AddrMode(encoder.TargetRegister.Arg0, null, factory.Target.PointerSize, 0, AddrModeSize.Int32);
-                            encoder.EmitCMP(ref initialized, 1);
+                            AddrMode initialized = new AddrMode(encoder.TargetRegister.Arg0, null, 0, 0, AddrModeSize.Int64);
+                            encoder.EmitCMP(ref initialized, 0);
                             encoder.EmitRETIfEqual();
 
                             encoder.EmitMOV(encoder.TargetRegister.Arg1, encoder.TargetRegister.Result);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X86/X86ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X86/X86ReadyToRunHelperNode.cs
@@ -39,8 +39,8 @@ namespace ILCompiler.DependencyAnalysis
                             // We need to trigger the cctor before returning the base. It is stored at the beginning of the non-GC statics region.
                             encoder.EmitMOV(encoder.TargetRegister.Arg0, factory.TypeNonGCStaticsSymbol(target), -NonGCStaticsNode.GetClassConstructorContextSize(factory.Target));
 
-                            AddrMode initialized = new AddrMode(encoder.TargetRegister.Arg0, null, factory.Target.PointerSize, 0, AddrModeSize.Int32);
-                            encoder.EmitCMP(ref initialized, 1);
+                            AddrMode initialized = new AddrMode(encoder.TargetRegister.Arg0, null, 0, 0, AddrModeSize.Int32);
+                            encoder.EmitCMP(ref initialized, 0);
                             encoder.EmitRETIfEqual();
 
                             encoder.EmitMOV(encoder.TargetRegister.Arg1, encoder.TargetRegister.Result);


### PR DESCRIPTION
This makes native aot compiled binaries smaller and reduces code size of inlined static constructor checks that are being worked on.