### PR TITLE
wip test

### DIFF
--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -290,11 +290,11 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, Statement* stmt, GenTree*
         return;
     }
 
-    //if (DoesOverflow(block, treeIndex))
-    //{
-    //    JITDUMP("Method determined to overflow.\n");
-    //    return;
-    //}
+    if (IsMonotonicallyIncreasing(treeIndex, true) && DoesOverflow(block, treeIndex))
+    {
+        JITDUMP("Method determined to overflow.\n");
+        return;
+    }
 
     JITDUMP("Range value %s\n", range.ToString(m_pCompiler->getAllocatorDebugOnly()));
     m_pSearchPath->RemoveAll();

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -290,11 +290,11 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, Statement* stmt, GenTree*
         return;
     }
 
-    if (DoesOverflow(block, treeIndex))
-    {
-        JITDUMP("Method determined to overflow.\n");
-        return;
-    }
+    //if (DoesOverflow(block, treeIndex))
+    //{
+    //    JITDUMP("Method determined to overflow.\n");
+    //    return;
+    //}
 
     JITDUMP("Range value %s\n", range.ToString(m_pCompiler->getAllocatorDebugOnly()));
     m_pSearchPath->RemoveAll();


### PR DESCRIPTION

```csharp
void Foo(int[] arr, int i)
{
    int j = i + 1;
    if (j >= 0 && j < arr.Length)
        arr[j] = 0;
}
```
in this case we don't remove bound checks beecause `i+1` "may overflow" despite the fact its value is correctly checked after.