### PR TITLE
Set minimum language version allowed by config binding generator

### DIFF
--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -213,18 +213,23 @@ The diagnostic id values reserved for .NET Libraries analyzer warnings are `SYSL
 |  __`SYSLIB1099`__ | _`SYSLIB1092`-`SYSLIB1099` reserved for Microsoft.Interop.ComInteropGenerator._ |
 |  __`SYSLIB1100`__ | Configuration binding generator: type is not supported. |
 |  __`SYSLIB1101`__ | Configuration binding generator: property on type is not supported. |
-|  __`SYSLIB1102`__ | *_`SYSLIB1101`-`SYSLIB1113` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1103`__ | *_`SYSLIB1101`-`SYSLIB1113` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1104`__ | *_`SYSLIB1101`-`SYSLIB1113` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1105`__ | *_`SYSLIB1101`-`SYSLIB1113` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1106`__ | *_`SYSLIB1101`-`SYSLIB1113` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1107`__ | *_`SYSLIB1101`-`SYSLIB1113` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1108`__ | *_`SYSLIB1101`-`SYSLIB1113` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1109`__ | *_`SYSLIB1101`-`SYSLIB1113` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1110`__ | *_`SYSLIB1101`-`SYSLIB1113` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1111`__ | *_`SYSLIB1101`-`SYSLIB1113` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1112`__ | *_`SYSLIB1101`-`SYSLIB1113` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1113`__ | *_`SYSLIB1101`-`SYSLIB1113` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1102`__ | Configuration binding generator: project's language version must be at least C# 11.|
+|  __`SYSLIB1103`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1104`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1105`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1106`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1107`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1108`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1109`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1110`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1111`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1112`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1113`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1114`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1115`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1116`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1117`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1118`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
 
 
 ### Diagnostic Suppressions (`SYSLIBSUPPRESS****`)

--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -214,22 +214,22 @@ The diagnostic id values reserved for .NET Libraries analyzer warnings are `SYSL
 |  __`SYSLIB1100`__ | Configuration binding generator: type is not supported. |
 |  __`SYSLIB1101`__ | Configuration binding generator: property on type is not supported. |
 |  __`SYSLIB1102`__ | Configuration binding generator: project's language version must be at least C# 11.|
-|  __`SYSLIB1103`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1104`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1105`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1106`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1107`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1108`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1109`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1110`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1111`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1112`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1113`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1114`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1115`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1116`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1117`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
-|  __`SYSLIB1118`__ | *_`SYSLIB1103`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1103`__ | *_`SYSLIB1100`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1104`__ | *_`SYSLIB1100`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1105`__ | *_`SYSLIB1100`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1106`__ | *_`SYSLIB1100`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1107`__ | *_`SYSLIB1100`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1108`__ | *_`SYSLIB1100`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1109`__ | *_`SYSLIB1100`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1110`__ | *_`SYSLIB1100`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1111`__ | *_`SYSLIB1100`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1112`__ | *_`SYSLIB1100`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1113`__ | *_`SYSLIB1100`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1114`__ | *_`SYSLIB1100`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1115`__ | *_`SYSLIB1100`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1116`__ | *_`SYSLIB1100`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1117`__ | *_`SYSLIB1100`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
+|  __`SYSLIB1118`__ | *_`SYSLIB1100`-`SYSLIB1118` reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.* |
 
 
 ### Diagnostic Suppressions (`SYSLIBSUPPRESS****`)

--- a/src/libraries/Common/tests/SourceGenerators/RoslynTestUtils.cs
+++ b/src/libraries/Common/tests/SourceGenerators/RoslynTestUtils.cs
@@ -26,7 +26,10 @@ namespace SourceGenerators.Tests
         /// </summary>
         /// <param name="references">Assembly references to include in the project.</param>
         /// <param name="includeBaseReferences">Whether to include references to the BCL assemblies.</param>
-        public static Project CreateTestProject(IEnumerable<Assembly>? references, bool includeBaseReferences = true)
+        public static Project CreateTestProject(
+            IEnumerable<Assembly>? references,
+            bool includeBaseReferences = true,
+            LanguageVersion langVersion = LanguageVersion.Preview)
         {
             string corelib = Assembly.GetAssembly(typeof(object))!.Location;
             string runtimeDir = Path.GetDirectoryName(corelib)!;
@@ -51,7 +54,8 @@ namespace SourceGenerators.Tests
                 .AddSolution(SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Create()))
                 .AddProject("Test", "test.dll", "C#")
                 .WithMetadataReferences(refs)
-                .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary).WithNullableContextOptions(NullableContextOptions.Enable));
+                .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary).WithNullableContextOptions(NullableContextOptions.Enable))
+                .WithParseOptions(new CSharpParseOptions(langVersion));
         }
 
         public static Task CommitChanges(this Project proj, params string[] ignorables)
@@ -149,9 +153,10 @@ namespace SourceGenerators.Tests
             IEnumerable<Assembly>? references,
             IEnumerable<string> sources,
             bool includeBaseReferences = true,
+            LanguageVersion langVersion = LanguageVersion.Preview,
             CancellationToken cancellationToken = default)
         {
-            Project proj = CreateTestProject(references, includeBaseReferences);
+            Project proj = CreateTestProject(references, includeBaseReferences, langVersion);
             proj = proj.WithDocuments(sources);
             Assert.True(proj.Solution.Workspace.TryApplyChanges(proj.Solution));
             Compilation? comp = await proj!.GetCompilationAsync(CancellationToken.None).ConfigureAwait(false);

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingSourceGenerator.Helpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingSourceGenerator.Helpers.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Diagnostics;
-using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 {
@@ -18,7 +15,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             title: new LocalizableResourceString(nameof(SR.TypeNotSupportedTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Configuration.Binder.SourceGeneration.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.TypeNotSupportedMessageFormat), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Configuration.Binder.SourceGeneration.SR)),
             category: GeneratorProjectName,
-            defaultSeverity: DiagnosticSeverity.Info,
+            defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
         private static DiagnosticDescriptor PropertyNotSupported { get; } = new DiagnosticDescriptor(
@@ -26,7 +23,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             title: new LocalizableResourceString(nameof(SR.PropertyNotSupportedTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Configuration.Binder.SourceGeneration.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.PropertyNotSupportedMessageFormat), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Configuration.Binder.SourceGeneration.SR)),
             category: GeneratorProjectName,
-            defaultSeverity: DiagnosticSeverity.Info,
+            defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
         private static DiagnosticDescriptor LanguageVersionNotSupported { get; } = new DiagnosticDescriptor(
@@ -34,7 +31,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             title: new LocalizableResourceString(nameof(SR.LanguageVersionIsNotSupportedTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Configuration.Binder.SourceGeneration.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.Language_VersionIsNotSupportedMessageFormat), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Configuration.Binder.SourceGeneration.SR)),
             category: GeneratorProjectName,
-            defaultSeverity: DiagnosticSeverity.Info,
+            defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
         // Unlike sourcegen warnings, exception messages should not be localized so we keep them in source.

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingSourceGenerator.Helpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingSourceGenerator.Helpers.cs
@@ -29,6 +29,14 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             defaultSeverity: DiagnosticSeverity.Info,
             isEnabledByDefault: true);
 
+        private static DiagnosticDescriptor LanguageVersionNotSupported { get; } = new DiagnosticDescriptor(
+            id: "SYSLIB1102",
+            title: new LocalizableResourceString(nameof(SR.LanguageVersionIsNotSupportedTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Configuration.Binder.SourceGeneration.SR)),
+            messageFormat: new LocalizableResourceString(nameof(SR.Language_VersionIsNotSupportedMessageFormat), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Configuration.Binder.SourceGeneration.SR)),
+            category: GeneratorProjectName,
+            defaultSeverity: DiagnosticSeverity.Info,
+            isEnabledByDefault: true);
+
         // Unlike sourcegen warnings, exception messages should not be localized so we keep them in source.
         private static class ExceptionMessages
         {

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingSourceGenerator.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingSourceGenerator.cs
@@ -69,9 +69,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         private sealed record CompilationData
         {
             public bool LanguageVersionIsSupported { get; }
-
             public KnownTypeData? TypeData { get; }
-
 
             public CompilationData(CSharpCompilation compilation)
             {

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingSourceGenerator.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingSourceGenerator.cs
@@ -5,6 +5,7 @@
 using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.DotnetRuntime.Extensions;
 using Microsoft.CodeAnalysis.Operations;
@@ -19,15 +20,17 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
     {
         public void Initialize(IncrementalGeneratorInitializationContext context)
         {
-            IncrementalValueProvider<KnownTypeData> compilationData =
+            IncrementalValueProvider<CompilationData?> compilationData =
                 context.CompilationProvider
-                    .Select((compilation, _) => new KnownTypeData(compilation));
+                    .Select((compilation, _) => compilation.Options is CSharpCompilationOptions options
+                        ? new CompilationData((CSharpCompilation)compilation)
+                        : null);
 
             IncrementalValuesProvider<BinderInvocationOperation> inputCalls = context.SyntaxProvider.CreateSyntaxProvider(
                 (node, _) => node is InvocationExpressionSyntax invocation,
                 (context, cancellationToken) => new BinderInvocationOperation(context, cancellationToken));
 
-            IncrementalValueProvider<(KnownTypeData, ImmutableArray<BinderInvocationOperation>)> inputData = compilationData.Combine(inputCalls.Collect());
+            IncrementalValueProvider<(CompilationData?, ImmutableArray<BinderInvocationOperation>)> inputData = compilationData.Combine(inputCalls.Collect());
 
             context.RegisterSourceOutput(inputData, (spc, source) => Execute(source.Item1, source.Item2, spc));
         }
@@ -35,7 +38,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         /// <summary>
         /// Generates source code to optimize binding with ConfigurationBinder.
         /// </summary>
-        private static void Execute(KnownTypeData typeData, ImmutableArray<BinderInvocationOperation> inputCalls, SourceProductionContext context)
+        private static void Execute(CompilationData compilationData, ImmutableArray<BinderInvocationOperation> inputCalls, SourceProductionContext context)
         {
 #if LAUNCH_DEBUGGER
             if (!System.Diagnostics.Debugger.IsAttached)
@@ -48,12 +51,35 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 return;
             }
 
-            Parser parser = new(context, typeData);
+            if (compilationData?.LanguageVersionIsSupported != true)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(LanguageVersionNotSupported, location: null));
+                return;
+            }
+
+            Parser parser = new(context, compilationData.TypeData!);
             SourceGenerationSpec? spec = parser.GetSourceGenerationSpec(inputCalls);
             if (spec is not null)
             {
                 Emitter emitter = new(context, spec);
                 emitter.Emit();
+            }
+        }
+
+        private sealed record CompilationData
+        {
+            public bool LanguageVersionIsSupported { get; }
+
+            public KnownTypeData? TypeData { get; }
+
+
+            public CompilationData(CSharpCompilation compilation)
+            {
+                LanguageVersionIsSupported = compilation.LanguageVersion >= LanguageVersion.CSharp11;
+                if (LanguageVersionIsSupported)
+                {
+                    TypeData = new KnownTypeData(compilation);
+                }
             }
         }
 
@@ -75,7 +101,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             public INamedTypeSymbol? SymbolForISet { get; }
             public INamedTypeSymbol? SymbolForList { get; }
 
-            public KnownTypeData(Compilation compilation)
+            public KnownTypeData(CSharpCompilation compilation)
             {
                 SymbolForIEnumerable = compilation.GetSpecialType(SpecialType.System_Collections_IEnumerable);
                 SymbolForConfigurationKeyNameAttribute = compilation.GetBestTypeByMetadataName(TypeFullName.ConfigurationKeyNameAttribute);

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/Strings.resx
@@ -117,16 +117,22 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Language VersionIsNotSupportedMessageFormat" xml:space="preserve">
+    <value>The project's language version has to be at least 'C# 11'.</value>
+  </data>
+  <data name="LanguageVersionIsNotSupportedTitle" xml:space="preserve">
+    <value>Language version is required to be at least C# 11</value>
+  </data>
   <data name="PropertyNotSupportedMessageFormat" xml:space="preserve">
     <value>Property '{0}' on type '{1}' is not supported.</value>
   </data>
   <data name="PropertyNotSupportedTitle" xml:space="preserve">
-    <value>Did not generate binding logic for a property on a type.</value>
+    <value>Did not generate binding logic for a property on a type</value>
   </data>
   <data name="TypeNotSupportedMessageFormat" xml:space="preserve">
     <value>Type '{0}' is not supported: {1}.</value>
   </data>
   <data name="TypeNotSupportedTitle" xml:space="preserve">
-    <value>Did not generate binding logic for a type.</value>
+    <value>Did not generate binding logic for a type</value>
   </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.cs.xlf
@@ -2,14 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Strings.resx">
     <body>
+      <trans-unit id="Language VersionIsNotSupportedMessageFormat">
+        <source>The project's language version has to be at least 'C# 11'.</source>
+        <target state="new">The project's language version has to be at least 'C# 11'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LanguageVersionIsNotSupportedTitle">
+        <source>Language version is required to be at least C# 11</source>
+        <target state="new">Language version is required to be at least C# 11</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyNotSupportedMessageFormat">
         <source>Property '{0}' on type '{1}' is not supported.</source>
         <target state="translated">Vlastnost „{0}“ u typu „{1}“ se nepodporuje.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNotSupportedTitle">
-        <source>Did not generate binding logic for a property on a type.</source>
-        <target state="translated">Nevygenerovala se logika vazby pro vlastnost typu.</target>
+        <source>Did not generate binding logic for a property on a type</source>
+        <target state="needs-review-translation">Nevygenerovala se logika vazby pro vlastnost typu.</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedMessageFormat">
@@ -18,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedTitle">
-        <source>Did not generate binding logic for a type.</source>
-        <target state="translated">Nevygenerovala se logika vazby pro typ.</target>
+        <source>Did not generate binding logic for a type</source>
+        <target state="needs-review-translation">Nevygenerovala se logika vazby pro typ.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.de.xlf
@@ -2,14 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
     <body>
+      <trans-unit id="Language VersionIsNotSupportedMessageFormat">
+        <source>The project's language version has to be at least 'C# 11'.</source>
+        <target state="new">The project's language version has to be at least 'C# 11'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LanguageVersionIsNotSupportedTitle">
+        <source>Language version is required to be at least C# 11</source>
+        <target state="new">Language version is required to be at least C# 11</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyNotSupportedMessageFormat">
         <source>Property '{0}' on type '{1}' is not supported.</source>
         <target state="translated">Die Eigenschaft „{0}“ für den Typ „{1}“ wird nicht unterstützt.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNotSupportedTitle">
-        <source>Did not generate binding logic for a property on a type.</source>
-        <target state="translated">Für eine Eigenschaft eines Typs wurde keine Bindungslogik generiert.</target>
+        <source>Did not generate binding logic for a property on a type</source>
+        <target state="needs-review-translation">Für eine Eigenschaft eines Typs wurde keine Bindungslogik generiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedMessageFormat">
@@ -18,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedTitle">
-        <source>Did not generate binding logic for a type.</source>
-        <target state="translated">Für einen Typ wurde keine Bindungslogik generiert.</target>
+        <source>Did not generate binding logic for a type</source>
+        <target state="needs-review-translation">Für einen Typ wurde keine Bindungslogik generiert.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.es.xlf
@@ -2,14 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
     <body>
+      <trans-unit id="Language VersionIsNotSupportedMessageFormat">
+        <source>The project's language version has to be at least 'C# 11'.</source>
+        <target state="new">The project's language version has to be at least 'C# 11'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LanguageVersionIsNotSupportedTitle">
+        <source>Language version is required to be at least C# 11</source>
+        <target state="new">Language version is required to be at least C# 11</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyNotSupportedMessageFormat">
         <source>Property '{0}' on type '{1}' is not supported.</source>
         <target state="translated">La propiedad '{0}' en el tipo '{1}' no se admite.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNotSupportedTitle">
-        <source>Did not generate binding logic for a property on a type.</source>
-        <target state="translated">No se generó la lógica de enlace para una propiedad en un tipo.</target>
+        <source>Did not generate binding logic for a property on a type</source>
+        <target state="needs-review-translation">No se generó la lógica de enlace para una propiedad en un tipo.</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedMessageFormat">
@@ -18,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedTitle">
-        <source>Did not generate binding logic for a type.</source>
-        <target state="translated">No se generó la lógica de enlace para un tipo.</target>
+        <source>Did not generate binding logic for a type</source>
+        <target state="needs-review-translation">No se generó la lógica de enlace para un tipo.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.fr.xlf
@@ -2,14 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
     <body>
+      <trans-unit id="Language VersionIsNotSupportedMessageFormat">
+        <source>The project's language version has to be at least 'C# 11'.</source>
+        <target state="new">The project's language version has to be at least 'C# 11'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LanguageVersionIsNotSupportedTitle">
+        <source>Language version is required to be at least C# 11</source>
+        <target state="new">Language version is required to be at least C# 11</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyNotSupportedMessageFormat">
         <source>Property '{0}' on type '{1}' is not supported.</source>
         <target state="translated">La propriété '{0}' sur le type '{1}' n’est pas prise en charge.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNotSupportedTitle">
-        <source>Did not generate binding logic for a property on a type.</source>
-        <target state="translated">La logique de liaison n’a pas été généré pour une propriété sur un type.</target>
+        <source>Did not generate binding logic for a property on a type</source>
+        <target state="needs-review-translation">La logique de liaison n’a pas été généré pour une propriété sur un type.</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedMessageFormat">
@@ -18,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedTitle">
-        <source>Did not generate binding logic for a type.</source>
-        <target state="translated">La logique de liaison n’a pas été générée pour un type.</target>
+        <source>Did not generate binding logic for a type</source>
+        <target state="needs-review-translation">La logique de liaison n’a pas été générée pour un type.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.it.xlf
@@ -2,14 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
     <body>
+      <trans-unit id="Language VersionIsNotSupportedMessageFormat">
+        <source>The project's language version has to be at least 'C# 11'.</source>
+        <target state="new">The project's language version has to be at least 'C# 11'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LanguageVersionIsNotSupportedTitle">
+        <source>Language version is required to be at least C# 11</source>
+        <target state="new">Language version is required to be at least C# 11</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyNotSupportedMessageFormat">
         <source>Property '{0}' on type '{1}' is not supported.</source>
         <target state="translated">La proprietà '{0}' nel tipo '{1}' non è supportata.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNotSupportedTitle">
-        <source>Did not generate binding logic for a property on a type.</source>
-        <target state="translated">Non è stata generata la logica di binding per una proprietà in un tipo.</target>
+        <source>Did not generate binding logic for a property on a type</source>
+        <target state="needs-review-translation">Non è stata generata la logica di binding per una proprietà in un tipo.</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedMessageFormat">
@@ -18,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedTitle">
-        <source>Did not generate binding logic for a type.</source>
-        <target state="translated">Non è stata generata la logica di binding per un tipo.</target>
+        <source>Did not generate binding logic for a type</source>
+        <target state="needs-review-translation">Non è stata generata la logica di binding per un tipo.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.ja.xlf
@@ -2,14 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
     <body>
+      <trans-unit id="Language VersionIsNotSupportedMessageFormat">
+        <source>The project's language version has to be at least 'C# 11'.</source>
+        <target state="new">The project's language version has to be at least 'C# 11'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LanguageVersionIsNotSupportedTitle">
+        <source>Language version is required to be at least C# 11</source>
+        <target state="new">Language version is required to be at least C# 11</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyNotSupportedMessageFormat">
         <source>Property '{0}' on type '{1}' is not supported.</source>
         <target state="translated">型 '{1}' のプロパティ '{0}' はサポートされていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNotSupportedTitle">
-        <source>Did not generate binding logic for a property on a type.</source>
-        <target state="translated">型のプロパティのバインディング ロジックを生成しませんでした。</target>
+        <source>Did not generate binding logic for a property on a type</source>
+        <target state="needs-review-translation">型のプロパティのバインディング ロジックを生成しませんでした。</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedMessageFormat">
@@ -18,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedTitle">
-        <source>Did not generate binding logic for a type.</source>
-        <target state="translated">型のバインディング ロジックを生成しませんでした。</target>
+        <source>Did not generate binding logic for a type</source>
+        <target state="needs-review-translation">型のバインディング ロジックを生成しませんでした。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.ko.xlf
@@ -2,14 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
     <body>
+      <trans-unit id="Language VersionIsNotSupportedMessageFormat">
+        <source>The project's language version has to be at least 'C# 11'.</source>
+        <target state="new">The project's language version has to be at least 'C# 11'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LanguageVersionIsNotSupportedTitle">
+        <source>Language version is required to be at least C# 11</source>
+        <target state="new">Language version is required to be at least C# 11</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyNotSupportedMessageFormat">
         <source>Property '{0}' on type '{1}' is not supported.</source>
         <target state="translated">'{1}' 형식의 속성 '{0}'은(는) 지원되지 않습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNotSupportedTitle">
-        <source>Did not generate binding logic for a property on a type.</source>
-        <target state="translated">형식의 속성에 대한 바인딩 논리를 생성하지 않았습니다.</target>
+        <source>Did not generate binding logic for a property on a type</source>
+        <target state="needs-review-translation">형식의 속성에 대한 바인딩 논리를 생성하지 않았습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedMessageFormat">
@@ -18,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedTitle">
-        <source>Did not generate binding logic for a type.</source>
-        <target state="translated">형식에 대한 바인딩 논리를 생성하지 않았습니다.</target>
+        <source>Did not generate binding logic for a type</source>
+        <target state="needs-review-translation">형식에 대한 바인딩 논리를 생성하지 않았습니다.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.pl.xlf
@@ -2,14 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
     <body>
+      <trans-unit id="Language VersionIsNotSupportedMessageFormat">
+        <source>The project's language version has to be at least 'C# 11'.</source>
+        <target state="new">The project's language version has to be at least 'C# 11'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LanguageVersionIsNotSupportedTitle">
+        <source>Language version is required to be at least C# 11</source>
+        <target state="new">Language version is required to be at least C# 11</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyNotSupportedMessageFormat">
         <source>Property '{0}' on type '{1}' is not supported.</source>
         <target state="translated">Właściwość „{0}” w typie „{1}” nie jest obsługiwana.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNotSupportedTitle">
-        <source>Did not generate binding logic for a property on a type.</source>
-        <target state="translated">Nie wygenerowano logiki powiązania dla właściwości w typie.</target>
+        <source>Did not generate binding logic for a property on a type</source>
+        <target state="needs-review-translation">Nie wygenerowano logiki powiązania dla właściwości w typie.</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedMessageFormat">
@@ -18,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedTitle">
-        <source>Did not generate binding logic for a type.</source>
-        <target state="translated">Nie wygenerowano logiki powiązania dla typu.</target>
+        <source>Did not generate binding logic for a type</source>
+        <target state="needs-review-translation">Nie wygenerowano logiki powiązania dla typu.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -2,14 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Strings.resx">
     <body>
+      <trans-unit id="Language VersionIsNotSupportedMessageFormat">
+        <source>The project's language version has to be at least 'C# 11'.</source>
+        <target state="new">The project's language version has to be at least 'C# 11'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LanguageVersionIsNotSupportedTitle">
+        <source>Language version is required to be at least C# 11</source>
+        <target state="new">Language version is required to be at least C# 11</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyNotSupportedMessageFormat">
         <source>Property '{0}' on type '{1}' is not supported.</source>
         <target state="translated">Não há suporte para a propriedade '{0}' no tipo '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNotSupportedTitle">
-        <source>Did not generate binding logic for a property on a type.</source>
-        <target state="translated">Não foi gerada lógica de associação para uma propriedade em um tipo.</target>
+        <source>Did not generate binding logic for a property on a type</source>
+        <target state="needs-review-translation">Não foi gerada lógica de associação para uma propriedade em um tipo.</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedMessageFormat">
@@ -18,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedTitle">
-        <source>Did not generate binding logic for a type.</source>
-        <target state="translated">Não foi gerada lógica de associação para um tipo.</target>
+        <source>Did not generate binding logic for a type</source>
+        <target state="needs-review-translation">Não foi gerada lógica de associação para um tipo.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.ru.xlf
@@ -2,14 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
     <body>
+      <trans-unit id="Language VersionIsNotSupportedMessageFormat">
+        <source>The project's language version has to be at least 'C# 11'.</source>
+        <target state="new">The project's language version has to be at least 'C# 11'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LanguageVersionIsNotSupportedTitle">
+        <source>Language version is required to be at least C# 11</source>
+        <target state="new">Language version is required to be at least C# 11</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyNotSupportedMessageFormat">
         <source>Property '{0}' on type '{1}' is not supported.</source>
         <target state="translated">Свойство "{0}" типа "{1}" не поддерживается.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNotSupportedTitle">
-        <source>Did not generate binding logic for a property on a type.</source>
-        <target state="translated">Не создана логика привязки для свойства типа.</target>
+        <source>Did not generate binding logic for a property on a type</source>
+        <target state="needs-review-translation">Не создана логика привязки для свойства типа.</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedMessageFormat">
@@ -18,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedTitle">
-        <source>Did not generate binding logic for a type.</source>
-        <target state="translated">Не создана логика привязки для типа.</target>
+        <source>Did not generate binding logic for a type</source>
+        <target state="needs-review-translation">Не создана логика привязки для типа.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.tr.xlf
@@ -2,14 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Strings.resx">
     <body>
+      <trans-unit id="Language VersionIsNotSupportedMessageFormat">
+        <source>The project's language version has to be at least 'C# 11'.</source>
+        <target state="new">The project's language version has to be at least 'C# 11'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LanguageVersionIsNotSupportedTitle">
+        <source>Language version is required to be at least C# 11</source>
+        <target state="new">Language version is required to be at least C# 11</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyNotSupportedMessageFormat">
         <source>Property '{0}' on type '{1}' is not supported.</source>
         <target state="translated">'{1}' türündeki '{0}' özelliği desteklenmiyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNotSupportedTitle">
-        <source>Did not generate binding logic for a property on a type.</source>
-        <target state="translated">Türdeki bir özellik için bağlama mantığı oluşturulmadı.</target>
+        <source>Did not generate binding logic for a property on a type</source>
+        <target state="needs-review-translation">Türdeki bir özellik için bağlama mantığı oluşturulmadı.</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedMessageFormat">
@@ -18,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedTitle">
-        <source>Did not generate binding logic for a type.</source>
-        <target state="translated">Bir tür için bağlama mantığı oluşturulmadı.</target>
+        <source>Did not generate binding logic for a type</source>
+        <target state="needs-review-translation">Bir tür için bağlama mantığı oluşturulmadı.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -2,14 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Strings.resx">
     <body>
+      <trans-unit id="Language VersionIsNotSupportedMessageFormat">
+        <source>The project's language version has to be at least 'C# 11'.</source>
+        <target state="new">The project's language version has to be at least 'C# 11'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LanguageVersionIsNotSupportedTitle">
+        <source>Language version is required to be at least C# 11</source>
+        <target state="new">Language version is required to be at least C# 11</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyNotSupportedMessageFormat">
         <source>Property '{0}' on type '{1}' is not supported.</source>
         <target state="translated">类型“{1}”中的属性“{0}”不受支持。</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNotSupportedTitle">
-        <source>Did not generate binding logic for a property on a type.</source>
-        <target state="translated">没有为类型中的属性生成绑定逻辑。</target>
+        <source>Did not generate binding logic for a property on a type</source>
+        <target state="needs-review-translation">没有为类型中的属性生成绑定逻辑。</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedMessageFormat">
@@ -18,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedTitle">
-        <source>Did not generate binding logic for a type.</source>
-        <target state="translated">没有为类型生成绑定逻辑。</target>
+        <source>Did not generate binding logic for a type</source>
+        <target state="needs-review-translation">没有为类型生成绑定逻辑。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -2,14 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
     <body>
+      <trans-unit id="Language VersionIsNotSupportedMessageFormat">
+        <source>The project's language version has to be at least 'C# 11'.</source>
+        <target state="new">The project's language version has to be at least 'C# 11'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LanguageVersionIsNotSupportedTitle">
+        <source>Language version is required to be at least C# 11</source>
+        <target state="new">Language version is required to be at least C# 11</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyNotSupportedMessageFormat">
         <source>Property '{0}' on type '{1}' is not supported.</source>
         <target state="translated">不支援類型 '{1}' 的屬性 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNotSupportedTitle">
-        <source>Did not generate binding logic for a property on a type.</source>
-        <target state="translated">未在類型上產生屬性的繫結邏輯。</target>
+        <source>Did not generate binding logic for a property on a type</source>
+        <target state="needs-review-translation">未在類型上產生屬性的繫結邏輯。</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedMessageFormat">
@@ -18,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNotSupportedTitle">
-        <source>Did not generate binding logic for a type.</source>
-        <target state="translated">未產生類型的繫結邏輯。</target>
+        <source>Did not generate binding logic for a type</source>
+        <target state="needs-review-translation">未產生類型的繫結邏輯。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/ConfingurationBindingSourceGeneratorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/ConfingurationBindingSourceGeneratorTests.cs
@@ -3,8 +3,12 @@
 
 using System;
 using System.Collections;
+using System.Collections.Immutable;
+using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.DependencyInjection;
 using SourceGenerators.Tests;
 using Xunit;
@@ -15,10 +19,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests
     [ActiveIssue("https://github.com/dotnet/runtime/issues/52062", TestPlatforms.Browser)]
     public class ConfingurationBindingSourceGeneratorTests
     {
-        [Fact]
-        public async Task TestBaseline_TestBindCallGen()
-        {
-            string testSourceCode = @"
+        private const string BindCallSampleCode = @"
 using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 
@@ -45,8 +46,11 @@ public class Program
     public class MyClass2 { }
 }";
 
-            await VerifyAgainstBaselineUsingFile("TestBindCallGen.generated.txt", testSourceCode);
-        }
+        [Theory]
+        [InlineData(LanguageVersion.Preview)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public async Task TestBaseline_TestBindCallGen(LanguageVersion langVersion) =>
+            await VerifyAgainstBaselineUsingFile("TestBindCallGen.generated.txt", BindCallSampleCode, langVersion);
 
         [Fact]
         public async Task TestBaseline_TestGetCallGen()
@@ -110,13 +114,38 @@ public class Program
             await VerifyAgainstBaselineUsingFile("TestConfigureCallGen.generated.txt", testSourceCode);
         }
 
-        private async Task VerifyAgainstBaselineUsingFile(string filename, string testSourceCode)
+        [Fact]
+        public async Task LangVersionMustBeCharp11OrHigher()
+        {
+            var (d, r) = await RunGenerator(BindCallSampleCode, LanguageVersion.CSharp10);
+            Assert.Single(d);
+            Assert.Empty(r);
+            Assert.True(d[0].Id == "SYSLIB1102");
+            Assert.Contains("C# 11", d[0].Descriptor.Title.ToString(CultureInfo.InvariantCulture));
+        }
+
+        private async Task VerifyAgainstBaselineUsingFile(
+            string filename,
+            string testSourceCode,
+            LanguageVersion languageVersion = LanguageVersion.Preview)
         {
             string baseline = LineEndingsHelper.Normalize(await File.ReadAllTextAsync(Path.Combine("Baselines", filename)).ConfigureAwait(false));
             string[] expectedLines = baseline.Replace("%VERSION%", typeof(ConfigurationBindingSourceGenerator).Assembly.GetName().Version?.ToString())
                                              .Split(Environment.NewLine);
 
-            var (d, r) = await RoslynTestUtils.RunGenerator(
+            var (d, r) = await RunGenerator(testSourceCode, languageVersion);
+
+            Assert.Empty(d);
+            Assert.Single(r);
+
+            Assert.True(RoslynTestUtils.CompareLines(expectedLines, r[0].SourceText,
+                out string errorMessage), errorMessage);
+        }
+
+        private async Task<(ImmutableArray<Diagnostic>, ImmutableArray<GeneratedSourceResult>)> RunGenerator(
+            string testSourceCode,
+            LanguageVersion langVersion = LanguageVersion.CSharp11) =>
+            await RoslynTestUtils.RunGenerator(
                 new ConfigurationBindingSourceGenerator(),
                 new[] {
                     typeof(ConfigurationBinder).Assembly,
@@ -126,14 +155,8 @@ public class Program
                     typeof(ServiceCollection).Assembly,
                     typeof(OptionsConfigurationServiceCollectionExtensions).Assembly,
                 },
-                new[] { testSourceCode }).ConfigureAwait(false);
-
-            Assert.Empty(d);
-            Assert.Single(r);
-
-            Assert.True(RoslynTestUtils.CompareLines(expectedLines, r[0].SourceText,
-                out string errorMessage), errorMessage);
-        }
+                new[] { testSourceCode },
+                langVersion: langVersion).ConfigureAwait(false);
     }
 #endif
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/ConfingurationBindingSourceGeneratorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/ConfingurationBindingSourceGeneratorTests.cs
@@ -118,10 +118,12 @@ public class Program
         public async Task LangVersionMustBeCharp11OrHigher()
         {
             var (d, r) = await RunGenerator(BindCallSampleCode, LanguageVersion.CSharp10);
-            Assert.Single(d);
             Assert.Empty(r);
-            Assert.True(d[0].Id == "SYSLIB1102");
-            Assert.Contains("C# 11", d[0].Descriptor.Title.ToString(CultureInfo.InvariantCulture));
+
+            Diagnostic diagnostic = Assert.Single(d);
+            Assert.True(diagnostic.Id == "SYSLIB1102");
+            Assert.Contains("C# 11", diagnostic.Descriptor.Title.ToString(CultureInfo.InvariantCulture));
+            Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
         }
 
         private async Task VerifyAgainstBaselineUsingFile(

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests.csproj
@@ -3,9 +3,6 @@
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <EnableDefaultItems>true</EnableDefaultItems>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <DefineConstants>$(DefineConstants);BUILDING_SOURCE_GENERATOR_TESTS;ROSLYN4_0_OR_GREATER;ROSLYN4_4_OR_GREATER</DefineConstants>
   </PropertyGroup>
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests.csproj
@@ -4,6 +4,8 @@
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <EnableDefaultItems>true</EnableDefaultItems>
     <DefineConstants>$(DefineConstants);BUILDING_SOURCE_GENERATOR_TESTS;ROSLYN4_0_OR_GREATER;ROSLYN4_4_OR_GREATER</DefineConstants>
+    <!-- Type not supported; property on type not suppported. -->
+    <NoWarn>SYSLIB1100,SYSLIB1101</NoWarn>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/83535. Requires language version to be at least C# 11. This choice is rather arbitrary but follows the version required by the Regex generator (though it appears regex still generates partial code in some scenarios). The only feature we (currently) need to enforce a minimum version for is `nullable`, which would be C# 8.0.

The benefit of this change is that we'll emit a single diagnostic rather than generating `nullable` annotating code which would cause multiple compiler diagnostics. The logic will probably be slightly refactored as part of https://github.com/dotnet/runtime/issues/83534, but wanted to fix now & discuss as it seems like a policy decision.

cc @eerhardt @ericstj