### PR TITLE
Fix handling of load for msquic and search paths for nativeaot and mono

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
@@ -310,8 +310,8 @@ namespace Internal.Runtime.CompilerHelpers
 
                 hModule = NativeLibrary.LoadBySearch(
                     callingAssembly,
-                    searchAssemblyDirectory: false,
-                    dllImportSearchPathFlags: 0,
+                    searchAssemblyDirectory: (dllImportSearchPath & (uint)DllImportSearchPath.AssemblyDirectory) != 0,
+                    dllImportSearchPathFlags: (int)(dllImportSearchPath & ~(uint)DllImportSearchPath.AssemblyDirectory),
                     ref loadLibErrorTracker,
                     moduleName);
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -65,8 +65,21 @@ internal sealed unsafe partial class MsQuicApi
 #pragma warning disable CA1810 // Initialize all static fields in 'MsQuicApi' when those fields are declared and remove the explicit static constructor
     static MsQuicApi()
     {
-        if (!NativeLibrary.TryLoad($"{Interop.Libraries.MsQuic}.{s_minMsQuicVersion.Major}", typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out IntPtr msQuicHandle) &&
-            !NativeLibrary.TryLoad(Interop.Libraries.MsQuic, typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle))
+        bool loaded = false;
+        IntPtr msQuicHandle;
+        if (OperatingSystem.IsWindows())
+        {
+            // Windows ships msquic in the assembly directory.
+            loaded = NativeLibrary.TryLoad(Interop.Libraries.MsQuic, typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle);
+        }
+        else
+        {
+            // Non-Windows relies on the package being installed on the system and may include the version in its name
+            loaded = NativeLibrary.TryLoad($"{Interop.Libraries.MsQuic}.{s_minMsQuicVersion.Major}", typeof(MsQuicApi).Assembly, null, out msQuicHandle) ||
+                     NativeLibrary.TryLoad(Interop.Libraries.MsQuic, typeof(MsQuicApi).Assembly, null, out msQuicHandle);
+        }
+
+        if (!loaded)
         {
             // MsQuic library not loaded
             if (NetEventSource.Log.IsEnabled())

--- a/src/mono/mono/metadata/native-library.c
+++ b/src/mono/mono/metadata/native-library.c
@@ -533,10 +533,13 @@ netcore_probe_for_module (MonoImage *image, const char *file_name, int flags, Mo
 
 	ERROR_DECL (bad_image_error);
 
-	// Try without any path additions
+#if defined(HOST_ANDROID)
+	// On Android, try without any path additions first. It is sensitive to probing that will always miss
+    // and lookup for some libraries is required to use a relative path
 	module = netcore_probe_for_module_variations (NULL, file_name, lflags, error);
 	if (!module && !is_ok (error) && mono_error_get_error_code (error) == MONO_ERROR_BAD_IMAGE)
 		mono_error_move (bad_image_error, error);
+#endif
 
 	// Check the NATIVE_DLL_SEARCH_DIRECTORIES
 	for (int i = 0; i < pinvoke_search_directories_count && module == NULL; ++i) {
@@ -559,6 +562,16 @@ netcore_probe_for_module (MonoImage *image, const char *file_name, int flags, Mo
 			module = netcore_probe_for_module_variations (mdirname, file_name, lflags, error);
 		g_free (mdirname);
 	}
+
+#if !defined(HOST_ANDROID)
+	// Try without any path additions
+	if (module == NULL)
+	{
+		module = netcore_probe_for_module_variations (NULL, file_name, lflags, error);
+		if (!module && !is_ok (error) && mono_error_get_error_code (error) == MONO_ERROR_BAD_IMAGE)
+			mono_error_move (bad_image_error, error);
+	}
+#endif
 
 	// TODO: Pass remaining flags on to LoadLibraryEx on Windows where appropriate, see https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.dllimportsearchpath?view=netcore-3.1
 

--- a/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
@@ -10,7 +10,7 @@ namespace TestLibrary
     {
         public static bool Is32BitProcess => IntPtr.Size == 4;
         public static bool Is64BitProcess => IntPtr.Size == 8;
-    
+
         public static bool IsX86Process => RuntimeInformation.ProcessArchitecture == Architecture.X86;
         public static bool IsNotX86Process => !IsX86Process;
 

--- a/src/tests/Common/testenvironment.proj
+++ b/src/tests/Common/testenvironment.proj
@@ -305,6 +305,8 @@
       <!-- Mono interpreter -->
       <_TestEnvFileLine Condition="'$(RuntimeVariant)' == 'monointerpreter'" Include="export MONO_ENV_OPTIONS=--interpreter" />
 
+      <_TestEnvFileLine Condition="'$(RuntimeVariant)' != ''" Include="export DOTNET_RUNTIME_VARIANT=$(RuntimeVariant)" />
+
       <!-- Use Mono LLVM JIT when JIT-compiling the non-AOT-compiled parts of the runtime tests -->
       <!-- FIXME: temporarily disable LLVM JIT and use mini JIT until LLVM JIT support is brought back -->
       <_TestEnvFileLine Condition="'false' == 'true' and '$(RuntimeVariant)' == 'llvmaot'" Include="export MONO_ENV_OPTIONS=--llvm" />

--- a/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.cs
+++ b/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Xunit;
+
+public class DllImportSearchPathsTest
+{
+    private static string Subdirectory => Path.Combine(NativeLibraryToLoad.GetDirectory(), "subdirectory");
+
+    [Fact]
+    public static void AssemblyDirectory_NotFound()
+    {
+        // Library should not be found in the assembly directory
+        Assert.Throws<DllNotFoundException>(() => NativeLibraryPInvoke.Sum(1, 2));
+    }
+
+    public static bool CanLoadAssemblyInSubdirectory =>
+        !TestLibrary.Utilities.IsNativeAot && !TestLibrary.PlatformDetection.IsMonoLLVMFULLAOT;
+
+    [ConditionalFact(nameof(CanLoadAssemblyInSubdirectory))]
+    public static void AssemblyDirectory_Found()
+    {
+        // Library should be found in the assembly directory
+        var assembly = Assembly.LoadFile(Path.Combine(Subdirectory, $"{nameof(DllImportSearchPathsTest)}.dll"));
+        var type = assembly.GetType(nameof(NativeLibraryPInvoke));
+        var method = type.GetMethod(nameof(NativeLibraryPInvoke.Sum));
+
+        int sum = (int)method.Invoke(null, new object[] { 1, 2 });
+        Assert.Equal(3, sum);
+    }
+
+    [Fact]
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public static void AssemblyDirectory_Fallback_Found()
+    {
+        string currentDirectory = Environment.CurrentDirectory;
+        try
+        {
+            Environment.CurrentDirectory = Subdirectory;
+
+            // Library should not be found in the assembly directory, but should fall back to the default OS search which includes CWD on Windows
+            int sum = NativeLibraryPInvoke.Sum(1, 2);
+            Assert.Equal(3, sum);
+        }
+        finally
+        {
+            Environment.CurrentDirectory = currentDirectory;
+        }
+    }
+}
+
+public class NativeLibraryPInvoke
+{
+    public static int Sum(int a, int b)
+    {
+        return NativeSum(a, b);
+    }
+
+    [DllImport(NativeLibraryToLoad.Name)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory)]
+    static extern int NativeSum(int arg1, int arg2);
+}

--- a/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.csproj
+++ b/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="*.cs" />
+    <Compile Include="../NativeLibrary/NativeLibraryToLoad/NativeLibraryToLoad.cs" />
+    <CMakeProjectReference Include="../NativeLibrary/NativeLibraryToLoad/CMakeLists.txt" />
+  </ItemGroup>
+
+  <Target Name="SetUpSubdirectory" AfterTargets="CopyNativeProjectBinaries">
+    <PropertyGroup>
+      <NativeLibrarySubdirectory>$(OutDir)/subdirectory</NativeLibrarySubdirectory>
+      <FileNameSuffix>-in-subdirectory</FileNameSuffix>
+    </PropertyGroup>
+    <ItemGroup>
+      <_FilesToCopy Include="$(OutDir)/$(TargetName).dll" />
+      <_FilesToMove Include="$(OutDir)/libNativeLibrary.*" />
+      <_FilesToMove Include="$(OutDir)/NativeLibrary.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_FilesToCopy)" DestinationFiles="@(_FilesToCopy -> '$(NativeLibrarySubdirectory)/%(Filename)%(Extension)')" />
+    <Move SourceFiles="@(_FilesToMove)" DestinationFiles="@(_FilesToMove -> '$(NativeLibrarySubdirectory)/%(Filename)%(Extension)')" />
+  </Target>
+</Project>

--- a/src/tests/Interop/NativeLibrary/API/GetMainProgramHandleTests.cs
+++ b/src/tests/Interop/NativeLibrary/API/GetMainProgramHandleTests.cs
@@ -45,7 +45,7 @@ class GetMainProgramHandleTests
         // On non-Windows platforms, symbols from globally loaded shared libraries will also be discoverable.
         // Globally loading symbols is not the .NET default, so we use a call to dlopen in native code
         // with the right flags to test the scenario.
-        IntPtr handle = LoadLibraryGlobally(Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location), NativeLibraryToLoad.GetLibraryFileName("GloballyLoadedNativeLibrary")));
+        IntPtr handle = LoadLibraryGlobally(Path.Combine(NativeLibraryToLoad.GetDirectory(), NativeLibraryToLoad.GetLibraryFileName("GloballyLoadedNativeLibrary")));
 
         try
         {
@@ -64,7 +64,7 @@ class GetMainProgramHandleTests
         // On non-Windows platforms, symbols from globally loaded shared libraries will also be discoverable.
         // Globally loading symbols is not the .NET default, so we use a call to dlopen in native code
         // with the right flags to test the scenario.
-        IntPtr handle = LoadLibraryGlobally(Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location), NativeLibraryToLoad.GetLibraryFileName("GloballyLoadedNativeLibrary")));
+        IntPtr handle = LoadLibraryGlobally(Path.Combine(NativeLibraryToLoad.GetDirectory(), NativeLibraryToLoad.GetLibraryFileName("GloballyLoadedNativeLibrary")));
 
         try
         {
@@ -83,7 +83,7 @@ class GetMainProgramHandleTests
         // On non-Windows platforms, symbols from globally loaded shared libraries will also be discoverable.
         // Globally loading symbols is not the .NET default, so we use a call to dlopen in native code
         // with the right flags to test the scenario.
-        IntPtr handle = LoadLibraryGlobally(Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location), NativeLibraryToLoad.GetLibraryFileName("GloballyLoadedNativeLibrary")));
+        IntPtr handle = LoadLibraryGlobally(Path.Combine(NativeLibraryToLoad.GetDirectory(), NativeLibraryToLoad.GetLibraryFileName("GloballyLoadedNativeLibrary")));
 
         try
         {

--- a/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.cs
+++ b/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.cs
@@ -17,7 +17,7 @@ public class NativeLibraryTests : IDisposable
     public NativeLibraryTests()
     {
         assembly = System.Reflection.Assembly.GetExecutingAssembly();
-        testBinDir = Path.GetDirectoryName(assembly.Location);
+        testBinDir = NativeLibraryToLoad.GetDirectory();
         libFullPath = NativeLibraryToLoad.GetFullPath();
     }
 
@@ -133,11 +133,19 @@ public class NativeLibraryTests : IDisposable
     public void LoadSystemLibrary_WithSearchPath()
     {
         string libName = "url.dll";
-        // Calls on a valid library from System32 directory
+        // Library should be found in the system directory
         EXPECT(LoadLibrary_WithAssembly(libName, assembly, DllImportSearchPath.System32));
         EXPECT(TryLoadLibrary_WithAssembly(libName, assembly, DllImportSearchPath.System32));
 
-        // Calls on a valid library from application directory
+        // Library should not be found in the assembly directory and should be found in the system directory
+        EXPECT(LoadLibrary_WithAssembly(libName, assembly, DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.System32));
+        EXPECT(TryLoadLibrary_WithAssembly(libName, assembly, DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.System32));
+
+        // Library should not be found in the assembly directory, but should fall back to the default OS search which includes CWD on Windows
+        EXPECT(LoadLibrary_WithAssembly(libName, assembly, DllImportSearchPath.AssemblyDirectory));
+        EXPECT(TryLoadLibrary_WithAssembly(libName, assembly, DllImportSearchPath.AssemblyDirectory));
+
+        // Library should not be found in application directory
         EXPECT(LoadLibrary_WithAssembly(libName, assembly, DllImportSearchPath.ApplicationDirectory), TestResult.DllNotFound);
         EXPECT(TryLoadLibrary_WithAssembly(libName, assembly, DllImportSearchPath.ApplicationDirectory), TestResult.ReturnFailure);
     }
@@ -163,6 +171,40 @@ public class NativeLibraryTests : IDisposable
         string libName = Path.Combine(testBinDir, Path.Combine("lib", NativeLibraryToLoad.Name));
         EXPECT(LoadLibrary_WithAssembly(libName, assembly, DllImportSearchPath.AssemblyDirectory), TestResult.DllNotFound);
         EXPECT(TryLoadLibrary_WithAssembly(libName, assembly, DllImportSearchPath.AssemblyDirectory), TestResult.ReturnFailure);
+    }
+
+    [Fact]
+    public void LoadLibrary_AssemblyDirectory()
+    {
+        string suffix = "-in-subdirectory";
+        string libName = $"{NativeLibraryToLoad.Name}{suffix}";
+
+        string subdirectory = Path.Combine(testBinDir, "subdirectory");
+
+        if (!TestLibrary.Utilities.IsNativeAot && !TestLibrary.PlatformDetection.IsMonoLLVMFULLAOT)
+        {
+            // Library should be found in the assembly directory
+            Assembly assemblyInSubdirectory = Assembly.LoadFile(Path.Combine(subdirectory, $"{Path.GetFileNameWithoutExtension(assembly.Location)}{suffix}.dll"));
+            EXPECT(LoadLibrary_WithAssembly(libName, assemblyInSubdirectory, DllImportSearchPath.AssemblyDirectory));
+            EXPECT(TryLoadLibrary_WithAssembly(libName, assemblyInSubdirectory, DllImportSearchPath.AssemblyDirectory));
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            string currentDirectory = Environment.CurrentDirectory;
+            try
+            {
+                Environment.CurrentDirectory = subdirectory;
+
+                // Library should not be found in the assembly directory, but should fall back to the default OS search which includes CWD on Windows
+                EXPECT(LoadLibrary_WithAssembly(libName, assembly, DllImportSearchPath.AssemblyDirectory));
+                EXPECT(TryLoadLibrary_WithAssembly(libName, assembly, DllImportSearchPath.AssemblyDirectory));
+            }
+            finally
+            {
+                Environment.CurrentDirectory = currentDirectory;
+            }
+        }
     }
 
     [Fact]

--- a/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.csproj
+++ b/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.csproj
@@ -17,4 +17,17 @@
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <CMakeProjectReference Include="../NativeLibraryToLoad/CMakeLists.txt" />
   </ItemGroup>
+
+  <Target Name="SetUpSubdirectory" AfterTargets="CopyNativeProjectBinaries">
+    <PropertyGroup>
+      <NativeLibrarySubdirectory>$(OutDir)/subdirectory</NativeLibrarySubdirectory>
+      <FileNameSuffix>-in-subdirectory</FileNameSuffix>
+    </PropertyGroup>
+    <ItemGroup>
+      <AssembliesToCopy Include="$(OutDir)/libNativeLibrary.*" />
+      <AssembliesToCopy Include="$(OutDir)/NativeLibrary.*" />
+      <AssembliesToCopy Include="$(OutDir)/$(TargetName).dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(AssembliesToCopy)" DestinationFiles="@(AssembliesToCopy -> '$(NativeLibrarySubdirectory)/%(Filename)$(FileNameSuffix)%(Extension)')" />
+  </Target>
 </Project>

--- a/src/tests/Interop/NativeLibrary/Callback/CallbackTests.cs
+++ b/src/tests/Interop/NativeLibrary/Callback/CallbackTests.cs
@@ -99,7 +99,7 @@ public class CallbackTests
             if (string.Equals(libraryName, NativeLibraryToLoad.InvalidName))
             {
                 Assert.Equal(DllImportSearchPath.System32, dllImportSearchPath);
-                return NativeLibrary.Load(NativeLibraryToLoad.Name, asm, null);
+                return NativeLibrary.Load(NativeLibraryToLoad.GetFullPath(), asm, null);
             }
 
             return IntPtr.Zero;

--- a/src/tests/Interop/NativeLibrary/NativeLibraryToLoad/NativeLibraryToLoad.cs
+++ b/src/tests/Interop/NativeLibrary/NativeLibraryToLoad/NativeLibraryToLoad.cs
@@ -32,8 +32,23 @@ public class NativeLibraryToLoad
 
     public static string GetFullPath()
     {
-        Assembly assembly = Assembly.GetExecutingAssembly();
-        string directory = Path.GetDirectoryName(assembly.Location);
-        return Path.Combine(directory, GetFileName());
+        return Path.Combine(GetDirectory(), GetFileName());
+    }
+
+    public static string GetDirectory()
+    {
+        string directory;
+        if (TestLibrary.Utilities.IsNativeAot)
+        {
+            // NativeAOT test is put in a native/ subdirectory, so we want the parent
+            // directory that contains the native library to load
+            directory = new DirectoryInfo(AppContext.BaseDirectory).Parent.FullName;
+        }
+        else
+        {
+            directory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        }
+
+        return directory;
     }
 }

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3266,6 +3266,10 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/SuppressGCTransition/SuppressGCTransitionTest/**">
             <Issue>https://github.com/dotnet/runtime/issues/82859</Issue>
         </ExcludeList>
+        <!-- DllImportSearchPaths and NativeLibrary tests use the same test helpers that fail here -->
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/DllImportSearchPaths/DllImportSearchPathsTest/**">
+            <Issue>https://github.com/dotnet/runtime/issues/82859</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/NativeLibrary/API/NativeLibraryTests/**">
             <Issue>https://github.com/dotnet/runtime/issues/82859</Issue>
         </ExcludeList>
@@ -3828,6 +3832,9 @@
         </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_64125/Runtime_64125/**">
             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/DllImportSearchPaths/DllImportSearchPathsTest/**">
+            <Issue>Loads an assembly from file</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_64883/Runtime_64883/*">
             <Issue>Loads an assembly from file</Issue>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1012,9 +1012,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/NativeLibrary/Callback/CallbackStressTest_TargetWindows/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/166</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/NativeLibrary/Callback/CallbackTests/*">
-            <Issue>https://github.com/dotnet/runtimelab/issues/206</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/Array/MarshalArrayAsParam/AsDefault/AsDefaultTest/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/176: VARIANT marshalling</Issue>
         </ExcludeList>


### PR DESCRIPTION
This is a port of a change already 7.0.5.

### System.Net.Quic
Loading msquic with the version was always attempted first. This will never exist on Windows. This change separates the loading logic for Windows and non-Windows. Windows looks for msquic.dll (which we ship) with `DllImportSearchPath.AssemblyDirectory` and non-Windows looks for `libmsquic` with and without the version number.

### mono
Loading without any path additions (so just the file name) was always attempted first. This change switches the logic to try loads with path additions first.

### nativeaot
For p/invokes, only `DefaultDllImportSearchPaths` attribute on the assembly was checked, not on the method. If there is no `DllImportResolver` set or it doesn't resolve the native library, libraries were always loaded with flags of 0. This change checks for the search paths attribute on p/invoke methods and propagates any flags to the load.