### PR TITLE
Add a test for warning behavior of Requires on type with a const field

### DIFF
--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnClass.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnClass.cs
@@ -39,6 +39,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 			KeepFieldOnAttribute ();
 			AttributeParametersAndProperties.Test ();
 			MembersOnClassWithRequires<int>.Test ();
+			ConstFieldsOnClassWithRequires.Test ();
 		}
 
 		[RequiresUnreferencedCode ("Message for --ClassWithRequires--")]
@@ -1227,6 +1228,61 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				var g = new GenericClassWithWarningWithRequires<int> ();
 				var h = new ClassWithWarningWithRequires ();
 				var j = new GenericAnnotatedWithWarningWithRequires<int> ();
+			}
+		}
+
+		class ConstFieldsOnClassWithRequires
+		{
+			[RequiresUnreferencedCode ("--ConstClassWithRequires--")]
+			[RequiresDynamicCode ("--ConstClassWithRequires--")]
+			class ConstClassWithRequires
+			{
+				public const string Message = "Message";
+				public const int Number = 42;
+
+				public static void Method () { }
+			}
+
+			// https://github.com/dotnet/runtime/issues/84433
+			[ExpectedWarning ("IL2026", "--ConstClassWithRequires--", nameof (ConstClassWithRequires.Message), ProducedBy = Tool.Analyzer)]
+			[ExpectedWarning ("IL3050", "--ConstClassWithRequires--", nameof (ConstClassWithRequires.Message), ProducedBy = Tool.Analyzer)]
+			[ExpectedWarning ("IL2026", "--ConstClassWithRequires--", nameof (ConstClassWithRequires.Number), ProducedBy = Tool.Analyzer)]
+			[ExpectedWarning ("IL3050", "--ConstClassWithRequires--", nameof (ConstClassWithRequires.Number), ProducedBy = Tool.Analyzer)]
+			[ExpectedWarning ("IL2026", "--ConstClassWithRequires--", nameof (ConstClassWithRequires.Method))]
+			[ExpectedWarning ("IL3050", "--ConstClassWithRequires--", nameof (ConstClassWithRequires.Method), ProducedBy = Tool.Analyzer | Tool.NativeAot)]
+			static void TestClassWithRequires ()
+			{
+				var a = ConstClassWithRequires.Message;
+				var b = ConstClassWithRequires.Number;
+
+				ConstClassWithRequires.Method ();
+			}
+
+			// https://github.com/dotnet/runtime/issues/84433
+			[ExpectedWarning ("IL2026", "--ConstClassWithRequiresUsingField--", nameof (ConstClassWithRequiresUsingField.Message), ProducedBy = Tool.Analyzer)]
+			[ExpectedWarning ("IL3050", "--ConstClassWithRequiresUsingField--", nameof (ConstClassWithRequiresUsingField.Message), ProducedBy = Tool.Analyzer)]
+			[RequiresUnreferencedCode (ConstClassWithRequiresUsingField.Message)]
+			[ExpectedWarning ("IL2026", "--ConstClassWithRequiresUsingField--", nameof (ConstClassWithRequiresUsingField.Message), ProducedBy = Tool.Analyzer)]
+			[ExpectedWarning ("IL3050", "--ConstClassWithRequiresUsingField--", nameof (ConstClassWithRequiresUsingField.Message), ProducedBy = Tool.Analyzer)]
+			[RequiresDynamicCode (ConstClassWithRequiresUsingField.Message)]
+			class ConstClassWithRequiresUsingField
+			{
+				public const string Message = "--ConstClassWithRequiresUsingField--";
+
+				public static void Method () { }
+			}
+
+			[ExpectedWarning ("IL2026", "--ConstClassWithRequiresUsingField--", nameof (ConstClassWithRequiresUsingField.Method))]
+			[ExpectedWarning ("IL3050", "--ConstClassWithRequiresUsingField--", nameof (ConstClassWithRequiresUsingField.Method), ProducedBy = Tool.Analyzer | Tool.NativeAot)]
+			static void TestClassUsingFieldInAttribute ()
+			{
+				ConstClassWithRequiresUsingField.Method ();
+			}
+
+			public static void Test ()
+			{
+				TestClassWithRequires ();
+				TestClassUsingFieldInAttribute ();
 			}
 		}
 	}


### PR DESCRIPTION
The IL tools (illink, ilc) don't see const field references in code, since the compiler inlines the values. But analyzer does see them. If the const field is on a type with Requires attribute, that access is reported as a warning, which is only produced by the analyzer.

This adds tests for these cases, no product changes.

Tests for https://github.com/dotnet/runtime/issues/84433