### PR TITLE
Disable gcstress and jitstress for tracing tests

### DIFF
--- a/src/tests/tracing/eventactivityidcontrol/eventactivityidcontrol.csproj
+++ b/src/tests/tracing/eventactivityidcontrol/eventactivityidcontrol.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
+    <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="EventActivityIdControl.cs" />

--- a/src/tests/tracing/eventcounter/eventcounter.csproj
+++ b/src/tests/tracing/eventcounter/eventcounter.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
-    <!-- This test is timing sensitive and JIT timing affects the results of the test -->
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <!-- This test has a secondary thread with an infinite loop -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>

--- a/src/tests/tracing/eventcounter/gh53564.csproj
+++ b/src/tests/tracing/eventcounter/gh53564.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
-    <!-- This test is timing sensitive and JIT timing affects the results of the test -->
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <!-- This test has a secondary thread with an infinite loop -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>

--- a/src/tests/tracing/eventcounter/incrementingeventcounter.csproj
+++ b/src/tests/tracing/eventcounter/incrementingeventcounter.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
-    <!-- This test is timing sensitive and JIT timing affects the results of the test -->
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <!-- This test has a secondary thread with an infinite loop -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>

--- a/src/tests/tracing/eventcounter/incrementingpollingcounter.csproj
+++ b/src/tests/tracing/eventcounter/incrementingpollingcounter.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
-    <!-- This test is timing sensitive and JIT timing affects the results of the test -->
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <!-- This test has a secondary thread with an infinite loop -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>

--- a/src/tests/tracing/eventcounter/pollingcounter.csproj
+++ b/src/tests/tracing/eventcounter/pollingcounter.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
-    <!-- This test is timing sensitive and JIT timing affects the results of the test -->
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <!-- This test has a secondary thread with an infinite loop -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>

--- a/src/tests/tracing/eventcounter/regression-25709.csproj
+++ b/src/tests/tracing/eventcounter/regression-25709.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
-    <!-- This test is timing sensitive and JIT timing affects the results of the test -->
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <!-- This test has a secondary thread with an infinite loop -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>

--- a/src/tests/tracing/eventcounter/regression-46938.csproj
+++ b/src/tests/tracing/eventcounter/regression-46938.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
-    <!-- This test is timing sensitive and JIT timing affects the results of the test -->
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <!-- This test has a secondary thread with an infinite loop -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>

--- a/src/tests/tracing/eventcounter/runtimecounters.csproj
+++ b/src/tests/tracing/eventcounter/runtimecounters.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
-    <!-- This test is timing sensitive and JIT timing affects the results of the test -->
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <!-- This test has a secondary thread with an infinite loop -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>

--- a/src/tests/tracing/eventlistener/EventListenerThreadPool.csproj
+++ b/src/tests/tracing/eventlistener/EventListenerThreadPool.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>v
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
     <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>

--- a/src/tests/tracing/eventlistener/EventListenerThreadPool.csproj
+++ b/src/tests/tracing/eventlistener/EventListenerThreadPool.csproj
@@ -1,8 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>v
     <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
+    <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="EventListenerThreadPool.cs" />

--- a/src/tests/tracing/eventlistener/eventlistener.csproj
+++ b/src/tests/tracing/eventlistener/eventlistener.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
+    <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="EventListener.cs" />

--- a/src/tests/tracing/eventlistener/eventlistenerenabledisable.csproj
+++ b/src/tests/tracing/eventlistener/eventlistenerenabledisable.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
+    <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="eventlistenerenabledisable.cs" />

--- a/src/tests/tracing/eventpipe/bigevent/bigevent.csproj
+++ b/src/tests/tracing/eventpipe/bigevent/bigevent.csproj
@@ -3,11 +3,10 @@
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
+    <GCStressIncompatible>true</GCStressIncompatible>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
-    <!-- GCStress timeout: https://github.com/dotnet/runtime/issues/51133, https://github.com/dotnet/runtime/issues/82251 -->
-    <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm64' and '$(TargetOS)' == 'osx'">true</GCStressIncompatible>
-    <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm'">true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/tracing/eventpipe/buffersize/buffersize.csproj
+++ b/src/tests/tracing/eventpipe/buffersize/buffersize.csproj
@@ -4,8 +4,9 @@
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
-    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/tracing/eventpipe/config/name_config_with_pid.csproj
+++ b/src/tests/tracing/eventpipe/config/name_config_with_pid.csproj
@@ -2,7 +2,9 @@
   <PropertyGroup>
     <OutputType>exe</OutputType>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/tracing/eventpipe/diagnosticport/diagnosticport.csproj
+++ b/src/tests/tracing/eventpipe/diagnosticport/diagnosticport.csproj
@@ -4,9 +4,9 @@
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
-    <JitOptimizationSensitive>true</JitOptimizationSensitive>
-    <!-- Disable for GCStress due to test failure: https://github.com/dotnet/runtime/issues/38524 -->
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/tracing/eventpipe/enabledisable/enabledisable.csproj
+++ b/src/tests/tracing/eventpipe/enabledisable/enabledisable.csproj
@@ -4,9 +4,10 @@
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants Condition="'$(GitHubRepositoryName)' == 'runtime'">$(DefineConstants);DIAGNOSTICS_RUNTIME</DefineConstants>
-    <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/tracing/eventpipe/eventsourceerror/eventsourceerror.csproj
+++ b/src/tests/tracing/eventpipe/eventsourceerror/eventsourceerror.csproj
@@ -3,8 +3,9 @@
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- https://github.com/dotnet/runtime/issues/36028 -->
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/tracing/eventpipe/eventsvalidation/ExceptionThrown_V1.csproj
+++ b/src/tests/tracing/eventpipe/eventsvalidation/ExceptionThrown_V1.csproj
@@ -5,11 +5,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
-    <JitOptimizationSensitive>true</JitOptimizationSensitive>
-    <!-- This test isn't technically incompatible with GCStress, but it ends up running very slowly
-         in some configurations, e.g. GCStress=3 on Linux/arm32 measured at 15 minutes.
-    -->
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ExceptionThrown_V1.cs" />

--- a/src/tests/tracing/eventpipe/eventsvalidation/GCEvents.csproj
+++ b/src/tests/tracing/eventpipe/eventsvalidation/GCEvents.csproj
@@ -5,8 +5,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
-    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GCEvents.cs" />

--- a/src/tests/tracing/eventpipe/eventsvalidation/GCFinalizers.csproj
+++ b/src/tests/tracing/eventpipe/eventsvalidation/GCFinalizers.csproj
@@ -5,8 +5,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
-    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GCFinalizers.cs" />

--- a/src/tests/tracing/eventpipe/gcdump/gcdump.csproj
+++ b/src/tests/tracing/eventpipe/gcdump/gcdump.csproj
@@ -4,8 +4,9 @@
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
-    <!-- This test provides no interesting scenarios for GCStress -->
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/tracing/eventpipe/pauseonstart/pauseonstart.csproj
+++ b/src/tests/tracing/eventpipe/pauseonstart/pauseonstart.csproj
@@ -4,9 +4,9 @@
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
-    <JitOptimizationSensitive>true</JitOptimizationSensitive>
-    <!-- Disable for GCStress due to test failure: https://github.com/dotnet/runtime/issues/38524 -->
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/tracing/eventpipe/processenvironment/processenvironment.csproj
+++ b/src/tests/tracing/eventpipe/processenvironment/processenvironment.csproj
@@ -4,10 +4,10 @@
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
+    <GCStressIncompatible>true</GCStressIncompatible>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
-    <!-- This test provides no interesting scenarios for GCStress -->
-    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/tracing/eventpipe/processinfo/processinfo.csproj
+++ b/src/tests/tracing/eventpipe/processinfo/processinfo.csproj
@@ -4,6 +4,8 @@
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
+    <GCStressIncompatible>true</GCStressIncompatible>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <!-- ilasm round-trip testing doesn't work, as test expects unchanged assembly name.
          Issue: https://github.com/dotnet/runtime/issues/39935

--- a/src/tests/tracing/eventpipe/processinfo2/processinfo2.csproj
+++ b/src/tests/tracing/eventpipe/processinfo2/processinfo2.csproj
@@ -4,6 +4,8 @@
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
+    <GCStressIncompatible>true</GCStressIncompatible>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <!-- ilasm round-trip testing doesn't work, as test expects unchanged assembly name.
          Issue: https://github.com/dotnet/runtime/issues/39935

--- a/src/tests/tracing/eventpipe/providervalidation/providervalidation.csproj
+++ b/src/tests/tracing/eventpipe/providervalidation/providervalidation.csproj
@@ -4,8 +4,9 @@
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
-    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/tracing/eventpipe/reverse/reverse.csproj
+++ b/src/tests/tracing/eventpipe/reverse/reverse.csproj
@@ -5,8 +5,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
-    <!-- Disable for GCStress due to test failure: https://github.com/dotnet/runtime/issues/38524 -->
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/tracing/eventpipe/reverseouter/reverseouter.csproj
+++ b/src/tests/tracing/eventpipe/reverseouter/reverseouter.csproj
@@ -4,9 +4,9 @@
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
-    <JitOptimizationSensitive>true</JitOptimizationSensitive>
-    <!-- reverseouter fails under GCStress. Issue: https://github.com/dotnet/runtime/issues/38801 -->
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/tracing/eventpipe/rundownvalidation/rundownvalidation.csproj
+++ b/src/tests/tracing/eventpipe/rundownvalidation/rundownvalidation.csproj
@@ -3,15 +3,14 @@
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
+    <GCStressIncompatible>true</GCStressIncompatible>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <!-- The test launches a secondary process and process launch creates
     an infinite event loop in the SocketAsyncEngine on Linux. Since
     runincontext loads even framework assemblies into the unloadable
     context, locals in this loop prevent unloading -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
-    <!-- Times out -->
-    <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm64' and '$(TargetOS)' == 'osx'">true</GCStressIncompatible>
-    <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm'">true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/tracing/eventpipe/simpleprovidervalidation/simpleprovidervalidation.csproj
+++ b/src/tests/tracing/eventpipe/simpleprovidervalidation/simpleprovidervalidation.csproj
@@ -4,8 +4,9 @@
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
-    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <EventSourceSupport Condition="'$(TestBuildMode)' == 'nativeaot'">true</EventSourceSupport>
     <EnableNativeEventPipe Condition="'$(TestBuildMode)' == 'nativeaot'">true</EnableNativeEventPipe>
   </PropertyGroup>

--- a/src/tests/tracing/runtimeeventsource/nativeruntimeeventsource.csproj
+++ b/src/tests/tracing/runtimeeventsource/nativeruntimeeventsource.csproj
@@ -2,7 +2,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <!-- This test has a secondary thread with an infinite loop -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>

--- a/src/tests/tracing/runtimeeventsource/runtimeeventsource.csproj
+++ b/src/tests/tracing/runtimeeventsource/runtimeeventsource.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
+    <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <!-- This test has a secondary thread with an infinite loop -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>


### PR DESCRIPTION
The tracing tests time out pretty reliably if run under GCStress or JITStress, especially on arm or x86 platforms. We have one by one disabled most tests, but since the issues keep being filed for the remaining tests it is time to admit that they are not interesting and cause us more trouble than they're worth in the stress modes.

Fixes #84555
Fixes #83015
Fixes #80767
