### PR TITLE
Disable StackallocBlkTests test on Mono

### DIFF
--- a/src/tests/JIT/opt/Vectorization/StackallocBlkTests.cs
+++ b/src/tests/JIT/opt/Vectorization/StackallocBlkTests.cs
@@ -48,7 +48,7 @@ public unsafe class StackallocTests
     }
     
     [MethodImpl(MethodImplOptions.NoInlining)]
-    static void Consume(byte* ptr) { } // to avoid dead-code elimination
+    static void Consume(byte* ptr) {} // to avoid dead-code elimination
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     static T ToVar<T>(T o) => o; // convert a constant to a variable

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2197,6 +2197,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/StringMarshalling/VBByRefStr/VBByRefStrTest/*">
             <Issue>https://github.com/dotnet/runtime/issues/65698</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/opt/Vectorization/StackallocBlkTests/*">
+            <Issue>https://github.com/dotnet/runtime/issues/84398</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/callconv/PlatformDefaultMemberFunction/PlatformDefaultMemberFunctionTest/*">
             <Issue>https://github.com/dotnet/runtime/issues/50440</Issue>
         </ExcludeList>


### PR DESCRIPTION
Unblocks CI https://github.com/dotnet/runtime/issues/84398

The following test is failing on Mono-Windows-x64:
```csharp
[MethodImpl(MethodImplOptions.NoInlining)]
static void PoisonStack()
{
    var b = stackalloc byte[20000];
    Unsafe.InitBlockUnaligned(b, 0xFF, 20000);
    Consume(b);
}

[MethodImpl(MethodImplOptions.NoInlining)]
static void EnsureZeroed(byte* ptr, int size)
{
    for (int i = 0; i < size; i++)
    {
        if (ptr[i] != 0)
            throw new InvalidOperationException();
    }
}

[MethodImpl(MethodImplOptions.NoInlining)]
static void Consume(byte* ptr) { } // to avoid dead-code elimination

[MethodImpl(MethodImplOptions.NoInlining)]
public static Guid Test4096(out Guid g)
{
    const int size = 4096;
    PoisonStack();
    byte* p = stackalloc byte[size];
    EnsureZeroed(p, size);
    g = default;
    return default;
}
```