### PR TITLE
[Android] Free up more disk space on CI builds

### DIFF
--- a/eng/testing/tests.android.targets
+++ b/eng/testing/tests.android.targets
@@ -70,7 +70,7 @@
           SkipUnchangedFiles="true"
           Condition="'$(ArchiveTests)' == 'true' and '$(IgnoreForCI)' != 'true'" />
 
-    <RemoveDir Condition="'$(ArchiveTests)' == 'true'" Directories="$(OutDir)" />
+    <RemoveDir Condition="'$(ArchiveTests)' == 'true' and '$(AndroidGenerateAppBundle)' == 'true'" Directories="$(OutDir)" />
   </Target>
 
 </Project>

--- a/eng/testing/tests.android.targets
+++ b/eng/testing/tests.android.targets
@@ -69,6 +69,8 @@
           DestinationFolder="$(TestArchiveTestsDir)"
           SkipUnchangedFiles="true"
           Condition="'$(ArchiveTests)' == 'true' and '$(IgnoreForCI)' != 'true'" />
+
+    <RemoveDir Condition="'$(ArchiveTests)' == 'true'" Directories="$(OutDir)" />
   </Target>
 
 </Project>

--- a/src/tests/FunctionalTests/Android/Device_Emulator/StartupHook/Android.Device_Emulator.StartupHook.Test.csproj
+++ b/src/tests/FunctionalTests/Android/Device_Emulator/StartupHook/Android.Device_Emulator.StartupHook.Test.csproj
@@ -14,6 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-      <ProjectReference Include="..\..\..\TestAssets\StartupHookForFunctionalTest\StartupHookForFunctionalTest.csproj" />
+      <ProjectReference Include="..\..\..\TestAssets\StartupHookForFunctionalTest\StartupHookForFunctionalTest.csproj">
+        <Private>true</Private>
+      </ProjectReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The android builds are running out of disk space when building the library test apps.  This change tries to recoup some of that space by deleting artifacts after each test was built.

Addresses https://github.com/dotnet/arcade/issues/13036