### PR TITLE
DependencyGraphViewer: Fix catastrophic designer fail for NodeForm

### DIFF
--- a/src/coreclr/tools/aot/DependencyGraphViewer/NodeForm.cs
+++ b/src/coreclr/tools/aot/DependencyGraphViewer/NodeForm.cs
@@ -67,21 +67,5 @@ namespace DependencyLogViewer
             string dMessage = "Dependent nodes depend on the current node. The current node depends on the dependees.";
             MessageBox.Show(dMessage);
         }
-    }
-    public class BoxDisplay
-    {
-        public Node node;
-        public List<string> reason;
-
-        public BoxDisplay(Node node, List<string> reason)
-        {
-            this.node = node;
-            this.reason = reason;
-        }
-
-        public override string ToString()
-        {
-            return $"Index: {node.Index}, Name: {node.Name}, {reason.Count} Reason(s): {string.Join(", ", reason.ToArray())}";
-        }
-    }
+    }   
 }

--- a/src/coreclr/tools/aot/DependencyGraphViewer/Program.cs
+++ b/src/coreclr/tools/aot/DependencyGraphViewer/Program.cs
@@ -17,6 +17,22 @@ using Microsoft.Diagnostics.Tracing.Session;
 
 namespace DependencyLogViewer
 {
+	public class BoxDisplay
+    {
+        public Node node;
+        public List<string> reason;
+
+        public BoxDisplay(Node node, List<string> reason)
+        {
+            this.node = node;
+            this.reason = reason;
+        }
+
+        public override string ToString()
+        {
+            return $"Index: {node.Index}, Name: {node.Name}, {reason.Count} Reason(s): {string.Join(", ", reason.ToArray())}";
+        }
+    }
     public class Node
     {
         public readonly int Index;


### PR DESCRIPTION
Fixes experimental designer failure due to having multiple classes in NodeForm.cs.

Fixes #84538

normally wouldn't stick these things in Program.cs but it is the style of this project.