### PR TITLE
Extend PreInitialization Support to readonly GC fields

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -1475,7 +1475,7 @@ namespace ILCompiler
 
         private static BaseValueTypeValue NewUninitializedLocationValue(TypeDesc locationType)
         {
-            if (locationType.IsGCPointer || locationType.IsByRef)
+            if (locationType.IsGCPointer || locationType.IsByRef || locationType.IsFunctionPointer)
             {
                 return null;
             }
@@ -2180,7 +2180,7 @@ namespace ILCompiler
             }
         }
 
-        private sealed class MethodPointerValue : BaseValueTypeValue, IInternalModelingOnlyValue
+        private sealed class MethodPointerValue : BaseValueTypeValue
         {
             public MethodDesc PointedToMethod { get; }
 
@@ -2203,7 +2203,7 @@ namespace ILCompiler
 
             public override void WriteFieldData(ref ObjectDataBuilder builder, NodeFactory factory)
             {
-                throw new NotSupportedException();
+                builder.EmitPointerReloc(factory.ExactCallableAddress(PointedToMethod));
             }
 
             public override bool GetRawData(NodeFactory factory, out object data)


### PR DESCRIPTION
@MichalStrehovsky do you think the approach with the `Dictionary<FieldDesc, Value> GCFields;` overlaying the `InstanceBytes` is viable?

fixes #82993
fixes #83043

TODO:
- [x] InitObj must clear the GCFields
- [x] Switch from Keying GCFields on FieldDesc to instead using Offset to handle overlapping fields
- [ ] figure out why on localhost, `Assert.IsLazyInitialized` always fails in Preinitialization tests (even if ILC claimed it did not initialize that class)