### PR TITLE
[browser] Enable webcil in Wasm SDK

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -169,6 +169,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_WasmInvariantGlobalization Condition="'$(_WasmInvariantGlobalization)' == ''">true</_WasmInvariantGlobalization>
       <_WasmCopyOutputSymbolsToOutputDirectory>$(CopyOutputSymbolsToOutputDirectory)</_WasmCopyOutputSymbolsToOutputDirectory>
       <_WasmCopyOutputSymbolsToOutputDirectory Condition="'$(_WasmCopyOutputSymbolsToOutputDirectory)'==''">true</_WasmCopyOutputSymbolsToOutputDirectory>
+      <_WasmEnableWebcil>$(WasmEnableWebcil)</_WasmEnableWebcil>
+      <_WasmEnableWebcil Condition="'$(_WasmEnableWebcil)' == ''">false</_WasmEnableWebcil>
       <_BlazorWebAssemblyStartupMemoryCache>$(BlazorWebAssemblyStartupMemoryCache)</_BlazorWebAssemblyStartupMemoryCache>
       <_BlazorWebAssemblyJiterpreter>$(BlazorWebAssemblyJiterpreter)</_BlazorWebAssemblyJiterpreter>
       <_BlazorWebAssemblyRuntimeOptions>$(BlazorWebAssemblyRuntimeOptions)</_BlazorWebAssemblyRuntimeOptions>
@@ -210,7 +212,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_WasmBuildWebCilPath>$(IntermediateOutputPath)webcil</_WasmBuildWebCilPath>
     </PropertyGroup>
 
-    <ConvertDllsToWebCil Candidates="@(_BuildAssetsCandidates)" OutputPath="$(_WasmBuildWebCilPath)" IsEnabled="$(WasmEnableWebcil)">
+    <ConvertDllsToWebCil Candidates="@(_BuildAssetsCandidates)" OutputPath="$(_WasmBuildWebCilPath)" IsEnabled="$(_WasmEnableWebcil)">
       <Output TaskParameter="WebCilCandidates" ItemName="_WebCilAssetsCandidates" />
       <Output TaskParameter="FileWrites" ItemName="FileWrites" />
     </ConvertDllsToWebCil>
@@ -372,7 +374,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       ExistingAssets="@(_WasmPublishPrefilteredAssets)"
       DotNetJsVersion="$(_DotNetJsVersion)"
       FingerprintDotNetJs="$(WasmFingerprintDotnetJs)"
-      IsWebCilEnabled="$(WasmEnableWebcil)"
+      IsWebCilEnabled="$(_WasmEnableWebcil)"
     >
       <Output TaskParameter="NewCandidates" ItemName="_NewWasmPublishStaticWebAssets" />
       <Output TaskParameter="FilesToRemove" ItemName="_PublishResolvedFilesToRemove" />
@@ -382,7 +384,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_WasmPublishWebCilPath>$(IntermediateOutputPath)webcil\publish</_WasmPublishWebCilPath>
     </PropertyGroup>
 
-    <ConvertDllsToWebCil Candidates="@(_NewWasmPublishStaticWebAssets)" OutputPath="$(_WasmPublishWebCilPath)" IsEnabled="$(WasmEnableWebcil)">
+    <ConvertDllsToWebCil Candidates="@(_NewWasmPublishStaticWebAssets)" OutputPath="$(_WasmPublishWebCilPath)" IsEnabled="$(_WasmEnableWebcil)">
       <Output TaskParameter="WebCilCandidates" ItemName="_NewWebCilPublishStaticWebAssets" />
       <Output TaskParameter="FileWrites" ItemName="FileWrites" />
     </ConvertDllsToWebCil>

--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -40,6 +40,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="Microsoft.NET.Sdk.WebAssembly.GenerateWasmBootJson" AssemblyFile="$(_WebAssemblySdkTasksAssembly)" />
   <UsingTask TaskName="Microsoft.NET.Sdk.WebAssembly.ComputeWasmBuildAssets" AssemblyFile="$(_WebAssemblySdkTasksAssembly)" />
   <UsingTask TaskName="Microsoft.NET.Sdk.WebAssembly.ComputeWasmPublishAssets" AssemblyFile="$(_WebAssemblySdkTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.NET.Sdk.WebAssembly.ConvertDllsToWebCil" AssemblyFile="$(_WebAssemblySdkTasksAssembly)" />
 
   <PropertyGroup>
     <SelfContained>true</SelfContained>
@@ -205,8 +206,16 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="FilesToRemove" ItemName="_WasmBuildFilesToRemove" />
     </ComputeWasmBuildAssets>
 
+    <PropertyGroup>
+      <_WasmBuildWebCilPath>$(IntermediateOutputPath)\webcil</_WasmBuildWebCilPath>
+    </PropertyGroup>
+
+    <ConvertDllsToWebCil Candidates="@(_BuildAssetsCandidates)" OutputPath="$(_WasmBuildWebCilPath)" IsEnabled="$(WasmEnableWebcil)">
+      <Output TaskParameter="WebCilCandidates" ItemName="_WebCilAssetsCandidates" />
+    </ConvertDllsToWebCil>
+
     <DefineStaticWebAssets
-      CandidateAssets="@(_BuildAssetsCandidates)"
+      CandidateAssets="@(_WebCilAssetsCandidates)"
       SourceId="$(PackageId)"
       SourceType="Computed"
       AssetKind="Build"

--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -207,11 +207,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ComputeWasmBuildAssets>
 
     <PropertyGroup>
-      <_WasmBuildWebCilPath>$(IntermediateOutputPath)\webcil</_WasmBuildWebCilPath>
+      <_WasmBuildWebCilPath>$(IntermediateOutputPath)webcil</_WasmBuildWebCilPath>
     </PropertyGroup>
 
     <ConvertDllsToWebCil Candidates="@(_BuildAssetsCandidates)" OutputPath="$(_WasmBuildWebCilPath)" IsEnabled="$(WasmEnableWebcil)">
       <Output TaskParameter="WebCilCandidates" ItemName="_WebCilAssetsCandidates" />
+      <Output TaskParameter="FileWrites" ItemName="FileWrites" />
     </ConvertDllsToWebCil>
 
     <DefineStaticWebAssets
@@ -371,14 +372,24 @@ Copyright (c) .NET Foundation. All rights reserved.
       ExistingAssets="@(_WasmPublishPrefilteredAssets)"
       DotNetJsVersion="$(_DotNetJsVersion)"
       FingerprintDotNetJs="$(WasmFingerprintDotnetJs)"
+      IsWebCilEnabled="$(WasmEnableWebcil)"
     >
       <Output TaskParameter="NewCandidates" ItemName="_NewWasmPublishStaticWebAssets" />
       <Output TaskParameter="FilesToRemove" ItemName="_PublishResolvedFilesToRemove" />
     </ComputeWasmPublishAssets>
 
+    <PropertyGroup>
+      <_WasmPublishWebCilPath>$(IntermediateOutputPath)webcil\publish</_WasmPublishWebCilPath>
+    </PropertyGroup>
+
+    <ConvertDllsToWebCil Candidates="@(_NewWasmPublishStaticWebAssets)" OutputPath="$(_WasmPublishWebCilPath)" IsEnabled="$(WasmEnableWebcil)">
+      <Output TaskParameter="WebCilCandidates" ItemName="_NewWebCilPublishStaticWebAssets" />
+      <Output TaskParameter="FileWrites" ItemName="FileWrites" />
+    </ConvertDllsToWebCil>
+
     <ItemGroup>
       <ResolvedFileToPublish Remove="@(_PublishResolvedFilesToRemove)" />
-      <StaticWebAsset Include="@(_NewWasmPublishStaticWebAssets)" />
+      <StaticWebAsset Include="@(_NewWebCilPublishStaticWebAssets)" />
 
       <!-- TODO: Probably doesn't do anything as of now, original https://github.com/dotnet/aspnetcore/pull/34798 -->
       <PublishBlazorBootStaticWebAsset 

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ComputeWasmPublishAssets.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ComputeWasmPublishAssets.cs
@@ -55,6 +55,8 @@ public class ComputeWasmPublishAssets : Task
 
     public bool FingerprintDotNetJs { get; set; }
 
+    public bool IsWebCilEnabled { get; set; }
+
     [Output]
     public ITaskItem[] NewCandidates { get; set; }
 
@@ -329,6 +331,9 @@ public class ComputeWasmPublishAssets : Task
         {
             var asset = kvp.Value;
             var fileName = Path.GetFileName(asset.GetMetadata("RelativePath"));
+            if (IsWebCilEnabled)
+                fileName = Path.ChangeExtension(fileName, ".dll");
+
             if (resolvedAssembliesToPublish.TryGetValue(fileName, out var existing))
             {
                 // We found the assembly, so it'll have to be updated.
@@ -550,7 +555,7 @@ public class ComputeWasmPublishAssets : Task
             }
 
             var extension = candidate.GetMetadata("Extension");
-            if (string.Equals(extension, ".dll", StringComparison.Ordinal))
+            if (string.Equals(extension, ".dll", StringComparison.Ordinal) || string.Equals(extension, ".webcil", StringComparison.Ordinal))
             {
                 var culture = candidate.GetMetadata("Culture");
                 var inferredCulture = candidate.GetMetadata("DestinationSubDirectory").Replace("\\", "/").Trim('/');

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ConvertDllsToWebCil.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ConvertDllsToWebCil.cs
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Json;
+using System.Text;
+using System.Xml;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using ResourceHashesByNameDictionary = System.Collections.Generic.Dictionary<string, string>;
+
+namespace Microsoft.NET.Sdk.WebAssembly;
+
+public class ConvertDllsToWebCil : Task
+{
+    [Required]
+    public ITaskItem[] Candidates { get; set; }
+
+    [Required]
+    public string OutputPath { get; set; }
+
+    [Required]
+    public bool IsEnabled { get; set; }
+
+    [Output]
+    public ITaskItem[] WebCilCandidates { get; set; }
+
+    public override bool Execute()
+    {
+        var webCilCandidates = new List<ITaskItem>();
+
+        if (!IsEnabled)
+        {
+            WebCilCandidates = Candidates;
+            return true;
+        }
+
+        for (int i = 0; i < Candidates.Length; i++)
+        {
+            var candidate = Candidates[i];
+
+            var extension = candidate.GetMetadata("Extension");
+            var filePath = candidate.ItemSpec;
+
+            if (!Directory.Exists(OutputPath))
+                Directory.CreateDirectory(OutputPath);
+
+            if (extension == ".dll")
+            {
+                var tmpWebcil = Path.GetTempFileName();
+                var webcilWriter = Microsoft.WebAssembly.Build.Tasks.WebcilConverter.FromPortableExecutable(inputPath: filePath, outputPath: tmpWebcil, logger: Log);
+                webcilWriter.ConvertToWebcil();
+
+                var finalWebcil = Path.Combine(OutputPath, Path.GetFileNameWithoutExtension(filePath) + ".webcil");
+                if (Utils.CopyIfDifferent(tmpWebcil, finalWebcil, useHash: true))
+                    Log.LogMessage(MessageImportance.Low, $"Generated {finalWebcil} .");
+                else
+                    Log.LogMessage(MessageImportance.Low, $"Skipped generating {finalWebcil} as the contents are unchanged.");
+
+                var webcilItem = new TaskItem(finalWebcil, candidate.CloneCustomMetadata());
+                webcilItem.SetMetadata("RelativePath", Path.ChangeExtension(candidate.GetMetadata("RelativePath"), ".webcil"));
+                webcilItem.SetMetadata("AssetTraitName", "WasmResource");
+                webcilItem.SetMetadata("AssetTraitValue", "runtime");
+                webcilItem.SetMetadata("OriginalItemSpec", finalWebcil);
+
+                webCilCandidates.Add(webcilItem);
+            }
+            else
+            {
+                webCilCandidates.Add(candidate);
+            }
+        }
+
+        WebCilCandidates = webCilCandidates.ToArray();
+        return true;
+    }
+}

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ConvertDllsToWebCil.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ConvertDllsToWebCil.cs
@@ -31,6 +31,11 @@ public class ConvertDllsToWebCil : Task
     [Output]
     public ITaskItem[] WebCilCandidates { get; set; }
 
+    protected readonly List<string> _fileWrites = new();
+
+    [Output]
+    public string[]? FileWrites => _fileWrites.ToArray();
+
     public override bool Execute()
     {
         var webCilCandidates = new List<ITaskItem>();
@@ -62,6 +67,8 @@ public class ConvertDllsToWebCil : Task
                     Log.LogMessage(MessageImportance.Low, $"Generated {finalWebcil} .");
                 else
                     Log.LogMessage(MessageImportance.Low, $"Skipped generating {finalWebcil} as the contents are unchanged.");
+
+                _fileWrites.Add(finalWebcil);
 
                 var webcilItem = new TaskItem(finalWebcil, candidate.CloneCustomMetadata());
                 webcilItem.SetMetadata("RelativePath", Path.ChangeExtension(candidate.GetMetadata("RelativePath"), ".webcil"));

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks.csproj
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Microsoft.NET.Sdk.WebAssembly</RootNamespace>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>$(NoWarn);CS8632</NoWarn>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
@@ -16,8 +17,13 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
+    <Compile Include="..\Common\Utils.cs" />
+    <Compile Include="..\WasmAppBuilder\WebcilConverter.cs" />
+
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" ExcludeAssets="runtime" />
+
+    <ProjectReference Include="..\..\libraries\Microsoft.NET.WebAssembly.Webcil\src\Microsoft.NET.WebAssembly.Webcil.csproj" />
   </ItemGroup>
 
   <Target Name="GetFilesToPackage" Returns="@(FilesToPackage)">


### PR DESCRIPTION
- Support webcil format in Wasm SDK, which is shared with blazor
- Enable webcil by setting msbuild property `WasmEnableWebcil=true`
- Tested only locally with manually constructed SDK

<!--
TODO
- [x] Fix publish
-->