### PR TITLE
[Draft] Limit length of System.Runtime.BigInteger to int.MaxValue-32 bits

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -356,7 +356,9 @@ namespace System.Numerics
                 int dwordCount = byteCount / 4 + (unalignedBytes == 0 ? 0 : 1);
 
                 if (dwordCount > MaxLength)
+                {
                     ThrowHelper.ThrowOverflowException();
+                }
 
                 uint[] val = new uint[dwordCount];
                 int byteCountMinus1 = byteCount - 1;

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/op_rightshift.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/op_rightshift.cs
@@ -28,20 +28,22 @@ namespace System.Numerics.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))] // May fail on 32-bit due to a large memory requirement
         public static void LargeNegativeBigIntegerShiftTest()
         {
+            int maxShift = int.MaxValue - 32;
+
             // Create a very large negative BigInteger
-            BigInteger bigInt = new BigInteger(-1) << int.MaxValue;
-            Assert.Equal(2147483647, bigInt.GetBitLength());
+            BigInteger bigInt = new BigInteger(-1) << maxShift;
+            Assert.Equal(maxShift, bigInt.GetBitLength());
             Assert.Equal(-1, bigInt.Sign);
 
             // Validate internal representation.
-            // At this point, bigInt should be a 1 followed by int.MaxValue zeros.
+            // At this point, bigInt should be a 1 followed by maxShift zeros.
             // Given this, bigInt._bits is expected to be structured as follows:
-            // - _bits.Length == (int.MaxValue + 1) / (8 * sizeof(uint))
+            // - _bits.Length == (maxShift + 1) / (8 * sizeof(uint))
             // - First (_bits.Length - 1) elements: 0x00000000
             // - Last element: 0x80000000
             //                   ^------ (There's the leading '1')
 
-            Assert.Equal(((uint)int.MaxValue + 1) / (8 * sizeof(uint)), (uint)bigInt._bits.Length);
+            Assert.Equal(((uint)maxShift + 1) / (8 * sizeof(uint)), (uint)bigInt._bits.Length);
 
             uint i = 0;
             for (; i < (bigInt._bits.Length - 1); i++) {
@@ -52,18 +54,18 @@ namespace System.Numerics.Tests
 
             // Right shift the BigInteger
             BigInteger shiftedBigInt = bigInt >> 1;
-            Assert.Equal(2147483646, shiftedBigInt.GetBitLength());
+            Assert.Equal(maxShift - 1, shiftedBigInt.GetBitLength());
             Assert.Equal(-1, shiftedBigInt.Sign);
 
             // Validate internal representation.
             // At this point, shiftedBigInt should be a 1 followed by int.MaxValue - 1 zeros.
             // Given this, shiftedBigInt._bits is expected to be structured as follows:
-            // - _bits.Length == (int.MaxValue + 1) / (8 * sizeof(uint))
+            // - _bits.Length == (maxShift + 1) / (8 * sizeof(uint))
             // - First (_bits.Length - 1) elements: 0x00000000
             // - Last element: 0x40000000
             //                   ^------ (the '1' is now one position to the right)
 
-            Assert.Equal(((uint)int.MaxValue + 1) / (8 * sizeof(uint)), (uint)shiftedBigInt._bits.Length);
+            Assert.Equal(((uint)maxShift + 1) / (8 * sizeof(uint)), (uint)shiftedBigInt._bits.Length);
 
             i = 0;
             for (; i < (shiftedBigInt._bits.Length - 1); i++) {


### PR DESCRIPTION
See discussion in dotnet#84670

- Limit `BigInteger.MaxLength` to `int.MaxValue/32` uints. This is equal to limit length in bits to `int.MaxValue-32 bits`
- Fix ctor `BigInteger(ReadOnlySpan<byte>, bool, bool)` to check MaxLength limit
- Fix private ctor `BigInteger(ReadOnlySpan<uint>, bool)` to check `MaxLength` limit after trying to conserve space, not before
- Fix private ctor `BigInteger(Span<uint>)` to check MaxLength limit after trying to conserve space, not before
- Fix obsolete comment in AssertValid()
- Fix test `LargeNegativeBigIntegerShiftTest` to respect new limit.

fix dotnet#84670