### PR TITLE
[mono][jit] Improve mono_print_ins ().

### DIFF
--- a/src/mono/mono/mini/mini-codegen.c
+++ b/src/mono/mono/mini/mini-codegen.c
@@ -436,89 +436,35 @@ mono_print_ins_index_strbuf (int i, MonoInst *ins)
 	GString *sbuf = g_string_new (NULL);
 	int num_sregs, j;
 	int sregs [MONO_MAX_SRC_REGS];
+	char spec_dest = (char)0, spec_src1 = (char)0, spec_src2 = (char)0, spec_src3 = (char)0;
 
 	if (i != -1)
 		g_string_append_printf (sbuf, "\t%-2d %s", i, mono_inst_name (ins->opcode));
 	else
 		g_string_append_printf (sbuf, " %s", mono_inst_name (ins->opcode));
-	if (spec == (gpointer)/*FIXME*/MONO_ARCH_CPU_SPEC) {
-		gboolean dest_base = FALSE;
-		switch (ins->opcode) {
-		case OP_STOREV_MEMBASE:
-			dest_base = TRUE;
-			break;
-		default:
-			break;
-		}
-
+	if (spec == (gpointer)MONO_ARCH_CPU_SPEC) {
 		/* This is a lowered opcode */
 		if (ins->dreg != -1) {
-			if (dest_base)
-				g_string_append_printf (sbuf, " [R%d + 0x%lx] <-", ins->dreg, (long)ins->inst_offset);
+			if (MONO_IS_STORE_MEMBASE (ins))
+				spec_dest = 'b';
 			else
-				g_string_append_printf (sbuf, " R%d <-", ins->dreg);
+				spec_dest = 'i';
 		}
 		if (ins->sreg1 != -1)
-			g_string_append_printf (sbuf, " R%d", ins->sreg1);
+			spec_src1 = 'i';
 		if (ins->sreg2 != -1)
-			g_string_append_printf (sbuf, " R%d", ins->sreg2);
+			spec_src2 = 'i';
 		if (ins->sreg3 != -1)
-			g_string_append_printf (sbuf, " R%d", ins->sreg3);
-
-		switch (ins->opcode) {
-		case OP_LBNE_UN:
-		case OP_LBEQ:
-		case OP_LBLT:
-		case OP_LBLT_UN:
-		case OP_LBGT:
-		case OP_LBGT_UN:
-		case OP_LBGE:
-		case OP_LBGE_UN:
-		case OP_LBLE:
-		case OP_LBLE_UN:
-			if (!ins->inst_false_bb)
-				g_string_append_printf (sbuf, " [B%d]", ins->inst_true_bb->block_num);
-			else
-				g_string_append_printf (sbuf, " [T:B%d F:B%d]", ins->inst_true_bb->block_num,
-				                        ins->inst_false_bb->block_num);
-			break;
-		case OP_PHI:
-		case OP_VPHI:
-		case OP_XPHI:
-		case OP_FPHI: {
-			g_string_append_printf (sbuf, " [%d (", (int)ins->inst_c0);
-			for (j = 0; j < ins->inst_phi_args [0]; j++) {
-				if (j)
-					g_string_append_printf (sbuf, ", ");
-				g_string_append_printf (sbuf, "R%d", ins->inst_phi_args [j + 1]);
-			}
-			g_string_append_printf (sbuf, ")]");
-			break;
-		}
-		case OP_LDADDR:
-		case OP_OUTARG_VTRETADDR:
-			g_string_append_printf (sbuf, " R%d", ((MonoInst*)ins->inst_p0)->dreg);
-			break;
-		case OP_REGOFFSET:
-		case OP_GSHAREDVT_ARG_REGOFFSET:
-			g_string_append_printf (sbuf, " + 0x%lx", (long)ins->inst_offset);
-			break;
-		case OP_ISINST:
-		case OP_CASTCLASS:
-			g_string_append_printf (sbuf, " %s", m_class_get_name (ins->klass));
-			break;
-		default:
-			break;
-		}
-
-		//g_error ("Unknown opcode: %s\n", mono_inst_name (ins->opcode));
-		return sbuf;
+			spec_src3 = 'i';
+	} else {
+		spec_dest = spec [MONO_INST_DEST];
+		spec_src1 = spec [MONO_INST_SRC1];
 	}
 
-	if (spec [MONO_INST_DEST]) {
+	if (spec_dest) {
 		int bank = dreg_bank (spec);
 		if (is_soft_reg (ins->dreg, bank)) {
-			if (spec [MONO_INST_DEST] == 'b') {
+			if (spec_dest == 'b') {
 				if (ins->inst_offset == 0)
 					g_string_append_printf (sbuf, " [R%d] <-", ins->dreg);
 				else
@@ -526,7 +472,7 @@ mono_print_ins_index_strbuf (int i, MonoInst *ins)
 			}
 			else
 				g_string_append_printf (sbuf, " R%d <-", ins->dreg);
-		} else if (spec [MONO_INST_DEST] == 'b') {
+		} else if (spec_dest == 'b') {
 			if (ins->inst_offset == 0)
 				g_string_append_printf (sbuf, " [%s] <-", mono_arch_regname (ins->dreg));
 			else
@@ -534,25 +480,32 @@ mono_print_ins_index_strbuf (int i, MonoInst *ins)
 		} else
 			g_string_append_printf (sbuf, " %s <-", mono_regname_full (ins->dreg, bank));
 	}
-	if (spec [MONO_INST_SRC1]) {
+	if (spec_src1) {
 		int bank = sreg1_bank (spec);
 		if (is_soft_reg (ins->sreg1, bank)) {
-			if (spec [MONO_INST_SRC1] == 'b')
+			if (spec_src1 == 'b')
 				g_string_append_printf (sbuf, " [R%d + 0x%lx]", ins->sreg1, (long)ins->inst_offset);
 			else
 				g_string_append_printf (sbuf, " R%d", ins->sreg1);
-		} else if (spec [MONO_INST_SRC1] == 'b')
+		} else if (spec_src1 == 'b')
 			g_string_append_printf (sbuf, " [%s + 0x%lx]", mono_arch_regname (ins->sreg1), (long)ins->inst_offset);
 		else
 			g_string_append_printf (sbuf, " %s", mono_regname_full (ins->sreg1, bank));
 	}
-	num_sregs = mono_inst_get_src_registers (ins, sregs);
-	for (j = 1; j < num_sregs; ++j) {
-		int bank = sreg_bank (j, spec);
-		if (is_soft_reg (sregs [j], bank))
-			g_string_append_printf (sbuf, " R%d", sregs [j]);
-		else
-			g_string_append_printf (sbuf, " %s", mono_regname_full (sregs [j], bank));
+	if (spec != (gpointer)MONO_ARCH_CPU_SPEC) {
+		num_sregs = mono_inst_get_src_registers (ins, sregs);
+		for (j = 1; j < num_sregs; ++j) {
+			int bank = sreg_bank (j, spec);
+			if (is_soft_reg (sregs [j], bank))
+				g_string_append_printf (sbuf, " R%d", sregs [j]);
+			else
+				g_string_append_printf (sbuf, " %s", mono_regname_full (sregs [j], bank));
+		}
+	} else {
+		if (spec_src2)
+			g_string_append_printf (sbuf, " R%d", ins->sreg2);
+		if (spec_src3)
+			g_string_append_printf (sbuf, " R%d", ins->sreg3);
 	}
 
 	switch (ins->opcode) {
@@ -735,6 +688,43 @@ mono_print_ins_index_strbuf (int i, MonoInst *ins)
 	case OP_COND_EXC_INC:
 		g_string_append_printf (sbuf, " %s", (const char*)ins->inst_p1);
 		break;
+	case OP_PHI:
+	case OP_VPHI:
+	case OP_XPHI:
+	case OP_FPHI: {
+		g_string_append_printf (sbuf, " [%d (", (int)ins->inst_c0);
+		for (j = 0; j < ins->inst_phi_args [0]; j++) {
+			if (j)
+				g_string_append_printf (sbuf, ", ");
+			g_string_append_printf (sbuf, "R%d", ins->inst_phi_args [j + 1]);
+		}
+		g_string_append_printf (sbuf, ")]");
+		break;
+	}
+	case OP_LDADDR:
+	case OP_OUTARG_VTRETADDR:
+		g_string_append_printf (sbuf, " R%d", ((MonoInst*)ins->inst_p0)->dreg);
+		break;
+	case OP_REGOFFSET:
+	case OP_GSHAREDVT_ARG_REGOFFSET:
+		g_string_append_printf (sbuf, " + 0x%lx", (long)ins->inst_offset);
+		break;
+	case OP_ISINST:
+	case OP_CASTCLASS:
+		g_string_append_printf (sbuf, " %s", m_class_get_name (ins->klass));
+		break;
+	case OP_XZERO:
+	case OP_XMOVE:
+	case OP_XBINOP:
+	case OP_LOADX_MEMBASE:
+	case OP_STOREX_MEMBASE: {
+		if (ins->klass) {
+			char *s = mono_class_full_name (ins->klass);
+			g_string_append_printf (sbuf, " [%s]", s);
+			g_free (s);
+		}
+		break;
+	}
 	default:
 		break;
 	}


### PR DESCRIPTION
Print more information for instructions which are not in the cpu-<arch>.mdesc files.