### PR TITLE
Unit tests should re-enable BinaryFormatter for compat testing

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -441,6 +441,8 @@
 
   <!-- Warnings that should be disabled in our test projects. -->
   <PropertyGroup Condition="'$(IsTestProject)' == 'true' or '$(IsTestSupportProject)' == 'true' or '$(IsPublishedAppTestProject)' == 'true'">
+    <!-- we need to re-enable BinaryFormatter within test projects since some tests exercise these code paths to ensure compat -->
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
     <!-- don't warn on usage of BinaryFormatter from test projects -->
     <NoWarn>$(NoWarn);SYSLIB0011</NoWarn>
     <!-- don't warn about unnecessary trim warning suppressions. can be removed with preview 6. -->

--- a/src/libraries/System.Runtime.Serialization.Formatters/tests/DisableBitTests.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/tests/DisableBitTests.cs
@@ -36,6 +36,27 @@ namespace System.Runtime.Serialization.Formatters.Tests
         }
 
         [ConditionalFact(nameof(ShouldRunFullFeatureSwitchEnablementChecks))]
+        public static void EnabledThroughFeatureSwitch()
+        {
+            RemoteInvokeOptions options = new RemoteInvokeOptions();
+            options.RuntimeConfigurationOptions[EnableBinaryFormatterSwitchName] = bool.TrueString;
+
+            RemoteExecutor.Invoke(() =>
+            {
+                // Test serialization
+
+                MemoryStream ms = new MemoryStream();
+                new BinaryFormatter().Serialize(ms, "A string to serialize.");
+
+                // Test round-trippability
+
+                ms.Position = 0;
+                object roundTripped = new BinaryFormatter().Deserialize(ms);
+                Assert.Equal("A string to serialize.", roundTripped);
+            }, options).Dispose();
+        }
+
+        [ConditionalFact(nameof(ShouldRunFullFeatureSwitchEnablementChecks))]
         public static void DisabledThroughFeatureSwitch()
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions();

--- a/src/libraries/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
+++ b/src/libraries/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
@@ -4,6 +4,16 @@
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-freebsd;$(NetCoreAppCurrent)-illumos;$(NetCoreAppCurrent)-solaris;$(NetCoreAppCurrent)-linux;$(NetCoreAppCurrent)-osx;$(NetCoreAppCurrent)-ios;$(NetCoreAppCurrent)-tvos;net48</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup>
+    <!--
+      We're testing the BinaryFormatter enablement / disablement switch, so we need to suppress any inherited behavior.
+      The specific combination below accomplishes this. Normal apps should *NOT* set this combination of switches and
+      should instead set the switches documented at:
+      https://learn.microsoft.com/dotnet/core/compatibility/core-libraries/7.0/binaryformatter-apis-produce-errors#recommended-action
+    -->
+    <_ProjectTypeRequiresBinaryFormatter>true</_ProjectTypeRequiresBinaryFormatter>
+    <EnableUnsafeBinaryFormatterSerialization><!-- intentionally left blank --></EnableUnsafeBinaryFormatterSerialization>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="BinaryFormatterTestData.cs" />
     <Compile Include="BinaryFormatterTests.cs" />


### PR DESCRIPTION
Split out from https://github.com/dotnet/runtime/pull/84383 so it can be fast-tracked. Re-enables BinaryFormatter support _only within unit tests_ so that the changes going in as part of https://github.com/dotnet/sdk/pull/31591 don't break our build.