### PR TITLE
Add SIMD to LowerCallMemcmp

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -7341,9 +7341,9 @@ GenTree* Compiler::gtNewZeroConNode(var_types type)
 #ifdef FEATURE_SIMD
     if (varTypeIsSIMD(type))
     {
-        GenTreeVecCon* allBitsSet = gtNewVconNode(type);
-        allBitsSet->gtSimdVal     = simd_t::Zero();
-        return allBitsSet;
+        GenTreeVecCon* vecCon = gtNewVconNode(type);
+        vecCon->gtSimdVal     = simd_t::Zero();
+        return vecCon;
     }
 #endif // FEATURE_SIMD
 

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -1902,8 +1902,20 @@ GenTree* Lowering::LowerCallMemcmp(GenTreeCall* call)
         {
             GenTree* lArg = call->gtArgs.GetUserArgByIndex(0)->GetNode();
             GenTree* rArg = call->gtArgs.GetUserArgByIndex(1)->GetNode();
-            // TODO: Add SIMD path for [16..128] via GT_HWINTRINSIC nodes
-            if (cnsSize <= 16)
+
+            unsigned MaxUnrollSize = 16;
+#ifdef FEATURE_SIMD
+            MaxUnrollSize = 32;
+#ifdef TARGET_XARCH
+            if (comp->compOpportunisticallyDependsOn(InstructionSet_Vector256))
+            {
+                MaxUnrollSize = 64;
+            }
+// TODO-XARCH-AVX512: Consider enabling this for AVX512
+#endif
+#endif
+
+            if (cnsSize <= MaxUnrollSize)
             {
                 unsigned  loadWidth = 1 << BitOperations::Log2((unsigned)cnsSize);
                 var_types loadType;
@@ -1919,11 +1931,25 @@ GenTree* Lowering::LowerCallMemcmp(GenTreeCall* call)
                 {
                     loadType = TYP_INT;
                 }
-                else if ((loadWidth == 8) || (loadWidth == 16))
+                else if ((loadWidth == 8) || (MaxUnrollSize == 16))
                 {
                     loadWidth = 8;
                     loadType  = TYP_LONG;
                 }
+#ifdef FEATURE_SIMD
+                else if ((loadWidth == 16) || (MaxUnrollSize == 32))
+                {
+                    loadWidth = 16;
+                    loadType  = TYP_SIMD16;
+                }
+#ifdef TARGET_XARCH
+                else if ((loadWidth == 32) || (MaxUnrollSize == 64))
+                {
+                    loadWidth = 32;
+                    loadType  = TYP_SIMD32;
+                }
+#endif // TARGET_XARCH
+#endif // FEATURE_SIMD
                 else
                 {
                     unreached();
@@ -1932,8 +1958,26 @@ GenTree* Lowering::LowerCallMemcmp(GenTreeCall* call)
 
                 GenTree* result = nullptr;
 
+                auto newBinaryOp = [](Compiler* comp, genTreeOps oper, var_types type, GenTree* op1,
+                                      GenTree* op2) -> GenTree* {
+#ifdef FEATURE_SIMD
+                    if (varTypeIsSIMD(op1))
+                    {
+                        if (GenTree::OperIsCmpCompare(oper))
+                        {
+                            assert(type == TYP_INT);
+                            return comp->gtNewSimdCmpOpAllNode(oper, TYP_BOOL, op1, op2, CORINFO_TYPE_NATIVEUINT,
+                                                               genTypeSize(op1), false);
+                        }
+                        return comp->gtNewSimdBinOpNode(oper, op1->TypeGet(), op1, op2, CORINFO_TYPE_NATIVEUINT,
+                                                        genTypeSize(op1), false);
+                    }
+#endif
+                    return comp->gtNewOperNode(oper, type, op1, op2);
+                };
+
                 // loadWidth == cnsSize means a single load is enough for both args
-                if ((loadWidth == (unsigned)cnsSize) && (loadWidth <= 8))
+                if (loadWidth == (unsigned)cnsSize)
                 {
                     // We're going to emit something like the following:
                     //
@@ -1943,7 +1987,7 @@ GenTree* Lowering::LowerCallMemcmp(GenTreeCall* call)
                     //
                     GenTree* lIndir = comp->gtNewIndir(loadType, lArg);
                     GenTree* rIndir = comp->gtNewIndir(loadType, rArg);
-                    result          = comp->gtNewOperNode(GT_EQ, TYP_INT, lIndir, rIndir);
+                    result          = newBinaryOp(comp, GT_EQ, TYP_INT, lIndir, rIndir);
 
                     BlockRange().InsertAfter(lArg, lIndir);
                     BlockRange().InsertAfter(rArg, rIndir);
@@ -1990,17 +2034,17 @@ GenTree* Lowering::LowerCallMemcmp(GenTreeCall* call)
                     //
                     GenTree* l1Indir   = comp->gtNewIndir(loadType, lArgUse.Def());
                     GenTree* r1Indir   = comp->gtNewIndir(loadType, rArgUse.Def());
-                    GenTree* lXor      = comp->gtNewOperNode(GT_XOR, actualLoadType, l1Indir, r1Indir);
+                    GenTree* lXor      = newBinaryOp(comp, GT_XOR, actualLoadType, l1Indir, r1Indir);
                     GenTree* l2Offs    = comp->gtNewIconNode(cnsSize - loadWidth, TYP_I_IMPL);
-                    GenTree* l2AddOffs = comp->gtNewOperNode(GT_ADD, lArg->TypeGet(), lArgClone, l2Offs);
+                    GenTree* l2AddOffs = newBinaryOp(comp, GT_ADD, lArg->TypeGet(), lArgClone, l2Offs);
                     GenTree* l2Indir   = comp->gtNewIndir(loadType, l2AddOffs);
                     GenTree* r2Offs    = comp->gtCloneExpr(l2Offs); // offset is the same
-                    GenTree* r2AddOffs = comp->gtNewOperNode(GT_ADD, rArg->TypeGet(), rArgClone, r2Offs);
+                    GenTree* r2AddOffs = newBinaryOp(comp, GT_ADD, rArg->TypeGet(), rArgClone, r2Offs);
                     GenTree* r2Indir   = comp->gtNewIndir(loadType, r2AddOffs);
-                    GenTree* rXor      = comp->gtNewOperNode(GT_XOR, actualLoadType, l2Indir, r2Indir);
-                    GenTree* resultOr  = comp->gtNewOperNode(GT_OR, actualLoadType, lXor, rXor);
-                    GenTree* zeroCns   = comp->gtNewIconNode(0, actualLoadType);
-                    result             = comp->gtNewOperNode(GT_EQ, TYP_INT, resultOr, zeroCns);
+                    GenTree* rXor      = newBinaryOp(comp, GT_XOR, actualLoadType, l2Indir, r2Indir);
+                    GenTree* resultOr  = newBinaryOp(comp, GT_OR, actualLoadType, lXor, rXor);
+                    GenTree* zeroCns   = comp->gtNewZeroConNode(actualLoadType);
+                    result             = newBinaryOp(comp, GT_EQ, TYP_INT, resultOr, zeroCns);
 
                     BlockRange().InsertAfter(rArgClone, l1Indir, r1Indir, l2Offs, l2AddOffs);
                     BlockRange().InsertAfter(l2AddOffs, l2Indir, r2Offs, r2AddOffs, r2Indir);

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -1903,7 +1903,7 @@ GenTree* Lowering::LowerCallMemcmp(GenTreeCall* call)
             GenTree* lArg = call->gtArgs.GetUserArgByIndex(0)->GetNode();
             GenTree* rArg = call->gtArgs.GetUserArgByIndex(1)->GetNode();
 
-            unsigned MaxUnrollSize = 16;
+            ssize_t MaxUnrollSize = 16;
 #ifdef FEATURE_SIMD
             MaxUnrollSize = 32;
 #ifdef TARGET_XARCH


### PR DESCRIPTION
Add SIMD to unroll length `[16..64]` (can be enabled for `[64..128]` with avx512), `[16..32]` on arm64.

```csharp
bool Test(Span<byte> s) => s.SequenceEqual(
    "THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND"u8);
```
#### Old codegen:
```asm
; Method Prog:Test(System.Span`1[ubyte]):bool:this
G_M52730_IG01:              
       4883EC28             sub      rsp, 40
G_M52730_IG02:              
       49B8882A908BDA010000 mov      r8, 0x1DA8B902A88
       488B0A               mov      rcx, bword ptr [rdx]
       8B5208               mov      edx, dword ptr [rdx+08H]
       4C89442420           mov      bword ptr [rsp+20H], r8
       83FA3E               cmp      edx, 62
       7513                 jne      SHORT G_M52730_IG04
G_M52730_IG03:              
       41B83E000000         mov      r8d, 62
       488B542420           mov      rdx, bword ptr [rsp+20H]
       FF1591FE1600         call     [System.SpanHelpers:SequenceEqual(byref,byref,ulong):bool]
       EB02                 jmp      SHORT G_M52730_IG05
G_M52730_IG04:              
       33C0                 xor      eax, eax
G_M52730_IG05:              
       4883C428             add      rsp, 40
       C3                   ret      
; Total bytes of code: 56
```

#### New codegen:
```asm
; Method Prog:Test(System.Span`1[ubyte]):bool:this
G_M52730_IG01:              
       C5F877               vzeroupper 
G_M52730_IG02:              
       48B8882A7D01B3020000 mov      rax, 0x2B3017D2A88
       488B0A               mov      rcx, bword ptr [rdx]
       8B5208               mov      edx, dword ptr [rdx+08H]
       4883FA3E             cmp      rdx, 62
       752B                 jne      SHORT G_M52730_IG04
G_M52730_IG03:              
       C5FC1001             vmovups  ymm0, ymmword ptr[rcx]
       C5FC1008             vmovups  ymm1, ymmword ptr[rax]
       C5FC10511E           vmovups  ymm2, ymmword ptr[rcx+1EH]
       C5FC10581E           vmovups  ymm3, ymmword ptr[rax+1EH]
       C5FDEFC1             vpxor    ymm0, ymm0, ymm1
       C5EDEFCB             vpxor    ymm1, ymm2, ymm3
       C5FDEBC1             vpor     ymm0, ymm0, ymm1
       C4E27D17C0           vptest   ymm0, ymm0
       0F94C0               sete     al
       0FB6C0               movzx    rax, al
       EB02                 jmp      SHORT G_M52730_IG05
G_M52730_IG04:              
       33C0                 xor      eax, eax
G_M52730_IG05:              
       C5F877               vzeroupper 
       C3                   ret      
; Total bytes of code: 74
```