### PR TITLE
[LoongArch64] revert the modification about the LA64's PageSize by #83632.

### DIFF
--- a/src/coreclr/vm/loongarch64/thunktemplates.S
+++ b/src/coreclr/vm/loongarch64/thunktemplates.S
@@ -4,6 +4,8 @@
 #include "unixasmmacros.inc"
 #include "asmconstants.h"
 
+// Note that the offsets specified in pcaddi must match the behavior of GetStubCodePageSize() on this architecture/os.
+
 LEAF_ENTRY StubPrecodeCode
     pcaddi  $r21, 0x1004  //4, for Type encoding.
     ld.d  $t2,$r21, (StubPrecodeData__MethodDesc - 4*4)

--- a/src/coreclr/vm/loongarch64/thunktemplates.S
+++ b/src/coreclr/vm/loongarch64/thunktemplates.S
@@ -4,20 +4,18 @@
 #include "unixasmmacros.inc"
 #include "asmconstants.h"
 
-; Note that the offsets specified in pcaddi must match the behavior of GetStubCodePageSize() on this architecture/os. 
-
 LEAF_ENTRY StubPrecodeCode
-    pcaddi  $r21, 0x4004  //4, for Type encoding.
+    pcaddi  $r21, 0x1004  //4, for Type encoding.
     ld.d  $t2,$r21, (StubPrecodeData__MethodDesc - 4*4)
     ld.d  $r21,$r21,  (StubPrecodeData__Target - 4*4)
     jirl  $r0,$r21,0
 LEAF_END_MARKED StubPrecodeCode
 
 LEAF_ENTRY FixupPrecodeCode
-    pcaddi  $r21, 0x4003  //3, for Type encoding.
+    pcaddi  $r21, 0x1003  //3, for Type encoding.
     ld.d  $r21,$r21, (FixupPrecodeData__Target - 4*3)
     jirl  $r0,$r21,0
-    pcaddi  $r21, 0x4003
+    pcaddi  $r21, 0x1003
     ld.d  $t2,$r21,  (FixupPrecodeData__MethodDesc - 4*3 -4*3)
     ld.d  $r21,$r21, (FixupPrecodeData__PrecodeFixupThunk - 4*3 - 4*3)
     jirl  $r0,$r21,0
@@ -26,7 +24,7 @@ LEAF_END_MARKED FixupPrecodeCode
 // NOTE: For LoongArch64 `CallCountingStubData__RemainingCallCountCell` must be zero !!!
 // Because the stub-identifying token is $t1 within the `OnCallCountThresholdReachedStub`.
 LEAF_ENTRY CallCountingStubCode
-    pcaddi  $t2, 0x4000
+    pcaddi  $t2, 0x1000
     ld.d  $t1, $t2, CallCountingStubData__RemainingCallCountCell
     ld.h  $r21, $t1, 0
     addi.w  $r21, $r21, -1


### PR DESCRIPTION
This PR is part of the issue https://github.com/dotnet/runtime/issues/69705 to amend the LA's port.

 revert the modification about the LA64's PageSize by #83632.