### PR TITLE
[wasm][debugger] Rename DebuggerTests.EvaluateOnCallFrameTests2 to prevent timeouts

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestSuite.csproj
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestSuite.csproj
@@ -23,6 +23,10 @@
 
     <Compile Include="..\BrowserDebugProxy\Common\*.cs" />
 
+    <!-- TODO [ActiveIssue("https://github.com/dotnet/runtime/issues/85168")] 
+    <Compile Remove="EvaluateOnCallFrameTests.cs" />
+    -->
+
     <Compile Include="$(LibrariesProjectRoot)Microsoft.Extensions.Logging\tests\DI.Common\Common\src\XunitLoggerFactoryExtensions.cs" />
     <Compile Include="$(LibrariesProjectRoot)Microsoft.Extensions.Logging\tests\DI.Common\Common\src\XunitLoggerProvider.cs" />
   </ItemGroup>

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
@@ -12,9 +12,9 @@ using Xunit.Abstractions;
 namespace DebuggerTests
 {
     // TODO: static async, static method args
-    public class EvaluateOnCallFrameTests2 : DebuggerTests
+    public class EvaluateOnCallFrame2Tests : DebuggerTests
     {
-        public EvaluateOnCallFrameTests2(ITestOutputHelper testOutput) : base(testOutput)
+        public EvaluateOnCallFrame2Tests(ITestOutputHelper testOutput) : base(testOutput)
         {}
 
         public static IEnumerable<object[]> InstanceMethodsTestData(string type_name)

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -11,7 +11,6 @@ using Xunit.Abstractions;
 
 namespace DebuggerTests
 {
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/85168")]
     // TODO: static async, static method args
     public class EvaluateOnCallFrameTests : DebuggerTests
     {

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -11,6 +11,7 @@ using Xunit.Abstractions;
 
 namespace DebuggerTests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/85168")]
     // TODO: static async, static method args
     public class EvaluateOnCallFrameTests : DebuggerTests
     {


### PR DESCRIPTION
See https://github.com/dotnet/runtime/issues/85168