### PR TITLE
Fix enterprise linux build

### DIFF
--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/Dockerfile
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/Dockerfile
@@ -8,6 +8,27 @@ COPY ./common/krb5.conf /etc/krb5.conf
 RUN apt-get update && \
     apt-get install -y --no-install-recommends krb5-user gss-ntlmssp iputils-ping dnsutils nano
 
+# Enable openssl legacy provider in system openssl config
+RUN fixOpensslConf=$(mktemp) && \
+    printf "#!/usr/bin/env sh\n\
+        sed -i '\n\
+            # Append 'legacy = legacy_sect' after 'default = default_sect' under [provdier_sect]
+            /^default = default_sect/a legacy_sect\n\
+            # Search for [default_sect]
+            /\[default_sect\]/ {\n\
+                # Go to next line
+                n\n\
+                # Uncomment '# activate = 1'
+                s/# //\n\
+                # Append new [legacy_sect], with 'activate = 1'
+                a\n\
+                a [legacy_sect]\n\
+                a activate = 1\n\
+            }\n\
+            ' /etc/ssl/openssl.cnf\n" > $fixOpensslConf && \
+    sh $fixOpensslConf && \
+    rm $fixOpensslConf
+
 # Set environment variable to turn on enterprise tests
 ENV DOTNET_RUNTIME_ENTERPRISETESTS_ENABLED 1
 

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/Dockerfile
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
 RUN fixOpensslConf=$(mktemp) && \
     printf "#!/usr/bin/env sh\n\
         sed -i '\n\
-            # Append 'legacy = legacy_sect' after 'default = default_sect' under [provdier_sect]
-            /^default = default_sect/a legacy_sect\n\
+            # Append 'legacy = legacy_sect' after 'default = default_sect' under [provider_sect]
+            /^default = default_sect/a legacy = legacy_sect\n\
             # Search for [default_sect]
             /\[default_sect\]/ {\n\
                 # Go to next line

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/Dockerfile
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
 
 # Prevents dialog prompting when installing packages
 ARG DEBIAN_FRONTEND=noninteractive
@@ -6,7 +6,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Install Kerberos, NTLM, and diagnostic tools
 COPY ./common/krb5.conf /etc/krb5.conf
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends krb5-user gss-ntlmssp iputils-ping dnsutils nano
+    apt-get install -y --no-install-recommends krb5-user gss-ntlmssp iputils-ping dnsutils nano lld
 
 # Set environment variable to turn on enterprise tests
 ENV DOTNET_RUNTIME_ENTERPRISETESTS_ENABLED 1

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/Dockerfile
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/Dockerfile
@@ -6,7 +6,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Install Kerberos, NTLM, and diagnostic tools
 COPY ./common/krb5.conf /etc/krb5.conf
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends krb5-user gss-ntlmssp iputils-ping dnsutils nano lld
+    apt-get install -y --no-install-recommends krb5-user gss-ntlmssp iputils-ping dnsutils nano
 
 # Set environment variable to turn on enterprise tests
 ENV DOTNET_RUNTIME_ENTERPRISETESTS_ENABLED 1


### PR DESCRIPTION
Ensure a recent lld is available on the build host. See https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/843.

Attempting to fix the issue mentioned in https://github.com/dotnet/runtime/pull/84148#issuecomment-1506517575.

Fixes https://github.com/dotnet/runtime/issues/85035