### PR TITLE
[release/6.0-staging] define UNW_AARCH64 aliases conditionally

### DIFF
--- a/src/coreclr/pal/src/config.h.in
+++ b/src/coreclr/pal/src/config.h.in
@@ -68,6 +68,7 @@
 #cmakedefine01 HAVE_SCHED_SETAFFINITY
 #cmakedefine HAVE_UNW_GET_SAVE_LOC
 #cmakedefine HAVE_UNW_GET_ACCESSORS
+#cmakedefine HAVE_UNW_AARCH64_X19
 #cmakedefine01 HAVE_XSWDEV
 #cmakedefine01 HAVE_XSW_USAGE
 #cmakedefine01 HAVE_PUBLIC_XSTATE_STRUCT

--- a/src/coreclr/pal/src/configure.cmake
+++ b/src/coreclr/pal/src/configure.cmake
@@ -1047,6 +1047,15 @@ int main(int argc, char **argv)
 check_symbol_exists(unw_get_save_loc libunwind.h HAVE_UNW_GET_SAVE_LOC)
 check_symbol_exists(unw_get_accessors libunwind.h HAVE_UNW_GET_ACCESSORS)
 
+check_cxx_source_compiles("
+#include <libunwind.h>
+
+int main(int argc, char **argv)
+{
+    int flag = (int)UNW_AARCH64_X19;
+    return 0;
+}" HAVE_UNW_AARCH64_X19)
+
 if(NOT CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
   list(REMOVE_AT CMAKE_REQUIRED_INCLUDES 0 1)
 endif()

--- a/src/coreclr/pal/src/exception/seh-unwind.cpp
+++ b/src/coreclr/pal/src/exception/seh-unwind.cpp
@@ -54,7 +54,7 @@ Abstract:
 
 #endif // HOST_UNIX
 
-#if defined(TARGET_OSX) && defined(TARGET_ARM64)
+#if defined(TARGET_OSX) && defined(TARGET_ARM64) && !defined(HAVE_UNW_AARCH64_X19)
 // MacOS uses ARM64 instead of AARCH64 to describe these registers
 // Create aliases to reuse more code
 enum


### PR DESCRIPTION
backport of: https://github.com/dotnet/runtime/pull/84591

## Customer Impact

Fixes a build break with the new macOS SDK.

---

The libunwind.h that comes with the new MacOS SDK now has the enum for things like `UNW_AARCH64_X19`, so the workaround for not having those constants now causes build failures due to duplicate definition.

https://github.com/dotnet/runtime/blob/4ece8f0e73c72271b3e4afa95bfeb7d28ec50869/src/coreclr/pal/src/exception/seh-unwind.cpp#L58

Without taking build dependency on the newest SDK, we need to apply the workaround conditionally.
Since this is an enum (not a define), we can't do simple `#ifndef` and need to do a configure test.

## Testing

## Risk
