### PR TITLE
Correctly display the GCSettings specified in the runtimeconfig json via the GC Configuration API Call 

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -14053,6 +14053,7 @@ gc_heap::init_semi_shared()
     if (conserve_mem_setting > 9)
         conserve_mem_setting = 9;
 
+    GCConfig::SetGCConserveMem(conserve_mem_setting);
     dprintf (1, ("conserve_mem_setting = %d", conserve_mem_setting));
 
     reset_mm_p = TRUE;
@@ -45360,6 +45361,9 @@ HRESULT GCHeap::Initialize()
 #endif //USE_REGIONS
 
 #endif //HOST_64BIT
+
+    GCConfig::SetRetainVM(GCConfig::GetRetainVM());
+    GCConfig::SetGCHeapHardLimitPercent(GCConfig::GetGCHeapHardLimitPercent());
     GCConfig::SetGCLargePages(gc_heap::use_large_pages_p);
 
     uint32_t nhp = 1;
@@ -45414,6 +45418,8 @@ HRESULT GCHeap::Initialize()
 
     gc_heap::gc_thread_no_affinitize_p = (gc_heap::heap_hard_limit ?
         !affinity_config_specified_p : (GCConfig::GetNoAffinitize() != 0));
+
+    GCConfig::SetNoAffinitize(GCConfig::GetNoAffinitize());
 
     if (!(gc_heap::gc_thread_no_affinitize_p))
     {
@@ -45549,6 +45555,10 @@ HRESULT GCHeap::Initialize()
     GCConfig::SetGCHeapHardLimitSOH(static_cast<int64_t>(gc_heap::heap_hard_limit_oh[soh]));
     GCConfig::SetGCHeapHardLimitLOH(static_cast<int64_t>(gc_heap::heap_hard_limit_oh[loh]));
     GCConfig::SetGCHeapHardLimitPOH(static_cast<int64_t>(gc_heap::heap_hard_limit_oh[poh]));
+
+    GCConfig::SetGCHeapHardLimitSOHPercent(GCConfig::GetGCHeapHardLimitSOHPercent());
+    GCConfig::SetGCHeapHardLimitLOHPercent(GCConfig::GetGCHeapHardLimitLOHPercent());
+    GCConfig::SetGCHeapHardLimitPOHPercent(GCConfig::GetGCHeapHardLimitPOHPercent());
 
     if (hr != S_OK)
         return hr;

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -14053,7 +14053,6 @@ gc_heap::init_semi_shared()
     if (conserve_mem_setting > 9)
         conserve_mem_setting = 9;
 
-    GCConfig::SetGCConserveMem(conserve_mem_setting);
     dprintf (1, ("conserve_mem_setting = %d", conserve_mem_setting));
 
     reset_mm_p = TRUE;
@@ -45361,7 +45360,6 @@ HRESULT GCHeap::Initialize()
 #endif //USE_REGIONS
 
 #endif //HOST_64BIT
-
     GCConfig::SetGCLargePages(gc_heap::use_large_pages_p);
 
     uint32_t nhp = 1;

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -45356,7 +45356,8 @@ HRESULT GCHeap::Initialize()
         }
         gc_heap::regions_range = align_on_page(gc_heap::regions_range);
     }
-    // TODO: Set config after config API is merged.
+
+    GCConfig::SetGCRegionRange(gc_heap::regions_range);
 #endif //USE_REGIONS
 
 #endif //HOST_64BIT

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -45362,8 +45362,6 @@ HRESULT GCHeap::Initialize()
 
 #endif //HOST_64BIT
 
-    GCConfig::SetRetainVM(GCConfig::GetRetainVM());
-    GCConfig::SetGCHeapHardLimitPercent(GCConfig::GetGCHeapHardLimitPercent());
     GCConfig::SetGCLargePages(gc_heap::use_large_pages_p);
 
     uint32_t nhp = 1;
@@ -45418,8 +45416,6 @@ HRESULT GCHeap::Initialize()
 
     gc_heap::gc_thread_no_affinitize_p = (gc_heap::heap_hard_limit ?
         !affinity_config_specified_p : (GCConfig::GetNoAffinitize() != 0));
-
-    GCConfig::SetNoAffinitize(GCConfig::GetNoAffinitize());
 
     if (!(gc_heap::gc_thread_no_affinitize_p))
     {
@@ -45556,10 +45552,6 @@ HRESULT GCHeap::Initialize()
     GCConfig::SetGCHeapHardLimitLOH(static_cast<int64_t>(gc_heap::heap_hard_limit_oh[loh]));
     GCConfig::SetGCHeapHardLimitPOH(static_cast<int64_t>(gc_heap::heap_hard_limit_oh[poh]));
 
-    GCConfig::SetGCHeapHardLimitSOHPercent(GCConfig::GetGCHeapHardLimitSOHPercent());
-    GCConfig::SetGCHeapHardLimitLOHPercent(GCConfig::GetGCHeapHardLimitLOHPercent());
-    GCConfig::SetGCHeapHardLimitPOHPercent(GCConfig::GetGCHeapHardLimitPOHPercent());
-
     if (hr != S_OK)
         return hr;
 
@@ -45595,8 +45587,6 @@ HRESULT GCHeap::Initialize()
         gc_heap::high_memory_load_th = 100 - available_mem_th;
         gc_heap::v_high_memory_load_th = 97;
     }
-
-    GCConfig::SetGCHighMemPercent(highmem_th_from_config);
 
     gc_heap::m_high_memory_load_th = min ((gc_heap::high_memory_load_th + 5), gc_heap::v_high_memory_load_th);
 

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -45586,6 +45586,8 @@ HRESULT GCHeap::Initialize()
         gc_heap::v_high_memory_load_th = 97;
     }
 
+    GCConfig::SetGCHighMemPercent(highmem_th_from_config);
+
     gc_heap::m_high_memory_load_th = min ((gc_heap::high_memory_load_th + 5), gc_heap::v_high_memory_load_th);
 
     gc_heap::pm_stress_on = (GCConfig::GetGCProvModeStress() != 0);

--- a/src/coreclr/gc/gcconfig.cpp
+++ b/src/coreclr/gc/gcconfig.cpp
@@ -18,8 +18,13 @@
 
 #define INT_CONFIG(name, unused_private_key, unused_public_key, default, unused_doc)  \
   int64_t GCConfig::Get##name() { return s_##name; }                                  \
+  int64_t GCConfig::Get##name(int64_t defaultValue)                                   \
+  {                                                                                   \
+      return s_##name##Provided ? s_##name : defaultValue;                            \
+  }                                                                                   \
   void GCConfig::Set##name(int64_t value) { s_Updated##name = value; }                \
   int64_t GCConfig::s_##name = default;                                               \
+  bool GCConfig::s_##name##Provided = false;                                          \
   int64_t GCConfig::s_Updated##name = default;
 
 // String configs are not cached because 1) they are rare and
@@ -68,9 +73,9 @@ void GCConfig::Initialize()
     s_##name##Provided = GCToEEInterface::GetBooleanConfigValue(private_key, public_key, &s_##name); \
     s_Updated##name = s_##name; 
     
-#define INT_CONFIG(name, private_key, public_key, unused_default, unused_doc)   \
-    GCToEEInterface::GetIntConfigValue(private_key, public_key, &s_##name);     \
-    s_Updated##name = s_##name;                                                 
+#define INT_CONFIG(name, private_key, public_key, unused_default, unused_doc)                    \
+    s_##name##Provided = GCToEEInterface::GetIntConfigValue(private_key, public_key, &s_##name); \
+    s_Updated##name = s_##name;                                                                  \
 
 #define STRING_CONFIG(unused_name, unused_private_key, unused_public_key, unused_doc)
 

--- a/src/coreclr/gc/gcconfig.cpp
+++ b/src/coreclr/gc/gcconfig.cpp
@@ -64,10 +64,10 @@ GC_CONFIGURATION_KEYS
 
 void GCConfig::Initialize()
 {
-#define BOOL_CONFIG(name, private_key, public_key, unused_default, unused_doc)  \
-    s_Updated##name = s_##name##Provided = GCToEEInterface::GetBooleanConfigValue(private_key, public_key, &s_##name);
+#define BOOL_CONFIG(name, private_key, public_key, unused_default, unused_doc)                       \
+    s_##name##Provided = GCToEEInterface::GetBooleanConfigValue(private_key, public_key, &s_##name); \
+    s_Updated##name = s_##name; 
     
-
 #define INT_CONFIG(name, private_key, public_key, unused_default, unused_doc)   \
     GCToEEInterface::GetIntConfigValue(private_key, public_key, &s_##name);     \
     s_Updated##name = s_##name;                                                 

--- a/src/coreclr/gc/gcconfig.cpp
+++ b/src/coreclr/gc/gcconfig.cpp
@@ -65,10 +65,12 @@ GC_CONFIGURATION_KEYS
 void GCConfig::Initialize()
 {
 #define BOOL_CONFIG(name, private_key, public_key, unused_default, unused_doc)  \
-    s_##name##Provided = GCToEEInterface::GetBooleanConfigValue(private_key, public_key, &s_##name);
+    s_Updated##name = s_##name##Provided = GCToEEInterface::GetBooleanConfigValue(private_key, public_key, &s_##name);
+    
 
 #define INT_CONFIG(name, private_key, public_key, unused_default, unused_doc)   \
-    GCToEEInterface::GetIntConfigValue(private_key, public_key, &s_##name);
+    GCToEEInterface::GetIntConfigValue(private_key, public_key, &s_##name);     \
+    s_Updated##name = s_##name;                                                 
 
 #define STRING_CONFIG(unused_name, unused_private_key, unused_public_key, unused_doc)
 

--- a/src/coreclr/gc/gcconfig.h
+++ b/src/coreclr/gc/gcconfig.h
@@ -151,9 +151,11 @@ class GCConfig
   
 #define INT_CONFIG(name, unused_private_key, unused_public_key, unused_default, unused_doc) \
   public: static int64_t Get##name();                            \
+  public: static int64_t Get##name(int64_t defaultValue);        \
   public: static void Set##name(int64_t value);                  \
   private: static int64_t s_##name;                              \
-  private: static int64_t s_Updated##name;
+  private: static bool s_##name##Provided;                       \
+  private: static int64_t s_Updated##name;                       \
 
 #define STRING_CONFIG(name, unused_private_key, unused_public_key, unused_doc) \
   public: static GCConfigStringHolder Get##name();


### PR DESCRIPTION
Fixes #84198 by honoring the user specified GC Configuration by appropriately setting the Configuration obtained from both the Environment Variables and the JSON Configuration.