### PR TITLE
Caching settings.pause_mode to avoid deadlock

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -22634,6 +22634,8 @@ void gc_heap::garbage_collect_pm_full_gc()
 
 void gc_heap::garbage_collect (int n)
 {
+    gc_pause_mode saved_settings_pause_mode = settings.pause_mode;
+
     //reset the number of alloc contexts
     alloc_contexts_used = 0;
 
@@ -23039,7 +23041,7 @@ void gc_heap::garbage_collect (int n)
 #endif //MULTIPLE_HEAPS
 
 done:
-    if (settings.pause_mode == pause_no_gc)
+    if (saved_settings_pause_mode == pause_no_gc)
         allocate_for_no_gc_after_gc();
 }
 


### PR DESCRIPTION
This fixes #84096.

[This](https://github.com/dotnet/runtime/issues/84096#issuecomment-1491263807) comment explains the problem and how this fix works.

Here is the validation done for the PR.

- [x] GC Perf Sim 
	 - [x] Normal Server 
	- [ ] Normal Workstation 
	- [ ] Large Pages Server 
	- [ ] Large Pages Workstation 
	- [ ] Low Memory Container 
	- [ ] High Memory Load
- [x] Microbenchmarks 
	 - [x] V8 Test 
	- [ ] Top 20 Microbenchmarks
- [x] ASPNet Benchmarks 
	 - [x] JsonMin - Windows 
	- [ ] JsonMin - Linux 
	- [ ]  Fortunes ETF - Windows 
	- [ ]  Fortunes ETF - Linux