### PR TITLE
Enable building preview workload components

### DIFF
--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -160,10 +160,13 @@
       <SwixWorkloadPackProjects Include="@(SwixProjects)" Condition="'%(PackageType)' == 'msi-pack'"
                                 ManifestOutputPath="$(VStemp)\p\%(SwixProjects.SdkFeatureBand)"
                                 ZipFile="Workload.VSDrop.mono.net.$(MajorVersion).$(MinorVersion)-%(SwixProjects.SdkFeatureBand).packs.zip"/>
-      <SwixComponentsAndManifests Include="@(SwixProjects)" Condition="'%(PackageType)' == 'msi-manifest' Or '%(PackageType)' == 'component'"
+      <SwixComponentsAndManifests Include="@(SwixProjects)" Condition="('%(PackageType)' == 'msi-manifest') Or ('%(PackageType)' == 'component' And '%(IsPreview)' == 'false')"
                                   ManifestOutputPath="$(VStemp)\c\%(SwixProjects.SdkFeatureBand)"
                                   ZipFile="Workload.VSDrop.mono.net.$(MajorVersion).$(MinorVersion)-%(SwixProjects.SdkFeatureBand).components.zip"/>
-      <PartitionedSwixProjects Include="@(SwixWorkloadPackProjects);@(SwixComponentsAndManifests)" />
+      <SwixPreviewComponentsAndManifests Include="@(SwixProjects)" Condition="('%(PackageType)' == 'msi-manifest') Or ('%(PackageType)' == 'component' And '%(IsPreview)' == 'true')"
+                                         ManifestOutputPath="$(VStemp)\c\%(SwixProjects.SdkFeatureBand).pre"
+                                         ZipFile="Workload.VSDrop.mono.net.$(MajorVersion).$(MinorVersion)-%(SwixProjects.SdkFeatureBand)-pre.components.zip"/>
+      <PartitionedSwixProjects Include="@(SwixWorkloadPackProjects);@(SwixComponentsAndManifests);@(SwixPreviewComponentsAndManifests)" />
     </ItemGroup>
 
     <!-- Can't build in parallel to the same output folder because of a shared file from the SWIX compiler. -->


### PR DESCRIPTION
To support insertions of multiple SDKs into Visual Studio, the components associated with workloads need to have unique IDs. Currently there is a 1:1 mapping between VS components and .NET workloads. Inserting multiple SDKs into VS creates a conflict. The Aracde tasks used to create workloads were updated to produce two sets of components with the second set containing an additional .pre suffix. 

The build would produce one additional artifact for VS

![image](https://user-images.githubusercontent.com/7409981/230166259-b903ed79-14cc-4e74-9cf6-4a132dc822f1.png)
