### PR TITLE
Upgrade arm64 cross image to Ubuntu 22.04 / llvm-15

### DIFF
--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -15,7 +15,7 @@ resources:
         ROOTFS_DIR: /crossrootfs/armv6
 
     - container: linux_arm64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-cross-arm64
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm64
       env:
         ROOTFS_DIR: /crossrootfs/arm64
 

--- a/eng/pipelines/common/templates/runtimes/build-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/build-test-job.yml
@@ -36,11 +36,7 @@ jobs:
     testGroup: ${{ parameters.testGroup }}
     pool: ${{ parameters.pool }}
     dependOnEvaluatePaths: ${{ parameters.dependOnEvaluatePaths }}
-
-    ${{ if and(ne(parameters.osGroup, 'windows'), ne(parameters.compilerName, 'gcc'), not(and(eq(parameters.osGroup, 'linux'), eq(parameters.osSubgroup, '_musl'))), not(eq(parameters.osGroup, 'osx'))) }}:
-      compilerArg: '-clang9'
-    ${{ if not(and(ne(parameters.osGroup, 'windows'), ne(parameters.compilerName, 'gcc'), not(and(eq(parameters.osGroup, 'linux'), eq(parameters.osSubgroup, '_musl'))), not(eq(parameters.osGroup, 'osx')))) }}:
-      compilerArg: ''
+    compilerArg: ''
 
     # Test jobs should continue on error for internal builds
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
@@ -72,19 +68,6 @@ jobs:
         - ${{ variable }}
       - name: liveRuntimeBuildParams
         value: 'libs.sfx+libs.oob+clr.iltools /p:RefOnly=true -c Release -ci'
-      - name: compilerArg
-        value: ''
-      - ${{ if and(ne(parameters.osGroup, 'windows'), ne(parameters.compilerName, 'gcc')) }}:
-        - name: compilerArg
-          value: '-clang9'
-        # We need to use the stable version available on Alpine Linux
-      - ${{ if and(eq(parameters.osGroup, 'linux'), eq(parameters.osSubgroup, '_musl')) }}:
-        - name: compilerArg
-          value: ''
-      # AppleClang has different version scheme, so we let compiler introspection pick up the available clang from PATH
-      - ${{ if eq(parameters.osGroup, 'osx') }}:
-        - name: compilerArg
-          value: ''
 
       - name: runtimeFlavorArgs
         value: ''

--- a/eng/pipelines/coreclr/templates/build-jit-job.yml
+++ b/eng/pipelines/coreclr/templates/build-jit-job.yml
@@ -51,19 +51,9 @@ jobs:
     - name: uploadAs
       value: ${{ parameters.uploadAs }}
 
+    # let the init-compiler script select the correct compiler (we only override it for -gcc in other places)
     - name: compilerArg
       value: ''
-    - ${{ if ne(parameters.osGroup, 'windows') }}:
-      - name: compilerArg
-        value: '-clang9'
-      # We need to use the stable version available on Alpine Linux
-      - ${{ if and(eq(parameters.osGroup, 'linux'), eq(parameters.osSubgroup, '_musl')) }}:
-        - name: compilerArg
-          value: ''
-      # AppleClang has different version scheme, so we let compiler introspection pick up the available clang from PATH
-      - ${{ if eq(parameters.osGroup, 'osx') }}:
-        - name: compilerArg
-          value: ''
 
     - ${{ if eq(parameters.osGroup, 'windows') }}:
       - name: PythonScript

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -87,8 +87,6 @@ jobs:
       - name: publishLogsArtifactPrefix
         value: 'BuildLogs_CoreCLR_GCC'
     - ${{ if and(ne(parameters.osGroup, 'windows'), ne(parameters.compilerName, 'gcc')) }}:
-      - name: compilerArg
-        value: '-clang9'
       # We need to use the stable version available on Alpine Linux
       - ${{ if and(eq(parameters.osGroup, 'linux'), eq(parameters.osSubgroup, '_musl')) }}:
         - name: compilerArg

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
@@ -22,8 +22,7 @@
     <NativeAotSupported Condition="'$(CrossBuild)' == 'true' and '$(TargetOS)' != '$(HostOS)'">false</NativeAotSupported>
     <!-- Can't use NativeAOT in source build yet https://github.com/dotnet/runtime/issues/66859 -->
     <NativeAotSupported Condition="'$(DotNetBuildFromSource)' == 'true'">false</NativeAotSupported>
-    <ObjCopyName Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(CrossBuild)' == 'true' and '$(RuntimeIdentifier)' == 'linux-musl-arm64'">llvm-objcopy-15</ObjCopyName>
-    <ObjCopyName Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(CrossBuild)' == 'true' and '$(RuntimeIdentifier)' == 'linux-arm64'">aarch64-linux-gnu-objcopy</ObjCopyName>
+    <ObjCopyName Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(CrossBuild)' == 'true' and ('$(RuntimeIdentifier)' == 'linux-arm64' or '$(RuntimeIdentifier)' == 'linux-musl-arm64')">llvm-objcopy-15</ObjCopyName>
   </PropertyGroup>
 
   <Target Name="PublishCrossgen"


### PR DESCRIPTION
This image is based on Ubuntu 22.04 instead of 20.04 with llvm-15 toolchain instead of llvm-9 in the host layer. It has the same Ubuntu 16.04 (which we lowered in https://github.com/dotnet/runtime/pull/80939) in `/crossrootfs` dir. See https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/815.

llvm9 has a bug in `llvm-objcopy` which causes the size regression (https://github.com/dotnet/runtime/issues/49081), it was fixed in llvm10. That means we can bring crossgen2's NativeAOT `linux-arm64` publishing to the same plan as `linux-musl-arm64` with this update. Hence the change in sfxproj.