### PR TITLE
JIT: Set GTF_DEBUG_NODE_MORPHED properly in block morph

### DIFF
--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -144,7 +144,9 @@ GenTree* MorphInitBlockHelper::Morph()
     assert(m_result != nullptr);
 
 #ifdef DEBUG
-    if (m_result != m_asg)
+    // If we are going to return a different node than the input then morph
+    // expects us to have set GTF_DEBUG_NODE_MORPHED.
+    if ((m_result != m_asg) || (sideEffects != nullptr))
     {
         m_result->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
     }
@@ -158,6 +160,7 @@ GenTree* MorphInitBlockHelper::Morph()
             commaPool      = commaPool->gtNext;
 
             assert(comma->OperIs(GT_COMMA));
+            comma->gtType = m_result->TypeGet();
             comma->AsOp()->gtOp1 = sideEffects;
             comma->AsOp()->gtOp2 = m_result;
             comma->gtFlags       = (sideEffects->gtFlags | m_result->gtFlags) & GTF_ALL_EFFECT;

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -160,7 +160,7 @@ GenTree* MorphInitBlockHelper::Morph()
             commaPool      = commaPool->gtNext;
 
             assert(comma->OperIs(GT_COMMA));
-            comma->gtType = m_result->TypeGet();
+            comma->gtType        = m_result->TypeGet();
             comma->AsOp()->gtOp1 = sideEffects;
             comma->AsOp()->gtOp2 = m_result;
             comma->gtFlags       = (sideEffects->gtFlags | m_result->gtFlags) & GTF_ALL_EFFECT;


### PR DESCRIPTION
With side effects that may go on top, it may be block morph's responsibility to set this flag.

Also set the type of the reused GT_COMMA nodes; haven't actually seen any issues here, but seems prudent to do this.

Fixes some stress issues seen over in #83771.