### PR TITLE
Skip DllImportSearchPathsTest on wasm

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3590,6 +3590,9 @@
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_64125/Runtime_64125/**">
             <Issue>needs triage</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/DllImportSearchPaths/DllImportSearchPathsTest/**">
+            <Issue>Loads an assembly from file</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_64883/Runtime_64883/*">
             <Issue>Loads an assembly from file</Issue>
         </ExcludeList>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/84724