### PR TITLE
Implement `load_assembly_bytes` delegate for hosting API

### DIFF
--- a/src/installer/tests/Assets/TestProjects/ComponentWithNoDependencies/Component.cs
+++ b/src/installer/tests/Assets/TestProjects/ComponentWithNoDependencies/Component.cs
@@ -19,6 +19,7 @@ namespace Component
         {
             Assembly asm = Assembly.GetExecutingAssembly();
             Console.WriteLine($"{asm.GetName().Name}: AssemblyLoadContext = {AssemblyLoadContext.GetLoadContext(asm)}");
+            Console.WriteLine($"{asm.GetName().Name}: Location = '{asm.Location}'");
         }
 
         private static void PrintComponentCallLog(string name, IntPtr arg, int size)

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/FunctionPointerResultExtensions.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/FunctionPointerResultExtensions.cs
@@ -42,5 +42,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         {
             return assertion.HaveStdOutContaining($"{assemblyName}: AssemblyLoadContext = \"Default\" System.Runtime.Loader.DefaultAssemblyLoadContext");
         }
+
+        public static FluentAssertions.AndConstraint<CommandResultAssertions> ExecuteWithLocation(this CommandResultAssertions assertion, string assemblyName, string location)
+        {
+            return assertion.HaveStdOutContaining($"{assemblyName}: Location = '{location}'");
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.LibraryBuild.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.LibraryBuild.xml
@@ -31,6 +31,7 @@
     <type fullname="Internal.Runtime.InteropServices.ComponentActivator">
       <!-- Used by hostpolicy.cpp -->
       <method name="LoadAssembly" />
+      <method name="LoadAssemblyBytes" />
       <method name="LoadAssemblyAndGetFunctionPointer" />
       <method name="GetFunctionPointer" />
     </type>

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -16,6 +16,7 @@
     -->
     <type fullname="Internal.Runtime.InteropServices.ComponentActivator">
       <method name="LoadAssembly" />
+      <method name="LoadAssemblyBytes" />
       <method name="LoadAssemblyAndGetFunctionPointer" />
     </type>
   </assembly>

--- a/src/native/corehost/coreclr_delegates.h
+++ b/src/native/corehost/coreclr_delegates.h
@@ -49,4 +49,12 @@ typedef int (CORECLR_DELEGATE_CALLTYPE *load_assembly_fn)(
     void         *load_context      /* Extensibility parameter (currently unused and must be 0) */,
     void         *reserved          /* Extensibility parameter (currently unused and must be 0) */);
 
+typedef int (CORECLR_DELEGATE_CALLTYPE *load_assembly_bytes_fn)(
+    const void *assembly_bytes      /* Bytes of the assembly to load */,
+    size_t     assembly_bytes_len   /* Byte length of the assembly to load */,
+    const void *symbols_bytes       /* Optional. Bytes of the symbols for the assembly */,
+    size_t     symbols_bytes_len    /* Optional. Byte length of the symbols for the assembly */,
+    void       *load_context        /* Extensibility parameter (currently unused and must be 0) */,
+    void       *reserved            /* Extensibility parameter (currently unused and must be 0) */);
+
 #endif // __CORECLR_DELEGATES_H__

--- a/src/native/corehost/corehost_context_contract.h
+++ b/src/native/corehost/corehost_context_contract.h
@@ -29,6 +29,7 @@ enum class coreclr_delegate_type
     load_assembly_and_get_function_pointer,
     get_function_pointer,
     load_assembly,
+    load_assembly_bytes,
 
     __last, // Sentinel value for determining the last known delegate type
 };

--- a/src/native/corehost/fxr/hostfxr.cpp
+++ b/src/native/corehost/fxr/hostfxr.cpp
@@ -669,6 +669,8 @@ namespace
             return coreclr_delegate_type::get_function_pointer;
         case hostfxr_delegate_type::hdt_load_assembly:
             return coreclr_delegate_type::load_assembly;
+        case hostfxr_delegate_type::hdt_load_assembly_bytes:
+            return coreclr_delegate_type::load_assembly_bytes;
         }
         return coreclr_delegate_type::invalid;
     }

--- a/src/native/corehost/hostfxr.h
+++ b/src/native/corehost/hostfxr.h
@@ -29,6 +29,7 @@ enum hostfxr_delegate_type
     hdt_load_assembly_and_get_function_pointer,
     hdt_get_function_pointer,
     hdt_load_assembly,
+    hdt_load_assembly_bytes,
 };
 
 typedef int32_t(HOSTFXR_CALLTYPE *hostfxr_main_fn)(const int argc, const char_t **argv);

--- a/src/native/corehost/hostpolicy/hostpolicy.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy.cpp
@@ -543,6 +543,12 @@ namespace
                 "Internal.Runtime.InteropServices.ComponentActivator",
                 "LoadAssembly",
                 delegate);
+        case coreclr_delegate_type::load_assembly_bytes:
+            return coreclr->create_delegate(
+                "System.Private.CoreLib",
+                "Internal.Runtime.InteropServices.ComponentActivator",
+                "LoadAssemblyBytes",
+                delegate);
         default:
             return StatusCode::LibHostInvalidArgs;
         }

--- a/src/native/corehost/test/nativehost/host_context_test.cpp
+++ b/src/native/corehost/test/nativehost/host_context_test.cpp
@@ -373,6 +373,42 @@ namespace
         return success;
     }
 
+    bool call_load_assembly_bytes(
+        load_assembly_bytes_fn load_assembly_bytes,
+        const pal::char_t *assembly_path,
+        const pal::char_t *symbols_path,
+        const pal::char_t *log_prefix,
+        pal::stringstream_t &test_output)
+    {
+        std::ifstream assembly_file(assembly_path, std::ios::binary);
+        std::vector<char> assembly_bytes { std::istreambuf_iterator<char>(assembly_file), std::istreambuf_iterator<char>() };
+        assembly_file.close();
+
+        std::vector<char> symbols_bytes;
+        if (pal::strcmp(symbols_path, _X("nullptr")) != 0)
+        {
+            std::ifstream symbols_file(symbols_path, std::ios::binary);
+            symbols_bytes = std::vector<char>((std::istreambuf_iterator<char>(symbols_file)), (std::istreambuf_iterator<char>()));
+            symbols_file.close();
+        }
+
+        test_output << log_prefix << _X("calling load_assembly_bytes(")
+            << std::hex << (size_t)(assembly_bytes.data()) << _X(", ") << assembly_bytes.size() << _X(", ")
+            << std::hex << (size_t)(symbols_bytes.data()) << _X(", ") << symbols_bytes.size()
+            << _X(")") << std::endl;
+
+        int rc = load_assembly_bytes(
+            (unsigned char *)assembly_bytes.data(),
+            assembly_bytes.size(),
+            symbols_bytes.empty() ? nullptr : (unsigned char *)symbols_bytes.data(),
+            symbols_bytes.size(),
+            nullptr /* load_context */,
+            nullptr /* reserved */);
+        bool success = rc == StatusCode::Success;
+        test_output << log_prefix << _X("load_assembly_bytes ") << (success ? _X("succeeded: ") : _X("failed: ")) << std::hex << std::showbase << rc << std::endl;
+        return success;
+    }
+
     bool component_load_assembly_test(
         const hostfxr_exports &hostfxr,
         const pal::char_t *config_path,
@@ -436,9 +472,86 @@ namespace
             {
                 const pal::char_t *assembly_path = argv[i];
                 success &= call_load_assembly(load_assembly, assembly_path, log_prefix, test_output);
-            
+
                 const pal::char_t *type_name = argv[i + 1];
                 const pal::char_t *method_name = argv[i + 2];
+                success &= call_get_function_pointer_flavour(get_function_pointer, type_name, method_name, log_prefix, test_output);
+            }
+        }
+        int rcClose = hostfxr.close(handle);
+        if (rcClose != StatusCode::Success)
+            test_output << log_prefix << _X("hostfxr_close failed: ") << std::hex << std::showbase << rcClose << std::endl;
+        return success && rcClose == StatusCode::Success;
+    }
+
+    bool component_load_assembly_bytes_test(
+        const hostfxr_exports &hostfxr,
+        const pal::char_t *config_path,
+        int argc,
+        const pal::char_t *argv[],
+        const pal::char_t *log_prefix,
+        pal::stringstream_t &test_output)
+    {
+        hostfxr_handle handle;
+        if (!init_for_config(hostfxr, config_path, &handle, log_prefix, test_output))
+            return false;
+
+        load_assembly_bytes_fn load_assembly_bytes = nullptr;
+        hostfxr_delegate_type hdt = hostfxr_delegate_type::hdt_load_assembly_bytes;
+        bool success = get_runtime_delegate(hostfxr, handle, hdt, (void **)&load_assembly_bytes, log_prefix, test_output);
+
+        get_function_pointer_fn get_function_pointer = nullptr;
+        hdt = hostfxr_delegate_type::hdt_get_function_pointer;
+        success &= get_runtime_delegate(hostfxr, handle, hdt, (void **)&get_function_pointer, log_prefix, test_output);
+        if (success)
+        {
+            for (int i = 0; i <= argc - 4; i += 4)
+            {
+                const pal::char_t *assembly_path = argv[i];
+                const pal::char_t *symbols_path = argv[i + 1];
+                success &= call_load_assembly_bytes(load_assembly_bytes, assembly_path, symbols_path, log_prefix, test_output);
+
+                const pal::char_t *type_name = argv[i + 2];
+                const pal::char_t *method_name = argv[i + 3];
+                success &= call_get_function_pointer_flavour(get_function_pointer, type_name, method_name, log_prefix, test_output);
+            }
+        }
+
+        int rcClose = hostfxr.close(handle);
+        if (rcClose != StatusCode::Success)
+            test_output << log_prefix << _X("hostfxr_close failed: ") << std::hex << std::showbase << rcClose << std::endl;
+
+        return success && rcClose == StatusCode::Success;
+    }
+
+    bool app_load_assembly_bytes_test(
+        const hostfxr_exports &hostfxr,
+        int argc,
+        const pal::char_t *argv[],
+        const pal::char_t *log_prefix,
+        pal::stringstream_t &test_output)
+    {
+        hostfxr_handle handle;
+        if (!init_for_command_line(hostfxr, argc, argv, &handle, log_prefix, test_output))
+            return false;
+
+        load_assembly_bytes_fn load_assembly_bytes = nullptr;
+        hostfxr_delegate_type hdt = hostfxr_delegate_type::hdt_load_assembly_bytes;
+        bool success = get_runtime_delegate(hostfxr, handle, hdt, (void **)&load_assembly_bytes, log_prefix, test_output);
+
+        get_function_pointer_fn get_function_pointer = nullptr;
+        hdt = hostfxr_delegate_type::hdt_get_function_pointer;
+        success &= get_runtime_delegate(hostfxr, handle, hdt, (void **)&get_function_pointer, log_prefix, test_output);
+        if (success)
+        {
+            for (int i = 1; i <= argc - 4; i += 4)
+            {
+                const pal::char_t *assembly_path = argv[i];
+                const pal::char_t *symbols_path = argv[i + 1];
+                success &= call_load_assembly_bytes(load_assembly_bytes, assembly_path, symbols_path, log_prefix, test_output);
+
+                const pal::char_t *type_name = argv[i + 2];
+                const pal::char_t *method_name = argv[i + 3];
                 success &= call_get_function_pointer_flavour(get_function_pointer, type_name, method_name, log_prefix, test_output);
             }
         }
@@ -817,6 +930,29 @@ bool host_context_test::app_load_assembly(
     hostfxr_exports hostfxr{ hostfxr_path };
 
     return app_load_assembly_test(hostfxr, argc, argv, config_log_prefix, test_output);
+}
+
+bool host_context_test::component_load_assembly_bytes(
+    const pal::string_t &hostfxr_path,
+    const pal::char_t *config_path,
+    int argc,
+    const pal::char_t *argv[],
+    pal::stringstream_t &test_output)
+{
+    hostfxr_exports hostfxr{ hostfxr_path };
+
+    return component_load_assembly_bytes_test(hostfxr, config_path, argc, argv, config_log_prefix, test_output);
+}
+
+bool host_context_test::app_load_assembly_bytes(
+    const pal::string_t &hostfxr_path,
+    int argc,
+    const pal::char_t *argv[],
+    pal::stringstream_t &test_output)
+{
+    hostfxr_exports hostfxr{ hostfxr_path };
+
+    return app_load_assembly_bytes_test(hostfxr, argc, argv, config_log_prefix, test_output);
 }
 
 bool host_context_test::component_load_assembly_and_get_function_pointer(

--- a/src/native/corehost/test/nativehost/host_context_test.h
+++ b/src/native/corehost/test/nativehost/host_context_test.h
@@ -70,6 +70,17 @@ namespace host_context_test
         int argc,
         const pal::char_t *argv[],
         pal::stringstream_t &test_output);
+    bool component_load_assembly_bytes(
+        const pal::string_t &hostfxr_path,
+        const pal::char_t *config_path,
+        int argc,
+        const pal::char_t *argv[],
+        pal::stringstream_t &test_output);
+    bool app_load_assembly_bytes(
+        const pal::string_t &hostfxr_path,
+        int argc,
+        const pal::char_t *argv[],
+        pal::stringstream_t &test_output);
     bool component_load_assembly_and_get_function_pointer(
         const pal::string_t &hostfxr_path,
         const pal::char_t *config_path,

--- a/src/native/corehost/test/nativehost/nativehost.cpp
+++ b/src/native/corehost/test/nativehost/nativehost.cpp
@@ -267,6 +267,57 @@ int main(const int argc, const pal::char_t *argv[])
         std::cout << tostr(test_output.str()).data() << std::endl;
         return success ? EXIT_SUCCESS : EXIT_FAILURE;
     }
+        else if (pal::strcmp(command, _X("component_load_assembly_bytes")) == 0)
+    {
+        // args: ... <hostfxr_path> <config_path> <assembly_path> <symbols_path> <type_name> <method_name> [<assembly_path> <type_name> <method_name>...]
+        const int min_argc = 4;
+        if (argc < min_argc + 4)
+        {
+            std::cerr << "Invalid arguments" << std::endl;
+            return -1;
+        }
+
+        const pal::string_t hostfxr_path = argv[2];
+        const pal::char_t *config_path = argv[3];
+
+        int remaining_argc = argc - min_argc;
+        const pal::char_t **remaining_argv = nullptr;
+        if (argc > min_argc)
+            remaining_argv = &argv[min_argc];
+
+        pal::stringstream_t test_output;
+        bool success = false;
+
+        success = host_context_test::component_load_assembly_bytes(hostfxr_path, config_path, remaining_argc, remaining_argv, test_output);
+
+        std::cout << tostr(test_output.str()).data() << std::endl;
+        return success ? EXIT_SUCCESS : EXIT_FAILURE;
+    }
+    else if (pal::strcmp(command, _X("app_load_assembly_bytes")) == 0)
+    {
+        // args: ... <hostfxr_path> <app_path> <assembly_path> <symbols_path> <type_name> <method_name> [<assembly_path> <type_name> <method_name>...]
+        const int min_argc = 3;
+        if (argc < min_argc + 5)
+        {
+            std::cerr << "Invalid arguments" << std::endl;
+            return -1;
+        }
+
+        const pal::string_t hostfxr_path = argv[2];
+
+        int remaining_argc = argc - min_argc;
+        const pal::char_t **remaining_argv = nullptr;
+        if (argc > min_argc)
+            remaining_argv = &argv[min_argc];
+
+        pal::stringstream_t test_output;
+        bool success = false;
+
+        success = host_context_test::app_load_assembly_bytes(hostfxr_path, remaining_argc, remaining_argv, test_output);
+
+        std::cout << tostr(test_output.str()).data() << std::endl;
+        return success ? EXIT_SUCCESS : EXIT_FAILURE;
+    }
     else if (pal::strcmp(command, _X("component_load_assembly_and_get_function_pointer")) == 0)
     {
         // args: ... <hostfxr_path> <app_or_config_path> <assembly_path> <type_name> <method_name> [<assembly_path> <type_name> <method_name>...]


### PR DESCRIPTION
- `hdt_load_assembly_bytes` indicates the delegate type for loading an assembly from a path
  - https://github.com/dotnet/runtime/blob/main/docs/design/features/native-hosting.md#loading-managed-components-net-8-and-above
- `ComponentActivator.LoadAssemblyBytes` loads the assembly - currently always in the default ALC

Resolves #77696