### PR TITLE
Make `MethodTable` base size access more "typed"

### DIFF
--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -1338,7 +1338,8 @@ namespace Internal.Runtime
         {
             get
             {
-                return (EETypeElementType)((_uFlags & (uint)EETypeFlags.ElementTypeMask) >> (byte)EETypeFlags.ElementTypeShift);
+                return (EETypeElementType)((_uFlags >> (byte)EETypeFlags.ElementTypeShift) &
+                    ((uint)EETypeFlags.ElementTypeMask >> (byte)EETypeFlags.ElementTypeShift));
             }
 #if TYPE_LOADER_IMPLEMENTATION
             set

--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -363,10 +363,12 @@ namespace Internal.Runtime
             {
                 return _uBaseSize;
             }
+#if TYPE_LOADER_IMPLEMENTATION
             set
             {
                 _uBaseSize = value;
             }
+#endif
         }
 
         internal uint BaseSize
@@ -516,7 +518,8 @@ namespace Internal.Runtime
         {
             get
             {
-                return ElementType == EETypeElementType.SzArray;
+                Debug.Assert(IsArray);
+                return BaseSize == SZARRAY_BASE_SIZE;
             }
         }
 

--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -357,10 +357,23 @@ namespace Internal.Runtime
 #endif
         }
 
+        internal uint RawBaseSize
+        {
+            get
+            {
+                return _uBaseSize;
+            }
+            set
+            {
+                _uBaseSize = value;
+            }
+        }
+
         internal uint BaseSize
         {
             get
             {
+                Debug.Assert(IsCanonical || IsArray);
                 return _uBaseSize;
             }
 #if TYPE_LOADER_IMPLEMENTATION
@@ -713,6 +726,7 @@ namespace Internal.Runtime
         {
             get
             {
+                Debug.Assert(IsParameterizedType);
                 return _uBaseSize;
             }
 #if TYPE_LOADER_IMPLEMENTATION
@@ -830,22 +844,6 @@ namespace Internal.Runtime
                 // padding for GC heap alignment. Must subtract all of these to get the size used for locals, array
                 // elements or fields of another type.
                 return BaseSize - ((uint)sizeof(ObjHeader) + (uint)sizeof(MethodTable*) + ValueTypeFieldPadding);
-            }
-        }
-
-        internal uint FieldByteCountNonGCAligned
-        {
-            get
-            {
-                // This api is designed to return correct results for EETypes which can be derived from
-                // And results indistinguishable from correct for DefTypes which cannot be derived from (sealed classes)
-                // (For sealed classes, this should always return BaseSize-((uint)sizeof(ObjHeader));
-                Debug.Assert(!IsInterface && !IsParameterizedType);
-
-                // get_BaseSize returns the GC size including space for the sync block index field, the MethodTable* and
-                // padding for GC heap alignment. Must subtract all of these to get the size used for the fields of
-                // the type (where the fields of the type includes the MethodTable*)
-                return BaseSize - ((uint)sizeof(ObjHeader) + ValueTypeFieldPadding);
             }
         }
 

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/EETypePtr.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/EETypePtr.cs
@@ -44,13 +44,5 @@ namespace System
         {
             throw new NotImplementedException();
         }
-
-        internal unsafe uint BaseSize
-        {
-            get
-            {
-                return ToPointer()->BaseSize;
-            }
-        }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Array.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Array.NativeAot.cs
@@ -32,14 +32,6 @@ namespace System
         private int _numComponents;
 #pragma warning restore
 
-#if TARGET_64BIT
-        private const int POINTER_SIZE = 8;
-#else
-        private const int POINTER_SIZE = 4;
-#endif
-        //                                    Header       + m_pEEType    + _numComponents (with an optional padding)
-        private const int SZARRAY_BASE_SIZE = POINTER_SIZE + POINTER_SIZE + POINTER_SIZE;
-
         public int Length => checked((int)Unsafe.As<RawArrayData>(this).Length);
 
         // This could return a length greater than int.MaxValue
@@ -47,11 +39,11 @@ namespace System
 
         public long LongLength => (long)NativeLength;
 
-        internal bool IsSzArray
+        internal unsafe bool IsSzArray
         {
             get
             {
-                return this.GetEETypePtr().BaseSize == SZARRAY_BASE_SIZE;
+                return this.GetMethodTable()->IsSzArray;
             }
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/EETypePtr.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/EETypePtr.cs
@@ -310,14 +310,6 @@ namespace System
             }
         }
 
-        internal uint BaseSize
-        {
-            get
-            {
-                return _value->BaseSize;
-            }
-        }
-
         internal IntPtr DispatchMap
         {
             get

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/EETypePtr.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/EETypePtr.cs
@@ -360,10 +360,8 @@ namespace System
                     return CorElementType.ELEMENT_TYPE_BYREF;
                 else if (IsPointer)
                     return CorElementType.ELEMENT_TYPE_PTR;
-                else if (IsSzArray)
-                    return CorElementType.ELEMENT_TYPE_SZARRAY;
                 else if (IsArray)
-                    return CorElementType.ELEMENT_TYPE_ARRAY;
+                    return IsSzArray ? CorElementType.ELEMENT_TYPE_SZARRAY : CorElementType.ELEMENT_TYPE_ARRAY;
                 else
                     return CorElementType.ELEMENT_TYPE_CLASS;
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/EETypePtr.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/EETypePtr.cs
@@ -339,32 +339,47 @@ namespace System
         {
             get
             {
-                Debug.Assert((int)CorElementType.ELEMENT_TYPE_BOOLEAN == (int)EETypeElementType.Boolean);
-                Debug.Assert((int)CorElementType.ELEMENT_TYPE_I1 == (int)EETypeElementType.SByte);
-                Debug.Assert((int)CorElementType.ELEMENT_TYPE_I8 == (int)EETypeElementType.Int64);
-                EETypeElementType elementType = ElementType;
+                ReadOnlySpan<byte> map = new byte[]
+                {
+                    default,
+                    (byte)CorElementType.ELEMENT_TYPE_VOID,      // EETypeElementType.Void
+                    (byte)CorElementType.ELEMENT_TYPE_BOOLEAN,   // EETypeElementType.Boolean
+                    (byte)CorElementType.ELEMENT_TYPE_CHAR,      // EETypeElementType.Char
+                    (byte)CorElementType.ELEMENT_TYPE_I1,        // EETypeElementType.SByte
+                    (byte)CorElementType.ELEMENT_TYPE_U1,        // EETypeElementType.Byte
+                    (byte)CorElementType.ELEMENT_TYPE_I2,        // EETypeElementType.Int16
+                    (byte)CorElementType.ELEMENT_TYPE_U2,        // EETypeElementType.UInt16
+                    (byte)CorElementType.ELEMENT_TYPE_I4,        // EETypeElementType.Int32
+                    (byte)CorElementType.ELEMENT_TYPE_U4,        // EETypeElementType.UInt32
+                    (byte)CorElementType.ELEMENT_TYPE_I8,        // EETypeElementType.Int64
+                    (byte)CorElementType.ELEMENT_TYPE_U8,        // EETypeElementType.UInt64
+                    (byte)CorElementType.ELEMENT_TYPE_I,         // EETypeElementType.IntPtr
+                    (byte)CorElementType.ELEMENT_TYPE_U,         // EETypeElementType.UIntPtr
+                    (byte)CorElementType.ELEMENT_TYPE_R4,        // EETypeElementType.Single
+                    (byte)CorElementType.ELEMENT_TYPE_R8,        // EETypeElementType.Double
 
-                if (elementType <= EETypeElementType.UInt64)
-                    return (CorElementType)elementType;
-                else if (elementType == EETypeElementType.Single)
-                    return CorElementType.ELEMENT_TYPE_R4;
-                else if (elementType == EETypeElementType.Double)
-                    return CorElementType.ELEMENT_TYPE_R8;
-                else if (elementType == EETypeElementType.IntPtr)
-                    return CorElementType.ELEMENT_TYPE_I;
-                else if (elementType == EETypeElementType.UIntPtr)
-                    return CorElementType.ELEMENT_TYPE_U;
-                else if (IsValueType)
-                    return CorElementType.ELEMENT_TYPE_VALUETYPE;
-                else if (IsByRef)
-                    return CorElementType.ELEMENT_TYPE_BYREF;
-                else if (IsPointer)
-                    return CorElementType.ELEMENT_TYPE_PTR;
-                else if (IsArray)
-                    return IsSzArray ? CorElementType.ELEMENT_TYPE_SZARRAY : CorElementType.ELEMENT_TYPE_ARRAY;
-                else
-                    return CorElementType.ELEMENT_TYPE_CLASS;
+                    (byte)CorElementType.ELEMENT_TYPE_VALUETYPE, // EETypeElementType.ValueType
+                    (byte)CorElementType.ELEMENT_TYPE_VALUETYPE,
+                    (byte)CorElementType.ELEMENT_TYPE_VALUETYPE, // EETypeElementType.Nullable
+                    (byte)CorElementType.ELEMENT_TYPE_VALUETYPE,
+                    (byte)CorElementType.ELEMENT_TYPE_CLASS,     // EETypeElementType.Class
+                    (byte)CorElementType.ELEMENT_TYPE_CLASS,     // EETypeElementType.Interface
+                    (byte)CorElementType.ELEMENT_TYPE_CLASS,     // EETypeElementType.SystemArray
+                    (byte)CorElementType.ELEMENT_TYPE_ARRAY,     // EETypeElementType.Array
+                    (byte)CorElementType.ELEMENT_TYPE_SZARRAY,   // EETypeElementType.SzArray
+                    (byte)CorElementType.ELEMENT_TYPE_BYREF,     // EETypeElementType.ByRef
+                    (byte)CorElementType.ELEMENT_TYPE_PTR,       // EETypeElementType.Pointer
+                    default, // Pad the map to 32 elements to enable range check elimination
+                    default,
+                    default,
+                    default,
+                    default
+                };
 
+                // Verify last element of the map
+                Debug.Assert((byte)CorElementType.ELEMENT_TYPE_PTR == map[(int)EETypeElementType.Pointer]);
+
+                return (CorElementType)map[(int)ElementType];
             }
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.NativeAot.cs
@@ -41,7 +41,7 @@ namespace System.Runtime.InteropServices
             // to special-case arrays of known type and dimension.
 
             // See comment on RawArrayData (in RuntimeHelpers.CoreCLR.cs) for details
-            return ref Unsafe.AddByteOffset(ref Unsafe.As<RawData>(array).Data, (nuint)array.GetEETypePtr().BaseSize - (nuint)(2 * sizeof(IntPtr)));
+            return ref Unsafe.AddByteOffset(ref Unsafe.As<RawData>(array).Data, (nuint)array.GetMethodTable()->BaseSize - (nuint)(2 * sizeof(IntPtr)));
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -177,7 +177,7 @@ namespace Internal.Runtime.TypeLoader
                     runtimeInterfacesLength = checked((ushort)state.RuntimeInterfaces.Length);
                 }
 
-                baseSize = (int)pTemplateEEType->BaseSize;
+                baseSize = (int)pTemplateEEType->RawBaseSize;
                 isValueType = pTemplateEEType->IsValueType;
                 hasFinalizer = pTemplateEEType->IsFinalizable;
                 isNullable = pTemplateEEType->IsNullable;
@@ -269,7 +269,7 @@ namespace Internal.Runtime.TypeLoader
 
                     // Set basic MethodTable fields
                     pEEType->Flags = flags;
-                    pEEType->BaseSize = (uint)baseSize;
+                    pEEType->RawBaseSize = (uint)baseSize;
                     pEEType->NumVtableSlots = numVtableSlots;
                     pEEType->NumInterfaces = runtimeInterfacesLength;
                     pEEType->HashCode = hashCodeOfNewType;

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -597,7 +597,7 @@ namespace Internal.Runtime.TypeLoader
             if (state.ThreadDataSize != 0)
                 TypeLoaderEnvironment.Instance.RegisterDynamicThreadStaticsInfo(state.HalfBakedRuntimeTypeHandle, state.ThreadStaticOffset, state.ThreadStaticDesc);
 
-            TypeLoaderLogger.WriteLine("Allocated new type " + type.ToString() + " with hashcode value = 0x" + type.GetHashCode().LowLevelToString() + " with MethodTable = " + rtt.ToIntPtr().LowLevelToString() + " of size " + rtt.ToEETypePtr()->BaseSize.LowLevelToString());
+            TypeLoaderLogger.WriteLine("Allocated new type " + type.ToString() + " with hashcode value = 0x" + type.GetHashCode().LowLevelToString() + " with MethodTable = " + rtt.ToIntPtr().LowLevelToString() + " of size " + rtt.ToEETypePtr()->RawBaseSize.LowLevelToString());
         }
 
         private static void AllocateRuntimeMethodDictionary(InstantiatedMethod method)


### PR DESCRIPTION
We reuse the base size field for other purposes for `MethodTable`s that cannot actually exist on heap (otherwise GC needs this to be legit). I almost reused it for similar reasons for function pointers, but looks like we don't need it for those, so just submitting these asserts that we don't read the wrong meaning of the field.

Cc @dotnet/ilc-contrib 