### PR TITLE
[RISC-V] Disable corelib crossgen2

### DIFF
--- a/src/coreclr/crossgen-corelib.proj
+++ b/src/coreclr/crossgen-corelib.proj
@@ -16,6 +16,7 @@
       <CrossDir Condition="'$(CrossBuild)' == 'true' or '$(BuildArchitecture)' != '$(TargetArchitecture)'">$(BuildArchitecture)</CrossDir>
 
       <BuildDll>true</BuildDll>
+      <BuildDll Condition="'$(TargetArchitecture)' == 'riscv64'">false</BuildDll>
 
       <BuildPdb>false</BuildPdb>
       <BuildPdb Condition="$(BuildDll) and '$(OS)' == 'Windows_NT' and '$(TargetOS)' == 'windows'">true</BuildPdb>


### PR DESCRIPTION
- crossgen2 is not supported yet in RISC-V
- Fix RISC-V build error due to https://github.com/dotnet/runtime/pull/84148 which enables corelib crossgen2 in RISC-V