### PR TITLE
Reconfigure the HWIntrinsic tests to run more selectively

### DIFF
--- a/src/tests/JIT/HardwareIntrinsics/Arm/Directory.Build.props
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Directory.Build.props
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
+
+  <PropertyGroup>
+    <HWITestsArm64Only>true</HWITestsArm64Only>
+  </PropertyGroup>
+
+</Project>

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Directory.Build.targets
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Directory.Build.targets
@@ -4,12 +4,6 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
 
   <PropertyGroup>
-    <!-- We have a lot of tests here so run them in outerloop on platforms where they aren't accelerated -->
-    <CLRTestPriority>1</CLRTestPriority>
-    <CLRTestPriority Condition="'$(TargetArchitecture)' == 'arm64'">0</CLRTestPriority>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GeneratedHWIntrinsicTestDirectory Condition="'$(GeneratedHWIntrinsicTestDirectory)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName)/gen/</GeneratedHWIntrinsicTestDirectory>
     <GeneratedHWIntrinsicTestListFile Condition="'$(GeneratedHWIntrinsicTestListFile)' == ''">$(GeneratedHWIntrinsicTestDirectory)GeneratedHWIntrinsicTestList.txt</GeneratedHWIntrinsicTestListFile>
   </PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/Directory.Build.props
+++ b/src/tests/JIT/HardwareIntrinsics/Directory.Build.props
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="..\..\Directory.Merged.props" />
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />

--- a/src/tests/JIT/HardwareIntrinsics/Directory.Build.targets
+++ b/src/tests/JIT/HardwareIntrinsics/Directory.Build.targets
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
+
+  <PropertyGroup Condition="'$(HWITestsArm64Only)' == 'true'">
+    <!-- Various platforms will always throw, so we don't want to spend cycles running tests unnecessarily -->
+    <!-- We don't need to worry about coverage as we have a number of stress tests that can disable intrinsics per ISA and run on the normally supported platforms -->
+    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'arm64'">true</CLRTestTargetUnsupported>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(HWITestsXarchOnly)' == 'true'">
+    <!-- Various platforms will always throw, so we don't want to spend cycles running tests unnecessarily -->
+    <!-- We don't need to worry about coverage as we have a number of stress tests that can disable intrinsics per ISA and run on the normally supported platforms -->
+    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x64' AND '$(TargetArchitecture)' != 'x86'">true</CLRTestTargetUnsupported>
+    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'x86' AND '$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <CLRTestTargetUnsupported Condition="'$(TargetsOSX)' == 'true' AND $(MSBuildProjectName.StartsWith('Avx512'))">true</CLRTestTargetUnsupported>
+  </PropertyGroup>
+
+</Project>

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector256/Vector256_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector256/Vector256_r.csproj
@@ -1,16 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <HWITestsXarchOnly>true</HWITestsXarchOnly>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>
     <Optimize />
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- We have a lot of tests here so run them in outerloop on platforms where they aren't accelerated -->
-    <CLRTestPriority>1</CLRTestPriority>
-    <CLRTestPriority Condition="'$(TargetArchitecture)' == 'x64'">0</CLRTestPriority>
-    <CLRTestPriority Condition="'$(TargetArchitecture)' == 'x86' AND '$(TargetsWindows)' == 'true'">0</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.Vector256.cs" />

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector256/Vector256_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector256/Vector256_ro.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>
-    <Optimize />
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.Vector256.cs" />

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector256/Vector256_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector256/Vector256_ro.csproj
@@ -1,16 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <HWITestsXarchOnly>true</HWITestsXarchOnly>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>
-    <Optimize>True</Optimize>
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- We have a lot of tests here so run them in outerloop on platforms where they aren't accelerated -->
-    <CLRTestPriority>1</CLRTestPriority>
-    <CLRTestPriority Condition="'$(TargetArchitecture)' == 'x64'">0</CLRTestPriority>
-    <CLRTestPriority Condition="'$(TargetArchitecture)' == 'x86' AND '$(TargetsWindows)' == 'true'">0</CLRTestPriority>
+    <Optimize />
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.Vector256.cs" />

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector256_1/Vector256_1_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector256_1/Vector256_1_r.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-
+    <HWITestsXarchOnly>true</HWITestsXarchOnly>
     <!-- https://github.com/dotnet/runtime/issues/57352 -->
     <MonoAotIncompatible>true</MonoAotIncompatible>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
@@ -9,12 +9,6 @@
   <PropertyGroup>
     <DebugType>Embedded</DebugType>
     <Optimize />
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- We have a lot of tests here so run them in outerloop on platforms where they aren't accelerated -->
-    <CLRTestPriority>1</CLRTestPriority>
-    <CLRTestPriority Condition="'$(TargetArchitecture)' == 'x64'">0</CLRTestPriority>
-    <CLRTestPriority Condition="'$(TargetArchitecture)' == 'x86' AND '$(TargetsWindows)' == 'true'">0</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.Vector256_1.cs" />

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector256_1/Vector256_1_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector256_1/Vector256_1_ro.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-
+    <HWITestsXarchOnly>true</HWITestsXarchOnly>
     <!-- https://github.com/dotnet/runtime/issues/57352 -->
     <MonoAotIncompatible>true</MonoAotIncompatible>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
@@ -9,12 +9,6 @@
   <PropertyGroup>
     <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- We have a lot of tests here so run them in outerloop on platforms where they aren't accelerated -->
-    <CLRTestPriority>1</CLRTestPriority>
-    <CLRTestPriority Condition="'$(TargetArchitecture)' == 'x64'">0</CLRTestPriority>
-    <CLRTestPriority Condition="'$(TargetArchitecture)' == 'x86' AND '$(TargetsWindows)' == 'true'">0</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.Vector256_1.cs" />

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector512/Vector512_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector512/Vector512_r.csproj
@@ -1,15 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <HWITestsXarchOnly>true</HWITestsXarchOnly>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>
     <Optimize />
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- We have a lot of tests here so run them in outerloop on platforms where they aren't accelerated -->
-    <!-- Unlock other types, Vector512 is only accelerated on a single small pool of machines, so it is always outerloop -->
-    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.Vector512.cs" />

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector512/Vector512_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector512/Vector512_ro.csproj
@@ -1,15 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <HWITestsXarchOnly>true</HWITestsXarchOnly>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>
-    <Optimize>True</Optimize>
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- We have a lot of tests here so run them in outerloop on platforms where they aren't accelerated -->
-    <!-- Unlock other types, Vector512 is only accelerated on a single small pool of machines, so it is always outerloop -->
-    <CLRTestPriority>1</CLRTestPriority>
+    <Optimize />
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.Vector512.cs" />

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector512/Vector512_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector512/Vector512_ro.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>
-    <Optimize />
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.Vector512.cs" />

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector512_1/Vector512_1_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector512_1/Vector512_1_r.csproj
@@ -1,15 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <HWITestsXarchOnly>true</HWITestsXarchOnly>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>
     <Optimize />
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- We have a lot of tests here so run them in outerloop on platforms where they aren't accelerated -->
-    <!-- Unlock other types, Vector512 is only accelerated on a single small pool of machines, so it is always outerloop -->
-    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.Vector512_1.cs" />

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector512_1/Vector512_1_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector512_1/Vector512_1_ro.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>
-    <Optimize />
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.Vector512_1.cs" />

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector512_1/Vector512_1_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector512_1/Vector512_1_ro.csproj
@@ -1,15 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <HWITestsXarchOnly>true</HWITestsXarchOnly>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>
-    <Optimize>True</Optimize>
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- We have a lot of tests here so run them in outerloop on platforms where they aren't accelerated -->
-    <!-- Unlock other types, Vector512 is only accelerated on a single small pool of machines, so it is always outerloop -->
-    <CLRTestPriority>1</CLRTestPriority>
+    <Optimize />
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.Vector512_1.cs" />

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector64/Vector64_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector64/Vector64_r.csproj
@@ -1,15 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <HWITestsArm64Only>true</HWITestsArm64Only>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>
     <Optimize />
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- We have a lot of tests here so run them in outerloop on platforms where they aren't accelerated -->
-    <CLRTestPriority>1</CLRTestPriority>
-    <CLRTestPriority Condition="'$(TargetArchitecture)' == 'arm64'">0</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.Vector64.cs" />

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector64/Vector64_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector64/Vector64_ro.csproj
@@ -1,15 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <HWITestsArm64Only>true</HWITestsArm64Only>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- We have a lot of tests here so run them in outerloop on platforms where they aren't accelerated -->
-    <CLRTestPriority>1</CLRTestPriority>
-    <CLRTestPriority Condition="'$(TargetArchitecture)' == 'arm64'">0</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.Vector64.cs" />

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector64_1/Vector64_1_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector64_1/Vector64_1_r.csproj
@@ -1,15 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <HWITestsArm64Only>true</HWITestsArm64Only>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>
     <Optimize />
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- We have a lot of tests here so run them in outerloop on platforms where they aren't accelerated -->
-    <CLRTestPriority>1</CLRTestPriority>
-    <CLRTestPriority Condition="'$(TargetArchitecture)' == 'arm64'">0</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.Vector64_1.cs" />

--- a/src/tests/JIT/HardwareIntrinsics/General/Vector64_1/Vector64_1_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/Vector64_1/Vector64_1_ro.csproj
@@ -1,15 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <HWITestsArm64Only>true</HWITestsArm64Only>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- We have a lot of tests here so run them in outerloop on platforms where they aren't accelerated -->
-    <CLRTestPriority>1</CLRTestPriority>
-    <CLRTestPriority Condition="'$(TargetArchitecture)' == 'arm64'">0</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.Vector64_1.cs" />

--- a/src/tests/JIT/HardwareIntrinsics/HardwareIntrinsics_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/HardwareIntrinsics_r.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <NumberOfStripesToUseInStress>20</NumberOfStripesToUseInStress>
+    <NumberOfStripesToUseInStress>32</NumberOfStripesToUseInStress>
     <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm64' and '$(TargetOS)' == 'osx'">true</GCStressIncompatible>
     <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm'">true</GCStressIncompatible>
   </PropertyGroup>
+
   <ItemGroup>
     <MergedWrapperProjectReference Include="*/**/*.csproj" Exclude="**/*_ro.csproj" />
   </ItemGroup>

--- a/src/tests/JIT/HardwareIntrinsics/HardwareIntrinsics_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/HardwareIntrinsics_ro.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <NumberOfStripesToUseInStress>20</NumberOfStripesToUseInStress>
+    <NumberOfStripesToUseInStress>32</NumberOfStripesToUseInStress>
     <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm64' and '$(TargetOS)' == 'osx'">true</GCStressIncompatible>
     <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm'">true</GCStressIncompatible>
   </PropertyGroup>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Directory.Build.props
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Directory.Build.props
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
+
+  <PropertyGroup>
+    <HWITestsXarchOnly>true</HWITestsXarchOnly>
+  </PropertyGroup>
+
+</Project>

--- a/src/tests/JIT/HardwareIntrinsics/X86/Directory.Build.targets
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Directory.Build.targets
@@ -4,13 +4,6 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
 
   <PropertyGroup>
-    <!-- We have a lot of tests here so run them in outerloop on platforms where they aren't accelerated -->
-    <CLRTestPriority>1</CLRTestPriority>
-    <CLRTestPriority Condition="'$(TargetArchitecture)' == 'x64'">0</CLRTestPriority>
-    <CLRTestPriority Condition="'$(TargetArchitecture)' == 'x86' AND '$(TargetsWindows)' == 'true'">0</CLRTestPriority>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GeneratedHWIntrinsicTestDirectory Condition="'$(GeneratedHWIntrinsicTestDirectory)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName)/gen/</GeneratedHWIntrinsicTestDirectory>
     <GeneratedHWIntrinsicTestListFile Condition="'$(GeneratedHWIntrinsicTestListFile)' == ''">$(GeneratedHWIntrinsicTestDirectory)GeneratedHWIntrinsicTestList.txt</GeneratedHWIntrinsicTestListFile>
   </PropertyGroup>


### PR DESCRIPTION
As we're adding more tests for AVX512 and similar, we're more regularly hitting timeouts.

Given we already have extensive coverage across all the various stress legs (which disable intrinsics entirely or per-ISA) and the across the full breadth of Linux vs Windows vs OSX, I've opted to just not run some tests on particular platforms entirely.