### PR TITLE
Enable regex source gen / compiler vectorization of all sets

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -962,10 +962,21 @@ namespace System.Text.RegularExpressions
                             // ReadOnlySpan<char> span = inputSpan...;
                             Stloc(span);
 
-                            // int i = span.IndexOfAnyExcept(indexOfAnyValuesArray[...]);
+                            // int i = span.
                             Ldloc(span);
-                            LoadIndexOfAnyValues(CollectionsMarshal.AsSpan(asciiChars));
-                            Call(s_spanIndexOfAnyExceptIndexOfAnyValues);
+                            if (asciiChars.Count == 128)
+                            {
+                                // IndexOfAnyExceptInRange('\0', '\u007f');
+                                Ldc(0);
+                                Ldc(127);
+                                Call(s_spanIndexOfAnyExceptInRange);
+                            }
+                            else
+                            {
+                                // IndexOfAnyExcept(indexOfAnyValuesArray[...]);
+                                LoadIndexOfAnyValues(CollectionsMarshal.AsSpan(asciiChars));
+                                Call(s_spanIndexOfAnyExceptIndexOfAnyValues);
+                            }
                             Stloc(i);
 
                             // if ((uint)i >= span.Length) goto doneSearch;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace System.Text.RegularExpressions
@@ -831,14 +832,11 @@ namespace System.Text.RegularExpressions
                 Call(s_spanSliceIntMethod);
                 Stloc(textSpanLocal);
 
-                // If we can use IndexOf{Any}, try to accelerate the skip loop via vectorization to match the first prefix.
-                // We can use it if this is a case-sensitive class with a small number of characters in the class.
-                // We avoid using it for the relatively common case of the starting set being '.', aka anything other than
+                // Use IndexOf{Any} to accelerate the skip loop via vectorization to match the first prefix.
+                // But we avoid using it for the relatively common case of the starting set being '.', aka anything other than
                 // a newline, as it's very rare to have long, uninterrupted sequences of newlines.
                 int setIndex = 0;
-                bool canUseIndexOf =
-                    primarySet.Set != RegexCharClass.NotNewLineClass &&
-                    (primarySet.Chars is not null || primarySet.Range is not null || primarySet.AsciiSet is not null);
+                bool canUseIndexOf = primarySet.Set != RegexCharClass.NotNewLineClass;
                 bool needLoop = !canUseIndexOf || setsToUse > 1;
 
                 Label checkSpanLengthLabel = default;
@@ -926,9 +924,9 @@ namespace System.Text.RegularExpressions
                         LoadIndexOfAnyValues(primarySet.AsciiSet);
                         Call(s_spanIndexOfAnyIndexOfAnyValues);
                     }
-                    else
+                    else if (primarySet.Range is not null)
                     {
-                        if (primarySet.Range!.Value.LowInclusive == primarySet.Range.Value.HighInclusive)
+                        if (primarySet.Range.Value.LowInclusive == primarySet.Range.Value.HighInclusive)
                         {
                             // tmp = ...IndexOf{AnyExcept}(low);
                             Ldc(primarySet.Range.Value.LowInclusive);
@@ -940,6 +938,81 @@ namespace System.Text.RegularExpressions
                             Ldc(primarySet.Range.Value.LowInclusive);
                             Ldc(primarySet.Range.Value.HighInclusive);
                             Call(primarySet.Negated ? s_spanIndexOfAnyExceptInRange : s_spanIndexOfAnyInRange);
+                        }
+                    }
+                    else
+                    {
+                        // In order to optimize the search for ASCII characters, we use IndexOfAnyValues to vectorize a search
+                        // for those characters plus anything non-ASCII (if we find something non-ASCII, we'll fall back to
+                        // a sequential walk).  In order to do that search, we actually build up a set for all of the ASCII
+                        // characters _not_ contained in the set, and then do a search for the inverse of that, which will be
+                        // all of the target ASCII characters and all of non-ASCII.
+                        var asciiChars = new List<char>();
+                        for (int i = 0; i <= 0x7f; i++)
+                        {
+                            if (!RegexCharClass.CharInClass((char)i, primarySet.Set))
+                            {
+                                asciiChars.Add((char)i);
+                            }
+                        }
+
+                        using (RentedLocalBuilder span = RentReadOnlySpanCharLocal())
+                        using (RentedLocalBuilder i = RentInt32Local())
+                        {
+                            // ReadOnlySpan<char> span = inputSpan...;
+                            Stloc(span);
+
+                            // int i = span.IndexOfAnyExcept(indexOfAnyValuesArray[...]);
+                            Ldloc(span);
+                            LoadIndexOfAnyValues(CollectionsMarshal.AsSpan(asciiChars));
+                            Call(s_spanIndexOfAnyExceptIndexOfAnyValues);
+                            Stloc(i);
+
+                            // if ((uint)i >= span.Length) goto doneSearch;
+                            Label doneSearch = DefineLabel();
+                            Ldloc(i);
+                            Ldloca(span);
+                            Call(s_spanGetLengthMethod);
+                            BgeUnFar(doneSearch);
+
+                            // if (span[i] <= 0x7f) goto doneSearch;
+                            Ldc(0x7f);
+                            Ldloca(span);
+                            Ldloc(i);
+                            Call(s_spanGetItemMethod);
+                            LdindU2();
+                            BgeUnFar(doneSearch);
+
+                            Label loop = DefineLabel();
+                            MarkLabel(loop);
+                            // do { ...
+
+                            // if (CharInClass(span[i])) goto doneSearch;
+                            Ldloca(span);
+                            Ldloc(i);
+                            Call(s_spanGetItemMethod);
+                            LdindU2();
+                            EmitMatchCharacterClass(primarySet.Set);
+                            Brtrue(doneSearch);
+
+                            // i++;
+                            Ldloc(i);
+                            Ldc(1);
+                            Add();
+                            Stloc(i);
+
+                            // } while ((uint)i < span.Length);
+                            Ldloc(i);
+                            Ldloca(span);
+                            Call(s_spanGetLengthMethod);
+                            BltUnFar(loop);
+
+                            // i = -1;
+                            Ldc(-1);
+                            Stloc(i);
+
+                            MarkLabel(doneSearch);
+                            Ldloc(i);
                         }
                     }
 
@@ -6008,7 +6081,7 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Adds an entry in <see cref="CompiledRegexRunner._indexOfAnyValues"/> for the given <paramref name="chars"/> and emits a load of that initialized value.
         /// </summary>
-        private void LoadIndexOfAnyValues(char[] chars)
+        private void LoadIndexOfAnyValues(ReadOnlySpan<char> chars)
         {
             List<IndexOfAnyValues<char>> list = _indexOfAnyValues ??= new();
             int index = list.Count;

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorOutputTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorOutputTests.cs
@@ -660,7 +660,7 @@ namespace System.Text.RegularExpressions.Tests
                                                 // Match a character in the set [^>\s] atomically at least once.
                                                 {
                                                     int iteration3 = 0;
-                                                    while ((uint)iteration3 < (uint)slice.Length && ((ch = slice[iteration3]) < 128 ? ("쇿\uffff\ufffe뿿\uffff\uffff\uffff\uffff"[ch >> 4] & (1 << (ch & 0xF))) != 0 : RegexRunner.CharInClass((char)ch, "\u0001\u0002\u0001>?d")))
+                                                    while ((uint)iteration3 < (uint)slice.Length && ((ch = slice[iteration3]) < 128 ? ("쇿\uffff\ufffe뿿\uffff\uffff\uffff\uffff"[ch >> 4] & (1 << (ch & 0xF))) != 0 : Utilities.Base.CharInClass((char)ch, "\u0001\u0002\u0001>?d")))
                                                     {
                                                         iteration3++;
                                                     }
@@ -702,6 +702,16 @@ namespace System.Text.RegularExpressions.Tests
 
                     }
 
+                    /// <summary>Helper methods used by generated <see cref="Regex"/>-derived implementations.</summary>
+                    [GeneratedCodeAttribute("System.Text.RegularExpressions.Generator", "42.42.42.42")]
+                    file static class Utilities
+                    {
+                        internal class Base : RegexRunner
+                        {
+                            /// <summary>Determines whether the specified character in is in the specified character class.</summary>
+                            internal static new bool CharInClass(char ch, string charClass) => RegexRunner.CharInClass(ch, charClass);
+                        }
+                    }
                 }
                 """
             };
@@ -864,7 +874,7 @@ namespace System.Text.RegularExpressions.Tests
                         /// <summary>Whether <see cref="s_defaultTimeout"/> is non-infinite.</summary>
                         internal static readonly bool s_hasTimeout = s_defaultTimeout != Regex.InfiniteMatchTimeout;
 
-                        /// <summary>Cached data to efficiently search for a character in the set "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".</summary>
+                        /// <summary>Supports searching for characters in or not in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".</summary>
                         internal static readonly IndexOfAnyValues<char> s_asciiLetters = IndexOfAnyValues.Create("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
                     }
                 }


### PR DESCRIPTION
When emitting TryFindNextPossibleStartingPosition based on a set that's a fixed-distance from the start of the pattern, today we're able to vectorize a variety of cases.  In .NET 7, this was largely limited to very small sets that contained only 1-5 characters.  Earlier in .NET 8, we expanded this to include ranges (e.g. [0-9]) and more impactfully sets containing any number of only ASCII values (e.g. [A-Za-z0-9]).  That still, however, leaves sets that are non-continguous and contain anything non-ASCII, which is extremely common.  For example, the set `[a-z]` with `RegexOptions.IgnoreCase` actually gets expanded to be `[A-Za-z\u212A]` because the Kelvin sign is considered case-equivalent with `k`, and that means for such a set, we wouldn't employ any vectorized helper and would instead just walk character by character.

With this PR, we'lll now employ some vectorization as part of that remaining class of set as well in the compiler and source generator.  In particular, we do a vectorize a search for the ASCII portion of the set along with anything non-ASCII.  If the found result is ASCII, we're done.  If the found result is non-ASCII, then we proceed to walk character by character as was done previously.

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Net.Http;
using System.Text.RegularExpressions;

public partial class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    private static readonly string s_input = new HttpClient().GetStringAsync("https://www.gutenberg.org/cache/epub/3200/pg3200.txt").Result;

    [GeneratedRegex(@"\s+")] private static partial Regex FindWhitespace();
    [GeneratedRegex(@"\d+")] private static partial Regex FindNumbers();
    [GeneratedRegex(@"\b\w+\b")] private static partial Regex FindWords();
    [GeneratedRegex(@"\p{P}")] private static partial Regex FindPunctuation();

    [Benchmark] public int CountWhitespace() => FindWhitespace().Count(s_input);
    [Benchmark] public int CountNumbers() => FindNumbers().Count(s_input);
    [Benchmark] public int CountWords() => FindWords().Count(s_input);
    [Benchmark] public int CountPunctuation() => FindPunctuation().Count(s_input);
}
```

Before (source gen):

|           Method |      Mean |    Error |   StdDev |
|----------------- |----------:|---------:|---------:|
|  CountWhitespace | 125.06 ms | 0.407 ms | 0.340 ms |
|     CountNumbers |  15.25 ms | 0.027 ms | 0.025 ms |
|       CountWords | 145.53 ms | 2.324 ms | 2.174 ms |
| CountPunctuation |  37.27 ms | 0.336 ms | 0.263 ms |

After (source gen):

|           Method |       Mean |     Error |    StdDev |
|----------------- |-----------:|----------:|----------:|
|  CountWhitespace |  98.698 ms | 0.7504 ms | 0.6652 ms |
|     CountNumbers |   2.520 ms | 0.0158 ms | 0.0124 ms |
|       CountWords | 146.225 ms | 2.9665 ms | 2.7748 ms |
| CountPunctuation |  21.003 ms | 0.0400 ms | 0.0354 ms |