### PR TITLE
Fix R2R test build

### DIFF
--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -527,9 +527,7 @@
 
     <PropertyGroup>
       <CrossgenDir>$(__BinDir)</CrossgenDir>
-      <CrossgenDir Condition="'$(TargetArchitecture)' == 'arm'">$(CrossgenDir)\x64</CrossgenDir>
-      <CrossgenDir Condition="'$(TargetArchitecture)' == 'arm64'">$(CrossgenDir)\x64</CrossgenDir>
-      <CrossgenDir Condition="'$(TargetArchitecture)' == 'x86'">$(CrossgenDir)\x64</CrossgenDir>
+      <CrossgenDir Condition="'$(CrossBuild)' == 'true' or '$(BuildArchitecture)' != '$(TargetArchitecture)'">$(CrossgenDir)\$(BuildArchitecture)</CrossgenDir>
 
       <CrossgenOutputDir>$(__TestIntermediatesDir)\crossgen.out</CrossgenOutputDir>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/84949.

https://github.com/dotnet/runtime/pull/84148 broke the outerloop R2R jobs, because the x64 musl build became a cross build, but the R2R test compilation did not use the x64 glibc hosted crossgen2.

Validated by running the failing build command
```
./src/tests/build.sh generatelayoutonly -log:Layout  crossgen2 checked x64 -cross priority1  /p:LibrariesConfiguration=Release \
```

locally in the mariner build image. I observed the same failure as in ci, and validated that this fixed it.