### PR TITLE
[JIT] ARM32/ARM64 - Fixed zero/sign-extension for `GT_STORE_LCL_VAR` in codegen

### DIFF
--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -1120,16 +1120,9 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
             else // store into register (i.e move into register)
             {
                 // Assign into targetReg when dataReg (from op1) is not the same register
-                if (!data->isUsedFromReg())
-                {
-                    inst_Mov(targetType, targetReg, dataReg, /* canSkip */ true);
-                }
-                else
-                {
-                    // We use 'emitActualTypeSize' as the instructions require 4BYTE.
-                    inst_Mov_Extend(targetType, /* srcInReg */ true, targetReg, dataReg, /* canSkip */ true,
-                                    emitActualTypeSize(targetType));
-                }
+                // We use 'emitActualTypeSize' as the instructions require 4BYTE.
+                inst_Mov_Extend(targetType, /* srcInReg */ true, targetReg, dataReg, /* canSkip */ true,
+                                emitActualTypeSize(targetType));
             }
 
             genUpdateLifeStore(tree, targetReg, varDsc);

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -1082,6 +1082,8 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
         LclVarDsc* varDsc     = compiler->lvaGetDesc(varNum);
         var_types  targetType = varDsc->GetRegisterType(tree);
 
+        emitter* emit = GetEmitter();
+
         if (targetType == TYP_LONG)
         {
             genStoreLongLclVar(tree);
@@ -1114,13 +1116,14 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
                 instruction ins  = ins_StoreFromSrc(dataReg, targetType);
                 emitAttr    attr = emitTypeSize(targetType);
 
-                emitter* emit = GetEmitter();
                 emit->emitIns_S_R(ins, attr, dataReg, varNum, /* offset */ 0);
             }
             else // store into register (i.e move into register)
             {
                 // Assign into targetReg when dataReg (from op1) is not the same register
-                if (varTypeIsIntegral(targetType))
+                // Only zero/sign extend if we are using general registers.
+                if (varTypeIsIntegral(targetType) && emit->isGeneralRegister(targetReg) &&
+                    emit->isGeneralRegister(dataReg))
                 {
                     // We use 'emitActualTypeSize' as the instructions require 4BYTE.
                     inst_Mov_Extend(targetType, /* srcInReg */ true, targetReg, dataReg, /* canSkip */ true,

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -1120,7 +1120,16 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
             else // store into register (i.e move into register)
             {
                 // Assign into targetReg when dataReg (from op1) is not the same register
-                inst_Mov(targetType, targetReg, dataReg, /* canSkip */ true);
+                if (!data->isUsedFromReg())
+                {
+                    inst_Mov(targetType, targetReg, dataReg, /* canSkip */ true);
+                }
+                else
+                {
+                    // We use 'emitActualTypeSize' as the instructions require 4BYTE.
+                    inst_Mov_Extend(targetType, /* srcInReg */ true, targetReg, dataReg, /* canSkip */ true,
+                                    emitActualTypeSize(targetType));
+                }
             }
 
             genUpdateLifeStore(tree, targetReg, varDsc);

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -1120,9 +1120,16 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
             else // store into register (i.e move into register)
             {
                 // Assign into targetReg when dataReg (from op1) is not the same register
-                // We use 'emitActualTypeSize' as the instructions require 4BYTE.
-                inst_Mov_Extend(targetType, /* srcInReg */ true, targetReg, dataReg, /* canSkip */ true,
-                                emitActualTypeSize(targetType));
+                if (varTypeIsIntegral(targetType))
+                {
+                    // We use 'emitActualTypeSize' as the instructions require 4BYTE.
+                    inst_Mov_Extend(targetType, /* srcInReg */ true, targetReg, dataReg, /* canSkip */ true,
+                                    emitActualTypeSize(targetType));
+                }
+                else
+                {
+                    inst_Mov(targetType, targetReg, dataReg, /* canSkip */ true);
+                }
             }
 
             genUpdateLifeStore(tree, targetReg, varDsc);

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2970,8 +2970,8 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* lclNode)
             }
             else
             {
-                // We use 'emitActualTypeSize' as ARM64 instructions require 8BYTE or 4BYTE.
-                inst_Mov_Extend(targetType, true, targetReg, dataReg, /* canSkip */ true,
+                // We use 'emitActualTypeSize' as the instructions require 8BYTE or 4BYTE.
+                inst_Mov_Extend(targetType, /* srcInReg */ true, targetReg, dataReg, /* canSkip */ true,
                                 emitActualTypeSize(targetType));
             }
         }

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2965,7 +2965,8 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* lclNode)
         {
             // Assign into targetReg when dataReg (from op1) is not the same register
             // Only zero/sign extend if we are not using a vector or zero register.
-            if (!emit->isVectorRegister(targetReg) && !emit->isVectorRegister(dataReg) && (dataReg != REG_ZR))
+            if (varTypeIsIntegral(targetType) && !emit->isVectorRegister(targetReg) &&
+                !emit->isVectorRegister(dataReg) && (dataReg != REG_ZR))
             {
                 // We use 'emitActualTypeSize' as the instructions require 8BYTE or 4BYTE.
                 inst_Mov_Extend(targetType, /* srcInReg */ true, targetReg, dataReg, /* canSkip */ true,

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2964,15 +2964,16 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* lclNode)
         else // store into register (i.e move into register)
         {
             // Assign into targetReg when dataReg (from op1) is not the same register
-            if (!data->isUsedFromReg())
-            {
-                inst_Mov(targetType, targetReg, dataReg, /* canSkip */ true);
-            }
-            else
+            // Only zero/sign extend if we are not using a vector or zero register.
+            if (!emit->isVectorRegister(targetReg) && !emit->isVectorRegister(dataReg) && (dataReg != REG_ZR))
             {
                 // We use 'emitActualTypeSize' as the instructions require 8BYTE or 4BYTE.
                 inst_Mov_Extend(targetType, /* srcInReg */ true, targetReg, dataReg, /* canSkip */ true,
                                 emitActualTypeSize(targetType));
+            }
+            else
+            {
+                inst_Mov(targetType, targetReg, dataReg, /* canSkip */ true);
             }
         }
         genUpdateLifeStore(lclNode, targetReg, varDsc);

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2964,7 +2964,16 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* lclNode)
         else // store into register (i.e move into register)
         {
             // Assign into targetReg when dataReg (from op1) is not the same register
-            inst_Mov(targetType, targetReg, dataReg, /* canSkip */ true);
+            if (!data->isUsedFromReg())
+            {
+                inst_Mov(targetType, targetReg, dataReg, /* canSkip */ true);
+            }
+            else
+            {
+                // We use 'emitActualTypeSize' as ARM64 instructions require 8BYTE or 4BYTE.
+                inst_Mov_Extend(targetType, true, targetReg, dataReg, /* canSkip */ true,
+                                emitActualTypeSize(targetType));
+            }
         }
         genUpdateLifeStore(lclNode, targetReg, varDsc);
     }

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2964,9 +2964,8 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* lclNode)
         else // store into register (i.e move into register)
         {
             // Assign into targetReg when dataReg (from op1) is not the same register
-            // Only zero/sign extend if we are not using a vector or zero register.
-            if (varTypeIsIntegral(targetType) && !emit->isVectorRegister(targetReg) &&
-                !emit->isVectorRegister(dataReg) && (dataReg != REG_ZR))
+            // Only zero/sign extend if we are using general registers.
+            if (varTypeIsIntegral(targetType) && emit->isGeneralRegister(targetReg) && emit->isGeneralRegister(dataReg))
             {
                 // We use 'emitActualTypeSize' as the instructions require 8BYTE or 4BYTE.
                 inst_Mov_Extend(targetType, /* srcInReg */ true, targetReg, dataReg, /* canSkip */ true,

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -4185,7 +4185,7 @@ void emitter::emitIns_Mov(
 
         case INS_sxtw:
         {
-            assert(size == EA_8BYTE);
+            assert((size == EA_8BYTE) || (size == EA_4BYTE));
             FALLTHROUGH;
         }
 

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -4203,12 +4203,6 @@ void emitter::emitIns_Mov(
             assert(insOptsNone(opt));
             assert(isValidGeneralDatasize(size));
             assert(isGeneralRegister(dstReg));
-            if (!isGeneralRegister(srcReg))
-            {
-                printf("\n");
-                printf("%i\n", srcReg);
-                assert(isGeneralRegister(srcReg));
-            }
             assert(isGeneralRegister(srcReg));
             fmt = IF_DR_2H;
             break;

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -4203,6 +4203,12 @@ void emitter::emitIns_Mov(
             assert(insOptsNone(opt));
             assert(isValidGeneralDatasize(size));
             assert(isGeneralRegister(dstReg));
+            if (!isGeneralRegister(srcReg))
+            {
+                printf("\n");
+                printf("%i\n", srcReg);
+                assert(isGeneralRegister(srcReg));
+            }
             assert(isGeneralRegister(srcReg));
             fmt = IF_DR_2H;
             break;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_84693/Runtime_84693.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_84693/Runtime_84693.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 public class Test
 {
+    // This is trying to verify that we zero-extend from the result of "(byte)(-s_2)".
 	public class Program
 	{
 		public static short s_2;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_84693/Runtime_84693.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_84693/Runtime_84693.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Test
+{
+	public class Program
+	{
+		public static short s_2;
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		public static void Consume(int x) {}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		public static int M8(byte arg0)
+		{
+			s_2 = 1;
+			arg0 = (byte)(-s_2);
+			var vr1 = arg0 & arg0;
+			Consume(vr1);
+			return vr1;
+		}
+	}
+
+	[Fact]
+	public static int TestEntryPoint() {
+		var result = Test.Program.M8(1);
+		if (result != 255)
+		{
+			return 0;
+		}
+		return 100;
+	}
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_84693/Runtime_84693.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_84693/Runtime_84693.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/84693

We were not handling zero/sign-extends for NormalizeOnLoad local stores correctly on ARM.
