### PR TITLE
[release/6.0] Fix pinned assembly version 6.0

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -51,7 +51,7 @@
     <_IsWindowsDesktopApp Condition="$(WindowsDesktopCoreAppLibrary.Contains('$(AssemblyName);'))">true</_IsWindowsDesktopApp>
     <_IsAspNetCoreApp Condition="$(AspNetCoreAppLibrary.Contains('$(AssemblyName);'))">true</_IsAspNetCoreApp>
     <_AssemblyInTargetingPack Condition="('$(IsNETCoreAppSrc)' == 'true' or '$(IsNetCoreAppRef)' == 'true' or '$(_IsAspNetCoreApp)' == 'true' or '$(_IsWindowsDesktopApp)' == 'true') and '$(TargetFrameworkIdentifier)' != '.NETFramework'">true</_AssemblyInTargetingPack>
-    <!-- Assembly version do not get updated in non-netfx ref pack assemblies. -->
+    <!-- The assembly version gets updated when the assembly isn't part of a targeting pack. -->
     <AssemblyVersion Condition="'$(_AssemblyInTargetingPack)' != 'true'">$(MajorVersion).$(MinorVersion).0.$(ServicingVersion)</AssemblyVersion>
   </PropertyGroup>
 

--- a/src/libraries/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
+++ b/src/libraries/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
@@ -6,7 +6,7 @@
     <NoTargetsDoNotReferenceOutputAssemblies>false</NoTargetsDoNotReferenceOutputAssemblies>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <ServicingVersion>4</ServicingVersion>
+    <ServicingVersion>5</ServicingVersion>
     <!-- This is a meta package and doesn't contain any libs. -->
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <PackageDescription>This Windows Compatibility Pack provides access to APIs that were previously available only for .NET Framework. It can be used from both .NET Core as well as .NET Standard.</PackageDescription>

--- a/src/libraries/System.ComponentModel.Composition/Directory.Build.props
+++ b/src/libraries/System.ComponentModel.Composition/Directory.Build.props
@@ -1,7 +1,6 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.ComponentModel.Composition/Directory.Build.targets
+++ b/src/libraries/System.ComponentModel.Composition/Directory.Build.targets
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
     <!-- This assembly is inbox in .NETFramework, ensure that the AssemblyVersion
-         remains <= the desktop version -->
+         remains <= the .NETFramework version -->
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.ComponentModel.Composition/Directory.Build.targets
+++ b/src/libraries/System.ComponentModel.Composition/Directory.Build.targets
@@ -1,0 +1,8 @@
+﻿<Project>
+  <Import Project="..\Directory.Build.targets" />
+  <PropertyGroup>
+    <!-- This assembly is inbox in .NETFramework, ensure that the AssemblyVersion
+         remains <= the desktop version -->
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+  </PropertyGroup>
+</Project>

--- a/src/libraries/System.DirectoryServices.AccountManagement/Directory.Build.props
+++ b/src/libraries/System.DirectoryServices.AccountManagement/Directory.Build.props
@@ -1,10 +1,6 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <!-- this assembly is inbox in desktop, do not version it unless you
-         plan on shipping a new desktop version out of band. Instead add API
-         to a different assembly. -->
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
     <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>

--- a/src/libraries/System.DirectoryServices.AccountManagement/Directory.Build.targets
+++ b/src/libraries/System.DirectoryServices.AccountManagement/Directory.Build.targets
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
     <!-- This assembly is inbox in .NETFramework, ensure that the AssemblyVersion
-         remains <= the desktop version -->
+         remains <= the .NETFramework version -->
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.DirectoryServices.AccountManagement/Directory.Build.targets
+++ b/src/libraries/System.DirectoryServices.AccountManagement/Directory.Build.targets
@@ -1,0 +1,8 @@
+﻿<Project>
+  <Import Project="..\Directory.Build.targets" />
+  <PropertyGroup>
+    <!-- This assembly is inbox in .NETFramework, ensure that the AssemblyVersion
+         remains <= the desktop version -->
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+  </PropertyGroup>
+</Project>

--- a/src/libraries/System.DirectoryServices.Protocols/Directory.Build.props
+++ b/src/libraries/System.DirectoryServices.Protocols/Directory.Build.props
@@ -1,10 +1,6 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <!-- this assembly is inbox in desktop, do not version it unless you
-         plan on shipping a new desktop version out of band. Instead add API
-         to a different assembly. -->
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
     <UnsupportedOSPlatforms>browser;android;ios;tvos</UnsupportedOSPlatforms>

--- a/src/libraries/System.DirectoryServices.Protocols/Directory.Build.targets
+++ b/src/libraries/System.DirectoryServices.Protocols/Directory.Build.targets
@@ -1,0 +1,10 @@
+﻿<Project>
+  <Import Project="..\Directory.Build.targets" />
+  <PropertyGroup>
+    <!-- This assembly is inbox in .NETFramework, ensure that the .NETStandard assembly 
+         remains <= the desktop version.
+         Allow non-NETStandard assemblies to version to be compatible with past serviced packages which
+         shipped higher versions. -->
+    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
+  </PropertyGroup>
+</Project>

--- a/src/libraries/System.DirectoryServices.Protocols/Directory.Build.targets
+++ b/src/libraries/System.DirectoryServices.Protocols/Directory.Build.targets
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
     <!-- This assembly is inbox in .NETFramework, ensure that the .NETStandard assembly 
-         remains <= the desktop version.
+         remains <= the .NETFramework version.
          Allow non-NETStandard assemblies to version to be compatible with past serviced packages which
          shipped higher versions. -->
     <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>

--- a/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
@@ -5,8 +5,8 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-OSX;$(NetCoreAppCurrent)-Linux;$(NetCoreAppCurrent);netcoreapp3.1-windows;netcoreapp3.1-OSX;netcoreapp3.1-Linux;netcoreapp3.1;netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <!-- If you enable GeneratePackageOnBuild for this package and bump ServicingVersion, make sure to also bump ServicingVersion in Microsoft.Windows.Compatibility.csproj once for the next release. -->
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <ServicingVersion>1</ServicingVersion>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>2</ServicingVersion>
     <AddNETFrameworkPlaceholderFileToPackage>true</AddNETFrameworkPlaceholderFileToPackage>
     <AddNETFrameworkAssemblyReferenceToPackage>true</AddNETFrameworkAssemblyReferenceToPackage>
     <PackageDescription>Provides the methods defined in the Lightweight Directory Access Protocol (LDAP) version 3 (V3) and Directory Services Markup Language (DSML) version 2.0 (V2) standards.</PackageDescription>

--- a/src/libraries/System.DirectoryServices/Directory.Build.props
+++ b/src/libraries/System.DirectoryServices/Directory.Build.props
@@ -1,10 +1,6 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <!-- this assembly is inbox in desktop, do not version it unless you
-         plan on shipping a new desktop version out of band. Instead add API
-         to a different assembly. -->
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <!-- Since this assembly version is pinned, we don't want to validate that it matches
     the expected assembly version on the targeting pack. -->
     <SkipValidateAssemblyVersion>true</SkipValidateAssemblyVersion>

--- a/src/libraries/System.DirectoryServices/Directory.Build.targets
+++ b/src/libraries/System.DirectoryServices/Directory.Build.targets
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
     <!-- This assembly is inbox in .NETFramework, ensure that the AssemblyVersion
-         remains <= the desktop version -->
+         remains <= the .NETFramework version -->
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.DirectoryServices/Directory.Build.targets
+++ b/src/libraries/System.DirectoryServices/Directory.Build.targets
@@ -1,0 +1,8 @@
+﻿<Project>
+  <Import Project="..\Directory.Build.targets" />
+  <PropertyGroup>
+    <!-- This assembly is inbox in .NETFramework, ensure that the AssemblyVersion
+         remains <= the desktop version -->
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+  </PropertyGroup>
+</Project>

--- a/src/libraries/System.Management/Directory.Build.props
+++ b/src/libraries/System.Management/Directory.Build.props
@@ -1,10 +1,6 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <!-- this assembly is inbox in desktop, do not version it unless you
-         plan on shipping a new desktop version out of band. Instead add API
-         to a different assembly. -->
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>

--- a/src/libraries/System.Management/Directory.Build.targets
+++ b/src/libraries/System.Management/Directory.Build.targets
@@ -1,0 +1,10 @@
+﻿<Project>
+  <Import Project="..\Directory.Build.targets" />
+  <PropertyGroup>
+    <!-- This assembly is inbox in .NETFramework, ensure that the .NETStandard assembly 
+         remains <= the desktop version.
+         Allow non-NETStandard assemblies to version to be compatible with past serviced packages which
+         shipped higher versions. -->
+    <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>
+  </PropertyGroup>
+</Project>

--- a/src/libraries/System.Management/Directory.Build.targets
+++ b/src/libraries/System.Management/Directory.Build.targets
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
     <!-- This assembly is inbox in .NETFramework, ensure that the .NETStandard assembly 
-         remains <= the desktop version.
+         remains <= the .NETFramework version.
          Allow non-NETStandard assemblies to version to be compatible with past serviced packages which
          shipped higher versions. -->
     <AssemblyVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">4.0.0.0</AssemblyVersion>

--- a/src/libraries/System.Management/src/System.Management.csproj
+++ b/src/libraries/System.Management/src/System.Management.csproj
@@ -7,7 +7,7 @@
     <IsPackable>true</IsPackable>
     <!-- If you enable GeneratePackageOnBuild for this package and bump ServicingVersion, make sure to also bump ServicingVersion in Microsoft.Windows.Compatibility.csproj once for the next release. -->
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <ServicingVersion>1</ServicingVersion>
+    <ServicingVersion>2</ServicingVersion>
     <AddNETFrameworkPlaceholderFileToPackage>true</AddNETFrameworkPlaceholderFileToPackage>
     <AddNETFrameworkAssemblyReferenceToPackage>true</AddNETFrameworkAssemblyReferenceToPackage>
     <PackageDescription>Provides access to a rich set of management information and management events about the system, devices, and applications instrumented to the Windows Management Instrumentation (WMI) infrastructure.

--- a/src/libraries/System.Reflection.Context/Directory.Build.props
+++ b/src/libraries/System.Reflection.Context/Directory.Build.props
@@ -1,7 +1,6 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Reflection.Context/Directory.Build.targets
+++ b/src/libraries/System.Reflection.Context/Directory.Build.targets
@@ -1,0 +1,9 @@
+﻿<Project>
+  <Import Project="..\Directory.Build.targets" />
+  <PropertyGroup>
+    <!-- This assembly is inbox in .NETFramework, ensure that the AssemblyVersion
+         remains <= the desktop version.
+         4.0.3.0 breaks this causing https://github.com/dotnet/runtime/issues/84320  -->
+    <AssemblyVersion>4.0.3.0</AssemblyVersion>
+  </PropertyGroup>
+</Project>

--- a/src/libraries/System.Reflection.Context/Directory.Build.targets
+++ b/src/libraries/System.Reflection.Context/Directory.Build.targets
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
     <!-- This assembly is inbox in .NETFramework, ensure that the AssemblyVersion
-         remains <= the desktop version.
+         remains <= the .NETFramework version.
          4.0.3.0 breaks this causing https://github.com/dotnet/runtime/issues/84320  -->
     <AssemblyVersion>4.0.3.0</AssemblyVersion>
   </PropertyGroup>

--- a/src/libraries/System.Runtime.Caching/Directory.Build.props
+++ b/src/libraries/System.Runtime.Caching/Directory.Build.props
@@ -1,10 +1,6 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <!-- this assembly is inbox in desktop, do not version it unless you
-         plan on shipping a new desktop version out of band. Instead add API
-         to a different assembly. -->
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>

--- a/src/libraries/System.Runtime.Caching/Directory.Build.targets
+++ b/src/libraries/System.Runtime.Caching/Directory.Build.targets
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
     <!-- This assembly is inbox in .NETFramework, ensure that the AssemblyVersion
-         remains <= the desktop version -->
+         remains <= the .NETFramework version -->
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Runtime.Caching/Directory.Build.targets
+++ b/src/libraries/System.Runtime.Caching/Directory.Build.targets
@@ -1,0 +1,8 @@
+﻿<Project>
+  <Import Project="..\Directory.Build.targets" />
+  <PropertyGroup>
+    <!-- This assembly is inbox in .NETFramework, ensure that the AssemblyVersion
+         remains <= the desktop version -->
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+  </PropertyGroup>
+</Project>

--- a/src/libraries/System.Speech/Directory.Build.props
+++ b/src/libraries/System.Speech/Directory.Build.props
@@ -1,10 +1,6 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <!-- this assembly is inbox in desktop, do not version it unless you
-         plan on shipping a new desktop version out of band. Instead add API
-         to a different assembly. -->
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
     <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>

--- a/src/libraries/System.Speech/Directory.Build.targets
+++ b/src/libraries/System.Speech/Directory.Build.targets
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
     <!-- This assembly is inbox in .NETFramework, ensure that the AssemblyVersion
-         remains <= the desktop version -->
+         remains <= the .NETFramework version -->
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Speech/Directory.Build.targets
+++ b/src/libraries/System.Speech/Directory.Build.targets
@@ -1,0 +1,8 @@
+﻿<Project>
+  <Import Project="..\Directory.Build.targets" />
+  <PropertyGroup>
+    <!-- This assembly is inbox in .NETFramework, ensure that the AssemblyVersion
+         remains <= the desktop version -->
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/84079 to release/6.0-staging

## Customer Impact
Customer using 6.0.1 and 7.0.1 package of System.Management faces assembly load errors when running on .NETFramework, or all frameworks when upgrading from these packages to a non-servicing release (7.0.0, 8.0.0-preview).  
Customer using 6.0.1 System.DirectoryServices.Protocols package faces assembly load errors when running on .NETFramework, or all frameworks when upgrading from this packages to a non-servicing release (7.0.0, 8.0.0-preview).  
```
Unhandled Exception: System.IO.FileNotFoundException: Could not load file or assembly 'System.DirectoryServices.Protocols, Version=6.0.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified.
```

Customer on .NETFramework who consumes a NETStandard library using either package will see build warnings like:
```
warning MSB3277: Found conflicts between different versions of "System.DirectoryServices.Protocols" that could not be resolved. 
warning MSB3277: There was a conflict between "System.DirectoryServices.Protocols, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" and "System.DirectoryServices.Protocols, Version=6.0.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a". 
warning MSB3277:     "System.DirectoryServices.Protocols, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" was chosen because it was primary and "System.DirectoryServices.Protocols, Version=6.0.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" was not. 
```

Root cause is that we accidentally increased the assembly versions of these libraries (and 5 others that luckily haven't shipped) from 4.0.0.0 to 6|7.0.0.n during our servicing builds.

## Testing
Build / diff all assembly versions.  Package testing.  TODO: Targeted manual regression tests along upgrade path and in cross-framework consumption scenario.
7.0 diff: https://gist.github.com/ericstj/5e914be725066df9824fd1e3fca12c08
6.0 diff: https://gist.github.com/ericstj/83579179870f159bdbbe0c923f457526

## Risk
Low, the change is isolated to the 8 libraries that pin their assembly versions to enable .NETFramework support.  We further reduced risk by only allowing the higher versions of the 2 libraries that already shipped.   To reduce the number of people that need to update to get a fix, we let those 2 libraries stay at the higher version for .NET 7.  In .NET 8 we made all 8 libraries reduce their use of this pinned assembly version so-as to make them less special.