### PR TITLE
Disable AOT build of GitHub_27678 under Mono

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/GitHub_27678/GitHub_27678.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_27678/GitHub_27678.ilproj
@@ -2,6 +2,12 @@
   <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
+
+    <!-- * Assertion at
+         /__w/1/s/src/mono/mono/mini/memory-access.c:120, condition `size < MAX_INLINE_COPY_SIZE' not met -->
+    <MonoAotIncompatible>true</MonoAotIncompatible>
+    <!-- Needed for MonoAotIncompatible -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />


### PR DESCRIPTION
This is a known failure (in issues.targets), but merged test groups cause the AOT failure to fail the entire build of Regression_3.  MonoAotIncompatible (and RequiresProcessIsolation) separate them and allow the test to be failed (and skipped) separately.