### PR TITLE
[release/7.0] Move mono.mscordbi subset off the offical build

### DIFF
--- a/eng/pipelines/runtime-extra-platforms-other.yml
+++ b/eng/pipelines/runtime-extra-platforms-other.yml
@@ -143,7 +143,7 @@ jobs:
     jobParameters:
       testScope: innerloop
       nameSuffix: AllSubsets_Mono
-      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true
+      buildArgs: -s mono+mono.mscordbi+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true
       timeoutInMinutes: 120
       condition: >-
         or(

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -144,7 +144,7 @@ stages:
       # - windows_arm
       # - windows_arm64
       jobParameters:
-        buildArgs: -s mono+libs+host+packs+mono.mscordbi -c $(_BuildConfig)
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
         nameSuffix: AllSubsets_Mono
         isOfficialBuild: ${{ variables.isOfficialBuild }}
         extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
@@ -159,7 +159,7 @@ stages:
       platforms:
       - Browser_wasm
       jobParameters:
-        buildArgs: -s mono+libs+host+packs+mono.mscordbi -c $(_BuildConfig) /p:MonoWasmBuildVariant=perftrace
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoWasmBuildVariant=perftrace
         nameSuffix: AllSubsets_Mono_perftrace
         isOfficialBuild: ${{ variables.isOfficialBuild }}
         runtimeVariant: perftrace
@@ -175,7 +175,7 @@ stages:
       platforms:
       - Browser_wasm
       jobParameters:
-        buildArgs: -s mono+libs+host+packs+mono.mscordbi -c $(_BuildConfig) /p:MonoWasmBuildVariant=multithread
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoWasmBuildVariant=multithread
         nameSuffix: AllSubsets_Mono_multithread
         isOfficialBuild: ${{ variables.isOfficialBuild }}
         runtimeVariant: multithread


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/81917

This isn't in use, so there's no need to build and ship it. Instead, this is being moved to the mono windows x64 public leg.