### PR TITLE
Expose DOTNET_JitPrintInlinedMethods in Release

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4629,8 +4629,8 @@ public:
 
 #if defined(DEBUG)
     unsigned impInlinedCodeSize;
-    bool     fgPrintInlinedMethods;
 #endif
+    bool     fgPrintInlinedMethods;
 
     jitstd::vector<FlowEdge*>* fgPredListSortVector;
 

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -16,9 +16,7 @@ void Compiler::fgInit()
 
     fgFirstBBScratch = nullptr;
 
-#ifdef DEBUG
     fgPrintInlinedMethods = false;
-#endif // DEBUG
 
     /* We haven't yet computed the bbPreds lists */
     fgPredsComputed = false;

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -593,10 +593,8 @@ PhaseStatus Compiler::fgInline()
         return PhaseStatus::MODIFIED_NOTHING;
     }
 
-#ifdef DEBUG
     fgPrintInlinedMethods =
         JitConfig.JitPrintInlinedMethods().contains(info.compMethodHnd, info.compClassHnd, &info.compMethodInfo->args);
-#endif // DEBUG
 
     noway_assert(fgFirstBB != nullptr);
 
@@ -717,8 +715,13 @@ PhaseStatus Compiler::fgInline()
         printf("\n");
         m_inlineStrategy->Dump(verbose || JitConfig.JitPrintInlinedMethodsVerbose());
     }
-
-#endif // DEBUG
+#else // DEBUG
+    if (fgPrintInlinedMethods)
+    {
+        printf("\n");
+        m_inlineStrategy->Dump(false);
+    }
+#endif
 
     if (madeChanges)
     {

--- a/src/coreclr/jit/inline.cpp
+++ b/src/coreclr/jit/inline.cpp
@@ -352,8 +352,6 @@ InlineContext::InlineContext(InlineStrategy* strategy)
     // Empty
 }
 
-#if defined(DEBUG) || defined(INLINE_DATA)
-
 //------------------------------------------------------------------------
 // Dump: Dump an InlineContext entry and all descendants to jitstdout
 //
@@ -380,15 +378,10 @@ void InlineContext::Dump(bool verbose, unsigned indent)
     }
     else
     {
-
-#if defined(DEBUG)
         calleeName = compiler->eeGetMethodFullName(m_Callee);
-#else
-        calleeName         = "callee";
-#endif // defined(DEBUG)
     }
 
-    mdMethodDef calleeToken = compiler->info.compCompHnd->getMethodDefFromMethod(m_Callee);
+    INDEBUG(mdMethodDef calleeToken = compiler->info.compCompHnd->getMethodDefFromMethod(m_Callee));
 
     // Dump this node
     if (m_Parent == nullptr)
@@ -396,11 +389,13 @@ void InlineContext::Dump(bool verbose, unsigned indent)
         // Root method
         InlinePolicy* policy = InlinePolicy::GetPolicy(compiler, true);
 
+#if defined(DEBUG)
         if (verbose)
         {
             printf("\nInlines into %08X [via %s] %s:\n", calleeToken, policy->GetName(), calleeName);
         }
         else
+#endif
         {
             printf("\nInlines into %s:\n", calleeName);
         }
@@ -417,6 +412,7 @@ void InlineContext::Dump(bool verbose, unsigned indent)
 
         IL_OFFSET offs = m_ActualCallOffset;
 
+#if defined(DEBUG)
         if (verbose)
         {
             if (offs == BAD_IL_OFFSET)
@@ -433,6 +429,7 @@ void InlineContext::Dump(bool verbose, unsigned indent)
             }
         }
         else
+#endif
         {
             printf("%*s[%s%s%s%s%s] %s\n", indent, "", inlineResult, inlineReason, guarded, devirtualized, unboxed,
                    calleeName);
@@ -445,6 +442,8 @@ void InlineContext::Dump(bool verbose, unsigned indent)
         m_Child->Dump(verbose, indent + 2);
     }
 }
+
+#if defined(DEBUG) || defined(INLINE_DATA)
 
 //------------------------------------------------------------------------
 // DumpData: Dump a successful InlineContext entry, detailed data, and
@@ -1357,8 +1356,6 @@ void InlineContext::SetFailed(const InlineResult* result)
     m_InlineStrategy->NoteOutcome(this);
 }
 
-#if defined(DEBUG) || defined(INLINE_DATA)
-
 //------------------------------------------------------------------------
 // Dump: dump description of inline behavior
 //
@@ -1394,6 +1391,8 @@ void InlineStrategy::Dump(bool verbose)
 
     printf("Budget: initialSize=%d, finalSize=%d\n", m_InitialSizeEstimate, m_CurrentSizeEstimate);
 }
+
+#if defined(DEBUG) || defined(INLINE_DATA)
 
 // Static to track emission of the inline data header
 

--- a/src/coreclr/jit/inline.cpp
+++ b/src/coreclr/jit/inline.cpp
@@ -431,8 +431,8 @@ void InlineContext::Dump(bool verbose, unsigned indent)
         else
 #endif
         {
-            printf("%*s[%s%s%s%s%s] %s\n", indent, "", inlineResult, inlineReason, guarded, devirtualized, unboxed,
-                   calleeName);
+            printf("%*s[%s%s%s%s%s IL=%04d] %s\n", indent, "", inlineResult, inlineReason, guarded, devirtualized,
+                   unboxed, offs, calleeName);
         }
     }
 

--- a/src/coreclr/jit/inline.h
+++ b/src/coreclr/jit/inline.h
@@ -738,10 +738,9 @@ class InlineContext
     friend class InlineStrategy;
 
 public:
-#if defined(DEBUG) || defined(INLINE_DATA)
-
     // Dump the full subtree, including failures
     void Dump(bool verbose, unsigned indent = 0);
+#if defined(DEBUG) || defined(INLINE_DATA)
 
     // Dump only the success subtree, with rich data
     void DumpData(unsigned indent = 0);
@@ -1010,10 +1009,10 @@ public:
     // Check if inlining is disabled for the method being jitted
     bool IsInliningDisabled();
 
-#if defined(DEBUG) || defined(INLINE_DATA)
-
     // Dump textual description of inlines done so far.
     void Dump(bool verbose);
+
+#if defined(DEBUG) || defined(INLINE_DATA)
 
     // Dump data-format description of inlines done so far.
     void DumpData();

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -138,12 +138,6 @@ CONFIG_INTEGER(JitReportFastTailCallDecisions, W("JitReportFastTailCallDecisions
 CONFIG_INTEGER(JitPInvokeCheckEnabled, W("JITPInvokeCheckEnabled"), 0)
 CONFIG_INTEGER(JitPInvokeEnabled, W("JITPInvokeEnabled"), 1)
 
-// Controls verbosity for JitPrintInlinedMethods. Ignored for JitDump where
-// it's always set.
-CONFIG_INTEGER(JitPrintInlinedMethodsVerbose, W("JitPrintInlinedMethodsVerboseLevel"), 0)
-// Prints a tree of inlinees for a specific method (use '*' for all methods)
-CONFIG_METHODSET(JitPrintInlinedMethods, W("JitPrintInlinedMethods"))
-
 CONFIG_METHODSET(JitPrintDevirtualizedMethods, W("JitPrintDevirtualizedMethods"))
 CONFIG_INTEGER(JitProfileChecks, W("JitProfileChecks"), 0) // Bitflag: 0x1 check classic, 0x2 check likely, 0x4 enable
                                                            // asserts
@@ -251,6 +245,14 @@ CONFIG_STRING(JitStressRange, W("JitStressRange"))               // Internal Jit
 ///
 CONFIG_INTEGER(EnableIncompleteISAClass, W("EnableIncompleteISAClass"), 0) // Enable testing not-yet-implemented
 #endif                                                                     // defined(DEBUG)
+
+#ifdef DEBUG
+// Controls verbosity for JitPrintInlinedMethods. Ignored for JitDump where
+// it's always set.
+CONFIG_INTEGER(JitPrintInlinedMethodsVerbose, W("JitPrintInlinedMethodsVerboseLevel"), 0)
+#endif
+// Prints a tree of inlinees for a specific method (use '*' for all methods)
+CONFIG_METHODSET(JitPrintInlinedMethods, W("JitPrintInlinedMethods"))
 
 CONFIG_METHODSET(JitDisasm, W("JitDisasm"))                  // Print codegen for given methods
 CONFIG_INTEGER(JitDisasmDiffable, W("JitDisasmDiffable"), 0) // Make the disassembly diff-able


### PR DESCRIPTION
Prints a call graph with inliner's decisions for a given method/class/everything (same syntax as for `DOTNET_JitDisasm`)

e.g. `$env:DOTNET_JitPrintInlinedMethods="System.SpanHelpers:*"`: for a hello world 
```
Inlines into System.SpanHelpers:IndexOfNullCharacter(ulong):int:
  [INLINED: aggressive inline attribute] System.SpanHelpers:UnalignedCountVector128(ulong):long
  [INLINED: aggressive inline attribute] System.SpanHelpers:GetCharVector256SpanLength(long,long):long
  [INLINED: aggressive inline attribute] System.SpanHelpers:GetCharVector128SpanLength(long,long):long
  [FAILED: does not return] System.SpanHelpers:ThrowMustBeNullTerminatedString()


Inlines into System.SpanHelpers:IndexOfNullByte(ulong):int:
  [INLINED: aggressive inline attribute] System.SpanHelpers:UnalignedCountVector128(ulong):ulong
  [INLINED: aggressive inline attribute] System.SpanHelpers:GetByteVector256SpanLength(ulong,int):ulong
  [INLINED: aggressive inline attribute] System.SpanHelpers:GetByteVector128SpanLength(ulong,int):ulong
  [FAILED: does not return] System.SpanHelpers:ThrowMustBeNullTerminatedString()


Inlines into System.SpanHelpers:LastIndexOfValueType[short,System.SpanHelpers+DontNegate`1[short]](byref,short,int):int:
  [INLINED: below ALWAYS_INLINE size] System.Int16:System.Numerics.IEqualityOperators<System.Int16,System.Int16,System.Boolean>.op_Equality(short,short):bool
  [INLINED: below ALWAYS_INLINE size] System.SpanHelpers+DontNegate`1[short]:NegateIfNeeded(bool):bool
  [INLINED: below ALWAYS_INLINE size] System.Int16:System.Numerics.IEqualityOperators<System.Int16,System.Int16,System.Boolean>.op_Equality(short,short):bool
  [INLINED: below ALWAYS_INLINE size] System.SpanHelpers+DontNegate`1[short]:NegateIfNeeded(bool):bool
  [INLINED: below ALWAYS_INLINE size] System.Int16:System.Numerics.IEqualityOperators<System.Int16,System.Int16,System.Boolean>.op_Equality(short,short):bool
  [INLINED: below ALWAYS_INLINE size] System.SpanHelpers+DontNegate`1[short]:NegateIfNeeded(bool):bool
  [INLINED: below ALWAYS_INLINE size] System.Int16:System.Numerics.IEqualityOperators<System.Int16,System.Int16,System.Boolean>.op_Equality(short,short):bool
  [INLINED: below ALWAYS_INLINE size] System.SpanHelpers+DontNegate`1[short]:NegateIfNeeded(bool):bool
  [INLINED: below ALWAYS_INLINE size] System.Int16:System.Numerics.IEqualityOperators<System.Int16,System.Int16,System.Boolean>.op_Equality(short,short):bool
  [INLINED: below ALWAYS_INLINE size] System.SpanHelpers+DontNegate`1[short]:NegateIfNeeded(bool):bool
  [INLINED: below ALWAYS_INLINE size] System.Int16:System.Numerics.IEqualityOperators<System.Int16,System.Int16,System.Boolean>.op_Equality(short,short):bool
  [INLINED: below ALWAYS_INLINE size] System.SpanHelpers+DontNegate`1[short]:NegateIfNeeded(bool):bool
  [INLINED: below ALWAYS_INLINE size] System.Int16:System.Numerics.IEqualityOperators<System.Int16,System.Int16,System.Boolean>.op_Equality(short,short):bool
  [INLINED: below ALWAYS_INLINE size] System.SpanHelpers+DontNegate`1[short]:NegateIfNeeded(bool):bool
  [INLINED: below ALWAYS_INLINE size] System.Int16:System.Numerics.IEqualityOperators<System.Int16,System.Int16,System.Boolean>.op_Equality(short,short):bool
  [INLINED: below ALWAYS_INLINE size] System.SpanHelpers+DontNegate`1[short]:NegateIfNeeded(bool):bool
  [INLINED: below ALWAYS_INLINE size] System.Int16:System.Numerics.IEqualityOperators<System.Int16,System.Int16,System.Boolean>.op_Equality(short,short):bool
  [INLINED: below ALWAYS_INLINE size] System.SpanHelpers+DontNegate`1[short]:NegateIfNeeded(bool):bool
  [INLINED: below ALWAYS_INLINE size] System.Int16:System.Numerics.IEqualityOperators<System.Int16,System.Int16,System.Boolean>.op_Equality(short,short):bool
  [INLINED: below ALWAYS_INLINE size] System.SpanHelpers+DontNegate`1[short]:NegateIfNeeded(bool):bool
  [INLINED: below ALWAYS_INLINE size] System.Int16:System.Numerics.IEqualityOperators<System.Int16,System.Int16,System.Boolean>.op_Equality(short,short):bool
  [INLINED: below ALWAYS_INLINE size] System.SpanHelpers+DontNegate`1[short]:NegateIfNeeded(bool):bool
  [INLINED: below ALWAYS_INLINE size] System.Int16:System.Numerics.IEqualityOperators<System.Int16,System.Int16,System.Boolean>.op_Equality(short,short):bool
  [INLINED: below ALWAYS_INLINE size] System.SpanHelpers+DontNegate`1[short]:NegateIfNeeded(bool):bool
  [INLINED: below ALWAYS_INLINE size] System.Int16:System.Numerics.IEqualityOperators<System.Int16,System.Int16,System.Boolean>.op_Equality(short,short):bool
  [INLINED: below ALWAYS_INLINE size] System.SpanHelpers+DontNegate`1[short]:NegateIfNeeded(bool):bool
  [INLINED: below ALWAYS_INLINE size] System.SpanHelpers+DontNegate`1[short]:NegateIfNeeded(System.Runtime.Intrinsics.Vector256`1[short]):System.Runtime.Intrinsics.Vector256`1[short]
  [INLINED: aggressive inline attribute] System.SpanHelpers:ComputeLastIndex[short](long,System.Runtime.Intrinsics.Vector256`1[short]):int
  [INLINED: below ALWAYS_INLINE size] System.SpanHelpers+DontNegate`1[short]:NegateIfNeeded(System.Runtime.Intrinsics.Vector256`1[short]):System.Runtime.Intrinsics.Vector256`1[short]
  [INLINED: aggressive inline attribute] System.SpanHelpers:ComputeLastIndex[short](long,System.Runtime.Intrinsics.Vector256`1[short]):int
  [INLINED: below ALWAYS_INLINE size] System.SpanHelpers+DontNegate`1[short]:NegateIfNeeded(System.Runtime.Intrinsics.Vector128`1[short]):System.Runtime.Intrinsics.Vector128`1[short]
  [INLINED: aggressive inline attribute] System.SpanHelpers:ComputeLastIndex[short](long,System.Runtime.Intrinsics.Vector128`1[short]):int
  [INLINED: below ALWAYS_INLINE size] System.SpanHelpers+DontNegate`1[short]:NegateIfNeeded(System.Runtime.Intrinsics.Vector128`1[short]):System.Runtime.Intrinsics.Vector128`1[short]
  [INLINED: aggressive inline attribute] System.SpanHelpers:ComputeLastIndex[short](long,System.Runtime.Intrinsics.Vector128`1[short]):int


Inlines into System.SpanHelpers:SequenceCompareTo(byref,int,byref,int):int:
  [INLINED: below ALWAYS_INLINE size] System.Byte:CompareTo(ubyte):int:this
  [INLINED: below ALWAYS_INLINE size] System.Byte:CompareTo(ubyte):int:this
  [INLINED: aggressive inline attribute] System.SpanHelpers:LoadNUInt(byref,ulong):ulong
    [INLINED: aggressive inline attribute] System.Runtime.CompilerServices.Unsafe:ReadUnaligned[ulong](byref):ulong
  [INLINED: aggressive inline attribute] System.SpanHelpers:LoadNUInt(byref,ulong):ulong
    [INLINED: aggressive inline attribute] System.Runtime.CompilerServices.Unsafe:ReadUnaligned[ulong](byref):ulong
  [INLINED: below ALWAYS_INLINE size] System.Byte:CompareTo(ubyte):int:this
System.Byte[]
```

First of all it's useful to catch cases where inliner gives up due to the "budget" thing or callgraph depth, etc so it can quickly highlight problematic cases.
Another bonus that it highlights devirtualized + inlined calls (with PGO)


Since we're making it public we can rename it now if needed.

cc @stephentoub 