### PR TITLE
Fix for test build break in the outerloop pipeline

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaField.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaField.cs
@@ -147,8 +147,10 @@ namespace Internal.TypeSystem.Ecma
                 if ((fieldAttributes & FieldAttributes.HasFieldRVA) != 0)
                     flags |= FieldFlags.HasRva;
 
+#pragma warning disable SYSLIB0050 // Legacy serialization infrastructure is obsolete
                 if ((fieldAttributes & FieldAttributes.NotSerialized) != 0)
                     flags |= FieldFlags.NotSerialized;
+#pragma warning restore SYSLIB0050
 
                 flags |= FieldFlags.BasicMetadataCache;
             }


### PR DESCRIPTION
The PR

https://github.com/dotnet/runtime/pull/84383

missed one case that is now causing build errors in the Pri1 test suite. I have attempted to fix this along the lines of the above PR.

Thanks

Tomas

/cc @dotnet/crossgen-contrib, @dotnet/ilc-contrib 

Example run:

https://dev.azure.com/dnceng-public/public/_build/results?buildId=234211&view=logs&j=3725811e-4a8b-5f6a-b03b-a353ee894148&t=d59fccfb-2b13-5841-75bf-bfec705ee16a

Diagnostics:

<pre>
    Lib -> /__w/1/s/artifacts/tests/coreclr/AnyOS.x64.Checked/Loader/classloader/generics/Variance/Delegates/Lib/Lib.dll
/__w/1/s/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaField.cs(150,40): error SYSLIB0050: 'FieldAttributes.NotSerialized' is obsolete: 'Formatter-based serialization is obsolete and should not be used.' [/__w/1/s/src/tests/ilverify/ILVerificationTests.csproj] [/__w/1/s/src/tests/build.proj]
##[error]src/coreclr/tools/Common/TypeSystem/Ecma/EcmaField.cs(150,40): error SYSLIB0050: 'FieldAttributes.NotSerialized' is obsolete: 'Formatter-based serialization is obsolete and should not be used.' [/__w/1/s/src/tests/ilverify/ILVerificationTests.csproj]
    Lib -> /__w/1/s/artifacts/tests/coreclr/AnyOS.x64.Checked/Loader/classloader/generics/Variance/IL/Lib/Lib.dll
</pre>
