### PR TITLE
Fix BigInteger parse hex strings on negative numbers

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
@@ -466,6 +466,11 @@ namespace System.Numerics
 
                 Debug.Assert(partialDigitCount == 0 && bitsBufferPos == -1);
 
+                if (isNegative)
+                {
+                    NumericsHelpers.DangerousMakeTwosComplement(bitsBuffer);
+                }
+
                 // BigInteger requires leading zero blocks to be truncated.
                 bitsBuffer = bitsBuffer.TrimEnd(0u);
 
@@ -477,26 +482,15 @@ namespace System.Numerics
                     sign = 0;
                     bits = null;
                 }
-                else if (bitsBuffer.Length == 1)
+                else if (bitsBuffer.Length == 1 && bitsBuffer[0] <= int.MaxValue)
                 {
-                    sign = (int)bitsBuffer[0];
+                    sign = (int)bitsBuffer[0] * (isNegative ? -1 : 1);
                     bits = null;
-
-                    if ((!isNegative && sign < 0) || sign == int.MinValue)
-                    {
-                        bits = new[] { (uint)sign };
-                        sign = isNegative ? -1 : 1;
-                    }
                 }
                 else
                 {
                     sign = isNegative ? -1 : 1;
                     bits = bitsBuffer.ToArray();
-
-                    if (isNegative)
-                    {
-                        NumericsHelpers.DangerousMakeTwosComplement(bits);
-                    }
                 }
 
                 result = new BigInteger(sign, bits);

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/parse.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/parse.cs
@@ -132,6 +132,11 @@ namespace System.Numerics.Tests
             Assert.True(BigInteger.TryParse("080000001", NumberStyles.HexNumber, null, out result));
             Assert.Equal(0x80000001u, result);
 
+            // Regression test for: https://github.com/dotnet/runtime/issues/74758
+            Assert.True(BigInteger.TryParse("FFFFFFFFE", NumberStyles.HexNumber, null, out result));
+            Assert.Equal(new BigInteger(-2), result);
+            Assert.Equal(-2, result);
+
             Assert.Throws<FormatException>(() =>
             {
                 BigInteger.Parse("zzz", NumberStyles.HexNumber);


### PR DESCRIPTION
fixes dotnet#74758