### PR TITLE
Fix for incorrect release of CCW holder

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -142,7 +142,7 @@ namespace System.Runtime.InteropServices
 
                 // If we observe the destroy sentinel, then this release
                 // must destroy the wrapper.
-                if (RefCount == DestroySentinel)
+                if (curr == DestroySentinel)
                     Destroy();
 
                 return GetTrackerCount(RefCount);
@@ -710,11 +710,6 @@ namespace System.Runtime.InteropServices
         {
             ManagedObjectWrapper* wrapper = ComInterfaceDispatch.ToManagedObjectWrapper((ComInterfaceDispatch*)pThis);
             uint refcount = wrapper->Release();
-            if (wrapper->RefCount == 0)
-            {
-                wrapper->Destroy();
-            }
-
             return refcount;
         }
 

--- a/src/tests/nativeaot/SmokeTests/ComWrappers/ComWrappers.cs
+++ b/src/tests/nativeaot/SmokeTests/ComWrappers/ComWrappers.cs
@@ -20,8 +20,6 @@ namespace ComWrappersTests
             TestComInteropRegistrationRequired();
             GlobalComWrappers = new SimpleComWrapper();
             ComWrappers.RegisterForMarshalling(GlobalComWrappers);
-            TestComInteropReleaseProcess();
-            TestRCWRoundTripRequireUnwrap();
             TestRCWCached();
             TestRCWRoundTrip();
 
@@ -72,34 +70,6 @@ namespace ComWrappersTests
             IComInterface comPointer = null;
             var result = IsNULL(comPointer);
             ThrowIfNotEquals(true, IsNULL(comPointer), "COM interface marshalling null check failed");
-        }
-
-        public static void TestComInteropRegistrationRequired()
-        {
-            Console.WriteLine("Testing COM Interop registration process");
-            ComObject target = new ComObject();
-            try
-            {
-                CaptureComPointer(target);
-                throw new Exception("Cannot work without ComWrappers.RegisterForMarshalling called");
-            }
-            catch (NotSupportedException)
-            {
-            }
-        }
-
-        public static void TestComInteropReleaseProcess()
-        {
-            Console.WriteLine("Testing RCW release process");
-            WeakReference comPointerHolder = CreateComReference();
-
-            GC.Collect();
-            ThrowIfNotEquals(true, comPointerHolder.IsAlive, ".NET object should be alive");
-
-            ReleaseComPointer();
-
-            GC.Collect();
-            ThrowIfNotEquals(false, comPointerHolder.IsAlive, ".NET object should be disposed by then");
         }
 
         public static void TestRCWRoundTripRequireUnwrap()
@@ -165,19 +135,6 @@ namespace ComWrappersTests
 
             comPointer = BuildComPointerNoPreserveSig();
             comPointer.DoWork(22);
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static WeakReference CreateComReference()
-        {
-            ComObject target = new ComObject();
-            WeakReference comPointerHolder = new WeakReference(target);
-
-            int result = CaptureComPointer(target);
-            ThrowIfNotEquals(0, result, "Seems to be COM marshalling behave strange.");
-            ThrowIfNotEquals(11, target.TestResult, "Call to method should work");
-
-            return comPointerHolder;
         }
     }
 


### PR DESCRIPTION
Fixes: https://github.com/microsoft/CsWinRT/issues/1321 Make ComWrappers in C# work closely with how C++ part works
- `RefCount` => `curr` is plain typo
- Do not destroy wrappers if ref count == 0. That's mimic how CoreCLR work. MOWHolder's finilizer calls Destroy
- Also discover 2 tests which are plainly wrong, since they do not work under CoreCLR