### PR TITLE
[wasm] Disable failing AOT tests to get CI green again

### DIFF
--- a/src/libraries/System.Collections.Immutable/tests/ImmutableListTestBase.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableListTestBase.cs
@@ -419,6 +419,7 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/85012", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
         public void BinarySearchPartialSortedList()
         {
             ImmutableArray<int> reverseSorted = ImmutableArray.CreateRange(Enumerable.Range(1, 150).Select(n => n * 2).Reverse());

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
@@ -495,6 +495,7 @@ public static class XmlDictionaryWriterTest
     }
 
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/85013", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
     public static void XmlBaseWriter_WriteString()
     {
         const byte Chars8Text = 152;


### PR DESCRIPTION
- System.Collections.Immutable
- System.Runtime.Serialization.Xml
- System.Runtime.Serialization.Xml.ReflectionOnly

Issue: #85012
Issue: #85013