### PR TITLE
[mono] Fix build error due to undeclared identifier 'llvm'

### DIFF
--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -3138,7 +3138,9 @@ mini_method_compile (MonoMethod *method, guint32 opts, JitFlags flags, int parts
 	opts |= MONO_OPT_FLOAT32;
 #else
 	opts &= ~MONO_OPT_FLOAT32;
+#ifdef ENABLE_LLVM
 	g_assert (!llvm);
+#endif
 #endif
 
  restart_compile:


### PR DESCRIPTION
`llvm` is only declared when ENABLE_LLVM is defined.

/cc @vargaz 