### PR TITLE
[JIT] ARM64 Fix - Use `SetOper` instead of `ChangeOper` to preserve flags

### DIFF
--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -2277,7 +2277,7 @@ void Lowering::ContainCheckCompare(GenTreeOp* cmp)
     if (cmp->OperIsCompare() && CheckImmedAndMakeContained(cmp, op1))
     {
         std::swap(cmp->gtOp1, cmp->gtOp2);
-        cmp->ChangeOper(cmp->SwapRelop(cmp->gtOper));
+        cmp->SetOper(cmp->SwapRelop(cmp->gtOper));
         return;
     }
 
@@ -2294,7 +2294,7 @@ void Lowering::ContainCheckCompare(GenTreeOp* cmp)
         {
             MakeSrcContained(cmp, op1);
             std::swap(cmp->gtOp1, cmp->gtOp2);
-            cmp->ChangeOper(cmp->SwapRelop(cmp->gtOper));
+            cmp->SetOper(cmp->SwapRelop(cmp->gtOper));
             return;
         }
     }


### PR DESCRIPTION
## Description

Resolves https://github.com/dotnet/runtime/issues/84966

The changes from https://github.com/dotnet/runtime/pull/84605 resulted in the failing test.

I narrowed down the IL to this:
```IL
	ldc.r4		ZERO
	ldc.r4		NAN
	bge.un PASS
	br FAIL
```

This is an `unordered` comparison against a float ZERO and float NAN. In the importer, when we see this, the `GTF_RELOP_NAN_UN` flag gets set on the relop. However, if we decide to later swap the relop, calling `ChangeOper` will clear this bit which is what resulted in the test failing.

The fix is to use `SetOper` as it will not clear this flag.