### PR TITLE
Fix parallel SuperPMI output handling

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi-shared/logging.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/logging.h
@@ -20,6 +20,9 @@
 #define LogVerbose(...) LogMessage(LOGLEVEL_VERBOSE, __VA_ARGS__)
 #define LogDebug(...) LogMessage(LOGLEVEL_DEBUG, __VA_ARGS__)
 
+#define LogPassThroughStdout(...) LogMessage(LOGLEVEL_PASSTHROUGH_STDOUT, __VA_ARGS__)
+#define LogPassThroughStderr(...) LogMessage(LOGLEVEL_PASSTHROUGH_STDERR, __VA_ARGS__)
+
 #define LogIssue(issue, msg, ...) IssueLogger::LogIssueHelper(__FUNCTION__, __FILE__, __LINE__, issue, msg, __VA_ARGS__)
 
 // Captures the exception message before throwing so we can log it at the point of occurrence
@@ -33,13 +36,15 @@
 // These are specified as flags so subsets of the logging functionality can be enabled/disabled at once
 enum LogLevel : UINT32
 {
-    LOGLEVEL_ERROR   = 0x00000001, // Internal fatal errors that are non-recoverable
-    LOGLEVEL_WARNING = 0x00000002, // Internal conditions that are unusual, but not serious
-    LOGLEVEL_MISSING = 0x00000004, // Failures to due to missing JIT-EE details
-    LOGLEVEL_ISSUE   = 0x00000008, // Issues found with the JIT, e.g. asm diffs, asserts
-    LOGLEVEL_INFO    = 0x00000010, // Notifications/summaries, e.g. 'Loaded 5  Jitted 4  FailedCompile 1'
-    LOGLEVEL_VERBOSE = 0x00000020, // Status messages, e.g. 'Jit startup took 151.12ms'
-    LOGLEVEL_DEBUG   = 0x00000040  // Detailed output that's only useful for SuperPMI debugging
+    LOGLEVEL_ERROR              = 0x00000001, // Internal fatal errors that are non-recoverable
+    LOGLEVEL_WARNING            = 0x00000002, // Internal conditions that are unusual, but not serious
+    LOGLEVEL_MISSING            = 0x00000004, // Failures to due to missing JIT-EE details
+    LOGLEVEL_ISSUE              = 0x00000008, // Issues found with the JIT, e.g. asm diffs, asserts
+    LOGLEVEL_INFO               = 0x00000010, // Notifications/summaries, e.g. 'Loaded 5  Jitted 4  FailedCompile 1'
+    LOGLEVEL_VERBOSE            = 0x00000020, // Status messages, e.g. 'Jit startup took 151.12ms'
+    LOGLEVEL_DEBUG              = 0x00000040, // Detailed output that's only useful for SuperPMI debugging
+    LOGLEVEL_PASSTHROUGH_STDOUT = 0x00000080, // Special: pass through parallel SuperPMI stdout
+    LOGLEVEL_PASSTHROUGH_STDERR = 0x00000100  // Special: pass through parallel SuperPMI stderr
 };
 
 // Preset log level combinations
@@ -77,6 +82,10 @@ public:
     static UINT32 GetLogLevel()
     {
         return s_logLevel;
+    }
+    static bool IsPassThrough(LogLevel level)
+    {
+        return (level == LOGLEVEL_PASSTHROUGH_STDOUT) || (level == LOGLEVEL_PASSTHROUGH_STDERR);
     }
 
     // Return true if all specified log levels are enabled.

--- a/src/coreclr/tools/superpmi/superpmi/commandline.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/commandline.cpp
@@ -365,7 +365,8 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
                     return false;
                 }
 
-                Logger::SetLogLevel(Logger::ParseLogLevelString(argv[i]));
+                o->verbosity = argv[i];
+                Logger::SetLogLevel(Logger::ParseLogLevelString(o->verbosity));
             }
             else if ((_strnicmp(&argv[i][1], "writeLogFile", argLen) == 0))
             {

--- a/src/coreclr/tools/superpmi/superpmi/commandline.h
+++ b/src/coreclr/tools/superpmi/superpmi/commandline.h
@@ -17,6 +17,7 @@ public:
             : nameOfJit(nullptr)
             , nameOfJit2(nullptr)
             , nameOfInputMethodContextFile(nullptr)
+            , verbosity(nullptr)
             , writeLogFile(nullptr)
             , reproName(nullptr)
             , breakOnError(false)
@@ -55,6 +56,7 @@ public:
         char* nameOfJit;
         char* nameOfJit2;
         char* nameOfInputMethodContextFile;
+        char* verbosity;
         char* writeLogFile;
         char* reproName;
         bool  breakOnError;


### PR DESCRIPTION
Previously, parallel SuperPMI parsed very few kinds of output from the child processes, and ignored and discarded the rest. Change this so all output from the child processes is output by the parent process.

For example, this allows the child process JIT to print out statistics, disasm, etc., and have it visible by the parent invoker.

Also, fix `-writeLogFile` and don't pass it to parallel SuperPMI child processes (it will just fail to open the single log file).