### PR TITLE
Refactor `GetGetSystemTimeAsFileTimeFnPtr`

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetSystemTimeAsFileTime.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetSystemTimeAsFileTime.cs
@@ -1,17 +1,21 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
     internal static partial class Kernel32
     {
+#pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
         // https://learn.microsoft.com/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsystemtimeasfiletime
         [LibraryImport(Libraries.Kernel32)]
         [SuppressGCTransition]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
         internal static unsafe partial void GetSystemTimeAsFileTime(
             // [NativeTypeName("LPFILETIME")]
             ulong* lpSystemTimeAsFileTime);
     }
+#pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetSystemTimeAsFileTime.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetSystemTimeAsFileTime.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Kernel32
+    {
+        // https://learn.microsoft.com/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsystemtimeasfiletime
+        [LibraryImport(Libraries.Kernel32)]
+        [SuppressGCTransition]
+        internal static unsafe partial void GetSystemTimeAsFileTime(
+            // [NativeTypeName("LPFILETIME")]
+            ulong* lpSystemTimeAsFileTime);
+    }
+}

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetSystemTimePreciseAsFileTime.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetSystemTimePreciseAsFileTime.cs
@@ -1,17 +1,21 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
     internal static partial class Kernel32
     {
+#pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
         // https://learn.microsoft.com/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsystemtimepreciseasfiletime
         [LibraryImport(Libraries.Kernel32)]
         [SuppressGCTransition]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
         internal static unsafe partial void GetSystemTimePreciseAsFileTime(
             // [NativeTypeName("LPFILETIME")]
             ulong* lpSystemTimeAsFileTime);
     }
+#pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetSystemTimePreciseAsFileTime.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetSystemTimePreciseAsFileTime.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Kernel32
+    {
+        // https://learn.microsoft.com/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsystemtimepreciseasfiletime
+        [LibraryImport(Libraries.Kernel32)]
+        [SuppressGCTransition]
+        internal static unsafe partial void GetSystemTimePreciseAsFileTime(
+            // [NativeTypeName("LPFILETIME")]
+            ulong* lpSystemTimeAsFileTime);
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -1748,6 +1748,12 @@
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetSystemTime.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetSystemTime.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetSystemTimeAsFileTime.cs">
+      <Link>Common\Interop\Windows\Kernel32\Interop.GetSystemTimeAsFileTime.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetSystemTimePreciseAsFileTime.cs">
+      <Link>Common\Interop\Windows\Kernel32\Interop.GetSystemTimePreciseAsFileTime.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetSystemTimes.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetSystemTimes.cs</Link>
     </Compile>


### PR DESCRIPTION
* Don't check whether `GetSystemTimePreciseAsFileTime` exists, it is always available in `win8`.
* Move PInvokes to `Interop.Kernel32`.
* Don't use `Math.Abs` to avoid unecessary overflow check.
