### PR TITLE
Switch attribute equality to the valuetype equality plan

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -130,7 +130,6 @@
     <Compile Include="Internal\Reflection\Extensions\NonPortable\CustomAttributeInheritanceRules.cs" />
     <Compile Include="Internal\Reflection\Extensions\NonPortable\CustomAttributeInstantiator.cs" />
     <Compile Include="Internal\Reflection\Extensions\NonPortable\CustomAttributeSearcher.cs" />
-    <Compile Include="System\Attribute.NativeAot.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="System\Reflection\RuntimeAssembly.cs" />
@@ -159,6 +158,7 @@
     <Compile Include="System\Activator.NativeAot.cs" />
     <Compile Include="System\AppContext.NativeAot.cs" />
     <Compile Include="System\ArgIterator.cs" />
+    <Compile Include="System\Attribute.NativeAot.cs" />
     <Compile Include="System\Buffer.NativeAot.cs" />
     <Compile Include="System\Collections\Generic\ArraySortHelper.NativeAot.cs" />
     <Compile Include="System\Collections\Generic\Comparer.NativeAot.cs" />

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Internal\Reflection\Extensions\NonPortable\CustomAttributeInheritanceRules.cs" />
     <Compile Include="Internal\Reflection\Extensions\NonPortable\CustomAttributeInstantiator.cs" />
     <Compile Include="Internal\Reflection\Extensions\NonPortable\CustomAttributeSearcher.cs" />
+    <Compile Include="System\Attribute.NativeAot.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="System\Reflection\RuntimeAssembly.cs" />

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Attribute.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Attribute.NativeAot.cs
@@ -1,0 +1,89 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime;
+using System.Runtime.CompilerServices;
+
+using Internal.Runtime;
+
+namespace System
+{
+    public abstract partial class Attribute
+    {
+        // An override of this method will be injected by the compiler into all attributes that have fields.
+        // This API is a bit awkward because we want to avoid burning more than one vtable slot on this.
+        // When index is negative, this method is expected to return the number of fields of this
+        // valuetype. Otherwise, it returns the offset and type handle of the index-th field on this type.
+        internal virtual unsafe int __GetFieldHelper(int index, out MethodTable* mt)
+        {
+            Debug.Assert(index < 0);
+            mt = default;
+            return 0;
+        }
+
+        public override unsafe bool Equals([NotNullWhen(true)] object? obj)
+        {
+            if (obj == null)
+                return false;
+
+            if (this.GetType() != obj.GetType())
+                return false;
+
+            int numFields = __GetFieldHelper(-1, out _);
+
+            // Subtract nint size to get to the m_pEEType field. Can't get from "ref MethodTable*" to "ref byte" currently.
+            ref byte thisRawData = ref Unsafe.Subtract(ref this.GetRawData(), nint.Size);
+            ref byte thatRawData = ref Unsafe.Subtract(ref obj.GetRawData(), nint.Size);
+
+            for (int i = 0; i < numFields; i++)
+            {
+                int fieldOffset = __GetFieldHelper(i, out MethodTable* fieldType);
+
+                // Fetch the value of the field on both types
+                object thisResult = RuntimeImports.RhBoxAny(ref Unsafe.Add(ref thisRawData, fieldOffset), fieldType);
+                object thatResult = RuntimeImports.RhBoxAny(ref Unsafe.Add(ref thatRawData, fieldOffset), fieldType);
+
+                if (!AreFieldValuesEqual(thisResult, thatResult))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public override unsafe int GetHashCode()
+        {
+            int numFields = __GetFieldHelper(-1, out _);
+
+            // Subtract nint size to get to the m_pEEType field. Can't get from "ref MethodTable*" to "ref byte" currently.
+            ref byte thisRawData = ref Unsafe.Subtract(ref this.GetRawData(), nint.Size);
+
+            object? vThis = null;
+
+            for (int i = 0; i < numFields; i++)
+            {
+                int fieldOffset = __GetFieldHelper(i, out MethodTable* fieldType);
+                object? fieldValue = RuntimeImports.RhBoxAny(ref Unsafe.Add(ref thisRawData, fieldOffset), fieldType);
+
+                // The hashcode of an array ignores the contents of the array, so it can produce
+                // different hashcodes for arrays with the same contents.
+                // Since we do deep comparisons of arrays in Equals(), this means Equals and GetHashCode will
+                // be inconsistent for arrays. Therefore, we ignore hashes of arrays.
+                if (fieldValue != null && !fieldValue.GetType().IsArray)
+                    vThis = fieldValue;
+
+                if (vThis != null)
+                    break;
+            }
+
+            if (vThis != null)
+                return vThis.GetHashCode();
+
+            // Matches the reflection-based implementation in other runtimes
+            return typeof(Attribute).GetHashCode();
+        }
+    }
+}

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Attribute.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Attribute.NativeAot.cs
@@ -33,9 +33,8 @@ namespace System
 
             int numFields = __GetFieldHelper(-1, out _);
 
-            // Subtract nint size to get to the m_pEEType field. Can't get from "ref MethodTable*" to "ref byte" currently.
-            ref byte thisRawData = ref Unsafe.Subtract(ref this.GetRawData(), nint.Size);
-            ref byte thatRawData = ref Unsafe.Subtract(ref obj.GetRawData(), nint.Size);
+            ref byte thisRawData = ref this.GetRawData();
+            ref byte thatRawData = ref obj.GetRawData();
 
             for (int i = 0; i < numFields; i++)
             {
@@ -58,8 +57,7 @@ namespace System
         {
             int numFields = __GetFieldHelper(-1, out _);
 
-            // Subtract nint size to get to the m_pEEType field. Can't get from "ref MethodTable*" to "ref byte" currently.
-            ref byte thisRawData = ref Unsafe.Subtract(ref this.GetRawData(), nint.Size);
+            ref byte thisRawData = ref this.GetRawData();
 
             object? vThis = null;
 

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ValueTypeGetFieldHelperMethodOverride.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ValueTypeGetFieldHelperMethodOverride.cs
@@ -67,6 +67,9 @@ namespace Internal.IL.Stubs
             TypeDesc methodTableType = Context.SystemModule.GetKnownType("Internal.Runtime", "MethodTable");
             MethodDesc methodTableOfMethod = methodTableType.GetKnownMethod("Of", null);
 
+            ILToken firstFieldToken = owningType.IsValueType ? default :
+                emitter.NewToken(Context.GetWellKnownType(WellKnownType.Object).GetKnownField("m_pEEType"));
+
             var switchStream = emitter.NewCodeStream();
             var getFieldStream = emitter.NewCodeStream();
 
@@ -107,6 +110,10 @@ namespace Internal.IL.Stubs
 
                 getFieldStream.EmitLdArg(0);
 
+                // If this is a reference type, we subtract from the first field. Otherwise subtract from `ref this`.
+                if (!owningType.IsValueType)
+                    getFieldStream.Emit(ILOpcode.ldflda, firstFieldToken);
+
                 getFieldStream.Emit(ILOpcode.sub);
 
                 getFieldStream.Emit(ILOpcode.ret);
@@ -118,9 +125,38 @@ namespace Internal.IL.Stubs
                 switchStream.EmitSwitch(fieldGetters.ToArray());
             }
 
-            switchStream.EmitLdc(fieldGetters.Count);
-
-            switchStream.Emit(ILOpcode.ret);
+            if (!owningType.IsValueType
+                && MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(this) is MethodDesc slotMethod
+                && owningType.BaseType.FindVirtualFunctionTargetMethodOnObjectType(slotMethod) is MethodDesc baseMethod
+                && slotMethod != baseMethod)
+            {
+                // On reference types, we recurse into base implementation too, handling both the case of asking
+                // for number of fields (add number of fields on the current class before returning), and
+                // handling field indices higher than what we handle (subtract number of fields handled here first).
+                switchStream.EmitLdArg(0);
+                switchStream.EmitLdArg(1);
+                switchStream.EmitLdc(fieldGetters.Count);
+                switchStream.Emit(ILOpcode.sub);
+                switchStream.EmitLdArg(2);
+                switchStream.Emit(ILOpcode.call, emitter.NewToken(baseMethod));
+                switchStream.EmitLdArg(1);
+                switchStream.EmitLdc(0);
+                ILCodeLabel lGotBaseFieldAddress = emitter.NewCodeLabel();
+                switchStream.Emit(ILOpcode.bge, lGotBaseFieldAddress);
+                switchStream.EmitLdc(fieldGetters.Count);
+                ILCodeLabel lGotNumFieldsInBase = emitter.NewCodeLabel();
+                switchStream.Emit(ILOpcode.br, lGotNumFieldsInBase);
+                switchStream.EmitLabel(lGotBaseFieldAddress);
+                switchStream.EmitLdc(0);
+                switchStream.EmitLabel(lGotNumFieldsInBase);
+                switchStream.Emit(ILOpcode.add);
+                switchStream.Emit(ILOpcode.ret);
+            }
+            else
+            {
+                switchStream.EmitLdc(fieldGetters.Count);
+                switchStream.Emit(ILOpcode.ret);
+            }
 
             return emitter.Link(this);
         }

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ValueTypeGetFieldHelperMethodOverride.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ValueTypeGetFieldHelperMethodOverride.cs
@@ -67,8 +67,8 @@ namespace Internal.IL.Stubs
             TypeDesc methodTableType = Context.SystemModule.GetKnownType("Internal.Runtime", "MethodTable");
             MethodDesc methodTableOfMethod = methodTableType.GetKnownMethod("Of", null);
 
-            ILToken firstFieldToken = owningType.IsValueType ? default :
-                emitter.NewToken(Context.GetWellKnownType(WellKnownType.Object).GetKnownField("m_pEEType"));
+            ILToken rawDataToken = owningType.IsValueType ? default :
+                emitter.NewToken(Context.SystemModule.GetKnownType("System.Runtime.CompilerServices", "RawData").GetKnownField("Data"));
 
             var switchStream = emitter.NewCodeStream();
             var getFieldStream = emitter.NewCodeStream();
@@ -112,7 +112,7 @@ namespace Internal.IL.Stubs
 
                 // If this is a reference type, we subtract from the first field. Otherwise subtract from `ref this`.
                 if (!owningType.IsValueType)
-                    getFieldStream.Emit(ILOpcode.ldflda, firstFieldToken);
+                    getFieldStream.Emit(ILOpcode.ldflda, rawDataToken);
 
                 getFieldStream.Emit(ILOpcode.sub);
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/BlockedInternalsBlockingPolicy.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/BlockedInternalsBlockingPolicy.cs
@@ -144,14 +144,12 @@ namespace ILCompiler
         private BlockedTypeHashtable _blockedTypes;
 
         private MetadataType ArrayOfTType { get; }
-        private MetadataType AttributeType { get; }
 
         public BlockedInternalsBlockingPolicy(TypeSystemContext context)
         {
             _blockedTypes = new BlockedTypeHashtable(_blockedModules);
 
             ArrayOfTType = context.SystemModule.GetType("System", "Array`1", throwIfNotFound: false);
-            AttributeType = context.SystemModule.GetType("System", "Attribute", throwIfNotFound: false);
         }
 
         public override bool IsBlocked(MetadataType type)
@@ -227,25 +225,9 @@ namespace ILCompiler
                 return true;
 
             FieldAttributes accessibility = ecmaField.Attributes & FieldAttributes.FieldAccessMask;
-            if (accessibility != FieldAttributes.Family
+            return accessibility != FieldAttributes.Family
                 && accessibility != FieldAttributes.FamORAssem
-                && accessibility != FieldAttributes.Public)
-            {
-                // Exempt fields on custom attributes from blocking.
-                // Attribute.Equals and Attribute.GetHashCode depends on being able to
-                // walk all fields on custom attributes using reflection.
-                // We're opening this hole in hopes that the fields won't have any "interesting"
-                // types (that would be themselves blocked). Doing that could be problematic.
-                if (AttributeType != null
-                    && owningType.CanCastTo(AttributeType))
-                {
-                    return false;
-                }
-
-                return true;
-            }
-
-            return false;
+                && accessibility != FieldAttributes.Public;
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.Aot.cs
@@ -38,6 +38,7 @@ namespace ILCompiler
         private TypeDesc[] _arrayOfTInterfaces;
         private ArrayOfTRuntimeInterfacesAlgorithm _arrayOfTRuntimeInterfacesAlgorithm;
         private MetadataType _arrayOfTType;
+        private MetadataType _attributeType;
 
         public CompilerTypeSystemContext(TargetDetails details, SharedGenericsMode genericsMode, DelegateFeature delegateFeatures, int genericCycleCutoffPoint = DefaultGenericCycleCutoffPoint)
             : base(details)
@@ -132,6 +133,8 @@ namespace ILCompiler
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private IEnumerable<MethodDesc> GetAllMethods(TypeDesc type, bool virtualOnly)
         {
+            MetadataType attributeType = _attributeType ??= SystemModule.GetType("System", "Attribute");
+
             if (type.IsDelegate)
             {
                 return GetAllMethodsForDelegate(type, virtualOnly);
@@ -143,6 +146,10 @@ namespace ILCompiler
             else if (type.IsValueType)
             {
                 return GetAllMethodsForValueType(type, virtualOnly);
+            }
+            else if (type.CanCastTo(attributeType))
+            {
+                return GetAllMethodsForAttribute(type, virtualOnly);
             }
 
             return virtualOnly ? type.GetVirtualMethods() : type.GetMethods();

--- a/src/libraries/System.Private.CoreLib/src/System/Attribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Attribute.cs
@@ -14,6 +14,7 @@ namespace System
     {
         protected Attribute() { }
 
+#if !NATIVEAOT
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
             Justification = "Unused fields don't make a difference for equality")]
         public override bool Equals([NotNullWhen(true)] object? obj)
@@ -82,6 +83,7 @@ namespace System
 
             return type.GetHashCode();
         }
+#endif
 
         // Compares values of custom-attribute fields.
         private static bool AreFieldValuesEqual(object? thisValue, object? thatValue)


### PR DESCRIPTION
`Attribute.Equals`/`GetHashCode` is currently implemented using reflection. The implementation iterates over all instance fields and calls `Equals`/`GetHashCode` as needed.

This has problems because the code is not actually trim safe (requires special casing in the compiler to work around an invalid suppression in CoreLib) and has extra problems for reflection blocking (we need to make sure the fields are never subject to blocking).

In this PR I'm switching Attribute to a similar plan that .NET Native had. In .NET Native we injected a pair of virtual methods to read and access fields on System.Attribute descendants. We can actually get away with one method - I'm reusing all the infrastructure we have for `ValueType.Equals`/`GetHashCode` since the problem is the same.

Saves 5.8% on a Hello World. For BasicMinimalApi, this is a wash (almost to the byte). It will become an improvement once RyuJIT starts generating better code for the field offset computations we're doing in the injected method.

Contributes to #83069.

Cc @dotnet/ilc-contrib 