### PR TITLE
Inline function pointer composition details into MethodTable

### DIFF
--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -748,6 +748,68 @@ namespace Internal.Runtime
 #endif
         }
 
+        internal uint NumFunctionPointerParameters
+        {
+            get
+            {
+                Debug.Assert(IsFunctionPointerType);
+                return _uBaseSize & ~FunctionPointerFlags.FlagsMask;
+            }
+#if TYPE_LOADER_IMPLEMENTATION
+            set
+            {
+                Debug.Assert(IsFunctionPointerType);
+                _uBaseSize = value | (_uBaseSize & FunctionPointerFlags.FlagsMask);
+            }
+#endif
+        }
+
+        internal bool IsUnmanagedFunctionPointer
+        {
+            get
+            {
+                Debug.Assert(IsFunctionPointerType);
+                return (_uBaseSize & FunctionPointerFlags.IsUnmanaged) != 0;
+            }
+#if TYPE_LOADER_IMPLEMENTATION
+            set
+            {
+                Debug.Assert(IsFunctionPointerType);
+                if (value)
+                    _uBaseSize |= FunctionPointerFlags.IsUnmanaged;
+                else
+                    _uBaseSize &= ~FunctionPointerFlags.IsUnmanaged;
+            }
+#endif
+        }
+
+        internal MethodTableList FunctionPointerParameters
+        {
+            get
+            {
+                void* pStart = (byte*)Unsafe.AsPointer(ref this) + GetFieldOffset(EETypeField.ETF_FunctionPointerParameters);
+                if (IsDynamicType || !SupportsRelativePointers)
+                    return new MethodTableList((MethodTable*)pStart);
+                return new MethodTableList((RelativePointer<MethodTable>*)pStart);
+            }
+        }
+
+        internal MethodTable* FunctionPointerReturnType
+        {
+            get
+            {
+                Debug.Assert(IsFunctionPointerType);
+                return _relatedType._pRelatedParameterType;
+            }
+#if TYPE_LOADER_IMPLEMENTATION
+            set
+            {
+                Debug.Assert(IsDynamicType && IsFunctionPointerType);
+                _relatedType._pRelatedParameterType = value;
+            }
+#endif
+        }
+
         internal bool IsRelatedTypeViaIAT
         {
             get
@@ -945,18 +1007,13 @@ namespace Internal.Runtime
         {
             get
             {
-                if (IsParameterizedType)
+                if (!IsCanonical)
                 {
                     if (IsArray)
                         return GetArrayEEType();
                     else
                         return null;
                 }
-
-                // Function pointers naturally set the base type field to null.
-                Debug.Assert(!IsFunctionPointerType || (!IsRelatedTypeViaIAT && _relatedType._pBaseType == null));
-
-                Debug.Assert(IsCanonical);
 
                 if (IsRelatedTypeViaIAT)
                     return *_relatedType._ppBaseTypeViaIAT;
@@ -1449,6 +1506,16 @@ namespace Internal.Runtime
                 cbOffset += relativeOrFullPointerOffset;
             }
 
+            if (eField == EETypeField.ETF_FunctionPointerParameters)
+            {
+                Debug.Assert(IsFunctionPointerType);
+                return cbOffset;
+            }
+            if (IsFunctionPointerType)
+            {
+                cbOffset += NumFunctionPointerParameters * relativeOrFullPointerOffset;
+            }
+
             if (eField == EETypeField.ETF_DynamicTemplateType)
             {
                 Debug.Assert(IsDynamicType);
@@ -1640,6 +1707,48 @@ namespace Internal.Runtime
                     return *(T**)((byte*)Unsafe.AsPointer(ref Unsafe.AsRef(in _value)) + (_value & ~IndirectionConstants.IndirectionCellPointer));
                 }
             }
+        }
+    }
+
+    // Abstracts a list of MethodTable pointers that could either be relative
+    // pointers or full pointers. We store the IsRelative bit in the lowest
+    // bit so this assumes the list is at least 2 byte aligned.
+    internal readonly unsafe struct MethodTableList
+    {
+        private const int IsRelative = 1;
+
+        private readonly void* _pFirst;
+
+        public MethodTableList(MethodTable* pFirst)
+        {
+            // If the first element is not aligned, we don't have the spare bit we need
+            Debug.Assert(((nint)pFirst & IsRelative) == 0);
+            _pFirst = pFirst;
+        }
+
+        public MethodTableList(RelativePointer<MethodTable>* pFirst)
+        {
+            // If the first element is not aligned, we don't have the spare bit we need
+            Debug.Assert(((nint)pFirst & IsRelative) == 0);
+            _pFirst = (void*)((nint)pFirst | IsRelative);
+        }
+
+        public MethodTable* this[int index]
+        {
+            get
+            {
+                if (((nint)_pFirst & IsRelative) != 0)
+                    return (((RelativePointer<MethodTable>*)((nint)_pFirst - IsRelative)) + index)->Value;
+
+                return (MethodTable*)_pFirst + index;
+            }
+#if TYPE_LOADER_IMPLEMENTATION
+            set
+            {
+                Debug.Assert(((nint)_pFirst & IsRelative) == 0);
+                *((MethodTable**)_pFirst + index) = value;
+            }
+#endif
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -642,6 +642,43 @@ namespace Internal.Runtime.Augments
             return typeHandle.ToEETypePtr().IsFunctionPointer;
         }
 
+        public static unsafe RuntimeTypeHandle GetFunctionPointerReturnType(RuntimeTypeHandle typeHandle)
+        {
+            return new RuntimeTypeHandle(new EETypePtr(typeHandle.ToMethodTable()->FunctionPointerReturnType));
+        }
+
+        public static unsafe int GetFunctionPointerParameterCount(RuntimeTypeHandle typeHandle)
+        {
+            return (int)typeHandle.ToMethodTable()->NumFunctionPointerParameters;
+        }
+
+        public static unsafe RuntimeTypeHandle GetFunctionPointerParameterType(RuntimeTypeHandle typeHandle, int argumentIndex)
+        {
+            Debug.Assert(argumentIndex < GetFunctionPointerParameterCount(typeHandle));
+            return new RuntimeTypeHandle(new EETypePtr(typeHandle.ToMethodTable()->FunctionPointerParameters[argumentIndex]));
+        }
+
+        public static unsafe RuntimeTypeHandle[] GetFunctionPointerParameterTypes(RuntimeTypeHandle typeHandle)
+        {
+            int paramCount = GetFunctionPointerParameterCount(typeHandle);
+            if (paramCount == 0)
+                return Array.Empty<RuntimeTypeHandle>();
+
+            RuntimeTypeHandle[] result = new RuntimeTypeHandle[paramCount];
+            MethodTableList parameters = typeHandle.ToMethodTable()->FunctionPointerParameters;
+            for (int i = 0; i < result.Length; i++)
+            {
+                result[i] = new RuntimeTypeHandle(new EETypePtr(parameters[i]));
+            }
+
+            return result;
+        }
+
+        public static unsafe bool IsUnmanagedFunctionPointerType(RuntimeTypeHandle typeHandle)
+        {
+            return typeHandle.ToMethodTable()->IsUnmanagedFunctionPointer;
+        }
+
         public static bool IsByRefType(RuntimeTypeHandle typeHandle)
         {
             return typeHandle.ToEETypePtr().IsByRef;

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -306,7 +306,9 @@ namespace Internal.Reflection.Execution
         //
         public override void GetFunctionPointerTypeComponents(RuntimeTypeHandle functionPointerHandle, out RuntimeTypeHandle returnTypeHandle, out RuntimeTypeHandle[] parameterHandles, out bool isUnmanaged)
         {
-            TypeLoaderEnvironment.Instance.GetFunctionPointerTypeComponents(functionPointerHandle, out returnTypeHandle, out parameterHandles, out isUnmanaged);
+            returnTypeHandle = RuntimeAugments.GetFunctionPointerReturnType(functionPointerHandle);
+            parameterHandles = RuntimeAugments.GetFunctionPointerParameterTypes(functionPointerHandle);
+            isUnmanaged = RuntimeAugments.IsUnmanagedFunctionPointerType(functionPointerHandle);
         }
 
         //

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
@@ -360,14 +360,6 @@ namespace Internal.Runtime.TypeLoader
             return TryGetStaticFunctionPointerTypeForComponents(returnTypeHandle, parameterHandles, isUnmanaged, out runtimeTypeHandle);
         }
 
-        public void GetFunctionPointerTypeComponents(RuntimeTypeHandle functionPointerHandle, out RuntimeTypeHandle returnTypeHandle, out RuntimeTypeHandle[] parameterHandles, out bool isUnmanaged)
-        {
-            if (RuntimeAugments.IsDynamicType(functionPointerHandle))
-                throw new NotImplementedException();
-
-            GetStaticFunctionPointerTypeComponents(functionPointerHandle, out returnTypeHandle, out parameterHandles, out isUnmanaged);
-        }
-
         // Get an array RuntimeTypeHandle given an element's RuntimeTypeHandle and rank. Pass false for isMdArray, and rank == -1 for SzArrays
         public bool TryGetArrayTypeForElementType(RuntimeTypeHandle elementTypeHandle, bool isMdArray, int rank, out RuntimeTypeHandle arrayTypeHandle)
         {

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/TypeSystemContext.Runtime.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/TypeSystemContext.Runtime.cs
@@ -183,9 +183,9 @@ namespace Internal.TypeSystem
             }
             else if (RuntimeAugments.IsFunctionPointerType(rtth))
             {
-                TypeLoaderEnvironment.Instance.GetFunctionPointerTypeComponents(rtth, out RuntimeTypeHandle returnTypeHandle,
-                                                                                      out RuntimeTypeHandle[] parameterHandles,
-                                                                                      out bool isUnmanaged);
+                RuntimeTypeHandle returnTypeHandle = RuntimeAugments.GetFunctionPointerReturnType(rtth);
+                RuntimeTypeHandle[] parameterHandles = RuntimeAugments.GetFunctionPointerParameterTypes(rtth);
+                bool isUnmanaged = RuntimeAugments.IsUnmanagedFunctionPointerType(rtth);
 
                 var sig = new MethodSignature(
                     isUnmanaged ? MethodSignatureFlags.UnmanagedCallingConvention : 0,

--- a/src/coreclr/tools/Common/Internal/Runtime/MappingTableFlags.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/MappingTableFlags.cs
@@ -17,12 +17,6 @@ namespace Internal.Runtime
         public const int FlagsMask = 1;
     }
 
-    internal struct FunctionPointerMapEntry
-    {
-        public const uint IsUnmanagedFlag = 1;
-        public const int ParameterCountShift = 1;
-    }
-
     [Flags]
     public enum InvokeTableFlags : uint
     {

--- a/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
@@ -192,6 +192,7 @@ namespace Internal.Runtime
         ETF_DynamicTemplateType,
         ETF_GenericDefinition,
         ETF_GenericComposition,
+        ETF_FunctionPointerParameters,
         ETF_DynamicGcStatics,
         ETF_DynamicNonGcStatics,
         ETF_DynamicThreadStaticOffset,
@@ -281,6 +282,12 @@ namespace Internal.Runtime
         // size for an actual array.
         public const int Pointer = 0;
         public const int ByRef = 1;
+    }
+
+    internal static class FunctionPointerFlags
+    {
+        public const uint IsUnmanaged = 0x80000000;
+        public const uint FlagsMask = IsUnmanaged;
     }
 
     internal static class StringComponentSize

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FunctionPointerMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FunctionPointerMapNode.cs
@@ -4,11 +4,8 @@
 using System;
 
 using Internal.NativeFormat;
-using Internal.Runtime;
 using Internal.Text;
 using Internal.TypeSystem;
-
-using MethodSignature = Internal.TypeSystem.MethodSignature;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -66,22 +63,7 @@ namespace ILCompiler.DependencyAnalysis
                 if (!type.IsFunctionPointer)
                     continue;
 
-                MethodSignature sig = ((FunctionPointerType)type).Signature;
-
-                Vertex sigPart = writer.GetUnsignedConstant(_externalReferences.GetIndex(factory.NecessaryTypeSymbol(sig.ReturnType)));
-                foreach (TypeDesc p in sig)
-                    sigPart = writer.GetTuple(sigPart, writer.GetUnsignedConstant(_externalReferences.GetIndex(factory.NecessaryTypeSymbol(p))));
-
-                uint flags = (sig.Flags & MethodSignatureFlags.UnmanagedCallingConventionMask) != 0
-                    ? FunctionPointerMapEntry.IsUnmanagedFlag : 0;
-
-                flags |= (uint)sig.Length << FunctionPointerMapEntry.ParameterCountShift;
-
-                Vertex vertex =
-                    writer.GetTuple(
-                        writer.GetUnsignedConstant(_externalReferences.GetIndex(factory.NecessaryTypeSymbol(type))),
-                        writer.GetUnsignedConstant(flags),
-                        sigPart);
+                Vertex vertex = writer.GetUnsignedConstant(_externalReferences.GetIndex(factory.NecessaryTypeSymbol(type)));
 
                 int hashCode = type.GetHashCode();
                 typeMapHashTable.Append((uint)hashCode, hashTableSection.Place(vertex));


### PR DESCRIPTION
I initially placed function pointer composition info into a separate hashtable because it's not a runtime concern. Turns out this makes things really inconvenient within the type loader. We store information about runtime-constructed types in hashtables like `RuntimeTypeHandleToParameterTypeRuntimeTypeHandleHashtable`. But those are one way only (from composition to `MethodTable`). We'd need another hashtable to go from `MethodTable` to composition.

Inline the composition details into `MethodTable` instead. We have prior art - the runtime doesn't care about composition of non-variant generic types, but we still keep them as part of `MethodTable`. Similar to parameter types of pointers or byrefs. (For arrays, the runtime does care because of variance so I'm not naming those.)

Cc @dotnet/ilc-contrib 