### PR TITLE
fix: Ensure that JSImport/JSExport use fully qualified name for DebuggerNonUserCode

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/Constants.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/Constants.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Interop.JavaScript
         public const string JSImportAttribute = "System.Runtime.InteropServices.JavaScript.JSImportAttribute";
         public const string JSExportAttribute = "System.Runtime.InteropServices.JavaScript.JSExportAttribute";
         public const string JavaScriptMarshal = "System.Runtime.InteropServices.JavaScript.JavaScriptMarshal";
-        public const string DebuggerNonUserCodeAttribute = "System.Diagnostics.DebuggerNonUserCode";
+        public const string DebuggerNonUserCodeAttribute = "global::System.Diagnostics.DebuggerNonUserCode";
 
         public const string JSFunctionSignatureGlobal = "global::System.Runtime.InteropServices.JavaScript.JSFunctionBinding";
         public const string JSMarshalerArgumentGlobal = "global::System.Runtime.InteropServices.JavaScript.JSMarshalerArgument";


### PR DESCRIPTION
Adds a global qualifier to avoid having namespace conflicts if an import or export is declared in a scope that already contains `System`.