### PR TITLE
[wasm] Implement LEAVE_CHECK in the jiterpreter (as a bailout)

### DIFF
--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -645,6 +645,12 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 		case MINT_SDB_SEQ_POINT:
 			return TRACE_IGNORE;
 
+		case MINT_LEAVE_CHECK:
+		case MINT_LEAVE_S_CHECK:
+			// These are only generated inside catch clauses, so it's safe to assume that
+			//  during normal execution they won't run, and compile them as a bailout.
+			return TRACE_IGNORE;
+
 		case MINT_INITLOCAL:
 		case MINT_INITLOCALS:
 		case MINT_LOCALLOC:
@@ -746,10 +752,6 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 			if (*inside_branch_block)
 				return TRACE_CONDITIONAL_ABORT;
 
-			return TRACE_ABORT;
-
-		case MINT_LEAVE_CHECK:
-		case MINT_LEAVE_S_CHECK:
 			return TRACE_ABORT;
 
 		case MINT_RETHROW:

--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -51,6 +51,7 @@ export const enum BailoutReason {
     Debugging,
     Icall,
     UnexpectedRetIp,
+    LeaveCheck,
 }
 
 export const BailoutReasonNames = [
@@ -80,6 +81,7 @@ export const BailoutReasonNames = [
     "Debugging",
     "Icall",
     "UnexpectedRetIp",
+    "LeaveCheck",
 ];
 
 type FunctionType = [

--- a/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
@@ -925,6 +925,14 @@ export function generateWasmBody (
                 isLowValueOpcode = true;
                 break;
 
+            // These are generated in place of regular LEAVEs inside of the body of a catch clause.
+            // We can safely assume that during normal execution, catch clauses won't be running.
+            case MintOpcode.MINT_LEAVE_CHECK:
+            case MintOpcode.MINT_LEAVE_S_CHECK:
+                append_bailout(builder, ip, BailoutReason.LeaveCheck);
+                isLowValueOpcode = true;
+                break;
+
             case MintOpcode.MINT_ENDFINALLY: {
                 if (
                     (builder.callHandlerReturnAddresses.length > 0) &&


### PR DESCRIPTION
LEAVE_CHECK is a variant of LEAVE that only appears inside catch clauses, and catch clauses will not be running during normal optimized execution. So it's reasonable for the jiterpreter to compile them into bailouts, which will allow trace compilation to continue past the catch clause.