### PR TITLE
Fix ThunkGenerator

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/ThunkGenerator/Program.cs
+++ b/src/coreclr/tools/Common/JitInterface/ThunkGenerator/Program.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -174,7 +175,7 @@ namespace Thunkerator
             IFDEFING
         }
 
-        private static IEnumerable<FunctionDecl> ParseInput(TextReader tr)
+        private static ReadOnlyCollection<FunctionDecl> ParseInput(StreanReader tr)
         {
             Dictionary<string, TypeReplacement> ThunkReturnTypes = new Dictionary<string, TypeReplacement>();
             Dictionary<string, TypeReplacement> ThunkTypes = new Dictionary<string, TypeReplacement>();

--- a/src/coreclr/tools/Common/JitInterface/ThunkGenerator/Program.cs
+++ b/src/coreclr/tools/Common/JitInterface/ThunkGenerator/Program.cs
@@ -175,7 +175,7 @@ namespace Thunkerator
             IFDEFING
         }
 
-        private static ReadOnlyCollection<FunctionDecl> ParseInput(StreanReader tr)
+        private static ReadOnlyCollection<FunctionDecl> ParseInput(StreamReader tr)
         {
             Dictionary<string, TypeReplacement> ThunkReturnTypes = new Dictionary<string, TypeReplacement>();
             Dictionary<string, TypeReplacement> ThunkTypes = new Dictionary<string, TypeReplacement>();


### PR DESCRIPTION
Fixes:
```
 error CA1859: Change type of parameter 'tr' from 'System.IO.TextReader' to 'System.IO.StreamReader' for improved performance
 error CA1859: Change return type of method 'ParseInput' from 'System.Collections.Generic.IEnumerable<Thunkerator.FunctionDecl>' to 'System.Collections.ObjectModel.ReadOnlyCollection<Thunkerator.FunctionDecl>' for improved performance
```