### PR TITLE
Check that array element size fits in 16 bits

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -780,7 +780,7 @@ namespace ILCompiler.DependencyAnalysis
                 {
                     int elementSize = elementType.GetElementSize().AsInt;
                     // We validated that this will fit the short when the node was constructed. No need for nice messages.
-                    flags |= (uint)elementSize;
+                    flags |= (uint)checked((ushort)elementSize);
                 }
             }
             else if (_type.IsString)


### PR DESCRIPTION
Looks like the `checked` cast was lost in #75436. Noticed a comment that doesn't make sense as I was looking at implementing function pointer MethodTables. We want a compiler crash if this doesn't hold, not invalid outputs.

Cc @dotnet/ilc-contrib 