### PR TITLE
Reserving two diagnostic codes for serialization work

### DIFF
--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -104,6 +104,8 @@ The PR that reveals the implementation of the `<IncludeInternalObsoleteAttribute
 |  __`SYSLIB0047`__ | XmlSecureResolver is obsolete. Use XmlResolver.ThrowingResolver instead when attempting to forbid XML external entity resolution. |
 |  __`SYSLIB0048`__ | RSA.EncryptValue and DecryptValue are not supported and throw NotSupportedException. Use RSA.Encrypt and RSA.Decrypt instead. |
 |  __`SYSLIB0049`__ | JsonSerializerOptions.AddContext is obsolete. To register a JsonSerializerContext, use either the TypeInfoResolver or TypeInfoResolverChain properties. |
+|  __`SYSLIB0050`__ | (reserved for serialization work) |
+|  __`SYSLIB0051`__ | (reserved for serialization work) |
 
 ## Analyzer Warnings
 

--- a/src/libraries/Common/src/System/Obsoletions.cs
+++ b/src/libraries/Common/src/System/Obsoletions.cs
@@ -159,5 +159,11 @@ namespace System
 
         internal const string JsonSerializerOptionsAddContextMessage = "JsonSerializerOptions.AddContext is obsolete. To register a JsonSerializerContext, use either the TypeInfoResolver or TypeInfoResolverChain properties.";
         internal const string JsonSerializerOptionsAddContextDiagId = "SYSLIB0049";
+
+        internal const string LegacyFormatterMessage = "(reserved for serialization work)";
+        internal const string LegacyFormatterDiagId = "SYSLIB0050";
+
+        internal const string LegacyFormatterImplMessage = "(reserved for serialization work)";
+        internal const string LegacyFormatterImplDiagId = "SYSLIB0051";
     }
 }


### PR DESCRIPTION
Split out from https://github.com/dotnet/runtime/pull/84383 so that it can be fast-tracked. Reserves obsoletion diagnostic codes while the main PR is under review to help minimize the risk of conflicts.