### PR TITLE
Disable all in-process execution in JIT\Regression

### DIFF
--- a/src/tests/JIT/Regression/Directory.Build.props
+++ b/src/tests/JIT/Regression/Directory.Build.props
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
+    <!-- Temporary: disable all in-process execution for JIT\Regression
+         to fix gcstress runs -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+
     <BuildAsStandalone Condition="'$(BuildAsStandalone)' == ''">false</BuildAsStandalone>
 
     <AssemblyName Condition="'$(BuildAsStandalone)' != 'true'">$(MSBuildProjectName.Replace('_il_d', '').Replace('_il_r', ''))</AssemblyName>


### PR DESCRIPTION
Backup plan to unblock gcstress if #84193 doesn't go anywhere and we decide we want gcstress over merged test groups for now.