### PR TITLE
Fix eventpipe/enabledisable.cs test on Android

### DIFF
--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/AssemblyInfo.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/AssemblyInfo.cs
@@ -5,4 +5,5 @@ using System.IO;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("common")]
+[assembly: InternalsVisibleTo("enabledisable")]
 #endif

--- a/src/tests/tracing/eventpipe/enabledisable/enabledisable.cs
+++ b/src/tests/tracing/eventpipe/enabledisable/enabledisable.cs
@@ -72,6 +72,10 @@ namespace Tracing.Tests.EnableDisableValidation
             };
 
             DiagnosticsClient client = new DiagnosticsClient(Process.GetCurrentProcess().Id);
+#if DIAGNOSTICS_RUNTIME
+            if (OperatingSystem.IsAndroid())
+                client = new DiagnosticsClient(new IpcEndpointConfig("127.0.0.1:9000", IpcEndpointConfig.TransportType.TcpSocket, IpcEndpointConfig.PortType.Listen));
+#endif
             using (EventPipeSession session1 = client.StartEventPipeSession(providers))
             {
                 EventPipeEventSource source1 = new EventPipeEventSource(session1.EventStream);

--- a/src/tests/tracing/eventpipe/enabledisable/enabledisable.csproj
+++ b/src/tests/tracing/eventpipe/enabledisable/enabledisable.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants Condition="'$(GitHubRepositoryName)' == 'runtime'">$(DefineConstants);DIAGNOSTICS_RUNTIME</DefineConstants>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <!-- GCStress timeout: https://github.com/dotnet/runtime/issues/51133 -->


### PR DESCRIPTION
It needs the same customization that we have in IpcTraceTest.cs