### PR TITLE
[wasm] Detect constant-size cpblk copies in the jiterpreter and unroll them

### DIFF
--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -1482,10 +1482,8 @@ export function append_memset_dest (builder: WasmBuilder, value: number, count: 
 
 export function try_append_memmove_fast (
     builder: WasmBuilder, destLocalOffset: number, srcLocalOffset: number,
-    count: number, addressesOnStack: boolean
+    count: number, addressesOnStack: boolean, destLocal?: string, srcLocal?: string
 ) {
-    let destLocal = "math_lhs32", srcLocal = "math_rhs32";
-
     if (count <= 0) {
         if (addressesOnStack) {
             builder.appendU8(WasmOpcode.drop);
@@ -1498,10 +1496,14 @@ export function try_append_memmove_fast (
         return false;
 
     if (addressesOnStack) {
+        destLocal = destLocal || "math_lhs32";
+        srcLocal = srcLocal || "math_rhs32";
         builder.local(srcLocal, WasmOpcode.set_local);
         builder.local(destLocal, WasmOpcode.set_local);
-    } else {
+    } else if (!destLocal || !srcLocal) {
         destLocal = srcLocal = "pLocals";
+    } else {
+        // the addresses were already stored in the local args
     }
 
     let destOffset = addressesOnStack ? 0 : destLocalOffset,


### PR DESCRIPTION
The utf8 formatting PRs introduced many uses of cpblk with a constant size. I tried detecting this at the interpreter level, but that failed because the size constant is an expression:

https://github.com/dotnet/runtime/blob/ad8eaba7db978d30803a37578c197db3694fc7fe/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs#L1851-L1854

Unfortunately it seems like constant folding in the interpreter occurs after intrinsics, so the intrinsic handler for cpblk sees something like 'sizeof; ldc; mul; cpblk' which is not something we can easily optimize in the interpreter atm - a lot of stuff expects to see a bare ldc opcode as an argument.

So instead, the jiterpreter now does basic tracking of LDCs and their destinations which allows us to optimize the (post-interpreter-optimizations) 'ldc_i4; cpblk' pairs that show up in these traces. All the cpblks I found in System.Runtime.Tests traces seem to have small constant sizes like 2 or 4, so this should help reduce the negative impact of the utf8 formatting changes on wasm.

cc @stephentoub based on my instrumentation a lot of the cpblks in the BCL are constant-sized between 1 and 8 bytes. this optimization will only help for wasm; it might be valuable to have a special helper that does cpblk for a size known to be between say 1-4 bytes and then does a chain like this:
```csharp
if (size == 1)
  *(byte*)dest = *(byte*)src;
else if (size == 2)
  *(ushort*)dest = *(ushort*)src;
else if (size == 4)
  *(uint*)dest = *(uint*)src;
else
  throw new ArgumentOutOfRangeException("size");
```
because I think that would constant fold + DCE perfectly and maybe also perform better in aot and non-wasm interpreter. Not sure if this matters though or if you have a better idea for how to improve on it. (We could probably add a complex optimization to the mono interpreter that would constant fold the 3rd cpblk argument, then at codegen time turn it into a fixed-size mov, but that seems like it could be complex. I'll leave that question to @BrzVlad.) I don't know if AOT is already able to optimize the existing code down to a constant-size move.

I'm working on running the datetime benchmark suite with and without these changes to compare, and will add perf numbers once I have them.