### PR TITLE
[release/7.0][Android] Free up more disk space on CI builds

### DIFF
--- a/eng/testing/tests.android.targets
+++ b/eng/testing/tests.android.targets
@@ -69,6 +69,8 @@
           DestinationFolder="$(TestArchiveTestsDir)"
           SkipUnchangedFiles="true"
           Condition="'$(ArchiveTests)' == 'true' and '$(IgnoreForCI)' != 'true'" />
+
+    <RemoveDir Condition="'$(ArchiveTests)' == 'true' and '$(AndroidGenerateAppBundle)' == 'true'" Directories="$(OutDir)" />
   </Target>
 
 </Project>

--- a/src/mono/msbuild/android/build/AndroidApp.targets
+++ b/src/mono/msbuild/android/build/AndroidApp.targets
@@ -1,4 +1,9 @@
 <Project>
+  <PropertyGroup>
+    <AndroidGenerateAppBundle Condition="'$(AndroidGenerateAppBundle)' == '' and '$(GenerateAppBundle)' != ''">$(GenerateAppBundle)</AndroidGenerateAppBundle>
+    <AndroidGenerateAppBundle Condition="'$(AndroidGenerateAppBundle)' == ''">true</AndroidGenerateAppBundle>
+  </PropertyGroup>
+
   <UsingTask TaskName="AndroidAppBuilderTask" 
              AssemblyFile="$(AndroidAppBuilderTasksAssemblyPath)" />
 


### PR DESCRIPTION
backport of https://github.com/dotnet/runtime/pull/84354

The android builds are running out of disk space when building the library test apps. This change tries to recoup some of that space by deleting artifacts after each test was built.