### PR TITLE
[release/6.0][Android] Free up more disk space on CI builds

### DIFF
--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -137,6 +137,9 @@
           DestinationFolder="$(TestArchiveTestsDir)"
           SkipUnchangedFiles="true"
           Condition="'$(ArchiveTests)' == 'true' and '$(IgnoreForCI)' != 'true'" />
+
+    <RemoveDir Condition="'$(ArchiveTests)' == 'true' and '$(IgnoreForCI)' != 'true'" 
+               Directories="$(OutDir)" />
   </Target>
 
   <!-- Generate a self-contained app bundle for iOS with tests. -->


### PR DESCRIPTION
backport of https://github.com/dotnet/runtime/pull/84354

The android builds are running out of disk space when building the library test apps. This change tries to recoup some of that space by deleting artifacts after each test was built.