### PR TITLE
[wasm] Fix publishing Microsoft.NET.Sdk.WebAssembly.Pack

### DIFF
--- a/src/installer/prepare-artifacts.proj
+++ b/src/installer/prepare-artifacts.proj
@@ -248,6 +248,7 @@
       <RidAgnosticNupkgToPublishFile
         Include="
           $(DownloadDirectory)**\Microsoft.NET.Workload.Mono.Toolchain.*Manifest-*.nupkg;
+          $(DownloadDirectory)**\Microsoft.NET.Sdk.WebAssembly.Pack.*.nupkg;
           $(DownloadDirectory)*\$(PublishRidAgnosticPackagesFromPlatform)\**\*.nupkg;
           $(DownloadDirectory)*\*AllConfigurations\**\*.nupkg"
         Exclude="@(RuntimeNupkgFile);@(DownloadedSymbolNupkgFile)" />


### PR DESCRIPTION
Update pattern for matching `RidAgnosticNupkgToPublishFile` to include `Microsoft.NET.Sdk.WebAssembly.Pack`.

Fixes https://github.com/dotnet/runtime/issues/84742