### PR TITLE
dotnet.exe prints error messages to console when launched with empty DOTNET_MULTILEVEL_LOOKUP

### DIFF
--- a/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
@@ -205,7 +205,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                     .Should().Pass()
                     .And.HaveStdOutContaining("Hello World")
                     .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion)
-                    .And.NotHaveStdErrContaining("Failed to read environment variable"); ;
+                    .And.NotHaveStdErrContaining("Failed to read environment variable");
 
                 // Verify running from within the working directory
                 Command.Create(appExe)
@@ -222,7 +222,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                     .Should().Pass()
                     .And.HaveStdOutContaining("Hello World")
                     .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion)
-                    .And.NotHaveStdErrContaining("Failed to read environment variable"); ;
+                    .And.NotHaveStdErrContaining("Failed to read environment variable");
             }
         }
 

--- a/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
@@ -193,7 +193,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
                 // Verify running with the default working directory
                 Command.Create(appExe)
-                    .EnableTracingAndCaptureOutputs()
+                    .CaptureStdErr()
+                    .CaptureStdOut()
                     .MultilevelLookup(false)
                     .ApplyRegisteredInstallLocationOverride(registeredInstallLocationOverride)
                     .EnvironmentVariable(Constants.TestOnlyEnvironmentVariables.DefaultInstallPath, useRegisteredLocation ? null : builtDotnet)
@@ -202,11 +203,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                     .Should().Pass()
                     .And.HaveStdOutContaining("Hello World")
                     .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion)
-                    .And.NotHaveStdErrContaining("Failed to read environment variable");
+                    .And.NotHaveStdErr();
 
                 // Verify running from within the working directory
                 Command.Create(appExe)
-                    .EnableTracingAndCaptureOutputs()
+                    .CaptureStdErr()
+                    .CaptureStdOut()
                     .MultilevelLookup(false)
                     .WorkingDirectory(fixture.TestProject.OutputDirectory)
                     .ApplyRegisteredInstallLocationOverride(registeredInstallLocationOverride)
@@ -216,7 +218,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                     .Should().Pass()
                     .And.HaveStdOutContaining("Hello World")
                     .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion)
-                    .And.NotHaveStdErrContaining("Failed to read environment variable");
+                    .And.NotHaveStdErr();
             }
         }
 

--- a/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
@@ -193,13 +193,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
                 // Verify running with the default working directory
                 Command.Create(appExe)
-                    .CaptureStdErr()
-                    .CaptureStdOut()
+                    .EnableTracingAndCaptureOutputs()
                     .MultilevelLookup(false)
                     .ApplyRegisteredInstallLocationOverride(registeredInstallLocationOverride)
                     .EnvironmentVariable(Constants.TestOnlyEnvironmentVariables.DefaultInstallPath, useRegisteredLocation ? null : builtDotnet)
-                    .EnvironmentVariable(Constants.HostTracing.TraceLevelEnvironmentVariable, "1")
-                    .EnvironmentVariable(Constants.HostTracing.VerbosityEnvironmentVariable, "2")
                     .DotNetRoot(null)
                     .Execute()
                     .Should().Pass()
@@ -209,14 +206,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
                 // Verify running from within the working directory
                 Command.Create(appExe)
-                    .CaptureStdErr()
-                    .CaptureStdOut()
+                    .EnableTracingAndCaptureOutputs()
                     .MultilevelLookup(false)
                     .WorkingDirectory(fixture.TestProject.OutputDirectory)
                     .ApplyRegisteredInstallLocationOverride(registeredInstallLocationOverride)
                     .EnvironmentVariable(Constants.TestOnlyEnvironmentVariables.DefaultInstallPath, useRegisteredLocation ? null : builtDotnet)
-                    .EnvironmentVariable(Constants.HostTracing.TraceLevelEnvironmentVariable, "1")
-                    .EnvironmentVariable(Constants.HostTracing.VerbosityEnvironmentVariable, "2")
                     .DotNetRoot(null)
                     .Execute()
                     .Should().Pass()

--- a/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
@@ -198,11 +198,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                     .MultilevelLookup(false)
                     .ApplyRegisteredInstallLocationOverride(registeredInstallLocationOverride)
                     .EnvironmentVariable(Constants.TestOnlyEnvironmentVariables.DefaultInstallPath, useRegisteredLocation ? null : builtDotnet)
+                    .EnvironmentVariable(Constants.HostTracing.TraceLevelEnvironmentVariable, "1")
+                    .EnvironmentVariable(Constants.HostTracing.VerbosityEnvironmentVariable, "2")
                     .DotNetRoot(null)
                     .Execute()
                     .Should().Pass()
                     .And.HaveStdOutContaining("Hello World")
-                    .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
+                    .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion)
+                    .And.NotHaveStdErrContaining("Failed to read environment variable"); ;
 
                 // Verify running from within the working directory
                 Command.Create(appExe)
@@ -212,11 +215,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                     .WorkingDirectory(fixture.TestProject.OutputDirectory)
                     .ApplyRegisteredInstallLocationOverride(registeredInstallLocationOverride)
                     .EnvironmentVariable(Constants.TestOnlyEnvironmentVariables.DefaultInstallPath, useRegisteredLocation ? null : builtDotnet)
+                    .EnvironmentVariable(Constants.HostTracing.TraceLevelEnvironmentVariable, "1")
+                    .EnvironmentVariable(Constants.HostTracing.VerbosityEnvironmentVariable, "2")
                     .DotNetRoot(null)
                     .Execute()
                     .Should().Pass()
                     .And.HaveStdOutContaining("Hello World")
-                    .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
+                    .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion)
+                    .And.NotHaveStdErrContaining("Failed to read environment variable"); ;
             }
         }
 

--- a/src/installer/tests/HostActivation.Tests/StartupHooks.cs
+++ b/src/installer/tests/HostActivation.Tests/StartupHooks.cs
@@ -174,7 +174,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             dotnet.Exec(appDll)
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
                 .EnvironmentVariable(Constants.HostTracing.TraceLevelEnvironmentVariable, "1")
-                    .EnvironmentVariable(Constants.HostTracing.VerbosityEnvironmentVariable, "2")
+                .EnvironmentVariable(Constants.HostTracing.VerbosityEnvironmentVariable, "2")
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute()

--- a/src/installer/tests/HostActivation.Tests/StartupHooks.cs
+++ b/src/installer/tests/HostActivation.Tests/StartupHooks.cs
@@ -173,11 +173,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             var startupHookVar = "";
             dotnet.Exec(appDll)
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
+                .EnvironmentVariable(Constants.HostTracing.TraceLevelEnvironmentVariable, "1")
+                    .EnvironmentVariable(Constants.HostTracing.VerbosityEnvironmentVariable, "2")
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute()
                 .Should().Pass()
-                .And.HaveStdOutContaining("Hello World");
+                .And.HaveStdOutContaining("Hello World")
+                .And.NotHaveStdErrContaining("Failed to read environment variable");
         }
 
         // Run the app with a startup hook assembly that depends on assemblies not on the TPA list

--- a/src/installer/tests/HostActivation.Tests/StartupHooks.cs
+++ b/src/installer/tests/HostActivation.Tests/StartupHooks.cs
@@ -173,11 +173,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             var startupHookVar = "";
             dotnet.Exec(appDll)
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
-                .EnableTracingAndCaptureOutputs()
+                .CaptureStdErr()
+                .CaptureStdOut()
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.NotHaveStdErrContaining("Failed to read environment variable");
+                .And.NotHaveStdErr();
         }
 
         // Run the app with a startup hook assembly that depends on assemblies not on the TPA list

--- a/src/installer/tests/HostActivation.Tests/StartupHooks.cs
+++ b/src/installer/tests/HostActivation.Tests/StartupHooks.cs
@@ -173,10 +173,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             var startupHookVar = "";
             dotnet.Exec(appDll)
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
-                .EnvironmentVariable(Constants.HostTracing.TraceLevelEnvironmentVariable, "1")
-                .EnvironmentVariable(Constants.HostTracing.VerbosityEnvironmentVariable, "2")
-                .CaptureStdOut()
-                .CaptureStdErr()
+                .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")

--- a/src/installer/tests/HostActivation.Tests/StartupHooks.cs
+++ b/src/installer/tests/HostActivation.Tests/StartupHooks.cs
@@ -173,8 +173,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             var startupHookVar = "";
             dotnet.Exec(appDll)
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
-                .CaptureStdErr()
                 .CaptureStdOut()
+                .CaptureStdErr()
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")

--- a/src/native/corehost/hostmisc/pal.windows.cpp
+++ b/src/native/corehost/hostmisc/pal.windows.cpp
@@ -570,7 +570,7 @@ bool pal::getenv(const char_t* name, string_t* recv)
         auto err = GetLastError();
         if (err != ERROR_ENVVAR_NOT_FOUND)
         {
-            trace::warning(_X("Failed to read environment variable [%s], HRESULT: 0x%X"), name, HRESULT_FROM_WIN32(GetLastError()));
+            trace::warning(_X("Failed to read environment variable [%s], HRESULT: 0x%X"), name, HRESULT_FROM_WIN32(err));
         }
         return false;
     }

--- a/src/native/corehost/hostmisc/pal.windows.cpp
+++ b/src/native/corehost/hostmisc/pal.windows.cpp
@@ -570,14 +570,18 @@ bool pal::getenv(const char_t* name, string_t* recv)
         auto err = GetLastError();
         if (err != ERROR_ENVVAR_NOT_FOUND)
         {
-            trace::error(_X("Failed to read environment variable [%s], HRESULT: 0x%X"), name, HRESULT_FROM_WIN32(GetLastError()));
+            trace::warning(_X("Failed to read environment variable [%s], HRESULT: 0x%X"), name, HRESULT_FROM_WIN32(GetLastError()));
         }
         return false;
     }
     auto buf = new char_t[length];
     if (::GetEnvironmentVariableW(name, buf, length) == 0)
     {
-        trace::error(_X("Failed to read environment variable [%s], HRESULT: 0x%X"), name, HRESULT_FROM_WIN32(GetLastError()));
+        auto err = GetLastError();
+        if (err != ERROR_ENVVAR_NOT_FOUND)
+        {
+            trace::warning(_X("Failed to read environment variable [%s], HRESULT: 0x%X"), name, HRESULT_FROM_WIN32(GetLastError()));
+        }
         return false;
     }
 

--- a/src/native/corehost/hostmisc/pal.windows.cpp
+++ b/src/native/corehost/hostmisc/pal.windows.cpp
@@ -580,7 +580,7 @@ bool pal::getenv(const char_t* name, string_t* recv)
         auto err = GetLastError();
         if (err != ERROR_ENVVAR_NOT_FOUND)
         {
-            trace::warning(_X("Failed to read environment variable [%s], HRESULT: 0x%X"), name, HRESULT_FROM_WIN32(GetLastError()));
+            trace::warning(_X("Failed to read environment variable [%s], HRESULT: 0x%X"), name, HRESULT_FROM_WIN32(err));
         }
         return false;
     }


### PR DESCRIPTION
Fixes #54073
Fixes https://github.com/dotnet/runtime/issues/82260