### PR TITLE
[mono] remove unneeded PKG_CONFIG_PATH for FreeBSD

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -339,13 +339,14 @@
     <ItemGroup Condition="'$(TargetsFreeBSD)' == 'true' and '$(MonoCrossDir)' != '' and '$(TargetArchitecture)' == 'x64'">
       <_MonoCMakeArgs Include="-DCMAKE_TOOLCHAIN_FILE=$(CrossToolchainFile)" />
       <_MonoBuildEnv Include="TARGET_BUILD_ARCH=x64" />
+      <_MonoBuildEnv Include="PKG_CONFIG_PATH=$(MonoCrossDir)/usr/local/libdata/pkgconfig" />
     </ItemGroup>
 
     <!-- ARM64 FreeBSD cross build options -->
     <ItemGroup Condition="'$(TargetsFreeBSD)' == 'true' and '$(MonoCrossDir)' != '' and '$(TargetArchitecture)' == 'arm64'">
       <_MonoCMakeArgs Include="-DCMAKE_TOOLCHAIN_FILE=$(CrossToolchainFile)" />
       <_MonoBuildEnv Include="TARGET_BUILD_ARCH=arm64" />
-      <_MonoBuildEnv Include="PKG_CONFIG_PATH=$(MonoCrossDir)usr/local/libdata/pkgconfig" />
+      <_MonoBuildEnv Include="PKG_CONFIG_PATH=$(MonoCrossDir)/usr/local/libdata/pkgconfig" />
     </ItemGroup>
 
     <!-- Windows specific options -->

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -339,14 +339,12 @@
     <ItemGroup Condition="'$(TargetsFreeBSD)' == 'true' and '$(MonoCrossDir)' != '' and '$(TargetArchitecture)' == 'x64'">
       <_MonoCMakeArgs Include="-DCMAKE_TOOLCHAIN_FILE=$(CrossToolchainFile)" />
       <_MonoBuildEnv Include="TARGET_BUILD_ARCH=x64" />
-      <_MonoBuildEnv Include="PKG_CONFIG_PATH=$(MonoCrossDir)/usr/local/libdata/pkgconfig" />
     </ItemGroup>
 
     <!-- ARM64 FreeBSD cross build options -->
     <ItemGroup Condition="'$(TargetsFreeBSD)' == 'true' and '$(MonoCrossDir)' != '' and '$(TargetArchitecture)' == 'arm64'">
       <_MonoCMakeArgs Include="-DCMAKE_TOOLCHAIN_FILE=$(CrossToolchainFile)" />
       <_MonoBuildEnv Include="TARGET_BUILD_ARCH=arm64" />
-      <_MonoBuildEnv Include="PKG_CONFIG_PATH=$(MonoCrossDir)/usr/local/libdata/pkgconfig" />
     </ItemGroup>
 
     <!-- Windows specific options -->


### PR DESCRIPTION
When cross building mono component, `PKG_CONFIG_PATH` was either not listed (x86_64) or contained a typo (ARM64).
As pointed out by @am11 neither variants use `PKG_CONFIG_PATH` here