### PR TITLE
Fix gtMarkAddrMode assert

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -4471,7 +4471,10 @@ bool Compiler::gtMarkAddrMode(GenTree* addr, int* pCostEx, int* pCostSz, var_typ
                     op2op1->gtFlags |= GTF_ADDRMODE_NO_CSE;
                     op2op1 = op2op1->AsOp()->gtOp1;
                 }
-                assert(op1->gtEffectiveVal() == base);
+
+                // if genCreateAddrMode reported base as nullptr it means that op1 is effectively null address
+                assert((op1->gtEffectiveVal() == base) ||
+                       (base == nullptr && op1->gtEffectiveVal()->IsIntegralConst(0)));
                 assert(op2op1 == idx);
             }
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/83333

I was not able to come up with a simple repro as Roslyn or earlier JIT phases were constantly eliminating zero address, so it's just yet another edge case in the gtMarkAddrMode - `genCreateAddrMode` can legally report base as nullptr e.g. for:

![image](https://user-images.githubusercontent.com/523221/229530843-da8556ed-d4d3-4849-9f4f-faceb630b42f.png)

so the addressing mode becomes `[V13 * 4]` (with a nullcheck on top of null as a side effect) and op1 being unused. In theory it should be possible to reproduce in Tier0 but Roslyn didn't let me to use `null` and optimized it even for Debug.