### PR TITLE
Fix IUtf8SpanFormattable.TryFormat argument name

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IUtf8SpanFormattable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IUtf8SpanFormattable.cs
@@ -7,15 +7,15 @@ namespace System
     public interface IUtf8SpanFormattable
     {
         /// <summary>Tries to format the value of the current instance as UTF8 into the provided span of bytes.</summary>
-        /// <param name="destination">When this method returns, this instance's value formatted as a span of bytes.</param>
-        /// <param name="bytesWritten">When this method returns, the number of bytes that were written in <paramref name="destination"/>.</param>
-        /// <param name="format">A span containing the characters that represent a standard or custom format string that defines the acceptable format for <paramref name="destination"/>.</param>
-        /// <param name="provider">An optional object that supplies culture-specific formatting information for <paramref name="destination"/>.</param>
+        /// <param name="utf8Destination">When this method returns, this instance's value formatted as a span of bytes.</param>
+        /// <param name="bytesWritten">When this method returns, the number of bytes that were written in <paramref name="utf8Destination"/>.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string that defines the acceptable format for <paramref name="utf8Destination"/>.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for <paramref name="utf8Destination"/>.</param>
         /// <returns><see langword="true"/> if the formatting was successful; otherwise, <see langword="false"/>.</returns>
         /// <remarks>
         /// An implementation of this interface should produce the same string of characters as an implementation of <see cref="IFormattable.ToString"/> or <see cref="ISpanFormattable.TryFormat"/>
         /// on the same type. TryFormat should return false only if there is not enough space in the destination buffer; any other failures should throw an exception.
         /// </remarks>
-        bool TryFormat(Span<byte> destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider);
+        bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider);
     }
 }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -3867,7 +3867,7 @@ namespace System
     }
     public partial interface IUtf8SpanFormattable
     {
-        bool TryFormat(System.Span<byte> destination, out int bytesWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider);
+        bool TryFormat(System.Span<byte> utf8Destination, out int bytesWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider);
     }
     public partial class Lazy<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]T>
     {

--- a/src/libraries/System.Runtime/tests/System/Text/Unicode/Utf8Tests.TryWrite.cs
+++ b/src/libraries/System.Runtime/tests/System/Text/Unicode/Utf8Tests.TryWrite.cs
@@ -584,14 +584,14 @@ namespace System.Text.Unicode.Tests
                 _value = value;
             }
 
-            public bool TryFormat(Span<byte> destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider provider)
+            public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider provider)
             {
                 ToStringState.LastFormat = format.ToString();
                 ToStringState.LastProvider = provider;
                 ToStringState.ToStringMode = ToStringMode.ISpanFormattableTryFormat;
 
                 ReadOnlySpan<byte> src = Encoding.UTF8.GetBytes(_value.ToString(format.ToString(), provider)).AsSpan();
-                if (src.TryCopyTo(destination))
+                if (src.TryCopyTo(utf8Destination))
                 {
                     bytesWritten = src.Length;
                     return true;


### PR DESCRIPTION
The approved parameter name was `utf8Destination` rather than just `destination`.