### PR TITLE
Fix function pointer as fields inspection

### DIFF
--- a/src/coreclr/vm/siginfo.cpp
+++ b/src/coreclr/vm/siginfo.cpp
@@ -1648,8 +1648,8 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
             // Find an existing function pointer or make a new one
             thRet = ClassLoader::LoadFnptrTypeThrowing((BYTE) uCallConv, cArgs, retAndArgTypes, fLoadTypes, level);                
 #else
-            DacNotImpl();
-            thRet = TypeHandle();
+            // Function pointers are interpreted as IntPtr to the debugger.
+            thRet = TypeHandle(CoreLibBinder::GetElementType(ELEMENT_TYPE_I));
 #endif
             break;
         }


### PR DESCRIPTION
This was missed when C# function pointers support
was added to the runtime. The current fix is reporting
all functions pointers as `IntPtr` type. It should be
possible in a future update to properly share the accurate
type of the function pointer.

/cc @dotnet/dotnet-diag 