### PR TITLE
Don't overwrite pinned assembly versions in servicing

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -48,8 +48,10 @@
     <_IsWindowsDesktopApp Condition="$(WindowsDesktopCoreAppLibrary.Contains('$(AssemblyName);'))">true</_IsWindowsDesktopApp>
     <_IsAspNetCoreApp Condition="$(AspNetCoreAppLibrary.Contains('$(AssemblyName);'))">true</_IsAspNetCoreApp>
     <_AssemblyInTargetingPack Condition="('$(IsNETCoreAppSrc)' == 'true' or '$(IsNetCoreAppRef)' == 'true' or '$(_IsAspNetCoreApp)' == 'true' or '$(_IsWindowsDesktopApp)' == 'true') and '$(TargetFrameworkIdentifier)' != '.NETFramework'">true</_AssemblyInTargetingPack>
-    <!-- Assembly version do not get updated in non-netfx ref pack assemblies. -->
-    <AssemblyVersion Condition="'$(_AssemblyInTargetingPack)' != 'true'">$(MajorVersion).$(MinorVersion).0.$(ServicingVersion)</AssemblyVersion>
+    <!-- The assembly version gets updated when
+      - it isn't already set (i.e. it could be pinned to a specific version for .NET Framework compatibility) and
+      - the assembly isn't part of a targeting pack (always true for .NET Framework). -->
+    <AssemblyVersion Condition="'$(AssemblyVersion)' == '' and '$(_AssemblyInTargetingPack)' != 'true'">$(MajorVersion).$(MinorVersion).0.$(ServicingVersion)</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -318,12 +318,6 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="ValidateAssemblyVersionsInRefPack"
-          Condition="'$(SkipValidateAssemblyVersion)' != 'true' and '$(_AssemblyInTargetingPack)' == 'true' and '$(PreReleaseVersionLabel)' == 'servicing'"
-          AfterTargets="CoreCompile" >
-    <Error Condition="'$(AssemblyVersion)' != '$(LastReleasedStableAssemblyVersion)'" Text="AssemblyVersion should match last released assembly version $(LastReleasedStableAssemblyVersion)" />
-  </Target>
-
   <Target Name="ValidateServicingVersionIsProperlySet"
           Condition="'$(PreReleaseVersionLabel)' == 'servicing' and
                      '$(PackageUseIncrementalServicingVersion)' == 'true' and

--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -48,10 +48,8 @@
     <_IsWindowsDesktopApp Condition="$(WindowsDesktopCoreAppLibrary.Contains('$(AssemblyName);'))">true</_IsWindowsDesktopApp>
     <_IsAspNetCoreApp Condition="$(AspNetCoreAppLibrary.Contains('$(AssemblyName);'))">true</_IsAspNetCoreApp>
     <_AssemblyInTargetingPack Condition="('$(IsNETCoreAppSrc)' == 'true' or '$(IsNetCoreAppRef)' == 'true' or '$(_IsAspNetCoreApp)' == 'true' or '$(_IsWindowsDesktopApp)' == 'true') and '$(TargetFrameworkIdentifier)' != '.NETFramework'">true</_AssemblyInTargetingPack>
-    <!-- The assembly version gets updated when
-      - it isn't already set (i.e. it could be pinned to a specific version for .NET Framework compatibility) and
-      - the assembly isn't part of a targeting pack (always true for .NET Framework). -->
-    <AssemblyVersion Condition="'$(AssemblyVersion)' == '' and '$(_AssemblyInTargetingPack)' != 'true'">$(MajorVersion).$(MinorVersion).0.$(ServicingVersion)</AssemblyVersion>
+    <!-- The assembly version gets updated when the assembly isn't part of a targeting pack. -->
+    <AssemblyVersion Condition="'$(_AssemblyInTargetingPack)' != 'true'">$(MajorVersion).$(MinorVersion).0.$(ServicingVersion)</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/System.ComponentModel.Composition/Directory.Build.props
+++ b/src/libraries/System.ComponentModel.Composition/Directory.Build.props
@@ -1,10 +1,6 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <!-- this assembly is inbox in desktop, do not version it unless you
-         plan on shipping a new desktop version out of band. Instead add API
-         to a different assembly. -->
-    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.ComponentModel.Composition/Directory.Build.props
+++ b/src/libraries/System.ComponentModel.Composition/Directory.Build.props
@@ -4,7 +4,7 @@
     <!-- this assembly is inbox in desktop, do not version it unless you
          plan on shipping a new desktop version out of band. Instead add API
          to a different assembly. -->
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.ComponentModel.Composition/Directory.Build.props
+++ b/src/libraries/System.ComponentModel.Composition/Directory.Build.props
@@ -1,6 +1,9 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
+    <!-- this assembly is inbox in desktop, do not version it unless you
+         plan on shipping a new desktop version out of band. Instead add API
+         to a different assembly. -->
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
   </PropertyGroup>

--- a/src/libraries/System.ComponentModel.Composition/Directory.Build.targets
+++ b/src/libraries/System.ComponentModel.Composition/Directory.Build.targets
@@ -1,9 +1,8 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
-    <!-- this assembly is inbox in desktop, do not version it unless you
-         plan on shipping a new desktop version out of band. Instead add API
-         to a different assembly. -->
+    <!-- This assembly is inbox in .NETFramework, ensure that the .NETStandard assembly 
+         remains <= the desktop version -->
     <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.ComponentModel.Composition/Directory.Build.targets
+++ b/src/libraries/System.ComponentModel.Composition/Directory.Build.targets
@@ -1,0 +1,9 @@
+﻿<Project>
+  <Import Project="..\Directory.Build.targets" />
+  <PropertyGroup>
+    <!-- this assembly is inbox in desktop, do not version it unless you
+         plan on shipping a new desktop version out of band. Instead add API
+         to a different assembly. -->
+    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
+  </PropertyGroup>
+</Project>

--- a/src/libraries/System.ComponentModel.Composition/Directory.Build.targets
+++ b/src/libraries/System.ComponentModel.Composition/Directory.Build.targets
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
     <!-- This assembly is inbox in .NETFramework, ensure that the .NETStandard assembly 
-         remains <= the desktop version -->
+         remains <= the .NETFramework version -->
     <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Data.DataSetExtensions/Directory.Build.props
+++ b/src/libraries/System.Data.DataSetExtensions/Directory.Build.props
@@ -1,8 +1,6 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <!-- AssemblyVersion is frozen to that which originally shipped in 2.1 -->
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.DirectoryServices.AccountManagement/Directory.Build.props
+++ b/src/libraries/System.DirectoryServices.AccountManagement/Directory.Build.props
@@ -4,7 +4,7 @@
     <!-- this assembly is inbox in desktop, do not version it unless you
          plan on shipping a new desktop version out of band. Instead add API
          to a different assembly. -->
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
     <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>

--- a/src/libraries/System.DirectoryServices.AccountManagement/Directory.Build.props
+++ b/src/libraries/System.DirectoryServices.AccountManagement/Directory.Build.props
@@ -1,10 +1,6 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <!-- this assembly is inbox in desktop, do not version it unless you
-         plan on shipping a new desktop version out of band. Instead add API
-         to a different assembly. -->
-    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
     <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>

--- a/src/libraries/System.DirectoryServices.AccountManagement/Directory.Build.targets
+++ b/src/libraries/System.DirectoryServices.AccountManagement/Directory.Build.targets
@@ -1,9 +1,8 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
-    <!-- this assembly is inbox in desktop, do not version it unless you
-         plan on shipping a new desktop version out of band. Instead add API
-         to a different assembly. -->
+    <!-- This assembly is inbox in .NETFramework, ensure that the .NETStandard assembly 
+         remains <= the desktop version -->
     <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.DirectoryServices.AccountManagement/Directory.Build.targets
+++ b/src/libraries/System.DirectoryServices.AccountManagement/Directory.Build.targets
@@ -1,0 +1,9 @@
+﻿<Project>
+  <Import Project="..\Directory.Build.targets" />
+  <PropertyGroup>
+    <!-- this assembly is inbox in desktop, do not version it unless you
+         plan on shipping a new desktop version out of band. Instead add API
+         to a different assembly. -->
+    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
+  </PropertyGroup>
+</Project>

--- a/src/libraries/System.DirectoryServices.AccountManagement/Directory.Build.targets
+++ b/src/libraries/System.DirectoryServices.AccountManagement/Directory.Build.targets
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
     <!-- This assembly is inbox in .NETFramework, ensure that the .NETStandard assembly 
-         remains <= the desktop version -->
+         remains <= the .NETFramework version -->
     <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.DirectoryServices.Protocols/Directory.Build.props
+++ b/src/libraries/System.DirectoryServices.Protocols/Directory.Build.props
@@ -4,7 +4,7 @@
     <!-- this assembly is inbox in desktop, do not version it unless you
          plan on shipping a new desktop version out of band. Instead add API
          to a different assembly. -->
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
     <UnsupportedOSPlatforms>browser;android;ios;tvos</UnsupportedOSPlatforms>

--- a/src/libraries/System.DirectoryServices.Protocols/Directory.Build.props
+++ b/src/libraries/System.DirectoryServices.Protocols/Directory.Build.props
@@ -1,10 +1,6 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <!-- this assembly is inbox in desktop, do not version it unless you
-         plan on shipping a new desktop version out of band. Instead add API
-         to a different assembly. -->
-    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
     <UnsupportedOSPlatforms>browser;android;ios;tvos</UnsupportedOSPlatforms>

--- a/src/libraries/System.DirectoryServices.Protocols/Directory.Build.targets
+++ b/src/libraries/System.DirectoryServices.Protocols/Directory.Build.targets
@@ -1,0 +1,9 @@
+﻿<Project>
+  <Import Project="..\Directory.Build.targets" />
+  <PropertyGroup>
+    <!-- this assembly is inbox in desktop, do not version it unless you
+         plan on shipping a new desktop version out of band. Instead add API
+         to a different assembly. -->
+    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
+  </PropertyGroup>
+</Project>

--- a/src/libraries/System.DirectoryServices.Protocols/Directory.Build.targets
+++ b/src/libraries/System.DirectoryServices.Protocols/Directory.Build.targets
@@ -1,9 +1,8 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
-    <!-- this assembly is inbox in desktop, do not version it unless you
-         plan on shipping a new desktop version out of band. Instead add API
-         to a different assembly. -->
+    <!-- This assembly is inbox in .NETFramework, ensure that the .NETStandard assembly
+         remains <= the desktop version -->
     <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.DirectoryServices.Protocols/Directory.Build.targets
+++ b/src/libraries/System.DirectoryServices.Protocols/Directory.Build.targets
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
     <!-- This assembly is inbox in .NETFramework, ensure that the .NETStandard assembly
-         remains <= the desktop version -->
+         remains <= the .NETFramework version -->
     <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.DirectoryServices/Directory.Build.props
+++ b/src/libraries/System.DirectoryServices/Directory.Build.props
@@ -4,7 +4,7 @@
     <!-- this assembly is inbox in desktop, do not version it unless you
          plan on shipping a new desktop version out of band. Instead add API
          to a different assembly. -->
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
     <!-- Since this assembly version is pinned, we don't want to validate that it matches
     the expected assembly version on the targeting pack. -->
     <SkipValidateAssemblyVersion>true</SkipValidateAssemblyVersion>

--- a/src/libraries/System.DirectoryServices/Directory.Build.props
+++ b/src/libraries/System.DirectoryServices/Directory.Build.props
@@ -1,13 +1,6 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <!-- this assembly is inbox in desktop, do not version it unless you
-         plan on shipping a new desktop version out of band. Instead add API
-         to a different assembly. -->
-    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
-    <!-- Since this assembly version is pinned, we don't want to validate that it matches
-    the expected assembly version on the targeting pack. -->
-    <SkipValidateAssemblyVersion>true</SkipValidateAssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>

--- a/src/libraries/System.DirectoryServices/Directory.Build.targets
+++ b/src/libraries/System.DirectoryServices/Directory.Build.targets
@@ -1,9 +1,8 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
-    <!-- this assembly is inbox in desktop, do not version it unless you
-         plan on shipping a new desktop version out of band. Instead add API
-         to a different assembly. -->
+    <!-- This assembly is inbox in .NETFramework, ensure that the .NETStandard assembly 
+         remains <= the desktop version -->
     <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.DirectoryServices/Directory.Build.targets
+++ b/src/libraries/System.DirectoryServices/Directory.Build.targets
@@ -1,0 +1,9 @@
+﻿<Project>
+  <Import Project="..\Directory.Build.targets" />
+  <PropertyGroup>
+    <!-- this assembly is inbox in desktop, do not version it unless you
+         plan on shipping a new desktop version out of band. Instead add API
+         to a different assembly. -->
+    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
+  </PropertyGroup>
+</Project>

--- a/src/libraries/System.DirectoryServices/Directory.Build.targets
+++ b/src/libraries/System.DirectoryServices/Directory.Build.targets
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
     <!-- This assembly is inbox in .NETFramework, ensure that the .NETStandard assembly 
-         remains <= the desktop version -->
+         remains <= the .NETFramework version -->
     <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Management/Directory.Build.props
+++ b/src/libraries/System.Management/Directory.Build.props
@@ -1,10 +1,6 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <!-- this assembly is inbox in desktop, do not version it unless you
-         plan on shipping a new desktop version out of band. Instead add API
-         to a different assembly. -->
-    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>

--- a/src/libraries/System.Management/Directory.Build.props
+++ b/src/libraries/System.Management/Directory.Build.props
@@ -4,7 +4,7 @@
     <!-- this assembly is inbox in desktop, do not version it unless you
          plan on shipping a new desktop version out of band. Instead add API
          to a different assembly. -->
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>

--- a/src/libraries/System.Management/Directory.Build.targets
+++ b/src/libraries/System.Management/Directory.Build.targets
@@ -1,0 +1,9 @@
+﻿<Project>
+  <Import Project="..\Directory.Build.targets" />
+  <PropertyGroup>
+    <!-- this assembly is inbox in desktop, do not version it unless you
+         plan on shipping a new desktop version out of band. Instead add API
+         to a different assembly. -->
+    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
+  </PropertyGroup>
+</Project>

--- a/src/libraries/System.Management/Directory.Build.targets
+++ b/src/libraries/System.Management/Directory.Build.targets
@@ -1,9 +1,8 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
-    <!-- this assembly is inbox in desktop, do not version it unless you
-         plan on shipping a new desktop version out of band. Instead add API
-         to a different assembly. -->
+    <!-- This assembly is inbox in .NETFramework, ensure that the .NETStandard assembly
+         remains <= the desktop version -->
     <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Management/Directory.Build.targets
+++ b/src/libraries/System.Management/Directory.Build.targets
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
     <!-- This assembly is inbox in .NETFramework, ensure that the .NETStandard assembly
-         remains <= the desktop version -->
+         remains <= the .NETFramework version -->
     <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Reflection.Context/Directory.Build.props
+++ b/src/libraries/System.Reflection.Context/Directory.Build.props
@@ -4,7 +4,7 @@
     <!-- this assembly is inbox in desktop, do not version it unless you
          plan on shipping a new desktop version out of band. Instead add API
          to a different assembly. -->
-    <AssemblyVersion>4.0.3.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.3.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Reflection.Context/Directory.Build.props
+++ b/src/libraries/System.Reflection.Context/Directory.Build.props
@@ -1,6 +1,9 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
+    <!-- this assembly is inbox in desktop, do not version it unless you
+         plan on shipping a new desktop version out of band. Instead add API
+         to a different assembly. -->
     <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
   </PropertyGroup>

--- a/src/libraries/System.Reflection.Context/Directory.Build.props
+++ b/src/libraries/System.Reflection.Context/Directory.Build.props
@@ -1,10 +1,6 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <!-- this assembly is inbox in desktop, do not version it unless you
-         plan on shipping a new desktop version out of band. Instead add API
-         to a different assembly. -->
-    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.3.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Reflection.Context/Directory.Build.targets
+++ b/src/libraries/System.Reflection.Context/Directory.Build.targets
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
     <!-- This assembly is inbox in .NETFramework, ensure that the .NETStandard assembly 
-         remains <= the desktop version.
+         remains <= the .NETFramework version.
          4.0.3.0 breaks this causing https://github.com/dotnet/runtime/issues/84320  -->
     <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.3.0</AssemblyVersion>
   </PropertyGroup>

--- a/src/libraries/System.Reflection.Context/Directory.Build.targets
+++ b/src/libraries/System.Reflection.Context/Directory.Build.targets
@@ -1,0 +1,9 @@
+﻿<Project>
+  <Import Project="..\Directory.Build.targets" />
+  <PropertyGroup>
+    <!-- this assembly is inbox in desktop, do not version it unless you
+         plan on shipping a new desktop version out of band. Instead add API
+         to a different assembly. -->
+    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.3.0</AssemblyVersion>
+  </PropertyGroup>
+</Project>

--- a/src/libraries/System.Reflection.Context/Directory.Build.targets
+++ b/src/libraries/System.Reflection.Context/Directory.Build.targets
@@ -1,9 +1,9 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
-    <!-- this assembly is inbox in desktop, do not version it unless you
-         plan on shipping a new desktop version out of band. Instead add API
-         to a different assembly. -->
+    <!-- This assembly is inbox in .NETFramework, ensure that the .NETStandard assembly 
+         remains <= the desktop version.
+         4.0.3.0 breaks this causing https://github.com/dotnet/runtime/issues/84320  -->
     <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.3.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Reflection.Context/ref/System.Reflection.Context.csproj
+++ b/src/libraries/System.Reflection.Context/ref/System.Reflection.Context.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- this assembly is inbox in desktop, do not version it unless you
-         plan on shipping a new desktop version out of band. Instead add API
-         to a different assembly. -->
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppPrevious);$(NetCoreAppMinimum);netstandard2.1;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/libraries/System.Runtime.Caching/Directory.Build.props
+++ b/src/libraries/System.Runtime.Caching/Directory.Build.props
@@ -1,10 +1,6 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <!-- this assembly is inbox in desktop, do not version it unless you
-         plan on shipping a new desktop version out of band. Instead add API
-         to a different assembly. -->
-    <AssemblyVersion  Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>

--- a/src/libraries/System.Runtime.Caching/Directory.Build.props
+++ b/src/libraries/System.Runtime.Caching/Directory.Build.props
@@ -4,7 +4,7 @@
     <!-- this assembly is inbox in desktop, do not version it unless you
          plan on shipping a new desktop version out of band. Instead add API
          to a different assembly. -->
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion  Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>

--- a/src/libraries/System.Runtime.Caching/Directory.Build.targets
+++ b/src/libraries/System.Runtime.Caching/Directory.Build.targets
@@ -1,0 +1,9 @@
+﻿<Project>
+  <Import Project="..\Directory.Build.targets" />
+  <PropertyGroup>
+    <!-- this assembly is inbox in desktop, do not version it unless you
+         plan on shipping a new desktop version out of band. Instead add API
+         to a different assembly. -->
+    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
+  </PropertyGroup>
+</Project>

--- a/src/libraries/System.Runtime.Caching/Directory.Build.targets
+++ b/src/libraries/System.Runtime.Caching/Directory.Build.targets
@@ -1,9 +1,8 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
-    <!-- this assembly is inbox in desktop, do not version it unless you
-         plan on shipping a new desktop version out of band. Instead add API
-         to a different assembly. -->
+    <!-- This assembly is inbox in .NETFramework, ensure that the .NETStandard assembly
+         remains <= the desktop version -->
     <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Runtime.Caching/Directory.Build.targets
+++ b/src/libraries/System.Runtime.Caching/Directory.Build.targets
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
     <!-- This assembly is inbox in .NETFramework, ensure that the .NETStandard assembly
-         remains <= the desktop version -->
+         remains <= the .NETFramework version -->
     <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Speech/Directory.Build.props
+++ b/src/libraries/System.Speech/Directory.Build.props
@@ -4,7 +4,7 @@
     <!-- this assembly is inbox in desktop, do not version it unless you
          plan on shipping a new desktop version out of band. Instead add API
          to a different assembly. -->
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
     <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>

--- a/src/libraries/System.Speech/Directory.Build.props
+++ b/src/libraries/System.Speech/Directory.Build.props
@@ -1,10 +1,6 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <!-- this assembly is inbox in desktop, do not version it unless you
-         plan on shipping a new desktop version out of band. Instead add API
-         to a different assembly. -->
-    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
     <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>

--- a/src/libraries/System.Speech/Directory.Build.targets
+++ b/src/libraries/System.Speech/Directory.Build.targets
@@ -1,0 +1,9 @@
+﻿<Project>
+  <Import Project="..\Directory.Build.targets" />
+  <PropertyGroup>
+    <!-- this assembly is inbox in desktop, do not version it unless you
+         plan on shipping a new desktop version out of band. Instead add API
+         to a different assembly. -->
+    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
+  </PropertyGroup>
+</Project>

--- a/src/libraries/System.Speech/Directory.Build.targets
+++ b/src/libraries/System.Speech/Directory.Build.targets
@@ -1,9 +1,8 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
-    <!-- this assembly is inbox in desktop, do not version it unless you
-         plan on shipping a new desktop version out of band. Instead add API
-         to a different assembly. -->
+    <!-- This assembly is inbox in .NETFramework, ensure that the .NETStandard assembly
+         remains <= the desktop version -->
     <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Speech/Directory.Build.targets
+++ b/src/libraries/System.Speech/Directory.Build.targets
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
     <!-- This assembly is inbox in .NETFramework, ensure that the .NETStandard assembly
-         remains <= the desktop version -->
+         remains <= the .NETFramework version -->
     <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/84031

Eight packable projects pin their assembly version for .NET Framework compatibility. The incremental package servicing infrastructure didn't check if the assembly version is pinned and changed it during servicing.

As an example, System.Speech pins its assembly version to 4.0.0.0 but that version gets overwritten during servicing. I.e. for .NET 7 the version would then change to "7.0.0.$(ServicingVersion)" which is incorrect.

Please find the full list of impacted assemblies below:
- System.ComponentModel.Composition
- System.DirectoryServices
- System.DirectoryServices.AccountManagement
- System.DirectoryServices.Protocols
- System.Management
- System.Reflection.Context
- System.Runtime.Caching
- System.Speech

This change should be backported into release/6.0 and release/7.0.