### PR TITLE
Fix minor jitdisasm issue

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -6999,7 +6999,14 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
                 printf("\n%s:", emitLabelString(ig));
                 if (!emitComp->opts.disDiffable)
                 {
-                    printf("              ;; offset=%04XH", emitCurCodeOffs(cp));
+                    if (emitComp->opts.disAddr)
+                    {
+                        printf("              ;; offset=%04XH", emitCurCodeOffs(cp));
+                    }
+                    else
+                    {
+                        printf("  ;; offset=%04XH", emitCurCodeOffs(cp));
+                    }
                 }
                 printf("\n");
             }

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -7005,7 +7005,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
                         printf("              ;; offset=%04XH", emitCurCodeOffs(cp));
                     }
                     else
-#else // DEBUG
+#endif // DEBUG
                     {
                         printf("  ;; offset=%04XH", emitCurCodeOffs(cp));
                     }

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -6999,11 +6999,13 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
                 printf("\n%s:", emitLabelString(ig));
                 if (!emitComp->opts.disDiffable)
                 {
+#ifdef DEBUG
                     if (emitComp->opts.disAddr)
                     {
                         printf("              ;; offset=%04XH", emitCurCodeOffs(cp));
                     }
                     else
+#else // DEBUG
                     {
                         printf("  ;; offset=%04XH", emitCurCodeOffs(cp));
                     }

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -10430,8 +10430,17 @@ void emitter::emitDispShift(instruction ins, int cnt)
 
 void emitter::emitDispInsHex(instrDesc* id, BYTE* code, size_t sz)
 {
+#ifdef DEBUG
+    if (!emitComp->opts.disAddr)
+    {
+        return;
+    }
+#else // DEBUG
+    return;
+#endif
+
     // We do not display the instruction hex if we want diff-able disassembly
-    if (!emitComp->opts.disDiffable && emitComp->opts.disAddr)
+    if (!emitComp->opts.disDiffable)
     {
 #ifdef TARGET_AMD64
         // how many bytes per instruction we format for

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -10431,7 +10431,7 @@ void emitter::emitDispShift(instruction ins, int cnt)
 void emitter::emitDispInsHex(instrDesc* id, BYTE* code, size_t sz)
 {
     // We do not display the instruction hex if we want diff-able disassembly
-    if (!emitComp->opts.disDiffable)
+    if (!emitComp->opts.disDiffable && emitComp->opts.disAddr)
     {
 #ifdef TARGET_AMD64
         // how many bytes per instruction we format for

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -238,8 +238,8 @@ const char* CodeGen::genSizeStr(emitAttr attr)
         "dword ptr ",
         "qword ptr ",
         "xmmword ptr ",
-        "ymmword ptr",
-        "zmmword ptr"
+        "ymmword ptr ",
+        "zmmword ptr "
     };
     // clang-format on
 


### PR DESCRIPTION
e.g.
```asm
    vmovdqu  ymm0, ymmword ptr[rax]
    vmovdqu  xmm1, xmmword ptr [rax+1AH]
```
to:
```asm
    vmovdqu  ymm0, ymmword ptr [rax]
    vmovdqu  xmm1, xmmword ptr [rax+1AH]
```

Also, let's print raw instruction bytes only with `DOTNET_JitDasmWithAddress=1`, it makes default JitDisasm cleaner, also, makes output more `llvm-mca` friendly.

```asm
; Method Prog:Copy(ubyte[],ubyte[]):this
G_M18430_IG01:  ;; offset=0000H
       sub      rsp, 40
						;; size=4 bbWeight=1 PerfScore 0.25

G_M18430_IG02:  ;; offset=0004H
       test     rdx, rdx
       je       SHORT G_M18430_IG07
       cmp      dword ptr [rdx+08H], 222
       jb       SHORT G_M18430_IG07
       add      rdx, 16
       test     r8, r8
       jne      SHORT G_M18430_IG04
						;; size=23 bbWeight=1 PerfScore 6.75

G_M18430_IG03:  ;; offset=001BH
       xor      rcx, rcx
       xor      eax, eax
       jmp      SHORT G_M18430_IG05
						;; size=6 bbWeight=0.50 PerfScore 1.25

G_M18430_IG04:  ;; offset=0021H
       lea      rcx, bword ptr [r8+10H]
       mov      eax, dword ptr [r8+08H]
						;; size=8 bbWeight=0.50 PerfScore 1.25

G_M18430_IG05:  ;; offset=0029H
       cmp      eax, 222
       jb       SHORT G_M18430_IG08
       mov      r8d, 222
       call     [System.Buffer:Memmove(byref,byref,ulong)]
       nop      
						;; size=20 bbWeight=1 PerfScore 4.75

G_M18430_IG06:  ;; offset=003DH
       add      rsp, 40
       ret      
						;; size=5 bbWeight=1 PerfScore 1.25

G_M18430_IG07:  ;; offset=0042H
       call     [System.ThrowHelper:ThrowArgumentOutOfRangeException()]
       int3     
						;; size=7 bbWeight=0 PerfScore 0.00

G_M18430_IG08:  ;; offset=0049H
       call     [System.ThrowHelper:ThrowArgumentException_DestinationTooShort()]
       int3     
						;; size=7 bbWeight=0 PerfScore 0.00
; Total bytes of code: 80
```