### PR TITLE
[wasm] Implement integer log2 in jiterpreter

### DIFF
--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -702,9 +702,11 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 		case MINT_CLZ_I4:
 		case MINT_CTZ_I4:
 		case MINT_POPCNT_I4:
+		case MINT_LOG2_I4:
 		case MINT_CLZ_I8:
 		case MINT_CTZ_I8:
 		case MINT_POPCNT_I8:
+		case MINT_LOG2_I8:
 			return TRACE_CONTINUE;
 
 		case MINT_BR:

--- a/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
@@ -1075,6 +1075,28 @@ export function generate_wasm_body (
                 builder.callImport("cmpxchg_i64");
                 break;
 
+            case MintOpcode.MINT_LOG2_I4:
+            case MintOpcode.MINT_LOG2_I8: {
+                const isI64 = (opcode === MintOpcode.MINT_LOG2_I8);
+
+                builder.local("pLocals");
+
+                append_ldloc(builder, getArgU16(ip, 2), isI64 ? WasmOpcode.i64_load : WasmOpcode.i32_load);
+                if (isI64)
+                    builder.i52_const(1);
+                else
+                    builder.i32_const(1);
+                builder.appendU8(isI64 ? WasmOpcode.i64_or : WasmOpcode.i32_or);
+                builder.appendU8(isI64 ? WasmOpcode.i64_clz : WasmOpcode.i32_clz);
+                if (isI64)
+                    builder.appendU8(WasmOpcode.i32_wrap_i64);
+                builder.i32_const(isI64 ? 63 : 31);
+                builder.appendU8(WasmOpcode.i32_xor);
+
+                append_stloc_tail(builder, getArgU16(ip, 1), WasmOpcode.i32_store);
+                break;
+            }
+
             case MintOpcode.MINT_FMA:
             case MintOpcode.MINT_FMAF: {
                 const isF32 = (opcode === MintOpcode.MINT_FMAF),


### PR DESCRIPTION
This intrinsic wasn't implemented along with clz/ctz/popcnt since it's a bit more complex, but it gets used in parts of browser-bench among other places