### PR TITLE
Improve docs for the linker analyzer tool

### DIFF
--- a/src/tools/illink/src/analyzer/README.md
+++ b/src/tools/illink/src/analyzer/README.md
@@ -20,8 +20,8 @@ with trimming enabled and use the `_TrimmerDumpDependencies` property:
 
 ```dotnet publish /p:PublishTrimmed=true /p:_TrimmerDumpDependencies=true```
 
-In this case the dependencies file will be in 
-`obj\<Configuration>\<TargetFramework>\<arch>\linked\linker-dependencies.xml`.
+In this case the dependencies file will be in
+`obj/<Configuration>/<TargetFramework>/<RID>/linked/linker-dependencies.xml`.
 
 For Xamarin.Android and Xamarin.iOS, that can be done on the command line by setting
 `LinkerDumpDependencies` property to `true` and building the

--- a/src/tools/illink/src/analyzer/README.md
+++ b/src/tools/illink/src/analyzer/README.md
@@ -13,7 +13,15 @@ etc. The edges represent the dependencies.
 
 The ILLink analyzer needs a ILLink dependencies file as an input. It
 can be retrieved by enabling dependencies dumping during trimming of a
-Xamarin.Android, Xamarin.iOS, or .NET SDK style project.
+project.
+
+For console .NET projects you need to publish the application
+with trimming enabled and use the `_TrimmerDumpDependencies` property:
+
+```dotnet publish /p:PublishTrimmed=true /p:_TrimmerDumpDependencies=true```
+
+In this case the dependencies file will be in 
+`obj\<Configuration>\<TargetFramework>\<arch>\linked\linker-dependencies.xml`.
 
 For Xamarin.Android and Xamarin.iOS, that can be done on the command line by setting
 `LinkerDumpDependencies` property to `true` and building the


### PR DESCRIPTION
The instructions were valid only for Xamarin projects which run linker during build. .NET Console projects only run linker during publish, so the instructions need to look different.