### PR TITLE
Implement function pointer type support

### DIFF
--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -483,7 +483,7 @@ namespace Internal.Runtime
             get
             {
                 // String is currently the only non-array type with a non-zero component size.
-                return ComponentSize == StringComponentSize.Value && !IsArray && !IsGenericTypeDefinition;
+                return ComponentSize == StringComponentSize.Value && IsCanonical;
             }
         }
 
@@ -720,6 +720,14 @@ namespace Internal.Runtime
             }
         }
 
+        internal bool IsFunctionPointerType
+        {
+            get
+            {
+                return Kind == EETypeKind.FunctionPointerEEType;
+            }
+        }
+
         // The parameterized type shape defines the particular form of parameterized type that
         // is being represented.
         // Currently, the meaning is a shape of 0 indicates that this is a Pointer,
@@ -945,6 +953,9 @@ namespace Internal.Runtime
                         return null;
                 }
 
+                // Function pointers naturally set the base type field to null.
+                Debug.Assert(!IsFunctionPointerType || (!IsRelatedTypeViaIAT && _relatedType._pBaseType == null));
+
                 Debug.Assert(IsCanonical);
 
                 if (IsRelatedTypeViaIAT)
@@ -957,6 +968,7 @@ namespace Internal.Runtime
             {
                 Debug.Assert(IsDynamicType);
                 Debug.Assert(!IsParameterizedType);
+                Debug.Assert(!IsFunctionPointerType);
                 Debug.Assert(IsCanonical);
                 _uFlags &= (uint)~EETypeFlags.RelatedTypeViaIATFlag;
                 _relatedType._pBaseType = value;

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/MethodTable.Runtime.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/MethodTable.Runtime.cs
@@ -45,43 +45,6 @@ namespace Internal.Runtime
             return (IntPtr)InternalCalls.RhpGetClasslibFunctionFromEEType((MethodTable*)Unsafe.AsPointer(ref this), id);
         }
 
-        // Returns an address in the module most closely associated with this MethodTable that can be handed to
-        // EH.GetClasslibException and use to locate the compute the correct exception type. In most cases
-        // this is just the MethodTable pointer itself, but when this type represents a generic that has been
-        // unified at runtime (and thus the MethodTable pointer resides in the process heap rather than a specific
-        // module) we need to do some work.
-        internal unsafe MethodTable* GetAssociatedModuleAddress()
-        {
-            fixed (MethodTable* pThis = &this)
-            {
-                if (!IsDynamicType)
-                    return pThis;
-
-                // There are currently four types of runtime allocated EETypes, arrays, pointers, byrefs, and generic types.
-                // Arrays/Pointers/ByRefs can be handled by looking at their element type.
-                if (IsParameterizedType)
-                    return pThis->RelatedParameterType->GetAssociatedModuleAddress();
-
-                if (!IsGeneric)
-                {
-                    // No way to resolve module information for a non-generic dynamic type.
-                    return null;
-                }
-
-                // Generic types are trickier. Often we could look at the parent type (since eventually it
-                // would derive from the class library's System.Object which is definitely not runtime
-                // allocated). But this breaks down for generic interfaces. Instead we fetch the generic
-                // instantiation information and use the generic type definition, which will always be module
-                // local. We know this lookup will succeed since we're dealing with a unified generic type
-                // and the unification process requires this metadata.
-                MethodTable* pGenericType = pThis->GenericDefinition;
-
-                Debug.Assert(pGenericType != null, "Generic type expected");
-
-                return pGenericType;
-            }
-        }
-
         /// <summary>
         /// Return true if type is good for simple casting : canonical, no related type via IAT, no generic variance
         /// </summary>

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/RuntimeExports.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/RuntimeExports.cs
@@ -30,6 +30,8 @@ namespace System.Runtime
                 !pEEType->IsInterface &&
                 !pEEType->IsArray &&
                 !pEEType->IsString &&
+                !pEEType->IsPointerType &&
+                !pEEType->IsFunctionPointerType &&
                 !pEEType->IsByRefLike;
             if (!isValid)
                 Debug.Assert(false);
@@ -394,7 +396,7 @@ namespace System.Runtime
                         return (IntPtr)(delegate*<MethodTable*, object, object>)&TypeCast.IsInstanceOfArray;
                     else if (pEEType->IsInterface)
                         return (IntPtr)(delegate*<MethodTable*, object, object>)&TypeCast.IsInstanceOfInterface;
-                    else if (pEEType->IsParameterizedType)
+                    else if (pEEType->IsParameterizedType || pEEType->IsFunctionPointerType)
                         return (IntPtr)(delegate*<MethodTable*, object, object>)&TypeCast.IsInstanceOf; // Array handled above; pointers and byrefs handled here
                     else
                         return (IntPtr)(delegate*<MethodTable*, object, object>)&TypeCast.IsInstanceOfClass;
@@ -404,7 +406,7 @@ namespace System.Runtime
                         return (IntPtr)(delegate*<MethodTable*, object, object>)&TypeCast.CheckCastArray;
                     else if (pEEType->IsInterface)
                         return (IntPtr)(delegate*<MethodTable*, object, object>)&TypeCast.CheckCastInterface;
-                    else if (pEEType->IsParameterizedType)
+                    else if (pEEType->IsParameterizedType || pEEType->IsFunctionPointerType)
                         return (IntPtr)(delegate*<MethodTable*, object, object>)&TypeCast.CheckCast; // Array handled above; pointers and byrefs handled here
                     else
                         return (IntPtr)(delegate*<MethodTable*, object, object>)&TypeCast.CheckCastClass;

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
@@ -52,6 +52,7 @@ namespace System.Runtime
             MethodTable* pObjType = obj.GetMethodTable();
 
             Debug.Assert(!pTargetType->IsParameterizedType, "IsInstanceOfClass called with parameterized MethodTable");
+            Debug.Assert(!pTargetType->IsFunctionPointerType, "IsInstanceOfClass called with function pointer MethodTable");
             Debug.Assert(!pTargetType->IsInterface, "IsInstanceOfClass called with interface MethodTable");
 
             // Quick check if both types are good for simple casting: canonical, no related type via IAT, no generic variance
@@ -251,6 +252,7 @@ namespace System.Runtime
         internal static unsafe bool ImplementsInterface(MethodTable* pObjType, MethodTable* pTargetType, EETypePairList* pVisited)
         {
             Debug.Assert(!pTargetType->IsParameterizedType, "did not expect parameterized type");
+            Debug.Assert(!pTargetType->IsFunctionPointerType, "did not expect function pointer type");
             Debug.Assert(pTargetType->IsInterface, "IsInstanceOfInterface called with non-interface MethodTable");
 
             int numInterfaces = pObjType->NumInterfaces;
@@ -536,8 +538,9 @@ namespace System.Runtime
                 if (pSourceType->IsParameterizedType
                     && (pTargetType->ParameterizedTypeShape == pSourceType->ParameterizedTypeShape))
                 {
+                    MethodTable* pSourceRelatedParameterType = pSourceType->RelatedParameterType;
                     // Source type is also a parameterized type. Are the parameter types compatible?
-                    if (pSourceType->RelatedParameterType->IsPointerType)
+                    if (pSourceRelatedParameterType->IsPointerType)
                     {
                         // If the parameter types are pointers, then only exact matches are correct.
                         // As we've already called AreTypesEquivalent at the start of this function,
@@ -545,11 +548,18 @@ namespace System.Runtime
                         // int** is not compatible with uint**, nor is int*[] oompatible with uint*[].
                         return false;
                     }
-                    else if (pSourceType->RelatedParameterType->IsByRefType)
+                    else if (pSourceRelatedParameterType->IsByRefType)
                     {
                         // Only allow exact matches for ByRef types - same as pointers above. This should
                         // be unreachable and it's only a defense in depth. ByRefs can't be parameters
                         // of any parameterized type.
+                        return false;
+                    }
+                    else if (pSourceRelatedParameterType->IsFunctionPointerType)
+                    {
+                        // If the parameter types are function pointers, then only exact matches are correct.
+                        // As we've already called AreTypesEquivalent at the start of this function,
+                        // return false as the exact match case has already been handled.
                         return false;
                     }
                     else
@@ -565,12 +575,23 @@ namespace System.Runtime
                 // Can't cast a non-parameter type to a parameter type or a parameter type of different shape to a parameter type
                 return false;
             }
+
+            if (pTargetType->IsFunctionPointerType)
+            {
+                // Function pointers only cast if source and target are equivalent types.
+                return false;
+            }
+
             if (pSourceType->IsArray)
             {
                 // Target type is not an array. But we can still cast arrays to Object or System.Array.
                 return WellKnownEETypes.IsSystemObject(pTargetType) || WellKnownEETypes.IsSystemArray(pTargetType);
             }
             else if (pSourceType->IsParameterizedType)
+            {
+                return false;
+            }
+            else if (pSourceType->IsFunctionPointerType)
             {
                 return false;
             }
@@ -829,9 +850,11 @@ namespace System.Runtime
         {
             Debug.Assert(!pDerivedType->IsArray, "did not expect array type");
             Debug.Assert(!pDerivedType->IsParameterizedType, "did not expect parameterType");
+            Debug.Assert(!pDerivedType->IsFunctionPointerType, "did not expect function pointer");
             Debug.Assert(!pBaseType->IsArray, "did not expect array type");
             Debug.Assert(!pBaseType->IsInterface, "did not expect interface type");
             Debug.Assert(!pBaseType->IsParameterizedType, "did not expect parameterType");
+            Debug.Assert(!pBaseType->IsFunctionPointerType, "did not expect function pointer");
             Debug.Assert(pBaseType->IsCanonical || pBaseType->IsGenericTypeDefinition, "unexpected MethodTable");
             Debug.Assert(pDerivedType->IsCanonical || pDerivedType->IsGenericTypeDefinition, "unexpected MethodTable");
 
@@ -879,7 +902,7 @@ namespace System.Runtime
                 return IsInstanceOfArray(pTargetType, obj);
             else if (pTargetType->IsInterface)
                 return IsInstanceOfInterface(pTargetType, obj);
-            else if (pTargetType->IsParameterizedType)
+            else if (pTargetType->IsParameterizedType || pTargetType->IsFunctionPointerType)
                 return null; // We handled arrays above so this is for pointers and byrefs only.
             else
                 return IsInstanceOfClass(pTargetType, obj);
@@ -921,13 +944,13 @@ namespace System.Runtime
                 return CheckCastArray(pTargetType, obj);
             else if (pTargetType->IsInterface)
                 return CheckCastInterface(pTargetType, obj);
-            else if (pTargetType->IsParameterizedType)
-                return CheckCastNonArrayParameterizedType(pTargetType, obj);
+            else if (pTargetType->IsParameterizedType || pTargetType->IsFunctionPointerType)
+                return CheckCastUnboxableType(pTargetType, obj);
             else
                 return CheckCastClass(pTargetType, obj);
         }
 
-        private static unsafe object CheckCastNonArrayParameterizedType(MethodTable* pTargetType, object obj)
+        private static unsafe object CheckCastUnboxableType(MethodTable* pTargetType, object obj)
         {
             // a null value can be cast to anything
             if (obj == null)

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
@@ -945,12 +945,12 @@ namespace System.Runtime
             else if (pTargetType->IsInterface)
                 return CheckCastInterface(pTargetType, obj);
             else if (pTargetType->IsParameterizedType || pTargetType->IsFunctionPointerType)
-                return CheckCastUnboxableType(pTargetType, obj);
+                return CheckCastNonboxableType(pTargetType, obj);
             else
                 return CheckCastClass(pTargetType, obj);
         }
 
-        private static unsafe object CheckCastUnboxableType(MethodTable* pTargetType, object obj)
+        private static unsafe object CheckCastNonboxableType(MethodTable* pTargetType, object obj)
         {
             // a null value can be cast to anything
             if (obj == null)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/CompatibilitySuppressions.xml
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/CompatibilitySuppressions.xml
@@ -574,6 +574,10 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Internal.Metadata.NativeFormat.SignatureCallingConvention</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Internal.Metadata.NativeFormat.SingleCollection</Target>
   </Suppression>
   <Suppression>

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
@@ -152,6 +152,23 @@ namespace Internal.Reflection.Core.Execution
             return targetTypeHandle.GetTypeForRuntimeTypeHandle().GetPointerType(typeHandle);
         }
 
+        public Type GetFunctionPointerTypeForHandle(RuntimeTypeHandle typeHandle)
+        {
+            ExecutionEnvironment.GetFunctionPointerTypeComponents(typeHandle, out RuntimeTypeHandle returnTypeHandle,
+                                                                              out RuntimeTypeHandle[] parameterHandles,
+                                                                              out bool isUnmanaged);
+
+            RuntimeTypeInfo returnType = returnTypeHandle.GetTypeForRuntimeTypeHandle();
+            int count = parameterHandles.Length;
+            RuntimeTypeInfo[] parameterTypes = new RuntimeTypeInfo[count];
+            for (int i = 0; i < count; i++)
+            {
+                parameterTypes[i] = parameterHandles[i].GetTypeForRuntimeTypeHandle();
+            }
+
+            return RuntimeFunctionPointerTypeInfo.GetFunctionPointerTypeInfo(returnType, parameterTypes, isUnmanaged, typeHandle);
+        }
+
         public Type GetByRefTypeForHandle(RuntimeTypeHandle typeHandle)
         {
             RuntimeTypeHandle targetTypeHandle;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
@@ -64,6 +64,9 @@ namespace Internal.Reflection.Core.Execution
 
         public abstract bool TryGetMultiDimArrayTypeForElementType(RuntimeTypeHandle elementTypeHandle, int rank, out RuntimeTypeHandle arrayTypeHandle);
 
+        public abstract bool TryGetFunctionPointerTypeForComponents(RuntimeTypeHandle returnTypeHandle, RuntimeTypeHandle[] parameterHandles, bool isUnmanaged, out RuntimeTypeHandle functionPointerTypeHandle);
+        public abstract void GetFunctionPointerTypeComponents(RuntimeTypeHandle functionPointerHandle, out RuntimeTypeHandle returnTypeHandle, out RuntimeTypeHandle[] parameterHandles, out bool isUnmanaged);
+
         public abstract bool TryGetPointerTypeForTargetType(RuntimeTypeHandle targetTypeHandle, out RuntimeTypeHandle pointerTypeHandle);
         public abstract bool TryGetPointerTypeTargetType(RuntimeTypeHandle pointerTypeHandle, out RuntimeTypeHandle targetTypeHandle);
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/NonPortable/RuntimeTypeUnifier.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/NonPortable/RuntimeTypeUnifier.cs
@@ -106,6 +106,10 @@ namespace Internal.Reflection.Core.NonPortable
             {
                 return callbacks.GetPointerTypeForHandle(runtimeTypeHandle);
             }
+            else if (eeType.IsFunctionPointer)
+            {
+                return callbacks.GetFunctionPointerTypeForHandle(runtimeTypeHandle);
+            }
             else if (eeType.IsByRef)
             {
                 return callbacks.GetByRefTypeForHandle(runtimeTypeHandle);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/ReflectionExecutionDomainCallbacks.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/ReflectionExecutionDomainCallbacks.cs
@@ -37,6 +37,7 @@ namespace Internal.Runtime.Augments
         public abstract Type GetArrayTypeForHandle(RuntimeTypeHandle typeHandle);
         public abstract Type GetMdArrayTypeForHandle(RuntimeTypeHandle typeHandle, int rank);
         public abstract Type GetPointerTypeForHandle(RuntimeTypeHandle typeHandle);
+        public abstract Type GetFunctionPointerTypeForHandle(RuntimeTypeHandle typeHandle);
         public abstract Type GetByRefTypeForHandle(RuntimeTypeHandle typeHandle);
         public abstract Type GetConstructedGenericTypeForHandle(RuntimeTypeHandle typeHandle);
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -473,7 +473,7 @@ namespace Internal.Runtime.Augments
         public static bool TryGetBaseType(RuntimeTypeHandle typeHandle, out RuntimeTypeHandle baseTypeHandle)
         {
             EETypePtr eeType = typeHandle.ToEETypePtr();
-            if (eeType.IsGenericTypeDefinition || eeType.IsPointer || eeType.IsByRef)
+            if (eeType.IsGenericTypeDefinition || eeType.IsPointer || eeType.IsByRef || eeType.IsFunctionPointer)
             {
                 baseTypeHandle = default(RuntimeTypeHandle);
                 return false;
@@ -490,7 +490,7 @@ namespace Internal.Runtime.Augments
         public static IEnumerable<RuntimeTypeHandle> TryGetImplementedInterfaces(RuntimeTypeHandle typeHandle)
         {
             EETypePtr eeType = typeHandle.ToEETypePtr();
-            if (eeType.IsGenericTypeDefinition || eeType.IsPointer || eeType.IsByRef)
+            if (eeType.IsGenericTypeDefinition || eeType.IsPointer || eeType.IsByRef || eeType.IsFunctionPointer)
                 return null;
 
             LowLevelList<RuntimeTypeHandle> implementedInterfaces = new LowLevelList<RuntimeTypeHandle>();
@@ -637,6 +637,11 @@ namespace Internal.Runtime.Augments
             return typeHandle.ToEETypePtr().IsPointer;
         }
 
+        public static bool IsFunctionPointerType(RuntimeTypeHandle typeHandle)
+        {
+            return typeHandle.ToEETypePtr().IsFunctionPointer;
+        }
+
         public static bool IsByRefType(RuntimeTypeHandle typeHandle)
         {
             return typeHandle.ToEETypePtr().IsByRef;
@@ -658,6 +663,8 @@ namespace Internal.Runtime.Augments
             if (srcEEType.IsGenericTypeDefinition || dstEEType.IsGenericTypeDefinition)
                 return false;
             if (srcEEType.IsPointer || dstEEType.IsPointer)
+                return false;
+            if (srcEEType.IsFunctionPointer || dstEEType.IsFunctionPointer)
                 return false;
             if (srcEEType.IsByRef || dstEEType.IsByRef)
                 return false;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -154,6 +154,8 @@
     <Compile Include="System\Reflection\Metadata\AssemblyExtensions.cs" />
     <Compile Include="System\Reflection\Metadata\MetadataUpdater.cs" />
     <Compile Include="System\Reflection\ModifiedType.NativeAot.cs" />
+    <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimeFunctionPointerTypeInfo.cs" />
+    <Compile Include="System\Reflection\Runtime\TypeInfos\RuntimeFunctionPointerTypeInfo.UnificationKey.cs" />
     <Compile Include="System\Runtime\InteropServices\CriticalHandle.NativeAot.cs" />
     <Compile Include="System\Activator.NativeAot.cs" />
     <Compile Include="System\AppContext.NativeAot.cs" />

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Array.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Array.NativeAot.cs
@@ -175,9 +175,9 @@ namespace System
             EETypePtr sourceElementEEType = sourceArray.ElementEEType;
             EETypePtr destinationElementEEType = destinationArray.ElementEEType;
 
-            if (!destinationElementEEType.IsValueType && !destinationElementEEType.IsPointer)
+            if (!destinationElementEEType.IsValueType && !destinationElementEEType.IsPointer && !destinationElementEEType.IsFunctionPointer)
             {
-                if (!sourceElementEEType.IsValueType && !sourceElementEEType.IsPointer)
+                if (!sourceElementEEType.IsValueType && !sourceElementEEType.IsPointer && !sourceElementEEType.IsFunctionPointer)
                 {
                     CopyImplGcRefArray(sourceArray, sourceIndex, destinationArray, destinationIndex, length, reliable);
                 }
@@ -203,7 +203,7 @@ namespace System
                         CopyImplValueTypeArrayNoInnerGcRefs(sourceArray, sourceIndex, destinationArray, destinationIndex, length);
                     }
                 }
-                else if (sourceElementEEType.IsPointer && destinationElementEEType.IsPointer)
+                else if ((sourceElementEEType.IsPointer || sourceElementEEType.IsFunctionPointer) && (destinationElementEEType.IsPointer || destinationElementEEType.IsFunctionPointer))
                 {
                     // CLR compat note: CLR only allows Array.Copy between pointee types that would be assignable
                     // to using array covariance rules (so int*[] can be copied to uint*[], but not to float*[]).
@@ -238,7 +238,7 @@ namespace System
 
         private static bool IsSourceElementABaseClassOrInterfaceOfDestinationValueType(EETypePtr sourceElementEEType, EETypePtr destinationElementEEType)
         {
-            if (sourceElementEEType.IsValueType || sourceElementEEType.IsPointer)
+            if (sourceElementEEType.IsValueType || sourceElementEEType.IsPointer || sourceElementEEType.IsFunctionPointer)
                 return false;
 
             // It may look like we're passing the arguments to AreTypesAssignable in the wrong order but we're not. The source array is an interface or Object array, the destination
@@ -259,8 +259,8 @@ namespace System
             EETypePtr sourceElementEEType = sourceArray.ElementEEType;
             EETypePtr destinationElementEEType = destinationArray.ElementEEType;
 
-            Debug.Assert(!sourceElementEEType.IsValueType && !sourceElementEEType.IsPointer);
-            Debug.Assert(!destinationElementEEType.IsValueType && !destinationElementEEType.IsPointer);
+            Debug.Assert(!sourceElementEEType.IsValueType && !sourceElementEEType.IsPointer && !sourceElementEEType.IsFunctionPointer);
+            Debug.Assert(!destinationElementEEType.IsValueType && !destinationElementEEType.IsPointer && !destinationElementEEType.IsFunctionPointer);
 
             bool attemptCopy = RuntimeImports.AreTypesAssignable(sourceElementEEType, destinationElementEEType);
             bool mustCastCheckEachElement = !attemptCopy;
@@ -315,8 +315,8 @@ namespace System
         //
         private static unsafe void CopyImplValueTypeArrayToReferenceArray(Array sourceArray, int sourceIndex, Array destinationArray, int destinationIndex, int length, bool reliable)
         {
-            Debug.Assert(sourceArray.ElementEEType.IsValueType || sourceArray.ElementEEType.IsPointer);
-            Debug.Assert(!destinationArray.ElementEEType.IsValueType && !destinationArray.ElementEEType.IsPointer);
+            Debug.Assert(sourceArray.ElementEEType.IsValueType);
+            Debug.Assert(!destinationArray.ElementEEType.IsValueType && !destinationArray.ElementEEType.IsPointer && !destinationArray.ElementEEType.IsFunctionPointer);
 
             // Caller has already validated this.
             Debug.Assert(RuntimeImports.AreTypesAssignable(sourceArray.ElementEEType, destinationArray.ElementEEType));
@@ -345,8 +345,8 @@ namespace System
         //
         private static unsafe void CopyImplReferenceArrayToValueTypeArray(Array sourceArray, int sourceIndex, Array destinationArray, int destinationIndex, int length, bool reliable)
         {
-            Debug.Assert(!sourceArray.ElementEEType.IsValueType && !sourceArray.ElementEEType.IsPointer);
-            Debug.Assert(destinationArray.ElementEEType.IsValueType || destinationArray.ElementEEType.IsPointer);
+            Debug.Assert(!sourceArray.ElementEEType.IsValueType && !sourceArray.ElementEEType.IsPointer && !sourceArray.ElementEEType.IsFunctionPointer);
+            Debug.Assert(destinationArray.ElementEEType.IsValueType);
 
             if (reliable)
                 throw new ArrayTypeMismatchException(SR.ArrayTypeMismatch_CantAssignType);
@@ -455,9 +455,9 @@ namespace System
         private static unsafe void CopyImplValueTypeArrayNoInnerGcRefs(Array sourceArray, int sourceIndex, Array destinationArray, int destinationIndex, int length)
         {
             Debug.Assert((sourceArray.ElementEEType.IsValueType && !sourceArray.ElementEEType.ContainsGCPointers) ||
-                sourceArray.ElementEEType.IsPointer);
+                sourceArray.ElementEEType.IsPointer || sourceArray.ElementEEType.IsFunctionPointer);
             Debug.Assert((destinationArray.ElementEEType.IsValueType && !destinationArray.ElementEEType.ContainsGCPointers) ||
-                destinationArray.ElementEEType.IsPointer);
+                destinationArray.ElementEEType.IsPointer || destinationArray.ElementEEType.IsFunctionPointer);
 
             // Copy scenario: ValueType-array to value-type array with no embedded gc-refs.
             nuint elementSize = sourceArray.ElementSize;
@@ -952,7 +952,7 @@ namespace System
         {
             Debug.Assert((nuint)flattenedIndex < NativeLength);
 
-            if (ElementEEType.IsPointer)
+            if (ElementEEType.IsPointer || ElementEEType.IsFunctionPointer)
                 throw new NotSupportedException(SR.NotSupported_Type);
 
             ref byte element = ref Unsafe.AddByteOffset(ref MemoryMarshal.GetArrayDataReference(this), (nuint)flattenedIndex * ElementSize);
@@ -964,7 +964,7 @@ namespace System
             }
             else
             {
-                Debug.Assert(!pElementEEType.IsPointer);
+                Debug.Assert(!pElementEEType.IsPointer && !pElementEEType.IsFunctionPointer);
                 return Unsafe.As<byte, object>(ref element);
             }
         }
@@ -972,9 +972,6 @@ namespace System
         private unsafe void InternalSetValue(object? value, nint flattenedIndex)
         {
             Debug.Assert((nuint)flattenedIndex < NativeLength);
-
-            if (ElementEEType.IsPointer)
-                throw new NotSupportedException(SR.NotSupported_Type);
 
             ref byte element = ref Unsafe.AddByteOffset(ref MemoryMarshal.GetArrayDataReference(this), (nuint)flattenedIndex * ElementSize);
 
@@ -990,7 +987,7 @@ namespace System
 
                 RuntimeImports.RhUnbox(value, ref element, pElementEEType);
             }
-            else if (pElementEEType.IsPointer)
+            else if (pElementEEType.IsPointer || pElementEEType.IsFunctionPointer)
             {
                 throw new NotSupportedException(SR.NotSupported_Type);
             }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Attribute.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Attribute.NativeAot.cs
@@ -40,6 +40,8 @@ namespace System
             {
                 int fieldOffset = __GetFieldHelper(i, out MethodTable* fieldType);
 
+                Debug.Assert(!fieldType->IsPointerType && !fieldType->IsFunctionPointerType);
+
                 // Fetch the value of the field on both types
                 object thisResult = RuntimeImports.RhBoxAny(ref Unsafe.Add(ref thisRawData, fieldOffset), fieldType);
                 object thatResult = RuntimeImports.RhBoxAny(ref Unsafe.Add(ref thatRawData, fieldOffset), fieldType);
@@ -64,6 +66,9 @@ namespace System
             for (int i = 0; i < numFields; i++)
             {
                 int fieldOffset = __GetFieldHelper(i, out MethodTable* fieldType);
+
+                Debug.Assert(!fieldType->IsPointerType && !fieldType->IsFunctionPointerType);
+
                 object? fieldValue = RuntimeImports.RhBoxAny(ref Unsafe.Add(ref thisRawData, fieldOffset), fieldType);
 
                 // The hashcode of an array ignores the contents of the array, so it can produce

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/EETypePtr.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/EETypePtr.cs
@@ -120,6 +120,14 @@ namespace System
             }
         }
 
+        internal bool IsFunctionPointer
+        {
+            get
+            {
+                return _value->IsFunctionPointerType;
+            }
+        }
+
         internal bool IsByRef
         {
             get
@@ -211,7 +219,7 @@ namespace System
         {
             get
             {
-                return !_value->IsParameterizedType;
+                return !_value->IsParameterizedType && !_value->IsFunctionPointerType;
             }
         }
 
@@ -302,7 +310,7 @@ namespace System
                 if (IsArray)
                     return EETypePtr.EETypePtrOf<Array>();
 
-                if (IsPointer || IsByRef)
+                if (IsPointer || IsByRef || IsFunctionPointer)
                     return new EETypePtr(default(IntPtr));
 
                 EETypePtr baseEEType = new EETypePtr(_value->NonArrayBaseType);
@@ -369,15 +377,15 @@ namespace System
                     (byte)CorElementType.ELEMENT_TYPE_SZARRAY,   // EETypeElementType.SzArray
                     (byte)CorElementType.ELEMENT_TYPE_BYREF,     // EETypeElementType.ByRef
                     (byte)CorElementType.ELEMENT_TYPE_PTR,       // EETypeElementType.Pointer
+                    (byte)CorElementType.ELEMENT_TYPE_FNPTR,     // EETypeElementType.FunctionPointer
                     default, // Pad the map to 32 elements to enable range check elimination
-                    default,
                     default,
                     default,
                     default
                 };
 
                 // Verify last element of the map
-                Debug.Assert((byte)CorElementType.ELEMENT_TYPE_PTR == map[(int)EETypeElementType.Pointer]);
+                Debug.Assert((byte)CorElementType.ELEMENT_TYPE_FNPTR == map[(int)EETypeElementType.FunctionPointer]);
 
                 return (CorElementType)map[(int)ElementType];
             }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
@@ -106,7 +106,7 @@ namespace System
                 return CreateChangeTypeException(srcEEType, dstEEType, semantics);
             }
 
-            if (dstEEType.IsPointer)
+            if (dstEEType.IsPointer || dstEEType.IsFunctionPointer)
             {
                 Exception exception = ConvertPointerIfPossible(srcObject, dstEEType, semantics, out object dstPtr);
                 if (exception != null)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/DynamicInvokeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/DynamicInvokeInfo.cs
@@ -36,7 +36,8 @@ namespace System.Reflection
             Nullable = 0x0002,
             Pointer = 0x0004,
             Reference = 0x0008,
-            AllocateReturnBox = 0x0010,
+            FunctionPointer = 0x0010,
+            AllocateReturnBox = 0x0020,
         }
 
         private readonly struct ArgumentInfo
@@ -98,6 +99,12 @@ namespace System.Reflection
 
                         transform |= Transform.Pointer;
                     }
+                    else if (eeArgumentType.IsFunctionPointer)
+                    {
+                        Debug.Assert(argumentType.IsFunctionPointer);
+
+                        transform |= Transform.FunctionPointer;
+                    }
                     else
                     {
                         transform |= Transform.Reference;
@@ -148,6 +155,14 @@ namespace System.Reflection
                     Debug.Assert(returnType.IsPointer);
 
                     transform |= Transform.Pointer;
+                    if ((transform & Transform.ByRef) == 0)
+                        transform |= Transform.AllocateReturnBox;
+                }
+                else if (eeReturnType.IsFunctionPointer)
+                {
+                    Debug.Assert(returnType.IsFunctionPointer);
+
+                    transform |= Transform.FunctionPointer;
                     if ((transform & Transform.ByRef) == 0)
                         transform |= Transform.AllocateReturnBox;
                 }
@@ -208,7 +223,7 @@ namespace System.Reflection
             if ((_returnTransform & Transform.AllocateReturnBox) != 0)
             {
                 returnObject = RuntimeImports.RhNewObject(
-                    (_returnTransform & Transform.Pointer) != 0 ?
+                    (_returnTransform & (Transform.Pointer | Transform.FunctionPointer)) != 0 ?
                         EETypePtr.EETypePtrOf<IntPtr>() : _returnType);
                 ret = ref returnObject.GetRawData();
             }
@@ -257,7 +272,7 @@ namespace System.Reflection
                 }
             }
 
-            return ((_returnTransform & (Transform.Nullable | Transform.Pointer | Transform.ByRef)) != 0) ?
+            return ((_returnTransform & (Transform.Nullable | Transform.Pointer | Transform.FunctionPointer | Transform.ByRef)) != 0) ?
                 ReturnTransform(ref ret, wrapInTargetInvocationException) : returnObject;
         }
 
@@ -348,7 +363,7 @@ namespace System.Reflection
                     // null is substituded by zero-initialized value for non-reference type
                     if ((argumentInfo.Transform & Transform.Reference) == 0)
                         arg = RuntimeImports.RhNewObject(
-                            (argumentInfo.Transform & Transform.Pointer) != 0 ?
+                            (argumentInfo.Transform & (Transform.Pointer | Transform.FunctionPointer)) != 0 ?
                                 EETypePtr.EETypePtrOf<IntPtr>() : argumentInfo.Type);
                 }
                 else
@@ -426,13 +441,17 @@ namespace System.Reflection
 
                 object obj = Unsafe.Add(ref copyOfParameters, i);
 
-                if ((transform & (Transform.Pointer | Transform.Nullable)) != 0)
+                if ((transform & (Transform.Pointer | Transform.FunctionPointer | Transform.Nullable)) != 0)
                 {
                     if ((transform & Transform.Pointer) != 0)
                     {
                         Type type = Type.GetTypeFromEETypePtr(argumentInfo.Type);
                         Debug.Assert(type.IsPointer);
                         obj = Pointer.Box((void*)Unsafe.As<byte, IntPtr>(ref obj.GetRawData()), type);
+                    }
+                    if ((transform & Transform.FunctionPointer) != 0)
+                    {
+                        obj = RuntimeImports.RhBox(EETypePtr.EETypePtrOf<IntPtr>(), ref obj.GetRawData());
                     }
                     else
                     {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/NativeFormat/NativeFormatMethodCommon.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/NativeFormat/NativeFormatMethodCommon.cs
@@ -132,7 +132,9 @@ namespace System.Reflection.Runtime.MethodInfos.NativeFormat
         {
             get
             {
-                return MethodSignature.CallingConvention;
+                var sigCallingConvention = MethodSignature.CallingConvention;
+                return (sigCallingConvention & Internal.Metadata.NativeFormat.SignatureCallingConvention.HasThis) != 0
+                    ? CallingConventions.HasThis : 0;
             }
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeFunctionPointerTypeInfo.UnificationKey.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeFunctionPointerTypeInfo.UnificationKey.cs
@@ -1,0 +1,79 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+
+namespace System.Reflection.Runtime.TypeInfos
+{
+    internal sealed partial class RuntimeFunctionPointerTypeInfo : RuntimeTypeInfo, IKeyedItem<RuntimeFunctionPointerTypeInfo.UnificationKey>
+    {
+        //
+        // Key for unification.
+        //
+        internal struct UnificationKey : IEquatable<UnificationKey>
+        {
+            //
+            // Q: Why is the type handle part of the unification key when it doesn't participate in the Equals/HashCode computations?
+            // A: It's a passenger.
+            //
+            //    The typeHandle argument is "redundant" in that it can be computed from the rest of the key. However, we have callers (Type.GetTypeFromHandle()) that
+            //    already have the typeHandle so to avoid an unnecessary round-trip computation, we require the caller to pass it in separately.
+            //    We allow it to ride along in the key object because the ConcurrentUnifier classes we use don't support passing "extra" parameters to
+            //    their Factory methods.
+            //
+            public UnificationKey(RuntimeTypeInfo returnType, RuntimeTypeInfo[] parameterTypes, bool isUnmanaged, RuntimeTypeHandle typeHandle)
+            {
+                ReturnType = returnType;
+                ParameterTypes = parameterTypes;
+                IsUnmanaged = isUnmanaged;
+                TypeHandle = typeHandle;
+            }
+
+            public RuntimeTypeInfo ReturnType { get; }
+            public RuntimeTypeInfo[] ParameterTypes { get; }
+            public bool IsUnmanaged { get; }
+            public RuntimeTypeHandle TypeHandle { get; }
+
+            public override bool Equals(object obj)
+            {
+                if (!(obj is UnificationKey other))
+                    return false;
+                return Equals(other);
+            }
+
+            public bool Equals(UnificationKey other)
+            {
+                if (IsUnmanaged != other.IsUnmanaged)
+                    return false;
+                if (!ReturnType.Equals(other.ReturnType))
+                    return false;
+                if (ParameterTypes.Length != other.ParameterTypes.Length)
+                    return false;
+                for (int i = 0; i < ParameterTypes.Length; i++)
+                {
+                    if (!(ParameterTypes[i].Equals(other.ParameterTypes[i])))
+                        return false;
+                }
+
+                // The TypeHandle is not actually part of the key but riding along for convenience (see comment at head of class.)
+                // If the other parts of the key matched, this must too.
+                Debug.Assert(TypeHandle.Equals(other.TypeHandle));
+                return true;
+            }
+
+            public override int GetHashCode()
+            {
+                int hashCode = ReturnType.GetHashCode();
+                for (int i = 0; i < ParameterTypes.Length; i++)
+                {
+                    hashCode ^= ParameterTypes[i].GetHashCode();
+                }
+                return hashCode;
+            }
+        }
+    }
+}

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeFunctionPointerTypeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeFunctionPointerTypeInfo.cs
@@ -1,0 +1,143 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Reflection.Runtime.General;
+using System.Text;
+
+using StructLayoutAttribute = System.Runtime.InteropServices.StructLayoutAttribute;
+
+namespace System.Reflection.Runtime.TypeInfos
+{
+    //
+    // The runtime's implementation of TypeInfo for function pointer types.
+    //
+    internal sealed partial class RuntimeFunctionPointerTypeInfo : RuntimeTypeInfo, IRuntimeMemberInfoWithNoMetadataDefinition
+    {
+        private RuntimeFunctionPointerTypeInfo(UnificationKey key)
+        {
+            _key = key;
+        }
+
+        public override bool IsTypeDefinition => false;
+        public override bool IsGenericTypeDefinition => false;
+        protected override bool HasElementTypeImpl() => false;
+        protected override bool IsArrayImpl() => false;
+        public override bool IsSZArray => false;
+        public override bool IsVariableBoundArray => false;
+        protected override bool IsByRefImpl() => false;
+        protected override bool IsPointerImpl() => false;
+        public override bool IsConstructedGenericType => false;
+        public override bool IsGenericParameter => false;
+        public override bool IsGenericTypeParameter => false;
+        public override bool IsGenericMethodParameter => false;
+        public override bool IsByRefLike => false;
+
+        //
+        // Implements IKeyedItem.PrepareKey.
+        //
+        // This method is the keyed item's chance to do any lazy evaluation needed to produce the key quickly.
+        // Concurrent unifiers are guaranteed to invoke this method at least once and wait for it
+        // to complete before invoking the Key property. The unifier lock is NOT held across the call.
+        //
+        // PrepareKey() must be idempodent and thread-safe. It may be invoked multiple times and concurrently.
+        //
+        public void PrepareKey()
+        {
+        }
+
+        //
+        // Implements IKeyedItem.Key.
+        //
+        // Produce the key. This is a high-traffic property and is called while the hash table's lock is held. Thus, it should
+        // return a precomputed stored value and refrain from invoking other methods. If the keyed item wishes to
+        // do lazy evaluation of the key, it should do so in the PrepareKey() method.
+        //
+        public UnificationKey Key
+        {
+            get
+            {
+                return _key;
+            }
+        }
+
+        public override Assembly Assembly => typeof(object).Assembly;
+        public override IEnumerable<CustomAttributeData> CustomAttributes => Array.Empty<CustomAttributeData>();
+        public override Type[] GetFunctionPointerCallingConventions() => Type.EmptyTypes;
+
+        public override bool ContainsGenericParameters
+        {
+            get
+            {
+                if (_key.ReturnType.ContainsGenericParameters)
+                    return true;
+
+                foreach (var p in _key.ParameterTypes)
+                    if (p.ContainsGenericParameters)
+                        return true;
+
+                return false;
+            }
+        }
+        public override string FullName => null!;
+        public override bool HasSameMetadataDefinitionAs(MemberInfo other)
+        {
+            ArgumentNullException.ThrowIfNull(other);
+
+            // This logic is written to match CoreCLR's behavior.
+            return other is Type && other is IRuntimeMemberInfoWithNoMetadataDefinition;
+        }
+
+        public override bool IsFunctionPointer => true;
+        public override bool IsUnmanagedFunctionPointer => _key.IsUnmanaged;
+
+        public override Type[] GetFunctionPointerParameterTypes()
+        {
+
+            if (_key.ParameterTypes.Length == 0)
+                return EmptyTypes;
+
+            Type[] result = new Type[_key.ParameterTypes.Length];
+            Array.Copy(_key.ParameterTypes, result, result.Length);
+            return result;
+        }
+
+        public override Type GetFunctionPointerReturnType() => _key.ReturnType;
+
+        public override string Namespace => null!;
+
+        public override StructLayoutAttribute StructLayoutAttribute => null;
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append(_key.ReturnType.ToString());
+            sb.Append('(');
+            RuntimeTypeInfo[] parameters = _key.ParameterTypes;
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                if (i != 0)
+                    sb.Append(", ");
+                sb.Append(parameters[i].ToString());
+            }
+            sb.Append(')');
+            return sb.ToString();
+        }
+
+        public override int MetadataToken
+        {
+            get
+            {
+                return 0x02000000; // nil TypeDef token
+            }
+        }
+
+        protected override TypeAttributes GetAttributeFlagsImpl() => TypeAttributes.Public;
+        protected override int InternalGetHashCode() =>_key.GetHashCode();
+        internal override Type InternalDeclaringType => null;
+        public override string Name => string.Empty;
+        internal override string InternalFullNameOfAssembly => string.Empty;
+        internal override RuntimeTypeHandle InternalTypeHandleIfAvailable => _key.TypeHandle;
+
+        private readonly UnificationKey _key;
+    }
+}

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -238,6 +238,30 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
+        //
+        // Left unsealed so that RuntimeFunctionPointerInfo can override.
+        //
+        public override Type[] GetFunctionPointerCallingConventions()
+        {
+            throw new InvalidOperationException(SR.InvalidOperation_NotFunctionPointer);
+        }
+
+        //
+        // Left unsealed so that RuntimeFunctionPointerInfo can override.
+        //
+        public override Type[] GetFunctionPointerParameterTypes()
+        {
+            throw new InvalidOperationException(SR.InvalidOperation_NotFunctionPointer);
+        }
+
+        //
+        // Left unsealed so that RuntimeFunctionPointerInfo can override.
+        //
+        public override Type GetFunctionPointerReturnType()
+        {
+            throw new InvalidOperationException(SR.InvalidOperation_NotFunctionPointer);
+        }
+
         public abstract override bool HasSameMetadataDefinitionAs(MemberInfo other);
 
         public sealed override IEnumerable<Type> ImplementedInterfaces

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/TypedReference.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/TypedReference.cs
@@ -58,7 +58,7 @@ namespace System
             {
                 return RuntimeImports.RhBox(eeType, ref value.Value);
             }
-            else if (eeType.IsPointer)
+            else if (eeType.IsPointer || eeType.IsFunctionPointer)
             {
                 return RuntimeImports.RhBox(EETypePtr.EETypePtrOf<UIntPtr>(), ref value.Value);
             }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ValueType.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ValueType.cs
@@ -138,7 +138,7 @@ namespace System
                 int fieldOffset = __GetFieldHelper(i, out MethodTable* fieldType);
                 ref byte fieldData = ref Unsafe.Add(ref data, fieldOffset);
 
-                Debug.Assert(!fieldType->IsPointerType);
+                Debug.Assert(!fieldType->IsPointerType && !fieldType->IsFunctionPointerType);
 
                 if (fieldType->ElementType == EETypeElementType.Single)
                 {

--- a/src/coreclr/nativeaot/System.Private.DisabledReflection/src/Internal/Reflection/ReflectionExecutionDomainCallbacksImplementation.cs
+++ b/src/coreclr/nativeaot/System.Private.DisabledReflection/src/Internal/Reflection/ReflectionExecutionDomainCallbacksImplementation.cs
@@ -22,6 +22,7 @@ namespace Internal.Reflection
         public override MethodBase GetMethodBaseFromStartAddressIfAvailable(IntPtr methodStartAddress) => null;
         public override Type GetNamedTypeForHandle(RuntimeTypeHandle typeHandle, bool isGenericTypeDefinition) => RuntimeTypeInfo.GetRuntimeTypeInfo(typeHandle);
         public override Type GetPointerTypeForHandle(RuntimeTypeHandle typeHandle) => RuntimeTypeInfo.GetRuntimeTypeInfo(typeHandle);
+        public override Type GetFunctionPointerTypeForHandle(RuntimeTypeHandle typeHandle) => RuntimeTypeInfo.GetRuntimeTypeInfo(typeHandle);
         public override RuntimeTypeHandle GetTypeHandleIfAvailable(Type type) => type.TypeHandle;
         public override bool IsReflectionBlocked(RuntimeTypeHandle typeHandle) => false;
         public override bool SupportsReflection(Type type) => false;

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -293,6 +293,22 @@ namespace Internal.Reflection.Execution
             return true;
         }
 
+        public override bool TryGetFunctionPointerTypeForComponents(RuntimeTypeHandle returnTypeHandle, RuntimeTypeHandle[] parameterHandles, bool isUnmanaged, out RuntimeTypeHandle functionPointerTypeHandle)
+        {
+            return TypeLoaderEnvironment.Instance.TryGetFunctionPointerTypeForComponents(returnTypeHandle, parameterHandles, isUnmanaged, out functionPointerTypeHandle);
+        }
+
+        //
+        // Given a RuntimeTypeHandle for any function pointer pointer type, return the composition of it.
+        //
+        // Preconditions:
+        //      pointerTypeHandle is a valid RuntimeTypeHandle of type function pointer.
+        //
+        public override void GetFunctionPointerTypeComponents(RuntimeTypeHandle functionPointerHandle, out RuntimeTypeHandle returnTypeHandle, out RuntimeTypeHandle[] parameterHandles, out bool isUnmanaged)
+        {
+            TypeLoaderEnvironment.Instance.GetFunctionPointerTypeComponents(functionPointerHandle, out returnTypeHandle, out parameterHandles, out isUnmanaged);
+        }
+
         //
         // Given a RuntimeTypeHandle for any type E, return a RuntimeTypeHandle for type E&, if the pay-for-play policy denotes E& as browsable. This is used to
         // ensure that "typeof(E&)" and "typeof(E).MakeByRefType()" returns the same Type object.
@@ -989,7 +1005,7 @@ namespace Internal.Reflection.Execution
                         return RuntimeAugments.IsValueType(fieldTypeHandle) ?
                             (FieldAccessor)new ValueTypeFieldAccessorForInstanceFields(
                                 fieldAccessMetadata.Offset + fieldOffsetDelta, declaringTypeHandle, fieldTypeHandle) :
-                            RuntimeAugments.IsUnmanagedPointerType(fieldTypeHandle) ?
+                            (RuntimeAugments.IsUnmanagedPointerType(fieldTypeHandle) || RuntimeAugments.IsFunctionPointerType(fieldTypeHandle)) ?
                                 (FieldAccessor)new PointerTypeFieldAccessorForInstanceFields(
                                     fieldAccessMetadata.Offset + fieldOffsetDelta, declaringTypeHandle, fieldTypeHandle) :
                                 (FieldAccessor)new ReferenceTypeFieldAccessorForInstanceFields(
@@ -1038,7 +1054,7 @@ namespace Internal.Reflection.Execution
 
                         return RuntimeAugments.IsValueType(fieldTypeHandle) ?
                             (FieldAccessor)new ValueTypeFieldAccessorForStaticFields(cctorContext, staticsBase, fieldOffset, fieldAccessMetadata.Flags, fieldTypeHandle) :
-                            RuntimeAugments.IsUnmanagedPointerType(fieldTypeHandle) ?
+                            (RuntimeAugments.IsUnmanagedPointerType(fieldTypeHandle) || RuntimeAugments.IsFunctionPointerType(fieldTypeHandle)) ?
                                 (FieldAccessor)new PointerTypeFieldAccessorForStaticFields(cctorContext, staticsBase, fieldOffset, fieldAccessMetadata.Flags, fieldTypeHandle) :
                                 (FieldAccessor)new ReferenceTypeFieldAccessorForStaticFields(cctorContext, staticsBase, fieldOffset, fieldAccessMetadata.Flags, fieldTypeHandle);
                     }

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
@@ -60,6 +60,11 @@ namespace Internal.Reflection.Execution
             return _executionDomain.GetPointerTypeForHandle(typeHandle);
         }
 
+        public sealed override Type GetFunctionPointerTypeForHandle(RuntimeTypeHandle typeHandle)
+        {
+            return _executionDomain.GetFunctionPointerTypeForHandle(typeHandle);
+        }
+
         public sealed override Type GetByRefTypeForHandle(RuntimeTypeHandle typeHandle)
         {
             return _executionDomain.GetByRefTypeForHandle(typeHandle);

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -998,7 +998,13 @@ namespace Internal.Runtime.TypeLoader
             {
                 ParameterizedType typeAsParameterizedType = _typesThatNeedTypeHandles[i] as ParameterizedType;
                 if (typeAsParameterizedType == null)
+                {
+                    if (_typesThatNeedTypeHandles[i] is FunctionPointerType typeAsFunctionPointerType)
+                    {
+                        throw new NotImplementedException();
+                    }
                     continue;
+                }
 
                 Debug.Assert(!typeAsParameterizedType.RuntimeTypeHandle.IsNull());
                 Debug.Assert(!typeAsParameterizedType.ParameterType.RuntimeTypeHandle.IsNull());

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
@@ -342,6 +342,32 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
+        public bool TryGetFunctionPointerTypeForComponents(RuntimeTypeHandle returnTypeHandle, RuntimeTypeHandle[] parameterHandles, bool isUnmanaged, out RuntimeTypeHandle runtimeTypeHandle)
+        {
+            if (TryLookupFunctionPointerTypeForComponents(returnTypeHandle, parameterHandles, isUnmanaged, out runtimeTypeHandle))
+                return true;
+
+            using (LockHolder.Hold(_typeLoaderLock))
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public bool TryLookupFunctionPointerTypeForComponents(RuntimeTypeHandle returnTypeHandle, RuntimeTypeHandle[] parameterHandles, bool isUnmanaged, out RuntimeTypeHandle runtimeTypeHandle)
+        {
+            // TODO: cache same as for arrays
+            // TODO: lookup dynamically built ones
+            return TryGetStaticFunctionPointerTypeForComponents(returnTypeHandle, parameterHandles, isUnmanaged, out runtimeTypeHandle);
+        }
+
+        public void GetFunctionPointerTypeComponents(RuntimeTypeHandle functionPointerHandle, out RuntimeTypeHandle returnTypeHandle, out RuntimeTypeHandle[] parameterHandles, out bool isUnmanaged)
+        {
+            if (RuntimeAugments.IsDynamicType(functionPointerHandle))
+                throw new NotImplementedException();
+
+            GetStaticFunctionPointerTypeComponents(functionPointerHandle, out returnTypeHandle, out parameterHandles, out isUnmanaged);
+        }
+
         // Get an array RuntimeTypeHandle given an element's RuntimeTypeHandle and rank. Pass false for isMdArray, and rank == -1 for SzArrays
         public bool TryGetArrayTypeForElementType(RuntimeTypeHandle elementTypeHandle, bool isMdArray, int rank, out RuntimeTypeHandle arrayTypeHandle)
         {

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/TypeSystemContext.Runtime.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/TypeSystemContext.Runtime.cs
@@ -100,7 +100,7 @@ namespace Internal.TypeSystem
         internal static RuntimeTypeHandleToParameterTypeRuntimeTypeHandleHashtable ByRefTypesCache { get; } =
             new RuntimeTypeHandleToParameterTypeRuntimeTypeHandleHashtable();
 
-        public TypeDesc[] ResolveRuntimeTypeHandlesInternal(RuntimeTypeHandle[] runtimeTypeHandles)
+        private TypeDesc[] ResolveRuntimeTypeHandlesInternal(RuntimeTypeHandle[] runtimeTypeHandles)
         {
             TypeDesc[] TypeDescs = new TypeDesc[runtimeTypeHandles.Length];
             for (int i = 0; i < runtimeTypeHandles.Length; i++)

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/TypeSystemContext.Runtime.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/TypeSystemContext.Runtime.cs
@@ -100,12 +100,17 @@ namespace Internal.TypeSystem
         internal static RuntimeTypeHandleToParameterTypeRuntimeTypeHandleHashtable ByRefTypesCache { get; } =
             new RuntimeTypeHandleToParameterTypeRuntimeTypeHandleHashtable();
 
-        public Instantiation ResolveRuntimeTypeHandles(RuntimeTypeHandle[] runtimeTypeHandles)
+        public TypeDesc[] ResolveRuntimeTypeHandlesInternal(RuntimeTypeHandle[] runtimeTypeHandles)
         {
             TypeDesc[] TypeDescs = new TypeDesc[runtimeTypeHandles.Length];
             for (int i = 0; i < runtimeTypeHandles.Length; i++)
                 TypeDescs[i] = ResolveRuntimeTypeHandle(runtimeTypeHandles[i]);
-            return new Instantiation(TypeDescs);
+            return TypeDescs;
+        }
+
+        public Instantiation ResolveRuntimeTypeHandles(RuntimeTypeHandle[] runtimeTypeHandles)
+        {
+            return new Instantiation(ResolveRuntimeTypeHandlesInternal(runtimeTypeHandles));
         }
 
         // This dictionary is in every scenario - create it eagerly
@@ -175,6 +180,20 @@ namespace Internal.TypeSystem
                 RuntimeTypeHandle targetTypeHandle = RuntimeAugments.GetRelatedParameterTypeHandle(rtth);
                 TypeDesc targetType = ResolveRuntimeTypeHandle(targetTypeHandle);
                 returnedType = GetPointerType(targetType);
+            }
+            else if (RuntimeAugments.IsFunctionPointerType(rtth))
+            {
+                TypeLoaderEnvironment.Instance.GetFunctionPointerTypeComponents(rtth, out RuntimeTypeHandle returnTypeHandle,
+                                                                                      out RuntimeTypeHandle[] parameterHandles,
+                                                                                      out bool isUnmanaged);
+
+                var sig = new MethodSignature(
+                    isUnmanaged ? MethodSignatureFlags.UnmanagedCallingConvention : 0,
+                    genericParameterCount: 0,
+                    ResolveRuntimeTypeHandle(returnTypeHandle),
+                    ResolveRuntimeTypeHandlesInternal(parameterHandles));
+
+                returnedType = GetFunctionPointerType(sig);
             }
             else if (RuntimeAugments.IsByRefType(rtth))
             {

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/SortableDependencyNode.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/SortableDependencyNode.cs
@@ -77,6 +77,7 @@ namespace ILCompiler.DependencyAnalysis
             DelegateMarshallingStubMapNode,
             StructMarshallingStubMapNode,
             ArrayMapNode,
+            FunctionPointerMapNode,
             ReflectionFieldMapNode,
             NativeLayoutInfoNode,
             ExactMethodInstantiationsNode,

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/SchemaDef.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/SchemaDef.cs
@@ -177,6 +177,7 @@ class SchemaDef
         new EnumType("AssemblyFlags", "uint"),
         new EnumType("AssemblyHashAlgorithm", "uint"),
         new EnumType("CallingConventions", "ushort"),
+        new EnumType("SignatureCallingConvention", "byte"),
         new EnumType("EventAttributes", "ushort"),
         new EnumType("FieldAttributes", "ushort"),
         new EnumType("GenericParameterAttributes", "ushort"),
@@ -253,7 +254,24 @@ class SchemaDef
                 new MemberDef(name: "GenericTypeParameter", value: "0x0", comment: "Represents a type parameter for a generic type."),
                 new MemberDef(name: "GenericMethodParameter", value: "0x1", comment: "Represents a type parameter from a generic method."),
             }
-        )
+        ),
+        new RecordDef(
+            name: "SignatureCallingConvention",
+            baseTypeName: "byte",
+            flags: RecordDefFlags.Enum,
+            members: new MemberDef[] {
+                new MemberDef(name: "HasThis", value: "0x20"),
+                new MemberDef(name: "ExplicitThis", value: "0x40"),
+                new MemberDef(name: "Default", value: "0x00"),
+                new MemberDef(name: "Vararg", value: "0x05"),
+                new MemberDef(name: "Cdecl", value: "0x01"),
+                new MemberDef(name: "StdCall", value: "0x02"),
+                new MemberDef(name: "ThisCall", value: "0x03"),
+                new MemberDef(name: "FastCall", value: "0x04"),
+                new MemberDef(name: "Unmanaged", value: "0x09"),
+                new MemberDef(name: "UnmanagedCallingConventionMask", value: "0x0F"),
+            }
+        ),
     }
     .OrderBy(record => record.Name, StringComparer.Ordinal)
     .ToArray();
@@ -721,7 +739,7 @@ class SchemaDef
         new RecordDef(
             name: "MethodSignature",
             members: new MemberDef[] {
-                new MemberDef("CallingConvention", "CallingConventions"),
+                new MemberDef("CallingConvention", "SignatureCallingConvention"),
                 new MemberDef("GenericParameterCount", "int"),
                 new MemberDef("ReturnType", TypeDefOrRefOrSpecOrMod, MemberDefFlags.RecordRef),
                 new MemberDef("Parameters", TypeDefOrRefOrSpecOrMod, MemberDefFlags.List | MemberDefFlags.RecordRef | MemberDefFlags.EnumerateForHashCode),

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/MdBinaryReaderGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/MdBinaryReaderGen.cs
@@ -148,6 +148,14 @@ namespace Internal.Metadata.NativeFormat
             return offset;
         } // Read
 
+        public static uint Read(this NativeReader reader, uint offset, out SignatureCallingConvention value)
+        {
+            uint ivalue;
+            offset = reader.DecodeUnsigned(offset, out ivalue);
+            value = (SignatureCallingConvention)ivalue;
+            return offset;
+        } // Read
+
         public static uint Read(this NativeReader reader, uint offset, out EventAttributes value)
         {
             uint ivalue;

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderCommonGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderCommonGen.cs
@@ -75,6 +75,24 @@ namespace Internal.Metadata.NativeFormat
     [CLSCompliant(false)]
     [ReflectionBlocked]
 #endif
+    public enum SignatureCallingConvention : byte
+    {
+        HasThis = 0x20,
+        ExplicitThis = 0x40,
+        Default = 0x00,
+        Vararg = 0x05,
+        Cdecl = 0x01,
+        StdCall = 0x02,
+        ThisCall = 0x03,
+        FastCall = 0x04,
+        Unmanaged = 0x09,
+        UnmanagedCallingConventionMask = 0x0F,
+    } // SignatureCallingConvention
+
+#if SYSTEM_PRIVATE_CORELIB
+    [CLSCompliant(false)]
+    [ReflectionBlocked]
+#endif
     public enum HandleType : byte
     {
         Null = 0x0,

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
@@ -5141,7 +5141,7 @@ namespace Internal.Metadata.NativeFormat
             }
         } // Handle
 
-        public CallingConventions CallingConvention
+        public SignatureCallingConvention CallingConvention
         {
             get
             {
@@ -5149,7 +5149,7 @@ namespace Internal.Metadata.NativeFormat
             }
         } // CallingConvention
 
-        internal CallingConventions _callingConvention;
+        internal SignatureCallingConvention _callingConvention;
 
         public int GenericParameterCount
         {

--- a/src/coreclr/tools/Common/Internal/Runtime/EETypeBuilderHelpers.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/EETypeBuilderHelpers.cs
@@ -34,7 +34,7 @@ namespace Internal.Runtime
 
                 // Would be surprising to get these here though.
                 Debug.Assert(elementType != EETypeElementType.SystemArray);
-                Debug.Assert(elementType <= EETypeElementType.Pointer);
+                Debug.Assert(elementType <= EETypeElementType.FunctionPointer);
 
                 return elementType;
 
@@ -43,8 +43,13 @@ namespace Internal.Runtime
 
         public static uint ComputeFlags(TypeDesc type)
         {
-            uint flags = type.IsParameterizedType ?
-                (uint)EETypeKind.ParameterizedEEType : (uint)EETypeKind.CanonicalEEType;
+            uint flags;
+            if (type.IsParameterizedType)
+                flags = (uint)EETypeKind.ParameterizedEEType;
+            else if (type.IsFunctionPointer)
+                flags = (uint)EETypeKind.FunctionPointerEEType;
+            else
+                flags = (uint)EETypeKind.CanonicalEEType;
 
             // 5 bits near the top of flags are used to convey enum underlying type, primitive type, or mark the type as being System.Array
             EETypeElementType elementType = ComputeEETypeElementType(type);

--- a/src/coreclr/tools/Common/Internal/Runtime/MappingTableFlags.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/MappingTableFlags.cs
@@ -17,6 +17,12 @@ namespace Internal.Runtime
         public const int FlagsMask = 1;
     }
 
+    internal struct FunctionPointerMapEntry
+    {
+        public const uint IsUnmanagedFlag = 1;
+        public const int ParameterCountShift = 1;
+    }
+
     [Flags]
     public enum InvokeTableFlags : uint
     {

--- a/src/coreclr/tools/Common/Internal/Runtime/MetadataBlob.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/MetadataBlob.cs
@@ -8,7 +8,7 @@ namespace Internal.Runtime
         TypeMap                                     = 1,
         ArrayMap                                    = 2,
         // unused                                   = 3,
-        // unused                                   = 4,
+        FunctionPointerTypeMap                      = 4,
         BlockReflectionTypeMap                      = 5,
         InvokeMap                                   = 6,
         VirtualInvokeMap                            = 7,

--- a/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
@@ -98,7 +98,10 @@ namespace Internal.Runtime
         /// </summary>
         CanonicalEEType = 0x00000000,
 
-        // unused = 0x00010000,
+        /// <summary>
+        /// Represents a function pointer
+        /// </summary>
+        FunctionPointerEEType = 0x00010000,
 
         /// <summary>
         /// Represents a parameterized type. For example a single dimensional array or pointer type
@@ -231,6 +234,7 @@ namespace Internal.Runtime
         SzArray = 0x18,
         ByRef = 0x19,
         Pointer = 0x1A,
+        FunctionPointer = 0x1B,
     }
 
     internal enum EETypeOptionalFieldTag : byte

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FunctionPointerMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FunctionPointerMapNode.cs
@@ -1,0 +1,100 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+using Internal.NativeFormat;
+using Internal.Runtime;
+using Internal.Text;
+using Internal.TypeSystem;
+
+using MethodSignature = Internal.TypeSystem.MethodSignature;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a hash table of function pointer types generated into the image.
+    /// </summary>
+    internal sealed class FunctionPointerMapNode : ObjectNode, ISymbolDefinitionNode
+    {
+        private readonly ObjectAndOffsetSymbolNode _endSymbol;
+        private readonly ExternalReferencesTableNode _externalReferences;
+
+        public FunctionPointerMapNode(ExternalReferencesTableNode externalReferences)
+        {
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, "__fnptr_type_map_End", true);
+            _externalReferences = externalReferences;
+        }
+
+        public ISymbolDefinitionNode EndSymbol => _endSymbol;
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix).Append("__fnptr_type_map");
+        }
+        public int Offset => 0;
+        public override bool IsShareable => false;
+
+        public override ObjectNodeSection GetSection(NodeFactory factory) => _externalReferences.GetSection(factory);
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
+
+        public static void GetHashtableDependencies(ref DependencyList dependencies, NodeFactory factory, FunctionPointerType type)
+        {
+            dependencies ??= new DependencyList();
+            dependencies.Add(factory.NecessaryTypeSymbol(type.Signature.ReturnType), "Function pointer type composition");
+            foreach (TypeDesc paramType in type.Signature)
+                dependencies.Add(factory.NecessaryTypeSymbol(paramType), "Function pointer type composition");
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node does not trigger generation of other nodes.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this });
+
+            var writer = new NativeWriter();
+            var typeMapHashTable = new VertexHashtable();
+
+            Section hashTableSection = writer.NewSection();
+            hashTableSection.Place(typeMapHashTable);
+
+            foreach (var type in factory.MetadataManager.GetTypesWithEETypes())
+            {
+                if (!type.IsFunctionPointer)
+                    continue;
+
+                MethodSignature sig = ((FunctionPointerType)type).Signature;
+
+                Vertex sigPart = writer.GetUnsignedConstant(_externalReferences.GetIndex(factory.NecessaryTypeSymbol(sig.ReturnType)));
+                foreach (TypeDesc p in sig)
+                    sigPart = writer.GetTuple(sigPart, writer.GetUnsignedConstant(_externalReferences.GetIndex(factory.NecessaryTypeSymbol(p))));
+
+                uint flags = (sig.Flags & MethodSignatureFlags.UnmanagedCallingConventionMask) != 0
+                    ? FunctionPointerMapEntry.IsUnmanagedFlag : 0;
+
+                flags |= (uint)sig.Length << FunctionPointerMapEntry.ParameterCountShift;
+
+                Vertex vertex =
+                    writer.GetTuple(
+                        writer.GetUnsignedConstant(_externalReferences.GetIndex(factory.NecessaryTypeSymbol(type))),
+                        writer.GetUnsignedConstant(flags),
+                        sigPart);
+
+                int hashCode = type.GetHashCode();
+                typeMapHashTable.Append((uint)hashCode, hashTableSection.Place(vertex));
+            }
+
+            byte[] hashTableBytes = writer.Save();
+
+            _endSymbol.SetSymbolOffset(hashTableBytes.Length);
+
+            return new ObjectData(hashTableBytes, Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this, _endSymbol });
+        }
+
+        protected internal override int Phase => (int)ObjectNodePhase.Ordered;
+        public override int ClassCode => (int)ObjectNodeOrder.FunctionPointerMapNode;
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectedFieldNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectedFieldNode.cs
@@ -94,20 +94,7 @@ namespace ILCompiler.DependencyAnalysis
 
             if (!_field.OwningType.IsCanonicalSubtype(CanonicalFormKind.Any))
             {
-                // Runtime reflection stack needs to obtain the type handle of the field
-                // (but there's no type handles for function pointers)
-                static bool ContainsFunctionPointers(TypeDesc type)
-                {
-                    if (type.IsParameterizedType)
-                        return ContainsFunctionPointers(((ParameterizedType)type).ParameterType);
-                    foreach (TypeDesc instArg in type.Instantiation)
-                        if (ContainsFunctionPointers(instArg))
-                            return true;
-                    return type.IsFunctionPointer;
-                }
-
-                if (!ContainsFunctionPointers(_field.FieldType))
-                    dependencies.Add(factory.MaximallyConstructableType(_field.FieldType.NormalizeInstantiation()), "Type of the field");
+                dependencies.Add(factory.MaximallyConstructableType(_field.FieldType.NormalizeInstantiation()), "Type of the field");
             }
 
             return dependencies;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
@@ -79,20 +79,6 @@ namespace ILCompiler.DependencyAnalysis
                     if (type.IsPrimitive || type.IsVoid)
                         return;
 
-                    // Function pointers are not supported yet.
-                    // https://github.com/dotnet/runtime/issues/71883
-                    static bool ContainsFunctionPointers(TypeDesc type)
-                    {
-                        if (type.IsParameterizedType)
-                            return ContainsFunctionPointers(((ParameterizedType)type).ParameterType);
-                        foreach (TypeDesc instArg in type.Instantiation)
-                            if (ContainsFunctionPointers(instArg))
-                                return true;
-                        return type.IsFunctionPointer;
-                    }
-                    if (ContainsFunctionPointers(type))
-                        return;
-
                     TypeDesc canonType = type.ConvertToCanonForm(CanonicalFormKind.Specific);
                     if (canonType.IsCanonicalSubtype(CanonicalFormKind.Any))
                         GenericTypesTemplateMap.GetTemplateTypeDependencies(ref dependencies, factory, type.ConvertToCanonForm(CanonicalFormKind.Specific));

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -146,6 +146,9 @@ namespace ILCompiler
             var arrayMapNode = new ArrayMapNode(commonFixupsTableNode);
             header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.ArrayMap), arrayMapNode, arrayMapNode, arrayMapNode.EndSymbol);
 
+            var functionPointerMapNode = new FunctionPointerMapNode(commonFixupsTableNode);
+            header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.FunctionPointerTypeMap), functionPointerMapNode, functionPointerMapNode, functionPointerMapNode.EndSymbol);
+
             var fieldMapNode = new ReflectionFieldMapNode(commonFixupsTableNode);
             header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.FieldAccessMap), fieldMapNode, fieldMapNode, fieldMapNode.EndSymbol);
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -402,6 +402,7 @@
     <Compile Include="Compiler\DependencyAnalysis\DynamicDependencyAttributesOnEntityNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExternSymbolsImportedNodeProvider.cs" />
     <Compile Include="Compiler\DependencyAnalysis\FieldRvaDataNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\FunctionPointerMapNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericStaticBaseInfoNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericVirtualMethodImplNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\IndirectionExtensions.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler/Metadata/Transform.Method.cs
+++ b/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler/Metadata/Transform.Method.cs
@@ -9,10 +9,10 @@ using Internal.Metadata.NativeFormat.Writer;
 using Cts = Internal.TypeSystem;
 using Ecma = System.Reflection.Metadata;
 
-using CallingConventions = System.Reflection.CallingConventions;
 using Debug = System.Diagnostics.Debug;
 using MethodAttributes = System.Reflection.MethodAttributes;
 using MethodImplAttributes = System.Reflection.MethodImplAttributes;
+using SignatureCallingConvention = Internal.Metadata.NativeFormat.SignatureCallingConvention;
 
 namespace ILCompiler.Metadata
 {
@@ -196,14 +196,16 @@ namespace ILCompiler.Metadata
                 throw new NotImplementedException();
         }
 
-        private static CallingConventions GetSignatureCallingConvention(Cts.MethodSignature signature)
+        private static SignatureCallingConvention GetSignatureCallingConvention(Cts.MethodSignature signature)
         {
-            CallingConventions callingConvention = CallingConventions.Standard;
+            Debug.Assert((int)Cts.MethodSignatureFlags.UnmanagedCallingConventionCdecl == (int)SignatureCallingConvention.Cdecl);
+            Debug.Assert((int)Cts.MethodSignatureFlags.UnmanagedCallingConventionThisCall == (int)SignatureCallingConvention.ThisCall);
+            Debug.Assert((int)Cts.MethodSignatureFlags.UnmanagedCallingConventionMask == (int)SignatureCallingConvention.UnmanagedCallingConventionMask);
+            SignatureCallingConvention callingConvention = (SignatureCallingConvention)(signature.Flags & Cts.MethodSignatureFlags.UnmanagedCallingConventionMask);
             if ((signature.Flags & Cts.MethodSignatureFlags.Static) == 0)
             {
-                callingConvention = CallingConventions.HasThis;
+                callingConvention |= SignatureCallingConvention.HasThis;
             }
-            // TODO: additional calling convention flags like stdcall / cdecl etc.
             return callingConvention;
         }
     }

--- a/src/coreclr/tools/aot/ILCompiler.MetadataTransform/Internal/Metadata/NativeFormat/Writer/MdBinaryWriterGen.cs
+++ b/src/coreclr/tools/aot/ILCompiler.MetadataTransform/Internal/Metadata/NativeFormat/Writer/MdBinaryWriterGen.cs
@@ -200,6 +200,11 @@ namespace Internal.Metadata.NativeFormat.Writer
             writer.WriteUnsigned((uint)value);
         } // Write
 
+        public static void Write(this NativeWriter writer, SignatureCallingConvention value)
+        {
+            writer.WriteUnsigned((uint)value);
+        } // Write
+
         public static void Write(this NativeWriter writer, EventAttributes value)
         {
             writer.WriteUnsigned((uint)value);

--- a/src/coreclr/tools/aot/ILCompiler.MetadataTransform/Internal/Metadata/NativeFormat/Writer/NativeFormatWriterGen.cs
+++ b/src/coreclr/tools/aot/ILCompiler.MetadataTransform/Internal/Metadata/NativeFormat/Writer/NativeFormatWriterGen.cs
@@ -3192,7 +3192,7 @@ namespace Internal.Metadata.NativeFormat.Writer
             }
         } // Handle
 
-        public CallingConventions CallingConvention;
+        public SignatureCallingConvention CallingConvention;
         public int GenericParameterCount;
         public MetadataRecord ReturnType;
         public List<MetadataRecord> Parameters = new List<MetadataRecord>();

--- a/src/libraries/Common/tests/System/FunctionPointerEqualityTests.cs
+++ b/src/libraries/Common/tests/System/FunctionPointerEqualityTests.cs
@@ -16,7 +16,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void DifferentReturnValue()
         {
             Type t = typeof(FunctionPointerHolder).Project();
@@ -69,7 +68,6 @@ namespace System.Tests.Types
         [InlineData(nameof(FunctionPointerHolder.MethodCallConv_Cdecl), nameof(FunctionPointerHolder.MethodCallConv_Thiscall))]
         [InlineData(nameof(FunctionPointerHolder.MethodCallConv_Cdecl), nameof(FunctionPointerHolder.MethodCallConv_Fastcall))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void CallingConvention_Unmodified(string methodName1, string methodName2)
         {
             Type t = typeof(FunctionPointerHolder).Project();

--- a/src/libraries/Common/tests/System/FunctionPointerTests.cs
+++ b/src/libraries/Common/tests/System/FunctionPointerTests.cs
@@ -15,7 +15,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void TypeMembers()
         {
             // Get an arbitrary function pointer
@@ -118,7 +117,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void NonFunctionPointerThrows()
         {
             Assert.Throws<InvalidOperationException>(() => typeof(int).GetFunctionPointerCallingConventions());
@@ -128,7 +126,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void TestToString()
         {
             // Function pointer types are inline in metadata and can't be loaded independently so they do not support the
@@ -150,7 +147,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void FunctionPointerReturn()
         {
             Type t = typeof(FunctionPointerHolder).Project();

--- a/src/libraries/System.Reflection/tests/MethodInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/MethodInfoTests.cs
@@ -895,7 +895,6 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]        
         private static unsafe void TestFunctionPointers()
         {
             void* fn = FunctionPointerMethods.GetFunctionPointer();
@@ -911,9 +910,17 @@ namespace System.Reflection.Tests
             MethodInfo m;
 
             m = GetMethod(typeof(FunctionPointerMethods), nameof(FunctionPointerMethods.CallFcnPtr_FP));
-            //  System.ArgumentException : Object of type 'System.IntPtr' cannot be converted to type 'System.Boolean(System.Int32)'
-            Assert.Throws<ArgumentException>(() => m.Invoke(null, new object[] { (IntPtr)fn, 42 }));
-            Assert.Throws<ArgumentException>(() => m.Invoke(null, new object[] { (IntPtr)fn, 41 }));
+            if (PlatformDetection.IsNativeAot)
+            {
+                Assert.True((bool)m.Invoke(null, new object[] { (IntPtr)fn, 42 }));
+                Assert.False((bool)m.Invoke(null, new object[] { (IntPtr)fn, 41 }));
+            }
+            else
+            {
+                //  System.ArgumentException : Object of type 'System.IntPtr' cannot be converted to type 'System.Boolean(System.Int32)'
+                Assert.Throws<ArgumentException>(() => m.Invoke(null, new object[] { (IntPtr)fn, 42 }));
+                Assert.Throws<ArgumentException>(() => m.Invoke(null, new object[] { (IntPtr)fn, 41 }));
+            }
 
             m = GetMethod(typeof(FunctionPointerMethods), nameof(FunctionPointerMethods.CallFcnPtr_IntPtr));
             Assert.True((bool)m.Invoke(null, new object[] { (IntPtr)fn, 42 }));

--- a/src/libraries/System.Runtime/tests/System/Reflection/TypeDelegatorTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/TypeDelegatorTests.cs
@@ -59,7 +59,6 @@ namespace System.Reflection.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]          
         public void FunctionPointers()
         {
             Assert.True(new TypeDelegator(typeof(delegate*<void>)).IsFunctionPointer);

--- a/src/libraries/System.Runtime/tests/System/Type/FunctionPointerTests.Runtime.cs
+++ b/src/libraries/System.Runtime/tests/System/Type/FunctionPointerTests.Runtime.cs
@@ -13,7 +13,6 @@ namespace System.Tests.Types
     {
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void CompileTimeIdentity_Managed()
         {
             object obj = new delegate*<int>[1];
@@ -29,7 +28,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void CompileTimeIdentity_ManagedWithMods()
         {
             object obj = new delegate*<ref int, void>[1];
@@ -45,7 +43,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void CompileTimeIdentity_Unmanaged()
         {
             object obj = new delegate* unmanaged[MemberFunction]<void>[1];
@@ -63,7 +60,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void CompileTimeIdentity_UnmanagedIsPartOfIdentity()
         {
             object obj = new delegate* unmanaged[MemberFunction]<void>[1];


### PR DESCRIPTION
Implements function pointer type support in the compiler, runtime, and reflection stack.

Contributes to #71883.

* Introduce a new kind of `MethodTable` for function pointers in the compiler.
* Remove function pointer type blocking from various places in the compiler.
* Generate a new summary table so we can construct/deconstruct function pointer types at runtime.
* Update metadata format so that we can capture calling conventions and distinguish managed/unmanaged function pointers in metadata.
* Update `MethodTable` reader.
* Update casting logic in the runtime.
* Update BCL (arrays, TypedReference, etc.)
* Update reflection stack: representation of the type, parsing metadata, invoke, field get/set
* Enable applicable tests.

Not implemented yet: the modified type stuff, runtime type loader support.

Cc @dotnet/ilc-contrib 