### PR TITLE
Update error thrown on multiple non-conforming StartupHook.Initialize signatures

### DIFF
--- a/src/installer/tests/Assets/TestProjects/StartupHookWithMultipleIncorrectSignatures/StartupHookWithMultipleIncorrectSignatures.cs
+++ b/src/installer/tests/Assets/TestProjects/StartupHookWithMultipleIncorrectSignatures/StartupHookWithMultipleIncorrectSignatures.cs
@@ -11,11 +11,10 @@ internal class StartupHook
     // case where there are multiple incorrect Initialize
     // methods. Instead, the startup hook provider code should throw
     // an exception.
- 
-    public static int Initialize()
+
+    public void Initialize()
     {
-        Console.WriteLine("Hello from startup hook returning int!");
-        return 10;
+        Console.WriteLine("Hello from startup hook with instance method!");
     }
 
     public static void Initialize(int input)


### PR DESCRIPTION
`StartupHookProvider` intentionally tries to give a more detailed error if the startup hook has an `Initialize` method with a different signature. However, in the case where there are multiple methods that aren't parameterless and static, we end up throwing `MissingMethodException` indicating that `StartupHook.Initialize` doesn't exist at all. This updates the logic such that we throw with the message about an incorrect signature instead.
