### PR TITLE
Use emit-based invoke for all of WASM including DI

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/MethodInvoker.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/MethodInvoker.CoreCLR.cs
@@ -22,7 +22,7 @@ namespace System.Reflection
             }
             else if (LocalAppContextSwitches.ForceEmitInvoke && !LocalAppContextSwitches.ForceInterpretedInvoke)
             {
-                // Always use emit invoke (if IsDynamicCodeCompiled == true); useful for testing.
+                // Always use emit invoke (if IsDynamicCodeSupported == true); useful for testing.
                 _invoked = true;
             }
         }

--- a/src/libraries/Common/tests/System/Reflection/InvokeEmitTests.cs
+++ b/src/libraries/Common/tests/System/Reflection/InvokeEmitTests.cs
@@ -34,8 +34,8 @@ namespace System.Reflection.Tests
 
         private static bool IsEmitInvokeSupported()
         {
-            // Emit is only used for Invoke when RuntimeFeature.IsDynamicCodeCompiled is true.
-            return RuntimeFeature.IsDynamicCodeCompiled;
+            // Emit is only used for Invoke when RuntimeFeature.IsDynamicCodeSupported is true.
+            return RuntimeFeature.IsDynamicCodeSupported;
         }
 
         private static string InterpretedMethodName => PlatformDetection.IsMonoRuntime ?

--- a/src/libraries/Common/tests/System/Reflection/InvokeInterpretedTests.cs
+++ b/src/libraries/Common/tests/System/Reflection/InvokeInterpretedTests.cs
@@ -8,7 +8,7 @@ namespace System.Reflection.Tests
     public class InvokeInterpretedTests
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50957", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50957", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoAOT))]
         public static void VerifyInvokeIsUsingEmit_Method()
         {
             MethodInfo method = typeof(TestClassThatThrows).GetMethod(nameof(TestClassThatThrows.Throw))!;
@@ -25,7 +25,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50957", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50957", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoAOT))]
         public static void VerifyInvokeIsUsingEmit_Constructor()
         {
             ConstructorInfo ctor = typeof(TestClassThatThrows).GetConstructor(Type.EmptyTypes)!;

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ActivatorUtilities.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ActivatorUtilities.cs
@@ -314,6 +314,11 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return (IServiceProvider serviceProvider, object?[]? arguments) =>
             {
+                if (serviceProvider is null)
+                {
+                    throw new ArgumentNullException(nameof(serviceProvider));
+                }
+
                 object?[] constructorArguments = new object?[parameters.Length];
                 for (int i = 0; i < parameters.Length; i++)
                 {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ActivatorUtilities.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ActivatorUtilities.cs
@@ -129,10 +129,14 @@ namespace Microsoft.Extensions.DependencyInjection
             Type[] argumentTypes)
         {
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP
-            if (!RuntimeFeature.IsDynamicCodeSupported)
+            if (!RuntimeFeature.IsDynamicCodeCompiled)
             {
-                // Create a reflection-based factory when dynamic code isn't supported, e.g. app is published with NativeAOT.
-                // Reflection-based factory is faster than interpreted expressions and doesn't pull in System.Linq.Expressions dependency.
+                // Create a reflection-based factory when dynamic code is not compiled\jitted as would be the case with
+                // NativeAOT, iOS or WASM.
+                // For NativeAOT and iOS, using the reflection-based factory is faster than reflection-fallback interpreted
+                // expressions and also doesn't pull in the large System.Linq.Expressions dependency.
+                // For WASM, although it has the ability to use expressions (with dynamic code) and interpet the dynamic code
+                // efficiently, the size savings of not using System.Linq.Expressions is more important than CPU perf.
                 return CreateFactoryReflection(instanceType, argumentTypes);
             }
 #endif
@@ -163,10 +167,9 @@ namespace Microsoft.Extensions.DependencyInjection
                 Type[] argumentTypes)
         {
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP
-            if (!RuntimeFeature.IsDynamicCodeSupported)
+            if (!RuntimeFeature.IsDynamicCodeCompiled)
             {
-                // Create a reflection-based factory when dynamic code isn't supported, e.g. app is published with NativeAOT.
-                // Reflection-based factory is faster than interpreted expressions and doesn't pull in System.Linq.Expressions dependency.
+                // See the comment above in the non-generic CreateFactory() for why we use 'IsDynamicCodeCompiled' here.
                 var factory = CreateFactoryReflection(typeof(T), argumentTypes);
                 return (serviceProvider, arguments) => (T)factory(serviceProvider, arguments);
             }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ActivatorUtilitiesTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ActivatorUtilitiesTests.cs
@@ -204,12 +204,12 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 #if NETCOREAPP
         [InlineData(false)]
 #endif
-        public void CreateFactory_RemoteExecutor_CreatesFactoryMethod(bool isDynamicCodeSupported)
+        public void CreateFactory_RemoteExecutor_CreatesFactoryMethod(bool useDynamicCode)
         {
             var options = new RemoteInvokeOptions();
-            if (!isDynamicCodeSupported)
+            if (!useDynamicCode)
             {
-                options.RuntimeConfigurationOptions.Add("System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported", "false");
+                DisableDynamicCode(options);
             }
 
             using var remoteHandle = RemoteExecutor.Invoke(static () =>
@@ -238,12 +238,12 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 #if NETCOREAPP
         [InlineData(false)]
 #endif
-        public void CreateFactory_RemoteExecutor_NullArguments_Throws(bool isDynamicCodeSupported)
+        public void CreateFactory_RemoteExecutor_NullArguments_Throws(bool useDynamicCode)
         {
             var options = new RemoteInvokeOptions();
-            if (!isDynamicCodeSupported)
+            if (!useDynamicCode)
             {
-                options.RuntimeConfigurationOptions.Add("System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported", "false");
+                DisableDynamicCode(options);
             }
 
             using var remoteHandle = RemoteExecutor.Invoke(static () =>
@@ -261,12 +261,12 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 #if NETCOREAPP
         [InlineData(false)]
 #endif
-        public void CreateFactory_RemoteExecutor_NoArguments_UseNullDefaultValue(bool isDynamicCodeSupported)
+        public void CreateFactory_RemoteExecutor_NoArguments_UseNullDefaultValue(bool useDynamicCode)
         {
             var options = new RemoteInvokeOptions();
-            if (!isDynamicCodeSupported)
+            if (!useDynamicCode)
             {
-                options.RuntimeConfigurationOptions.Add("System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported", "false");
+                DisableDynamicCode(options);
             }
 
             using var remoteHandle = RemoteExecutor.Invoke(static () =>
@@ -285,12 +285,12 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 #if NETCOREAPP
         [InlineData(false)]
 #endif
-        public void CreateFactory_RemoteExecutor_NoArguments_ThrowRequiredValue(bool isDynamicCodeSupported)
+        public void CreateFactory_RemoteExecutor_NoArguments_ThrowRequiredValue(bool useDynamicCode)
         {
             var options = new RemoteInvokeOptions();
-            if (!isDynamicCodeSupported)
+            if (!useDynamicCode)
             {
-                options.RuntimeConfigurationOptions.Add("System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported", "false");
+                DisableDynamicCode(options);
             }
 
             using var remoteHandle = RemoteExecutor.Invoke(static () =>
@@ -309,12 +309,12 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 #if NETCOREAPP
         [InlineData(false)]
 #endif
-        public void CreateFactory_RemoteExecutor_NullArgument_UseDefaultValue(bool isDynamicCodeSupported)
+        public void CreateFactory_RemoteExecutor_NullArgument_UseDefaultValue(bool useDynamicCode)
         {
             var options = new RemoteInvokeOptions();
-            if (!isDynamicCodeSupported)
+            if (!useDynamicCode)
             {
-                options.RuntimeConfigurationOptions.Add("System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported", "false");
+                DisableDynamicCode(options);
             }
 
             using var remoteHandle = RemoteExecutor.Invoke(static () =>
@@ -333,12 +333,12 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 #if NETCOREAPP
         [InlineData(false)]
 #endif
-        public void CreateFactory_RemoteExecutor_NoParameters_Success(bool isDynamicCodeSupported)
+        public void CreateFactory_RemoteExecutor_NoParameters_Success(bool useDynamicCode)
         {
             var options = new RemoteInvokeOptions();
-            if (!isDynamicCodeSupported)
+            if (!useDynamicCode)
             {
-                options.RuntimeConfigurationOptions.Add("System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported", "false");
+                DisableDynamicCode(options);
             }
 
             using var remoteHandle = RemoteExecutor.Invoke(static () =>
@@ -351,7 +351,16 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                 Assert.NotNull(item);
             }, options);
         }
+
+        private static void DisableDynamicCode(RemoteInvokeOptions options)
+        {
+            // We probably only need to set 'IsDynamicCodeCompiled' since only that is checked,
+            // but also set 'IsDynamicCodeSupported' for correctness.
+            options.RuntimeConfigurationOptions.Add("System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported", "false");
+            options.RuntimeConfigurationOptions.Add("System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeCompiled", "false");
+        }
     }
+}
 
     internal class A { }
     internal class B { }
@@ -532,4 +541,4 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             Text = text;
         }
     }
-}
+

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ActivatorUtilitiesTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ActivatorUtilitiesTests.cs
@@ -355,12 +355,11 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         private static void DisableDynamicCode(RemoteInvokeOptions options)
         {
             // We probably only need to set 'IsDynamicCodeCompiled' since only that is checked,
-            // but also set 'IsDynamicCodeSupported' for correctness.
+            // but also set 'IsDynamicCodeSupported for correctness.
             options.RuntimeConfigurationOptions.Add("System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported", "false");
             options.RuntimeConfigurationOptions.Add("System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeCompiled", "false");
         }
     }
-}
 
     internal class A { }
     internal class B { }
@@ -370,8 +369,8 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
     internal class ClassWithABCS : ClassWithABC
     {
         public S S { get; }
-        public ClassWithABCS(A a, B b, C c, S s) : base (a, b, c) { S = s; }
-        public ClassWithABCS(A a, C c, S s) : this (a, null, c, s) { }
+        public ClassWithABCS(A a, B b, C c, S s) : base(a, b, c) { S = s; }
+        public ClassWithABCS(A a, C c, S s) : this(a, null, c, s) { }
     }
 
     internal class ClassWithABC_FirstConstructorWithAttribute : ClassWithABC
@@ -383,9 +382,9 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 
     internal class ClassWithABC_LastConstructorWithAttribute : ClassWithABC
     {
-        public ClassWithABC_LastConstructorWithAttribute(B b, C c) : this(null, b, c) {  }
+        public ClassWithABC_LastConstructorWithAttribute(B b, C c) : this(null, b, c) { }
         [ActivatorUtilitiesConstructor]
-        public ClassWithABC_LastConstructorWithAttribute(A a, B b, C c) : base(a, b , c) { }
+        public ClassWithABC_LastConstructorWithAttribute(A a, B b, C c) : base(a, b, c) { }
     }
 
     internal class FakeServiceProvider : IServiceProvider
@@ -521,14 +520,14 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
     {
         public ClassWithABC_DefaultConstructorFirst() : base() { }
         public ClassWithABC_DefaultConstructorFirst(A a) : base(a) { }
-        public ClassWithABC_DefaultConstructorFirst(A a, B b) : base (a, b) { }
-        public ClassWithABC_DefaultConstructorFirst(A a, B b, C c) : base (a, b, c) { }
+        public ClassWithABC_DefaultConstructorFirst(A a, B b) : base(a, b) { }
+        public ClassWithABC_DefaultConstructorFirst(A a, B b, C c) : base(a, b, c) { }
     }
 
     internal class ClassWithABC_DefaultConstructorLast : ClassWithABC
     {
-        public ClassWithABC_DefaultConstructorLast(A a, B b, C c) : base (a, b, c) { }
-        public ClassWithABC_DefaultConstructorLast(A a, B b) : base (a, b) { }
+        public ClassWithABC_DefaultConstructorLast(A a, B b, C c) : base(a, b, c) { }
+        public ClassWithABC_DefaultConstructorLast(A a, B b) : base(a, b) { }
         public ClassWithABC_DefaultConstructorLast(A a) : base(a) { }
         public ClassWithABC_DefaultConstructorLast() : base() { }
     }
@@ -541,4 +540,5 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             Text = text;
         }
     }
+}
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
@@ -939,6 +939,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.RuntimeConfigurationOptions.Add("System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported", "false");
+            options.RuntimeConfigurationOptions.Add("System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeCompiled", "false");
 
             using RemoteInvokeHandle remoteHandle = RemoteExecutor.Invoke(() =>
             {
@@ -966,7 +967,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 Assert.Equal(2, ((Struct1)callSite.Value).Value);
             }, options);
 
-            // Verify the above scenarios work when IsDynamicCodeSupported is not set
+            // Verify the above scenarios work when IsDynamicCodeSupported + IsDynamicCodeCompiled are not set
             Func<Type, ServiceCallSite> callSiteFactory = CreateAotCompatibilityCallSiteFactory();
 
             // Open Generics

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/ConstructorInvoker.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/ConstructorInvoker.cs
@@ -25,7 +25,7 @@ namespace System.Reflection
             }
             else if (LocalAppContextSwitches.ForceEmitInvoke && !LocalAppContextSwitches.ForceInterpretedInvoke)
             {
-                // Always use emit invoke (if IsDynamicCodeCompiled == true); useful for testing.
+                // Always use emit invoke (if IsDynamicCodeSupported == true); useful for testing.
                 _invoked = true;
             }
         }
@@ -53,7 +53,7 @@ namespace System.Reflection
                 }
                 else
                 {
-                    if (RuntimeFeature.IsDynamicCodeCompiled)
+                    if (RuntimeFeature.IsDynamicCodeSupported)
                     {
                         _invokeFunc = InvokerEmitUtil.CreateInvokeDelegate(_method);
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokerEmitUtil.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokerEmitUtil.cs
@@ -66,11 +66,13 @@ namespace System.Reflection
 
             // Invoke the method.
             // For CallStack reasons, don't inline target method.
-#if MONO
-            il.Emit(OpCodes.Call, Methods.DisableInline());
+#if TARGET_WASM
+            // Mono interpreter does not support\need this intrinsic.
+#elif MONO
+             il.Emit(OpCodes.Call, Methods.DisableInline());
 #else
-            il.Emit(OpCodes.Call, Methods.NextCallReturnAddress());
-            il.Emit(OpCodes.Pop);
+             il.Emit(OpCodes.Call, Methods.NextCallReturnAddress());
+             il.Emit(OpCodes.Pop);
 #endif
 
             if (emitNew)

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokerEmitUtil.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokerEmitUtil.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
 
 namespace System.Reflection
 {
@@ -64,17 +65,19 @@ namespace System.Reflection
                 }
             }
 
-            // Invoke the method.
             // For CallStack reasons, don't inline target method.
-#if TARGET_WASM
-            // Mono interpreter does not support\need this intrinsic.
-#elif MONO
-             il.Emit(OpCodes.Call, Methods.DisableInline());
+            // Mono interpreter does not support\need this.
+            if (RuntimeFeature.IsDynamicCodeCompiled)
+            {
+#if MONO
+                il.Emit(OpCodes.Call, Methods.DisableInline());
 #else
-             il.Emit(OpCodes.Call, Methods.NextCallReturnAddress());
-             il.Emit(OpCodes.Pop);
+                il.Emit(OpCodes.Call, Methods.NextCallReturnAddress());
+                il.Emit(OpCodes.Pop);
 #endif
+            }
 
+            // Invoke the method.
             if (emitNew)
             {
                 il.Emit(OpCodes.Newobj, (ConstructorInfo)method);

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodInvoker.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodInvoker.cs
@@ -37,7 +37,7 @@ namespace System.Reflection
                 }
                 else
                 {
-                    if (RuntimeFeature.IsDynamicCodeCompiled)
+                    if (RuntimeFeature.IsDynamicCodeSupported)
                     {
                         _invokeFunc = InvokerEmitUtil.CreateInvokeDelegate(_method);
                     }

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/MethodInvoker.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/MethodInvoker.Mono.cs
@@ -18,7 +18,7 @@ namespace System.Reflection
             }
             else if (LocalAppContextSwitches.ForceEmitInvoke && !LocalAppContextSwitches.ForceInterpretedInvoke)
             {
-                // Always use emit invoke (if IsDynamicCodeCompiled == true); useful for testing.
+                // Always use emit invoke (if IsDynamicCodeSupported == true); useful for testing.
                 _invoked = true;
             }
         }


### PR DESCRIPTION
Makes the newer emit-based reflection added to Mono in .NET 8.0 also support Blazor\WASM.

Also addresses main requirement for https://github.com/dotnet/runtime/issues/66153 which is to allow ASP.NET to use DI's `ActivatorUtilities.CreateFactory` without a ~259K size regression (measuring size of .br files).

The perf results for using an emit-based invoke instead of interpreted are not as good as the 2x-3x we saw for Core and Mono, but the expected overall improvement should be ~20-30% with the largest gain by far being a zero-arg constructor which is ~2.2x faster. Once the new fast invoke APIs are ready (which are based on emit), those are expected to further improve most cases; these will be used by DI once available.

Measurements below are in ms and for 1,000,000 iterations. Also includes the `object[] parameters` alloc for `MethodBase.Invoke()` for cases that have parameters.
| Test | Before| After | Ratio |
| --- | ---: | ---: | ---: |
| constructor (0 args) | 430 | 195 | 2.21 |
| constructor (3 args) | 2015 | 1660 | 1.21 |
| constructor (5 args) | 2585 | 2293 | 1.13 |
| method (0 args) | 1008 | 718 | 1.40 |
| method (3 args) | 2601 | 2322 | 1.12 |
| method (5 args) | 3218 | 2918| 1.10 |
| set property |1730 |1420 | 1.22 |
| get property |111|108| 1.03 |
