### PR TITLE
Fix indirection for RunInitializers when target does not support relative pointers

### DIFF
--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/CompilerHelpers/StartupCodeHelpers.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/CompilerHelpers/StartupCodeHelpers.cs
@@ -177,7 +177,7 @@ namespace Internal.Runtime.CompilerHelpers
                 pCurrent < (pInitializers + length);
                 pCurrent += MethodTable.SupportsRelativePointers ? sizeof(int) : sizeof(nint))
             {
-                var initializer = MethodTable.SupportsRelativePointers ? (delegate*<void>)ReadRelPtr32(pCurrent) : (delegate*<void>)pCurrent;
+                var initializer = MethodTable.SupportsRelativePointers ? (delegate*<void>)ReadRelPtr32(pCurrent) : *(delegate*<void>*)pCurrent;
                 initializer();
             }
 


### PR DESCRIPTION
This PR adds an indirection when getting the function pointer when `MethodTable.SupportsRelativePointers` is `false`

Fixes https://github.com/dotnet/runtimelab/issues/2252

I assume that this code is only exercised only in NAOT and as there are all tested targets support relative pointers (apart from the experimental LLVM/Wasm) that this was not caught originally.

cc @jkotas @SingleAccretion 

Thanks!