### PR TITLE
SPMI: Add possibility to specify custom options in diffs pipeline

### DIFF
--- a/eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
+++ b/eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
@@ -30,6 +30,8 @@ parameters:
   shouldContinueOnError: false
   SuperPmiCollect: ''
   SuperPmiDiffType: ''
+  SuperPmiBaseJitOptions: ''
+  SuperPmiDiffJitOptions: ''
 
 
 steps:
@@ -64,6 +66,8 @@ steps:
       _RuntimeVariant: ${{ parameters.runtimeVariant }}
       _SuperPmiCollect: ${{ parameters.SuperPmiCollect }}
       _SuperPmiDiffType: ${{ parameters.SuperPmiDiffType }}
+      _SuperPmiBaseJitOptions: ${{ parameters.SuperPmiBaseJitOptions }}
+      _SuperPmiDiffJitOptions: ${{ parameters.SuperPmiDiffJitOptions }}
       ${{ if eq(parameters.publishTestResults, 'true') }}:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       # TODO: remove NUGET_PACKAGES once https://github.com/dotnet/arcade/issues/1578 is fixed

--- a/eng/pipelines/coreclr/superpmi-diffs.yml
+++ b/eng/pipelines/coreclr/superpmi-diffs.yml
@@ -1,3 +1,13 @@
+parameters:
+- name: spmi_jitoptions_base
+  displayName: JIT options (base)
+  type: string
+  default: ' '
+- name: spmi_jitoptions_diff
+  displayName: JIT options (diff)
+  type: string
+  default: ' '
+
 # This pipeline only runs on GitHub PRs, not on merges.
 trigger: none
 
@@ -67,6 +77,8 @@ extends:
           jobParameters:
             condition: not(eq(dependencies.evaluate_paths.outputs['SetPathVars_jiteeversionguid.containsChange'], true))
             diffType: asmdiffs
+            baseJitOptions: ${{ parameters.spmi_jitoptions_base }}
+            diffJitOptions: ${{ parameters.spmi_jitoptions_diff }}
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -80,3 +92,5 @@ extends:
           jobParameters:
             condition: not(eq(dependencies.evaluate_paths.outputs['SetPathVars_jiteeversionguid.containsChange'], true))
             diffType: tpdiff
+            baseJitOptions: ${{ parameters.spmi_jitoptions_base }}
+            diffJitOptions: ${{ parameters.spmi_jitoptions_diff }}

--- a/eng/pipelines/coreclr/templates/run-superpmi-diffs-job.yml
+++ b/eng/pipelines/coreclr/templates/run-superpmi-diffs-job.yml
@@ -17,6 +17,8 @@ parameters:
   helixQueues: ''                 # required -- Helix queues
   dependOnEvaluatePaths: false
   diffType: 'asmdiffs'            # required -- 'asmdiffs', 'tpdiff', or 'all'
+  baseJitOptions: ''              # e.g. JitStressModeNames=STRESS_PHYSICAL_PROMOTION;JitFullyInt=1
+  diffJitOptions: ''
 
 jobs:
 - template: xplat-pipeline-job.yml
@@ -104,6 +106,8 @@ jobs:
         osGroup: ${{ parameters.osGroup }}
         archType: ${{ parameters.archType }}
         SuperPmiDiffType: ${{ parameters.diffType }}
+        SuperPmiBaseJitOptions: ${{ parameters.baseJitOptions }}
+        SuperPmiDiffJitOptions: ${{ parameters.diffJitOptions }}
 
       # Always upload the available logs for diagnostics
     - task: CopyFiles@2

--- a/eng/pipelines/coreclr/templates/superpmi-diffs-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-diffs-job.yml
@@ -11,6 +11,8 @@ parameters:
   dependOnEvaluatePaths: false
   runJobTemplate: '/eng/pipelines/coreclr/templates/run-superpmi-diffs-job.yml'
   diffType: 'asmdiffs'            # required -- 'asmdiffs', 'tpdiff', or 'all'
+  baseJitOptions: ''              # e.g. JitStressModeNames=STRESS_PHYSICAL_PROMOTION;JitFullyInt=1
+  diffJitOptions: ''
 
 jobs:
 - template: ${{ parameters.runJobTemplate }}
@@ -27,6 +29,8 @@ jobs:
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     helixQueues: ${{ parameters.helixQueues }}
     diffType: ${{ parameters.diffType }}
+    baseJitOptions: ${{ parameters.baseJitOptions }}
+    diffJitOptions: ${{ parameters.diffJitOptions }}
     dependsOn:
       - ${{ if in(parameters.diffType, 'asmdiffs', 'all') }}:
         - ${{ format('coreclr_jit_build_{0}{1}_{2}_checked', parameters.osGroup, parameters.osSubgroup, parameters.archType) }}

--- a/src/coreclr/scripts/superpmi-diffs.proj
+++ b/src/coreclr/scripts/superpmi-diffs.proj
@@ -47,10 +47,13 @@
     <!-- Default to asmdiffs -->
     <SuperPmiDiffType Condition=" '$(_SuperPmiDiffType)' == '' ">asmdiffs</SuperPmiDiffType>
     <SuperPmiDiffType Condition=" '$(_SuperPmiDiffType)' != '' ">$(_SuperPmiDiffType)</SuperPmiDiffType>
+
+    <SuperPmiBaseJitOptionsArg Condition="'$(_SuperPmiBaseJitOptions)' != ''">-base_jit_options &quot;$(_SuperPmiBaseJitOptions)&quot;</SuperPmiBaseJitOptionsArg>
+    <SuperPmiDiffJitOptionsArg Condition="'$(_SuperPmiDiffJitOptions)' != ''">-diff_jit_options &quot;$(_SuperPmiDiffJitOptions)&quot;</SuperPmiDiffJitOptionsArg>
   </PropertyGroup>
 
   <PropertyGroup>
-    <WorkItemCommand>$(Python) $(ProductDirectory)\superpmi_diffs.py -type $(SuperPmiDiffType) -base_jit_directory $(ProductDirectory)\base -diff_jit_directory $(ProductDirectory)\diff -log_directory $(SuperpmiLogsLocation)</WorkItemCommand>
+    <WorkItemCommand>$(Python) $(ProductDirectory)\superpmi_diffs.py -type $(SuperPmiDiffType) -base_jit_directory $(ProductDirectory)\base -diff_jit_directory $(ProductDirectory)\diff $(SuperPmiBaseJitOptionsArg) $(SuperPmiDiffJitOptionsArg) -log_directory $(SuperpmiLogsLocation)</WorkItemCommand>
     <WorkItemTimeout>2:00</WorkItemTimeout>
   </PropertyGroup>
 


### PR DESCRIPTION
Allow specifying jit options on manual triggers of superpmi-diffs. I want to use this to look at diffs with future changes in physical promotion given that it is still disabled by default.