### PR TITLE
Fix AREA alignment warning on Windows ARM64

### DIFF
--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -56,7 +56,8 @@
     IMPORT JIT_WriteBarrier_Table_Loc
     IMPORT JIT_WriteBarrier_Loc
 
-    TEXTAREA
+    ;;like TEXTAREA, but with 64 byte alignment so that we can align the patchable pool below to 64 without warning
+    AREA    |.text|,ALIGN=6,CODE,READONLY
 
 ;; LPVOID __stdcall GetCurrentIP(void);
     LEAF_ENTRY GetCurrentIP


### PR DESCRIPTION
The arm64 build on Windows is warning about ALIGN instruction in the asmhelpers.asm having alignment larger than the alignment of the current area. This change fixes it by replacing TEXTAREA by an area with the proper alignment set.

Close #77146