### PR TITLE
Backport #78136 to .NET 7

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSImportGenerator.cs
@@ -60,21 +60,9 @@ namespace Microsoft.Interop.JavaScript
         {
             // Collect all methods adorned with JSImportAttribute
             var attributedMethods = context.SyntaxProvider
-                .CreateSyntaxProvider(
-                    static (node, ct) => ShouldVisitNode(node),
-                    static (context, ct) =>
-                    {
-                        MethodDeclarationSyntax syntax = (MethodDeclarationSyntax)context.Node;
-                        if (context.SemanticModel.GetDeclaredSymbol(syntax, ct) is IMethodSymbol methodSymbol
-                            && methodSymbol.GetAttributes().Any(static attribute => attribute.AttributeClass?.ToDisplayString() == Constants.JSImportAttribute))
-                        {
-                            return new { Syntax = syntax, Symbol = methodSymbol };
-                        }
-
-                        return null;
-                    })
-                .Where(
-                    static modelData => modelData is not null);
+                .ForAttributeWithMetadataName(Constants.JSImportAttribute,
+                   static (node, ct) => node is MethodDeclarationSyntax,
+                   static (context, ct) => new { Syntax = (MethodDeclarationSyntax)context.TargetNode, Symbol = (IMethodSymbol)context.TargetSymbol });
 
             // Validate if attributed methods can have source generated
             var methodsWithDiagnostics = attributedMethods.Select(static (data, ct) =>
@@ -302,19 +290,6 @@ namespace Microsoft.Interop.JavaScript
             BlockSyntax code = stubGenerator.GenerateJSImportBody();
 
             return (PrintGeneratedSource(incrementalContext.StubMethodSyntaxTemplate, incrementalContext.SignatureContext, code), incrementalContext.Diagnostics.AddRange(diagnostics.Diagnostics));
-        }
-
-        private static bool ShouldVisitNode(SyntaxNode syntaxNode)
-        {
-            // We only support C# method declarations.
-            if (syntaxNode.Language != LanguageNames.CSharp
-                || !syntaxNode.IsKind(SyntaxKind.MethodDeclaration))
-            {
-                return false;
-            }
-
-            // Filter out methods with no attributes early.
-            return ((MethodDeclarationSyntax)syntaxNode).AttributeLists.Count > 0;
         }
 
         private static Diagnostic? GetDiagnosticIfInvalidMethodForGeneration(MethodDeclarationSyntax methodSyntax, IMethodSymbol method)


### PR DESCRIPTION
main PR #78136

# Description

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

The JSImportGenerator and JSExportGenerator are causing VS performance issues due to not using more efficient APIs that Roslyn introduced in VS 17.4.

# Customer Impact

<!-- What is the impact to customers of not taking this fix? -->
Visual Studio experiences large amounts of allocations that show up in VS performance traces. https://github.com/dotnet/runtime/pull/78136#issuecomment-1509442884

# Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->
This is not a regression.

# Testing

<!-- What kind of testing has been done with the fix. -->
This change has been in .NET 8 for months, and very similar changes have been applied to other similar generators in .NET 7 since before release.

# Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
Low risk. This change is very mechanical and follows an established pattern to convert to using the new API and has been working in main for months.

# Package authoring signed off?

N/A

IMPORTANT: If this change touches code that ships in a NuGet package, please make certain that you have added any necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.
