### PR TITLE
Add a dedicated Ascii.IsValid path

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.CaseConversion.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.CaseConversion.cs
@@ -238,7 +238,7 @@ namespace System.Text
                 // Unaligned read and check for non-ASCII data.
 
                 Vector128<TFrom> srcVector = Vector128.LoadUnsafe(ref *pSrc);
-                if (VectorContainsAnyNonAsciiData(srcVector))
+                if (VectorContainsNonAsciiChar(srcVector))
                 {
                     goto Drain64;
                 }
@@ -291,7 +291,7 @@ namespace System.Text
                     // Unaligned read & check for non-ASCII data.
 
                     srcVector = Vector128.LoadUnsafe(ref *pSrc, i);
-                    if (VectorContainsAnyNonAsciiData(srcVector))
+                    if (VectorContainsNonAsciiChar(srcVector))
                     {
                         goto Drain64;
                     }
@@ -461,30 +461,6 @@ namespace System.Text
         Return:
 
             return i;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe bool VectorContainsAnyNonAsciiData<T>(Vector128<T> vector)
-            where T : unmanaged
-        {
-            if (sizeof(T) == 1)
-            {
-                if (vector.ExtractMostSignificantBits() != 0) { return true; }
-            }
-            else if (sizeof(T) == 2)
-            {
-                if (VectorContainsNonAsciiChar(vector.AsUInt16()))
-                {
-                    return true;
-                }
-            }
-            else
-            {
-                Debug.Fail("Unknown types provided.");
-                throw new NotSupportedException();
-            }
-
-            return false;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -1458,9 +1458,9 @@ namespace System.Text
         private static bool AllCharsInVectorAreAscii<T>(Vector128<T> vector)
             where T : unmanaged
         {
-            Debug.Assert(Avx.IsSupported);
             Debug.Assert(typeof(T) == typeof(byte) || typeof(T) == typeof(ushort));
 
+            // This is a copy of VectorContainsNonAsciiChar with an inverted condition.
             if (typeof(T) == typeof(byte))
             {
                 return

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -42,6 +42,17 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool AllCharsInUInt64AreAscii<T>(ulong value)
+            where T : unmanaged
+        {
+            Debug.Assert(typeof(T) == typeof(byte) || typeof(T) == typeof(ushort));
+
+            return typeof(T) == typeof(byte)
+                ? AllBytesInUInt64AreAscii(value)
+                : AllCharsInUInt64AreAscii(value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int GetIndexOfFirstNonAsciiByteInLane_AdvSimd(Vector128<byte> value, Vector128<byte> bitmask)
         {
             if (!AdvSimd.Arm64.IsSupported || !BitConverter.IsLittleEndian)
@@ -1430,6 +1441,52 @@ namespace System.Text
                 // If a non-ASCII bit is set in any WORD of the vector, we have seen non-ASCII data.
                 return zeroIsAscii != Vector128<ushort>.Zero;
             }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool VectorContainsNonAsciiChar<T>(Vector128<T> vector)
+            where T : unmanaged
+        {
+            Debug.Assert(typeof(T) == typeof(byte) || typeof(T) == typeof(ushort));
+
+            return typeof(T) == typeof(byte)
+                ? VectorContainsNonAsciiChar(vector.AsByte())
+                : VectorContainsNonAsciiChar(vector.AsUInt16());
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool AllCharsInVectorAreAscii<T>(Vector128<T> vector)
+            where T : unmanaged
+        {
+            Debug.Assert(Avx.IsSupported);
+            Debug.Assert(typeof(T) == typeof(byte) || typeof(T) == typeof(ushort));
+
+            if (typeof(T) == typeof(byte))
+            {
+                return
+                    Sse41.IsSupported ? Sse41.TestZ(vector.AsByte(), Vector128.Create((byte)0x80)) :
+                    AdvSimd.Arm64.IsSupported ? AllBytesInUInt64AreAscii(AdvSimd.Arm64.MaxPairwise(vector.AsByte(), vector.AsByte()).AsUInt64().ToScalar()) :
+                    vector.AsByte().ExtractMostSignificantBits() == 0;
+            }
+            else
+            {
+                return
+                    Sse41.IsSupported ? Sse41.TestZ(vector.AsInt16(), Vector128.Create((short)-128)) :
+                    AdvSimd.Arm64.IsSupported ? AllCharsInUInt64AreAscii(AdvSimd.Arm64.MaxPairwise(vector.AsUInt16(), vector.AsUInt16()).AsUInt64().ToScalar()) :
+                    (vector.AsUInt16() & Vector128.Create((ushort)(ushort.MaxValue - 127))) == Vector128<ushort>.Zero;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool AllCharsInVectorAreAscii<T>(Vector256<T> vector)
+            where T : unmanaged
+        {
+            Debug.Assert(Avx.IsSupported);
+            Debug.Assert(typeof(T) == typeof(byte) || typeof(T) == typeof(ushort));
+
+            return typeof(T) == typeof(byte)
+                ? Avx.TestZ(vector.AsByte(), Vector256.Create((byte)0x80))
+                : Avx.TestZ(vector.AsInt16(), Vector256.Create((short)-128));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 
 namespace System.Text
 {
@@ -14,21 +16,9 @@ namespace System.Text
         /// <param name="value">The value to inspect.</param>
         /// <returns>True if <paramref name="value"/> contains only ASCII bytes or is
         /// empty; False otherwise.</returns>
-        public static unsafe bool IsValid(ReadOnlySpan<byte> value)
-        {
-            if (value.IsEmpty)
-            {
-                return true;
-            }
-
-            nuint bufferLength = (uint)value.Length;
-            fixed (byte* pBuffer = &MemoryMarshal.GetReference(value))
-            {
-                nuint idxOfFirstNonAsciiElement = GetIndexOfFirstNonAsciiByte(pBuffer, bufferLength);
-                Debug.Assert(idxOfFirstNonAsciiElement <= bufferLength);
-                return idxOfFirstNonAsciiElement == bufferLength;
-            }
-        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsValid(ReadOnlySpan<byte> value) =>
+            IsValidCore(ref MemoryMarshal.GetReference(value), value.Length);
 
         /// <summary>
         /// Determines whether the provided value contains only ASCII chars.
@@ -36,34 +26,205 @@ namespace System.Text
         /// <param name="value">The value to inspect.</param>
         /// <returns>True if <paramref name="value"/> contains only ASCII chars or is
         /// empty; False otherwise.</returns>
-        public static unsafe bool IsValid(ReadOnlySpan<char> value)
-        {
-            if (value.IsEmpty)
-            {
-                return true;
-            }
-
-            nuint bufferLength = (uint)value.Length;
-            fixed (char* pBuffer = &MemoryMarshal.GetReference(value))
-            {
-                nuint idxOfFirstNonAsciiElement = GetIndexOfFirstNonAsciiChar(pBuffer, bufferLength);
-                Debug.Assert(idxOfFirstNonAsciiElement <= bufferLength);
-                return idxOfFirstNonAsciiElement == bufferLength;
-            }
-        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsValid(ReadOnlySpan<char> value) =>
+            IsValidCore(ref Unsafe.As<char, ushort>(ref MemoryMarshal.GetReference(value)), value.Length);
 
         /// <summary>
         /// Determines whether the provided value is ASCII byte.
         /// </summary>
         /// <param name="value">The value to inspect.</param>
         /// <returns>True if <paramref name="value"/> is ASCII, False otherwise.</returns>
-        public static unsafe bool IsValid(byte value) => value <= 127;
+        public static bool IsValid(byte value) => value <= 127;
 
         /// <summary>
         /// Determines whether the provided value is ASCII char.
         /// </summary>
         /// <param name="value">The value to inspect.</param>
         /// <returns>True if <paramref name="value"/> is ASCII, False otherwise.</returns>
-        public static unsafe bool IsValid(char value) => value <= 127;
+        public static bool IsValid(char value) => value <= 127;
+
+        private static unsafe bool IsValidCore<T>(ref T searchSpace, int length) where T : unmanaged
+        {
+            Debug.Assert(typeof(T) == typeof(byte) || typeof(T) == typeof(ushort));
+
+            ref T searchSpaceEnd = ref Unsafe.Add(ref searchSpace, length);
+
+            if (!Vector128.IsHardwareAccelerated || length < Vector128<T>.Count)
+            {
+                int elementsPerUlong = sizeof(ulong) / sizeof(T);
+
+                if (length < elementsPerUlong)
+                {
+                    if (typeof(T) == typeof(byte) && length >= sizeof(uint))
+                    {
+                        // Process byte inputs with lengths [4, 7]
+                        return AllBytesInUInt32AreAscii(
+                            Unsafe.ReadUnaligned<uint>(ref Unsafe.As<T, byte>(ref searchSpace)) |
+                            Unsafe.ReadUnaligned<uint>(ref Unsafe.As<T, byte>(ref Unsafe.Subtract(ref searchSpaceEnd, sizeof(uint)))));
+                    }
+
+                    // Process inputs with lengths [0, 3]
+                    while (Unsafe.IsAddressLessThan(ref searchSpace, ref searchSpaceEnd))
+                    {
+                        if (typeof(T) == typeof(byte)
+                            ? (Unsafe.BitCast<T, byte>(searchSpace) > 127)
+                            : (Unsafe.BitCast<T, char>(searchSpace) > 127))
+                        {
+                            return false;
+                        }
+
+                        searchSpace = ref Unsafe.Add(ref searchSpace, 1);
+                    }
+
+                    return true;
+                }
+
+                // If vectorization isn't supported, process 16 bytes at a time.
+                if (!Vector128.IsHardwareAccelerated && length > 2 * elementsPerUlong)
+                {
+                    ref T finalStart = ref Unsafe.Subtract(ref searchSpaceEnd, 2 * elementsPerUlong);
+
+                    do
+                    {
+                        if (!AllCharsInUInt64AreAscii<T>(
+                            Unsafe.ReadUnaligned<ulong>(ref Unsafe.As<T, byte>(ref searchSpace)) |
+                            Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref Unsafe.As<T, byte>(ref searchSpace), sizeof(ulong)))))
+                        {
+                            return false;
+                        }
+
+                        searchSpace = ref Unsafe.Add(ref searchSpace, 2 * elementsPerUlong);
+                    }
+                    while (Unsafe.IsAddressLessThan(ref searchSpace, ref finalStart));
+
+                    searchSpace = ref finalStart;
+                }
+
+                // Process the last [8, 16] bytes.
+                return AllCharsInUInt64AreAscii<T>(
+                    Unsafe.ReadUnaligned<ulong>(ref Unsafe.As<T, byte>(ref searchSpace)) |
+                    Unsafe.ReadUnaligned<ulong>(ref Unsafe.Subtract(ref Unsafe.As<T, byte>(ref searchSpaceEnd), sizeof(ulong))));
+            }
+
+            // Process inputs with lengths [16, 32] bytes.
+            if (length <= 2 * Vector128<T>.Count)
+            {
+                return AllCharsInVectorAreAscii(
+                    Vector128.LoadUnsafe(ref searchSpace) |
+                    Vector128.LoadUnsafe(ref Unsafe.Subtract(ref searchSpaceEnd, (nuint)Vector128<T>.Count)));
+            }
+
+            if (Vector256.IsHardwareAccelerated)
+            {
+                // Process inputs with lengths [33, 64] bytes.
+                if (length <= 2 * Vector256<T>.Count)
+                {
+                    return AllCharsInVectorAreAscii(
+                        Vector256.LoadUnsafe(ref searchSpace) |
+                        Vector256.LoadUnsafe(ref Unsafe.Subtract(ref searchSpaceEnd, (nuint)Vector256<T>.Count)));
+                }
+
+                // Process long inputs 128 bytes at a time.
+                if (length > 4 * Vector256<T>.Count)
+                {
+                    // Process the first 128 bytes.
+                    if (!AllCharsInVectorAreAscii(
+                        Vector256.LoadUnsafe(ref searchSpace) |
+                        Vector256.LoadUnsafe(ref searchSpace, (nuint)Vector256<T>.Count) |
+                        Vector256.LoadUnsafe(ref searchSpace, 2 * (nuint)Vector256<T>.Count) |
+                        Vector256.LoadUnsafe(ref searchSpace, 3 * (nuint)Vector256<T>.Count)))
+                    {
+                        return false;
+                    }
+
+                    searchSpace = ref Unsafe.Add(ref searchSpace, 4 * Vector256<T>.Count);
+
+                    // Try to opportunistically align the reads below. The input isn't pinned, so the GC
+                    // is free to move the references. We're therefore assuming that reads may still be unaligned.
+                    // They may also be unaligned if the input chars aren't 2-byte aligned.
+                    nuint misalignedElements = ((nuint)Unsafe.AsPointer(ref searchSpace) & (nuint)(Vector256<byte>.Count - 1)) / (nuint)sizeof(T);
+                    searchSpace = ref Unsafe.Subtract(ref searchSpace, misalignedElements);
+
+                    ref T finalStart = ref Unsafe.Subtract(ref searchSpaceEnd, 4 * Vector256<T>.Count);
+
+                    while (Unsafe.IsAddressLessThan(ref searchSpace, ref finalStart))
+                    {
+                        if (!AllCharsInVectorAreAscii(
+                            Vector256.LoadUnsafe(ref searchSpace) |
+                            Vector256.LoadUnsafe(ref searchSpace, (nuint)Vector256<T>.Count) |
+                            Vector256.LoadUnsafe(ref searchSpace, 2 * (nuint)Vector256<T>.Count) |
+                            Vector256.LoadUnsafe(ref searchSpace, 3 * (nuint)Vector256<T>.Count)))
+                        {
+                            return false;
+                        }
+
+                        searchSpace = ref Unsafe.Add(ref searchSpace, 4 * Vector256<T>.Count);
+                    }
+
+                    searchSpace = ref finalStart;
+                }
+
+                // Process the last [1, 128] bytes.
+                // The search space has at least 2 * Vector256 bytes available to read.
+                // We process the first 2 and last 2 vectors, which may overlap.
+                return AllCharsInVectorAreAscii(
+                    Vector256.LoadUnsafe(ref searchSpace) |
+                    Vector256.LoadUnsafe(ref searchSpace, (nuint)Vector256<T>.Count) |
+                    Vector256.LoadUnsafe(ref Unsafe.Subtract(ref searchSpaceEnd, 2 * (nuint)Vector256<T>.Count)) |
+                    Vector256.LoadUnsafe(ref Unsafe.Subtract(ref searchSpaceEnd, (nuint)Vector256<T>.Count)));
+            }
+            else
+            {
+                // Process long inputs 64 bytes at a time.
+                if (length > 4 * Vector128<T>.Count)
+                {
+                    // Process the first 64 bytes.
+                    if (!AllCharsInVectorAreAscii(
+                        Vector128.LoadUnsafe(ref searchSpace) |
+                        Vector128.LoadUnsafe(ref searchSpace, (nuint)Vector128<T>.Count) |
+                        Vector128.LoadUnsafe(ref searchSpace, 2 * (nuint)Vector128<T>.Count) |
+                        Vector128.LoadUnsafe(ref searchSpace, 3 * (nuint)Vector128<T>.Count)))
+                    {
+                        return false;
+                    }
+
+                    searchSpace = ref Unsafe.Add(ref searchSpace, 4 * Vector128<T>.Count);
+
+                    // Try to opportunistically align the reads below. The input isn't pinned, so the GC
+                    // is free to move the references. We're therefore assuming that reads may still be unaligned.
+                    // They may also be unaligned if the input chars aren't 2-byte aligned.
+                    nuint misalignedElements = ((nuint)Unsafe.AsPointer(ref searchSpace) & (nuint)(Vector128<byte>.Count - 1)) / (nuint)sizeof(T);
+                    searchSpace = ref Unsafe.Subtract(ref searchSpace, misalignedElements);
+
+                    ref T finalStart = ref Unsafe.Subtract(ref searchSpaceEnd, 4 * Vector128<T>.Count);
+
+                    while (Unsafe.IsAddressLessThan(ref searchSpace, ref finalStart))
+                    {
+                        if (!AllCharsInVectorAreAscii(
+                            Vector128.LoadUnsafe(ref searchSpace) |
+                            Vector128.LoadUnsafe(ref searchSpace, (nuint)Vector128<T>.Count) |
+                            Vector128.LoadUnsafe(ref searchSpace, 2 * (nuint)Vector128<T>.Count) |
+                            Vector128.LoadUnsafe(ref searchSpace, 3 * (nuint)Vector128<T>.Count)))
+                        {
+                            return false;
+                        }
+
+                        searchSpace = ref Unsafe.Add(ref searchSpace, 4 * Vector128<T>.Count);
+                    }
+
+                    searchSpace = ref finalStart;
+                }
+
+                // Process the last [1, 64] bytes.
+                // The search space has at least 2 * Vector128 bytes available to read.
+                // We process the first 2 and last 2 vectors, which may overlap.
+                return AllCharsInVectorAreAscii(
+                    Vector128.LoadUnsafe(ref searchSpace) |
+                    Vector128.LoadUnsafe(ref searchSpace, (nuint)Vector128<T>.Count) |
+                    Vector128.LoadUnsafe(ref Unsafe.Subtract(ref searchSpaceEnd, 2 * (nuint)Vector128<T>.Count)) |
+                    Vector128.LoadUnsafe(ref Unsafe.Subtract(ref searchSpaceEnd, (nuint)Vector128<T>.Count)));
+            }
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.cs
@@ -63,7 +63,7 @@ namespace System.Text
                     }
 
                     // Process inputs with lengths [0, 3]
-                    for (int j = 0; j < length; j++)
+                    for (nuint j = 0; j < (uint)length; j++)
                     {
                         if (typeof(T) == typeof(byte)
                             ? (Unsafe.BitCast<T, byte>(Unsafe.Add(ref searchSpace, j)) > 127)

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.cs
@@ -142,6 +142,7 @@ namespace System.Text
                     // They may also be unaligned if the input chars aren't 2-byte aligned.
                     nuint misalignedElements = ((nuint)Unsafe.AsPointer(ref searchSpace) & (nuint)(Vector256<byte>.Count - 1)) / (nuint)sizeof(T);
                     i -= misalignedElements;
+                    Debug.Assert((int)i > 3 * Vector256<T>.Count);
 
                     nuint finalStart = (nuint)length - 4 * (nuint)Vector256<T>.Count;
 
@@ -195,6 +196,7 @@ namespace System.Text
                     // They may also be unaligned if the input chars aren't 2-byte aligned.
                     nuint misalignedElements = ((nuint)Unsafe.AsPointer(ref searchSpace) & (nuint)(Vector128<byte>.Count - 1)) / (nuint)sizeof(T);
                     i -= misalignedElements;
+                    Debug.Assert((int)i > 3 * Vector128<T>.Count);
 
                     nuint finalStart = (nuint)length - 4 * (nuint)Vector128<T>.Count;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.cs
@@ -189,8 +189,6 @@ namespace System.Text
 
                     nuint i = 4 * (nuint)Vector128<T>.Count;
 
-                    searchSpace = ref Unsafe.Add(ref searchSpace, 4 * Vector128<T>.Count);
-
                     // Try to opportunistically align the reads below. The input isn't pinned, so the GC
                     // is free to move the references. We're therefore assuming that reads may still be unaligned.
                     // They may also be unaligned if the input chars aren't 2-byte aligned.


### PR DESCRIPTION
Similar idea as `IndexOf` vs `Contains`.
`IsValid` only cares about the yes/no, so it can employ tricks like reading and or-ing together multiple vectors per iteration.

|            Method |    Toolchain | Length |       Mean |     Error | Ratio |
|------------------ |------------- |------- |-----------:|----------:|------:|
| AsciiIsValid_Byte |         main |      1 |   3.235 ns | 0.0070 ns |  1.00 |
| AsciiIsValid_Byte |  pr-original |      1 |   2.433 ns | 0.0066 ns |  0.75 |
| AsciiIsValid_Byte |           pr |      1 |   2.221 ns | 0.0072 ns |  0.69 |
|                   |              |        |            |           |       |
| AsciiIsValid_Byte |         main |      7 |   3.152 ns | 0.0062 ns |  1.00 |
| AsciiIsValid_Byte |  pr-original |      7 |   1.899 ns | 0.0057 ns |  0.60 |
| AsciiIsValid_Byte |           pr |      7 |   1.754 ns | 0.0061 ns |  0.56 |
|                   |              |        |            |           |       |
| AsciiIsValid_Byte |         main |      8 |   3.168 ns | 0.0064 ns |  1.00 |
| AsciiIsValid_Byte |  pr-original |      8 |   1.899 ns | 0.0055 ns |  0.60 |
| AsciiIsValid_Byte |           pr |      8 |   1.862 ns | 0.0012 ns |  0.59 |
|                   |              |        |            |           |       |
| AsciiIsValid_Byte |         main |     16 |   2.470 ns | 0.0041 ns |  1.00 |
| AsciiIsValid_Byte |  pr-original |     16 |   1.750 ns | 0.0014 ns |  0.71 |
| AsciiIsValid_Byte |           pr |     16 |   1.851 ns | 0.0011 ns |  0.75 |
|                   |              |        |            |           |       |
| AsciiIsValid_Byte |         main |     32 |   2.947 ns | 0.0059 ns |  1.00 |
| AsciiIsValid_Byte |  pr-original |     32 |   1.748 ns | 0.0013 ns |  0.59 |
| AsciiIsValid_Byte |           pr |     32 |   1.851 ns | 0.0012 ns |  0.63 |
|                   |              |        |            |           |       |
| AsciiIsValid_Byte |         main |     64 |   4.340 ns | 0.0067 ns |  1.00 |
| AsciiIsValid_Byte |  pr-original |     64 |   1.892 ns | 0.0043 ns |  0.44 |
| AsciiIsValid_Byte |           pr |     64 |   2.179 ns | 0.0013 ns |  0.50 |
|                   |              |        |            |           |       |
| AsciiIsValid_Byte |         main |    128 |   5.044 ns | 0.0398 ns |  1.00 |
| AsciiIsValid_Byte |  pr-original |    128 |   2.469 ns | 0.0072 ns |  0.49 |
| AsciiIsValid_Byte |           pr |    128 |   2.444 ns | 0.0065 ns |  0.49 |
|                   |              |        |            |           |       |
| AsciiIsValid_Byte |         main |    256 |   7.108 ns | 0.0190 ns |  1.00 |
| AsciiIsValid_Byte |  pr-original |    256 |   3.104 ns | 0.0495 ns |  0.44 |
| AsciiIsValid_Byte |           pr |    256 |   3.315 ns | 0.0526 ns |  0.47 |
|                   |              |        |            |           |       |
| AsciiIsValid_Byte |         main |   1000 |  25.653 ns | 0.0449 ns |  1.00 |
| AsciiIsValid_Byte |  pr-original |   1000 |   6.195 ns | 0.0042 ns |  0.24 |
| AsciiIsValid_Byte |           pr |   1000 |   6.519 ns | 0.0056 ns |  0.25 |
|                   |              |        |            |           |       |
| AsciiIsValid_Byte |         main |  10000 | 167.230 ns | 0.0811 ns |  1.00 |
| AsciiIsValid_Byte |  pr-original |  10000 |  53.478 ns | 0.0281 ns |  0.32 |
| AsciiIsValid_Byte |           pr |  10000 |  54.200 ns | 0.0334 ns |  0.32 |

|            Method |    Toolchain | Length |       Mean |     Error | Ratio |
|------------------ |------------- |------- |-----------:|----------:|------:|
|                   |              |        |            |           |       |
| AsciiIsValid_Char |         main |      1 |   3.578 ns | 0.0085 ns |  1.00 |
| AsciiIsValid_Char |  pr-original |      1 |   2.024 ns | 0.0078 ns |  0.57 |
| AsciiIsValid_Char |           pr |      1 |   1.749 ns | 0.0083 ns |  0.49 |
|                   |              |        |            |           |       |
| AsciiIsValid_Char |         main |      7 |   3.668 ns | 0.0109 ns |  1.00 |
| AsciiIsValid_Char |  pr-original |      7 |   1.659 ns | 0.0052 ns |  0.45 |
| AsciiIsValid_Char |           pr |      7 |   1.962 ns | 0.0077 ns |  0.54 |
|                   |              |        |            |           |       |
| AsciiIsValid_Char |         main |      8 |   2.793 ns | 0.0064 ns |  1.00 |
| AsciiIsValid_Char |  pr-original |      8 |   1.810 ns | 0.0022 ns |  0.65 |
| AsciiIsValid_Char |           pr |      8 |   1.913 ns | 0.0032 ns |  0.68 |
|                   |              |        |            |           |       |
| AsciiIsValid_Char |         main |     16 |   3.418 ns | 0.0023 ns |  1.00 |
| AsciiIsValid_Char |  pr-original |     16 |   1.807 ns | 0.0012 ns |  0.53 |
| AsciiIsValid_Char |           pr |     16 |   1.881 ns | 0.0014 ns |  0.55 |
|                   |              |        |            |           |       |
| AsciiIsValid_Char |         main |     32 |   4.015 ns | 0.0068 ns |  1.00 |
| AsciiIsValid_Char |  pr-original |     32 |   2.074 ns | 0.0013 ns |  0.52 |
| AsciiIsValid_Char |           pr |     32 |   1.900 ns | 0.0014 ns |  0.47 |
|                   |              |        |            |           |       |
| AsciiIsValid_Char |         main |     64 |   4.970 ns | 0.0299 ns |  1.00 |
| AsciiIsValid_Char |  pr-original |     64 |   2.344 ns | 0.0033 ns |  0.47 |
| AsciiIsValid_Char |           pr |     64 |   2.400 ns | 0.0110 ns |  0.49 |
|                   |              |        |            |           |       |
| AsciiIsValid_Char |         main |    128 |   6.941 ns | 0.0275 ns |  1.00 |
| AsciiIsValid_Char |  pr-original |    128 |   4.338 ns | 0.0106 ns |  0.63 |
| AsciiIsValid_Char |           pr |    128 |   3.542 ns | 0.0118 ns |  0.51 |
|                   |              |        |            |           |       |
| AsciiIsValid_Char |         main |    256 |  10.511 ns | 0.0302 ns |  1.00 |
| AsciiIsValid_Char |  pr-original |    256 |   5.020 ns | 0.0183 ns |  0.48 |
| AsciiIsValid_Char |           pr |    256 |   5.043 ns | 0.0134 ns |  0.48 |
|                   |              |        |            |           |       |
| AsciiIsValid_Char |         main |   1000 |  36.325 ns | 0.1159 ns |  1.00 |
| AsciiIsValid_Char |  pr-original |   1000 |  11.441 ns | 0.0083 ns |  0.32 |
| AsciiIsValid_Char |           pr |   1000 |  12.329 ns | 0.0174 ns |  0.34 |
|                   |              |        |            |           |       |
| AsciiIsValid_Char |         main |  10000 | 279.953 ns | 0.1557 ns |  1.00 |
| AsciiIsValid_Char |  pr-original |  10000 | 101.407 ns | 0.0657 ns |  0.36 |
| AsciiIsValid_Char |           pr |  10000 | 100.405 ns | 0.0688 ns |  0.36 |