### PR TITLE
[release/7.0-staging] Add status code and exception info to System.Net.Http events

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -1024,7 +1024,8 @@ namespace System.Net.Http
                         Debug.Assert(!wait);
                     }
 
-                    if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.ResponseHeadersStop();
+                    Debug.Assert(_response is not null);
+                    if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.ResponseHeadersStop((int)_response.StatusCode);
                 }
                 catch
                 {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -352,7 +352,7 @@ namespace System.Net.Http
 
             _headerState = HeaderState.TrailingHeaders;
 
-            if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.ResponseHeadersStop();
+            if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.ResponseHeadersStop((int)_response.StatusCode);
         }
 
         private async Task SendContentAsync(HttpContent content, CancellationToken cancellationToken)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -666,7 +666,7 @@ namespace System.Net.Http
                     ParseHeaderNameValue(this, line.Span, response, isFromTrailer: false);
                 }
 
-                if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.ResponseHeadersStop();
+                if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.ResponseHeadersStop((int)response.StatusCode);
 
                 if (allowExpect100ToContinue != null)
                 {

--- a/src/libraries/System.Net.Http/tests/UnitTests/Fakes/HttpTelemetry.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Fakes/HttpTelemetry.cs
@@ -11,9 +11,9 @@ namespace System.Net.Http
 
         public void RequestStart(HttpRequestMessage request) { }
 
-        public void RequestStop() { }
+        public void RequestStop(HttpResponseMessage response) { }
 
-        public void RequestFailed() { }
+        public void RequestFailed(Exception exception) { }
 
         public void ResponseContentStart() { }
 


### PR DESCRIPTION
Backport of #84036 to 7.0.
Contributes to #83734.

## Customer Impact

The networking stack is already instrumented with EventSource events that allow telemetry consumers to observe when requests are made and where they are spending time. Aside from a timestamp, these events often provide no or very few extra details.

On .NET Framework, a different EventSource provider exists that exposes information like the HTTP response status code. This provider does not exist on .NET Core+, and as a result, customers migrating their services from Framework are losing diagnostics information (e.g. XBox Live service).

This PR adds the response status code and exception message to existing events to cover that gap.

## Testing

I added targeted CI tests that confirm new parameters are included in events.

## Risk

Minimal.
Impacted code paths are all only reachable when telemetry is enabled.
With confirmation from @brianrob and @noahfalk, modifications to existing events in the manner done here are safe and non-breaking for existing telemetry consumers.