### PR TITLE
Reverting: Set AssemblyName.ProcessorArchitecture for compatibility (#80581)

### DIFF
--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
@@ -3095,7 +3095,7 @@ namespace System.Reflection.Metadata.Tests
                 Assert.Equal(new AssemblyName(a.FullName).ToString(), name.ToString());
 
 #pragma warning disable SYSLIB0037 // AssemblyName.ProcessorArchitecture is obsolete
-                Assert.Equal(ProcessorArchitecture.MSIL, name.ProcessorArchitecture);
+                Assert.Equal(ProcessorArchitecture.None, name.ProcessorArchitecture);
 #pragma warning restore SYSLIB0037
             }
         }


### PR DESCRIPTION
This is a revert of https://github.com/dotnet/runtime/pull/80581

Also see: [release/7.0] Reverting: Set AssemblyName.ProcessorArchitecture for compatibility (#81101) 

`AssemblyName.ProcessorArchitecture` is unnatural concept in CoreCLR (and thus the property is deprecated).

The attempt to make the behavior closer to the native implementation in #80581 caused more issues than the original minor compat break that it tried to fix.

## Customer Impact

After the original change an application that obtain AssemblyName from assembly files may get ProcessorArchitecture set, which could be now unexpected when the name is subsequently used. 

For example a scenario when an app scans assemblies in a folder used to work prior the original "fix" may now fail with:
```
Loading assembly: LoadAssemblyBug, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
Loading assembly: Microsoft.AspNetCore.Antiforgery, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
Could not load file or assembly 'Microsoft.AspNetCore.Antiforgery, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=AMD64'. The system cannot find the file specified.
```

See: https://github.com/dotnet/runtime/issues/83526

We think that the original fix does not precisely replicate the .NET desktop behavior. However, trying to replicate the exact deprecated API behavior seems very difficult. For instance, the API doesn't support ARM64, so we would have to somehow provide back-compat for a deprecated API even as our product evolves in a way that the original API can't support and we don't want to evolve.

There are also similar issues reported directly by internal teams updating to 7.0.201.

## Testing
We have regression tests for this feature and they were updated as a part of this change. Our understanding of the "modern" API set is quite good, compared to the deprecated set.
