### PR TITLE
[RISC-V] Fix build error

### DIFF
--- a/src/coreclr/debug/inc/dbgtargetcontext.h
+++ b/src/coreclr/debug/inc/dbgtargetcontext.h
@@ -560,6 +560,7 @@ typedef DECLSPEC_ALIGN(16) struct {
     //
 
     /* +0x000 */ DWORD ContextFlags;
+    /* +0x004 */ DWORD Fcsr;
 
     //
     // Integer registers

--- a/src/coreclr/inc/crosscomp.h
+++ b/src/coreclr/inc/crosscomp.h
@@ -525,8 +525,7 @@ typedef struct _T_KNONVOLATILE_CONTEXT_POINTERS {
 
 //
 // Specify the number of breakpoints and watchpoints that the OS
-// will track. Architecturally, LOONGARCH64 supports up to 16. In practice,
-// however, almost no one implements more than 4 of each.
+// will track.
 //
 
 #define RISCV64_MAX_BREAKPOINTS     8
@@ -541,6 +540,7 @@ typedef struct DECLSPEC_ALIGN(16) _T_CONTEXT {
     //
 
     /* +0x000 */ DWORD ContextFlags;
+    /* +0x004 */ DWORD Fcsr;
 
     //
     // Integer registers
@@ -584,7 +584,6 @@ typedef struct DECLSPEC_ALIGN(16) _T_CONTEXT {
     //
     //TODO-RISCV64: support the SIMD.
     ULONGLONG F[32];
-    DWORD   Fcsr;
 } T_CONTEXT, *PT_CONTEXT;
 
 // _IMAGE_RISCV64_RUNTIME_FUNCTION_ENTRY (see ExternalAPIs\Win9CoreSystem\inc\winnt.h)

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -2280,6 +2280,7 @@ typedef struct DECLSPEC_ALIGN(16) _CONTEXT {
     //
 
     /* +0x000 */ DWORD ContextFlags;
+    /* +0x004 */ DWORD Fcsr;
 
     //
     // Integer registers.
@@ -2323,7 +2324,6 @@ typedef struct DECLSPEC_ALIGN(16) _CONTEXT {
     //
     // TODO-RISCV64: support the SIMD.
     ULONGLONG F[32];
-    DWORD Fcsr;
 } CONTEXT, *PCONTEXT, *LPCONTEXT;
 
 //

--- a/src/coreclr/vm/riscv64/asmconstants.h
+++ b/src/coreclr/vm/riscv64/asmconstants.h
@@ -141,7 +141,7 @@ ASMCONSTANTS_C_ASSERT(SIZEOF__GSCookie == sizeof(GSCookie));
 #define SIZEOF__Frame                 0x10
 ASMCONSTANTS_C_ASSERT(SIZEOF__Frame == sizeof(Frame));
 
-#define SIZEOF__CONTEXT               0x220
+#define SIZEOF__CONTEXT               0x210
 ASMCONSTANTS_C_ASSERT(SIZEOF__CONTEXT == sizeof(T_CONTEXT));
 
 


### PR DESCRIPTION
- Resolve assertion because size of DT_CONTEXT and T_CONTEXT is not equal