### PR TITLE
Baseline two systemic failures in the CoreCLR outerloop pipeline

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -509,6 +509,12 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Stress/ABI/pinvokes_do/**">
             <Issue>https://github.com/dotnet/runtime/issues/66745</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/profiler/elt/slowpatheltenter/**">
+            <Issue>https://github.com/dotnet/runtime/issues/84750</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/profiler/elt/slowpatheltleave/**">
+            <Issue>https://github.com/dotnet/runtime/issues/84750</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/eventsourceerror/eventsourceerror/*">
             <Issue>https://github.com/dotnet/runtime/issues/81241</Issue>
         </ExcludeList>


### PR DESCRIPTION
On Windows arm, several tests typically fail in the runtime-coreclr outerloop pipeline. This change introduces issues.targets exclusions for two tests that fail all the time and apparently due to a different cause than the rest of the tests that involve non-deterministic nullrefs the cause of which hasn't yet been established to my knowledge.

Thanks

Tomas