### PR TITLE
Add TargetHostName to QuicConnection

### DIFF
--- a/src/libraries/Common/src/System/Net/Security/TargetHostNameHelper.cs
+++ b/src/libraries/Common/src/System/Net/Security/TargetHostNameHelper.cs
@@ -26,12 +26,6 @@ namespace System.Net.Security
             // RFC 6066 section 3 says to exclude trailing dot from fully qualified DNS hostname
             targetHost = targetHost.TrimEnd('.');
 
-            // RFC 6066 forbids IP literals
-            if (IsValidAddress(targetHost))
-            {
-                return string.Empty;
-            }
-
             try
             {
                 return s_idnMapping.GetAscii(targetHost);
@@ -46,8 +40,15 @@ namespace System.Net.Security
 
         // Simplified version of IPAddressParser.Parse to avoid allocations and dependencies.
         // It purposely ignores scopeId as we don't really use so we do not need to map it to actual interface id.
-        private static unsafe bool IsValidAddress(ReadOnlySpan<char> ipSpan)
+        internal static unsafe bool IsValidAddress(string? hostname)
         {
+            if (string.IsNullOrEmpty(hostname))
+            {
+                return false;
+            }
+
+            ReadOnlySpan<char> ipSpan = hostname.AsSpan();
+
             int end = ipSpan.Length;
 
             if (ipSpan.Contains(':'))

--- a/src/libraries/Common/src/System/Net/Security/TargetHostNameHelper.cs
+++ b/src/libraries/Common/src/System/Net/Security/TargetHostNameHelper.cs
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Buffers;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Runtime.InteropServices;
+
+namespace System.Net.Security
+{
+    internal static class TargetHostNameHelper
+    {
+        private static readonly IdnMapping s_idnMapping = new IdnMapping();
+        private static readonly IndexOfAnyValues<char> s_safeDnsChars =
+            IndexOfAnyValues.Create("-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz");
+
+        private static bool IsSafeDnsString(ReadOnlySpan<char> name) =>
+            name.IndexOfAnyExcept(s_safeDnsChars) < 0;
+
+        internal static string NormalizeHostName(string? targetHost)
+        {
+            if (string.IsNullOrEmpty(targetHost))
+            {
+                return string.Empty;
+            }
+
+            // RFC 6066 section 3 says to exclude trailing dot from fully qualified DNS hostname
+            targetHost = targetHost.TrimEnd('.');
+
+            // RFC 6066 forbids IP literals
+            if (IsValidAddress(targetHost))
+            {
+                return targetHost;
+            }
+
+            try
+            {
+                return s_idnMapping.GetAscii(targetHost);
+            }
+            catch (ArgumentException) when (IsSafeDnsString(targetHost))
+            {
+                // Seems like name that does not confrom to IDN but apers somewhat valid according to original DNS rfc.
+            }
+
+            return targetHost;
+        }
+
+        // Simplified version of IPAddressParser.Parse to avoid allocations and dependencies.
+        // It purposely ignores scopeId as we don't really use so we do not need to map it to actual interface id.
+        private static unsafe bool IsValidAddress(ReadOnlySpan<char> ipSpan)
+        {
+            int end = ipSpan.Length;
+
+            if (ipSpan.Contains(':'))
+            {
+                // The address is parsed as IPv6 if and only if it contains a colon. This is valid because
+                // we don't support/parse a port specification at the end of an IPv4 address.
+                Span<ushort> numbers = stackalloc ushort[IPAddressParserStatics.IPv6AddressShorts];
+
+                fixed (char* ipStringPtr = &MemoryMarshal.GetReference(ipSpan))
+                {
+                    return IPv6AddressHelper.IsValidStrict(ipStringPtr, 0, ref end);
+                }
+            }
+            else if (char.IsDigit(ipSpan[0]))
+            {
+                long tmpAddr;
+
+                fixed (char* ipStringPtr = &MemoryMarshal.GetReference(ipSpan))
+                {
+                    tmpAddr = IPv4AddressHelper.ParseNonCanonical(ipStringPtr, 0, ref end, notImplicitFile: true);
+                }
+
+                if (tmpAddr != IPv4AddressHelper.Invalid && end == ipSpan.Length)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+    }
+}

--- a/src/libraries/Common/src/System/Net/Security/TargetHostNameHelper.cs
+++ b/src/libraries/Common/src/System/Net/Security/TargetHostNameHelper.cs
@@ -29,7 +29,7 @@ namespace System.Net.Security
             // RFC 6066 forbids IP literals
             if (IsValidAddress(targetHost))
             {
-                return targetHost;
+                return string.Empty;
             }
 
             try

--- a/src/libraries/Common/src/System/Net/Security/TargetHostNameHelper.cs
+++ b/src/libraries/Common/src/System/Net/Security/TargetHostNameHelper.cs
@@ -78,6 +78,5 @@ namespace System.Net.Security
 
             return false;
         }
-
     }
 }

--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -28,7 +28,7 @@ namespace System.Net.Quic
         public System.Net.Security.SslApplicationProtocol NegotiatedApplicationProtocol { get { throw null; } }
         public System.Security.Cryptography.X509Certificates.X509Certificate? RemoteCertificate { get { throw null; } }
         public System.Net.IPEndPoint RemoteEndPoint { get { throw null; } }
-        public string? TargetHostName { get { throw null; } }
+        public string TargetHostName { get { throw null; } }
         public System.Threading.Tasks.ValueTask<System.Net.Quic.QuicStream> AcceptInboundStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.Threading.Tasks.ValueTask CloseAsync(long errorCode, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static System.Threading.Tasks.ValueTask<System.Net.Quic.QuicConnection> ConnectAsync(System.Net.Quic.QuicClientConnectionOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -28,6 +28,7 @@ namespace System.Net.Quic
         public System.Net.Security.SslApplicationProtocol NegotiatedApplicationProtocol { get { throw null; } }
         public System.Security.Cryptography.X509Certificates.X509Certificate? RemoteCertificate { get { throw null; } }
         public System.Net.IPEndPoint RemoteEndPoint { get { throw null; } }
+        public string? TargetHostName { get { throw null; } }
         public System.Threading.Tasks.ValueTask<System.Net.Quic.QuicStream> AcceptInboundStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.Threading.Tasks.ValueTask CloseAsync(long errorCode, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static System.Threading.Tasks.ValueTask<System.Net.Quic.QuicConnection> ConnectAsync(System.Net.Quic.QuicClientConnectionOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -122,6 +123,7 @@ namespace System.Net.Quic
         public override int ReadByte() { throw null; }
         public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
         public override void SetLength(long value) { }
+        public override string ToString() { throw null; }
         public override void Write(byte[] buffer, int offset, int count) { }
         public override void Write(System.ReadOnlySpan<byte> buffer) { }
         public override System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -32,6 +32,10 @@
     <Compile Include="$(CommonPath)System\Net\IPAddressParserStatics.cs" Link="Common\System\Net\IPAddressParserStatics.cs" />
     <Compile Include="$(CommonPath)System\Net\Internals\IPEndPointExtensions.cs" Link="Common\System\Net\Internals\IPEndPointExtensions.cs" />
     <Compile Include="$(CommonPath)System\Net\Security\TlsAlertMessage.cs" Link="Common\System\Net\Security\TlsAlertMessage.cs" />
+    <Compile Include="$(CommonPath)System\Net\Security\TargetHostNameHelper.cs" Link="Common\System\Net\Security\TargetHostNameHelper.cs" />
+    <!-- IP parser -->
+    <Compile Include="$(CommonPath)System\Net\IPv4AddressHelper.Common.cs" Link="System\Net\IPv4AddressHelper.Common.cs" />
+    <Compile Include="$(CommonPath)System\Net\IPv6AddressHelper.Common.cs" Link="System\Net\IPv6AddressHelper.Common.cs" />
   </ItemGroup>
   <!-- Unsupported platforms -->
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == ''">

--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -32,10 +32,6 @@
     <Compile Include="$(CommonPath)System\Net\IPAddressParserStatics.cs" Link="Common\System\Net\IPAddressParserStatics.cs" />
     <Compile Include="$(CommonPath)System\Net\Internals\IPEndPointExtensions.cs" Link="Common\System\Net\Internals\IPEndPointExtensions.cs" />
     <Compile Include="$(CommonPath)System\Net\Security\TlsAlertMessage.cs" Link="Common\System\Net\Security\TlsAlertMessage.cs" />
-    <Compile Include="$(CommonPath)System\Net\Security\TargetHostNameHelper.cs" Link="Common\System\Net\Security\TargetHostNameHelper.cs" />
-    <!-- IP parser -->
-    <Compile Include="$(CommonPath)System\Net\IPv4AddressHelper.Common.cs" Link="System\Net\IPv4AddressHelper.Common.cs" />
-    <Compile Include="$(CommonPath)System\Net\IPv6AddressHelper.Common.cs" Link="System\Net\IPv6AddressHelper.Common.cs" />
   </ItemGroup>
   <!-- Unsupported platforms -->
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == ''">

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.SslConnectionOptions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.SslConnectionOptions.cs
@@ -28,7 +28,8 @@ public partial class QuicConnection
         /// <summary>
         /// Host name send in SNI, set only for outbound/client connections. Configured via <see cref="SslClientAuthenticationOptions.TargetHost"/>.
         /// </summary>
-        private readonly string? _targetHost;
+        internal string TargetHost => _targetHost;
+        private readonly string _targetHost;
         /// <summary>
         /// Always <c>true</c> for outbound/client connections. Configured for inbound/server ones via <see cref="SslServerAuthenticationOptions.ClientCertificateRequired"/>.
         /// </summary>
@@ -48,7 +49,7 @@ public partial class QuicConnection
         private readonly X509ChainPolicy? _certificateChainPolicy;
 
         public SslConnectionOptions(QuicConnection connection, bool isClient,
-            string? targetHost, bool certificateRequired, X509RevocationMode
+            string targetHost, bool certificateRequired, X509RevocationMode
             revocationMode, RemoteCertificateValidationCallback? validationCallback,
             X509ChainPolicy? certificateChainPolicy)
         {

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.SslConnectionOptions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.SslConnectionOptions.cs
@@ -28,7 +28,6 @@ public partial class QuicConnection
         /// <summary>
         /// Host name send in SNI, set only for outbound/client connections. Configured via <see cref="SslClientAuthenticationOptions.TargetHost"/>.
         /// </summary>
-        internal string TargetHost => _targetHost;
         private readonly string _targetHost;
         /// <summary>
         /// Always <c>true</c> for outbound/client connections. Configured for inbound/server ones via <see cref="SslServerAuthenticationOptions.ClientCertificateRequired"/>.
@@ -47,6 +46,8 @@ public partial class QuicConnection
         /// Configured via <see cref="SslServerAuthenticationOptions.CertificateChainPolicy"/> or <see cref="SslClientAuthenticationOptions.CertificateChainPolicy"/>.
         /// </summary>
         private readonly X509ChainPolicy? _certificateChainPolicy;
+
+        internal string TargetHost => _targetHost;
 
         public SslConnectionOptions(QuicConnection connection, bool isClient,
             string targetHost, bool certificateRequired, X509RevocationMode

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.SslConnectionOptions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.SslConnectionOptions.cs
@@ -120,7 +120,7 @@ public partial class QuicConnection
                 if (result is not null)
                 {
                     bool checkCertName = !chain!.ChainPolicy!.VerificationFlags.HasFlag(X509VerificationFlags.IgnoreInvalidName);
-                    sslPolicyErrors |= CertificateValidation.BuildChainAndVerifyProperties(chain!, result, checkCertName, !_isClient, _targetHost, certificateBuffer, certificateLength);
+                    sslPolicyErrors |= CertificateValidation.BuildChainAndVerifyProperties(chain!, result, checkCertName, !_isClient, TargetHostNameHelper.NormalizeHostName(_targetHost), certificateBuffer, certificateLength);
                 }
                 else if (_certificateRequired)
                 {

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -334,10 +334,16 @@ public sealed partial class QuicConnection : IAsyncDisposable
             _defaultStreamErrorCode = options.DefaultStreamErrorCode;
             _defaultCloseErrorCode = options.DefaultCloseErrorCode;
 
+            // RFC 6066 forbids IP literals, avoid setting IP address here for consistency with SslStream
+            if (TargetHostNameHelper.IsValidAddress(targetHost))
+            {
+                targetHost = string.Empty;
+            }
+
             _sslConnectionOptions = new SslConnectionOptions(
                 this,
                 isClient: false,
-                targetHost: targetHost,
+                targetHost,
                 options.ServerAuthenticationOptions.ClientCertificateRequired,
                 options.ServerAuthenticationOptions.CertificateRevocationCheckMode,
                 options.ServerAuthenticationOptions.RemoteCertificateValidationCallback,

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -47,6 +47,12 @@ public sealed partial class QuicConnection : IAsyncDisposable
     public static bool IsSupported => MsQuicApi.IsQuicSupported;
 
     /// <summary>
+    /// Gets the name of the server the client is trying to connect to. That name is used for server certificate validation. It can be a DNS name or an IP address.
+    /// </summary>
+    /// <returns>The name of the server the client is trying to connect to.</returns>
+    public string? TargetHostName => _sslConnectionOptions.TargetHost;
+
+    /// <summary>
     /// Creates a new <see cref="QuicConnection"/> and connects it to the peer.
     /// </summary>
     /// <param name="options">Options for the connection.</param>
@@ -282,7 +288,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
             _sslConnectionOptions = new SslConnectionOptions(
                 this,
                 isClient: true,
-                options.ClientAuthenticationOptions.TargetHost,
+                TargetHostNameHelper.NormalizeHostName(options.ClientAuthenticationOptions.TargetHost),
                 certificateRequired: true,
                 options.ClientAuthenticationOptions.CertificateRevocationCheckMode,
                 options.ClientAuthenticationOptions.RemoteCertificateValidationCallback,
@@ -312,7 +318,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
         await valueTask.ConfigureAwait(false);
     }
 
-    internal ValueTask FinishHandshakeAsync(QuicServerConnectionOptions options, string? targetHost, CancellationToken cancellationToken = default)
+    internal ValueTask FinishHandshakeAsync(QuicServerConnectionOptions options, string targetHost, CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed == 1, this);
 
@@ -325,7 +331,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
             _sslConnectionOptions = new SslConnectionOptions(
                 this,
                 isClient: false,
-                targetHost: null,
+                targetHost: targetHost,
                 options.ServerAuthenticationOptions.ClientCertificateRequired,
                 options.ServerAuthenticationOptions.CertificateRevocationCheckMode,
                 options.ServerAuthenticationOptions.RemoteCertificateValidationCallback,

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -47,12 +47,6 @@ public sealed partial class QuicConnection : IAsyncDisposable
     public static bool IsSupported => MsQuicApi.IsQuicSupported;
 
     /// <summary>
-    /// Gets the name of the server the client is trying to connect to. That name is used for server certificate validation. It can be a DNS name or an IP address.
-    /// </summary>
-    /// <returns>The name of the server the client is trying to connect to.</returns>
-    public string TargetHostName => _sslConnectionOptions.TargetHost ?? string.Empty;
-
-    /// <summary>
     /// Creates a new <see cref="QuicConnection"/> and connects it to the peer.
     /// </summary>
     /// <param name="options">Options for the connection.</param>
@@ -154,6 +148,12 @@ public sealed partial class QuicConnection : IAsyncDisposable
     /// The local endpoint used for this connection.
     /// </summary>
     public IPEndPoint LocalEndPoint => _localEndPoint;
+
+    /// <summary>
+    /// Gets the name of the server the client is trying to connect to. That name is used for server certificate validation. It can be a DNS name or an IP address.
+    /// </summary>
+    /// <returns>The name of the server the client is trying to connect to.</returns>
+    public string TargetHostName => _sslConnectionOptions.TargetHost ?? string.Empty;
 
     /// <summary>
     /// The certificate provided by the peer.
@@ -288,7 +288,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
             _sslConnectionOptions = new SslConnectionOptions(
                 this,
                 isClient: true,
-                TargetHostNameHelper.NormalizeHostName(options.ClientAuthenticationOptions.TargetHost),
+                options.ClientAuthenticationOptions.TargetHost ?? "",
                 certificateRequired: true,
                 options.ClientAuthenticationOptions.CertificateRevocationCheckMode,
                 options.ClientAuthenticationOptions.RemoteCertificateValidationCallback,

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -50,7 +50,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
     /// Gets the name of the server the client is trying to connect to. That name is used for server certificate validation. It can be a DNS name or an IP address.
     /// </summary>
     /// <returns>The name of the server the client is trying to connect to.</returns>
-    public string? TargetHostName => _sslConnectionOptions.TargetHost;
+    public string TargetHostName => _sslConnectionOptions?.TargetHost ?? string.Empty;
 
     /// <summary>
     /// Creates a new <see cref="QuicConnection"/> and connects it to the peer.

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -50,7 +50,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
     /// Gets the name of the server the client is trying to connect to. That name is used for server certificate validation. It can be a DNS name or an IP address.
     /// </summary>
     /// <returns>The name of the server the client is trying to connect to.</returns>
-    public string TargetHostName => _sslConnectionOptions?.TargetHost ?? string.Empty;
+    public string TargetHostName => _sslConnectionOptions.TargetHost ?? string.Empty;
 
     /// <summary>
     /// Creates a new <see cref="QuicConnection"/> and connects it to the peer.

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -285,10 +285,16 @@ public sealed partial class QuicConnection : IAsyncDisposable
                 MsQuicHelpers.SetMsQuicParameter(_handle, QUIC_PARAM_CONN_LOCAL_ADDRESS, quicAddress);
             }
 
+            // RFC 6066 forbids IP literals
+            // DNI mapping is handled by MsQuic
+            var hostname = TargetHostNameHelper.IsValidAddress(options.ClientAuthenticationOptions.TargetHost)
+                ? string.Empty
+                : options.ClientAuthenticationOptions.TargetHost ?? string.Empty;
+
             _sslConnectionOptions = new SslConnectionOptions(
                 this,
                 isClient: true,
-                options.ClientAuthenticationOptions.TargetHost ?? "",
+                hostname,
                 certificateRequired: true,
                 options.ClientAuthenticationOptions.CertificateRevocationCheckMode,
                 options.ClientAuthenticationOptions.RemoteCertificateValidationCallback,

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -22,7 +22,8 @@ namespace System.Net.Quic.Tests
         {
             await using QuicListener listener = await CreateQuicListener();
 
-            ValueTask<QuicConnection> connectTask = CreateQuicConnection(listener.LocalEndPoint);
+            var options = CreateQuicClientOptions(listener.LocalEndPoint);
+            ValueTask<QuicConnection> connectTask = CreateQuicConnection(options);
             ValueTask<QuicConnection> acceptTask = listener.AcceptConnectionAsync();
 
             await new Task[] { connectTask.AsTask(), acceptTask.AsTask() }.WhenAllOrAnyFailed(PassingTestTimeoutMilliseconds);
@@ -34,6 +35,8 @@ namespace System.Net.Quic.Tests
             Assert.Equal(clientConnection.LocalEndPoint, serverConnection.RemoteEndPoint);
             Assert.Equal(ApplicationProtocol.ToString(), clientConnection.NegotiatedApplicationProtocol.ToString());
             Assert.Equal(ApplicationProtocol.ToString(), serverConnection.NegotiatedApplicationProtocol.ToString());
+            Assert.Equal(options.ClientAuthenticationOptions.TargetHost, clientConnection.TargetHostName);
+            Assert.Equal(options.ClientAuthenticationOptions.TargetHost, serverConnection.TargetHostName);
         }
 
         private static async Task<QuicStream> OpenAndUseStreamAsync(QuicConnection c)

--- a/src/libraries/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/libraries/System.Net.Security/src/System.Net.Security.csproj
@@ -92,6 +92,8 @@
              Link="Common\System\NotImplemented.cs" />
     <Compile Include="$(CommonPath)System\Net\Security\TlsAlertMessage.cs"
              Link="Common\System\Net\Security\TlsAlertMessage.cs" />
+    <Compile Include="$(CommonPath)System\Net\Security\TargetHostNameHelper.cs"
+             Link="Common\System\Net\Security\TargetHostNameHelper.cs" />
     <Compile Include="$(CommonPath)System\Net\Security\SafeCredentialReference.cs"
              Link="Common\System\Net\Security\SafeCredentialReference.cs" />
     <Compile Include="$(CommonPath)System\Net\Security\SSPIHandleCache.cs"

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -4,8 +4,6 @@
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
-using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 
@@ -13,49 +11,6 @@ namespace System.Net.Security
 {
     internal sealed class SslAuthenticationOptions
     {
-        private static readonly IdnMapping s_idnMapping = new IdnMapping();
-
-        // Simplified version of IPAddressParser.Parse to avoid allocations and dependencies.
-        // It purposely ignores scopeId as we don't really use so we do not need to map it to actual interface id.
-        private static unsafe bool IsValidAddress(ReadOnlySpan<char> ipSpan)
-        {
-            int end = ipSpan.Length;
-
-            if (ipSpan.Contains(':'))
-            {
-                // The address is parsed as IPv6 if and only if it contains a colon. This is valid because
-                // we don't support/parse a port specification at the end of an IPv4 address.
-                Span<ushort> numbers = stackalloc ushort[IPAddressParserStatics.IPv6AddressShorts];
-
-                fixed (char* ipStringPtr = &MemoryMarshal.GetReference(ipSpan))
-                {
-                    return IPv6AddressHelper.IsValidStrict(ipStringPtr, 0, ref end);
-                }
-            }
-            else if (char.IsDigit(ipSpan[0]))
-            {
-                long tmpAddr;
-
-                fixed (char* ipStringPtr = &MemoryMarshal.GetReference(ipSpan))
-                {
-                    tmpAddr = IPv4AddressHelper.ParseNonCanonical(ipStringPtr, 0, ref end, notImplicitFile: true);
-                }
-
-                if (tmpAddr != IPv4AddressHelper.Invalid && end == ipSpan.Length)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private static readonly IndexOfAnyValues<char> s_safeDnsChars =
-            IndexOfAnyValues.Create("-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz");
-
-        private static bool IsSafeDnsString(ReadOnlySpan<char> name) =>
-            name.IndexOfAnyExcept(s_safeDnsChars) < 0;
-
         internal SslAuthenticationOptions()
         {
             TargetHost = string.Empty;
@@ -93,29 +48,7 @@ namespace System.Net.Security
             IsServer = false;
             RemoteCertRequired = true;
             CertificateContext = sslClientAuthenticationOptions.ClientCertificateContext;
-            if (!string.IsNullOrEmpty(sslClientAuthenticationOptions.TargetHost))
-            {
-                // RFC 6066 section 3 says to exclude trailing dot from fully qualified DNS hostname
-                string targetHost = sslClientAuthenticationOptions.TargetHost.TrimEnd('.');
-
-                // RFC 6066 forbids IP literals
-                if (IsValidAddress(targetHost))
-                {
-                    TargetHost = string.Empty;
-                }
-                else
-                {
-                    try
-                    {
-                        TargetHost = s_idnMapping.GetAscii(targetHost);
-                    }
-                    catch (ArgumentException) when (IsSafeDnsString(targetHost))
-                    {
-                        // Seems like name that does not confrom to IDN but apers somewhat valid according to orogional DNS rfc.
-                        TargetHost = targetHost;
-                    }
-                }
-            }
+            TargetHost = TargetHostNameHelper.NormalizeHostName(sslClientAuthenticationOptions.TargetHost);
 
             // Client specific options.
             CertificateRevocationCheckMode = sslClientAuthenticationOptions.CertificateRevocationCheckMode;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -48,7 +48,11 @@ namespace System.Net.Security
             IsServer = false;
             RemoteCertRequired = true;
             CertificateContext = sslClientAuthenticationOptions.ClientCertificateContext;
-            TargetHost = TargetHostNameHelper.NormalizeHostName(sslClientAuthenticationOptions.TargetHost);
+
+            // RFC 6066 forbids IP literals
+            TargetHost = TargetHostNameHelper.IsValidAddress(sslClientAuthenticationOptions.TargetHost)
+                ? string.Empty
+                : sslClientAuthenticationOptions.TargetHost ?? string.Empty;
 
             // Client specific options.
             CertificateRevocationCheckMode = sslClientAuthenticationOptions.CertificateRevocationCheckMode;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
@@ -844,10 +844,11 @@ namespace System.Net.Security
                     }
                     else
                     {
+                        string hostName = TargetHostNameHelper.NormalizeHostName(_sslAuthenticationOptions.TargetHost);
                         status = SslStreamPal.InitializeSecurityContext(
                                        ref _credentialsHandle!,
                                        ref _securityContext,
-                                       _sslAuthenticationOptions.TargetHost,
+                                       hostName,
                                        inputBuffer,
                                        ref result,
                                        _sslAuthenticationOptions);
@@ -863,7 +864,7 @@ namespace System.Net.Security
                             status = SslStreamPal.InitializeSecurityContext(
                                        ref _credentialsHandle!,
                                        ref _securityContext,
-                                       _sslAuthenticationOptions.TargetHost,
+                                       hostName,
                                        ReadOnlySpan<byte>.Empty,
                                        ref result,
                                        _sslAuthenticationOptions);

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
@@ -1060,7 +1060,7 @@ namespace System.Net.Security
                         _remoteCertificate,
                         _sslAuthenticationOptions.CheckCertName,
                         _sslAuthenticationOptions.IsServer,
-                        _sslAuthenticationOptions.TargetHost);
+                        TargetHostNameHelper.NormalizeHostName(_sslAuthenticationOptions.TargetHost));
                 }
 
                 if (remoteCertValidationCallback != null)

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslAuthenticationOptionsTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslAuthenticationOptionsTest.cs
@@ -101,7 +101,6 @@ namespace System.Net.Security.Tests
                     Assert.Same(clientLocalCallback, clientOptions.LocalCertificateSelectionCallback);
                     Assert.Same(clientRemoteCallback, clientOptions.RemoteCertificateValidationCallback);
                     Assert.Same(clientHost, clientOptions.TargetHost);
-                    Assert.Same(clientHost, clientOptions.TargetHost);
                     Assert.Same(policy, clientOptions.CertificateChainPolicy);
 
                     // Validate that server options are unchanged

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
@@ -44,6 +44,8 @@ namespace System.Net.Security.Tests
                     await TaskTimeoutExtensions.WhenAllOrAnyFailed(new[] { clientJob, server.AuthenticateAsServerAsync(options, CancellationToken.None) });
 
                     Assert.Equal(1, timesCallbackCalled);
+                    Assert.Equal(hostName, server.TargetHostName);
+                    Assert.Equal(hostName, client.TargetHostName);
                 },
                 (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) =>
                 {
@@ -200,6 +202,7 @@ namespace System.Net.Security.Tests
                         server.AuthenticateAsServerAsync(serverOptions, default));
 
             Assert.Equal(string.Empty, server.TargetHostName);
+            Assert.Equal(string.Empty, client.TargetHostName);
         }
 
         [Theory]
@@ -320,10 +323,10 @@ namespace System.Net.Security.Tests
 
         public static IEnumerable<object[]> HostNameData()
         {
-            yield return new object[] { "a" };
-            yield return new object[] { "test" };
+            // yield return new object[] { "a" };
+            // yield return new object[] { "test" };
             // max allowed hostname length is 63
-            yield return new object[] { new string('a', 63) };
+            // yield return new object[] { new string('a', 63) };
             yield return new object[] { "\u017C\u00F3\u0142\u0107 g\u0119\u015Bl\u0105 ja\u017A\u0144. \u7EA2\u70E7. \u7167\u308A\u713C\u304D" };
         }
     }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
@@ -323,10 +323,10 @@ namespace System.Net.Security.Tests
 
         public static IEnumerable<object[]> HostNameData()
         {
-            // yield return new object[] { "a" };
-            // yield return new object[] { "test" };
+            yield return new object[] { "a" };
+            yield return new object[] { "test" };
             // max allowed hostname length is 63
-            // yield return new object[] { new string('a', 63) };
+            yield return new object[] { new string('a', 63) };
             yield return new object[] { "\u017C\u00F3\u0142\u0107 g\u0119\u015Bl\u0105 ja\u017A\u0144. \u7EA2\u70E7. \u7167\u308A\u713C\u304D" };
         }
     }

--- a/src/libraries/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
@@ -50,6 +50,8 @@
              Link="Common\System\Net\Security\RC4.cs" />
     <Compile Include="$(CommonPath)System\Net\Security\TlsAlertMessage.cs"
              Link="Common\System\Net\Security\TlsAlertMessage.cs" />
+    <Compile Include="$(CommonPath)System\Net\Security\TargetHostNameHelper.cs"
+             Link="Common\System\Net\Security\TargetHostNameHelper.cs" />
     <Compile Include="..\..\src\System\Net\Security\NetEventSource.Security.cs"
              Link="ProductionCode\System\Net\Security\NetEventSource.Security.cs" />
     <Compile Include="..\..\src\System\Net\Security\SslStream.cs"


### PR DESCRIPTION
Fixes #80508, also ports #82934 and #81631 to System.Net.Quic to unify behavior.

I discovered that we have some inconsistency in TargetHostName on SslStream side, we will report the encoded TargetHost on client side TargetHostName property and in client cert selection callback, but decoded on server side. So I made changes to always store user-provided TargetHost and encode it only for the parts we need it. I also added a SslStream test for cert validation with IDN domain.

Closes #55687 (added tests which exercise IDN in S.N.Q).