### PR TITLE
Disable component governance for internal JIT pipelines

### DIFF
--- a/eng/pipelines/common/build-coreclr-and-libraries-job.yml
+++ b/eng/pipelines/common/build-coreclr-and-libraries-job.yml
@@ -13,6 +13,7 @@ parameters:
   pool: ''
   platform: ''
   testBuildPlatforms: []
+  disableComponentGovernance: false
 
 jobs:
 - template: /eng/pipelines/coreclr/templates/build-job.yml
@@ -29,6 +30,7 @@ jobs:
     signBinaries: ${{ parameters.signBinaries }}
     variables: ${{ parameters.variables }}
     pool: ${{ parameters.pool }}
+    disableComponentGovernance: ${{ parameters.disableComponentGovernance }}
 
 - template: /eng/pipelines/libraries/build-job.yml
   parameters:
@@ -48,3 +50,4 @@ jobs:
     liveRuntimeBuildConfig: ${{ parameters.buildConfig }}
     platform: ${{ parameters.platform }}
     testBuildPlatforms: ${{ parameters.testBuildPlatforms }}
+    disableComponentGovernance: ${{ parameters.disableComponentGovernance }}

--- a/eng/pipelines/common/templates/runtimes/xplat-job.yml
+++ b/eng/pipelines/common/templates/runtimes/xplat-job.yml
@@ -19,6 +19,7 @@ parameters:
   timeoutInMinutes: ''
   enableMicrobuild: ''
   gatherAssetManifests: false
+  disableComponentGovernance: false
 
   variables: {} ## any extra variables to add to the defaults defined below
 
@@ -63,8 +64,8 @@ jobs:
     ${{ if eq(parameters.osGroup, 'windows') }}:
       agentOs: windows
 
-    # Component governance does not work on musl machines
-    ${{ if eq(parameters.osSubGroup, '_musl') }}:
+    # Disable component governance if requested or on musl machines where it does not work well
+    ${{ if or(eq(parameters.disableComponentGovernance, true), eq(parameters.osSubGroup, '_musl')) }}:
       disableComponentGovernance: true
 
     # Setting this results in the arcade job template including a step

--- a/eng/pipelines/coreclr/jitrollingbuild.yml
+++ b/eng/pipelines/coreclr/jitrollingbuild.yml
@@ -33,6 +33,7 @@ extends:
           - windows_x64
           - windows_x86
           - windows_arm64
+          disableComponentGovernance: true # Not a shipping artifact
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -47,3 +48,4 @@ extends:
           - windows_x64
           - windows_x86
           - windows_arm64
+          disableComponentGovernance: true # Not a shipping artifact

--- a/eng/pipelines/coreclr/superpmi-collect.yml
+++ b/eng/pipelines/coreclr/superpmi-collect.yml
@@ -49,6 +49,7 @@ extends:
             testBuildPlatforms:
             - linux_x64
             - windows_x64
+            disableComponentGovernance: true # No shipping artifacts produced by this pipeline
 
       # superpmi-collect-job that targets macOS/arm64 depends on coreclr binaries produced by the macOS/x64 job
       # We don't collect osx-x64 (it's essentially the same as linux-x64). If we did, we'd add osx_x64 in the
@@ -61,6 +62,7 @@ extends:
           - osx_x64
           jobParameters:
             testGroup: outerloop
+            disableComponentGovernance: true # No shipping artifacts produced by this pipeline
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:

--- a/eng/pipelines/coreclr/templates/build-jit-job.yml
+++ b/eng/pipelines/coreclr/templates/build-jit-job.yml
@@ -10,6 +10,7 @@ parameters:
   timeoutInMinutes: ''
   variables: {}
   dependOnEvaluatePaths: false
+  disableComponentGovernance: false
   uploadAs: 'azureBlob'
 
 ### Product build
@@ -25,6 +26,7 @@ jobs:
     enableMicrobuild: true
     pool: ${{ parameters.pool }}
     dependOnEvaluatePaths: ${{ parameters.dependOnEvaluatePaths }}
+    disableComponentGovernance: ${{ parameters.disableComponentGovernance }}
 
     # Compute job name from template parameters
     name: ${{ format('coreclr_jit_build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -8,6 +8,7 @@ parameters:
   container: ''
   crossBuild: false
   dependOnEvaluatePaths: false
+  disableComponentGovernance: false
   disableClrTest: false
   isOfficialBuild: false
   osGroup: ''
@@ -36,6 +37,7 @@ jobs:
     pool: ${{ parameters.pool }}
     condition: ${{ parameters.condition }}
     dependOnEvaluatePaths: ${{ parameters.dependOnEvaluatePaths }}
+    disableComponentGovernance: ${{ parameters.disableComponentGovernance }}
     disableClrTest: ${{ parameters.disableClrTest }}
     pgoType: ${{ parameters.pgoType }}
 

--- a/eng/pipelines/coreclr/templates/xplat-pipeline-job.yml
+++ b/eng/pipelines/coreclr/templates/xplat-pipeline-job.yml
@@ -21,6 +21,7 @@ parameters:
   timeoutInMinutes: ''
   enableMicrobuild: ''
   gatherAssetManifests: false
+  disableComponentGovernance: false
 
   variables: {} ## any extra variables to add to the defaults defined below
 
@@ -48,6 +49,7 @@ jobs:
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     enableMicrobuild: ${{ parameters.enableMicrobuild }}
     gatherAssetManifests: ${{ parameters.gatherAssetManifests }}
+    disableComponentGovernance: ${{ parameters.disableComponentGovernance }}
 
     variables:
     - ${{ if ne(parameters.testGroup, '') }}:

--- a/eng/pipelines/libraries/base-job.yml
+++ b/eng/pipelines/libraries/base-job.yml
@@ -15,6 +15,7 @@ parameters:
   steps: []
   dependsOn: []
   dependOnEvaluatePaths: false
+  disableComponentGovernance: false
   variables: {}
   name: ''
   displayName: ''
@@ -40,8 +41,8 @@ jobs:
       helixRepo: dotnet/runtime
       pool: ${{ parameters.pool }}
 
-      # Component governance does not work on musl machines
-      ${{ if eq(parameters.osSubGroup, '_musl') }}:
+      # Disable component governance if requested or on musl machines where it does not work well
+      ${{ if or(eq(parameters.disableComponentGovernance, true), eq(parameters.osSubGroup, '_musl')) }}:
         disableComponentGovernance: true
 
       variables:

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -24,6 +24,7 @@ parameters:
   container: ''
   condition: true
   dependOnEvaluatePaths: false
+  disableComponentGovernance: false
   shouldContinueOnError: false
   variables: {}
   pool: ''
@@ -52,6 +53,7 @@ jobs:
       container: ${{ parameters.container }}
       condition: ${{ parameters.condition }}
       dependOnEvaluatePaths: ${{ parameters.dependOnEvaluatePaths }}
+      disableComponentGovernance: ${{ parameters.disableComponentGovernance }}
       pool: ${{ parameters.pool }}
       runtimeVariant: ${{ parameters.runtimeVariant }}
       testScope: ${{ parameters.testScope }}


### PR DESCRIPTION
The jitrollingbuild and superpmi-collect pipelines do not produce any shipping artifacts, but they run on our internal AzDO and thus get CG checks injected into them. Disable this.