### PR TITLE
[MONO] Add JIT_CODE_DEBUG_INFO record functionality for Jitdump

### DIFF
--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -2162,16 +2162,14 @@ mono_emit_jit_dump (MonoJitInfo *jinfo, gpointer code)
                 rec.code_addr = (guint64)dmji->code_start;
                 rec.header.total_size = sizeof(rec) + sizeof(ent) + 1;
                 rec.nr_entry=1;
-                for(i=0;i < dmji->num_line_numbers;++i)
-                {
-                        loc = mono_debug_lookup_source_location_by_il(jinfo->d.method,dmji->line_numbers[i].il_offset,NULL);
+                for(i=0;i < dmji->num_line_numbers;++i){
+                        
+			loc = mono_debug_lookup_source_location_by_il(jinfo->d.method,dmji->line_numbers[i].il_offset,NULL);
 
-                        if(!(loc))
-                        {
+                        if(!(loc)
                                 continue;
-                        }
-                        if(!(loc->source_file))
-                        {
+                        
+			if(!(loc->source_file)){
                                 mono_debug_free_source_location(loc);
                                 continue;
                         }
@@ -2183,24 +2181,23 @@ mono_emit_jit_dump (MonoJitInfo *jinfo, gpointer code)
                 fwrite(&rec,sizeof(rec), 1 ,perf_dump_file);
 
 
-                for( i = 0; i < dmji->num_line_numbers;++i)
-		 {
+                for( i = 0; i < dmji->num_line_numbers;++i){
+		
 			//get the line number using il offset
                         loc = mono_debug_lookup_source_location_by_il(jinfo->d.method,dmji->line_numbers[i].il_offset,NULL);
 
                         if(!loc)
                                 continue;
-                        if(!(loc->source_file))
-                        {
-                                mono_debug_free_source_location(loc);
+				
+                        if(!(loc->source_file)){
+                                
+				mono_debug_free_source_location(loc);
                                 continue;
                         }
 
                         ent.code_addr = (guint64)dmji->code_start + dmji->line_numbers[i].native_offset;
                         ent.discrim = 0;
                         ent.line = (guint32)loc->row;
-
-
 
                         fwrite(&ent, sizeof(ent),1,perf_dump_file);
                         fwrite(loc->source_file,strlen(loc->source_file)+1,1,perf_dump_file);

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -2070,16 +2070,16 @@ typedef struct
         guint32 line;
         guint32 discrim;
         char name[];
-}DebugEntry;
+} DebugEntry;
 typedef struct
 {
         RecordHeader header;
         guint64 code_addr;
         guint64 nr_entry;
         DebugEntry debug_entry[];
-}JitCodeDebug;
+} JitCodeDebug;
 
-static void add_basic_JitCodeDebug_info(JitCodeDebug *record);
+static void add_basic_JitCodeDebug_info (JitCodeDebug *record);
 static void add_file_header_info (FileHeader *header);
 static void add_basic_JitCodeLoadRecord_info (JitCodeLoadRecord *record);
 

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -2164,7 +2164,7 @@ mono_emit_jit_dump (MonoJitInfo *jinfo, gpointer code)
                 rec.nr_entry = 1;
                 for (i = 0; i < dmji->num_line_numbers; ++i){
                         
-			loc = mono_debug_lookup_source_location_by_il (jinfo->d.method,dmji->line_numbers[i].il_offset,NULL);
+			loc = mono_debug_lookup_source_location_by_il (jinfo->d.method, dmji->line_numbers[i].il_offset, NULL);
 
                         if(!loc)
                                 continue;
@@ -2178,7 +2178,7 @@ mono_emit_jit_dump (MonoJitInfo *jinfo, gpointer code)
                         rec.nr_entry++;
                 }
 
-                fwrite (&rec, sizeof (rec), 1 , perf_dump_file);
+                fwrite (&rec, sizeof (rec), 1, perf_dump_file);
 
 
                 for( i = 0; i < dmji->num_line_numbers; ++i){

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -2152,7 +2152,7 @@ mono_emit_jit_dump (MonoJitInfo *jinfo, gpointer code)
                 MonoDebugSourceLocation *loc;
                 int i;
 
-		memset (&rec, 0, sizeof(rec));
+		memset (&rec, 0, sizeof (rec));
 		
 		//populating info relating debug methods
 		minfo = mono_debug_lookup_method (jinfo->d.method);

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -2152,7 +2152,8 @@ mono_emit_jit_dump (MonoJitInfo *jinfo, gpointer code)
                 int i;
 
 		memset(&rec, 0, sizeof(rec));
-
+		
+		//populating info relating debug methods
 		minfo = mono_debug_lookup_method(jinfo->d.method);
                 dmji = mono_debug_find_method( jinfo->d.method, NULL);
 
@@ -2183,6 +2184,7 @@ mono_emit_jit_dump (MonoJitInfo *jinfo, gpointer code)
 
                 for( i = 0; i < dmji->num_line_numbers;++i)
 		 {
+			//get the line number using il offset
                         loc = mono_debug_lookup_source_location_by_il(jinfo->d.method,dmji->line_numbers[i].il_offset,NULL);
 
                         if(!loc)
@@ -2203,14 +2205,14 @@ mono_emit_jit_dump (MonoJitInfo *jinfo, gpointer code)
                         fwrite(loc->source_file,strlen(loc->source_file)+1,1,perf_dump_file);
                 }
 
-                // TODO: write unwindInfo immediately before the JitCodeLoadRecord (while lock is held).
+               
                 ent.code_addr = (guint64)jinfo->code_start + jinfo->code_size;
                 ent.discrim = 0;
                 ent.line = 0;
                 fwrite(&ent,sizeof(ent),1,perf_dump_file);
                 fwrite("",1,1,perf_dump_file);
 
-		// TODO: write debugInfo and unwindInfo immediately before the JitCodeLoadRecord (while lock is held).
+		// TODO: write unwindInfo immediately before the JitCodeLoadRecord (while lock is held).
 
 		record.header.timestamp = mono_clock_get_time_ns (clock_id);
 

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -38,6 +38,7 @@
 #include <mono/metadata/threads.h>
 #include <mono/metadata/appdomain.h>
 #include <mono/metadata/debug-helpers.h>
+#include <mono/metadata/debug-internals.h>
 #include <mono/metadata/domain-internals.h>
 #include <mono/metadata/profiler-private.h>
 #include <mono/metadata/mono-config.h>

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -2152,46 +2152,46 @@ mono_emit_jit_dump (MonoJitInfo *jinfo, gpointer code)
                 MonoDebugSourceLocation *loc;
                 int i;
 
-		memset(&rec, 0, sizeof(rec));
+		memset (&rec, 0, sizeof(rec));
 		
 		//populating info relating debug methods
-		minfo = mono_debug_lookup_method(jinfo->d.method);
-                dmji = mono_debug_find_method( jinfo->d.method, NULL);
+		minfo = mono_debug_lookup_method (jinfo->d.method);
+                dmji = mono_debug_find_method (jinfo->d.method, NULL);
 
-                add_basic_JitCodeDebug_info(&rec);
+                add_basic_JitCodeDebug_info (&rec);
                 rec.code_addr = (guint64)dmji->code_start;
-                rec.header.total_size = sizeof(rec) + sizeof(ent) + 1;
-                rec.nr_entry=1;
-                for(i=0;i < dmji->num_line_numbers;++i){
+                rec.header.total_size = sizeof (rec) + sizeof (ent) + 1;
+                rec.nr_entry = 1;
+                for (i = 0; i < dmji->num_line_numbers; ++i){
                         
-			loc = mono_debug_lookup_source_location_by_il(jinfo->d.method,dmji->line_numbers[i].il_offset,NULL);
+			loc = mono_debug_lookup_source_location_by_il (jinfo->d.method,dmji->line_numbers[i].il_offset,NULL);
 
-                        if(!(loc)
+                        if(!loc)
                                 continue;
                         
-			if(!(loc->source_file)){
-                                mono_debug_free_source_location(loc);
+			if(!loc->source_file){
+                                mono_debug_free_source_location (loc);
                                 continue;
                         }
 
-                        rec.header.total_size += sizeof(ent) + strlen(loc->source_file) + 1;
+                        rec.header.total_size += sizeof (ent) + strlen (loc->source_file) + 1;
                         rec.nr_entry++;
                 }
 
-                fwrite(&rec,sizeof(rec), 1 ,perf_dump_file);
+                fwrite (&rec, sizeof (rec), 1 , perf_dump_file);
 
 
-                for( i = 0; i < dmji->num_line_numbers;++i){
+                for( i = 0; i < dmji->num_line_numbers; ++i){
 		
 			//get the line number using il offset
-                        loc = mono_debug_lookup_source_location_by_il(jinfo->d.method,dmji->line_numbers[i].il_offset,NULL);
+                        loc = mono_debug_lookup_source_location_by_il (jinfo->d.method, dmji->line_numbers[i].il_offset, NULL);
 
                         if(!loc)
                                 continue;
 				
-                        if(!(loc->source_file)){
+                        if(!loc->source_file){
                                 
-				mono_debug_free_source_location(loc);
+				mono_debug_free_source_location (loc);
                                 continue;
                         }
 
@@ -2199,16 +2199,16 @@ mono_emit_jit_dump (MonoJitInfo *jinfo, gpointer code)
                         ent.discrim = 0;
                         ent.line = (guint32)loc->row;
 
-                        fwrite(&ent, sizeof(ent),1,perf_dump_file);
-                        fwrite(loc->source_file,strlen(loc->source_file)+1,1,perf_dump_file);
+                        fwrite (&ent, sizeof(ent), 1, perf_dump_file);
+                        fwrite (loc->source_file, strlen (loc->source_file) + 1, 1, perf_dump_file);
                 }
 
                
                 ent.code_addr = (guint64)jinfo->code_start + jinfo->code_size;
                 ent.discrim = 0;
                 ent.line = 0;
-                fwrite(&ent,sizeof(ent),1,perf_dump_file);
-                fwrite("",1,1,perf_dump_file);
+                fwrite (&ent, sizeof (ent), 1, perf_dump_file);
+                fwrite ("", 1, 1, perf_dump_file);
 
 		// TODO: write unwindInfo immediately before the JitCodeLoadRecord (while lock is held).
 
@@ -2222,7 +2222,7 @@ mono_emit_jit_dump (MonoJitInfo *jinfo, gpointer code)
 	}
 }
 static void
-add_basic_JitCodeDebug_info(JitCodeDebug *record)
+add_basic_JitCodeDebug_info (JitCodeDebug *record)
 {
         record->header.id = JIT_DEBUG_INFO;
         record->header.timestamp = mono_clock_get_time_ns (clock_id);


### PR DESCRIPTION
This is related to #36774 . added support for `JIT_CODE_DEBUG_INFO` record which helps to annotate source code in perf.

Changed the jitdump version to 1 as the perf sources expect version 1

https://github.com/torvalds/linux/blob/master/tools/perf/util/jitdump.h#L25

Example use:-
    MONO_ENV_OPTIONS="--jitdump" perf record -k 1 dotnet <path/to/binary>
    perf inject --jit -i perf.data -o perf.jit.data
    perf report -i perf.jit.data

cc: @fanyang-mono 