### PR TITLE
Always set `GTF_GLOB_REF` on block indirs

### DIFF
--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1196,16 +1196,7 @@ inline GenTreeBlk* Compiler::gtNewBlkIndir(ClassLayout* layout, GenTree* addr, G
     blkNode->gtFlags |= indirFlags;
     blkNode->SetIndirExceptionFlags(this);
 
-    // TODO-Bug: this method does not have enough information to make this determination.
-    // The local may end up (or already is) address-exposed.
-    if (addr->OperIs(GT_LCL_ADDR))
-    {
-        if (lvaIsImplicitByRefLocal(addr->AsLclVarCommon()->GetLclNum()))
-        {
-            blkNode->gtFlags |= GTF_GLOB_REF;
-        }
-    }
-    else
+    if ((indirFlags & GTF_IND_INVARIANT) == 0)
     {
         blkNode->gtFlags |= GTF_GLOB_REF;
     }


### PR DESCRIPTION
Eventually, this logic will be shared by all indirs.

No diffs.