### PR TITLE
JIT: fix exit edge likelihood computation for capped loops

### DIFF
--- a/src/coreclr/jit/fgprofilesynthesis.cpp
+++ b/src/coreclr/jit/fgprofilesynthesis.cpp
@@ -1145,7 +1145,10 @@ void ProfileSynthesis::ComputeCyclicProbabilities(SimpleLoop* loop)
         m_cappedCyclicProbabilities++;
     }
 
-    weight_t cyclicProbability = 1.0 / (1.0 - cyclicWeight);
+    // Note this value is not actually a probability; it is the expected
+    // iteration count of the loop.
+    //
+    weight_t const cyclicProbability = 1.0 / (1.0 - cyclicWeight);
 
     JITDUMP("For loop at " FMT_BB " cyclic weight is " FMT_WT " cyclic probability is " FMT_WT "%s\n",
             loop->m_head->bbNum, cyclicWeight, cyclicProbability, capped ? " [capped]" : "");
@@ -1154,17 +1157,53 @@ void ProfileSynthesis::ComputeCyclicProbabilities(SimpleLoop* loop)
 
     // Try and adjust loop exit likelihood to reflect capping.
     // If there are multiple exits we just adjust the first one we can. This is somewhat arbitrary.
+    // If there are no exits, there's nothing we can do.
     //
-    if (capped)
+    if (capped && (loop->m_exitEdges.size() > 0))
     {
+        // Figure out how much flow exits the loop with the capped probablility
+        // and current block frequencies and exit likelihoods.
+        //
+        weight_t cappedExitWeight = 0.0;
+
+        for (FlowEdge* const exitEdge : loop->m_exitEdges)
+        {
+            BasicBlock* const exitBlock          = exitEdge->getSourceBlock();
+            weight_t const    exitBlockFrequency = exitBlock->bbWeight;
+            weight_t const    exitBlockWeight    = exitBlockFrequency * cyclicProbability;
+            cappedExitWeight += exitEdge->getLikelihood() * exitBlockWeight;
+        }
+
+        // We should end up with a value less than one since we input one unit of flow into the
+        // loop and are artificially capping the iteration count of the loop, so less weight is
+        // now flowing out than in.
+        //
+        assert(cappedExitWeight < 1.0);
+
+        // We want to increase the exit likelihood of one exit block to create
+        // additional flow out of the loop. Figure out how much we need.
+        //
+        weight_t const missingExitWeight = 1.0 - cappedExitWeight;
+        JITDUMP("Loop exit flow deficit from capping is " FMT_WT "\n", missingExitWeight);
+
         bool adjustedExit = false;
 
         for (FlowEdge* const exitEdge : loop->m_exitEdges)
         {
-            BasicBlock* const exitBlock = exitEdge->getSourceBlock();
+            // Does this block have enough weight that it can supply all the missing weight?
+            //
+            BasicBlock* const exitBlock          = exitEdge->getSourceBlock();
+            weight_t const    exitBlockFrequency = exitBlock->bbWeight;
+            weight_t const    exitBlockWeight    = exitBlockFrequency * cyclicProbability;
+            weight_t const    currentExitWeight  = exitEdge->getLikelihood() * exitBlockWeight;
 
-            if ((exitBlock->bbJumpKind == BBJ_COND) &&
-                !Compiler::fgProfileWeightsEqual(exitBlock->bbWeight, 0.0, epsilon))
+            // TODO: we might also want to exclude edges that are exiting from child loops here,
+            // or think harder about what might be appropriate in those cases. Seems like we ought
+            // to adjust an edge's likelihoods at most once.
+            //
+            // Currently we don't know which edges do this.
+            //
+            if ((exitBlock->bbJumpKind == BBJ_COND) && (exitBlockWeight > (missingExitWeight + currentExitWeight)))
             {
                 JITDUMP("Will adjust likelihood of the exit edge from loop exit block " FMT_BB
                         " to reflect capping; current likelihood is " FMT_WT "\n",
@@ -1174,19 +1213,24 @@ void ProfileSynthesis::ComputeCyclicProbabilities(SimpleLoop* loop)
                 BasicBlock* const next               = exitBlock->bbNext;
                 FlowEdge* const   jumpEdge           = m_comp->fgGetPredForBlock(jump, exitBlock);
                 FlowEdge* const   nextEdge           = m_comp->fgGetPredForBlock(next, exitBlock);
-                weight_t const    continueLikelihood = cappedLikelihood / exitBlock->bbWeight;
-                weight_t const    breakLikelihood    = 1 - continueLikelihood;
+                weight_t const    exitLikelihood     = (missingExitWeight + currentExitWeight) / exitBlockWeight;
+                weight_t const    continueLikelihood = 1.0 - exitLikelihood;
+
+                // We are making it more likely that the loop exits, so the new exit likelihood
+                // should be greater than the old.
+                //
+                assert(exitLikelihood > exitEdge->getLikelihood());
 
                 if (jumpEdge == exitEdge)
                 {
-                    jumpEdge->setLikelihood(breakLikelihood);
+                    jumpEdge->setLikelihood(exitLikelihood);
                     nextEdge->setLikelihood(continueLikelihood);
                 }
                 else
                 {
                     assert(nextEdge == exitEdge);
                     jumpEdge->setLikelihood(continueLikelihood);
-                    nextEdge->setLikelihood(breakLikelihood);
+                    nextEdge->setLikelihood(exitLikelihood);
                 }
                 adjustedExit = true;
 
@@ -1197,6 +1241,8 @@ void ProfileSynthesis::ComputeCyclicProbabilities(SimpleLoop* loop)
 
         if (!adjustedExit)
         {
+            // Possibly we could have fixed things up by adjusting more than one exit?
+            //
             JITDUMP("Unable to find suitable exit to carry off capped flow\n");
         }
     }


### PR DESCRIPTION
The initial version of this only really worked for very simple cases. Generalize to handle loops with multiple exits better.

The rough idea is to compute how much additional profile flow needs to come out of the loop to match the capped probability, and then try and find one exit block where we can adjust likelhoods to cause exactly this amount of extra flow to leave the loop.

Closes #84798.