### PR TITLE
Add issues.targets entries for four tests failing on Windows arm

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -293,6 +293,9 @@
 
     <!-- Windows arm32 specific excludes -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(TargetArchitecture)' == 'arm' or '$(AltJitArch)' == 'arm') and '$(TargetsWindows)' == 'true' and '$(RuntimeFlavor)' == 'coreclr'">
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/TieredCompilation/BasicTestWithMcj/*">
+            <Issue>https://github.com/dotnet/runtime/issues/84818</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/Convert/out_of_range_fp_to_int_conversions/*">
             <Issue>https://github.com/dotnet/runtime/issues/49184</Issue>
         </ExcludeList>
@@ -509,11 +512,20 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Stress/ABI/pinvokes_do/**">
             <Issue>https://github.com/dotnet/runtime/issues/66745</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Loader/binding/tracing/BinderTracingTest.ResolutionFlow/*">
+            <Issue>https://github.com/dotnet/runtime/issues/84818</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/profiler/elt/slowpatheltenter/**">
             <Issue>https://github.com/dotnet/runtime/issues/84750</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/profiler/elt/slowpatheltleave/**">
             <Issue>https://github.com/dotnet/runtime/issues/84750</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/readytorun/coreroot_determinism/coreroot_determinism/*">
+            <Issue>https://github.com/dotnet/runtime/issues/84818</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/readytorun/determinism/crossgen2determinism/*">
+            <Issue>https://github.com/dotnet/runtime/issues/84818</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/eventsourceerror/eventsourceerror/*">
             <Issue>https://github.com/dotnet/runtime/issues/81241</Issue>


### PR DESCRIPTION
After several fixes and additions to issues.targets I'm now seeing a relatively limited set of tests failing on Windows arm with a nullref tracked under

https://github.com/dotnet/runtime/issues/84818

This should finally let us see a green outerloop run despite the fact that some additional rare failures still remain, I've seen a few in the runs from the last couple of days.

Thanks

Tomas

P.S. At this point I'm not adding the <code>tlstest_il_r</code> test Mark quotes in the issue title as it seems to be one of the tests hitting this less often, I'm adding the tests that failed in each of the 10 or so most recent outerloop runs I looked at.

/cc @dotnet/runtime-infrastructure 