### PR TITLE
[7.0] Reset OOB packages from 7.0.5

### DIFF
--- a/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -25,7 +25,7 @@
     <!-- When building from source, ensure the RID we're building for is part of the RID graph -->
     <AdditionalRuntimeIdentifiers Condition="'$(DotNetBuildFromSource)' == 'true'">$(AdditionalRuntimeIdentifiers);$(OutputRID)</AdditionalRuntimeIdentifiers>
     <ServicingVersion>2</ServicingVersion>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">


### PR DESCRIPTION
**IMPORTANT: Merge on code-complete day (April 10th).**

OOB packages published in 7.0.5:

- Microsoft.NETCore.Platforms: https://github.com/dotnet/runtime/pull/82208
- [ignored] Microsoft.Windows.Compatibility & System.Management: https://github.com/dotnet/runtime/pull/83549 
  - I had to reset them here to fix the merge conflict: https://github.com/dotnet/runtime/pull/83557

Keeping track of the OOB packages that will go to 7.0.6 to avoid reseting them here:
- System.Text.Json & Microsoft.Extensions.Logging.Abstractions: https://github.com/dotnet/runtime/pull/83743
- System.Reflection.Metadata: https://github.com/dotnet/runtime/pull/83565
- Microsoft.Windows.Compatibility & System.Management (again) and System.DirectoryServices.Protocols: https://github.com/dotnet/runtime/pull/84355