### PR TITLE
Fix x64 macOS and Linux managed debugging

### DIFF
--- a/src/coreclr/debug/createdump/datatarget.cpp
+++ b/src/coreclr/debug/createdump/datatarget.cpp
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include "createdump.h"
+#include <dbgtargetcontext.h>
 
 #if defined(HOST_ARM64)
 // Flag to check if atomics feature is available on
@@ -181,7 +182,7 @@ DumpDataTarget::GetThreadContext(
     /* [in] */ ULONG32 contextSize,
     /* [out, size_is(contextSize)] */ PBYTE context)
 {
-    if (contextSize < sizeof(CONTEXT))
+    if (contextSize < sizeof(DT_CONTEXT))
     {
         assert(false);
         return E_INVALIDARG;

--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -7896,7 +7896,7 @@ void DacStackReferenceWalker::WalkStack()
     // Get the current thread's context and set that as the filter context
     if (mThread->GetFilterContext() == NULL && mThread->GetProfilerFilterContext() == NULL)
     {
-        mDac->m_pTarget->GetThreadContext(mThread->GetOSThreadId(), CONTEXT_FULL, sizeof(ctx), (BYTE*)&ctx);
+        mDac->m_pTarget->GetThreadContext(mThread->GetOSThreadId(), CONTEXT_FULL, sizeof(DT_CONTEXT), (BYTE*)&ctx);
         mThread->SetProfilerFilterContext(&ctx);
         contextHolder.Activate(mThread);
     }

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -5199,7 +5199,7 @@ void DacDbiInterfaceImpl::Hijack(
     HRESULT hr = m_pTarget->GetThreadContext(
         dwThreadId,
         CONTEXT_FULL,
-        sizeof(ctx),
+        sizeof(DT_CONTEXT),
         (BYTE*) &ctx);
     IfFailThrow(hr);
 
@@ -5346,7 +5346,7 @@ void DacDbiInterfaceImpl::Hijack(
     //
     // Commit the context.
     //
-    hr = m_pMutableTarget->SetThreadContext(dwThreadId, sizeof(ctx), reinterpret_cast<BYTE*> (&ctx));
+    hr = m_pMutableTarget->SetThreadContext(dwThreadId, sizeof(DT_CONTEXT), reinterpret_cast<BYTE*> (&ctx));
     IfFailThrow(hr);
 }
 
@@ -5717,7 +5717,7 @@ void DacDbiInterfaceImpl::GetContext(VMPTR_Thread vmThread, DT_CONTEXT * pContex
         pContextBuffer->ContextFlags = DT_CONTEXT_ALL;
         HRESULT hr = m_pTarget->GetThreadContext(pThread->GetOSThreadId(),
                                                 pContextBuffer->ContextFlags,
-                                                sizeof(*pContextBuffer),
+                                                sizeof(DT_CONTEXT),
                                                 reinterpret_cast<BYTE *>(pContextBuffer));
         if (hr == E_NOTIMPL)
         {

--- a/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
@@ -1162,12 +1162,12 @@ void DacDbiInterfaceImpl::UpdateContextFromRegDisp(REGDISPLAY * pRegDisp,
     {
         *pContext = *pRegDisp->pContext;
     }
-#elif defined(TARGET_AMD64)
+#elif !defined(TARGET_WINDOWS) && defined(TARGET_AMD64)
     memcpy(pContext, pRegDisp->pCurrentContext, offsetof(T_CONTEXT, XStateFeaturesMask));
     pContext->ContextFlags = (CONTEXT_INTEGER | CONTEXT_CONTROL);
-#else // TARGET_X86 && !FEATURE_EH_FUNCLETS && !TARGET_AMD64
+#else
     *pContext = *pRegDisp->pCurrentContext;
-#endif // !TARGET_X86 || FEATURE_EH_FUNCLETS
+#endif
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
@@ -1162,7 +1162,10 @@ void DacDbiInterfaceImpl::UpdateContextFromRegDisp(REGDISPLAY * pRegDisp,
     {
         *pContext = *pRegDisp->pContext;
     }
-#else // TARGET_X86 && !FEATURE_EH_FUNCLETS
+#elif defined(TARGET_AMD64)
+    memcpy(pContext, pRegDisp->pCurrentContext, offsetof(T_CONTEXT, XStateFeaturesMask));
+    pContext->ContextFlags = (CONTEXT_INTEGER | CONTEXT_CONTROL);
+#else // TARGET_X86 && !FEATURE_EH_FUNCLETS && !TARGET_AMD64
     *pContext = *pRegDisp->pCurrentContext;
 #endif // !TARGET_X86 || FEATURE_EH_FUNCLETS
 }

--- a/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
@@ -158,7 +158,9 @@ void DacDbiInterfaceImpl::GetStackWalkCurrentContext(StackFrameIterator * pIter,
     T_CONTEXT tmpContext = { };
     UpdateContextFromRegDisp(pCF->GetRegisterSet(), &tmpContext);
     CopyMemory(pContext, &tmpContext, sizeof(*pContext));
+#if defined(TARGET_X86) || defined(TARGET_AMD64)
     pContext->ContextFlags &= ~(CONTEXT_XSTATE & CONTEXT_AREA_MASK);
+#endif
 }
 
 

--- a/src/coreclr/debug/daccess/reimpl.cpp
+++ b/src/coreclr/debug/daccess/reimpl.cpp
@@ -107,7 +107,7 @@ DacGetThreadContext(Thread* thread, T_CONTEXT* context)
     HRESULT status =
         g_dacImpl->m_pTarget->
         GetThreadContext(thread->GetOSThreadId(), contextFlags,
-                         sizeof(*context), (PBYTE)context);
+                         sizeof(DT_CONTEXT), (PBYTE)context);
     if (status != S_OK)
     {
         DacError(status);

--- a/src/coreclr/debug/daccess/stack.cpp
+++ b/src/coreclr/debug/daccess/stack.cpp
@@ -104,8 +104,9 @@ ClrDataStackWalk::GetContext(
         }
         else
         {
-            *(PT_CONTEXT)contextBuf = m_context;
-            UpdateContextFromRegDisp(&m_regDisp, (PT_CONTEXT)contextBuf);
+            T_CONTEXT tmpContext = m_context;
+            UpdateContextFromRegDisp(&m_regDisp, &tmpContext);
+            CopyMemory(contextBuf, &tmpContext, contextBufSize);
             status = S_OK;
         }
     }
@@ -154,7 +155,7 @@ ClrDataStackWalk::SetContext2(
     {
         // Copy the context to local state so
         // that its lifetime extends beyond this call.
-        m_context = *(PT_CONTEXT)context;
+        CopyMemory(&m_context, context, contextSize);
         m_thread->FillRegDisplay(&m_regDisp, &m_context);
         m_frameIter.ResetRegDisp(&m_regDisp, (flags & CLRDATA_STACK_SET_CURRENT_CONTEXT) != 0);
         m_stackPrev = (TADDR)GetRegdisplaySP(&m_regDisp);
@@ -660,7 +661,7 @@ ClrDataFrame::GetContext(
 
     EX_TRY
     {
-        *(PT_CONTEXT)contextBuf = m_context;
+        CopyMemory(contextBuf, &m_context, contextBufSize);
         status = S_OK;
     }
     EX_CATCH

--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -6438,7 +6438,7 @@ HRESULT CordbProcess::GetThreadContext(DWORD threadID, ULONG32 contextSize, BYTE
 
     DT_CONTEXT * pContext;
 
-    if (contextSize != sizeof(DT_CONTEXT))
+    if (contextSize < sizeof(DT_CONTEXT))
     {
         LOG((LF_CORDB, LL_INFO10000, "CP::GTC: thread=0x%x, context size is invalid.\n", threadID));
         return E_INVALIDARG;
@@ -11179,10 +11179,10 @@ void CordbProcess::HandleSetThreadContextNeeded(DWORD dwThreadId)
         ThrowHR(HRESULT_FROM_GetLastError());
     }
 
-    CONTEXT context = { 0 };
+    DT_CONTEXT context = { 0 };
     context.ContextFlags = CONTEXT_FULL;
 
-    HRESULT hr = GetDataTarget()->GetThreadContext(dwThreadId, CONTEXT_FULL, sizeof(CONTEXT), reinterpret_cast<BYTE*> (&context));
+    HRESULT hr = GetDataTarget()->GetThreadContext(dwThreadId, CONTEXT_FULL, sizeof(DT_CONTEXT), reinterpret_cast<BYTE*> (&context));
     IfFailThrow(hr);
 
     TADDR lsContextAddr = (TADDR)context.Rcx;

--- a/src/coreclr/debug/inc/common.h
+++ b/src/coreclr/debug/inc/common.h
@@ -96,7 +96,15 @@ ULONG32 ContextSizeForFlags(ULONG32 flags)
     else
 #endif // TARGET_X86
     {
+#if defined(TARGET_AMD64)
+        if ((flags & CONTEXT_XSTATE) == CONTEXT_XSTATE)
+        {
+            return sizeof(T_CONTEXT);
+        }
+        return offsetof(T_CONTEXT, XStateFeaturesMask);
+#else
         return sizeof(T_CONTEXT);
+#endif
     }
 }
 

--- a/src/coreclr/debug/inc/common.h
+++ b/src/coreclr/debug/inc/common.h
@@ -96,7 +96,7 @@ ULONG32 ContextSizeForFlags(ULONG32 flags)
     else
 #endif // TARGET_X86
     {
-#if defined(TARGET_AMD64)
+#if !defined(TARGET_WINDOWS) && defined(TARGET_AMD64)
         if ((flags & CONTEXT_XSTATE) == CONTEXT_XSTATE)
         {
             return sizeof(T_CONTEXT);

--- a/src/coreclr/debug/inc/common.h
+++ b/src/coreclr/debug/inc/common.h
@@ -96,7 +96,7 @@ ULONG32 ContextSizeForFlags(ULONG32 flags)
     else
 #endif // TARGET_X86
     {
-#if !defined(TARGET_WINDOWS) && defined(TARGET_AMD64)
+#if !defined(CROSS_COMPILE) && !defined(TARGET_WINDOWS) && defined(TARGET_AMD64)
         if ((flags & CONTEXT_XSTATE) == CONTEXT_XSTATE)
         {
             return sizeof(T_CONTEXT);


### PR DESCRIPTION
A recent change to T_CONTEXT size breaks managed debugging.  This addresses the necessary debugger API's to unblock managed debugging.

Fixes #84466