### PR TITLE
[release/7.0] Fix AwaitableSocketAsyncEventArgs reorderings on weaker memory models

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
@@ -934,7 +934,7 @@ namespace System.Net.Sockets
             /// <see cref="s_completedSentinel"/> if it has completed. Another delegate if OnCompleted was called before the operation could complete,
             /// in which case it's the delegate to invoke when the operation does complete.
             /// </summary>
-            private Action<object?>? _continuation;
+            private volatile Action<object?>? _continuation;
             private ExecutionContext? _executionContext;
             private object? _scheduler;
             /// <summary>Current token value given to a ValueTask and then verified against the value it passes back to us.</summary>
@@ -1007,7 +1007,7 @@ namespace System.Net.Sockets
             /// <returns>This instance.</returns>
             public ValueTask<Socket> AcceptAsync(Socket socket, CancellationToken cancellationToken)
             {
-                Debug.Assert(Volatile.Read(ref _continuation) == null, "Expected null continuation to indicate reserved for use");
+                Debug.Assert(_continuation == null, "Expected null continuation to indicate reserved for use");
 
                 if (socket.AcceptAsync(this, cancellationToken))
                 {
@@ -1031,7 +1031,7 @@ namespace System.Net.Sockets
             /// <returns>This instance.</returns>
             public ValueTask<int> ReceiveAsync(Socket socket, CancellationToken cancellationToken)
             {
-                Debug.Assert(Volatile.Read(ref _continuation) == null, "Expected null continuation to indicate reserved for use");
+                Debug.Assert(_continuation == null, "Expected null continuation to indicate reserved for use");
 
                 if (socket.ReceiveAsync(this, cancellationToken))
                 {
@@ -1051,7 +1051,7 @@ namespace System.Net.Sockets
 
             public ValueTask<SocketReceiveFromResult> ReceiveFromAsync(Socket socket, CancellationToken cancellationToken)
             {
-                Debug.Assert(Volatile.Read(ref _continuation) == null, "Expected null continuation to indicate reserved for use");
+                Debug.Assert(_continuation == null, "Expected null continuation to indicate reserved for use");
 
                 if (socket.ReceiveFromAsync(this, cancellationToken))
                 {
@@ -1072,7 +1072,7 @@ namespace System.Net.Sockets
 
             public ValueTask<SocketReceiveMessageFromResult> ReceiveMessageFromAsync(Socket socket, CancellationToken cancellationToken)
             {
-                Debug.Assert(Volatile.Read(ref _continuation) == null, "Expected null continuation to indicate reserved for use");
+                Debug.Assert(_continuation == null, "Expected null continuation to indicate reserved for use");
 
                 if (socket.ReceiveMessageFromAsync(this, cancellationToken))
                 {
@@ -1097,7 +1097,7 @@ namespace System.Net.Sockets
             /// <returns>This instance.</returns>
             public ValueTask<int> SendAsync(Socket socket, CancellationToken cancellationToken)
             {
-                Debug.Assert(Volatile.Read(ref _continuation) == null, "Expected null continuation to indicate reserved for use");
+                Debug.Assert(_continuation == null, "Expected null continuation to indicate reserved for use");
 
                 if (socket.SendAsync(this, cancellationToken))
                 {
@@ -1117,7 +1117,7 @@ namespace System.Net.Sockets
 
             public ValueTask SendAsyncForNetworkStream(Socket socket, CancellationToken cancellationToken)
             {
-                Debug.Assert(Volatile.Read(ref _continuation) == null, "Expected null continuation to indicate reserved for use");
+                Debug.Assert(_continuation == null, "Expected null continuation to indicate reserved for use");
 
                 if (socket.SendAsync(this, cancellationToken))
                 {
@@ -1136,7 +1136,7 @@ namespace System.Net.Sockets
 
             public ValueTask SendPacketsAsync(Socket socket, CancellationToken cancellationToken)
             {
-                Debug.Assert(Volatile.Read(ref _continuation) == null, "Expected null continuation to indicate reserved for use");
+                Debug.Assert(_continuation == null, "Expected null continuation to indicate reserved for use");
 
                 if (socket.SendPacketsAsync(this, cancellationToken))
                 {
@@ -1155,7 +1155,7 @@ namespace System.Net.Sockets
 
             public ValueTask<int> SendToAsync(Socket socket, CancellationToken cancellationToken)
             {
-                Debug.Assert(Volatile.Read(ref _continuation) == null, "Expected null continuation to indicate reserved for use");
+                Debug.Assert(_continuation == null, "Expected null continuation to indicate reserved for use");
 
                 if (socket.SendToAsync(this, cancellationToken))
                 {
@@ -1175,7 +1175,7 @@ namespace System.Net.Sockets
 
             public ValueTask ConnectAsync(Socket socket)
             {
-                Debug.Assert(Volatile.Read(ref _continuation) == null, "Expected null continuation to indicate reserved for use");
+                Debug.Assert(_continuation == null, "Expected null continuation to indicate reserved for use");
 
                 try
                 {
@@ -1201,7 +1201,7 @@ namespace System.Net.Sockets
 
             public ValueTask DisconnectAsync(Socket socket, CancellationToken cancellationToken)
             {
-                Debug.Assert(Volatile.Read(ref _continuation) == null, $"Expected null continuation to indicate reserved for use");
+                Debug.Assert(_continuation == null, $"Expected null continuation to indicate reserved for use");
 
                 if (socket.DisconnectAsync(this, cancellationToken))
                 {


### PR DESCRIPTION
Port of #84432 to release/7.0-staging per tactics approval of the 6.0 fix. Performed with a clean cherry-pick of 36a721aa3855e9e29ea6b90594a77307fefeea56 from [stephentoub:fixsocketreordering](https://github.com/stephentoub/runtime/tree/fixsocketreordering).