### PR TITLE
Fix infinite timeout passed to CancellationTokenSource.CancelAfter

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
@@ -446,7 +446,9 @@ namespace System.Threading
                 }
             }
 
-            timer.Change(TimeSpan.FromMilliseconds(millisecondsDelay), Timeout.InfiniteTimeSpan);
+            timer.Change(
+                millisecondsDelay == Timeout.UnsignedInfinite ? Timeout.InfiniteTimeSpan : TimeSpan.FromMilliseconds(millisecondsDelay),
+                Timeout.InfiniteTimeSpan);
         }
 
         /// <summary>

--- a/src/libraries/System.Threading.Tasks/tests/CancellationTokenTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/CancellationTokenTests.cs
@@ -1078,6 +1078,32 @@ namespace System.Threading.Tasks.Tests
         }
 
         [Fact]
+        public static void CancellationTokenSourceWithTimer_SupportsInfinite()
+        {
+            var cts = new CancellationTokenSource(TimeSpan.FromDays(1));
+            Assert.False(cts.IsCancellationRequested);
+
+            cts.CancelAfter(Timeout.InfiniteTimeSpan);
+            Assert.False(cts.IsCancellationRequested);
+
+            Assert.True(cts.TryReset());
+
+            cts.CancelAfter(TimeSpan.FromDays(1));
+            Assert.False(cts.IsCancellationRequested);
+
+            cts.CancelAfter(Timeout.Infinite);
+            Assert.False(cts.IsCancellationRequested);
+
+            Assert.True(cts.TryReset());
+
+            cts = new CancellationTokenSource(Timeout.InfiniteTimeSpan);
+            Assert.False(cts.IsCancellationRequested);
+
+            cts = new CancellationTokenSource(Timeout.Infinite);
+            Assert.False(cts.IsCancellationRequested);
+        }
+
+        [Fact]
         public static void CancellationTokenSource_TryReset_ReturnsFalseIfAlreadyCanceled()
         {
             var cts = new CancellationTokenSource();


### PR DESCRIPTION
The recent change to introduce ITimer broke CTS.CancelAfter(Timeout.InfiniteTimeSpan).  The TimeSpan's milliseconds were extracted as a uint but then ended up being cast to a long, such that rather than representing -1 milliseconds, it represented 4294967295 milliseconds.  With the uint representation in Timer, Timeout.UnsignedInfinite needs to be special-cased.

https://github.com/aspnet/Benchmarks/issues/1822