### PR TITLE
Fix a number of issues related to boxed value serialization

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectConverter.cs
@@ -111,4 +111,29 @@ namespace System.Text.Json.Serialization.Converters
             runtimeConverter.WriteAsPropertyNameCoreAsObject(writer, value, options, isWritingExtensionDataProperty);
         }
     }
+
+    /// <summary>
+    /// A placeholder ObjectConverter used for driving boxed root value serialization only
+    /// and does not root JsonNode/JsonDocument.
+    /// </summary>
+    internal sealed class ObjectConverterSlim : JsonConverter<object?>
+    {
+        private protected override ConverterStrategy GetDefaultConverterStrategy() => ConverterStrategy.Object;
+
+        public ObjectConverterSlim()
+        {
+            CanBePolymorphic = true;
+        }
+
+        public override object? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            Debug.Fail("Converter should only be used to drive root-level object serialization.");
+            return null;
+        }
+
+        public override void Write(Utf8JsonWriter writer, object? value, JsonSerializerOptions options)
+        {
+            Debug.Fail("Converter should only be used to drive root-level object serialization.");
+        }
+    }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectConverter.cs
@@ -113,8 +113,8 @@ namespace System.Text.Json.Serialization.Converters
     }
 
     /// <summary>
-    /// A placeholder ObjectConverter used for driving boxed root value serialization only
-    /// and does not root JsonNode/JsonDocument.
+    /// A placeholder ObjectConverter used for driving object root value
+    /// serialization only and does not root JsonNode/JsonDocument.
     /// </summary>
     internal sealed class ObjectConverterSlim : JsonConverter<object?>
     {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -248,7 +248,7 @@ namespace System.Text.Json.Serialization
             {
                 // Special case object converters since they don't
                 // require the expensive ReadStack.Push()/Pop() operations.
-                Debug.Assert(this is ObjectConverter);
+                Debug.Assert(this is ObjectConverter or ObjectConverterSlim);
                 success = OnTryRead(ref reader, typeToConvert, options, ref state, out value);
                 Debug.Assert(success);
                 return true;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Helpers.cs
@@ -29,7 +29,7 @@ namespace System.Text.Json
 
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(SerializationRequiresDynamicCodeMessage)]
-        private static JsonTypeInfo GetTypeInfo(JsonSerializerOptions? options, Type inputType, bool fallBackToNearestAncestorType = false)
+        private static JsonTypeInfo GetTypeInfo(JsonSerializerOptions? options, Type inputType)
         {
             Debug.Assert(inputType != null);
 
@@ -45,7 +45,7 @@ namespace System.Text.Json
             // This lets any derived types take advantage of the cache in GetTypeInfoForRootType themselves.
             return inputType == JsonTypeInfo.ObjectType
                 ? options.ObjectTypeInfo
-                : options.GetTypeInfoForRootType(inputType, fallBackToNearestAncestorType);
+                : options.GetTypeInfoForRootType(inputType);
         }
 
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
@@ -55,7 +55,7 @@ namespace System.Text.Json
             JsonSerializerOptions? options = null)
         {
             ValidateInputType(value, inputType);
-            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, inputType, fallBackToNearestAncestorType: true);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, inputType);
             return WriteBytesAsObject(value, jsonTypeInfo);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Document.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Document.cs
@@ -51,7 +51,7 @@ namespace System.Text.Json
         public static JsonDocument SerializeToDocument(object? value, Type inputType, JsonSerializerOptions? options = null)
         {
             ValidateInputType(value, inputType);
-            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, inputType, fallBackToNearestAncestorType: true);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, inputType);
             return WriteDocumentAsObject(value, jsonTypeInfo);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Element.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Element.cs
@@ -51,7 +51,7 @@ namespace System.Text.Json
         public static JsonElement SerializeToElement(object? value, Type inputType, JsonSerializerOptions? options = null)
         {
             ValidateInputType(value, inputType);
-            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, inputType, fallBackToNearestAncestorType: true);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, inputType);
             return WriteElementAsObject(value, jsonTypeInfo);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleMetadata.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleMetadata.cs
@@ -34,10 +34,10 @@ namespace System.Text.Json
 
             if (state.PolymorphicTypeDiscriminator is object discriminator)
             {
-                Debug.Assert(state.Parent.JsonPropertyInfo!.JsonTypeInfo.PolymorphicTypeResolver != null);
+                Debug.Assert(state.PolymorphicTypeResolver != null);
 
                 JsonEncodedText propertyName =
-                    state.Parent.JsonPropertyInfo.JsonTypeInfo.PolymorphicTypeResolver.CustomTypeDiscriminatorPropertyNameJsonEncoded is JsonEncodedText customPropertyName
+                    state.PolymorphicTypeResolver.CustomTypeDiscriminatorPropertyNameJsonEncoded is JsonEncodedText customPropertyName
                     ? customPropertyName
                     : s_metadataType;
 
@@ -88,7 +88,9 @@ namespace System.Text.Json
                 writer.WriteString(s_metadataRef, referenceId);
                 writer.WriteEndObject();
 
-                state.PolymorphicTypeDiscriminator = null; // clear out any polymorphism state.
+                // clear out any polymorphism state.
+                state.PolymorphicTypeDiscriminator = null;
+                state.PolymorphicTypeResolver = null;
             }
             else
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Node.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Node.cs
@@ -52,7 +52,7 @@ namespace System.Text.Json
         public static JsonNode? SerializeToNode(object? value, Type inputType, JsonSerializerOptions? options = null)
         {
             ValidateInputType(value, inputType);
-            JsonTypeInfo typeInfo = GetTypeInfo(options, inputType, fallBackToNearestAncestorType: true);
+            JsonTypeInfo typeInfo = GetTypeInfo(options, inputType);
             return WriteNodeAsObject(value, typeInfo);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -117,7 +117,7 @@ namespace System.Text.Json
             }
 
             ValidateInputType(value, inputType);
-            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, inputType, fallBackToNearestAncestorType: true);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, inputType);
             return jsonTypeInfo.SerializeAsObjectAsync(utf8Json, value, cancellationToken);
         }
 
@@ -152,7 +152,7 @@ namespace System.Text.Json
             }
 
             ValidateInputType(value, inputType);
-            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, inputType, fallBackToNearestAncestorType: true);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, inputType);
             jsonTypeInfo.SerializeAsObject(utf8Json, value);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
@@ -62,7 +62,7 @@ namespace System.Text.Json
             JsonSerializerOptions? options = null)
         {
             ValidateInputType(value, inputType);
-            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, inputType, fallBackToNearestAncestorType: true);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, inputType);
             return WriteStringAsObject(value, jsonTypeInfo);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Utf8JsonWriter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Utf8JsonWriter.cs
@@ -70,7 +70,7 @@ namespace System.Text.Json
             }
 
             ValidateInputType(value, inputType);
-            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, inputType, fallBackToNearestAncestorType: true);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, inputType);
             jsonTypeInfo.SerializeAsObject(writer, value);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -166,7 +166,10 @@ namespace System.Text.Json
                 // 1. Find the JsonTypeInfo for the runtime type with fallback to the nearest ancestor, if not available.
                 // 2. If the resolved type is deriving from a polymorphic type, use the contract of the polymorphic type instead.
                 polymorphicTypeInfo = GetTypeInfoForRootType(runtimeType, fallBackToNearestAncestorType: true);
-                polymorphicTypeInfo = polymorphicTypeInfo.AncestorPolymorphicType ?? polymorphicTypeInfo;
+                if (polymorphicTypeInfo.AncestorPolymorphicType is { } ancestorPolymorphicType)
+                {
+                    polymorphicTypeInfo = ancestorPolymorphicType;
+                }
                 return true;
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -161,7 +161,11 @@ namespace System.Text.Json
             Type runtimeType = rootValue.GetType();
             if (runtimeType != JsonTypeInfo.ObjectType)
             {
+                // To determine the contract for an object value:
+                // 1. Find the JsonTypeInfo for the runtime type with fallback to the nearest ancestor, if not available.
+                // 2. If the resolved type is deriving from a polymorphic type, use the contract of the polymorphic type instead.
                 polymorphicTypeInfo = GetTypeInfoForRootType(runtimeType, fallBackToNearestAncestorType: true);
+                polymorphicTypeInfo = polymorphicTypeInfo.AncestorPolymorphicType ?? polymorphicTypeInfo;
                 return true;
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -630,6 +630,30 @@ namespace System.Text.Json.Serialization.Metadata
         }
 
         /// <summary>
+        /// Gets any ancestor polymorphic types that declare
+        /// a type discriminator for the current type. Consulted
+        /// when serializing polymorphic values as objects.
+        /// </summary>
+        internal JsonTypeInfo? AncestorPolymorphicType
+        {
+            get
+            {
+                Debug.Assert(IsConfigured);
+
+                if (!_isAncestorPolymorphicTypeResolved)
+                {
+                    _ancestorPolymorhicType = PolymorphicTypeResolver.FindNearestPolymorphicBaseType(this);
+                    _isAncestorPolymorphicTypeResolved = true;
+                }
+
+                return _ancestorPolymorhicType;
+            }
+        }
+
+        private JsonTypeInfo? _ancestorPolymorhicType;
+        private volatile bool _isAncestorPolymorphicTypeResolved;
+
+        /// <summary>
         /// Determines if the transitive closure of all JsonTypeInfo metadata referenced
         /// by the current type (property types, key types, element types, ...) are
         /// compatible with the settings as specified in JsonSerializerOptions.
@@ -877,9 +901,9 @@ namespace System.Text.Json.Serialization.Metadata
         internal JsonParameterInfoValues[]? ParameterInfoValues { get; set; }
 
         // Untyped, root-level serialization methods
-        internal abstract void SerializeAsObject(Utf8JsonWriter writer, object? rootValue, bool isInvokedByPolymorphicConverter = false);
-        internal abstract Task SerializeAsObjectAsync(Stream utf8Json, object? rootValue, CancellationToken cancellationToken, bool isInvokedByPolymorphicConverter = false);
-        internal abstract void SerializeAsObject(Stream utf8Json, object? rootValue, bool isInvokedByPolymorphicConverter = false);
+        internal abstract void SerializeAsObject(Utf8JsonWriter writer, object? rootValue);
+        internal abstract Task SerializeAsObjectAsync(Stream utf8Json, object? rootValue, CancellationToken cancellationToken);
+        internal abstract void SerializeAsObject(Stream utf8Json, object? rootValue);
 
         // Untyped, root-level deserialization methods
         internal abstract object? DeserializeAsObject(ref Utf8JsonReader reader, ref ReadStack state);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -1272,7 +1272,7 @@ namespace System.Text.Json.Serialization.Metadata
             if (type == typeof(object) && converter.CanBePolymorphic)
             {
                 // System.Object is polymorphic and will not respect Properties
-                Debug.Assert(converter is ObjectConverter);
+                Debug.Assert(converter is ObjectConverter or ObjectConverterSlim);
                 return JsonTypeInfoKind.None;
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
@@ -232,6 +232,71 @@ namespace System.Text.Json.Serialization.Metadata
         }
 
         /// <summary>
+        /// Walks the type hierarchy above the current type for any types that use polymorphic configuration.
+        /// </summary>
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
+            Justification = "The call to GetInterfaces will cross-reference results with interface types " +
+                            "already declared as derived types of the polymorphic base type.")]
+        internal static JsonTypeInfo? FindNearestPolymorphicBaseType(JsonTypeInfo typeInfo)
+        {
+            Debug.Assert(typeInfo.IsConfigured);
+
+            if (typeInfo.PolymorphismOptions != null)
+            {
+                // Type defines its own polymorphic configuration.
+                return null;
+            }
+
+            JsonTypeInfo? matchingResult = null;
+
+            // First, walk up the class hierarchy for any supported types.
+            for (Type? candidate = typeInfo.Type.BaseType; candidate != null; candidate = candidate.BaseType)
+            {
+                JsonTypeInfo? candidateInfo = typeInfo.Options.GetTypeInfoInternal(candidate, ensureNotNull: null);
+                if (candidateInfo?.PolymorphismOptions != null)
+                {
+                    // stop on the first ancestor that has a match
+                    matchingResult = candidateInfo;
+                    break;
+                }
+            }
+
+            // Now, walk the interface hierarchy for any polymorphic interface declarations.
+            foreach (Type interfaceType in typeInfo.Type.GetInterfaces())
+            {
+                JsonTypeInfo? candidateInfo = typeInfo.Options.GetTypeInfoInternal(interfaceType, ensureNotNull: null);
+                if (candidateInfo?.PolymorphismOptions != null)
+                {
+                    if (matchingResult != null)
+                    {
+                        // Resolve any conflicting matches.
+                        if (matchingResult.Type.IsAssignableFrom(interfaceType))
+                        {
+                            // interface is more derived than previous match, replace it.
+                            matchingResult = candidateInfo;
+                        }
+                        else if (interfaceType.IsAssignableFrom(matchingResult.Type))
+                        {
+                            // interface is less derived than previous match, keep the previous one.
+                            continue;
+                        }
+                        else
+                        {
+                            // Diamond ambiguity, do not report any ancestors.
+                            return null;
+                        }
+                    }
+                    else
+                    {
+                        matchingResult = candidateInfo;
+                    }
+                }
+            }
+
+            return matchingResult;
+        }
+
+        /// <summary>
         /// Lazy JsonTypeInfo result holder for a derived type.
         /// </summary>
         private sealed class DerivedJsonTypeInfo

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -17,7 +17,7 @@ namespace System.Text.Json
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal struct WriteStack
     {
-        public int CurrentDepth => _count;
+        public readonly int CurrentDepth => _count;
 
         /// <summary>
         /// Exposes the stackframe that is currently active.
@@ -91,13 +91,7 @@ namespace System.Text.Json
         /// <summary>
         /// Indicates that the state still contains suspended frames waiting re-entry.
         /// </summary>
-        public bool IsContinuation => _continuationCount != 0;
-
-        /// <summary>
-        /// Indicates that the root-level JsonTypeInfo is the result of
-        /// polymorphic dispatch from the internal System.Object converter.
-        /// </summary>
-        public bool IsPolymorphicRootValue;
+        public readonly bool IsContinuation => _continuationCount != 0;
 
         // The bag of preservable references.
         public ReferenceResolver ReferenceResolver;
@@ -123,9 +117,14 @@ namespace System.Text.Json
         public object? PolymorphicTypeDiscriminator;
 
         /// <summary>
+        /// The polymorphic type resolver used by the next converter.
+        /// </summary>
+        public PolymorphicTypeResolver? PolymorphicTypeResolver;
+
+        /// <summary>
         /// Whether the current frame needs to write out any metadata.
         /// </summary>
-        public bool CurrentContainsMetadata => NewReferenceId != null || PolymorphicTypeDiscriminator != null;
+        public readonly bool CurrentContainsMetadata => NewReferenceId != null || PolymorphicTypeDiscriminator != null;
 
         private void EnsurePushCapacity()
         {
@@ -142,7 +141,6 @@ namespace System.Text.Json
         internal void Initialize(
             JsonTypeInfo jsonTypeInfo,
             object? rootValueBoxed = null,
-            bool isPolymorphicRootValue = false,
             bool supportContinuation = false,
             bool supportAsync = false)
         {
@@ -153,7 +151,6 @@ namespace System.Text.Json
             Current.JsonTypeInfo = jsonTypeInfo;
             Current.JsonPropertyInfo = jsonTypeInfo.PropertyInfoForTypeInfo;
             Current.NumberHandling = Current.JsonPropertyInfo.EffectiveNumberHandling;
-            IsPolymorphicRootValue = isPolymorphicRootValue;
             SupportContinuation = supportContinuation;
             SupportAsync = supportAsync;
 
@@ -175,7 +172,7 @@ namespace System.Text.Json
         /// <summary>
         /// Gets the nested JsonTypeInfo before resolving any polymorphic converters
         /// </summary>
-        public JsonTypeInfo PeekNestedJsonTypeInfo()
+        public readonly JsonTypeInfo PeekNestedJsonTypeInfo()
         {
             Debug.Assert(Current.PolymorphicSerializationState != PolymorphicSerializationState.PolymorphicReEntryStarted);
             return _count == 0 ? Current.JsonTypeInfo : Current.JsonPropertyInfo!.JsonTypeInfo;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
@@ -76,7 +76,7 @@ namespace System.Text.Json
         // Serialization state for the child value serialized by the current frame.
         public PolymorphicSerializationState PolymorphicSerializationState;
         // Holds the entered polymorphic type info and acts as an LRU cache for element/field serializations.
-        private JsonPropertyInfo? PolymorphicJsonTypeInfo;
+        public JsonTypeInfo? PolymorphicTypeInfo;
 
         // Whether to use custom number handling.
         public JsonNumberHandling? NumberHandling;
@@ -105,33 +105,33 @@ namespace System.Text.Json
         /// <summary>
         /// Returns the JsonTypeInfo instance for the nested value we are trying to access.
         /// </summary>
-        public JsonTypeInfo GetNestedJsonTypeInfo()
+        public readonly JsonTypeInfo GetNestedJsonTypeInfo()
         {
-            JsonPropertyInfo? propInfo =
-                PolymorphicSerializationState == PolymorphicSerializationState.PolymorphicReEntryStarted ?
-                PolymorphicJsonTypeInfo :
-                JsonPropertyInfo;
-
-            return propInfo!.JsonTypeInfo;
+            return PolymorphicSerializationState is PolymorphicSerializationState.PolymorphicReEntryStarted
+                ? PolymorphicTypeInfo!
+                : JsonPropertyInfo!.JsonTypeInfo;
         }
 
         /// <summary>
         /// Configures the next stack frame for a polymorphic converter.
         /// </summary>
-        public JsonConverter InitializePolymorphicReEntry(Type runtimeType, JsonSerializerOptions options)
+        public JsonTypeInfo InitializePolymorphicReEntry(Type runtimeType, JsonSerializerOptions options)
         {
             Debug.Assert(PolymorphicSerializationState == PolymorphicSerializationState.None);
 
-            // For perf, avoid the dictionary lookup in GetOrAddJsonTypeInfo() for every element of a collection
+            // For perf, avoid the dictionary lookup in GetTypeInfoInternal() for every element of a collection
             // if the current element is the same type as the previous element.
-            if (PolymorphicJsonTypeInfo?.PropertyType != runtimeType)
+            if (PolymorphicTypeInfo?.Type != runtimeType)
             {
+                // To determine the contract for an object value:
+                // 1. Find the JsonTypeInfo for the runtime type with fallback to the nearest ancestor, if not available.
+                // 2. If the resolved type is deriving from a polymorphic type, use the contract of the polymorphic type instead.
                 JsonTypeInfo typeInfo = options.GetTypeInfoInternal(runtimeType, fallBackToNearestAncestorType: true);
-                PolymorphicJsonTypeInfo = typeInfo.PropertyInfoForTypeInfo;
+                PolymorphicTypeInfo = typeInfo.AncestorPolymorphicType ?? typeInfo;
             }
 
             PolymorphicSerializationState = PolymorphicSerializationState.PolymorphicReEntryStarted;
-            return PolymorphicJsonTypeInfo.EffectiveConverter;
+            return PolymorphicTypeInfo;
         }
 
         /// <summary>
@@ -139,11 +139,11 @@ namespace System.Text.Json
         /// </summary>
         public JsonConverter InitializePolymorphicReEntry(JsonTypeInfo derivedJsonTypeInfo)
         {
-            Debug.Assert(PolymorphicSerializationState == PolymorphicSerializationState.None);
+            Debug.Assert(PolymorphicSerializationState is PolymorphicSerializationState.None or PolymorphicSerializationState.PolymorphicReEntryStarted);
 
-            PolymorphicJsonTypeInfo = derivedJsonTypeInfo.PropertyInfoForTypeInfo;
+            PolymorphicTypeInfo = derivedJsonTypeInfo;
             PolymorphicSerializationState = PolymorphicSerializationState.PolymorphicReEntryStarted;
-            return PolymorphicJsonTypeInfo.EffectiveConverter;
+            return derivedJsonTypeInfo.Converter;
         }
 
         /// <summary>
@@ -152,9 +152,9 @@ namespace System.Text.Json
         public JsonConverter ResumePolymorphicReEntry()
         {
             Debug.Assert(PolymorphicSerializationState == PolymorphicSerializationState.PolymorphicReEntrySuspended);
-            Debug.Assert(PolymorphicJsonTypeInfo is not null);
+            Debug.Assert(PolymorphicTypeInfo is not null);
             PolymorphicSerializationState = PolymorphicSerializationState.PolymorphicReEntryStarted;
-            return PolymorphicJsonTypeInfo.EffectiveConverter;
+            return PolymorphicTypeInfo.Converter;
         }
 
         /// <summary>
@@ -166,6 +166,6 @@ namespace System.Text.Json
         }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private string DebuggerDisplay => $"ConverterStrategy.{JsonTypeInfo?.Converter.ConverterStrategy}, {JsonTypeInfo?.Type.Name}";
+        private readonly string DebuggerDisplay => $"ConverterStrategy.{JsonTypeInfo?.Converter.ConverterStrategy}, {JsonTypeInfo?.Type.Name}";
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.IO;
 using System.Reflection;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
+using System.Text.Json.Serialization.Tests;
 using System.Threading.Tasks;
 using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
@@ -117,6 +117,23 @@ namespace System.Text.Json.SourceGeneration.Tests
                 JsonMessage deserialized = (JsonMessage)JsonSerializer.Deserialize(json, typeof(JsonMessage), context);
                 Assert.Equal("Hi", deserialized.Message);
             }
+        }
+
+        [Fact]
+        public static async Task SupportsBoxedRootLevelValues()
+        {
+            PersonJsonContext context = PersonJsonContext.Default;
+            object person = new Person("John", "Smith");
+            string expectedJson = """{"firstName":"John","lastName":"Smith"}""";
+            // Sanity check -- context does not specify object metadata
+            Assert.Null(context.GetTypeInfo(typeof(object)));
+
+            string json = JsonSerializer.Serialize(person, context.Options);
+            Assert.Equal(expectedJson, json);
+
+            var stream = new Utf8MemoryStream();
+            await JsonSerializer.SerializeAsync(stream, person, context.Options);
+            Assert.Equal(expectedJson, stream.AsString());
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/UnspeakableTypeTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/UnspeakableTypeTests.cs
@@ -95,11 +95,6 @@ namespace System.Text.Json.SourceGeneration.Tests
             Assert.Contains("TypeWithDiamondAmbiguity", exn.Message);
             Assert.Contains("BasePoco", exn.Message);
             Assert.Contains("IEnumerable", exn.Message);
-
-            exn = await Assert.ThrowsAsync<NotSupportedException>(() => Serializer.SerializeWrapper(value, value.GetType(), UnspeakableTypeContext.Default.Options));
-            Assert.Contains("TypeWithDiamondAmbiguity", exn.Message);
-            Assert.Contains("BasePoco", exn.Message);
-            Assert.Contains("IEnumerable", exn.Message);
         }
 
         public static IEnumerable<object[]> GetUnspeakableTypes()
@@ -157,7 +152,6 @@ namespace System.Text.Json.SourceGeneration.Tests
 
         public record Envelope<T>(T Value);
 
-        [JsonSerializable(typeof(object))]
         [JsonSerializable(typeof(BasePoco))]
         [JsonSerializable(typeof(IMyInterface))]
         [JsonSerializable(typeof(IEnumerable))]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/UnspeakableTypeTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/UnspeakableTypeTests.cs
@@ -37,9 +37,8 @@ namespace System.Text.Json.SourceGeneration.Tests
             json = await Serializer.SerializeWrapper<object>(envelope.Value, options);
             Assert.Equal(expectedJson, json);
 
-            // or if you pass in its runtime type 
-            json = await Serializer.SerializeWrapper(envelope.Value, envelope.Value.GetType(), options);
-            Assert.Equal(expectedJson, json);
+            // But fails if you pass in its runtime type 
+            await Assert.ThrowsAsync<NotSupportedException>(() => Serializer.SerializeWrapper(envelope.Value, envelope.Value.GetType(), options));
 
             if (isBaseTypeDeserializable)
             {

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonPropertyInfo.cs
@@ -1,15 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text.Json.Nodes;
-using System.Text.Json.Nodes.Tests;
 using System.Text.Json.Serialization.Metadata;
-using System.Text.Json.Tests;
-using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -63,11 +56,13 @@ namespace System.Text.Json.Serialization.Tests
             public JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options)
             {
                 JsonTypeInfo? typeInfo = _context.GetTypeInfo(type, options);
-                Assert.NotNull(typeInfo);
 
-                foreach (var modifier in _modifiers)
+                if (typeInfo != null)
                 {
-                    modifier(typeInfo);
+                    foreach (var modifier in _modifiers)
+                    {
+                        modifier(typeInfo);
+                    }
                 }
 
                 return typeInfo;


### PR DESCRIPTION
This PR:

- Removes unspeakable type support form serialization overloads that accept an explicit `Type` parameter. Unspeakable type support now only works for values that are serialized as `object` types. Fix #82457.
- Update the type hierarchies feature so that polymorphism metadata is honored when serializing boxed values. This is done using a nearest polymorphic ancestor traversal algorithm similar to how unspeakable type support is implemented. Fix #77532.
- Adds support for boxed root value serialization in source generators that don't supply metadata for `object`. Fix #84704.

I've split up the PR into three separate commits for easier reviewing.
