### PR TITLE
Remove usage of Newtonsoft.Json from host test assets

### DIFF
--- a/src/installer/tests/Assets/TestProjects/StandaloneApp/Program.cs
+++ b/src/installer/tests/Assets/TestProjects/StandaloneApp/Program.cs
@@ -13,9 +13,6 @@ namespace StandaloneApp
             Console.WriteLine("Hello World!");
             Console.WriteLine(string.Join(Environment.NewLine, args));
             Console.WriteLine(RuntimeInformation.FrameworkDescription);
-
-            // A small operation involving NewtonSoft.Json to ensure the assembly is loaded properly
-            var t = typeof(Newtonsoft.Json.JsonReader);
         }
     }
 }

--- a/src/installer/tests/Assets/TestProjects/StandaloneApp/StandaloneApp.csproj
+++ b/src/installer/tests/Assets/TestProjects/StandaloneApp/StandaloneApp.csproj
@@ -7,8 +7,4 @@
     <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-  </ItemGroup>
-
 </Project>

--- a/src/installer/tests/Assets/TestProjects/StandaloneApp20/Program.cs
+++ b/src/installer/tests/Assets/TestProjects/StandaloneApp20/Program.cs
@@ -11,9 +11,6 @@ namespace StandaloneApp
         {
             Console.WriteLine("Hello World!");
             Console.WriteLine(string.Join(Environment.NewLine, args));
-
-            // A small operation involving NewtonSoft.Json to ensure the assembly is loaded properly
-            var t = typeof(Newtonsoft.Json.JsonReader);
         }
     }
 }

--- a/src/installer/tests/Assets/TestProjects/StandaloneApp20/StandaloneApp20.csproj
+++ b/src/installer/tests/Assets/TestProjects/StandaloneApp20/StandaloneApp20.csproj
@@ -8,8 +8,4 @@
     <RuntimeFrameworkVersion>2.0.7</RuntimeFrameworkVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-  </ItemGroup>
-
 </Project>

--- a/src/installer/tests/Assets/TestProjects/StandaloneApp21/Program.cs
+++ b/src/installer/tests/Assets/TestProjects/StandaloneApp21/Program.cs
@@ -11,9 +11,6 @@ namespace StandaloneApp
         {
             Console.WriteLine("Hello World!");
             Console.WriteLine(string.Join(Environment.NewLine, args));
-
-            // A small operation involving NewtonSoft.Json to ensure the assembly is loaded properly
-            var t = typeof(Newtonsoft.Json.JsonReader);
         }
     }
 }

--- a/src/installer/tests/Assets/TestProjects/StandaloneApp21/StandaloneApp21.csproj
+++ b/src/installer/tests/Assets/TestProjects/StandaloneApp21/StandaloneApp21.csproj
@@ -8,8 +8,4 @@
     <RuntimeFrameworkVersion>2.1.0</RuntimeFrameworkVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-  </ItemGroup>
-
 </Project>

--- a/src/installer/tests/Assets/TestUtils/TestProjects.props
+++ b/src/installer/tests/Assets/TestUtils/TestProjects.props
@@ -13,7 +13,5 @@
       win-x86 tests that assumed a win-x64 app host RID based on the runner SDK.
     -->
     <AppHostRuntimeIdentifier>$(TestTargetRid)</AppHostRuntimeIdentifier>
-
-    <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
We've moved all the host tests that were using `Newtonsoft.Json` for dependency testing to do things differently. So we can now get rid of the dependency from the test assets - thanks to @am11 for calling it out in https://github.com/dotnet/runtime/issues/77807#issuecomment-1301967819