### PR TITLE
Write linker script for lld to enable gc-sections

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -318,7 +318,8 @@ The .NET Foundation licenses this file to you under the MIT license.
     </ItemGroup>
     <ItemGroup Condition="'$(_targetOS)' != 'win' and '$(_IsApplePlatform)' != 'true'">
       <CustomLinkerArg Include="-Wl,--discard-all" />
-      <CustomLinkerArg Include="-Wl,--gc-sections" Condition="'$(LinkerFlavor)' == '' or '$(LinkerFlavor)' == 'bfd'" />
+      <CustomLinkerArg Include="-Wl,--gc-sections" Condition="'$(LinkerFlavor)' == '' or '$(LinkerFlavor)' == 'bfd' or '$(LinkerFlavor)' == 'lld'" />
+      <CustomLinkerArg Include="-Wl,-T,&quot;$(NativeIntermediateOutputPath)sections.ld&quot;" Condition="'$(LinkerFlavor)' == 'lld'" />
     </ItemGroup>
     <ItemGroup>
       <CustomLibArg Include="-crs &quot;$(NativeBinary)&quot;" Condition="'$(_targetOS)' != 'win'" />
@@ -334,6 +335,9 @@ The .NET Foundation licenses this file to you under the MIT license.
       <_IgnoreLinkerWarnings Condition="'$(_IsApplePlatform)' == 'true'">true</_IgnoreLinkerWarnings>
       <StripFlag Condition="'$(_IsApplePlatform)' == 'true' and '$(NativeLib)' == 'Shared'">-x</StripFlag> <!-- keep global symbols in dylib -->
     </PropertyGroup>
+
+    <!-- write linker script for lld to retain the __modules section -->
+    <WriteLinesToFile File="$(NativeIntermediateOutputPath)sections.ld" Lines="OVERWRITE_SECTIONS { __modules : { KEEP(*(__modules)) } }" Overwrite="true" Condition="'$(LinkerFlavor)' == 'lld'" />
 
     <Exec Command="&quot;$(CppLinker)&quot; @(CustomLinkerArg, ' ')" Condition="'$(_targetOS)' != 'win' and '$(NativeLib)' != 'Static'" IgnoreStandardErrorWarningFormat="$(_IgnoreLinkerWarnings)" />
     <Exec Command="&quot;$(CppLibCreator)&quot; @(CustomLibArg, ' ')" Condition="'$(_targetOS)' != 'win' and '$(NativeLib)' == 'Static'" />


### PR DESCRIPTION
The gc-sections (size) optimization was disabled for llvm linker because we were getting the following link errors with
`dotnet publish -p:PublishAot=true -p:LinkerFlavor=lld`

```sh
  Generating native code
ld.lld : error : undefined symbol: __start___modules [/exe1/exe1.csproj]
  >>> referenced by main.cpp:182 (/__w/1/s/src/coreclr/nativeaot/Bootstrap/main.cpp:182)
  >>>               main.cpp.o:(main) in archive libbootstrapper.a
  >>> referenced by main.cpp:182 (/__w/1/s/src/coreclr/nativeaot/Bootstrap/main.cpp:182)
  >>>               main.cpp.o:(main) in archive libbootstrapper.a
  >>> the encapsulation symbol needs to be retained under --gc-sections properly; consider -z nostart-stop-gc (see https://lld.llvm.org/ELF/start-stop-gc)
  
ld.lld : error : undefined symbol: __stop___modules [/exe1/exe1.csproj]
  >>> referenced by main.cpp:182 (/__w/1/s/src/coreclr/nativeaot/Bootstrap/main.cpp:182)
  >>>               main.cpp.o:(main) in archive libbootstrapper.a
  >>> referenced by main.cpp:182 (/__w/1/s/src/coreclr/nativeaot/Bootstrap/main.cpp:182)
  >>>               main.cpp.o:(main) in archive libbootstrapper.a
clang : error : linker command failed with exit code 1 (use -v to see invocation) [/exe1/exe1.csproj]
```
`lld` eagerly drops this section while the default linker, `bfd`, sees it as effective and retains it. The differences are described in this article: https://maskray.me/blog/2020-12-19-lld-and-gnu-linker-incompatibilities. The weak sections are discarded by lld's `--gc-sections` which are needed by live-sections and we don't get the `DT_NEEDED`.

There are (at least) three ways to fix this:
* Explicitly specify the section we want to keep in linker script.
    * This is what the current state of this PR is bringing.
    * Not a neatest solution but it is better than the current situation (gc-sections opt. completely disabled).
* Annotate section definition `__attribute__((retain,used,section(__modules)))`.
    * We experimented it in https://github.com/dotnet/runtime/pull/75513#issuecomment-1248510864, while it works for `lld`, it breaks `bfd` v2.39+.
    * We don't package separate code for each linker, so further preprocessor conditions (`#ifdef __llvm` etc.) around those macros in code will not help.
* Emit `DT_NEEDED` for `__modules` section to get the formal treatment.
    * This would be a nicest solution for range of linkers in the wild, but so far, I haven't figured out how to achieve that (maybe some dummy usage in `main` will do the trick or some other `__attribute`?). If anyone else has insights, feel free to chime in.

With `-p:LinkerFlavor=lld and -p:StripSymbols=true`,  there is a noticeable difference in size of published binary due to gc-sections optimization:
```diff
--- main
+++ pr

- 1922376 (1.9M)
+ 1807688 (1.8M)
```