### PR TITLE
Bugfix/30024 problem with concurrency type descriptor getconverter

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -287,10 +287,8 @@ namespace System.ComponentModel
                 {
                     if (!s_processedTypes.ContainsKey(type))
                     {
-                        ResetEventContext contextForAdd;
-                        ManualResetEvent resetEventForAdd;
-                        resetEventForAdd = new ManualResetEvent(false);
-                        contextForAdd = new ResetEventContext(resetEventForAdd, Environment.CurrentManagedThreadId);
+                        ManualResetEvent resetEventForAdd = new ManualResetEvent(false);
+                        ResetEventContext contextForAdd = new ResetEventContext(resetEventForAdd, Environment.CurrentManagedThreadId);
                         s_processedTypes.Add(type, contextForAdd);
 
                         var providerAttr = type.GetCustomAttributes<TypeDescriptionProviderAttribute>(false)

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -8,6 +8,7 @@ using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -298,11 +299,12 @@ namespace System.ComponentModel
                         // own cache state against the type. There shouldn't be
                         // more than one of these, but walk anyway. Walk in
                         // reverse order so that the most derived takes precidence.
-                        var attrs = type.GetCustomAttributes<TypeDescriptionProviderAttribute>(false);
+                        var attrs = type.GetCustomAttributes<TypeDescriptionProviderAttribute>(false)
+                            .ToArray();
                         bool providerAdded = false;
-                        foreach (var currentAttr in attrs)
+                        for (int i = 0; i != attrs.Length; i++)
                         {
-                            Type? providerType = Type.GetType(currentAttr.TypeName);
+                            Type? providerType = Type.GetType(attrs[i].TypeName);
                             if (providerType != null && typeof(TypeDescriptionProvider).IsAssignableFrom(providerType))
                             {
                                 TypeDescriptionProvider prov = (TypeDescriptionProvider)Activator.CreateInstance(providerType)!;

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -293,22 +293,17 @@ namespace System.ComponentModel
                         contextForAdd = new ResetEventContext(resetEventForAdd, Environment.CurrentManagedThreadId);
                         s_processedTypes.Add(type, contextForAdd);
 
-                        // Always use core reflection when checking for
-                        // the default provider attribute. If there is a
-                        // provider, we probably don't want to build up our
-                        // own cache state against the type. There shouldn't be
-                        // more than one of these, but walk anyway. Walk in
-                        // reverse order so that the most derived takes precidence.
-                        var attrs = type.GetCustomAttributes<TypeDescriptionProviderAttribute>(false)
-                            .ToArray();
+                        var providerAttr = type.GetCustomAttributes<TypeDescriptionProviderAttribute>(false)
+                            .SingleOrDefault();
                         bool providerAdded = false;
-                        for (int i = 0; i != attrs.Length; i++)
+
+                        if (providerAttr != null)
                         {
-                            Type? providerType = Type.GetType(attrs[i].TypeName);
+                            Type? providerType = Type.GetType(providerAttr.TypeName);
                             if (providerType != null && typeof(TypeDescriptionProvider).IsAssignableFrom(providerType))
                             {
-                                TypeDescriptionProvider prov = (TypeDescriptionProvider)Activator.CreateInstance(providerType)!;
-                                AddProvider(prov, type);
+                                TypeDescriptionProvider provider = (TypeDescriptionProvider)Activator.CreateInstance(providerType)!;
+                                AddProvider(provider, type);
                                 providerAdded = true;
                             }
                         }

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -8,7 +8,6 @@ using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -291,8 +290,7 @@ namespace System.ComponentModel
                         ResetEventContext contextForAdd = new ResetEventContext(resetEventForAdd, Environment.CurrentManagedThreadId);
                         s_processedTypes.Add(type, contextForAdd);
 
-                        var providerAttr = type.GetCustomAttributes<TypeDescriptionProviderAttribute>(false)
-                            .SingleOrDefault();
+                        var providerAttr = type.GetCustomAttribute<TypeDescriptionProviderAttribute>(false);
                         bool providerAdded = false;
 
                         if (providerAttr != null)


### PR DESCRIPTION
This PR fix #30024 .
Problem was linked with race condition inside private method [System.ComponentModel.TypeDescriptor.CheckDefaultProvider(Type)](https://github.com/dotnet/runtime/blob/f107b4b53e831ac631ab91cc9cee0200d96a7eee/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs#L262).
I think, it'll better to change base type of [WeakHashtable](https://github.com/dotnet/runtime/blob/f107b4b53e831ac631ab91cc9cee0200d96a7eee/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/WeakHashtable.cs#L14) from [Hashtable](https://learn.microsoft.com/en-us/dotnet/api/system.collections.hashtable?view=net-7.0) to [ConcurrentDictionary<TKey,TValue>](https://learn.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentdictionary-2?view=net-7.0) and use method [GetOrAdd(TKey, Func<TKey,TValue>)](https://learn.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentdictionary-2.getoradd?view=net-7.0#system-collections-concurrent-concurrentdictionary-2-getoradd(-0-system-func((-0-1)))), but this changes can be very dangerous and I'm afraid to do them.