### PR TITLE
Publish Aggregated Values For `Counter` and `UpDownCounter` For System.Diagnostics.Metrics

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -62,7 +62,7 @@ System.Diagnostics.DiagnosticSource</PackageDescription>
     <Compile Include="System\Diagnostics\Metrics\ObservableGauge.cs" />
     <Compile Include="System\Diagnostics\Metrics\ObservableInstrument.cs" />
     <Compile Include="System\Diagnostics\Metrics\ObservableUpDownCounter.cs" />
-    <Compile Include="System\Diagnostics\Metrics\RateAggregator.cs" />
+    <Compile Include="System\Diagnostics\Metrics\CounterAggregator.cs" />
     <Compile Include="System\Diagnostics\Metrics\StringSequence.cs" />
     <Compile Include="System\Diagnostics\Metrics\TagList.cs" />
     <Compile Include="System\Diagnostics\Metrics\UpDownCounter.cs" />

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/AggregationManager.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/AggregationManager.cs
@@ -275,7 +275,7 @@ namespace System.Diagnostics.Metrics
                 {
                     lock (this)
                     {
-                        return CheckTimeSeriesAllowed() ? new RateSumAggregator(isMonotonic: true) : null;
+                        return CheckTimeSeriesAllowed() ? new CounterAggregator(isMonotonic: true) : null;
                     }
                 };
             }
@@ -285,7 +285,7 @@ namespace System.Diagnostics.Metrics
                 {
                     lock (this)
                     {
-                        return CheckTimeSeriesAllowed() ? new RateAggregator(isMonotonic: true) : null;
+                        return CheckTimeSeriesAllowed() ? new ObservableCounterAggregator(isMonotonic: true) : null;
                     }
                 };
             }
@@ -318,7 +318,7 @@ namespace System.Diagnostics.Metrics
                 {
                     lock (this)
                     {
-                        return CheckTimeSeriesAllowed() ? new RateSumAggregator(isMonotonic: false) : null;
+                        return CheckTimeSeriesAllowed() ? new CounterAggregator(isMonotonic: false) : null;
                     }
                 };
             }
@@ -328,7 +328,7 @@ namespace System.Diagnostics.Metrics
                 {
                     lock (this)
                     {
-                        return CheckTimeSeriesAllowed() ? new RateAggregator(isMonotonic: false) : null;
+                        return CheckTimeSeriesAllowed() ? new ObservableCounterAggregator(isMonotonic: false) : null;
                     }
                 };
             }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/CounterAggregator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/CounterAggregator.cs
@@ -3,13 +3,13 @@
 
 namespace System.Diagnostics.Metrics
 {
-    internal sealed class RateSumAggregator : Aggregator
+    internal sealed class CounterAggregator : Aggregator
     {
         private readonly bool _isMonotonic;
         private double _delta;
         private double _aggregatedValue;
 
-        public RateSumAggregator(bool isMonotonic)
+        public CounterAggregator(bool isMonotonic)
         {
             _isMonotonic = isMonotonic;
         }
@@ -27,22 +27,20 @@ namespace System.Diagnostics.Metrics
             lock (this)
             {
                 _aggregatedValue += _delta;
-                RateStatistics? stats = new RateStatistics(_delta, _isMonotonic, _aggregatedValue);
+                CounterStatistics? stats = new CounterStatistics(_delta, _isMonotonic, _aggregatedValue);
                 _delta = 0;
                 return stats;
             }
         }
     }
 
-    internal sealed class RateAggregator : Aggregator
+    internal sealed class ObservableCounterAggregator : Aggregator
     {
         private readonly bool _isMonotonic;
         private double? _prevValue;
         private double _currValue;
-        private double _aggregatedValue;
-        private bool _updated;
 
-        public RateAggregator(bool isMonotonic)
+        public ObservableCounterAggregator(bool isMonotonic)
         {
             _isMonotonic = isMonotonic;
         }
@@ -52,7 +50,6 @@ namespace System.Diagnostics.Metrics
             lock (this)
             {
                 _currValue = value;
-                _updated = true;
             }
         }
 
@@ -65,19 +62,17 @@ namespace System.Diagnostics.Metrics
                 {
                     delta = _currValue - _prevValue.Value;
                 }
-                _aggregatedValue += _updated ? _currValue : 0;
-                _updated = false;
 
-                RateStatistics stats = new RateStatistics(delta, _isMonotonic, _aggregatedValue);
+                CounterStatistics stats = new CounterStatistics(delta, _isMonotonic, _currValue);
                 _prevValue = _currValue;
                 return stats;
             }
         }
     }
 
-    internal sealed class RateStatistics : IAggregationStatistics
+    internal sealed class CounterStatistics : IAggregationStatistics
     {
-        public RateStatistics(double? delta, bool isMonotonic, double value)
+        public CounterStatistics(double? delta, bool isMonotonic, double value)
         {
             Delta = delta;
             IsMonotonic = isMonotonic;

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
@@ -413,7 +413,7 @@ namespace System.Diagnostics.Metrics
 
             private static void TransmitMetricValue(Instrument instrument, LabeledAggregationStatistics stats, string sessionId)
             {
-                if (stats.AggregationStatistics is RateStatistics rateStats)
+                if (stats.AggregationStatistics is CounterStatistics rateStats)
                 {
                     if (rateStats.IsMonotonic)
                     {

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
@@ -102,7 +102,7 @@ namespace System.Diagnostics.Metrics
             WriteEvent(3, sessionId, intervalStartTime, intervalEndTime);
         }
 
-        [Event(4, Keywords = Keywords.TimeSeriesValues)]
+        [Event(4, Keywords = Keywords.TimeSeriesValues, Version=1)]
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
                             Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
         public void CounterRateValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string rate, string value)
@@ -191,7 +191,7 @@ namespace System.Diagnostics.Metrics
             WriteEvent(15, runningSessionId);
         }
 
-        [Event(16, Keywords = Keywords.TimeSeriesValues)]
+        [Event(16, Keywords = Keywords.TimeSeriesValues, Version=1)]
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
                             Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
         public void UpDownCounterRateValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string rate, string value)

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
@@ -105,9 +105,9 @@ namespace System.Diagnostics.Metrics
         [Event(4, Keywords = Keywords.TimeSeriesValues)]
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
                             Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
-        public void CounterRateValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string rate)
+        public void CounterRateValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string rate, string value)
         {
-            WriteEvent(4, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, rate);
+            WriteEvent(4, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, rate, value);
         }
 
         [Event(5, Keywords = Keywords.TimeSeriesValues)]
@@ -194,9 +194,9 @@ namespace System.Diagnostics.Metrics
         [Event(16, Keywords = Keywords.TimeSeriesValues)]
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
                             Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
-        public void UpDownCounterRateValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string rate)
+        public void UpDownCounterRateValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string rate, string value)
         {
-            WriteEvent(16, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, rate);
+            WriteEvent(16, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, rate, value);
         }
 
         /// <summary>
@@ -418,12 +418,14 @@ namespace System.Diagnostics.Metrics
                     if (rateStats.IsMonotonic)
                     {
                         Log.CounterRateValuePublished(sessionId, instrument.Meter.Name, instrument.Meter.Version, instrument.Name, instrument.Unit, FormatTags(stats.Labels),
-                            rateStats.Delta.HasValue ? rateStats.Delta.Value.ToString(CultureInfo.InvariantCulture) : "");
+                            rateStats.Delta.HasValue ? rateStats.Delta.Value.ToString(CultureInfo.InvariantCulture) : "",
+                            rateStats.Value.ToString(CultureInfo.InvariantCulture));
                     }
                     else
                     {
                         Log.UpDownCounterRateValuePublished(sessionId, instrument.Meter.Name, instrument.Meter.Version, instrument.Name, instrument.Unit, FormatTags(stats.Labels),
-                            rateStats.Delta.HasValue ? rateStats.Delta.Value.ToString(CultureInfo.InvariantCulture) : "");
+                            rateStats.Delta.HasValue ? rateStats.Delta.Value.ToString(CultureInfo.InvariantCulture) : "",
+                            rateStats.Value.ToString(CultureInfo.InvariantCulture));
                     }
                 }
                 else if (stats.AggregationStatistics is LastValueStatistics lastValueStats)

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
@@ -25,7 +25,7 @@ namespace System.Diagnostics.Metrics.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        //[OuterLoop("Slow and has lots of console spew")]
+        [OuterLoop("Slow and has lots of console spew")]
         public void EventSourcePublishesTimeSeriesWithEmptyMetadata()
         {
             using Meter meter = new Meter("TestMeter1");
@@ -70,7 +70,7 @@ namespace System.Diagnostics.Metrics.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        //[OuterLoop("Slow and has lots of console spew")]
+        [OuterLoop("Slow and has lots of console spew")]
         public void EventSourcePublishesTimeSeriesWithMetadata()
         {
             using Meter meter = new Meter("TestMeter2");
@@ -115,7 +115,7 @@ namespace System.Diagnostics.Metrics.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        //[OuterLoop("Slow and has lots of console spew")]
+        [OuterLoop("Slow and has lots of console spew")]
         public void EventSourcePublishesTimeSeriesForLateMeter()
         {
             // this ensures the MetricsEventSource exists when the listener tries to query
@@ -179,7 +179,7 @@ namespace System.Diagnostics.Metrics.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        //[OuterLoop("Slow and has lots of console spew")]
+        [OuterLoop("Slow and has lots of console spew")]
         public void EventSourcePublishesTimeSeriesForLateInstruments()
         {
             // this ensures the MetricsEventSource exists when the listener tries to query
@@ -234,7 +234,7 @@ namespace System.Diagnostics.Metrics.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        //[OuterLoop("Slow and has lots of console spew")]
+        [OuterLoop("Slow and has lots of console spew")]
         public void EventSourcePublishesTimeSeriesWithTags()
         {
             using Meter meter = new Meter("TestMeter5");
@@ -322,7 +322,7 @@ namespace System.Diagnostics.Metrics.Tests
 
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        //[OuterLoop("Slow and has lots of console spew")]
+        [OuterLoop("Slow and has lots of console spew")]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/79749", TargetFrameworkMonikers.NetFramework)]
         public void EventSourceFiltersInstruments()
         {
@@ -384,7 +384,7 @@ namespace System.Diagnostics.Metrics.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        //[OuterLoop("Slow and has lots of console spew")]
+        [OuterLoop("Slow and has lots of console spew")]
         public void EventSourcePublishesMissingDataPoints()
         {
             using Meter meter = new Meter("TestMeter6");
@@ -476,7 +476,7 @@ namespace System.Diagnostics.Metrics.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        //[OuterLoop("Slow and has lots of console spew")]
+        [OuterLoop("Slow and has lots of console spew")]
         public void EventSourceRejectsNewListener()
         {
             using Meter meter = new Meter("TestMeter7");
@@ -526,7 +526,7 @@ namespace System.Diagnostics.Metrics.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        //[OuterLoop("Slow and has lots of console spew")]
+        [OuterLoop("Slow and has lots of console spew")]
         public void EventSourcePublishesEndEventsOnMeterDispose()
         {
             using Meter meterA = new Meter("TestMeter8");
@@ -580,7 +580,7 @@ namespace System.Diagnostics.Metrics.Tests
 
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        //[OuterLoop("Slow and has lots of console spew")]
+        [OuterLoop("Slow and has lots of console spew")]
         public void EventSourcePublishesInstruments()
         {
             using Meter meterA = new Meter("TestMeter10");
@@ -607,7 +607,7 @@ namespace System.Diagnostics.Metrics.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        //[OuterLoop("Slow and has lots of console spew")]
+        [OuterLoop("Slow and has lots of console spew")]
         public void EventSourcePublishesAllDataTypes()
         {
             using Meter meter = new Meter("TestMeter12");
@@ -673,7 +673,7 @@ namespace System.Diagnostics.Metrics.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        //[OuterLoop("Slow and has lots of console spew")]
+        [OuterLoop("Slow and has lots of console spew")]
         public void EventSourceEnforcesTimeSeriesLimit()
         {
             using Meter meter = new Meter("TestMeter13");
@@ -709,7 +709,7 @@ namespace System.Diagnostics.Metrics.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        //[OuterLoop("Slow and has lots of console spew")]
+        [OuterLoop("Slow and has lots of console spew")]
         public void EventSourceEnforcesHistogramLimit()
         {
             using Meter meter = new Meter("TestMeter14");
@@ -746,7 +746,7 @@ namespace System.Diagnostics.Metrics.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        //[OuterLoop("Slow and has lots of console spew")]
+        [OuterLoop("Slow and has lots of console spew")]
         public void EventSourceHandlesObservableCallbackException()
         {
             using Meter meter = new Meter("TestMeter15");
@@ -773,7 +773,7 @@ namespace System.Diagnostics.Metrics.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        //[OuterLoop("Slow and has lots of console spew")]
+        [OuterLoop("Slow and has lots of console spew")]
         public void EventSourceWorksWithSequentialListeners()
         {
             using Meter meter = new Meter("TestMeter16");
@@ -849,7 +849,7 @@ namespace System.Diagnostics.Metrics.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        //[OuterLoop("Slow and has lots of console spew")]
+        [OuterLoop("Slow and has lots of console spew")]
         public void EventSourceEnforcesHistogramLimitAndNotMaxTimeSeries()
         {
             using Meter meter = new Meter("TestMeter17");

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
@@ -1055,7 +1055,6 @@ namespace System.Diagnostics.Metrics.Tests
                 Assert.Equal(expectedUnit, filteredEvents[i].Unit);
                 Assert.Equal(expectedValues[i], filteredEvents[i].Value);
             }
-
         }
 
         private void AssertCounterEventsNotPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags)

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
@@ -25,7 +25,7 @@ namespace System.Diagnostics.Metrics.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        [OuterLoop("Slow and has lots of console spew")]
+        //[OuterLoop("Slow and has lots of console spew")]
         public void EventSourcePublishesTimeSeriesWithEmptyMetadata()
         {
             using Meter meter = new Meter("TestMeter1");
@@ -56,17 +56,21 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", "5", "12");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", "", "7");
+            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "", "", "5", "12");
+            AssertCounterRateEventsPresent(events, meter.Name, oc.Name, "", "", "", "7");
+            AssertCounterValueEventsPresent(events, meter.Name, c.Name, "", "", "5", "17");
+            AssertCounterValueEventsPresent(events, meter.Name, oc.Name, "", "", "10", "27");
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "9", "18");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", "-33", "-40");
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", "", "-11");
+            AssertUpDownCounterRateEventsPresent(events, meter.Name, udc.Name, "", "", "-33", "-40");
+            AssertUpDownCounterRateEventsPresent(events, meter.Name, oudc.Name, "", "", "", "-11");
+            AssertUpDownCounterValueEventsPresent(events, meter.Name, udc.Name, "", "", "-33", "-73");
+            AssertUpDownCounterValueEventsPresent(events, meter.Name, oudc.Name, "", "", "-11", "-33");
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        [OuterLoop("Slow and has lots of console spew")]
+        //[OuterLoop("Slow and has lots of console spew")]
         public void EventSourcePublishesTimeSeriesWithMetadata()
         {
             using Meter meter = new Meter("TestMeter2");
@@ -97,17 +101,21 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", c.Unit, "5", "12");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, "", "7", "7");
+            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "", c.Unit, "5", "12");
+            AssertCounterRateEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, "", "7", "7");
+            AssertCounterValueEventsPresent(events, meter.Name, c.Name, "", c.Unit, "5", "17");
+            AssertCounterValueEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, "10", "27", "51");
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "", og.Unit, "9", "18", "27");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "", h.Unit, "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, "33", "40");
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, "", "11");
+            AssertUpDownCounterRateEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, "33", "40");
+            AssertUpDownCounterRateEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, "", "11", "11");
+            AssertUpDownCounterValueEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, "33", "73");
+            AssertUpDownCounterValueEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, "11", "33", "66");
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        [OuterLoop("Slow and has lots of console spew")]
+        //[OuterLoop("Slow and has lots of console spew")]
         public void EventSourcePublishesTimeSeriesForLateMeter()
         {
             // this ensures the MetricsEventSource exists when the listener tries to query
@@ -152,12 +160,16 @@ namespace System.Diagnostics.Metrics.Tests
 
                 AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc);
                 AssertInitialEnumerationCompleteEventPresent(events);
-                AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", "5", "12");
-                AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", "", "7");
+                AssertCounterRateEventsPresent(events, meter.Name, c.Name, "", "", "5", "12");
+                AssertCounterRateEventsPresent(events, meter.Name, oc.Name, "", "", "", "7");
+                AssertCounterValueEventsPresent(events, meter.Name, c.Name, "", "", "5", "17");
+                AssertCounterValueEventsPresent(events, meter.Name, oc.Name, "", "", "10", "27");
                 AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "9", "18");
                 AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
-                AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", "33", "40");
-                AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", "", "-11");
+                AssertUpDownCounterRateEventsPresent(events, meter.Name, udc.Name, "", "", "33", "40");
+                AssertUpDownCounterRateEventsPresent(events, meter.Name, oudc.Name, "", "", "", "-11");
+                AssertUpDownCounterValueEventsPresent(events, meter.Name, udc.Name, "", "", "33", "73");
+                AssertUpDownCounterValueEventsPresent(events, meter.Name, oudc.Name, "", "", "-11", "-33");
                 AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
             }
             finally
@@ -167,7 +179,7 @@ namespace System.Diagnostics.Metrics.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        [OuterLoop("Slow and has lots of console spew")]
+        //[OuterLoop("Slow and has lots of console spew")]
         public void EventSourcePublishesTimeSeriesForLateInstruments()
         {
             // this ensures the MetricsEventSource exists when the listener tries to query
@@ -208,17 +220,21 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", "5", "12");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", "", "7");
+            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "", "", "5", "12");
+            AssertCounterRateEventsPresent(events, meter.Name, oc.Name, "", "", "", "7");
+            AssertCounterValueEventsPresent(events, meter.Name, c.Name, "", "", "5", "17");
+            AssertCounterValueEventsPresent(events, meter.Name, oc.Name, "", "", "10", "27");
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "9", "18");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", "-33", "-40");
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", "", "11");
+            AssertUpDownCounterRateEventsPresent(events, meter.Name, udc.Name, "", "", "-33", "-40");
+            AssertUpDownCounterRateEventsPresent(events, meter.Name, oudc.Name, "", "", "", "11");
+            AssertUpDownCounterValueEventsPresent(events, meter.Name, udc.Name, "", "", "-33", "-73");
+            AssertUpDownCounterValueEventsPresent(events, meter.Name, oudc.Name, "", "", "11", "33");
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        [OuterLoop("Slow and has lots of console spew")]
+        //[OuterLoop("Slow and has lots of console spew")]
         public void EventSourcePublishesTimeSeriesWithTags()
         {
             using Meter meter = new Meter("TestMeter5");
@@ -281,24 +297,32 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "Color=red", "", "5", "12");
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "Color=blue", "", "6", "13");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, "Color=red,Size=19", "", "", "7");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, "Color=blue,Size=4", "", "", "14");
+            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "Color=red", "", "5", "12");
+            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "Color=blue", "", "6", "13");
+            AssertCounterRateEventsPresent(events, meter.Name, oc.Name, "Color=red,Size=19", "", "", "7");
+            AssertCounterRateEventsPresent(events, meter.Name, oc.Name, "Color=blue,Size=4", "", "", "14");
+            AssertCounterValueEventsPresent(events, meter.Name, c.Name, "Color=red", "", "5", "17");
+            AssertCounterValueEventsPresent(events, meter.Name, c.Name, "Color=blue", "", "6", "19");
+            AssertCounterValueEventsPresent(events, meter.Name, oc.Name, "Color=red,Size=19", "", "10");
+            AssertCounterValueEventsPresent(events, meter.Name, oc.Name, "Color=blue,Size=4", "", "20");
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "Color=red,Size=19", "", "9", "18");
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "Color=blue,Size=4", "", "18", "36");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "Size=123", "", "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "Size=124", "", "0.5=20;0.95=20;0.99=20", "0.5=27;0.95=27;0.99=27");
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "Color=red", "", "-33", "40");
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "Color=blue", "", "-34", "41");
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "Color=red,Size=19", "", "", "-11");
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "Color=blue,Size=4", "", "", "-22");
+            AssertUpDownCounterRateEventsPresent(events, meter.Name, udc.Name, "Color=red", "", "-33", "40");
+            AssertUpDownCounterRateEventsPresent(events, meter.Name, udc.Name, "Color=blue", "", "-34", "41");
+            AssertUpDownCounterRateEventsPresent(events, meter.Name, oudc.Name, "Color=red,Size=19", "", "", "-11");
+            AssertUpDownCounterRateEventsPresent(events, meter.Name, oudc.Name, "Color=blue,Size=4", "", "", "-22");
+            AssertUpDownCounterValueEventsPresent(events, meter.Name, udc.Name, "Color=red", "", "-33", "7");
+            AssertUpDownCounterValueEventsPresent(events, meter.Name, udc.Name, "Color=blue", "", "-34", "7");
+            AssertUpDownCounterValueEventsPresent(events, meter.Name, oudc.Name, "Color=red,Size=19", "", "-11");
+            AssertUpDownCounterValueEventsPresent(events, meter.Name, oudc.Name, "Color=blue,Size=4", "", "-22");
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        [OuterLoop("Slow and has lots of console spew")]
+        //[OuterLoop("Slow and has lots of console spew")]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/79749", TargetFrameworkMonikers.NetFramework)]
         public void EventSourceFiltersInstruments()
         {
@@ -347,12 +371,12 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c3a, c1b, c2b, c3b, c2c, c3c);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meterA.Name, c3a.Name, "", "", "1", "2");
-            AssertCounterEventsPresent(events, meterB.Name, c1b.Name, "", "", "1", "2");
-            AssertCounterEventsPresent(events, meterB.Name, c2b.Name, "", "", "1", "2");
-            AssertCounterEventsPresent(events, meterB.Name, c3b.Name, "", "", "1", "2");
-            AssertCounterEventsPresent(events, meterC.Name, c3c.Name, "", "", "1", "2");
-            AssertCounterEventsPresent(events, meterC.Name, c3c.Name, "", "", "1", "2");
+            AssertCounterRateEventsPresent(events, meterA.Name, c3a.Name, "", "", "1", "2");
+            AssertCounterRateEventsPresent(events, meterB.Name, c1b.Name, "", "", "1", "2");
+            AssertCounterRateEventsPresent(events, meterB.Name, c2b.Name, "", "", "1", "2");
+            AssertCounterRateEventsPresent(events, meterB.Name, c3b.Name, "", "", "1", "2");
+            AssertCounterRateEventsPresent(events, meterC.Name, c3c.Name, "", "", "1", "2");
+            AssertCounterRateEventsPresent(events, meterC.Name, c3c.Name, "", "", "1", "2");
             AssertCounterEventsNotPresent(events, meterA.Name, c1a.Name, "");
             AssertCounterEventsNotPresent(events, meterA.Name, c2a.Name, "");
             AssertCounterEventsNotPresent(events, meterC.Name, c1c.Name, "");
@@ -360,7 +384,7 @@ namespace System.Diagnostics.Metrics.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        [OuterLoop("Slow and has lots of console spew")]
+        //[OuterLoop("Slow and has lots of console spew")]
         public void EventSourcePublishesMissingDataPoints()
         {
             using Meter meter = new Meter("TestMeter6");
@@ -438,17 +462,21 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", "5", "0", "12");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", "", "0", "14", "0");
+            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "", "", "5", "0", "12");
+            AssertCounterRateEventsPresent(events, meter.Name, oc.Name, "", "", "", "0", "14", "0");
+            AssertCounterValueEventsPresent(events, meter.Name, c.Name, "", "", "5", "5", "17");
+            AssertCounterValueEventsPresent(events, meter.Name, oc.Name, "", "", "17", "17", "48", "48");
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "18", "", "36", "");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", "0.5=19;0.95=19;0.99=19", "", "0.5=26;0.95=26;0.99=26", "");
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", "33", "0", "40");
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", "", "0", "22", "0");
+            AssertUpDownCounterRateEventsPresent(events, meter.Name, udc.Name, "", "", "33", "0", "40");
+            AssertUpDownCounterRateEventsPresent(events, meter.Name, oudc.Name, "", "", "", "0", "22", "0");
+            AssertUpDownCounterValueEventsPresent(events, meter.Name, udc.Name, "", "", "33", "33", "73");
+            AssertUpDownCounterValueEventsPresent(events, meter.Name, oudc.Name, "", "", "22", "22", "66", "66");
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 5);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        [OuterLoop("Slow and has lots of console spew")]
+        //[OuterLoop("Slow and has lots of console spew")]
         public void EventSourceRejectsNewListener()
         {
             using Meter meter = new Meter("TestMeter7");
@@ -484,17 +512,21 @@ namespace System.Diagnostics.Metrics.Tests
             }
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", c.Unit, "5", "12");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, "", "7", "7");
+            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "", c.Unit, "5", "12");
+            AssertCounterRateEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, "", "7", "7");
+            AssertCounterValueEventsPresent(events, meter.Name, c.Name, "", c.Unit, "5", "17");
+            AssertCounterValueEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, "10", "27", "51");
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "", og.Unit, "9", "18", "27");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "", h.Unit, "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, "33", "40");
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, "", "11");
+            AssertUpDownCounterRateEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, "33", "40");
+            AssertUpDownCounterRateEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, "", "11", "11");
+            AssertUpDownCounterValueEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, "33", "73");
+            AssertUpDownCounterValueEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, "11", "33", "66");
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        [OuterLoop("Slow and has lots of console spew")]
+        //[OuterLoop("Slow and has lots of console spew")]
         public void EventSourcePublishesEndEventsOnMeterDispose()
         {
             using Meter meterA = new Meter("TestMeter8");
@@ -532,19 +564,23 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meterA.Name, c.Name, "", c.Unit, "5", "12");
-            AssertCounterEventsPresent(events, meterA.Name, oc.Name, "", oc.Unit, "", "7", "7");
+            AssertCounterRateEventsPresent(events, meterA.Name, c.Name, "", c.Unit, "5", "12");
+            AssertCounterRateEventsPresent(events, meterA.Name, oc.Name, "", oc.Unit, "", "7", "7");
+            AssertCounterValueEventsPresent(events, meterA.Name, c.Name, "", c.Unit, "5", "17");
+            AssertCounterValueEventsPresent(events, meterA.Name, oc.Name, "", oc.Unit, "10", "27", "51");
             AssertGaugeEventsPresent(events, meterA.Name, og.Name, "", og.Unit, "9", "18", "27");
             AssertHistogramEventsPresent(events, meterB.Name, h.Name, "", h.Unit, "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26", "0.5=21;0.95=21;0.99=21");
-            AssertUpDownCounterEventsPresent(events, meterA.Name, udc.Name, "", udc.Unit, "33", "40");
-            AssertUpDownCounterEventsPresent(events, meterA.Name, oudc.Name, "", oudc.Unit, "", "11", "11");
+            AssertUpDownCounterRateEventsPresent(events, meterA.Name, udc.Name, "", udc.Unit, "33", "40");
+            AssertUpDownCounterRateEventsPresent(events, meterA.Name, oudc.Name, "", oudc.Unit, "", "11", "11");
+            AssertUpDownCounterValueEventsPresent(events, meterA.Name, udc.Name, "", udc.Unit, "33", "73");
+            AssertUpDownCounterValueEventsPresent(events, meterA.Name, oudc.Name, "", oudc.Unit, "11", "33", "66");
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 4);
             AssertEndInstrumentReportingEventsPresent(events, c, oc, og, udc, oudc);
         }
 
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        [OuterLoop("Slow and has lots of console spew")]
+        //[OuterLoop("Slow and has lots of console spew")]
         public void EventSourcePublishesInstruments()
         {
             using Meter meterA = new Meter("TestMeter10");
@@ -571,7 +607,7 @@ namespace System.Diagnostics.Metrics.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        [OuterLoop("Slow and has lots of console spew")]
+        //[OuterLoop("Slow and has lots of console spew")]
         public void EventSourcePublishesAllDataTypes()
         {
             using Meter meter = new Meter("TestMeter12");
@@ -626,18 +662,18 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, i, s, b, l, dec, f, d);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, i.Name, "", "", "1234568", "1234568");
-            AssertCounterEventsPresent(events, meter.Name, s.Name, "", "", "21433", "21433");
-            AssertCounterEventsPresent(events, meter.Name, b.Name, "", "", "2", "2");
-            AssertCounterEventsPresent(events, meter.Name, l.Name, "", "", "123456789013", "123456789013");
-            AssertCounterEventsPresent(events, meter.Name, dec.Name, "", "", "123456789012346", "123456789012346");
-            AssertCounterEventsPresent(events, meter.Name, f.Name, "", "", "123457.7890625", "123457.7890625");
-            AssertCounterEventsPresent(events, meter.Name, d.Name, "", "", "87654321987655.4", "87654321987655.4");
+            AssertCounterRateEventsPresent(events, meter.Name, i.Name, "", "", "1234568", "1234568");
+            AssertCounterRateEventsPresent(events, meter.Name, s.Name, "", "", "21433", "21433");
+            AssertCounterRateEventsPresent(events, meter.Name, b.Name, "", "", "2", "2");
+            AssertCounterRateEventsPresent(events, meter.Name, l.Name, "", "", "123456789013", "123456789013");
+            AssertCounterRateEventsPresent(events, meter.Name, dec.Name, "", "", "123456789012346", "123456789012346");
+            AssertCounterRateEventsPresent(events, meter.Name, f.Name, "", "", "123457.7890625", "123457.7890625");
+            AssertCounterRateEventsPresent(events, meter.Name, d.Name, "", "", "87654321987655.4", "87654321987655.4");
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        [OuterLoop("Slow and has lots of console spew")]
+        //[OuterLoop("Slow and has lots of console spew")]
         public void EventSourceEnforcesTimeSeriesLimit()
         {
             using Meter meter = new Meter("TestMeter13");
@@ -664,8 +700,8 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "Color=red", "", "5", "12");
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "Color=blue", "", "6", "13");
+            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "Color=red", "", "5", "12");
+            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "Color=blue", "", "6", "13");
             AssertTimeSeriesLimitPresent(events);
             AssertCounterEventsNotPresent(events, meter.Name, c.Name, "Color=green");
             AssertCounterEventsNotPresent(events, meter.Name, c.Name, "Color=yellow");
@@ -673,7 +709,7 @@ namespace System.Diagnostics.Metrics.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        [OuterLoop("Slow and has lots of console spew")]
+        //[OuterLoop("Slow and has lots of console spew")]
         public void EventSourceEnforcesHistogramLimit()
         {
             using Meter meter = new Meter("TestMeter14");
@@ -710,7 +746,7 @@ namespace System.Diagnostics.Metrics.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        [OuterLoop("Slow and has lots of console spew")]
+        //[OuterLoop("Slow and has lots of console spew")]
         public void EventSourceHandlesObservableCallbackException()
         {
             using Meter meter = new Meter("TestMeter15");
@@ -731,13 +767,13 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", "5", "12");
+            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "", "", "5", "12");
             AssertObservableCallbackErrorPresent(events);
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        [OuterLoop("Slow and has lots of console spew")]
+        //[OuterLoop("Slow and has lots of console spew")]
         public void EventSourceWorksWithSequentialListeners()
         {
             using Meter meter = new Meter("TestMeter16");
@@ -768,12 +804,16 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", "5", "12");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", "", "7");
+            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "", "", "5", "12");
+            AssertCounterRateEventsPresent(events, meter.Name, oc.Name, "", "", "", "7");
+            AssertCounterValueEventsPresent(events, meter.Name, c.Name, "", "", "5", "17");
+            AssertCounterValueEventsPresent(events, meter.Name, oc.Name, "", "", "10", "27");
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "9", "18");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", "33", "40");
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", "", "11");
+            AssertUpDownCounterRateEventsPresent(events, meter.Name, udc.Name, "", "", "33", "40");
+            AssertUpDownCounterRateEventsPresent(events, meter.Name, oudc.Name, "", "", "", "11");
+            AssertUpDownCounterValueEventsPresent(events, meter.Name, udc.Name, "", "", "33", "73");
+            AssertUpDownCounterValueEventsPresent(events, meter.Name, oudc.Name, "", "", "11", "33");
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
 
             // Now create a new listener and do everything a 2nd time. Because the listener above has been disposed the source should be
@@ -795,17 +835,21 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", "5", "12");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", "", "7");
+            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "", "", "5", "12");
+            AssertCounterRateEventsPresent(events, meter.Name, oc.Name, "", "", "", "7");
+            AssertCounterValueEventsPresent(events, meter.Name, c.Name, "", "", "5", "17");
+            AssertCounterValueEventsPresent(events, meter.Name, oc.Name, "", "", "31", "69");
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "36", "45");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
-            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", "33", "40");
-            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", "", "11");
+            AssertUpDownCounterRateEventsPresent(events, meter.Name, udc.Name, "", "", "33", "40");
+            AssertUpDownCounterRateEventsPresent(events, meter.Name, oudc.Name, "", "", "", "11");
+            AssertUpDownCounterValueEventsPresent(events, meter.Name, udc.Name, "", "", "33", "73");
+            AssertUpDownCounterValueEventsPresent(events, meter.Name, oudc.Name, "", "", "44", "99");
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-        [OuterLoop("Slow and has lots of console spew")]
+        //[OuterLoop("Slow and has lots of console spew")]
         public void EventSourceEnforcesHistogramLimitAndNotMaxTimeSeries()
         {
             using Meter meter = new Meter("TestMeter17");
@@ -943,19 +987,31 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.Equal(expectedInstruments.Length, publishEvents.Length);
         }
 
-        private void AssertCounterEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
+        private void AssertCounterRateEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
             string expectedUnit, params string[] expectedRates)
         {
-            AssertGenericCounterEventsPresent("CounterRateValuePublished", events, meterName, instrumentName, tags, expectedUnit, expectedRates);
+            AssertGenericCounterRateEventsPresent("CounterRateValuePublished", events, meterName, instrumentName, tags, expectedUnit, expectedRates);
         }
 
-        private void AssertUpDownCounterEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
+        private void AssertCounterValueEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
+            string expectedUnit, params string[] expectedValues)
+        {
+            AssertGenericCounterValueEventsPresent("CounterRateValuePublished", events, meterName, instrumentName, tags, expectedUnit, expectedValues);
+        }
+
+        private void AssertUpDownCounterRateEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
             string expectedUnit, params string[] expectedRates)
         {
-            AssertGenericCounterEventsPresent("UpDownCounterRateValuePublished", events, meterName, instrumentName, tags, expectedUnit, expectedRates);
+            AssertGenericCounterRateEventsPresent("UpDownCounterRateValuePublished", events, meterName, instrumentName, tags, expectedUnit, expectedRates);
         }
 
-        private void AssertGenericCounterEventsPresent(string eventName, EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
+        private void AssertUpDownCounterValueEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
+            string expectedUnit, params string[] expectedValues)
+        {
+            AssertGenericCounterValueEventsPresent("UpDownCounterRateValuePublished", events, meterName, instrumentName, tags, expectedUnit, expectedValues);
+        }
+
+        private void AssertGenericCounterRateEventsPresent(string eventName, EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
             string expectedUnit, params string[] expectedRates)
         {
             var counterEvents = events.Where(e => e.EventName == eventName).Select(e =>
@@ -975,6 +1031,31 @@ namespace System.Diagnostics.Metrics.Tests
                 Assert.Equal(expectedUnit, filteredEvents[i].Unit);
                 Assert.Equal(expectedRates[i], filteredEvents[i].Rate);
             }
+        }
+
+        private void AssertGenericCounterValueEventsPresent(string eventName, EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
+            string expectedUnit, params string[] expectedValues)
+        {
+            var counterEvents = events.Where(e => e.EventName == eventName).Select(e =>
+                new
+                {
+                    MeterName = e.Payload[1].ToString(),
+                    MeterVersion = e.Payload[2].ToString(),
+                    InstrumentName = e.Payload[3].ToString(),
+                    Unit = e.Payload[4].ToString(),
+                    Tags = e.Payload[5].ToString(),
+                    Rate = e.Payload[6].ToString(),
+                    Value = e.Payload[7].ToString()
+                }).ToArray();
+            var filteredEvents = counterEvents.Where(e => e.MeterName == meterName && e.InstrumentName == instrumentName && e.Tags == tags).ToArray();
+
+            Assert.True(filteredEvents.Length >= expectedValues.Length);
+            for (int i = 0; i < expectedValues.Length; i++)
+            {
+                Assert.Equal(expectedUnit, filteredEvents[i].Unit);
+                Assert.Equal(expectedValues[i], filteredEvents[i].Value);
+            }
+
         }
 
         private void AssertCounterEventsNotPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags)

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
@@ -56,16 +56,12 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "", "", "5", "12");
-            AssertCounterRateEventsPresent(events, meter.Name, oc.Name, "", "", "", "7");
-            AssertCounterValueEventsPresent(events, meter.Name, c.Name, "", "", "5", "17");
-            AssertCounterValueEventsPresent(events, meter.Name, oc.Name, "", "", "10", "27");
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("", "10"), ("7", "17"));
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "9", "18");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
-            AssertUpDownCounterRateEventsPresent(events, meter.Name, udc.Name, "", "", "-33", "-40");
-            AssertUpDownCounterRateEventsPresent(events, meter.Name, oudc.Name, "", "", "", "-11");
-            AssertUpDownCounterValueEventsPresent(events, meter.Name, udc.Name, "", "", "-33", "-73");
-            AssertUpDownCounterValueEventsPresent(events, meter.Name, oudc.Name, "", "", "-11", "-33");
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("-33", "-33"), ("-40", "-73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "-11"), ("-11", "-22"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -101,16 +97,12 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "", c.Unit, "5", "12");
-            AssertCounterRateEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, "", "7", "7");
-            AssertCounterValueEventsPresent(events, meter.Name, c.Name, "", c.Unit, "5", "17");
-            AssertCounterValueEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, "10", "27", "51");
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "", og.Unit, "9", "18", "27");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "", h.Unit, "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
-            AssertUpDownCounterRateEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, "33", "40");
-            AssertUpDownCounterRateEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, "", "11", "11");
-            AssertUpDownCounterValueEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, "33", "73");
-            AssertUpDownCounterValueEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, "11", "33", "66");
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -160,16 +152,12 @@ namespace System.Diagnostics.Metrics.Tests
 
                 AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc);
                 AssertInitialEnumerationCompleteEventPresent(events);
-                AssertCounterRateEventsPresent(events, meter.Name, c.Name, "", "", "5", "12");
-                AssertCounterRateEventsPresent(events, meter.Name, oc.Name, "", "", "", "7");
-                AssertCounterValueEventsPresent(events, meter.Name, c.Name, "", "", "5", "17");
-                AssertCounterValueEventsPresent(events, meter.Name, oc.Name, "", "", "10", "27");
+                AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
+                AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("", "10"), ("7", "17"));
                 AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "9", "18");
                 AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
-                AssertUpDownCounterRateEventsPresent(events, meter.Name, udc.Name, "", "", "33", "40");
-                AssertUpDownCounterRateEventsPresent(events, meter.Name, oudc.Name, "", "", "", "-11");
-                AssertUpDownCounterValueEventsPresent(events, meter.Name, udc.Name, "", "", "33", "73");
-                AssertUpDownCounterValueEventsPresent(events, meter.Name, oudc.Name, "", "", "-11", "-33");
+                AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("33", "33"), ("40", "73"));
+                AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "-11"), ("-11", "-22"));
                 AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
             }
             finally
@@ -220,16 +208,12 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "", "", "5", "12");
-            AssertCounterRateEventsPresent(events, meter.Name, oc.Name, "", "", "", "7");
-            AssertCounterValueEventsPresent(events, meter.Name, c.Name, "", "", "5", "17");
-            AssertCounterValueEventsPresent(events, meter.Name, oc.Name, "", "", "10", "27");
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("", "10"), ("7", "17"));
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "9", "18");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
-            AssertUpDownCounterRateEventsPresent(events, meter.Name, udc.Name, "", "", "-33", "-40");
-            AssertUpDownCounterRateEventsPresent(events, meter.Name, oudc.Name, "", "", "", "11");
-            AssertUpDownCounterValueEventsPresent(events, meter.Name, udc.Name, "", "", "-33", "-73");
-            AssertUpDownCounterValueEventsPresent(events, meter.Name, oudc.Name, "", "", "11", "33");
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("-33", "-33"), ("-40", "-73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "11"), ("11", "22"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -297,26 +281,18 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "Color=red", "", "5", "12");
-            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "Color=blue", "", "6", "13");
-            AssertCounterRateEventsPresent(events, meter.Name, oc.Name, "Color=red,Size=19", "", "", "7");
-            AssertCounterRateEventsPresent(events, meter.Name, oc.Name, "Color=blue,Size=4", "", "", "14");
-            AssertCounterValueEventsPresent(events, meter.Name, c.Name, "Color=red", "", "5", "17");
-            AssertCounterValueEventsPresent(events, meter.Name, c.Name, "Color=blue", "", "6", "19");
-            AssertCounterValueEventsPresent(events, meter.Name, oc.Name, "Color=red,Size=19", "", "10");
-            AssertCounterValueEventsPresent(events, meter.Name, oc.Name, "Color=blue,Size=4", "", "20");
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "Color=red", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "Color=blue", "", ("6", "6"), ("13", "19"));
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, "Color=red,Size=19", "", ("", "10"), ("7", "17"));
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, "Color=blue,Size=4", "", ("", "20"), ("14", "34"));
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "Color=red,Size=19", "", "9", "18");
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "Color=blue,Size=4", "", "18", "36");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "Size=123", "", "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "Size=124", "", "0.5=20;0.95=20;0.99=20", "0.5=27;0.95=27;0.99=27");
-            AssertUpDownCounterRateEventsPresent(events, meter.Name, udc.Name, "Color=red", "", "-33", "40");
-            AssertUpDownCounterRateEventsPresent(events, meter.Name, udc.Name, "Color=blue", "", "-34", "41");
-            AssertUpDownCounterRateEventsPresent(events, meter.Name, oudc.Name, "Color=red,Size=19", "", "", "-11");
-            AssertUpDownCounterRateEventsPresent(events, meter.Name, oudc.Name, "Color=blue,Size=4", "", "", "-22");
-            AssertUpDownCounterValueEventsPresent(events, meter.Name, udc.Name, "Color=red", "", "-33", "7");
-            AssertUpDownCounterValueEventsPresent(events, meter.Name, udc.Name, "Color=blue", "", "-34", "7");
-            AssertUpDownCounterValueEventsPresent(events, meter.Name, oudc.Name, "Color=red,Size=19", "", "-11");
-            AssertUpDownCounterValueEventsPresent(events, meter.Name, oudc.Name, "Color=blue,Size=4", "", "-22");
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "Color=red", "", ("-33", "-33"), ("40", "7"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "Color=blue", "", ("-34", "-34"), ("41", "7"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "Color=red,Size=19", "", ("", "-11"), ("-11", "-22"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "Color=blue,Size=4", "", ("", "-22"), ("-22", "-44"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -371,12 +347,12 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c3a, c1b, c2b, c3b, c2c, c3c);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterRateEventsPresent(events, meterA.Name, c3a.Name, "", "", "1", "2");
-            AssertCounterRateEventsPresent(events, meterB.Name, c1b.Name, "", "", "1", "2");
-            AssertCounterRateEventsPresent(events, meterB.Name, c2b.Name, "", "", "1", "2");
-            AssertCounterRateEventsPresent(events, meterB.Name, c3b.Name, "", "", "1", "2");
-            AssertCounterRateEventsPresent(events, meterC.Name, c3c.Name, "", "", "1", "2");
-            AssertCounterRateEventsPresent(events, meterC.Name, c3c.Name, "", "", "1", "2");
+            AssertCounterEventsPresent(events, meterA.Name, c3a.Name, "", "", ("1", "1"), ("2", "3"));
+            AssertCounterEventsPresent(events, meterB.Name, c1b.Name, "", "", ("1", "1"), ("2", "3"));
+            AssertCounterEventsPresent(events, meterB.Name, c2b.Name, "", "", ("1", "1"), ("2", "3"));
+            AssertCounterEventsPresent(events, meterB.Name, c3b.Name, "", "", ("1", "1"), ("2", "3"));
+            AssertCounterEventsPresent(events, meterC.Name, c3c.Name, "", "", ("1", "1"), ("2", "3"));
+            AssertCounterEventsPresent(events, meterC.Name, c3c.Name, "", "", ("1", "1"), ("2", "3"));
             AssertCounterEventsNotPresent(events, meterA.Name, c1a.Name, "");
             AssertCounterEventsNotPresent(events, meterA.Name, c2a.Name, "");
             AssertCounterEventsNotPresent(events, meterC.Name, c1c.Name, "");
@@ -462,16 +438,12 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "", "", "5", "0", "12");
-            AssertCounterRateEventsPresent(events, meter.Name, oc.Name, "", "", "", "0", "14", "0");
-            AssertCounterValueEventsPresent(events, meter.Name, c.Name, "", "", "5", "5", "17");
-            AssertCounterValueEventsPresent(events, meter.Name, oc.Name, "", "", "17", "17", "48", "48");
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("0", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("",  "17"), ("0", "17"), ("14", "31"), ("0", "31"));
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "18", "", "36", "");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", "0.5=19;0.95=19;0.99=19", "", "0.5=26;0.95=26;0.99=26", "");
-            AssertUpDownCounterRateEventsPresent(events, meter.Name, udc.Name, "", "", "33", "0", "40");
-            AssertUpDownCounterRateEventsPresent(events, meter.Name, oudc.Name, "", "", "", "0", "22", "0");
-            AssertUpDownCounterValueEventsPresent(events, meter.Name, udc.Name, "", "", "33", "33", "73");
-            AssertUpDownCounterValueEventsPresent(events, meter.Name, oudc.Name, "", "", "22", "22", "66", "66");
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("33", "33"), ("0", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "22"), ("0", "22"), ("22", "44"), ("0", "44"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 5);
         }
 
@@ -512,16 +484,12 @@ namespace System.Diagnostics.Metrics.Tests
             }
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc);
-            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "", c.Unit, "5", "12");
-            AssertCounterRateEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, "", "7", "7");
-            AssertCounterValueEventsPresent(events, meter.Name, c.Name, "", c.Unit, "5", "17");
-            AssertCounterValueEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, "10", "27", "51");
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "", og.Unit, "9", "18", "27");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "", h.Unit, "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
-            AssertUpDownCounterRateEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, "33", "40");
-            AssertUpDownCounterRateEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, "", "11", "11");
-            AssertUpDownCounterValueEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, "33", "73");
-            AssertUpDownCounterValueEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, "11", "33", "66");
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -564,16 +532,12 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterRateEventsPresent(events, meterA.Name, c.Name, "", c.Unit, "5", "12");
-            AssertCounterRateEventsPresent(events, meterA.Name, oc.Name, "", oc.Unit, "", "7", "7");
-            AssertCounterValueEventsPresent(events, meterA.Name, c.Name, "", c.Unit, "5", "17");
-            AssertCounterValueEventsPresent(events, meterA.Name, oc.Name, "", oc.Unit, "10", "27", "51");
+            AssertCounterEventsPresent(events, meterA.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events, meterA.Name, oc.Name, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
             AssertGaugeEventsPresent(events, meterA.Name, og.Name, "", og.Unit, "9", "18", "27");
             AssertHistogramEventsPresent(events, meterB.Name, h.Name, "", h.Unit, "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26", "0.5=21;0.95=21;0.99=21");
-            AssertUpDownCounterRateEventsPresent(events, meterA.Name, udc.Name, "", udc.Unit, "33", "40");
-            AssertUpDownCounterRateEventsPresent(events, meterA.Name, oudc.Name, "", oudc.Unit, "", "11", "11");
-            AssertUpDownCounterValueEventsPresent(events, meterA.Name, udc.Name, "", udc.Unit, "33", "73");
-            AssertUpDownCounterValueEventsPresent(events, meterA.Name, oudc.Name, "", oudc.Unit, "11", "33", "66");
+            AssertUpDownCounterEventsPresent(events, meterA.Name, udc.Name, "", udc.Unit, ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meterA.Name, oudc.Name, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 4);
             AssertEndInstrumentReportingEventsPresent(events, c, oc, og, udc, oudc);
         }
@@ -662,13 +626,13 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, i, s, b, l, dec, f, d);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterRateEventsPresent(events, meter.Name, i.Name, "", "", "1234568", "1234568");
-            AssertCounterRateEventsPresent(events, meter.Name, s.Name, "", "", "21433", "21433");
-            AssertCounterRateEventsPresent(events, meter.Name, b.Name, "", "", "2", "2");
-            AssertCounterRateEventsPresent(events, meter.Name, l.Name, "", "", "123456789013", "123456789013");
-            AssertCounterRateEventsPresent(events, meter.Name, dec.Name, "", "", "123456789012346", "123456789012346");
-            AssertCounterRateEventsPresent(events, meter.Name, f.Name, "", "", "123457.7890625", "123457.7890625");
-            AssertCounterRateEventsPresent(events, meter.Name, d.Name, "", "", "87654321987655.4", "87654321987655.4");
+            AssertCounterEventsPresent(events, meter.Name, i.Name, "", "", ("1234568", "1234568"), ("1234568", "2469136"));
+            AssertCounterEventsPresent(events, meter.Name, s.Name, "", "", ("21433", "21433"), ("21433", "42866"));
+            AssertCounterEventsPresent(events, meter.Name, b.Name, "", "", ("2", "2"), ("2", "4"));
+            AssertCounterEventsPresent(events, meter.Name, l.Name, "", "", ("123456789013", "123456789013"), ("123456789013", "246913578026"));
+            AssertCounterEventsPresent(events, meter.Name, dec.Name, "", "", ("123456789012346", "123456789012346"), ("123456789012346", "246913578024692"));
+            AssertCounterEventsPresent(events, meter.Name, f.Name, "", "", ("123457.7890625", "123457.7890625"), ("123457.7890625", "246915.578125"));
+            AssertCounterEventsPresent(events, meter.Name, d.Name, "", "", ("87654321987655.4", "87654321987655.4"), ("87654321987655.4", "175308643975310.8"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -700,8 +664,8 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "Color=red", "", "5", "12");
-            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "Color=blue", "", "6", "13");
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "Color=red", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "Color=blue", "", ("6", "6"), ("13", "19"));
             AssertTimeSeriesLimitPresent(events);
             AssertCounterEventsNotPresent(events, meter.Name, c.Name, "Color=green");
             AssertCounterEventsNotPresent(events, meter.Name, c.Name, "Color=yellow");
@@ -767,7 +731,7 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "", "", "5", "12");
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
             AssertObservableCallbackErrorPresent(events);
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
@@ -804,16 +768,12 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "", "", "5", "12");
-            AssertCounterRateEventsPresent(events, meter.Name, oc.Name, "", "", "", "7");
-            AssertCounterValueEventsPresent(events, meter.Name, c.Name, "", "", "5", "17");
-            AssertCounterValueEventsPresent(events, meter.Name, oc.Name, "", "", "10", "27");
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("", "10"), ("7", "17"));
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "9", "18");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
-            AssertUpDownCounterRateEventsPresent(events, meter.Name, udc.Name, "", "", "33", "40");
-            AssertUpDownCounterRateEventsPresent(events, meter.Name, oudc.Name, "", "", "", "11");
-            AssertUpDownCounterValueEventsPresent(events, meter.Name, udc.Name, "", "", "33", "73");
-            AssertUpDownCounterValueEventsPresent(events, meter.Name, oudc.Name, "", "", "11", "33");
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "11"), ("11", "22"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
 
             // Now create a new listener and do everything a 2nd time. Because the listener above has been disposed the source should be
@@ -835,16 +795,12 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h, udc, oudc);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertCounterRateEventsPresent(events, meter.Name, c.Name, "", "", "5", "12");
-            AssertCounterRateEventsPresent(events, meter.Name, oc.Name, "", "", "", "7");
-            AssertCounterValueEventsPresent(events, meter.Name, c.Name, "", "", "5", "17");
-            AssertCounterValueEventsPresent(events, meter.Name, oc.Name, "", "", "31", "69");
+            AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("", "31"), ("7", "38"));
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "36", "45");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
-            AssertUpDownCounterRateEventsPresent(events, meter.Name, udc.Name, "", "", "33", "40");
-            AssertUpDownCounterRateEventsPresent(events, meter.Name, oudc.Name, "", "", "", "11");
-            AssertUpDownCounterValueEventsPresent(events, meter.Name, udc.Name, "", "", "33", "73");
-            AssertUpDownCounterValueEventsPresent(events, meter.Name, oudc.Name, "", "", "44", "99");
+            AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("33", "33"), ("40", "73"));
+            AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "44"), ("11", "55"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
         }
 
@@ -987,54 +943,20 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.Equal(expectedInstruments.Length, publishEvents.Length);
         }
 
-        private void AssertCounterRateEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
-            string expectedUnit, params string[] expectedRates)
+        private void AssertCounterEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
+            string expectedUnit, params (string, string)[] expected)
         {
-            AssertGenericCounterRateEventsPresent("CounterRateValuePublished", events, meterName, instrumentName, tags, expectedUnit, expectedRates);
+            AssertGenericCounterEventsPresent("CounterRateValuePublished", events, meterName, instrumentName, tags, expectedUnit, expected);
         }
 
-        private void AssertCounterValueEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
-            string expectedUnit, params string[] expectedValues)
+        private void AssertUpDownCounterEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
+            string expectedUnit, params (string, string)[] expected)
         {
-            AssertGenericCounterValueEventsPresent("CounterRateValuePublished", events, meterName, instrumentName, tags, expectedUnit, expectedValues);
+            AssertGenericCounterEventsPresent("UpDownCounterRateValuePublished", events, meterName, instrumentName, tags, expectedUnit, expected);
         }
 
-        private void AssertUpDownCounterRateEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
-            string expectedUnit, params string[] expectedRates)
-        {
-            AssertGenericCounterRateEventsPresent("UpDownCounterRateValuePublished", events, meterName, instrumentName, tags, expectedUnit, expectedRates);
-        }
-
-        private void AssertUpDownCounterValueEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
-            string expectedUnit, params string[] expectedValues)
-        {
-            AssertGenericCounterValueEventsPresent("UpDownCounterRateValuePublished", events, meterName, instrumentName, tags, expectedUnit, expectedValues);
-        }
-
-        private void AssertGenericCounterRateEventsPresent(string eventName, EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
-            string expectedUnit, params string[] expectedRates)
-        {
-            var counterEvents = events.Where(e => e.EventName == eventName).Select(e =>
-                new
-                {
-                    MeterName = e.Payload[1].ToString(),
-                    MeterVersion = e.Payload[2].ToString(),
-                    InstrumentName = e.Payload[3].ToString(),
-                    Unit = e.Payload[4].ToString(),
-                    Tags = e.Payload[5].ToString(),
-                    Rate = e.Payload[6].ToString()
-                }).ToArray();
-            var filteredEvents = counterEvents.Where(e => e.MeterName == meterName && e.InstrumentName == instrumentName && e.Tags == tags).ToArray();
-            Assert.True(filteredEvents.Length >= expectedRates.Length);
-            for (int i = 0; i < expectedRates.Length; i++)
-            {
-                Assert.Equal(expectedUnit, filteredEvents[i].Unit);
-                Assert.Equal(expectedRates[i], filteredEvents[i].Rate);
-            }
-        }
-
-        private void AssertGenericCounterValueEventsPresent(string eventName, EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
-            string expectedUnit, params string[] expectedValues)
+        private void AssertGenericCounterEventsPresent(string eventName, EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
+            string expectedUnit, params (string, string)[] expected)
         {
             var counterEvents = events.Where(e => e.EventName == eventName).Select(e =>
                 new
@@ -1048,12 +970,12 @@ namespace System.Diagnostics.Metrics.Tests
                     Value = e.Payload[7].ToString()
                 }).ToArray();
             var filteredEvents = counterEvents.Where(e => e.MeterName == meterName && e.InstrumentName == instrumentName && e.Tags == tags).ToArray();
-
-            Assert.True(filteredEvents.Length >= expectedValues.Length);
-            for (int i = 0; i < expectedValues.Length; i++)
+            Assert.True(filteredEvents.Length >= expected.Length);
+            for (int i = 0; i < expected.Length; i++)
             {
                 Assert.Equal(expectedUnit, filteredEvents[i].Unit);
-                Assert.Equal(expectedValues[i], filteredEvents[i].Value);
+                Assert.Equal(expected[i].Item1, filteredEvents[i].Rate);
+                Assert.Equal(expected[i].Item2, filteredEvents[i].Value);
             }
         }
 


### PR DESCRIPTION
This amends the changes made in https://github.com/dotnet/runtime/pull/81041 so that deltas and sums are both published for counters/updowncounters. Includes updated testing.

@noahfalk let me know if this is what you had in mind / you have any adjustments you'd like to see - once this is in I'll revisit integrating this into dotnet-monitor and dotnet-counters.