### PR TITLE
Use double VectorTableLookup on ARM in ProbabilisticMap

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IndexOfAnyValues/ProbabilisticMap.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IndexOfAnyValues/ProbabilisticMap.cs
@@ -167,7 +167,7 @@ namespace System.Buffers
             // X86 doesn't have a logical right shift intrinsic for bytes: https://github.com/dotnet/runtime/issues/82564
             Vector128<byte> highNibble = Sse2.IsSupported
                 ? (values.AsInt32() >>> VectorizedIndexShift).AsByte() & Vector128.Create((byte)15)
-                : AdvSimd.ShiftRightLogical(values, VectorizedIndexShift);
+                : values >>> VectorizedIndexShift;
 
             Vector128<byte> bitPositions = Vector128.ShuffleUnsafe(Vector128.Create(0x8040201008040201).AsByte(), highNibble);
 

--- a/src/libraries/System.Private.CoreLib/src/System/IndexOfAnyValues/ProbabilisticMap.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IndexOfAnyValues/ProbabilisticMap.cs
@@ -167,7 +167,7 @@ namespace System.Buffers
             // X86 doesn't have a logical right shift intrinsic for bytes: https://github.com/dotnet/runtime/issues/82564
             Vector128<byte> highNibble = Sse2.IsSupported
                 ? (values.AsInt32() >>> VectorizedIndexShift).AsByte() & Vector128.Create((byte)15)
-                : values >>> VectorizedIndexShift;
+                : AdvSimd.ShiftRightLogical(values, VectorizedIndexShift);
 
             Vector128<byte> bitPositions = Vector128.ShuffleUnsafe(Vector128.Create(0x8040201008040201).AsByte(), highNibble);
 


### PR DESCRIPTION
Contributes to #84328

Before
|         Method |     Mean |     Error |
|--------------- |---------:|----------:|
| IndexOfAnyProb | 3.776 µs | 0.0024 µs |

After
|         Method |     Mean |     Error |
|--------------- |---------:|----------:|
| IndexOfAnyProb | 2.576 µs | 0.0011 µs |