### PR TITLE
Suppress linker warnings properly

### DIFF
--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/MetadataHelper.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/MetadataHelper.cs
@@ -6,7 +6,7 @@ using System.Reflection.Metadata.Ecma335;
 
 namespace System.Reflection.Emit
 {
-    // This static helper class adds common entities to a Metadata Builder.
+    // This static helper class adds common entities to a MetadataBuilder.
     internal static class MetadataHelper
     {
         internal static AssemblyReferenceHandle AddAssemblyReference(Assembly assembly, MetadataBuilder metadata)
@@ -34,7 +34,7 @@ namespace System.Reflection.Emit
             // Add type metadata
             return metadata.AddTypeDefinition(
                 attributes: typeBuilder.Attributes,
-                (typeBuilder.Namespace == null) ? default : metadata.GetOrAddString(typeBuilder.Namespace),
+                @namespace: (typeBuilder.Namespace == null) ? default : metadata.GetOrAddString(typeBuilder.Namespace),
                 name: metadata.GetOrAddString(typeBuilder.Name),
                 baseType: baseType,
                 fieldList: MetadataTokens.FieldDefinitionHandle(fieldToken),
@@ -49,28 +49,30 @@ namespace System.Reflection.Emit
         internal static TypeReferenceHandle AddTypeReference(MetadataBuilder metadata, AssemblyReferenceHandle parent, string name, string? nameSpace)
         {
             return metadata.AddTypeReference(
-                parent,
-                (nameSpace == null) ? default : metadata.GetOrAddString(nameSpace),
-                metadata.GetOrAddString(name)
+                resolutionScope: parent,
+                @namespace: (nameSpace == null) ? default : metadata.GetOrAddString(nameSpace),
+                name: metadata.GetOrAddString(name)
                 );
         }
 
         internal static MethodDefinitionHandle AddMethodDefinition(MetadataBuilder metadata, MethodBuilderImpl methodBuilder, BlobBuilder methodSignatureBlob)
         {
             return metadata.AddMethodDefinition(
-                methodBuilder.Attributes,
-                MethodImplAttributes.IL,
-                metadata.GetOrAddString(methodBuilder.Name),
-                metadata.GetOrAddBlob(methodSignatureBlob),
-                -1, // No body supported yet
+                attributes: methodBuilder.Attributes,
+                implAttributes: MethodImplAttributes.IL,
+                name: metadata.GetOrAddString(methodBuilder.Name),
+                signature: metadata.GetOrAddBlob(methodSignatureBlob),
+                bodyOffset: -1, // No body supported yet
                 parameterList: MetadataTokens.ParameterHandle(1)
                 );
         }
 
-        internal static FieldDefinitionHandle AddFieldDefinition(MetadataBuilder metadata, FieldInfo field)
+        internal static FieldDefinitionHandle AddFieldDefinition(MetadataBuilder metadata, FieldInfo field, BlobBuilder fieldSignatureBlob)
         {
-            return metadata.AddFieldDefinition(field.Attributes, metadata.GetOrAddString(field.Name),
-                metadata.GetOrAddBlob(MetadataSignatureHelper.FieldSignatureEncoder(field.FieldType)));
+            return metadata.AddFieldDefinition(
+                attributes: field.Attributes,
+                name: metadata.GetOrAddString(field.Name),
+                signature: metadata.GetOrAddBlob(fieldSignatureBlob));
         }
     }
 }

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/MethodBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/MethodBuilderImpl.cs
@@ -17,13 +17,11 @@ namespace System.Reflection.Emit
         private readonly CallingConventions _callingConventions;
         private readonly TypeBuilderImpl _declaringType;
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-            Justification = "Do not expect System.Void type will be trimmed from core assembly")]
         internal MethodBuilderImpl(string name, MethodAttributes attributes, CallingConventions callingConventions, Type? returnType,
             Type[]? parameterTypes, ModuleBuilderImpl module, TypeBuilderImpl declaringType)
         {
             _module = module;
-            _returnType = returnType ?? _module.GetTypeFromCoreAssembly("System.Void"); ;
+            _returnType = returnType ?? _module.GetTypeFromCoreAssembly(CoreTypeId.Void)!;
             _name = name;
             _attributes = attributes;
             _callingConventions = callingConventions;

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/MethodBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/MethodBuilderImpl.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection.Metadata;
-using System.Reflection.Metadata.Ecma335;
 
 namespace System.Reflection.Emit
 {
@@ -18,6 +17,8 @@ namespace System.Reflection.Emit
         private readonly CallingConventions _callingConventions;
         private readonly TypeBuilderImpl _declaringType;
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+            Justification = "Do not expect System.Void type will be trimmed from core assembly")]
         internal MethodBuilderImpl(string name, MethodAttributes attributes, CallingConventions callingConventions, Type? returnType,
             Type[]? parameterTypes, ModuleBuilderImpl module, TypeBuilderImpl declaringType)
         {

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/MethodBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/MethodBuilderImpl.cs
@@ -21,7 +21,7 @@ namespace System.Reflection.Emit
             Type[]? parameterTypes, ModuleBuilderImpl module, TypeBuilderImpl declaringType)
         {
             _module = module;
-            _returnType = returnType ?? _module.GetTypeFromCoreAssembly(CoreTypeId.Void)!;
+            _returnType = returnType ?? _module.GetTypeFromCoreAssembly(CoreTypeId.Void);
             _name = name;
             _attributes = attributes;
             _callingConventions = callingConventions;

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
@@ -26,6 +26,7 @@ namespace System.Reflection.Emit
             _name = name;
         }
 
+        [RequiresUnreferencedCode("Types might be removed")]
         internal Type GetTypeFromCoreAssembly(string name)
         {
             Type? type;
@@ -33,9 +34,7 @@ namespace System.Reflection.Emit
             // TODO: Use Enum as the key for perf
             if (!_coreTypes.TryGetValue(name, out type))
             {
-#pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
                 type = _coreAssembly.GetType(name, throwOnError: true)!;
-#pragma warning restore IL2026
                 _coreTypes.Add(name, type);
             }
 

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
@@ -56,62 +56,61 @@ namespace System.Reflection.Emit
             CoreTypeId? typeId = module.GetTypeIdFromCoreTypes(type);
 
             // We need to translate from Reflection.Type to SignatureTypeEncoder.
-            if (typeId.HasValue)
+            switch (typeId)
             {
-                switch (typeId)
-                {
-                    case CoreTypeId.Boolean:
-                        signature.Boolean();
-                        return;
-                    case CoreTypeId.Byte:
-                        signature.Byte();
-                        return;
-                    case CoreTypeId.SByte:
-                        signature.SByte();
-                        return;
-                    case CoreTypeId.Char:
-                        signature.Char();
-                        return;
-                    case CoreTypeId.Int16:
-                        signature.Int16();
-                        break;
-                    case CoreTypeId.UInt16:
-                        signature.UInt16();
-                        return;
-                    case CoreTypeId.Int32:
-                        signature.Int32();
-                        return;
-                    case CoreTypeId.UInt32:
-                        signature.UInt32();
-                        return;
-                    case CoreTypeId.Int64:
-                        signature.Int64();
-                        return;
-                    case CoreTypeId.UInt64:
-                        signature.UInt64();
-                        return;
-                    case CoreTypeId.Single:
-                        signature.Single();
-                        return;
-                    case CoreTypeId.Double:
-                        signature.Double();
-                        return;
-                    case CoreTypeId.IntPtr:
-                        signature.IntPtr();
-                        return;
-                    case CoreTypeId.UIntPtr:
-                        signature.UIntPtr();
-                        return;
-                    case CoreTypeId.Object:
-                        signature.Object();
-                        return;
-                    case CoreTypeId.String:
-                        signature.String();
-                        return;
-                }
+                case CoreTypeId.Boolean:
+                    signature.Boolean();
+                    break;
+                case CoreTypeId.Byte:
+                    signature.Byte();
+                    break;
+                case CoreTypeId.SByte:
+                    signature.SByte();
+                    break;
+                case CoreTypeId.Char:
+                    signature.Char();
+                    break;
+                case CoreTypeId.Int16:
+                    signature.Int16();
+                    break;
+                case CoreTypeId.UInt16:
+                    signature.UInt16();
+                    break;
+                case CoreTypeId.Int32:
+                    signature.Int32();
+                    break;
+                case CoreTypeId.UInt32:
+                    signature.UInt32();
+                    break;
+                case CoreTypeId.Int64:
+                    signature.Int64();
+                    break;
+                case CoreTypeId.UInt64:
+                    signature.UInt64();
+                    break;
+                case CoreTypeId.Single:
+                    signature.Single();
+                    break;
+                case CoreTypeId.Double:
+                    signature.Double();
+                    break;
+                case CoreTypeId.IntPtr:
+                    signature.IntPtr();
+                    break;
+                case CoreTypeId.UIntPtr:
+                    signature.UIntPtr();
+                    break;
+                case CoreTypeId.Object:
+                    signature.Object();
+                    break;
+                case CoreTypeId.String:
+                    signature.String();
+                    break;
+                default:
+                    throw new NotSupportedException(SR.Format(SR.NotSupported_Signature, type.FullName));
+            }
             }
 
-            throw new NotSupportedException(SR.Format(SR.NotSupported_Signature, type.FullName));
         }
     }
 

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
@@ -53,10 +53,12 @@ namespace System.Reflection.Emit
 
         private static void WriteSignatureTypeForReflectionType(SignatureTypeEncoder signature, Type type, ModuleBuilderImpl module)
         {
+            int id = module.GetTypeIdFromCoreTypes(type);
+
             // We need to translate from Reflection.Type to SignatureTypeEncoder.
-            if (Enum.TryParse(type.Name, out CoreTypeId typeId) && type.Equals(module.GetTypeFromCoreAssembly(typeId)))
+            if (id > -1)
             {
-                switch (typeId)
+                switch ((CoreTypeId)id)
                 {
                     case CoreTypeId.Boolean:
                         signature.Boolean();
@@ -115,24 +117,22 @@ namespace System.Reflection.Emit
 
     internal enum CoreTypeId
     {
-        Void = 0,
-        Object = 1,
-        Boolean = 2,
-        Char = 3,
-        SByte = 4,
-        Byte = 5,
-        Int16 = 6,
-        UInt16 = 7,
-        Int32 = 8,
-        UInt32 = 9,
-        Int64 = 10,
-        UInt64 = 11,
-        Single = 12,
-        Double = 13,
-        Decimal = 14,
-        DateTime = 15,
-        String = 16,
-        IntPtr = 17,
-        UIntPtr = 18,
+        Void,
+        Object,
+        Boolean,
+        Char,
+        SByte,
+        Byte,
+        Int16,
+        UInt16,
+        Int32,
+        UInt32,
+        Int64,
+        UInt64,
+        Single,
+        Double,
+        String,
+        IntPtr,
+        UIntPtr,
     }
 }

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 
@@ -18,6 +19,8 @@ namespace System.Reflection.Emit
             return fieldSignature;
         }
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+            Justification = "Do not expect System.Void type will be trimmed from core assembly")]
         internal static BlobBuilder MethodSignatureEncoder(ModuleBuilderImpl _module, Type[]? parameters, Type? returnType, bool isInstance)
         {
             // Encoding return type and parameters.

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
@@ -53,12 +53,12 @@ namespace System.Reflection.Emit
 
         private static void WriteSignatureTypeForReflectionType(SignatureTypeEncoder signature, Type type, ModuleBuilderImpl module)
         {
-            int id = module.GetTypeIdFromCoreTypes(type);
+            CoreTypeId? typeId = module.GetTypeIdFromCoreTypes(type);
 
             // We need to translate from Reflection.Type to SignatureTypeEncoder.
-            if (id > -1)
+            if (typeId.HasValue)
             {
-                switch ((CoreTypeId)id)
+                switch (typeId)
                 {
                     case CoreTypeId.Boolean:
                         signature.Boolean();

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
@@ -109,8 +109,6 @@ namespace System.Reflection.Emit
                 default:
                     throw new NotSupportedException(SR.Format(SR.NotSupported_Signature, type.FullName));
             }
-            }
-
         }
     }
 

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
@@ -72,7 +72,7 @@ namespace System.Reflection.Emit
         protected override void SetCustomAttributeCore(CustomAttributeBuilder customBuilder) => throw new NotImplementedException();
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2074:DynamicallyAccessedMembers",
-            Justification = "No need to propogate the attribute to the called method")]
+            Justification = "TODO: Need to figure out how to preserve System.Object public constructor")]
         protected override void SetParentCore([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type? parent)
         {
             if (parent != null)

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
@@ -72,9 +72,7 @@ namespace System.Reflection.Emit
         protected override void SetCustomAttributeCore(CustomAttributeBuilder customBuilder) => throw new NotImplementedException();
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2074:DynamicallyAccessedMembers",
-            Justification = "No need to propogate the attriubte for called method")]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-            Justification = "Do not expect System.Object type will be trimmed from core assembly")]
+            Justification = "No need to propogate the attribute to the called method")]
         protected override void SetParentCore([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type? parent)
         {
             if (parent != null)
@@ -90,7 +88,7 @@ namespace System.Reflection.Emit
             {
                 if ((_attributes & TypeAttributes.Interface) != TypeAttributes.Interface)
                 {
-                    _typeParent = _module.GetTypeFromCoreAssembly("System.Object");
+                    _typeParent = _module.GetTypeFromCoreAssembly(CoreTypeId.Object);
                 }
                 else
                 {

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
@@ -71,7 +71,11 @@ namespace System.Reflection.Emit
         protected override void SetCustomAttributeCore(ConstructorInfo con, byte[] binaryAttribute) => throw new NotImplementedException();
         protected override void SetCustomAttributeCore(CustomAttributeBuilder customBuilder) => throw new NotImplementedException();
 
-        protected override void SetParentCore([DynamicallyAccessedMembers((DynamicallyAccessedMemberTypes)(-1))] Type? parent)
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2074:DynamicallyAccessedMembers",
+            Justification = "No need to propogate the attriubte for called method")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+            Justification = "Do not expect System.Object type will be trimmed from core assembly")]
+        protected override void SetParentCore([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type? parent)
         {
             if (parent != null)
             {
@@ -86,9 +90,7 @@ namespace System.Reflection.Emit
             {
                 if ((_attributes & TypeAttributes.Interface) != TypeAttributes.Interface)
                 {
-#pragma warning disable IL2074 // Value stored in field does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of the source method does not have matching annotations.
                     _typeParent = _module.GetTypeFromCoreAssembly("System.Object");
-#pragma warning restore IL2074
                 }
                 else
                 {

--- a/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveTestsWithVariousTypes.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveTestsWithVariousTypes.cs
@@ -63,7 +63,7 @@ namespace System.Reflection.Emit.Tests
             yield return new object[] { new Type[] { typeof(EmptyStruct) } };
             yield return new object[] { new Type[] { typeof(StructWithField) } };
             yield return new object[] { new Type[] { typeof(StructWithField), typeof(EmptyStruct) } };
-            yield return new object[] { new Type[] { typeof(IMultipleMethod), typeof(EmptyStruct) , typeof(INoMethod2), typeof(StructWithField) } };
+            yield return new object[] { new Type[] { typeof(IMultipleMethod), typeof(EmptyStruct), typeof(INoMethod2), typeof(StructWithField) } };
         }
 
         [Theory]


### PR DESCRIPTION
The Linker warnings were incorrectly suppressed in https://github.com/dotnet/runtime/pull/83554 and causing a build failure in https://github.com/dotnet/sdk/pull/31571#issuecomment-1493980936

The method will be referenced for loading all .NET primitive types from user provided `Core` assembly. I assumed core primitive types are trimmer safe, but it seems unreferenced primitive type could be trimmed, therefore propagating the linker warning for the method.  And suppressing the warning for the usages as I think it is safe to suppress these warnings for `System.Object` and `System.Void` types.

In order to unblock build failure caused by this raising this PR with the quick fix. Will reiterate the handling of other primitive types separately