### PR TITLE
Revert "Add SIMD to LowerCallMemcmp"

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -7384,9 +7384,9 @@ GenTree* Compiler::gtNewZeroConNode(var_types type)
 #ifdef FEATURE_SIMD
     if (varTypeIsSIMD(type))
     {
-        GenTreeVecCon* vecCon = gtNewVconNode(type);
-        vecCon->gtSimdVal     = simd_t::Zero();
-        return vecCon;
+        GenTreeVecCon* allBitsSet = gtNewVconNode(type);
+        allBitsSet->gtSimdVal     = simd_t::Zero();
+        return allBitsSet;
     }
 #endif // FEATURE_SIMD
 


### PR DESCRIPTION
Reverts dotnet/runtime#84530

This is causing PR builds to fail with
```
error C2660: 'Compiler::gtNewSimdCmpOpAllNode': function does not take 7 arguments
```

See for example https://github.com/dotnet/runtime/pull/84591, https://github.com/dotnet/runtime/pull/84588, https://github.com/dotnet/runtime/pull/84148.