### PR TITLE
[release/6.0-staging] Add status code and exception info to System.Net.Http events

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpMessageInvoker.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpMessageInvoker.cs
@@ -46,18 +46,20 @@ namespace System.Net.Http
             {
                 HttpTelemetry.Log.RequestStart(request);
 
+                HttpResponseMessage? response = null;
                 try
                 {
-                    return _handler.Send(request, cancellationToken);
+                    response = _handler.Send(request, cancellationToken);
+                    return response;
                 }
-                catch when (LogRequestFailed(telemetryStarted: true))
+                catch (Exception ex) when (LogRequestFailed(ex, telemetryStarted: true))
                 {
                     // Unreachable as LogRequestFailed will return false
                     throw;
                 }
                 finally
                 {
-                    HttpTelemetry.Log.RequestStop();
+                    HttpTelemetry.Log.RequestStop(response);
                 }
             }
             else
@@ -85,18 +87,20 @@ namespace System.Net.Http
             {
                 HttpTelemetry.Log.RequestStart(request);
 
+                HttpResponseMessage? response = null;
                 try
                 {
-                    return await handler.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                    response = await handler.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                    return response;
                 }
-                catch when (LogRequestFailed(telemetryStarted: true))
+                catch (Exception ex) when (LogRequestFailed(ex, telemetryStarted: true))
                 {
                     // Unreachable as LogRequestFailed will return false
                     throw;
                 }
                 finally
                 {
-                    HttpTelemetry.Log.RequestStop();
+                    HttpTelemetry.Log.RequestStop(response);
                 }
             }
         }
@@ -107,11 +111,11 @@ namespace System.Net.Http
             request.RequestUri is Uri requestUri &&
             requestUri.IsAbsoluteUri;
 
-        internal static bool LogRequestFailed(bool telemetryStarted)
+        internal static bool LogRequestFailed(Exception exception, bool telemetryStarted)
         {
             if (HttpTelemetry.Log.IsEnabled() && telemetryStarted)
             {
-                HttpTelemetry.Log.RequestFailed();
+                HttpTelemetry.Log.RequestFailed(exception);
             }
             return false;
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
@@ -48,18 +48,34 @@ namespace System.Net.Http
                 request.VersionPolicy);
         }
 
-        [Event(2, Level = EventLevel.Informational)]
-        public void RequestStop()
+        [NonEvent]
+        public void RequestStop(HttpResponseMessage? response)
         {
-            Interlocked.Increment(ref _stoppedRequests);
-            WriteEvent(eventId: 2);
+            RequestStop(response is null ? -1 : (int)response.StatusCode);
         }
 
-        [Event(3, Level = EventLevel.Error)]
-        public void RequestFailed()
+        [Event(2, Level = EventLevel.Informational, Version = 1)]
+        private void RequestStop(int statusCode)
+        {
+            Interlocked.Increment(ref _stoppedRequests);
+            WriteEvent(eventId: 2, statusCode);
+        }
+
+        [NonEvent]
+        public void RequestFailed(Exception exception)
         {
             Interlocked.Increment(ref _failedRequests);
-            WriteEvent(eventId: 3);
+
+            if (IsEnabled(EventLevel.Error, EventKeywords.None))
+            {
+                RequestFailed(exceptionMessage: exception.Message);
+            }
+        }
+
+        [Event(3, Level = EventLevel.Error, Version = 1)]
+        private void RequestFailed(string exceptionMessage)
+        {
+            WriteEvent(eventId: 3, exceptionMessage);
         }
 
         [Event(4, Level = EventLevel.Informational)]
@@ -110,10 +126,10 @@ namespace System.Net.Http
             WriteEvent(eventId: 11);
         }
 
-        [Event(12, Level = EventLevel.Informational)]
-        public void ResponseHeadersStop()
+        [Event(12, Level = EventLevel.Informational, Version = 1)]
+        public void ResponseHeadersStop(int statusCode)
         {
-            WriteEvent(eventId: 12);
+            WriteEvent(eventId: 12, statusCode);
         }
 
         [Event(13, Level = EventLevel.Informational)]

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -998,7 +998,8 @@ namespace System.Net.Http
                         Debug.Assert(!wait);
                     }
 
-                    if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.ResponseHeadersStop();
+                    Debug.Assert(_response is not null);
+                    if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.ResponseHeadersStop((int)_response.StatusCode);
                 }
                 catch
                 {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -669,7 +669,7 @@ namespace System.Net.Http
                     ParseHeaderNameValue(this, line.Span, response, isFromTrailer: false);
                 }
 
-                if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.ResponseHeadersStop();
+                if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.ResponseHeadersStop((int)response.StatusCode);
 
                 if (allowExpect100ToContinue != null)
                 {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
@@ -409,14 +409,25 @@ namespace System.Net.Http.Functional.Tests
             Assert.Equal(count, starts.Length);
 
             (EventWrittenEventArgs Event, Guid ActivityId)[] stops = events.Where(e => e.Event.EventName == "RequestStop").ToArray();
-            Assert.All(stops, stopEvent => Assert.Empty(stopEvent.Event.Payload));
+            foreach (EventWrittenEventArgs stopEvent in stops.Select(e => e.Event))
+            {
+                object payload = Assert.Single(stopEvent.Payload);
+                int statusCode = Assert.IsType<int>(payload);
+                Assert.Equal(shouldHaveFailures ? -1 : 200, statusCode);
+            }
 
             ValidateSameActivityIds(starts, stops);
 
             (EventWrittenEventArgs Event, Guid ActivityId)[] failures = events.Where(e => e.Event.EventName == "RequestFailed").ToArray();
-            Assert.All(failures, failedEvent => Assert.Empty(failedEvent.Event.Payload));
             if (shouldHaveFailures)
             {
+                foreach (EventWrittenEventArgs failedEvent in failures.Select(e => e.Event))
+                {
+                    object payload = Assert.Single(failedEvent.Payload);
+                    string exceptionMessage = Assert.IsType<string>(payload);
+                    Assert.Equal(new OperationCanceledException().Message, exceptionMessage);
+                }
+
                 ValidateSameActivityIds(starts, failures);
             }
             else
@@ -467,8 +478,8 @@ namespace System.Net.Http.Functional.Tests
             foreach (EventWrittenEventArgs requestContentStop in requestContentStops.Select(e => e.Event))
             {
                 object payload = Assert.Single(requestContentStop.Payload);
-                Assert.True(payload is long);
-                Assert.Equal(requestContentLength.Value, (long)payload);
+                long contentLength = Assert.IsType<long>(payload);
+                Assert.Equal(requestContentLength.Value, contentLength);
             }
 
             ValidateSameActivityIds(requestContentStarts, requestContentStops);
@@ -479,7 +490,12 @@ namespace System.Net.Http.Functional.Tests
 
             (EventWrittenEventArgs Event, Guid ActivityId)[] responseHeadersStops = events.Where(e => e.Event.EventName == "ResponseHeadersStop").ToArray();
             Assert.Equal(count, responseHeadersStops.Length);
-            Assert.All(responseHeadersStops, r => Assert.Empty(r.Event.Payload));
+            foreach (EventWrittenEventArgs responseHeadersStop in responseHeadersStops.Select(e => e.Event))
+            {
+                object payload = Assert.Single(responseHeadersStop.Payload);
+                int statusCode = Assert.IsType<int>(payload);
+                Assert.Equal(200, statusCode);
+            }
 
             ValidateSameActivityIds(responseHeadersStarts, responseHeadersStops);
 

--- a/src/libraries/System.Net.Http/tests/UnitTests/Fakes/HttpTelemetry.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Fakes/HttpTelemetry.cs
@@ -11,9 +11,9 @@ namespace System.Net.Http
 
         public void RequestStart(HttpRequestMessage request) { }
 
-        public void RequestStop() { }
+        public void RequestStop(HttpResponseMessage response) { }
 
-        public void RequestFailed() { }
+        public void RequestFailed(Exception exception) { }
 
         public void ResponseContentStart() { }
 


### PR DESCRIPTION
Backport of #84036 to 6.0.
Contributes to #83734.

## Customer Impact

The networking stack is already instrumented with EventSource events that allow telemetry consumers to observe when requests are made and where they are spending time. Aside from a timestamp, these events often provide no or very few extra details.

On .NET Framework, a different EventSource provider exists that exposes information like the HTTP response status code. This provider does not exist on .NET Core+, and as a result, customers migrating their services from Framework are losing diagnostics information (e.g. XBox Live service).

This PR adds the response status code and exception message to existing events to cover that gap.

## Testing

I added targeted CI tests that confirm new parameters are included in events.

## Risk

Minimal.
Impacted code paths are all only reachable when telemetry is enabled.
With confirmation from @brianrob and @noahfalk, modifications to existing events in the manner done here are safe and non-breaking for existing telemetry consumers.