### PR TITLE
Fix double writes for M.Extensions xml docs

### DIFF
--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -84,16 +84,7 @@
     <BinPlaceRef Condition="'$(BinPlaceRef)' == '' and ('$(IsReferenceAssemblyProject)' == 'true' or '$(IsRuntimeAndReferenceAssembly)' == 'true')">true</BinPlaceRef>
     <BinPlaceRuntime Condition="'$(BinPlaceRuntime)' == '' and ('$(IsSourceProject)' == 'true' or '$(IsRuntimeAndReferenceAssembly)' == 'true')">true</BinPlaceRuntime>
     <BinPlaceForTargetVertical Condition="'$(BinPlaceForTargetVertical)' == ''">true</BinPlaceForTargetVertical>
-    <GetBinPlaceItemsDependsOn Condition="$(MSBuildProjectName.StartsWith('Microsoft.Extensions.'))">$(GetBinPlaceItemsDependsOn);AddDocumentationFileAsBinPlaceItemForExtensionsProjects</GetBinPlaceItemsDependsOn>
   </PropertyGroup>
-
-  <Target Name="AddDocumentationFileAsBinPlaceItemForExtensionsProjects"
-          Condition="Exists('$(DocumentationFile)')">
-    <ItemGroup>
-      <!-- Microsoft.Extensions are not yet using the doc-file package -->
-      <BinPlaceItem Include="$(DocumentationFile)" />
-    </ItemGroup>
-  </Target>
 
   <ItemGroup>
     <!-- Used by the runtime tests to prepare the CORE_ROOT layout. Don't use in libraries. -->

--- a/src/libraries/shims/Directory.Build.props
+++ b/src/libraries/shims/Directory.Build.props
@@ -16,6 +16,7 @@
     <ApiCompatValidateAssemblies>false</ApiCompatValidateAssemblies>
     <ILLinkTrimAssembly>false</ILLinkTrimAssembly>
     <AddOSPlatformAttributes>false</AddOSPlatformAttributes>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <!-- Allow shim ref projects to reference source projects which is required for referencing shared
         framework dependencies. -->
     <SkipValidateReferenceAssemblyProjectReferences Condition="'$(IsReferenceAssemblyProject)' == 'true'">true</SkipValidateReferenceAssemblyProjectReferences>


### PR DESCRIPTION
We don't need the binplace item anymore as the intellisense.targets file already takes care of copying / setting docs xml files.
Also stop generating an xml file for shim assemblies under src/libraries/shims as such don't contain any source code.

Fixes https://github.com/dotnet/runtime/issues/84762

With these changes, the libs subset doesn't have any double writes anymore.

I also verified that produced package still contain their corresponding xml files:
- Microsoft.Internal.Runtime.AspNetCore.Transport.nupkg
- Microsoft.Extension.*

and same for the artifacts\bin\runtime\net8.0-...\ folder.