### PR TITLE
fix Kernel32.GetSystemTimes usage on Windows

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSourceHelper.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSourceHelper.Windows.cs
@@ -17,7 +17,7 @@ namespace System.Diagnostics.Tracing
             double cpuUsage = 0.0;
 
             if (Interop.Kernel32.GetProcessTimes(Interop.Kernel32.GetCurrentProcess(), out _, out _, out long procKernelTime, out long procUserTime) &&
-                Interop.Kernel32.GetSystemTimes(out _, out long systemUserTime, out long systemKernelTime))
+                Interop.Kernel32.GetSystemTimes(out _, out long systemKernelTime, out long systemUserTime))
             {
                 long totalProcTime = (procUserTime - s_prevProcUserTime) + (procKernelTime - s_prevProcKernelTime);
                 long totalSystemTime = (systemUserTime - s_prevSystemUserTime) + (systemKernelTime - s_prevSystemKernelTime);


### PR DESCRIPTION
`systemUserTime` & `systemKernelTime` were mixed up
The method is declared as
```
internal static partial class Kernel32
{
    [LibraryImport(Libraries.Kernel32, SetLastError = true)]
    [return: MarshalAs(UnmanagedType.Bool)]
    internal static partial bool GetSystemTimes(out long idle, out long kernel, out long user);
}
```
Method's documentation [https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getsystemtimes](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getsystemtimes)

All other usages of this method are correct