### PR TITLE
Use FastAllocateString in InvariantModeCasing

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/InvariantModeCasing.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/InvariantModeCasing.cs
@@ -53,13 +53,13 @@ namespace System.Globalization
                 return s;
             }
 
-            return string.Create(s.Length, (s, i), static (destination, state) =>
-            {
-                ReadOnlySpan<char> src = state.s;
-                src.Slice(0, state.i).CopyTo(destination);
-                InvariantModeCasing.ToLower(src.Slice(state.i), destination.Slice(state.i));
-            });
+            string result = string.FastAllocateString(s.Length);
+            var destination = new Span<char>(ref result.GetRawStringData(), result.Length);
+            ReadOnlySpan<char> src = s;
+            src.Slice(0, i).CopyTo(destination);
+            InvariantModeCasing.ToLower(src.Slice(i), destination.Slice(i));
 
+            return result;
         }
 
         internal static string ToUpper(string s)
@@ -99,12 +99,13 @@ namespace System.Globalization
                 return s;
             }
 
-            return string.Create(s.Length, (s, i), static (destination, state) =>
-            {
-                ReadOnlySpan<char> src = state.s;
-                src.Slice(0, state.i).CopyTo(destination);
-                InvariantModeCasing.ToUpper(src.Slice(state.i), destination.Slice(state.i));
-            });
+            string result = string.FastAllocateString(s.Length);
+            var destination = new Span<char>(ref result.GetRawStringData(), result.Length);
+            ReadOnlySpan<char> src = s;
+            src.Slice(0, i).CopyTo(destination);
+            InvariantModeCasing.ToUpper(src.Slice(i), destination.Slice(i));
+
+            return result;
         }
 
         internal static void ToUpper(ReadOnlySpan<char> source, Span<char> destination)


### PR DESCRIPTION
A delegate with a ValueTuple over a reference type triggers generation of type loader data structures to load arbitrary ValueTuples over reference types at runtime. The replacement is a lot less expensive.

https://github.com/dotnet/runtime/pull/84156#issuecomment-1491405388

Cc @dotnet/ilc-contrib 