### PR TITLE
Fix static test methods on abstract classes

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.NistValidation.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.NistValidation.cs
@@ -15,7 +15,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         // SigGen.txt
 #if NETCOREAPP
         [Fact]
-        public static void ValidateNistP256Sha256()
+        public void ValidateNistP256Sha256()
         {
             byte[] msg = (
                 "5905238877c77421f73e43ee3da6f2d9e2ccad5fc942dcec0cbd25482935faaf" +
@@ -51,7 +51,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         }
 
         [Fact]
-        public static void ValidateNistP256Sha384()
+        public void ValidateNistP256Sha384()
         {
             byte[] msg = (
                 "e0b8596b375f3306bbc6e77a0b42f7469d7e83635990e74aa6d713594a3a2449" +
@@ -87,7 +87,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         }
 
         [Fact]
-        public static void ValidateNistP384Sha256()
+        public void ValidateNistP384Sha256()
         {
             byte[] msg = (
                 "663b12ebf44b7ed3872b385477381f4b11adeb0aec9e0e2478776313d536376d" +
@@ -126,7 +126,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         }
 
         [Fact]
-        public static void ValidateNistP384Sha512()
+        public void ValidateNistP384Sha512()
         {
             byte[] msg = (
                 "67d9eb88f289454d61def4764d1573db49b875cfb11e139d7eacc4b7a79d3db3" +
@@ -165,7 +165,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         }
 
         [Fact]
-        public static void ValidateNistP521Sha384()
+        public void ValidateNistP521Sha384()
         {
             byte[] msg = (
                 "dbc094402c5b559d53168c6f0c550d827499c6fb2186ae2db15b89b4e6f46220" +
@@ -206,7 +206,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         }
 
         [Fact]
-        public static void ValidateNistP521Sha512()
+        public void ValidateNistP521Sha512()
         {
             byte[] msg = (
                 "9ecd500c60e701404922e58ab20cc002651fdee7cbc9336adda33e4c1088fab1" +

--- a/src/libraries/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.Constructor.cs
+++ b/src/libraries/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.Constructor.cs
@@ -9,7 +9,7 @@ namespace System.Collections.Tests
     public abstract partial class LinkedList_Generic_Tests<T> : ICollection_Generic_Tests<T>
     {
         [Fact]
-        public static void CtorTest()
+        public void CtorTest()
         {
             LinkedList_T_Tests<string> helper = new LinkedList_T_Tests<string>(new LinkedList<string>(), new string[0]);
             helper.InitialItems_Tests();
@@ -18,7 +18,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void Ctor_IEnumerableTest()
+        public void Ctor_IEnumerableTest()
         {
             int arraySize = 16;
             int[] intArray = new int[arraySize];
@@ -64,7 +64,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        public static void Ctor_IEnumerableTest_Negative()
+        public void Ctor_IEnumerableTest_Negative()
         {
             Assert.Throws<ArgumentNullException>(() => new LinkedList<string>(null)); //"Err_982092 Expected ArgumentNullException to be thrown with null collection"
         }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
@@ -22,7 +22,7 @@ namespace System.Net.Http.Functional.Tests
         public TelemetryTest(ITestOutputHelper output) : base(output) { }
 
         [Fact]
-        public static void EventSource_ExistsWithCorrectId()
+        public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(HttpClient).Assembly.GetType("System.Net.Http.HttpTelemetry", throwOnError: true, ignoreCase: false);
             Assert.NotNull(esType);

--- a/src/libraries/System.Runtime/tests/System/ArraySegmentTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ArraySegmentTests.cs
@@ -79,7 +79,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void Ctor_Invalid()
+        public void Ctor_Invalid()
         {
             AssertExtensions.Throws<ArgumentNullException>("array", () => new ArraySegment<T>(null));
             AssertExtensions.Throws<ArgumentNullException>("array", () => new ArraySegment<T>(null, -1, 1));

--- a/src/libraries/System.Text.Json/tests/Common/CollectionTests/CollectionTests.Dictionary.KeyPolicy.cs
+++ b/src/libraries/System.Text.Json/tests/Common/CollectionTests/CollectionTests.Dictionary.KeyPolicy.cs
@@ -195,7 +195,7 @@ namespace System.Text.Json.Serialization.Tests
         }
       
         [Fact]
-        public static void EnumSerialization_DictionaryPolicy_Honored_CamelCase()
+        public void EnumSerialization_DictionaryPolicy_Honored_CamelCase()
         {
             var options = new JsonSerializerOptions
             {
@@ -216,7 +216,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void EnumSerializationAsDictKey_NoDictionaryKeyPolicy()
+        public void EnumSerializationAsDictKey_NoDictionaryKeyPolicy()
         {
             Dictionary<ETestEnum, ETestEnum> dict = new Dictionary<ETestEnum, ETestEnum> { [ETestEnum.TestValue1] = ETestEnum.TestValue1 };
             string value = JsonSerializer.Serialize(dict);
@@ -238,7 +238,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void EnumSerialization_DictionaryPolicy_NotApplied_WhenEnumsAreSerialized()
+        public void EnumSerialization_DictionaryPolicy_NotApplied_WhenEnumsAreSerialized()
         {
             var options = new JsonSerializerOptions
             {
@@ -268,8 +268,9 @@ namespace System.Text.Json.Serialization.Tests
             public override string ConvertName(string name) => null;
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/84053")]
         [Fact]
-        public static void EnumSerialization_DictionaryPolicy_ThrowsException_WhenNamingPolicyReturnsNull()
+        public void EnumSerialization_DictionaryPolicy_ThrowsException_WhenNamingPolicyReturnsNull()
         {
             var options = new JsonSerializerOptions
             {


### PR DESCRIPTION
xunit isn't finding these to run them.  The fix is to make them non-static.

Closes https://github.com/dotnet/runtime/issues/83617