### PR TITLE
[mono][jit] Fix the removal of relations added by basic blocks.

### DIFF
--- a/src/mono/mono/mini/abcremoval.c
+++ b/src/mono/mono/mini/abcremoval.c
@@ -546,9 +546,15 @@ apply_change_to_evaluation_area (MonoVariableRelationsEvaluationArea *area, Mono
 static void
 remove_change_from_evaluation_area (MonoAdditionalVariableRelation *change)
 {
-	if (change->insertion_point != NULL) {
-		change->insertion_point->next = change->relation.next;
-		change->relation.next = NULL;
+	//change->relation.relation = MONO_ANY_RELATION;
+	MonoSummarizedValueRelation *rel = change->insertion_point;
+	while (rel) {
+		if (rel->next == &(change->relation)) {
+			rel->next = rel->next->next;
+			break;
+		} else {
+			rel = rel->next;
+		}
 	}
 }
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_83941/Runtime_83941.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_83941/Runtime_83941.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+public class Test
+{
+	public int test (IEqualityComparer comparer) {
+		int k = 0;
+		switch (k) {
+		case 0:
+			return comparer.GetHashCode(null);
+		case 1:
+			return test2(comparer.GetHashCode(null), comparer.GetHashCode(null));
+		}
+		return -1;
+	}
+
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	internal static int test2 (int h1, int h2) {
+		return 0;
+	}
+
+	public static int Main () {
+		try {
+			var t = new Test ();
+			t.test (null);
+		} catch (NullReferenceException) {
+			return 100;
+		}
+		return 101;
+	}
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_83941/Runtime_83941.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_83941/Runtime_83941.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
If a basic block added two relations to the same variable, like by two op_not_null opcodes, then sometimes the relations were not removed, causing invalid null check elimination in unrelated basic blocks.