### PR TITLE
Update CodeAnalysis.src.globalconfig

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -348,7 +348,7 @@ dotnet_diagnostic.CA1816.severity = none
 dotnet_diagnostic.CA1819.severity = none
 
 # CA1820: Test for empty strings using string length
-dotnet_diagnostic.CA1820.severity = none
+dotnet_diagnostic.CA1820.severity = suggestion
 
 # CA1821: Remove empty Finalizers
 dotnet_diagnostic.CA1821.severity = warning
@@ -468,7 +468,7 @@ dotnet_diagnostic.CA1858.severity = warning
 # CA1859: Use concrete types when possible for improved performance
 dotnet_diagnostic.CA1859.severity = warning
 
-# CA1860: Prefer Length/Count/IsEmpty property check over Any()
+# CA1860: Avoid using 'Enumerable.Any()' extension method
 dotnet_diagnostic.CA1860.severity = warning
 
 # CA2000: Dispose objects before losing scope
@@ -513,7 +513,7 @@ dotnet_diagnostic.CA2018.severity = warning
 # CA2019: Improper 'ThreadStatic' field initialization
 dotnet_diagnostic.CA2019.severity = warning
 
-# CA2020: Prevent behavioral changes
+# CA2020: Prevent behavioral change
 dotnet_diagnostic.CA2020.severity = warning
 
 # CA2021: Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
@@ -769,7 +769,7 @@ dotnet_diagnostic.CA3061.severity = warning
 # CA3075: Insecure DTD processing in XML
 dotnet_diagnostic.CA3075.severity = warning
 
-# CA3076: Insecure XSLT script processing.
+# CA3076: Insecure XSLT script processing
 dotnet_diagnostic.CA3076.severity = warning
 
 # CA3077: Insecure Processing in API Design, XmlDocument and XmlTextReader
@@ -1658,6 +1658,15 @@ dotnet_diagnostic.IDE0241.severity = suggestion
 
 # IDE0250: Make struct readonly
 dotnet_diagnostic.IDE0250.severity = suggestion
+
+# IDE0260: Use pattern matching
+dotnet_diagnostic.IDE0260.severity = suggestion
+
+# IDE0270: Use coalesce expression
+dotnet_diagnostic.IDE0270.severity = suggestion
+
+# IDE0280: Use 'nameof'
+dotnet_diagnostic.IDE0280.severity = warning
 
 # IDE1005: Delegate invocation can be simplified.
 dotnet_diagnostic.IDE1005.severity = warning

--- a/eng/CodeAnalysis.test.globalconfig
+++ b/eng/CodeAnalysis.test.globalconfig
@@ -465,7 +465,7 @@ dotnet_diagnostic.CA1858.severity = none
 # CA1859: Use concrete types when possible for improved performance
 dotnet_diagnostic.CA1859.severity = none
 
-# CA1860: Prefer Length/Count/IsEmpty property check over Any()
+# CA1860: Avoid using 'Enumerable.Any()' extension method
 dotnet_diagnostic.CA1860.severity = none
 
 # CA2000: Dispose objects before losing scope
@@ -510,7 +510,7 @@ dotnet_diagnostic.CA2018.severity = none
 # CA2019: Improper 'ThreadStatic' field initialization
 dotnet_diagnostic.CA2019.severity = none
 
-# CA2020: Prevent behavioral changes
+# CA2020: Prevent behavioral change
 dotnet_diagnostic.CA2020.severity = none
 
 # CA2021: Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
@@ -765,7 +765,7 @@ dotnet_diagnostic.CA3061.severity = none
 # CA3075: Insecure DTD processing in XML
 dotnet_diagnostic.CA3075.severity = none
 
-# CA3076: Insecure XSLT script processing.
+# CA3076: Insecure XSLT script processing
 dotnet_diagnostic.CA3076.severity = none
 
 # CA3077: Insecure Processing in API Design, XmlDocument and XmlTextReader
@@ -1652,6 +1652,15 @@ dotnet_diagnostic.IDE0241.severity = silent
 
 # IDE0250: Make struct readonly
 dotnet_diagnostic.IDE0250.severity = silent
+
+# IDE0260: Use pattern matching
+dotnet_diagnostic.IDE0260.severity = silent
+
+# IDE0270: Use coalesce expression
+dotnet_diagnostic.IDE0270.severity = silent
+
+# IDE0280: Use 'nameof'
+dotnet_diagnostic.IDE0280.severity = silent
 
 # IDE1005: Delegate invocation can be simplified.
 dotnet_diagnostic.IDE1005.severity = silent

--- a/src/libraries/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.csproj
+++ b/src/libraries/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.csproj
@@ -9,6 +9,7 @@
   <PropertyGroup>
     <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
     <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetPlatformIdentifier)' != 'windows'">SR.PlatformNotSupported_Registry</GeneratePlatformNotSupportedAssemblyMessage>
+    <NoWarn Condition="'$(TargetPlatformIdentifier)' != 'windows'">$(NoWarn);IDE0280</NoWarn> <!-- https://github.com/dotnet/runtime/issues/84104 -->
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' != ''">
     <Compile Include="$(CommonPath)DisableRuntimeMarshalling.cs"

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs
@@ -490,7 +490,7 @@ namespace System.Threading
         {
         }
 
-        private static uint GetMilliseconds(TimeSpan time, [CallerArgumentExpression("time")] string? parameter = null)
+        private static uint GetMilliseconds(TimeSpan time, [CallerArgumentExpression(nameof(time))] string? parameter = null)
         {
             long tm = (long)time.TotalMilliseconds;
             ArgumentOutOfRangeException.ThrowIfLessThan(tm, -1, parameter);

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/SchemaImporter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/SchemaImporter.cs
@@ -43,7 +43,7 @@ namespace System.Runtime.Serialization
 
         [RequiresDynamicCode(DataContract.SerializerAOTWarning)]
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        internal void Import([NotNullIfNotNull("_elements")] out List<XmlQualifiedName>? elementTypeNames)
+        internal void Import([NotNullIfNotNull(nameof(_elements))] out List<XmlQualifiedName>? elementTypeNames)
         {
             elementTypeNames = null!;
 

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXmlDebugLog.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXmlDebugLog.cs
@@ -572,7 +572,7 @@ namespace System.Security.Cryptography.Xml
         /// <param name="reference">The reference being processed</param>
         /// <param name="data">Stream containing the output of the reference</param>
         /// <returns>Stream containing the output of the reference</returns>
-        [return: NotNullIfNotNull("data")]
+        [return: NotNullIfNotNull(nameof(data))]
         internal static Stream? LogReferenceData(Reference reference, Stream? data)
         {
             if (VerboseLoggingEnabled)

--- a/src/libraries/System.Text.Json/gen/Reflection/RoslynExtensions.cs
+++ b/src/libraries/System.Text.Json/gen/Reflection/RoslynExtensions.cs
@@ -10,7 +10,7 @@ namespace System.Text.Json.Reflection
 {
     internal static class RoslynExtensions
     {
-        [return: NotNullIfNotNull("typeSymbol")]
+        [return: NotNullIfNotNull(nameof(typeSymbol))]
         public static Type? AsType(this ITypeSymbol? typeSymbol, MetadataLoadContextInternal metadataLoadContext)
         {
             if (typeSymbol == null)

--- a/src/tools/illink/src/linker/Linker.Steps/UnreachableBlocksOptimizer.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/UnreachableBlocksOptimizer.cs
@@ -571,8 +571,8 @@ namespace Mono.Linker.Steps
 
 			Collection<Instruction>? FoldedInstructions { get; set; }
 
-			[MemberNotNull ("FoldedInstructions")]
-			[MemberNotNull ("mapping")]
+			[MemberNotNull (nameof(FoldedInstructions))]
+			[MemberNotNull (nameof(mapping))]
 			void InitializeFoldedInstruction ()
 			{
 				FoldedInstructions = new Collection<Instruction> (Instructions);
@@ -1475,7 +1475,7 @@ namespace Mono.Linker.Steps
 			//
 			public bool SideEffectFreeResult { get; private set; }
 
-			[MemberNotNullWhen (true, "Result")]
+			[MemberNotNullWhen (true, nameof(Result))]
 			public bool Analyze (in CalleePayload callee, Stack<MethodDefinition> callStack)
 			{
 				MethodDefinition method = callee.Method;
@@ -1852,7 +1852,7 @@ namespace Mono.Linker.Steps
 				return false;
 			}
 
-			[MemberNotNullWhen (true, "Result")]
+			[MemberNotNullWhen (true, nameof(Result))]
 			bool ConvertStackToResult ()
 			{
 				if (stack_instr == null)

--- a/src/tools/illink/src/linker/Linker/Tracer.cs
+++ b/src/tools/illink/src/linker/Linker/Tracer.cs
@@ -66,7 +66,7 @@ namespace Mono.Linker
 			recorders.Add (recorder);
 		}
 
-		[MemberNotNullWhen (true, "recorders")]
+		[MemberNotNullWhen (true, nameof(recorders))]
 		bool IsRecordingEnabled ()
 		{
 			return recorders != null;


### PR DESCRIPTION
- Update the names of rules to match the current ones defined in NetAnalyzers
- Add a few more IDE rules, including enabling `IDE0280 Use nameof`