### PR TITLE
JsonConsoleFormatter: keep escaped line breaks for Exceptions #83726

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatter.cs
@@ -55,12 +55,7 @@ namespace Microsoft.Extensions.Logging.Console
 
                     if (exception != null)
                     {
-                        string exceptionMessage = exception.ToString();
-                        if (!FormatterOptions.JsonWriterOptions.Indented)
-                        {
-                            exceptionMessage = exceptionMessage.Replace(Environment.NewLine, " ");
-                        }
-                        writer.WriteString(nameof(Exception), exceptionMessage);
+                        writer.WriteString(nameof(Exception), exception.ToString());
                     }
 
                     if (logEntry.State != null)

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/JsonConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/JsonConsoleFormatterTests.cs
@@ -490,7 +490,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             JsonConsoleFormatterOptions jsonOptions = new JsonConsoleFormatterOptions()
             {
                 JsonWriterOptions = new JsonWriterOptions()
-                { 
+                {
                     Indented = indented,
                     Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
                 }
@@ -519,15 +519,15 @@ namespace Microsoft.Extensions.Logging.Console.Test
 
             Assert.Contains(rootException.Message, json);
             Assert.Contains(rootException.InnerException.Message, json);
-            
-            Assert.Contains(GetContent(rootException, indented), json);
-            Assert.Contains(GetContent(rootException.InnerException, indented), json);
+
+            Assert.Contains(GetContent(rootException), json);
+            Assert.Contains(GetContent(rootException.InnerException), json);
         }
 
-        static string GetContent(Exception exception, bool indented)
+        static string GetContent(Exception exception)
         {
             // Depending on OS, Environment.NewLine is either '\r\n' OR '\n'
-            string newLineReplacement = indented ? (Environment.NewLine.Length == 2 ? "\\r\\n" : "\\n") : " ";
+            string newLineReplacement = Environment.NewLine.Length == 2 ? "\\r\\n" : "\\n";
 
             return exception.ToString()
                 .Replace(@"\", @"\\") // for paths in json content
@@ -546,9 +546,9 @@ namespace Microsoft.Extensions.Logging.Console.Test
 
             Assert.Contains(rootException.Message, json);
             rootException.InnerExceptions.ToList().ForEach((inner) => Assert.Contains(inner.Message, json));
-            
-            Assert.Contains(GetContent(rootException, indented), json);
-            rootException.InnerExceptions.ToList().ForEach((inner) => Assert.Contains(GetContent(inner, indented), json));
+
+            Assert.Contains(GetContent(rootException), json);
+            rootException.InnerExceptions.ToList().ForEach((inner) => Assert.Contains(GetContent(inner), json));
         }
     }
 }


### PR DESCRIPTION
Fixes #83726

Linebreaks of Exceptions no longer get removed in JsonConsoleFormatter, but instead get escaped by `Utf8JsonWriter`, so original format can be restored by log viewer.