### PR TITLE
Fix incorrect covariant returns tests

### DIFF
--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/Interfaces/UnitTest.il
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/Interfaces/UnitTest.il
@@ -321,7 +321,7 @@
     throw
   }
 
-  .method public hidebysig virtual instance class IGenRetType<!0, class IDictionary<string,!1>> MyGenFunc(string& res)
+  .method public hidebysig virtual instance class IGenRetType<!2, class IDictionary<string,!3>> MyGenFunc(string& res)
   {
     ldstr "Should never execute this method"
     newobj instance void [System.Runtime]System.Exception::.ctor(string)

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/UnitTest.il
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/UnitTest.il
@@ -303,7 +303,7 @@
     throw
   }
 
-  .method public hidebysig virtual instance class GenRetType<!0, class Dictionary<string,!1>> MyGenFunc(string& res)
+  .method public hidebysig virtual instance class GenRetType<!2, class Dictionary<string,!3>> MyGenFunc(string& res)
   {
     ldstr "Should never execute this method"
     newobj instance void [System.Runtime]System.Exception::.ctor(string)

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/UnitTestDelegates.il
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/UnitTestDelegates.il
@@ -316,7 +316,7 @@
     throw
   }
 
-  .method public hidebysig virtual instance class GenRetType<!0, class Dictionary<string,!1>> MyGenFunc(string& res)
+  .method public hidebysig virtual instance class GenRetType<!2, class Dictionary<string,!3>> MyGenFunc(string& res)
   {
     ldstr "Should never execute this method"
     newobj instance void [System.Runtime]System.Exception::.ctor(string)


### PR DESCRIPTION
The intention of the methods is to override a base method, but the signature is wrong so they introduce a new slot instead. The test is not testing what it wanted to tests (that the override is not reachable) because we would never call this new method through a virtual call.

`!0` and `!1` corresponds to `UNUSED1` and `UNUSED2`.

Peeled off from #84404 so that I can get a review.

Cc @dotnet/ilc-contrib 