### PR TITLE
Ensure ins_Copy, ins_Load, ins_Move, and ins_Store all handle TYP_MASK

### DIFF
--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -1725,7 +1725,7 @@ instruction CodeGen::ins_Copy(regNumber srcReg, var_types dstType)
 
     if (varTypeUsesIntReg(dstType))
     {
-        if (genIsValidIntReg(srcReg))
+        if (genIsValidIntOrFakeReg(srcReg))
         {
             // int to int
             return ins_Copy(dstType);
@@ -1737,7 +1737,7 @@ instruction CodeGen::ins_Copy(regNumber srcReg, var_types dstType)
             // mask to int
             return INS_kmovq_gpr;
         }
-#endif
+#endif // TARGET_XARCH
 
         // float to int
         assert(genIsValidFloatReg(srcReg));
@@ -1773,7 +1773,7 @@ instruction CodeGen::ins_Copy(regNumber srcReg, var_types dstType)
         }
 
         // mask to int
-        assert(genIsValidIntReg(srcReg));
+        assert(genIsValidIntOrFakeReg(srcReg));
         return INS_kmovq_gpr;
     }
 #endif // TARGET_XARCH
@@ -1787,7 +1787,7 @@ instruction CodeGen::ins_Copy(regNumber srcReg, var_types dstType)
     }
 
     // int to float
-    assert(genIsValidIntReg(srcReg));
+    assert(genIsValidIntOrFakeReg(srcReg));
 
 #if defined(TARGET_XARCH)
     return INS_movd;
@@ -1958,7 +1958,7 @@ instruction CodeGenInterface::ins_StoreFromSrc(regNumber srcReg, var_types dstTy
 
     if (varTypeUsesIntReg(dstType))
     {
-        if (genIsValidIntReg(srcReg))
+        if (genIsValidIntOrFakeReg(srcReg))
         {
             // int to int
             return ins_Store(dstType, aligned);
@@ -2004,14 +2004,14 @@ instruction CodeGenInterface::ins_StoreFromSrc(regNumber srcReg, var_types dstTy
         }
 
         // mask to int, keep as mask so it works on 32-bit
-        assert(genIsValidIntReg(srcReg));
+        assert(genIsValidIntOrFakeReg(srcReg));
         return ins_Store(dstType, aligned);
     }
 #endif // TARGET_XARCH
 
     assert(varTypeUsesFloatReg(dstType));
 
-    if (genIsValidIntReg(srcReg))
+    if (genIsValidIntOrFakeReg(srcReg))
     {
         // int to float, treat as int to int
 
@@ -2288,7 +2288,7 @@ void CodeGen::instGen_Return(unsigned stkArgSize)
  */
 void CodeGen::instGen_Set_Reg_To_Zero(emitAttr size, regNumber reg, insFlags flags)
 {
-    assert(genIsValidIntReg(reg));
+    assert(genIsValidIntOrFakeReg(reg));
 
 #if defined(TARGET_XARCH)
     GetEmitter()->emitIns_R_R(INS_xor, size, reg, reg);

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -1421,12 +1421,12 @@ instruction CodeGen::ins_Move_Extend(var_types srcType, bool srcInReg)
         return ins;
     }
 
-#if defined(TARGET_XARCH)
+#if defined(TARGET_XARCH) && defined(FEATURE_SIMD)
     if (varTypeUsesMaskReg(srcType))
     {
         return INS_kmovq_msk;
     }
-#endif // TARGET_XARCH
+#endif // TARGET_XARCH && FEATURE_SIMD
 
     assert(varTypeUsesFloatReg(srcType));
 
@@ -1570,12 +1570,12 @@ instruction CodeGenInterface::ins_Load(var_types srcType, bool aligned /*=false*
         return ins;
     }
 
-#if defined(TARGET_XARCH)
+#if defined(TARGET_XARCH) && defined(FEATURE_SIMD)
     if (varTypeUsesMaskReg(srcType))
     {
         return INS_kmovq_msk;
     }
-#endif // TARGET_XARCH
+#endif // TARGET_XARCH && FEATURE_SIMD
 
     assert(varTypeUsesFloatReg(srcType));
 
@@ -1654,12 +1654,12 @@ instruction CodeGen::ins_Copy(var_types dstType)
 #endif
     }
 
-#if defined(TARGET_XARCH)
+#if defined(TARGET_XARCH) && defined(FEATURE_SIMD)
     if (varTypeUsesMaskReg(dstType))
     {
         return INS_kmovq_msk;
     }
-#endif // TARGET_XARCH
+#endif // TARGET_XARCH && FEATURE_SIMD
 
     assert(varTypeUsesFloatReg(dstType));
 
@@ -1731,13 +1731,13 @@ instruction CodeGen::ins_Copy(regNumber srcReg, var_types dstType)
             return ins_Copy(dstType);
         }
 
-#if defined(TARGET_XARCH)
+#if defined(TARGET_XARCH) && defined(FEATURE_SIMD)
         if (genIsValidMaskReg(srcReg))
         {
             // mask to int
             return INS_kmovq_gpr;
         }
-#endif // TARGET_XARCH
+#endif // TARGET_XARCH && FEATURE_SIMD
 
         // float to int
         assert(genIsValidFloatReg(srcReg));
@@ -1763,7 +1763,7 @@ instruction CodeGen::ins_Copy(regNumber srcReg, var_types dstType)
 #endif
     }
 
-#if defined(TARGET_XARCH)
+#if defined(TARGET_XARCH) && defined(FEATURE_SIMD)
     if (varTypeUsesMaskReg(dstType))
     {
         if (genIsValidMaskReg(srcReg))
@@ -1776,7 +1776,7 @@ instruction CodeGen::ins_Copy(regNumber srcReg, var_types dstType)
         assert(genIsValidIntOrFakeReg(srcReg));
         return INS_kmovq_gpr;
     }
-#endif // TARGET_XARCH
+#endif // TARGET_XARCH && FEATURE_SIMD
 
     assert(varTypeUsesFloatReg(dstType));
 
@@ -1877,12 +1877,12 @@ instruction CodeGenInterface::ins_Store(var_types dstType, bool aligned /*=false
         return ins;
     }
 
-#if defined(TARGET_XARCH)
+#if defined(TARGET_XARCH) && defined(FEATURE_SIMD)
     if (varTypeUsesMaskReg(dstType))
     {
         return INS_kmovq_msk;
     }
-#endif // TARGET_XARCH
+#endif // TARGET_XARCH && FEATURE_SIMD
 
     assert(varTypeUsesFloatReg(dstType));
 
@@ -1964,13 +1964,13 @@ instruction CodeGenInterface::ins_StoreFromSrc(regNumber srcReg, var_types dstTy
             return ins_Store(dstType, aligned);
         }
 
-#if defined(TARGET_XARCH)
+#if defined(TARGET_XARCH) && defined(FEATURE_SIMD)
         if (genIsValidMaskReg(srcReg))
         {
             // mask to int, treat as mask so it works on 32-bit
             return ins_Store(TYP_MASK, aligned);
         }
-#endif
+#endif // TARGET_XARCH && FEATURE_SIMD
 
         // float to int, treat as float to float
         assert(genIsValidFloatReg(srcReg));
@@ -1994,7 +1994,7 @@ instruction CodeGenInterface::ins_StoreFromSrc(regNumber srcReg, var_types dstTy
         return ins_Store(dstType, aligned);
     }
 
-#if defined(TARGET_XARCH)
+#if defined(TARGET_XARCH) && defined(FEATURE_SIMD)
     if (varTypeUsesMaskReg(dstType))
     {
         if (genIsValidMaskReg(srcReg))
@@ -2007,7 +2007,7 @@ instruction CodeGenInterface::ins_StoreFromSrc(regNumber srcReg, var_types dstTy
         assert(genIsValidIntOrFakeReg(srcReg));
         return ins_Store(dstType, aligned);
     }
-#endif // TARGET_XARCH
+#endif // TARGET_XARCH && FEATURE_SIMD
 
     assert(varTypeUsesFloatReg(dstType));
 

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -1316,153 +1316,158 @@ bool CodeGenInterface::validImmForBL(ssize_t addr)
  */
 instruction CodeGen::ins_Move_Extend(var_types srcType, bool srcInReg)
 {
-    NYI_LOONGARCH64("ins_Move_Extend");
-    NYI_RISCV64("ins_Move_Extend");
-
-    instruction ins = INS_invalid;
-
-    if (varTypeIsSIMD(srcType))
+    if (varTypeUsesIntReg(srcType))
     {
-#if defined(TARGET_XARCH)
-        // SSE2/AVX requires destination to be a reg always.
-        // If src is in reg means, it is a reg-reg move.
-        //
-        // SSE2 Note: always prefer movaps/movups over movapd/movupd since the
-        // former doesn't require 66h prefix and one byte smaller than the
-        // latter.
-        //
-        // TODO-CQ: based on whether src type is aligned use movaps instead
-
-        return (srcInReg) ? INS_movaps : INS_movups;
-#elif defined(TARGET_ARM64)
-        return (srcInReg) ? INS_mov : ins_Load(srcType);
-#else  // !defined(TARGET_ARM64) && !defined(TARGET_XARCH)
-        assert(!"unhandled SIMD type");
-#endif // !defined(TARGET_ARM64) && !defined(TARGET_XARCH)
-    }
+        instruction ins = INS_invalid;
 
 #if defined(TARGET_XARCH)
-    if (varTypeIsFloating(srcType))
-    {
-        if (srcType == TYP_DOUBLE)
-        {
-            return (srcInReg) ? INS_movaps : INS_movsd_simd;
-        }
-        else if (srcType == TYP_FLOAT)
-        {
-            return (srcInReg) ? INS_movaps : INS_movss;
-        }
-        else
-        {
-            assert(!"unhandled floating type");
-        }
-    }
-#elif defined(TARGET_ARM)
-    if (varTypeIsFloating(srcType))
-        return INS_vmov;
-#else
-    if (varTypeIsFloating(srcType))
-        return INS_mov;
-#endif
-
-#if defined(TARGET_XARCH)
-    if (!varTypeIsSmall(srcType))
-    {
-        ins = INS_mov;
-    }
-    else if (varTypeIsUnsigned(srcType))
-    {
-        ins = INS_movzx;
-    }
-    else
-    {
-        ins = INS_movsx;
-    }
-#elif defined(TARGET_ARM)
-    //
-    // Register to Register zero/sign extend operation
-    //
-    if (srcInReg)
-    {
         if (!varTypeIsSmall(srcType))
         {
             ins = INS_mov;
         }
         else if (varTypeIsUnsigned(srcType))
         {
-            if (varTypeIsByte(srcType))
-                ins = INS_uxtb;
-            else
-                ins = INS_uxth;
+            ins = INS_movzx;
         }
         else
         {
-            if (varTypeIsByte(srcType))
-                ins = INS_sxtb;
-            else
-                ins = INS_sxth;
+            ins = INS_movsx;
         }
-    }
-    else
-    {
-        ins = ins_Load(srcType);
-    }
-#elif defined(TARGET_ARM64)
-    //
-    // Register to Register zero/sign extend operation
-    //
-    if (srcInReg)
-    {
-        if (varTypeIsUnsigned(srcType))
+#elif defined(TARGET_ARM)
+        //
+        // Register to Register zero/sign extend operation
+        //
+        if (srcInReg)
         {
-            if (varTypeIsByte(srcType))
+            if (!varTypeIsSmall(srcType))
             {
-                ins = INS_uxtb;
-            }
-            else if (varTypeIsShort(srcType))
-            {
-                ins = INS_uxth;
-            }
-            else
-            {
-                // A mov Rd, Rm instruction performs the zero extend
-                // for the upper 32 bits when the size is EA_4BYTE
-
                 ins = INS_mov;
             }
-        }
-        else
-        {
-            if (varTypeIsByte(srcType))
+            else if (varTypeIsUnsigned(srcType))
             {
-                ins = INS_sxtb;
-            }
-            else if (varTypeIsShort(srcType))
-            {
-                ins = INS_sxth;
+                if (varTypeIsByte(srcType))
+                    ins = INS_uxtb;
+                else
+                    ins = INS_uxth;
             }
             else
             {
-                if (srcType == TYP_INT)
+                if (varTypeIsByte(srcType))
+                    ins = INS_sxtb;
+                else
+                    ins = INS_sxth;
+            }
+        }
+        else
+        {
+            ins = ins_Load(srcType);
+        }
+#elif defined(TARGET_ARM64)
+        //
+        // Register to Register zero/sign extend operation
+        //
+        if (srcInReg)
+        {
+            if (varTypeIsUnsigned(srcType))
+            {
+                if (varTypeIsByte(srcType))
                 {
-                    ins = INS_sxtw;
+                    ins = INS_uxtb;
+                }
+                else if (varTypeIsShort(srcType))
+                {
+                    ins = INS_uxth;
                 }
                 else
                 {
+                    // A mov Rd, Rm instruction performs the zero extend
+                    // for the upper 32 bits when the size is EA_4BYTE
+
                     ins = INS_mov;
                 }
             }
+            else
+            {
+                if (varTypeIsByte(srcType))
+                {
+                    ins = INS_sxtb;
+                }
+                else if (varTypeIsShort(srcType))
+                {
+                    ins = INS_sxth;
+                }
+                else
+                {
+                    if (srcType == TYP_INT)
+                    {
+                        ins = INS_sxtw;
+                    }
+                    else
+                    {
+                        ins = INS_mov;
+                    }
+                }
+            }
         }
+        else
+        {
+            ins = ins_Load(srcType);
+        }
+#else
+        NYI("ins_Move_Extend");
+#endif
+
+        assert(ins != INS_invalid);
+        return ins;
+    }
+
+#if defined(TARGET_XARCH)
+    if (varTypeUsesMaskReg(srcType))
+    {
+        return INS_kmovq_msk;
+    }
+#endif // TARGET_XARCH
+
+    assert(varTypeUsesFloatReg(srcType));
+
+#if defined(TARGET_XARCH)
+    // SSE2/AVX requires destination to be a reg always.
+    // If src is in reg means, it is a reg-reg move.
+    //
+    // SSE2 Note: always prefer movaps/movups over movapd/movupd since the
+    // former doesn't require 66h prefix and one byte smaller than the
+    // latter.
+    //
+    // TODO-CQ: based on whether src type is aligned use movaps instead
+
+    if (srcInReg)
+    {
+        return INS_movaps;
+    }
+
+    unsigned srcSize = genTypeSize(srcType);
+
+    if (srcSize == 4)
+    {
+        return INS_movss;
+    }
+    else if (srcSize == 8)
+    {
+        return INS_movsd_simd;
     }
     else
     {
-        ins = ins_Load(srcType);
+        assert((srcSize == 12) || (srcSize == 16) || (srcSize == 32) || (srcSize == 64));
+        return INS_movups;
     }
+#elif defined(TARGET_ARM64)
+    return (srcInReg) ? INS_mov : ins_Load(srcType);
+#elif defined(TARGET_ARM)
+    assert(!varTypeIsSIMD(srcType));
+    return INS_vmov;
 #else
     NYI("ins_Move_Extend");
 #endif
-    assert(ins != INS_invalid);
-    return ins;
 }
 
 /*****************************************************************************
@@ -1475,166 +1480,158 @@ instruction CodeGen::ins_Move_Extend(var_types srcType, bool srcInReg)
  */
 instruction CodeGenInterface::ins_Load(var_types srcType, bool aligned /*=false*/)
 {
-    instruction ins = INS_invalid;
-
-    if (varTypeIsSIMD(srcType))
+    if (varTypeUsesIntReg(srcType))
     {
-#if defined(TARGET_XARCH)
-#ifdef FEATURE_SIMD
-        if (srcType == TYP_SIMD8)
-        {
-            return INS_movsd_simd;
-        }
-        else
-#endif // FEATURE_SIMD
-        {
-            // SSE2 Note: always prefer movaps/movups over movapd/movupd since the
-            // former doesn't require 66h prefix and one byte smaller than the
-            // latter.
-            return (aligned) ? INS_movaps : INS_movups;
-        }
-#elif defined(TARGET_ARM64)
-        return INS_ldr;
-#else
-        assert(!"ins_Load with SIMD type");
-#endif
-    }
-
-    if (varTypeIsFloating(srcType))
-    {
-#if defined(TARGET_XARCH)
-        if (srcType == TYP_DOUBLE)
-        {
-            return INS_movsd_simd;
-        }
-        else if (srcType == TYP_FLOAT)
-        {
-            return INS_movss;
-        }
-        else
-        {
-            assert(!"unhandled floating type");
-        }
-#elif defined(TARGET_ARM64)
-        return INS_ldr;
-#elif defined(TARGET_ARM)
-        return INS_vldr;
-#elif defined(TARGET_LOONGARCH64)
-        if (srcType == TYP_DOUBLE)
-        {
-            return INS_fld_d;
-        }
-        else if (srcType == TYP_FLOAT)
-        {
-            return INS_fld_s;
-        }
-        else
-        {
-            assert(!"unhandled floating type");
-        }
-#elif defined(TARGET_RISCV64)
-        if (srcType == TYP_DOUBLE)
-        {
-            return INS_fld;
-        }
-        else if (srcType == TYP_FLOAT)
-        {
-            return INS_flw;
-        }
-        else
-        {
-            assert(!"unhandled floating type");
-        }
-#else
-        assert(!varTypeIsFloating(srcType));
-#endif
-    }
+        instruction ins = INS_invalid;
 
 #if defined(TARGET_XARCH)
-    if (!varTypeIsSmall(srcType))
-    {
-        ins = INS_mov;
-    }
-    else if (varTypeIsUnsigned(srcType))
-    {
-        ins = INS_movzx;
-    }
-    else
-    {
-        ins = INS_movsx;
-    }
-
+        if (!varTypeIsSmall(srcType))
+        {
+            ins = INS_mov;
+        }
+        else if (varTypeIsUnsigned(srcType))
+        {
+            ins = INS_movzx;
+        }
+        else
+        {
+            ins = INS_movsx;
+        }
 #elif defined(TARGET_ARMARCH)
-    if (!varTypeIsSmall(srcType))
-    {
-        ins = INS_ldr;
-    }
-    else if (varTypeIsByte(srcType))
-    {
-        if (varTypeIsUnsigned(srcType))
-            ins = INS_ldrb;
-        else
-            ins = INS_ldrsb;
-    }
-    else if (varTypeIsShort(srcType))
-    {
-        if (varTypeIsUnsigned(srcType))
-            ins = INS_ldrh;
-        else
-            ins = INS_ldrsh;
-    }
+        if (!varTypeIsSmall(srcType))
+        {
+            ins = INS_ldr;
+        }
+        else if (varTypeIsByte(srcType))
+        {
+            if (varTypeIsUnsigned(srcType))
+                ins = INS_ldrb;
+            else
+                ins = INS_ldrsb;
+        }
+        else if (varTypeIsShort(srcType))
+        {
+            if (varTypeIsUnsigned(srcType))
+                ins = INS_ldrh;
+            else
+                ins = INS_ldrsh;
+        }
 #elif defined(TARGET_LOONGARCH64)
-    if (varTypeIsByte(srcType))
-    {
-        if (varTypeIsUnsigned(srcType))
-            ins = INS_ld_bu;
+        if (varTypeIsByte(srcType))
+        {
+            if (varTypeIsUnsigned(srcType))
+                ins = INS_ld_bu;
+            else
+                ins = INS_ld_b;
+        }
+        else if (varTypeIsShort(srcType))
+        {
+            if (varTypeIsUnsigned(srcType))
+                ins = INS_ld_hu;
+            else
+                ins = INS_ld_h;
+        }
+        else if (TYP_INT == srcType)
+        {
+            ins = INS_ld_w;
+        }
         else
-            ins = INS_ld_b;
-    }
-    else if (varTypeIsShort(srcType))
-    {
-        if (varTypeIsUnsigned(srcType))
-            ins = INS_ld_hu;
+        {
+            ins = INS_ld_d; // default ld_d.
+        }
+#elif defined(TARGET_RISCV64)
+        if (varTypeIsByte(srcType))
+        {
+            if (varTypeIsUnsigned(srcType))
+                ins = INS_lbu;
+            else
+                ins = INS_lb;
+        }
+        else if (varTypeIsShort(srcType))
+        {
+            if (varTypeIsUnsigned(srcType))
+                ins = INS_lhu;
+            else
+                ins = INS_lh;
+        }
+        else if (TYP_INT == srcType)
+        {
+            ins = INS_lw;
+        }
         else
-            ins = INS_ld_h;
+        {
+            ins = INS_ld; // default ld.
+        }
+#else
+        NYI("ins_Load");
+#endif
+
+        assert(ins != INS_invalid);
+        return ins;
     }
-    else if (TYP_INT == srcType)
+
+#if defined(TARGET_XARCH)
+    if (varTypeUsesMaskReg(srcType))
     {
-        ins = INS_ld_w;
+        return INS_kmovq_msk;
+    }
+#endif // TARGET_XARCH
+
+    assert(varTypeUsesFloatReg(srcType));
+
+#if defined(TARGET_XARCH)
+    unsigned srcSize = genTypeSize(srcType);
+
+    if (srcSize == 4)
+    {
+        return INS_movss;
+    }
+    else if (srcSize == 8)
+    {
+        return INS_movsd_simd;
     }
     else
     {
-        ins = INS_ld_d; // default ld_d.
+        assert((srcSize == 12) || (srcSize == 16) || (srcSize == 32) || (srcSize == 64));
+
+        // SSE2 Note: always prefer movaps/movups over movapd/movupd since the
+        // former doesn't require 66h prefix and one byte smaller than the
+        // latter.
+
+        return (aligned) ? INS_movaps : INS_movups;
+    }
+#elif defined(TARGET_ARM64)
+    return INS_ldr;
+#elif defined(TARGET_ARM)
+    assert(!varTypeIsSIMD(srcType));
+    return INS_vldr;
+#elif defined(TARGET_LOONGARCH64)
+    assert(!varTypeIsSIMD(srcType));
+
+    if (srcType == TYP_DOUBLE)
+    {
+        return INS_fld_d;
+    }
+    else
+    {
+        assert(srcType == TYP_FLOAT);
+        return INS_fld_s;
     }
 #elif defined(TARGET_RISCV64)
-    if (varTypeIsByte(srcType))
+    assert(!varTypeIsSIMD(srcType));
+
+    if (srcType == TYP_DOUBLE)
     {
-        if (varTypeIsUnsigned(srcType))
-            ins = INS_lbu;
-        else
-            ins = INS_lb;
-    }
-    else if (varTypeIsShort(srcType))
-    {
-        if (varTypeIsUnsigned(srcType))
-            ins = INS_lhu;
-        else
-            ins = INS_lh;
-    }
-    else if (TYP_INT == srcType)
-    {
-        ins = INS_lw;
+        return INS_fld;
     }
     else
     {
-        ins = INS_ld; // default ld.
+        assert(srcType == TYP_FLOAT);
+        return INS_flw;
     }
 #else
     NYI("ins_Load");
 #endif
-
-    assert(ins != INS_invalid);
-    return ins;
 }
 
 /*****************************************************************************
@@ -1647,59 +1644,66 @@ instruction CodeGenInterface::ins_Load(var_types srcType, bool aligned /*=false*
 instruction CodeGen::ins_Copy(var_types dstType)
 {
     assert(emitTypeActSz[dstType] != 0);
+
+    if (varTypeUsesIntReg(dstType))
+    {
+#if defined(TARGET_XARCH) || defined(TARGET_ARMARCH) || defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
+        return INS_mov;
+#else
+        NYI("ins_Copy");
+#endif
+    }
+
 #if defined(TARGET_XARCH)
+    if (varTypeUsesMaskReg(dstType))
+    {
+        return INS_kmovq_msk;
+    }
+#endif // TARGET_XARCH
+
+    assert(varTypeUsesFloatReg(dstType));
+
+#if defined(TARGET_XARCH)
+    return INS_movaps;
+#elif defined(TARGET_ARM64)
     if (varTypeIsSIMD(dstType))
     {
-        return INS_movaps;
-    }
-    else if (varTypeIsFloating(dstType))
-    {
-        // Both float and double copy can use movaps
-        return INS_movaps;
+        return INS_mov;
     }
     else
     {
-        return INS_mov;
-    }
-#elif defined(TARGET_ARM64)
-    if (varTypeIsFloating(dstType))
-    {
+        assert(varTypeIsFloating(dstType));
         return INS_fmov;
-    }
-    else
-    {
-        return INS_mov;
     }
 #elif defined(TARGET_ARM)
     assert(!varTypeIsSIMD(dstType));
-    if (varTypeIsFloating(dstType))
-    {
-        return INS_vmov;
-    }
-    else
-    {
-        return INS_mov;
-    }
+    return INS_vmov;
 #elif defined(TARGET_LOONGARCH64)
-    if (varTypeIsFloating(dstType))
+    assert(!varTypeIsSIMD(dstType));
+
+    if (dstType == TYP_DOUBLE)
     {
-        return dstType == TYP_FLOAT ? INS_fmov_s : INS_fmov_d;
+        return INS_fmov_d;
     }
     else
     {
-        return INS_mov;
+        assert(dstType == TYP_FLOAT);
+        return INS_fmov_s;
     }
 #elif defined(TARGET_RISCV64)
-    if (varTypeIsFloating(dstType))
+    assert(!varTypeIsSIMD(dstType));
+
+    if (dstType == TYP_DOUBLE)
     {
-        return dstType == TYP_FLOAT ? INS_fsgnj_s : INS_fsgnj_d;
+        return INS_fsgnj_d;
     }
     else
     {
-        return INS_mov;
+        assert(dstType == TYP_FLOAT);
+        return INS_fsgnj_s;
     }
-#else // TARGET_*
-#error "Unknown TARGET"
+#else
+    NYI("ins_Copy");
 #endif
 }
 
@@ -1717,67 +1721,110 @@ instruction CodeGen::ins_Copy(var_types dstType)
 //
 instruction CodeGen::ins_Copy(regNumber srcReg, var_types dstType)
 {
-    bool dstIsFloatReg = isFloatRegType(dstType);
-    bool srcIsFloatReg = genIsValidFloatReg(srcReg);
-    if (srcIsFloatReg == dstIsFloatReg)
+    assert(srcReg != REG_NA);
+
+    if (varTypeUsesIntReg(dstType))
     {
+        if (genIsValidIntReg(srcReg))
+        {
+            // int to int
+            return ins_Copy(dstType);
+        }
+
+#if defined(TARGET_XARCH)
+        if (genIsValidMaskReg(srcReg))
+        {
+            // mask to int
+            return INS_kmovq_gpr;
+        }
+#endif
+
+        // float to int
+        assert(genIsValidFloatReg(srcReg));
+
+#if defined(TARGET_XARCH)
+        return INS_movd;
+#elif defined(TARGET_ARM64)
+        return INS_mov;
+#elif defined(TARGET_ARM)
+        // Can't have LONG in a register.
+        assert(dstType == TYP_INT);
+
+        assert(!varTypeIsSIMD(dstType));
+        return INS_vmov_f2i;
+#elif defined(TARGET_LOONGARCH64)
+        assert(!varTypeIsSIMD(dstType));
+        return EA_SIZE(emitActualTypeSize(dstType)) == EA_4BYTE ? INS_movfr2gr_s : INS_movfr2gr_d;
+#elif defined(TARGET_RISCV64)
+        assert(!varTypeIsSIMD(dstType));
+        return EA_SIZE(emitActualTypeSize(dstType)) == EA_4BYTE ? INS_fcvt_w_d : INS_fcvt_l_d;
+#else
+        NYI("ins_Copy");
+#endif
+    }
+
+#if defined(TARGET_XARCH)
+    if (varTypeUsesMaskReg(dstType))
+    {
+        if (genIsValidMaskReg(srcReg))
+        {
+            // mask to mask
+            return ins_Copy(dstType);
+        }
+
+        // mask to int
+        assert(genIsValidIntReg(srcReg));
+        return INS_kmovq_gpr;
+    }
+#endif // TARGET_XARCH
+
+    assert(varTypeUsesFloatReg(dstType));
+
+    if (genIsValidFloatReg(srcReg))
+    {
+        // float to float
         return ins_Copy(dstType);
     }
+
+    // int to float
+    assert(genIsValidIntReg(srcReg));
+
 #if defined(TARGET_XARCH)
     return INS_movd;
 #elif defined(TARGET_ARM64)
-    if (dstIsFloatReg)
-    {
-        return INS_fmov;
-    }
-    else
-    {
-        return INS_mov;
-    }
+    return INS_fmov;
 #elif defined(TARGET_ARM)
-    // No SIMD support yet.
+    // Can't have LONG in a register.
+    assert(dstType == TYP_FLOAT);
+
     assert(!varTypeIsSIMD(dstType));
-    if (dstIsFloatReg)
-    {
-        // Can't have LONG in a register.
-        assert(dstType == TYP_FLOAT);
-        return INS_vmov_i2f;
-    }
-    else
-    {
-        // Can't have LONG in a register.
-        assert(dstType == TYP_INT);
-        return INS_vmov_f2i;
-    }
+    return INS_vmov_i2f;
 #elif defined(TARGET_LOONGARCH64)
-    // TODO-LoongArch64-CQ: supporting SIMD.
     assert(!varTypeIsSIMD(dstType));
-    if (dstIsFloatReg)
+
+    if (dstType == TYP_DOUBLE)
     {
-        assert(!genIsValidFloatReg(srcReg));
-        return dstType == TYP_FLOAT ? INS_movgr2fr_w : INS_movgr2fr_d;
+        return INS_movgr2fr_d;
     }
     else
     {
-        assert(genIsValidFloatReg(srcReg));
-        return EA_SIZE(emitActualTypeSize(dstType)) == EA_4BYTE ? INS_movfr2gr_s : INS_movfr2gr_d;
+        assert(dstType == TYP_FLOAT);
+        return INS_movgr2fr_w;
     }
 #elif defined(TARGET_RISCV64)
-    // TODO-RISCV64-CQ: supporting SIMD.
     assert(!varTypeIsSIMD(dstType));
-    if (dstIsFloatReg)
+
+    if (dstType == TYP_DOUBLE)
     {
-        assert(!genIsValidFloatReg(srcReg));
-        return dstType == TYP_FLOAT ? INS_fcvt_s_l : INS_fcvt_d_l;
+        return INS_fcvt_d_l;
     }
     else
     {
-        assert(genIsValidFloatReg(srcReg));
-        return EA_SIZE(emitActualTypeSize(dstType)) == EA_4BYTE ? INS_fcvt_w_d : INS_fcvt_l_d;
+        assert(dstType == TYP_FLOAT);
+        return INS_fcvt_s_l;
     }
-    return INS_invalid;
-#else // TARGET*
-#error "Unknown TARGET"
+#else
+    NYI("ins_Copy");
 #endif
 }
 
@@ -1792,116 +1839,106 @@ instruction CodeGen::ins_Copy(regNumber srcReg, var_types dstType)
  */
 instruction CodeGenInterface::ins_Store(var_types dstType, bool aligned /*=false*/)
 {
-    instruction ins = INS_invalid;
+    if (varTypeUsesIntReg(dstType))
+    {
+        instruction ins = INS_invalid;
 
 #if defined(TARGET_XARCH)
-    if (varTypeIsSIMD(dstType))
-    {
-#ifdef FEATURE_SIMD
-        if (dstType == TYP_SIMD8)
-        {
-            return INS_movsd_simd;
-        }
+        ins = INS_mov;
+#elif defined(TARGET_ARMARCH)
+        if (!varTypeIsSmall(dstType))
+            ins = INS_str;
+        else if (varTypeIsByte(dstType))
+            ins = INS_strb;
+        else if (varTypeIsShort(dstType))
+            ins = INS_strh;
+#elif defined(TARGET_LOONGARCH64)
+        if (varTypeIsByte(dstType))
+            ins = aligned ? INS_stx_b : INS_st_b;
+        else if (varTypeIsShort(dstType))
+            ins = aligned ? INS_stx_h : INS_st_h;
+        else if (TYP_INT == dstType)
+            ins = aligned ? INS_stx_w : INS_st_w;
         else
-#endif // FEATURE_SIMD
-        {
-            // SSE2 Note: always prefer movaps/movups over movapd/movupd since the
-            // former doesn't require 66h prefix and one byte smaller than the
-            // latter.
-            return (aligned) ? INS_movaps : INS_movups;
-        }
+            ins = aligned ? INS_stx_d : INS_st_d;
+#elif defined(TARGET_RISCV64)
+        if (varTypeIsByte(dstType))
+            ins = INS_sb;
+        else if (varTypeIsShort(dstType))
+            ins = INS_sh;
+        else if (TYP_INT == dstType)
+            ins = INS_sw;
+        else
+            ins = INS_sd;
+#else
+        NYI("ins_Store");
+#endif
+        assert(ins != INS_invalid);
+        return ins;
     }
-    else if (varTypeIsFloating(dstType))
+
+#if defined(TARGET_XARCH)
+    if (varTypeUsesMaskReg(dstType))
     {
-        if (dstType == TYP_DOUBLE)
-        {
-            return INS_movsd_simd;
-        }
-        else if (dstType == TYP_FLOAT)
-        {
-            return INS_movss;
-        }
-        else
-        {
-            assert(!"unhandled floating type");
-        }
+        return INS_kmovq_msk;
+    }
+#endif // TARGET_XARCH
+
+    assert(varTypeUsesFloatReg(dstType));
+
+#if defined(TARGET_XARCH)
+    unsigned dstSize = genTypeSize(dstType);
+
+    if (dstSize == 4)
+    {
+        return INS_movss;
+    }
+    else if (dstSize == 8)
+    {
+        return INS_movsd_simd;
+    }
+    else
+    {
+        assert((dstSize == 12) || (dstSize == 16) || (dstSize == 32) || (dstSize == 64));
+
+        // SSE2 Note: always prefer movaps/movups over movapd/movupd since the
+        // former doesn't require 66h prefix and one byte smaller than the
+        // latter.
+
+        return (aligned) ? INS_movaps : INS_movups;
     }
 #elif defined(TARGET_ARM64)
-    if (varTypeIsSIMD(dstType) || varTypeIsFloating(dstType))
-    {
-        // All sizes of SIMD and FP instructions use INS_str
-        return INS_str;
-    }
+    return INS_str;
 #elif defined(TARGET_ARM)
     assert(!varTypeIsSIMD(dstType));
-    if (varTypeIsFloating(dstType))
-    {
-        return INS_vstr;
-    }
+    return INS_vstr;
 #elif defined(TARGET_LOONGARCH64)
     assert(!varTypeIsSIMD(dstType));
-    if (varTypeIsFloating(dstType))
-    {
-        if (dstType == TYP_DOUBLE)
-        {
-            return aligned ? INS_fstx_d : INS_fst_d;
-        }
-        else if (dstType == TYP_FLOAT)
-        {
-            return aligned ? INS_fstx_s : INS_fst_s;
-        }
-    }
-#elif defined(TARGET_RISCV64)
-    assert(!varTypeIsSIMD(dstType));
-    if (varTypeIsFloating(dstType))
-    {
-        if (dstType == TYP_DOUBLE)
-        {
-            return INS_fsd;
-        }
-        else if (dstType == TYP_FLOAT)
-        {
-            return INS_fsw;
-        }
-    }
-#else
-    assert(!varTypeIsSIMD(dstType));
-    assert(!varTypeIsFloating(dstType));
-#endif
 
-#if defined(TARGET_XARCH)
-    ins = INS_mov;
-#elif defined(TARGET_ARMARCH)
-    if (!varTypeIsSmall(dstType))
-        ins = INS_str;
-    else if (varTypeIsByte(dstType))
-        ins = INS_strb;
-    else if (varTypeIsShort(dstType))
-        ins = INS_strh;
-#elif defined(TARGET_LOONGARCH64)
-    if (varTypeIsByte(dstType))
-        ins = aligned ? INS_stx_b : INS_st_b;
-    else if (varTypeIsShort(dstType))
-        ins = aligned ? INS_stx_h : INS_st_h;
-    else if (TYP_INT == dstType)
-        ins = aligned ? INS_stx_w : INS_st_w;
+    if (dstType == TYP_DOUBLE)
+    {
+        return aligned ? INS_fstx_d : INS_fst_d;
+    }
     else
-        ins = aligned ? INS_stx_d : INS_st_d;
+    {
+        assert(dstType == TYP_FLOAT);
+        return aligned ? INS_fstx_s : INS_fst_s;
+    }
 #elif defined(TARGET_RISCV64)
-    if (varTypeIsByte(dstType))
-        ins = INS_sb;
-    else if (varTypeIsShort(dstType))
-        ins = INS_sh;
-    else if (TYP_INT == dstType)
-        ins = INS_sw;
+    assert(!varTypeIsSIMD(dstType));
+
+    if (dstType == TYP_DOUBLE)
+    {
+        return INS_fsd;
+    }
     else
-        ins = INS_sd;
+    {
+        assert(dstType == TYP_FLOAT);
+        return INS_fsw;
+    }
 #else
     NYI("ins_Store");
 #endif
-
-    assert(ins != INS_invalid);
-    return ins;
 }
 
 //------------------------------------------------------------------------
@@ -1919,34 +1956,88 @@ instruction CodeGenInterface::ins_StoreFromSrc(regNumber srcReg, var_types dstTy
 {
     assert(srcReg != REG_NA);
 
-    bool dstIsFloatType = isFloatRegType(dstType);
-    bool srcIsFloatReg  = genIsValidFloatReg(srcReg);
-    if (srcIsFloatReg == dstIsFloatType)
+    if (varTypeUsesIntReg(dstType))
     {
+        if (genIsValidIntReg(srcReg))
+        {
+            // int to int
+            return ins_Store(dstType, aligned);
+        }
+
+#if defined(TARGET_XARCH)
+        if (genIsValidMaskReg(srcReg))
+        {
+            // mask to int, treat as mask so it works on 32-bit
+            return ins_Store(TYP_MASK, aligned);
+        }
+#endif
+
+        // float to int, treat as float to float
+        assert(genIsValidFloatReg(srcReg));
+
+        unsigned dstSize = genTypeSize(dstType);
+
+        if (dstSize == 4)
+        {
+            dstType = TYP_FLOAT;
+        }
+        else
+        {
+#if defined(TARGET_64BIT)
+            assert(dstSize == 8);
+            dstType = TYP_DOUBLE;
+#else
+            unreached();
+#endif
+        }
+
         return ins_Store(dstType, aligned);
+    }
+
+#if defined(TARGET_XARCH)
+    if (varTypeUsesMaskReg(dstType))
+    {
+        if (genIsValidMaskReg(srcReg))
+        {
+            // mask to mask
+            return ins_Store(dstType, aligned);
+        }
+
+        // mask to int, keep as mask so it works on 32-bit
+        assert(genIsValidIntReg(srcReg));
+        return ins_Store(dstType, aligned);
+    }
+#endif // TARGET_XARCH
+
+    assert(varTypeUsesFloatReg(dstType));
+
+    if (genIsValidIntReg(srcReg))
+    {
+        // int to float, treat as int to int
+
+        unsigned dstSize = genTypeSize(dstType);
+
+        if (dstSize == 4)
+        {
+            dstType = TYP_INT;
+        }
+        else
+        {
+#if defined(TARGET_64BIT)
+            assert(dstSize == 8);
+            dstType = TYP_LONG;
+#else
+            unreached();
+#endif
+        }
     }
     else
     {
-        // We know that we are writing to memory, so make the destination type same
-        // as the source type.
-        var_types dstTypeForStore = TYP_UNDEF;
-        unsigned  dstSize         = genTypeSize(dstType);
-        switch (dstSize)
-        {
-            case 4:
-                dstTypeForStore = srcIsFloatReg ? TYP_FLOAT : TYP_INT;
-                break;
-#if defined(TARGET_64BIT)
-            case 8:
-                dstTypeForStore = srcIsFloatReg ? TYP_DOUBLE : TYP_LONG;
-                break;
-#endif // TARGET_64BIT
-            default:
-                assert(!"unexpected write to the stack.");
-                break;
-        }
-        return ins_Store(dstTypeForStore, aligned);
+        // float to float
+        assert(genIsValidFloatReg(srcReg));
     }
+
+    return ins_Store(dstType, aligned);
 }
 
 #if defined(TARGET_XARCH)
@@ -2197,6 +2288,8 @@ void CodeGen::instGen_Return(unsigned stkArgSize)
  */
 void CodeGen::instGen_Set_Reg_To_Zero(emitAttr size, regNumber reg, insFlags flags)
 {
+    assert(genIsValidIntReg(reg));
+
 #if defined(TARGET_XARCH)
     GetEmitter()->emitIns_R_R(INS_xor, size, reg, reg);
 #elif defined(TARGET_ARM)
@@ -2210,6 +2303,7 @@ void CodeGen::instGen_Set_Reg_To_Zero(emitAttr size, regNumber reg, insFlags fla
 #else
 #error "Unknown TARGET"
 #endif
+
     regSet.verifyRegUsed(reg);
 }
 

--- a/src/coreclr/jit/target.h
+++ b/src/coreclr/jit/target.h
@@ -379,6 +379,18 @@ inline bool genIsValidIntReg(regNumber reg)
 }
 
 /*****************************************************************************
+ * Return true if the register is a valid integer or fake register
+ */
+inline bool genIsValidIntOrFakeReg(regNumber reg)
+{
+#if defined(TARGET_ARM64)
+    return genIsValidIntReg(reg) || (reg == REG_SP);
+#else
+    return genIsValidIntReg(reg);
+#endif
+}
+
+/*****************************************************************************
  * Return true if the register is a valid floating point register
  */
 inline bool genIsValidFloatReg(regNumber reg)

--- a/src/coreclr/jit/target.h
+++ b/src/coreclr/jit/target.h
@@ -386,6 +386,16 @@ inline bool genIsValidFloatReg(regNumber reg)
     return reg >= REG_FP_FIRST && reg <= REG_FP_LAST;
 }
 
+#if defined(TARGET_XARCH)
+/*****************************************************************************
+ * Return true if the register is a valid mask register
+ */
+inline bool genIsValidMaskReg(regNumber reg)
+{
+    return reg >= REG_MASK_FIRST && reg <= REG_MASK_LAST;
+}
+#endif // TARGET_XARCH
+
 #ifdef TARGET_ARM
 
 /*****************************************************************************


### PR DESCRIPTION
This resolves #85058 

This also streamlines the existing code to prioritize the integer register path and to minimize the overall number of checks needed for some paths, so it should minimally help throughput as well.