### PR TITLE
[LoongArch64] revert TARGET_LOONGARCH64 which destroyed by RISCV#84584.

### DIFF
--- a/src/coreclr/jit/scopeinfo.cpp
+++ b/src/coreclr/jit/scopeinfo.cpp
@@ -961,7 +961,7 @@ void CodeGen::psiBegProlog()
                 else
                 {
                     regType = compiler->mangleVarArgsType(lclVarDsc->TypeGet());
-#ifdef TARGET_LOONGARCH
+#ifdef TARGET_LOONGARCH64
                     if (emitter::isGeneralRegisterOrR0(lclVarDsc->GetArgReg()) && isFloatRegType(regType))
                     {
                         // For LoongArch64's ABI, the float args may be passed by integer register.


### PR DESCRIPTION
This PR is part of the issue https://github.com/dotnet/runtime/issues/69705 to amend the LA's port.

Revert TARGET_LOONGARCH64 which destroyed by RISCV within #84584.