### PR TITLE
Add `AggressiveInlining` to `Char.IsLatin1`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Char.cs
@@ -81,7 +81,8 @@ namespace System
         };
 
         // Return true for all characters below or equal U+00ff, which is ASCII + Latin-1 Supplement.
-        private static bool IsLatin1(char c) => (uint)c < (uint)Latin1CharInfo.Length;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsLatin1(char c) => c < Latin1CharInfo.Length;
 
         // Return true for all characters below or equal U+007f, which is ASCII.
 


### PR DESCRIPTION
* Force the JIT to inline this 17 byte method to elide bounds checks.
* Remove useless `uint` casts as `char` is unsigned and `ReadOnlySpan<T>.Length` is never negative.