### PR TITLE
NativeAOT ComWrappers: extend managed object lifetime based on refcount

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -127,7 +127,7 @@ namespace System.Runtime.InteropServices
 
         internal unsafe struct ManagedObjectWrapper
         {
-            public IntPtr HolderHandle; // This is GC Handle
+            public volatile IntPtr HolderHandle; // This is GC Handle
             public ulong RefCount;
 
             public int UserDefinedCount;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -145,6 +145,7 @@ namespace System.Runtime.InteropServices
                     if (!rooted)
                     {
                         // TODO: global pegging state
+                        // https://github.com/dotnet/runtime/issues/85137
                         rooted = GetTrackerCount(refCount) > 0 && (Flags & CreateComInterfaceFlagsEx.IsPegged) != 0;
                     }
                     return rooted;
@@ -442,7 +443,12 @@ namespace System.Runtime.InteropServices
                 }
                 else
                 {
-                    // There are still outstanding references on the COM side
+                    // There are still outstanding references on the COM side.
+                    // This case should only be hit when an outstanding
+                    // tracker refcount exists from AddRefFromReferenceTracker.
+                    // When implementing IReferenceTrackerHost, this should be
+                    // reconsidered.
+                    // https://github.com/dotnet/runtime/issues/85137
                     GC.ReRegisterForFinalize(this);
                 }
             }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -402,8 +402,10 @@ namespace System.Runtime.InteropServices
             static bool IsRootedCallback(IntPtr pObj)
             {
                 // We are paused in the GC, so this is safe.
-                ManagedObjectWrapperHolder holder = Unsafe.AsRef<ManagedObjectWrapperHolder>((void*)&pObj);
-                return holder._wrapper->IsRooted;
+#pragma warning disable CS8500 // Takes a pointer to a managed type
+                ManagedObjectWrapperHolder* holder = (ManagedObjectWrapperHolder*)&pObj;
+                return holder->_wrapper->IsRooted;
+#pragma warning restore CS8500
             }
 
             private ManagedObjectWrapper* _wrapper;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -174,7 +174,7 @@ namespace System.Runtime.InteropServices
 
                 // If we observe the destroy sentinel, then this release
                 // must destroy the wrapper.
-                if (RefCount == DestroySentinel)
+                if (curr == DestroySentinel)
                     Destroy();
 
                 return GetTrackerCount(RefCount);
@@ -806,11 +806,6 @@ namespace System.Runtime.InteropServices
         {
             ManagedObjectWrapper* wrapper = ComInterfaceDispatch.ToManagedObjectWrapper((ComInterfaceDispatch*)pThis);
             uint refcount = wrapper->Release();
-            if (wrapper->RefCount == 0)
-            {
-                wrapper->Destroy();
-            }
-
             return refcount;
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -81,7 +81,7 @@ namespace System.Runtime.InteropServices
             public static unsafe T GetInstance<T>(ComInterfaceDispatch* dispatchPtr) where T : class
             {
                 ManagedObjectWrapper* comInstance = ToManagedObjectWrapper(dispatchPtr);
-                return Unsafe.As<T>(RuntimeImports.RhHandleGet(comInstance->Target));
+                return Unsafe.As<T>(comInstance->Holder.WrappedObject);
             }
 
             internal static unsafe ManagedObjectWrapper* ToManagedObjectWrapper(ComInterfaceDispatch* dispatchPtr)
@@ -127,7 +127,7 @@ namespace System.Runtime.InteropServices
 
         internal unsafe struct ManagedObjectWrapper
         {
-            public IntPtr Target; // This is GC Handle
+            public IntPtr HolderHandle; // This is GC Handle
             public ulong RefCount;
 
             public int UserDefinedCount;
@@ -135,6 +135,33 @@ namespace System.Runtime.InteropServices
             internal InternalComInterfaceDispatch* Dispatches;
 
             internal CreateComInterfaceFlagsEx Flags;
+
+            public bool IsRooted
+            {
+                get
+                {
+                    ulong refCount = Interlocked.Read(ref RefCount);
+                    bool rooted = GetComCount(refCount) > 0;
+                    if (!rooted)
+                    {
+                        // TODO: global pegging state
+                        rooted = GetTrackerCount(refCount) > 0 && (Flags & CreateComInterfaceFlagsEx.IsPegged) != 0;
+                    }
+                    return rooted;
+                }
+            }
+
+            public ManagedObjectWrapperHolder? Holder
+            {
+                get
+                {
+                    IntPtr handle = HolderHandle;
+                    if (handle == IntPtr.Zero)
+                        return null;
+                    else
+                        return Unsafe.As<ManagedObjectWrapperHolder>(GCHandle.FromIntPtr(handle).Target);
+                }
+            }
 
             public uint AddRef()
             {
@@ -177,7 +204,7 @@ namespace System.Runtime.InteropServices
                 if (curr == DestroySentinel)
                     Destroy();
 
-                return GetTrackerCount(RefCount);
+                return GetTrackerCount(curr);
             }
 
             public uint Peg()
@@ -192,20 +219,26 @@ namespace System.Runtime.InteropServices
                 return HResults.S_OK;
             }
 
-            public unsafe int QueryInterface(in Guid riid, out IntPtr ppvObject)
+
+            public unsafe int QueryInterfaceForTracker(in Guid riid, out IntPtr ppvObject)
             {
-                if (GetComCount(RefCount) == 0)
+                if (IsMarkedToDestroy(RefCount) || Holder is null)
                 {
                     ppvObject = IntPtr.Zero;
                     return COR_E_ACCESSING_CCW;
                 }
 
+                return QueryInterface(in riid, out ppvObject);
+            }
+
+            public unsafe int QueryInterface(in Guid riid, out IntPtr ppvObject)
+            {
                 ppvObject = AsRuntimeDefined(in riid);
                 if (ppvObject == IntPtr.Zero)
                 {
                     if ((Flags & CreateComInterfaceFlagsEx.LacksICustomQueryInterface) == 0)
                     {
-                        var customQueryInterface = GCHandle.FromIntPtr(Target).Target as ICustomQueryInterface;
+                        var customQueryInterface = Holder.WrappedObject as ICustomQueryInterface;
                         if (customQueryInterface is null)
                         {
                             SetFlag(CreateComInterfaceFlagsEx.LacksICustomQueryInterface);
@@ -244,15 +277,38 @@ namespace System.Runtime.InteropServices
                 return typeMaybe;
             }
 
-            public unsafe void Destroy()
+            /// <returns>true if actually destroyed</returns>
+            public unsafe bool Destroy()
             {
-                if (Target == IntPtr.Zero)
+                Debug.Assert(GetComCount(RefCount) == 0 || HolderHandle == IntPtr.Zero);
+
+                if (HolderHandle == IntPtr.Zero)
                 {
-                    return;
+                    // We either were previously destroyed or multiple ManagedObjectWrapperHolder
+                    // were created by the ConditionalWeakTable for the same object and we lost the race.
+                    return true;
                 }
 
-                RuntimeImports.RhHandleFree(Target);
-                Target = IntPtr.Zero;
+                ulong prev, refCount;
+                do
+                {
+                    prev = RefCount;
+                    refCount = prev | DestroySentinel;
+                } while (Interlocked.CompareExchange(ref RefCount, refCount, prev) != prev);
+
+                if (refCount == DestroySentinel)
+                {
+                    IntPtr handle = Interlocked.Exchange(ref HolderHandle, IntPtr.Zero);
+                    if (handle != IntPtr.Zero)
+                    {
+                        RuntimeImports.RhHandleFree(handle);
+                    }
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
             }
 
             private unsafe IntPtr AsRuntimeDefined(in Guid riid)
@@ -333,22 +389,60 @@ namespace System.Runtime.InteropServices
 
         internal unsafe class ManagedObjectWrapperHolder
         {
-            private ManagedObjectWrapper* _wrapper;
+            static ManagedObjectWrapperHolder()
+            {
+                delegate* unmanaged<IntPtr, bool> callback = &IsRootedCallback;
+                if (!RuntimeImports.RhRegisterRefCountedHandleCallback((nint)callback, typeof(ManagedObjectWrapperHolder).GetEEType()))
+                {
+                    throw new OutOfMemoryException();
+                }
+            }
 
-            public ManagedObjectWrapperHolder(ManagedObjectWrapper* wrapper)
+            [UnmanagedCallersOnly]
+            static bool IsRootedCallback(IntPtr pObj)
+            {
+                // We are paused in the GC, so this is safe.
+                ManagedObjectWrapperHolder holder = Unsafe.AsRef<ManagedObjectWrapperHolder>((void*)&pObj);
+                return holder._wrapper->IsRooted;
+            }
+
+            private ManagedObjectWrapper* _wrapper;
+            private object _wrappedObject;
+
+            public ManagedObjectWrapperHolder(ManagedObjectWrapper* wrapper, object wrappedObject)
             {
                 _wrapper = wrapper;
+                _wrappedObject = wrappedObject;
+            }
+
+            public void InitializeHandle()
+            {
+                IntPtr handle = RuntimeImports.RhHandleAllocRefCounted(this);
+                IntPtr prev = Interlocked.CompareExchange(ref _wrapper->HolderHandle, handle, IntPtr.Zero);
+                if (prev != IntPtr.Zero)
+                {
+                    RuntimeImports.RhHandleFree(handle);
+                }
             }
 
             public unsafe IntPtr ComIp => _wrapper->As(in ComWrappers.IID_IUnknown);
+
+            public object WrappedObject => _wrappedObject;
 
             public uint AddRef() => _wrapper->AddRef();
 
             ~ManagedObjectWrapperHolder()
             {
                 // Release GC handle created when MOW was built.
-                _wrapper->Destroy();
-                NativeMemory.Free(_wrapper);
+                if (_wrapper->Destroy())
+                {
+                    NativeMemory.Free(_wrapper);
+                }
+                else
+                {
+                    // There are still outstanding references on the COM side
+                    GC.ReRegisterForFinalize(this);
+                }
             }
         }
 
@@ -427,8 +521,9 @@ namespace System.Runtime.InteropServices
             ccwValue = _ccwTable.GetValue(instance, (c) =>
             {
                 ManagedObjectWrapper* value = CreateCCW(c, flags);
-                return new ManagedObjectWrapperHolder(value);
+                return new ManagedObjectWrapperHolder(value, c);
             });
+            ccwValue.InitializeHandle();
             return ccwValue.ComIp;
         }
 
@@ -477,7 +572,7 @@ namespace System.Runtime.InteropServices
                 pDispatches[i]._thisPtr = mow;
             }
 
-            mow->Target = RuntimeImports.RhHandleAlloc(instance, GCHandleType.Normal);
+            mow->HolderHandle = IntPtr.Zero;
             mow->RefCount = 1;
             mow->UserDefinedCount = userDefinedCount;
             mow->UserDefined = userDefined;
@@ -813,7 +908,7 @@ namespace System.Runtime.InteropServices
         internal static unsafe int IReferenceTrackerTarget_QueryInterface(IntPtr pThis, Guid* guid, IntPtr* ppObject)
         {
             ManagedObjectWrapper* wrapper = ComInterfaceDispatch.ToManagedObjectWrapper((ComInterfaceDispatch*)pThis);
-            return wrapper->QueryInterface(in *guid, out *ppObject);
+            return wrapper->QueryInterfaceForTracker(in *guid, out *ppObject);
         }
 
         [UnmanagedCallersOnly]

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -175,6 +175,77 @@ namespace ComWrappersTests
             Assert.Equal(0, count);
         }
 
+        static void ValidateComObjectExtendsManagedLifetime()
+        {
+            Console.WriteLine($"Running {nameof(ValidateComObjectExtendsManagedLifetime)}...");
+
+            // Cleanup any existing objects
+            ForceGC();
+            Assert.Equal(0, Test.InstanceCount);
+
+            // Allocate a wrapper for the object
+            IntPtr comWrapper = CreateObjectAndGetComInterface();
+            Assert.NotEqual(IntPtr.Zero, comWrapper);
+
+            // GC should not free object
+            Assert.Equal(1, Test.InstanceCount);
+            ForceGC();
+            Assert.Equal(1, Test.InstanceCount);
+
+            // Release the wrapper
+            int count = Marshal.Release(comWrapper);
+            Assert.Equal(0, count);
+
+            // Check that the object is no longer rooted.
+            ForceGC();
+            Assert.Equal(0, Test.InstanceCount);
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static IntPtr CreateObjectAndGetComInterface()
+            {
+                var wrappers = new TestComWrappers();
+                return wrappers.GetOrCreateComInterfaceForObject(new Test(), CreateComInterfaceFlags.None);
+            }
+        }
+
+        // Just because one use of a COM interface returned from GetOrCreateComInterfaceForObject
+        // hits zero ref count does not mean future calls to GetOrCreateComInterfaceForObject
+        // should return an unusable object.
+        static void ValidateCreatingAComInterfaceForObjectAfterTheFirstIsFree()
+        {
+            Console.WriteLine($"Running {nameof(ValidateCreatingAComInterfaceForObjectAfterTheFirstIsFree)}...");
+
+            var wrappers = new TestComWrappers();
+            var testInstance = new Test();
+
+            CallSetValue(wrappers, testInstance, 1);
+            CallSetValue(wrappers, testInstance, 2);
+
+            GC.KeepAlive(testInstance);
+
+            unsafe static void CallSetValue(TestComWrappers wrappers, Test testInstance, int value)
+            {
+                IntPtr nativeInstance = wrappers.GetOrCreateComInterfaceForObject(testInstance, CreateComInterfaceFlags.None);
+                Assert.NotEqual(IntPtr.Zero, nativeInstance);
+
+                var iid = typeof(ITest).GUID;
+                IntPtr itestPtr;
+                Assert.Equal(0, Marshal.QueryInterface(nativeInstance, ref iid, out itestPtr));
+
+                var inst = Marshal.PtrToStructure<VtblPtr>(itestPtr);
+                var vtbl = Marshal.PtrToStructure<ITestVtbl>(inst.Vtbl);
+                var setValue = (delegate* unmanaged<IntPtr, int, int>)vtbl.SetValue;
+
+                Assert.Equal(0, setValue(itestPtr, value));
+                Assert.Equal(value, testInstance.GetValue());
+
+                // release for QueryInterface
+                Assert.Equal(1, Marshal.Release(itestPtr));
+                // release for GetOrCreateComInterfaceForObject
+                Assert.Equal(0, Marshal.Release(itestPtr));
+            }
+        }
+
         static void ValidateFallbackQueryInterface()
         {
             Console.WriteLine($"Running {nameof(ValidateFallbackQueryInterface)}...");
@@ -702,6 +773,8 @@ namespace ComWrappersTests
             {
                 ValidateComInterfaceCreation();
                 ValidateComInterfaceCreationRoundTrip();
+                ValidateComObjectExtendsManagedLifetime();
+                ValidateCreatingAComInterfaceForObjectAfterTheFirstIsFree();
                 ValidateFallbackQueryInterface();
                 ValidateCreateObjectCachingScenario();
                 ValidateMappingAPIs();
@@ -713,8 +786,13 @@ namespace ComWrappersTests
                 ValidateBadComWrapperImpl();
                 ValidateRuntimeTrackerScenario();
                 ValidateQueryInterfaceAfterManagedObjectCollected();
-                ValidateAggregationWithComObject();
-                ValidateAggregationWithReferenceTrackerObject();
+
+                // Tracked by https://github.com/dotnet/runtime/issues/74620
+                if (!TestLibrary.Utilities.IsNativeAot)
+                {
+                    ValidateAggregationWithComObject();
+                    ValidateAggregationWithReferenceTrackerObject();
+                }
 
                 // Ensure all objects have been cleaned up.
                 ForceGC();

--- a/src/tests/nativeaot/SmokeTests/ComWrappers/ComWrappers.cs
+++ b/src/tests/nativeaot/SmokeTests/ComWrappers/ComWrappers.cs
@@ -20,8 +20,6 @@ namespace ComWrappersTests
             TestComInteropRegistrationRequired();
             GlobalComWrappers = new SimpleComWrapper();
             ComWrappers.RegisterForMarshalling(GlobalComWrappers);
-            TestComInteropReleaseProcess();
-            TestRCWRoundTripRequireUnwrap();
             TestRCWCached();
             TestRCWRoundTrip();
 
@@ -72,34 +70,6 @@ namespace ComWrappersTests
             IComInterface comPointer = null;
             var result = IsNULL(comPointer);
             ThrowIfNotEquals(true, IsNULL(comPointer), "COM interface marshalling null check failed");
-        }
-
-        public static void TestComInteropRegistrationRequired()
-        {
-            Console.WriteLine("Testing COM Interop registration process");
-            ComObject target = new ComObject();
-            try
-            {
-                CaptureComPointer(target);
-                throw new Exception("Cannot work without ComWrappers.RegisterForMarshalling called");
-            }
-            catch (NotSupportedException)
-            {
-            }
-        }
-
-        public static void TestComInteropReleaseProcess()
-        {
-            Console.WriteLine("Testing RCW release process");
-            WeakReference comPointerHolder = CreateComReference();
-
-            GC.Collect();
-            ThrowIfNotEquals(true, comPointerHolder.IsAlive, ".NET object should be alive");
-
-            ReleaseComPointer();
-
-            GC.Collect();
-            ThrowIfNotEquals(false, comPointerHolder.IsAlive, ".NET object should be disposed by then");
         }
 
         public static void TestRCWRoundTripRequireUnwrap()
@@ -165,19 +135,6 @@ namespace ComWrappersTests
 
             comPointer = BuildComPointerNoPreserveSig();
             comPointer.DoWork(22);
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static WeakReference CreateComReference()
-        {
-            ComObject target = new ComObject();
-            WeakReference comPointerHolder = new WeakReference(target);
-
-            int result = CaptureComPointer(target);
-            ThrowIfNotEquals(0, result, "Seems to be COM marshalling behave strange.");
-            ThrowIfNotEquals(11, target.TestResult, "Call to method should work");
-
-            return comPointerHolder;
         }
     }
 


### PR DESCRIPTION
This PR builds on #84927 by @kant2002 and is inspired by the [comment](https://github.com/dotnet/runtime/pull/84927#pullrequestreview-1388647063) by @jkoritzinsky. It uses a ref-counted GC handle to extend the lifetime of the managed object while the managed object wrapper still has a non-zero refcount.

I have added two test cases to the ComWrappers unit tests to show the problem. On the `main` branch the tests pass on CoreCLR and fail on NativeAOT. The tests pass on NativeAOT after this change.
