### PR TITLE
Unsubscribe from codegen-coreclr notifications

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -29,8 +29,7 @@
           ],
           "mentionees": [
             "JulieLeeMSFT",
-            "jakobbotsch",
-            "kunalspathak"
+            "jakobbotsch"
           ]
         },
         {


### PR DESCRIPTION
Remove my entry from the bot notifications. I initially subscribed to this to make sure I keep track of PR/Issues/Discussions, but over the time, I was not able to keep up with all the notifications and importantly was missing the notifications that were directed to me specifically. With this, I will have less number of notifications and I can pay attention to what is needed.