### PR TITLE
[6.0-staging] Bump branding to 6.0.18

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,11 +1,11 @@
 <Project>
   <PropertyGroup>
     <!-- The .NET product branding version -->
-    <ProductVersion>6.0.17</ProductVersion>
+    <ProductVersion>6.0.18</ProductVersion>
     <!-- File version numbers -->
     <MajorVersion>6</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>17</PatchVersion>
+    <PatchVersion>18</PatchVersion>
     <SdkBandVersion>6.0.400</SdkBandVersion>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>


### PR DESCRIPTION
Moving the staging branch to the next servicing version now that code complete is done.

Base branch branding will continue happening as usual, on branding day.