### PR TITLE
Report contents of chained resolvers in exception messages.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -859,6 +859,6 @@ namespace System.Text.Json
             return Interlocked.CompareExchange(ref s_defaultOptions, options, null) ?? options;
         }
 
-        private string DebuggerDisplay => $"TypeInfoResolver = {(TypeInfoResolver is JsonTypeInfoResolverChain chain ? chain.DebuggerDisplay : TypeInfoResolver?.GetType().Name)}, IsReadOnly = {IsReadOnly}";
+        private string DebuggerDisplay => $"TypeInfoResolver = {(TypeInfoResolver?.ToString() ?? "<null>")}, IsReadOnly = {IsReadOnly}";
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoResolverChain.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoResolverChain.cs
@@ -1,11 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
-
 namespace System.Text.Json.Serialization.Metadata
 {
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal class JsonTypeInfoResolverChain : ConfigurationList<IJsonTypeInfoResolver>, IJsonTypeInfoResolver, IBuiltInJsonTypeInfoResolver
     {
         public JsonTypeInfoResolverChain() : base(null) { }
@@ -57,23 +54,20 @@ namespace System.Text.Json.Serialization.Metadata
             return true;
         }
 
-        internal string DebuggerDisplay
+        public override string ToString()
         {
-            get
+            var sb = new StringBuilder("[");
+            foreach (IJsonTypeInfoResolver resolver in _list)
             {
-                var sb = new StringBuilder("[");
-                foreach (IJsonTypeInfoResolver resolver in _list)
-                {
-                    sb.Append(resolver.GetType().Name);
-                    sb.Append(", ");
-                }
-
-                if (_list.Count > 0)
-                    sb.Length -= 2;
-
-                sb.Append(']');
-                return sb.ToString();
+                sb.Append(resolver);
+                sb.Append(", ");
             }
+
+            if (_list.Count > 0)
+                sb.Length -= 2;
+
+            sb.Append(']');
+            return sb.ToString();
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -723,7 +723,7 @@ namespace System.Text.Json
         [DoesNotReturn]
         public static void ThrowNotSupportedException_NoMetadataForType(Type type, IJsonTypeInfoResolver? resolver)
         {
-            throw new NotSupportedException(SR.Format(SR.NoMetadataForType, type, resolver?.GetType().FullName ?? "<null>"));
+            throw new NotSupportedException(SR.Format(SR.NoMetadataForType, type, resolver?.ToString() ?? "<null>"));
         }
 
         public static NotSupportedException GetNotSupportedException_AmbiguousMetadataForType(Type type, Type match1, Type match2)
@@ -740,12 +740,12 @@ namespace System.Text.Json
         [DoesNotReturn]
         public static void ThrowInvalidOperationException_NoMetadataForType(Type type, IJsonTypeInfoResolver? resolver)
         {
-            throw new InvalidOperationException(SR.Format(SR.NoMetadataForType, type, resolver?.GetType().FullName ?? "<null>"));
+            throw new InvalidOperationException(SR.Format(SR.NoMetadataForType, type, resolver?.ToString() ?? "<null>"));
         }
 
         public static Exception GetInvalidOperationException_NoMetadataForTypeProperties(IJsonTypeInfoResolver? resolver, Type type)
         {
-            return new InvalidOperationException(SR.Format(SR.NoMetadataForTypeProperties, resolver?.GetType().FullName ?? "<null>", type));
+            return new InvalidOperationException(SR.Format(SR.NoMetadataForTypeProperties, resolver?.ToString() ?? "<null>", type));
         }
 
         [DoesNotReturn]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
@@ -223,6 +223,10 @@ namespace System.Text.Json.SourceGeneration.Tests
             JsonTypeInfo personInfo = options.GetTypeInfo(typeof(Person));
             Assert.IsAssignableFrom<JsonTypeInfo<Person>>(personInfo);
             Assert.Same(options, personInfo.Options);
+
+            NotSupportedException exn = Assert.Throws<NotSupportedException>(() => options.GetTypeInfo(typeof(MyStruct)));
+            Assert.Contains(typeof(NestedContext).FullName, exn.Message);
+            Assert.Contains(typeof(PersonJsonContext).FullName, exn.Message);
         }
 
         [Fact]


### PR DESCRIPTION
Old exception message:
> System.NotSupportedException : JsonTypeInfo metadata for type 'System.Text.Json.SourceGeneration.Tests.MyStruct' was not provided by TypeInfoResolver of type 'System.Text.Json.JsonSerializerOptions+OptionsBoundJsonTypeInfoResolverChain'.

New exception message:

> System.NotSupportedException : JsonTypeInfo metadata for type 'System.Text.Json.SourceGeneration.Tests.MyStruct' was not provided by TypeInfoResolver of type '[System.Text.Json.SourceGeneration.Tests.JsonSerializerContextTests+NestedContext, System.Text.Json.SourceGeneration.Tests.JsonSerializerContextTests+PersonJsonContext]'.