### PR TITLE
Shrink hello world by 3.2%

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
@@ -251,28 +251,17 @@ namespace Internal.Reflection.Core.Execution
             return true;
         }
 
+        public static bool IsPrimitiveType(Type type)
+            => type == typeof(bool) || type == typeof(char)
+                || type == typeof(sbyte) || type == typeof(byte)
+                || type == typeof(short) || type == typeof(ushort)
+                || type == typeof(int) || type == typeof(uint)
+                || type == typeof(long) || type == typeof(ulong)
+                || type == typeof(float) || type == typeof(double)
+                || type == typeof(nint) || type == typeof(nint);
+
         internal ExecutionEnvironment ExecutionEnvironment { get; }
 
         internal ReflectionDomainSetup ReflectionDomainSetup { get; }
-
-        internal static IEnumerable<Type> PrimitiveTypes => s_primitiveTypes;
-
-        private static readonly Type[] s_primitiveTypes =
-        {
-                    typeof(bool),
-                    typeof(char),
-                    typeof(sbyte),
-                    typeof(byte),
-                    typeof(short),
-                    typeof(ushort),
-                    typeof(int),
-                    typeof(uint),
-                    typeof(long),
-                    typeof(ulong),
-                    typeof(float),
-                    typeof(double),
-                    typeof(IntPtr),
-                    typeof(UIntPtr),
-        };
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
@@ -258,7 +258,7 @@ namespace Internal.Reflection.Core.Execution
                 || type == typeof(int) || type == typeof(uint)
                 || type == typeof(long) || type == typeof(ulong)
                 || type == typeof(float) || type == typeof(double)
-                || type == typeof(nint) || type == typeof(nint);
+                || type == typeof(nint) || type == typeof(nuint);
 
         internal ExecutionEnvironment ExecutionEnvironment { get; }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -833,14 +833,8 @@ namespace System.Reflection.Runtime.TypeInfos
                         if (baseType == valueType && this != enumType)
                         {
                             classification |= TypeClassification.IsValueType;
-                            foreach (Type primitiveType in ExecutionDomain.PrimitiveTypes)
-                            {
-                                if (this.Equals(primitiveType))
-                                {
-                                    classification |= TypeClassification.IsPrimitive;
-                                    break;
-                                }
-                            }
+                            if (ExecutionDomain.IsPrimitiveType(this))
+                                classification |= TypeClassification.IsPrimitive;
                         }
                     }
                     _lazyClassification = classification;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/RuntimeAssemblyName.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/RuntimeAssemblyName.cs
@@ -152,8 +152,7 @@ namespace System.Reflection
             {
                 // We must not hand out our own copy of the PKT to AssemblyName as AssemblyName is amazingly trusting and gives untrusted callers
                 // full freedom to scribble on its PKT array. (As do we but we only have trusted callers!)
-                byte[] pkCopy = new byte[this.PublicKeyOrToken.Length];
-                ((ICollection<byte>)(this.PublicKeyOrToken)).CopyTo(pkCopy, 0);
+                var pkCopy = (byte[])this.PublicKeyOrToken.Clone();
 
                 if (0 != (this.Flags & AssemblyNameFlags.PublicKey))
                     blank.SetPublicKey(pkCopy);

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/NativeFormatEnumInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/NativeFormatEnumInfo.cs
@@ -43,7 +43,7 @@ namespace Internal.Reflection.Execution
                     var handle = field.DefaultValue;
                     unsortedBoxedValues[i] = handle.HandleType switch
                     {
-                        HandleType.ConstantSByteValue => (byte)handle.ToConstantSByteValueHandle(reader).GetConstantSByteValue(reader).Value,
+                        HandleType.ConstantSByteValue => (object)(byte)handle.ToConstantSByteValueHandle(reader).GetConstantSByteValue(reader).Value,
                         HandleType.ConstantByteValue => handle.ToConstantByteValueHandle(reader).GetConstantByteValue(reader).Value,
                         HandleType.ConstantInt16Value => (ushort)handle.ToConstantInt16ValueHandle(reader).GetConstantInt16Value(reader).Value,
                         HandleType.ConstantUInt16Value => handle.ToConstantUInt16ValueHandle(reader).GetConstantUInt16Value(reader).Value,
@@ -51,7 +51,7 @@ namespace Internal.Reflection.Execution
                         HandleType.ConstantUInt32Value => handle.ToConstantUInt32ValueHandle(reader).GetConstantUInt32Value(reader).Value,
                         HandleType.ConstantInt64Value => (ulong)handle.ToConstantInt64ValueHandle(reader).GetConstantInt64Value(reader).Value,
                         HandleType.ConstantUInt64Value => handle.ToConstantUInt64ValueHandle(reader).GetConstantUInt64Value(reader).Value,
-                        _ => handle.ParseConstantNumericValue(reader), // fallback for unhandled cases
+                        _ => throw new InvalidOperationException(), // unreachable - we would have thrown InvalidOperationException earlier
                     };
                     i++;
                 }


### PR DESCRIPTION
* Get rid of the MethodTable for double/float
* Get rid of any `Array<T>` methods

Cc @dotnet/ilc-contrib 