### PR TITLE
Use RegexRunner.CharInClass directly from source-generated regex code

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -4932,19 +4932,6 @@ namespace System.Text.RegularExpressions.Generator
                     $"({range0Clause} | {range1Clause})";
             }
 
-            const string Base = nameof(Base);
-            if (!requiredHelpers.ContainsKey(Base))
-            {
-                requiredHelpers.Add(Base, new string[]
-                {
-                    $"internal class {Base} : RegexRunner",
-                    $"{{",
-                    $"    /// <summary>Determines whether the specified character in is in the specified character class.</summary>",
-                    $"    internal static new bool CharInClass(char ch, string charClass) => RegexRunner.CharInClass(ch, charClass);",
-                    $"}}",
-                });
-            }
-
             if (analysis.ContainsNoAscii)
             {
                 // We determined that the character class contains only non-ASCII,
@@ -5041,20 +5028,20 @@ namespace System.Text.RegularExpressions.Generator
 
                 _ => $"({Literal(bitVectorString)}[ch >> 4] & (1 << (ch & 0xF))) {(negate ? "=" : "!")}= 0",
             };
-            return $"((ch = {chExpr}) < 128 ? {asciiExpr} : {(negate ? "!" : "")}{HelpersTypeName}.{Base}.CharInClass((char)ch, {Literal(charClass)}))";
+            return $"((ch = {chExpr}) < 128 ? {asciiExpr} : {(negate ? "!" : "")}RegexRunner.CharInClass((char)ch, {Literal(charClass)}))";
 
             string EmitContainsNoAscii()
             {
                 return negate ?
-                    $"((ch = {chExpr}) < 128 || !{HelpersTypeName}.{Base}.CharInClass((char)ch, {Literal(charClass)}))" :
-                    $"((ch = {chExpr}) >= 128 && {HelpersTypeName}.{Base}.CharInClass((char)ch, {Literal(charClass)}))";
+                    $"((ch = {chExpr}) < 128 || !RegexRunner.CharInClass((char)ch, {Literal(charClass)}))" :
+                    $"((ch = {chExpr}) >= 128 && RegexRunner.CharInClass((char)ch, {Literal(charClass)}))";
             }
 
             string EmitAllAsciiContained()
             {
                 return negate ?
-                    $"((ch = {chExpr}) >= 128 && !{HelpersTypeName}.{Base}.CharInClass((char)ch, {Literal(charClass)}))" :
-                    $"((ch = {chExpr}) < 128 || {HelpersTypeName}.{Base}.CharInClass((char)ch, {Literal(charClass)}))";
+                    $"((ch = {chExpr}) >= 128 && !RegexRunner.CharInClass((char)ch, {Literal(charClass)}))" :
+                    $"((ch = {chExpr}) < 128 || RegexRunner.CharInClass((char)ch, {Literal(charClass)}))";
             }
         }
 

--- a/src/libraries/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.cs
+++ b/src/libraries/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.cs
@@ -354,7 +354,7 @@ namespace System.Text.RegularExpressions
         protected internal int runtrackpos;
         protected internal RegexRunner() { }
         protected void Capture(int capnum, int start, int end) { }
-        protected static bool CharInClass(char ch, string charClass) { throw null; }
+        public static bool CharInClass(char ch, string charClass) { throw null; }
         protected static bool CharInSet(char ch, string @set, string category) { throw null; }
         protected void CheckTimeout() { }
         protected void Crawl(int i) { }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
@@ -399,7 +399,7 @@ namespace System.Text.RegularExpressions
             return RegexCharClass.CharInClass(ch, charClass);
         }
 
-        protected static bool CharInClass(char ch, string charClass)
+        public static bool CharInClass(char ch, string charClass)
         {
             return RegexCharClass.CharInClass(ch, charClass);
         }

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorOutputTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorOutputTests.cs
@@ -660,7 +660,7 @@ namespace System.Text.RegularExpressions.Tests
                                                 // Match a character in the set [^>\s] atomically at least once.
                                                 {
                                                     int iteration3 = 0;
-                                                    while ((uint)iteration3 < (uint)slice.Length && ((ch = slice[iteration3]) < 128 ? ("쇿\uffff\ufffe뿿\uffff\uffff\uffff\uffff"[ch >> 4] & (1 << (ch & 0xF))) != 0 : Utilities.Base.CharInClass((char)ch, "\u0001\u0002\u0001>?d")))
+                                                    while ((uint)iteration3 < (uint)slice.Length && ((ch = slice[iteration3]) < 128 ? ("쇿\uffff\ufffe뿿\uffff\uffff\uffff\uffff"[ch >> 4] & (1 << (ch & 0xF))) != 0 : RegexRunner.CharInClass((char)ch, "\u0001\u0002\u0001>?d")))
                                                     {
                                                         iteration3++;
                                                     }
@@ -702,16 +702,6 @@ namespace System.Text.RegularExpressions.Tests
 
                     }
 
-                    /// <summary>Helper methods used by generated <see cref="Regex"/>-derived implementations.</summary>
-                    [GeneratedCodeAttribute("System.Text.RegularExpressions.Generator", "42.42.42.42")]
-                    file static class Utilities
-                    {
-                        internal class Base : RegexRunner
-                        {
-                            /// <summary>Determines whether the specified character in is in the specified character class.</summary>
-                            internal static new bool CharInClass(char ch, string charClass) => RegexRunner.CharInClass(ch, charClass);
-                        }
-                    }
                 }
                 """
             };


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/84783