### PR TITLE
Mitigation for #84446: comment out problematic JIT assertion check

### DIFF
--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -2611,7 +2611,10 @@ PhaseStatus Compiler::fgIncorporateProfileData()
         // We expect not to have both block and edge counts. We may have other
         // forms of profile data even if we do not have any counts.
         //
-        assert(!haveBlockCounts || !haveEdgeCounts);
+        // As of 4/6/2023 the following invariant check turns out to no longer hold.
+        // Tracking issue: https://github.com/dotnet/runtime/issues/84446
+        //
+        // assert(!haveBlockCounts || !haveEdgeCounts);
 
         bool dataIsGood = false;
 


### PR DESCRIPTION
The most recent aggregated runtime MIBC optimization data contains a combination of block and edge counts, possibly after a change from January 2023 that switched MIBC logic over from using block counts to edge counts. The offending assertion check wasn't expecting it and started crashing Crossgen2 during compilation of System.Private.CoreLib on Windows x64 / arm. Based on Andy Ayers' advice I'm proposing to comment out the assertion check; I have created the tracking issue #84446 to follow up on consolidation of JIT and MIBC production logic in this respect.

Thanks

Tomas

/cc @dotnet/jit-contrib, @dotnet/crossgen-contrib

Expected to unblock PR: https://github.com/dotnet/runtime/pull/83624