### PR TITLE
fix a typo

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DistributedContextPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DistributedContextPropagator.cs
@@ -42,7 +42,7 @@ namespace System.Diagnostics
         public abstract IReadOnlyCollection<string> Fields { get; }
 
         /// <summary>
-        /// Injects the trace values stroed in the <see cref="Activity"/> object into a carrier. For example, into the headers of an HTTP request.
+        /// Injects the trace values stored in the <see cref="Activity"/> object into a carrier. For example, into the headers of an HTTP request.
         /// </summary>
         /// <param name="activity">The Activity object has the distributed context to inject to the carrier.</param>
         /// <param name="carrier">Carrier is the medium in which the distributed context will be stored.</param>


### PR DESCRIPTION
fix a typo in `src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DistributedContextPropagator.cs`