### PR TITLE
Fix type parsing error returned for type names with invalid start of assembly name

### DIFF
--- a/src/libraries/Common/src/System/Reflection/TypeNameParser.cs
+++ b/src/libraries/Common/src/System/Reflection/TypeNameParser.cs
@@ -48,6 +48,8 @@ namespace System.Reflection
                     return null;
 
                 assemblyName = GetNextAssemblyName();
+                if (assemblyName is null)
+                    return null;
                 Debug.Assert(Peek == TokenType.End);
             }
 
@@ -126,7 +128,7 @@ namespace System.Reflection
                 return null;
 
             // Because "[" is used both for generic arguments and array indexes, we must peek two characters deep.
-            if (!(Peek == TokenType.OpenSqBracket && (PeekSecond == TokenType.Other || PeekSecond == TokenType.OpenSqBracket)))
+            if (!(Peek is TokenType.OpenSqBracket && (PeekSecond is TokenType.Other or TokenType.OpenSqBracket)))
                 return namedType;
 
             Skip();
@@ -328,9 +330,10 @@ namespace System.Reflection
         // Lex the next segment as the assembly name at the end of an assembly-qualified type name. (Do not use for
         // assembly names embedded inside generic type arguments.)
         //
-        private string GetNextAssemblyName()
+        private string? GetNextAssemblyName()
         {
-            SkipWhiteSpace();
+            if (!StartAssemblyName())
+                return null;
 
             string assemblyName = new string(_input.Slice(_index));
             _index = _input.Length;
@@ -344,7 +347,8 @@ namespace System.Reflection
         //
         private string? GetNextEmbeddedAssemblyName()
         {
-            SkipWhiteSpace();
+            if (!StartAssemblyName())
+                return null;
 
             ValueStringBuilder sb = new ValueStringBuilder(stackalloc char[64]);
 
@@ -380,6 +384,18 @@ namespace System.Reflection
             }
 
             return sb.ToString();
+        }
+
+        private bool StartAssemblyName()
+        {
+            // Compat: Treat invalid starting token of assembly name as type name parsing error instead of assembly name parsing error. This only affects
+            // exception returned by the parser.
+            if (Peek is TokenType.End or TokenType.Comma)
+            {
+                ParseError();
+                return false;
+            }
+            return true;
         }
 
         //

--- a/src/libraries/System.Reflection/tests/GetTypeTests.cs
+++ b/src/libraries/System.Reflection/tests/GetTypeTests.cs
@@ -271,6 +271,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37871", TestRuntimes.Mono)]
         public void GetType_InvalidAssemblyName()
         {
             Assert.Null(Type.GetType("MissingAssemblyName, "));

--- a/src/libraries/System.Reflection/tests/GetTypeTests.cs
+++ b/src/libraries/System.Reflection/tests/GetTypeTests.cs
@@ -269,6 +269,15 @@ namespace System.Reflection.Tests
             Assert.Equal(typeof(System.Reflection.Tests.GenericClass<System.String>), Type.GetType("System.Reflection.Tests.GenericClass`1[[System.String, System.Private.CoreLib]]", throwOnError: true));
             Assert.Throws<FileNotFoundException>(() => Type.GetType("System.Reflection.Tests.GenericClass`1[[Bogus, BogusAssembly]]", throwOnError: true));
         }
+
+        [Fact]
+        public void GetType_InvalidAssemblyName()
+        {
+            Assert.Null(Type.GetType("MissingAssemblyName, "));
+            Assert.Null(Type.GetType("ExtraComma, ,"));
+            Assert.Null(Type.GetType("ExtraComma, , System.Runtime"));
+            Assert.Throws<FileLoadException>(() => Type.GetType("System.Object, System.Runtime, Version=x.y"));
+        }
     }
 
     namespace MyNamespace1


### PR DESCRIPTION
Fixes #84118