### PR TITLE
Avoid unnecessary array allocation in DateTimeParse

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
@@ -1204,7 +1204,7 @@ namespace System.Globalization
         /// Retrieve the array which contains the month names in genitive form.
         /// If this culture does not use the genitive form, the normal month name is returned.
         /// </summary>
-        private string[] InternalGetGenitiveMonthNames(bool abbreviated)
+        internal string[] InternalGetGenitiveMonthNames(bool abbreviated)
         {
             if (abbreviated)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
@@ -3353,7 +3353,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
                 // Search genitive form.
                 if ((dtfi.FormatFlags & DateTimeFormatFlags.UseGenitiveMonth) != 0)
                 {
-                    int tempResult = str.MatchLongestWords(dtfi.AbbreviatedMonthGenitiveNames, ref maxMatchStrLen);
+                    int tempResult = str.MatchLongestWords(dtfi.InternalGetGenitiveMonthNames(abbreviated: true), ref maxMatchStrLen);
 
                     // We found a longer match in the genitive month name.  Use this as the result.
                     // tempResult + 1 should be the month value.
@@ -3453,7 +3453,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
                 // Search genitive form.
                 if ((dtfi.FormatFlags & DateTimeFormatFlags.UseGenitiveMonth) != 0)
                 {
-                    int tempResult = str.MatchLongestWords(dtfi.MonthGenitiveNames, ref maxMatchStrLen);
+                    int tempResult = str.MatchLongestWords(dtfi.InternalGetGenitiveMonthNames(abbreviated: false), ref maxMatchStrLen);
                     // We found a longer match in the genitive month name.  Use this as the result.
                     // The result from MatchLongestWords is 0 ~ length of word array.
                     // So we increment the result by one to become the month value.


### PR DESCRIPTION
When using DateTime{Offset}.ParseExact with a culture that employs genitive month names, the public DateTimeFormatInfo.AbbreviatedMonthGenitiveNames and DateTimeFormatInfo.MonthGenitiveNames properties are being accessed to get a string[] of the month names, but those properties clone.  If we instead access the internal non-cloning version, we save on an array allocation on each parse.

```C#
private CultureInfo _ci = new CultureInfo("ru-RU");

[Benchmark] public DateTime Parse() => DateTime.ParseExact("вторник, 18 апреля 2023 04:31:26", "dddd, dd MMMM yyyy HH:mm:ss", _ci);
```

| Method |         Toolchain |     Mean | Ratio | Allocated | Alloc Ratio |
|------- |------------------ |---------:|------:|----------:|------------:|
|  Parse | \main\corerun.exe | 2.517 us |  1.00 |     128 B |        1.00 |
|  Parse |   \pr\corerun.exe | 2.465 us |  0.98 |         - |        0.00 |