### PR TITLE
Add a test for `STORE_DYN_BLK(..., IND(null), ...)`

### DIFF
--- a/src/tests/JIT/opt/AssertionPropagation/DynBlkNullAssertions.cs
+++ b/src/tests/JIT/opt/AssertionPropagation/DynBlkNullAssertions.cs
@@ -29,7 +29,7 @@ public class DynBlkNullAssertions
     {
         Unsafe.CopyBlock(ref dst, ref src, size);
 
-        return Unsafe.AreSame(ref dst, ref Unsafe.NullRef<byte>());
+        return Unsafe.AreSame(ref dst, ref Unsafe.NullRef<byte>()) && Unsafe.AreSame(ref src, ref Unsafe.NullRef<byte>());
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
The underlying problem was fixed by marking the source indirection with `NO_CSE` in #83814.

Closes #62328.