### PR TITLE
[browser] Wasm SDK packed as a nuget package

### DIFF
--- a/src/installer/prepare-artifacts.proj
+++ b/src/installer/prepare-artifacts.proj
@@ -248,6 +248,7 @@
       <RidAgnosticNupkgToPublishFile
         Include="
           $(DownloadDirectory)**\Microsoft.NET.Workload.Mono.Toolchain.*Manifest-*.nupkg;
+          $(DownloadDirectory)**\Microsoft.NET.Sdk.WebAssembly.Pack.*.nupkg;
           $(DownloadDirectory)*\$(PublishRidAgnosticPackagesFromPlatform)\**\*.nupkg;
           $(DownloadDirectory)*\*AllConfigurations\**\*.nupkg"
         Exclude="@(RuntimeNupkgFile);@(DownloadedSymbolNupkgFile)" />

--- a/src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Sdk/Sdk/Sdk.props
+++ b/src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Sdk/Sdk/Sdk.props
@@ -1,5 +1,5 @@
 <Project>
-  <PropertyGroup Condition="'$(UsingMicrosoftNETSdkBlazorWebAssembly)' != 'true'">
+  <PropertyGroup Condition="'$(UsingMicrosoftNETSdkBlazorWebAssembly)' != 'true' and '$(UsingMicrosoftNETSdkWebAssembly)' != 'true'">
     <TargetArchitecture>wasm</TargetArchitecture>
     <TargetOS>browser</TargetOS>
     <UseMonoRuntime>true</UseMonoRuntime>

--- a/src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Sdk/Sdk/Sdk.targets.in
+++ b/src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Sdk/Sdk/Sdk.targets.in
@@ -9,7 +9,7 @@
     <WasmAppHostDir>$([MSBuild]::NormalizeDirectory($(MSBuildThisFileDirectory), '..', 'WasmAppHost'))</WasmAppHostDir>
 
     <!-- only for non-blazor projects -->
-    <WasmEmitSymbolMap Condition="'$(UsingMicrosoftNETSdkBlazorWebAssembly)' != 'true' and '$(WasmEmitSymbolMap)' == '' and '$(RunAOTCompilation)' != 'true'">true</WasmEmitSymbolMap>
+    <WasmEmitSymbolMap Condition="'$(UsingMicrosoftNETSdkBlazorWebAssembly)' != 'true' and '$(UsingMicrosoftNETSdkWebAssembly)' != 'true' and '$(WasmEmitSymbolMap)' == '' and '$(RunAOTCompilation)' != 'true'">true</WasmEmitSymbolMap>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)\WasmApp.props" />

--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/Microsoft.NET.Sdk.WebAssembly.Pack.pkgproj
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/Microsoft.NET.Sdk.WebAssembly.Pack.pkgproj
@@ -1,0 +1,14 @@
+<Project DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
+
+  <PropertyGroup>
+    <PackageDescription>SDK for building and publishing WebAssembly applications.</PackageDescription>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoTasksDir)Microsoft.NET.Sdk.WebAssembly.Pack.Tasks\Microsoft.NET.Sdk.WebAssembly.Pack.Tasks.csproj" />
+    <PackageFile Include="build\*.props;build\*.targets;build\*.web.config" TargetPath="build" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
+</Project>

--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.props
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.props
@@ -1,0 +1,43 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.Sdk.WebAssembly.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0" TreatAsLocalProperty="RuntimeIdentifier">
+  <PropertyGroup>
+    <!-- Avoid having the rid show up in output paths -->
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+
+    <OutputType>exe</OutputType>
+
+    <IsPackable>false</IsPackable>
+
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
+
+    <!-- Turn off symbol publishing by default -->
+    <CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
+
+    <!-- Trimmer defaults -->
+    <PublishTrimmed Condition="'$(PublishTrimmed)' == ''">true</PublishTrimmed>
+    <TrimMode Condition="'$(TrimMode)' == ''">partial</TrimMode>
+    <TrimmerRemoveSymbols Condition="'$(TrimmerRemoveSymbols)' == ''">false</TrimmerRemoveSymbols>
+
+    <!-- Static web assets defaults -->
+    <StaticWebAssetBasePath Condition="'$(StaticWebAssetBasePath)' == ''">/</StaticWebAssetBasePath>
+    <StaticWebAssetProjectMode Condition="'$(StaticWebAssetProjectMode)' == ''">Root</StaticWebAssetProjectMode>
+    <StaticWebAssetsAdditionalBuildPropertiesToRemove>$(StaticWebAssetsAdditionalBuildPropertiesToRemove);RuntimeIdentifier;SelfContained</StaticWebAssetsAdditionalBuildPropertiesToRemove>
+    <StaticWebAssetsGetPublishAssetsTargets>ComputeFilesToPublish;GetCurrentProjectPublishStaticWebAssetItems</StaticWebAssetsGetPublishAssetsTargets>
+    <StaticWebAssetsAdditionalPublishProperties>$(StaticWebAssetsAdditionalPublishProperties);BuildProjectReferences=false;ResolveAssemblyReferencesFindRelatedSatellites=true</StaticWebAssetsAdditionalPublishProperties>
+    <StaticWebAssetsAdditionalPublishPropertiesToRemove>$(StaticWebAssetsAdditionalPublishPropertiesToRemove);NoBuild;RuntimeIdentifier</StaticWebAssetsAdditionalPublishPropertiesToRemove>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectCapability Include="WebAssembly" />
+  </ItemGroup>
+</Project>

--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -1,0 +1,493 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.Sdk.WebAssembly.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0">
+
+  <PropertyGroup>
+    <EnableDefaultContentItems Condition=" '$(EnableDefaultContentItems)' == '' ">true</EnableDefaultContentItems>
+
+    <!-- Trimmer defaults that depend on user-definable settings.
+        This must be configured before it's initialized in the .NET SDK targets (which are imported by the Razor SDK). -->
+    <SuppressTrimAnalysisWarnings Condition="'$(SuppressTrimAnalysisWarnings)' == '' And '$(TrimmerDefaultAction)' != 'link'">true</SuppressTrimAnalysisWarnings>
+  </PropertyGroup>
+
+  <!--
+    Targets supporting Razor MSBuild integration. Contain support for generating C# code using Razor
+    and including the generated code in the project lifecycle, including compiling, publishing and producing
+    nuget packages.
+  -->
+
+  <PropertyGroup>
+    <!-- Paths to tools, tasks, and extensions are calculated relative to the WebAssemblySdkDirectoryRoot. This can be modified to test a local build. -->
+    <WebAssemblySdkDirectoryRoot Condition="'$(WebAssemblySdkDirectoryRoot)'==''">$(MSBuildThisFileDirectory)..\</WebAssemblySdkDirectoryRoot>
+    <_WebAssemblySdkTasksTFM Condition=" '$(MSBuildRuntimeType)' == 'Core'">net8.0</_WebAssemblySdkTasksTFM>
+    <_WebAssemblySdkTasksTFM Condition=" '$(MSBuildRuntimeType)' != 'Core'">net472</_WebAssemblySdkTasksTFM>
+    <_WebAssemblySdkTasksAssembly>$(WebAssemblySdkDirectoryRoot)tools\$(_WebAssemblySdkTasksTFM)\Microsoft.NET.Sdk.WebAssembly.Pack.Tasks.dll</_WebAssemblySdkTasksAssembly>
+  </PropertyGroup>
+
+  <UsingTask TaskName="Microsoft.NET.Sdk.WebAssembly.GenerateWasmBootJson" AssemblyFile="$(_WebAssemblySdkTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.NET.Sdk.WebAssembly.ComputeWasmBuildAssets" AssemblyFile="$(_WebAssemblySdkTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.NET.Sdk.WebAssembly.ComputeWasmPublishAssets" AssemblyFile="$(_WebAssemblySdkTasksAssembly)" />
+
+  <PropertyGroup>
+    <SelfContained>true</SelfContained>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+
+    <!-- Runtime feature defaults to trim unnecessary code -->
+    <InvariantGlobalization Condition="'$(InvariantGlobalization)' == ''">false</InvariantGlobalization>
+    <EventSourceSupport Condition="'$(EventSourceSupport)' == ''">false</EventSourceSupport>
+    <UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">true</UseSystemResourceKeys>
+    <EnableUnsafeUTF7Encoding Condition="'$(EnableUnsafeUTF7Encoding)' == ''">false</EnableUnsafeUTF7Encoding>
+    <HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == ''">false</HttpActivityPropagationSupport>
+    <NullabilityInfoContextSupport Condition="'$(NullabilityInfoContextSupport)' == ''">false</NullabilityInfoContextSupport>
+    <_AggressiveAttributeTrimming Condition="'$(_AggressiveAttributeTrimming)' == ''">true</_AggressiveAttributeTrimming>
+    <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(Configuration)' != 'Debug'">false</DebuggerSupport>
+    <BlazorCacheBootResources Condition="'$(BlazorCacheBootResources)' == ''">true</BlazorCacheBootResources>
+    <WasmFingerprintDotnetJs Condition="'$(WasmFingerprintDotnetJs)' == ''">false</WasmFingerprintDotnetJs>
+
+    <!-- Turn off parts of the build that do not apply to WASM projects -->
+    <GenerateDependencyFile>false</GenerateDependencyFile>
+    <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>
+    <PreserveCompilationContext>false</PreserveCompilationContext>
+    <PreserveCompilationReferences>false</PreserveCompilationReferences>
+    <IsWebConfigTransformDisabled>true</IsWebConfigTransformDisabled>
+
+    <!-- JS Modules -->
+    <!-- We disable the manifest generation because we are going to inline the modules in the blazor.boot.json manifest -->
+    <GenerateJSModuleManifest>false</GenerateJSModuleManifest>
+
+    <EnableDefaultWasmAssembliesToBundle>false</EnableDefaultWasmAssembliesToBundle>
+    <WasmNestedPublishAppDependsOn>_GatherWasmFilesToPublish;$(WasmNestedPublishAppDependsOn)</WasmNestedPublishAppDependsOn>
+    <_WasmNestedPublishAppPreTarget>ComputeFilesToPublish</_WasmNestedPublishAppPreTarget>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Configuration for the platform compatibility analyzer. See https://github.com/dotnet/designs/blob/main/accepted/2020/platform-exclusion/platform-exclusion.md#build-configuration-for-platforms -->
+    <SupportedPlatform Remove="@(SupportedPlatform)" />
+    <SupportedPlatform Include="browser" />
+  </ItemGroup>
+
+  <!-- Wire-up static web assets -->
+  <PropertyGroup>
+    <ResolveStaticWebAssetsInputsDependsOn>
+      $(ResolveStaticWebAssetsInputsDependsOn);
+      _AddWasmStaticWebAssets;
+    </ResolveStaticWebAssetsInputsDependsOn>
+
+    <StaticWebAssetsPrepareForRunDependsOn>
+      _GenerateBuildWasmBootJson;
+      $(StaticWebAssetsPrepareForRunDependsOn)
+    </StaticWebAssetsPrepareForRunDependsOn>
+
+    <ResolvePublishStaticWebAssetsDependsOn Condition="'$(WasmBuildingForNestedPublish)' != 'true'">
+      $(ResolvePublishStaticWebAssetsDependsOn);
+      ProcessPublishFilesForWasm;
+      ComputeWasmExtensions;
+      _AddPublishWasmBootJsonToStaticWebAssets;
+    </ResolvePublishStaticWebAssetsDependsOn>
+
+    <GenerateStaticWebAssetsPublishManifestDependsOn Condition="'$(WasmBuildingForNestedPublish)' != 'true'">
+      $(GenerateStaticWebAssetsPublishManifestDependsOn);
+      GeneratePublishWasmBootJson;
+    </GenerateStaticWebAssetsPublishManifestDependsOn>
+
+    <AddWasmStaticWebAssetsDependsOn>
+      $(AddWasmStaticWebAssetsDependsOn);
+      ResolveWasmOutputs;
+    </AddWasmStaticWebAssetsDependsOn>
+    <GenerateBuildWasmBootJsonDependsOn>
+      $(GenerateBuildWasmBootJsonDependsOn);
+      ResolveStaticWebAssetsInputs;
+    </GenerateBuildWasmBootJsonDependsOn>
+    <GeneratePublishWasmBootJsonDependsOn>
+      $(GeneratePublishWasmBootJsonDependsOn);
+    </GeneratePublishWasmBootJsonDependsOn>
+  </PropertyGroup>
+
+  <Target Name="_WasmNativeForBuild" DependsOnTargets="_GatherWasmFilesToBuild;WasmBuildApp" Condition="'$(UsingBrowserRuntimeWorkload)' == 'true'" />
+
+  <Target Name="_GatherWasmFilesToBuild">
+    <ItemGroup>
+      <WasmAssembliesToBundle Remove="@(WasmAssembliesToBundle)" />
+      <WasmAssembliesToBundle Include="@(IntermediateAssembly)" />
+      <WasmAssembliesToBundle Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Extension)' == '.dll'" />
+    </ItemGroup>
+  </Target>
+  
+  <Target Name="_ResolveGlobalizationConfiguration">
+    <Error Condition="'$(BlazorIcuDataFileName)' != '' AND !$([System.IO.Path]::GetFileName('$(BlazorIcuDataFileName)').StartsWith('icudt'))" Text="File name in %24(BlazorIcuDataFileName) has to start with 'icudt'." />
+    <Warning Condition="'$(InvariantGlobalization)' == 'true' AND '$(BlazorWebAssemblyLoadAllGlobalizationData)' == 'true'" Text="%24(BlazorWebAssemblyLoadAllGlobalizationData) has no effect when %24(InvariantGlobalization) is set to true." />
+    <Warning Condition="'$(InvariantGlobalization)' == 'true' AND '$(BlazorIcuDataFileName)' != ''" Text="%24(BlazorIcuDataFileName) has no effect when %24(InvariantGlobalization) is set to true." />
+    <Warning Condition="'$(BlazorWebAssemblyLoadAllGlobalizationData)' == 'true' AND '$(BlazorIcuDataFileName)' != ''" Text="%24(BlazorIcuDataFileName) has no effect when %24(BlazorWebAssemblyLoadAllGlobalizationData) is set to true." />
+    <PropertyGroup>
+      <_BlazorWebAssemblyLoadAllGlobalizationData Condition="'$(InvariantGlobalization)' != 'true'">$(BlazorWebAssemblyLoadAllGlobalizationData)</_BlazorWebAssemblyLoadAllGlobalizationData>
+      <_BlazorWebAssemblyLoadAllGlobalizationData Condition="'$(_BlazorWebAssemblyLoadAllGlobalizationData)' == ''">false</_BlazorWebAssemblyLoadAllGlobalizationData>
+      <_BlazorIcuDataFileName Condition="'$(InvariantGlobalization)' != 'true' AND '$(BlazorWebAssemblyLoadAllGlobalizationData)' != 'true'">$(BlazorIcuDataFileName)</_BlazorIcuDataFileName>
+      <_LoadCustomIcuData>false</_LoadCustomIcuData>
+      <_LoadCustomIcuData Condition="'$(_BlazorIcuDataFileName)' != ''">true</_LoadCustomIcuData>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="_ResolveWasmConfiguration" DependsOnTargets="_ResolveGlobalizationConfiguration">
+    <PropertyGroup>
+      <_BlazorEnableTimeZoneSupport>$(BlazorEnableTimeZoneSupport)</_BlazorEnableTimeZoneSupport>
+      <_BlazorEnableTimeZoneSupport Condition="'$(_BlazorEnableTimeZoneSupport)' == ''">true</_BlazorEnableTimeZoneSupport>
+      <_WasmInvariantGlobalization>$(InvariantGlobalization)</_WasmInvariantGlobalization>
+      <_WasmInvariantGlobalization Condition="'$(_WasmInvariantGlobalization)' == ''">true</_WasmInvariantGlobalization>
+      <_WasmCopyOutputSymbolsToOutputDirectory>$(CopyOutputSymbolsToOutputDirectory)</_WasmCopyOutputSymbolsToOutputDirectory>
+      <_WasmCopyOutputSymbolsToOutputDirectory Condition="'$(_WasmCopyOutputSymbolsToOutputDirectory)'==''">true</_WasmCopyOutputSymbolsToOutputDirectory>
+      <_BlazorWebAssemblyStartupMemoryCache>$(BlazorWebAssemblyStartupMemoryCache)</_BlazorWebAssemblyStartupMemoryCache>
+      <_BlazorWebAssemblyJiterpreter>$(BlazorWebAssemblyJiterpreter)</_BlazorWebAssemblyJiterpreter>
+      <_BlazorWebAssemblyRuntimeOptions>$(BlazorWebAssemblyRuntimeOptions)</_BlazorWebAssemblyRuntimeOptions>
+
+      <!-- Workaround for https://github.com/dotnet/sdk/issues/12114-->
+      <PublishDir Condition="'$(AppendRuntimeIdentifierToOutputPath)' != 'true' AND '$(PublishDir)' == '$(OutputPath)$(RuntimeIdentifier)\$(PublishDirName)\'">$(OutputPath)$(PublishDirName)\</PublishDir>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="ResolveWasmOutputs" DependsOnTargets="_ResolveWasmOutputs" />
+
+  <Target Name="_ResolveWasmOutputs" DependsOnTargets="ResolveReferences;PrepareResourceNames;ComputeIntermediateSatelliteAssemblies;_ResolveWasmConfiguration;_WasmNativeForBuild">
+    <ItemGroup>
+      <_WasmConfigFileCandidates Include="@(StaticWebAsset)" Condition="'%(SourceType)' == 'Discovered'" />
+
+      <!-- Remove dotnet.js/wasm from runtime pack, in favor of the relinked ones in @(WasmNativeAsset) -->
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"
+                               Condition="@(WasmNativeAsset->Count()) > 0 and '%(FileName)' == 'dotnet' and ('%(Extension)' == '.wasm' or '%(Extension)' == '.js')" />
+    </ItemGroup>
+
+    <ComputeWasmBuildAssets
+      Candidates="@(ReferenceCopyLocalPaths->Distinct());@(WasmNativeAsset)"
+      CustomIcuCandidate="$(_BlazorIcuDataFileName)"
+      ProjectAssembly="@(IntermediateAssembly)"
+      ProjectDebugSymbols="@(_DebugSymbolsIntermediatePath)"
+      SatelliteAssemblies="@(ReferenceSatellitePaths)"
+      ProjectSatelliteAssemblies="@(IntermediateSatelliteAssembliesWithTargetPath)"
+      TimeZoneSupport="$(_BlazorEnableTimeZoneSupport)"
+      InvariantGlobalization="$(_WasmInvariantGlobalization)"
+      CopySymbols="$(_WasmCopyOutputSymbolsToOutputDirectory)"
+      OutputPath="$(OutputPath)"
+      FingerprintDotNetJs="$(WasmFingerprintDotnetJs)"
+    >
+      <Output TaskParameter="AssetCandidates" ItemName="_BuildAssetsCandidates" />
+      <Output TaskParameter="FilesToRemove" ItemName="_WasmBuildFilesToRemove" />
+    </ComputeWasmBuildAssets>
+
+    <DefineStaticWebAssets
+      CandidateAssets="@(_BuildAssetsCandidates)"
+      SourceId="$(PackageId)"
+      SourceType="Computed"
+      AssetKind="Build"
+      AssetRole="Primary"
+      CopyToOutputDirectory="PreserveNewest"
+      CopyToPublishDirectory="Never"
+      ContentRoot="$(OutputPath)wwwroot"
+      BasePath="$(StaticWebAssetBasePath)"
+    >
+      <Output TaskParameter="Assets" ItemName="WasmStaticWebAsset" />
+    </DefineStaticWebAssets>
+
+    <DefineStaticWebAssets
+      CandidateAssets="@(_WasmConfigFileCandidates)"
+      AssetTraitName="WasmResource"
+      AssetTraitValue="settings"
+      RelativePathFilter="appsettings*.json"
+    >
+      <Output TaskParameter="Assets" ItemName="_WasmJsConfigStaticWebAsset" />
+    </DefineStaticWebAssets>
+
+    <ItemGroup>
+      <!-- Update the boot config static web asset since we've given it a trait -->
+      <StaticWebAsset Remove="@(_WasmJsConfigStaticWebAsset)" />
+      <StaticWebAsset Include="@(_WasmJsConfigStaticWebAsset)" />
+
+      <ReferenceCopyLocalPaths Remove="@(_WasmBuildFilesToRemove)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_WasmBuildBootJsonPath>$(IntermediateOutputPath)blazor.boot.json</_WasmBuildBootJsonPath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_BuildWasmBootJson
+        Include="$(_WasmBuildBootJsonPath)"
+        RelativePath="_framework/blazor.boot.json" />
+    </ItemGroup>
+
+    <DefineStaticWebAssets
+      CandidateAssets="@(_BuildWasmBootJson)"
+      SourceId="$(PackageId)"
+      SourceType="Computed"
+      AssetKind="Build"
+      AssetRole="Primary"
+      AssetTraitName="WasmResource"
+      AssetTraitValue="manifest"
+      CopyToOutputDirectory="PreserveNewest"
+      CopyToPublishDirectory="Never"
+      ContentRoot="$(OutDir)wwwroot"
+      BasePath="$(StaticWebAssetBasePath)"
+    >
+      <Output TaskParameter="Assets" ItemName="_BuildWasmBootJsonStaticWebAsset" />
+    </DefineStaticWebAssets>
+  </Target>
+
+  <Target Name="_AddWasmStaticWebAssets" DependsOnTargets="$(AddWasmStaticWebAssetsDependsOn)">
+    <ItemGroup>
+      <StaticWebAsset Include="@(WasmStaticWebAsset)" />
+      <StaticWebAsset Include="@(_BuildWasmBootJsonStaticWebAsset)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_GenerateBuildWasmBootJson" DependsOnTargets="$(GenerateBuildWasmBootJsonDependsOn)">
+    <PropertyGroup>
+      <_WasmBuildBootJsonPath>$(IntermediateOutputPath)blazor.boot.json</_WasmBuildBootJsonPath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_WasmJsModuleCandidatesForBuild
+        Include="@(StaticWebAsset)"
+        Condition="'%(StaticWebAsset.AssetTraitName)' == 'JSModule' and '%(StaticWebAsset.AssetTraitValue)' == 'JSLibraryModule' and '%(AssetKind)' != 'Publish'" />
+    </ItemGroup>
+
+    <GetFileHash Files="@(WasmStaticWebAsset->'%(OriginalItemSpec)')" Algorithm="SHA256" HashEncoding="base64">
+      <Output TaskParameter="Items" ItemName="_WasmOutputWithHash" />
+    </GetFileHash>
+
+    <ComputeStaticWebAssetsTargetPaths
+      Assets="@(_WasmJsModuleCandidatesForBuild)"
+      PathPrefix=""
+      UseAlternatePathDirectorySeparator="true"
+    >
+      <Output TaskParameter="AssetsWithTargetPath" ItemName="_WasmJsModuleCandidatesForBuildWithTargetPath" />
+    </ComputeStaticWebAssetsTargetPaths>
+
+    <GetFileHash Files="@(_WasmJsModuleCandidatesForBuildWithTargetPath)" Algorithm="SHA256" HashEncoding="base64">
+      <Output TaskParameter="Items" ItemName="_WasmOutputWithHash" />
+    </GetFileHash>
+
+
+
+    <GenerateWasmBootJson
+      AssemblyPath="@(IntermediateAssembly)"
+      Resources="@(_WasmOutputWithHash)"
+      DebugBuild="true"
+      LinkerEnabled="false"
+      CacheBootResources="$(BlazorCacheBootResources)"
+      OutputPath="$(_WasmBuildBootJsonPath)"
+      ConfigurationFiles="@(_WasmJsConfigStaticWebAsset)"
+      LazyLoadedAssemblies="@(BlazorWebAssemblyLazyLoad)"
+      InvariantGlobalization="$(InvariantGlobalization)"
+      LoadCustomIcuData="$(_LoadCustomIcuData)"
+      LoadAllICUData="$(_BlazorWebAssemblyLoadAllGlobalizationData)"
+      StartupMemoryCache="$(_BlazorWebAssemblyStartupMemoryCache)"
+      Jiterpreter="$(_BlazorWebAssemblyJiterpreter)"
+      RuntimeOptions="$(_BlazorWebAssemblyRuntimeOptions)"
+      Extensions="@(WasmBootConfigExtension)" />
+
+    <ItemGroup>
+      <FileWrites Include="$(_WasmBuildBootJsonPath)" />
+    </ItemGroup>
+  </Target>
+
+  <!-- Publish starts here -->
+
+  <!-- Make sure that ResolveAssemblyReferences runs early enough to ensure satellite assemblies are populated in the ResolvedFilesToPublish -->
+  <Target Name="_WasmPrepareForPublish"
+    DependsOnTargets="PrepareResourceNames;ComputeIntermediateSatelliteAssemblies;ResolveAssemblyReferences"
+    BeforeTargets="PrepareForPublish" />
+
+  <!-- Wasm's Nested publish is run just to build the native bits. We don't need to run blazor targets for that -->
+  <Target Name="ProcessPublishFilesForWasm" DependsOnTargets="_ResolveWasmConfiguration;LoadStaticWebAssetsBuildManifest" AfterTargets="ILLink" Condition="'$(WasmBuildingForNestedPublish)' != 'true'">
+    <!-- The list of static web assets already contains all the assets from the build. We want to correct certain assets that might
+         have changed as part of the publish process. We are going to do so as follows:
+         * We will update Blazor runtime asset dlls if we are running PublishTrimmed
+         * We will update Blazor native runtime resources if we are using Aot
+         Other than that, we'll filter the unwanted assets from the list of resolved files to publish in the same way we did during the build.
+    -->
+
+    <ItemGroup>
+      <_WasmPublishPrefilteredAssets
+        Include="@(StaticWebAsset)"
+        Condition="'%(StaticWebAsset.AssetTraitName)' == 'WasmResource' or '%(StaticWebAsset.AssetTraitName)' == 'Culture' or '%(AssetRole)' == 'Alternative'" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <_DotNetJsItem Include="@(ResolvedFileToPublish)" Condition="'%(ResolvedFileToPublish.DestinationSubPath)' == 'dotnet.js' AND '%(ResolvedFileToPublish.AssetType)' == 'native'" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_DotNetJsVersion>%(_DotNetJsItem.NuGetPackageVersion)</_DotNetJsVersion>
+    </PropertyGroup>
+
+    <ComputeWasmPublishAssets
+      ResolvedFilesToPublish="@(ResolvedFileToPublish)"
+      CustomIcuCandidate="$(_BlazorIcuDataFileName)"
+      TimeZoneSupport="$(_BlazorEnableTimeZoneSupport)"
+      PublishPath="$(PublishDir)"
+      WasmAotAssets="@(WasmNativeAsset)"
+      InvariantGlobalization="$(_WasmInvariantGlobalization)"
+      CopySymbols="$(CopyOutputSymbolsToPublishDirectory)"
+      ExistingAssets="@(_WasmPublishPrefilteredAssets)"
+      DotNetJsVersion="$(_DotNetJsVersion)"
+      FingerprintDotNetJs="$(WasmFingerprintDotnetJs)"
+    >
+      <Output TaskParameter="NewCandidates" ItemName="_NewWasmPublishStaticWebAssets" />
+      <Output TaskParameter="FilesToRemove" ItemName="_PublishResolvedFilesToRemove" />
+    </ComputeWasmPublishAssets>
+
+    <ItemGroup>
+      <ResolvedFileToPublish Remove="@(_PublishResolvedFilesToRemove)" />
+      <StaticWebAsset Include="@(_NewWasmPublishStaticWebAssets)" />
+
+      <!-- TODO: Probably doesn't do anything as of now, original https://github.com/dotnet/aspnetcore/pull/34798 -->
+      <PublishBlazorBootStaticWebAsset 
+        Include="@(StaticWebAsset)"
+        Condition="'%(AssetKind)' != 'Build' and 
+                    (('%(StaticWebAsset.AssetTraitName)' == 'WasmResource' and '%(StaticWebAsset.AssetTraitValue)' != 'manifest' and '%(StaticWebAsset.AssetTraitValue)' != 'boot') or
+                    '%(StaticWebAsset.AssetTraitName)' == 'Culture')" />
+    </ItemGroup>
+  </Target>
+
+  <Target 
+    Name="ComputeWasmExtensions"
+    AfterTargets="ProcessPublishFilesForWasm"
+    DependsOnTargets="$(ComputeBlazorExtensionsDependsOn)" >
+    <ItemGroup>
+      <_BlazorExtensionsCandidate Include="@(BlazorPublishExtension->'%(FullPath)')">
+        <SourceId>$(PackageId)</SourceId>
+        <SourceType>Computed</SourceType>
+        <ContentRoot>$(PublishDir)wwwroot</ContentRoot>
+        <BasePath>$(StaticWebAssetBasePath)</BasePath>
+        <RelativePath>%(BlazorPublishExtension.RelativePath)</RelativePath>
+        <AssetKind>Publish</AssetKind>
+        <AssetMode>All</AssetMode>
+        <AssetRole>Primary</AssetRole>
+        <AssetTraitName>WasmResource</AssetTraitName>
+        <AssetTraitValue>extension:%(BlazorPublishExtension.ExtensionName)</AssetTraitValue>
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+        <OriginalItemSpec>%(BlazorPublishExtension.Identity)</OriginalItemSpec>
+      </_BlazorExtensionsCandidate>
+    </ItemGroup>
+
+    <DefineStaticWebAssets CandidateAssets="@(_BlazorExtensionsCandidate)">
+      <Output TaskParameter="Assets" ItemName="StaticWebAsset" />
+      <Output TaskParameter="Assets" ItemName="_BlazorExtensionsCandidatesForPublish" />
+    </DefineStaticWebAssets>
+  </Target>
+
+  <Target Name="_AddWasmWebConfigFile" AfterTargets="ILLink">
+    <ItemGroup Condition="'@(ResolvedFileToPublish->AnyHaveMetadataValue('RelativePath', 'web.config'))' != 'true'">
+      <ResolvedFileToPublish
+         Include="$(MSBuildThisFileDirectory)Wasm.web.config"
+         ExcludeFromSingleFile="true"
+         CopyToPublishDirectory="PreserveNewest"
+         RelativePath="web.config" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_AddPublishWasmBootJsonToStaticWebAssets">
+    <ItemGroup>
+      <_PublishWasmBootJson
+        Include="$(IntermediateOutputPath)blazor.publish.boot.json"
+        RelativePath="_framework/blazor.boot.json" />
+    </ItemGroup>
+
+    <DefineStaticWebAssets
+      CandidateAssets="@(_PublishWasmBootJson)"
+      SourceId="$(PackageId)"
+      SourceType="Computed"
+      AssetKind="Publish"
+      AssetRole="Primary"
+      AssetTraitName="WasmResource"
+      AssetTraitValue="manifest"
+      CopyToOutputDirectory="Never"
+      CopyToPublishDirectory="PreserveNewest"
+      ContentRoot="$(PublishDir)wwwroot"
+      BasePath="$(StaticWebAssetBasePath)"
+    >
+      <Output TaskParameter="Assets" ItemName="StaticWebAsset" />
+    </DefineStaticWebAssets>
+  </Target>
+
+  <Target Name="GeneratePublishWasmBootJson" DependsOnTargets="$(GeneratePublishWasmBootJsonDependsOn)">
+
+    <ItemGroup>
+      <_WasmPublishAsset
+        Include="@(StaticWebAsset)"
+        Condition="'%(AssetKind)' != 'Build' and '%(StaticWebAsset.AssetTraitValue)' != 'manifest' and ('%(StaticWebAsset.AssetTraitName)' == 'WasmResource' or '%(StaticWebAsset.AssetTraitName)' == 'Culture') and '%(StaticWebAsset.AssetTraitValue)' != 'boot'" />
+
+      <_WasmPublishConfigFile
+        Include="@(StaticWebAsset)"
+        Condition="'%(StaticWebAsset.AssetTraitName)' == 'WasmResource' and '%(StaticWebAsset.AssetTraitValue)' == 'settings'"/>
+
+      <_WasmJsModuleCandidatesForPublish
+        Include="@(StaticWebAsset)"
+        Condition="'%(StaticWebAsset.AssetTraitName)' == 'JSModule' and '%(StaticWebAsset.AssetTraitValue)' == 'JSLibraryModule' and '%(AssetKind)' != 'Build'" />
+
+      <!-- We remove the extensions since they are added to the list of static web assets but we need to compute the target path for them -->
+      <_WasmPublishAsset Remove="@(_BlazorExtensionsCandidatesForPublish)" />
+
+    </ItemGroup>
+
+    <ComputeStaticWebAssetsTargetPaths
+      Assets="@(_WasmJsModuleCandidatesForPublish);@(_BlazorExtensionsCandidatesForPublish)"
+      PathPrefix=""
+      UseAlternatePathDirectorySeparator="true"
+    >
+      <Output TaskParameter="AssetsWithTargetPath" ItemName="_WasmCandidatesForPublishWithTargetPath" />
+    </ComputeStaticWebAssetsTargetPaths>
+
+    <GetFileHash Files="@(_WasmPublishAsset);@(_WasmCandidatesForPublishWithTargetPath)" Algorithm="SHA256" HashEncoding="base64">
+      <Output TaskParameter="Items" ItemName="_WasmPublishBootResourceWithHash" />
+    </GetFileHash>
+
+    <GenerateWasmBootJson
+      AssemblyPath="@(IntermediateAssembly)"
+      Resources="@(_WasmPublishBootResourceWithHash)"
+      DebugBuild="false"
+      LinkerEnabled="$(PublishTrimmed)"
+      CacheBootResources="$(BlazorCacheBootResources)"
+      OutputPath="$(IntermediateOutputPath)blazor.publish.boot.json"
+      ConfigurationFiles="@(_WasmPublishConfigFile)"
+      LazyLoadedAssemblies="@(BlazorWebAssemblyLazyLoad)"
+      InvariantGlobalization="$(InvariantGlobalization)"
+      LoadCustomIcuData="$(_LoadCustomIcuData)"
+      LoadAllICUData="$(_BlazorWebAssemblyLoadAllGlobalizationData)"
+      StartupMemoryCache="$(_BlazorWebAssemblyStartupMemoryCache)"
+      Jiterpreter="$(_BlazorWebAssemblyJiterpreter)"
+      RuntimeOptions="$(_BlazorWebAssemblyRuntimeOptions)"
+      Extensions="@(WasmBootConfigExtension)" />
+
+    <ItemGroup>
+      <FileWrites Include="$(IntermediateOutputPath)blazor.publish.boot.json" />
+    </ItemGroup>
+
+  </Target>
+
+  <Target Name="_WasmNative"
+      DependsOnTargets="_EnsureWasmRuntimeWorkload;WasmTriggerPublishApp"
+      BeforeTargets="ProcessPublishFilesForWasm"
+      Condition="'$(UsingBrowserRuntimeWorkload)' == 'true'" />
+
+  <Target Name="_EnsureWasmRuntimeWorkload" Condition="'$(UsingBlazorAOTWorkloadManifest)' != 'true'">
+    <Error
+      Text="Publishing with AOT enabled requires the .NET WebAssembly AOT workload to be installed. To learn more, visit https://aka.ms/AAb4uzl."
+      Code="BLAZORSDK1002" />
+  </Target>
+
+  <Target Name="_GatherWasmFilesToPublish">
+    <ItemGroup>
+      <WasmAssembliesToBundle Remove="@(WasmAssembliesToBundle)" />
+      <WasmAssembliesToBundle Include="%(ResolvedFileToPublish.FullPath)" Exclude="@(_Exclude)" Condition="%(Extension) == '.dll'" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Pack.props
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Pack.props
@@ -1,0 +1,20 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.Sdk.WebAssembly.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0">
+  <PropertyGroup>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">browser-wasm</RuntimeIdentifier>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'browser-wasm'">
+    <_WebAssemblyPropsFile>$(MSBuildThisFileDirectory)\Microsoft.NET.Sdk.WebAssembly.Browser.props</_WebAssemblyPropsFile>
+    <_WebAssemblyTargetsFile>$(MSBuildThisFileDirectory)\Microsoft.NET.Sdk.WebAssembly.Browser.targets</_WebAssemblyTargetsFile>
+  </PropertyGroup>
+</Project>

--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Pack.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Pack.targets
@@ -1,0 +1,12 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.Sdk.WebAssembly.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0"></Project>

--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Wasm.web.config
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Wasm.web.config
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <system.webServer>
+    <staticContent>
+      <remove fileExtension=".blat" />
+      <remove fileExtension=".dat" />
+      <remove fileExtension=".dll" />
+      <remove fileExtension=".webcil" />
+      <remove fileExtension=".json" />
+      <remove fileExtension=".wasm" />
+      <remove fileExtension=".woff" />
+      <remove fileExtension=".woff2" />
+      <mimeMap fileExtension=".blat" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".dll" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".webcil" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".dat" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".json" mimeType="application/json" />
+      <mimeMap fileExtension=".wasm" mimeType="application/wasm" />
+      <mimeMap fileExtension=".woff" mimeType="application/font-woff" />
+      <mimeMap fileExtension=".woff2" mimeType="application/font-woff" />
+    </staticContent>
+    <httpCompression>
+      <dynamicTypes>
+        <add mimeType="application/octet-stream" enabled="true" />
+        <add mimeType="application/wasm" enabled="true" />
+      </dynamicTypes>
+    </httpCompression>
+    <rewrite>
+      <rules>
+        <rule name="Serve subdir">
+          <match url=".*" />
+          <action type="Rewrite" url="wwwroot\{R:0}" />
+        </rule>
+        <rule name="SPA fallback routing" stopProcessing="true">
+          <match url=".*" />
+          <conditions logicalGrouping="MatchAll">
+            <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+          </conditions>
+          <action type="Rewrite" url="wwwroot\" />
+        </rule>
+      </rules>
+    </rewrite>
+  </system.webServer>
+</configuration>

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.targets.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.targets.in
@@ -20,6 +20,8 @@
     <_BrowserWorkloadNotSupportedForTFM Condition="$([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '6.0'))">true</_BrowserWorkloadNotSupportedForTFM>
     <_BrowserWorkloadDisabled>$(_BrowserWorkloadNotSupportedForTFM)</_BrowserWorkloadDisabled>
 
+    <_UsingBlazorOrWasmSdk Condition="'$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' or '$(UsingMicrosoftNETSdkWebAssembly)' == 'true'">true</_UsingBlazorOrWasmSdk>
+
     <!-- Is the workload for the target framework available -->
     <!--<WasmNativeWorkloadAvailable />-->
     <!--<WasmNativeWorkloadAvailable Condition="'$(TargetsNet8)' == 'true' and $(WasmNativeWorkloadAvailableList.Contains('+net8.0+'))">true</WasmNativeWorkloadAvailable>-->
@@ -39,7 +41,7 @@
     <!-- $(WasmBuildNative)==true is needed to enable workloads, when using native references, without AOT -->
     <!-- FIXME: is the blazor condition here correct? -->
     <_WasmNativeWorkloadNeeded Condition="'$(RunAOTCompilation)' == 'true' or '$(WasmEnableSIMD)' == 'true' or '$(WasmBuildNative)' == 'true' or
-      '$(WasmGenerateAppBundle)' == 'true' or '$(UsingMicrosoftNETSdkBlazorWebAssembly)' != 'true'" >true</_WasmNativeWorkloadNeeded>
+      '$(WasmGenerateAppBundle)' == 'true' or '$(_UsingBlazorOrWasmSdk)' != 'true'" >true</_WasmNativeWorkloadNeeded>
 
     <UsingBrowserRuntimeWorkload Condition="'$(_BrowserWorkloadNotSupportedForTFM)' == 'true'">false</UsingBrowserRuntimeWorkload>
     <UsingBrowserRuntimeWorkload Condition="'$(UsingBrowserRuntimeWorkload)' == '' and '$(_WasmNativeWorkloadNeeded)' == 'true'">true</UsingBrowserRuntimeWorkload>
@@ -59,7 +61,7 @@
     <UsingMobileWorkload>true</UsingMobileWorkload>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' and '$(UsingBrowserRuntimeWorkload)' == 'true'">
+  <PropertyGroup Condition="'$(_UsingBlazorOrWasmSdk)' == 'true' and '$(UsingBrowserRuntimeWorkload)' == 'true'">
     <WasmGenerateAppBundle>false</WasmGenerateAppBundle>
     <UsingBlazorAOTWorkloadManifest>true</UsingBlazorAOTWorkloadManifest>
   </PropertyGroup>

--- a/src/mono/nuget/mono-packages.proj
+++ b/src/mono/nuget/mono-packages.proj
@@ -8,6 +8,7 @@
     <ProjectReference Include="Microsoft.NETCore.BrowserDebugHost.Transport\Microsoft.NETCore.BrowserDebugHost.Transport.pkgproj" />
     <ProjectReference Include="Microsoft.NET.Runtime.WebAssembly.Sdk\Microsoft.NET.Runtime.WebAssembly.Sdk.pkgproj" />
     <ProjectReference Include="..\wasm\templates\Microsoft.NET.Runtime.WebAssembly.Templates.csproj" />
+    <ProjectReference Include="Microsoft.NET.Sdk.WebAssembly.Pack\Microsoft.NET.Sdk.WebAssembly.Pack.pkgproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetsWasi)' == 'true'">

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/AssetsComputingHelper.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/AssetsComputingHelper.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.NET.Sdk.WebAssembly;
+
+public class AssetsComputingHelper
+{
+    public static bool ShouldFilterCandidate(
+        ITaskItem candidate,
+        bool timezoneSupport,
+        bool invariantGlobalization,
+        bool copySymbols,
+        string customIcuCandidateFilename,
+        out string reason)
+    {
+        var extension = candidate.GetMetadata("Extension");
+        var fileName = candidate.GetMetadata("FileName");
+        var assetType = candidate.GetMetadata("AssetType");
+        var fromMonoPackage = string.Equals(
+            candidate.GetMetadata("NuGetPackageId"),
+            "Microsoft.NETCore.App.Runtime.Mono.browser-wasm",
+            StringComparison.Ordinal);
+
+        reason = extension switch
+        {
+            ".a" when fromMonoPackage => "extension is .a is not supported.",
+            ".c" when fromMonoPackage => "extension is .c is not supported.",
+            ".h" when fromMonoPackage => "extension is .h is not supported.",
+            // It is safe to filter out all XML files since we are not interested in any XML file from the list
+            // of ResolvedFilesToPublish to become a static web asset. Things like this include XML doc files and
+            // so on.
+            ".xml" => "it is a documentation file",
+            ".rsp" when fromMonoPackage => "extension is .rsp is not supported.",
+            ".props" when fromMonoPackage => "extension is .props is not supported.",
+            ".blat" when !timezoneSupport => "timezone support is not enabled.",
+            ".dat" when invariantGlobalization && fileName.StartsWith("icudt") => "invariant globalization is enabled",
+            ".dat" when !string.IsNullOrEmpty(customIcuCandidateFilename) && fileName != customIcuCandidateFilename => "custom icu file will be used instead of icu from the runtime pack",
+            ".json" when fromMonoPackage && (fileName == "emcc-props" || fileName == "package") => $"{fileName}{extension} is not used by Blazor",
+            ".ts" when fromMonoPackage && fileName == "dotnet.d" => "dotnet type definition is not used by Blazor",
+            ".ts" when fromMonoPackage && fileName == "dotnet-legacy.d" => "dotnet type definition is not used by Blazor",
+            ".js" when assetType == "native" && fileName != "dotnet" => $"{fileName}{extension} is not used by Blazor",
+            ".pdb" when !copySymbols => "copying symbols is disabled",
+            ".symbols" when fromMonoPackage => "extension .symbols is not required.",
+            _ => null
+        };
+
+        return reason != null;
+    }
+
+    public static string GetCandidateRelativePath(ITaskItem candidate)
+    {
+        var destinationSubPath = candidate.GetMetadata("DestinationSubPath");
+        if (!string.IsNullOrEmpty(destinationSubPath))
+            return $"_framework/{destinationSubPath}";
+
+        var relativePath = candidate.GetMetadata("FileName") + candidate.GetMetadata("Extension");
+        return $"_framework/{relativePath}";
+    }
+
+    public static ITaskItem GetCustomIcuAsset(ITaskItem candidate)
+    {
+        var customIcuCandidate = new TaskItem(candidate);
+        var relativePath = GetCandidateRelativePath(customIcuCandidate);
+        customIcuCandidate.SetMetadata("RelativePath", relativePath);
+        customIcuCandidate.SetMetadata("AssetTraitName", "BlazorWebAssemblyResource");
+        customIcuCandidate.SetMetadata("AssetTraitValue", "native");
+        customIcuCandidate.SetMetadata("AssetType", "native");
+        return customIcuCandidate;
+    }
+
+    public static bool TryGetAssetFilename(ITaskItem candidate, out string filename)
+    {
+        bool candidateIsValid = candidate != null && !string.IsNullOrEmpty(candidate.ItemSpec);
+        filename = candidateIsValid ?
+            $"{candidate.GetMetadata("FileName")}" :
+            "";
+        return candidateIsValid;
+    }
+}

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonData.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonData.cs
@@ -1,0 +1,157 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using ResourceHashesByNameDictionary = System.Collections.Generic.Dictionary<string, string>;
+
+namespace Microsoft.NET.Sdk.WebAssembly;
+
+/// <summary>
+/// Defines the structure of a Blazor boot JSON file
+/// </summary>
+public class BootJsonData
+{
+    /// <summary>
+    /// Gets the name of the assembly with the application entry point
+    /// </summary>
+    public string entryAssembly { get; set; }
+
+    /// <summary>
+    /// Gets the set of resources needed to boot the application. This includes the transitive
+    /// closure of .NET assemblies (including the entrypoint assembly), the dotnet.wasm file,
+    /// and any PDBs to be loaded.
+    ///
+    /// Within <see cref="ResourceHashesByNameDictionary"/>, dictionary keys are resource names,
+    /// and values are SHA-256 hashes formatted in prefixed base-64 style (e.g., 'sha256-abcdefg...')
+    /// as used for subresource integrity checking.
+    /// </summary>
+    public ResourcesData resources { get; set; } = new ResourcesData();
+
+    /// <summary>
+    /// Gets a value that determines whether to enable caching of the <see cref="resources"/>
+    /// inside a CacheStorage instance within the browser.
+    /// </summary>
+    public bool cacheBootResources { get; set; }
+
+    /// <summary>
+    /// Gets a value that determines if this is a debug build.
+    /// </summary>
+    public bool debugBuild { get; set; }
+
+    /// <summary>
+    /// Gets a value that determines if the linker is enabled.
+    /// </summary>
+    public bool linkerEnabled { get; set; }
+
+    /// <summary>
+    /// Config files for the application
+    /// </summary>
+    public List<string> config { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="ICUDataMode"/> that determines how icu files are loaded.
+    /// </summary>
+    public ICUDataMode icuDataMode { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value that determines if the caching startup memory is enabled.
+    /// </summary>
+    public bool? startupMemoryCache { get; set; }
+
+    /// <summary>
+    /// Gets a value for mono runtime options.
+    /// </summary>
+    public string[] runtimeOptions { get; set; }
+
+    /// <summary>
+    /// Gets or sets configuration extensions.
+    /// </summary>
+    public Dictionary<string, Dictionary<string, object>> extensions { get; set; }
+}
+
+public class ResourcesData
+{
+    /// <summary>
+    /// .NET Wasm runtime resources (dotnet.wasm, dotnet.js) etc.
+    /// </summary>
+    public ResourceHashesByNameDictionary runtime { get; set; } = new ResourceHashesByNameDictionary();
+
+    /// <summary>
+    /// "assembly" (.dll) resources
+    /// </summary>
+    public ResourceHashesByNameDictionary assembly { get; set; } = new ResourceHashesByNameDictionary();
+
+    /// <summary>
+    /// "debug" (.pdb) resources
+    /// </summary>
+    [DataMember(EmitDefaultValue = false)]
+    public ResourceHashesByNameDictionary pdb { get; set; }
+
+    /// <summary>
+    /// localization (.satellite resx) resources
+    /// </summary>
+    [DataMember(EmitDefaultValue = false)]
+    public Dictionary<string, ResourceHashesByNameDictionary> satelliteResources { get; set; }
+
+    /// <summary>
+    /// Assembly (.dll) resources that are loaded lazily during runtime
+    /// </summary>
+    [DataMember(EmitDefaultValue = false)]
+    public ResourceHashesByNameDictionary lazyAssembly { get; set; }
+
+    /// <summary>
+    /// JavaScript module initializers that Blazor will be in charge of loading.
+    /// </summary>
+    [DataMember(EmitDefaultValue = false)]
+    public ResourceHashesByNameDictionary libraryInitializers { get; set; }
+
+    /// <summary>
+    /// Extensions created by users customizing the initialization process. The format of the file(s)
+    /// is up to the user.
+    /// </summary>
+    [DataMember(EmitDefaultValue = false)]
+    public Dictionary<string, ResourceHashesByNameDictionary> extensions { get; set; }
+
+    /// <summary>
+    /// Additional assets that the runtime consumes as part of the boot process.
+    /// </summary>
+    [DataMember(EmitDefaultValue = false)]
+    public Dictionary<string, AdditionalAsset> runtimeAssets { get; set; }
+
+}
+
+public enum ICUDataMode : int
+{
+    // Note that the numeric values are serialized and used in JS code, so don't change them without also updating the JS code
+
+    /// <summary>
+    /// Load optimized icu data file based on the user's locale
+    /// </summary>
+    Sharded = 0,
+
+    /// <summary>
+    /// Use the combined icudt.dat file
+    /// </summary>
+    All = 1,
+
+    /// <summary>
+    /// Do not load any icu data files.
+    /// </summary>
+    Invariant = 2,
+
+    /// <summary>
+    /// Load custom icu file provided by the developer.
+    /// </summary>
+    Custom = 3,
+}
+
+[DataContract]
+public class AdditionalAsset
+{
+    [DataMember(Name = "hash")]
+    public string Hash { get; set; }
+
+    [DataMember(Name = "behavior")]
+    public string Behavior { get; set; }
+}

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ComputeWasmBuildAssets.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ComputeWasmBuildAssets.cs
@@ -1,0 +1,266 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.NET.Sdk.WebAssembly;
+
+namespace Microsoft.NET.Sdk.WebAssembly;
+
+// This task does the build work of processing the project inputs and producing a set of pseudo-static web assets.
+public class ComputeWasmBuildAssets : Task
+{
+    [Required]
+    public ITaskItem[] Candidates { get; set; }
+
+    public ITaskItem CustomIcuCandidate { get; set; }
+
+    [Required]
+    public ITaskItem[] ProjectAssembly { get; set; }
+
+    [Required]
+    public ITaskItem[] ProjectDebugSymbols { get; set; }
+
+    [Required]
+    public ITaskItem[] SatelliteAssemblies { get; set; }
+
+    [Required]
+    public ITaskItem[] ProjectSatelliteAssemblies { get; set; }
+
+    [Required]
+    public string OutputPath { get; set; }
+
+    [Required]
+    public bool TimeZoneSupport { get; set; }
+
+    [Required]
+    public bool InvariantGlobalization { get; set; }
+
+    [Required]
+    public bool CopySymbols { get; set; }
+
+    public bool FingerprintDotNetJs { get; set; }
+
+    [Output]
+    public ITaskItem[] AssetCandidates { get; set; }
+
+    [Output]
+    public ITaskItem[] FilesToRemove { get; set; }
+
+    public override bool Execute()
+    {
+        var filesToRemove = new List<ITaskItem>();
+        var assetCandidates = new List<ITaskItem>();
+
+        try
+        {
+            if (ProjectAssembly.Length != 1)
+            {
+                Log.LogError("Invalid number of project assemblies '{0}'", string.Join("," + Environment.NewLine, ProjectAssembly.Select(a => a.ItemSpec)));
+                return true;
+            }
+
+            if (ProjectDebugSymbols.Length > 1)
+            {
+                Log.LogError("Invalid number of symbol assemblies '{0}'", string.Join("," + Environment.NewLine, ProjectDebugSymbols.Select(a => a.ItemSpec)));
+                return true;
+            }
+
+            if (AssetsComputingHelper.TryGetAssetFilename(CustomIcuCandidate, out string customIcuCandidateFilename))
+            {
+                var customIcuCandidate = AssetsComputingHelper.GetCustomIcuAsset(CustomIcuCandidate);
+                assetCandidates.Add(customIcuCandidate);
+            }
+
+            for (int i = 0; i < Candidates.Length; i++)
+            {
+                var candidate = Candidates[i];
+                if (AssetsComputingHelper.ShouldFilterCandidate(candidate, TimeZoneSupport, InvariantGlobalization, CopySymbols, customIcuCandidateFilename, out var reason))
+                {
+                    Log.LogMessage(MessageImportance.Low, "Skipping asset '{0}' because '{1}'", candidate.ItemSpec, reason);
+                    filesToRemove.Add(candidate);
+                    continue;
+                }
+
+                var satelliteAssembly = SatelliteAssemblies.FirstOrDefault(s => s.ItemSpec == candidate.ItemSpec);
+                if (satelliteAssembly != null)
+                {
+                    var inferredCulture = satelliteAssembly.GetMetadata("DestinationSubDirectory").Trim('\\', '/');
+                    Log.LogMessage(MessageImportance.Low, "Found satellite assembly '{0}' asset for candidate '{1}' with inferred culture '{2}'", satelliteAssembly.ItemSpec, candidate.ItemSpec, inferredCulture);
+
+                    var assetCandidate = new TaskItem(satelliteAssembly);
+                    assetCandidate.SetMetadata("AssetKind", "Build");
+                    assetCandidate.SetMetadata("AssetRole", "Related");
+                    assetCandidate.SetMetadata("AssetTraitName", "Culture");
+                    assetCandidate.SetMetadata("AssetTraitValue", inferredCulture);
+                    assetCandidate.SetMetadata("RelativePath", $"_framework/{inferredCulture}/{satelliteAssembly.GetMetadata("FileName")}{satelliteAssembly.GetMetadata("Extension")}");
+                    assetCandidate.SetMetadata("RelatedAsset", Path.GetFullPath(Path.Combine(OutputPath, "wwwroot", "_framework", Path.GetFileName(assetCandidate.GetMetadata("ResolvedFrom")))));
+
+                    assetCandidates.Add(assetCandidate);
+                    continue;
+                }
+
+                if (candidate.GetMetadata("FileName") == "dotnet" && candidate.GetMetadata("Extension") == ".js")
+                {
+                    string newDotnetJSFileName = null;
+                    string newDotNetJSFullPath = null;
+                    if (FingerprintDotNetJs)
+                    {
+                        var itemHash = FileHasher.GetFileHash(candidate.ItemSpec);
+                        newDotnetJSFileName = $"dotnet.{candidate.GetMetadata("NuGetPackageVersion")}.{itemHash}.js";
+
+                        var originalFileFullPath = Path.GetFullPath(candidate.ItemSpec);
+                        var originalFileDirectory = Path.GetDirectoryName(originalFileFullPath);
+
+                        newDotNetJSFullPath = Path.Combine(originalFileDirectory, newDotnetJSFileName);
+                    }
+                    else
+                    {
+                        newDotNetJSFullPath = candidate.ItemSpec;
+                        newDotnetJSFileName = Path.GetFileName(newDotNetJSFullPath);
+                    }
+
+                    var newDotNetJs = new TaskItem(newDotNetJSFullPath, candidate.CloneCustomMetadata());
+                    newDotNetJs.SetMetadata("OriginalItemSpec", candidate.ItemSpec);
+
+                    var newRelativePath = $"_framework/{newDotnetJSFileName}";
+                    newDotNetJs.SetMetadata("RelativePath", newRelativePath);
+
+                    newDotNetJs.SetMetadata("AssetTraitName", "WasmResource");
+                    newDotNetJs.SetMetadata("AssetTraitValue", "native");
+
+                    assetCandidates.Add(newDotNetJs);
+                    continue;
+                }
+                else
+                {
+                    string relativePath = AssetsComputingHelper.GetCandidateRelativePath(candidate);
+                    candidate.SetMetadata("RelativePath", relativePath);
+                }
+
+                // Workaround for https://github.com/dotnet/aspnetcore/issues/37574.
+                // For items added as "Reference" in project references, the OriginalItemSpec is incorrect.
+                // Ignore it, and use the FullPath instead.
+                if (candidate.GetMetadata("ReferenceSourceTarget") == "ProjectReference")
+                {
+                    candidate.SetMetadata("OriginalItemSpec", candidate.ItemSpec);
+                }
+
+                var culture = candidate.GetMetadata("Culture");
+                if (!string.IsNullOrEmpty(culture))
+                {
+                    candidate.SetMetadata("AssetKind", "Build");
+                    candidate.SetMetadata("AssetRole", "Related");
+                    candidate.SetMetadata("AssetTraitName", "Culture");
+                    candidate.SetMetadata("AssetTraitValue", culture);
+                    var fileName = candidate.GetMetadata("FileName");
+                    var suffixIndex = fileName.Length - ".resources".Length;
+                    var relatedAssetPath = Path.GetFullPath(Path.Combine(
+                        OutputPath,
+                        "wwwroot",
+                        "_framework",
+                        fileName.Substring(0, suffixIndex) + ProjectAssembly[0].GetMetadata("Extension")));
+
+                    candidate.SetMetadata("RelatedAsset", relatedAssetPath);
+
+                    Log.LogMessage(MessageImportance.Low, "Found satellite assembly '{0}' asset for inferred candidate '{1}' with culture '{2}'", candidate.ItemSpec, relatedAssetPath, culture);
+                }
+
+                assetCandidates.Add(candidate);
+            }
+
+            var intermediateAssembly = new TaskItem(ProjectAssembly[0]);
+            intermediateAssembly.SetMetadata("RelativePath", $"_framework/{intermediateAssembly.GetMetadata("FileName")}{intermediateAssembly.GetMetadata("Extension")}");
+            assetCandidates.Add(intermediateAssembly);
+
+            if (ProjectDebugSymbols.Length > 0)
+            {
+                var debugSymbols = new TaskItem(ProjectDebugSymbols[0]);
+                debugSymbols.SetMetadata("RelativePath", $"_framework/{debugSymbols.GetMetadata("FileName")}{debugSymbols.GetMetadata("Extension")}");
+                assetCandidates.Add(debugSymbols);
+            }
+
+            for (int i = 0; i < ProjectSatelliteAssemblies.Length; i++)
+            {
+                var projectSatelliteAssembly = ProjectSatelliteAssemblies[i];
+                var candidateCulture = projectSatelliteAssembly.GetMetadata("Culture");
+                Log.LogMessage(
+                    "Found satellite assembly '{0}' asset for project '{1}' with culture '{2}'",
+                    projectSatelliteAssembly.ItemSpec,
+                    intermediateAssembly.ItemSpec,
+                    candidateCulture);
+
+                var assetCandidate = new TaskItem(Path.GetFullPath(projectSatelliteAssembly.ItemSpec), projectSatelliteAssembly.CloneCustomMetadata());
+                var projectAssemblyAssetPath = Path.GetFullPath(Path.Combine(
+                    OutputPath,
+                    "wwwroot",
+                    "_framework",
+                    ProjectAssembly[0].GetMetadata("FileName") + ProjectAssembly[0].GetMetadata("Extension")));
+
+                var normalizedPath = assetCandidate.GetMetadata("TargetPath").Replace('\\', '/');
+
+                assetCandidate.SetMetadata("AssetKind", "Build");
+                assetCandidate.SetMetadata("AssetRole", "Related");
+                assetCandidate.SetMetadata("AssetTraitName", "Culture");
+                assetCandidate.SetMetadata("AssetTraitValue", candidateCulture);
+                assetCandidate.SetMetadata("RelativePath", Path.Combine("_framework", normalizedPath));
+                assetCandidate.SetMetadata("RelatedAsset", projectAssemblyAssetPath);
+
+                assetCandidates.Add(assetCandidate);
+            }
+
+            for (var i = 0; i < assetCandidates.Count; i++)
+            {
+                var candidate = assetCandidates[i];
+                ApplyUniqueMetadataProperties(candidate);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.LogError(ex.ToString());
+            return false;
+        }
+
+        FilesToRemove = filesToRemove.ToArray();
+        AssetCandidates = assetCandidates.ToArray();
+
+        return !Log.HasLoggedErrors;
+    }
+
+    private static void ApplyUniqueMetadataProperties(ITaskItem candidate)
+    {
+        var extension = candidate.GetMetadata("Extension");
+        var filename = candidate.GetMetadata("FileName");
+        switch (extension)
+        {
+            case ".dll":
+                if (string.IsNullOrEmpty(candidate.GetMetadata("AssetTraitName")))
+                {
+                    candidate.SetMetadata("AssetTraitName", "WasmResource");
+                    candidate.SetMetadata("AssetTraitValue", "runtime");
+                }
+                if (string.Equals(candidate.GetMetadata("ResolvedFrom"), "{HintPathFromItem}", StringComparison.Ordinal))
+                {
+                    candidate.RemoveMetadata("OriginalItemSpec");
+                }
+                break;
+            case ".wasm":
+            case ".blat":
+            case ".dat" when filename.StartsWith("icudt"):
+                candidate.SetMetadata("AssetTraitName", "WasmResource");
+                candidate.SetMetadata("AssetTraitValue", "native");
+                break;
+            case ".pdb":
+                candidate.SetMetadata("AssetTraitName", "WasmResource");
+                candidate.SetMetadata("AssetTraitValue", "symbol");
+                candidate.RemoveMetadata("OriginalItemSpec");
+                break;
+            default:
+                break;
+        }
+    }
+}

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ComputeWasmPublishAssets.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ComputeWasmPublishAssets.cs
@@ -1,0 +1,628 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.NET.Sdk.WebAssembly;
+
+namespace Microsoft.NET.Sdk.WebAssembly;
+
+// This target computes the list of publish static web assets based on the changes that happen during publish and the list of build static
+// web assets.
+// In this target we need to do 2 things:
+// * Harmonize the list of dlls produced at build time with the list of resolved files to publish.
+//   * We iterate over the list of existing static web assets and do as follows:
+//     * If we find the assembly in the resolved files to publish and points to the original assembly (linker disabled or assembly not linked)
+//       we create a new "Publish" static web asset for the assembly.
+//     * If we find the assembly in the resolved files to publish and points to a new location, we assume this assembly has been updated (as part of linking)
+//       and we create a new "Publish" static web asset for the asembly pointing to the new location.
+//     * If we don't find the assembly on the resolved files to publish it has been linked out from the app, so we don't add any new static web asset and we
+//       also avoid adding any existing related static web asset (satellite assemblies and compressed versions).
+//   * We update static web assets for satellite assemblies and compressed assets accordingly.
+// * Look at the list of "native" assets and determine whether we need to create new publish assets for the current build assets or if we need to
+//   update the native assets because the app was ahead of time compiled.
+public class ComputeWasmPublishAssets : Task
+{
+    [Required]
+    public ITaskItem[] ResolvedFilesToPublish { get; set; }
+
+    public ITaskItem CustomIcuCandidate { get; set; }
+
+    [Required]
+    public ITaskItem[] WasmAotAssets { get; set; }
+
+    [Required]
+    public ITaskItem[] ExistingAssets { get; set; }
+
+    [Required]
+    public bool TimeZoneSupport { get; set; }
+
+    [Required]
+    public bool InvariantGlobalization { get; set; }
+
+    [Required]
+    public bool CopySymbols { get; set; }
+
+    [Required]
+    public string PublishPath { get; set; }
+
+    [Required]
+    public string DotNetJsVersion { get; set; }
+
+    public bool FingerprintDotNetJs { get; set; }
+
+    [Output]
+    public ITaskItem[] NewCandidates { get; set; }
+
+    [Output]
+    public ITaskItem[] FilesToRemove { get; set; }
+
+    public override bool Execute()
+    {
+        var filesToRemove = new List<ITaskItem>();
+        var newAssets = new List<ITaskItem>();
+
+        try
+        {
+            // We'll do a first pass over the resolved files to publish to figure out what files need to be removed
+            // as well as categorize resolved files into different groups.
+            var resolvedFilesToPublishToRemove = new Dictionary<string, ITaskItem>(StringComparer.Ordinal);
+
+            // These assemblies are keyed of the assembly name "computed" based on the relative path, which must be
+            // unique.
+            var resolvedAssembliesToPublish = new Dictionary<string, ITaskItem>(StringComparer.Ordinal);
+            var resolvedSymbolsToPublish = new Dictionary<string, ITaskItem>(StringComparer.Ordinal);
+            var satelliteAssemblyToPublish = new Dictionary<(string, string), ITaskItem>(EqualityComparer<(string, string)>.Default);
+            var resolvedNativeAssetToPublish = new Dictionary<string, ITaskItem>(StringComparer.Ordinal);
+            GroupResolvedFilesToPublish(
+                resolvedFilesToPublishToRemove,
+                resolvedAssembliesToPublish,
+                satelliteAssemblyToPublish,
+                resolvedSymbolsToPublish,
+                resolvedNativeAssetToPublish);
+
+            // Group candidate static web assets
+            var assemblyAssets = new Dictionary<string, ITaskItem>();
+            var symbolAssets = new Dictionary<string, ITaskItem>();
+            var nativeAssets = new Dictionary<string, ITaskItem>();
+            var satelliteAssemblyAssets = new Dictionary<string, ITaskItem>();
+            var compressedRepresentations = new Dictionary<string, ITaskItem>();
+            GroupExistingStaticWebAssets(
+                assemblyAssets,
+                nativeAssets,
+                satelliteAssemblyAssets,
+                symbolAssets,
+                compressedRepresentations);
+
+            var newStaticWebAssets = ComputeUpdatedAssemblies(
+                satelliteAssemblyToPublish,
+                filesToRemove,
+                resolvedAssembliesToPublish,
+                assemblyAssets,
+                satelliteAssemblyAssets,
+                compressedRepresentations);
+
+            newAssets.AddRange(newStaticWebAssets);
+
+            var nativeStaticWebAssets = ProcessNativeAssets(
+                nativeAssets,
+                resolvedFilesToPublishToRemove,
+                resolvedNativeAssetToPublish,
+                compressedRepresentations,
+                filesToRemove);
+
+            newAssets.AddRange(nativeStaticWebAssets);
+
+            var symbolStaticWebAssets = ProcessSymbolAssets(
+                symbolAssets,
+                compressedRepresentations,
+                resolvedFilesToPublishToRemove,
+                resolvedSymbolsToPublish,
+                filesToRemove);
+
+            newAssets.AddRange(symbolStaticWebAssets);
+
+            foreach (var kvp in resolvedFilesToPublishToRemove)
+            {
+                var resolvedPublishFileToRemove = kvp.Value;
+                filesToRemove.Add(resolvedPublishFileToRemove);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.LogError(ex.ToString());
+            return false;
+        }
+
+        FilesToRemove = filesToRemove.ToArray();
+        NewCandidates = newAssets.ToArray();
+
+        return !Log.HasLoggedErrors;
+    }
+
+    private List<ITaskItem> ProcessNativeAssets(
+        Dictionary<string, ITaskItem> nativeAssets,
+        IDictionary<string, ITaskItem> resolvedPublishFilesToRemove,
+        Dictionary<string, ITaskItem> resolvedNativeAssetToPublish,
+        Dictionary<string, ITaskItem> compressedRepresentations,
+        List<ITaskItem> filesToRemove)
+    {
+        var nativeStaticWebAssets = new List<ITaskItem>();
+
+        // Keep track of the updated assets to determine what compressed assets we can reuse
+        var updateMap = new Dictionary<string, ITaskItem>();
+
+        foreach (var kvp in nativeAssets)
+        {
+            var key = kvp.Key;
+            var asset = kvp.Value;
+            var isDotNetJs = IsDotNetJs(key);
+            var isDotNetWasm = IsDotNetWasm(key);
+            if (!isDotNetJs && !isDotNetWasm)
+            {
+                if (resolvedNativeAssetToPublish.TryGetValue(Path.GetFileName(asset.GetMetadata("OriginalItemSpec")), out var existing))
+                {
+                    if (!resolvedPublishFilesToRemove.TryGetValue(existing.ItemSpec, out var removed))
+                    {
+                        // This is a native asset like timezones.blat or similar that was not filtered and that needs to be updated
+                        // to a publish asset.
+                        var newAsset = new TaskItem(asset);
+                        ApplyPublishProperties(newAsset);
+                        nativeStaticWebAssets.Add(newAsset);
+                        filesToRemove.Add(existing);
+                        updateMap.Add(asset.ItemSpec, newAsset);
+                        Log.LogMessage(MessageImportance.Low, "Promoting asset '{0}' to Publish asset.", asset.ItemSpec);
+                    }
+                    else
+                    {
+                        Log.LogMessage(MessageImportance.Low, "Removing asset '{0}'.", existing.ItemSpec);
+                        // This was a file that was filtered, so just remove it, we don't need to add any publish static web asset
+                        filesToRemove.Add(removed);
+
+                        // Remove the file from the list to avoid double processing later when we process other files we filtered.
+                        resolvedPublishFilesToRemove.Remove(existing.ItemSpec);
+                    }
+                }
+
+                continue;
+            }
+
+            if (isDotNetJs)
+            {
+                var aotDotNetJs = WasmAotAssets.SingleOrDefault(a => $"{a.GetMetadata("FileName")}{a.GetMetadata("Extension")}" == "dotnet.js");
+                ITaskItem newDotNetJs = null;
+                if (aotDotNetJs != null && FingerprintDotNetJs)
+                {
+                    newDotNetJs = new TaskItem(Path.GetFullPath(aotDotNetJs.ItemSpec), asset.CloneCustomMetadata());
+                    newDotNetJs.SetMetadata("OriginalItemSpec", aotDotNetJs.ItemSpec);
+                    newDotNetJs.SetMetadata("RelativePath", $"_framework/{$"dotnet.{DotNetJsVersion}.{FileHasher.GetFileHash(aotDotNetJs.ItemSpec)}.js"}");
+
+                    updateMap.Add(asset.ItemSpec, newDotNetJs);
+                    Log.LogMessage(MessageImportance.Low, "Replacing asset '{0}' with AoT version '{1}'", asset.ItemSpec, newDotNetJs.ItemSpec);
+                }
+                else
+                {
+                    newDotNetJs = new TaskItem(asset);
+                    Log.LogMessage(MessageImportance.Low, "Promoting asset '{0}' to Publish asset.", asset.ItemSpec);
+                }
+
+                ApplyPublishProperties(newDotNetJs);
+                nativeStaticWebAssets.Add(newDotNetJs);
+                if (resolvedNativeAssetToPublish.TryGetValue("dotnet.js", out var resolved))
+                {
+                    filesToRemove.Add(resolved);
+                }
+                continue;
+            }
+
+            if (isDotNetWasm)
+            {
+                var aotDotNetWasm = WasmAotAssets.SingleOrDefault(a => $"{a.GetMetadata("FileName")}{a.GetMetadata("Extension")}" == "dotnet.wasm");
+                ITaskItem newDotNetWasm = null;
+                if (aotDotNetWasm != null)
+                {
+                    newDotNetWasm = new TaskItem(Path.GetFullPath(aotDotNetWasm.ItemSpec), asset.CloneCustomMetadata());
+                    newDotNetWasm.SetMetadata("OriginalItemSpec", aotDotNetWasm.ItemSpec);
+                    updateMap.Add(asset.ItemSpec, newDotNetWasm);
+                    Log.LogMessage(MessageImportance.Low, "Replacing asset '{0}' with AoT version '{1}'", asset.ItemSpec, newDotNetWasm.ItemSpec);
+                }
+                else
+                {
+                    newDotNetWasm = new TaskItem(asset);
+                    Log.LogMessage(MessageImportance.Low, "Promoting asset '{0}' to Publish asset.", asset.ItemSpec);
+                }
+
+                ApplyPublishProperties(newDotNetWasm);
+                nativeStaticWebAssets.Add(newDotNetWasm);
+                if (resolvedNativeAssetToPublish.TryGetValue("dotnet.wasm", out var resolved))
+                {
+                    filesToRemove.Add(resolved);
+                }
+                continue;
+            }
+        }
+
+        var compressedUpdatedFiles = ProcessCompressedAssets(compressedRepresentations, nativeAssets, updateMap);
+        foreach (var f in compressedUpdatedFiles)
+        {
+            nativeStaticWebAssets.Add(f);
+        }
+
+        return nativeStaticWebAssets;
+
+        static bool IsDotNetJs(string key)
+        {
+            var fileName = Path.GetFileName(key);
+            return fileName.StartsWith("dotnet.", StringComparison.Ordinal) && fileName.EndsWith(".js", StringComparison.Ordinal) && !fileName.Contains("worker");
+        }
+
+        static bool IsDotNetWasm(string key) => string.Equals("dotnet.wasm", Path.GetFileName(key), StringComparison.Ordinal);
+    }
+
+    private List<ITaskItem> ProcessSymbolAssets(
+        Dictionary<string, ITaskItem> symbolAssets,
+        Dictionary<string, ITaskItem> compressedRepresentations,
+        Dictionary<string, ITaskItem> resolvedPublishFilesToRemove,
+        Dictionary<string, ITaskItem> resolvedSymbolAssetToPublish,
+        List<ITaskItem> filesToRemove)
+    {
+        var symbolStaticWebAssets = new List<ITaskItem>();
+        var updateMap = new Dictionary<string, ITaskItem>();
+
+        foreach (var kvp in symbolAssets)
+        {
+            var asset = kvp.Value;
+            if (resolvedSymbolAssetToPublish.TryGetValue(Path.GetFileName(asset.GetMetadata("OriginalItemSpec")), out var existing))
+            {
+                if (!resolvedPublishFilesToRemove.TryGetValue(existing.ItemSpec, out var removed))
+                {
+                    // This is a symbol asset like classlibrary.pdb or similar that was not filtered and that needs to be updated
+                    // to a publish asset.
+                    var newAsset = new TaskItem(asset);
+                    ApplyPublishProperties(newAsset);
+                    symbolStaticWebAssets.Add(newAsset);
+                    updateMap.Add(newAsset.ItemSpec, newAsset);
+                    filesToRemove.Add(existing);
+                    Log.LogMessage(MessageImportance.Low, "Promoting asset '{0}' to Publish asset.", asset.ItemSpec);
+                }
+                else
+                {
+                    // This was a file that was filtered, so just remove it, we don't need to add any publish static web asset
+                    filesToRemove.Add(removed);
+
+                    // Remove the file from the list to avoid double processing later when we process other files we filtered.
+                    resolvedPublishFilesToRemove.Remove(existing.ItemSpec);
+                }
+            }
+        }
+
+        var compressedFiles = ProcessCompressedAssets(compressedRepresentations, symbolAssets, updateMap);
+
+        foreach (var file in compressedFiles)
+        {
+            symbolStaticWebAssets.Add(file);
+        }
+
+        return symbolStaticWebAssets;
+    }
+
+    private List<ITaskItem> ComputeUpdatedAssemblies(
+        IDictionary<(string, string assemblyName), ITaskItem> satelliteAssemblies,
+        List<ITaskItem> filesToRemove,
+        Dictionary<string, ITaskItem> resolvedAssembliesToPublish,
+        Dictionary<string, ITaskItem> assemblyAssets,
+        Dictionary<string, ITaskItem> satelliteAssemblyAssets,
+        Dictionary<string, ITaskItem> compressedRepresentations)
+    {
+        // All assemblies, satellite assemblies and gzip files are initially defined as build assets.
+        // We need to update them to publish assets when they haven't changed or when they have been linked.
+        // For satellite assemblies and compressed files, we won't include them in the list of assets to update
+        // when the original assembly they depend on has been linked out.
+        var assetsToUpdate = new Dictionary<string, ITaskItem>();
+        var linkedAssets = new Dictionary<string, ITaskItem>();
+
+        foreach (var kvp in assemblyAssets)
+        {
+            var asset = kvp.Value;
+            var fileName = Path.GetFileName(asset.GetMetadata("RelativePath"));
+            if (resolvedAssembliesToPublish.TryGetValue(fileName, out var existing))
+            {
+                // We found the assembly, so it'll have to be updated.
+                assetsToUpdate.Add(asset.ItemSpec, asset);
+                filesToRemove.Add(existing);
+                if (!string.Equals(asset.ItemSpec, existing.GetMetadata("FullPath"), StringComparison.Ordinal))
+                {
+                    linkedAssets.Add(asset.ItemSpec, existing);
+                }
+            }
+        }
+
+        foreach (var kvp in satelliteAssemblyAssets)
+        {
+            var satelliteAssembly = kvp.Value;
+            var relatedAsset = satelliteAssembly.GetMetadata("RelatedAsset");
+            if (assetsToUpdate.ContainsKey(relatedAsset))
+            {
+                assetsToUpdate.Add(satelliteAssembly.ItemSpec, satelliteAssembly);
+                var culture = satelliteAssembly.GetMetadata("AssetTraitValue");
+                var fileName = Path.GetFileName(satelliteAssembly.GetMetadata("RelativePath"));
+                if (satelliteAssemblies.TryGetValue((culture, fileName), out var existing))
+                {
+                    filesToRemove.Add(existing);
+                }
+                else
+                {
+                    var message = $"Can't find the original satellite assembly in the list of resolved files to " +
+                        $"publish for asset '{satelliteAssembly.ItemSpec}'.";
+                    throw new InvalidOperationException(message);
+                }
+            }
+        }
+
+        var compressedFiles = ProcessCompressedAssets(compressedRepresentations, assetsToUpdate, linkedAssets);
+
+        foreach (var file in compressedFiles)
+        {
+            assetsToUpdate.Add(file.ItemSpec, file);
+        }
+
+        var updatedAssetsMap = new Dictionary<string, ITaskItem>(StringComparer.Ordinal);
+        foreach (var asset in assetsToUpdate.Select(a => a.Value).OrderBy(a => a.GetMetadata("AssetRole"), Comparer<string>.Create(OrderByAssetRole)))
+        {
+            var assetTraitName = asset.GetMetadata("AssetTraitName");
+            switch (assetTraitName)
+            {
+                case "WasmResource":
+                    ITaskItem newAsemblyAsset = null;
+                    if (linkedAssets.TryGetValue(asset.ItemSpec, out var linked))
+                    {
+                        newAsemblyAsset = new TaskItem(linked.GetMetadata("FullPath"), asset.CloneCustomMetadata());
+                        newAsemblyAsset.SetMetadata("OriginalItemSpec", linked.ItemSpec);
+                        Log.LogMessage(MessageImportance.Low, "Replacing asset '{0}' with linked version '{1}'",
+                            asset.ItemSpec,
+                            newAsemblyAsset.ItemSpec);
+                    }
+                    else
+                    {
+                        Log.LogMessage(MessageImportance.Low, "Linked asset not found for asset '{0}'", asset.ItemSpec);
+                        newAsemblyAsset = new TaskItem(asset);
+                    }
+                    ApplyPublishProperties(newAsemblyAsset);
+
+                    updatedAssetsMap.Add(asset.ItemSpec, newAsemblyAsset);
+                    break;
+                default:
+                    // Satellite assembliess and compressed assets
+                    var dependentAsset = new TaskItem(asset);
+                    ApplyPublishProperties(dependentAsset);
+                    UpdateRelatedAssetProperty(asset, dependentAsset, updatedAssetsMap);
+                    Log.LogMessage(MessageImportance.Low, "Promoting asset '{0}' to Publish asset.", asset.ItemSpec);
+
+                    updatedAssetsMap.Add(asset.ItemSpec, dependentAsset);
+                    break;
+            }
+        }
+
+        return updatedAssetsMap.Values.ToList();
+    }
+
+    private List<ITaskItem> ProcessCompressedAssets(
+        Dictionary<string, ITaskItem> compressedRepresentations,
+        Dictionary<string, ITaskItem> assetsToUpdate,
+        Dictionary<string, ITaskItem> updatedAssets)
+    {
+        var processed = new List<string>();
+        var runtimeAssetsToUpdate = new List<ITaskItem>();
+        foreach (var kvp in compressedRepresentations)
+        {
+            var compressedAsset = kvp.Value;
+            var relatedAsset = compressedAsset.GetMetadata("RelatedAsset");
+            if (assetsToUpdate.ContainsKey(relatedAsset))
+            {
+                if (!updatedAssets.ContainsKey(relatedAsset))
+                {
+                    Log.LogMessage(MessageImportance.Low, "Related assembly for '{0}' was not updated and the compressed asset can be reused.", relatedAsset);
+                    var newCompressedAsset = new TaskItem(compressedAsset);
+                    ApplyPublishProperties(newCompressedAsset);
+                    runtimeAssetsToUpdate.Add(newCompressedAsset);
+                }
+                else
+                {
+                    Log.LogMessage(MessageImportance.Low, "Related assembly for '{0}' was updated and the compressed asset will be discarded.", relatedAsset);
+                }
+
+                processed.Add(kvp.Key);
+            }
+        }
+
+        // Remove all the elements we've found to avoid having to iterate over them when we process other assets.
+        foreach (var element in processed)
+        {
+            compressedRepresentations.Remove(element);
+        }
+
+        return runtimeAssetsToUpdate;
+    }
+
+    private static void UpdateRelatedAssetProperty(ITaskItem asset, TaskItem newAsset, Dictionary<string, ITaskItem> updatedAssetsMap)
+    {
+        if (!updatedAssetsMap.TryGetValue(asset.GetMetadata("RelatedAsset"), out var updatedRelatedAsset))
+        {
+            throw new InvalidOperationException("Related asset not found.");
+        }
+
+        newAsset.SetMetadata("RelatedAsset", updatedRelatedAsset.ItemSpec);
+    }
+
+    private int OrderByAssetRole(string left, string right)
+    {
+        var leftScore = GetScore(left);
+        var rightScore = GetScore(right);
+
+        return leftScore - rightScore;
+
+        static int GetScore(string candidate) => candidate switch
+        {
+            "Primary" => 0,
+            "Related" => 1,
+            "Alternative" => 2,
+            _ => throw new InvalidOperationException("Invalid asset role"),
+        };
+    }
+
+    private void ApplyPublishProperties(ITaskItem newAsemblyAsset)
+    {
+        newAsemblyAsset.SetMetadata("AssetKind", "Publish");
+        newAsemblyAsset.SetMetadata("ContentRoot", Path.Combine(PublishPath, "wwwroot"));
+        newAsemblyAsset.SetMetadata("CopyToOutputDirectory", "Never");
+        newAsemblyAsset.SetMetadata("CopyToPublishDirectory", "PreserveNewest");
+    }
+
+    private void GroupExistingStaticWebAssets(
+        Dictionary<string, ITaskItem> assemblyAssets,
+        Dictionary<string, ITaskItem> nativeAssets,
+        Dictionary<string, ITaskItem> satelliteAssemblyAssets,
+        Dictionary<string, ITaskItem> symbolAssets,
+        Dictionary<string, ITaskItem> compressedRepresentations)
+    {
+        foreach (var asset in ExistingAssets)
+        {
+            var traitName = asset.GetMetadata("AssetTraitName");
+            if (IsWebAssemblyResource(traitName))
+            {
+                var traitValue = asset.GetMetadata("AssetTraitValue");
+                if (IsRuntimeAsset(traitValue))
+                {
+                    assemblyAssets.Add(asset.ItemSpec, asset);
+                }
+                else if (IsNativeAsset(traitValue))
+                {
+                    nativeAssets.Add(asset.ItemSpec, asset);
+                }
+                else if (IsSymbolAsset(traitValue))
+                {
+                    symbolAssets.Add(asset.ItemSpec, asset);
+                }
+            }
+            else if (IsCulture(traitName))
+            {
+                satelliteAssemblyAssets.Add(asset.ItemSpec, asset);
+            }
+            else if (IsAlternative(asset))
+            {
+                compressedRepresentations.Add(asset.ItemSpec, asset);
+            }
+        }
+    }
+
+    private void GroupResolvedFilesToPublish(
+        Dictionary<string, ITaskItem> resolvedFilesToPublishToRemove,
+        Dictionary<string, ITaskItem> resolvedAssemblyToPublish,
+        Dictionary<(string, string), ITaskItem> satelliteAssemblyToPublish,
+        Dictionary<string, ITaskItem> resolvedSymbolsToPublish,
+        Dictionary<string, ITaskItem> resolvedNativeAssetToPublish)
+    {
+        var resolvedFilesToPublish = ResolvedFilesToPublish.ToList();
+        if (AssetsComputingHelper.TryGetAssetFilename(CustomIcuCandidate, out string customIcuCandidateFilename))
+        {
+            var customIcuCandidate = AssetsComputingHelper.GetCustomIcuAsset(CustomIcuCandidate);
+            resolvedFilesToPublish.Add(customIcuCandidate);
+        }
+
+        foreach (var candidate in resolvedFilesToPublish)
+        {
+            if (AssetsComputingHelper.ShouldFilterCandidate(candidate, TimeZoneSupport, InvariantGlobalization, CopySymbols, customIcuCandidateFilename, out var reason))
+            {
+                Log.LogMessage(MessageImportance.Low, "Skipping asset '{0}' because '{1}'", candidate.ItemSpec, reason);
+                if (!resolvedFilesToPublishToRemove.ContainsKey(candidate.ItemSpec))
+                {
+                    resolvedFilesToPublishToRemove.Add(candidate.ItemSpec, candidate);
+                }
+                else
+                {
+                    Log.LogMessage(MessageImportance.Low, "Duplicate candidate '{0}' found in ResolvedFilesToPublish", candidate.ItemSpec);
+                }
+                continue;
+            }
+
+            var extension = candidate.GetMetadata("Extension");
+            if (string.Equals(extension, ".dll", StringComparison.Ordinal))
+            {
+                var culture = candidate.GetMetadata("Culture");
+                var inferredCulture = candidate.GetMetadata("DestinationSubDirectory").Replace("\\", "/").Trim('/');
+                if (!string.IsNullOrEmpty(culture) || !string.IsNullOrEmpty(inferredCulture))
+                {
+                    var finalCulture = !string.IsNullOrEmpty(culture) ? culture : inferredCulture;
+                    var assemblyName = Path.GetFileName(candidate.GetMetadata("RelativePath").Replace("\\", "/"));
+                    if (!satelliteAssemblyToPublish.ContainsKey((finalCulture, assemblyName)))
+                    {
+                        satelliteAssemblyToPublish.Add((finalCulture, assemblyName), candidate);
+                    }
+                    else
+                    {
+                        Log.LogMessage(MessageImportance.Low, "Duplicate candidate '{0}' found in ResolvedFilesToPublish", candidate.ItemSpec);
+                    }
+                    continue;
+                }
+
+                var candidateName = Path.GetFileName(candidate.GetMetadata("RelativePath"));
+                if (!resolvedAssemblyToPublish.ContainsKey(candidateName))
+                {
+                    resolvedAssemblyToPublish.Add(candidateName, candidate);
+                }
+                else
+                {
+                    Log.LogMessage(MessageImportance.Low, "Duplicate candidate '{0}' found in ResolvedFilesToPublish", candidate.ItemSpec);
+                }
+
+                continue;
+            }
+
+            if (string.Equals(extension, ".pdb", StringComparison.Ordinal))
+            {
+                var candidateName = Path.GetFileName(candidate.GetMetadata("RelativePath"));
+                if (!resolvedSymbolsToPublish.ContainsKey(candidateName))
+                {
+                    resolvedSymbolsToPublish.Add(candidateName, candidate);
+                }
+                else
+                {
+                    Log.LogMessage(MessageImportance.Low, "Duplicate candidate '{0}' found in ResolvedFilesToPublish", candidate.ItemSpec);
+                }
+
+                continue;
+            }
+
+            // Capture all the native unfiltered assets since we need to process them to determine what static web assets need to get
+            // upgraded
+            if (string.Equals(candidate.GetMetadata("AssetType"), "native", StringComparison.Ordinal))
+            {
+                var candidateName = $"{candidate.GetMetadata("FileName")}{extension}";
+                if (!resolvedNativeAssetToPublish.ContainsKey(candidateName))
+                {
+                    resolvedNativeAssetToPublish.Add(candidateName, candidate);
+                }
+                else
+                {
+                    Log.LogMessage(MessageImportance.Low, "Duplicate candidate '{0}' found in ResolvedFilesToPublish", candidate.ItemSpec);
+                }
+                continue;
+            }
+        }
+    }
+
+    private static bool IsNativeAsset(string traitValue) => string.Equals(traitValue, "native", StringComparison.Ordinal);
+
+    private static bool IsRuntimeAsset(string traitValue) => string.Equals(traitValue, "runtime", StringComparison.Ordinal);
+    private static bool IsSymbolAsset(string traitValue) => string.Equals(traitValue, "symbol", StringComparison.Ordinal);
+
+    private static bool IsAlternative(ITaskItem asset) => string.Equals(asset.GetMetadata("AssetRole"), "Alternative", StringComparison.Ordinal);
+
+    private static bool IsCulture(string traitName) => string.Equals(traitName, "Culture", StringComparison.Ordinal);
+
+    private static bool IsWebAssemblyResource(string traitName) => string.Equals(traitName, "WasmResource", StringComparison.Ordinal);
+}

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/FileHasher.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/FileHasher.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Numerics;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Microsoft.NET.Sdk.WebAssembly;
+
+public static class FileHasher
+{
+    public static string GetFileHash(string filePath)
+    {
+        using var hash = SHA256.Create();
+        var bytes = Encoding.UTF8.GetBytes(filePath);
+        var hashBytes = hash.ComputeHash(bytes);
+        return ToBase36(hashBytes);
+    }
+
+    private static string ToBase36(byte[] hash)
+    {
+        const string chars = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+        var result = new char[10];
+        var dividend = BigInteger.Abs(new BigInteger(hash.AsSpan().Slice(0, 9).ToArray()));
+        for (var i = 0; i < 10; i++)
+        {
+            dividend = BigInteger.DivRem(dividend, 36, out var remainder);
+            result[i] = chars[(int)remainder];
+        }
+
+        return new string(result);
+    }
+}

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/GenerateWasmBootJson.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/GenerateWasmBootJson.cs
@@ -1,0 +1,341 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Json;
+using System.Text;
+using System.Xml;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using ResourceHashesByNameDictionary = System.Collections.Generic.Dictionary<string, string>;
+
+namespace Microsoft.NET.Sdk.WebAssembly;
+
+public class GenerateWasmBootJson : Task
+{
+    private static readonly string[] jiterpreterOptions = new[] { "jiterpreter-traces-enabled", "jiterpreter-interp-entry-enabled", "jiterpreter-jit-call-enabled" };
+
+    [Required]
+    public string AssemblyPath { get; set; }
+
+    [Required]
+    public ITaskItem[] Resources { get; set; }
+
+    [Required]
+    public bool DebugBuild { get; set; }
+
+    [Required]
+    public bool LinkerEnabled { get; set; }
+
+    [Required]
+    public bool CacheBootResources { get; set; }
+
+    public bool LoadAllICUData { get; set; }
+
+    public bool LoadCustomIcuData { get; set; }
+
+    public string InvariantGlobalization { get; set; }
+
+    public ITaskItem[] ConfigurationFiles { get; set; }
+
+    public ITaskItem[] Extensions { get; set; }
+
+    public string StartupMemoryCache { get; set; }
+
+    public string Jiterpreter { get; set; }
+
+    public string RuntimeOptions { get; set; }
+
+    [Required]
+    public string OutputPath { get; set; }
+
+    public ITaskItem[] LazyLoadedAssemblies { get; set; }
+
+    public override bool Execute()
+    {
+        using var fileStream = File.Create(OutputPath);
+        var entryAssemblyName = AssemblyName.GetAssemblyName(AssemblyPath).Name;
+
+        try
+        {
+            WriteBootJson(fileStream, entryAssemblyName);
+        }
+        catch (Exception ex)
+        {
+            Log.LogError(ex.ToString());
+        }
+
+        return !Log.HasLoggedErrors;
+    }
+
+    // Internal for tests
+    public void WriteBootJson(Stream output, string entryAssemblyName)
+    {
+        var icuDataMode = ICUDataMode.Sharded;
+
+        if (string.Equals(InvariantGlobalization, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            icuDataMode = ICUDataMode.Invariant;
+        }
+        else if (LoadAllICUData)
+        {
+            icuDataMode = ICUDataMode.All;
+        }
+        else if (LoadCustomIcuData)
+        {
+            icuDataMode = ICUDataMode.Custom;
+        }
+
+        var result = new BootJsonData
+        {
+            entryAssembly = entryAssemblyName,
+            cacheBootResources = CacheBootResources,
+            debugBuild = DebugBuild,
+            linkerEnabled = LinkerEnabled,
+            resources = new ResourcesData(),
+            config = new List<string>(),
+            icuDataMode = icuDataMode,
+            startupMemoryCache = ParseOptionalBool(StartupMemoryCache),
+        };
+
+        if (!string.IsNullOrEmpty(RuntimeOptions))
+        {
+            string[] runtimeOptions = RuntimeOptions.Split(' ');
+            result.runtimeOptions = runtimeOptions;
+        }
+
+        bool? jiterpreter = ParseOptionalBool(Jiterpreter);
+        if (jiterpreter != null)
+        {
+            var runtimeOptions = result.runtimeOptions?.ToHashSet() ?? new HashSet<string>(3);
+            foreach (var jiterpreterOption in jiterpreterOptions)
+            {
+                if (jiterpreter == true)
+                {
+                    if (!runtimeOptions.Contains($"--no-{jiterpreterOption}"))
+                        runtimeOptions.Add($"--{jiterpreterOption}");
+                }
+                else
+                {
+                    if (!runtimeOptions.Contains($"--{jiterpreterOption}"))
+                        runtimeOptions.Add($"--no-{jiterpreterOption}");
+                }
+            }
+
+            result.runtimeOptions = runtimeOptions.ToArray();
+        }
+
+        // Build a two-level dictionary of the form:
+        // - assembly:
+        //   - UriPath (e.g., "System.Text.Json.dll")
+        //     - ContentHash (e.g., "4548fa2e9cf52986")
+        // - runtime:
+        //   - UriPath (e.g., "dotnet.js")
+        //     - ContentHash (e.g., "3448f339acf512448")
+        if (Resources != null)
+        {
+            var remainingLazyLoadAssemblies = new List<ITaskItem>(LazyLoadedAssemblies ?? Array.Empty<ITaskItem>());
+            var resourceData = result.resources;
+            foreach (var resource in Resources)
+            {
+                ResourceHashesByNameDictionary resourceList = null;
+
+                string behavior = null;
+                var fileName = resource.GetMetadata("FileName");
+                var fileExtension = resource.GetMetadata("Extension");
+                var assetTraitName = resource.GetMetadata("AssetTraitName");
+                var assetTraitValue = resource.GetMetadata("AssetTraitValue");
+                var resourceName = Path.GetFileName(resource.GetMetadata("RelativePath"));
+
+                if (TryGetLazyLoadedAssembly(resourceName, out var lazyLoad))
+                {
+                    Log.LogMessage(MessageImportance.Low, "Candidate '{0}' is defined as a lazy loaded assembly.", resource.ItemSpec);
+                    remainingLazyLoadAssemblies.Remove(lazyLoad);
+                    resourceData.lazyAssembly ??= new ResourceHashesByNameDictionary();
+                    resourceList = resourceData.lazyAssembly;
+                }
+                else if (string.Equals("Culture", assetTraitName, StringComparison.OrdinalIgnoreCase))
+                {
+                    Log.LogMessage(MessageImportance.Low, "Candidate '{0}' is defined as satellite assembly with culture '{1}'.", resource.ItemSpec, assetTraitValue);
+                    resourceData.satelliteResources ??= new Dictionary<string, ResourceHashesByNameDictionary>(StringComparer.OrdinalIgnoreCase);
+                    resourceName = assetTraitValue + "/" + resourceName;
+
+                    if (!resourceData.satelliteResources.TryGetValue(assetTraitValue, out resourceList))
+                    {
+                        resourceList = new ResourceHashesByNameDictionary();
+                        resourceData.satelliteResources.Add(assetTraitValue, resourceList);
+                    }
+                }
+                else if (string.Equals("symbol", assetTraitValue, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (TryGetLazyLoadedAssembly($"{fileName}.dll", out _))
+                    {
+                        Log.LogMessage(MessageImportance.Low, "Candidate '{0}' is defined as a lazy loaded symbols file.", resource.ItemSpec);
+                        resourceData.lazyAssembly ??= new ResourceHashesByNameDictionary();
+                        resourceList = resourceData.lazyAssembly;
+                    }
+                    else
+                    {
+                        Log.LogMessage(MessageImportance.Low, "Candidate '{0}' is defined as symbols file.", resource.ItemSpec);
+                        resourceData.pdb ??= new ResourceHashesByNameDictionary();
+                        resourceList = resourceData.pdb;
+                    }
+                }
+                else if (string.Equals("runtime", assetTraitValue, StringComparison.OrdinalIgnoreCase))
+                {
+                    Log.LogMessage(MessageImportance.Low, "Candidate '{0}' is defined as an app assembly.", resource.ItemSpec);
+                    resourceList = resourceData.assembly;
+                }
+                else if (string.Equals(assetTraitName, "WasmResource", StringComparison.OrdinalIgnoreCase) &&
+                        string.Equals(assetTraitValue, "native", StringComparison.OrdinalIgnoreCase))
+                {
+                    Log.LogMessage(MessageImportance.Low, "Candidate '{0}' is defined as a native application resource.", resource.ItemSpec);
+                    if (string.Equals(fileName, "dotnet", StringComparison.OrdinalIgnoreCase) &&
+                        string.Equals(fileExtension, ".wasm", StringComparison.OrdinalIgnoreCase))
+                    {
+                        behavior = "dotnetwasm";
+                    }
+
+                    resourceList = resourceData.runtime;
+                }
+                else if (string.Equals("JSModule", assetTraitName, StringComparison.OrdinalIgnoreCase) &&
+                            string.Equals(assetTraitValue, "JSLibraryModule", StringComparison.OrdinalIgnoreCase))
+                {
+                    Log.LogMessage(MessageImportance.Low, "Candidate '{0}' is defined as a library initializer resource.", resource.ItemSpec);
+                    resourceData.libraryInitializers ??= new();
+                    resourceList = resourceData.libraryInitializers;
+                    var targetPath = resource.GetMetadata("TargetPath");
+                    Debug.Assert(!string.IsNullOrEmpty(targetPath), "Target path for '{0}' must exist.", resource.ItemSpec);
+                    AddResourceToList(resource, resourceList, targetPath);
+                    continue;
+                }
+                else if (string.Equals("WasmResource", assetTraitName, StringComparison.OrdinalIgnoreCase) &&
+                            assetTraitValue.StartsWith("extension:", StringComparison.OrdinalIgnoreCase))
+                {
+                    Log.LogMessage(MessageImportance.Low, "Candidate '{0}' is defined as an extension resource '{1}'.", resource.ItemSpec, assetTraitValue);
+                    var extensionName = assetTraitValue.Substring("extension:".Length);
+                    resourceData.extensions ??= new();
+                    if (!resourceData.extensions.TryGetValue(extensionName, out resourceList))
+                    {
+                        resourceList = new();
+                        resourceData.extensions[extensionName] = resourceList;
+                    }
+                    var targetPath = resource.GetMetadata("TargetPath");
+                    Debug.Assert(!string.IsNullOrEmpty(targetPath), "Target path for '{0}' must exist.", resource.ItemSpec);
+                    AddResourceToList(resource, resourceList, targetPath);
+                    continue;
+                }
+                else
+                {
+                    Log.LogMessage(MessageImportance.Low, "Skipping resource '{0}' since it doesn't belong to a defined category.", resource.ItemSpec);
+                    // This should include items such as XML doc files, which do not need to be recorded in the manifest.
+                    continue;
+                }
+
+                if (resourceList != null)
+                {
+                    AddResourceToList(resource, resourceList, resourceName);
+                }
+
+                if (!string.IsNullOrEmpty(behavior))
+                {
+                    resourceData.runtimeAssets ??= new Dictionary<string, AdditionalAsset>();
+                    AddToAdditionalResources(resource, resourceData.runtimeAssets, resourceName, behavior);
+                }
+            }
+
+            if (remainingLazyLoadAssemblies.Count > 0)
+            {
+                const string message = "Unable to find '{0}' to be lazy loaded later. Confirm that project or " +
+                    "package references are included and the reference is used in the project.";
+
+                Log.LogError(
+                    subcategory: null,
+                    errorCode: "BLAZORSDK1001",
+                    helpKeyword: null,
+                    file: null,
+                    lineNumber: 0,
+                    columnNumber: 0,
+                    endLineNumber: 0,
+                    endColumnNumber: 0,
+                    message: message,
+                    string.Join(";", LazyLoadedAssemblies.Select(a => a.ItemSpec)));
+
+                return;
+            }
+        }
+
+        if (ConfigurationFiles != null)
+        {
+            foreach (var configFile in ConfigurationFiles)
+            {
+                result.config.Add(Path.GetFileName(configFile.ItemSpec));
+            }
+        }
+
+        if (Extensions != null && Extensions.Length > 0)
+        {
+            var configSerializer = new DataContractJsonSerializer(typeof(Dictionary<string, object>), new DataContractJsonSerializerSettings
+            {
+                UseSimpleDictionaryFormat = true
+            });
+
+            result.extensions = new Dictionary<string, Dictionary<string, object>> ();
+            foreach (var configExtension in Extensions)
+            {
+                var key = configExtension.GetMetadata("key");
+                var config = (Dictionary<string, object>)configSerializer.ReadObject(File.OpenRead(configExtension.ItemSpec));
+                result.extensions[key] = config;
+            }
+        }
+
+        var serializer = new DataContractJsonSerializer(typeof(BootJsonData), new DataContractJsonSerializerSettings
+        {
+            UseSimpleDictionaryFormat = true
+        });
+
+        using var writer = JsonReaderWriterFactory.CreateJsonWriter(output, Encoding.UTF8, ownsStream: false, indent: true);
+        serializer.WriteObject(writer, result);
+
+        void AddResourceToList(ITaskItem resource, ResourceHashesByNameDictionary resourceList, string resourceKey)
+        {
+            if (!resourceList.ContainsKey(resourceKey))
+            {
+                Log.LogMessage(MessageImportance.Low, "Added resource '{0}' to the manifest.", resource.ItemSpec);
+                resourceList.Add(resourceKey, $"sha256-{resource.GetMetadata("FileHash")}");
+            }
+        }
+    }
+
+    private static bool? ParseOptionalBool(string value)
+    {
+        if (string.IsNullOrEmpty(value) || !bool.TryParse(value, out var boolValue))
+            return null;
+
+        return boolValue;
+    }
+
+    private void AddToAdditionalResources(ITaskItem resource, Dictionary<string, AdditionalAsset> additionalResources, string resourceName, string behavior)
+    {
+        if (!additionalResources.ContainsKey(resourceName))
+        {
+            Log.LogMessage(MessageImportance.Low, "Added resource '{0}' to the list of additional assets in the manifest.", resource.ItemSpec);
+            additionalResources.Add(resourceName, new AdditionalAsset
+            {
+                Hash = $"sha256-{resource.GetMetadata("FileHash")}",
+                Behavior = behavior
+            });
+        }
+    }
+
+    private bool TryGetLazyLoadedAssembly(string fileName, out ITaskItem lazyLoadedAssembly)
+    {
+        return (lazyLoadedAssembly = LazyLoadedAssemblies?.SingleOrDefault(a => a.ItemSpec == fileName)) != null;
+    }
+}

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks.csproj
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(TargetFrameworkForNETCoreTasks);$(TargetFrameworkForNETFrameworkTasks)</TargetFrameworks>
+    <NoWarn>$(NoWarn),CA1050,CA1850,CA1845,CA1859,NU5128</NoWarn>
+    <RootNamespace>Microsoft.NET.Sdk.WebAssembly</RootNamespace>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <PackageReference>
+      <PrivateAssets>All</PrivateAssets>
+      <Publish>true</Publish>
+    </PackageReference>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" ExcludeAssets="runtime" />
+  </ItemGroup>
+
+  <Target Name="GetFilesToPackage" Returns="@(FilesToPackage)">
+    <ItemGroup>
+      <_PublishFramework Remove="@(_PublishFramework)" />
+      <_PublishFramework Include="$(TargetFrameworks)" />
+
+      <FilesToPackage Include="$(OutputPath)%(_PublishFramework.Identity)\*.dll" TargetPath="tools\%(_PublishFramework.Identity)" />
+      <FilesToPackage Include="$(OutputPath)%(_PublishFramework.Identity)\*.pdb" TargetPath="tools\%(_PublishFramework.Identity)" />
+    </ItemGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
Produce a `Microsoft.NET.Sdk.WebAssembly.Pack` package containing most of the Wasm SDK bits.

- Contains original PR https://github.com/dotnet/runtime/pull/84082 and fix for official build https://github.com/dotnet/runtime/pull/84754
- Original sources https://github.com/dotnet/sdk/tree/main/src/WasmSdk
- This PR tries to make a minimal change
- Tests and integration with in-tree building will come in follow-up PRs
- Update pattern for matching `RidAgnosticNupkgToPublishFile` to include `Microsoft.NET.Sdk.WebAssembly.Pack`

Contributes to https://github.com/dotnet/runtime/issues/81367
Fixes https://github.com/dotnet/runtime/issues/84742

<!--
TODO
- [x] dotnet.js gets copied to a wrong folder during publish
- [x] ~Integrate blazor build tests~ Follow-up PR
- [x] Update blazor property in workload manifest (use `UsingMicrosoftNETSdkWebAssembly`)
-->