### PR TITLE
Add fast path to MemoryExtensions.Trim for input that needs no trimming

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -309,12 +309,7 @@ namespace System
                 throw new FormatException(SR.Format_InvalidGuidFormatSpecification);
             }
 
-            if (input.Length > 0 &&
-                char.IsWhiteSpace(input[0]) ||
-                char.IsWhiteSpace(input[input.Length - 1]))
-            {
-                input = input.Trim();
-            }
+            input = input.Trim();
 
             var result = new GuidResult(GuidParseThrowStyle.AllButOverflow);
             bool success = ((char)(format[0] | 0x20)) switch
@@ -349,11 +344,7 @@ namespace System
                 return false;
             }
 
-            if (char.IsWhiteSpace(input[0]) ||
-                char.IsWhiteSpace(input[input.Length - 1]))
-            {
-                input = input.Trim();
-            }
+            input = input.Trim();
 
             var parseResult = new GuidResult(GuidParseThrowStyle.None);
             bool success = false;
@@ -394,21 +385,12 @@ namespace System
 
         private static bool TryParseGuid(ReadOnlySpan<char> guidString, ref GuidResult result)
         {
+            guidString = guidString.Trim(); // Remove whitespace from beginning and end
+
             if (guidString.Length < 32) // Minimal length we can parse ('N' format)
             {
                 result.SetFailure(ParseFailure.Format_GuidUnrecognized);
                 return false;
-            }
-
-            if (char.IsWhiteSpace(guidString[0]) ||
-                char.IsWhiteSpace(guidString[guidString.Length - 1]))
-            {
-                guidString = guidString.Trim(); // Remove whitespace from beginning and end
-                if (guidString.Length < 32) // Minimal length we can parse ('N' format)
-                {
-                    result.SetFailure(ParseFailure.Format_GuidUnrecognized);
-                    return false;
-                }
             }
 
             return (guidString[0]) switch

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -349,8 +349,7 @@ namespace System
                 return false;
             }
 
-            if (input.Length > 0 &&
-                char.IsWhiteSpace(input[0]) ||
+            if (char.IsWhiteSpace(input[0]) ||
                 char.IsWhiteSpace(input[input.Length - 1]))
             {
                 input = input.Trim();

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.Trim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.Trim.cs
@@ -804,6 +804,7 @@ namespace System
                         break;
                     }
                 }
+
                 int end = span.Length - 1;
                 for (; end > start; end--)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.Trim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.Trim.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace System
 {
@@ -565,27 +566,38 @@ namespace System
         /// Removes all leading and trailing white-space characters from the span.
         /// </summary>
         /// <param name="span">The source span from which the characters are removed.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ReadOnlySpan<char> Trim(this ReadOnlySpan<char> span)
         {
-            int start = 0;
-            for (; start < span.Length; start++)
+            // Assume that in most cases input doesn't need trimming
+            if (span.Length == 0 ||
+                (span.Length > 0 && !char.IsWhiteSpace(span[0]) && !char.IsWhiteSpace(span[^1])))
             {
-                if (!char.IsWhiteSpace(span[start]))
-                {
-                    break;
-                }
+                return span;
             }
+            return TrimFallback(span);
 
-            int end = span.Length - 1;
-            for (; end > start; end--)
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static ReadOnlySpan<char> TrimFallback(ReadOnlySpan<char> span)
             {
-                if (!char.IsWhiteSpace(span[end]))
+                int start = 0;
+                for (; start < span.Length; start++)
                 {
-                    break;
+                    if (!char.IsWhiteSpace(span[start]))
+                    {
+                        break;
+                    }
                 }
+                int end = span.Length - 1;
+                for (; end > start; end--)
+                {
+                    if (!char.IsWhiteSpace(span[end]))
+                    {
+                        break;
+                    }
+                }
+                return span.Slice(start, end - start + 1);
             }
-
-            return span.Slice(start, end - start + 1);
         }
 
         /// <summary>
@@ -770,11 +782,38 @@ namespace System
         /// Removes all leading and trailing white-space characters from the span.
         /// </summary>
         /// <param name="span">The source span from which the characters are removed.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Span<char> Trim(this Span<char> span)
         {
-            int start = ClampStart(span);
-            int length = ClampEnd(span, start);
-            return span.Slice(start, length);
+            // Assume that in most cases input doesn't need trimming
+            if (span.Length == 0 ||
+                (span.Length > 0 && !char.IsWhiteSpace(span[0]) && !char.IsWhiteSpace(span[^1])))
+            {
+                return span;
+            }
+            return TrimFallback(span);
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static Span<char> TrimFallback(Span<char> span)
+            {
+                int start = 0;
+                for (; start < span.Length; start++)
+                {
+                    if (!char.IsWhiteSpace(span[start]))
+                    {
+                        break;
+                    }
+                }
+                int end = span.Length - 1;
+                for (; end > start; end--)
+                {
+                    if (!char.IsWhiteSpace(span[end]))
+                    {
+                        break;
+                    }
+                }
+                return span.Slice(start, end - start + 1);
+            }
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.Trim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.Trim.cs
@@ -571,7 +571,7 @@ namespace System
         {
             // Assume that in most cases input doesn't need trimming
             if (span.Length == 0 ||
-                (span.Length > 0 && !char.IsWhiteSpace(span[0]) && !char.IsWhiteSpace(span[^1])))
+                (!char.IsWhiteSpace(span[0]) && !char.IsWhiteSpace(span[^1])))
             {
                 return span;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.Trim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.Trim.cs
@@ -787,7 +787,7 @@ namespace System
         {
             // Assume that in most cases input doesn't need trimming
             if (span.Length == 0 ||
-                (span.Length > 0 && !char.IsWhiteSpace(span[0]) && !char.IsWhiteSpace(span[^1])))
+                (!char.IsWhiteSpace(span[0]) && !char.IsWhiteSpace(span[^1])))
             {
                 return span;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.Trim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.Trim.cs
@@ -588,6 +588,7 @@ namespace System
                         break;
                     }
                 }
+
                 int end = span.Length - 1;
                 for (; end > start; end--)
                 {


### PR DESCRIPTION
Profiler states that majority of time during `Guid.Parse` is spent inside `.Trim()` and it seems that if we can trade around 1% of perf for inputs with trailing/leading whitespaces we can get up to 45% boost for other cases, e.g.:
```csharp
[Benchmark]
public Guid ParseN() => Guid.Parse("14c63ab0f7cd464f8096539cbe70a80e");

[Benchmark]
public Guid ParseB() => Guid.Parse("{8FB23982-A2C4-4F46-B915-C0CE14241EFD}");

[Benchmark]
public Guid ParseDefault() => Guid.Parse("d1f168a8-ca0e-428d-8677-8b343b745376");

[Benchmark]
public Guid ParseDefaultWhitespaces() => Guid.Parse("  d1f168a8-ca0e-428d-8677-8b343b745376  ");

string _emptyInput = "";
[Benchmark]
public bool TryParseEmpty() => Guid.TryParse(_emptyInput, out Guid _);
```
```
|                  Method |                   Toolchain |      Mean |
|------------------------ |---------------------------- |----------:|
|                  ParseN |      \Core_Root\corerun.exe | 18.802 ns |
|                  ParseN | \Core_Root_base\corerun.exe | 24.441 ns |
|                         |                             |           |
|                  ParseB |      \Core_Root\corerun.exe | 12.714 ns |
|                  ParseB | \Core_Root_base\corerun.exe | 19.173 ns |
|                         |                             |           |
|            ParseDefault |      \Core_Root\corerun.exe | 18.007 ns |
|            ParseDefault | \Core_Root_base\corerun.exe | 24.995 ns |
|                         |                             |           |
| ParseDefaultWhitespaces |      \Core_Root\corerun.exe | 25.903 ns |
| ParseDefaultWhitespaces | \Core_Root_base\corerun.exe | 25.747 ns |
|                         |                             |           |
|           TryParseEmpty |      \Core_Root\corerun.exe |  2.544 ns |
|           TryParseEmpty | \Core_Root_base\corerun.exe |  6.919 ns |
```
Another mystery is why B format is faster than N (reproduces accross multiple runs)

PS: grep.app for Guid.Parse with constant input: https://grep.app/search?q=Guid.Parse%28%22&filter[lang][0]=C%23 (unlikely on hot path but anyway)