### PR TITLE
Use a tuned ConcurrentDictionary in the default caching implementation for the COM source generator

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/Ancillary.Interop/DefaultCaching.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/Ancillary.Interop/DefaultCaching.cs
@@ -2,14 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Implementations of the COM strategy interfaces defined in Com.cs that we would want to ship (can be internal only if we don't want to allow users to provide their own implementations in v1).
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace System.Runtime.InteropServices.Marshalling
 {
     internal sealed unsafe class DefaultCaching : IIUnknownCacheStrategy
     {
-        // [TODO] Implement some smart/thread-safe caching
-        private readonly Dictionary<RuntimeTypeHandle, IIUnknownCacheStrategy.TableInfo> _cache = new();
+        // We limit the concurrency level to 1 writer as we believe this is the most common scenario and limiting the concurrency level
+        // significantly reduces memory overhead.
+        // We set the default capacity a similar CoreCLR's COM-interop's RCW cache size.
+        private readonly ConcurrentDictionary<RuntimeTypeHandle, IIUnknownCacheStrategy.TableInfo> _cache = new(concurrencyLevel: 1, capacity: 16);
 
         IIUnknownCacheStrategy.TableInfo IIUnknownCacheStrategy.ConstructTableInfo(RuntimeTypeHandle handle, IIUnknownDerivedDetails details, void* ptr)
         {

--- a/src/libraries/System.Runtime.InteropServices/tests/Ancillary.Interop/DefaultCaching.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/Ancillary.Interop/DefaultCaching.cs
@@ -11,7 +11,7 @@ namespace System.Runtime.InteropServices.Marshalling
     {
         // We limit the concurrency level to 1 writer as we believe this is the most common scenario and limiting the concurrency level
         // significantly reduces memory overhead.
-        // We set the default capacity a similar CoreCLR's COM-interop's RCW cache size.
+        // We set the default capacity as a decent guess.
         private readonly ConcurrentDictionary<RuntimeTypeHandle, IIUnknownCacheStrategy.TableInfo> _cache = new(concurrencyLevel: 1, capacity: 16);
 
         IIUnknownCacheStrategy.TableInfo IIUnknownCacheStrategy.ConstructTableInfo(RuntimeTypeHandle handle, IIUnknownDerivedDetails details, void* ptr)


### PR DESCRIPTION
Use a ConcurrentDictionary to ensure we have at least a simple decently performant thread-safe cache.

Based on experience with CsWinRT, we'll try to tune this a little bit as we don't expect many concurrent writes to the cache.