### PR TITLE
Add status code and exception info to System.Net.Http events

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -227,7 +227,7 @@ namespace System.Net.Http
             }
             finally
             {
-                FinishSend(cts, disposeCts, telemetryStarted, responseContentTelemetryStarted);
+                FinishSend(response, cts, disposeCts, telemetryStarted, responseContentTelemetryStarted);
             }
         }
 
@@ -306,7 +306,7 @@ namespace System.Net.Http
             }
             finally
             {
-                FinishSend(cts, disposeCts, telemetryStarted, responseContentTelemetryStarted);
+                FinishSend(response, cts, disposeCts, telemetryStarted, responseContentTelemetryStarted);
             }
         }
 
@@ -352,7 +352,7 @@ namespace System.Net.Http
             }
             finally
             {
-                FinishSend(cts, disposeCts, telemetryStarted, responseContentTelemetryStarted: false);
+                FinishSend(response, cts, disposeCts, telemetryStarted, responseContentTelemetryStarted: false);
             }
         }
 
@@ -496,7 +496,7 @@ namespace System.Net.Http
             }
             finally
             {
-                FinishSend(cts, disposeCts, telemetryStarted, responseContentTelemetryStarted);
+                FinishSend(response, cts, disposeCts, telemetryStarted, responseContentTelemetryStarted);
             }
         }
 
@@ -551,7 +551,7 @@ namespace System.Net.Http
                 }
                 finally
                 {
-                    FinishSend(cts, disposeCts, telemetryStarted, responseContentTelemetryStarted);
+                    FinishSend(response, cts, disposeCts, telemetryStarted, responseContentTelemetryStarted);
                 }
             }
         }
@@ -583,8 +583,6 @@ namespace System.Net.Http
 
         private void HandleFailure(Exception e, bool telemetryStarted, HttpResponseMessage? response, CancellationTokenSource cts, CancellationToken cancellationToken, CancellationTokenSource pendingRequestsCts)
         {
-            LogRequestFailed(telemetryStarted);
-
             response?.Dispose();
 
             Exception? toThrow = null;
@@ -623,6 +621,8 @@ namespace System.Net.Http
                 e = toThrow = new OperationCanceledException(cancellationToken.IsCancellationRequested ? cancellationToken : cts.Token);
             }
 
+            LogRequestFailed(e, telemetryStarted);
+
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, e);
 
             if (toThrow != null)
@@ -642,7 +642,7 @@ namespace System.Net.Http
             return false;
         }
 
-        private static void FinishSend(CancellationTokenSource cts, bool disposeCts, bool telemetryStarted, bool responseContentTelemetryStarted)
+        private static void FinishSend(HttpResponseMessage? response, CancellationTokenSource cts, bool disposeCts, bool telemetryStarted, bool responseContentTelemetryStarted)
         {
             // Log completion.
             if (HttpTelemetry.Log.IsEnabled() && telemetryStarted)
@@ -652,7 +652,7 @@ namespace System.Net.Http
                     HttpTelemetry.Log.ResponseContentStop();
                 }
 
-                HttpTelemetry.Log.RequestStop();
+                HttpTelemetry.Log.RequestStop(response);
             }
 
             // Dispose of the CancellationTokenSource if it was created specially for this request

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -1024,7 +1024,8 @@ namespace System.Net.Http
                         Debug.Assert(!wait);
                     }
 
-                    if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.ResponseHeadersStop();
+                    Debug.Assert(_response is not null);
+                    if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.ResponseHeadersStop((int)_response.StatusCode);
                 }
                 catch
                 {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -352,7 +352,7 @@ namespace System.Net.Http
 
             _headerState = HeaderState.TrailingHeaders;
 
-            if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.ResponseHeadersStop();
+            if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.ResponseHeadersStop((int)_response.StatusCode);
         }
 
         private async Task SendContentAsync(HttpContent content, CancellationToken cancellationToken)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -696,7 +696,7 @@ namespace System.Net.Http
                     await FillForHeadersAsync(async).ConfigureAwait(false);
                 }
 
-                if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.ResponseHeadersStop();
+                if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.ResponseHeadersStop((int)response.StatusCode);
 
                 if (allowExpect100ToContinue != null)
                 {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.IO;
 using System.Linq;
-using System.Net.Quic;
 using System.Net.Test.Common;
 using System.Text;
 using System.Threading;
@@ -412,19 +411,40 @@ namespace System.Net.Http.Functional.Tests
             Assert.Equal(count, starts.Length);
 
             (EventWrittenEventArgs Event, Guid ActivityId)[] stops = events.Where(e => e.Event.EventName == "RequestStop").ToArray();
-            Assert.All(stops, stopEvent => Assert.Empty(stopEvent.Event.Payload));
+            foreach (EventWrittenEventArgs stopEvent in stops.Select(e => e.Event))
+            {
+                object payload = Assert.Single(stopEvent.Payload);
+                int statusCode = Assert.IsType<int>(payload);
+                Assert.Equal(shouldHaveFailures ? -1 : 200, statusCode);
+            }
 
             ValidateSameActivityIds(starts, stops);
 
             (EventWrittenEventArgs Event, Guid ActivityId)[] failures = events.Where(e => e.Event.EventName == "RequestFailed").ToArray();
-            Assert.All(failures, failedEvent => Assert.Empty(failedEvent.Event.Payload));
+            (EventWrittenEventArgs Event, Guid ActivityId)[] detailedFailures = events.Where(e => e.Event.EventName == "RequestFailedDetailed").ToArray();
             if (shouldHaveFailures)
             {
+                foreach (EventWrittenEventArgs failedEvent in failures.Select(e => e.Event))
+                {
+                    object payload = Assert.Single(failedEvent.Payload);
+                    string exceptionMessage = Assert.IsType<string>(payload);
+                    Assert.Equal(new OperationCanceledException().Message, exceptionMessage);
+                }
+
+                foreach (EventWrittenEventArgs failedEvent in detailedFailures.Select(e => e.Event))
+                {
+                    object payload = Assert.Single(failedEvent.Payload);
+                    string exception = Assert.IsType<string>(payload);
+                    Assert.StartsWith("System.Threading.Tasks.TaskCanceledException", exception);
+                }
+
                 ValidateSameActivityIds(starts, failures);
+                ValidateSameActivityIds(starts, detailedFailures);
             }
             else
             {
                 Assert.Empty(failures);
+                Assert.Empty(detailedFailures);
             }
         }
 
@@ -470,8 +490,8 @@ namespace System.Net.Http.Functional.Tests
             foreach (EventWrittenEventArgs requestContentStop in requestContentStops.Select(e => e.Event))
             {
                 object payload = Assert.Single(requestContentStop.Payload);
-                Assert.True(payload is long);
-                Assert.Equal(requestContentLength.Value, (long)payload);
+                long contentLength = Assert.IsType<long>(payload);
+                Assert.Equal(requestContentLength.Value, contentLength);
             }
 
             ValidateSameActivityIds(requestContentStarts, requestContentStops);
@@ -482,7 +502,12 @@ namespace System.Net.Http.Functional.Tests
 
             (EventWrittenEventArgs Event, Guid ActivityId)[] responseHeadersStops = events.Where(e => e.Event.EventName == "ResponseHeadersStop").ToArray();
             Assert.Equal(count, responseHeadersStops.Length);
-            Assert.All(responseHeadersStops, r => Assert.Empty(r.Event.Payload));
+            foreach (EventWrittenEventArgs responseHeadersStop in responseHeadersStops.Select(e => e.Event))
+            {
+                object payload = Assert.Single(responseHeadersStop.Payload);
+                int statusCode = Assert.IsType<int>(payload);
+                Assert.Equal(200, statusCode);
+            }
 
             ValidateSameActivityIds(responseHeadersStarts, responseHeadersStops);
 

--- a/src/libraries/System.Net.Http/tests/UnitTests/Fakes/HttpTelemetry.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Fakes/HttpTelemetry.cs
@@ -11,9 +11,9 @@ namespace System.Net.Http
 
         public void RequestStart(HttpRequestMessage request) { }
 
-        public void RequestStop() { }
+        public void RequestStop(HttpResponseMessage response) { }
 
-        public void RequestFailed() { }
+        public void RequestFailed(string exception) { }
 
         public void ResponseContentStart() { }
 

--- a/src/libraries/System.Net.Http/tests/UnitTests/Fakes/HttpTelemetry.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Fakes/HttpTelemetry.cs
@@ -13,7 +13,7 @@ namespace System.Net.Http
 
         public void RequestStop(HttpResponseMessage response) { }
 
-        public void RequestFailed(string exception) { }
+        public void RequestFailed(Exception exception) { }
 
         public void ResponseContentStart() { }
 


### PR DESCRIPTION
Contributes to #83734

This PR adds the following parameters to existing events:
```diff
-void RequestStop()
+void RequestStop(int statusCode)

-void ResponseHeadersStop()
+void ResponseHeadersStop(int statusCode)

-void RequestFailed();
+void RequestFailed(string exceptionMessage)
```

and a new event under a dedicated keyword
```c#
[Event(15, Level = EventLevel.Error, Keywords = Keywords.RequestFailedDetailed)]
void RequestFailedDetailed(string exception);
```

Copying the reasoning behind having the status code on both `RequestStop` and `ResponseHeadersStop` from https://github.com/dotnet/runtime/issues/83734#issue-1634164607:
> ResponseHeadersStop in addition to RequestStop because we may not have a status code available in RequestStop in failure cases, and because a single RequestStart may span multiple actual requests internally due to redirects (or custom user handler logic such as retries). Having a status code on the RequestStop is still valuable for users that just care about the result of the HttpClient call, without diving into details of what happened as part of that call. See https://github.com/dotnet/runtime/commit/003e675d50bbb04b3406c160f8d99b7eef4529ad#r103790748 for more discussion about this.

@dotnet/ncl please confirm that the added parameters make sense (not just to me) -- this is akin to adding a public API in that we don't want to break it in the future (we can add more parameters, but wouldn't want to remove them for example).