### PR TITLE
Fix source-build oob package orchestration

### DIFF
--- a/src/libraries/oob-all.proj
+++ b/src/libraries/oob-all.proj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.Build.Traversal">
 
-  <PropertyGroup Condition="'$(BuildTargetFramework)' == '$(NetFrameworkCurrent)'">
+  <PropertyGroup Condition="'$(BuildTargetFramework)' != '' and '$(BuildTargetFramework)' == '$(NetFrameworkCurrent)'">
     <TargetFramework>$(BuildTargetFramework)</TargetFramework>
     <!-- Filter ProjectReferences to build the best matching target framework only. -->
     <FilterTraversalProjectReferences>true</FilterTraversalProjectReferences>


### PR DESCRIPTION
Regressed with https://github.com/dotnet/runtime/commit/e3c370086d9325d51eb96656dced208d9151bb0e. By replacing "net48" with `$(NetFrameworkCurrent)`, the condition became true (as both BuildTargetFramework and NetFrameworkCurrent are empty in source build) and projects were filtered out.

Unblocks https://github.com/dotnet/sdk/pull/31752