### PR TITLE
[release/6.0] Fix AwaitableSocketAsyncEventArgs reorderings on weaker memory models

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
@@ -857,7 +857,7 @@ namespace System.Net.Sockets
             /// <see cref="s_completedSentinel"/> if it has completed. Another delegate if OnCompleted was called before the operation could complete,
             /// in which case it's the delegate to invoke when the operation does complete.
             /// </summary>
-            private Action<object?>? _continuation;
+            private volatile Action<object?>? _continuation;
             private ExecutionContext? _executionContext;
             private object? _scheduler;
             /// <summary>Current token value given to a ValueTask and then verified against the value it passes back to us.</summary>
@@ -930,7 +930,7 @@ namespace System.Net.Sockets
             /// <returns>This instance.</returns>
             public ValueTask<Socket> AcceptAsync(Socket socket, CancellationToken cancellationToken)
             {
-                Debug.Assert(Volatile.Read(ref _continuation) == null, "Expected null continuation to indicate reserved for use");
+                Debug.Assert(_continuation == null, "Expected null continuation to indicate reserved for use");
 
                 if (socket.AcceptAsync(this, cancellationToken))
                 {
@@ -952,7 +952,7 @@ namespace System.Net.Sockets
             /// <returns>This instance.</returns>
             public ValueTask<int> ReceiveAsync(Socket socket, CancellationToken cancellationToken)
             {
-                Debug.Assert(Volatile.Read(ref _continuation) == null, "Expected null continuation to indicate reserved for use");
+                Debug.Assert(_continuation == null, "Expected null continuation to indicate reserved for use");
 
                 if (socket.ReceiveAsync(this, cancellationToken))
                 {
@@ -972,7 +972,7 @@ namespace System.Net.Sockets
 
             public ValueTask<SocketReceiveFromResult> ReceiveFromAsync(Socket socket, CancellationToken cancellationToken)
             {
-                Debug.Assert(Volatile.Read(ref _continuation) == null, "Expected null continuation to indicate reserved for use");
+                Debug.Assert(_continuation == null, "Expected null continuation to indicate reserved for use");
 
                 if (socket.ReceiveFromAsync(this, cancellationToken))
                 {
@@ -993,7 +993,7 @@ namespace System.Net.Sockets
 
             public ValueTask<SocketReceiveMessageFromResult> ReceiveMessageFromAsync(Socket socket, CancellationToken cancellationToken)
             {
-                Debug.Assert(Volatile.Read(ref _continuation) == null, "Expected null continuation to indicate reserved for use");
+                Debug.Assert(_continuation == null, "Expected null continuation to indicate reserved for use");
 
                 if (socket.ReceiveMessageFromAsync(this, cancellationToken))
                 {
@@ -1018,7 +1018,7 @@ namespace System.Net.Sockets
             /// <returns>This instance.</returns>
             public ValueTask<int> SendAsync(Socket socket, CancellationToken cancellationToken)
             {
-                Debug.Assert(Volatile.Read(ref _continuation) == null, "Expected null continuation to indicate reserved for use");
+                Debug.Assert(_continuation == null, "Expected null continuation to indicate reserved for use");
 
                 if (socket.SendAsync(this, cancellationToken))
                 {
@@ -1038,7 +1038,7 @@ namespace System.Net.Sockets
 
             public ValueTask SendAsyncForNetworkStream(Socket socket, CancellationToken cancellationToken)
             {
-                Debug.Assert(Volatile.Read(ref _continuation) == null, "Expected null continuation to indicate reserved for use");
+                Debug.Assert(_continuation == null, "Expected null continuation to indicate reserved for use");
 
                 if (socket.SendAsync(this, cancellationToken))
                 {
@@ -1057,7 +1057,7 @@ namespace System.Net.Sockets
 
             public ValueTask SendPacketsAsync(Socket socket, CancellationToken cancellationToken)
             {
-                Debug.Assert(Volatile.Read(ref _continuation) == null, "Expected null continuation to indicate reserved for use");
+                Debug.Assert(_continuation == null, "Expected null continuation to indicate reserved for use");
 
                 if (socket.SendPacketsAsync(this, cancellationToken))
                 {
@@ -1076,7 +1076,7 @@ namespace System.Net.Sockets
 
             public ValueTask<int> SendToAsync(Socket socket, CancellationToken cancellationToken)
             {
-                Debug.Assert(Volatile.Read(ref _continuation) == null, "Expected null continuation to indicate reserved for use");
+                Debug.Assert(_continuation == null, "Expected null continuation to indicate reserved for use");
 
                 if (socket.SendToAsync(this, cancellationToken))
                 {
@@ -1096,7 +1096,7 @@ namespace System.Net.Sockets
 
             public ValueTask ConnectAsync(Socket socket)
             {
-                Debug.Assert(Volatile.Read(ref _continuation) == null, "Expected null continuation to indicate reserved for use");
+                Debug.Assert(_continuation == null, "Expected null continuation to indicate reserved for use");
 
                 try
                 {
@@ -1122,7 +1122,7 @@ namespace System.Net.Sockets
 
             public ValueTask DisconnectAsync(Socket socket, CancellationToken cancellationToken)
             {
-                Debug.Assert(Volatile.Read(ref _continuation) == null, $"Expected null continuation to indicate reserved for use");
+                Debug.Assert(_continuation == null, $"Expected null continuation to indicate reserved for use");
 
                 if (socket.DisconnectAsync(this, cancellationToken))
                 {


### PR DESCRIPTION
There are a couple of places where we read the _continuation field and then read some other state which we assume to be consistent with the value we read in _continuation.  But without a fence, those secondary reads could be reordered with respect to the first.

Fixes https://github.com/dotnet/runtime/issues/84407
Fixes https://github.com/dotnet/runtime/issues/70486
Fixes https://github.com/dotnet/runtime/issues/72365

I don't have a repro, but we've received several related reports and this is the most likely cause based on code inspection.

## Customer Impact
Rare crashes on arm64 due to an exception occurring in networking code the application doesn't control.

## Testing
Only CI.  The failure is so sporadic, we don't have a good repro or even ability to exercise it with stress.

## Risk
Low.  Other than changes to some Debug.Asserts, this is a one-word change to add `volatile` to a field. The change is effectively a nop on x86/64. It'll result in a few additional memory barriers being output on arm64, which are both necessary for correctness (whether or not it fixes this issue) and could have a small impact on performance.

(Note that this code no longer exists in .NET 8, having been replaced by use of the shared, public ManualResetValueTaskSourceCore implementation.  We will want to port the fix to .NET 7 as well, though.)