### PR TITLE
[android][ios] Output Exported Symbols ItemGroup in LibraryBuilder

### DIFF
--- a/src/mono/msbuild/common/LibraryBuilder.targets
+++ b/src/mono/msbuild/common/LibraryBuilder.targets
@@ -32,7 +32,7 @@
       UsesCustomRuntimeInitCallback="$(_UsesCustomRuntimeInitCallback)"
       UsesRuntimeInitCallback="$(_UsesRuntimeInitCallback)">
       <Output TaskParameter="OutputPath" PropertyName="LibraryOutputPath" />
-      <Output Condition="'$(_IsSharedLibrary)' != 'true'" TaskParameter="ExportedSymbols" ItemName="LibraryRuntimeExportedSymbols" />
+      <Output TaskParameter="ExportedSymbols" ItemName="LibraryRuntimeExportedSymbols" />
     </LibraryBuilderTask>
   </Target>
 

--- a/src/mono/msbuild/common/LibraryBuilder.targets
+++ b/src/mono/msbuild/common/LibraryBuilder.targets
@@ -32,6 +32,7 @@
       UsesCustomRuntimeInitCallback="$(_UsesCustomRuntimeInitCallback)"
       UsesRuntimeInitCallback="$(_UsesRuntimeInitCallback)">
       <Output TaskParameter="OutputPath" PropertyName="LibraryOutputPath" />
+      <Output Condition="'$(_IsSharedLibrary)' != 'true'" TaskParameter="ExportedSymbols" ItemName="LibraryRuntimeExportedSymbols" />
     </LibraryBuilderTask>
   </Target>
 

--- a/src/tasks/LibraryBuilder/LibraryBuilder.cs
+++ b/src/tasks/LibraryBuilder/LibraryBuilder.cs
@@ -93,6 +93,14 @@ public class LibraryBuilderTask : AppBuilderTask
     [Output]
     public string OutputPath { get; set; } = ""!;
 
+    /// <summary>
+    /// The set of export symbols that need to be understood when building for a static library
+    ///
+    /// Note, this does not apply when IsSharedLibrary == true.
+    /// </summary>
+    [Output]
+    public string[] ExportedSymbols { get; set; } = Array.Empty<string>();
+
     private string MobileSymbolFileName
     {
         get => Path.Combine(OutputDirectory, "mobile_symbols.txt");
@@ -152,7 +160,6 @@ public class LibraryBuilderTask : AppBuilderTask
     private void GatherAotSourcesObjects(StringBuilder aotSources, StringBuilder aotObjects, StringBuilder extraSources, StringBuilder linkerArgs)
     {
         List<string> exportedSymbols = new List<string>();
-        bool hasExports = false;
 
         foreach (CompiledAssembly compiledAssembly in CompiledAssemblies)
         {
@@ -173,8 +180,6 @@ public class LibraryBuilderTask : AppBuilderTask
 
             if (!string.IsNullOrEmpty(compiledAssembly.ExportsFile))
             {
-                hasExports = true;
-
                 int symbolsAdded = GatherExportedSymbols(compiledAssembly.ExportsFile, exportedSymbols);
 
                 if (symbolsAdded > 0)
@@ -183,26 +188,35 @@ public class LibraryBuilderTask : AppBuilderTask
                 }
             }
         }
-        if (IsSharedLibrary && exportedAssemblies.Count == 0)
+
+        if (exportedAssemblies.Count == 0)
         {
-            throw new LogAsErrorException($"None of the compiled assemblies contain exported symbols. Resulting shared library would be unusable.");
+            throw new LogAsErrorException($"None of the compiled assemblies contain exported symbols. The library must export only symbols resulting from [UnmanageCallersOnly(Entrypoint = )]Resulting shared library would be unusable.");
         }
 
-        // for android, all symbols to keep go in one linker script
-        //
-        // for ios, multiple files can be specified
-        if (hasExports && TargetOS == "android")
+        if (IsSharedLibrary)
         {
-            WriteLinkerScriptFile(MobileSymbolFileName, exportedSymbols);
-            WriteLinkerScriptArg(MobileSymbolFileName, linkerArgs);
+            // for android, all symbols to keep go in one linker script
+            //
+            // for ios, multiple files can be specified
+            if (TargetOS == "android")
+            {
+                WriteLinkerScriptFile(MobileSymbolFileName, exportedSymbols);
+                WriteLinkerScriptArg(MobileSymbolFileName, linkerArgs);
+            }
+            else
+            {
+                File.WriteAllText(
+                    MobileSymbolFileName,
+                    string.Join("\n", exportedSymbols.Select(symbol => symbol))
+                );
+                WriteExportedSymbolsArg(MobileSymbolFileName, linkerArgs);
+            }
         }
-        else if (hasExports && exportedSymbols.Count > 0)
+        else
         {
-            File.WriteAllText(
-                MobileSymbolFileName,
-                string.Join("\n", exportedSymbols.Select(symbol => symbol))
-            );
-            WriteExportedSymbolsArg(MobileSymbolFileName, linkerArgs);
+            // static library, responsibility of enforcing exported symbols is external.
+            ExportedSymbols = exportedSymbols.ToArray();
         }
 
         foreach (ITaskItem item in ExtraSources)

--- a/src/tasks/LibraryBuilder/LibraryBuilder.cs
+++ b/src/tasks/LibraryBuilder/LibraryBuilder.cs
@@ -94,9 +94,7 @@ public class LibraryBuilderTask : AppBuilderTask
     public string OutputPath { get; set; } = ""!;
 
     /// <summary>
-    /// The set of export symbols that need to be understood when building for a static library
-    ///
-    /// Note, this does not apply when IsSharedLibrary == true.
+    /// The set of exported symbols identified by the aot compiler.
     /// </summary>
     [Output]
     public string[] ExportedSymbols { get; set; } = Array.Empty<string>();
@@ -213,16 +211,13 @@ public class LibraryBuilderTask : AppBuilderTask
                 WriteExportedSymbolsArg(MobileSymbolFileName, linkerArgs);
             }
         }
-        else
-        {
-            // static library, responsibility of enforcing exported symbols is external.
-            ExportedSymbols = exportedSymbols.ToArray();
-        }
 
         foreach (ITaskItem item in ExtraSources)
         {
             extraSources.AppendLine($"    {item.ItemSpec}");
         }
+
+        ExportedSymbols = exportedSymbols.ToArray();
     }
 
     private void GatherLinkerArgs(StringBuilder linkerArgs)


### PR DESCRIPTION
When `NativeLib=static`, output an ItemGroup that contains the set of export symbols gathered from the AOT compiler. The intent of library mode is to create a library with only exports gathered from the AOT compiler. Since the library is static, that responsibility is pushed outward.