### PR TITLE
Fix clang tool downloads

### DIFF
--- a/eng/formatting/download-tools.sh
+++ b/eng/formatting/download-tools.sh
@@ -17,12 +17,25 @@ scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 function DownloadClangTool {
     targetPlatform=$(dotnet --info |grep RID:)
     targetPlatform=${targetPlatform##*RID:* }
+    echo "dotnet RID: ${targetPlatform}"
+
+    # override common RIDs with compatible version so we don't need to upload binaries for each RID
+    case $targetPlatform in
+        osx.*-x64)
+            targetPlatform=osx.10.15-x64
+            ;;
+        ubuntu.*-x64)
+            targetPlatform=ubuntu.18.04-x64
+            ;;
+    esac
 
     toolUrl=https://clrjit.blob.core.windows.net/clang-tools/${targetPlatform}/$1
     toolOutput=$2/$1
 
+    echo "Downloading $1 from ${toolUrl} to ${toolOutput}"
+
     if [[ ! -x "$toolOutput" ]]; then
-        curl --retry 5 -o "${toolOutput}" "$toolUrl"
+        curl --silent --retry 5 --fail -o "${toolOutput}" "$toolUrl"
         chmod 751 $toolOutput
     fi
 

--- a/src/coreclr/scripts/jitformat.py
+++ b/src/coreclr/scripts/jitformat.py
@@ -81,7 +81,7 @@ def main(argv):
     args, unknown = parser.parse_known_args(argv)
 
     if unknown:
-        logging.warn('Ignoring argument(s): {}'.format(','.join(unknown)))
+        logging.warning('Ignoring argument(s): {}'.format(','.join(unknown)))
 
     if args.coreclr is None:
         logging.error('Specify --coreclr')


### PR DESCRIPTION
1. Make downloading more robust by failing the download script if there is a download error.
2. Map macOS and Ubuntu RIDs to RIDs that we know have versions to download. This same logic is in the dotnet/jitutils bootstrap.sh script. We don't want to upload versions for every RID since they are all compatible. This makes the script robust to people running on new releases.
3. Add more logging.

Fixes #84780
