### PR TITLE
Split `TryGetGenericMethodComponents` into two overloads

### DIFF
--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -890,8 +890,7 @@ namespace Internal.Reflection.Execution
                 {
                     if ((entryFlags & InvokeTableFlags.RequiresInstArg) != 0)
                     {
-                        MethodNameAndSignature dummyNameAndSignature;
-                        bool success = TypeLoaderEnvironment.Instance.TryGetGenericMethodComponents(instantiationArgument, out declaringTypeHandle, out dummyNameAndSignature, out genericMethodTypeArgumentHandles);
+                        bool success = TypeLoaderEnvironment.Instance.TryGetGenericMethodComponents(instantiationArgument, out declaringTypeHandle, out genericMethodTypeArgumentHandles);
                         Debug.Assert(success);
                     }
                     else

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -1101,9 +1101,8 @@ namespace Internal.Runtime.TypeLoader
             if ((contextKind & GenericContextKind.FromMethodHiddenArg) != 0)
             {
                 RuntimeTypeHandle declaringTypeHandle;
-                MethodNameAndSignature nameAndSignature;
                 RuntimeTypeHandle[] genericMethodArgHandles;
-                bool success = TypeLoaderEnvironment.Instance.TryGetGenericMethodComponents(context, out declaringTypeHandle, out nameAndSignature, out genericMethodArgHandles);
+                bool success = TypeLoaderEnvironment.Instance.TryGetGenericMethodComponents(context, out declaringTypeHandle, out genericMethodArgHandles);
                 Debug.Assert(success);
 
                 if (RuntimeAugments.IsGenericType(declaringTypeHandle))

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.Metadata.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.Metadata.cs
@@ -651,13 +651,7 @@ namespace Internal.Runtime.TypeLoader
 
                 uint nameAndSigPointerToken = entryParser.GetUnsigned();
 
-                MethodNameAndSignature nameAndSig;
-                if (!TypeLoaderEnvironment.Instance.TryGetMethodNameAndSignatureFromNativeLayoutOffset(module.Handle, nameAndSigPointerToken, out nameAndSig))
-                {
-                    Debug.Assert(false);
-                    continue;
-                }
-
+                MethodNameAndSignature nameAndSig = TypeLoaderEnvironment.Instance.GetMethodNameAndSignatureFromNativeLayoutOffset(module.Handle, nameAndSigPointerToken);
                 if (!methodSignatureComparer.IsMatchingNativeLayoutMethodNameAndSignature(nameAndSig.Name, nameAndSig.Signature))
                 {
                     continue;
@@ -972,12 +966,7 @@ namespace Internal.Runtime.TypeLoader
                 else
                 {
                     uint nameAndSigToken = entryParser.GetUnsigned();
-                    MethodNameAndSignature nameAndSig;
-                    if (!TypeLoaderEnvironment.Instance.TryGetMethodNameAndSignatureFromNativeLayoutOffset(_moduleHandle, nameAndSigToken, out nameAndSig))
-                    {
-                        Debug.Assert(false);
-                        return;
-                    }
+                    MethodNameAndSignature nameAndSig = TypeLoaderEnvironment.Instance.GetMethodNameAndSignatureFromNativeLayoutOffset(_moduleHandle, nameAndSigToken);
                     Debug.Assert(nameAndSig.Signature.IsNativeLayoutSignature);
                     if (!methodSignatureComparer.IsMatchingNativeLayoutMethodNameAndSignature(nameAndSig.Name, nameAndSig.Signature))
                         return;
@@ -1004,11 +993,7 @@ namespace Internal.Runtime.TypeLoader
                     Debug.Assert((_hasEntryPoint || ((_flags & InvokeTableFlags.HasVirtualInvoke) != 0)) && ((_flags & InvokeTableFlags.RequiresInstArg) != 0));
 
                     uint nameAndSigPointerToken = entryParser.GetUnsigned();
-                    if (!TypeLoaderEnvironment.Instance.TryGetMethodNameAndSignatureFromNativeLayoutOffset(_moduleHandle, nameAndSigPointerToken, out _nameAndSignature))
-                    {
-                        Debug.Assert(false);    //Error
-                        _isMatchingMethodHandleAndDeclaringType = false;
-                    }
+                    _nameAndSignature = TypeLoaderEnvironment.Instance.GetMethodNameAndSignatureFromNativeLayoutOffset(_moduleHandle, nameAndSigPointerToken);
                 }
                 else if (((_flags & InvokeTableFlags.RequiresInstArg) != 0) && _hasEntryPoint)
                     _entryDictionary = extRefTable.GetGenericDictionaryFromIndex(entryParser.GetUnsigned());

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.SignatureParsing.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.SignatureParsing.cs
@@ -138,17 +138,11 @@ namespace Internal.Runtime.TypeLoader
             return true;
         }
 
-        public bool TryGetMethodNameAndSignatureFromNativeLayoutOffset(TypeManagerHandle moduleHandle, uint nativeLayoutOffset, out MethodNameAndSignature nameAndSignature)
+        public MethodNameAndSignature GetMethodNameAndSignatureFromNativeLayoutOffset(TypeManagerHandle moduleHandle, uint nativeLayoutOffset)
         {
-            nameAndSignature = null;
-
             NativeReader reader = GetNativeLayoutInfoReader(moduleHandle);
             NativeParser parser = new NativeParser(reader, nativeLayoutOffset);
-            if (parser.IsNull)
-                return false;
-
-            nameAndSignature = GetMethodNameAndSignature(ref parser, moduleHandle, out _, out _);
-            return true;
+            return GetMethodNameAndSignature(ref parser, moduleHandle, out _, out _);
         }
 
         internal static MethodNameAndSignature GetMethodNameAndSignature(ref NativeParser parser, TypeManagerHandle moduleHandle, out RuntimeSignature methodNameSig, out RuntimeSignature methodSig)

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/Program.cs
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/Program.cs
@@ -20,18 +20,17 @@ unsafe class Program
         Console.WriteLine($"* Size of the executable is {fileSize / 1024,7:n0} kB             *");
         Console.WriteLine("****************************************************");
 
-        const int Meg = 1024 * 1024;
-        const int HalfMeg = Meg / 2;
         long lowerBound, upperBound;
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
+            const int Meg = 1024 * 1024;
             lowerBound = 2 * Meg; // 2 MB
             upperBound = 4 * Meg; // 4 MB
         }
         else
         {
-            lowerBound = Meg + HalfMeg; // 1.5 MB
-            upperBound = 2 * Meg; // 2 MB
+            lowerBound = 1300 * 1024; // ~1.3 MB
+            upperBound = 1600 * 1024; // ~1.6 MB
         }
 
         if (fileSize < lowerBound || fileSize > upperBound)

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/Program.cs
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/Program.cs
@@ -27,10 +27,15 @@ unsafe class Program
             lowerBound = 2 * Meg; // 2 MB
             upperBound = 4 * Meg; // 4 MB
         }
-        else
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             lowerBound = 1300 * 1024; // ~1.3 MB
             upperBound = 1600 * 1024; // ~1.6 MB
+        }
+        else
+        {
+            lowerBound = 1500 * 1024; // ~1.5 MB
+            upperBound = 1900 * 1024; // ~1.9 MB
         }
 
         if (fileSize < lowerBound || fileSize > upperBound)


### PR DESCRIPTION
Resolves #83069. Hello World is now 1.45 MB, down from 1.65 MB.

Half of the callers don't care about the `MethodNameAndSignature` part - don't spend time computing it.

This also allows trimming `MethodNameAndSignature` from a hello world, which allows trimming pretty much all of the type loader.

Cc @dotnet/ilc-contrib 