### PR TITLE
Ensure that CONTEXT_XStateFeaturesMask is explicitly zeroed out on RtlCaptureContext

### DIFF
--- a/src/coreclr/pal/src/arch/amd64/context2.S
+++ b/src/coreclr/pal/src/arch/amd64/context2.S
@@ -81,6 +81,7 @@ LEAF_END CONTEXT_CaptureContext, _TEXT
 
 LEAF_ENTRY RtlCaptureContext, _TEXT
     mov     DWORD PTR [rdi + CONTEXT_ContextFlags], (CONTEXT_AMD64 | CONTEXT_FULL | CONTEXT_SEGMENTS)
+    mov     QWORD PTR [rdi + CONTEXT_XStateFeaturesMask], 0
     jmp     C_FUNC(CONTEXT_CaptureContext)
 LEAF_END RtlCaptureContext, _TEXT
 


### PR DESCRIPTION
We don't explicitly zero the `CONTEXT` structs we create before calling `RtlCaptureContext` and so it leaves these bits otherwise undefined.

This resolves the issue raised in https://github.com/dotnet/runtime/pull/84000#issuecomment-1486123492

This resolves https://github.com/dotnet/runtime/issues/84010