### PR TITLE
Introduce a diagnostic switch to turn off the use of file mapping in PE loader.

### DIFF
--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -133,7 +133,7 @@ CONFIG_DWORD_INFO(INTERNAL_GetAssemblyIfLoadedIgnoreRidMap, W("GetAssemblyIfLoad
 ///
 /// PE Loader
 ///
-RETAIL_CONFIG_DWORD_INFO(INTERNAL_PELoader_DisableMapping, W("PELoader_DisableMapping"), 1, "Disable file mapping when performing non-OS layout.")
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_PELoader_DisableMapping, W("PELoader_DisableMapping"), 0, "Disable file mapping when performing non-OS layout.")
 
 ///
 /// Conditional breakpoints

--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -131,6 +131,11 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_JitPitchMaxVal, W("JitPitchMaxVal"), (DWORD)0x
 CONFIG_DWORD_INFO(INTERNAL_GetAssemblyIfLoadedIgnoreRidMap, W("GetAssemblyIfLoadedIgnoreRidMap"), 0, "Used to force loader to ignore assemblies cached in the rid-map")
 
 ///
+/// PE Loader
+///
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_PELoader_DisableMapping, W("PELoader_DisableMapping"), 1, "Disable file mapping when performing non-OS layout.")
+
+///
 /// Conditional breakpoints
 ///
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_BreakOnBadExit, W("BreakOnBadExit"), 0, "")

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -109,19 +109,26 @@ PEImageLayout* PEImageLayout::Load(PEImage* pOwner, HRESULT* loadFailure)
     {
         if (!pOwner->IsInBundle()
 #if defined(TARGET_UNIX)
-            || ((pOwner->GetUncompressedSize() == 0) && !disableMapping)
+            || (pOwner->GetUncompressedSize() == 0)
 #endif
             )
         {
-            PEImageLayoutHolder pAlloc(new LoadedImageLayout(pOwner, loadFailure));
-            if (pAlloc->GetBase() != NULL)
-                return pAlloc.Extract();
+#if defined(TARGET_UNIX)
+            if (!disableMapping)
+#endif
+            {
+
+                PEImageLayoutHolder pAlloc(new LoadedImageLayout(pOwner, loadFailure));
+                if (pAlloc->GetBase() != NULL)
+                    return pAlloc.Extract();
 
 #if TARGET_WINDOWS
-            // For regular PE files always use OS loader. If a file cannot be loaded, do not try any further.
-            // Even if we may be able to load it, we do not want to support such files.
-            return NULL;
+                // For regular PE files always use OS loader on Windows.
+                // If a file cannot be loaded, do not try any further.
+                // Even if we may be able to load it, we do not want to support such files.
+                return NULL;
 #endif
+            }
         }
     }
 

--- a/src/coreclr/vm/peimagelayout.h
+++ b/src/coreclr/vm/peimagelayout.h
@@ -50,7 +50,7 @@ public:
 #endif
     static PEImageLayout* Load(PEImage* pOwner, HRESULT* loadFailure);
     static PEImageLayout* LoadFlat(PEImage* pOwner);
-    static PEImageLayout* LoadConverted(PEImage* pOwner);
+    static PEImageLayout* LoadConverted(PEImage* pOwner, bool disableMapping);
     static PEImageLayout* LoadNative(LPCWSTR fullPath);
 #endif
     PEImageLayout();
@@ -104,7 +104,7 @@ class ConvertedImageLayout: public PEImageLayout
 public:
     static const int MAX_PARTS = 16;
 #ifndef DACCESS_COMPILE
-    ConvertedImageLayout(FlatImageLayout* source);
+    ConvertedImageLayout(FlatImageLayout* source, bool disableMapping);
     virtual ~ConvertedImageLayout();
     void  FreeImageParts();
 #endif


### PR DESCRIPTION
Introducing unsupported/internal `DOTNET_PELoader_DisableMapping` switch.

The switch is available in both debug and release builds.
Setting `DOTNET_PELoader_DisableMapping` to not 0 will force the fallback paths in PE loader where file sections are copied to preallocated memory ranges instead of being mapped. 

We needed to turn off file mapping in a few scenarios recently when narrowing down the root cause of bugs. 
Without a switch, turning off the file mapping is nontrivial and especially so in a singlefile scenario.
