### PR TITLE
fix aarch64+clang compilation errors

### DIFF
--- a/src/mono/mono/mini/mini-exceptions.c
+++ b/src/mono/mono/mini/mini-exceptions.c
@@ -754,7 +754,7 @@ unwinder_init (Unwinder *unwinder)
 	memset (unwinder, 0, sizeof (Unwinder));
 }
 
-#if defined(__GNUC__) && defined(TARGET_ARM64)
+#if defined(__GNUC__) && defined(TARGET_ARM64) && !defined(__clang__)
 /* gcc 4.9.2 seems to miscompile this on arm64 */
 static __attribute__((optimize("O0"))) gboolean
 #else

--- a/src/mono/mono/utils/valgrind.h
+++ b/src/mono/mono/utils/valgrind.h
@@ -769,12 +769,14 @@ typedef
   __extension__                                                   \
   ({volatile unsigned long long int  _zzq_args[6];                \
     volatile unsigned long long int  _zzq_result;                 \
+    volatile unsigned long long int  _zzq_default_ll;             \
     _zzq_args[0] = (unsigned long long int)(_zzq_request);        \
     _zzq_args[1] = (unsigned long long int)(_zzq_arg1);           \
     _zzq_args[2] = (unsigned long long int)(_zzq_arg2);           \
     _zzq_args[3] = (unsigned long long int)(_zzq_arg3);           \
     _zzq_args[4] = (unsigned long long int)(_zzq_arg4);           \
     _zzq_args[5] = (unsigned long long int)(_zzq_arg5);           \
+    _zzq_default_ll = (unsigned long long int)(_zzq_default);     \
     __asm__ volatile("mov x3, %1\n\t" /*default*/                 \
                      "mov x4, %2\n\t" /*ptr*/                     \
                      __SPECIAL_INSTRUCTION_PREAMBLE               \
@@ -782,7 +784,7 @@ typedef
                      "orr x10, x10, x10\n\t"                      \
                      "mov %0, x3"     /*result*/                  \
                      : "=r" (_zzq_result)                         \
-                     : "r" (_zzq_default), "r" (&_zzq_args[0])    \
+                     : "r" (_zzq_default_ll), "r" (&_zzq_args[0]) \
                      : "cc","memory", "x3", "x4");                \
     _zzq_result;                                                  \
   })


### PR DESCRIPTION
See https://github.com/mono/mono/commit/6ee958c0418db7a5a92146cbf34ba5ce7257ecbd , ported from https://github.com/mono/mono/pull/21642