### PR TITLE
JIT: use blend rather then repair for profile inconsistencies

### DIFF
--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -2697,12 +2697,12 @@ PhaseStatus Compiler::fgIncorporateProfileData()
         // encountered major issues. This is perhaps too drastic. Consider
         // at least keeping the class profile data, or perhaps enable full synthesis.
         //
-        // If profile incorporation hit fixable problems, run synthesis in repair mode.
+        // If profile incorporation hit fixable problems, run synthesis in blend mode.
         //
         if (fgPgoHaveWeights && !dataIsGood)
         {
-            JITDUMP("\nIncorporated count data had inconsistencies; repairing profile...\n");
-            ProfileSynthesis::Run(this, ProfileSynthesisOption::RepairLikelihoods);
+            JITDUMP("\nIncorporated count data had inconsistencies; blending profile...\n");
+            ProfileSynthesis::Run(this, ProfileSynthesisOption::BlendLikelihoods);
         }
     }
 


### PR DESCRIPTION
If we have a partial profile then the current count reconstruction will adjust the exit likelihood of some loop exit when it hits a capped loop. But for multiple exit loops we might wish to see some profile flow out of all exits, not just one.

In `ludcmp` we choose to send all the profile weights down an early return path, leaving the bulk of the method with zero counts.

Instead of trying increasingly elaborate repair schemes, we will now use blend mode for these sorts of problems; this gives a more balanced count redistribution.

I also updated blend to use the same logic as repair if a block has zero weights, since presumably whatever likelihood was assigned there during reconstruction is not well supported.

Fixes the `ludcmp` regression with PGO over no PGO, noted in https://github.com/dotnet/runtime/issues/84264#issuecomment-1517046280