### PR TITLE
Use ubuntu 22.04 for gcc build

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -331,7 +331,7 @@ jobs:
       targetRid: linux-x64
       platform: linux_x64
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: debian-11-gcc12-amd64
+      container: ubuntu-22.04-gcc12-amd64
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
         buildConfig: ${{ parameters.buildConfig }}

--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -69,8 +69,8 @@ resources:
       env:
         ROOTFS_DIR: /crossrootfs/ppc64le
 
-    - container: debian-11-gcc12-amd64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-gcc12-amd64
+    - container: ubuntu-22.04-gcc12-amd64
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
 
     - container: linux_x64_llvmaot
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7


### PR DESCRIPTION
See https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/843