### PR TITLE
Update mariner image versions

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -339,27 +339,6 @@ jobs:
         compilerName: gcc
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Mono Linux arm64 product build
-
-- ${{ if containsValue(parameters.platforms, 'mono_linux_arm64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: linux
-      archType: arm64
-      targetRid: linux-arm64
-      platform: linux_arm64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: mono_linux_arm64
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        ${{ insert }}: ${{ parameters.jobParameters }}
-
 # Mono LLVMAot test build
 
 - ${{ if containsValue(parameters.platforms, 'linux_x64_llvmaot') }}:

--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -14,12 +14,6 @@ resources:
       env:
         ROOTFS_DIR: /crossrootfs/armv6
 
-    # Use old build images until we can avoid a clang-12 crash: https://github.com/dotnet/runtime/issues/84503
-    - container: mono_linux_arm64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-cross-arm64
-      env:
-        ROOTFS_DIR: /crossrootfs/arm64
-
     - container: linux_arm64
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64-20230414124727-8100bf7
       env:

--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -5,7 +5,7 @@ parameters:
 resources:
   containers:
     - container: linux_arm
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm-20230410173854-290f679
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm-20230414124727-8100bf7
       env:
         ROOTFS_DIR: /crossrootfs/arm
 
@@ -21,22 +21,22 @@ resources:
         ROOTFS_DIR: /crossrootfs/arm64
 
     - container: linux_arm64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64-20230410173854-2288685
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64-20230414124727-8100bf7
       env:
         ROOTFS_DIR: /crossrootfs/arm64
 
     - container: linux_musl_x64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-alpine-20230410173854-2288685
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-alpine-20230414124727-8100bf7
       env:
         ROOTFS_DIR: /crossrootfs/x64
 
     - container: linux_musl_arm
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm-alpine-20230410173854-290f679
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm-alpine-20230414124727-8100bf7
       env:
         ROOTFS_DIR: /crossrootfs/arm
 
     - container: linux_musl_arm64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64-alpine-20230410173854-2288685
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64-alpine-20230414124727-8100bf7
       env:
         ROOTFS_DIR: /crossrootfs/arm64
     # This container contains all required toolsets to build for Android and for Linux with bionic libc.
@@ -45,12 +45,12 @@ resources:
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-android
 
     - container: linux_x64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-20230410173854-2288685
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-20230414124727-8100bf7
       env:
         ROOTFS_DIR: /crossrootfs/x64
 
     - container: linux_x86
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-x86-20230410173854-2288685
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-x86-20230414124727-8100bf7
       env:
         ROOTFS_DIR: /crossrootfs/x86
 

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -701,9 +701,7 @@ extends:
           - osx_x64
           - osx_arm64
           - linux_x64
-          # - linux_arm64
-          # Remove once we can use linux_arm64: https://github.com/dotnet/runtime/issues/84503
-          - mono_linux_arm64
+          - linux_arm64
           # - linux_musl_arm64
           - windows_x64
           - windows_x86


### PR DESCRIPTION
To pick up clang fix from https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/842.

Note: this is using fixed versions to avoid destabilizing ci as we modify the mariner images (for example, upgrading the llvm version). Once we're in a good spot I'll switch to floating versions.

Hoping this solves https://github.com/dotnet/runtime/issues/84503 and https://github.com/dotnet/runtime/issues/84802.