### PR TITLE
Coalesce identical constant WordCategories

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -300,7 +300,7 @@ namespace System.Text.RegularExpressions.Generator
                     "internal static bool IsWordChar(char ch)",
                     "{",
                     "    // Mask of Unicode categories that combine to form [\\w]",
-                    "    const int WordCategories =",
+                    "    const int WordCategoriesMask =",
                     "        1 << (int)UnicodeCategory.UppercaseLetter |",
                     "        1 << (int)UnicodeCategory.LowercaseLetter |",
                     "        1 << (int)UnicodeCategory.TitlecaseLetter |",
@@ -321,7 +321,7 @@ namespace System.Text.RegularExpressions.Generator
                     "    int chDiv8 = ch >> 3;",
                     "    return (uint)chDiv8 < (uint)ascii.Length ?",
                     "        (ascii[chDiv8] & (1 << (ch & 0x7))) != 0 :",
-                    "        (WordCategories & (1 << (int)CharUnicodeInfo.GetUnicodeCategory(ch))) != 0;",
+                    "        (WordCategoriesMask & (1 << (int)CharUnicodeInfo.GetUnicodeCategory(ch))) != 0;",
                     "}",
                 });
             }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1142,14 +1142,8 @@ namespace System.Text.RegularExpressions
             0xFE, 0xFF, 0xFF, 0x87, 0xFE, 0xFF, 0xFF, 0x07
         };
 
-        /// <summary>Determines whether a character is considered a word character for the purposes of testing the \w set.</summary>
-        public static bool IsWordChar(char ch)
-        {
-            // This is the same as IsBoundaryWordChar, except that IsBoundaryWordChar also
-            // returns true for \u200c and \u200d.
-
-           // Mask of Unicode categories that combine to form [\\w]"
-           const int WordCategories =
+         // Mask of Unicode categories that combine to form [\\w]
+         private const int WordCategoriesMask =
                1 << (int)UnicodeCategory.UppercaseLetter |
                1 << (int)UnicodeCategory.LowercaseLetter |
                1 << (int)UnicodeCategory.TitlecaseLetter |
@@ -1159,14 +1153,20 @@ namespace System.Text.RegularExpressions
                1 << (int)UnicodeCategory.DecimalDigitNumber |
                1 << (int)UnicodeCategory.ConnectorPunctuation;
 
-           // Bitmap for whether each character 0 through 127 is in [\\w]",
-           ReadOnlySpan<byte> ascii = WordCharAsciiLookup;
+        /// <summary>Determines whether a character is considered a word character for the purposes of testing the \w set.</summary>
+        public static bool IsWordChar(char ch)
+        {
+            // This is the same as IsBoundaryWordChar, except that IsBoundaryWordChar also
+            // returns true for \u200c and \u200d.
 
-           // If the char is ASCII, look it up in the bitmap. Otherwise, query its Unicode category.",
-           int chDiv8 = ch >> 3;
-           return (uint)chDiv8 < (uint)ascii.Length ?
-               (ascii[chDiv8] & (1 << (ch & 0x7))) != 0 :
-               (WordCategories & (1 << (int)CharUnicodeInfo.GetUnicodeCategory(ch))) != 0;
+            // Bitmap for whether each character 0 through 127 is in [\\w]
+            ReadOnlySpan<byte> ascii = WordCharAsciiLookup;
+
+            // If the char is ASCII, look it up in the bitmap. Otherwise, query its Unicode category.
+            int chDiv8 = ch >> 3;
+            return (uint)chDiv8 < (uint)ascii.Length ?
+                (ascii[chDiv8] & (1 << (ch & 0x7))) != 0 :
+                (WordCategoriesMask & (1 << (int)CharUnicodeInfo.GetUnicodeCategory(ch))) != 0;
         }
 
         /// <summary>Determines whether a character is considered a word character for the purposes of testing a word character boundary.</summary>
@@ -1178,25 +1178,14 @@ namespace System.Text.RegularExpressions
             // ZERO WIDTH NON-JOINER and U+200D ZERO WIDTH JOINER.
             const char ZeroWidthNonJoiner = '\u200C', ZeroWidthJoiner = '\u200D';
 
-            // Mask of Unicode categories that combine to form [\\w]"
-            const int WordCategories =
-                1 << (int)UnicodeCategory.UppercaseLetter |
-                1 << (int)UnicodeCategory.LowercaseLetter |
-                1 << (int)UnicodeCategory.TitlecaseLetter |
-                1 << (int)UnicodeCategory.ModifierLetter |
-                1 << (int)UnicodeCategory.OtherLetter |
-                1 << (int)UnicodeCategory.NonSpacingMark |
-                1 << (int)UnicodeCategory.DecimalDigitNumber |
-                1 << (int)UnicodeCategory.ConnectorPunctuation;
-
-            // Bitmap for whether each character 0 through 127 is in [\\w]",
+            // Bitmap for whether each character 0 through 127 is in [\\w]
             ReadOnlySpan<byte> ascii = WordCharAsciiLookup;
 
-            // If the char is ASCII, look it up in the bitmap. Otherwise, query its Unicode category.",
+            // If the char is ASCII, look it up in the bitmap. Otherwise, query its Unicode category.
             int chDiv8 = ch >> 3;
             return (uint)chDiv8 < (uint)ascii.Length ?
                 (ascii[chDiv8] & (1 << (ch & 0x7))) != 0 :
-                ((WordCategories & (1 << (int)CharUnicodeInfo.GetUnicodeCategory(ch))) != 0 ||
+                ((WordCategoriesMask & (1 << (int)CharUnicodeInfo.GetUnicodeCategory(ch))) != 0 ||
                  (ch == ZeroWidthJoiner | ch == ZeroWidthNonJoiner));
         }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1142,7 +1142,7 @@ namespace System.Text.RegularExpressions
             0xFE, 0xFF, 0xFF, 0x87, 0xFE, 0xFF, 0xFF, 0x07
         };
 
-         // Mask of Unicode categories that combine to form [\\w]
+         /// <summary>Mask of Unicode categories that combine to form [\\w]</summary>
          private const int WordCategoriesMask =
                1 << (int)UnicodeCategory.UppercaseLetter |
                1 << (int)UnicodeCategory.LowercaseLetter |

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorOutputTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorOutputTests.cs
@@ -355,7 +355,7 @@ namespace System.Text.RegularExpressions.Tests
                         internal static bool IsWordChar(char ch)
                         {
                             // Mask of Unicode categories that combine to form [\w]
-                            const int WordCategories =
+                            const int WordCategoriesMask =
                                 1 << (int)UnicodeCategory.UppercaseLetter |
                                 1 << (int)UnicodeCategory.LowercaseLetter |
                                 1 << (int)UnicodeCategory.TitlecaseLetter |
@@ -364,19 +364,19 @@ namespace System.Text.RegularExpressions.Tests
                                 1 << (int)UnicodeCategory.NonSpacingMark |
                                 1 << (int)UnicodeCategory.DecimalDigitNumber |
                                 1 << (int)UnicodeCategory.ConnectorPunctuation;
-                            
+
                             // Bitmap for whether each character 0 through 127 is in [\w]
                             ReadOnlySpan<byte> ascii = new byte[]
                             {
                                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0x03,
                                 0xFE, 0xFF, 0xFF, 0x87, 0xFE, 0xFF, 0xFF, 0x07
                             };
-                            
+
                             // If the char is ASCII, look it up in the bitmap. Otherwise, query its Unicode category.
                             int chDiv8 = ch >> 3;
                             return (uint)chDiv8 < (uint)ascii.Length ?
                                 (ascii[chDiv8] & (1 << (ch & 0x7))) != 0 :
-                                (WordCategories & (1 << (int)CharUnicodeInfo.GetUnicodeCategory(ch))) != 0;
+                                (WordCategoriesMask & (1 << (int)CharUnicodeInfo.GetUnicodeCategory(ch))) != 0;
                         }
 
                         /// <summary>Pushes 2 values onto the backtracking stack.</summary>


### PR DESCRIPTION
As noted in https://github.com/dotnet/runtime/pull/84003, there are four places the same mask is computed in this project,. We can't eliminate the one in RegexGenerator.Emitter or its matching unit test because that's outputting the actual C# source string.

In the actual _RegexCharClass.cs_ file changed the name `WordCategoriesMask` to avoid a conflict with  existing member and added as a private constant. I also changed the Emitter and matching unit test to match for neatness.

Removed the detritus in the comments from the copy-paste from Emitter source (trailing `"` and `,`) and fixed the indentation error in the IsWordChar method.