### PR TITLE
Fix for x86 stublinker handling of optimized GC descs

### DIFF
--- a/src/coreclr/vm/i386/stublinkerx86.cpp
+++ b/src/coreclr/vm/i386/stublinkerx86.cpp
@@ -4546,7 +4546,7 @@ COPY_VALUE_CLASS:
                         if (cnt == 1)
                         {
                             // all pointers
-                            for (size_t i = 0; i < size; i += sizeof(DWORD*))
+                            for (size_t i = 0; i < size; i += sizeof(Object*))
                             {
                                 X86EmitCall(NewExternalCodeLabel((LPVOID)JIT_ByRefWriteBarrier), 0);
                                 total += sizeof(DWORD*);

--- a/src/coreclr/vm/i386/stublinkerx86.cpp
+++ b/src/coreclr/vm/i386/stublinkerx86.cpp
@@ -4541,29 +4541,43 @@ COPY_VALUE_CLASS:
                         total += cur->startoffset - elemOfs;
 
                         SSIZE_T cnt = (SSIZE_T) pArrayOpScript->m_gcDesc->GetNumSeries();
-                        // special array encoding
-                        _ASSERTE(cnt < 0);
 
-                        for (SSIZE_T __i = 0; __i > cnt; __i--)
+                        _ASSERTE(cnt < 0 || cnt == 1);
+                        if (cnt == 1)
                         {
-                            HALF_SIZE_T skip =  cur->val_serie[__i].skip;
-                            HALF_SIZE_T nptrs = cur->val_serie[__i].nptrs;
-                            total += nptrs*sizeof (DWORD*);
-                            do
+                            // all pointers
+                            for (size_t i = 0; i < size; i += sizeof(DWORD*))
                             {
-                                AMD64_ONLY(_ASSERTE(fNeedScratchArea));
-
-                                X86EmitCall(NewExternalCodeLabel((LPVOID) JIT_ByRefWriteBarrier), 0);
-                            } while (--nptrs);
-                            if (skip > 0)
-                            {
-                                //check if we are at the end of the series
-                                if (__i == (cnt + 1))
-                                    skip = skip - (HALF_SIZE_T)(cur->startoffset - elemOfs);
-                                if (skip > 0)
-                                    generate_noref_copy (skip, this);
+                                X86EmitCall(NewExternalCodeLabel((LPVOID)JIT_ByRefWriteBarrier), 0);
+                                total += sizeof(DWORD*);
                             }
-                            total += skip;
+                        }
+                        else
+                        {
+                            // special array encoding
+                            _ASSERTE(cnt < 0);
+
+                            for (SSIZE_T __i = 0; __i > cnt; __i--)
+                            {
+                                HALF_SIZE_T skip =  cur->val_serie[__i].skip;
+                                HALF_SIZE_T nptrs = cur->val_serie[__i].nptrs;
+                                total += nptrs*sizeof (DWORD*);
+                                do
+                                {
+                                    AMD64_ONLY(_ASSERTE(fNeedScratchArea));
+
+                                    X86EmitCall(NewExternalCodeLabel((LPVOID) JIT_ByRefWriteBarrier), 0);
+                                } while (--nptrs);
+                                if (skip > 0)
+                                {
+                                    //check if we are at the end of the series
+                                    if (__i == (cnt + 1))
+                                        skip = skip - (HALF_SIZE_T)(cur->startoffset - elemOfs);
+                                    if (skip > 0)
+                                        generate_noref_copy (skip, this);
+                                }
+                                total += skip;
+                            }
                         }
 
                         _ASSERTE (size == total);

--- a/src/coreclr/vm/i386/stublinkerx86.cpp
+++ b/src/coreclr/vm/i386/stublinkerx86.cpp
@@ -4542,7 +4542,6 @@ COPY_VALUE_CLASS:
 
                         SSIZE_T cnt = (SSIZE_T) pArrayOpScript->m_gcDesc->GetNumSeries();
 
-                        _ASSERTE(cnt < 0 || cnt == 1);
                         if (cnt == 1)
                         {
                             // all pointers

--- a/src/coreclr/vm/i386/stublinkerx86.cpp
+++ b/src/coreclr/vm/i386/stublinkerx86.cpp
@@ -4548,7 +4548,7 @@ COPY_VALUE_CLASS:
                             for (size_t i = 0; i < size; i += sizeof(Object*))
                             {
                                 X86EmitCall(NewExternalCodeLabel((LPVOID)JIT_ByRefWriteBarrier), 0);
-                                total += sizeof(DWORD*);
+                                total += sizeof(Object*);
                             }
                         }
                         else
@@ -4560,7 +4560,7 @@ COPY_VALUE_CLASS:
                             {
                                 HALF_SIZE_T skip =  cur->val_serie[__i].skip;
                                 HALF_SIZE_T nptrs = cur->val_serie[__i].nptrs;
-                                total += nptrs*sizeof (DWORD*);
+                                total += nptrs*sizeof (Object*);
                                 do
                                 {
                                     AMD64_ONLY(_ASSERTE(fNeedScratchArea));

--- a/src/tests/Regressions/coreclr/GitHub_84694/test84694.cs
+++ b/src/tests/Regressions/coreclr/GitHub_84694/test84694.cs
@@ -20,7 +20,7 @@ public class Program
 {
     public static int Main()
     {
-        var vr4 = new S0[,] { { new S0(new C0()) } };
+        GC.KeepAlive(new S0[,] { { new S0(new C0()) } });
         return 100;
     }
 }

--- a/src/tests/Regressions/coreclr/GitHub_84694/test84694.cs
+++ b/src/tests/Regressions/coreclr/GitHub_84694/test84694.cs
@@ -3,15 +3,11 @@
 
 using System;
 
-public class C0
-{
-}
-
 public struct S0
 {
-    public C0 F0;
-    public C0 F1;
-    public S0(C0 f1) : this()
+    public object F0;
+    public object F1;
+    public S0(object f1) : this()
     {
     }
 }
@@ -20,7 +16,7 @@ public class Program
 {
     public static int Main()
     {
-        GC.KeepAlive(new S0[,] { { new S0(new C0()) } });
+        GC.KeepAlive(new S0[,] { { new S0(new object()) } });
         return 100;
     }
 }

--- a/src/tests/Regressions/coreclr/GitHub_84694/test84694.cs
+++ b/src/tests/Regressions/coreclr/GitHub_84694/test84694.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+public class C0
+{
+}
+
+public struct S0
+{
+    public C0 F0;
+    public C0 F1;
+    public S0(C0 f1) : this()
+    {
+    }
+}
+
+public class Program
+{
+    public static int Main()
+    {
+        var vr4 = new S0[,] { { new S0(new C0()) } };
+        return 100;
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_84694/test84694.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_84694/test84694.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test84694.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes: #84694

x86 stublinker expected that an array of structs could not have "all pointers" GC desc. 
It is possible now if the element is an "all pointers" struct.
