### PR TITLE
Mark FirstCharInUInt32IsAscii with aggressiveinlining

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -69,6 +69,7 @@ namespace System.Text
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool FirstCharInUInt32IsAscii(uint value)
         {
             return (BitConverter.IsLittleEndian && (value & 0xFF80u) == 0)


### PR DESCRIPTION
This small method pops up in CPU traces for MinimalApi benchmark.
With this change I see up ~5% improvement for a simple `Utf8.FromUtf16` benchmark for small inputs (<32 bytes).

There are two problems here:
1) ILLink doesn't get rid of `BitConverter.IsLittleEndian`, see https://github.com/dotnet/runtime/issues/83169
2) JIT's inliner assigns big weights for `ldsfld` (it's afraid of potential helper calls)

I was playing with a fix for inliner but it needs a new JIT-EE API + diffs were huge and needs careful analysis. So for now let's slap an AggressiveInlining on it.