### PR TITLE
[RISC-V][GC] Use 128gb for regions_range on RISCV64

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -45747,8 +45747,8 @@ HRESULT GCHeap::Initialize()
         }
         else
         {
-            // If no hard_limit is configured the reservation size is max of 256gb or 2x physical limit
-            gc_heap::regions_range = max(((size_t)256 * 1024 * 1024 * 1024), (size_t)(2 * gc_heap::total_physical_mem));
+            // If no hard_limit is configured the reservation size is max of 2x physical limit or min of 1/2 GetVirtualMemoryLimit() and 256Gb
+            gc_heap::regions_range = max(min(GCToOSInterface::GetVirtualMemoryLimit()/2, (size_t)256 * 1024 * 1024 * 1024), (size_t)(2 * gc_heap::total_physical_mem));
         }
         gc_heap::regions_range = align_on_page(gc_heap::regions_range);
     }

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -45747,8 +45747,8 @@ HRESULT GCHeap::Initialize()
         }
         else
         {
-            // If no hard_limit is configured the reservation size is max of 2x physical limit or min of 1/2 GetVirtualMemoryLimit() and 256Gb
-            gc_heap::regions_range = max(min(GCToOSInterface::GetVirtualMemoryLimit()/2, (size_t)256 * 1024 * 1024 * 1024), (size_t)(2 * gc_heap::total_physical_mem));
+            // If no hard_limit is configured the reservation size is min of 1/2 GetVirtualMemoryLimit() or max of 256Gb or 2x physical limit.
+            gc_heap::regions_range = min(GCToOSInterface::GetVirtualMemoryLimit()/2, max((size_t)256 * 1024 * 1024 * 1024, (size_t)(2 * gc_heap::total_physical_mem)));
         }
         gc_heap::regions_range = align_on_page(gc_heap::regions_range);
     }

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -1080,12 +1080,18 @@ const AffinitySet* GCToOSInterface::SetGCThreadsAffinitySet(uintptr_t configAffi
 size_t GCToOSInterface::GetVirtualMemoryLimit()
 {
 #ifdef HOST_64BIT
+#ifndef TARGET_RISCV64
     // There is no API to get the total virtual address space size on
     // Unix, so we use a constant value representing 128TB, which is
     // the approximate size of total user virtual address space on
     // the currently supported Unix systems.
     static const uint64_t _128TB = (1ull << 47);
     return _128TB;
+#else // TARGET_RISCV64
+    // For RISC-V Linux Kernel SV39 virtual memory limit is 256gb.
+    static const uint64_t _256GB = (1ull << 38);
+    return _256GB;
+#endif // TARGET_RISCV64
 #else
     return (size_t)-1;
 #endif

--- a/src/coreclr/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/pal/src/misc/sysinfo.cpp
@@ -470,12 +470,17 @@ GlobalMemoryStatusEx(
 #endif // __APPLE__
     }
 
+#ifndef TARGET_RISCV64
     // There is no API to get the total virtual address space size on
     // Unix, so we use a constant value representing 128TB, which is
     // the approximate size of total user virtual address space on
     // the currently supported Unix systems.
-    static const UINT64 _128TB = (1ull << 47);
-    lpBuffer->ullTotalVirtual = _128TB;
+    static const UINT64 VMSize = (1ull << 47);
+#else // TARGET_RISCV64
+    // For RISC-V Linux Kernel SV39 virtual memory limit is 256gb.
+    static const UINT64 VMSize = (1ull << 38);
+#endif // TARGET_RISCV64
+    lpBuffer->ullTotalVirtual = VMSize;
     lpBuffer->ullAvailVirtual = lpBuffer->ullAvailPhys;
 
     LOGEXIT("GlobalMemoryStatusEx returns %d\n", fRetVal);


### PR DESCRIPTION
Use 128gb for regions_range cause RISCV64 SV39 memory layout allows to use only 256gb of virtual memory: https://docs.kernel.org/riscv/vm-layout.html#risc-v-linux-kernel-sv39.