### PR TITLE
OnBeforeBuild delegate to invoke actions just before building the ServiceProvider

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/IServiceCollection.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/IServiceCollection.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 
+
 namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
@@ -10,5 +11,6 @@ namespace Microsoft.Extensions.DependencyInjection
     /// </summary>
     public interface IServiceCollection : IList<ServiceDescriptor>
     {
+        OnBeforeBuild OnBeforeBuild { get; set; }
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/IServiceCollection.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/IServiceCollection.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 
-
 namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/OnBeforeBuild.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/OnBeforeBuild.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+public delegate void OnBeforeBuild(IServiceCollection serviceCollection);

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceCollection.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceCollection.cs
@@ -109,6 +109,11 @@ namespace Microsoft.Extensions.DependencyInjection
             _isReadOnly = true;
         }
 
+        /// <summary>
+        /// Hooks for invoking actions just before the ServiceProvider is built
+        /// </summary>
+        public OnBeforeBuild OnBeforeBuild { get; set; } = delegate { };
+
         private void CheckReadOnly()
         {
             if (_isReadOnly)

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/ServiceCollection.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/ServiceCollection.cs
@@ -7,5 +7,6 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
 {
     internal sealed class TestServiceCollection : List<ServiceDescriptor>, IServiceCollection
     {
+        public OnBeforeBuild OnBeforeBuild { get; set; }
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/CallSiteTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/CallSiteTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.DependencyInjection.ServiceLookup;
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
 using Xunit;
@@ -80,7 +81,13 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         public void BuiltExpressionWillReturnResolvedServiceWhenAppropriate(
             ServiceDescriptor[] descriptors, Type serviceType, Func<object, object, bool> compare)
         {
-            var provider = new ServiceProvider(descriptors, ServiceProviderOptions.Default);
+            var serviceCollection = new ServiceCollection();
+            foreach (ServiceDescriptor serviceDescriptor in descriptors)
+            {
+                serviceCollection.Add(serviceDescriptor);
+            }
+
+            var provider = new ServiceProvider(serviceCollection, ServiceProviderOptions.Default);
 
             var callSite = provider.CallSiteFactory.GetCallSite(serviceType, new CallSiteChain());
             var collectionCallSite = provider.CallSiteFactory.GetCallSite(typeof(IEnumerable<>).MakeGenericType(serviceType), new CallSiteChain());
@@ -136,7 +143,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 
             var disposables = new List<object>();
             var provider = new ServiceProvider(descriptors, ServiceProviderOptions.Default);
-            
+
             var callSite = provider.CallSiteFactory.GetCallSite(typeof(ServiceC), new CallSiteChain());
             var compiledCallSite = CompileCallSite(callSite, provider);
 
@@ -185,7 +192,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 
             var disposables = new List<object>();
             var provider = new ServiceProvider(descriptors, ServiceProviderOptions.Default);
-            
+
             var callSite = provider.CallSiteFactory.GetCallSite(typeof(ServiceC), new CallSiteChain());
             var compiledCallSite = CompileCallSite(callSite, provider);
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceCollectionBeforeBuildTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceCollectionBeforeBuildTests.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Xunit;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+public class ServiceCollectionBeforeBuildTests
+{
+    [Fact]
+    public void TestBeforeBuildHookRunsAfterOtherActions()
+    {
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.OnBeforeBuild += Decorate;
+        serviceCollection.AddSingleton<IInterface, Implementation>();
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var @interface = serviceProvider.GetRequiredService<IInterface>();
+
+        Assert.IsType<Decorator>(@interface);
+
+        string? foo = @interface.Foo();
+
+        Assert.Equal("Bar!", foo);
+    }
+
+    private void Decorate(IServiceCollection serviceCollection)
+    {
+        var implType = serviceCollection.First(x => x.ServiceType == typeof(IInterface)).ImplementationType;
+        serviceCollection.RemoveAll<IInterface>();
+        serviceCollection.AddSingleton<IInterface>(sp =>
+        {
+            IInterface originalImplementation = (IInterface)ActivatorUtilities.CreateInstance(sp, implType);
+            return new Decorator(originalImplementation);
+        });
+    }
+
+    private interface IInterface
+    {
+        string Foo();
+    }
+
+    private class Implementation : IInterface
+    {
+        public string Foo() => "Bar";
+    }
+
+    private class Decorator : IInterface
+    {
+        private readonly IInterface _interface;
+
+        public Decorator(IInterface @interface)
+        {
+            _interface = @interface;
+        }
+        public string Foo() => _interface.Foo() + "!";
+    }
+}


### PR DESCRIPTION
OnBeforeBuild delegate to invoke actions just before building the ServiceProvider. This would enable more advanced orchestration of service registrations, such as Decorators, without having to add them in a particular order.