### PR TITLE
Fix debugger stack unwind AV

### DIFF
--- a/src/coreclr/vm/amd64/cgenamd64.cpp
+++ b/src/coreclr/vm/amd64/cgenamd64.cpp
@@ -155,7 +155,7 @@ void HelperMethodFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
         ENUM_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
 
-#define CALLEE_SAVED_REGISTER(regname) pRD->pCurrentContextPointers->regname = pUnwoundState->m_Ptrs.p##regname;
+#define CALLEE_SAVED_REGISTER(regname) pRD->pCurrentContextPointers->regname = &pRD->pCurrentContext->regname;
         ENUM_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
 


### PR DESCRIPTION
In the debugger we do not have in-memory pointers to the context record.  Stack unwinds are all concrete, and update pCurrentContext instead.  Due to this, https://github.com/dotnet/runtime/commit/60adacb2b7a4ab9dc1e5af6c71fdfce7ad87fac0 zeroed out the m_Ptrs variable for all callee saved registers.

This change wasn't sufficient, however, because we actually try to use pCurrentContextPointers in a variety of places while dealing with reporting GC references, leading to an AV when GcInfoDecoder::GetStackSlot attempts to report an offset to RBP for certain kinds of coreclr!Frames.

This change updates pCurrentContextPointers to point to pCurrentContext in the dac.

(This issue/change only applies to AMD64.)