### PR TITLE
[mono][interp] Update ref count for local var defs during optimization

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -9398,10 +9398,12 @@ retry:
 					local_defs [dreg].type = LOCAL_VALUE_NONE;
 					local_defs [dreg].ins = def;
 					local_defs [dreg].def_index = local_defs [original_dreg].def_index;
+					local_defs [dreg].ref_count++;
 					local_defs [original_dreg].type = LOCAL_VALUE_LOCAL;
 					local_defs [original_dreg].ins = ins;
 					local_defs [original_dreg].local = dreg;
 					local_defs [original_dreg].def_index = ins_index;
+					local_defs [original_dreg].ref_count--;
 
 					local_ref_count [original_dreg]--;
 					local_ref_count [dreg]++;


### PR DESCRIPTION
Bug existing since https://github.com/dotnet/runtime/pull/79215/commits/65feed01276cac6f8ce413586c5c03318cd6d485, where the newly added ref_count wasn't updated during an optimization.

Fixes interp issues from https://github.com/dotnet/runtime/pull/84587