### PR TITLE
 [browser][non-icu] `HybridGlobalization` update string decoding for comparison

### DIFF
--- a/src/mono/wasm/runtime/net6-legacy/hybrid-globalization.ts
+++ b/src/mono/wasm/runtime/net6-legacy/hybrid-globalization.ts
@@ -5,7 +5,7 @@ import { Module } from "../imports";
 import { mono_wasm_new_external_root } from "../roots";
 import {MonoString, MonoStringRef } from "../types";
 import { Int32Ptr } from "../types/emscripten";
-import { conv_string_root, js_string_to_mono_string_root } from "../strings";
+import { conv_string_root, js_string_to_mono_string_root, string_decoder } from "../strings";
 import { setU16 } from "../memory";
 
 export function mono_wasm_change_case_invariant(exceptionMessage: Int32Ptr, src: number, srcLength: number, dst: number, dstLength: number, toUpper: number) : void{
@@ -47,12 +47,20 @@ export function mono_wasm_change_case(exceptionMessage: Int32Ptr, culture: MonoS
     }
 }
 
+export function get_utf16_string(ptr: number, length: number): string{
+    const view = new Uint16Array(Module.HEAPU16.buffer, ptr, length);
+    let string = "";
+    for (let i = 0; i < length; i++)
+        string += String.fromCharCode(view[i]);
+    return string;
+}
+
 export function mono_wasm_compare_string(exceptionMessage: Int32Ptr, culture: MonoStringRef, str1: number, str1Length: number, str2: number, str2Length: number, options: number) : number{
     const cultureRoot = mono_wasm_new_external_root<MonoString>(culture);
     try{
         const cultureName = conv_string_root(cultureRoot);
-        const string1  = get_utf16_string(str1, str1Length);
-        const string2 = get_utf16_string(str2, str2Length);
+        const string1 = string_decoder.decode(<any>str1, <any>(str1 + str1Length));
+        const string2 = string_decoder.decode(<any>str2, <any>(str2 + str2Length));
         const casePicker = (options & 0x1f);
         const locale = cultureName ? cultureName : undefined;
         const result = compare_strings(string1, string2, locale, casePicker);
@@ -67,14 +75,6 @@ export function mono_wasm_compare_string(exceptionMessage: Int32Ptr, culture: Mo
     finally {
         cultureRoot.release();
     }
-}
-
-export function get_utf16_string(ptr: number, length: number): string{
-    const view = new Uint16Array(Module.HEAPU16.buffer, ptr, length);
-    let string = "";
-    for (let i = 0; i < length; i++)
-        string += String.fromCharCode(view[i]);
-    return string;
 }
 
 export function pass_exception_details(ex: any, exceptionMessage: Int32Ptr){

--- a/src/mono/wasm/runtime/net6-legacy/hybrid-globalization.ts
+++ b/src/mono/wasm/runtime/net6-legacy/hybrid-globalization.ts
@@ -47,11 +47,11 @@ export function mono_wasm_change_case(exceptionMessage: Int32Ptr, culture: MonoS
     }
 }
 
-export function get_utf16_string(ptr: number, length: number): string{
+function get_utf16_string(ptr: number, length: number): string{
     const view = new Uint16Array(Module.HEAPU16.buffer, ptr, length);
     let string = "";
     for (let i = 0; i < length; i++)
-        string += String.fromCharCode(view[i]);
+        string += String.fromCharCode(view[i]);        
     return string;
 }
 
@@ -59,8 +59,8 @@ export function mono_wasm_compare_string(exceptionMessage: Int32Ptr, culture: Mo
     const cultureRoot = mono_wasm_new_external_root<MonoString>(culture);
     try{
         const cultureName = conv_string_root(cultureRoot);
-        const string1 = string_decoder.decode(<any>str1, <any>(str1 + str1Length));
-        const string2 = string_decoder.decode(<any>str2, <any>(str2 + str2Length));
+        const string1 = string_decoder.decode(<any>str1, <any>(str1 + 2*str1Length));
+        const string2 = string_decoder.decode(<any>str2, <any>(str2 + 2*str2Length));
         const casePicker = (options & 0x1f);
         const locale = cultureName ? cultureName : undefined;
         const result = compare_strings(string1, string2, locale, casePicker);


### PR DESCRIPTION
Implements a chunk of web-api based globalization. Is a part of HybridGlobalization feature and contributes to https://github.com/dotnet/runtime/issues/79989.

Speeds up the decoding process:
| **measurement** | **time without this PR [ms]** | **time with this PR [ms]** |  **time ICU4C [ms]** | **increase vs ICU [times]** |
|-:|-:|-:|-:|-:|
|                 String, String Compare |     5.0290 |     0.2381 | 0.0448 | 5,3
|                  String, String Equals |     4.9587 |     0.1886 | 0.0450 | 4,19
|            String, CompareInfo Compare |     4.9238 |     0.1957 | 0.0451 | 4,33

Change case needs encoding implementation which is more complex, so the update was limited to `compare` for now.