### PR TITLE
JIT: enable one particular flow opt when we have PGO

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -2776,15 +2776,6 @@ bool Compiler::fgOptimizeBranchToEmptyUnconditional(BasicBlock* block, BasicBloc
         optimizeJump = true;
     }
 
-    // If we are optimizing using real profile weights
-    // then don't optimize a conditional jump to an unconditional jump
-    // until after we have computed the edge weights
-    //
-    if (fgIsUsingProfileWeights() && !fgEdgeWeightsComputed)
-    {
-        optimizeJump = false;
-    }
-
     if (optimizeJump)
     {
 #ifdef DEBUG
@@ -3152,15 +3143,6 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
             // However jumping to a block that is not in any try region is OK
             //
             if (bDest->hasTryIndex() && !BasicBlock::sameTryRegion(block, bDest))
-            {
-                optimizeJump = false;
-            }
-
-            // If we are optimize using real profile weights
-            // then don't optimize a switch jump to an unconditional jump
-            // until after we have computed the edge weights
-            //
-            if (fgIsUsingProfileWeights() && !fgEdgeWeightsComputed)
             {
                 optimizeJump = false;
             }


### PR DESCRIPTION
This particular optimization seems to be a good idea, so not sure why the code was unwilling to do it if we had profile data.

This optimization removes a "branch around":

```
BlockA: jtrue (p) BlockC
BlockB: {empty} jmp BlockD
BlockC: ...
...
BlockD: ...
```
becomes

```
BlockA: jtrue (!p) BlockD
BlockC: ...
...
BlockD: ...
```

If later during code layout we decide we'd rather have
```
BlockA: jtrue (p) BlockC
BlockD: ...
...
BlockC: ...
```
we can still make that happen.