### PR TITLE
[release/6.0-staging][wasm][debugger] Remove error message when browser is closed

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsProxy.cs
@@ -340,7 +340,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                     }
                     catch (Exception e)
                     {
-                        Log("error", $"DevToolsProxy::Run: Exception {e}");
+                        //Log("error", $"DevToolsProxy::Run: Exception {e}");
                         _channelWriter.Complete(e);
                         //throw;
                     }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsProxy.cs
@@ -340,9 +340,9 @@ namespace Microsoft.WebAssembly.Diagnostics
                     }
                     catch (Exception e)
                     {
-                        //Log("error", $"DevToolsProxy::Run: Exception {e}");
+                        if (e.InnerException is null || e.InnerException is not System.Net.WebSockets.WebSocketException)
+                            Log("error", $"DevToolsProxy::Run: Exception {e}");
                         _channelWriter.Complete(e);
-                        //throw;
                     }
                     finally
                     {


### PR DESCRIPTION
# Description

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->
Only skipping printing the error if we have an exception of type: WebSocketException

# Customer Impact

<!-- What is the impact to customers of not taking this fix? -->
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1784268
When the browser is closed an exception is printed to console.
![image](https://user-images.githubusercontent.com/4503299/233172788-2693ba50-f5db-4471-8490-d67844dcc0b8.png)

# Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->
Yes, when we backported the communication from .net7 to .net6 to fix other issue, we regressed this and started printing the disconnection exception again.

# Testing

<!-- What kind of testing has been done with the fix. -->
Manually tested

# Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
Low risk. Only not printing the error.

# Package authoring signed off?

N/A

IMPORTANT: If this change touches code that ships in a NuGet package, please make certain that you have added any necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.
