### PR TITLE
[release/6.0] Disable 2 failing tests for 6.0

### DIFF
--- a/src/libraries/System.Net.Http.Json/tests/FunctionalTests/HttpClientJsonExtensionsTests.cs
+++ b/src/libraries/System.Net.Http.Json/tests/FunctionalTests/HttpClientJsonExtensionsTests.cs
@@ -266,6 +266,7 @@ namespace System.Net.Http.Json.Functional.Tests
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))] // No Socket support
         [MemberData(nameof(GetFromJsonAsync_EnforcesMaxResponseContentBufferSize_MemberData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public async Task GetFromJsonAsync_EnforcesMaxResponseContentBufferSize(int limit, int contentLength, bool chunked)
         {
             await LoopbackServer.CreateClientAndServerAsync(async uri =>

--- a/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
@@ -1594,6 +1594,7 @@ namespace System.Security.Cryptography.Xml.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public void VerifyXmlResolver(bool provideResolver)
         {
             HttpListener listener;


### PR DESCRIPTION
This is a test-only change. Fixes #84175. The failures are expected as explained in https://github.com/dotnet/runtime/issues/84175#issuecomment-1494904919.

## Customer Impact
N/A

## Testing
N/A

## Risk
None.