### PR TITLE
Fast-path in String.Trim

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -2154,7 +2154,7 @@ namespace System
         // Removes a set of characters from the beginning and end of this string.
         public unsafe string Trim(char trimChar)
         {
-            if (Length == 0 || (this[0] == trimChar && this[^1] == trimChar))
+            if (Length == 0 || (_firstChar != trimChar && this[^1] != trimChar))
             {
                 return this;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -2142,10 +2142,24 @@ namespace System
         // Trims the whitespace from both ends of the string.  Whitespace is defined by
         // char.IsWhiteSpace.
         //
-        public string Trim() => TrimWhiteSpaceHelper(TrimType.Both);
+        public string Trim()
+        {
+            if (Length == 0 || (!char.IsWhiteSpace(_firstChar) && !char.IsWhiteSpace(this[^1])))
+            {
+                return this;
+            }
+            return TrimWhiteSpaceHelper(TrimType.Both);
+        }
 
         // Removes a set of characters from the beginning and end of this string.
-        public unsafe string Trim(char trimChar) => TrimHelper(&trimChar, 1, TrimType.Both);
+        public unsafe string Trim(char trimChar)
+        {
+            if (Length == 0 || (this[0] == trimChar && this[^1] == trimChar))
+            {
+                return this;
+            }
+            return TrimHelper(&trimChar, 1, TrimType.Both);
+        }
 
         // Removes a set of characters from the beginning and end of this string.
         public unsafe string Trim(params char[]? trimChars)


### PR DESCRIPTION
Similar to https://github.com/dotnet/runtime/pull/84210 but for String. I tried to use Span APIs here but there was a small overhead. 

Bonus point - "string literal".Trim() is a no-op now, e.g.:
```csharp
string TrimLiteral() => "Hello".Trim();
```
```diff
; Method Program:TrimLiteral():System.String:this
       48B9809520802B020000 mov      rcx, 0x22B80209580 ;; 'string literal'
-      BA03000000           mov      edx, 3
-      FF251BFE0400         tail.jmp [System.String:TrimWhiteSpaceHelper(int):System.String:this]
-; Total bytes of code: 21
+; Total bytes of code: 11
```
Since JIT is able to fold `if (Length == 0 || (!char.IsWhiteSpace(_firstChar) && !char.IsWhiteSpace(this[^1])))` for a constant string 🙂 e.g. constant folding for RVA[cns] 

Benchmarks:
```csharp
[Benchmark]
[Arguments("Hello world")]
[Arguments("Hello world ")]
[MethodImpl(MethodImplOptions.NoInlining)]
public string Trim(string str) => str.Trim();

[Benchmark]
public string TrimLiteral() => "Hello".Trim();
```
```
|         Method |                   Toolchain |          str |      Mean |
|--------------- |---------------------------- |------------- |----------:|
|           Trim |      \Core_Root\corerun.exe |  Hello world | 0.4868 ns |
|           Trim | \Core_Root_base\corerun.exe |  Hello world | 2.0999 ns |
|                |                             |              |           |
|           Trim |      \Core_Root\corerun.exe | Hello world  | 7.4285 ns |
|           Trim | \Core_Root_base\corerun.exe | Hello world  | 6.4529 ns |
|                |                             |              |           |
|    TrimLiteral |      \Core_Root\corerun.exe |            ? | 0.0086 ns |
|    TrimLiteral | \Core_Root_base\corerun.exe |            ? | 2.0089 ns |
```
