### PR TITLE
Move over all interop generator unit tests to use raw string literals

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/JSImportGenerator.UnitTest/CodeSnippets.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/JSImportGenerator.UnitTest/CodeSnippets.cs
@@ -5,174 +5,174 @@ namespace JSImportGenerator.Unit.Tests
 {
     internal static class CodeSnippets
     {
-        public static readonly string AllDefault= @"
-//AllDefault
-using System;
-using System.Runtime.InteropServices.JavaScript;
-using System.Threading.Tasks;
-partial class Basic
-{
-    [JSImport(""DoesNotExist"")]
-    internal static partial void Relaxed(
-        string a1,
-        Exception ex,
-        bool ab, double a6, byte a2, char a3, short a4, float a5, IntPtr a7,
-        bool? nab, double? na6, byte? na2, char? na3, short? na4, float? na5, IntPtr? na7,
-        Task<string> ta1,
-        Task<Exception> tex,
-        Task<bool> tab,
-        Task<double> ta6,
-        Task<byte> ta2,
-        Task<char> ta3,
-        Task<short> ta4,
-        Task<float> ta5,
-        Task<IntPtr> ta7,
-        JSObject jso,
-        string[] aa1, byte[] aab, double[] aad, int[] aai
-    );
-}
-";
+        public static readonly string AllDefault = """
+            //AllDefault
+            using System;
+            using System.Runtime.InteropServices.JavaScript;
+            using System.Threading.Tasks;
+            partial class Basic
+            {
+                [JSImport("DoesNotExist")]
+                internal static partial void Relaxed(
+                    string a1,
+                    Exception ex,
+                    bool ab, double a6, byte a2, char a3, short a4, float a5, IntPtr a7,
+                    bool? nab, double? na6, byte? na2, char? na3, short? na4, float? na5, IntPtr? na7,
+                    Task<string> ta1,
+                    Task<Exception> tex,
+                    Task<bool> tab,
+                    Task<double> ta6,
+                    Task<byte> ta2,
+                    Task<char> ta3,
+                    Task<short> ta4,
+                    Task<float> ta5,
+                    Task<IntPtr> ta7,
+                    JSObject jso,
+                    string[] aa1, byte[] aab, double[] aad, int[] aai
+                );
+            }
+            """;
 
-        public static readonly string AllAnnotated = @"
-//AllAnnotated
-using System;
-using System.Runtime.InteropServices.JavaScript;
-using System.Threading.Tasks;
-partial class Basic
-{
-    [JSImport(""DoesNotExist"")]
-    internal static partial void Annotated(
-        [JSMarshalAs<JSType.Any>] object a1,
-        [JSMarshalAs<JSType.Number>] long a2,
-        [JSMarshalAs<JSType.BigInt>] long a3,
-        [JSMarshalAs<JSType.Function>] Action a4,
-        [JSMarshalAs<JSType.Function<JSType.Number>>] Func<int> a5,
-        [JSMarshalAs<JSType.MemoryView>] Span<byte> a6,
-        [JSMarshalAs<JSType.MemoryView>] ArraySegment<byte> a7,
-        [JSMarshalAs<JSType.Promise<JSType.Any>>] Task<object> a8,
-        [JSMarshalAs<JSType.Array<JSType.Any>>] object[] a9,
-        [JSMarshalAs<JSType.Date>] DateTime a10,
-        [JSMarshalAs<JSType.Date>] DateTimeOffset a11,
-        [JSMarshalAs<JSType.Promise<JSType.Date>>] Task<DateTime> a12,
-        [JSMarshalAs<JSType.Promise<JSType.Date>>] Task<DateTimeOffset> a13,
-        [JSMarshalAs<JSType.Promise<JSType.Number>>] Task<long> a14,
-        [JSMarshalAs<JSType.Promise<JSType.BigInt>>] Task<long> a15
-    );
-}
-";
+        public static readonly string AllAnnotated = """
+            //AllAnnotated
+            using System;
+            using System.Runtime.InteropServices.JavaScript;
+            using System.Threading.Tasks;
+            partial class Basic
+            {
+                [JSImport("DoesNotExist")]
+                internal static partial void Annotated(
+                    [JSMarshalAs<JSType.Any>] object a1,
+                    [JSMarshalAs<JSType.Number>] long a2,
+                    [JSMarshalAs<JSType.BigInt>] long a3,
+                    [JSMarshalAs<JSType.Function>] Action a4,
+                    [JSMarshalAs<JSType.Function<JSType.Number>>] Func<int> a5,
+                    [JSMarshalAs<JSType.MemoryView>] Span<byte> a6,
+                    [JSMarshalAs<JSType.MemoryView>] ArraySegment<byte> a7,
+                    [JSMarshalAs<JSType.Promise<JSType.Any>>] Task<object> a8,
+                    [JSMarshalAs<JSType.Array<JSType.Any>>] object[] a9,
+                    [JSMarshalAs<JSType.Date>] DateTime a10,
+                    [JSMarshalAs<JSType.Date>] DateTimeOffset a11,
+                    [JSMarshalAs<JSType.Promise<JSType.Date>>] Task<DateTime> a12,
+                    [JSMarshalAs<JSType.Promise<JSType.Date>>] Task<DateTimeOffset> a13,
+                    [JSMarshalAs<JSType.Promise<JSType.Number>>] Task<long> a14,
+                    [JSMarshalAs<JSType.Promise<JSType.BigInt>>] Task<long> a15
+                );
+            }
+            """;
 
-        public static readonly string AllMissing = @"
-//AllMissing
-using System;
-using System.Runtime.InteropServices.JavaScript;
-using System.Threading.Tasks;
-partial class Basic
-{
-    [JSImport(""DoesNotExist"")]
-    internal static partial void Missing(
-        object a1,
-        long a2,
-        long a3,
-        Action a4,
-        Func<int> a5,
-        Span<byte> a6,
-        ArraySegment<byte> a7,
-        Task<object> a8,
-        object[] a9,
-        DateTime a10,
-        DateTimeOffset a11,
-        Task<DateTime> a12,
-        Task<DateTimeOffset> a13,
-        Task<long> a14,
-        Task<long> a15
-    );
-}
-";
+        public static readonly string AllMissing = """
+            //AllMissing
+            using System;
+            using System.Runtime.InteropServices.JavaScript;
+            using System.Threading.Tasks;
+            partial class Basic
+            {
+                [JSImport("DoesNotExist")]
+                internal static partial void Missing(
+                    object a1,
+                    long a2,
+                    long a3,
+                    Action a4,
+                    Func<int> a5,
+                    Span<byte> a6,
+                    ArraySegment<byte> a7,
+                    Task<object> a8,
+                    object[] a9,
+                    DateTime a10,
+                    DateTimeOffset a11,
+                    Task<DateTime> a12,
+                    Task<DateTimeOffset> a13,
+                    Task<long> a14,
+                    Task<long> a15
+                );
+            }
+            """;
 
-        public static readonly string InOutRef = @"
-//InOutRef
-using System;
-using System.Runtime.InteropServices.JavaScript;
-using System.Threading.Tasks;
-partial class Basic
-{
-    [JSImport(""DoesNotExist"")]
-    internal static partial void InOutRef(
-        out int a1,
-        in int a2,
-        ref int a3
-    );
-}
-";
+        public static readonly string InOutRef = """
+            //InOutRef
+            using System;
+            using System.Runtime.InteropServices.JavaScript;
+            using System.Threading.Tasks;
+            partial class Basic
+            {
+                [JSImport("DoesNotExist")]
+                internal static partial void InOutRef(
+                    out int a1,
+                    in int a2,
+                    ref int a3
+                );
+            }
+            """;
 
-        public static readonly string AllUnsupported = @"
-//AllUnsupported
-using System;
-using System.Runtime.InteropServices.JavaScript;
-using System.Threading.Tasks;
-partial class Basic
-{
-    [JSImport(""DoesNotExist"")]
-    internal static partial void Missing(
-        Func<Action> a1,
-        Func<int,int,int,int,int> a2,
-        Span<char> a3,
-        ArraySegment<char> a4,
-        Task<object[]> a5,
-        ulong a6,
-        sbyte a7,
-        ushort a8,
-        uint a9
-    );
-}
-";
+        public static readonly string AllUnsupported = """
+            //AllUnsupported
+            using System;
+            using System.Runtime.InteropServices.JavaScript;
+            using System.Threading.Tasks;
+            partial class Basic
+            {
+                [JSImport("DoesNotExist")]
+                internal static partial void Missing(
+                    Func<Action> a1,
+                    Func<int,int,int,int,int> a2,
+                    Span<char> a3,
+                    ArraySegment<char> a4,
+                    Task<object[]> a5,
+                    ulong a6,
+                    sbyte a7,
+                    ushort a8,
+                    uint a9
+                );
+            }
+            """;
 
 
-        public static readonly string TrivialClassDeclarations = @"
-//TrivialClassDeclarations
-using System.Runtime.InteropServices.JavaScript;
-partial class Basic
-{
-    [JSImportAttribute(""DoesNotExist"")]
-    public static partial void Import1();
+        public static readonly string TrivialClassDeclarations = """
+            //TrivialClassDeclarations
+            using System.Runtime.InteropServices.JavaScript;
+            partial class Basic
+            {
+                [JSImportAttribute("DoesNotExist")]
+                public static partial void Import1();
 
-    [JSImport(""DoesNotExist"")]
-    public static partial void Import2();
+                [JSImport("DoesNotExist")]
+                public static partial void Import2();
 
-    [System.Runtime.InteropServices.JavaScript.JSImportAttribute(""DoesNotExist"")]
-    public static partial void Import3();
+                [System.Runtime.InteropServices.JavaScript.JSImportAttribute("DoesNotExist")]
+                public static partial void Import3();
 
-    [System.Runtime.InteropServices.JavaScript.JSImport(""DoesNotExist"")]
-    public static partial void Import4();
+                [System.Runtime.InteropServices.JavaScript.JSImport("DoesNotExist")]
+                public static partial void Import4();
 
-    [JSExportAttribute()]
-    public static void Export1(){}
+                [JSExportAttribute()]
+                public static void Export1(){}
 
-    [JSExport()]
-    public static void Export2(){}
+                [JSExport()]
+                public static void Export2(){}
 
-    [System.Runtime.InteropServices.JavaScript.JSExportAttribute]
-    public static void Export3(){}
+                [System.Runtime.InteropServices.JavaScript.JSExportAttribute]
+                public static void Export3(){}
 
-    [System.Runtime.InteropServices.JavaScript.JSExport]
-    public static void Export4(){}
+                [System.Runtime.InteropServices.JavaScript.JSExport]
+                public static void Export4(){}
 
-}
-";
+            }
+            """;
         public static string DefaultReturnMarshaler<T>() => DefaultReturnMarshaler(typeof(T).ToString());
 
-        public static string DefaultReturnMarshaler(string type) => $@"
-//DefaultReturnMarshaler<{type}>
-using System.Runtime.InteropServices.JavaScript;
-partial class Basic
-{{
-    [JSImport(""DoesNotExist"")]
-    public static partial {type} Import1();
-
-    [JSExport()]
-    public static {type} Export1(){{ throw null; }}
-}}
-";
+        public static string DefaultReturnMarshaler(string type) => $$"""
+            //DefaultReturnMarshaler<{{type}}>
+            using System.Runtime.InteropServices.JavaScript;
+            partial class Basic
+            {
+                [JSImport("DoesNotExist")]
+                public static partial {{type}} Import1();
+            
+                [JSExport()]
+                public static {{type}} Export1(){ throw null; }
+            }
+            """;
 
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/CodeSnippets.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/CodeSnippets.cs
@@ -50,177 +50,200 @@ namespace ComInterfaceGenerator.Unit.Tests
         public static readonly string DisableRuntimeMarshalling = "[assembly:System.Runtime.CompilerServices.DisableRuntimeMarshalling]";
         public static readonly string UsingSystemRuntimeInteropServicesMarshalling = "using System.Runtime.InteropServices.Marshalling;";
 
+        public string SpecifiedMethodIndexNoExplicitParameters => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            
+            {{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{GeneratedComInterface}}
+            partial interface INativeAPI
+            {
+                {{VirtualMethodIndex(0)}}
+                void Method();
+            }
+            {{_attributeProvider.AdditionalUserRequiredInterfaces("INativeAPI")}}
+            """;
 
-        public string SpecifiedMethodIndexNoExplicitParameters => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
+        public string SpecifiedMethodIndexNoExplicitParametersNoImplicitThis => $$"""
+            
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            
+            {{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{GeneratedComInterface}}
+            partial interface INativeAPI
+            {
+                {{VirtualMethodIndex(0, ImplicitThisParameter: false)}}
+                void Method();
+            
+            }
+            {{_attributeProvider.AdditionalUserRequiredInterfaces("INativeAPI")}}
+            """;
 
-{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}
-{GeneratedComInterface}
-partial interface INativeAPI
-{{
-    {VirtualMethodIndex(0)}
-    void Method();
-}}" + _attributeProvider.AdditionalUserRequiredInterfaces("INativeAPI");
+        public string SpecifiedMethodIndexNoExplicitParametersCallConvWithCallingConventions => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            
+            {{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{GeneratedComInterface}}
+            partial interface INativeAPI
+            {
+            
+                {{UnmanagedCallConv(CallConvs: new[] { typeof(CallConvCdecl) })}}
+                {{VirtualMethodIndex(0)}}
+                void Method();
+                {{UnmanagedCallConv(CallConvs: new[] { typeof(CallConvCdecl), typeof(CallConvMemberFunction) })}}
+                {{VirtualMethodIndex(1)}}
+                void Method1();
+            
+                [SuppressGCTransition]
+                {{UnmanagedCallConv(CallConvs: new[] { typeof(CallConvCdecl), typeof(CallConvMemberFunction) })}}
+                {{VirtualMethodIndex(2)}}
+                void Method2();
+            
+                [SuppressGCTransition]
+                {{UnmanagedCallConv()}}
+                {{VirtualMethodIndex(3)}}
+                void Method3();
+            
+                [SuppressGCTransition]
+                {{VirtualMethodIndex(4)}}
+                void Method4();
+            }
+            {{_attributeProvider.AdditionalUserRequiredInterfaces("INativeAPI")}}
+            """;
+        public string BasicParametersAndModifiers(string typeName, string preDeclaration = "") => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
+            
+            [assembly:DisableRuntimeMarshalling]
+            
+            {{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{GeneratedComInterface}}
+            partial interface INativeAPI
+            {
+                {{VirtualMethodIndex(0)}}
+                {{typeName}} Method({{typeName}} value, in {{typeName}} inValue, ref {{typeName}} refValue, out {{typeName}} outValue);
+            }
+            {{_attributeProvider.AdditionalUserRequiredInterfaces("INativeAPI")}}
+            """;
 
-        public string SpecifiedMethodIndexNoExplicitParametersNoImplicitThis => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-
-{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}
-{GeneratedComInterface}
-partial interface INativeAPI
-{{
-    {VirtualMethodIndex(0, ImplicitThisParameter: false)}
-    void Method();
-
-}}" + _attributeProvider.AdditionalUserRequiredInterfaces("INativeAPI");
-
-        public string SpecifiedMethodIndexNoExplicitParametersCallConvWithCallingConventions => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-
-{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}
-{GeneratedComInterface}
-partial interface INativeAPI
-{{
-
-    {UnmanagedCallConv(CallConvs: new[] { typeof(CallConvCdecl) })}
-    {VirtualMethodIndex(0)}
-    void Method();
-    {UnmanagedCallConv(CallConvs: new[] { typeof(CallConvCdecl), typeof(CallConvMemberFunction) })}
-    {VirtualMethodIndex(1)}
-    void Method1();
-
-    [SuppressGCTransition]
-    {UnmanagedCallConv(CallConvs: new[] { typeof(CallConvCdecl), typeof(CallConvMemberFunction) })}
-    {VirtualMethodIndex(2)}
-    void Method2();
-
-    [SuppressGCTransition]
-    {UnmanagedCallConv()}
-    {VirtualMethodIndex(3)}
-    void Method3();
-
-    [SuppressGCTransition]
-    {VirtualMethodIndex(4)}
-    void Method4();
-}}" + _attributeProvider.AdditionalUserRequiredInterfaces("INativeAPI");
-
-        public string BasicParametersAndModifiers(string typeName, string preDeclaration = "") => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
-
-[assembly:DisableRuntimeMarshalling]
-
-{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}
-{GeneratedComInterface}
-partial interface INativeAPI
-{{
-    {VirtualMethodIndex(0)}
-    {typeName} Method({typeName} value, in {typeName} inValue, ref {typeName} refValue, out {typeName} outValue);
-}}" + _attributeProvider.AdditionalUserRequiredInterfaces("INativeAPI");
-
-        public string BasicParametersAndModifiersManagedToUnmanaged(string typeName, string preDeclaration = "") => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
-
-[assembly:DisableRuntimeMarshalling]
-
-{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}
-{GeneratedComInterface}
-partial interface INativeAPI
-{{
-    {VirtualMethodIndex(0, Direction: MarshalDirection.ManagedToUnmanaged)}
-    {typeName} Method({typeName} value, in {typeName} inValue, ref {typeName} refValue, out {typeName} outValue);
-}}" + _attributeProvider.AdditionalUserRequiredInterfaces("INativeAPI");
+        public string BasicParametersAndModifiersManagedToUnmanaged(string typeName, string preDeclaration = "") => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
+            
+            [assembly:DisableRuntimeMarshalling]
+            
+            {{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{GeneratedComInterface}}
+            partial interface INativeAPI
+            {
+                {{VirtualMethodIndex(0, Direction: MarshalDirection.ManagedToUnmanaged)}}
+                {{typeName}} Method({{typeName}} value, in {{typeName}} inValue, ref {{typeName}} refValue, out {{typeName}} outValue);
+            }
+            
+            {{_attributeProvider.AdditionalUserRequiredInterfaces("INativeAPI")}}
+            """;
         public string BasicParametersAndModifiers<T>() => BasicParametersAndModifiers(typeof(T).FullName!);
-        public string BasicParametersAndModifiersNoRef(string typeName, string preDeclaration = "") => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
+        public string BasicParametersAndModifiersNoRef(string typeName, string preDeclaration = "") => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
+            
+            [assembly:DisableRuntimeMarshalling]
+            
+            {{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{GeneratedComInterface}}
+            partial interface INativeAPI
+            {
+                {{VirtualMethodIndex(0)}}
+                {{typeName}} Method({{typeName}} value, in {{typeName}} inValue, out {{typeName}} outValue);
+            }
+            
+            {{_attributeProvider.AdditionalUserRequiredInterfaces("INativeAPI")}}
+            """;
 
-[assembly:DisableRuntimeMarshalling]
-
-{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}
-{GeneratedComInterface}
-partial interface INativeAPI
-{{
-    {VirtualMethodIndex(0)}
-    {typeName} Method({typeName} value, in {typeName} inValue, out {typeName} outValue);
-}}" + _attributeProvider.AdditionalUserRequiredInterfaces("INativeAPI");
-
-        public string BasicParametersAndModifiersNoImplicitThis(string typeName) => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-
-{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}
-{GeneratedComInterface}
-partial interface INativeAPI
-{{
-    {VirtualMethodIndex(0, ImplicitThisParameter: false)}
-    {typeName} Method({typeName} value, in {typeName} inValue, ref {typeName} refValue, out {typeName} outValue);
-}}" + _attributeProvider.AdditionalUserRequiredInterfaces("INativeAPI");
+        public string BasicParametersAndModifiersNoImplicitThis(string typeName) => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            
+            {{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{GeneratedComInterface}}
+            partial interface INativeAPI
+            {
+                {{VirtualMethodIndex(0, ImplicitThisParameter: false)}}
+                {{typeName}} Method({{typeName}} value, in {{typeName}} inValue, ref {{typeName}} refValue, out {{typeName}} outValue);
+            }
+            {{_attributeProvider.AdditionalUserRequiredInterfaces("INativeAPI")}}
+            """;
 
         public string BasicParametersAndModifiersNoImplicitThis<T>() => BasicParametersAndModifiersNoImplicitThis(typeof(T).FullName!);
         public string MarshalUsingCollectionCountInfoParametersAndModifiers<T>() => MarshalUsingCollectionCountInfoParametersAndModifiers(typeof(T).ToString());
-        public string MarshalUsingCollectionCountInfoParametersAndModifiers(string collectionType) => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-[assembly:DisableRuntimeMarshalling]
+        public string MarshalUsingCollectionCountInfoParametersAndModifiers(string collectionType) => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            [assembly:DisableRuntimeMarshalling]
+            
+            {{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{GeneratedComInterface}}
+            partial interface INativeAPI
+            {
+                {{VirtualMethodIndex(0)}}
+                [return:MarshalUsing(ConstantElementCount=10)]
+                {{collectionType}} Method(
+                    [MarshalUsing(CountElementName = "pSize")] {{collectionType}} p,
+                    int pSize,
+                    [MarshalUsing(CountElementName = "pInSize")] in {{collectionType}} pIn,
+                    in int pInSize,
+                    int pRefSize,
+                    [MarshalUsing(CountElementName = "pRefSize")] ref {{collectionType}} pRef,
+                    [MarshalUsing(CountElementName = "pOutSize")] out {{collectionType}} pOut,
+                    out int pOutSize);
+            }
+            
+            {{_attributeProvider.AdditionalUserRequiredInterfaces("INativeAPI")}}
+            """;
 
-{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}
-{GeneratedComInterface}
-partial interface INativeAPI
-{{
-    {VirtualMethodIndex(0)}
-    [return:MarshalUsing(ConstantElementCount=10)]
-    {collectionType} Method(
-        [MarshalUsing(CountElementName = ""pSize"")] {collectionType} p,
-        int pSize,
-        [MarshalUsing(CountElementName = ""pInSize"")] in {collectionType} pIn,
-        in int pInSize,
-        int pRefSize,
-        [MarshalUsing(CountElementName = ""pRefSize"")] ref {collectionType} pRef,
-        [MarshalUsing(CountElementName = ""pOutSize"")] out {collectionType} pOut,
-        out int pOutSize);
-}}" + _attributeProvider.AdditionalUserRequiredInterfaces("INativeAPI");
+        public string BasicReturnTypeComExceptionHandling(string typeName, string preDeclaration = "") => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
+            
+            {{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{GeneratedComInterface}}
+            partial interface INativeAPI
+            {
+                {{VirtualMethodIndex(0, ExceptionMarshalling: ExceptionMarshalling.Com)}}
+                {{typeName}} Method();
+            }
+            
+            {{_attributeProvider.AdditionalUserRequiredInterfaces("INativeAPI")}}
+            """;
 
-        public string BasicReturnTypeComExceptionHandling(string typeName, string preDeclaration = "") => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
-
-{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}
-{GeneratedComInterface}
-partial interface INativeAPI
-{{
-    {VirtualMethodIndex(0, ExceptionMarshalling : ExceptionMarshalling.Com)}
-    {typeName} Method();
-}}" + _attributeProvider.AdditionalUserRequiredInterfaces("INativeAPI");
-
-        public string BasicReturnTypeCustomExceptionHandling(string typeName, string customExceptionType, string preDeclaration = "") => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
-
-{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}
-{GeneratedComInterface}
-partial interface INativeAPI
-{{
-    {VirtualMethodIndex(0, ExceptionMarshallingType : Type.GetType(customExceptionType))}
-    {typeName} Method();
-}}" + _attributeProvider.AdditionalUserRequiredInterfaces("INativeAPI");
+        public string BasicReturnTypeCustomExceptionHandling(string typeName, string customExceptionType, string preDeclaration = "") => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
+            
+            {{UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{GeneratedComInterface}}
+            partial interface INativeAPI
+            {
+                {{VirtualMethodIndex(0, ExceptionMarshallingType: Type.GetType(customExceptionType))}}
+                {{typeName}} Method();
+            }
+            {{_attributeProvider.AdditionalUserRequiredInterfaces("INativeAPI")}}
+            """;
 
         public class ManagedToUnmanaged : IVirtualMethodIndexSignatureProvider
         {

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/IVirtualMethodIndexSignatureProvider.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/IVirtualMethodIndexSignatureProvider.cs
@@ -21,221 +21,242 @@ namespace ComInterfaceGenerator.Unit.Tests
         public static readonly string DisableRuntimeMarshalling = "[assembly:System.Runtime.CompilerServices.DisableRuntimeMarshalling]";
         public static readonly string UsingSystemRuntimeInteropServicesMarshalling = "using System.Runtime.InteropServices.Marshalling;";
 
-        string ICustomMarshallingSignatureTestProvider.BasicParametersAndModifiers(string typeName, string preDeclaration) => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
+        string ICustomMarshallingSignatureTestProvider.BasicParametersAndModifiers(string typeName, string preDeclaration) => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
+            
+            [assembly:DisableRuntimeMarshalling]
+            
+            {{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{AttributeProvider.GeneratedComInterface}}
+            partial interface INativeAPI
+            {
+                {{AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}}
+                {{typeName}} Method({{typeName}} value, in {{typeName}} inValue, ref {{typeName}} refValue, out {{typeName}} outValue);
+            }
+            {{AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI")}}
+            """;
+        string ICustomMarshallingSignatureTestProvider.BasicParametersAndModifiersNoRef(string typeName, string preDeclaration) => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
+            
+            [assembly:DisableRuntimeMarshalling]
+            
+            {{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{AttributeProvider.GeneratedComInterface}}
+            partial interface INativeAPI
+            {
+                {{AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}}
+                {{typeName}} Method({{typeName}} value, in {{typeName}} inValue, out {{typeName}} outValue);
+            }
+            {{AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI")}}
+            """;
 
-[assembly:DisableRuntimeMarshalling]
+        string ICustomMarshallingSignatureTestProvider.BasicParameterByValue(string typeName, string preDeclaration) => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
+            
+            {{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{AttributeProvider.GeneratedComInterface}}
+            partial interface INativeAPI
+            {
+                {{AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}}
+                void Method({{typeName}} value);
+            }
+            {{AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI")}}
+            """;
 
-{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}
-{AttributeProvider.GeneratedComInterface}
-partial interface INativeAPI
-{{
-    {AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}
-    {typeName} Method({typeName} value, in {typeName} inValue, ref {typeName} refValue, out {typeName} outValue);
-}}" + AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI");
-        string ICustomMarshallingSignatureTestProvider.BasicParametersAndModifiersNoRef(string typeName, string preDeclaration) => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
+        string ICustomMarshallingSignatureTestProvider.BasicParameterWithByRefModifier(string modifier, string typeName, string preDeclaration) => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
+            
+            [assembly:DisableRuntimeMarshalling]
+            
+            {{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{AttributeProvider.GeneratedComInterface}}
+            partial interface INativeAPI
+            {
+                {{AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}}
+                void Method({{modifier}} {{typeName}} value);
+            }
+            {{AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI")}}
+            """;
+        string ICustomMarshallingSignatureTestProvider.BasicReturnType(string typeName, string preDeclaration) => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
+            
+            {{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{AttributeProvider.GeneratedComInterface}}
+            partial interface INativeAPI
+            {
+                {{AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}}
+                {{typeName}} Method();
+            }
+            {{AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI")}}
+            """;
+        string ICustomMarshallingSignatureTestProvider.MarshalUsingParametersAndModifiers(string typeName, string marshallerTypeName, string preDeclaration) => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
+            
+            {{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{AttributeProvider.GeneratedComInterface}}
+            partial interface INativeAPI
+            {
+                {{AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}}
+                [return: MarshalUsing(typeof({{marshallerTypeName}}))]
+                {{typeName}} Method(
+                    [MarshalUsing(typeof({{marshallerTypeName}}))] {{typeName}} p,
+                    [MarshalUsing(typeof({{marshallerTypeName}}))] in {{typeName}} pIn,
+                    [MarshalUsing(typeof({{marshallerTypeName}}))] ref {{typeName}} pRef,
+                    [MarshalUsing(typeof({{marshallerTypeName}}))] out {{typeName}} pOut);
+            }
+            {{AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI")}}
+            """;
+        string ICustomMarshallingSignatureTestProvider.MarshalUsingCollectionCountInfoParametersAndModifiers(string collectionType) => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            [assembly:DisableRuntimeMarshalling]
+            
+            {{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{AttributeProvider.GeneratedComInterface}}
+            partial interface INativeAPI
+            {
+                {{AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}}
+                [return:MarshalUsing(ConstantElementCount=10)]
+                {{collectionType}} Method(
+                    [MarshalUsing(CountElementName = "pSize")] {{collectionType}} p,
+                    int pSize,
+                    [MarshalUsing(CountElementName = "pInSize")] in {{collectionType}} pIn,
+                    in int pInSize,
+                    int pRefSize,
+                    [MarshalUsing(CountElementName = "pRefSize")] ref {{collectionType}} pRef,
+                    [MarshalUsing(CountElementName = "pOutSize")] out {{collectionType}} pOut,
+                    out int pOutSize);
+            }
+            {{AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI")}}
+            """;
+        string ICustomMarshallingSignatureTestProvider.MarshalUsingCollectionParametersAndModifiers(string collectionType, string marshallerType) => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            
+            [assembly:DisableRuntimeMarshalling]
+            
+            {{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{AttributeProvider.GeneratedComInterface}}
+            partial interface INativeAPI
+            {
+                {{AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}}
+                [return:MarshalUsing(typeof({{marshallerType}}), ConstantElementCount=10)]
+                {{collectionType}} Method(
+                    [MarshalUsing(typeof({{marshallerType}}), CountElementName = "pSize")] {{collectionType}} p,
+                    [MarshalUsing(typeof({{marshallerType}}), CountElementName = "pInSize")] in {{collectionType}} pIn,
+                    int pSize,
+                    in int pInSize,
+                    int pRefSize,
+                    [MarshalUsing(typeof({{marshallerType}}), CountElementName = "pRefSize")] ref {{collectionType}} pRef,
+                    [MarshalUsing(typeof({{marshallerType}}), CountElementName = "pOutSize")] out {{collectionType}} pOut,
+                    out int pOutSize
+                    );
+            }
+            {{AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI")}}
+            """;
+        string ICustomMarshallingSignatureTestProvider.MarshalUsingCollectionReturnValueLength(string collectionType, string marshallerType) => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            
+            [assembly:DisableRuntimeMarshalling]
+            
+            {{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{AttributeProvider.GeneratedComInterface}}
+            partial interface INativeAPI
+            {
+                {{AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}}
+                int Method(
+                    [MarshalUsing(typeof({{marshallerType}}), CountElementName = MarshalUsingAttribute.ReturnsCountValue)] out {{collectionType}} pOut
+                    );
+            }
+            {{AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI")}}
+            """;
 
-[assembly:DisableRuntimeMarshalling]
-
-{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}
-{AttributeProvider.GeneratedComInterface}
-partial interface INativeAPI
-{{
-    {AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}
-    {typeName} Method({typeName} value, in {typeName} inValue, out {typeName} outValue);
-}}" + AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI");
-
-        string ICustomMarshallingSignatureTestProvider.BasicParameterByValue(string typeName, string preDeclaration) => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
-
-{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}
-{AttributeProvider.GeneratedComInterface}
-partial interface INativeAPI
-{{
-    {AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}
-    void Method({typeName} value);
-}}" + AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI");
-
-        string ICustomMarshallingSignatureTestProvider.BasicParameterWithByRefModifier(string modifier, string typeName, string preDeclaration) => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
-
-[assembly:DisableRuntimeMarshalling]
-
-{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}
-{AttributeProvider.GeneratedComInterface}
-partial interface INativeAPI
-{{
-    {AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}
-    void Method({modifier} {typeName} value);
-}}" + AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI");
-        string ICustomMarshallingSignatureTestProvider.BasicReturnType(string typeName, string preDeclaration) => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
-
-{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}
-{AttributeProvider.GeneratedComInterface}
-partial interface INativeAPI
-{{
-    {AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}
-    {typeName} Method();
-}}" + AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI");
-        string ICustomMarshallingSignatureTestProvider.MarshalUsingParametersAndModifiers(string typeName, string marshallerTypeName, string preDeclaration) => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
-
-{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}
-{AttributeProvider.GeneratedComInterface}
-partial interface INativeAPI
-{{
-    {AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}
-    [return: MarshalUsing(typeof({marshallerTypeName}))]
-    {typeName} Method(
-        [MarshalUsing(typeof({marshallerTypeName}))] {typeName} p,
-        [MarshalUsing(typeof({marshallerTypeName}))] in {typeName} pIn,
-        [MarshalUsing(typeof({marshallerTypeName}))] ref {typeName} pRef,
-        [MarshalUsing(typeof({marshallerTypeName}))] out {typeName} pOut);
-}}" + AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI");
-        string ICustomMarshallingSignatureTestProvider.MarshalUsingCollectionCountInfoParametersAndModifiers(string collectionType) => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-[assembly:DisableRuntimeMarshalling]
-
-{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}
-{AttributeProvider.GeneratedComInterface}
-partial interface INativeAPI
-{{
-    {AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}
-    [return:MarshalUsing(ConstantElementCount=10)]
-    {collectionType} Method(
-        [MarshalUsing(CountElementName = ""pSize"")] {collectionType} p,
-        int pSize,
-        [MarshalUsing(CountElementName = ""pInSize"")] in {collectionType} pIn,
-        in int pInSize,
-        int pRefSize,
-        [MarshalUsing(CountElementName = ""pRefSize"")] ref {collectionType} pRef,
-        [MarshalUsing(CountElementName = ""pOutSize"")] out {collectionType} pOut,
-        out int pOutSize);
-}}" + AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI");
-        string ICustomMarshallingSignatureTestProvider.MarshalUsingCollectionParametersAndModifiers(string collectionType, string marshallerType) => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-
-[assembly:DisableRuntimeMarshalling]
-
-{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}
-{AttributeProvider.GeneratedComInterface}
-partial interface INativeAPI
-{{
-    {AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}
-    [return:MarshalUsing(typeof({marshallerType}), ConstantElementCount=10)]
-    {collectionType} Method(
-        [MarshalUsing(typeof({marshallerType}), CountElementName = ""pSize"")] {collectionType} p,
-        [MarshalUsing(typeof({marshallerType}), CountElementName = ""pInSize"")] in {collectionType} pIn,
-        int pSize,
-        in int pInSize,
-        int pRefSize,
-        [MarshalUsing(typeof({marshallerType}), CountElementName = ""pRefSize"")] ref {collectionType} pRef,
-        [MarshalUsing(typeof({marshallerType}), CountElementName = ""pOutSize"")] out {collectionType} pOut,
-        out int pOutSize
-        );
-}}" + AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI");
-        string ICustomMarshallingSignatureTestProvider.MarshalUsingCollectionReturnValueLength(string collectionType, string marshallerType) => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-
-[assembly:DisableRuntimeMarshalling]
-
-{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}
-{AttributeProvider.GeneratedComInterface}
-partial interface INativeAPI
-{{
-    {AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}
-    int Method(
-        [MarshalUsing(typeof({marshallerType}), CountElementName = MarshalUsingAttribute.ReturnsCountValue)] out {collectionType} pOut
-        );
-}}" + AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI");
-
-        string ICustomMarshallingSignatureTestProvider.MarshalUsingCollectionOutConstantLength(string collectionType, string predeclaration) => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{predeclaration}
-
-[assembly:DisableRuntimeMarshalling]
-
-{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}
-{AttributeProvider.GeneratedComInterface}
-partial interface INativeAPI
-{{
-    {AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}
-    int Method(
-        [MarshalUsing(ConstantElementCount = 10)] out {collectionType} pOut
-        );
-}}
-" + AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI");
-        string ICustomMarshallingSignatureTestProvider.MarshalUsingCollectionReturnConstantLength(string collectionType, string predeclaration) => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{predeclaration}
-
-[assembly:DisableRuntimeMarshalling]
-
-{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}
-{AttributeProvider.GeneratedComInterface}
-partial interface INativeAPI
-{{
-    {AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}
-    [return:MarshalUsing(ConstantElementCount = 10)]
-    {collectionType} Method();
-}}
-" + AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI");
-        string ICustomMarshallingSignatureTestProvider.CustomElementMarshalling(string collectionType, string elementMarshaller, string predeclaration) => $@"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{predeclaration}
-
-[assembly:DisableRuntimeMarshalling]
-
-{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}
-{AttributeProvider.GeneratedComInterface}
-partial interface INativeAPI
-{{
-    {AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}
-    [return:MarshalUsing(ConstantElementCount=10)]
-    [return:MarshalUsing(typeof({elementMarshaller}), ElementIndirectionDepth = 1)]
-    TestCollection<int> Method(
-        [MarshalUsing(CountElementName = ""pSize""), MarshalUsing(typeof({elementMarshaller}), ElementIndirectionDepth = 1)] {collectionType} p,
-        [MarshalUsing(CountElementName = ""pInSize""), MarshalUsing(typeof({elementMarshaller}), ElementIndirectionDepth = 1)] in {collectionType} pIn,
-        int pSize,
-        in int pInSize,
-        int pRefSize,
-        [MarshalUsing(CountElementName = ""pRefSize""), MarshalUsing(typeof({elementMarshaller}), ElementIndirectionDepth = 1)] ref {collectionType} pRef,
-        [MarshalUsing(CountElementName = ""pOutSize"")][MarshalUsing(typeof({elementMarshaller}), ElementIndirectionDepth = 1)] out {collectionType} pOut,
-        out int pOutSize
-        );
-}}
-" + AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI");
+        string ICustomMarshallingSignatureTestProvider.MarshalUsingCollectionOutConstantLength(string collectionType, string predeclaration) => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{predeclaration}}
+            
+            [assembly:DisableRuntimeMarshalling]
+            
+            {{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{AttributeProvider.GeneratedComInterface}}
+            partial interface INativeAPI
+            {
+                {{AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}}
+                int Method(
+                    [MarshalUsing(ConstantElementCount = 10)] out {{collectionType}} pOut
+                    );
+            }
+            {{AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI")}}
+            """;
+        string ICustomMarshallingSignatureTestProvider.MarshalUsingCollectionReturnConstantLength(string collectionType, string predeclaration) => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{predeclaration}}
+            
+            [assembly:DisableRuntimeMarshalling]
+            
+            {{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{AttributeProvider.GeneratedComInterface}}
+            partial interface INativeAPI
+            {
+                {{AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}}
+                [return:MarshalUsing(ConstantElementCount = 10)]
+                {{collectionType}} Method();
+            }
+            {{AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI")}}
+            """;
+        string ICustomMarshallingSignatureTestProvider.CustomElementMarshalling(string collectionType, string elementMarshaller, string predeclaration) => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{predeclaration}}
+            
+            [assembly:DisableRuntimeMarshalling]
+            
+            {{AttributeProvider.UnmanagedObjectUnwrapper(typeof(UnmanagedObjectUnwrapper.TestUnwrapper))}}
+            {{AttributeProvider.GeneratedComInterface}}
+            partial interface INativeAPI
+            {
+                {{AttributeProvider.VirtualMethodIndex(0, ImplicitThisParameter: ImplicitThisParameter, Direction: Direction)}}
+                [return:MarshalUsing(ConstantElementCount=10)]
+                [return:MarshalUsing(typeof({{elementMarshaller}}), ElementIndirectionDepth = 1)]
+                TestCollection<int> Method(
+                    [MarshalUsing(CountElementName = "pSize"), MarshalUsing(typeof({{elementMarshaller}}), ElementIndirectionDepth = 1)] {{collectionType}} p,
+                    [MarshalUsing(CountElementName = "pInSize"), MarshalUsing(typeof({{elementMarshaller}}), ElementIndirectionDepth = 1)] in {{collectionType}} pIn,
+                    int pSize,
+                    in int pInSize,
+                    int pRefSize,
+                    [MarshalUsing(CountElementName = "pRefSize"), MarshalUsing(typeof({{elementMarshaller}}), ElementIndirectionDepth = 1)] ref {{collectionType}} pRef,
+                    [MarshalUsing(CountElementName = "pOutSize")][MarshalUsing(typeof({{elementMarshaller}}), ElementIndirectionDepth = 1)] out {{collectionType}} pOut,
+                    out int pOutSize
+                    );
+            }
+            {{AttributeProvider.AdditionalUserRequiredInterfaces("INativeAPI")}}
+            """;
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/Common/CustomCollectionMarshallingCodeSnippets.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/Common/CustomCollectionMarshallingCodeSnippets.cs
@@ -25,55 +25,55 @@ class TestCollection<T> {{}}
 
         public string CollectionOutParameter(string collectionType, string predeclaration = "") => _provider.MarshalUsingCollectionOutConstantLength(collectionType, predeclaration);
         public string CollectionReturnType(string collectionType, string predeclaration = "") => _provider.MarshalUsingCollectionReturnConstantLength(collectionType, predeclaration);
-        public const string NonBlittableElement = @"
-[NativeMarshalling(typeof(ElementMarshaller))]
-struct Element
-{
-#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
-    public bool b;
-#pragma warning restore CS0649
-}
-";
-        public const string ElementMarshaller = @"
-[CustomMarshaller(typeof(Element), MarshalMode.ElementIn, typeof(ElementMarshaller))]
-[CustomMarshaller(typeof(Element), MarshalMode.ElementRef, typeof(ElementMarshaller))]
-[CustomMarshaller(typeof(Element), MarshalMode.ElementOut, typeof(ElementMarshaller))]
-static class ElementMarshaller
-{
-    public struct Native { }
-    public static Native ConvertToUnmanaged(Element e) => throw null;
-    public static Element ConvertToManaged(Native n) => throw null;
-}
-";
-        public const string ElementIn = @"
-[CustomMarshaller(typeof(Element), MarshalMode.ElementIn, typeof(ElementMarshaller))]
-static class ElementMarshaller
-{
-    public struct Native { }
-    public static Native ConvertToUnmanaged(Element e) => throw null;
-    public static Element ConvertToManaged(Native n) => throw null;
-}
-";
-        public const string ElementOut = @"
-[CustomMarshaller(typeof(Element), MarshalMode.ElementOut, typeof(ElementMarshaller))]
-static class ElementMarshaller
-{
-    public struct Native { }
-    public static Native ConvertToUnmanaged(Element e) => throw null;
-    public static Element ConvertToManaged(Native n) => throw null;
-}
-";
-        public const string CustomIntMarshaller = @"
-[CustomMarshaller(typeof(int), MarshalMode.ElementIn, typeof(CustomIntMarshaller))]
-[CustomMarshaller(typeof(int), MarshalMode.ElementRef, typeof(CustomIntMarshaller))]
-[CustomMarshaller(typeof(int), MarshalMode.ElementOut, typeof(CustomIntMarshaller))]
-static class CustomIntMarshaller
-{
-    public struct Native { }
-    public static Native ConvertToUnmanaged(int e) => throw null;
-    public static int ConvertToManaged(Native n) => throw null;
-}
-";
+        public const string NonBlittableElement = """
+            [NativeMarshalling(typeof(ElementMarshaller))]
+            struct Element
+            {
+            #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+                public bool b;
+            #pragma warning restore CS0649
+            }
+            """;
+        public const string ElementMarshaller = """
+            [CustomMarshaller(typeof(Element), MarshalMode.ElementIn, typeof(ElementMarshaller))]
+            [CustomMarshaller(typeof(Element), MarshalMode.ElementRef, typeof(ElementMarshaller))]
+            [CustomMarshaller(typeof(Element), MarshalMode.ElementOut, typeof(ElementMarshaller))]
+            static class ElementMarshaller
+            {
+                public struct Native { }
+                public static Native ConvertToUnmanaged(Element e) => throw null;
+                public static Element ConvertToManaged(Native n) => throw null;
+            }
+            """;
+        public const string ElementIn = """
+            [CustomMarshaller(typeof(Element), MarshalMode.ElementIn, typeof(ElementMarshaller))]
+            static class ElementMarshaller
+            {
+                public struct Native { }
+                public static Native ConvertToUnmanaged(Element e) => throw null;
+                public static Element ConvertToManaged(Native n) => throw null;
+            }
+            """;
+        public const string ElementOut = """
+            [CustomMarshaller(typeof(Element), MarshalMode.ElementOut, typeof(ElementMarshaller))]
+            static class ElementMarshaller
+            {
+                public struct Native { }
+                public static Native ConvertToUnmanaged(Element e) => throw null;
+                public static Element ConvertToManaged(Native n) => throw null;
+            }
+            """;
+        public const string CustomIntMarshaller = """
+            [CustomMarshaller(typeof(int), MarshalMode.ElementIn, typeof(CustomIntMarshaller))]
+            [CustomMarshaller(typeof(int), MarshalMode.ElementRef, typeof(CustomIntMarshaller))]
+            [CustomMarshaller(typeof(int), MarshalMode.ElementOut, typeof(CustomIntMarshaller))]
+            static class CustomIntMarshaller
+            {
+                public struct Native { }
+                public static Native ConvertToUnmanaged(int e) => throw null;
+                public static int ConvertToManaged(Native n) => throw null;
+            }
+            """;
         public class StatelessSnippets
         {
             ICustomMarshallingSignatureTestProvider _provider;
@@ -84,113 +84,113 @@ static class CustomIntMarshaller
                 _snippets = instance;
             }
 
-            public const string In = @"
-[CustomMarshaller(typeof(TestCollection<>), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller<,>))]
-[ContiguousCollectionMarshaller]
-static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
-{
-    public static byte* AllocateContainerForUnmanagedElements(TestCollection<T> managed, out int numElements) => throw null;
-    public static System.ReadOnlySpan<T> GetManagedValuesSource(TestCollection<T> managed) => throw null;
-    public static System.Span<TUnmanagedElement> GetUnmanagedValuesDestination(byte* unmanaged, int numElements) => throw null;
-}
-";
-            public const string InPinnable = @"
-[CustomMarshaller(typeof(TestCollection<>), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller<,>))]
-[ContiguousCollectionMarshaller]
-static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
-{
-    public static byte* AllocateContainerForUnmanagedElements(TestCollection<T> managed, out int numElements) => throw null;
-    public static System.ReadOnlySpan<T> GetManagedValuesSource(TestCollection<T> managed) => throw null;
-    public static System.Span<TUnmanagedElement> GetUnmanagedValuesDestination(byte* unmanaged, int numElements) => throw null;
+            public const string In = """
+                [CustomMarshaller(typeof(TestCollection<>), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller<,>))]
+                [ContiguousCollectionMarshaller]
+                static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+                {
+                    public static byte* AllocateContainerForUnmanagedElements(TestCollection<T> managed, out int numElements) => throw null;
+                    public static System.ReadOnlySpan<T> GetManagedValuesSource(TestCollection<T> managed) => throw null;
+                    public static System.Span<TUnmanagedElement> GetUnmanagedValuesDestination(byte* unmanaged, int numElements) => throw null;
+                }
+                """;
+            public const string InPinnable = """
+                [CustomMarshaller(typeof(TestCollection<>), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller<,>))]
+                [ContiguousCollectionMarshaller]
+                static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+                {
+                    public static byte* AllocateContainerForUnmanagedElements(TestCollection<T> managed, out int numElements) => throw null;
+                    public static System.ReadOnlySpan<T> GetManagedValuesSource(TestCollection<T> managed) => throw null;
+                    public static System.Span<TUnmanagedElement> GetUnmanagedValuesDestination(byte* unmanaged, int numElements) => throw null;
 
-    public static ref byte GetPinnableReference(TestCollection<T> managed) => throw null;
-}
-";
-            public const string InBuffer = @"
-[CustomMarshaller(typeof(TestCollection<>), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller<,>))]
-[ContiguousCollectionMarshaller]
-static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
-{
-    public const int BufferSize = 0x100;
-    public static byte* AllocateContainerForUnmanagedElements(TestCollection<T> managed, System.Span<byte> buffer, out int numElements) => throw null;
-    public static System.ReadOnlySpan<T> GetManagedValuesSource(TestCollection<T> managed) => throw null;
-    public static System.Span<TUnmanagedElement> GetUnmanagedValuesDestination(byte* unmanaged, int numElements) => throw null;
-}
-";
-            public const string Default = @"
-[CustomMarshaller(typeof(TestCollection<>), MarshalMode.Default, typeof(Marshaller<,>))]
-[ContiguousCollectionMarshaller]
-static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
-{
-    public static byte* AllocateContainerForUnmanagedElements(TestCollection<T> managed, out int numElements) => throw null;
-    public static System.ReadOnlySpan<T> GetManagedValuesSource(TestCollection<T> managed) => throw null;
-    public static System.Span<TUnmanagedElement> GetUnmanagedValuesDestination(byte* unmanaged, int numElements) => throw null;
+                    public static ref byte GetPinnableReference(TestCollection<T> managed) => throw null;
+                }
+                """;
+            public const string InBuffer = """
+                [CustomMarshaller(typeof(TestCollection<>), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller<,>))]
+                [ContiguousCollectionMarshaller]
+                static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+                {
+                    public const int BufferSize = 0x100;
+                    public static byte* AllocateContainerForUnmanagedElements(TestCollection<T> managed, System.Span<byte> buffer, out int numElements) => throw null;
+                    public static System.ReadOnlySpan<T> GetManagedValuesSource(TestCollection<T> managed) => throw null;
+                    public static System.Span<TUnmanagedElement> GetUnmanagedValuesDestination(byte* unmanaged, int numElements) => throw null;
+                }
+                """;
+            public const string Default = """
+                [CustomMarshaller(typeof(TestCollection<>), MarshalMode.Default, typeof(Marshaller<,>))]
+                [ContiguousCollectionMarshaller]
+                static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+                {
+                    public static byte* AllocateContainerForUnmanagedElements(TestCollection<T> managed, out int numElements) => throw null;
+                    public static System.ReadOnlySpan<T> GetManagedValuesSource(TestCollection<T> managed) => throw null;
+                    public static System.Span<TUnmanagedElement> GetUnmanagedValuesDestination(byte* unmanaged, int numElements) => throw null;
 
-    public static TestCollection<T> AllocateContainerForManagedElements(byte* unmanaged, int length) => throw null;
-    public static System.Span<T> GetManagedValuesDestination(TestCollection<T> managed) => throw null;
-    public static System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(byte* unmanaged, int numElements) => throw null;
-}
-";
-            public const string DefaultNested = @"
-[CustomMarshaller(typeof(TestCollection<>), MarshalMode.Default, typeof(Marshaller<,>.Nested.Ref))]
-[ContiguousCollectionMarshaller]
-static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
-{
-    internal static class Nested
-    {
-        internal static class Ref
-        {
-            public static byte* AllocateContainerForUnmanagedElements(TestCollection<T> managed, out int numElements) => throw null;
-            public static System.ReadOnlySpan<T> GetManagedValuesSource(TestCollection<T> managed) => throw null;
-            public static System.Span<TUnmanagedElement> GetUnmanagedValuesDestination(byte* unmanaged, int numElements) => throw null;
+                    public static TestCollection<T> AllocateContainerForManagedElements(byte* unmanaged, int length) => throw null;
+                    public static System.Span<T> GetManagedValuesDestination(TestCollection<T> managed) => throw null;
+                    public static System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(byte* unmanaged, int numElements) => throw null;
+                }
+                """;
+            public const string DefaultNested = """
+                [CustomMarshaller(typeof(TestCollection<>), MarshalMode.Default, typeof(Marshaller<,>.Nested.Ref))]
+                [ContiguousCollectionMarshaller]
+                static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+                {
+                    internal static class Nested
+                    {
+                        internal static class Ref
+                        {
+                            public static byte* AllocateContainerForUnmanagedElements(TestCollection<T> managed, out int numElements) => throw null;
+                            public static System.ReadOnlySpan<T> GetManagedValuesSource(TestCollection<T> managed) => throw null;
+                            public static System.Span<TUnmanagedElement> GetUnmanagedValuesDestination(byte* unmanaged, int numElements) => throw null;
 
-            public static TestCollection<T> AllocateContainerForManagedElements(byte* unmanaged, int length) => throw null;
-            public static System.Span<T> GetManagedValuesDestination(TestCollection<T> managed) => throw null;
-            public static System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(byte* unmanaged, int numElements) => throw null;
-        }
-    }
-}
-";
-            public const string Out = @"
-[CustomMarshaller(typeof(TestCollection<>), MarshalMode.ManagedToUnmanagedOut, typeof(Marshaller<,>))]
-[ContiguousCollectionMarshaller]
-static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
-{
-    public static TestCollection<T> AllocateContainerForManagedElements(byte* unmanaged, int length) => throw null;
-    public static System.Span<T> GetManagedValuesDestination(TestCollection<T> managed) => throw null;
-    public static System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(byte* unmanaged, int numElements) => throw null;
-}
-";
-            public const string OutGuaranteed = @"
-[CustomMarshaller(typeof(TestCollection<>), MarshalMode.ManagedToUnmanagedOut, typeof(Marshaller<,>))]
-[ContiguousCollectionMarshaller]
-static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
-{
-    public static TestCollection<T> AllocateContainerForManagedElementsFinally(byte* unmanaged, int length) => throw null;
-    public static System.Span<T> GetManagedValuesDestination(TestCollection<T> managed) => throw null;
-    public static System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(byte* unmanaged, int numElements) => throw null;
-}
-";
-            public const string DefaultIn = @"
-[CustomMarshaller(typeof(TestCollection<>), MarshalMode.Default, typeof(Marshaller<,>))]
-[ContiguousCollectionMarshaller]
-static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
-{
-    public static byte* AllocateContainerForUnmanagedElements(TestCollection<T> managed, out int numElements) => throw null;
-    public static System.ReadOnlySpan<T> GetManagedValuesSource(TestCollection<T> managed) => throw null;
-    public static System.Span<TUnmanagedElement> GetUnmanagedValuesDestination(byte* unmanaged, int numElements) => throw null;
-}
-";
-            public const string DefaultOut = @"
-[CustomMarshaller(typeof(TestCollection<>), MarshalMode.Default, typeof(Marshaller<,>))]
-[ContiguousCollectionMarshaller]
-static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
-{
-    public static TestCollection<T> AllocateContainerForManagedElements(byte* unmanaged, int length) => throw null;
-    public static System.Span<T> GetManagedValuesDestination(TestCollection<T> managed) => throw null;
-    public static System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(byte* unmanaged, int numElements) => throw null;
-}
-";
+                            public static TestCollection<T> AllocateContainerForManagedElements(byte* unmanaged, int length) => throw null;
+                            public static System.Span<T> GetManagedValuesDestination(TestCollection<T> managed) => throw null;
+                            public static System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(byte* unmanaged, int numElements) => throw null;
+                        }
+                    }
+                }
+                """;
+            public const string Out = """
+                [CustomMarshaller(typeof(TestCollection<>), MarshalMode.ManagedToUnmanagedOut, typeof(Marshaller<,>))]
+                [ContiguousCollectionMarshaller]
+                static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+                {
+                    public static TestCollection<T> AllocateContainerForManagedElements(byte* unmanaged, int length) => throw null;
+                    public static System.Span<T> GetManagedValuesDestination(TestCollection<T> managed) => throw null;
+                    public static System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(byte* unmanaged, int numElements) => throw null;
+                }
+                """;
+            public const string OutGuaranteed = """
+                [CustomMarshaller(typeof(TestCollection<>), MarshalMode.ManagedToUnmanagedOut, typeof(Marshaller<,>))]
+                [ContiguousCollectionMarshaller]
+                static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+                {
+                    public static TestCollection<T> AllocateContainerForManagedElementsFinally(byte* unmanaged, int length) => throw null;
+                    public static System.Span<T> GetManagedValuesDestination(TestCollection<T> managed) => throw null;
+                    public static System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(byte* unmanaged, int numElements) => throw null;
+                }
+                """;
+            public const string DefaultIn = """
+                [CustomMarshaller(typeof(TestCollection<>), MarshalMode.Default, typeof(Marshaller<,>))]
+                [ContiguousCollectionMarshaller]
+                static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+                {
+                    public static byte* AllocateContainerForUnmanagedElements(TestCollection<T> managed, out int numElements) => throw null;
+                    public static System.ReadOnlySpan<T> GetManagedValuesSource(TestCollection<T> managed) => throw null;
+                    public static System.Span<TUnmanagedElement> GetUnmanagedValuesDestination(byte* unmanaged, int numElements) => throw null;
+                }
+                """;
+            public const string DefaultOut = """
+                [CustomMarshaller(typeof(TestCollection<>), MarshalMode.Default, typeof(Marshaller<,>))]
+                [ContiguousCollectionMarshaller]
+                static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+                {
+                    public static TestCollection<T> AllocateContainerForManagedElements(byte* unmanaged, int length) => throw null;
+                    public static System.Span<T> GetManagedValuesDestination(TestCollection<T> managed) => throw null;
+                    public static System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(byte* unmanaged, int numElements) => throw null;
+                }
+                """;
             public string ByValue<T>() => ByValue(typeof(T).ToString());
             public string ByValue(string elementType) => _provider.BasicParameterByValue($"TestCollection<{elementType}>", DisableRuntimeMarshalling)
                 + TestCollection()
@@ -277,23 +277,23 @@ static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : u
                 + DefaultOut;
 
             public string GenericCollectionMarshallingArityMismatch => _provider.BasicParameterByValue("TestCollection<int>", DisableRuntimeMarshalling)
-                + @"
-[NativeMarshalling(typeof(Marshaller<,,>))]
-class TestCollection<T> {}
+                + """
+                [NativeMarshalling(typeof(Marshaller<,,>))]
+                class TestCollection<T> {}
 
-[CustomMarshaller(typeof(TestCollection<>), MarshalMode.Default, typeof(Marshaller<,,>))]
-[ContiguousCollectionMarshaller]
-static unsafe class Marshaller<T, U, TUnmanagedElement> where TUnmanagedElement : unmanaged
-{
-    public static byte* AllocateContainerForUnmanagedElements(TestCollection<T> managed, out int numElements) => throw null;
-    public static System.ReadOnlySpan<T> GetManagedValuesSource(TestCollection<T> managed) => throw null;
-    public static System.Span<TUnmanagedElement> GetUnmanagedValuesDestination(byte* unmanaged, int numElements) => throw null;
+                [CustomMarshaller(typeof(TestCollection<>), MarshalMode.Default, typeof(Marshaller<,,>))]
+                [ContiguousCollectionMarshaller]
+                static unsafe class Marshaller<T, U, TUnmanagedElement> where TUnmanagedElement : unmanaged
+                {
+                    public static byte* AllocateContainerForUnmanagedElements(TestCollection<T> managed, out int numElements) => throw null;
+                    public static System.ReadOnlySpan<T> GetManagedValuesSource(TestCollection<T> managed) => throw null;
+                    public static System.Span<TUnmanagedElement> GetUnmanagedValuesDestination(byte* unmanaged, int numElements) => throw null;
 
-    public static TestCollection<T> AllocateContainerForManagedElements(byte* unmanaged, int length) => throw null;
-    public static System.Span<T> GetManagedValuesDestination(TestCollection<T> managed) => throw null;
-    public static System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(byte* unmanaged, int numElements) => throw null;
-}
-";
+                    public static TestCollection<T> AllocateContainerForManagedElements(byte* unmanaged, int length) => throw null;
+                    public static System.Span<T> GetManagedValuesDestination(TestCollection<T> managed) => throw null;
+                    public static System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(byte* unmanaged, int numElements) => throw null;
+                }
+                """;
 
             public string CustomElementMarshalling => _provider.CustomElementMarshalling("TestCollection<int>", "CustomIntMarshaller")
                 + TestCollection()
@@ -311,140 +311,140 @@ static unsafe class Marshaller<T, U, TUnmanagedElement> where TUnmanagedElement 
                 _snippets = snippets;
             }
 
-            public const string In = @"
-[ContiguousCollectionMarshaller]
-[CustomMarshaller(typeof(TestCollection<>), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller<,>.In))]
-static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
-{
-    public ref struct In
-    {
-        public void FromManaged(TestCollection<T> managed) => throw null;
-        public byte* ToUnmanaged() => throw null;
-        public System.ReadOnlySpan<T> GetManagedValuesSource() => throw null;
-        public System.Span<TUnmanagedElement> GetUnmanagedValuesDestination() => throw null;
-    }
-}
-";
-            public const string InPinnable = @"
-[ContiguousCollectionMarshaller]
-[CustomMarshaller(typeof(TestCollection<>), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller<,>.In))]
-static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
-{
-    public ref struct In
-    {
-        public void FromManaged(TestCollection<T> managed) => throw null;
-        public byte* ToUnmanaged() => throw null;
-        public System.ReadOnlySpan<T> GetManagedValuesSource() => throw null;
-        public System.Span<TUnmanagedElement> GetUnmanagedValuesDestination() => throw null;
-        public ref byte GetPinnableReference() => throw null;
-    }
-}
-";
-            public const string InStaticPinnable = @"
-[ContiguousCollectionMarshaller]
-[CustomMarshaller(typeof(TestCollection<>), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller<,>.In))]
-static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
-{
-    public ref struct In
-    {
-        public void FromManaged(TestCollection<T> managed) => throw null;
-        public byte* ToUnmanaged() => throw null;
-        public System.ReadOnlySpan<T> GetManagedValuesSource() => throw null;
-        public System.Span<TUnmanagedElement> GetUnmanagedValuesDestination() => throw null;
-        public static ref byte GetPinnableReference(TestCollection<T> managed) => throw null;
-    }
-}
-";
-            public const string InBuffer = @"
-[ContiguousCollectionMarshaller]
-[CustomMarshaller(typeof(TestCollection<>), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller<,>.In))]
-static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
-{
-    public ref struct In
-    {
-        public static int BufferSize { get; }
-        public void FromManaged(TestCollection<T> managed, System.Span<TUnmanagedElement> buffer) => throw null;
-        public byte* ToUnmanaged() => throw null;
-        public System.ReadOnlySpan<T> GetManagedValuesSource() => throw null;
-        public System.Span<TUnmanagedElement> GetUnmanagedValuesDestination() => throw null;
-    }
-}
-";
-            public const string Ref = @"
-[ContiguousCollectionMarshaller]
-[CustomMarshaller(typeof(TestCollection<>), MarshalMode.Default, typeof(Marshaller<,>.Ref))]
-static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
-{
-    public ref struct Ref
-    {
-        public void FromManaged(TestCollection<T> managed) => throw null;
-        public byte* ToUnmanaged() => throw null;
-        public System.ReadOnlySpan<T> GetManagedValuesSource() => throw null;
-        public System.Span<TUnmanagedElement> GetUnmanagedValuesDestination() => throw null;
+            public const string In = """
+                [ContiguousCollectionMarshaller]
+                [CustomMarshaller(typeof(TestCollection<>), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller<,>.In))]
+                static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+                {
+                    public ref struct In
+                    {
+                        public void FromManaged(TestCollection<T> managed) => throw null;
+                        public byte* ToUnmanaged() => throw null;
+                        public System.ReadOnlySpan<T> GetManagedValuesSource() => throw null;
+                        public System.Span<TUnmanagedElement> GetUnmanagedValuesDestination() => throw null;
+                    }
+                }
+                """;
+            public const string InPinnable = """
+                [ContiguousCollectionMarshaller]
+                [CustomMarshaller(typeof(TestCollection<>), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller<,>.In))]
+                static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+                {
+                    public ref struct In
+                    {
+                        public void FromManaged(TestCollection<T> managed) => throw null;
+                        public byte* ToUnmanaged() => throw null;
+                        public System.ReadOnlySpan<T> GetManagedValuesSource() => throw null;
+                        public System.Span<TUnmanagedElement> GetUnmanagedValuesDestination() => throw null;
+                        public ref byte GetPinnableReference() => throw null;
+                    }
+                }
+                """;
+            public const string InStaticPinnable = """
+                [ContiguousCollectionMarshaller]
+                [CustomMarshaller(typeof(TestCollection<>), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller<,>.In))]
+                static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+                {
+                    public ref struct In
+                    {
+                        public void FromManaged(TestCollection<T> managed) => throw null;
+                        public byte* ToUnmanaged() => throw null;
+                        public System.ReadOnlySpan<T> GetManagedValuesSource() => throw null;
+                        public System.Span<TUnmanagedElement> GetUnmanagedValuesDestination() => throw null;
+                        public static ref byte GetPinnableReference(TestCollection<T> managed) => throw null;
+                    }
+                }
+                """;
+            public const string InBuffer = """
+                [ContiguousCollectionMarshaller]
+                [CustomMarshaller(typeof(TestCollection<>), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller<,>.In))]
+                static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+                {
+                    public ref struct In
+                    {
+                        public static int BufferSize { get; }
+                        public void FromManaged(TestCollection<T> managed, System.Span<TUnmanagedElement> buffer) => throw null;
+                        public byte* ToUnmanaged() => throw null;
+                        public System.ReadOnlySpan<T> GetManagedValuesSource() => throw null;
+                        public System.Span<TUnmanagedElement> GetUnmanagedValuesDestination() => throw null;
+                    }
+                }
+                """;
+            public const string Ref = """
+                [ContiguousCollectionMarshaller]
+                [CustomMarshaller(typeof(TestCollection<>), MarshalMode.Default, typeof(Marshaller<,>.Ref))]
+                static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+                {
+                    public ref struct Ref
+                    {
+                        public void FromManaged(TestCollection<T> managed) => throw null;
+                        public byte* ToUnmanaged() => throw null;
+                        public System.ReadOnlySpan<T> GetManagedValuesSource() => throw null;
+                        public System.Span<TUnmanagedElement> GetUnmanagedValuesDestination() => throw null;
 
-        public void FromUnmanaged(byte* value) => throw null;
-        public TestCollection<T> ToManaged() => throw null;
-        public System.Span<T> GetManagedValuesDestination(int numElements) => throw null;
-        public System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(int numElements) => throw null;
-    }
-}
-";
-            public const string Out = @"
-[ContiguousCollectionMarshaller]
-[CustomMarshaller(typeof(TestCollection<>), MarshalMode.ManagedToUnmanagedOut, typeof(Marshaller<,>.Out))]
-static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
-{
-    public ref struct Out
-    {
-        public void FromUnmanaged(byte* value) => throw null;
-        public TestCollection<T> ToManaged() => throw null;
-        public System.Span<T> GetManagedValuesDestination(int numElements) => throw null;
-        public System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(int numElements) => throw null;
-    }
-}
-";
-            public const string OutGuaranteed = @"
-[ContiguousCollectionMarshaller]
-[CustomMarshaller(typeof(TestCollection<>), MarshalMode.ManagedToUnmanagedOut, typeof(Marshaller<,>.Out))]
-static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
-{
-    public ref struct Out
-    {
-        public void FromUnmanaged(byte* value) => throw null;
-        public TestCollection<T> ToManagedFinally() => throw null;
-        public System.Span<T> GetManagedValuesDestination(int numElements) => throw null;
-        public System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(int numElements) => throw null;
-    }
-}
-";
-            public const string DefaultIn = @"
-[ContiguousCollectionMarshaller]
-[CustomMarshaller(typeof(TestCollection<>), MarshalMode.Default, typeof(Marshaller<,>.In))]
-static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
-{
-    public ref struct In
-    {
-        public void FromManaged(TestCollection<T> managed) => throw null;
-        public byte* ToUnmanaged() => throw null;
-        public System.ReadOnlySpan<T> GetManagedValuesSource() => throw null;
-        public System.Span<TUnmanagedElement> GetUnmanagedValuesDestination() => throw null;
-    }
-}
-";
-            public const string DefaultOut = @"
-[ContiguousCollectionMarshaller]
-[CustomMarshaller(typeof(TestCollection<>), MarshalMode.Default, typeof(Marshaller<,>.Out))]
-static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
-{
-    public ref struct Out
-    {
-        public void FromUnmanaged(byte* value) => throw null;
-        public TestCollection<T> ToManaged() => throw null;
-        public System.Span<T> GetManagedValuesDestination(int numElements) => throw null;
-        public System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(int numElements) => throw null;
-    }
-}
-";
+                        public void FromUnmanaged(byte* value) => throw null;
+                        public TestCollection<T> ToManaged() => throw null;
+                        public System.Span<T> GetManagedValuesDestination(int numElements) => throw null;
+                        public System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(int numElements) => throw null;
+                    }
+                }
+                """;
+            public const string Out = """
+                [ContiguousCollectionMarshaller]
+                [CustomMarshaller(typeof(TestCollection<>), MarshalMode.ManagedToUnmanagedOut, typeof(Marshaller<,>.Out))]
+                static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+                {
+                    public ref struct Out
+                    {
+                        public void FromUnmanaged(byte* value) => throw null;
+                        public TestCollection<T> ToManaged() => throw null;
+                        public System.Span<T> GetManagedValuesDestination(int numElements) => throw null;
+                        public System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(int numElements) => throw null;
+                    }
+                }
+                """;
+            public const string OutGuaranteed = """
+                [ContiguousCollectionMarshaller]
+                [CustomMarshaller(typeof(TestCollection<>), MarshalMode.ManagedToUnmanagedOut, typeof(Marshaller<,>.Out))]
+                static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+                {
+                    public ref struct Out
+                    {
+                        public void FromUnmanaged(byte* value) => throw null;
+                        public TestCollection<T> ToManagedFinally() => throw null;
+                        public System.Span<T> GetManagedValuesDestination(int numElements) => throw null;
+                        public System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(int numElements) => throw null;
+                    }
+                }
+                """;
+            public const string DefaultIn = """
+                [ContiguousCollectionMarshaller]
+                [CustomMarshaller(typeof(TestCollection<>), MarshalMode.Default, typeof(Marshaller<,>.In))]
+                static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+                {
+                    public ref struct In
+                    {
+                        public void FromManaged(TestCollection<T> managed) => throw null;
+                        public byte* ToUnmanaged() => throw null;
+                        public System.ReadOnlySpan<T> GetManagedValuesSource() => throw null;
+                        public System.Span<TUnmanagedElement> GetUnmanagedValuesDestination() => throw null;
+                    }
+                }
+                """;
+            public const string DefaultOut = """
+                [ContiguousCollectionMarshaller]
+                [CustomMarshaller(typeof(TestCollection<>), MarshalMode.Default, typeof(Marshaller<,>.Out))]
+                static unsafe class Marshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+                {
+                    public ref struct Out
+                    {
+                        public void FromUnmanaged(byte* value) => throw null;
+                        public TestCollection<T> ToManaged() => throw null;
+                        public System.Span<T> GetManagedValuesDestination(int numElements) => throw null;
+                        public System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(int numElements) => throw null;
+                    }
+                }
+                """;
             public string ByValue<T>() => ByValue(typeof(T).ToString());
             public string ByValue(string elementType) => _provider.BasicParameterByValue($"TestCollection<{elementType}>", DisableRuntimeMarshalling)
                 + TestCollection()

--- a/src/libraries/System.Runtime.InteropServices/tests/Common/CustomStructMarshallingCodeSnippets.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/Common/CustomStructMarshallingCodeSnippets.cs
@@ -17,38 +17,38 @@ namespace Microsoft.Interop.UnitTests
 
         private static readonly string UsingSystemRuntimeInteropServicesMarshalling = "using System.Runtime.InteropServices.Marshalling;";
 
-        public static string NonBlittableUserDefinedType(bool defineNativeMarshalling = true) => $@"
-{(defineNativeMarshalling ? "[NativeMarshalling(typeof(Marshaller))]" : string.Empty)}
-public struct S
-{{
-#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
-    public bool b;
-#pragma warning restore CS0649
-}}
-";
-        private static string NonStatic = @"
-[CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller))]
-public class Marshaller
-{
-    public struct Native { }
+        public static string NonBlittableUserDefinedType(bool defineNativeMarshalling = true) => $$"""
+            {{(defineNativeMarshalling ? "[NativeMarshalling(typeof(Marshaller))]" : string.Empty)}}
+            public struct S
+            {
+            #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+                public bool b;
+            #pragma warning restore CS0649
+            }
+            """;
+        private static string NonStatic = """
+            [CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller))]
+            public class Marshaller
+            {
+                public struct Native { }
 
-    public static Native ConvertToUnmanaged(S s) => default;
-}
-";
+                public static Native ConvertToUnmanaged(S s) => default;
+            }
+            """;
         public string NonStaticMarshallerEntryPoint => _provider.BasicParameterByValue("S")
             + NonBlittableUserDefinedType()
             + NonStatic;
 
-        private static string Struct = @"
-[CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller))]
-public struct Marshaller
-{
-    public struct Native { }
+        private static string Struct = """
+            [CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller))]
+            public struct Marshaller
+            {
+                public struct Native { }
 
-    public void FromManaged(S s) {}
-    public Native ToUnmanaged() => default;
-}
-";
+                public void FromManaged(S s) {}
+                public Native ToUnmanaged() => default;
+            }
+            """;
         public string StructMarshallerEntryPoint => _provider.BasicParameterByValue("S")
             + NonBlittableUserDefinedType()
             + Struct;
@@ -62,120 +62,120 @@ public struct Marshaller
                 this._provider = provider;
             }
 
-            private static string In = @"
-[CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller))]
-[CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedOut, typeof(Marshaller))]
-public static class Marshaller
-{
-    public struct Native { }
+            private static string In = """
+                [CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller))]
+                [CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedOut, typeof(Marshaller))]
+                public static class Marshaller
+                {
+                    public struct Native { }
 
-    public static Native ConvertToUnmanaged(S s) => default;
-}
-";
-            private static string InBuffer = @"
-[CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller))]
-public static class Marshaller
-{
-    public struct Native { }
+                    public static Native ConvertToUnmanaged(S s) => default;
+                }
+                """;
+            private static string InBuffer = """
+                [CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller))]
+                public static class Marshaller
+                {
+                    public struct Native { }
 
-    public const int BufferSize = 0x100;
-    public static Native ConvertToUnmanaged(S s, System.Span<byte> buffer) => default;
-}
-";
+                    public const int BufferSize = 0x100;
+                    public static Native ConvertToUnmanaged(S s, System.Span<byte> buffer) => default;
+                }
+                """;
 
-            public static string InPinnable = @"
-[CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller))]
-[CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedOut, typeof(Marshaller))]
-public static unsafe class Marshaller
-{
-    public static byte* ConvertToUnmanaged(S s) => default;
-    public static ref byte GetPinnableReference(S s) => throw null;
-}
-";
-            private static string Out = @"
-[CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedOut, typeof(Marshaller))]
-[CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedIn, typeof(Marshaller))]
-public static class Marshaller
-{
-    public struct Native { }
+            public static string InPinnable = """
+                [CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller))]
+                [CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedOut, typeof(Marshaller))]
+                public static unsafe class Marshaller
+                {
+                    public static byte* ConvertToUnmanaged(S s) => default;
+                    public static ref byte GetPinnableReference(S s) => throw null;
+                }
+                """;
+            private static string Out = """
+                [CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedOut, typeof(Marshaller))]
+                [CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedIn, typeof(Marshaller))]
+                public static class Marshaller
+                {
+                    public struct Native { }
 
-    public static S ConvertToManaged(Native n) => default;
-}
-";
-            private static string OutGuaranteed = @"
-[CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedOut, typeof(Marshaller))]
-[CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedIn, typeof(Marshaller))]
-public static class Marshaller
-{
-    public struct Native { }
+                    public static S ConvertToManaged(Native n) => default;
+                }
+                """;
+            private static string OutGuaranteed = """
+                [CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedOut, typeof(Marshaller))]
+                [CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedIn, typeof(Marshaller))]
+                public static class Marshaller
+                {
+                    public struct Native { }
 
-    public static S ConvertToManagedFinally(Native n) => default;
-}
-";
-            public static string Ref = @"
-[CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedRef, typeof(Marshaller))]
-[CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedRef, typeof(Marshaller))]
-public static class Marshaller
-{
-    public struct Native { }
+                    public static S ConvertToManagedFinally(Native n) => default;
+                }
+                """;
+            public static string Ref = """
+                [CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedRef, typeof(Marshaller))]
+                [CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedRef, typeof(Marshaller))]
+                public static class Marshaller
+                {
+                    public struct Native { }
 
-    public static Native ConvertToUnmanaged(S s) => default;
-    public static S ConvertToManaged(Native n) => default;
-}
-";
-            public static string Default = @"
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
-public static class Marshaller
-{
-    public struct Native { }
+                    public static Native ConvertToUnmanaged(S s) => default;
+                    public static S ConvertToManaged(Native n) => default;
+                }
+                """;
+            public static string Default = """
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
+                public static class Marshaller
+                {
+                    public struct Native { }
 
-    public static Native ConvertToUnmanaged(S s) => default;
-    public static S ConvertToManaged(Native n) => default;
-}
-";
-            public static string InOutBuffer = @"
-[CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller))]
-[CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedOut, typeof(Marshaller))]
-[CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedIn, typeof(Marshaller))]
-public static class Marshaller
-{
-    public struct Native { }
+                    public static Native ConvertToUnmanaged(S s) => default;
+                    public static S ConvertToManaged(Native n) => default;
+                }
+                """;
+            public static string InOutBuffer = """
+                [CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller))]
+                [CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedOut, typeof(Marshaller))]
+                [CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedIn, typeof(Marshaller))]
+                public static class Marshaller
+                {
+                    public struct Native { }
 
-    public const int BufferSize = 0x100;
-    public static Native ConvertToUnmanaged(S s, System.Span<byte> buffer) => default;
-    public static S ConvertToManaged(Native n) => default;
-}
-";
-            public static string DefaultOptionalBuffer = @"
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
-public static class Marshaller
-{
-    public struct Native { }
+                    public const int BufferSize = 0x100;
+                    public static Native ConvertToUnmanaged(S s, System.Span<byte> buffer) => default;
+                    public static S ConvertToManaged(Native n) => default;
+                }
+                """;
+            public static string DefaultOptionalBuffer = """
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
+                public static class Marshaller
+                {
+                    public struct Native { }
 
-    public const int BufferSize = 0x100;
-    public static Native ConvertToUnmanaged(S s) => default;
-    public static Native ConvertToUnmanaged(S s, System.Span<byte> buffer) => default;
-    public static S ConvertToManaged(Native n) => default;
-}
-";
-            private static string DefaultIn = @"
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
-public static class Marshaller
-{
-    public struct Native { }
+                    public const int BufferSize = 0x100;
+                    public static Native ConvertToUnmanaged(S s) => default;
+                    public static Native ConvertToUnmanaged(S s, System.Span<byte> buffer) => default;
+                    public static S ConvertToManaged(Native n) => default;
+                }
+                """;
+            private static string DefaultIn = """
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
+                public static class Marshaller
+                {
+                    public struct Native { }
 
-    public static Native ConvertToUnmanaged(S s) => default;
-}
-";
-            private static string DefaultOut = @"
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
-public static class Marshaller
-{
-    public struct Native { }
+                    public static Native ConvertToUnmanaged(S s) => default;
+                }
+                """;
+            private static string DefaultOut = """
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
+                public static class Marshaller
+                {
+                    public struct Native { }
 
-    public static S ConvertToManaged(Native n) => default;
-}
-";
+                    public static S ConvertToManaged(Native n) => default;
+                }
+                """;
             public string ManagedToNativeOnlyOutParameter => _provider.BasicParameterWithByRefModifier("out", "S")
                 + NonBlittableUserDefinedType()
                 + In;
@@ -264,216 +264,216 @@ public static class Marshaller
             {
                 _provider = provider;
             }
-            private static string In = @"
-[CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedIn, typeof(M))]
-[CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedOut, typeof(M))]
-public static class Marshaller
-{
-    public struct Native { }
+            private static string In = """
+                [CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedIn, typeof(M))]
+                [CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedOut, typeof(M))]
+                public static class Marshaller
+                {
+                    public struct Native { }
 
-    public struct M
-    {
-        public void FromManaged(S s) {}
-        public Native ToUnmanaged() => default;
-    }
-}
-";
+                    public struct M
+                    {
+                        public void FromManaged(S s) {}
+                        public Native ToUnmanaged() => default;
+                    }
+                }
+                """;
 
-            public static string InStatelessPinnable = @"
-[CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedIn, typeof(M))]
-[CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedOut, typeof(M))]
-public static class Marshaller
-{
-    public unsafe struct M
-    {
-        public void FromManaged(S s) {}
-        public byte* ToUnmanaged() => default;
+            public static string InStatelessPinnable = """
+                [CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedIn, typeof(M))]
+                [CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedOut, typeof(M))]
+                public static class Marshaller
+                {
+                    public unsafe struct M
+                    {
+                        public void FromManaged(S s) {}
+                        public byte* ToUnmanaged() => default;
 
-        public static ref byte GetPinnableReference(S s) => throw null;
-    }
-}
-";
+                        public static ref byte GetPinnableReference(S s) => throw null;
+                    }
+                }
+                """;
 
-            public static string InPinnable = @"
-[CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedIn, typeof(M))]
-public static class Marshaller
-{
-    public unsafe struct M
-    {
-        public void FromManaged(S s) {}
-        public byte* ToUnmanaged() => default;
+            public static string InPinnable = """
+                [CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedIn, typeof(M))]
+                public static class Marshaller
+                {
+                    public unsafe struct M
+                    {
+                        public void FromManaged(S s) {}
+                        public byte* ToUnmanaged() => default;
 
-        public ref byte GetPinnableReference() => throw null;
-    }
-}
-";
+                        public ref byte GetPinnableReference() => throw null;
+                    }
+                }
+                """;
 
-            private static string InBuffer = @"
-[CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedIn, typeof(M))]
-public static class Marshaller
-{
-    public struct Native { }
+            private static string InBuffer = """
+                [CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedIn, typeof(M))]
+                public static class Marshaller
+                {
+                    public struct Native { }
 
-    public struct M
-    {
-        public const int BufferSize = 0x100;
-        public void FromManaged(S s, System.Span<byte> buffer) {}
-        public Native ToUnmanaged() => default;
-    }
-}
-";
-            private static string Out = @"
-[CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedOut, typeof(M))]
-[CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedIn, typeof(M))]
-public static class Marshaller
-{
-    public struct Native { }
+                    public struct M
+                    {
+                        public const int BufferSize = 0x100;
+                        public void FromManaged(S s, System.Span<byte> buffer) {}
+                        public Native ToUnmanaged() => default;
+                    }
+                }
+                """;
+            private static string Out = """
+                [CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedOut, typeof(M))]
+                [CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedIn, typeof(M))]
+                public static class Marshaller
+                {
+                    public struct Native { }
 
-    public struct M
-    {
-        public void FromUnmanaged(Native n) {}
-        public S ToManaged() => default;
-    }
-}
-";
-            private static string OutGuaranteed = @"
-[CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedOut, typeof(M))]
-[CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedIn, typeof(M))]
-public static class Marshaller
-{
-    public struct Native { }
+                    public struct M
+                    {
+                        public void FromUnmanaged(Native n) {}
+                        public S ToManaged() => default;
+                    }
+                }
+                """;
+            private static string OutGuaranteed = """
+                [CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedOut, typeof(M))]
+                [CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedIn, typeof(M))]
+                public static class Marshaller
+                {
+                    public struct Native { }
 
-    public struct M
-    {
-        public void FromUnmanaged(Native n) {}
-        public S ToManagedFinally() => default;
-    }
-}
-";
-            public static string Ref = @"
-[CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedRef, typeof(M))]
-[CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedRef, typeof(M))]
-public static class Marshaller
-{
-    public struct Native { }
+                    public struct M
+                    {
+                        public void FromUnmanaged(Native n) {}
+                        public S ToManagedFinally() => default;
+                    }
+                }
+                """;
+            public static string Ref = """
+                [CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedRef, typeof(M))]
+                [CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedRef, typeof(M))]
+                public static class Marshaller
+                {
+                    public struct Native { }
 
-    public struct M
-    {
-        public void FromManaged(S s) {}
-        public Native ToUnmanaged() => default;
-        public void FromUnmanaged(Native n) {}
-        public S ToManaged() => default;
-    }
-}
-";
-            public static string Default = @"
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(M))]
-public static class Marshaller
-{
-    public struct Native { }
+                    public struct M
+                    {
+                        public void FromManaged(S s) {}
+                        public Native ToUnmanaged() => default;
+                        public void FromUnmanaged(Native n) {}
+                        public S ToManaged() => default;
+                    }
+                }
+                """;
+            public static string Default = """
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(M))]
+                public static class Marshaller
+                {
+                    public struct Native { }
 
-    public struct M
-    {
-        public void FromManaged(S s) {}
-        public Native ToUnmanaged() => default;
-        public void FromUnmanaged(Native n) {}
-        public S ToManaged() => default;
-    }
-}
-";
-            public static string DefaultWithFree = @"
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(M))]
-public static class Marshaller
-{
-    public struct Native { }
+                    public struct M
+                    {
+                        public void FromManaged(S s) {}
+                        public Native ToUnmanaged() => default;
+                        public void FromUnmanaged(Native n) {}
+                        public S ToManaged() => default;
+                    }
+                }
+                """;
+            public static string DefaultWithFree = """
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(M))]
+                public static class Marshaller
+                {
+                    public struct Native { }
 
-    public struct M
-    {
-        public void FromManaged(S s) {}
-        public Native ToUnmanaged() => default;
-        public void FromUnmanaged(Native n) {}
-        public S ToManaged() => default;
-        public void Free() {}
-    }
-}
-";
-            public static string DefaultWithOnInvoked = @"
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(M))]
-public static class Marshaller
-{
-    public struct Native { }
+                    public struct M
+                    {
+                        public void FromManaged(S s) {}
+                        public Native ToUnmanaged() => default;
+                        public void FromUnmanaged(Native n) {}
+                        public S ToManaged() => default;
+                        public void Free() {}
+                    }
+                }
+                """;
+            public static string DefaultWithOnInvoked = """
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(M))]
+                public static class Marshaller
+                {
+                    public struct Native { }
 
-    public struct M
-    {
-        public void FromManaged(S s) {}
-        public Native ToUnmanaged() => default;
-        public void FromUnmanaged(Native n) {}
-        public S ToManaged() => default;
-        public void OnInvoked() {}
-    }
-}
-";
-            public static string InOutBuffer = @"
-[CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedIn, typeof(M))]
-[CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedOut, typeof(M))]
-[CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedIn, typeof(M))]
-public static class Marshaller
-{
-    public struct Native { }
+                    public struct M
+                    {
+                        public void FromManaged(S s) {}
+                        public Native ToUnmanaged() => default;
+                        public void FromUnmanaged(Native n) {}
+                        public S ToManaged() => default;
+                        public void OnInvoked() {}
+                    }
+                }
+                """;
+            public static string InOutBuffer = """
+                [CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedIn, typeof(M))]
+                [CustomMarshaller(typeof(S), MarshalMode.ManagedToUnmanagedOut, typeof(M))]
+                [CustomMarshaller(typeof(S), MarshalMode.UnmanagedToManagedIn, typeof(M))]
+                public static class Marshaller
+                {
+                    public struct Native { }
 
-    public struct M
-    {
-        public const int BufferSize = 0x100;
-        public void FromManaged(S s, System.Span<byte> buffer) {}
-        public Native ToUnmanaged() => default;
-        public void FromUnmanaged(Native n) {}
-        public S ToManaged() => default;
-    }
-}
-";
-            public static string DefaultOptionalBuffer = @"
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(M))]
-public static class Marshaller
-{
-    public struct Native { }
+                    public struct M
+                    {
+                        public const int BufferSize = 0x100;
+                        public void FromManaged(S s, System.Span<byte> buffer) {}
+                        public Native ToUnmanaged() => default;
+                        public void FromUnmanaged(Native n) {}
+                        public S ToManaged() => default;
+                    }
+                }
+                """;
+            public static string DefaultOptionalBuffer = """
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(M))]
+                public static class Marshaller
+                {
+                    public struct Native { }
 
-    public struct M
-    {
-        public const int BufferSize = 0x100;
-        public void FromManaged(S s) {}
-        public void FromManaged(S s, System.Span<byte> buffer) {}
-        public Native ToUnmanaged() => default;
-        public void FromUnmanaged(Native n) {}
-        public S ToManaged() => default;
-    }
-}
-";
-            private static string DefaultIn = @"
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(M))]
-public static class Marshaller
-{
-    public struct Native { }
+                    public struct M
+                    {
+                        public const int BufferSize = 0x100;
+                        public void FromManaged(S s) {}
+                        public void FromManaged(S s, System.Span<byte> buffer) {}
+                        public Native ToUnmanaged() => default;
+                        public void FromUnmanaged(Native n) {}
+                        public S ToManaged() => default;
+                    }
+                }
+                """;
+            private static string DefaultIn = """
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(M))]
+                public static class Marshaller
+                {
+                    public struct Native { }
 
-    public struct M
-    {
-        public void FromManaged(S s) {}
-        public Native ToUnmanaged() => default;
-    }
-}
-";
-            private static string DefaultOut = @"
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(M))]
-public static class Marshaller
-{
-    public struct Native { }
+                    public struct M
+                    {
+                        public void FromManaged(S s) {}
+                        public Native ToUnmanaged() => default;
+                    }
+                }
+                """;
+            private static string DefaultOut = """
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(M))]
+                public static class Marshaller
+                {
+                    public struct Native { }
 
-    public struct M
-    {
-        public void FromUnmanaged(Native n) {}
-        public S ToManaged() => default;
-    }
-}
-";
+                    public struct M
+                    {
+                        public void FromUnmanaged(Native n) {}
+                        public S ToManaged() => default;
+                    }
+                }
+                """;
             public string ManagedToNativeOnlyOutParameter => _provider.BasicParameterWithByRefModifier("out", "S")
                 + NonBlittableUserDefinedType()
                 + In;

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AddDisableRuntimeMarshallingAttributeFixerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AddDisableRuntimeMarshallingAttributeFixerTests.cs
@@ -32,32 +32,32 @@ namespace LibraryImportGenerator.UnitTests
         public static async Task Adds_NewFile_With_Attribute()
         {
             // Source will have CS8795 (Partial method must have an implementation) without generator run
-            var source = @"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-partial class Foo
-{
-    [LibraryImport(""Foo"")]
-    public static partial void {|CS8795:PInvoke|}(S {|#0:s|});
-}
+            var source = """
+                using System.Runtime.InteropServices;
+                using System.Runtime.InteropServices.Marshalling;
+                partial class Foo
+                {
+                    [LibraryImport("Foo")]
+                    public static partial void {|CS8795:PInvoke|}(S {|#0:s|});
+                }
 
-[NativeMarshalling(typeof(Marshaller))]
-struct S
-{
-}
+                [NativeMarshalling(typeof(Marshaller))]
+                struct S
+                {
+                }
 
-struct Native
-{
-}
+                struct Native
+                {
+                }
 
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
-static class Marshaller
-{
-    public static Native ConvertToUnmanaged(S s) => default;
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
+                static class Marshaller
+                {
+                    public static Native ConvertToUnmanaged(S s) => default;
 
-    public static S ConvertToManaged(Native n) => default;
-}
-";
+                    public static S ConvertToManaged(Native n) => default;
+                }
+                """;
             var expectedPropertiesFile = "[assembly: System.Runtime.CompilerServices.DisableRuntimeMarshalling]" + Environment.NewLine;
 
             var diagnostic = VerifyCS.Diagnostic(GeneratorDiagnostics.Ids.TypeNotSupported).WithLocation(0).WithArguments("S", "s");
@@ -67,43 +67,44 @@ static class Marshaller
         [Fact]
         public static async Task Appends_Attribute_To_Existing_AssemblyInfo_File()
         {
-            var source = @"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-partial class Foo
-{
-    [LibraryImport(""Foo"")]
-    public static partial void {|CS8795:PInvoke|}(S {|#0:s|});
-}
+            var source = """
+                using System.Runtime.InteropServices;
+                using System.Runtime.InteropServices.Marshalling;
+                partial class Foo
+                {
+                    [LibraryImport("Foo")]
+                    public static partial void {|CS8795:PInvoke|}(S {|#0:s|});
+                }
 
-[NativeMarshalling(typeof(Marshaller))]
-struct S
-{
-}
+                [NativeMarshalling(typeof(Marshaller))]
+                struct S
+                {
+                }
 
-struct Native
-{
-}
+                struct Native
+                {
+                }
 
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
-static class Marshaller
-{
-    public static Native ConvertToUnmanaged(S s) => default;
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
+                static class Marshaller
+                {
+                    public static Native ConvertToUnmanaged(S s) => default;
 
-    public static S ConvertToManaged(Native n) => default;
-}
-";
-            var propertiesFile = @"
-using System.Reflection;
+                    public static S ConvertToManaged(Native n) => default;
+                }
+                """;
+            var propertiesFile = """
+                using System.Reflection;
 
-[assembly: AssemblyMetadata(""MyMetadata"", ""Value"")]
-";
-            var expectedPropertiesFile = @"
-using System.Reflection;
+                [assembly: AssemblyMetadata("MyMetadata", "Value")]
+                """;
+            var expectedPropertiesFile = """
+                using System.Reflection;
 
-[assembly: AssemblyMetadata(""MyMetadata"", ""Value"")]
-[assembly: System.Runtime.CompilerServices.DisableRuntimeMarshalling]
-";
+                [assembly: AssemblyMetadata("MyMetadata", "Value")]
+                [assembly: System.Runtime.CompilerServices.DisableRuntimeMarshalling]
+
+                """;
 
             var diagnostic = VerifyCS.Diagnostic(GeneratorDiagnostics.Ids.TypeNotSupported).WithLocation(0).WithArguments("S", "s");
             await VerifyCodeFixAsync(source, propertiesFile, expectedPropertiesFile, diagnostic);

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AdditionalAttributesOnStub.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AdditionalAttributesOnStub.cs
@@ -18,33 +18,34 @@ namespace LibraryImportGenerator.UnitTests
         [Fact]
         public async Task SkipLocalsInitAdded()
         {
-            string source = @"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-[assembly:DisableRuntimeMarshalling]
-partial class C
-{
-    [LibraryImportAttribute(""DoesNotExist"")]
-    public static partial S Method();
-}
+            string source = """
+                using System.Runtime.CompilerServices;
+                using System.Runtime.InteropServices;
+                using System.Runtime.InteropServices.Marshalling;
+                [assembly:DisableRuntimeMarshalling]
+                partial class C
+                {
+                    [LibraryImportAttribute("DoesNotExist")]
+                    public static partial S Method();
+                }
 
-[NativeMarshalling(typeof(Marshaller))]
-struct S
-{
-}
+                [NativeMarshalling(typeof(Marshaller))]
+                struct S
+                {
+                }
 
-struct Native
-{
-}
+                struct Native
+                {
+                }
 
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
-static class Marshaller
-{
-    public static Native ConvertToUnmanaged(S s) => default;
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
+                static class Marshaller
+                {
+                    public static Native ConvertToUnmanaged(S s) => default;
 
-    public static S ConvertToManaged(Native n) => default;
-}";
+                    public static S ConvertToManaged(Native n) => default;
+                }
+                """;
             Compilation comp = await TestUtils.CreateCompilation(source);
 
             Compilation newComp = TestUtils.RunGenerators(comp, out _, new Microsoft.Interop.LibraryImportGenerator());
@@ -57,13 +58,14 @@ static class Marshaller
         [Fact]
         public async Task SkipLocalsInitNotAddedOnForwardingStub()
         {
-            string source = @"
-using System.Runtime.InteropServices;
-partial class C
-{
-    [LibraryImportAttribute(""DoesNotExist"")]
-    public static partial void Method();
-}";
+            string source = """
+                using System.Runtime.InteropServices;
+                partial class C
+                {
+                    [LibraryImportAttribute("DoesNotExist")]
+                    public static partial void Method();
+                }
+                """;
             Compilation comp = await TestUtils.CreateCompilation(source);
 
             Compilation newComp = TestUtils.RunGenerators(comp, out _, new Microsoft.Interop.LibraryImportGenerator());
@@ -76,33 +78,34 @@ partial class C
         [Fact]
         public async Task GeneratedCodeAdded()
         {
-            string source = @"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-[assembly:DisableRuntimeMarshalling]
-partial class C
-{
-    [LibraryImportAttribute(""DoesNotExist"")]
-    public static partial S Method();
-}
+            string source = """
+                using System.Runtime.CompilerServices;
+                using System.Runtime.InteropServices;
+                using System.Runtime.InteropServices.Marshalling;
+                [assembly:DisableRuntimeMarshalling]
+                partial class C
+                {
+                    [LibraryImportAttribute("DoesNotExist")]
+                    public static partial S Method();
+                }
 
-[NativeMarshalling(typeof(Marshaller))]
-struct S
-{
-}
+                [NativeMarshalling(typeof(Marshaller))]
+                struct S
+                {
+                }
 
-struct Native
-{
-}
+                struct Native
+                {
+                }
 
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
-static class Marshaller
-{
-    public static Native ConvertToUnmanaged(S s) => default;
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
+                static class Marshaller
+                {
+                    public static Native ConvertToUnmanaged(S s) => default;
 
-    public static S ConvertToManaged(Native n) => default;
-}";
+                    public static S ConvertToManaged(Native n) => default;
+                }
+                """;
             Compilation comp = await TestUtils.CreateCompilation(source);
 
             Compilation newComp = TestUtils.RunGenerators(comp, out _, new Microsoft.Interop.LibraryImportGenerator());
@@ -115,13 +118,14 @@ static class Marshaller
         [Fact]
         public async Task GeneratedCodeNotAddedOnForwardingStub()
         {
-            string source = @"
-using System.Runtime.InteropServices;
-partial class C
-{
-    [LibraryImportAttribute(""DoesNotExist"")]
-    public static partial void Method();
-}";
+            string source = """
+                using System.Runtime.InteropServices;
+                partial class C
+                {
+                    [LibraryImportAttribute("DoesNotExist")]
+                    public static partial void Method();
+                }
+                """;
             Compilation comp = await TestUtils.CreateCompilation(source);
 
             Compilation newComp = TestUtils.RunGenerators(comp, out _, new Microsoft.Interop.LibraryImportGenerator());
@@ -145,15 +149,16 @@ partial class C
         [OuterLoop("Uses the network for downlevel ref packs")]
         public async Task SkipLocalsInitOnDownlevelTargetFrameworks(TestTargetFramework targetFramework, bool expectSkipLocalsInit)
         {
-            string source = $@"
-using System.Runtime.InteropServices;
-{CodeSnippets.LibraryImportAttributeDeclaration}
-partial class C
-{{
-    [LibraryImportAttribute(""DoesNotExist"")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static partial bool Method();
-}}";
+            string source = $$"""
+                using System.Runtime.InteropServices;
+                {{CodeSnippets.LibraryImportAttributeDeclaration}}
+                partial class C
+                {
+                    [LibraryImportAttribute("DoesNotExist")]
+                    [return: MarshalAs(UnmanagedType.Bool)]
+                    public static partial bool Method();
+                }
+                """;
             Compilation comp = await TestUtils.CreateCompilation(source, targetFramework);
 
             Compilation newComp = TestUtils.RunGenerators(comp, new GlobalOptionsOnlyProvider(new TargetFrameworkConfigOptions(targetFramework)), out _, new Microsoft.Interop.LibraryImportGenerator());
@@ -173,33 +178,34 @@ partial class C
         [Fact]
         public async Task SkipLocalsInitNotAddedWhenDefinedAtModuleLevel()
         {
-            string source = @"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-using System.Runtime.CompilerServices;
-[module:SkipLocalsInit]
-partial class C
-{
-    [LibraryImportAttribute(""DoesNotExist"")]
-    public static partial S Method();
-}
+            string source = """
+                using System.Runtime.InteropServices;
+                using System.Runtime.InteropServices.Marshalling;
+                using System.Runtime.CompilerServices;
+                [module:SkipLocalsInit]
+                partial class C
+                {
+                    [LibraryImportAttribute("DoesNotExist")]
+                    public static partial S Method();
+                }
 
-[NativeMarshalling(typeof(Marshaller))]
-struct S
-{
-}
+                [NativeMarshalling(typeof(Marshaller))]
+                struct S
+                {
+                }
 
-struct Native
-{
-}
+                struct Native
+                {
+                }
 
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
-static class Marshaller
-{
-    public static Native ConvertToUnmanaged(S s) => default;
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
+                static class Marshaller
+                {
+                    public static Native ConvertToUnmanaged(S s) => default;
 
-    public static S ConvertToManaged(Native n) => default;
-}";
+                    public static S ConvertToManaged(Native n) => default;
+                }
+                """;
             Compilation comp = await TestUtils.CreateCompilation(source);
 
             Compilation newComp = TestUtils.RunGenerators(comp, out _, new Microsoft.Interop.LibraryImportGenerator());
@@ -212,33 +218,34 @@ static class Marshaller
         [Fact]
         public async Task SkipLocalsInitNotAddedWhenDefinedAtClassLevel()
         {
-            string source = @"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-using System.Runtime.CompilerServices;
-[SkipLocalsInit]
-partial class C
-{
-    [LibraryImportAttribute(""DoesNotExist"")]
-    public static partial S Method();
-}
+            string source = """
+                using System.Runtime.InteropServices;
+                using System.Runtime.InteropServices.Marshalling;
+                using System.Runtime.CompilerServices;
+                [SkipLocalsInit]
+                partial class C
+                {
+                    [LibraryImportAttribute("DoesNotExist")]
+                    public static partial S Method();
+                }
 
-[NativeMarshalling(typeof(Marshaller))]
-struct S
-{
-}
+                [NativeMarshalling(typeof(Marshaller))]
+                struct S
+                {
+                }
 
-struct Native
-{
-}
+                struct Native
+                {
+                }
 
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
-static class Marshaller
-{
-    public static Native ConvertToUnmanaged(S s) => default;
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
+                static class Marshaller
+                {
+                    public static Native ConvertToUnmanaged(S s) => default;
 
-    public static S ConvertToManaged(Native n) => default;
-}";
+                    public static S ConvertToManaged(Native n) => default;
+                }
+                """;
             Compilation comp = await TestUtils.CreateCompilation(source);
 
             Compilation newComp = TestUtils.RunGenerators(comp, out _, new Microsoft.Interop.LibraryImportGenerator());
@@ -251,33 +258,34 @@ static class Marshaller
         [Fact]
         public async Task SkipLocalsInitNotAddedWhenDefinedOnMethodByUser()
         {
-            string source = @"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-using System.Runtime.CompilerServices;
-partial class C
-{
-    [SkipLocalsInit]
-    [LibraryImportAttribute(""DoesNotExist"")]
-    public static partial S Method();
-}
+            string source = """
+                using System.Runtime.InteropServices;
+                using System.Runtime.InteropServices.Marshalling;
+                using System.Runtime.CompilerServices;
+                partial class C
+                {
+                    [SkipLocalsInit]
+                    [LibraryImportAttribute("DoesNotExist")]
+                    public static partial S Method();
+                }
 
-[NativeMarshalling(typeof(Marshaller))]
-struct S
-{
-}
+                [NativeMarshalling(typeof(Marshaller))]
+                struct S
+                {
+                }
 
-struct Native
-{
-}
+                struct Native
+                {
+                }
 
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
-static class Marshaller
-{
-    public static Native ConvertToUnmanaged(S s) => default;
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
+                static class Marshaller
+                {
+                    public static Native ConvertToUnmanaged(S s) => default;
 
-    public static S ConvertToManaged(Native n) => default;
-}";
+                    public static S ConvertToManaged(Native n) => default;
+                }
+                """;
             Compilation comp = await TestUtils.CreateCompilation(source);
 
             Compilation newComp = TestUtils.RunGenerators(comp, out _, new Microsoft.Interop.LibraryImportGenerator());

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AttributeForwarding.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AttributeForwarding.cs
@@ -24,35 +24,35 @@ namespace LibraryImportGenerator.UnitTests
         [InlineData("UnmanagedCallConv", "System.Runtime.InteropServices.UnmanagedCallConvAttribute")]
         public async Task KnownParameterlessAttribute(string attributeSourceName, string attributeMetadataName)
         {
-            string source = @$"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-[assembly:DisableRuntimeMarshalling]
-partial class C
-{{
-    [{attributeSourceName}]
-    [LibraryImportAttribute(""DoesNotExist"")]
-    public static partial S Method1();
-}}
-
-[NativeMarshalling(typeof(Marshaller))]
-struct S
-{{
-}}
-
-struct Native
-{{
-}}
-
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
-static class Marshaller
-{{
-    public static Native ConvertToUnmanaged(S s) => default;
-
-    public static S ConvertToManaged(Native n) => default;
-}}
-";
+            string source = $$"""
+                using System.Runtime.CompilerServices;
+                using System.Runtime.InteropServices;
+                using System.Runtime.InteropServices.Marshalling;
+                [assembly:DisableRuntimeMarshalling]
+                partial class C
+                {
+                    [{{attributeSourceName}}]
+                    [LibraryImportAttribute("DoesNotExist")]
+                    public static partial S Method1();
+                }
+                
+                [NativeMarshalling(typeof(Marshaller))]
+                struct S
+                {
+                }
+                
+                struct Native
+                {
+                }
+                
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
+                static class Marshaller
+                {
+                    public static Native ConvertToUnmanaged(S s) => default;
+                
+                    public static S ConvertToManaged(Native n) => default;
+                }
+                """;
             Compilation origComp = await TestUtils.CreateCompilation(source);
             Compilation newComp = TestUtils.RunGenerators(origComp, out _, new Microsoft.Interop.LibraryImportGenerator());
             Assert.Empty(newComp.GetDiagnostics());
@@ -71,36 +71,36 @@ static class Marshaller
         [Fact]
         public async Task UnmanagedCallConvAttribute_EmptyCallConvArray()
         {
-            string source = @"
-using System;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-[assembly:DisableRuntimeMarshalling]
-partial class C
-{
-    [UnmanagedCallConv(CallConvs = new Type[0])]
-    [LibraryImportAttribute(""DoesNotExist"")]
-    public static partial S Method1();
-}
+            string source = """
+                using System;
+                using System.Runtime.CompilerServices;
+                using System.Runtime.InteropServices;
+                using System.Runtime.InteropServices.Marshalling;
+                [assembly:DisableRuntimeMarshalling]
+                partial class C
+                {
+                    [UnmanagedCallConv(CallConvs = new Type[0])]
+                    [LibraryImportAttribute("DoesNotExist")]
+                    public static partial S Method1();
+                }
 
-[NativeMarshalling(typeof(Marshaller))]
-struct S
-{
-}
+                [NativeMarshalling(typeof(Marshaller))]
+                struct S
+                {
+                }
 
-struct Native
-{
-}
+                struct Native
+                {
+                }
 
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
-static class Marshaller
-{
-    public static Native ConvertToUnmanaged(S s) => default;
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
+                static class Marshaller
+                {
+                    public static Native ConvertToUnmanaged(S s) => default;
 
-    public static S ConvertToManaged(Native n) => default;
-}
-";
+                    public static S ConvertToManaged(Native n) => default;
+                }
+                """;
             Compilation origComp = await TestUtils.CreateCompilation(source);
             Compilation newComp = TestUtils.RunGenerators(origComp, out _, new Microsoft.Interop.LibraryImportGenerator());
             Assert.Empty(newComp.GetDiagnostics());
@@ -122,35 +122,35 @@ static class Marshaller
         [Fact]
         public async Task UnmanagedCallConvAttribute_SingleCallConvType()
         {
-            string source = @"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-[assembly:DisableRuntimeMarshalling]
-partial class C
-{
-    [UnmanagedCallConv(CallConvs = new[]{typeof(CallConvStdcall)})]
-    [LibraryImportAttribute(""DoesNotExist"")]
-    public static partial S Method1();
-}
+            string source = """
+                using System.Runtime.CompilerServices;
+                using System.Runtime.InteropServices;
+                using System.Runtime.InteropServices.Marshalling;
+                [assembly:DisableRuntimeMarshalling]
+                partial class C
+                {
+                    [UnmanagedCallConv(CallConvs = new[]{typeof(CallConvStdcall)})]
+                    [LibraryImportAttribute("DoesNotExist")]
+                    public static partial S Method1();
+                }
 
-[NativeMarshalling(typeof(Marshaller))]
-struct S
-{
-}
+                [NativeMarshalling(typeof(Marshaller))]
+                struct S
+                {
+                }
 
-struct Native
-{
-}
+                struct Native
+                {
+                }
 
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
-static class Marshaller
-{
-    public static Native ConvertToUnmanaged(S s) => default;
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
+                static class Marshaller
+                {
+                    public static Native ConvertToUnmanaged(S s) => default;
 
-    public static S ConvertToManaged(Native n) => default;
-}
-";
+                    public static S ConvertToManaged(Native n) => default;
+                }
+                """;
             Compilation origComp = await TestUtils.CreateCompilation(source);
             Compilation newComp = TestUtils.RunGenerators(origComp, out _, new Microsoft.Interop.LibraryImportGenerator());
             Assert.Empty(newComp.GetDiagnostics());
@@ -176,35 +176,35 @@ static class Marshaller
         [Fact]
         public async Task UnmanagedCallConvAttribute_MultipleCallConvTypes()
         {
-            string source = @"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-[assembly:DisableRuntimeMarshalling]
-partial class C
-{
-    [UnmanagedCallConv(CallConvs = new[]{typeof(CallConvStdcall), typeof(CallConvSuppressGCTransition)})]
-    [LibraryImportAttribute(""DoesNotExist"")]
-    public static partial S Method1();
-}
+            string source = """
+                using System.Runtime.CompilerServices;
+                using System.Runtime.InteropServices;
+                using System.Runtime.InteropServices.Marshalling;
+                [assembly:DisableRuntimeMarshalling]
+                partial class C
+                {
+                    [UnmanagedCallConv(CallConvs = new[]{typeof(CallConvStdcall), typeof(CallConvSuppressGCTransition)})]
+                    [LibraryImportAttribute("DoesNotExist")]
+                    public static partial S Method1();
+                }
 
-[NativeMarshalling(typeof(Marshaller))]
-struct S
-{
-}
+                [NativeMarshalling(typeof(Marshaller))]
+                struct S
+                {
+                }
 
-struct Native
-{
-}
+                struct Native
+                {
+                }
 
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
-static class Marshaller
-{
-    public static Native ConvertToUnmanaged(S s) => default;
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
+                static class Marshaller
+                {
+                    public static Native ConvertToUnmanaged(S s) => default;
 
-    public static S ConvertToManaged(Native n) => default;
-}
-";
+                    public static S ConvertToManaged(Native n) => default;
+                }
+                """;
             Compilation origComp = await TestUtils.CreateCompilation(source);
             Compilation newComp = TestUtils.RunGenerators(origComp, out _, new Microsoft.Interop.LibraryImportGenerator());
             Assert.Empty(newComp.GetDiagnostics());
@@ -234,35 +234,35 @@ static class Marshaller
         [Fact]
         public async Task DefaultDllImportSearchPathsAttribute()
         {
-            string source = @$"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-[assembly:DisableRuntimeMarshalling]
-partial class C
-{{
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32 | DllImportSearchPath.UserDirectories)]
-    [LibraryImportAttribute(""DoesNotExist"")]
-    public static partial S Method1();
-}}
-
-[NativeMarshalling(typeof(Marshaller))]
-struct S
-{{
-}}
-
-struct Native
-{{
-}}
-
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
-static class Marshaller
-{{
-    public static Native ConvertToUnmanaged(S s) => default;
-
-    public static S ConvertToManaged(Native n) => default;
-}}
-";
+            string source = $$"""
+                using System.Runtime.CompilerServices;
+                using System.Runtime.InteropServices;
+                using System.Runtime.InteropServices.Marshalling;
+                [assembly:DisableRuntimeMarshalling]
+                partial class C
+                {
+                    [DefaultDllImportSearchPaths(DllImportSearchPath.System32 | DllImportSearchPath.UserDirectories)]
+                    [LibraryImportAttribute("DoesNotExist")]
+                    public static partial S Method1();
+                }
+                
+                [NativeMarshalling(typeof(Marshaller))]
+                struct S
+                {
+                }
+                
+                struct Native
+                {
+                }
+                
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
+                static class Marshaller
+                {
+                    public static Native ConvertToUnmanaged(S s) => default;
+                
+                    public static S ConvertToManaged(Native n) => default;
+                }
+                """;
             Compilation origComp = await TestUtils.CreateCompilation(source);
             Compilation newComp = TestUtils.RunGenerators(origComp, out _, new Microsoft.Interop.LibraryImportGenerator());
             Assert.Empty(newComp.GetDiagnostics());
@@ -285,39 +285,39 @@ static class Marshaller
         [Fact]
         public async Task OtherAttributeType()
         {
-            string source = @"
-using System;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-[assembly:DisableRuntimeMarshalling]
+            string source = """
+                using System;
+                using System.Runtime.CompilerServices;
+                using System.Runtime.InteropServices;
+                using System.Runtime.InteropServices.Marshalling;
+                [assembly:DisableRuntimeMarshalling]
 
-class OtherAttribute : Attribute {}
+                class OtherAttribute : Attribute {}
 
-partial class C
-{
-    [Other]
-    [LibraryImportAttribute(""DoesNotExist"")]
-    public static partial S Method1();
-}
+                partial class C
+                {
+                    [Other]
+                    [LibraryImportAttribute("DoesNotExist")]
+                    public static partial S Method1();
+                }
 
-[NativeMarshalling(typeof(Marshaller))]
-struct S
-{
-}
+                [NativeMarshalling(typeof(Marshaller))]
+                struct S
+                {
+                }
 
-struct Native
-{
-}
+                struct Native
+                {
+                }
 
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
-static class Marshaller
-{
-    public static Native ConvertToUnmanaged(S s) => default;
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
+                static class Marshaller
+                {
+                    public static Native ConvertToUnmanaged(S s) => default;
 
-    public static S ConvertToManaged(Native n) => default;
-}
-";
+                    public static S ConvertToManaged(Native n) => default;
+                }
+                """;
             Compilation origComp = await TestUtils.CreateCompilation(source);
             Compilation newComp = TestUtils.RunGenerators(origComp, out _, new Microsoft.Interop.LibraryImportGenerator());
 
@@ -340,16 +340,16 @@ static class Marshaller
         {
             // This code is invalid configuration from the source generator's perspective.
             // We just use it as validation for forwarding the In and Out attributes.
-            string source = @"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-partial class C
-{
-    [LibraryImportAttribute(""DoesNotExist"")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static partial bool Method1([In, Out] int a);
-}
-" + CodeSnippets.LibraryImportAttributeDeclaration;
+            string source = """
+                using System.Runtime.CompilerServices;
+                using System.Runtime.InteropServices;
+                partial class C
+                {
+                    [LibraryImportAttribute("DoesNotExist")]
+                    [return: MarshalAs(UnmanagedType.Bool)]
+                    public static partial bool Method1([In, Out] int a);
+                }
+                """ + CodeSnippets.LibraryImportAttributeDeclaration;
             Compilation origComp = await TestUtils.CreateCompilation(source, TestTargetFramework.Standard);
             Compilation newComp = TestUtils.RunGenerators(
                 origComp,
@@ -382,16 +382,16 @@ partial class C
         [OuterLoop("Uses the network for downlevel ref packs")]
         public async Task MarshalAsAttribute_Forwarded_To_ForwardedParameter()
         {
-            string source = @"
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-partial class C
-{
-    [LibraryImportAttribute(""DoesNotExist"")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static partial bool Method1([MarshalAs(UnmanagedType.I2)] int a);
-}
-" + CodeSnippets.LibraryImportAttributeDeclaration;
+            string source = """
+                using System.Runtime.CompilerServices;
+                using System.Runtime.InteropServices;
+                partial class C
+                {
+                    [LibraryImportAttribute("DoesNotExist")]
+                    [return: MarshalAs(UnmanagedType.Bool)]
+                    public static partial bool Method1([MarshalAs(UnmanagedType.I2)] int a);
+                }
+                """ + CodeSnippets.LibraryImportAttributeDeclaration;
             Compilation origComp = await TestUtils.CreateCompilation(source, TestTargetFramework.Standard);
             Compilation newComp = TestUtils.RunGenerators(
                 origComp,

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CodeSnippets.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CodeSnippets.cs
@@ -48,330 +48,330 @@ namespace LibraryImportGenerator.UnitTests
         /// <summary>
         /// Partially define attribute for pre-.NET 7.0
         /// </summary>
-        public static readonly string LibraryImportAttributeDeclaration = @"
-namespace System.Runtime.InteropServices
-{
-    internal enum StringMarshalling
-    {
-        Custom = 0,
-        Utf8,
-        Utf16,
-    }
+        public static readonly string LibraryImportAttributeDeclaration = """
+            namespace System.Runtime.InteropServices
+            {
+                internal enum StringMarshalling
+                {
+                    Custom = 0,
+                    Utf8,
+                    Utf16,
+                }
 
-    sealed class LibraryImportAttribute : System.Attribute
-    {
-        public LibraryImportAttribute(string a) { }
-        public StringMarshalling StringMarshalling { get; set; }
-        public Type StringMarshallingCustomType { get; set; }
-    }
-}
-";
+                sealed class LibraryImportAttribute : System.Attribute
+                {
+                    public LibraryImportAttribute(string a) { }
+                    public StringMarshalling StringMarshalling { get; set; }
+                    public Type StringMarshallingCustomType { get; set; }
+                }
+            }
+            """;
 
         /// <summary>
         /// Trivial declaration of LibraryImport usage
         /// </summary>
-        public static readonly string TrivialClassDeclarations = @"
-using System.Runtime.InteropServices;
-partial class Basic
-{
-    [LibraryImportAttribute(""DoesNotExist"")]
-    public static partial void Method1();
+        public static readonly string TrivialClassDeclarations = """
+            using System.Runtime.InteropServices;
+            partial class Basic
+            {
+                [LibraryImportAttribute("DoesNotExist")]
+                public static partial void Method1();
 
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method2();
+                [LibraryImport("DoesNotExist")]
+                public static partial void Method2();
 
-    [System.Runtime.InteropServices.LibraryImportAttribute(""DoesNotExist"")]
-    public static partial void Method3();
+                [System.Runtime.InteropServices.LibraryImportAttribute("DoesNotExist")]
+                public static partial void Method3();
 
-    [System.Runtime.InteropServices.LibraryImport(""DoesNotExist"")]
-    public static partial void Method4();
-}
-";
+                [System.Runtime.InteropServices.LibraryImport("DoesNotExist")]
+                public static partial void Method4();
+            }
+            """;
         /// <summary>
         /// Trivial declaration of LibraryImport usage
         /// </summary>
-        public static readonly string TrivialStructDeclarations = @"
-using System.Runtime.InteropServices;
-partial struct Basic
-{
-    [LibraryImportAttribute(""DoesNotExist"")]
-    public static partial void Method1();
+        public static readonly string TrivialStructDeclarations = """
+            using System.Runtime.InteropServices;
+            partial struct Basic
+            {
+                [LibraryImportAttribute("DoesNotExist")]
+                public static partial void Method1();
 
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method2();
+                [LibraryImport("DoesNotExist")]
+                public static partial void Method2();
 
-    [System.Runtime.InteropServices.LibraryImportAttribute(""DoesNotExist"")]
-    public static partial void Method3();
+                [System.Runtime.InteropServices.LibraryImportAttribute("DoesNotExist")]
+                public static partial void Method3();
 
-    [System.Runtime.InteropServices.LibraryImport(""DoesNotExist"")]
-    public static partial void Method4();
-}
-";
+                [System.Runtime.InteropServices.LibraryImport("DoesNotExist")]
+                public static partial void Method4();
+            }
+            """;
 
         /// <summary>
         /// Declaration with multiple attributes
         /// </summary>
-        public static readonly string MultipleAttributes = @"
-using System;
-using System.Runtime.InteropServices;
+        public static readonly string MultipleAttributes = """
+            using System;
+            using System.Runtime.InteropServices;
 
-sealed class DummyAttribute : Attribute
-{
-    public DummyAttribute() { }
-}
+            sealed class DummyAttribute : Attribute
+            {
+                public DummyAttribute() { }
+            }
 
-sealed class Dummy2Attribute : Attribute
-{
-    public Dummy2Attribute(string input) { }
-}
+            sealed class Dummy2Attribute : Attribute
+            {
+                public Dummy2Attribute(string input) { }
+            }
 
-partial class Test
-{
-    [DummyAttribute]
-    [LibraryImport(""DoesNotExist""), Dummy2Attribute(""string value"")]
-    public static partial void Method();
-}
-";
+            partial class Test
+            {
+                [DummyAttribute]
+                [LibraryImport("DoesNotExist"), Dummy2Attribute("string value")]
+                public static partial void Method();
+            }
+            """;
 
         /// <summary>
         /// Validate nested namespaces are handled
         /// </summary>
-        public static readonly string NestedNamespace = @"
-using System.Runtime.InteropServices;
-namespace NS
-{
-    namespace InnerNS
-    {
-        partial class Test
-        {
-            [LibraryImport(""DoesNotExist"")]
-            public static partial void Method1();
-        }
-    }
-}
-namespace NS.InnerNS
-{
-    partial class Test
-    {
-        [LibraryImport(""DoesNotExist"")]
-        public static partial void Method2();
-    }
-}
-";
+        public static readonly string NestedNamespace = """
+            using System.Runtime.InteropServices;
+            namespace NS
+            {
+                namespace InnerNS
+                {
+                    partial class Test
+                    {
+                        [LibraryImport("DoesNotExist")]
+                        public static partial void Method1();
+                    }
+                }
+            }
+            namespace NS.InnerNS
+            {
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    public static partial void Method2();
+                }
+            }
+            """;
 
         /// <summary>
         /// Validate nested types are handled.
         /// </summary>
-        public static readonly string NestedTypes = @"
-using System.Runtime.InteropServices;
-namespace NS
-{
-    partial class OuterClass
-    {
-        partial class InnerClass
-        {
-            [LibraryImport(""DoesNotExist"")]
-            public static partial void Method();
-        }
-    }
-    partial struct OuterStruct
-    {
-        partial struct InnerStruct
-        {
-            [LibraryImport(""DoesNotExist"")]
-            public static partial void Method();
-        }
-    }
-    partial class OuterClass
-    {
-        partial struct InnerStruct
-        {
-            [LibraryImport(""DoesNotExist"")]
-            public static partial void Method();
-        }
-    }
-    partial struct OuterStruct
-    {
-        partial class InnerClass
-        {
-            [LibraryImport(""DoesNotExist"")]
-            public static partial void Method();
-        }
-    }
-}
-";
+        public static readonly string NestedTypes = """
+            using System.Runtime.InteropServices;
+            namespace NS
+            {
+                partial class OuterClass
+                {
+                    partial class InnerClass
+                    {
+                        [LibraryImport("DoesNotExist")]
+                        public static partial void Method();
+                    }
+                }
+                partial struct OuterStruct
+                {
+                    partial struct InnerStruct
+                    {
+                        [LibraryImport("DoesNotExist")]
+                        public static partial void Method();
+                    }
+                }
+                partial class OuterClass
+                {
+                    partial struct InnerStruct
+                    {
+                        [LibraryImport("DoesNotExist")]
+                        public static partial void Method();
+                    }
+                }
+                partial struct OuterStruct
+                {
+                    partial class InnerClass
+                    {
+                        [LibraryImport("DoesNotExist")]
+                        public static partial void Method();
+                    }
+                }
+            }
+            """;
 
         /// <summary>
         /// Containing type with and without unsafe
         /// </summary>
-        public static readonly string UnsafeContext = @"
-using System.Runtime.InteropServices;
-partial class Test
-{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method1();
-}
-unsafe partial class Test
-{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial int* Method2();
-}
-";
+        public static readonly string UnsafeContext = """
+            using System.Runtime.InteropServices;
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial void Method1();
+            }
+            unsafe partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial int* Method2();
+            }
+            """;
         /// <summary>
         /// Declaration with user defined EntryPoint.
         /// </summary>
-        public static readonly string UserDefinedEntryPoint = @"
-using System.Runtime.InteropServices;
-partial class Test
-{
-    [LibraryImport(""DoesNotExist"", EntryPoint=""UserDefinedEntryPoint"")]
-    public static partial void NotAnExport();
-}
-";
+        public static readonly string UserDefinedEntryPoint = """
+            using System.Runtime.InteropServices;
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist", EntryPoint="UserDefinedEntryPoint")]
+                public static partial void NotAnExport();
+            }
+            """;
 
         /// <summary>
         /// Declaration with all LibraryImport named arguments.
         /// </summary>
-        public static readonly string AllLibraryImportNamedArguments = @"
-using System.Runtime.InteropServices;
-partial class Test
-{
-    [LibraryImport(""DoesNotExist"",
-        StringMarshalling = StringMarshalling.Utf16,
-        EntryPoint = ""UserDefinedEntryPoint"",
-        SetLastError = true)]
-    public static partial void Method();
-}
-";
+        public static readonly string AllLibraryImportNamedArguments = """
+            using System.Runtime.InteropServices;
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist",
+                    StringMarshalling = StringMarshalling.Utf16,
+                    EntryPoint = "UserDefinedEntryPoint",
+                    SetLastError = true)]
+                public static partial void Method();
+            }
+            """;
 
         /// <summary>
         /// Declaration using various methods to compute constants in C#.
         /// </summary>
-        public static readonly string UseCSharpFeaturesForConstants = @"
-using System.Runtime.InteropServices;
-partial class Test
-{
-    private const bool IsTrue = true;
-    private const bool IsFalse = false;
-    private const string EntryPointName = nameof(Test) + nameof(IsFalse);
-    private const int One = 1;
-    private const int Two = 2;
+        public static readonly string UseCSharpFeaturesForConstants = """
+            using System.Runtime.InteropServices;
+            partial class Test
+            {
+                private const bool IsTrue = true;
+                private const bool IsFalse = false;
+                private const string EntryPointName = nameof(Test) + nameof(IsFalse);
+                private const int One = 1;
+                private const int Two = 2;
 
-    [LibraryImport(nameof(Test),
-        StringMarshalling = (StringMarshalling)2,
-        EntryPoint = EntryPointName,
-        SetLastError = IsFalse)]
-    public static partial void Method1();
+                [LibraryImport(nameof(Test),
+                    StringMarshalling = (StringMarshalling)2,
+                    EntryPoint = EntryPointName,
+                    SetLastError = IsFalse)]
+                public static partial void Method1();
 
-    [LibraryImport(nameof(Test) + ""Suffix"",
-        StringMarshalling = (StringMarshalling)Two,
-        EntryPoint = EntryPointName + ""Suffix"",
-        SetLastError = !IsTrue)]
-    public static partial void Method2();
+                [LibraryImport(nameof(Test) + "Suffix",
+                    StringMarshalling = (StringMarshalling)Two,
+                    EntryPoint = EntryPointName + "Suffix",
+                    SetLastError = !IsTrue)]
+                public static partial void Method2();
 
-    [LibraryImport($""{nameof(Test)}Suffix"",
-        StringMarshalling = (StringMarshalling)2,
-        EntryPoint = $""{EntryPointName}Suffix"",
-        SetLastError = 0 != 1)]
-    public static partial void Method3();
-}
-";
+                [LibraryImport($"{nameof(Test)}Suffix",
+                    StringMarshalling = (StringMarshalling)2,
+                    EntryPoint = $"{EntryPointName}Suffix",
+                    SetLastError = 0 != 1)]
+                public static partial void Method3();
+            }
+            """;
 
         /// <summary>
         /// Declaration with default parameters.
         /// </summary>
-        public static readonly string DefaultParameters = @"
-using System.Runtime.InteropServices;
-partial class Test
-{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method(int t = 0);
-}
-";
+        public static readonly string DefaultParameters = """
+            using System.Runtime.InteropServices;
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial void Method(int t = 0);
+            }
+            """;
 
         /// <summary>
         /// Declaration with LCIDConversionAttribute.
         /// </summary>
-        public static readonly string LCIDConversionAttribute = @"
-using System.Runtime.InteropServices;
-partial class Test
-{
-    [LCIDConversion(0)]
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method();
-}
-";
+        public static readonly string LCIDConversionAttribute = """
+            using System.Runtime.InteropServices;
+            partial class Test
+            {
+                [LCIDConversion(0)]
+                [LibraryImport("DoesNotExist")]
+                public static partial void Method();
+            }
+            """;
 
         /// <summary>
         /// Define a MarshalAsAttribute with a customer marshaller to parameters and return types.
         /// </summary>
-        public static readonly string MarshalAsCustomMarshalerOnTypes = @"
-using System;
-using System.Runtime.InteropServices;
-namespace NS
-{
-    class MyCustomMarshaler : ICustomMarshaler
-    {
-        static ICustomMarshaler GetInstance(string pstrCookie)
-            => new MyCustomMarshaler();
+        public static readonly string MarshalAsCustomMarshalerOnTypes = """
+            using System;
+            using System.Runtime.InteropServices;
+            namespace NS
+            {
+                class MyCustomMarshaler : ICustomMarshaler
+                {
+                    static ICustomMarshaler GetInstance(string pstrCookie)
+                        => new MyCustomMarshaler();
 
-        public void CleanUpManagedData(object ManagedObj)
-            => throw new NotImplementedException();
+                    public void CleanUpManagedData(object ManagedObj)
+                        => throw new NotImplementedException();
 
-        public void CleanUpNativeData(IntPtr pNativeData)
-            => throw new NotImplementedException();
+                    public void CleanUpNativeData(IntPtr pNativeData)
+                        => throw new NotImplementedException();
 
-        public int GetNativeDataSize()
-            => throw new NotImplementedException();
+                    public int GetNativeDataSize()
+                        => throw new NotImplementedException();
 
-        public IntPtr MarshalManagedToNative(object ManagedObj)
-            => throw new NotImplementedException();
+                    public IntPtr MarshalManagedToNative(object ManagedObj)
+                        => throw new NotImplementedException();
 
-        public object MarshalNativeToManaged(IntPtr pNativeData)
-            => throw new NotImplementedException();
-    }
-}
+                    public object MarshalNativeToManaged(IntPtr pNativeData)
+                        => throw new NotImplementedException();
+                }
+            }
 
-partial class Test
-{
-    [LibraryImport(""DoesNotExist"")]
-    [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(NS.MyCustomMarshaler), MarshalCookie=""COOKIE1"")]
-    public static partial bool Method1([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(NS.MyCustomMarshaler), MarshalCookie=""COOKIE2"")]bool t);
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(NS.MyCustomMarshaler), MarshalCookie="COOKIE1")]
+                public static partial bool Method1([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(NS.MyCustomMarshaler), MarshalCookie="COOKIE2")]bool t);
 
-    [LibraryImport(""DoesNotExist"")]
-    [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalType = ""NS.MyCustomMarshaler"", MarshalCookie=""COOKIE3"")]
-    public static partial bool Method2([MarshalAs(UnmanagedType.CustomMarshaler, MarshalType = ""NS.MyCustomMarshaler"", MarshalCookie=""COOKIE4"")]bool t);
-}
-";
+                [LibraryImport("DoesNotExist")]
+                [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalType = "NS.MyCustomMarshaler", MarshalCookie="COOKIE3")]
+                public static partial bool Method2([MarshalAs(UnmanagedType.CustomMarshaler, MarshalType = "NS.MyCustomMarshaler", MarshalCookie="COOKIE4")]bool t);
+            }
+            """;
 
         /// <summary>
         /// Declaration with user defined attributes with prefixed name.
         /// </summary>
-        public static readonly string UserDefinedPrefixedAttributes = @"
-using System;
-using System.Runtime.InteropServices;
+        public static readonly string UserDefinedPrefixedAttributes = """
+            using System;
+            using System.Runtime.InteropServices;
 
-namespace System.Runtime.InteropServices
-{
-    // Prefix with ATTRIBUTE so the lengths will match during check.
-    sealed class ATTRIBUTELibraryImportAttribute : Attribute
-    {
-        public ATTRIBUTELibraryImportAttribute(string a) { }
-    }
-}
+            namespace System.Runtime.InteropServices
+            {
+                // Prefix with ATTRIBUTE so the lengths will match during check.
+                sealed class ATTRIBUTELibraryImportAttribute : Attribute
+                {
+                    public ATTRIBUTELibraryImportAttribute(string a) { }
+                }
+            }
 
-partial class Test
-{
-    [ATTRIBUTELibraryImportAttribute(""DoesNotExist"")]
-    public static partial void Method1();
+            partial class Test
+            {
+                [ATTRIBUTELibraryImportAttribute("DoesNotExist")]
+                public static partial void Method1();
 
-    [ATTRIBUTELibraryImport(""DoesNotExist"")]
-    public static partial void Method2();
+                [ATTRIBUTELibraryImport("DoesNotExist")]
+                public static partial void Method2();
 
-    [System.Runtime.InteropServices.ATTRIBUTELibraryImport(""DoesNotExist"")]
-    public static partial void Method3();
-}
-";
+                [System.Runtime.InteropServices.ATTRIBUTELibraryImport("DoesNotExist")]
+                public static partial void Method3();
+            }
+            """;
 
         public static readonly string DisableRuntimeMarshalling = "[assembly:System.Runtime.CompilerServices.DisableRuntimeMarshalling]";
 
@@ -380,19 +380,19 @@ partial class Test
         /// <summary>
         /// Declaration with parameters with <see cref="StringMarshalling"/> set.
         /// </summary>
-        public static string BasicParametersAndModifiersWithStringMarshalling(string typename, StringMarshalling value, string preDeclaration = "") => $@"
-using System.Runtime.InteropServices;
-{preDeclaration}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"", StringMarshalling = StringMarshalling.{value})]
-    public static partial {typename} Method(
-        {typename} p,
-        in {typename} pIn,
-        ref {typename} pRef,
-        out {typename} pOut);
-}}
-";
+        public static string BasicParametersAndModifiersWithStringMarshalling(string typename, StringMarshalling value, string preDeclaration = "") => $$"""
+            using System.Runtime.InteropServices;
+            {{preDeclaration}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist", StringMarshalling = StringMarshalling.{{value}})]
+                public static partial {{typename}} Method(
+                    {{typename}} p,
+                    in {{typename}} pIn,
+                    ref {{typename}} pRef,
+                    out {{typename}} pOut);
+            }
+            """;
 
         public static string BasicParametersAndModifiersWithStringMarshalling<T>(StringMarshalling value, string preDeclaration = "") =>
             BasicParametersAndModifiersWithStringMarshalling(typeof(T).ToString(), value, preDeclaration);
@@ -400,20 +400,20 @@ partial class Test
         /// <summary>
         /// Declaration with parameters with <see cref="StringMarshallingCustomType"/> set.
         /// </summary>
-        public static string BasicParametersAndModifiersWithStringMarshallingCustomType(string typeName, string stringMarshallingCustomTypeName, string preDeclaration = "") => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"", StringMarshallingCustomType = typeof({stringMarshallingCustomTypeName}))]
-    public static partial {typeName} Method(
-        {typeName} p,
-        in {typeName} pIn,
-        ref {typeName} pRef,
-        out {typeName} pOut);
-}}
-";
+        public static string BasicParametersAndModifiersWithStringMarshallingCustomType(string typeName, string stringMarshallingCustomTypeName, string preDeclaration = "") => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist", StringMarshallingCustomType = typeof({{stringMarshallingCustomTypeName}}))]
+                public static partial {{typeName}} Method(
+                    {{typeName}} p,
+                    in {{typeName}} pIn,
+                    ref {{typeName}} pRef,
+                    out {{typeName}} pOut);
+            }
+            """;
 
         public static string BasicParametersAndModifiersWithStringMarshallingCustomType<T>(string stringMarshallingCustomTypeName, string preDeclaration = "") =>
             BasicParametersAndModifiersWithStringMarshallingCustomType(typeof(T).ToString(), stringMarshallingCustomTypeName, preDeclaration);
@@ -421,151 +421,158 @@ partial class Test
         public static string CustomStringMarshallingParametersAndModifiers<T>()
         {
             string typeName = typeof(T).ToString();
-            return BasicParametersAndModifiersWithStringMarshallingCustomType(typeName, "Marshaller", DisableRuntimeMarshalling) + $@"
-[CustomMarshaller(typeof({typeName}), MarshalMode.Default, typeof(Marshaller))]
-static class Marshaller
-{{
-    public static nint ConvertToUnmanaged({typeName} s) => default;
-
-    public static {typeName} ConvertToManaged(nint i) => default;
-}}";
+            return BasicParametersAndModifiersWithStringMarshallingCustomType(typeName, "Marshaller", DisableRuntimeMarshalling) + $$"""
+                [CustomMarshaller(typeof({{typeName}}), MarshalMode.Default, typeof(Marshaller))]
+                static class Marshaller
+                {
+                    public static nint ConvertToUnmanaged({{typeName}} s) => default;
+                
+                    public static {{typeName}} ConvertToManaged(nint i) => default;
+                }
+                """;
         }
 
         /// <summary>
         /// Declaration with parameters.
         /// </summary>
-        public static string BasicParametersAndModifiers(string typeName, string preDeclaration = "") => $@"
-using System.Runtime.InteropServices;
-{preDeclaration}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial {typeName} Method(
-        {typeName} p,
-        in {typeName} pIn,
-        ref {typeName} pRef,
-        out {typeName} pOut);
-}}";
+        public static string BasicParametersAndModifiers(string typeName, string preDeclaration = "") => $$"""
+            using System.Runtime.InteropServices;
+            {{preDeclaration}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial {{typeName}} Method(
+                    {{typeName}} p,
+                    in {{typeName}} pIn,
+                    ref {{typeName}} pRef,
+                    out {{typeName}} pOut);
+            }
+            """;
 
         /// <summary>
         /// Declaration with parameters.
         /// </summary>
-        public static string BasicParametersAndModifiersNoRef(string typeName, string preDeclaration = "") => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial {typeName} Method(
-        {typeName} p,
-        in {typeName} pIn,
-        out {typeName} pOut);
-}}";
+        public static string BasicParametersAndModifiersNoRef(string typeName, string preDeclaration = "") => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial {{typeName}} Method(
+                    {{typeName}} p,
+                    in {{typeName}} pIn,
+                    out {{typeName}} pOut);
+            }
+            """;
 
         /// <summary>
         /// Declaration with parameters and unsafe.
         /// </summary>
-        public static string BasicParametersAndModifiersUnsafe(string typeName, string preDeclaration = "") => $@"
-using System.Runtime.InteropServices;
-{preDeclaration}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static unsafe partial {typeName} Method(
-        {typeName} p,
-        in {typeName} pIn,
-        ref {typeName} pRef,
-        out {typeName} pOut);
-}}";
+        public static string BasicParametersAndModifiersUnsafe(string typeName, string preDeclaration = "") => $$"""
+            using System.Runtime.InteropServices;
+            {{preDeclaration}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static unsafe partial {{typeName}} Method(
+                    {{typeName}} p,
+                    in {{typeName}} pIn,
+                    ref {{typeName}} pRef,
+                    out {{typeName}} pOut);
+            }
+            """;
 
         public static string BasicParametersAndModifiers<T>(string preDeclaration = "") => BasicParametersAndModifiers(typeof(T).ToString(), preDeclaration);
 
         /// <summary>
         /// Declaration with [In, Out] style attributes on a by-value parameter.
         /// </summary>
-        public static string ByValueParameterWithModifier(string typeName, string attributeName, string preDeclaration = "") => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method(
-        [{attributeName}] {typeName} p);
-}}";
+        public static string ByValueParameterWithModifier(string typeName, string attributeName, string preDeclaration = "") => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial void Method(
+                    [{{attributeName}}] {{typeName}} p);
+            }
+            """;
 
         public static string ByValueParameterWithModifier<T>(string attributeName, string preDeclaration = "") => ByValueParameterWithModifier(typeof(T).ToString(), attributeName, preDeclaration);
 
         /// <summary>
         /// Declaration with by-value parameter with custom name.
         /// </summary>
-        public static string ByValueParameterWithName(string methodName, string paramName) => $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void {methodName}(
-        int {paramName});
-}}";
+        public static string ByValueParameterWithName(string methodName, string paramName) => $$"""
+            using System.Runtime.InteropServices;
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial void {{methodName}}(
+                    int {{paramName}});
+            }
+            """;
 
         /// <summary>
         /// Declaration with parameters with MarshalAs.
         /// </summary>
-        public static string MarshalAsParametersAndModifiers(string typeName, UnmanagedType unmanagedType) => $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    [return: MarshalAs(UnmanagedType.{unmanagedType})]
-    public static partial {typeName} Method(
-        [MarshalAs(UnmanagedType.{unmanagedType})] {typeName} p,
-        [MarshalAs(UnmanagedType.{unmanagedType})] in {typeName} pIn,
-        [MarshalAs(UnmanagedType.{unmanagedType})] ref {typeName} pRef,
-        [MarshalAs(UnmanagedType.{unmanagedType})] out {typeName} pOut);
-}}
-";
+        public static string MarshalAsParametersAndModifiers(string typeName, UnmanagedType unmanagedType) => $$"""
+            using System.Runtime.InteropServices;
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                [return: MarshalAs(UnmanagedType.{{unmanagedType}})]
+                public static partial {{typeName}} Method(
+                    [MarshalAs(UnmanagedType.{{unmanagedType}})] {{typeName}} p,
+                    [MarshalAs(UnmanagedType.{{unmanagedType}})] in {{typeName}} pIn,
+                    [MarshalAs(UnmanagedType.{{unmanagedType}})] ref {{typeName}} pRef,
+                    [MarshalAs(UnmanagedType.{{unmanagedType}})] out {{typeName}} pOut);
+            }
+            """;
 
         /// <summary>
         /// Declaration with parameters with MarshalAs.
         /// </summary>
-        public static string MarshalAsParametersAndModifiersUnsafe(string typeName, UnmanagedType unmanagedType) => $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    [return: MarshalAs(UnmanagedType.{unmanagedType})]
-    public static unsafe partial {typeName} Method(
-        [MarshalAs(UnmanagedType.{unmanagedType})] {typeName} p,
-        [MarshalAs(UnmanagedType.{unmanagedType})] in {typeName} pIn,
-        [MarshalAs(UnmanagedType.{unmanagedType})] ref {typeName} pRef,
-        [MarshalAs(UnmanagedType.{unmanagedType})] out {typeName} pOut);
-}}
-";
+        public static string MarshalAsParametersAndModifiersUnsafe(string typeName, UnmanagedType unmanagedType) => $$"""
+            using System.Runtime.InteropServices;
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                [return: MarshalAs(UnmanagedType.{{unmanagedType}})]
+                public static unsafe partial {{typeName}} Method(
+                    [MarshalAs(UnmanagedType.{{unmanagedType}})] {{typeName}} p,
+                    [MarshalAs(UnmanagedType.{{unmanagedType}})] in {{typeName}} pIn,
+                    [MarshalAs(UnmanagedType.{{unmanagedType}})] ref {{typeName}} pRef,
+                    [MarshalAs(UnmanagedType.{{unmanagedType}})] out {{typeName}} pOut);
+            }
+            """;
 
         public static string MarshalAsParametersAndModifiers<T>(UnmanagedType unmanagedType) => MarshalAsParametersAndModifiers(typeof(T).ToString(), unmanagedType);
 
         /// <summary>
         /// Declaration with enum parameters.
         /// </summary>
-        public static string EnumParameters => $@"
-using System.Runtime.InteropServices;
-using NS;
+        public static string EnumParameters => """
+            using System.Runtime.InteropServices;
+            using NS;
 
-namespace NS
-{{
-    enum MyEnum {{ A, B, C }}
-}}
+            namespace NS
+            {
+                enum MyEnum { A, B, C }
+            }
 
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial MyEnum Method(
-        MyEnum p,
-        in MyEnum pIn,
-        ref MyEnum pRef,
-        out MyEnum pOut);
-}}";
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial MyEnum Method(
+                    MyEnum p,
+                    in MyEnum pIn,
+                    ref MyEnum pRef,
+                    out MyEnum pOut);
+            }
+            """;
 
         /// <summary>
         /// Declaration with pointer parameters.
@@ -575,654 +582,680 @@ partial class Test
         /// <summary>
         /// Declaration with PreserveSig = false.
         /// </summary>
-        public static string SetLastErrorTrue(string typeName) => $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"", SetLastError = true)]
-    public static partial {typeName} Method({typeName} p);
-}}";
+        public static string SetLastErrorTrue(string typeName) => $$"""
+            using System.Runtime.InteropServices;
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist", SetLastError = true)]
+                public static partial {{typeName}} Method({{typeName}} p);
+            }
+            """;
 
         public static string SetLastErrorTrue<T>() => SetLastErrorTrue(typeof(T).ToString());
 
-        public static string DelegateParametersAndModifiers = BasicParametersAndModifiers("MyDelegate") + @"
-delegate int MyDelegate(int a);";
-        public static string DelegateMarshalAsParametersAndModifiers = MarshalAsParametersAndModifiers("MyDelegate", UnmanagedType.FunctionPtr) + @"
-delegate int MyDelegate(int a);";
+        public static string DelegateParametersAndModifiers = BasicParametersAndModifiers("MyDelegate") + """
+            delegate int MyDelegate(int a);
+            """;
+        public static string DelegateMarshalAsParametersAndModifiers = MarshalAsParametersAndModifiers("MyDelegate", UnmanagedType.FunctionPtr) + """
+            delegate int MyDelegate(int a);
+            """;
 
-        private static string BlittableMyStruct(string modifier = "") => $@"#pragma warning disable CS0169
-{modifier} unsafe struct MyStruct
-{{
-    private int i;
-    private short s;
-    private long l;
-    private double d;
-    private int* iptr;
-    private short* sptr;
-    private long* lptr;
-    private double* dptr;
-    private void* vptr;
-}}";
+        private static string BlittableMyStruct(string modifier = "") => $$$"""
+            #pragma warning disable CS0169
+            {{{modifier}}} unsafe struct MyStruct
+            {
+                private int i;
+                private short s;
+                private long l;
+                private double d;
+                private int* iptr;
+                private short* sptr;
+                private long* lptr;
+                private double* dptr;
+                private void* vptr;
+            }
+            """;
 
-        public static string BlittableStructParametersAndModifiers(string attr) => BasicParametersAndModifiers("MyStruct", attr) + $@"
-{BlittableMyStruct()}
-";
+        public static string BlittableStructParametersAndModifiers(string attr) => $$"""
+            {{BasicParametersAndModifiers("MyStruct", attr)}}
+            {{BlittableMyStruct()}}
+            """;
 
-        public static string MarshalAsArrayParametersAndModifiers(string elementType, string preDeclaration = "") => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    [return:MarshalAs(UnmanagedType.LPArray, SizeConst=10)]
-    public static partial {elementType}[] Method(
-        {elementType}[] p,
-        in {elementType}[] pIn,
-        int pRefSize,
-        [MarshalAs(UnmanagedType.LPArray, SizeParamIndex=2)] ref {elementType}[] pRef,
-        [MarshalAs(UnmanagedType.LPArray, SizeParamIndex=5, SizeConst=4)] out {elementType}[] pOut,
-        out int pOutSize
-        );
-}}";
+        public static string MarshalAsArrayParametersAndModifiers(string elementType, string preDeclaration = "") => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                [return:MarshalAs(UnmanagedType.LPArray, SizeConst=10)]
+                public static partial {{elementType}}[] Method(
+                    {{elementType}}[] p,
+                    in {{elementType}}[] pIn,
+                    int pRefSize,
+                    [MarshalAs(UnmanagedType.LPArray, SizeParamIndex=2)] ref {{elementType}}[] pRef,
+                    [MarshalAs(UnmanagedType.LPArray, SizeParamIndex=5, SizeConst=4)] out {{elementType}}[] pOut,
+                    out int pOutSize
+                    );
+            }
+            """;
 
         public static string MarshalAsArrayParametersAndModifiers<T>(string preDeclaration = "") => MarshalAsArrayParametersAndModifiers(typeof(T).ToString(), preDeclaration);
 
-        public static string MarshalAsArrayParameterWithSizeParam(string sizeParamType, bool isByRef) => $@"
-using System.Runtime.InteropServices;
-{DisableRuntimeMarshalling}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method(
-        {(isByRef ? "ref" : "")} {sizeParamType} pRefSize,
-        [MarshalAs(UnmanagedType.LPArray, SizeParamIndex=0)] ref int[] pRef
-        );
-}}";
+        public static string MarshalAsArrayParameterWithSizeParam(string sizeParamType, bool isByRef) => $$"""
+            using System.Runtime.InteropServices;
+            {{DisableRuntimeMarshalling}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial void Method(
+                    {{(isByRef ? "ref" : "")}} {{sizeParamType}} pRefSize,
+                    [MarshalAs(UnmanagedType.LPArray, SizeParamIndex=0)] ref int[] pRef
+                    );
+            }
+            """;
 
         public static string MarshalAsArrayParameterWithSizeParam<T>(bool isByRef) => MarshalAsArrayParameterWithSizeParam(typeof(T).ToString(), isByRef);
 
 
-        public static string MarshalAsArrayParameterWithNestedMarshalInfo(string elementType, UnmanagedType nestedMarshalInfo, string preDeclaration = "") => $@"
-using System.Runtime.InteropServices;
-{preDeclaration}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method(
-        [MarshalAs(UnmanagedType.LPArray, ArraySubType=UnmanagedType.{nestedMarshalInfo})] {elementType}[] pRef
-        );
-}}";
+        public static string MarshalAsArrayParameterWithNestedMarshalInfo(string elementType, UnmanagedType nestedMarshalInfo, string preDeclaration = "") => $$"""
+            using System.Runtime.InteropServices;
+            {{preDeclaration}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial void Method(
+                    [MarshalAs(UnmanagedType.LPArray, ArraySubType=UnmanagedType.{{nestedMarshalInfo}})] {{elementType}}[] pRef
+                    );
+            }
+            """;
 
         public static string MarshalAsArrayParameterWithNestedMarshalInfo<T>(UnmanagedType nestedMarshalType, string preDeclaration = "") => MarshalAsArrayParameterWithNestedMarshalInfo(typeof(T).ToString(), nestedMarshalType, preDeclaration);
 
         /// <summary>
         /// Declaration with parameters with MarshalAs.
         /// </summary>
-        public static string MarshalUsingParametersAndModifiers(string typeName, string nativeTypeName, string preDeclaration = "") => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    [return: MarshalUsing(typeof({nativeTypeName}))]
-    public static partial {typeName} Method(
-        [MarshalUsing(typeof({nativeTypeName}))] {typeName} p,
-        [MarshalUsing(typeof({nativeTypeName}))] in {typeName} pIn,
-        [MarshalUsing(typeof({nativeTypeName}))] ref {typeName} pRef,
-        [MarshalUsing(typeof({nativeTypeName}))] out {typeName} pOut);
-}}
-";
+        public static string MarshalUsingParametersAndModifiers(string typeName, string nativeTypeName, string preDeclaration = "") => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                [return: MarshalUsing(typeof({{nativeTypeName}}))]
+                public static partial {{typeName}} Method(
+                    [MarshalUsing(typeof({{nativeTypeName}}))] {{typeName}} p,
+                    [MarshalUsing(typeof({{nativeTypeName}}))] in {{typeName}} pIn,
+                    [MarshalUsing(typeof({{nativeTypeName}}))] ref {{typeName}} pRef,
+                    [MarshalUsing(typeof({{nativeTypeName}}))] out {{typeName}} pOut);
+            }
+            """;
+        public static string BasicParameterWithByRefModifier(string byRefKind, string typeName, string preDeclaration = "") => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial void Method(
+                    {{byRefKind}} {{typeName}} p);
+            }
+            """;
 
-        public static string BasicParameterWithByRefModifier(string byRefKind, string typeName, string preDeclaration = "") => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method(
-        {byRefKind} {typeName} p);
-}}";
+        public static string BasicParameterByValue(string typeName, string preDeclaration = "") => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial void Method(
+                    {{typeName}} p);
+            }
+            """;
 
-        public static string BasicParameterByValue(string typeName, string preDeclaration = "") => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method(
-        {typeName} p);
-}}";
+        public static string BasicReturnType(string typeName, string preDeclaration = "") => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial {{typeName}} Method();
+            }
+            """;
 
-        public static string BasicReturnType(string typeName, string preDeclaration = "") => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{preDeclaration}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial {typeName} Method();
-}}";
+        public static string BasicReturnAndParameterByValue(string returnType, string parameterType, string preDeclaration = "") => $$"""
+            using System.Runtime.InteropServices;
+            {{preDeclaration}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial {{returnType}} Method({{parameterType}} p);
+            }
+            """;
 
-        public static string BasicReturnAndParameterByValue(string returnType, string parameterType, string preDeclaration = "") => $@"
-using System.Runtime.InteropServices;
-{preDeclaration}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial {returnType} Method({parameterType} p);
-}}";
-
-        public static string SafeHandleWithCustomDefaultConstructorAccessibility(bool privateCtor) => BasicParametersAndModifiers("MySafeHandle") + $@"
-class MySafeHandle : SafeHandle
-{{
-    {(privateCtor ? "private" : "public")} MySafeHandle() : base(System.IntPtr.Zero, true) {{ }}
-
-    public override bool IsInvalid => handle == System.IntPtr.Zero;
-
-    protected override bool ReleaseHandle() => true;
-}}";
+        public static string SafeHandleWithCustomDefaultConstructorAccessibility(bool privateCtor) => BasicParametersAndModifiers("MySafeHandle") + $$"""
+            class MySafeHandle : SafeHandle
+            {
+                {{(privateCtor ? "private" : "public")}} MySafeHandle() : base(System.IntPtr.Zero, true) { }
+            
+                public override bool IsInvalid => handle == System.IntPtr.Zero;
+            
+                protected override bool ReleaseHandle() => true;
+            }
+            """;
 
         public static string PreprocessorIfAroundFullFunctionDefinition(string define) =>
-            $@"
-partial class Test
-{{
-#if {define}
-    [System.Runtime.InteropServices.LibraryImport(""DoesNotExist"")]
-    public static partial int Method(
-        int p,
-        in int pIn,
-        out int pOut);
-#endif
-}}";
+            $$"""
+            partial class Test
+            {
+            #if {{define}}
+                [System.Runtime.InteropServices.LibraryImport("DoesNotExist")]
+                public static partial int Method(
+                    int p,
+                    in int pIn,
+                    out int pOut);
+            #endif
+            }
+            """;
 
         public static string PreprocessorIfAroundFullFunctionDefinitionWithFollowingFunction(string define) =>
-            $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-#if {define}
-    [LibraryImport(""DoesNotExist"")]
-    public static partial int Method(
-        int p,
-        in int pIn,
-        out int pOut);
-#endif
-    public static int Method2(
-        SafeHandle p) => throw null;
-}}";
+            $$"""
+            using System.Runtime.InteropServices;
+            partial class Test
+            {
+            #if {{define}}
+                [LibraryImport("DoesNotExist")]
+                public static partial int Method(
+                    int p,
+                    in int pIn,
+                    out int pOut);
+            #endif
+                public static int Method2(
+                    SafeHandle p) => throw null;
+            }
+            """;
 
         public static string PreprocessorIfAfterAttributeAroundFunction(string define) =>
-            $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-#if {define}
-    public static partial int Method(
-        int p,
-        in int pIn,
-        out int pOut);
-#else
-    public static partial int Method2(
-        int p,
-        in int pIn,
-        out int pOut);
-#endif
-}}";
+            $$"""
+            using System.Runtime.InteropServices;
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+            #if {{define}}
+                public static partial int Method(
+                    int p,
+                    in int pIn,
+                    out int pOut);
+            #else
+                public static partial int Method2(
+                    int p,
+                    in int pIn,
+                    out int pOut);
+            #endif
+            }
+            """;
 
         public static string PreprocessorIfAfterAttributeAroundFunctionAdditionalFunctionAfter(string define) =>
-            $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-#if {define}
-    public static partial int Method(
-        int p,
-        in int pIn,
-        out int pOut);
-#else
-    public static partial int Method2(
-        int p,
-        in int pIn,
-        out int pOut);
-#endif
-    public static int Foo() => throw null;
-}}";
+            $$"""
+            using System.Runtime.InteropServices;
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+            #if {{define}}
+                public static partial int Method(
+                    int p,
+                    in int pIn,
+                    out int pOut);
+            #else
+                public static partial int Method2(
+                    int p,
+                    in int pIn,
+                    out int pOut);
+            #endif
+                public static int Foo() => throw null;
+            }
+            """;
 
-        public static string MaybeBlittableGenericTypeParametersAndModifiers(string typeArgument) => BasicParametersAndModifiers($"Generic<{typeArgument}>", DisableRuntimeMarshalling) + @"
-struct Generic<T>
-{
-#pragma warning disable CS0649
-    public T field;
-}
-";
+        public static string MaybeBlittableGenericTypeParametersAndModifiers(string typeArgument) => BasicParametersAndModifiers($"Generic<{typeArgument}>", DisableRuntimeMarshalling) + """
+            struct Generic<T>
+            {
+            #pragma warning disable CS0649
+                public T field;
+            }
+            """;
 
         public static string MaybeBlittableGenericTypeParametersAndModifiers<T>() =>
             MaybeBlittableGenericTypeParametersAndModifiers(typeof(T).ToString());
 
-        public static string RecursiveImplicitlyBlittableStruct => BasicParametersAndModifiers("RecursiveStruct", DisableRuntimeMarshalling) + @"
-struct RecursiveStruct
-{
-    RecursiveStruct s;
-    int i;
-}";
-        public static string MutuallyRecursiveImplicitlyBlittableStruct => BasicParametersAndModifiers("RecursiveStruct1", DisableRuntimeMarshalling) + @"
-struct RecursiveStruct1
-{
-    RecursiveStruct2 s;
-    int i;
-}
+        public static string RecursiveImplicitlyBlittableStruct => BasicParametersAndModifiers("RecursiveStruct", DisableRuntimeMarshalling) + """
+            struct RecursiveStruct
+            {
+                RecursiveStruct s;
+                int i;
+            }
+            """;
+        public static string MutuallyRecursiveImplicitlyBlittableStruct => BasicParametersAndModifiers("RecursiveStruct1", DisableRuntimeMarshalling) + """
+            struct RecursiveStruct1
+            {
+                RecursiveStruct2 s;
+                int i;
+            }
 
-struct RecursiveStruct2
-{
-    RecursiveStruct1 s;
-    int i;
-}";
+            struct RecursiveStruct2
+            {
+                RecursiveStruct1 s;
+                int i;
+            }
+            """;
 
-        public static string MarshalUsingCollectionCountInfoParametersAndModifiers(string collectionType) => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{DisableRuntimeMarshalling}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    [return:MarshalUsing(ConstantElementCount=10)]
-    public static partial {collectionType} Method(
-        {collectionType} p,
-        in {collectionType} pIn,
-        int pRefSize,
-        [MarshalUsing(CountElementName = ""pRefSize"")] ref {collectionType} pRef,
-        [MarshalUsing(CountElementName = ""pOutSize"")] out {collectionType} pOut,
-        out int pOutSize
-        );
-}}";
+        public static string MarshalUsingCollectionCountInfoParametersAndModifiers(string collectionType) => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{DisableRuntimeMarshalling}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                [return:MarshalUsing(ConstantElementCount=10)]
+                public static partial {{collectionType}} Method(
+                    {{collectionType}} p,
+                    in {{collectionType}} pIn,
+                    int pRefSize,
+                    [MarshalUsing(CountElementName = "pRefSize")] ref {{collectionType}} pRef,
+                    [MarshalUsing(CountElementName = "pOutSize")] out {{collectionType}} pOut,
+                    out int pOutSize
+                    );
+            }
+            """;
 
         public static string MarshalUsingCollectionCountInfoParametersAndModifiers<T>() => MarshalUsingCollectionCountInfoParametersAndModifiers(typeof(T).ToString());
 
-        public static string MarshalUsingCollectionParametersAndModifiers(string collectionType, string marshallerType) => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{DisableRuntimeMarshalling}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    [return:MarshalUsing(typeof({marshallerType}), ConstantElementCount=10)]
-    public static partial {collectionType} Method(
-        [MarshalUsing(typeof({marshallerType}))] {collectionType} p,
-        [MarshalUsing(typeof({marshallerType}))] in {collectionType} pIn,
-        int pRefSize,
-        [MarshalUsing(typeof({marshallerType}), CountElementName = ""pRefSize"")] ref {collectionType} pRef,
-        [MarshalUsing(typeof({marshallerType}), CountElementName = ""pOutSize"")] out {collectionType} pOut,
-        out int pOutSize
-        );
-}}";
+        public static string MarshalUsingCollectionParametersAndModifiers(string collectionType, string marshallerType) => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{DisableRuntimeMarshalling}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                [return:MarshalUsing(typeof({{marshallerType}}), ConstantElementCount=10)]
+                public static partial {{collectionType}} Method(
+                    [MarshalUsing(typeof({{marshallerType}}))] {{collectionType}} p,
+                    [MarshalUsing(typeof({{marshallerType}}))] in {{collectionType}} pIn,
+                    int pRefSize,
+                    [MarshalUsing(typeof({{marshallerType}}), CountElementName = "pRefSize")] ref {{collectionType}} pRef,
+                    [MarshalUsing(typeof({{marshallerType}}), CountElementName = "pOutSize")] out {{collectionType}} pOut,
+                    out int pOutSize
+                    );
+            }
+            """;
 
-        public static string MarshalUsingCollectionReturnValueLength(string collectionType, string marshallerType) => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{DisableRuntimeMarshalling}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial int Method(
-        [MarshalUsing(typeof({marshallerType}), CountElementName = MarshalUsingAttribute.ReturnsCountValue)] out {collectionType} pOut
-        );
-}}";
+        public static string MarshalUsingCollectionReturnValueLength(string collectionType, string marshallerType) => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{DisableRuntimeMarshalling}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial int Method(
+                    [MarshalUsing(typeof({{marshallerType}}), CountElementName = MarshalUsingAttribute.ReturnsCountValue)] out {{collectionType}} pOut
+                    );
+            }
+            """;
 
-        public static string MarshalUsingCollectionOutConstantLength(string collectionType, string predeclaration = "") => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{predeclaration}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial int Method(
-        [MarshalUsing(ConstantElementCount = 10)] out {collectionType} pOut);
-}}
-";
+        public static string MarshalUsingCollectionOutConstantLength(string collectionType, string predeclaration = "") => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{predeclaration}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial int Method(
+                    [MarshalUsing(ConstantElementCount = 10)] out {{collectionType}} pOut);
+            }
+            """;
 
-        public static string MarshalUsingCollectionReturnConstantLength(string collectionType, string predeclaration = "") => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{predeclaration}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    [return:MarshalUsing(ConstantElementCount = 10)]
-    public static partial {collectionType} Method();
-}}
-";
-        public static string CustomElementMarshalling(string collectionType, string elementMarshaller, string predeclaration = "") => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{predeclaration}
-{DisableRuntimeMarshalling}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    [return:MarshalUsing(ConstantElementCount=10)]
-    [return:MarshalUsing(typeof({elementMarshaller}), ElementIndirectionDepth = 1)]
-    public static partial {collectionType} Method(
-        [MarshalUsing(typeof({elementMarshaller}), ElementIndirectionDepth = 1)] {collectionType} p,
-        [MarshalUsing(typeof({elementMarshaller}), ElementIndirectionDepth = 1)] in {collectionType} pIn,
-        int pRefSize,
-        [MarshalUsing(CountElementName = ""pRefSize""), MarshalUsing(typeof({elementMarshaller}), ElementIndirectionDepth = 1)] ref {collectionType} pRef,
-        [MarshalUsing(CountElementName = ""pOutSize"")][MarshalUsing(typeof({elementMarshaller}), ElementIndirectionDepth = 1)] out {collectionType} pOut,
-        out int pOutSize
-        );
-}}
-";
+        public static string MarshalUsingCollectionReturnConstantLength(string collectionType, string predeclaration = "") => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{predeclaration}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                [return:MarshalUsing(ConstantElementCount = 10)]
+                public static partial {{collectionType}} Method();
+            }
+            """;
+        public static string CustomElementMarshalling(string collectionType, string elementMarshaller, string predeclaration = "") => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{predeclaration}}
+            {{DisableRuntimeMarshalling}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                [return:MarshalUsing(ConstantElementCount=10)]
+                [return:MarshalUsing(typeof({{elementMarshaller}}), ElementIndirectionDepth = 1)]
+                public static partial {{collectionType}} Method(
+                    [MarshalUsing(typeof({{elementMarshaller}}), ElementIndirectionDepth = 1)] {{collectionType}} p,
+                    [MarshalUsing(typeof({{elementMarshaller}}), ElementIndirectionDepth = 1)] in {{collectionType}} pIn,
+                    int pRefSize,
+                    [MarshalUsing(CountElementName = "pRefSize"), MarshalUsing(typeof({{elementMarshaller}}), ElementIndirectionDepth = 1)] ref {{collectionType}} pRef,
+                    [MarshalUsing(CountElementName = "pOutSize")][MarshalUsing(typeof({{elementMarshaller}}), ElementIndirectionDepth = 1)] out {{collectionType}} pOut,
+                    out int pOutSize
+                    );
+            }
+            """;
 
-        public static string MarshalUsingArrayParameterWithSizeParam(string sizeParamType, bool isByRef) => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{DisableRuntimeMarshalling}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method(
-        {(isByRef ? "ref" : "")} {sizeParamType} pRefSize,
-        [MarshalUsing(CountElementName = ""pRefSize"")] ref int[] pRef
-        );
-}}";
+        public static string MarshalUsingArrayParameterWithSizeParam(string sizeParamType, bool isByRef) => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{DisableRuntimeMarshalling}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial void Method(
+                    {{(isByRef ? "ref" : "")}} {{sizeParamType}} pRefSize,
+                    [MarshalUsing(CountElementName = "pRefSize")] ref int[] pRef
+                    );
+            }
+            """;
 
         public static string MarshalUsingArrayParameterWithSizeParam<T>(bool isByRef) => MarshalUsingArrayParameterWithSizeParam(typeof(T).ToString(), isByRef);
 
-        public static string MarshalUsingCollectionWithConstantAndElementCount => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{DisableRuntimeMarshalling}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method(
-        int pRefSize,
-        [MarshalUsing(ConstantElementCount = 10, CountElementName = ""pRefSize"")] ref int[] pRef
-        );
-}}";
+        public static string MarshalUsingCollectionWithConstantAndElementCount => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{DisableRuntimeMarshalling}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial void Method(
+                    int pRefSize,
+                    [MarshalUsing(ConstantElementCount = 10, CountElementName = "pRefSize")] ref int[] pRef
+                    );
+            }
+            """;
 
-        public static string MarshalUsingCollectionWithNullElementName => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{DisableRuntimeMarshalling}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method(
-        int pRefSize,
-        [MarshalUsing(CountElementName = null)] ref int[] pRef
-        );
-}}";
+        public static string MarshalUsingCollectionWithNullElementName => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{DisableRuntimeMarshalling}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial void Method(
+                    int pRefSize,
+                    [MarshalUsing(CountElementName = null)] ref int[] pRef
+                    );
+            }
+            """;
 
-        public static string MarshalAsAndMarshalUsingOnReturnValue => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{DisableRuntimeMarshalling}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    [return:MarshalUsing(ConstantElementCount=10)]
-    [return:MarshalAs(UnmanagedType.LPArray, SizeConst=10)]
-    public static partial int[] Method();
-}}
-";
-        public static string CustomElementMarshallingDuplicateElementIndirectionDepth => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{DisableRuntimeMarshalling}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method(
-        [MarshalUsing(typeof(CustomIntMarshaller), ElementIndirectionDepth = 1)] [MarshalUsing(typeof(CustomIntMarshaller), ElementIndirectionDepth = 1)] TestCollection<int> p);
-}}
-"
+        public static string MarshalAsAndMarshalUsingOnReturnValue => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{DisableRuntimeMarshalling}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                [return:MarshalUsing(ConstantElementCount=10)]
+                [return:MarshalAs(UnmanagedType.LPArray, SizeConst=10)]
+                public static partial int[] Method();
+            }
+            """;
+        public static string CustomElementMarshallingDuplicateElementIndirectionDepth => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{DisableRuntimeMarshalling}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial void Method(
+                    [MarshalUsing(typeof(CustomIntMarshaller), ElementIndirectionDepth = 1)] [MarshalUsing(typeof(CustomIntMarshaller), ElementIndirectionDepth = 1)] TestCollection<int> p);
+            }
+            """
                     + CustomCollectionMarshallingCodeSnippets.TestCollection()
                     + CustomCollectionMarshallingCodeSnippets.StatelessSnippets.In
                     + CustomCollectionMarshallingCodeSnippets.CustomIntMarshaller;
 
-        public static string CustomElementMarshallingUnusedElementIndirectionDepth => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{DisableRuntimeMarshalling}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method(
-        [MarshalUsing(typeof(CustomIntMarshaller), ElementIndirectionDepth = 2)] TestCollection<int> p);
-}}
-"
+        public static string CustomElementMarshallingUnusedElementIndirectionDepth => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{DisableRuntimeMarshalling}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial void Method(
+                    [MarshalUsing(typeof(CustomIntMarshaller), ElementIndirectionDepth = 2)] TestCollection<int> p);
+            }
+            """
             + CustomCollectionMarshallingCodeSnippets.TestCollection()
             + CustomCollectionMarshallingCodeSnippets.StatelessSnippets.In
             + CustomCollectionMarshallingCodeSnippets.CustomIntMarshaller;
 
-        public static string RecursiveCountElementNameOnReturnValue => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{DisableRuntimeMarshalling}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    [return:MarshalUsing(CountElementName=MarshalUsingAttribute.ReturnsCountValue)]
-    public static partial int[] Method();
-}}
-";
+        public static string RecursiveCountElementNameOnReturnValue => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{DisableRuntimeMarshalling}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                [return:MarshalUsing(CountElementName=MarshalUsingAttribute.ReturnsCountValue)]
+                public static partial int[] Method();
+            }
+            """;
 
-        public static string RecursiveCountElementNameOnParameter => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{DisableRuntimeMarshalling}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method(
-        [MarshalUsing(CountElementName=""arr"")] ref int[] arr
-    );
-}}
-";
-        public static string MutuallyRecursiveCountElementNameOnParameter => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{DisableRuntimeMarshalling}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method(
-        [MarshalUsing(CountElementName=""arr2"")] ref int[] arr,
-        [MarshalUsing(CountElementName=""arr"")] ref int[] arr2
-    );
-}}
-";
-        public static string MutuallyRecursiveSizeParamIndexOnParameter => $@"
-using System.Runtime.InteropServices;
-{DisableRuntimeMarshalling}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method(
-        [MarshalAs(UnmanagedType.LPArray, SizeParamIndex=1)] ref int[] arr,
-        [MarshalAs(UnmanagedType.LPArray, SizeParamIndex=0)] ref int[] arr2
-    );
-}}
-";
+        public static string RecursiveCountElementNameOnParameter => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{DisableRuntimeMarshalling}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial void Method(
+                    [MarshalUsing(CountElementName="arr")] ref int[] arr
+                );
+            }
+            """;
+        public static string MutuallyRecursiveCountElementNameOnParameter => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{DisableRuntimeMarshalling}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial void Method(
+                    [MarshalUsing(CountElementName="arr2")] ref int[] arr,
+                    [MarshalUsing(CountElementName="arr")] ref int[] arr2
+                );
+            }
+            """;
+        public static string MutuallyRecursiveSizeParamIndexOnParameter => $$"""
+            using System.Runtime.InteropServices;
+            {{DisableRuntimeMarshalling}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial void Method(
+                    [MarshalAs(UnmanagedType.LPArray, SizeParamIndex=1)] ref int[] arr,
+                    [MarshalAs(UnmanagedType.LPArray, SizeParamIndex=0)] ref int[] arr2
+                );
+            }
+            """;
 
-        public static string CollectionsOfCollectionsStress => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{DisableRuntimeMarshalling}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method(
-        [MarshalUsing(CountElementName=""arr0"", ElementIndirectionDepth = 0)]
-        [MarshalUsing(CountElementName=""arr1"", ElementIndirectionDepth = 1)]
-        [MarshalUsing(CountElementName=""arr2"", ElementIndirectionDepth = 2)]
-        [MarshalUsing(CountElementName=""arr3"", ElementIndirectionDepth = 3)]
-        [MarshalUsing(CountElementName=""arr4"", ElementIndirectionDepth = 4)]
-        [MarshalUsing(CountElementName=""arr5"", ElementIndirectionDepth = 5)]
-        [MarshalUsing(CountElementName=""arr6"", ElementIndirectionDepth = 6)]
-        [MarshalUsing(CountElementName=""arr7"", ElementIndirectionDepth = 7)]
-        [MarshalUsing(CountElementName=""arr8"", ElementIndirectionDepth = 8)]
-        [MarshalUsing(CountElementName=""arr9"", ElementIndirectionDepth = 9)]
-        [MarshalUsing(CountElementName=""arr10"", ElementIndirectionDepth = 10)]ref int[][][][][][][][][][][] arr11,
-        [MarshalUsing(CountElementName=""arr0"", ElementIndirectionDepth = 0)]
-        [MarshalUsing(CountElementName=""arr1"", ElementIndirectionDepth = 1)]
-        [MarshalUsing(CountElementName=""arr2"", ElementIndirectionDepth = 2)]
-        [MarshalUsing(CountElementName=""arr3"", ElementIndirectionDepth = 3)]
-        [MarshalUsing(CountElementName=""arr4"", ElementIndirectionDepth = 4)]
-        [MarshalUsing(CountElementName=""arr5"", ElementIndirectionDepth = 5)]
-        [MarshalUsing(CountElementName=""arr6"", ElementIndirectionDepth = 6)]
-        [MarshalUsing(CountElementName=""arr7"", ElementIndirectionDepth = 7)]
-        [MarshalUsing(CountElementName=""arr8"", ElementIndirectionDepth = 8)]
-        [MarshalUsing(CountElementName=""arr9"", ElementIndirectionDepth = 9)]ref int[][][][][][][][][][] arr10,
-        [MarshalUsing(CountElementName=""arr0"", ElementIndirectionDepth = 0)]
-        [MarshalUsing(CountElementName=""arr1"", ElementIndirectionDepth = 1)]
-        [MarshalUsing(CountElementName=""arr2"", ElementIndirectionDepth = 2)]
-        [MarshalUsing(CountElementName=""arr3"", ElementIndirectionDepth = 3)]
-        [MarshalUsing(CountElementName=""arr4"", ElementIndirectionDepth = 4)]
-        [MarshalUsing(CountElementName=""arr5"", ElementIndirectionDepth = 5)]
-        [MarshalUsing(CountElementName=""arr6"", ElementIndirectionDepth = 6)]
-        [MarshalUsing(CountElementName=""arr7"", ElementIndirectionDepth = 7)]
-        [MarshalUsing(CountElementName=""arr8"", ElementIndirectionDepth = 8)]ref int[][][][][][][][][] arr9,
-        [MarshalUsing(CountElementName=""arr0"", ElementIndirectionDepth = 0)]
-        [MarshalUsing(CountElementName=""arr1"", ElementIndirectionDepth = 1)]
-        [MarshalUsing(CountElementName=""arr2"", ElementIndirectionDepth = 2)]
-        [MarshalUsing(CountElementName=""arr3"", ElementIndirectionDepth = 3)]
-        [MarshalUsing(CountElementName=""arr4"", ElementIndirectionDepth = 4)]
-        [MarshalUsing(CountElementName=""arr5"", ElementIndirectionDepth = 5)]
-        [MarshalUsing(CountElementName=""arr6"", ElementIndirectionDepth = 6)]
-        [MarshalUsing(CountElementName=""arr7"", ElementIndirectionDepth = 7)]ref int[][][][][][][][] arr8,
-        [MarshalUsing(CountElementName=""arr0"", ElementIndirectionDepth = 0)]
-        [MarshalUsing(CountElementName=""arr1"", ElementIndirectionDepth = 1)]
-        [MarshalUsing(CountElementName=""arr2"", ElementIndirectionDepth = 2)]
-        [MarshalUsing(CountElementName=""arr3"", ElementIndirectionDepth = 3)]
-        [MarshalUsing(CountElementName=""arr4"", ElementIndirectionDepth = 4)]
-        [MarshalUsing(CountElementName=""arr5"", ElementIndirectionDepth = 5)]
-        [MarshalUsing(CountElementName=""arr6"", ElementIndirectionDepth = 6)]ref int[][][][][][][] arr7,
-        [MarshalUsing(CountElementName=""arr0"", ElementIndirectionDepth = 0)]
-        [MarshalUsing(CountElementName=""arr1"", ElementIndirectionDepth = 1)]
-        [MarshalUsing(CountElementName=""arr2"", ElementIndirectionDepth = 2)]
-        [MarshalUsing(CountElementName=""arr3"", ElementIndirectionDepth = 3)]
-        [MarshalUsing(CountElementName=""arr4"", ElementIndirectionDepth = 4)]
-        [MarshalUsing(CountElementName=""arr5"", ElementIndirectionDepth = 5)]ref int[][][][][][] arr6,
-        [MarshalUsing(CountElementName=""arr0"", ElementIndirectionDepth = 0)]
-        [MarshalUsing(CountElementName=""arr1"", ElementIndirectionDepth = 1)]
-        [MarshalUsing(CountElementName=""arr2"", ElementIndirectionDepth = 2)]
-        [MarshalUsing(CountElementName=""arr3"", ElementIndirectionDepth = 3)]
-        [MarshalUsing(CountElementName=""arr4"", ElementIndirectionDepth = 4)]ref int[][][][][] arr5,
-        [MarshalUsing(CountElementName=""arr0"", ElementIndirectionDepth = 0)]
-        [MarshalUsing(CountElementName=""arr1"", ElementIndirectionDepth = 1)]
-        [MarshalUsing(CountElementName=""arr2"", ElementIndirectionDepth = 2)]
-        [MarshalUsing(CountElementName=""arr3"", ElementIndirectionDepth = 3)]ref int[][][][] arr4,
-        [MarshalUsing(CountElementName=""arr0"", ElementIndirectionDepth = 0)]
-        [MarshalUsing(CountElementName=""arr1"", ElementIndirectionDepth = 1)]
-        [MarshalUsing(CountElementName=""arr2"", ElementIndirectionDepth = 2)]ref int[][][] arr3,
-        [MarshalUsing(CountElementName=""arr0"", ElementIndirectionDepth = 0)]
-        [MarshalUsing(CountElementName=""arr1"", ElementIndirectionDepth = 1)]ref int[][] arr2,
-        [MarshalUsing(CountElementName=""arr0"", ElementIndirectionDepth = 0)]ref int[] arr1,
-        ref int arr0
-    );
-}}
-";
+        public static string CollectionsOfCollectionsStress => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{DisableRuntimeMarshalling}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial void Method(
+                    [MarshalUsing(CountElementName="arr0", ElementIndirectionDepth = 0)]
+                    [MarshalUsing(CountElementName="arr1", ElementIndirectionDepth = 1)]
+                    [MarshalUsing(CountElementName="arr2", ElementIndirectionDepth = 2)]
+                    [MarshalUsing(CountElementName="arr3", ElementIndirectionDepth = 3)]
+                    [MarshalUsing(CountElementName="arr4", ElementIndirectionDepth = 4)]
+                    [MarshalUsing(CountElementName="arr5", ElementIndirectionDepth = 5)]
+                    [MarshalUsing(CountElementName="arr6", ElementIndirectionDepth = 6)]
+                    [MarshalUsing(CountElementName="arr7", ElementIndirectionDepth = 7)]
+                    [MarshalUsing(CountElementName="arr8", ElementIndirectionDepth = 8)]
+                    [MarshalUsing(CountElementName="arr9", ElementIndirectionDepth = 9)]
+                    [MarshalUsing(CountElementName="arr10", ElementIndirectionDepth = 10)]ref int[][][][][][][][][][][] arr11,
+                    [MarshalUsing(CountElementName="arr0", ElementIndirectionDepth = 0)]
+                    [MarshalUsing(CountElementName="arr1", ElementIndirectionDepth = 1)]
+                    [MarshalUsing(CountElementName="arr2", ElementIndirectionDepth = 2)]
+                    [MarshalUsing(CountElementName="arr3", ElementIndirectionDepth = 3)]
+                    [MarshalUsing(CountElementName="arr4", ElementIndirectionDepth = 4)]
+                    [MarshalUsing(CountElementName="arr5", ElementIndirectionDepth = 5)]
+                    [MarshalUsing(CountElementName="arr6", ElementIndirectionDepth = 6)]
+                    [MarshalUsing(CountElementName="arr7", ElementIndirectionDepth = 7)]
+                    [MarshalUsing(CountElementName="arr8", ElementIndirectionDepth = 8)]
+                    [MarshalUsing(CountElementName="arr9", ElementIndirectionDepth = 9)]ref int[][][][][][][][][][] arr10,
+                    [MarshalUsing(CountElementName="arr0", ElementIndirectionDepth = 0)]
+                    [MarshalUsing(CountElementName="arr1", ElementIndirectionDepth = 1)]
+                    [MarshalUsing(CountElementName="arr2", ElementIndirectionDepth = 2)]
+                    [MarshalUsing(CountElementName="arr3", ElementIndirectionDepth = 3)]
+                    [MarshalUsing(CountElementName="arr4", ElementIndirectionDepth = 4)]
+                    [MarshalUsing(CountElementName="arr5", ElementIndirectionDepth = 5)]
+                    [MarshalUsing(CountElementName="arr6", ElementIndirectionDepth = 6)]
+                    [MarshalUsing(CountElementName="arr7", ElementIndirectionDepth = 7)]
+                    [MarshalUsing(CountElementName="arr8", ElementIndirectionDepth = 8)]ref int[][][][][][][][][] arr9,
+                    [MarshalUsing(CountElementName="arr0", ElementIndirectionDepth = 0)]
+                    [MarshalUsing(CountElementName="arr1", ElementIndirectionDepth = 1)]
+                    [MarshalUsing(CountElementName="arr2", ElementIndirectionDepth = 2)]
+                    [MarshalUsing(CountElementName="arr3", ElementIndirectionDepth = 3)]
+                    [MarshalUsing(CountElementName="arr4", ElementIndirectionDepth = 4)]
+                    [MarshalUsing(CountElementName="arr5", ElementIndirectionDepth = 5)]
+                    [MarshalUsing(CountElementName="arr6", ElementIndirectionDepth = 6)]
+                    [MarshalUsing(CountElementName="arr7", ElementIndirectionDepth = 7)]ref int[][][][][][][][] arr8,
+                    [MarshalUsing(CountElementName="arr0", ElementIndirectionDepth = 0)]
+                    [MarshalUsing(CountElementName="arr1", ElementIndirectionDepth = 1)]
+                    [MarshalUsing(CountElementName="arr2", ElementIndirectionDepth = 2)]
+                    [MarshalUsing(CountElementName="arr3", ElementIndirectionDepth = 3)]
+                    [MarshalUsing(CountElementName="arr4", ElementIndirectionDepth = 4)]
+                    [MarshalUsing(CountElementName="arr5", ElementIndirectionDepth = 5)]
+                    [MarshalUsing(CountElementName="arr6", ElementIndirectionDepth = 6)]ref int[][][][][][][] arr7,
+                    [MarshalUsing(CountElementName="arr0", ElementIndirectionDepth = 0)]
+                    [MarshalUsing(CountElementName="arr1", ElementIndirectionDepth = 1)]
+                    [MarshalUsing(CountElementName="arr2", ElementIndirectionDepth = 2)]
+                    [MarshalUsing(CountElementName="arr3", ElementIndirectionDepth = 3)]
+                    [MarshalUsing(CountElementName="arr4", ElementIndirectionDepth = 4)]
+                    [MarshalUsing(CountElementName="arr5", ElementIndirectionDepth = 5)]ref int[][][][][][] arr6,
+                    [MarshalUsing(CountElementName="arr0", ElementIndirectionDepth = 0)]
+                    [MarshalUsing(CountElementName="arr1", ElementIndirectionDepth = 1)]
+                    [MarshalUsing(CountElementName="arr2", ElementIndirectionDepth = 2)]
+                    [MarshalUsing(CountElementName="arr3", ElementIndirectionDepth = 3)]
+                    [MarshalUsing(CountElementName="arr4", ElementIndirectionDepth = 4)]ref int[][][][][] arr5,
+                    [MarshalUsing(CountElementName="arr0", ElementIndirectionDepth = 0)]
+                    [MarshalUsing(CountElementName="arr1", ElementIndirectionDepth = 1)]
+                    [MarshalUsing(CountElementName="arr2", ElementIndirectionDepth = 2)]
+                    [MarshalUsing(CountElementName="arr3", ElementIndirectionDepth = 3)]ref int[][][][] arr4,
+                    [MarshalUsing(CountElementName="arr0", ElementIndirectionDepth = 0)]
+                    [MarshalUsing(CountElementName="arr1", ElementIndirectionDepth = 1)]
+                    [MarshalUsing(CountElementName="arr2", ElementIndirectionDepth = 2)]ref int[][][] arr3,
+                    [MarshalUsing(CountElementName="arr0", ElementIndirectionDepth = 0)]
+                    [MarshalUsing(CountElementName="arr1", ElementIndirectionDepth = 1)]ref int[][] arr2,
+                    [MarshalUsing(CountElementName="arr0", ElementIndirectionDepth = 0)]ref int[] arr1,
+                    ref int arr0
+                );
+            }
+            """;
 
-        public static string GenericsStress => $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{DisableRuntimeMarshalling}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method(S<int>.N<bool> v);
-}}
+        public static string GenericsStress => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{DisableRuntimeMarshalling}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial void Method(S<int>.N<bool> v);
+            }
 
-class S<T>
-{{
-    [NativeMarshalling(typeof(Container<,>.NestedMarshallerType))]
-    public struct N<U>
-    {{
-    }}
-}}
+            class S<T>
+            {
+                [NativeMarshalling(typeof(Container<,>.NestedMarshallerType))]
+                public struct N<U>
+                {
+                }
+            }
 
-class Container<T, U>
-{{
-    [CustomMarshaller(typeof(S<>.N<>), MarshalMode.ManagedToUnmanagedIn, typeof(Container<,>.NestedMarshallerType))]
-    public static class NestedMarshallerType
-    {{
-        public static int ConvertToUnmanaged(S<T>.N<U> managed) => 0;
-    }}
-}}
-";
+            class Container<T, U>
+            {
+                [CustomMarshaller(typeof(S<>.N<>), MarshalMode.ManagedToUnmanagedIn, typeof(Container<,>.NestedMarshallerType))]
+                public static class NestedMarshallerType
+                {
+                    public static int ConvertToUnmanaged(S<T>.N<U> managed) => 0;
+                }
+            }
+            """;
 
-        public static string RefReturn(string typeName) => $@"
-using System.Runtime.InteropServices;
-partial struct Basic
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial ref {typeName} RefReturn();
-    [LibraryImport(""DoesNotExist"")]
-    public static partial ref readonly {typeName} RefReadonlyReturn();
-}}";
+        public static string RefReturn(string typeName) => $$"""
+            using System.Runtime.InteropServices;
+            partial struct Basic
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial ref {{typeName}} RefReturn();
+                [LibraryImport("DoesNotExist")]
+                public static partial ref readonly {{typeName}} RefReadonlyReturn();
+            }
+            """;
 
-        public static string PartialPropertyName => @"
-using System.Runtime.InteropServices;
+        public static string PartialPropertyName => """
+            using System.Runtime.InteropServices;
 
-partial struct Basic
-{
-    [LibraryImport(""DoesNotExist"", SetLa)]
-    public static partial void Method();
-}
-";
-        public static string InvalidConstantForModuleName => @"
-using System.Runtime.InteropServices;
+            partial struct Basic
+            {
+                [LibraryImport("DoesNotExist", SetLa)]
+                public static partial void Method();
+            }
+            """;
+        public static string InvalidConstantForModuleName => """
+            using System.Runtime.InteropServices;
 
-partial struct Basic
-{
-    [LibraryImport(DoesNotExist)]
-    public static partial void Method();
-}
-";
-        public static string IncorrectAttributeFieldType => @"
-using System.Runtime.InteropServices;
+            partial struct Basic
+            {
+                [LibraryImport(DoesNotExist)]
+                public static partial void Method();
+            }
+            """;
+        public static string IncorrectAttributeFieldType => """
+            using System.Runtime.InteropServices;
 
-partial struct Basic
-{
-    [LibraryImport(""DoesNotExist"", SetLastError = ""Foo"")]
-    public static partial void Method();
-}
-";
+            partial struct Basic
+            {
+                [LibraryImport("DoesNotExist", SetLastError = "Foo")]
+                public static partial void Method();
+            }
+            """;
 
         public static class ValidateDisableRuntimeMarshalling
         {
-            public static string NonBlittableUserDefinedTypeWithNativeType = $@"
-public struct S
-{{
-    public string s;
-}}
+            public static string NonBlittableUserDefinedTypeWithNativeType = """
+                public struct S
+                {
+                    public string s;
+                }
 
-[CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
-public static class Marshaller
-{{
-    public static Native ConvertToUnmanaged(S s) => new(s);
+                [CustomMarshaller(typeof(S), MarshalMode.Default, typeof(Marshaller))]
+                public static class Marshaller
+                {
+                    public static Native ConvertToUnmanaged(S s) => new(s);
 
-    public static S ConvertToManaged(Native unmanaged) => unmanaged.ToManaged();
+                    public static S ConvertToManaged(Native unmanaged) => unmanaged.ToManaged();
 
-    public struct Native
-    {{
-        private System.IntPtr p;
-        public Native(S s)
-        {{
-            p = System.IntPtr.Zero;
-        }}
+                    public struct Native
+                    {
+                        private System.IntPtr p;
+                        public Native(S s)
+                        {
+                            p = System.IntPtr.Zero;
+                        }
 
-        public S ToManaged() => new S {{ s = string.Empty }};
-    }}
-}}
-";
+                        public S ToManaged() => new S { s = string.Empty };
+                    }
+                }
+                """;
 
             public static string TypeUsage(string attr) => MarshalUsingParametersAndModifiers("S", "Marshaller", attr);
         }

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CompileFails.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CompileFails.cs
@@ -189,11 +189,11 @@ namespace LibraryImportGenerator.UnitTests
         [Fact]
         public async Task ValidateDisableRuntimeMarshallingForBlittabilityCheckFromAssemblyReference()
         {
-            string assemblySource = $@"
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-{CodeSnippets.ValidateDisableRuntimeMarshalling.NonBlittableUserDefinedTypeWithNativeType}
-";
+            string assemblySource = $$"""
+                using System.Runtime.InteropServices;
+                using System.Runtime.InteropServices.Marshalling;
+                {{CodeSnippets.ValidateDisableRuntimeMarshalling.NonBlittableUserDefinedTypeWithNativeType}}
+                """;
             Compilation assemblyComp = await TestUtils.CreateCompilation(assemblySource);
             TestUtils.AssertPreSourceGeneratorCompilation(assemblyComp);
 

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
@@ -647,10 +647,10 @@ namespace LibraryImportGenerator.UnitTests
 
         public static IEnumerable<object[]> CodeSnippetsToVerifyNoTreesProduced()
         {
-            string source = @"
-using System.Runtime.InteropServices;
-public class Basic { }
-";
+            string source = """
+                using System.Runtime.InteropServices;
+                public class Basic { }
+                """;
             yield return new object[] { ID(), source, TestTargetFramework.Standard };
             yield return new object[] { ID(), source, TestTargetFramework.Framework };
             yield return new object[] { ID(), source, TestTargetFramework.Net };

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/ConvertToLibraryImportAnalyzerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/ConvertToLibraryImportAnalyzerTests.cs
@@ -71,20 +71,20 @@ namespace LibraryImportGenerator.UnitTests
         public async Task ByRef_ReportsDiagnostic(Type type)
         {
             string typeName = type.FullName!;
-            string source = @$"
-using System.Runtime.InteropServices;
-unsafe partial class Test
-{{
-    [DllImport(""DoesNotExist"")]
-    public static extern void {{|#0:Method_In|}}(in {typeName} p);
-
-    [DllImport(""DoesNotExist"")]
-    public static extern void {{|#1:Method_Out|}}(out {typeName} p);
-
-    [DllImport(""DoesNotExist"")]
-    public static extern void {{|#2:Method_Ref|}}(ref {typeName} p);
-}}
-";
+            string source = $$"""
+                using System.Runtime.InteropServices;
+                unsafe partial class Test
+                {
+                    [DllImport("DoesNotExist")]
+                    public static extern void {|#0:Method_In|}(in {{typeName}} p);
+                
+                    [DllImport("DoesNotExist")]
+                    public static extern void {|#1:Method_Out|}(out {{typeName}} p);
+                
+                    [DllImport("DoesNotExist")]
+                    public static extern void {|#2:Method_Ref|}(ref {{typeName}} p);
+                }
+                """;
             await VerifyCS.VerifyAnalyzerAsync(
                 source,
                 VerifyCS.Diagnostic(ConvertToLibraryImport)
@@ -101,17 +101,18 @@ unsafe partial class Test
         [Fact]
         public async Task SetLastErrorTrue_ReportsDiagnostic()
         {
-            string source = @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [DllImport(""DoesNotExist"", SetLastError = false)]
-    public static extern void {{|#0:Method1|}}();
+            string source = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [DllImport("DoesNotExist", SetLastError = false)]
+                    public static extern void {|#0:Method1|}();
 
-    [DllImport(""DoesNotExist"", SetLastError = true)]
-    public static extern void {{|#1:Method2|}}();
-}}
-";
+                    [DllImport("DoesNotExist", SetLastError = true)]
+                    public static extern void {|#1:Method2|}();
+                }
+
+                """;
             await VerifyCS.VerifyAnalyzerAsync(
                 source,
                 VerifyCS.Diagnostic(ConvertToLibraryImport)
@@ -138,64 +139,64 @@ partial class Test
         [InlineData(UnmanagedType.SafeArray)]
         public async Task UnsupportedUnmanagedType_NoDiagnostic(UnmanagedType unmanagedType)
         {
-            string source = $@"
-using System.Runtime.InteropServices;
-unsafe partial class Test
-{{
-    [DllImport(""DoesNotExist"")]
-    public static extern void Method_Parameter([MarshalAs(UnmanagedType.{unmanagedType}, MarshalType = ""DNE"")]int p);
-
-    [DllImport(""DoesNotExist"")]
-    [return: MarshalAs(UnmanagedType.{unmanagedType}, MarshalType = ""DNE"")]
-    public static extern int Method_Return();
-}}
-";
+            string source = $$"""
+                using System.Runtime.InteropServices;
+                unsafe partial class Test
+                {
+                    [DllImport("DoesNotExist")]
+                    public static extern void Method_Parameter([MarshalAs(UnmanagedType.{{unmanagedType}}, MarshalType = "DNE")]int p);
+                
+                    [DllImport("DoesNotExist")]
+                    [return: MarshalAs(UnmanagedType.{{unmanagedType}}, MarshalType = "DNE")]
+                    public static extern int Method_Return();
+                }
+                """;
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
         [Fact]
         public async Task LibraryImport_NoDiagnostic()
         {
-            string source = @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method();
-}}
-partial class Test
-{{
-    [DllImport(""DoesNotExist"")]
-    public static extern partial void Method();
-}}
-";
+            string source = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    public static partial void Method();
+                }
+                partial class Test
+                {
+                    [DllImport("DoesNotExist")]
+                    public static extern partial void Method();
+                }
+                """;
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
         [Fact]
         public async Task NotDllImport_NoDiagnostic()
         {
-            string source = @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    public static extern bool Method1(bool p, in bool pIn, ref bool pRef, out bool pOut);
-    public static extern int Method2(int p, in int pIn, ref int pRef, out int pOut);
-}}
-";
+            string source = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    public static extern bool Method1(bool p, in bool pIn, ref bool pRef, out bool pOut);
+                    public static extern int Method2(int p, in int pIn, ref int pRef, out int pOut);
+                }
+                """;
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        private static string DllImportWithType(string typeName) => @$"
-using System.Runtime.InteropServices;
-unsafe partial class Test
-{{
-    [DllImport(""DoesNotExist"")]
-    public static extern void {{|#0:Method_Parameter|}}({typeName} p);
-
-    [DllImport(""DoesNotExist"")]
-    public static extern {typeName} {{|#1:Method_Return|}}();
-}}
-";
+        private static string DllImportWithType(string typeName) => $$"""
+            using System.Runtime.InteropServices;
+            unsafe partial class Test
+            {
+                [DllImport("DoesNotExist")]
+                public static extern void {|#0:Method_Parameter|}({{typeName}} p);
+            
+                [DllImport("DoesNotExist")]
+                public static extern {{typeName}} {|#1:Method_Return|}();
+            }
+            """;
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/ConvertToLibraryImportFixerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/ConvertToLibraryImportFixerTests.cs
@@ -25,21 +25,23 @@ namespace LibraryImportGenerator.UnitTests
         [Fact]
         public async Task Basic()
         {
-            string source = @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [DllImport(""DoesNotExist"")]
-    public static extern int [|Method|](out int ret);
-}}";
+            string source = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [DllImport("DoesNotExist")]
+                    public static extern int [|Method|](out int ret);
+                }
+                """;
             // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
-            string fixedSource = @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial int {{|CS8795:Method|}}(out int ret);
-}}";
+            string fixedSource = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    public static partial int {|CS8795:Method|}(out int ret);
+                }
+                """;
             await VerifyCodeFixAsync(
                 source,
                 fixedSource);
@@ -48,33 +50,35 @@ partial class Test
         [Fact]
         public async Task Comments()
         {
-            string source = @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    // P/Invoke
-    [DllImport(/*name*/""DoesNotExist"")] // comment
-    public static extern int [|Method1|](out int ret);
+            string source = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    // P/Invoke
+                    [DllImport(/*name*/"DoesNotExist")] // comment
+                    public static extern int [|Method1|](out int ret);
 
-    /** P/Invoke **/
-    [DllImport(""DoesNotExist"") /*name*/]
-    // < ... >
-    public static extern int [|Method2|](out int ret);
-}}";
+                    /** P/Invoke **/
+                    [DllImport("DoesNotExist") /*name*/]
+                    // < ... >
+                    public static extern int [|Method2|](out int ret);
+                }
+                """;
             // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
-            string fixedSource = @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    // P/Invoke
-    [LibraryImport(/*name*/""DoesNotExist"")] // comment
-    public static partial int {{|CS8795:Method1|}}(out int ret);
+            string fixedSource = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    // P/Invoke
+                    [LibraryImport(/*name*/"DoesNotExist")] // comment
+                    public static partial int {|CS8795:Method1|}(out int ret);
 
-    /** P/Invoke **/
-    [LibraryImport(""DoesNotExist"") /*name*/]
-    // < ... >
-    public static partial int {{|CS8795:Method2|}}(out int ret);
-}}";
+                    /** P/Invoke **/
+                    [LibraryImport("DoesNotExist") /*name*/]
+                    // < ... >
+                    public static partial int {|CS8795:Method2|}(out int ret);
+                }
+                """;
             await VerifyCodeFixAsync(
                 source,
                 fixedSource);
@@ -83,31 +87,33 @@ partial class Test
         [Fact]
         public async Task MultipleAttributes()
         {
-            string source = @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [System.ComponentModel.Description(""Test""), DllImport(""DoesNotExist"")]
-    public static extern int [|Method1|](out int ret);
+            string source = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [System.ComponentModel.Description("Test"), DllImport("DoesNotExist")]
+                    public static extern int [|Method1|](out int ret);
 
-    [System.ComponentModel.Description(""Test"")]
-    [DllImport(""DoesNotExist"")]
-    [return: MarshalAs(UnmanagedType.I4)]
-    public static extern int [|Method2|](out int ret);
-}}";
+                    [System.ComponentModel.Description("Test")]
+                    [DllImport("DoesNotExist")]
+                    [return: MarshalAs(UnmanagedType.I4)]
+                    public static extern int [|Method2|](out int ret);
+                }
+                """;
             // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
-            string fixedSource = @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [System.ComponentModel.Description(""Test""), LibraryImport(""DoesNotExist"")]
-    public static partial int {{|CS8795:Method1|}}(out int ret);
+            string fixedSource = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [System.ComponentModel.Description("Test"), LibraryImport("DoesNotExist")]
+                    public static partial int {|CS8795:Method1|}(out int ret);
 
-    [System.ComponentModel.Description(""Test"")]
-    [LibraryImport(""DoesNotExist"")]
-    [return: MarshalAs(UnmanagedType.I4)]
-    public static partial int {{|CS8795:Method2|}}(out int ret);
-}}";
+                    [System.ComponentModel.Description("Test")]
+                    [LibraryImport("DoesNotExist")]
+                    [return: MarshalAs(UnmanagedType.I4)]
+                    public static partial int {|CS8795:Method2|}(out int ret);
+                }
+                """;
             await VerifyCodeFixAsync(
                 source,
                 fixedSource);
@@ -116,27 +122,29 @@ partial class Test
         [Fact]
         public async Task NamedArguments()
         {
-            string source = @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [DllImport(""DoesNotExist"", EntryPoint = ""Entry"")]
-    public static extern int [|Method1|](out int ret);
+            string source = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [DllImport("DoesNotExist", EntryPoint = "Entry")]
+                    public static extern int [|Method1|](out int ret);
 
-    [DllImport(""DoesNotExist"", EntryPoint = ""Entry"", CharSet = CharSet.Unicode)]
-    public static extern string [|Method2|](out int ret);
-}}";
+                    [DllImport("DoesNotExist", EntryPoint = "Entry", CharSet = CharSet.Unicode)]
+                    public static extern string [|Method2|](out int ret);
+                }
+                """;
             // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
-            string fixedSource = @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"", EntryPoint = ""Entry"")]
-    public static partial int {{|CS8795:Method1|}}(out int ret);
+            string fixedSource = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist", EntryPoint = "Entry")]
+                    public static partial int {|CS8795:Method1|}(out int ret);
 
-    [LibraryImport(""DoesNotExist"", EntryPoint = ""Entry"", StringMarshalling = StringMarshalling.Utf16)]
-    public static partial string {{|CS8795:Method2|}}(out int ret);
-}}";
+                    [LibraryImport("DoesNotExist", EntryPoint = "Entry", StringMarshalling = StringMarshalling.Utf16)]
+                    public static partial string {|CS8795:Method2|}(out int ret);
+                }
+                """;
             await VerifyCodeFixAsync(
                 source,
                 fixedSource);
@@ -145,45 +153,47 @@ partial class Test
         [Fact]
         public async Task RemoveableNamedArguments()
         {
-            string source = @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [DllImport(""DoesNotExist"", EntryPoint = ""Entry"", ExactSpelling = true)]
-    public static extern int [|Method|](out int ret);
+            string source = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [DllImport("DoesNotExist", EntryPoint = "Entry", ExactSpelling = true)]
+                    public static extern int [|Method|](out int ret);
 
-    [DllImport(""DoesNotExist"", BestFitMapping = false, EntryPoint = ""Entry"")]
-    public static extern int [|Method1|](out int ret);
+                    [DllImport("DoesNotExist", BestFitMapping = false, EntryPoint = "Entry")]
+                    public static extern int [|Method1|](out int ret);
 
-    [DllImport(""DoesNotExist"", ThrowOnUnmappableChar = false)]
-    public static extern int [|Method2|](out int ret);
+                    [DllImport("DoesNotExist", ThrowOnUnmappableChar = false)]
+                    public static extern int [|Method2|](out int ret);
 
-    [DllImport(""DoesNotExist"", PreserveSig = true)]
-    public static extern int [|Method3|](out int ret);
+                    [DllImport("DoesNotExist", PreserveSig = true)]
+                    public static extern int [|Method3|](out int ret);
 
-    [DllImport(""DoesNotExist"", CharSet = CharSet.Unicode)]
-    public static extern int [|Method4|](out int ret);
-}}";
+                    [DllImport("DoesNotExist", CharSet = CharSet.Unicode)]
+                    public static extern int [|Method4|](out int ret);
+                }
+                """;
             // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
-            string fixedSource = @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"", EntryPoint = ""Entry"")]
-    public static partial int {{|CS8795:Method|}}(out int ret);
+            string fixedSource = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist", EntryPoint = "Entry")]
+                    public static partial int {|CS8795:Method|}(out int ret);
 
-    [LibraryImport(""DoesNotExist"", EntryPoint = ""Entry"")]
-    public static partial int {{|CS8795:Method1|}}(out int ret);
+                    [LibraryImport("DoesNotExist", EntryPoint = "Entry")]
+                    public static partial int {|CS8795:Method1|}(out int ret);
 
-    [LibraryImport(""DoesNotExist"")]
-    public static partial int {{|CS8795:Method2|}}(out int ret);
+                    [LibraryImport("DoesNotExist")]
+                    public static partial int {|CS8795:Method2|}(out int ret);
 
-    [LibraryImport(""DoesNotExist"")]
-    public static partial int {{|CS8795:Method3|}}(out int ret);
+                    [LibraryImport("DoesNotExist")]
+                    public static partial int {|CS8795:Method3|}(out int ret);
 
-    [LibraryImport(""DoesNotExist"")]
-    public static partial int {{|CS8795:Method4|}}(out int ret);
-}}";
+                    [LibraryImport("DoesNotExist")]
+                    public static partial int {|CS8795:Method4|}(out int ret);
+                }
+                """;
             await VerifyCodeFixAsync(
                 source,
                 fixedSource);
@@ -192,21 +202,23 @@ partial class Test
         [Fact]
         public async Task ReplaceableExplicitPlatformDefaultCallingConvention()
         {
-            string source = @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [DllImport(""DoesNotExist"", CallingConvention = CallingConvention.Winapi, EntryPoint = ""Entry"")]
-    public static extern int [|Method1|](out int ret);
-}}";
+            string source = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [DllImport("DoesNotExist", CallingConvention = CallingConvention.Winapi, EntryPoint = "Entry")]
+                    public static extern int [|Method1|](out int ret);
+                }
+                """;
             // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
-            string fixedSource = @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"", EntryPoint = ""Entry"")]
-    public static partial int {{|CS8795:Method1|}}(out int ret);
-}}";
+            string fixedSource = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist", EntryPoint = "Entry")]
+                    public static partial int {|CS8795:Method1|}(out int ret);
+                }
+                """;
             await VerifyCodeFixAsync(
                 source,
                 fixedSource);
@@ -219,22 +231,24 @@ partial class Test
         [InlineData(CallingConvention.FastCall, typeof(CallConvFastcall))]
         public async Task ReplaceableCallingConvention(CallingConvention callConv, Type callConvType)
         {
-            string source = @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [DllImport(""DoesNotExist"", CallingConvention = CallingConvention.{callConv}, EntryPoint = ""Entry"")]
-    public static extern int [|Method1|](out int ret);
-}}";
+            string source = $$"""
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [DllImport("DoesNotExist", CallingConvention = CallingConvention.{{callConv}}, EntryPoint = "Entry")]
+                    public static extern int [|Method1|](out int ret);
+                }
+                """;
             // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
-            string fixedSource = @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"", EntryPoint = ""Entry"")]
-    [UnmanagedCallConv(CallConvs = new System.Type[] {{ typeof({callConvType.FullName}) }})]
-    public static partial int {{|CS8795:Method1|}}(out int ret);
-}}";
+            string fixedSource = $$"""
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist", EntryPoint = "Entry")]
+                    [UnmanagedCallConv(CallConvs = new System.Type[] { typeof({{callConvType.FullName}}) })]
+                    public static partial int {|CS8795:Method1|}(out int ret);
+                }
+                """;
             await VerifyCodeFixAsync(
                 source,
                 fixedSource);
@@ -243,21 +257,23 @@ partial class Test
         [Fact]
         public async Task PreferredAttributeOrder()
         {
-            string source = @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [DllImport(""DoesNotExist"", SetLastError = true, EntryPoint = ""Entry"", CharSet = CharSet.Unicode)]
-    public static extern string [|Method|](out int ret);
-}}";
+            string source = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [DllImport("DoesNotExist", SetLastError = true, EntryPoint = "Entry", CharSet = CharSet.Unicode)]
+                    public static extern string [|Method|](out int ret);
+                }
+                """;
             // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
-            string fixedSource = @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"", EntryPoint = ""Entry"", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
-    public static partial string {{|CS8795:Method|}}(out int ret);
-}}";
+            string fixedSource = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist", EntryPoint = "Entry", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+                    public static partial string {|CS8795:Method|}(out int ret);
+                }
+                """;
             await VerifyCodeFixAsync(
                 source,
                 fixedSource);
@@ -268,217 +284,252 @@ partial class Test
         [Theory]
         public async Task ExactSpelling_False_NoAutoCharSet_Provides_No_Suffix_And_Suffix_Fix(CharSet charSet, char suffix)
         {
-            string source = $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [DllImport(""DoesNotExist"", EntryPoint = ""Entry"", ExactSpelling = false, CharSet = CharSet.{charSet})]
-    public static extern void [|Method|]();
-}}";
-            string fixedSourceNoSuffix = $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"", EntryPoint = ""Entry"")]
-    public static partial void {{|CS8795:Method|}}();
-}}";
+            string source = $$"""
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [DllImport("DoesNotExist", EntryPoint = "Entry", ExactSpelling = false, CharSet = CharSet.{{charSet}})]
+                    public static extern void [|Method|]();
+                }
+                """;
+            string fixedSourceNoSuffix = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist", EntryPoint = "Entry")]
+                    public static partial void {|CS8795:Method|}();
+                }
+                """;
             await VerifyCodeFixAsync(source, fixedSourceNoSuffix, ConvertToLibraryImportKey);
-            string fixedSourceWithSuffix = $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"", EntryPoint = ""Entry{suffix}"")]
-    public static partial void {{|CS8795:Method|}}();
-}}";
+            string fixedSourceWithSuffix = $$"""
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist", EntryPoint = "Entry{{suffix}}")]
+                    public static partial void {|CS8795:Method|}();
+                }
+                """;
             await VerifyCodeFixAsync(source, fixedSourceWithSuffix, $"{ConvertToLibraryImportKey}{suffix},");
         }
 
         [Fact]
         public async Task ExactSpelling_False_AutoCharSet_Provides_No_Suffix_And_Both_Suffix_Fixes()
         {
-            string source = $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [DllImport(""DoesNotExist"", EntryPoint = ""Entry"", ExactSpelling = false, CharSet = CharSet.Auto)]
-    public static extern void [|Method|]();
-}}";
-            string fixedSourceNoSuffix = $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"", EntryPoint = ""Entry"")]
-    public static partial void {{|CS8795:Method|}}();
-}}";
+            string source = """
+
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [DllImport("DoesNotExist", EntryPoint = "Entry", ExactSpelling = false, CharSet = CharSet.Auto)]
+                    public static extern void [|Method|]();
+                }
+                """;
+            string fixedSourceNoSuffix = """
+
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist", EntryPoint = "Entry")]
+                    public static partial void {|CS8795:Method|}();
+                }
+                """;
             await VerifyCodeFixAsync(source, fixedSourceNoSuffix, ConvertToLibraryImportKey);
-            string fixedSourceWithASuffix = $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"", EntryPoint = ""EntryA"")]
-    public static partial void {{|CS8795:Method|}}();
-}}";
+            string fixedSourceWithASuffix = """
+
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist", EntryPoint = "EntryA")]
+                    public static partial void {|CS8795:Method|}();
+                }
+                """;
             await VerifyCodeFixAsync(source, fixedSourceWithASuffix, $"{ConvertToLibraryImportKey}A,");
-            string fixedSourceWithWSuffix = $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"", EntryPoint = ""EntryW"")]
-    public static partial void {{|CS8795:Method|}}();
-}}";
+            string fixedSourceWithWSuffix = """
+
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist", EntryPoint = "EntryW")]
+                    public static partial void {|CS8795:Method|}();
+                }
+                """;
             await VerifyCodeFixAsync(source, fixedSourceWithWSuffix, $"{ConvertToLibraryImportKey}W,");
         }
 
         [Fact]
         public async Task ExactSpelling_False_ImplicitAnsiCharSet_Provides_No_Suffix_And_Suffix_Fix()
         {
-            string source = $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [DllImport(""DoesNotExist"", EntryPoint = ""Entry"", ExactSpelling = false)]
-    public static extern void [|Method|]();
-}}";
-            string fixedSourceNoSuffix = $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"", EntryPoint = ""Entry"")]
-    public static partial void {{|CS8795:Method|}}();
-}}";
+            string source = """
+
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [DllImport("DoesNotExist", EntryPoint = "Entry", ExactSpelling = false)]
+                    public static extern void [|Method|]();
+                }
+                """;
+            string fixedSourceNoSuffix = """
+
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist", EntryPoint = "Entry")]
+                    public static partial void {|CS8795:Method|}();
+                }
+                """;
             await VerifyCodeFixAsync(source, fixedSourceNoSuffix, ConvertToLibraryImportKey);
-            string fixedSourceWithASuffix = $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"", EntryPoint = ""EntryA"")]
-    public static partial void {{|CS8795:Method|}}();
-}}";
+            string fixedSourceWithASuffix = """
+
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist", EntryPoint = "EntryA")]
+                    public static partial void {|CS8795:Method|}();
+                }
+                """;
             await VerifyCodeFixAsync(source, fixedSourceWithASuffix, $"{ConvertToLibraryImportKey}A,");
         }
 
         [Fact]
         public async Task ExactSpelling_False_ConstantNonLiteralEntryPoint()
         {
-            string source = $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    private const string EntryPoint = ""Entry"";
-    [DllImport(""DoesNotExist"", EntryPoint = EntryPoint, CharSet = CharSet.Ansi, ExactSpelling = false)]
-    public static extern void [|Method|]();
-}}";
-            string fixedSourceWithASuffix = $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    private const string EntryPoint = ""Entry"";
-    [LibraryImport(""DoesNotExist"", EntryPoint = EntryPoint + ""A"")]
-    public static partial void {{|CS8795:Method|}}();
-}}";
+            string source = """
+
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    private const string EntryPoint = "Entry";
+                    [DllImport("DoesNotExist", EntryPoint = EntryPoint, CharSet = CharSet.Ansi, ExactSpelling = false)]
+                    public static extern void [|Method|]();
+                }
+                """;
+            string fixedSourceWithASuffix = """
+
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    private const string EntryPoint = "Entry";
+                    [LibraryImport("DoesNotExist", EntryPoint = EntryPoint + "A")]
+                    public static partial void {|CS8795:Method|}();
+                }
+                """;
             await VerifyCodeFixAsync(source, fixedSourceWithASuffix, $"{ConvertToLibraryImportKey}A,");
         }
 
         [Fact]
         public async Task Implicit_ExactSpelling_False_Offers_Suffix_Fix()
         {
-            string source = $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [DllImport(""DoesNotExist"", CharSet = CharSet.Ansi)]
-    public static extern void [|Method|]();
-}}";
-            string fixedSourceWithASuffix = $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"", EntryPoint = ""MethodA"")]
-    public static partial void {{|CS8795:Method|}}();
-}}";
+            string source = """
+
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [DllImport("DoesNotExist", CharSet = CharSet.Ansi)]
+                    public static extern void [|Method|]();
+                }
+                """;
+            string fixedSourceWithASuffix = """
+
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist", EntryPoint = "MethodA")]
+                    public static partial void {|CS8795:Method|}();
+                }
+                """;
             await VerifyCodeFixAsync(source, fixedSourceWithASuffix, $"{ConvertToLibraryImportKey}A,");
         }
 
         [Fact]
         public async Task ExactSpelling_False_NameOfEntryPoint()
         {
-            string source = $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    private const string Foo = ""Bar"";
-    [DllImport(""DoesNotExist"", EntryPoint = nameof(Foo), CharSet = CharSet.Ansi, ExactSpelling = false)]
-    public static extern void [|Method|]();
-}}";
-            string fixedSourceWithASuffix = $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    private const string Foo = ""Bar"";
-    [LibraryImport(""DoesNotExist"", EntryPoint = nameof(Foo) + ""A"")]
-    public static partial void {{|CS8795:Method|}}();
-}}";
+            string source = """
+
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    private const string Foo = "Bar";
+                    [DllImport("DoesNotExist", EntryPoint = nameof(Foo), CharSet = CharSet.Ansi, ExactSpelling = false)]
+                    public static extern void [|Method|]();
+                }
+                """;
+            string fixedSourceWithASuffix = """
+
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    private const string Foo = "Bar";
+                    [LibraryImport("DoesNotExist", EntryPoint = nameof(Foo) + "A")]
+                    public static partial void {|CS8795:Method|}();
+                }
+                """;
             await VerifyCodeFixAsync(source, fixedSourceWithASuffix, $"{ConvertToLibraryImportKey}A,");
         }
 
         [Fact]
         public async Task ExactSpelling_False_ImplicitEntryPointName()
         {
-            string source = $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [DllImport(""DoesNotExist"", CharSet = CharSet.Ansi, ExactSpelling = false)]
-    public static extern void [|Method|]();
-}}";
-            string fixedSourceWithASuffix = $@"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"", EntryPoint = ""MethodA"")]
-    public static partial void {{|CS8795:Method|}}();
-}}";
+            string source = """
+
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [DllImport("DoesNotExist", CharSet = CharSet.Ansi, ExactSpelling = false)]
+                    public static extern void [|Method|]();
+                }
+                """;
+            string fixedSourceWithASuffix = """
+
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist", EntryPoint = "MethodA")]
+                    public static partial void {|CS8795:Method|}();
+                }
+                """;
             await VerifyCodeFixAsync(source, fixedSourceWithASuffix, $"{ConvertToLibraryImportKey}A,");
         }
 
         [Fact]
         public async Task PreserveSigFalseSignatureModified()
         {
-            string source = @"
-using System.Runtime.InteropServices;
-partial class Test
-{
-    [DllImport(""DoesNotExist"", PreserveSig = false)]
-    public static extern void [|VoidMethod|](int param);
-    [DllImport(""DoesNotExist"", PreserveSig = false)]
-    public static extern long [|Method|](int param);
+            string source = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [DllImport("DoesNotExist", PreserveSig = false)]
+                    public static extern void [|VoidMethod|](int param);
+                    [DllImport("DoesNotExist", PreserveSig = false)]
+                    public static extern long [|Method|](int param);
 
-    public static void Code()
-    {
-        Test.VoidMethod(1);
-        Test.Method(1);
-        long value = Test.Method(1);
-        value = Test.Method(1);
-    }
-}";
+                    public static void Code()
+                    {
+                        Test.VoidMethod(1);
+                        Test.Method(1);
+                        long value = Test.Method(1);
+                        value = Test.Method(1);
+                    }
+                }
+                """;
             // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
-            string fixedSource = @"
-using System.Runtime.InteropServices;
-partial class Test
-{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial int {|CS8795:VoidMethod|}(int param);
-    [LibraryImport(""DoesNotExist"")]
-    public static partial int {|CS8795:Method|}(int param, out long @return);
+            string fixedSource = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    public static partial int {|CS8795:VoidMethod|}(int param);
+                    [LibraryImport("DoesNotExist")]
+                    public static partial int {|CS8795:Method|}(int param, out long @return);
 
-    public static void Code()
-    {
-        Marshal.ThrowExceptionForHR(Test.VoidMethod(1));
-        Marshal.ThrowExceptionForHR(Test.Method(1, out _));
-        Marshal.ThrowExceptionForHR(Test.Method(1, out long value));
-        Marshal.ThrowExceptionForHR(Test.Method(1, out value));
-    }
-}";
+                    public static void Code()
+                    {
+                        Marshal.ThrowExceptionForHR(Test.VoidMethod(1));
+                        Marshal.ThrowExceptionForHR(Test.Method(1, out _));
+                        Marshal.ThrowExceptionForHR(Test.Method(1, out long value));
+                        Marshal.ThrowExceptionForHR(Test.Method(1, out value));
+                    }
+                }
+                """;
             await VerifyCodeFixAsync(
                 source,
                 fixedSource);
@@ -487,61 +538,63 @@ partial class Test
         [Fact]
         public async Task MakeEnclosingTypesPartial()
         {
-            string source = @"
-using System.Runtime.InteropServices;
+            string source = """
+                using System.Runtime.InteropServices;
 
-class Enclosing
-{
-    class Test
-    {
-        [DllImport(""DoesNotExist"")]
-        public static extern int [|Method|](out int ret);
-        [DllImport(""DoesNotExist"")]
-        public static extern int [|Method2|](out int ret);
-        [DllImport(""DoesNotExist"")]
-        public static extern int [|Method3|](out int ret);
-    }
-}
-partial class EnclosingPartial
-{
-    class Test
-    {
-        [DllImport(""DoesNotExist"")]
-        public static extern int [|Method|](out int ret);
-        [DllImport(""DoesNotExist"")]
-        public static extern int [|Method2|](out int ret);
-        [DllImport(""DoesNotExist"")]
-        public static extern int [|Method3|](out int ret);
-    }
-}";
+                class Enclosing
+                {
+                    class Test
+                    {
+                        [DllImport("DoesNotExist")]
+                        public static extern int [|Method|](out int ret);
+                        [DllImport("DoesNotExist")]
+                        public static extern int [|Method2|](out int ret);
+                        [DllImport("DoesNotExist")]
+                        public static extern int [|Method3|](out int ret);
+                    }
+                }
+                partial class EnclosingPartial
+                {
+                    class Test
+                    {
+                        [DllImport("DoesNotExist")]
+                        public static extern int [|Method|](out int ret);
+                        [DllImport("DoesNotExist")]
+                        public static extern int [|Method2|](out int ret);
+                        [DllImport("DoesNotExist")]
+                        public static extern int [|Method3|](out int ret);
+                    }
+                }
+                """;
             // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
-            string fixedSource = @"
-using System.Runtime.InteropServices;
+            string fixedSource = """
+                using System.Runtime.InteropServices;
 
-partial class Enclosing
-{
-    partial class Test
-    {
-        [LibraryImport(""DoesNotExist"")]
-        public static partial int {|CS8795:Method|}(out int ret);
-        [LibraryImport(""DoesNotExist"")]
-        public static partial int {|CS8795:Method2|}(out int ret);
-        [LibraryImport(""DoesNotExist"")]
-        public static partial int {|CS8795:Method3|}(out int ret);
-    }
-}
-partial class EnclosingPartial
-{
-    partial class Test
-    {
-        [LibraryImport(""DoesNotExist"")]
-        public static partial int {|CS8795:Method|}(out int ret);
-        [LibraryImport(""DoesNotExist"")]
-        public static partial int {|CS8795:Method2|}(out int ret);
-        [LibraryImport(""DoesNotExist"")]
-        public static partial int {|CS8795:Method3|}(out int ret);
-    }
-}";
+                partial class Enclosing
+                {
+                    partial class Test
+                    {
+                        [LibraryImport("DoesNotExist")]
+                        public static partial int {|CS8795:Method|}(out int ret);
+                        [LibraryImport("DoesNotExist")]
+                        public static partial int {|CS8795:Method2|}(out int ret);
+                        [LibraryImport("DoesNotExist")]
+                        public static partial int {|CS8795:Method3|}(out int ret);
+                    }
+                }
+                partial class EnclosingPartial
+                {
+                    partial class Test
+                    {
+                        [LibraryImport("DoesNotExist")]
+                        public static partial int {|CS8795:Method|}(out int ret);
+                        [LibraryImport("DoesNotExist")]
+                        public static partial int {|CS8795:Method2|}(out int ret);
+                        [LibraryImport("DoesNotExist")]
+                        public static partial int {|CS8795:Method3|}(out int ret);
+                    }
+                }
+                """;
             await VerifyCodeFixAsync(
                 source,
                 fixedSource);
@@ -550,22 +603,24 @@ partial class EnclosingPartial
         [Fact]
         public async Task BooleanMarshalAsAdded()
         {
-            string source = @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [DllImport(""DoesNotExist"")]
-    public static extern bool [|Method|](bool b);
-}}";
+            string source = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [DllImport("DoesNotExist")]
+                    public static extern bool [|Method|](bool b);
+                }
+                """;
             // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
-            string fixedSource = @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static partial bool {{|CS8795:Method|}}([MarshalAs(UnmanagedType.Bool)] bool b);
-}}";
+            string fixedSource = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    [return: MarshalAs(UnmanagedType.Bool)]
+                    public static partial bool {|CS8795:Method|}([MarshalAs(UnmanagedType.Bool)] bool b);
+                }
+                """;
             await VerifyCodeFixAsync(
                 source,
                 fixedSource);
@@ -576,21 +631,23 @@ partial class Test
         [Fact]
         public async Task FixThatAddsUnsafeToProjectUpdatesLibraryImport()
         {
-            string source = @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [DllImport(""DoesNotExist"")]
-    public static extern int [|Method|](out int ret);
-}}";
+            string source = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [DllImport("DoesNotExist")]
+                    public static extern int [|Method|](out int ret);
+                }
+                """;
             // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
-            string fixedSource = @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial int {{|CS8795:Method|}}(out int ret);
-}}";
+            string fixedSource = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    public static partial int {|CS8795:Method|}(out int ret);
+                }
+                """;
             await VerifyCodeFixNoUnsafeAsync(
                 source,
                 fixedSource,
@@ -600,35 +657,37 @@ partial class Test
         [Fact]
         public async Task UserBlittableStructConvertsWithNoWarningCodeAction()
         {
-            string source = @$"
-using System.Runtime.InteropServices;
+            string source = """
+                using System.Runtime.InteropServices;
 
-struct Blittable
-{{
-    private short s;
-    private short t;
-}}
+                struct Blittable
+                {
+                    private short s;
+                    private short t;
+                }
 
-partial class Test
-{{
-    [DllImport(""DoesNotExist"")]
-    public static extern void [|Method|](Blittable b);
-}}";
+                partial class Test
+                {
+                    [DllImport("DoesNotExist")]
+                    public static extern void [|Method|](Blittable b);
+                }
+                """;
             // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
-            string fixedSource = @$"
-using System.Runtime.InteropServices;
+            string fixedSource = """
+                using System.Runtime.InteropServices;
 
-struct Blittable
-{{
-    private short s;
-    private short t;
-}}
+                struct Blittable
+                {
+                    private short s;
+                    private short t;
+                }
 
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void {{|CS8795:Method|}}(Blittable b);
-}}";
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    public static partial void {|CS8795:Method|}(Blittable b);
+                }
+                """;
             await VerifyCodeFixAsync(
                 source,
                 fixedSource,
@@ -638,35 +697,37 @@ partial class Test
         [Fact]
         public async Task UserNonBlittableStructConvertsOnlyWithWarningCodeAction()
         {
-            string source = @$"
-using System.Runtime.InteropServices;
+            string source = """
+                using System.Runtime.InteropServices;
 
-struct NonBlittable
-{{
-    private string s;
-    private short t;
-}}
+                struct NonBlittable
+                {
+                    private string s;
+                    private short t;
+                }
 
-partial class Test
-{{
-    [DllImport(""DoesNotExist"")]
-    public static extern void [|Method|](NonBlittable b);
-}}";
+                partial class Test
+                {
+                    [DllImport("DoesNotExist")]
+                    public static extern void [|Method|](NonBlittable b);
+                }
+                """;
             // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
-            string fixedSource = @$"
-using System.Runtime.InteropServices;
+            string fixedSource = """
+                using System.Runtime.InteropServices;
 
-struct NonBlittable
-{{
-    private string s;
-    private short t;
-}}
+                struct NonBlittable
+                {
+                    private string s;
+                    private short t;
+                }
 
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void {{|CS8795:Method|}}(NonBlittable b);
-}}";
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    public static partial void {|CS8795:Method|}(NonBlittable b);
+                }
+                """;
             // Verify that we don't update this signature with the "no additional work required" action.
             await VerifyCodeFixAsync(
                 source,
@@ -682,55 +743,57 @@ partial class Test
         [Fact]
         public async Task UserBlittableStructFixAllConvertsOnlyNoWarningLocations()
         {
-            string source = @$"
-using System.Runtime.InteropServices;
+            string source = """
+                using System.Runtime.InteropServices;
 
-struct Blittable
-{{
-    private short s;
-    private short t;
-}}
+                struct Blittable
+                {
+                    private short s;
+                    private short t;
+                }
 
-struct NonBlittable
-{{
-    private string s;
-    private short t;
-}}
+                struct NonBlittable
+                {
+                    private string s;
+                    private short t;
+                }
 
-partial class Test
-{{
-    [DllImport(""DoesNotExist"")]
-    public static extern void [|Method|](int i);
-    [DllImport(""DoesNotExist"")]
-    public static extern void [|Method|](Blittable b);
-    [DllImport(""DoesNotExist"")]
-    public static extern void [|Method|](NonBlittable b);
-}}";
+                partial class Test
+                {
+                    [DllImport("DoesNotExist")]
+                    public static extern void [|Method|](int i);
+                    [DllImport("DoesNotExist")]
+                    public static extern void [|Method|](Blittable b);
+                    [DllImport("DoesNotExist")]
+                    public static extern void [|Method|](NonBlittable b);
+                }
+                """;
             // Fixed sources will have CS8795 (Partial method must have an implementation) without generator run
-            string blittableOnlyFixedSource = @$"
-using System.Runtime.InteropServices;
+            string blittableOnlyFixedSource = """
+                using System.Runtime.InteropServices;
 
-struct Blittable
-{{
-    private short s;
-    private short t;
-}}
+                struct Blittable
+                {
+                    private short s;
+                    private short t;
+                }
 
-struct NonBlittable
-{{
-    private string s;
-    private short t;
-}}
+                struct NonBlittable
+                {
+                    private string s;
+                    private short t;
+                }
 
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void {{|CS8795:Method|}}(int i);
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void {{|CS8795:Method|}}(Blittable b);
-    [DllImport(""DoesNotExist"")]
-    public static extern void [|Method|](NonBlittable b);
-}}";
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    public static partial void {|CS8795:Method|}(int i);
+                    [LibraryImport("DoesNotExist")]
+                    public static partial void {|CS8795:Method|}(Blittable b);
+                    [DllImport("DoesNotExist")]
+                    public static extern void [|Method|](NonBlittable b);
+                }
+                """;
             // Verify that we only fix the blittable cases, not the non-blittable cases.
             await VerifyCodeFixAsync(
                 source,
@@ -741,80 +804,83 @@ partial class Test
         [Fact]
         public async Task UserNonBlittableStructFixAllConvertsAllLocations()
         {
-            string source = @$"
-using System.Runtime.InteropServices;
+            string source = """
+                using System.Runtime.InteropServices;
 
-struct Blittable
-{{
-    private short s;
-    private short t;
-}}
+                struct Blittable
+                {
+                    private short s;
+                    private short t;
+                }
 
-struct NonBlittable
-{{
-    private string s;
-    private short t;
-}}
+                struct NonBlittable
+                {
+                    private string s;
+                    private short t;
+                }
 
-partial class Test
-{{
-    [DllImport(""DoesNotExist"")]
-    public static extern void [|Method|](int i);
-    [DllImport(""DoesNotExist"")]
-    public static extern void [|Method|](Blittable b);
-    [DllImport(""DoesNotExist"")]
-    public static extern void [|Method|](NonBlittable b);
-}}";
+                partial class Test
+                {
+                    [DllImport("DoesNotExist")]
+                    public static extern void [|Method|](int i);
+                    [DllImport("DoesNotExist")]
+                    public static extern void [|Method|](Blittable b);
+                    [DllImport("DoesNotExist")]
+                    public static extern void [|Method|](NonBlittable b);
+                }
+                """;
             // Fixed sources will have CS8795 (Partial method must have an implementation) without generator run
-            string nonBlittableOnlyFixedSource = @$"
-using System.Runtime.InteropServices;
+            string nonBlittableOnlyFixedSource = """
+                using System.Runtime.InteropServices;
 
-struct Blittable
-{{
-    private short s;
-    private short t;
-}}
+                struct Blittable
+                {
+                    private short s;
+                    private short t;
+                }
 
-struct NonBlittable
-{{
-    private string s;
-    private short t;
-}}
+                struct NonBlittable
+                {
+                    private string s;
+                    private short t;
+                }
 
-partial class Test
-{{
-    [DllImport(""DoesNotExist"")]
-    public static extern void [|Method|](int i);
-    [DllImport(""DoesNotExist"")]
-    public static extern void [|Method|](Blittable b);
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void {{|CS8795:Method|}}(NonBlittable b);
-}}";
+                partial class Test
+                {
+                    [DllImport("DoesNotExist")]
+                    public static extern void [|Method|](int i);
+                    [DllImport("DoesNotExist")]
+                    public static extern void [|Method|](Blittable b);
+                    [LibraryImport("DoesNotExist")]
+                    public static partial void {|CS8795:Method|}(NonBlittable b);
+                }
+                """;
             // Fixed sources will have CS8795 (Partial method must have an implementation) without generator run
-            string allFixedSource = @$"
-using System.Runtime.InteropServices;
+            string allFixedSource = """
+                using System.Runtime.InteropServices;
 
-struct Blittable
-{{
-    private short s;
-    private short t;
-}}
+                struct Blittable
+                {
+                    private short s;
+                    private short t;
+                }
 
-struct NonBlittable
-{{
-    private string s;
-    private short t;
-}}
+                struct NonBlittable
+                {
+                    private string s;
+                    private short t;
+                }
 
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void {{|CS8795:Method|}}(int i);
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void {{|CS8795:Method|}}(Blittable b);
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void {{|CS8795:Method|}}(NonBlittable b);
-}}";
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    public static partial void {|CS8795:Method|}(int i);
+                    [LibraryImport("DoesNotExist")]
+                    public static partial void {|CS8795:Method|}(Blittable b);
+                    [LibraryImport("DoesNotExist")]
+                    public static partial void {|CS8795:Method|}(NonBlittable b);
+                }
+                """;
 
             // Verify that we fix all cases when we do fix-all on a P/Invoke with a non-blittable user type which
             // will require the user to write additional code.

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Diagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Diagnostics.cs
@@ -23,22 +23,23 @@ namespace LibraryImportGenerator.UnitTests
         [Fact]
         public async Task ParameterTypeNotSupported_ReportsDiagnostic()
         {
-            string source = @"
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-namespace NS
-{
-    class MyClass { }
-}
-partial class Test
-{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method1(NS.MyClass c);
+            string source = """
 
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method2(int i, List<int> list);
-}
-";
+                using System.Collections.Generic;
+                using System.Runtime.InteropServices;
+                namespace NS
+                {
+                    class MyClass { }
+                }
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    public static partial void Method1(NS.MyClass c);
+
+                    [LibraryImport("DoesNotExist")]
+                    public static partial void Method2(int i, List<int> list);
+                }
+                """;
             Compilation comp = await TestUtils.CreateCompilation(source);
             TestUtils.AssertPreSourceGeneratorCompilation(comp);
 
@@ -61,22 +62,23 @@ partial class Test
         [Fact]
         public async Task ReturnTypeNotSupported_ReportsDiagnostic()
         {
-            string source = @"
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-namespace NS
-{
-    class MyClass { }
-}
-partial class Test
-{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial NS.MyClass Method1();
+            string source = """
 
-    [LibraryImport(""DoesNotExist"")]
-    public static partial List<int> Method2();
-}
-";
+                using System.Collections.Generic;
+                using System.Runtime.InteropServices;
+                namespace NS
+                {
+                    class MyClass { }
+                }
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    public static partial NS.MyClass Method1();
+
+                    [LibraryImport("DoesNotExist")]
+                    public static partial List<int> Method2();
+                }
+                """;
             Compilation comp = await TestUtils.CreateCompilation(source);
             TestUtils.AssertPreSourceGeneratorCompilation(comp);
 
@@ -99,14 +101,15 @@ partial class Test
         [Fact]
         public async Task ParameterTypeNotSupportedWithDetails_ReportsDiagnostic()
         {
-            string source = @"
-using System.Runtime.InteropServices;
-partial class Test
-{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method(char c, string s);
-}
-";
+            string source = """
+
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    public static partial void Method(char c, string s);
+                }
+                """;
             Compilation comp = await TestUtils.CreateCompilation(source);
             TestUtils.AssertPreSourceGeneratorCompilation(comp);
 
@@ -127,17 +130,18 @@ partial class Test
         [Fact]
         public async Task ReturnTypeNotSupportedWithDetails_ReportsDiagnostic()
         {
-            string source = @"
-using System.Runtime.InteropServices;
-partial class Test
-{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial char Method1();
+            string source = """
 
-    [LibraryImport(""DoesNotExist"")]
-    public static partial string Method2();
-}
-";
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    public static partial char Method1();
+
+                    [LibraryImport("DoesNotExist")]
+                    public static partial string Method2();
+                }
+                """;
             Compilation comp = await TestUtils.CreateCompilation(source);
             TestUtils.AssertPreSourceGeneratorCompilation(comp);
 
@@ -158,17 +162,18 @@ partial class Test
         [Fact]
         public async Task ParameterConfigurationNotSupported_ReportsDiagnostic()
         {
-            string source = @"
-using System.Runtime.InteropServices;
-partial class Test
-{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method1([MarshalAs(UnmanagedType.BStr)] int i1, int i2);
+            string source = """
 
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method2(int i1, [MarshalAs(UnmanagedType.FunctionPtr)] bool b2);
-}
-";
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    public static partial void Method1([MarshalAs(UnmanagedType.BStr)] int i1, int i2);
+
+                    [LibraryImport("DoesNotExist")]
+                    public static partial void Method2(int i1, [MarshalAs(UnmanagedType.FunctionPtr)] bool b2);
+                }
+                """;
             Compilation comp = await TestUtils.CreateCompilation(source);
             TestUtils.AssertPreSourceGeneratorCompilation(comp);
 
@@ -191,19 +196,20 @@ partial class Test
         [Fact]
         public async Task ReturnConfigurationNotSupported_ReportsDiagnostic()
         {
-            string source = @"
-using System.Runtime.InteropServices;
-partial class Test
-{
-    [LibraryImport(""DoesNotExist"")]
-    [return: MarshalAs(UnmanagedType.BStr)]
-    public static partial int Method1(int i);
+            string source = """
 
-    [LibraryImport(""DoesNotExist"")]
-    [return: MarshalAs(UnmanagedType.FunctionPtr)]
-    public static partial bool Method2(int i);
-}
-";
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    [return: MarshalAs(UnmanagedType.BStr)]
+                    public static partial int Method1(int i);
+
+                    [LibraryImport("DoesNotExist")]
+                    [return: MarshalAs(UnmanagedType.FunctionPtr)]
+                    public static partial bool Method2(int i);
+                }
+                """;
             Compilation comp = await TestUtils.CreateCompilation(source);
             TestUtils.AssertPreSourceGeneratorCompilation(comp);
 
@@ -226,18 +232,19 @@ partial class Test
         [Fact]
         public async Task MarshalAsUnmanagedTypeNotSupported_ReportsDiagnostic()
         {
-            string source = @"
-using System.Runtime.InteropServices;
-partial class Test
-{
-    [LibraryImport(""DoesNotExist"")]
-    [return: MarshalAs(1)]
-    public static partial int Method1(int i);
+            string source = """
 
-    [LibraryImport(""DoesNotExist"")]
-    public static partial int Method2([MarshalAs((short)0)] bool b);
-}
-";
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    [return: MarshalAs(1)]
+                    public static partial int Method1(int i);
+
+                    [LibraryImport("DoesNotExist")]
+                    public static partial int Method2([MarshalAs((short)0)] bool b);
+                }
+                """;
             Compilation comp = await TestUtils.CreateCompilation(source);
             TestUtils.AssertPreSourceGeneratorCompilation(comp);
 
@@ -266,18 +273,19 @@ partial class Test
         [Fact]
         public async Task MarshalAsFieldNotSupported_ReportsDiagnostic()
         {
-            string source = @"
-using System.Runtime.InteropServices;
-partial class Test
-{
-    [LibraryImport(""DoesNotExist"")]
-    [return: MarshalAs(UnmanagedType.I4, SafeArraySubType=VarEnum.VT_I4)]
-    public static partial int Method1(int i);
+            string source = """
 
-    [LibraryImport(""DoesNotExist"")]
-    public static partial int Method2([MarshalAs(UnmanagedType.I1, IidParameterIndex = 1)] bool b);
-}
-";
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    [return: MarshalAs(UnmanagedType.I4, SafeArraySubType=VarEnum.VT_I4)]
+                    public static partial int Method1(int i);
+
+                    [LibraryImport("DoesNotExist")]
+                    public static partial int Method2([MarshalAs(UnmanagedType.I1, IidParameterIndex = 1)] bool b);
+                }
+                """;
             Compilation comp = await TestUtils.CreateCompilation(source);
             TestUtils.AssertPreSourceGeneratorCompilation(comp);
 
@@ -300,23 +308,24 @@ partial class Test
         [OuterLoop("Uses the network for downlevel ref packs")]
         public async Task StringMarshallingForwardingNotSupported_ReportsDiagnostic()
         {
-            string source = @"
-using System.Runtime.InteropServices;
-partial class Test
-{
-    [LibraryImport(""DoesNotExist"", StringMarshalling = StringMarshalling.Utf8)]
-    public static partial void Method1(string s);
+            string source = """
 
-    [LibraryImport(""DoesNotExist"", StringMarshalling = StringMarshalling.Custom, StringMarshallingCustomType = typeof(Native))]
-    public static partial void Method2(string s);
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist", StringMarshalling = StringMarshalling.Utf8)]
+                    public static partial void Method1(string s);
 
-    struct Native
-    {
-        public Native(string s) { }
-        public string ToManaged() => default;
-    }
-}
-" + CodeSnippets.LibraryImportAttributeDeclaration;
+                    [LibraryImport("DoesNotExist", StringMarshalling = StringMarshalling.Custom, StringMarshallingCustomType = typeof(Native))]
+                    public static partial void Method2(string s);
+
+                    struct Native
+                    {
+                        public Native(string s) { }
+                        public string ToManaged() => default;
+                    }
+                }
+                """ + CodeSnippets.LibraryImportAttributeDeclaration;
 
             // Compile against Standard so that we generate forwarders
             Compilation comp = await TestUtils.CreateCompilation(source, TestTargetFramework.Standard);
@@ -342,24 +351,25 @@ partial class Test
         [Fact]
         public async Task InvalidStringMarshallingConfiguration_ReportsDiagnostic()
         {
-            string source = @$"
-using System.Runtime.InteropServices;
-{CodeSnippets.DisableRuntimeMarshalling}
-partial class Test
-{{
-    [LibraryImport(""DoesNotExist"", StringMarshalling = StringMarshalling.Custom)]
-    public static partial void Method1(out int i);
+            string source = $$"""
 
-    [LibraryImport(""DoesNotExist"", StringMarshalling = StringMarshalling.Utf8, StringMarshallingCustomType = typeof(Native))]
-    public static partial void Method2(out int i);
-
-    struct Native
-    {{
-        public Native(string s) {{ }}
-        public string ToManaged() => default;
-    }}
-}}
-";
+                using System.Runtime.InteropServices;
+                {{CodeSnippets.DisableRuntimeMarshalling}}
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist", StringMarshalling = StringMarshalling.Custom)]
+                    public static partial void Method1(out int i);
+                
+                    [LibraryImport("DoesNotExist", StringMarshalling = StringMarshalling.Utf8, StringMarshallingCustomType = typeof(Native))]
+                    public static partial void Method2(out int i);
+                
+                    struct Native
+                    {
+                        public Native(string s) { }
+                        public string ToManaged() => default;
+                    }
+                }
+                """;
 
             Compilation comp = await TestUtils.CreateCompilation(source);
             TestUtils.AssertPreSourceGeneratorCompilation(comp);
@@ -380,17 +390,18 @@ partial class Test
         [Fact]
         public async Task NonPartialMethod_ReportsDiagnostic()
         {
-            string source = @"
-using System.Runtime.InteropServices;
-partial class Test
-{
-    [LibraryImport(""DoesNotExist"")]
-    public static void Method() { }
+            string source = """
 
-    [LibraryImport(""DoesNotExist"")]
-    public static extern void ExternMethod();
-}
-";
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    public static void Method() { }
+
+                    [LibraryImport("DoesNotExist")]
+                    public static extern void ExternMethod();
+                }
+                """;
             Compilation comp = await TestUtils.CreateCompilation(source);
             TestUtils.AssertPreSourceGeneratorCompilation(comp);
 
@@ -412,14 +423,15 @@ partial class Test
         [Fact]
         public async Task NonStaticMethod_ReportsDiagnostic()
         {
-            string source = @"
-using System.Runtime.InteropServices;
-partial class Test
-{
-    [LibraryImport(""DoesNotExist"")]
-    public partial void Method();
-}
-";
+            string source = """
+
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    public partial void Method();
+                }
+                """;
             Compilation comp = await TestUtils.CreateCompilation(source);
             TestUtils.AssertPreSourceGeneratorCompilation(comp);
 
@@ -439,17 +451,18 @@ partial class Test
         [Fact]
         public async Task GenericMethod_ReportsDiagnostic()
         {
-            string source = @"
-using System.Runtime.InteropServices;
-partial class Test
-{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method1<T>();
+            string source = """
 
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method2<T, U>();
-}
-";
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    public static partial void Method1<T>();
+
+                    [LibraryImport("DoesNotExist")]
+                    public static partial void Method2<T, U>();
+                }
+                """;
             Compilation comp = await TestUtils.CreateCompilation(source);
             TestUtils.AssertPreSourceGeneratorCompilation(comp);
 
@@ -475,14 +488,15 @@ partial class Test
         [InlineData("record")]
         public async Task NonPartialParentType_Diagnostic(string typeKind)
         {
-            string source = $@"
-using System.Runtime.InteropServices;
-{typeKind} Test
-{{
-    [LibraryImport(""DoesNotExist"")]
-    public static partial void Method();
-}}
-";
+            string source = $$"""
+
+                using System.Runtime.InteropServices;
+                {{typeKind}} Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    public static partial void Method();
+                }
+                """;
             Compilation comp = await TestUtils.CreateCompilation(source);
 
             // Also expect CS0751: A partial method must be declared within a partial type
@@ -508,17 +522,18 @@ using System.Runtime.InteropServices;
         [InlineData("record")]
         public async Task NonPartialGrandparentType_Diagnostic(string typeKind)
         {
-            string source = $@"
-using System.Runtime.InteropServices;
-{typeKind} Test
-{{
-    partial class TestInner
-    {{
-        [LibraryImport(""DoesNotExist"")]
-        static partial void Method();
-    }}
-}}
-";
+            string source = $$"""
+
+                using System.Runtime.InteropServices;
+                {{typeKind}} Test
+                {
+                    partial class TestInner
+                    {
+                        [LibraryImport("DoesNotExist")]
+                        static partial void Method();
+                    }
+                }
+                """;
             Compilation comp = await TestUtils.CreateCompilation(source);
             TestUtils.AssertPreSourceGeneratorCompilation(comp);
 

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/IncrementalGenerationTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/IncrementalGenerationTests.cs
@@ -49,7 +49,12 @@ namespace LibraryImportGenerator.UnitTests
         [Fact]
         public async Task AppendingUnrelatedSource_DoesNotRegenerateSource()
         {
-            string source = $"namespace NS{{{CodeSnippets.BasicParametersAndModifiers<int>()}}}";
+            string source = $$"""
+                namespace NS
+                {
+                    {{CodeSnippets.BasicParametersAndModifiers<int>()}}
+                }
+                """;
 
             SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview));
 


### PR DESCRIPTION
The way raw string literals allows you to customize the number of curly brackets for escape (and allowing a single curly bracket to not be an escape sequence for interpolation) makes future improvements I want to make in the source generator testing space (using the Roslyn-provided source generator testing SDK and having more specific emitted diagnostic checks) much cleaner and more consistent.

The improved text alignment in the source code is a nice bonus.

Majority of the changes here are whitespace, so reviewing with whitespace changes off will make seeing the improvements with interpolation more visible.