### PR TITLE
Update Random.cs

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Random.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Random.cs
@@ -30,15 +30,15 @@ namespace System
             _impl = GetType() == typeof(Random) ? new XoshiroImpl() : new Net5CompatDerivedImpl(this);
 
         /// <summary>Initializes a new instance of the Random class, using the specified seed value.</summary>
-        /// <param name="Seed">
+        /// <param name="seed">
         /// A number used to calculate a starting value for the pseudo-random number sequence. If a negative number
         /// is specified, the absolute value of the number is used.
         /// </param>
-        public Random(int Seed) =>
+        public Random(int seed) =>
             // With a custom seed, if this is the base Random class, we still need to respect the same algorithm that's been
             // used in the past, but we can do so without having to deal with calling the right overrides in a derived type.
             // If this is a derived type, we need to handle always using the same overrides we've done previously.
-            _impl = GetType() == typeof(Random) ? new Net5CompatSeedImpl(Seed) : new Net5CompatDerivedImpl(this, Seed);
+            _impl = GetType() == typeof(Random) ? new Net5CompatSeedImpl(seed) : new Net5CompatDerivedImpl(this, seed);
 
         /// <summary>Constructor used by <see cref="ThreadSafeRandom"/>.</summary>
         /// <param name="isThreadSafeRandom">Must be true.</param>


### PR DESCRIPTION
hello.
the parameter names should use _camel case_. 
the constructor for the Random class broke this convention! 
The parameter name should be **seed**, not **Seed**.