### PR TITLE
Add constprop handling for `typeof(T) == typeof(Foo)`

### DIFF
--- a/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
@@ -220,6 +220,47 @@ namespace ILCompiler
             return type.IsMdArray || elementType.IsPointer || elementType.IsFunctionPointer;
         }
 
+        public static bool? CompareTypesForEquality(TypeDesc type1, TypeDesc type2)
+        {
+            bool? result = null;
+
+            // If neither type is a canonical subtype, type handle comparison suffices
+            if (!type1.IsCanonicalSubtype(CanonicalFormKind.Any) && !type2.IsCanonicalSubtype(CanonicalFormKind.Any))
+            {
+                result = type1 == type2;
+            }
+            // If either or both types are canonical subtypes, we can sometimes prove inequality.
+            else
+            {
+                // If either is a value type then the types cannot
+                // be equal unless the type defs are the same.
+                if (type1.IsValueType || type2.IsValueType)
+                {
+                    if (!type1.IsCanonicalDefinitionType(CanonicalFormKind.Universal) && !type2.IsCanonicalDefinitionType(CanonicalFormKind.Universal))
+                    {
+                        if (!type1.HasSameTypeDefinition(type2))
+                        {
+                            result = false;
+                        }
+                    }
+                }
+                // If we have two ref types that are not __Canon, then the
+                // types cannot be equal unless the type defs are the same.
+                else
+                {
+                    if (!type1.IsCanonicalDefinitionType(CanonicalFormKind.Any) && !type2.IsCanonicalDefinitionType(CanonicalFormKind.Any))
+                    {
+                        if (!type1.HasSameTypeDefinition(type2))
+                        {
+                            result = false;
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
+
         public static TypeDesc MergeTypesToCommonParent(TypeDesc ta, TypeDesc tb)
         {
             if (ta == tb)

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -2658,46 +2658,15 @@ namespace Internal.JitInterface
 
         private TypeCompareState compareTypesForEquality(CORINFO_CLASS_STRUCT_* cls1, CORINFO_CLASS_STRUCT_* cls2)
         {
-            TypeCompareState result = TypeCompareState.May;
-
             TypeDesc type1 = HandleToObject(cls1);
             TypeDesc type2 = HandleToObject(cls2);
 
-            // If neither type is a canonical subtype, type handle comparison suffices
-            if (!type1.IsCanonicalSubtype(CanonicalFormKind.Any) && !type2.IsCanonicalSubtype(CanonicalFormKind.Any))
+            return TypeExtensions.CompareTypesForEquality(type1, type2) switch
             {
-                result = (type1 == type2 ? TypeCompareState.Must : TypeCompareState.MustNot);
-            }
-            // If either or both types are canonical subtypes, we can sometimes prove inequality.
-            else
-            {
-                // If either is a value type then the types cannot
-                // be equal unless the type defs are the same.
-                if (type1.IsValueType || type2.IsValueType)
-                {
-                    if (!type1.IsCanonicalDefinitionType(CanonicalFormKind.Universal) && !type2.IsCanonicalDefinitionType(CanonicalFormKind.Universal))
-                    {
-                        if (!type1.HasSameTypeDefinition(type2))
-                        {
-                            result = TypeCompareState.MustNot;
-                        }
-                    }
-                }
-                // If we have two ref types that are not __Canon, then the
-                // types cannot be equal unless the type defs are the same.
-                else
-                {
-                    if (!type1.IsCanonicalDefinitionType(CanonicalFormKind.Any) && !type2.IsCanonicalDefinitionType(CanonicalFormKind.Any))
-                    {
-                        if (!type1.HasSameTypeDefinition(type2))
-                        {
-                            result = TypeCompareState.MustNot;
-                        }
-                    }
-                }
-            }
-
-            return result;
+                true => TypeCompareState.Must,
+                false => TypeCompareState.MustNot,
+                _ => TypeCompareState.May,
+            };
         }
 
         private CORINFO_CLASS_STRUCT_* mergeClasses(CORINFO_CLASS_STRUCT_* cls1, CORINFO_CLASS_STRUCT_* cls2)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/FeatureSwitchManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/FeatureSwitchManager.cs
@@ -769,21 +769,14 @@ namespace ILCompiler
             if (type1.ContainsSignatureVariables() || type2.ContainsSignatureVariables())
                 return false;
 
-            // If either type is in canonical form, we cannot directly compare, but we could still be able
-            // to figure out things are false: if one of them is a reference type canon and the other is a valuetype.
-            if (type1.IsCanonicalDefinitionType(CanonicalFormKind.Specific) && !type1.IsValueType
-                && !type2.IsCanonicalDefinitionType(CanonicalFormKind.Any) && type2.IsValueType)
-                constant = 0;
-            else if (type2.IsCanonicalDefinitionType(CanonicalFormKind.Specific) && !type2.IsValueType
-                && !type1.IsCanonicalDefinitionType(CanonicalFormKind.Any) && type1.IsValueType)
-                constant = 0;
-            else if (type1.IsCanonicalSubtype(CanonicalFormKind.Any) || type2.IsCanonicalSubtype(CanonicalFormKind.Any))
+            bool? equality = TypeExtensions.CompareTypesForEquality(type1, type2);
+            if (!equality.HasValue)
                 return false;
-            else
-                constant = type1 == type2 ? 1 : 0;
+
+            constant = equality.Value ? 1 : 0;
 
             if (op == "op_Inequality")
-                constant = constant == 0 ? 1 : 0;
+                constant ^= 1;
 
             return true;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/FeatureSwitchManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/FeatureSwitchManager.cs
@@ -86,10 +86,10 @@ namespace ILCompiler
                 var resultDef = result.GetMethodILDefinition();
                 if (resultDef != result)
                 {
-                    MethodIL newBodyDef = GetMethodILWithInlinedSubstitutions(resultDef);
+                    MethodIL newBodyDef = GetMethodILWithInlinedSubstitutions(result);
 
                     // If we didn't rewrite the body, we can keep the existing result.
-                    if (newBodyDef != resultDef)
+                    if (newBodyDef != result)
                         result = new InstantiatedMethodIL(method, newBodyDef);
                 }
                 else
@@ -149,8 +149,6 @@ namespace ILCompiler
             //
             // We also attempt to rewrite calls to SR.SomeResourceString accessors with string
             // literals looked up from the managed resources.
-
-            Debug.Assert(method.GetMethodILDefinition() == method);
 
             // Do not attempt to inline resource strings if we only want to use resource keys.
             // The optimizations are not compatible.
@@ -542,7 +540,7 @@ namespace ILCompiler
                 }
             }
 
-            return new SubstitutedMethodIL(method, newBody, newEHRegions.ToArray(), debugInfo, newStrings.ToArray());
+            return new SubstitutedMethodIL(method.GetMethodILDefinition(), newBody, newEHRegions.ToArray(), debugInfo, newStrings.ToArray());
         }
 
         private bool TryGetConstantArgument(MethodIL methodIL, byte[] body, OpcodeFlags[] flags, int offset, int argIndex, out int constant)
@@ -570,6 +568,13 @@ namespace ILCompiler
                             && (opcode != ILOpcode.callvirt || !method.IsVirtual))
                         {
                             constant = (int)substitution.Value;
+                            return true;
+                        }
+                        else if (method.IsIntrinsic && method.Name is "op_Inequality" or "op_Equality"
+                            && method.OwningType is MetadataType mdType
+                            && mdType.Name == "Type" && mdType.Namespace == "System" && mdType.Module == mdType.Context.SystemModule
+                            && TryExpandTypeEquality(methodIL, body, flags, currentOffset, method.Name, out constant))
+                        {
                             return true;
                         }
                         else
@@ -724,6 +729,94 @@ namespace ILCompiler
             }
 
             return null;
+        }
+
+        private static bool TryExpandTypeEquality(MethodIL methodIL, byte[] body, OpcodeFlags[] flags, int offset, string op, out int constant)
+        {
+            // We expect to see a sequence:
+            // ldtoken Foo
+            // call GetTypeFromHandle
+            // ldtoken Bar
+            // call GetTypeFromHandle
+            // -> offset points here
+            constant = 0;
+            const int SequenceLength = 20;
+            if (offset < SequenceLength)
+                return false;
+
+            if ((flags[offset - SequenceLength] & OpcodeFlags.InstructionStart) == 0)
+                return false;
+
+            ILReader reader = new ILReader(body, offset - SequenceLength);
+
+            TypeDesc type1 = ReadLdToken(ref reader, methodIL, flags);
+            if (type1 == null)
+                return false;
+
+            if (!ReadGetTypeFromHandle(ref reader, methodIL, flags))
+                return false;
+
+            TypeDesc type2 = ReadLdToken(ref reader, methodIL, flags);
+            if (type1 == null)
+                return false;
+
+            if (!ReadGetTypeFromHandle(ref reader, methodIL, flags))
+                return false;
+
+            // Dataflow runs on top of uninstantiated IL and we can't answer some questions there.
+            // Unfortunately this means dataflow will still see code that the rest of the system
+            // might have optimized away. It should not be a problem in practice.
+            if (type1.ContainsSignatureVariables() || type2.ContainsSignatureVariables())
+                return false;
+
+            // If either type is in canonical form, we cannot directly compare, but we could still be able
+            // to figure out things are false: if one of them is a reference type canon and the other is a valuetype.
+            if (type1.IsCanonicalDefinitionType(CanonicalFormKind.Specific) && !type1.IsValueType
+                && !type2.IsCanonicalDefinitionType(CanonicalFormKind.Any) && type2.IsValueType)
+                constant = 0;
+            else if (type2.IsCanonicalDefinitionType(CanonicalFormKind.Specific) && !type2.IsValueType
+                && !type1.IsCanonicalDefinitionType(CanonicalFormKind.Any) && type1.IsValueType)
+                constant = 0;
+            else if (type1.IsCanonicalSubtype(CanonicalFormKind.Any) || type2.IsCanonicalSubtype(CanonicalFormKind.Any))
+                return false;
+            else
+                constant = type1 == type2 ? 1 : 0;
+
+            if (op == "op_Inequality")
+                constant = constant == 0 ? 1 : 0;
+
+            return true;
+
+            static TypeDesc ReadLdToken(ref ILReader reader, MethodIL methodIL, OpcodeFlags[] flags)
+            {
+                ILOpcode opcode = reader.ReadILOpcode();
+                if (opcode != ILOpcode.ldtoken)
+                    return null;
+
+                TypeDesc t = (TypeDesc)methodIL.GetObject(reader.ReadILToken());
+
+                if ((flags[reader.Offset] & OpcodeFlags.BasicBlockStart) != 0)
+                    return null;
+
+                return t;
+            }
+
+            static bool ReadGetTypeFromHandle(ref ILReader reader, MethodIL methodIL, OpcodeFlags[] flags)
+            {
+                ILOpcode opcode = reader.ReadILOpcode();
+                if (opcode != ILOpcode.call)
+                    return false;
+
+                MethodDesc method = (MethodDesc)methodIL.GetObject(reader.ReadILToken());
+
+                if (!method.IsIntrinsic || method.Name != "GetTypeFromHandle")
+                    return false;
+
+                if ((flags[reader.Offset] & OpcodeFlags.BasicBlockStart) != 0)
+                    return false;
+
+                return true;
+            }
         }
 
         private sealed class SubstitutedMethodIL : MethodIL

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
@@ -327,19 +327,34 @@ class DeadCodeElimination
 
     class TestBranchesInGenericCodeRemoval
     {
+        class ClassWithUnusedVirtual
+        {
+            public virtual string MyUnusedVirtualMethod() => typeof(UnusedFromVirtual).ToString();
+            public virtual string MyUsedVirtualMethod() => typeof(UsedFromVirtual).ToString();
+        }
+
+        class UnusedFromVirtual { }
+        class UsedFromVirtual { }
+
         struct Unused { public byte Val; }
         struct Used { public byte Val; }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static T Cast<T>(byte o)
+        static T Cast<T>(byte o, ClassWithUnusedVirtual inst)
         {
             if (typeof(T) == typeof(Unused))
             {
+                // Expect this not to be scanned. The virtual slot should not be created.
+                inst.MyUnusedVirtualMethod();
+
                 Unused result = new Unused { Val = o };
                 return (T)(object)result;
             }
             else if (typeof(T) == typeof(Used))
             {
+                // This will introduce a virtual slot.
+                inst.MyUsedVirtualMethod();
+
                 Used result = new Used { Val = o };
                 return (T)(object)result;
             }
@@ -350,13 +365,16 @@ class DeadCodeElimination
         {
             Console.WriteLine("Testing dead branches guarded by typeof in generic code removal");
 
-            Cast<Used>(12);
+            Cast<Used>(12, new ClassWithUnusedVirtual());
 
             // We only expect to be able to get rid of it when optimizing
 #if !DEBUG
             ThrowIfPresentWithTypeHandle(typeof(TestBranchesInGenericCodeRemoval), nameof(Unused));
 #endif
             ThrowIfNotPresent(typeof(TestBranchesInGenericCodeRemoval), nameof(Used));
+
+            ThrowIfPresent(typeof(TestBranchesInGenericCodeRemoval), nameof(UnusedFromVirtual));
+            ThrowIfNotPresent(typeof(TestBranchesInGenericCodeRemoval), nameof(UsedFromVirtual));
         }
     }
 

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
@@ -369,7 +369,7 @@ class DeadCodeElimination
 
             // We only expect to be able to get rid of it when optimizing
 #if !DEBUG
-            ThrowIfPresentWithTypeHandle(typeof(TestBranchesInGenericCodeRemoval), nameof(Unused));
+            ThrowIfPresent(typeof(TestBranchesInGenericCodeRemoval), nameof(Unused));
 #endif
             ThrowIfNotPresent(typeof(TestBranchesInGenericCodeRemoval), nameof(Used));
 
@@ -387,30 +387,6 @@ class DeadCodeElimination
         if (GetTypeSecretly(testType, typeName) != null)
         {
             throw new Exception(typeName);
-        }
-    }
-
-    private static void ThrowIfPresentWithTypeHandle(Type testType, string typeName)
-    {
-        Type t = GetTypeSecretly(testType, typeName);
-        if (t == null)
-        {
-            throw new Exception("Not found " + typeName);
-        }
-
-        bool thrown = false;
-        try
-        {
-            _ = t.TypeHandle;
-        }
-        catch (NotSupportedException)
-        {
-            thrown = true;
-        }
-
-        if (!thrown)
-        {
-            throw new Exception(typeName + " has type handle");
         }
     }
 


### PR DESCRIPTION
The pattern `typeof(T) == typeof(Foo)` is a common way to do generic specialization in C#. Since we operate on instantiated code, we should be able to optimize this in many situations. Adding support for this in constprop.

RyuJIT would already handle this, but the problem is that if we don't handle this in IL scanning, we might have expanded the whole program view graph too much and it's hard to get rid of side effects of that. The added test shows one of such examples (we introduce an extra "used" virtual slot that is impossible to get rid of after the fact).

Saves 0.5% on BasicMinimalApi.

Cc @dotnet/ilc-contrib 