### PR TITLE
[wasm] Restrict tests to browser/wasi only.

### DIFF
--- a/src/libraries/System.Globalization/tests/Hybrid/Hybrid.WASM.Tests.csproj
+++ b/src/libraries/System.Globalization/tests/Hybrid/Hybrid.WASM.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppCurrent)-browser;$(NetCoreAppCurrent)-wasi</TargetFramework>
+    <TargetFrameworks>$(NetCoreAppCurrent)-browser;$(NetCoreAppCurrent)-wasi</TargetFrameworks>
     <TestRuntime>true</TestRuntime>
     <HybridGlobalization>true</HybridGlobalization>
   </PropertyGroup>

--- a/src/libraries/System.Globalization/tests/Hybrid/Hybrid.WASM.Tests.csproj
+++ b/src/libraries/System.Globalization/tests/Hybrid/Hybrid.WASM.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrent)-browser;$(NetCoreAppCurrent)-wasi</TargetFramework>
     <TestRuntime>true</TestRuntime>
     <HybridGlobalization>true</HybridGlobalization>
   </PropertyGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/84477.