### PR TITLE
Add TimeProvider.GetElapsedTime(long) overload

### DIFF
--- a/src/libraries/Common/src/System/TimeProvider.cs
+++ b/src/libraries/Common/src/System/TimeProvider.cs
@@ -113,6 +113,13 @@ namespace System
             return new TimeSpan((long)((endingTimestamp - startingTimestamp) * ((double)TimeSpan.TicksPerSecond / timestampFrequency)));
         }
 
+        /// <summary>
+        /// Gets the elapsed time since the <paramref name="startingTimestamp"/> value retrieved using <see cref="GetTimestamp"/>.
+        /// </summary>
+        /// <param name="startingTimestamp">The timestamp marking the beginning of the time period.</param>
+        /// <returns>A <see cref="TimeSpan"/> for the elapsed time between the starting timestamp and the time of this call./></returns>
+        public TimeSpan GetElapsedTime(long startingTimestamp) => GetElapsedTime(startingTimestamp, GetTimestamp());
+
         /// <summary>Creates a new <see cref="ITimer"/> instance, using <see cref="TimeSpan"/> values to measure time intervals.</summary>
         /// <param name="callback">
         /// A delegate representing a method to be executed when the timer fires. The method specified for callback should be reentrant,

--- a/src/libraries/Common/tests/System/TimeProviderTests.cs
+++ b/src/libraries/Common/tests/System/TimeProviderTests.cs
@@ -94,6 +94,11 @@ namespace Tests.System
             Assert.True(providerTimestamp2 > timestamp2);
             Assert.Equal(GetElapsedTime(providerTimestamp1, providerTimestamp2), TimeProvider.System.GetElapsedTime(providerTimestamp1, providerTimestamp2));
 
+            long timestamp = TimeProvider.System.GetTimestamp();
+            TimeSpan period1 = TimeProvider.System.GetElapsedTime(timestamp);
+            TimeSpan period2 = TimeProvider.System.GetElapsedTime(timestamp);
+            Assert.True(period1 <= period2);
+
             Assert.Equal(Stopwatch.Frequency, TimeProvider.System.TimestampFrequency);
         }
 

--- a/src/libraries/Microsoft.Bcl.TimeProvider/ref/Microsoft.Bcl.TimeProvider.cs
+++ b/src/libraries/Microsoft.Bcl.TimeProvider/ref/Microsoft.Bcl.TimeProvider.cs
@@ -14,6 +14,7 @@ namespace System
         public virtual System.TimeZoneInfo LocalTimeZone { get; }
         public virtual long TimestampFrequency { get; }
         public virtual long GetTimestamp() { throw null; }
+        public TimeSpan GetElapsedTime(long startingTimestamp) { throw null; }
         public TimeSpan GetElapsedTime(long startingTimestamp, long endingTimestamp) { throw null; }
         public virtual System.Threading.ITimer CreateTimer(System.Threading.TimerCallback callback, object? state, System.TimeSpan dueTime, System.TimeSpan period) { throw null; }
     }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -1897,6 +1897,7 @@ namespace System
         public virtual System.TimeZoneInfo LocalTimeZone { get; }
         public virtual long TimestampFrequency { get; }
         public virtual long GetTimestamp() { throw null; }
+        public TimeSpan GetElapsedTime(long startingTimestamp) { throw null; }
         public TimeSpan GetElapsedTime(long startingTimestamp, long endingTimestamp) { throw null; }
         public virtual System.Threading.ITimer CreateTimer(System.Threading.TimerCallback callback, object? state, System.TimeSpan dueTime, System.TimeSpan period) { throw null; }
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/84945