### PR TITLE
Better support for chaining methods style (for Queue class)

### DIFF
--- a/src/libraries/System.Collections.NonGeneric/src/System/Collections/Queue.cs
+++ b/src/libraries/System.Collections.NonGeneric/src/System/Collections/Queue.cs
@@ -502,3 +502,71 @@ namespace System.Collections
         }
     }
 }
+
+namespace System.Collections.Extensions
+{
+    public static class QueueExtensions
+    {
+        public static Queue<T> Push<T>(this Queue<T> queue, T item)
+        {
+            queue.Enqueue(item);
+            return queue;
+        }
+        
+        public static Queue<T> Pop<T>(this Queue<T> queue)
+        {
+            if (queue.Count > 0)
+                _ = queue.Dequeue();
+            return queue;
+        }
+        
+        public static bool IsEmpty<T>(this Queue<T> queue) => queue.Count == 0;
+        
+        public static bool IsNotEmpty<T>(this Queue<T> queue) => queue.Count > 0;
+        
+        public static Queue<T> ForEach<T>(this Queue<T> queue, Action<T> action,
+            bool reappend = false, object? locker = null)
+        {
+            Queue<T> func()
+            {
+                var count = queue.Count;
+                while (count > 0)
+                {
+                    var item = queue.Dequeue();
+                    action.Invoke(item);
+                    --count;
+                    if (reappend) queue.Enqueue(item);
+                }
+                return queue;
+            }
+
+            if (locker is not null)
+            {
+                lock (locker)
+                {
+                    return func();
+                }
+            }
+            else return func();
+        }
+        
+        public static async Task<Queue<T>> ForEachAsync<T>(this Queue<T> queue, Action<T> action,
+            bool reappend = false)
+        {
+            Queue<T> func()
+            {
+                var count = queue.Count;
+                while (count > 0)
+                {
+                    var item = queue.Dequeue();
+                    action.Invoke(item);
+                    --count;
+                    if (reappend) queue.Enqueue(item);
+                }
+                return queue;
+            }
+
+            return await Task.Run(func);
+        }
+    }
+}

--- a/src/libraries/System.Collections.NonGeneric/src/System/Collections/Queue.cs
+++ b/src/libraries/System.Collections.NonGeneric/src/System/Collections/Queue.cs
@@ -501,10 +501,7 @@ namespace System.Collections
             }
         }
     }
-}
-
-namespace System.Collections.Extensions
-{
+    
     public static class QueueExtensions
     {
         public static Queue<T> Push<T>(this Queue<T> queue, T item)


### PR DESCRIPTION
With this edition, we can use `Queue` easily just on the grammatical level.

For example,

```csharp
var queue = new Queue<int>()
    .Push(1)
    .Pop()
    .Push(3)
    .Pop()
    .Push(5)
    .Push(6)
    .Pop()
    ;
queue.ForEach(x => Console.WriteLine(x));
// Output: 5
```


