### PR TITLE
[mono] Disable TestCurrentValueDoesNotAllocateOnceValueIsCached on mono

### DIFF
--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsMonitorTest.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsMonitorTest.cs
@@ -472,7 +472,7 @@ namespace Microsoft.Extensions.Options.Tests
         /// Tests the fix for https://github.com/dotnet/runtime/issues/61086
         /// </summary>
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/67611", TestPlatforms.iOS | TestPlatforms.tvOS)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/67611", TestRuntimes.Mono)]
         public void TestCurrentValueDoesNotAllocateOnceValueIsCached()
         {
             var monitor = new OptionsMonitor<FakeOptions>(


### PR DESCRIPTION
fixes https://github.com/dotnet/runtime/issues/84551