### PR TITLE
Add osx-arm64 for coreclr packages.

### DIFF
--- a/src/coreclr/.nuget/Directory.Build.props
+++ b/src/coreclr/.nuget/Directory.Build.props
@@ -17,7 +17,7 @@
     <!-- coreclr doesn't currently use the index so don't force it to be in sync -->
     <SkipIndexCheck>true</SkipIndexCheck>
   </PropertyGroup>
-  
+
   <!-- CoreCLR nuget packages shouldn't be published during servicing. -->
   <PropertyGroup Condition="'$(PreReleaseVersionLabel)' == 'servicing'">
     <IsShipping>false</IsShipping>
@@ -89,6 +89,7 @@
   </ItemGroup>
   <ItemGroup Condition="$(SupportedPackageOSGroups.Contains(';osx;'))">
     <OfficialBuildRID Include="osx-x64" />
+    <OfficialBuildRID Include="osx-arm64" />
   </ItemGroup>
   <ItemGroup Condition="$(SupportedPackageOSGroups.Contains(';freebsd;'))">
     <OfficialBuildRID Include="freebsd-x64" />

--- a/src/coreclr/.nuget/Directory.Build.props
+++ b/src/coreclr/.nuget/Directory.Build.props
@@ -89,7 +89,9 @@
   </ItemGroup>
   <ItemGroup Condition="$(SupportedPackageOSGroups.Contains(';osx;'))">
     <OfficialBuildRID Include="osx-x64" />
-    <OfficialBuildRID Include="osx-arm64" />
+    <OfficialBuildRID Include="osx-arm64">
+      <Platform>arm64</Platform>
+    </OfficialBuildRID>
   </ItemGroup>
   <ItemGroup Condition="$(SupportedPackageOSGroups.Contains(';freebsd;'))">
     <OfficialBuildRID Include="freebsd-x64" />


### PR DESCRIPTION
This was found looking for TestHost (that is, `corerun`) targeting osx-arm64

/cc @dotnet/runtime-infrastructure @dotnet/dotnet-diag 