### PR TITLE
[wasm] Freeze the emscripten cache

### DIFF
--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -255,6 +255,7 @@
       <EmscriptenEnvVars Include="PYTHONPATH=$(EmscriptenPythonToolsPath)" Condition="'$(OS)' == 'Windows_NT'" />
       <EmscriptenEnvVars Include="PYTHONHOME=" Condition="'$(OS)' == 'Windows_NT'" />
       <EmscriptenEnvVars Include="EM_CACHE=$(WasmCachePath)" Condition="'$(WasmCachePath)' != ''" />
+      <EmscriptenEnvVars Include="EM_FROZEN_CACHE=True" />
       <EmscriptenEnvVars Include="WasmEnableLegacyJsInterop=$(WasmEnableLegacyJsInterop)"/>
     </ItemGroup>
 


### PR DESCRIPTION
This fixes https://github.com/dotnet/runtime/issues/83655

We prime the cache before packaging the emsdk cache package and also in docker images, so we don't need to update the cache, which might be in read-only location anyway.

The underlying issue was problem with the cache lock:

    "C:/helix/work/correlation/build/emsdk/upstream/bin\clang.exe" --version
    cache:WARNING: Accessing the Emscripten cache at "C:\helix\work\correlation\build\emsdk\upstream\emscripten\cache" (for "sanity") is taking a long time, another process should be writing to it. If there are none and you suspect this process has deadlocked, try deleting the lock file "C:\helix\work\correlation\build\emsdk\upstream\emscripten\cache\cache.lock" and try again. If this occurs deterministically, consider filing a bug.
    cache:WARNING: Accessing the Emscripten cache at "C:\helix\work\correlation\build\emsdk\upstream\emscripten\cache" (for "sanity") is taking a long time, another process should be writing to it. If there are none and you suspect this process has deadlocked, try deleting the lock file "C:\helix\work\correlation\build\emsdk\upstream\emscripten\cache\cache.lock" and try again. If this occurs deterministically, consider filing a bug.