### PR TITLE
Revert Deflater/Inflater changes around SafeHandle initialization

### DIFF
--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Deflater.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Deflater.cs
@@ -64,20 +64,16 @@ namespace System.IO.Compression
 
             ZLibNative.CompressionStrategy strategy = ZLibNative.CompressionStrategy.DefaultStrategy;
 
-            ZLibNative.ZLibStreamHandle? zlibStream = null;
             ZErrorCode errC;
             try
             {
-                errC = ZLibNative.CreateZLibStreamForDeflate(out zlibStream, zlibCompressionLevel,
+                errC = ZLibNative.CreateZLibStreamForDeflate(out _zlibStream, zlibCompressionLevel,
                                                              windowBits, memLevel, strategy);
             }
             catch (Exception cause)
             {
-                zlibStream?.Dispose();
                 throw new ZLibException(SR.ZLibErrorDLLLoadError, cause);
             }
-
-            _zlibStream = zlibStream;
 
             switch (errC)
             {

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
@@ -239,19 +239,15 @@ namespace System.IO.Compression
         [MemberNotNull(nameof(_zlibStream))]
         private void InflateInit(int windowBits)
         {
-            ZLibNative.ZLibStreamHandle? zlibStream = null;
             ZLibNative.ErrorCode error;
             try
             {
-                error = ZLibNative.CreateZLibStreamForInflate(out zlibStream, windowBits);
+                error = ZLibNative.CreateZLibStreamForInflate(out _zlibStream, windowBits);
             }
             catch (Exception exception) // could not load the ZLib dll
             {
-                zlibStream?.Dispose();
                 throw new ZLibException(SR.ZLibErrorDLLLoadError, exception);
             }
-
-            _zlibStream = zlibStream;
 
             switch (error)
             {


### PR DESCRIPTION
Deflater/Inflater's ctor calls a P/Invoke that initializes a SafeHandle.  Previously this was being done to directly initialize a field, but I'd changed that months ago due to it leaving a handle for finalization.  What I failed to notice, however, was that these types themselves defined finalizers, and those finalizers expected that SafeHandle field to have been initialized; now that it's not, if a rare zlib initialization error occurs (e.g. zlib couldn't be found/loaded), the finalizer may crash the process due to an unhandled null reference exception.

For Deflater, it'd be possible to just call GC.SuppressFinalize(this) inside the existing catch block that's disposing of the SafeHandle in the event of an exception.  But it's more complicated for Inflater, where the SafeHandle might be recreated during the Inflater's lifetime, and thus the existing catch block is inside of a helper method that's used from more than just the ctor, and we shouldn't be suppressing finalization in that case.

So, rather than do something complicated for the small gains this provided (it was part of a much larger sweep to clean up non-disposed SafeHandles), I've just reverted these cases.

Fixes https://github.com/dotnet/runtime/issues/84994
cc: @rickbrew, @dotnet/area-system-io-compression 