### PR TITLE
[6.0] Add check-service-labels.yml to unblock base branch PRs

### DIFF
--- a/.github/workflows/check-service-labels.yml
+++ b/.github/workflows/check-service-labels.yml
@@ -1,0 +1,23 @@
+name: check-service-labels
+
+permissions:
+  pull-requests: read
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, labeled, unlabeled, synchronize]
+    branches:
+      - 'release/**'
+
+jobs:
+  check-labels:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check servicing labels
+      run: |
+        if [ "${{ contains(github.event.pull_request.labels.*.name, 'Servicing-approved') }}" = "true" ]; then
+          exit 0
+        else
+          exit 1
+        fi
+


### PR DESCRIPTION
Need to backport the action into this branch as well to unblock PRs waiting on the label to be detected.