### PR TITLE
Fix running tests against our DNNE'd NativeExports project to work in NativeAOT

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
@@ -274,7 +274,10 @@ namespace System.Runtime.CompilerServices
             ArgumentOutOfRangeException.ThrowIfNegative(size);
 
             // We don't support unloading; the memory will never be freed.
-            return (IntPtr)NativeMemory.Alloc((uint)size);
+            void* mem = NativeMemory.Alloc((uint)size);
+            NativeMemory.Clear(mem, (uint)size);
+
+            return (IntPtr)mem;
         }
 
         public static void PrepareDelegate(Delegate d)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
@@ -274,10 +274,7 @@ namespace System.Runtime.CompilerServices
             ArgumentOutOfRangeException.ThrowIfNegative(size);
 
             // We don't support unloading; the memory will never be freed.
-            void* mem = NativeMemory.Alloc((uint)size);
-            NativeMemory.Clear(mem, (uint)size);
-
-            return (IntPtr)mem;
+            return (IntPtr)NativeMemory.AllocZeroed((uint)size);
         }
 
         public static void PrepareDelegate(Delegate d)

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/ComInterfaceGenerator.Tests.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/ComInterfaceGenerator.Tests.csproj
@@ -20,9 +20,5 @@
     <ProjectReference Include="..\TestAssets\NativeExports\NativeExports.csproj" />
     <ProjectReference Include="..\TestAssets\SharedTypes\SharedTypes.csproj" />
   </ItemGroup>
-  <!-- Expose unmanaged entry points from NativeExports -->
-  <ItemGroup>
-    <UnmanagedEntryPointsAssembly Include="Microsoft.Interop.Tests.NativeExports" />
-    <DirectPInvoke Include="Microsoft.Interop.Tests.NativeExportsNE" />
-  </ItemGroup>
+
 </Project>

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/ComInterfaceGenerator.Tests.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/ComInterfaceGenerator.Tests.csproj
@@ -7,19 +7,22 @@
     <EnableLibraryImportGenerator>true</EnableLibraryImportGenerator>
     <!-- These tests pull the attributes from Ancillary.Interop, so we don't need to include the attribute sources in this assembly. -->
     <IncludeLibraryImportGeneratorSources>false</IncludeLibraryImportGeneratorSources>
-    <!-- suppress warning when referencing architecture specific NativeExports.csproj -->
-    <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
+    <ReferencesNativeExports>true</ReferencesNativeExports>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="$(CommonPath)DisableRuntimeMarshalling.cs" Link="Common\DisableRuntimeMarshalling.cs" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\gen\ComInterfaceGenerator\ComInterfaceGenerator.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
     <ProjectReference Include="..\Ancillary.Interop\Ancillary.Interop.csproj" />
     <ProjectReference Include="..\TestAssets\NativeExports\NativeExports.csproj" />
     <ProjectReference Include="..\TestAssets\SharedTypes\SharedTypes.csproj" />
   </ItemGroup>
-
+  <!-- Expose unmanaged entry points from NativeExports -->
+  <ItemGroup>
+    <UnmanagedEntryPointsAssembly Include="Microsoft.Interop.Tests.NativeExports" />
+    <DirectPInvoke Include="Microsoft.Interop.Tests.NativeExportsNE" />
+  </ItemGroup>
 </Project>

--- a/src/libraries/System.Runtime.InteropServices/tests/Directory.Build.targets
+++ b/src/libraries/System.Runtime.InteropServices/tests/Directory.Build.targets
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup Condition="'$(ReferencesNativeExports)' == 'true'">
+    <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
+    <IlcExportUnmanagedEntrypoints>true</IlcExportUnmanagedEntrypoints>
+  </PropertyGroup>
+  <!-- Expose unmanaged entry points from NativeExports -->
+  <ItemGroup Condition="'$(ReferencesNativeExports)' == 'true'">
+    <UnmanagedEntryPointsAssembly Include="Microsoft.Interop.Tests.NativeExports" />
+    <DirectPInvoke Include="Microsoft.Interop.Tests.NativeExportsNE" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
+</Project>

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/LibraryImportGenerator.Tests.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/LibraryImportGenerator.Tests.csproj
@@ -1,17 +1,17 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableLibraryImportGenerator>true</EnableLibraryImportGenerator>
     <IncludeLibraryImportGeneratorSources>false</IncludeLibraryImportGeneratorSources>
-    <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
+    <ReferencesNativeExports>true</ReferencesNativeExports>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="$(CommonPath)DisableRuntimeMarshalling.cs"
              Link="Common\DisableRuntimeMarshalling.cs" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\Ancillary.Interop\Ancillary.Interop.csproj" />
     <ProjectReference Include="..\TestAssets\NativeExports\NativeExports.csproj" />

--- a/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
@@ -370,10 +370,12 @@ namespace System.Runtime.CompilerServices.Tests
 
         [Fact]
         [SkipOnMono("Not presently implemented on Mono")]
-        public static void AllocateTypeAssociatedMemoryValidArguments()
+        public static unsafe void AllocateTypeAssociatedMemoryValidArguments()
         {
             IntPtr memory = RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(RuntimeHelpersTests), 32);
             Assert.NotEqual(memory, IntPtr.Zero);
+            // Validate that the memory is zeroed out
+            Assert.True(new Span<byte>((void*)memory, 32).SequenceEqual(new byte[32]));
         }
 
         [StructLayoutAttribute(LayoutKind.Sequential)]

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -453,12 +453,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices.JavaScript\tests\JSImportGenerator.UnitTest\JSImportGenerator.Unit.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration.Binder\tests\SourceGenerationTests\Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests.csproj" />
 
-    <!-- Depends on DNNE. Not particularly interesting because it tests marshalling-less p/invoke only. Low priority -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices\tests\LibraryImportGenerator.Tests\LibraryImportGenerator.Tests.csproj" />
-    
-    <!-- Depends on DNNE -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices\tests\ComInterfaceGenerator.Tests\ComInterfaceGenerator.Tests.csproj" />
-
     <!-- Many test failures due to trimming and MakeGeneric. XmlSerializer is not currently supported with NativeAOT. Low priority -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.XmlSerializer.Generator\tests\Microsoft.XmlSerializer.Generator.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ServiceModel.Syndication\tests\System.ServiceModel.Syndication.Tests.csproj" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -453,6 +453,10 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices.JavaScript\tests\JSImportGenerator.UnitTest\JSImportGenerator.Unit.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration.Binder\tests\SourceGenerationTests\Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests.csproj" />
 
+    <!-- Depends on ComWrappers, which is not enabled on NativeAOT on non-Windows. Tracked by #76005 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices\tests\ComInterfaceGenerator.Tests\ComInterfaceGenerator.Tests.csproj"
+      Condition="'$(TargetOS)' != 'windows'" />
+
     <!-- Many test failures due to trimming and MakeGeneric. XmlSerializer is not currently supported with NativeAOT. Low priority -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.XmlSerializer.Generator\tests\Microsoft.XmlSerializer.Generator.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ServiceModel.Syndication\tests\System.ServiceModel.Syndication.Tests.csproj" />


### PR DESCRIPTION
In NativeAOT, we'll forego using the DNNE-generated shim and instead will directly call the `[UnmanagedCallersOnly]` exports from the `[LibraryImport]`/`[DllImport]` methods in our tests. We'll use the functionality that was added for the iOS team to export the `[UnmanagedCallersOnly]` symbols from an assembly that is not the entry-point to include the unmanaged names for the symbols in `NativeExports`, and we'll use the Direct P/Invoke functionality to redirect the calls to the DNNE-based shim to call the symbols we now have exported from the same image, allowing the native linker to put the pieces together.

Contributes to #84451 by enabling libraries tests with DNNE components to run on our NativeAOT test runs.