### PR TITLE
Reduce size of RegexNode by 8 bytes

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNodeKind.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNodeKind.cs
@@ -4,7 +4,7 @@
 namespace System.Text.RegularExpressions
 {
     /// <summary>Specifies the kind of a <see cref="RegexNode"/>.</summary>
-    internal enum RegexNodeKind
+    internal enum RegexNodeKind : byte
     {
         /// <summary>Unknown node type.</summary>
         /// <remarks>This should never occur on an actual node, and instead is used as a sentinel.</remarks>


### PR DESCRIPTION
RegexNodeKind being 4 bytes instead of 1 byte pushes the containing class out into the next word.