### PR TITLE
[Arm64] Replace pairs of `str` with `stp`

### DIFF
--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -782,18 +782,18 @@ protected:
         unsigned _idNoGC : 1;       // Some helpers don't get recorded in GC tables
 
 #ifdef TARGET_ARM64
-        opSize   _idOpSize : 3; // operand size: 0=1 , 1=2 , 2=4 , 3=8, 4=16
-        insOpts  _idInsOpt : 6; // options for instructions
-        unsigned _idLclVar : 1; // access a local on stack
+        opSize   _idOpSize : 3;    // operand size: 0=1 , 1=2 , 2=4 , 3=8, 4=16
+        insOpts  _idInsOpt : 6;    // options for instructions
+        unsigned _idLclVar : 1;    // access a local on stack
         unsigned _idLclVarPair : 1 // carries information for 2 GC lcl vars.
 #endif
 
 #ifdef TARGET_LOONGARCH64
-        // TODO-LoongArch64: maybe delete on future.
-        opSize  _idOpSize : 3;  // operand size: 0=1 , 1=2 , 2=4 , 3=8, 4=16
-        insOpts _idInsOpt : 6;  // loongarch options for special: placeholders. e.g emitIns_R_C, also identifying the
-                                // accessing a local on stack.
-        unsigned _idLclVar : 1; // access a local on stack.
+            // TODO-LoongArch64: maybe delete on future.
+            opSize _idOpSize : 3; // operand size: 0=1 , 1=2 , 2=4 , 3=8, 4=16
+        insOpts    _idInsOpt : 6; // loongarch options for special: placeholders. e.g emitIns_R_C, also identifying the
+                                  // accessing a local on stack.
+        unsigned _idLclVar : 1;   // access a local on stack.
 #endif
 
 #ifdef TARGET_RISCV64

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1838,11 +1838,11 @@ protected:
         emitLclVarAddr iiaLclVar2;
     };
 
-    struct instrDescLclVarPairCns : instrDescLclVarPair // contains 2 gc vars to be tracked, with large cons
+    struct instrDescLclVarPairCns : instrDescCns // contains 2 gc vars to be tracked, with large cons
     {
         instrDescLclVarPairCns() = delete;
 
-        cnsval_ssize_t idcCnsVal;
+        emitLclVarAddr iiaLclVar2;
     };
 #endif
 
@@ -2733,7 +2733,7 @@ private:
 #if !defined(TARGET_ARM64)
     instrDescLbl* emitNewInstrLbl();
 #else
-    instrDescLclVarPair* emitNewInstrLclVarPair(emitAttr attr, cnsval_ssize_t cns);
+    instrDesc* emitNewInstrLclVarPair(emitAttr attr, cnsval_ssize_t cns);
 #endif // !TARGET_ARM64
 
     static const BYTE emitFmtToOps[];
@@ -3298,7 +3298,7 @@ inline emitter::instrDescLbl* emitter::emitNewInstrLbl()
     return emitAllocInstrLbl();
 }
 #else
-inline emitter::instrDescLclVarPair* emitter::emitNewInstrLclVarPair(emitAttr attr, cnsval_ssize_t cns)
+inline emitter::instrDesc* emitter::emitNewInstrLclVarPair(emitAttr attr, cnsval_ssize_t cns)
 {
 #if EMITTER_STATS
     emitTotalIDescCnt++;

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -6497,10 +6497,6 @@ void emitter::emitIns_R_R_R(
     appendToCurIG(id);
 }
 
-/*****************************************************************************
- *
- *
- */
 //-----------------------------------------------------------------------------------
 // emitIns_R_R_R_I_LdStPair: Add an instruction storing 2 registers into a memory
 //                     (pointed by reg3) and the offset (immediate).
@@ -6569,7 +6565,7 @@ void emitter::emitIns_R_R_R_I_LdStPair(instruction ins,
         {
             // Unlike emitIns_S_S_R_R(), we would never come here when
             // (imm & mask) != 0.
-            assert(false);
+            unreached();
         }
     }
 
@@ -6584,14 +6580,7 @@ void emitter::emitIns_R_R_R_I_LdStPair(instruction ins,
         id->idAddr()->iiaLclVar.initLclVarAddr(varx1, offs1);
         id->idSetIsLclVar();
 
-        if (id->idSmallCns())
-        {
-            ((instrDescLclVarPair*)id)->iiaLclVar2.initLclVarAddr(varx2, offs2);
-        }
-        else
-        {
-            ((instrDescLclVarPairCns*)id)->iiaLclVar2.initLclVarAddr(varx2, offs2);
-        }
+        emitGetLclVarPairLclVar2(id)->initLclVarAddr(varx2, offs2);
     }
     else
     {
@@ -11886,16 +11875,10 @@ SKIP_GC_UPDATE:
             if (id->idIsLclVarPair())
             {
                 bool FPbased2;
-                if (id->idSmallCns())
-                {
-                    varNum2 = ((instrDescLclVarPair*)id)->iiaLclVar2.lvaVarNum();
-                    ofs2    = ((instrDescLclVarPair*)id)->iiaLclVar2.lvaOffset();
-                }
-                else
-                {
-                    varNum2 = ((instrDescLclVarPairCns*)id)->iiaLclVar2.lvaVarNum();
-                    ofs2    = ((instrDescLclVarPairCns*)id)->iiaLclVar2.lvaOffset();
-                }
+
+                emitLclVarAddr* lclVarAddr2 = emitGetLclVarPairLclVar2(id);
+                varNum2                     = lclVarAddr2->lvaVarNum();
+                ofs2                        = lclVarAddr2->lvaOffset();
 
                 // If there are 2 GC vars in this instrDesc, get the 2nd variable
                 // that should be tracked.

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -11881,7 +11881,7 @@ SKIP_GC_UPDATE:
                     assert(idPair->idReg3() == REG_SP);
                 }
                 assert(varNum2 != -1);
-                // assert((varNum == varNum2) || (adr + ofs + size == adr2 + ofs2));
+// assert((varNum == varNum2) || (adr + ofs + size == adr2 + ofs2));
 
 #endif // DEBUG
             }

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -6570,6 +6570,7 @@ void emitter::emitIns_SS_R_R_R_I(instruction ins,
     {
         id = emitNewInstrLclVarPair(attr, imm);
         id->idAddr()->iiaLclVar.initLclVarAddr(varx1, offs);
+        id->idSetIsLclVar();
 
         if (id->idSmallCns())
         {
@@ -6586,10 +6587,12 @@ void emitter::emitIns_SS_R_R_R_I(instruction ins,
         if (validVar1)
         {
             id->idAddr()->iiaLclVar.initLclVarAddr(varx1, offs);
+            id->idSetIsLclVar();
         }
         if (validVar2)
         {
             id->idAddr()->iiaLclVar.initLclVarAddr(varx2, offs);
+            id->idSetIsLclVar();
         }
     }
 

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -6499,7 +6499,7 @@ void emitter::emitIns_R_R_R(
 
 /*****************************************************************************
  *
- *  
+ *
  */
 //-----------------------------------------------------------------------------------
 // emitIns_R_R_R_I_LdStPair: Add an instruction storing 2 registers into a memory
@@ -6519,16 +6519,16 @@ void emitter::emitIns_R_R_R(
 //     offs2    - Memory offset of lclvar number 2
 //
 void emitter::emitIns_R_R_R_I_LdStPair(instruction ins,
-                                 emitAttr    attr,
-                                 emitAttr    attr2,
-                                 regNumber   reg1,
-                                 regNumber   reg2,
-                                 regNumber   reg3,
-                                 ssize_t     imm,
-                                 int         varx1,
-                                 int         varx2,
-                                 int         offs1,
-                                 int         offs2)
+                                       emitAttr    attr,
+                                       emitAttr    attr2,
+                                       regNumber   reg1,
+                                       regNumber   reg2,
+                                       regNumber   reg3,
+                                       ssize_t     imm,
+                                       int         varx1,
+                                       int         varx2,
+                                       int         offs1,
+                                       int         offs2)
 {
     assert((ins == INS_stp) || (ins == INS_ldp));
     emitAttr  size  = EA_SIZE(attr);
@@ -11878,7 +11878,7 @@ SKIP_GC_UPDATE:
         }
         if (emitInsWritesToLclVarStackLocPair(id))
         {
-            int      varNum2 = varNum;            
+            int      varNum2 = varNum;
             int      adr2    = adr;
             unsigned ofs2    = ofs;
             unsigned ofs2Dist;
@@ -11900,7 +11900,7 @@ SKIP_GC_UPDATE:
                 // If there are 2 GC vars in this instrDesc, get the 2nd variable
                 // that should be tracked.
                 adr2     = emitComp->lvaFrameAddress(varNum2, &FPbased2);
-                ofs2Dist = EA_SIZE_IN_BYTES(size);                
+                ofs2Dist = EA_SIZE_IN_BYTES(size);
 #ifdef DEBUG
                 assert(FPbased == FPbased2);
                 if (FPbased)
@@ -11911,7 +11911,7 @@ SKIP_GC_UPDATE:
                 {
                     assert(id->idReg3() == REG_SP);
                 }
-                assert(varNum2 != -1);                
+                assert(varNum2 != -1);
 #endif // DEBUG
             }
             else
@@ -16529,13 +16529,13 @@ bool emitter::ReplaceLdrStrWithPairInstr(instruction ins,
 
     if (optimizationOrder == eRO_ascending)
     {
-        emitIns_R_R_R_I_LdStPair(optIns, prevReg1Attr, reg1Attr, prevReg1, reg1, reg2, prevImmSize, prevLclVarNum,
-                           varx, prevOffset, offs);
+        emitIns_R_R_R_I_LdStPair(optIns, prevReg1Attr, reg1Attr, prevReg1, reg1, reg2, prevImmSize, prevLclVarNum, varx,
+                                 prevOffset, offs);
     }
     else
     {
-        emitIns_R_R_R_I_LdStPair(optIns, reg1Attr, prevReg1Attr, reg1, prevReg1, reg2, newImmSize, varx, prevLclVarNum, offs,
-                           prevOffset);
+        emitIns_R_R_R_I_LdStPair(optIns, reg1Attr, prevReg1Attr, reg1, prevReg1, reg2, newImmSize, varx, prevLclVarNum,
+                                 offs, prevOffset);
     }
 
     return true;

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -11881,8 +11881,6 @@ SKIP_GC_UPDATE:
                     assert(idPair->idReg3() == REG_SP);
                 }
                 assert(varNum2 != -1);
-// assert((varNum == varNum2) || (adr + ofs + size == adr2 + ofs2));
-
 #endif // DEBUG
             }
 

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -130,7 +130,7 @@ size_t emitter::emitSizeOfInsDsc(instrDesc* id)
     {
         if (id->idIsLclVarPair())
         {
-            return sizeof(instrDescStrPairCns);
+            return sizeof(instrDescLclVarPairCns);
         }
         else if (id->idIsLargeDsp())
         {
@@ -145,7 +145,7 @@ size_t emitter::emitSizeOfInsDsc(instrDesc* id)
     {
         if (id->idIsLclVarPair())
         {
-            return sizeof(instrDescStrPair);
+            return sizeof(instrDescLclVarPair);
         }
         else if (id->idIsLargeDsp())
         {
@@ -6568,16 +6568,16 @@ void emitter::emitIns_SS_R_R_R_I(instruction ins,
 
     if (validVar1 && validVar2)
     {
-        id = emitNewInstrStrPair(attr, imm);
+        id = emitNewInstrLclVarPair(attr, imm);
         id->idAddr()->iiaLclVar.initLclVarAddr(varx1, offs);
 
         if (id->idSmallCns())
         {
-            ((instrDescStrPair*)id)->iiaLclVar2.initLclVarAddr(varx2, offs);
+            ((instrDescLclVarPair*)id)->iiaLclVar2.initLclVarAddr(varx2, offs);
         }
         else
         {
-            ((instrDescStrPairCns*)id)->iiaLclVar2.initLclVarAddr(varx2, offs);
+            ((instrDescLclVarPairCns*)id)->iiaLclVar2.initLclVarAddr(varx2, offs);
         }
     }
     else
@@ -11879,11 +11879,11 @@ SKIP_GC_UPDATE:
                     // that should be tracked.
                     if (id->idSmallCns())
                     {
-                        varNum2 = ((instrDescStrPair*)id)->iiaLclVar2.lvaVarNum();
+                        varNum2 = ((instrDescLclVarPair*)id)->iiaLclVar2.lvaVarNum();
                     }
                     else
                     {
-                        varNum2 = ((instrDescStrPairCns*)id)->iiaLclVar2.lvaVarNum();
+                        varNum2 = ((instrDescLclVarPairCns*)id)->iiaLclVar2.lvaVarNum();
                     }
                 }
                 assert(varNum2 != -1);

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -11864,7 +11864,7 @@ SKIP_GC_UPDATE:
         if (emitInsWritesToLclVarStackLocPair(id))
         {
             int      varNum2 = varNum;
-            unsigned ofs2    = ofs + size;
+            unsigned ofs2    = ofs + TARGET_POINTER_SIZE;
             int      adr2    = adr;
 
             if (id->idIsLclVarPair())
@@ -11884,7 +11884,7 @@ SKIP_GC_UPDATE:
                 // If there are 2 GC vars in this instrDesc, get the 2nd variable
                 // that should be tracked.
                 adr2 = emitComp->lvaFrameAddress(varNum2, &FPbased2);
-                ofs2 = AlignDown(ofs2, TARGET_POINTER_SIZE);
+                ofs2 = AlignDown(ofs2, size);
 #ifdef DEBUG
                 assert(FPbased == FPbased2);
                 if (FPbased)
@@ -11896,7 +11896,12 @@ SKIP_GC_UPDATE:
                     assert(id->idReg3() == REG_SP);
                 }
                 assert(varNum2 != -1);
+                assert((adr + ofs + size) == (adr2 + ofs2));
 #endif // DEBUG
+            }
+            else
+            {
+                assert((adr + ofs + TARGET_POINTER_SIZE) == (adr2 + ofs2));
             }
 
             if (id->idGCrefReg2() != GCT_NONE)

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -6499,11 +6499,26 @@ void emitter::emitIns_R_R_R(
 
 /*****************************************************************************
  *
- *  Add an instruction storing 2 registers into a memory (pointed by reg3) and the offset
-    (immediate).
+ *  
  */
-
-void emitter::emitIns_SS_R_R_R_I(instruction ins,
+//-----------------------------------------------------------------------------------
+// emitIns_R_R_R_I_LdStPair: Add an instruction storing 2 registers into a memory
+//                     (pointed by reg3) and the offset (immediate).
+//
+// Arguments:
+//     ins      - The instruction code
+//     attr     - The emit attribute for register 1
+//     attr2    - The emit attribute for register 2
+//     reg1     - Register 1
+//     reg2     - Register 2
+//     reg3     - Register 3
+//     imm      - Immediate offset, prior to scaling by operand size
+//     varx1    - LclVar number 1
+//     varx2    - LclVar number 2
+//     offs1    - Memory offset of lclvar number 1
+//     offs2    - Memory offset of lclvar number 2
+//
+void emitter::emitIns_R_R_R_I_LdStPair(instruction ins,
                                  emitAttr    attr,
                                  emitAttr    attr2,
                                  regNumber   reg1,
@@ -16473,20 +16488,18 @@ bool emitter::ReplaceLdrStrWithPairInstr(instruction ins,
     ssize_t  prevImmSize   = prevImm * size;
     ssize_t  newImmSize    = imm * size;
     bool     isLastLclVar  = emitLastIns->idIsLclVar();
-    int      currOffset    = -1;
     int      prevOffset    = -1;
     int      prevLclVarNum = -1;
-    int      currLclVarNum = -1;
 
     if (emitLastIns->idIsLclVar())
     {
         prevOffset    = emitLastIns->idAddr()->iiaLclVar.lvaOffset();
         prevLclVarNum = emitLastIns->idAddr()->iiaLclVar.lvaVarNum();
     }
-    if (isCurrLclVar)
+
+    if (!isCurrLclVar)
     {
-        currOffset    = offs;
-        currLclVarNum = varx;
+        assert((varx == -1) && (offs == -1));
     }
 
     switch (emitLastIns->idGCref())
@@ -16516,13 +16529,13 @@ bool emitter::ReplaceLdrStrWithPairInstr(instruction ins,
 
     if (optimizationOrder == eRO_ascending)
     {
-        emitIns_SS_R_R_R_I(optIns, prevReg1Attr, reg1Attr, prevReg1, reg1, reg2, prevImmSize, prevLclVarNum,
-                           currLclVarNum, prevOffset, currOffset);
+        emitIns_R_R_R_I_LdStPair(optIns, prevReg1Attr, reg1Attr, prevReg1, reg1, reg2, prevImmSize, prevLclVarNum,
+                           varx, prevOffset, offs);
     }
     else
     {
-        emitIns_SS_R_R_R_I(optIns, reg1Attr, prevReg1Attr, reg1, prevReg1, reg2, newImmSize, currLclVarNum,
-                           prevLclVarNum, currOffset, prevOffset);
+        emitIns_R_R_R_I_LdStPair(optIns, reg1Attr, prevReg1Attr, reg1, prevReg1, reg2, newImmSize, varx, prevLclVarNum, offs,
+                           prevOffset);
     }
 
     return true;

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -136,8 +136,8 @@ bool ReplaceLdrStrWithPairInstr(instruction ins,
                                 emitAttr    size,
                                 insFormat   fmt,
                                 bool        localVar = false,
-                                int         varx = 0,
-                                int         offs = 0);
+                                int         varx     = 0,
+                                int         offs     = 0);
 bool IsOptimizableLdrToMov(instruction ins, regNumber reg1, regNumber reg2, ssize_t imm, emitAttr size, insFormat fmt);
 
 // Try to optimize a Ldr or Str with an alternative instruction.
@@ -149,8 +149,8 @@ inline bool OptimizeLdrStr(instruction ins,
                            emitAttr    size,
                            insFormat   fmt,
                            bool        localVar = false,
-                           int         varx = 0,
-                           int         offs = 0)
+                           int         varx     = 0,
+                           int         offs     = 0)
 {
     assert(ins == INS_ldr || ins == INS_str);
 

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -141,50 +141,16 @@ bool ReplaceLdrStrWithPairInstr(instruction ins,
 bool IsOptimizableLdrToMov(instruction ins, regNumber reg1, regNumber reg2, ssize_t imm, emitAttr size, insFormat fmt);
 
 // Try to optimize a Ldr or Str with an alternative instruction.
-inline bool OptimizeLdrStr(instruction ins,
-                           emitAttr    reg1Attr,
-                           regNumber   reg1,
-                           regNumber   reg2,
-                           ssize_t     imm,
-                           emitAttr    size,
-                           insFormat   fmt,
-                           bool        localVar = false,
-                           int         varx     = -1,
-                           int offs = -1 DEBUG_ARG(bool useRsvdReg = false))
-{
-    assert(ins == INS_ldr || ins == INS_str);
-
-    if (!emitCanPeepholeLastIns() || (emitLastIns->idIns() != ins))
-    {
-        return false;
-    }
-
-    // Is the ldr/str even necessary?
-    if (IsRedundantLdStr(ins, reg1, reg2, imm, size, fmt))
-    {
-        return true;
-    }
-
-    // Register 2 needs conversion to unencoded value for following optimisation checks.
-    reg2 = encodingZRtoSP(reg2);
-
-    // If the previous instruction was a matching load/store, then try to replace it instead of emitting.
-    //
-    if (ReplaceLdrStrWithPairInstr(ins, reg1Attr, reg1, reg2, imm, size, fmt, localVar, varx, offs))
-    {
-        assert(!useRsvdReg);
-        return true;
-    }
-
-    // If we have a second LDR instruction from the same source, then try to replace it with a MOV.
-    if (IsOptimizableLdrToMov(ins, reg1, reg2, imm, size, fmt))
-    {
-        emitIns_Mov(INS_mov, reg1Attr, reg1, emitLastIns->idReg1(), true);
-        return true;
-    }
-
-    return false;
-}
+FORCEINLINE bool OptimizeLdrStr(instruction ins,
+                                emitAttr    reg1Attr,
+                                regNumber   reg1,
+                                regNumber   reg2,
+                                ssize_t     imm,
+                                emitAttr    size,
+                                insFormat   fmt,
+                                bool        localVar = false,
+                                int         varx     = -1,
+                                int offs = -1 DEBUG_ARG(bool useRsvdReg = false));
 
 /************************************************************************
 *

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -135,9 +135,9 @@ bool ReplaceLdrStrWithPairInstr(instruction ins,
                                 ssize_t     imm,
                                 emitAttr    size,
                                 insFormat   fmt,
-                                bool        localVar = false,
-                                int         varx     = 0,
-                                int         offs     = 0);
+                                bool        localVar      = false,
+                                int         currLclVarNum = 0,
+                                int         offs          = 0);
 bool IsOptimizableLdrToMov(instruction ins, regNumber reg1, regNumber reg2, ssize_t imm, emitAttr size, insFormat fmt);
 
 // Try to optimize a Ldr or Str with an alternative instruction.
@@ -893,8 +893,8 @@ void emitIns_SS_R_R_R_I(instruction ins,
                         regNumber   reg3,
                         ssize_t     imm,
                         int         varx1 = -1,
-                        int         offs  = -1,
-                        int         varx2 = -1);
+                        int         varx2 = -1,
+                        int offs  = -1);
 
 void emitIns_R_S(instruction ins, emitAttr attr, regNumber ireg, int varx, int offs);
 

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -136,8 +136,8 @@ bool ReplaceLdrStrWithPairInstr(instruction ins,
                                 emitAttr    size,
                                 insFormat   fmt,
                                 bool        localVar = false,
-                                int         varx     = 0,
-                                int         offs     = 0);
+                                int         varx     = -1,
+                                int         offs     = -1);
 bool IsOptimizableLdrToMov(instruction ins, regNumber reg1, regNumber reg2, ssize_t imm, emitAttr size, insFormat fmt);
 
 // Try to optimize a Ldr or Str with an alternative instruction.
@@ -149,8 +149,8 @@ inline bool OptimizeLdrStr(instruction ins,
                            emitAttr    size,
                            insFormat   fmt,
                            bool        localVar = false,
-                           int         varx     = 0,
-                           int         offs     = 0)
+                           int         varx     = -1,
+                           int offs = -1 DEBUG_ARG(bool useRsvdReg = false))
 {
     assert(ins == INS_ldr || ins == INS_str);
 
@@ -172,6 +172,7 @@ inline bool OptimizeLdrStr(instruction ins,
     //
     if (ReplaceLdrStrWithPairInstr(ins, reg1Attr, reg1, reg2, imm, size, fmt, localVar, varx, offs))
     {
+        assert(!useRsvdReg);
         return true;
     }
 

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -853,16 +853,16 @@ void emitIns_S_S_R_R(
     instruction ins, emitAttr attr, emitAttr attr2, regNumber ireg, regNumber ireg2, int varx, int offs);
 
 void emitIns_R_R_R_I_LdStPair(instruction ins,
-                        emitAttr    attr,
-                        emitAttr    attr2,
-                        regNumber   reg1,
-                        regNumber   reg2,
-                        regNumber   reg3,
-                        ssize_t     imm,
-                        int         varx1 = -1,
-                        int         varx2 = -1,
-                        int         offs1 = -1,
-                        int         offs2 = -1);
+                              emitAttr    attr,
+                              emitAttr    attr2,
+                              regNumber   reg1,
+                              regNumber   reg2,
+                              regNumber   reg3,
+                              ssize_t     imm,
+                              int         varx1 = -1,
+                              int         varx2 = -1,
+                              int         offs1 = -1,
+                              int         offs2 = -1);
 
 void emitIns_R_S(instruction ins, emitAttr attr, regNumber ireg, int varx, int offs);
 

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -139,8 +139,6 @@ bool ReplaceLdrStrWithPairInstr(instruction ins,
                                 int         varx     = -1,
                                 int         offs     = -1);
 bool IsOptimizableLdrToMov(instruction ins, regNumber reg1, regNumber reg2, ssize_t imm, emitAttr size, insFormat fmt);
-
-// Try to optimize a Ldr or Str with an alternative instruction.
 FORCEINLINE bool OptimizeLdrStr(instruction ins,
                                 emitAttr    reg1Attr,
                                 regNumber   reg1,
@@ -151,6 +149,19 @@ FORCEINLINE bool OptimizeLdrStr(instruction ins,
                                 bool        localVar = false,
                                 int         varx     = -1,
                                 int offs = -1 DEBUG_ARG(bool useRsvdReg = false));
+
+emitLclVarAddr* emitGetLclVarPairLclVar2(instrDesc* id)
+{
+    assert(id->idIsLclVarPair());
+    if (id->idIsLargeCns())
+    {
+        return &(((instrDescLclVarPairCns*)id)->iiaLclVar2);
+    }
+    else
+    {
+        return &(((instrDescLclVarPair*)id)->iiaLclVar2);
+    }
+}
 
 /************************************************************************
 *

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -894,7 +894,7 @@ void emitIns_SS_R_R_R_I(instruction ins,
                         ssize_t     imm,
                         int         varx1 = -1,
                         int         varx2 = -1,
-                        int offs  = -1);
+                        int         offs  = -1);
 
 void emitIns_R_S(instruction ins, emitAttr attr, regNumber ireg, int varx, int offs);
 

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -852,7 +852,7 @@ void emitIns_S_R(instruction ins, emitAttr attr, regNumber ireg, int varx, int o
 void emitIns_S_S_R_R(
     instruction ins, emitAttr attr, emitAttr attr2, regNumber ireg, regNumber ireg2, int varx, int offs);
 
-void emitIns_SS_R_R_R_I(instruction ins,
+void emitIns_R_R_R_I_LdStPair(instruction ins,
                         emitAttr    attr,
                         emitAttr    attr2,
                         regNumber   reg1,

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -135,9 +135,9 @@ bool ReplaceLdrStrWithPairInstr(instruction ins,
                                 ssize_t     imm,
                                 emitAttr    size,
                                 insFormat   fmt,
-                                bool        localVar      = false,
-                                int         currLclVarNum = 0,
-                                int         offs          = 0);
+                                bool        localVar = false,
+                                int         varx     = 0,
+                                int         offs     = 0);
 bool IsOptimizableLdrToMov(instruction ins, regNumber reg1, regNumber reg2, ssize_t imm, emitAttr size, insFormat fmt);
 
 // Try to optimize a Ldr or Str with an alternative instruction.
@@ -894,7 +894,8 @@ void emitIns_SS_R_R_R_I(instruction ins,
                         ssize_t     imm,
                         int         varx1 = -1,
                         int         varx2 = -1,
-                        int         offs  = -1);
+                        int         offs1 = -1,
+                        int         offs2 = -1);
 
 void emitIns_R_S(instruction ins, emitAttr attr, regNumber ireg, int varx, int offs);
 


### PR DESCRIPTION
Optimize pair of `str` with `stp` along with tracking the gc information.

Contributes to https://github.com/dotnet/runtime/issues/55365 and https://github.com/dotnet/runtime/issues/77010
Fixes: https://github.com/dotnet/runtime/issues/35134, https://github.com/dotnet/runtime/issues/35133 and https://github.com/dotnet/runtime/issues/81278