### PR TITLE
[JIT] ARM64 - Combine `cmp` and shift ops into a single `cmp` op

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -1552,6 +1552,7 @@ public:
 
 #if defined(TARGET_ARM64)
     static insCond JumpKindToInsCond(emitJumpKind condition);
+    static insOpts ShiftOpToInsOpts(genTreeOps op);
 #elif defined(TARGET_XARCH)
     static instruction JumpKindToCmov(emitJumpKind condition);
 #endif

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2626,31 +2626,7 @@ void CodeGen::genCodeForBinary(GenTreeOp* tree)
             }
         }
 
-        switch (op2->gtOper)
-        {
-            case GT_LSH:
-            {
-                opt = INS_OPTS_LSL;
-                break;
-            }
-
-            case GT_RSH:
-            {
-                opt = INS_OPTS_ASR;
-                break;
-            }
-
-            case GT_RSZ:
-            {
-                opt = INS_OPTS_LSR;
-                break;
-            }
-
-            default:
-            {
-                unreached();
-            }
-        }
+        opt = ShiftOpToInsOpts(op2->gtOper);
 
         emit->emitIns_R_R_R_I(ins, emitActualTypeSize(tree), targetReg, a->GetRegNum(), b->GetRegNum(),
                               c->AsIntConCommon()->IconValue(), opt);
@@ -4545,6 +4521,15 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
             }
 
             emit->emitIns_R_I(ins, cmpSize, op1Reg, intConst->IconValue());
+        }
+        else if (op2->isContained())
+        {
+            assert(op2->OperIs(GT_LSH, GT_RSH, GT_RSZ));
+            assert(op2->gtGetOp2()->IsCnsIntOrI());
+            assert(op2->gtGetOp2()->isContained());
+
+            emit->emitIns_R_R_I(ins, cmpSize, op1->GetRegNum(), op2->gtGetOp1()->GetRegNum(),
+                                op2->gtGetOp2()->AsIntConCommon()->IntegralValue(), ShiftOpToInsOpts(op2->gtOper));
         }
         else
         {
@@ -10326,6 +10311,31 @@ insCond CodeGen::JumpKindToInsCond(emitJumpKind condition)
         default:
             NO_WAY("unexpected condition type");
             return INS_COND_EQ;
+    }
+}
+
+//------------------------------------------------------------------------
+// ShiftOpToInsOpts: Convert a shift-op to a insOpts.
+//
+// Arguments:
+//    shiftOp - the shift-op tree.
+//
+insOpts CodeGen::ShiftOpToInsOpts(genTreeOps op)
+{
+    switch (op)
+    {
+        case GT_LSH:
+            return INS_OPTS_LSL;
+
+        case GT_RSH:
+            return INS_OPTS_ASR;
+
+        case GT_RSZ:
+            return INS_OPTS_LSR;
+
+        default:
+            NO_WAY("expected a shift-op");
+            return INS_OPTS_NONE;
     }
 }
 

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -10318,11 +10318,11 @@ insCond CodeGen::JumpKindToInsCond(emitJumpKind condition)
 // ShiftOpToInsOpts: Convert a shift-op to a insOpts.
 //
 // Arguments:
-//    shiftOp - the shift-op tree.
+//    shiftOp - the shift-op.
 //
-insOpts CodeGen::ShiftOpToInsOpts(genTreeOps op)
+insOpts CodeGen::ShiftOpToInsOpts(genTreeOps shiftOp)
 {
-    switch (op)
+    switch (shiftOp)
     {
         case GT_LSH:
             return INS_OPTS_LSL;

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -10318,7 +10318,7 @@ insCond CodeGen::JumpKindToInsCond(emitJumpKind condition)
 // ShiftOpToInsOpts: Convert a shift-op to a insOpts.
 //
 // Arguments:
-//    shiftOp - the shift-op.
+//    shiftOp - the shift-op
 //
 insOpts CodeGen::ShiftOpToInsOpts(genTreeOps shiftOp)
 {

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -2270,6 +2270,13 @@ void Lowering::ContainCheckCompare(GenTreeOp* cmp)
     if (CheckImmedAndMakeContained(cmp, op2))
         return;
 
+    if (CheckImmedAndMakeContained(cmp, op1))
+    {
+        std::swap(cmp->gtOp1, cmp->gtOp2);
+        cmp->ChangeOper(cmp->SwapRelop(cmp->gtOper));
+        return;
+    }
+
 #ifdef TARGET_ARM64
     if (comp->opts.OptimizationEnabled() && cmp->OperIsCompare())
     {

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -2270,7 +2270,7 @@ void Lowering::ContainCheckCompare(GenTreeOp* cmp)
     if (CheckImmedAndMakeContained(cmp, op2))
         return;
 
-    if (CheckImmedAndMakeContained(cmp, op1))
+    if (cmp->OperIsCompare() && CheckImmedAndMakeContained(cmp, op1))
     {
         std::swap(cmp->gtOp1, cmp->gtOp2);
         cmp->ChangeOper(cmp->SwapRelop(cmp->gtOper));

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -2271,7 +2271,7 @@ void Lowering::ContainCheckCompare(GenTreeOp* cmp)
         return;
 
 #ifdef TARGET_ARM64
-    if (comp->opts.OptimizationEnabled())
+    if (comp->opts.OptimizationEnabled() && cmp->OperIsCompare())
     {
         if (IsContainableBinaryOp(cmp, op2))
         {
@@ -2279,11 +2279,11 @@ void Lowering::ContainCheckCompare(GenTreeOp* cmp)
             return;
         }
 
-        if (cmp->OperIs(GT_EQ, GT_NE) && IsContainableBinaryOp(cmp, op1))
+        if (IsContainableBinaryOp(cmp, op1))
         {
             MakeSrcContained(cmp, op1);
-
             std::swap(cmp->gtOp1, cmp->gtOp2);
+            cmp->ChangeOper(cmp->SwapRelop(cmp->gtOper));
             return;
         }
     }

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -2288,43 +2288,6 @@ void Lowering::ContainCheckCompare(GenTreeOp* cmp)
         }
     }
 #endif
-
-//#ifdef TARGET_ARM64
-//    if (comp->opts.OptimizationEnabled() && cmp->gtGetOp2()->OperIs(GT_LSH, GT_RSH, GT_RSZ))
-//    {
-//        auto isValidImmForShift = [](ssize_t imm, var_types type)
-//        { return emitter::isValidImmShift(imm, EA_ATTR(genTypeSize(type))); };
-//
-//        GenTree* op2 = cmp->gtGetOp2();
-//
-//        if (op2->gtGetOp2()->IsCnsIntOrI() &&
-//            isValidImmForShift(op2->gtGetOp2()->AsIntConCommon()->IntegralValue(), cmp->TypeGet()) &&
-//            IsContainableBinaryOp(cmp, cmp->gtGetOp2()))
-//        {
-//            op2->ClearContained();
-//            op2->gtGetOp1()->ClearContained();
-//
-//            MakeSrcContained(op2, op2->gtGetOp2());
-//            MakeSrcContained(cmp, op2);
-//        }
-//        else if (cmp->OperIsCommutative() && IsContainableBinaryOp(cmp, cmp->gtGetOp1()))
-//        {
-//        }
-//
-//        //        if (node->OperIsCommutative() && IsContainableBinaryOp(node, op1))
-//        //{
-//        //    if (op1->OperIs(GT_CAST))
-//        //    {
-//        //        // We want to prefer the combined op here over containment of the cast op
-//        //        op1->AsCast()->CastOp()->ClearContained();
-//        //    }
-//        //    MakeSrcContained(node, op1);
-//
-//        //    std::swap(node->gtOp1, node->gtOp2);
-//        //    return;
-//        //}
-//    }
-//#endif // TARGET_ARM64
 }
 
 #ifdef TARGET_ARM64

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -269,7 +269,7 @@ bool Lowering::IsContainableBinaryOp(GenTree* parentNode, GenTree* childNode) co
             return false;
         }
 
-        if (parentNode->OperIs(GT_CMP, GT_OR, GT_XOR))
+        if (parentNode->OperIs(GT_CMP, GT_OR, GT_XOR) || parentNode->OperIsCompare())
         {
             if (IsInvariantInRange(childNode, parentNode))
             {
@@ -2264,27 +2264,67 @@ void Lowering::ContainCheckCast(GenTreeCast* node)
 //
 void Lowering::ContainCheckCompare(GenTreeOp* cmp)
 {
-    CheckImmedAndMakeContained(cmp, cmp->gtOp2);
+    GenTree* op1 = cmp->gtGetOp1();
+    GenTree* op2 = cmp->gtGetOp2();
+
+    if (CheckImmedAndMakeContained(cmp, op2))
+        return;
 
 #ifdef TARGET_ARM64
-    if (comp->opts.OptimizationEnabled() && cmp->gtGetOp2()->OperIs(GT_LSH, GT_RSH, GT_RSZ))
+    if (comp->opts.OptimizationEnabled())
     {
-        auto isValidImmForShift = [](ssize_t imm, var_types type)
-        { return emitter::isValidImmShift(imm, EA_ATTR(genTypeSize(type))); };
-
-        GenTree* op2 = cmp->gtGetOp2();
-
-        if (op2->gtGetOp2()->IsCnsIntOrI() &&
-            isValidImmForShift(op2->gtGetOp2()->AsIntConCommon()->IntegralValue(), cmp->TypeGet()))
+        if (IsContainableBinaryOp(cmp, op2))
         {
-            op2->ClearContained();
-            op2->gtGetOp1()->ClearContained();
-
-            MakeSrcContained(op2, op2->gtGetOp2());
             MakeSrcContained(cmp, op2);
+            return;
+        }
+
+        if (cmp->OperIs(GT_EQ, GT_NE) && IsContainableBinaryOp(cmp, op1))
+        {
+            MakeSrcContained(cmp, op1);
+
+            std::swap(cmp->gtOp1, cmp->gtOp2);
+            return;
         }
     }
-#endif // TARGET_ARM64
+#endif
+
+//#ifdef TARGET_ARM64
+//    if (comp->opts.OptimizationEnabled() && cmp->gtGetOp2()->OperIs(GT_LSH, GT_RSH, GT_RSZ))
+//    {
+//        auto isValidImmForShift = [](ssize_t imm, var_types type)
+//        { return emitter::isValidImmShift(imm, EA_ATTR(genTypeSize(type))); };
+//
+//        GenTree* op2 = cmp->gtGetOp2();
+//
+//        if (op2->gtGetOp2()->IsCnsIntOrI() &&
+//            isValidImmForShift(op2->gtGetOp2()->AsIntConCommon()->IntegralValue(), cmp->TypeGet()) &&
+//            IsContainableBinaryOp(cmp, cmp->gtGetOp2()))
+//        {
+//            op2->ClearContained();
+//            op2->gtGetOp1()->ClearContained();
+//
+//            MakeSrcContained(op2, op2->gtGetOp2());
+//            MakeSrcContained(cmp, op2);
+//        }
+//        else if (cmp->OperIsCommutative() && IsContainableBinaryOp(cmp, cmp->gtGetOp1()))
+//        {
+//        }
+//
+//        //        if (node->OperIsCommutative() && IsContainableBinaryOp(node, op1))
+//        //{
+//        //    if (op1->OperIs(GT_CAST))
+//        //    {
+//        //        // We want to prefer the combined op here over containment of the cast op
+//        //        op1->AsCast()->CastOp()->ClearContained();
+//        //    }
+//        //    MakeSrcContained(node, op1);
+//
+//        //    std::swap(node->gtOp1, node->gtOp2);
+//        //    return;
+//        //}
+//    }
+//#endif // TARGET_ARM64
 }
 
 #ifdef TARGET_ARM64


### PR DESCRIPTION
## Description

Given this example:
```asm
lsl    w1, w1, #2
cmp    w0, w1
```

Can be converted into a single `cmp`:
```asm
cmp    w0, w1, LSL #2
```

This PR will not include the `cmn` version.