### PR TITLE
[PERF] Enable daily perf runs on cloud VMs

### DIFF
--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -103,6 +103,8 @@ extends:
             jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
             buildConfig: release
             platforms:
+            - linux_x64
+            - windows_x64
             - linux_arm64
             - windows_arm64
             jobParameters:

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -217,7 +217,25 @@ extends:
               projectFile: microbenchmarks.proj
               runKind: micro
               runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-              logicalmachine: 'perfampere' 
+              logicalmachine: 'perfampere'
+        
+        # run coreclr cloudvm microbenchmarks perf job
+        # this run is added temporarily for measuring AVX-512 performance
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+            buildConfig: release
+            runtimeFlavor: coreclr
+            platforms:
+            - linux_x64
+            - windows_x64
+            jobParameters:
+              testGroup: perf
+              liveLibrariesBuildConfig: Release
+              projectFile: microbenchmarks.proj
+              runKind: micro
+              runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+              logicalmachine: 'cloudvm'
 
       # Uncomment once we fix https://github.com/dotnet/performance/issues/1950
       # # run coreclr linux crossgen perf job

--- a/eng/testing/performance/performance-setup.ps1
+++ b/eng/testing/performance/performance-setup.ps1
@@ -51,7 +51,7 @@ if ($Internal) {
         "perfsurf" { $Queue = "Windows.10.Arm64.Perf.Surf"  }
         "perfpixel4a" { $Queue = "Windows.10.Amd64.Pixel.Perf" }
         "perfampere" { $Queue = "Windows.Server.Arm64.Perf" }
-        "cloudvm" { $Queue = "Windows.10.Amd64.Open" }
+        "cloudvm" { $Queue = "Windows.10.Amd64" }
         Default { $Queue = "Windows.10.Amd64.19H1.Tiger.Perf" }
     }
     $PerfLabArguments = "--upload-to-perflab-container"

--- a/eng/testing/performance/performance-setup.ps1
+++ b/eng/testing/performance/performance-setup.ps1
@@ -51,6 +51,7 @@ if ($Internal) {
         "perfsurf" { $Queue = "Windows.10.Arm64.Perf.Surf"  }
         "perfpixel4a" { $Queue = "Windows.10.Amd64.Pixel.Perf" }
         "perfampere" { $Queue = "Windows.Server.Arm64.Perf" }
+        "cloudvm" { $Queue = "Windows.10.Amd64.Open" }
         Default { $Queue = "Windows.10.Amd64.19H1.Tiger.Perf" }
     }
     $PerfLabArguments = "--upload-to-perflab-container"

--- a/eng/testing/performance/performance-setup.sh
+++ b/eng/testing/performance/performance-setup.sh
@@ -255,6 +255,8 @@ if [[ "$internal" == true ]]; then
         queue=OSX.1015.Amd64.Iphone.Perf
     elif [[ "$logical_machine" == "perfampere" ]]; then
         queue=Ubuntu.2004.Arm64.Perf
+    elif [[ "$logical_machine" == "cloudvm" ]]; then
+        queue=Ubuntu.1804.Amd64.open
     elif [[ "$architecture" == "arm64" ]]; then
         queue=Ubuntu.1804.Arm64.Perf
     else

--- a/eng/testing/performance/performance-setup.sh
+++ b/eng/testing/performance/performance-setup.sh
@@ -256,7 +256,7 @@ if [[ "$internal" == true ]]; then
     elif [[ "$logical_machine" == "perfampere" ]]; then
         queue=Ubuntu.2004.Arm64.Perf
     elif [[ "$logical_machine" == "cloudvm" ]]; then
-        queue=Ubuntu.1804.Amd64.open
+        queue=Ubuntu.1804.Amd64
     elif [[ "$architecture" == "arm64" ]]; then
         queue=Ubuntu.1804.Arm64.Perf
     else


### PR DESCRIPTION
This adds two additional runs to dotnet-runtime-perf-slow pipeline which run on a queue that is backed by a cloud VM rather than on-prem. The main purpose of adding these for now is so that we are running benchmarks on machines that have AVX-512 support which the on-premise machines don't support today. It's acknowledged that results from these VMs will likely be much noisier.