### PR TITLE
[LoongArch64] Fix the compiling errors for aligned and definiations.

### DIFF
--- a/src/coreclr/debug/di/loongarch64/cordbregisterset.cpp
+++ b/src/coreclr/debug/di/loongarch64/cordbregisterset.cpp
@@ -282,14 +282,14 @@ void CordbRegisterSet::InternalCopyRDToContext(DT_CONTEXT *pInputContext)
             *pDest++ = *pSrc++;
         }
 
-        pInputContext->TP = m_rd->TP;
-        pInputContext->RA = m_rd->RA;
+        pInputContext->Tp = m_rd->TP;
+        pInputContext->Ra = m_rd->RA;
     }
 
     if ((pInputContext->ContextFlags & DT_CONTEXT_CONTROL) == DT_CONTEXT_CONTROL)
     {
-        pInputContext->SP = m_rd->SP;
-        pInputContext->PC = m_rd->PC;
-        pInputContext->FP = m_rd->FP;
+        pInputContext->Sp = m_rd->SP;
+        pInputContext->Pc = m_rd->PC;
+        pInputContext->Fp = m_rd->FP;
     }
 }

--- a/src/coreclr/debug/inc/dbgtargetcontext.h
+++ b/src/coreclr/debug/inc/dbgtargetcontext.h
@@ -487,7 +487,7 @@ static_assert(sizeof(DT_CONTEXT) == sizeof(T_CONTEXT), "DT_CONTEXT size must equ
 #define DT_LOONGARCH64_MAX_BREAKPOINTS     8
 #define DT_LOONGARCH64_MAX_WATCHPOINTS     2
 
-typedef DECLSPEC_ALIGN(16) struct {
+typedef struct DECLSPEC_ALIGN(16) {
     //
     // Control flags.
     //
@@ -498,9 +498,9 @@ typedef DECLSPEC_ALIGN(16) struct {
     // Integer registers
     //
     DWORD64 R0;
-    DWORD64 RA;
-    DWORD64 TP;
-    DWORD64 SP;
+    DWORD64 Ra;
+    DWORD64 Tp;
+    DWORD64 Sp;
     DWORD64 A0;
     DWORD64 A1;
     DWORD64 A2;
@@ -519,7 +519,7 @@ typedef DECLSPEC_ALIGN(16) struct {
     DWORD64 T7;
     DWORD64 T8;
     DWORD64 X0;
-    DWORD64 FP;
+    DWORD64 Fp;
     DWORD64 S0;
     DWORD64 S1;
     DWORD64 S2;
@@ -529,12 +529,13 @@ typedef DECLSPEC_ALIGN(16) struct {
     DWORD64 S6;
     DWORD64 S7;
     DWORD64 S8;
-    DWORD64 PC;
+    DWORD64 Pc;
 
     //
     // Floating Point Registers
     //
     ULONGLONG F[32];
+    DWORD Fcsr;
 } DT_CONTEXT;
 
 static_assert(sizeof(DT_CONTEXT) == sizeof(T_CONTEXT), "DT_CONTEXT size must equal the T_CONTEXT size");

--- a/src/coreclr/debug/inc/loongarch64/primitives.h
+++ b/src/coreclr/debug/inc/loongarch64/primitives.h
@@ -85,31 +85,31 @@ constexpr CorDebugRegister g_JITToCorDbgReg[] =
 inline void CORDbgSetIP(DT_CONTEXT *context, LPVOID ip) {
     LIMITED_METHOD_CONTRACT;
 
-    context->PC = (DWORD64)ip;
+    context->Pc = (DWORD64)ip;
 }
 
 inline LPVOID CORDbgGetSP(const DT_CONTEXT * context) {
     LIMITED_METHOD_CONTRACT;
 
-    return (LPVOID)(size_t)(context->SP);
+    return (LPVOID)(size_t)(context->Sp);
 }
 
 inline void CORDbgSetSP(DT_CONTEXT *context, LPVOID esp) {
     LIMITED_METHOD_CONTRACT;
 
-    context->SP = (DWORD64)esp;
+    context->Sp = (DWORD64)esp;
 }
 
 inline LPVOID CORDbgGetFP(const DT_CONTEXT * context) {
     LIMITED_METHOD_CONTRACT;
 
-    return (LPVOID)(size_t)(context->FP);
+    return (LPVOID)(size_t)(context->Fp);
 }
 
 inline void CORDbgSetFP(DT_CONTEXT *context, LPVOID fp) {
     LIMITED_METHOD_CONTRACT;
 
-    context->FP = (DWORD64)fp;
+    context->Fp = (DWORD64)fp;
 }
 
 
@@ -119,9 +119,9 @@ inline BOOL CompareControlRegisters(const DT_CONTEXT * pCtx1, const DT_CONTEXT *
 
     // TODO-LoongArch64: Sort out frame registers
 
-    if ((pCtx1->PC == pCtx2->PC) &&
-        (pCtx1->SP == pCtx2->SP) &&
-        (pCtx1->FP == pCtx2->FP))
+    if ((pCtx1->Pc == pCtx2->Pc) &&
+        (pCtx1->Sp == pCtx2->Sp) &&
+        (pCtx1->Fp == pCtx2->Fp))
     {
         return TRUE;
     }
@@ -166,7 +166,7 @@ inline LPVOID CORDbgGetIP(DT_CONTEXT *context)
 {
     LIMITED_METHOD_CONTRACT;
 
-    return (LPVOID)(size_t)(context->PC);
+    return (LPVOID)(size_t)(context->Pc);
 }
 
 inline void CORDbgSetInstructionExImpl(CORDB_ADDRESS_TYPE* address,

--- a/src/coreclr/debug/shared/loongarch64/primitives.cpp
+++ b/src/coreclr/debug/shared/loongarch64/primitives.cpp
@@ -29,30 +29,30 @@ void CORDbgCopyThreadContext(DT_CONTEXT* pDst, const DT_CONTEXT* pSrc)
     {
         LOG((LF_CORDB, LL_INFO1000000,
              "CP::CTC: RA: pDst=0x%lx, pSrc=0x%lx, Flags=0x%x\n",
-             pDst->RA, pSrc->RA, DT_CONTEXT_CONTROL));
-        pDst->RA = pSrc->RA;
+             pDst->Ra, pSrc->Ra, DT_CONTEXT_CONTROL));
+        pDst->Ra = pSrc->Ra;
 
         LOG((LF_CORDB, LL_INFO1000000,
              "CP::CTC: SP: pDst=0x%lx, pSrc=0x%lx, Flags=0x%x\n",
-             pDst->SP, pSrc->SP, DT_CONTEXT_CONTROL));
-        pDst->SP = pSrc->SP;
+             pDst->Sp, pSrc->Sp, DT_CONTEXT_CONTROL));
+        pDst->Sp = pSrc->Sp;
 
         LOG((LF_CORDB, LL_INFO1000000,
              "CP::CTC: FP: pDst=0x%lx, pSrc=0x%lx, Flags=0x%x\n",
-             pDst->FP, pSrc->FP, DT_CONTEXT_CONTROL));
-        pDst->FP = pSrc->FP;
+             pDst->Fp, pSrc->Fp, DT_CONTEXT_CONTROL));
+        pDst->Fp = pSrc->Fp;
 
         LOG((LF_CORDB, LL_INFO1000000,
              "CP::CTC: PC: pDst=0x%lx, pSrc=0x%lx, Flags=0x%x\n",
-             pDst->PC, pSrc->PC, DT_CONTEXT_CONTROL));
-        pDst->PC = pSrc->PC;
+             pDst->Pc, pSrc->Pc, DT_CONTEXT_CONTROL));
+        pDst->Pc = pSrc->Pc;
     }
 
     if ((dstFlags & srcFlags & DT_CONTEXT_INTEGER) == DT_CONTEXT_INTEGER)
     {
-        CopyContextChunk(&pDst->A0, &pSrc->A0, &pDst->FP,
+        CopyContextChunk(&pDst->A0, &pSrc->A0, &pDst->Fp,
                          DT_CONTEXT_INTEGER);
-        CopyContextChunk(&pDst->S0, &pSrc->S0, &pDst->PC,
+        CopyContextChunk(&pDst->S0, &pSrc->S0, &pDst->Pc,
                          DT_CONTEXT_INTEGER);
     }
 
@@ -60,6 +60,7 @@ void CORDbgCopyThreadContext(DT_CONTEXT* pDst, const DT_CONTEXT* pSrc)
     {
         CopyContextChunk(&pDst->F[0], &pSrc->F[0], &pDst->F[32],
                          DT_CONTEXT_FLOATING_POINT);
+        pDst->Fcsr = pSrc->Fcsr;
     }
 }
 
@@ -76,13 +77,13 @@ void SetDebuggerREGDISPLAYFromREGDISPLAY(DebuggerREGDISPLAY* pDRD, REGDISPLAY* p
     if ((flags & DT_CONTEXT_CONTROL) == DT_CONTEXT_CONTROL)
     {
         pDRD->FP = (SIZE_T)CORDbgGetFP(pContext);
-        pDRD->PC = (SIZE_T)pContext->PC;
-        pDRD->RA = (SIZE_T)pContext->RA;
+        pDRD->PC = (SIZE_T)pContext->Pc;
+        pDRD->RA = (SIZE_T)pContext->Ra;
     }
 
     if ((flags & DT_CONTEXT_INTEGER) == DT_CONTEXT_INTEGER)
     {
-        pDRD->TP = pContext->TP;
+        pDRD->TP = pContext->Tp;
         memcpy(&pDRD->A0, &pContext->A0, sizeof(pDRD->A0)*(21 - 4 + 1));
         memcpy(&pDRD->S0, &pContext->S0, sizeof(pDRD->S0)* 9);
     }


### PR DESCRIPTION
This PR is part of the issue https://github.com/dotnet/runtime/issues/69705 to amend the LA's port.

Fix the compiling errors for attribute aligned and some macro-definiation conflict liking `PC`.