### PR TITLE
Shared Readme: expand the section on GH Actions

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/ReadMe.SharedCode.md
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/ReadMe.SharedCode.md
@@ -35,6 +35,9 @@ dotnet/aspnetcore code paths:
 - `(aspnetcore) PS D:\github\aspnetcore\src\Shared\test\Shared.Tests> dotnet test`
 - `(aspnetcore) PS D:\github\aspnetcore\src\servers\Kestrel\core\test> dotnet test`
 
-## Automation
+## GitHub Actions
 
 In dotnet/aspnetcore, the [runtime-sync](https://github.com/dotnet/aspnetcore/actions/workflows/runtime-sync.yml) GitHub action automatically creates PRs to pull in changes from dotnet/runtime.
+
+In dotnet/runtime, the [aspnetcore-sync](https://github.com/dotnet/runtime/actions/workflows/aspnetcore-sync.yml) GitHub action must be run **manually** to create PRs to pull in changes from dotnet/aspnetcore.
+This is expected to be less common.


### PR DESCRIPTION
...to clarify that dotnet->aspnetcore is automatic but aspnetcore->dotnet is manual.

Prompted by #85149