### PR TITLE
Add message details for AmbiguousMatchException

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Attribute.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Attribute.CoreCLR.cs
@@ -515,10 +515,11 @@ namespace System
             if (attrib == null || attrib.Length == 0)
                 return null;
 
+            Attribute match = attrib[0];
             if (attrib.Length == 1)
-                return attrib[0];
+                return match;
 
-            throw new AmbiguousMatchException(SR.RFLCT_AmbigCust);
+            throw ThrowHelper.GetAmbiguousMatchException(match);
         }
 
         #endregion
@@ -614,10 +615,11 @@ namespace System
             if (attrib == null || attrib.Length == 0)
                 return null;
 
+            Attribute match = attrib[0];
             if (attrib.Length == 1)
-                return attrib[0];
+                return match;
 
-            throw new AmbiguousMatchException(SR.RFLCT_AmbigCust);
+            throw ThrowHelper.GetAmbiguousMatchException(match);
         }
 
         #endregion
@@ -683,10 +685,11 @@ namespace System
             if (attrib == null || attrib.Length == 0)
                 return null;
 
+            Attribute match = attrib[0];
             if (attrib.Length == 1)
-                return attrib[0];
+                return match;
 
-            throw new AmbiguousMatchException(SR.RFLCT_AmbigCust);
+            throw ThrowHelper.GetAmbiguousMatchException(match);
         }
 
         #endregion
@@ -752,10 +755,11 @@ namespace System
             if (attrib == null || attrib.Length == 0)
                 return null;
 
+            Attribute match = attrib[0];
             if (attrib.Length == 1)
-                return attrib[0];
+                return match;
 
-            throw new AmbiguousMatchException(SR.RFLCT_AmbigCust);
+            throw ThrowHelper.GetAmbiguousMatchException(match);
         }
 
         #endregion

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -2822,9 +2822,7 @@ namespace System
                     {
                         MethodInfo methodInfo = candidates[j];
                         if (!System.DefaultBinder.CompareMethodSig(methodInfo, firstCandidate))
-                        {
-                            throw new AmbiguousMatchException();
-                        }
+                            throw ThrowHelper.GetAmbiguousMatchException(firstCandidate);
                     }
 
                     // All the methods have the exact same name and sig so return the most derived one.
@@ -2878,10 +2876,10 @@ namespace System
             if (types == null || types.Length == 0)
             {
                 // no arguments
+                PropertyInfo firstCandidate = candidates[0];
+
                 if (candidates.Count == 1)
                 {
-                    PropertyInfo firstCandidate = candidates[0];
-
                     if (returnType is not null && !returnType.IsEquivalentTo(firstCandidate.PropertyType))
                         return null;
 
@@ -2891,7 +2889,7 @@ namespace System
                 {
                     if (returnType is null)
                         // if we are here we have no args or property type to select over and we have more than one property with that name
-                        throw new AmbiguousMatchException();
+                        throw ThrowHelper.GetAmbiguousMatchException(firstCandidate);
                 }
             }
 
@@ -2920,7 +2918,7 @@ namespace System
                 if ((bindingAttr & eventInfo.BindingFlags) == eventInfo.BindingFlags)
                 {
                     if (match != null)
-                        throw new AmbiguousMatchException();
+                        throw ThrowHelper.GetAmbiguousMatchException(match);
 
                     match = eventInfo;
                 }
@@ -2950,7 +2948,7 @@ namespace System
                     if (match != null)
                     {
                         if (ReferenceEquals(fieldInfo.DeclaringType, match.DeclaringType))
-                            throw new AmbiguousMatchException();
+                            throw ThrowHelper.GetAmbiguousMatchException(match);
 
                         if ((match.DeclaringType!.IsInterface) && (fieldInfo.DeclaringType!.IsInterface))
                             multipleStaticFieldMatches = true;
@@ -2962,7 +2960,7 @@ namespace System
             }
 
             if (multipleStaticFieldMatches && match!.DeclaringType!.IsInterface)
-                throw new AmbiguousMatchException();
+                throw ThrowHelper.GetAmbiguousMatchException(match);
 
             return match;
         }
@@ -2998,7 +2996,7 @@ namespace System
                 if (FilterApplyType(iface, bindingAttr, name, false, ns))
                 {
                     if (match != null)
-                        throw new AmbiguousMatchException();
+                        throw ThrowHelper.GetAmbiguousMatchException(match);
 
                     match = iface;
                 }
@@ -3027,7 +3025,7 @@ namespace System
                 if (FilterApplyType(nestedType, bindingAttr, name, false, ns))
                 {
                     if (match != null)
-                        throw new AmbiguousMatchException();
+                        throw ThrowHelper.GetAmbiguousMatchException(match);
 
                     match = nestedType;
                 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Attribute.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Attribute.NativeAot.cs
@@ -121,7 +121,7 @@ namespace System
                 return null;
             CustomAttributeData result = enumerator.Current;
             if (enumerator.MoveNext())
-                throw new AmbiguousMatchException();
+                throw ThrowHelper.GetAmbiguousMatchException(result);
             return result.Instantiate();
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/BindingFlagSupport/QueryResult.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/BindingFlagSupport/QueryResult.cs
@@ -112,11 +112,10 @@ namespace System.Reflection.Runtime.BindingFlagSupport
                         // Assuming the policy says it's ok to ignore the ambiguity, we're to resolve in favor of the member
                         // declared by the most derived type. Since QueriedMemberLists are sorted in order of decreasing derivation,
                         // that means we let the first match win - unless, of course, they're both the "most derived member".
-                        if (match.DeclaringType.Equals(challenger.DeclaringType))
-                            throw new AmbiguousMatchException();
-
-                        if (!_policies.OkToIgnoreAmbiguity(match, challenger))
-                            throw new AmbiguousMatchException();
+                        // If they're not from same type, we throw if the policy doesn't allow ambiguity.
+                        if (match.DeclaringType.Equals(challenger.DeclaringType) ||
+                            !_policies.OkToIgnoreAmbiguity(match, challenger))
+                            throw ThrowHelper.GetAmbiguousMatchException(match);
                     }
                     else
                     {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/ThunkedApis.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/ThunkedApis.cs
@@ -199,7 +199,7 @@ namespace System.Reflection.Runtime.TypeInfos
                 if (ns != null && !ns.Equals(ifc.Namespace))
                     continue;
                 if (match != null)
-                    throw new AmbiguousMatchException();
+                    throw ThrowHelper.GetAmbiguousMatchException(match);
                 match = ifc;
             }
             return match;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.BindingFlags.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.BindingFlags.cs
@@ -155,9 +155,10 @@ namespace System.Reflection.Runtime.TypeInfos
                 if (types == null || types.Length == 0)
                 {
                     // no arguments
+                    PropertyInfo firstCandidate = candidates[0];
+
                     if (candidates.Count == 1)
                     {
-                        PropertyInfo firstCandidate = candidates[0];
                         if (returnType is not null && !returnType.IsEquivalentTo(firstCandidate.PropertyType))
                             return null;
                         return firstCandidate;
@@ -165,8 +166,10 @@ namespace System.Reflection.Runtime.TypeInfos
                     else
                     {
                         if (returnType is null)
+                        {
                             // if we are here we have no args or property type to select over and we have more than one property with that name
-                            throw new AmbiguousMatchException();
+                            throw ThrowHelper.GetAmbiguousMatchException(firstCandidate);
+                        }
                     }
                 }
 

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Reflection/Execution/AssemblyBinderImplementation.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Reflection/Execution/AssemblyBinderImplementation.cs
@@ -84,7 +84,7 @@ namespace Internal.Reflection.Execution
                 {
                     if (foundMatch)
                     {
-                        exception = new AmbiguousMatchException();
+                        exception = new AmbiguousMatchException(SR.Format(SR.AmbiguousMatchException_Assembly, refName.FullName));
                         return false;
                     }
 

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Resources/Strings.resx
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Resources/Strings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -128,5 +128,8 @@
   </data>
   <data name="FileLoadException_RefDefMismatch" xml:space="preserve">
     <value>Cannot load assembly '{0}'. The assembly exists but its version {1} is lower than the requested version {2}.</value>
+  </data>
+  <data name="AmbiguousMatchException_Assembly" xml:space="preserve">
+    <value>Ambiguous match found for assembly '{0}'.</value>
   </data>
 </root>

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -172,17 +172,26 @@
   <data name="AppDomain_Policy_PrincipalTwice" xml:space="preserve">
     <value>Default principal object cannot be set twice.</value>
   </data>
-  <data name="AmbiguousImplementationException_NullMessage" xml:space="preserve">
-    <value>Ambiguous implementation found.</value>
-  </data>
   <data name="Arg_AccessException" xml:space="preserve">
     <value>Cannot access member.</value>
   </data>
   <data name="Arg_AccessViolationException" xml:space="preserve">
     <value>Attempted to read or write protected memory. This is often an indication that other memory is corrupt.</value>
   </data>
-  <data name="Arg_AmbiguousMatchException" xml:space="preserve">
+  <data name="Arg_AmbiguousImplementationException_NoMessage" xml:space="preserve">
+    <value>Ambiguous implementation found.</value>
+  </data>
+  <data name="Arg_AmbiguousMatchException_Attribute" xml:space="preserve">
+    <value>Multiple custom attributes of the same type '{0}' found.</value>
+  </data>
+  <data name="Arg_AmbiguousMatchException_NoMessage" xml:space="preserve">
     <value>Ambiguous match found.</value>
+  </data>
+  <data name="Arg_AmbiguousMatchException_CustomAttributeData" xml:space="preserve">
+    <value>Ambiguous match found for '{0}'.</value>
+  </data>
+  <data name="Arg_AmbiguousMatchException_MemberInfo" xml:space="preserve">
+    <value>Ambiguous match found for '{0} {1}'.</value>
   </data>
   <data name="Arg_ApplicationException" xml:space="preserve">
     <value>Error in the application.</value>
@@ -3298,9 +3307,6 @@
   </data>
   <data name="Resources_StreamNotValid" xml:space="preserve">
     <value>Stream is not a valid resource file.</value>
-  </data>
-  <data name="RFLCT_AmbigCust" xml:space="preserve">
-    <value>Multiple custom attributes of the same type found.</value>
   </data>
   <data name="InvalidFilterCriteriaException_CritInt" xml:space="preserve">
     <value>An Int32 must be provided for the filter criteria.</value>

--- a/src/libraries/System.Private.CoreLib/src/System/DefaultBinder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DefaultBinder.cs
@@ -383,8 +383,10 @@ namespace System
 #endregion
             }
 
+            MethodBase bestMatch = candidates[currentMin]!;
+
             if (ambig)
-                throw new AmbiguousMatchException();
+                throw ThrowHelper.GetAmbiguousMatchException(bestMatch);
 
             // Reorder (if needed)
             if (names != null)
@@ -395,7 +397,7 @@ namespace System
 
             // If the parameters and the args are not the same length or there is a paramArray
             //  then we need to create a argument array.
-            ParameterInfo[] parameters = candidates[currentMin]!.GetParametersNoCopy();
+            ParameterInfo[] parameters = bestMatch.GetParametersNoCopy();
             if (parameters.Length == args.Length)
             {
                 if (paramArrayTypes[currentMin] != null)
@@ -431,7 +433,7 @@ namespace System
             }
             else
             {
-                if ((candidates[currentMin]!.CallingConvention & CallingConventions.VarArgs) == 0)
+                if ((bestMatch.CallingConvention & CallingConventions.VarArgs) == 0)
                 {
                     object[] objs = new object[parameters.Length];
                     int paramArrayPos = parameters.Length - 1;
@@ -442,7 +444,7 @@ namespace System
                 }
             }
 
-            return candidates[currentMin]!;
+            return bestMatch;
         }
 
         // Given a set of fields that match the base criteria, select a field.
@@ -526,9 +528,10 @@ namespace System
                     }
                 }
             }
+            FieldInfo bestMatch = candidates[currentMin];
             if (ambig)
-                throw new AmbiguousMatchException();
-            return candidates[currentMin];
+                throw ThrowHelper.GetAmbiguousMatchException(bestMatch);
+            return bestMatch;
         }
 
         // Given a set of methods that match the base criteria, select a method based
@@ -620,9 +623,10 @@ namespace System
                     }
                 }
             }
+            MethodBase bestMatch = candidates[currentMin];
             if (ambig)
-                throw new AmbiguousMatchException();
-            return candidates[currentMin];
+                throw ThrowHelper.GetAmbiguousMatchException(bestMatch);
+            return bestMatch;
         }
 
         // Given a set of properties that match the base criteria, select one.
@@ -734,10 +738,10 @@ namespace System
                     currentMin = i;
                 }
             }
-
+            PropertyInfo bestMatch = candidates[currentMin];
             if (ambig)
-                throw new AmbiguousMatchException();
-            return candidates[currentMin];
+                throw ThrowHelper.GetAmbiguousMatchException(bestMatch);
+            return bestMatch;
         }
 
         // ChangeType
@@ -850,7 +854,7 @@ namespace System
                     continue;
 
                 if (bestMatch != null)
-                    throw new AmbiguousMatchException();
+                    throw ThrowHelper.GetAmbiguousMatchException(bestMatch);
 
                 bestMatch = match[i];
             }
@@ -1137,7 +1141,7 @@ namespace System
                 // This can only happen if at least one is vararg or generic.
                 if (currentHierarchyDepth == deepestHierarchy)
                 {
-                    throw new AmbiguousMatchException();
+                    throw ThrowHelper.GetAmbiguousMatchException(methWithDeepestHierarchy!);
                 }
 
                 // Check to see if this method is on the most derived class.

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/AmbiguousMatchException.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/AmbiguousMatchException.cs
@@ -10,7 +10,7 @@ namespace System.Reflection
     public sealed class AmbiguousMatchException : SystemException
     {
         public AmbiguousMatchException()
-            : base(SR.Arg_AmbiguousMatchException)
+            : base(SR.Arg_AmbiguousMatchException_NoMessage)
         {
             HResult = HResults.COR_E_AMBIGUOUSMATCH;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/AmbiguousImplementationException.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/AmbiguousImplementationException.cs
@@ -10,7 +10,7 @@ namespace System.Runtime
     public sealed class AmbiguousImplementationException : Exception
     {
         public AmbiguousImplementationException()
-            : base(SR.AmbiguousImplementationException_NullMessage)
+            : base(SR.Arg_AmbiguousImplementationException_NoMessage)
         {
             HResult = HResults.COR_E_AMBIGUOUSIMPLEMENTATION;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
@@ -40,6 +40,8 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Numerics;
+using System.Reflection;
+using System.Runtime;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
@@ -603,6 +605,22 @@ namespace System
         internal static void ThrowFormatIndexOutOfRange()
         {
             throw new FormatException(SR.Format_IndexOutOfRange);
+        }
+
+        internal static AmbiguousMatchException GetAmbiguousMatchException(MemberInfo memberInfo)
+        {
+            Type? declaringType = memberInfo.DeclaringType;
+            return new AmbiguousMatchException(SR.Format(SR.Arg_AmbiguousMatchException_MemberInfo, declaringType, memberInfo));
+        }
+
+        internal static AmbiguousMatchException GetAmbiguousMatchException(Attribute attribute)
+        {
+            return new AmbiguousMatchException(SR.Format(SR.Arg_AmbiguousMatchException_Attribute, attribute));
+        }
+
+        internal static AmbiguousMatchException GetAmbiguousMatchException(CustomAttributeData customAttributeData)
+        {
+            return new AmbiguousMatchException(SR.Format(SR.Arg_AmbiguousMatchException_CustomAttributeData, customAttributeData));
         }
 
         private static Exception GetArraySegmentCtorValidationFailedException(Array? array, int offset, int count)

--- a/src/libraries/System.Reflection.Context/src/Resources/Strings.resx
+++ b/src/libraries/System.Reflection.Context/src/Resources/Strings.resx
@@ -108,4 +108,7 @@
   <data name="Argument_ObjectArgumentMismatch" xml:space="preserve">
     <value>Object of type '{0}' cannot be converted to type '{1}'.</value>
   </data>
+  <data name="Arg_AmbiguousMatchException_MemberInfo" xml:space="preserve">
+    <value>Ambiguous match found for '{0} {1}'.</value>
+  </data>
 </root>

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Custom/CustomType.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Custom/CustomType.cs
@@ -257,7 +257,6 @@ namespace System.Reflection.Context.Custom
                 }
             }
 
-
             if (matchingMethods.Count == 0)
                 return null;
 
@@ -266,10 +265,12 @@ namespace System.Reflection.Context.Custom
                 Debug.Assert(types == null || types.Length == 0);
 
                 // matches any signature
+                MethodInfo match = matchingMethods[0];
                 if (matchingMethods.Count == 1)
-                    return matchingMethods[0];
-                else
-                    throw new AmbiguousMatchException();
+                    return match;
+
+                Type? declaringType = match.DeclaringType;
+                throw new AmbiguousMatchException(SR.Format(SR.Arg_AmbiguousMatchException_MemberInfo, declaringType, match));
             }
             else
             {

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/Resources/Strings.resx
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/Resources/Strings.resx
@@ -270,4 +270,10 @@
   <data name="Arg_InvalidPath" xml:space="preserve">
     <value>The path '{0}' is not valid.</value>
   </data>
+  <data name="Arg_AmbiguousMatchException_RoDefinitionType" xml:space="preserve">
+    <value>Ambiguous match found for '{0}'.</value>
+  </data>
+  <data name="Arg_AmbiguousMatchException_MemberInfo" xml:space="preserve">
+    <value>Ambiguous match found for '{0} {1}'.</value>
+  </data>
 </root>

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System.Reflection.MetadataLoadContext.csproj
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System.Reflection.MetadataLoadContext.csproj
@@ -147,6 +147,7 @@
     <Compile Include="System\Reflection\TypeLoading\Types\RoType.TypeClassification.cs" />
     <Compile Include="System\Reflection\TypeLoading\Types\RoWrappedType.cs" />
     <Compile Include="$(CommonPath)System\Obsoletions.cs" Link="Common\System\Obsoletions.cs" />
+    <Compile Include="System\ThrowHelper.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/DefaultBinder.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/DefaultBinder.cs
@@ -137,9 +137,10 @@ namespace System
                     ambig = false;
                 }
             }
+            MethodBase bestMatch = candidates[currentMin];
             if (ambig)
-                throw new AmbiguousMatchException();
-            return candidates[currentMin];
+                throw ThrowHelper.GetAmbiguousMatchException(bestMatch);
+            return bestMatch;
         }
 
         // Given a set of properties that match the base criteria, select one.
@@ -256,9 +257,10 @@ namespace System
                 }
             }
 
+            PropertyInfo bestMatch = candidates[currentMin];
             if (ambig)
-                throw new AmbiguousMatchException();
-            return candidates[currentMin];
+                throw ThrowHelper.GetAmbiguousMatchException(bestMatch);
+            return bestMatch;
         }
 
         // The default binder doesn't support any change type functionality.
@@ -341,7 +343,7 @@ namespace System
                     continue;
 
                 if (bestMatch != null)
-                    throw new AmbiguousMatchException();
+                    throw ThrowHelper.GetAmbiguousMatchException(bestMatch);
 
                 bestMatch = match[i];
             }
@@ -606,7 +608,7 @@ namespace System
                 // This can only happen if at least one is vararg or generic.
                 if (currentHierarchyDepth == deepestHierarchy)
                 {
-                    throw new AmbiguousMatchException();
+                    throw ThrowHelper.GetAmbiguousMatchException(methWithDeepestHierarchy!);
                 }
 
                 // Check to see if this method is on the most derived class.

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/Runtime/BindingFlagSupport/QueryResult.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/Runtime/BindingFlagSupport/QueryResult.cs
@@ -112,11 +112,11 @@ namespace System.Reflection.Runtime.BindingFlagSupport
                         // declared by the most derived type. Since QueriedMemberLists are sorted in order of decreasing derivation,
                         // that means we let the first match win - unless, of course, they're both the "most derived member".
                         if (match.DeclaringType!.Equals(challenger.DeclaringType))
-                            throw new AmbiguousMatchException();
+                            throw ThrowHelper.GetAmbiguousMatchException(match);
 
                         MemberPolicies<M> policies = MemberPolicies<M>.Default;
                         if (!policies.OkToIgnoreAmbiguity(match, challenger))
-                            throw new AmbiguousMatchException();
+                            throw ThrowHelper.GetAmbiguousMatchException(match);
                     }
                     else
                     {

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/CustomAttributes/CustomAttributeHelpers.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/CustomAttributes/CustomAttributeHelpers.cs
@@ -17,10 +17,10 @@ namespace System.Reflection.TypeLoading
             MemberInfo[] members = attributeType.GetMember(name, MemberTypes.Field | MemberTypes.Property, BindingFlags.Public | BindingFlags.Instance);
             if (members.Length == 0)
                 throw new MissingMemberException(attributeType.FullName, name);
+            MemberInfo match = members[0];
             if (members.Length > 1)
-                throw new AmbiguousMatchException();
-
-            return new CustomAttributeNamedArgument(members[0], new CustomAttributeTypedArgument(argumentType!, value));
+                throw ThrowHelper.GetAmbiguousMatchException(match);
+            return new CustomAttributeNamedArgument(match, new CustomAttributeTypedArgument(argumentType!, value));
         }
 
         /// <summary>

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/RuntimeTypeInfo.BindingFlags.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/RuntimeTypeInfo.BindingFlags.cs
@@ -136,10 +136,11 @@ namespace System.Reflection.TypeLoading
                 // For perf and .NET Framework compat, fast-path these specific checks before calling on the binder to break ties.
                 if (types == null || types.Length == 0)
                 {
+                    PropertyInfo firstCandidate = candidates[0];
+
                     // no arguments
                     if (candidates.Count == 1)
                     {
-                        PropertyInfo firstCandidate = candidates[0];
                         if (!(returnType is null) && !returnType.IsEquivalentTo(firstCandidate.PropertyType))
                             return null;
                         return firstCandidate;
@@ -148,7 +149,7 @@ namespace System.Reflection.TypeLoading
                     {
                         if (returnType is null)
                             // if we are here we have no args or property type to select over and we have more than one property with that name
-                            throw new AmbiguousMatchException();
+                            throw ThrowHelper.GetAmbiguousMatchException(firstCandidate);
                     }
                 }
 

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/Ecma/EcmaDefinitionType.BindingFlags.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/Ecma/EcmaDefinitionType.BindingFlags.cs
@@ -94,7 +94,7 @@ namespace System.Reflection.TypeLoading.Ecma
                 if (nestedTypeDefinition.Name.Equals(utf8Name, reader))
                 {
                     if (match != null)
-                        throw new AmbiguousMatchException();
+                        throw ThrowHelper.GetAmbiguousMatchException(match);
                     match = handle.ResolveTypeDef(GetEcmaModule());
                 }
             }

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/RoType.GetInterface.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/RoType.GetInterface.cs
@@ -33,7 +33,7 @@ namespace System.Reflection.TypeLoading
                 if (ns.Length != 0 && !ns.Equals(ifc.Namespace))
                     continue;
                 if (match != null)
-                    throw new AmbiguousMatchException();
+                    throw ThrowHelper.GetAmbiguousMatchException(match);
                 match = ifc;
             }
             return match;

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/ThrowHelper.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// This file defines an internal static class used to throw exceptions in the
+// the System.Reflection.MetadataLoadContext code.
+
+using System.Reflection;
+using System.Reflection.TypeLoading;
+
+namespace System
+{
+    internal static class ThrowHelper
+    {
+        internal static AmbiguousMatchException GetAmbiguousMatchException(RoDefinitionType roDefinitionType)
+        {
+            return new AmbiguousMatchException(SR.Format(SR.Arg_AmbiguousMatchException_RoDefinitionType, roDefinitionType.FullName));
+        }
+
+        internal static AmbiguousMatchException GetAmbiguousMatchException(MemberInfo memberInfo)
+        {
+            Type? declaringType = memberInfo.DeclaringType;
+            return  new AmbiguousMatchException(SR.Format(SR.Arg_AmbiguousMatchException_MemberInfo, declaringType, memberInfo));
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/src/Resources/Strings.resx
+++ b/src/libraries/System.Runtime.InteropServices/src/Resources/Strings.resx
@@ -70,7 +70,7 @@
     <value>Event invocation for COM objects requires the declaring interface of the event to be attributed with ComEventInterfaceAttribute.</value>
   </data>
   <data name="AmbiguousMatch_MultipleEventInterfaceAttributes" xml:space="preserve">
-    <value>More than one ComEventInterfaceAttribute was found on the declaring interface of the event.</value>
+    <value>More than one ComEventInterfaceAttribute found for '{0}' on the declaring interface of the event.</value>
   </data>
   <data name="InvalidOperation_NoDispIdAttribute" xml:space="preserve">
     <value>Event invocation for COM objects requires event to be attributed with DispIdAttribute.</value>

--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/ComAwareEventInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/ComAwareEventInfo.cs
@@ -106,14 +106,15 @@ namespace System.Runtime.InteropServices
                 throw new InvalidOperationException(SR.InvalidOperation_NoComEventInterfaceAttribute);
             }
 
+            ComEventInterfaceAttribute interfaceAttribute = (ComEventInterfaceAttribute)comEventInterfaces[0];
+
             if (comEventInterfaces.Length > 1)
             {
-                throw new AmbiguousMatchException(SR.AmbiguousMatch_MultipleEventInterfaceAttributes);
+                throw new AmbiguousMatchException(SR.Format(SR.AmbiguousMatch_MultipleEventInterfaceAttributes, interfaceAttribute));
             }
 
-            Type sourceInterface = ((ComEventInterfaceAttribute)comEventInterfaces[0]).SourceInterface;
+            Type sourceInterface = interfaceAttribute.SourceInterface;
             Guid guid = sourceInterface.GUID;
-
             MethodInfo methodInfo = sourceInterface.GetMethod(eventInfo.Name)!;
             Attribute? dispIdAttribute = Attribute.GetCustomAttribute(methodInfo, typeof(DispIdAttribute));
             if (dispIdAttribute == null)

--- a/src/mono/System.Private.CoreLib/src/System/Attribute.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Attribute.Mono.cs
@@ -17,9 +17,10 @@ namespace System
             object[] attrs = CustomAttribute.GetCustomAttributes(element, attributeType, inherit);
             if (attrs == null || attrs.Length == 0)
                 return null;
+            Attribute match = (Attribute)attrs[0];
             if (attrs.Length != 1)
-                throw new AmbiguousMatchException();
-            return (Attribute)(attrs[0]);
+                throw ThrowHelper.GetAmbiguousMatchException(match);
+            return match;
         }
 
         public static Attribute? GetCustomAttribute(Assembly element, Type attributeType) => GetAttr(element, attributeType, true);

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeTypeBuilder.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeTypeBuilder.Mono.cs
@@ -431,7 +431,7 @@ namespace System.Reflection.Emit
                 if (types == null)
                 {
                     if (count > 1)
-                        throw new AmbiguousMatchException();
+                        throw ThrowHelper.GetAmbiguousMatchException(found!);
                     return found;
                 }
                 MethodBase[] match = new MethodBase[count];

--- a/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -794,7 +794,7 @@ namespace System
                     {
                         MethodInfo methodInfo = candidates[j];
                         if (!System.DefaultBinder.CompareMethodSig(methodInfo, firstCandidate))
-                            throw new AmbiguousMatchException();
+                            throw ThrowHelper.GetAmbiguousMatchException(firstCandidate);
                     }
 
                     // All the methods have the exact same name and sig so return the most derived one.
@@ -850,10 +850,10 @@ namespace System
             if (types == null || types.Length == 0)
             {
                 // no arguments
+                PropertyInfo firstCandidate = candidates[0];
+
                 if (candidates.Count == 1)
                 {
-                    PropertyInfo firstCandidate = candidates[0];
-
                     if (returnType is not null && !returnType.IsEquivalentTo(firstCandidate.PropertyType))
                         return null;
 
@@ -863,7 +863,7 @@ namespace System
                 {
                     if (returnType is null)
                         // if we are here we have no args or property type to select over and we have more than one property with that name
-                        throw new AmbiguousMatchException();
+                        throw ThrowHelper.GetAmbiguousMatchException(firstCandidate);
                 }
             }
 
@@ -894,7 +894,7 @@ namespace System
                 if ((bindingAttr & eventInfo.BindingFlags) == eventInfo.BindingFlags)
                 {
                     if (match != null)
-                        throw new AmbiguousMatchException();
+                        throw ThrowHelper.GetAmbiguousMatchException(match);
 
                     match = eventInfo;
                 }
@@ -923,7 +923,7 @@ namespace System
                     if (match != null)
                     {
                         if (ReferenceEquals(fieldInfo.DeclaringType, match.DeclaringType))
-                            throw new AmbiguousMatchException();
+                            throw ThrowHelper.GetAmbiguousMatchException(match);
 
                         if (match.DeclaringType!.IsInterface && fieldInfo.DeclaringType!.IsInterface)
                             multipleStaticFieldMatches = true;
@@ -935,7 +935,7 @@ namespace System
             }
 
             if (multipleStaticFieldMatches && match!.DeclaringType!.IsInterface)
-                throw new AmbiguousMatchException();
+                throw ThrowHelper.GetAmbiguousMatchException(match);
 
             return match;
         }
@@ -987,7 +987,7 @@ namespace System
                 if (FilterApplyType(iface, bindingAttr, name, false, ns))
                 {
                     if (match != null)
-                        throw new AmbiguousMatchException();
+                        throw ThrowHelper.GetAmbiguousMatchException(match);
 
                     match = iface;
                 }
@@ -1015,7 +1015,7 @@ namespace System
                 if (FilterApplyType(nestedType, bindingAttr, name, false, ns))
                 {
                     if (match != null)
-                        throw new AmbiguousMatchException();
+                        throw ThrowHelper.GetAmbiguousMatchException(match);
 
                     match = nestedType;
                 }


### PR DESCRIPTION
Add information to what is ambiguously matched when an AmbiguousMatchException or an AmbiguousInvovationException is thrown as we know what we found multiple matching items for.

Fixes #18255

Basic idea is to use the known-first match as a source for the declaring type name and member name to format into the Exception message value.

There's a bunch of similar/common/duplicated code all over, so not sure where (which subset) to apply so this PR attempts most of the uses of `AmbigousMatchException` and `AmbiguousInvocationException` (which has similar issues).

Need to know before this gets final which of the libraries/builds this needs to be done in:
- [x] src/coreclr/nativeaot/System.Private.CoreLib
- [x] src/libraries/System.Private.CoreLib
- [x] src/libraries/System.Reflection.MetadataLoadContext
- [x] src/mono/System.Private.CoreLib

I also noted that the same localizable string ends up in several assemblies the way things are now (e.g. there's a Strings.resx and matching ThrowHelper.cs for each of the target libraries above, with some overlapped strings).  I am not sure there is anything to be done about that, but worth calling out in this PR