### PR TITLE
[browser][non-icu] `HybridGlobalization` initialized performance tests

### DIFF
--- a/src/mono/sample/wasm/Directory.Build.targets
+++ b/src/mono/sample/wasm/Directory.Build.targets
@@ -7,7 +7,7 @@
     <RunScriptInputName Condition="'$(TargetOS)' == 'browser' and '$(OS)' == 'Windows_NT'">WasmRunnerTemplate.cmd</RunScriptInputName>
 
     <RunScriptOutputPath>$([MSBuild]::NormalizePath('$(WasmAppDir)', '$(RunScriptOutputName)'))</RunScriptOutputPath>
-    
+
     <!-- so that SharedArrayBuffer is enabled -->
     <_MonoWasmThreads Condition="'$(WasmEnableThreads)' == 'true' or '$(WasmEnablePerfTracing)' == 'true' or '$(MonoWasmBuildVariant)' == 'multithread' or '$(MonoWasmBuildVariant)' == 'perftrace'">true</_MonoWasmThreads>
     <WasmXHarnessArgs Condition="'$(_MonoWasmThreads)' == 'true'">$(WasmXHarnessArgs) --web-server-use-cop</WasmXHarnessArgs>
@@ -39,11 +39,12 @@
       <_ScriptExt Condition="'$(OS)' != 'Windows_NT'">.sh</_ScriptExt>
       <_Dotnet>$(RepoRoot)dotnet$(_ScriptExt)</_Dotnet>
       <_AOTFlag Condition="'$(RunAOTCompilation)' != ''">/p:RunAOTCompilation=$(RunAOTCompilation)</_AOTFlag>
+      <_HybridGlobalizationFlag Condition="'$(HybridGlobalization)' != ''">/p:HybridGlobalization=$(HybridGlobalization)</_HybridGlobalizationFlag>
       <_SampleProject Condition="'$(_SampleProject)' == ''">$(MSBuildProjectFile)</_SampleProject>
       <_SampleAssembly Condition="'$(_SampleAssembly)' == ''">$(TargetFileName)</_SampleAssembly>
       <BuildAdditionalArgs Condition="'$(MonoDiagnosticsMock)' != ''">$(BuildAdditionalArgs) /p:MonoDiagnosticsMock=$(MonoDiagnosticsMock) </BuildAdditionalArgs>
     </PropertyGroup>
-    <Exec Command="$(_Dotnet) publish -bl /p:Configuration=$(Configuration) /p:TargetArchitecture=wasm /p:TargetOS=browser $(_AOTFlag) $(_SampleProject) $(BuildAdditionalArgs)" />
+    <Exec Command="$(_Dotnet) publish -bl /p:Configuration=$(Configuration) /p:TargetArchitecture=wasm /p:TargetOS=browser $(_AOTFlag) $(_HybridGlobalizationFlag) $(_SampleProject) $(BuildAdditionalArgs)" />
   </Target>
   <Target Name="_ComputeMainJSFileName">
     <Error Condition="'$(WasmMainJSPath)' == ''" Text="%24(WasmMainJSPath) property needs to be set" />

--- a/src/mono/sample/wasm/browser-bench/String.cs
+++ b/src/mono/sample/wasm/browser-bench/String.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using System.Globalization;
 
 namespace Sample
 {
@@ -17,6 +18,12 @@ namespace Sample
             measurements = new Measurement[] {
                 new NormalizeMeasurement(),
                 new NormalizeMeasurementASCII(),
+                new TextInfoToLower(),
+                new TextInfoToUpper(),
+                new TextInfoToTitleCase(),
+                new StringCompareMeasurement(),
+                new StringEqualsMeasurement(),
+                new CompareInfoMeasurement(),
             };
         }
 
@@ -32,15 +39,11 @@ namespace Sample
         {
             public override int InitialSamples => 30;
             protected Random random;
-        }
-
-        public class NormalizeMeasurement : StringMeasurement
-        {
             protected char[] data;
             protected int len = 64 * 1024;
             protected string str;
 
-            public override Task BeforeBatch()
+            public void InitializeString()
             {
                 data = new char[len];
                 random = new(123456);
@@ -48,28 +51,29 @@ namespace Sample
                 {
                     data[i] = (char)random.Next(0xd800);
                 }
-
                 str = new string(data);
+            }
 
+            public override Task BeforeBatch()
+            {
+                InitializeString();
                 return Task.CompletedTask;
             }
 
             public override Task AfterBatch()
             {
                 data = null;
-
                 return Task.CompletedTask;
-            }
-
-            public override string Name => "Normalize";
-
-            public override void RunStep()
-            {
-                str.Normalize();
             }
         }
 
-        public class NormalizeMeasurementASCII : NormalizeMeasurement
+        public class NormalizeMeasurement : StringMeasurement
+        {
+            public override string Name => "Normalize";
+            public override void RunStep() => str.Normalize();
+        }
+
+        public abstract class ASCIIStringMeasurement : StringMeasurement
         {
             public override Task BeforeBatch()
             {
@@ -79,11 +83,98 @@ namespace Sample
                     data[i] = (char)random.Next(0x80);
 
                 str = new string(data);
-
                 return Task.CompletedTask;
             }
+        }
 
+        public class NormalizeMeasurementASCII : ASCIIStringMeasurement
+        {
             public override string Name => "Normalize ASCII";
+            public override void RunStep() => str.Normalize();
+        }
+
+        public class TextInfoMeasurement : StringMeasurement
+        {
+            protected TextInfo textInfo;
+
+            public override Task BeforeBatch()
+            {
+                textInfo = new CultureInfo("de-DE").TextInfo;
+                InitializeString();
+                return Task.CompletedTask;
+            }
+            public override string Name => "TextInfo";
+        }
+
+        public class TextInfoToLower : TextInfoMeasurement
+        {
+            public override string Name => "TextInfo ToLower";
+            public override void RunStep() => textInfo.ToLower(str);
+        }
+
+        public class TextInfoToUpper : TextInfoMeasurement
+        {
+            public override string Name => "TextInfo ToUpper";
+            public override void RunStep() => textInfo.ToUpper(str);
+        }
+
+        public class TextInfoToTitleCase : TextInfoMeasurement
+        {
+            public override string Name => "TextInfo ToTileCase";
+            public override void RunStep() => textInfo.ToTitleCase(str);
+        }
+
+        public class StringsCompare : StringMeasurement
+        {
+            protected string str2;
+
+            public void InitializeStringsForComparison()
+            {
+                InitializeString();
+                // worst case: strings may differ only with the last char
+                data[len-1] = (char)random.Next(0x80);
+                str2 = new string(data);
+            }
+            public override string Name => "Strings Compare Base";
+        }
+
+        public class StringCompareMeasurement :  StringsCompare
+        {
+            protected CultureInfo cultureInfo;
+
+            public override Task BeforeBatch()
+            {
+                cultureInfo = new CultureInfo("sk-SK");
+                InitializeStringsForComparison();
+                return Task.CompletedTask;
+            }
+            public override string Name => "String Compare";
+            public override void RunStep() => string.Compare(str, str2, cultureInfo, CompareOptions.None);
+        }
+
+        public class StringEqualsMeasurement : StringsCompare
+        {
+            public override Task BeforeBatch()
+            {
+                InitializeStringsForComparison();
+                return Task.CompletedTask;
+            }
+            public override string Name => "String Equals";
+            public override void RunStep() => string.Equals(str, str2, StringComparison.InvariantCulture);
+        }
+
+        public class CompareInfoMeasurement : StringsCompare
+        {
+            protected CompareInfo compareInfo;
+
+            public override Task BeforeBatch()
+            {
+                compareInfo = new CultureInfo("tr-TR").CompareInfo;
+                InitializeStringsForComparison();
+                return Task.CompletedTask;
+            }
+            public override string Name => "CompareInfo Compare";
+            public override void RunStep() => compareInfo.Compare(str, str2);
         }
     }
 }


### PR DESCRIPTION
Initializes performance tests for the existing `HybridGlobalization` functionalities:
- TextInfo.ToLower,
- TextInfo.ToUpper,
- TextInfo.ToTitleCase,
- CompareInfo.Compare,
- String.Compare,
- String.Equals.

All the tests are done on non-ASCII characters because only then HybridGlobalization path is guaranteed to be triggered. Existing, normalization test are using ICU4C api, no matter if HG is on or off.

Quick overwiev of performance differences between ICU4C and HybridGlobalization:

|    **Test name**    | **time ICU4C [ms]** | **time HG [ms]** | **increase by [times]** |
|:-------------------:|:-------------------:|:----------------:|:-----------------------:|
|   TextInfo ToLower  |        0.2605       |      0.5065      |           1.94          |
|   TextInfo ToUpper  |        0.2672       |      0.5174      |           1.93          |
| TextInfo ToTileCase |       9.7404       |      14.7189     |           1.51          |
|    String Compare   |        0.0384       |      0.1286      |           3.35           |
|    String Equals    |        0.0378       |      0.1300      |            3.44          |
| CompareInfo Compare |        0.0383       |      0.1291      |            3.37          |

cc @SamMonoRT