### PR TITLE
Add error check for skipped tests in merged groups

### DIFF
--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -9,6 +9,16 @@
   <Import Project="$(MSBuildThisFileDirectory)/Common/disableversioncheck.targets"
           Condition="'$(DisableVersionCheckImported)' != 'true'" />
 
+  <!-- comment this.  should it go here or lower? -->
+  <Target Name="CheckForTestOutsideOfGroup" BeforeTargets="Build">
+    <Error Condition="'$(InMergedTestDirectory)' == 'true'
+      and '$(OutputType)' == 'Exe'
+      and '$(RequiresProcessIsolation)' != 'true'
+      and '$(BuildAsStandalone)' != 'true'
+      and '$(IsMergedTestRunnerAssembly)' != 'true'"
+      Text="Tests in merged test directories should not set OutputType to Exe unless it is RequiresProcessIsolation, BuildAsStandalone, or IsMergedTestRunnerAssembly." />
+  </Target>
+
   <!-- Default priority building values. -->
   <PropertyGroup>
     <DisableProjectBuild Condition="'$(IsMergedTestRunnerAssembly)' == 'true' and $(BuildAsStandalone)">true</DisableProjectBuild>

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -122,17 +122,17 @@
     <SkipImportILTargets Condition="'$(CLRTestBuildAllTargets)' != '' And '$(CLRTestNeedTarget)' != '$(CLRTestBuildAllTargets)'">true</SkipImportILTargets>
   </PropertyGroup>
 
-  <!-- If a test in a merged test directory (e.g., under JIT\Directed where Directed_1.csproj represent the groups) -->
-  <!-- has OutputType==Exe set, then it will end up skipped because the merged groups are supposed to cover all of  -->
-  <!-- the tests. The merged groups themselves should be Exes, as should any test marked RequiresProcessIsolation   -->
-  <!-- or BuildAsStandalone. -->
+  <!-- If a test in a merged test directory (e.g., under JIT\Directed where Directed_1.csproj and siblings -->
+  <!-- represent the groups) has OutputType==Exe set, then it will end up being skipped because the merged -->
+  <!-- groups are supposed to cover all of the tests. The merged groups themselves should be Exes, as      -->
+  <!-- should any test marked RequiresProcessIsolation or BuildAsStandalone. -->
   <Target Name="CheckForTestOutsideOfGroup" BeforeTargets="Build">
     <Error Condition="'$(InMergedTestDirectory)' == 'true'
       and '$(OutputType)' == 'Exe'
       and '$(RequiresProcessIsolation)' != 'true'
       and '$(BuildAsStandalone)' != 'true'
       and '$(IsMergedTestRunnerAssembly)' != 'true'"
-      Text="Tests in merged test directories should not set OutputType to Exe unless it is RequiresProcessIsolation, BuildAsStandalone, or IsMergedTestRunnerAssembly." />
+      Text="Tests in merged test directories should not set OutputType to Exe unless they are RequiresProcessIsolation, BuildAsStandalone, or IsMergedTestRunnerAssembly." />
   </Target>
 
   <Target Name="CopyNativeProjectBinaries" Condition="'$(_CopyNativeProjectBinaries)' == 'true'">

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -9,16 +9,6 @@
   <Import Project="$(MSBuildThisFileDirectory)/Common/disableversioncheck.targets"
           Condition="'$(DisableVersionCheckImported)' != 'true'" />
 
-  <!-- comment this.  should it go here or lower? -->
-  <Target Name="CheckForTestOutsideOfGroup" BeforeTargets="Build">
-    <Error Condition="'$(InMergedTestDirectory)' == 'true'
-      and '$(OutputType)' == 'Exe'
-      and '$(RequiresProcessIsolation)' != 'true'
-      and '$(BuildAsStandalone)' != 'true'
-      and '$(IsMergedTestRunnerAssembly)' != 'true'"
-      Text="Tests in merged test directories should not set OutputType to Exe unless it is RequiresProcessIsolation, BuildAsStandalone, or IsMergedTestRunnerAssembly." />
-  </Target>
-
   <!-- Default priority building values. -->
   <PropertyGroup>
     <DisableProjectBuild Condition="'$(IsMergedTestRunnerAssembly)' == 'true' and $(BuildAsStandalone)">true</DisableProjectBuild>
@@ -131,6 +121,19 @@
     <SkipImportILTargets Condition="'$(CLRTestPriority)' &gt; '$(CLRTestPriorityToBuild)'">true</SkipImportILTargets>
     <SkipImportILTargets Condition="'$(CLRTestBuildAllTargets)' != '' And '$(CLRTestNeedTarget)' != '$(CLRTestBuildAllTargets)'">true</SkipImportILTargets>
   </PropertyGroup>
+
+  <!-- If a test in a merged test directory (e.g., under JIT\Directed where Directed_1.csproj represent the groups) -->
+  <!-- has OutputType==Exe set, then it will end up skipped because the merged groups are supposed to cover all of  -->
+  <!-- the tests. The merged groups themselves should be Exes, as should any test marked RequiresProcessIsolation   -->
+  <!-- or BuildAsStandalone. -->
+  <Target Name="CheckForTestOutsideOfGroup" BeforeTargets="Build">
+    <Error Condition="'$(InMergedTestDirectory)' == 'true'
+      and '$(OutputType)' == 'Exe'
+      and '$(RequiresProcessIsolation)' != 'true'
+      and '$(BuildAsStandalone)' != 'true'
+      and '$(IsMergedTestRunnerAssembly)' != 'true'"
+      Text="Tests in merged test directories should not set OutputType to Exe unless it is RequiresProcessIsolation, BuildAsStandalone, or IsMergedTestRunnerAssembly." />
+  </Target>
 
   <Target Name="CopyNativeProjectBinaries" Condition="'$(_CopyNativeProjectBinaries)' == 'true'">
     <ItemGroup Condition="'$(UseVisualStudioNativeBinariesLayout)' == 'true'">

--- a/src/tests/Directory.Merged.props
+++ b/src/tests/Directory.Merged.props
@@ -1,0 +1,8 @@
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <InMergedTestDirectory>true</InMergedTestDirectory>
+    <BuildAsStandalone Condition="'$(BuildAsStandalone)' == ''">false</BuildAsStandalone>
+
+    <AssemblyName Condition="'$(BuildAsStandalone)' != 'true'">$(MSBuildProjectName.Replace('_il_d', '').Replace('_il_r', ''))</AssemblyName>
+  </PropertyGroup>
+</Project>

--- a/src/tests/JIT/Directed/Directory.Build.props
+++ b/src/tests/JIT/Directed/Directory.Build.props
@@ -1,13 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <PropertyGroup>
-    <BuildAsStandalone Condition="'$(BuildAsStandalone)' == ''">false</BuildAsStandalone>
-
-    <AssemblyName Condition="'$(BuildAsStandalone)' != 'true'">$(MSBuildProjectName.Replace('_il_d', '').Replace('_il_r', ''))</AssemblyName>
-  </PropertyGroup>
-
-  <Import Project="..\..\Directory.Build.props" />
+  <Import Project="..\..\Directory.Merged.props" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
 
   <PropertyGroup>
     <RunAnalyzers>true</RunAnalyzers>

--- a/src/tests/JIT/HardwareIntrinsics/Directory.Build.props
+++ b/src/tests/JIT/HardwareIntrinsics/Directory.Build.props
@@ -1,8 +1,5 @@
 <Project>
-  <PropertyGroup>
-    <BuildAsStandalone Condition="'$(BuildAsStandalone)' == ''">false</BuildAsStandalone>
-  </PropertyGroup>
-
+  <Import Project="..\..\Directory.Merged.props" />
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
 
   <ItemGroup>

--- a/src/tests/JIT/HardwareIntrinsics/General/ConstantFolding/StaticReadonlySimd.cs
+++ b/src/tests/JIT/HardwareIntrinsics/General/ConstantFolding/StaticReadonlySimd.cs
@@ -6,10 +6,12 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Threading;
+using Xunit;
 
-class StaticReadonlySimd
+public class StaticReadonlySimd
 {
-    static int Main()
+    [Fact]
+    public static void TestEntryPoint()
     {
         for (int i = 0; i < 100; i++)
         {
@@ -17,7 +19,6 @@ class StaticReadonlySimd
             Test();
             Thread.Sleep(15);
         }
-        return 100;
     }
 
     static readonly Vector2 v1 = new Vector2(-1.0f, 2.0f);

--- a/src/tests/JIT/HardwareIntrinsics/General/ConstantFolding/StaticReadonlySimd.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/ConstantFolding/StaticReadonlySimd.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/X86Serialize_X64/Serialize.X64.cs
+++ b/src/tests/JIT/HardwareIntrinsics/X86/X86Serialize_X64/Serialize.X64.cs
@@ -7,15 +7,17 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
+using Xunit;
 
 namespace IntelHardwareIntrinsicTest
 {
-    class Program
+    public class Program
     {
         const int Pass = 100;
         const int Fail = 0;
 
-        static unsafe int Main()
+        [Fact]
+        public static unsafe int TestEntryPoint()
         {
             int testResult = X86Serialize.X64.IsSupported ? Pass : Fail;
 

--- a/src/tests/JIT/HardwareIntrinsics/X86/X86Serialize_X64/Serialize.X64_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/X86Serialize_X64/Serialize.X64_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/X86Serialize_X64/Serialize.X64_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/X86Serialize_X64/Serialize.X64_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Directory.Build.props
+++ b/src/tests/JIT/IL_Conformance/Directory.Build.props
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <PropertyGroup>
-    <BuildAsStandalone Condition="'$(BuildAsStandalone)' == ''">false</BuildAsStandalone>
-  </PropertyGroup>
-
+  <Import Project="..\..\Directory.Merged.props" />
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
 
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Directory.Build.props
+++ b/src/tests/JIT/Methodical/Directory.Build.props
@@ -1,13 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <PropertyGroup>
-    <BuildAsStandalone Condition="'$(BuildAsStandalone)' == ''">false</BuildAsStandalone>
-
-    <AssemblyName Condition="'$(BuildAsStandalone)' != 'true'">$(MSBuildProjectName.Replace('_il_d', '').Replace('_il_r', ''))</AssemblyName>
-  </PropertyGroup>
-
-  <Import Project="..\..\Directory.Build.props" />
+  <Import Project="..\..\Directory.Merged.props" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
 
   <PropertyGroup>
     <RunAnalyzers>true</RunAnalyzers>

--- a/src/tests/JIT/Methodical/Directory.Build.targets
+++ b/src/tests/JIT/Methodical/Directory.Build.targets
@@ -3,4 +3,6 @@
   <Target Name="CheckForTestOutsideOfGroup" BeforeTargets="Build">
     <Error Condition="'$(OutputType)' == 'Exe'" Text="Tests should not set OutputType to Exe in a merged test subdirectory." />
   </Target>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
 </Project>

--- a/src/tests/JIT/Methodical/Directory.Build.targets
+++ b/src/tests/JIT/Methodical/Directory.Build.targets
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="CheckForTestOutsideOfGroup" BeforeTargets="Build">
-    <Error Condition="'$(OutputType)' == 'Exe'" Text="Tests should not set OutputType to Exe in a merged test subdirectory." />
-  </Target>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
-</Project>

--- a/src/tests/JIT/Methodical/Directory.Build.targets
+++ b/src/tests/JIT/Methodical/Directory.Build.targets
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="CheckForTestOutsideOfGroup" BeforeTargets="Build">
+    <Error Condition="'$(OutputType)' == 'Exe'" Text="Tests should not set OutputType to Exe in a merged test subdirectory." />
+  </Target>
+</Project>

--- a/src/tests/JIT/Regression/Directory.Build.props
+++ b/src/tests/JIT/Regression/Directory.Build.props
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <PropertyGroup>
-    <BuildAsStandalone Condition="'$(BuildAsStandalone)' == ''">false</BuildAsStandalone>
-
-    <AssemblyName Condition="'$(BuildAsStandalone)' != 'true'">$(MSBuildProjectName.Replace('_il_d', '').Replace('_il_r', ''))</AssemblyName>
-  </PropertyGroup>
-
+  <Import Project="..\..\Directory.Merged.props" />
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
 
   <PropertyGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/Directory.Build.props
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/Directory.Build.props
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <PropertyGroup>
-    <BuildAsStandalone>false</BuildAsStandalone>
-  </PropertyGroup>
-
-  <Import Project="..\..\..\Directory.Build.props" />
+  <Import Project="..\..\..\Directory.Merged.props" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
 
   <PropertyGroup>
     <RunAnalyzers>true</RunAnalyzers>

--- a/src/tests/baseservices/threading/Directory.Build.props
+++ b/src/tests/baseservices/threading/Directory.Build.props
@@ -1,13 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <PropertyGroup>
-    <BuildAsStandalone Condition="'$(BuildAsStandalone)' == ''">false</BuildAsStandalone>
-
-    <AssemblyName Condition="'$(BuildAsStandalone)' != 'true'">$(MSBuildProjectName.Replace('_il_d', '').Replace('_il_r', ''))</AssemblyName>
-  </PropertyGroup>
-
-  <Import Project="..\..\Directory.Build.props" />
+  <Import Project="..\..\Directory.Merged.props" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
 
   <PropertyGroup>
     <RunAnalyzers>true</RunAnalyzers>

--- a/src/tests/reflection/ldtoken/byrefs.il
+++ b/src/tests/reflection/ldtoken/byrefs.il
@@ -80,12 +80,12 @@
     }
 }
 
-.class private auto ansi beforefieldinit MyType1
+.class private auto ansi sealed beforefieldinit MyType1
        extends [mscorlib]System.ValueType
 {
 }
 
-.class private auto ansi beforefieldinit MyType2
+.class private auto ansi sealed beforefieldinit MyType2
        extends [mscorlib]System.ValueType
 {
 }


### PR DESCRIPTION
If I test is written in the old style (with a Main and OutputType==Exe without an attribute such as RequiresProcessIsolation) in a merged test group directory, it will be skipped.  This change adds a check to detect those cases.

I have struggled with ways to automatically set OutputType.  Directory.Build.props is too early (the test project file will override it).  Directory.Build.targets is too late as the C# targets files will already have been processed and set other variables based on the value of OutputType.  This Target doesn't execute until later, but since it is an error it doesn't matter how those additional properties were set.

Since this adds more boilerplate to each merged test directory, I created a src/tests/Directory.Merged.props to share all of that.

This catches 3 tests that aren't currently executing.

Unrelated:
- Use GetPathOfFileAbove in nearby locations for Directory.Build.props chaining rather than specific paths
- Fix two easy IL warnings that appeared in my local build of all tests

Resolves #84182