### PR TITLE
Propagate LibrariesConfiguration to LibraryImportGenerator project reference

### DIFF
--- a/eng/generators.targets
+++ b/eng/generators.targets
@@ -48,7 +48,9 @@
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\LibraryImportGenerator\LibraryImportGenerator.csproj;
                                $(LibrariesProjectRoot)System.Runtime.InteropServices\gen\Microsoft.Interop.SourceGeneration\Microsoft.Interop.SourceGeneration.csproj"
                       ReferenceOutputAssembly="false"
-                      OutputItemType="Analyzer" />
+                      OutputItemType="Analyzer">
+        <SetConfiguration>Configuration=$(LibrariesConfiguration)</SetConfiguration>
+    </ProjectReference>
   </ItemGroup>
 
   <Target Name="ConfigureGenerators"

--- a/src/tasks/Directory.Build.props
+++ b/src/tasks/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <Import Project="..\..\Directory.Build.props" />
+
+  <PropertyGroup>
+    <IsSourceProject>false</IsSourceProject>
+  </PropertyGroup>
+
+</Project>

--- a/src/tasks/tasks.proj
+++ b/src/tasks/tasks.proj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <MSBuild Projects="@(TaskProject)"
-             Properties="Configuration=Debug;Platform=AnyCPU"
+             Properties="Configuration=Debug;LibrariesConfiguration=$(LibrariesConfiguration);Platform=AnyCPU"
              Targets="Build" />
 
     <WriteLinesToFile File="$(TasksIntermediateFile)"


### PR DESCRIPTION
The LibraryImportGenerator was referenced by tasks both directly and transitively. Since tasks always build in Debug, the generator was being built in both Release and Debug when building libraries in Release, resulting in bin clashes and the potential for use to accidentally ship a debug version of the generator.

- Mark tasks as non-source projects (such that the generator is no longer automatically enabled and directly referenced)
- Propagate LibrariesConfiguration to LibraryImportGenerator project reference such that it will always build matching the libraries configuration when used