### PR TITLE
[wasm] WBT: Re-enable previously disabled test

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/MiscTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/MiscTests.cs
@@ -18,7 +18,6 @@ public class MiscTests : BuildTestBase
     }
 
     [Theory]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/84722")]
     [InlineData("Debug", true)]
     [InlineData("Debug", false)]
     [InlineData("Release", true)]


### PR DESCRIPTION
`NativeBuild_WithDeployOnBuild_UsedByVS`

The filed issue possibly incorrectly identified the issue.
```
      []   Restored C:\helix\work\workitem\e\wbt\blz_deploy_on_build_Release_True_5i4l1wn0.new\blz_deploy_on_build_Release_True_5i4l1wn0.new.csproj (in 3.34 sec).
      [] C:\helix\work\workitem\e\dotnet-latest\sdk\8.0.100-preview.4.23212.2\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.RuntimeIdentifierInference.targets(287,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [C:\helix\work\workitem\e\wbt\blz_deploy_on_build_Release_True_5i4l1wn0.new\blz_deploy_on_build_Release_True_5i4l1wn0.new.csproj]
      [] C:\helix\work\workitem\e\wbt\blz_deploy_on_build_Release_True_5i4l1wn0.new\Program.cs(3,49): error CS1001: Identifier expected [C:\helix\work\workitem\e\wbt\blz_deploy_on_build_Release_True_5i4l1wn0.new\blz_deploy_on_build_Release_True_5i4l1wn0.new.csproj]
      [] C:\helix\work\workitem\e\wbt\blz_deploy_on_build_Release_True_5i4l1wn0.new\Program.cs(3,49): error CS1002: ; expected [C:\helix\work\workitem\e\wbt\blz_deploy_on_build_Release_True_5i4l1wn0.new\blz_deploy_on_build_Release_True_5i4l1wn0.new.csproj]
      [] C:\helix\work\workitem\e\wbt\blz_deploy_on_build_Release_True_5i4l1wn0.new\Program.cs(3,52): error CS1526: A new expression requires an argument list or (), [], or {} after type [C:\helix\work\workitem\e\wbt\blz_deploy_on_build_Release_True_5i4l1wn0.new\blz_deploy_on_build_Release_True_5i4l1wn0.new.csproj]
      []
      [] Build FAILED.
      []
      [] C:\helix\work\workitem\e\wbt\blz_deploy_on_build_Release_True_5i4l1wn0.new\Program.cs(3,49): error CS1001: Identifier expected [C:\helix\work\workitem\e\wbt\blz_deploy_on_build_Release_True_5i4l1wn0.new\blz_deploy_on_build_Release_True_5i4l1wn0.new.csproj]
      [] C:\helix\work\workitem\e\wbt\blz_deploy_on_build_Release_True_5i4l1wn0.new\Program.cs(3,49): error CS1002: ; expected [C:\helix\work\workitem\e\wbt\blz_deploy_on_build_Release_True_5i4l1wn0.new\blz_deploy_on_build_Release_True_5i4l1wn0.new.csproj]
      [] C:\helix\work\workitem\e\wbt\blz_deploy_on_build_Release_True_5i4l1wn0.new\Program.cs(3,52): error CS1526: A new expression requires an argument list or (), [], or {} after type [C:\helix\work\workitem\e\wbt\blz_deploy_on_build_Release_True_5i4l1wn0.new\blz_deploy_on_build_Release_True_5i4l1wn0.new.csproj]
      []     0 Warning(s)
      []     3 Error(s)
```

This error has been seen intermittently seen before, and is likely caused by `Program.cs` having some error messages instead of the code.

Fixes https://github.com/dotnet/runtime/issues/84722