### PR TITLE
Eliminate bound checks for "arr[arr.Length - cns]"

### DIFF
--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -284,7 +284,7 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, Statement* stmt, GenTree*
     if (m_pCompiler->vnStore->GetVNFunc(idxVn, &funcApp) && funcApp.m_func == (VNFunc)GT_ADD)
     {
         bool     isArrlenAddCns = false;
-        ValueNum cnsVN;
+        ValueNum cnsVN          = {};
         if ((arrLenVn == funcApp.m_args[1]) && m_pCompiler->vnStore->IsVNInt32Constant(funcApp.m_args[0]))
         {
             // ADD(cnsVN, arrLenVn);

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -313,7 +313,8 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, Statement* stmt, GenTree*
 
                 // Negative delta in the array access (ArrLen + -CNS)
                 const int delta = m_pCompiler->vnStore->GetConstantInt32(cnsVN);
-                if ((lenLowerLimit > 0) && (delta < 0) && (lenLowerLimit >= -delta))
+                if ((lenLowerLimit > 0) && (delta < 0) && (delta > -CORINFO_Array_MaxLength) &&
+                    (lenLowerLimit >= -delta))
                 {
                     JITDUMP("[RangeCheck::OptimizeRangeCheck] Between bounds\n");
                     m_pCompiler->optRemoveRangeCheck(bndsChk, comma, stmt);

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -313,8 +313,7 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, Statement* stmt, GenTree*
 
                 // Negative delta in the array access (ArrLen + -CNS)
                 const int delta = m_pCompiler->vnStore->GetConstantInt32(cnsVN);
-                if ((lenLowerLimit > 0) && (lenLowerLimit <= CORINFO_Array_MaxLength) && (delta < 0) &&
-                    (delta > -CORINFO_Array_MaxLength) && (lenLowerLimit >= abs(delta)))
+                if ((lenLowerLimit > 0) && (delta < 0) && (lenLowerLimit >= -delta))
                 {
                     JITDUMP("[RangeCheck::OptimizeRangeCheck] Between bounds\n");
                     m_pCompiler->optRemoveRangeCheck(bndsChk, comma, stmt);

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -278,6 +278,49 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, Statement* stmt, GenTree*
     GetOverflowMap()->RemoveAll();
     m_pSearchPath = new (m_alloc) SearchPath(m_alloc);
 
+    // Special case: arr[arr.Length - CNS] if we know that arr.Length >= CNS
+    // We assume that SUB(x, CNS) is canonized into ADD(x, -CNS)
+    VNFuncApp funcApp;
+    if (m_pCompiler->vnStore->GetVNFunc(idxVn, &funcApp) && funcApp.m_func == (VNFunc)GT_ADD)
+    {
+        bool     isArrlenAddCns = false;
+        ValueNum cnsVN;
+        if ((arrLenVn == funcApp.m_args[1]) && m_pCompiler->vnStore->IsVNInt32Constant(funcApp.m_args[0]))
+        {
+            // ADD(cnsVN, arrLenVn);
+            isArrlenAddCns = true;
+            cnsVN          = funcApp.m_args[0];
+        }
+        else if ((arrLenVn == funcApp.m_args[0]) && m_pCompiler->vnStore->IsVNInt32Constant(funcApp.m_args[1]))
+        {
+            // ADD(arrLenVn, cnsVN);
+            isArrlenAddCns = true;
+            cnsVN          = funcApp.m_args[1];
+        }
+
+        if (isArrlenAddCns)
+        {
+            // Calculate range for arrLength from assertions, e.g. for
+            //
+            //   bool result = (arr.Length == 0) || (arr[arr.Length - 1] == 0);
+            //
+            // here for the array access we know that arr.Length >= 1
+            Range arrLenRange = GetRange(block, bndsChk->GetArrayLength(), false DEBUGARG(0));
+            if (arrLenRange.LowerLimit().IsConstant())
+            {
+                const int lenLowerLimit = arrLenRange.LowerLimit().GetConstant();
+                const int lenShift      = m_pCompiler->vnStore->GetConstantInt32(cnsVN);
+                if ((lenLowerLimit > 0) && (lenLowerLimit >= lenShift))
+                {
+                    JITDUMP("[RangeCheck::OptimizeRangeCheck] Between bounds\n");
+                    m_pCompiler->optRemoveRangeCheck(bndsChk, comma, stmt);
+                    m_updateStmt = true;
+                    return;
+                }
+            }
+        }
+    }
+
     // Get the range for this index.
     Range range = GetRange(block, treeIndex, false DEBUGARG(0));
 

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -314,7 +314,7 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, Statement* stmt, GenTree*
                 // Negative delta in the array access (ArrLen + -CNS)
                 const int delta = m_pCompiler->vnStore->GetConstantInt32(cnsVN);
                 if ((lenLowerLimit > 0) && (lenLowerLimit <= CORINFO_Array_MaxLength) && (delta < 0) &&
-                    (lenLowerLimit >= abs(delta)))
+                    (delta > -CORINFO_Array_MaxLength) && (lenLowerLimit >= abs(delta)))
                 {
                     JITDUMP("[RangeCheck::OptimizeRangeCheck] Between bounds\n");
                     m_pCompiler->optRemoveRangeCheck(bndsChk, comma, stmt);


### PR DESCRIPTION
Motivation: https://github.com/dotnet/runtime/pull/84210#discussion_r1155138738
```csharp
void Test1(int[] arr)
{
    if (arr.Length == 0 || arr[arr.Length - 1] == 0)
        Console.WriteLine();
}

void Test2(int[] arr)
{
    if (arr.Length < 10)
        return;
    
    if (arr[^10] == 0)
        Console.WriteLine();
}
```
Previous codegen:
```asm
; Method Test1(int[]):this
       sub      rsp, 40
       mov      eax, dword ptr [rdx+08H]
       test     eax, eax
       je       SHORT G_M32023_IG04
       lea      ecx, [rax-01H]
       cmp      ecx, eax
       jae      SHORT G_M32023_IG06
       mov      eax, ecx
       cmp      dword ptr [rdx+4*rax+10H], 0
       jne      SHORT G_M32023_IG05
G_M32023_IG04:
       add      rsp, 40
       tail.jmp [System.Console:WriteLine()]
G_M32023_IG05:
       add      rsp, 40
       ret      
G_M32023_IG06:
       call     CORINFO_HELP_RNGCHKFAIL
       int3     
; Total bytes of code: 48


; Method Test2(int[]):this
       sub      rsp, 40
       mov      eax, dword ptr [rdx+08H]
       cmp      eax, 10
       jge      SHORT G_M54292_IG04
       add      rsp, 40
       ret      
G_M54292_IG04:
       lea      ecx, [rax-0AH]
       cmp      ecx, eax
       jae      SHORT G_M54292_IG07
       mov      eax, ecx
       cmp      dword ptr [rdx+4*rax+10H], 0
       jne      SHORT G_M54292_IG06
       add      rsp, 40
       tail.jmp [System.Console:WriteLine()]
G_M54292_IG06:
       add      rsp, 40
       ret      
G_M54292_IG07:
       call     CORINFO_HELP_RNGCHKFAIL
       int3     
; Total bytes of code: 54
```
New codegen:
```asm
; Method Test1(int[]):this
       mov      eax, dword ptr [rdx+08H]
       test     eax, eax
       je       SHORT G_M32023_IG04
       dec      eax
       cmp      dword ptr [rdx+4*rax+10H], 0
       jne      SHORT G_M32023_IG05
G_M32023_IG04:
       tail.jmp [System.Console:WriteLine()]
G_M32023_IG05:
       ret      
; Total bytes of code: 23


; Method Test2(int[]):this
       mov      eax, dword ptr [rdx+08H]
       cmp      eax, 10
       jge      SHORT G_M54292_IG04
       ret      
G_M54292_IG04:
       add      eax, -10
       cmp      dword ptr [rdx+4*rax+10H], 0
       jne      SHORT G_M54292_IG06
       tail.jmp [System.Console:WriteLine()]
G_M54292_IG06:
       ret      
; Total bytes of code: 26
```