### PR TITLE
Renable running Arm64 test cases in CI

### DIFF
--- a/src/tests/JIT/HardwareIntrinsics/HardwareIntrinsics_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/HardwareIntrinsics_r.csproj
@@ -4,8 +4,6 @@
     <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm64' and '$(TargetOS)' == 'osx'">true</GCStressIncompatible>
     <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm'">true</GCStressIncompatible>
 
-    <_IncludeArm64HWIntrinsicTests>false</_IncludeArm64HWIntrinsicTests>
-    <_IncludeArm64HWIntrinsicTests Condition="'$(CLRTestPriorityToBuild)' &gt;= '1' OR '$(TargetArchitecture)' == 'arm64'">true</_IncludeArm64HWIntrinsicTests>
     <_IncludeXarchHWIntrinsicTests>false</_IncludeXarchHWIntrinsicTests>
     <_IncludeXarchHWIntrinsicTests Condition="'$(CLRTestPriorityToBuild)' &gt;= '1' OR '$(TargetArchitecture)' == 'x64' OR ('$(TargetArchitecture)' == 'x86' AND '$(TargetsWindows)' == 'true')">true</_IncludeXarchHWIntrinsicTests>
   </PropertyGroup>
@@ -16,9 +14,6 @@
 
     <MergedWrapperProjectReference Include="*/**/*.csproj" Exclude="**/*_ro.csproj" />
 
-    <MergedWrapperProjectReference Remove="Arm/**/*.csproj" Condition="'$(_IncludeArm64HWIntrinsicTests)' != 'true'" />
-    <MergedWrapperProjectReference Remove="General/Vector64/**/*.csproj" Condition="'$(_IncludeArm64HWIntrinsicTests)' != 'true'" />
-    <MergedWrapperProjectReference Remove="General/Vector64_1/**/*.csproj" Condition="'$(_IncludeArm64HWIntrinsicTests)' != 'true'" />
     <MergedWrapperProjectReference Remove="General/Vector256/**/*.csproj" Condition="'$(_IncludeXarchHWIntrinsicTests)' != 'true'" />
     <MergedWrapperProjectReference Remove="General/Vector256_1/**/*.csproj" Condition="'$(_IncludeXarchHWIntrinsicTests)' != 'true'" />
     <MergedWrapperProjectReference Remove="General/Vector512/**/*.csproj" Condition="'$(_IncludeXarchHWIntrinsicTests)' != 'true'" />

--- a/src/tests/JIT/HardwareIntrinsics/HardwareIntrinsics_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/HardwareIntrinsics_r.csproj
@@ -5,12 +5,7 @@
     <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm'">true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
-    <!-- We have a lot of tests here so run them in outerloop on platforms where they aren't accelerated -->
-    <!-- For most of these, that just involves excluding the projects when the architecture is mismatched -->
-    <!-- For Vector512, we only have a very small pool of machines with acceleration support, so they are always outerloop -->
-
     <MergedWrapperProjectReference Include="*/**/*.csproj" Exclude="**/*_ro.csproj" />
-
   </ItemGroup>
 
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />

--- a/src/tests/JIT/HardwareIntrinsics/HardwareIntrinsics_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/HardwareIntrinsics_r.csproj
@@ -3,9 +3,6 @@
     <NumberOfStripesToUseInStress>20</NumberOfStripesToUseInStress>
     <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm64' and '$(TargetOS)' == 'osx'">true</GCStressIncompatible>
     <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm'">true</GCStressIncompatible>
-
-    <_IncludeXarchHWIntrinsicTests>false</_IncludeXarchHWIntrinsicTests>
-    <_IncludeXarchHWIntrinsicTests Condition="'$(CLRTestPriorityToBuild)' &gt;= '1' OR '$(TargetArchitecture)' == 'x64' OR ('$(TargetArchitecture)' == 'x86' AND '$(TargetsWindows)' == 'true')">true</_IncludeXarchHWIntrinsicTests>
   </PropertyGroup>
   <ItemGroup>
     <!-- We have a lot of tests here so run them in outerloop on platforms where they aren't accelerated -->
@@ -13,12 +10,6 @@
     <!-- For Vector512, we only have a very small pool of machines with acceleration support, so they are always outerloop -->
 
     <MergedWrapperProjectReference Include="*/**/*.csproj" Exclude="**/*_ro.csproj" />
-
-    <MergedWrapperProjectReference Remove="General/Vector256/**/*.csproj" Condition="'$(_IncludeXarchHWIntrinsicTests)' != 'true'" />
-    <MergedWrapperProjectReference Remove="General/Vector256_1/**/*.csproj" Condition="'$(_IncludeXarchHWIntrinsicTests)' != 'true'" />
-    <MergedWrapperProjectReference Remove="General/Vector512/**/*.csproj" Condition="'$(_IncludeXarchHWIntrinsicTests)' != 'true'" />
-    <MergedWrapperProjectReference Remove="General/Vector512_1/**/*.csproj" Condition="'$(_IncludeXarchHWIntrinsicTests)' != 'true'" />
-    <MergedWrapperProjectReference Remove="X86/**/*.csproj" Condition="'$(_IncludeXarchHWIntrinsicTests)' != 'true'" />
 
   </ItemGroup>
 

--- a/src/tests/JIT/HardwareIntrinsics/HardwareIntrinsics_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/HardwareIntrinsics_ro.csproj
@@ -4,8 +4,6 @@
     <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm64' and '$(TargetOS)' == 'osx'">true</GCStressIncompatible>
     <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm'">true</GCStressIncompatible>
 
-    <_IncludeArm64HWIntrinsicTests>false</_IncludeArm64HWIntrinsicTests>
-    <_IncludeArm64HWIntrinsicTests Condition="'$(CLRTestPriorityToBuild)' &gt;= '1' OR '$(TargetArchitecture)' == 'arm64'">true</_IncludeArm64HWIntrinsicTests>
     <_IncludeXarchHWIntrinsicTests>false</_IncludeXarchHWIntrinsicTests>
     <_IncludeXarchHWIntrinsicTests Condition="'$(CLRTestPriorityToBuild)' &gt;= '1' OR '$(TargetArchitecture)' == 'x64' OR ('$(TargetArchitecture)' == 'x86' AND '$(TargetsWindows)' == 'true')">true</_IncludeXarchHWIntrinsicTests>
   </PropertyGroup>
@@ -17,9 +15,6 @@
 
     <MergedWrapperProjectReference Include="*/**/*_ro.csproj" />
 
-    <MergedWrapperProjectReference Remove="Arm/**/*_ro.csproj" Condition="'$(_IncludeArm64HWIntrinsicTests)' != 'true'" />
-    <MergedWrapperProjectReference Remove="General/Vector64/**/*_ro.csproj" Condition="'$(_IncludeArm64HWIntrinsicTests)' != 'true'" />
-    <MergedWrapperProjectReference Remove="General/Vector64_1/**/*_ro.csproj" Condition="'$(_IncludeArm64HWIntrinsicTests)' != 'true'" />
     <MergedWrapperProjectReference Remove="General/Vector256/**/*_ro.csproj" Condition="'$(_IncludeXarchHWIntrinsicTests)' != 'true'" />
     <MergedWrapperProjectReference Remove="General/Vector256_1/**/*_ro.csproj" Condition="'$(_IncludeXarchHWIntrinsicTests)' != 'true'" />
     <MergedWrapperProjectReference Remove="General/Vector512/**/*_ro.csproj" Condition="'$(_IncludeXarchHWIntrinsicTests)' != 'true'" />

--- a/src/tests/JIT/HardwareIntrinsics/HardwareIntrinsics_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/HardwareIntrinsics_ro.csproj
@@ -3,9 +3,6 @@
     <NumberOfStripesToUseInStress>20</NumberOfStripesToUseInStress>
     <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm64' and '$(TargetOS)' == 'osx'">true</GCStressIncompatible>
     <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm'">true</GCStressIncompatible>
-
-    <_IncludeXarchHWIntrinsicTests>false</_IncludeXarchHWIntrinsicTests>
-    <_IncludeXarchHWIntrinsicTests Condition="'$(CLRTestPriorityToBuild)' &gt;= '1' OR '$(TargetArchitecture)' == 'x64' OR ('$(TargetArchitecture)' == 'x86' AND '$(TargetsWindows)' == 'true')">true</_IncludeXarchHWIntrinsicTests>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,12 +11,6 @@
     <!-- For Vector512, we only have a very small pool of machines with acceleration support, so they are always outerloop -->
 
     <MergedWrapperProjectReference Include="*/**/*_ro.csproj" />
-
-    <MergedWrapperProjectReference Remove="General/Vector256/**/*_ro.csproj" Condition="'$(_IncludeXarchHWIntrinsicTests)' != 'true'" />
-    <MergedWrapperProjectReference Remove="General/Vector256_1/**/*_ro.csproj" Condition="'$(_IncludeXarchHWIntrinsicTests)' != 'true'" />
-    <MergedWrapperProjectReference Remove="General/Vector512/**/*_ro.csproj" Condition="'$(_IncludeXarchHWIntrinsicTests)' != 'true'" />
-    <MergedWrapperProjectReference Remove="General/Vector512_1/**/*_ro.csproj" Condition="'$(_IncludeXarchHWIntrinsicTests)' != 'true'" />
-    <MergedWrapperProjectReference Remove="X86/**/*_ro.csproj" Condition="'$(_IncludeXarchHWIntrinsicTests)' != 'true'" />
   </ItemGroup>
 
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />

--- a/src/tests/JIT/HardwareIntrinsics/HardwareIntrinsics_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/HardwareIntrinsics_ro.csproj
@@ -6,10 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- We have a lot of tests here so run them in outerloop on platforms where they aren't accelerated -->
-    <!-- For most of these, that just involves excluding the projects when the architecture is mismatched -->
-    <!-- For Vector512, we only have a very small pool of machines with acceleration support, so they are always outerloop -->
-
     <MergedWrapperProjectReference Include="*/**/*_ro.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
The original change prohibited running Arm tests from non-Arm platform, however, we build AnyOS/AnyConfiguration tests and we don't know what the targeted CI leg is for. For now, just remove such restriction and see if it picks up Arm test cases. After that, probably, add a property (or look for a property, if there is one available) that can be used to exclude the Arm test cases from getting included in non-arm platforms.

Fixes https://github.com/dotnet/runtime/issues/83947