### PR TITLE
Add Uri.QueryRfc3986 (no leading question mark), and mark Uri.Query as [Obsolete]

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -1076,8 +1076,12 @@ namespace System
             }
         }
 
-        //
-        //  Gets the escaped query.
+        /// <summary>
+        /// Legacy implementation that pre-dates RFC 3986 (January 2005),
+        /// that incorrectly starts with a question mark.
+        /// Please see: https://github.com/dotnet/runtime/issues/84955
+        /// </summary>
+        [Obsolete]
         public string Query
         {
             get
@@ -1089,6 +1093,24 @@ namespace System
 
                 MoreInfo info = EnsureUriInfo().MoreInfo;
                 return info.Query ??= GetParts(UriComponents.Query | UriComponents.KeepDelimiter, UriFormat.UriEscaped);
+            }
+        }
+
+        /// <summary>
+        /// "Query" implementation compliant with RFC 3986.
+        /// Does NOT start with a question mark.
+        /// </summary>
+        public string QueryRfc3986
+        {
+            get
+            {
+                if (IsNotAbsoluteUri)
+                {
+                    throw new InvalidOperationException(SR.net_uri_NotAbsolute);
+                }
+
+                MoreInfo info = EnsureUriInfo().MoreInfo;
+                return info.Query ??= GetParts(UriComponents.Query, UriFormat.UriEscaped);
             }
         }
 

--- a/src/libraries/System.Private.Uri/src/System/UriBuilder.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriBuilder.cs
@@ -17,6 +17,7 @@ namespace System
         private int _port = -1;
         private string _path = "/";
         private string _query = string.Empty;
+        private string _queryRfc3986 = string.Empty;
         private string _fragment = string.Empty;
 
         private bool _changed = true;
@@ -212,6 +213,17 @@ namespace System
                 }
 
                 _query = value ?? string.Empty;
+                _changed = true;
+            }
+        }
+
+        [AllowNull]
+        public string QueryRfc3986
+        {
+            get => _queryRfc3986;
+            set
+            {
+                _queryRfc3986 = value ?? string.Empty;
                 _changed = true;
             }
         }

--- a/src/libraries/System.Private.Uri/tests/ExtendedFunctionalTests/UriTests.cs
+++ b/src/libraries/System.Private.Uri/tests/ExtendedFunctionalTests/UriTests.cs
@@ -54,6 +54,8 @@ namespace System.PrivateUri.Tests
 
             Assert.Equal(@"", uri.Query);
 
+            // TODO Assert.Equal(@"", uri.QueryRfc3986);
+
             Assert.Equal(@"http", uri.Scheme);
 
             string[] ss = uri.Segments;
@@ -112,6 +114,8 @@ namespace System.PrivateUri.Tests
             Assert.Equal(80, uri.Port);
 
             Assert.Equal(@"?date=today", uri.Query);
+
+            // TODO Assert.Equal(@"date=today", uri.QueryRfc3986);
 
             Assert.Equal(@"http", uri.Scheme);
 

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -138,6 +138,8 @@ namespace System.PrivateUri.Tests
 
             Assert.Equal(@"?date=today", uri.Query);
 
+            // Assert.Equal(@"date=today", uri.QueryRfc3986);
+
             Assert.Equal(@"http", uri.Scheme);
 
             string[] ss = uri.Segments;
@@ -194,6 +196,8 @@ namespace System.PrivateUri.Tests
 
             Assert.Throws<InvalidOperationException>(() => uri.Query);
 
+            // TODO Assert.Throws<InvalidOperationException>(() => uri.QueryRfc3986);
+
             Assert.Throws<InvalidOperationException>(() => uri.Scheme);
 
             Assert.Throws<InvalidOperationException>(() => uri.Segments);
@@ -245,6 +249,8 @@ namespace System.PrivateUri.Tests
             Assert.Equal(80, uri.Port);
 
             Assert.Equal(@"?date=today", uri.Query);
+
+            // TODO Assert.Equal(@"date=today", uri.QueryRfc3986);
 
             Assert.Equal(@"http", uri.Scheme);
 


### PR DESCRIPTION
Resolves: https://github.com/dotnet/runtime/issues/84955

Remaining work:
- uncomment TODO items (How can unit tests target current code instead of pre-built Nuget?)
- additional impact of marking Uri.Query as [Obsolete]?
- documentation

