### PR TITLE
[mono][aot] Skip methods only in DEDUP_SKIP phase

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -4317,10 +4317,11 @@ collect_dedup_method (MonoAotCompile *acfg, MonoMethod *method)
 {
 	// Check if the dedup is enabled, and if the current method can be deduplicated
 	if ((acfg->dedup_phase == DEDUP_SKIP || acfg->dedup_phase == DEDUP_COLLECT) && mono_aot_can_dedup (method)) {
+		if (acfg->dedup_phase == DEDUP_SKIP)
+			return TRUE;
 		// Remember for later
 		if (acfg->dedup_phase == DEDUP_COLLECT && !g_hash_table_lookup (dedup_methods, method))
 				g_hash_table_insert (dedup_methods, method, method);
-		return TRUE;
 	}
 	return FALSE;
 }


### PR DESCRIPTION
This PR should fix https://github.com/dotnet/perf-autofiling-issues/issues/16477. It reverts the the change that skip collected methods in DEDUP_COLLECT phase.