### PR TITLE
[browser][non-icu] `HybridGlobalization` support interning

### DIFF
--- a/docs/design/features/hybrid-globalization.md
+++ b/docs/design/features/hybrid-globalization.md
@@ -8,7 +8,7 @@ Hybrid mode does not use ICU data for some functions connected with globalizatio
 
 ### WASM
 
-For WebAssembly in Browser we are using Web API instead of some ICU data.
+For WebAssembly in Browser we are using Web API instead of some ICU data. Ideally, we would use `System.Runtime.InteropServices.JavaScript` to call JS code from inside of C# but we cannot reference any assemblies from inside of `System.Private.CoreLib`. That is why we are using iCalls for that.
 
 **Case change**
 

--- a/src/libraries/Common/src/Interop/Browser/Interop.CompareInfo.cs
+++ b/src/libraries/Common/src/Interop/Browser/Interop.CompareInfo.cs
@@ -8,6 +8,6 @@ internal static partial class Interop
     internal static unsafe partial class JsGlobalization
     {
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern unsafe int CompareString(out string exceptionMessage, in string culture, char* str1, int str1Len, char* str2, int str2Len, global::System.Globalization.CompareOptions options);
+        internal static extern unsafe int CompareString(out string exceptionMessage, in string culture, in string str1, in string str2, global::System.Globalization.CompareOptions options);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.WebAssembly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.WebAssembly.cs
@@ -8,7 +8,7 @@ namespace System.Globalization
 {
     public partial class CompareInfo
     {
-        private unsafe int JsCompareString(ReadOnlySpan<char> string1, ReadOnlySpan<char> string2, CompareOptions options)
+        private unsafe int JsCompareString(ReadOnlySpan<char> span1, ReadOnlySpan<char> span2, CompareOptions options)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
             Debug.Assert(!GlobalizationMode.UseNls);
@@ -25,12 +25,7 @@ namespace System.Globalization
                 throw new PlatformNotSupportedException(GetPNSEForCulture(options, cultureName));
 
             string exceptionMessage;
-            int cmpResult;
-            fixed (char* pString1 = &MemoryMarshal.GetReference(string1))
-            fixed (char* pString2 = &MemoryMarshal.GetReference(string2))
-            {
-                cmpResult = Interop.JsGlobalization.CompareString(out exceptionMessage, cultureName, pString1, string1.Length, pString2, string2.Length, options);
-            }
+            int cmpResult = Interop.JsGlobalization.CompareString(out exceptionMessage, cultureName, span1.ToString(), span2.ToString(), options);
 
             if (!string.IsNullOrEmpty(exceptionMessage))
                 throw new Exception(exceptionMessage);

--- a/src/mono/wasm/runtime/corebindings.c
+++ b/src/mono/wasm/runtime/corebindings.c
@@ -45,7 +45,7 @@ extern void* mono_wasm_invoke_js_blazor (MonoString **exceptionMessage, void *ca
 // HybridGlobalization
 extern void mono_wasm_change_case_invariant(MonoString **exceptionMessage, const uint16_t* src, int32_t srcLength, uint16_t* dst, int32_t dstLength, mono_bool bToUpper);
 extern void mono_wasm_change_case(MonoString **exceptionMessage, MonoString **culture, const uint16_t* src, int32_t srcLength, uint16_t* dst, int32_t dstLength, mono_bool bToUpper);
-extern int mono_wasm_compare_string(MonoString **exceptionMessage, MonoString **culture, const uint16_t* str1, int32_t str1Length, const uint16_t* str2, int32_t str2Length, int32_t options);
+extern int mono_wasm_compare_string(MonoString **exceptionMessage, MonoString **culture, MonoString **str1, MonoString **str2, int32_t options);
 
 void bindings_initialize_internals (void)
 {

--- a/src/mono/wasm/runtime/net6-legacy/hybrid-globalization.ts
+++ b/src/mono/wasm/runtime/net6-legacy/hybrid-globalization.ts
@@ -47,14 +47,18 @@ export function mono_wasm_change_case(exceptionMessage: Int32Ptr, culture: MonoS
     }
 }
 
-export function mono_wasm_compare_string(exceptionMessage: Int32Ptr, culture: MonoStringRef, str1: number, str1Length: number, str2: number, str2Length: number, options: number) : number{
+export function mono_wasm_compare_string(exceptionMessage: Int32Ptr, culture: MonoStringRef, str1: MonoStringRef, str2: MonoStringRef, options: number) : number{
     const cultureRoot = mono_wasm_new_external_root<MonoString>(culture);
+    const str1Root = mono_wasm_new_external_root<MonoString>(str1);
+    const str2Root = mono_wasm_new_external_root<MonoString>(str2);
     try{
+        const string1 = conv_string_root(str1Root);
+        const string2 = conv_string_root(str2Root);
+        if (string1 === null || string2 === null)
+            throw new Error("$String conversion failed.");
         const cultureName = conv_string_root(cultureRoot);
-        const string1  = get_utf16_string(str1, str1Length);
-        const string2 = get_utf16_string(str2, str2Length);
-        const casePicker = (options & 0x1f);
         const locale = cultureName ? cultureName : undefined;
+        const casePicker = (options & 0x1f);
         const result = compare_strings(string1, string2, locale, casePicker);
         if (result == -2)
             throw new Error("$Invalid comparison option.");
@@ -66,6 +70,8 @@ export function mono_wasm_compare_string(exceptionMessage: Int32Ptr, culture: Mo
     }
     finally {
         cultureRoot.release();
+        str1Root.release();
+        str2Root.release();
     }
 }
 


### PR DESCRIPTION
Suggested in [comment](https://github.com/dotnet/runtime/pull/84471#issuecomment-1500308164). For performance reasons it pays off to exchange char*+lenght to string when passing data from managed code to JS. 
- In https://github.com/dotnet/runtime/pull/84019 we are passing only culture-sensitive `abc....xyz` string and that does not contain repetitive literals, we do not need to change the original implementation there. 
- In https://github.com/dotnet/runtime/pull/84249, the mechanism described by @kg can be beneficial. We are changing the implementation for `Comparison`.
- It is confusing why JSInterop is not used in HybridGlobalization, so information about it got added in docs.