### PR TITLE
Fix MacCatalyst .framework build

### DIFF
--- a/eng/native/functions.cmake
+++ b/eng/native/functions.cmake
@@ -401,10 +401,12 @@ function(strip_symbols targetName outputFilename)
 
       set(strip_command ${STRIP} -no_code_signature_warning -S ${strip_source_file})
 
-      # codesign release build
-      string(TOLOWER "${CMAKE_BUILD_TYPE}" LOWERCASE_CMAKE_BUILD_TYPE)
-      if (LOWERCASE_CMAKE_BUILD_TYPE STREQUAL release)
-        set(strip_command ${strip_command} && codesign -f -s - ${strip_source_file})
+      if (CLR_CMAKE_TARGET_OSX)
+        # codesign release build
+        string(TOLOWER "${CMAKE_BUILD_TYPE}" LOWERCASE_CMAKE_BUILD_TYPE)
+        if (LOWERCASE_CMAKE_BUILD_TYPE STREQUAL release)
+          set(strip_command ${strip_command} && codesign -f -s - ${strip_source_file})
+        endif ()
       endif ()
 
       execute_process(
@@ -421,9 +423,9 @@ function(strip_symbols targetName outputFilename)
         TARGET ${targetName}
         POST_BUILD
         VERBATIM
+        COMMAND sh -c "echo Stripping symbols from $(basename '${strip_source_file}') into $(basename '${strip_destination_file}')"
         COMMAND ${DSYMUTIL} ${DSYMUTIL_OPTS} ${strip_source_file}
         COMMAND ${strip_command}
-        COMMAND sh -c "echo Stripping symbols from $(basename '${strip_source_file}') into $(basename '${strip_destination_file}')"
         )
     else (CLR_CMAKE_TARGET_APPLE)
 
@@ -431,36 +433,41 @@ function(strip_symbols targetName outputFilename)
         TARGET ${targetName}
         POST_BUILD
         VERBATIM
+        COMMAND sh -c "echo Stripping symbols from $(basename '${strip_source_file}') into $(basename '${strip_destination_file}')"
         COMMAND ${CMAKE_OBJCOPY} --only-keep-debug ${strip_source_file} ${strip_destination_file}
         COMMAND ${CMAKE_OBJCOPY} --strip-debug --strip-unneeded ${strip_source_file}
         COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=${strip_destination_file} ${strip_source_file}
-        COMMAND sh -c "echo Stripping symbols from $(basename '${strip_source_file}') into $(basename '${strip_destination_file}')"
         )
     endif (CLR_CMAKE_TARGET_APPLE)
   endif(CLR_CMAKE_HOST_UNIX)
 endfunction()
 
 function(install_with_stripped_symbols targetName kind destination)
+    get_property(target_is_framework TARGET ${targetName} PROPERTY "FRAMEWORK")
     if(NOT CLR_CMAKE_KEEP_NATIVE_SYMBOLS)
       strip_symbols(${targetName} symbol_file)
-      if (NOT "${symbol_file}" STREQUAL "")
+      if (NOT "${symbol_file}" STREQUAL "" AND NOT target_is_framework)
         install_symbol_file(${symbol_file} ${destination} ${ARGN})
       endif()
     endif()
 
-    if (CLR_CMAKE_TARGET_APPLE AND ("${kind}" STREQUAL "TARGETS"))
-      # We want to avoid the kind=TARGET install behaviors which corrupt code signatures on osx-arm64
-      set(kind PROGRAMS)
-    endif()
-
-    if ("${kind}" STREQUAL "TARGETS")
-      set(install_source ${targetName})
-    elseif("${kind}" STREQUAL "PROGRAMS")
-      set(install_source $<TARGET_FILE:${targetName}>)
+    if (target_is_framework)
+      install(TARGETS ${targetName} FRAMEWORK DESTINATION ${destination} ${ARGN})
     else()
-      message(FATAL_ERROR "The `kind` argument has to be either TARGETS or PROGRAMS, ${kind} was provided instead")
+      if (CLR_CMAKE_TARGET_APPLE AND ("${kind}" STREQUAL "TARGETS"))
+        # We want to avoid the kind=TARGET install behaviors which corrupt code signatures on osx-arm64
+        set(kind PROGRAMS)
+      endif()
+
+      if ("${kind}" STREQUAL "TARGETS")
+        set(install_source ${targetName})
+      elseif("${kind}" STREQUAL "PROGRAMS")
+        set(install_source $<TARGET_FILE:${targetName}>)
+      else()
+        message(FATAL_ERROR "The `kind` argument has to be either TARGETS or PROGRAMS, ${kind} was provided instead")
+      endif()
+      install(${kind} ${install_source} DESTINATION ${destination} ${ARGN})
     endif()
-    install(${kind} ${install_source} DESTINATION ${destination} ${ARGN})
 endfunction()
 
 function(install_symbol_file symbol_file destination_path)

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -981,7 +981,10 @@
       <_MonoRuntimeArtifacts Condition="Exists('$(MonoObjDir)out\lib\Mono.release.framework') and Exists('$(MonoObjDir)out\lib\Mono.release.framework\Versions')" Include="$(MonoObjDir)out\lib\Mono.release.framework\Versions\Current\Mono.release">
         <Destination>$(RuntimeBinDir)\Mono.release.framework\Mono</Destination>
       </_MonoRuntimeArtifacts>
-      <_MonoRuntimeArtifacts Condition="Exists('$(MonoObjDir)out\lib\Mono.release.framework')" Include="$(MonoObjDir)out\lib\Mono.release.framework\Mono.release.dwarf">
+      <_MonoRuntimeArtifacts Condition="Exists('$(MonoObjDir)out\lib\Mono.release.framework') and !Exists('$(MonoObjDir)out\lib\Mono.release.framework\Versions')" Include="$(MonoObjDir)out\lib\Mono.release.framework\Mono.release.dwarf">
+        <Destination>$(RuntimeBinDir)\Mono.release.framework\Mono.dwarf</Destination>
+      </_MonoRuntimeArtifacts>
+      <_MonoRuntimeArtifacts Condition="Exists('$(MonoObjDir)out\lib\Mono.release.framework') and Exists('$(MonoObjDir)out\lib\Mono.release.framework\Versions')" Include="$(MonoObjDir)out\lib\Mono.release.framework\Versions\Current\Mono.release.dwarf">
         <Destination>$(RuntimeBinDir)\Mono.release.framework\Mono.dwarf</Destination>
       </_MonoRuntimeArtifacts>
       <_MonoRuntimeArtifacts Condition="'$(MonoComponentsStatic)' != 'true' and Exists('$(MonoObjDir)out\lib\Mono.debug.framework')" Include="@(_MonoRuntimeComponentsSharedFilePath)">
@@ -993,7 +996,10 @@
       <_MonoRuntimeArtifacts Condition="Exists('$(MonoObjDir)out\lib\Mono.debug.framework') and Exists('$(MonoObjDir)out\lib\Mono.debug.framework\Versions')" Include="$(MonoObjDir)out\lib\Mono.debug.framework\Versions\Current\Mono.debug">
         <Destination>$(RuntimeBinDir)\Mono.debug.framework\Mono</Destination>
       </_MonoRuntimeArtifacts>
-      <_MonoRuntimeArtifacts Condition="Exists('$(MonoObjDir)out\lib\Mono.debug.framework')" Include="$(MonoObjDir)out\lib\Mono.debug.framework\Mono.debug.dwarf">
+      <_MonoRuntimeArtifacts Condition="Exists('$(MonoObjDir)out\lib\Mono.debug.framework') and !Exists('$(MonoObjDir)out\lib\Mono.debug.framework\Versions')" Include="$(MonoObjDir)out\lib\Mono.debug.framework\Mono.debug.dwarf">
+        <Destination>$(RuntimeBinDir)\Mono.debug.framework\Mono.dwarf</Destination>
+      </_MonoRuntimeArtifacts>
+      <_MonoRuntimeArtifacts Condition="Exists('$(MonoObjDir)out\lib\Mono.debug.framework') and Exists('$(MonoObjDir)out\lib\Mono.debug.framework\Versions')" Include="$(MonoObjDir)out\lib\Mono.debug.framework\Versions\Current\Mono.debug.dwarf">
         <Destination>$(RuntimeBinDir)\Mono.debug.framework\Mono.dwarf</Destination>
       </_MonoRuntimeArtifacts>
       <_MonoRuntimeArtifacts Condition="Exists('$(MonoObjDir)out\lib\Mono.release.framework') and !Exists('$(MonoObjDir)out\lib\Mono.release.framework\Versions')" Include="$(MonoObjDir)out\lib\Mono.release.framework\Info.plist">


### PR DESCRIPTION
This got broken by https://github.com/dotnet/runtime/pull/83903 and wasn't noticed on the PR because we don't build .frameworks unless you pass `/p:BuildDarwinFrameworks=true`.

For .frameworks we need to use a different install command and we also don't need to codesign them, it actually causes an error trying to do so (only on Catalyst though, not on iOS/tvOS for some reason):

> /Users/alexander/dev/runtime/artifacts/obj/mono/maccatalyst.x64.Release/mono/mini/Mono.release.framework/Versions/C/Mono.release: code object is not signed at all
> In subcomponent: /Users/alexander/dev/runtime/artifacts/obj/mono/maccatalyst.x64.Release/mono/mini/Mono.release.framework/Versions/C/Mono.release.dwarf

/cc @am11