### PR TITLE
Fix superpmi.py to not cache local MCH files

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -3096,7 +3096,7 @@ def process_local_mch_files(coreclr_args, mch_files, mch_cache_dir):
     for item in mch_files:
         # On Windows only, see if any of the mch_files are UNC paths (i.e., "\\server\share\...").
         # If so, download and cache all the files found there to our usual local cache location, to avoid future network access.
-        if coreclr_args.host_os == "windows":# and item.startswith("\\\\"):
+        if coreclr_args.host_os == "windows" and item.startswith("\\\\"):
             # Special case: if the user specifies a .mch file, we'll also look for and cache a .mch.mct file next to it, if one exists.
             # This happens naturally if a directory is passed and we search for all .mch and .mct files in that directory.
             mch_file = os.path.abspath(item)


### PR DESCRIPTION
When an MCH file is specified via the `-mch_file` argument, if that file is local (not on a UNC Windows share, on Windows), then don't copy it to the MCH file cache.

This behavior -- to avoid caching local files -- was altered with https://github.com/dotnet/runtime/pull/56871, but it's not clear from that PR if it was required for something or was something used for testing that wasn't reverted before merge. I'm guessing the latter since the code was simply commented out.