### PR TITLE
Transform indirect calls to direct ones in the importer

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3831,14 +3831,7 @@ protected:
     void impCheckForPInvokeCall(
         GenTreeCall* call, CORINFO_METHOD_HANDLE methHnd, CORINFO_SIG_INFO* sig, unsigned mflags, BasicBlock* block);
 
-    enum SigTransform
-    {
-        LeaveIntact    = 0,
-        DeleteThis     = 1 << 0,
-        ReplaceRefThis = 1 << 1,
-    };
-
-    bool impCanSubstituteSig(CORINFO_SIG_INFO* sourceSig, CORINFO_SIG_INFO* targetSig, SigTransform transformation);
+    bool impCanSubstituteSig(CORINFO_SIG_INFO* sourceSig, CORINFO_SIG_INFO* targetSig, var_types sourceThis, var_types targetThis);
     GenTreeCall* impImportIndirectCall(CORINFO_SIG_INFO* sig, const DebugInfo& di = DebugInfo());
     void impPopArgsForUnmanagedCall(GenTreeCall* call, CORINFO_SIG_INFO* sig);
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3830,6 +3830,15 @@ protected:
     bool impCanPInvokeInlineCallSite(BasicBlock* block);
     void impCheckForPInvokeCall(
         GenTreeCall* call, CORINFO_METHOD_HANDLE methHnd, CORINFO_SIG_INFO* sig, unsigned mflags, BasicBlock* block);
+
+    enum SigTransform
+    {
+        LeaveIntact    = 0,
+        DeleteThis     = 1 << 0,
+        ReplaceRefThis = 1 << 1,
+    };
+
+    bool impCanSubstituteSig(CORINFO_SIG_INFO* sourceSig, CORINFO_SIG_INFO* targetSig, SigTransform transformation);
     GenTreeCall* impImportIndirectCall(CORINFO_SIG_INFO* sig, const DebugInfo& di = DebugInfo());
     void impPopArgsForUnmanagedCall(GenTreeCall* call, CORINFO_SIG_INFO* sig);
 
@@ -3858,6 +3867,7 @@ protected:
 
     GenTree* impInitClass(CORINFO_RESOLVED_TOKEN* pResolvedToken);
 
+    GenTree* impGetNodeFromLocal(GenTree* node);
     GenTree* impImportStaticReadOnlyField(CORINFO_FIELD_HANDLE field, CORINFO_CLASS_HANDLE ownerCls);
     GenTree* impImportCnsTreeFromBuffer(uint8_t* buffer, var_types valueType);
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -1873,16 +1873,16 @@ bool Compiler::impSpillStackEntry(unsigned level,
         {
             CORINFO_CLASS_HANDLE stkHnd = verCurrentState.esStack[level].seTypeInfo.GetClassHandle();
             lvaSetClass(tnum, tree, stkHnd);
-        }
 
-        // If we're assigning a GT_RET_EXPR, note the temp over on the call,
-        // so the inliner can use it in case it needs a return spill temp.
-        if (tree->OperGet() == GT_RET_EXPR)
-        {
-            JITDUMP("\n*** see V%02u = GT_RET_EXPR, noting temp\n", tnum);
-            GenTree*             call = tree->AsRetExpr()->gtInlineCandidate;
-            InlineCandidateInfo* ici  = call->AsCall()->gtInlineCandidateInfo;
-            ici->preexistingSpillTemp = tnum;
+            // If we're assigning a GT_RET_EXPR, note the temp over on the call,
+            // so the inliner can use it in case it needs a return spill temp.
+            if (tree->OperGet() == GT_RET_EXPR)
+            {
+                JITDUMP("\n*** see V%02u = GT_RET_EXPR, noting temp\n", tnum);
+                GenTree*             call = tree->AsRetExpr()->gtInlineCandidate;
+                InlineCandidateInfo* ici  = call->AsCall()->gtInlineCandidateInfo;
+                ici->preexistingSpillTemp = tnum;
+            }
         }
     }
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3800,8 +3800,8 @@ GenTree* Compiler::impGetNodeFromLocal(GenTree* node)
         return nullptr;
     };
 
-    GenTree* valueNode = findValue(impStmtList);
-    BasicBlock* bb = fgFirstBB;
+    GenTree*    valueNode = findValue(impStmtList);
+    BasicBlock* bb        = fgFirstBB;
     while (valueNode == nullptr && bb != nullptr)
     {
         valueNode = findValue(bb->bbStmtList);

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -1873,16 +1873,16 @@ bool Compiler::impSpillStackEntry(unsigned level,
         {
             CORINFO_CLASS_HANDLE stkHnd = verCurrentState.esStack[level].seTypeInfo.GetClassHandle();
             lvaSetClass(tnum, tree, stkHnd);
+        }
 
-            // If we're assigning a GT_RET_EXPR, note the temp over on the call,
-            // so the inliner can use it in case it needs a return spill temp.
-            if (tree->OperGet() == GT_RET_EXPR)
-            {
-                JITDUMP("\n*** see V%02u = GT_RET_EXPR, noting temp\n", tnum);
-                GenTree*             call = tree->AsRetExpr()->gtInlineCandidate;
-                InlineCandidateInfo* ici  = call->AsCall()->gtInlineCandidateInfo;
-                ici->preexistingSpillTemp = tnum;
-            }
+        // If we're assigning a GT_RET_EXPR, note the temp over on the call,
+        // so the inliner can use it in case it needs a return spill temp.
+        if (tree->OperGet() == GT_RET_EXPR)
+        {
+            JITDUMP("\n*** see V%02u = GT_RET_EXPR, noting temp\n", tnum);
+            GenTree*             call = tree->AsRetExpr()->gtInlineCandidate;
+            InlineCandidateInfo* ici  = call->AsCall()->gtInlineCandidateInfo;
+            ici->preexistingSpillTemp = tnum;
         }
     }
 

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -104,7 +104,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
     bool checkForSmallType  = false;
     bool bIntrinsicImported = false;
 
-    CORINFO_SIG_INFO originalSig;
+    CORINFO_SIG_INFO originalSig = {};
     NewCallArg       extraArg;
 
     // run transformations when instrumenting to not pollute PGO data

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -158,7 +158,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
         }
         else
         {
-            JITDUMP("impImportCall failed to import calli as call - call conv %u is not managed\n",
+            JITDUMP("\n\nimpImportCall failed to import calli as call - call conv %u is not managed\n",
                     originalSig.getCallConv());
         }
     }

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -1734,7 +1734,7 @@ bool Compiler::impCanSubstituteSig(CORINFO_SIG_INFO* sourceSig,
     if ((transformation & SigTransform::DeleteThis) != 0)
     {
         assert((transformation & SigTransform::ReplaceRefThis) == 0);
-        assert(sourceSig->HasThis());
+        assert(sourceSig->hasThis());
         sourceArgCount--;
     }
 

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -1732,7 +1732,7 @@ bool Compiler::impCanSubstituteSig(CORINFO_SIG_INFO* sourceSig,
         return false;
     }
 
-    if (sourceSig->hasThisNonExplicit() && sourceThis == TYP_UNDEF || targetSig->hasThisNonExplicit() && targetThis == TYP_UNDEF)
+    if ((sourceSig->hasThisNonExplicit() && sourceThis == TYP_UNDEF) || (targetSig->hasThisNonExplicit() && targetThis == TYP_UNDEF))
     {
         JITDUMP("impCanSubstituteSig returning false - unknown this type\n");
         return false;
@@ -1777,7 +1777,7 @@ bool Compiler::impCanSubstituteSig(CORINFO_SIG_INFO* sourceSig,
 
     unsigned numArgs = targetSig->totalILArgs();
 
-    if (sourceSig->hasThisNonExplicit() && targetThis != TYP_VOID || targetSig->hasThisNonExplicit())
+    if ((sourceSig->hasThisNonExplicit() && targetThis != TYP_VOID) || targetSig->hasThisNonExplicit())
     {
         if (sourceThis == TYP_UNDEF)
         {

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -108,10 +108,10 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
     NewCallArg       extraArg;
 
     // run transformations when instrumenting to not pollute PGO data
-    bool optimizedOrInstrumented = opts.OptimizationEnabled() || opts.IsInstrumented();
-    CORINFO_METHOD_HANDLE replacementMethod = nullptr;
-    GenTree* newThis = nullptr;
-    SigTransform sigTransformation = SigTransform::LeaveIntact;
+    bool                  optimizedOrInstrumented = opts.OptimizationEnabled() || opts.IsInstrumented();
+    CORINFO_METHOD_HANDLE replacementMethod       = nullptr;
+    GenTree*              newThis                 = nullptr;
+    SigTransform          sigTransformation       = SigTransform::LeaveIntact;
 
     // handle special import cases
     if (opcode == CEE_CALLI)
@@ -159,15 +159,15 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
         else
         {
             JITDUMP("impImportCall failed to import calli as call - call conv %u is not managed\n",
-                originalSig.getCallConv());
+                    originalSig.getCallConv());
         }
     }
 
     if (replacementMethod != nullptr)
     {
         JITDUMP("impImportCall trying to transform call - found target method %s\n",
-            eeGetMethodName(replacementMethod));
-        CORINFO_SIG_INFO methodSig;
+                eeGetMethodName(replacementMethod));
+        CORINFO_SIG_INFO     methodSig;
         CORINFO_CLASS_HANDLE targetClass = info.compCompHnd->getMethodClass(replacementMethod);
         info.compCompHnd->getMethodSig(replacementMethod, &methodSig, targetClass);
 
@@ -189,15 +189,14 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
             }
             JITDUMP("impImportCall transforming call\n");
             pResolvedToken->hMethod = replacementMethod;
-            pResolvedToken->hClass = targetClass;
+            pResolvedToken->hClass  = targetClass;
 
-            callInfo->sig = methodSig;
-            callInfo->hMethod = replacementMethod;
+            callInfo->sig         = methodSig;
+            callInfo->hMethod     = replacementMethod;
             callInfo->methodFlags = replacementFlags;
-            callInfo->classFlags = info.compCompHnd->getClassAttribs(targetClass);
+            callInfo->classFlags  = info.compCompHnd->getClassAttribs(targetClass);
 
-            return impImportCall(CEE_CALL, pResolvedToken, nullptr, nullptr,
-                prefixFlags, callInfo, rawILOffset);
+            return impImportCall(CEE_CALL, pResolvedToken, nullptr, nullptr, prefixFlags, callInfo, rawILOffset);
         }
     }
 
@@ -1715,7 +1714,9 @@ GenTree* Compiler::impFixupCallStructReturn(GenTreeCall* call, CORINFO_CLASS_HAN
 //  Return Value:
 //    Whether it's safe to change the IR to call the target method
 //
-bool Compiler::impCanSubstituteSig(CORINFO_SIG_INFO* sourceSig, CORINFO_SIG_INFO* targetSig, SigTransform transformation)
+bool Compiler::impCanSubstituteSig(CORINFO_SIG_INFO* sourceSig,
+                                   CORINFO_SIG_INFO* targetSig,
+                                   SigTransform      transformation)
 {
     const SigTransform thisChangeMask = (SigTransform)(SigTransform::DeleteThis | SigTransform::ReplaceRefThis);
     assert((transformation & thisChangeMask) != thisChangeMask);
@@ -1740,8 +1741,8 @@ bool Compiler::impCanSubstituteSig(CORINFO_SIG_INFO* sourceSig, CORINFO_SIG_INFO
 
     if (sourceSig->retType != targetSig->retType)
     {
-        JITDUMP("impCanSubstituteSig returning false - return type %u != %u\n",
-            (unsigned)sourceSig->retType, (unsigned)targetSig->retType);
+        JITDUMP("impCanSubstituteSig returning false - return type %u != %u\n", (unsigned)sourceSig->retType,
+                (unsigned)targetSig->retType);
         return false;
     }
 
@@ -1753,7 +1754,7 @@ bool Compiler::impCanSubstituteSig(CORINFO_SIG_INFO* sourceSig, CORINFO_SIG_INFO
         if (!ClassLayout::AreCompatible(layoutRetA, layoutRetB))
         {
             JITDUMP("impCanSubstituteSig returning false - return type %u is incompatible with %u\n",
-                (unsigned)sourceSig->retType, (unsigned)targetSig->retType);
+                    (unsigned)sourceSig->retType, (unsigned)targetSig->retType);
             return false;
         }
     }
@@ -1762,7 +1763,7 @@ bool Compiler::impCanSubstituteSig(CORINFO_SIG_INFO* sourceSig, CORINFO_SIG_INFO
     CORINFO_ARG_LIST_HANDLE targetArg = targetSig->args;
 
     assert((transformation & (SigTransform::DeleteThis | SigTransform::ReplaceRefThis)) == 0 ||
-        eeGetArgType(sourceArg, sourceSig) == TYP_REF);
+           eeGetArgType(sourceArg, sourceSig) == TYP_REF);
 
     if ((transformation & SigTransform::DeleteThis) != 0)
     {
@@ -1775,16 +1776,15 @@ bool Compiler::impCanSubstituteSig(CORINFO_SIG_INFO* sourceSig, CORINFO_SIG_INFO
         return false;
     }
 
-    for (unsigned i = 0; i < targetSig->numArgs; i++,
-        sourceArg = info.compCompHnd->getArgNext(sourceArg),
-        targetArg = info.compCompHnd->getArgNext(targetArg))
+    for (unsigned i = 0; i < targetSig->numArgs;
+         i++, sourceArg = info.compCompHnd->getArgNext(sourceArg), targetArg = info.compCompHnd->getArgNext(targetArg))
     {
         var_types sourceType = eeGetArgType(sourceArg, sourceSig);
         var_types targetType = eeGetArgType(targetArg, targetSig);
         if (sourceType != targetType)
         {
-            JITDUMP("impCanSubstituteSig returning false - parameter %u type %s != %s\n",
-                i, varTypeName(sourceType), varTypeName(targetType));
+            JITDUMP("impCanSubstituteSig returning false - parameter %u type %s != %s\n", i, varTypeName(sourceType),
+                    varTypeName(targetType));
             return false;
         }
 
@@ -1800,8 +1800,8 @@ bool Compiler::impCanSubstituteSig(CORINFO_SIG_INFO* sourceSig, CORINFO_SIG_INFO
 
             if (!ClassLayout::AreCompatible(sourceLayout, targetLayout))
             {
-                JITDUMP("impCanSubstituteSig returning false - parameter %u type %s is inconmpatible with %s\n",
-                    i, varTypeName(sourceType), varTypeName(targetType));
+                JITDUMP("impCanSubstituteSig returning false - parameter %u type %s is inconmpatible with %s\n", i,
+                        varTypeName(sourceType), varTypeName(targetType));
                 return false;
             }
         }

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -172,6 +172,11 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
         CORINFO_CLASS_HANDLE targetClass = info.compCompHnd->getMethodClass(replacementMethod);
         info.compCompHnd->getMethodSig(replacementMethod, &methodSig, targetClass);
 
+        if (methodSig.hasThisNonExplicit() && targetThis == TYP_UNDEF)
+        {
+            targetThis = eeIsValueClass(targetClass) ? TYP_BYREF : TYP_REF;
+        }
+
         unsigned replacementFlags = info.compCompHnd->getMethodAttribs(replacementMethod);
 
         if ((replacementFlags & CORINFO_FLG_PINVOKE) != 0)

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -112,7 +112,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
     CORINFO_METHOD_HANDLE replacementMethod       = nullptr;
     GenTree*              newThis                 = nullptr;
     var_types oldThis = TYP_UNDEF;
-    var_types newThis = TYP_UNDEF;
+    var_types targetThis = TYP_UNDEF;
 
     // handle special import cases
     if (opcode == CEE_CALLI)
@@ -178,13 +178,13 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
         {
             JITDUMP("impImportCall aborting transformation - found PInvoke\n");
         }
-        else if (impCanSubstituteSig(&originalSig, &methodSig, oldThis, newThis))
+        else if (impCanSubstituteSig(&originalSig, &methodSig, oldThis, targetThis))
         {
             impPopStack();
             if (newThis != nullptr)
             {
                 assert(oldThis == TYP_REF);
-                assert(newThis == TYP_REF);
+                assert(targetThis == TYP_REF);
                 CORINFO_CLASS_HANDLE thisCls = NO_CLASS_HANDLE;
                 info.compCompHnd->getArgType(&methodSig, methodSig.args, &thisCls);
                 impPushOnStack(newThis, typeInfo(TI_REF, thisCls));
@@ -1794,8 +1794,8 @@ bool Compiler::impCanSubstituteSig(CORINFO_SIG_INFO* sourceSig,
         assert(targetThis == TYP_REF || targetThis == TYP_BYREF || targetThis == TYP_I_IMPL);
         if (sourceThis != targetThis)
         {
-            JITDUMP("impCanSubstituteSig returning false - this type %s != %s\n", i, varTypeName(sourceType),
-                    varTypeName(targetType));
+            JITDUMP("impCanSubstituteSig returning false - this type %s != %s\n", varTypeName(sourceThis),
+                    varTypeName(targetThis));
             return false;
         }
     }

--- a/src/tests/JIT/opt/Devirtualization/CMakeLists.txt
+++ b/src/tests/JIT/opt/Devirtualization/CMakeLists.txt
@@ -1,0 +1,6 @@
+project (IndirectNative)
+include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake")
+set(SOURCES IndirectNative.cpp)
+add_library (IndirectNative SHARED ${SOURCES})
+# add the install targets
+install (TARGETS IndirectNative DESTINATION bin)

--- a/src/tests/JIT/opt/Devirtualization/CMakeLists.txt
+++ b/src/tests/JIT/opt/Devirtualization/CMakeLists.txt
@@ -1,5 +1,4 @@
 project (IndirectNative)
-include ("${CLR_INTEROP_TEST_ROOT}/Interop.cmake")
 set(SOURCES IndirectNative.cpp)
 add_library (IndirectNative SHARED ${SOURCES})
 # add the install targets

--- a/src/tests/JIT/opt/Devirtualization/Indirect.cs
+++ b/src/tests/JIT/opt/Devirtualization/Indirect.cs
@@ -136,10 +136,19 @@ public static unsafe class Test
             return ptr();
         }
 
-        AreSame(A(), Invoke(() => ConditionalAddressAssign(false)));
-        AreSame(B(), Invoke(() => ConditionalAddressAssign(true)));
-        AreSame(A(), Invoke(a => ConditionalAddressAssign(a), false));
-        AreSame(B(), Invoke(a => ConditionalAddressAssign(a), true));
+        AreSame(2, IndirectIL.StaticClass());
+        AreSame(1, IndirectIL.InstanceClass());
+        AreSame(1, IndirectIL.InstanceExplicitClass());
+        AreSame(4, IndirectIL.StaticClassParam());
+        AreSame(3, IndirectIL.InstanceClassParam());
+        AreSame(3, IndirectIL.InstanceExplicitClassParam());
+
+        AreSame(2, IndirectIL.StaticStruct());
+        AreSame(1, IndirectIL.InstanceStruct());
+        AreSame(1, IndirectIL.InstanceExplicitStruct());
+        AreSame(4, IndirectIL.StaticStructParam());
+        AreSame(3, IndirectIL.InstanceStructParam());
+        AreSame(3, IndirectIL.InstanceExplicitStructParam());
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/tests/JIT/opt/Devirtualization/Indirect.cs
+++ b/src/tests/JIT/opt/Devirtualization/Indirect.cs
@@ -37,6 +37,14 @@ public static unsafe class Test
     private static int B() => 2;
     private static void C() { }
 
+    private static int D() => 3;
+    [UnmanagedCallersOnly]
+    private static int UnmanagedDefault() => D();
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+    private static int UnmanagedCdecl() => D();
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+    private static int UnmanagedStdcall() => D();
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static delegate*<int> ExecuteCctor() => Ptr;
 
@@ -48,6 +56,9 @@ public static unsafe class Test
 
         AreSame(A(), Invoke(() => ((delegate*<int>)&A)()));
         AreSame(B(), Invoke(() => ((delegate*<int>)&B)()));
+        AreSame(D(), Invoke(() => ((delegate* unmanaged<int>)&UnmanagedDefault)()));
+        AreSame(D(), Invoke(() => ((delegate* unmanaged[Cdecl]<int>)&UnmanagedCdecl)()));
+        AreSame(D(), Invoke(() => ((delegate* unmanaged[Stdcall]<int>)&UnmanagedStdcall)()));
 
         AreSame(A(), Invoke(() => Ptr()));
 

--- a/src/tests/JIT/opt/Devirtualization/Indirect.cs
+++ b/src/tests/JIT/opt/Devirtualization/Indirect.cs
@@ -1,0 +1,164 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+public static unsafe class Program
+{
+    public static int Main()
+    {
+        _ = Test.ExecuteCctor();
+        Test.Run();
+        return 100;
+    }
+}
+
+public static unsafe class Test
+{
+    // valid ptrs
+    private static readonly delegate*<int> Ptr = &A;
+
+    // invalid ptrs
+    private static readonly delegate*<int> PtrNull = (delegate*<int>)0;
+    private static readonly delegate*<int> PtrPlus1 = (delegate*<int>)(((nuint)(delegate*<int>)(&A)) + 1);
+    private static readonly delegate*<int> PtrMinus1 = (delegate*<int>)(((nuint)(delegate*<int>)(&A)) - 1);
+    private static readonly delegate*<int> PtrPlus16 = (delegate*<int>)(((nuint)(delegate*<int>)(&A)) + 16);
+    private static readonly delegate*<int> PtrMinus16 = (delegate*<int>)(((nuint)(delegate*<int>)(&A)) - 16);
+    private static readonly delegate*<int> PtrPlus32 = (delegate*<int>)(((nuint)(delegate*<int>)(&A)) + 32);
+    private static readonly delegate*<int> PtrMinus32 = (delegate*<int>)(((nuint)(delegate*<int>)(&A)) - 32);
+    private static readonly delegate*<int> PtrSmall = (delegate*<int>)4096;
+    private static readonly delegate*<int> PtrDeadBeef = (delegate*<int>)0xDEADBEEFU;
+
+    // valid but failing checks
+    private static readonly delegate*<int> PtrWrongSig = (delegate*<int>)(delegate*<void>)&C;
+
+    private static int A() => 1;
+    private static int B() => 2;
+    private static void C() { }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static delegate*<int> ExecuteCctor() => Ptr;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Run()
+    {
+        AssertThrowsNullReferenceException(() => ((delegate*<int>)0)());
+        AssertThrowsNullReferenceException(() => PtrNull());
+
+        AreSame(A(), Invoke(() => ((delegate*<int>)&A)()));
+        AreSame(B(), Invoke(() => ((delegate*<int>)&B)()));
+
+        AreSame(A(), Invoke(() => Ptr()));
+
+        static int CallPtr(delegate*<int> ptr) => ptr();
+        AreSame(A(), Invoke(() => CallPtr(&A)));
+        AreSame(B(), Invoke(() => CallPtr(&B)));
+
+        static delegate*<int> ReturnA() => &A;
+        AreSame(A(), Invoke(() => ReturnA()()));
+        static delegate*<int> ReturnAStatic() => Ptr;
+        AreSame(A(), Invoke(() => ReturnAStatic()()));
+
+        AreSame(A(), Invoke(() =>
+        {
+            var ptr = (delegate*<int>)&A;
+            _ = B();
+            return ptr();
+        }));
+        AreSame(A(), Invoke(() =>
+        {
+            var ptr = (delegate*<int>)&A;
+            _ = NoInline(B());
+            return ptr();
+        }));
+
+        static int Branch(bool a)
+        {
+            delegate*<int> ptr;
+            if (a)
+                ptr = &A;
+            else
+                ptr = &B;
+            return ptr();
+        }
+
+        AreSame(A(), Invoke(() => Branch(true)));
+        AreSame(B(), Invoke(() => Branch(false)));
+        AreSame(A(), Invoke(a => Branch(a), true));
+        AreSame(B(), Invoke(a => Branch(a), false));
+
+        AreSame(A(), Invoke(a => a ? PtrNull() : Ptr(), false));
+        AreSame(A(), Invoke(a => a ? PtrPlus1() : Ptr(), false));
+        AreSame(A(), Invoke(a => a ? PtrMinus1() : Ptr(), false));
+        AreSame(A(), Invoke(a => a ? PtrPlus16() : Ptr(), false));
+        AreSame(A(), Invoke(a => a ? PtrMinus16() : Ptr(), false));
+        AreSame(A(), Invoke(a => a ? PtrPlus32() : Ptr(), false));
+        AreSame(A(), Invoke(a => a ? PtrMinus32() : Ptr(), false));
+        AreSame(A(), Invoke(a => a ? PtrSmall() : Ptr(), false));
+        AreSame(A(), Invoke(a => a ? PtrDeadBeef() : Ptr(), false));
+
+        AreSame(A(), Invoke(a => a ? PtrWrongSig() : Ptr(), false));
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void Assign(delegate*<int>* ptrptr, delegate*<int> ptr) => *ptrptr = ptr;
+
+        AreSame(A(), Invoke(() =>
+        {
+            delegate*<int> ptr = &A;
+            Assign(&ptr, &B);
+            return ptr();
+        }));
+        AreSame(A(), Invoke(() =>
+        {
+            delegate*<int> ptr;
+            Assign(&ptr, &B);
+            ptr = &A;
+            return ptr();
+        }));
+
+        static int ConditionalAddressAssign(bool a)
+        {
+            delegate*<int> ptr = &A;
+            if (a)
+                Assign(&ptr, &B);
+            return ptr();
+        }
+
+        AreSame(A(), Invoke(() => ConditionalAddressAssign(false)));
+        AreSame(B(), Invoke(() => ConditionalAddressAssign(true)));
+        AreSame(A(), Invoke(a => ConditionalAddressAssign(a), false));
+        AreSame(B(), Invoke(a => ConditionalAddressAssign(a), true));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static T Invoke<T>(Func<T> action) => action();
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static TRet Invoke<T, TRet>(Func<T, TRet> action, T value) => action(value);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static T NoInline<T>(T value) => value;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void AreSame<T>(T expected, T actual, [CallerLineNumber] int line = 0)
+    {
+        if (!EqualityComparer<T>.Default.Equals(expected, actual))
+            throw new InvalidOperationException($"Invalid value, expected {expected}, got {actual} at line {line}");
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void AssertThrowsNullReferenceException<T>(Func<T> a, [CallerLineNumber] int line = 0)
+    {
+        try
+        {
+            _ = a();
+        }
+        catch (NullReferenceException)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException($"Expected NullReferenceException at line {line}");
+    }
+}

--- a/src/tests/JIT/opt/Devirtualization/Indirect.csproj
+++ b/src/tests/JIT/opt/Devirtualization/Indirect.csproj
@@ -6,6 +6,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="Indirect.cs" />
+    <ProjectReference Include="IndirectIL.ilproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/opt/Devirtualization/Indirect.csproj
+++ b/src/tests/JIT/opt/Devirtualization/Indirect.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Indirect.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/opt/Devirtualization/Indirect.csproj
+++ b/src/tests/JIT/opt/Devirtualization/Indirect.csproj
@@ -11,4 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
+  <ItemGroup>
+    <CMakeProjectReference Include="CMakeLists.txt" />
+  </ItemGroup>
 </Project>

--- a/src/tests/JIT/opt/Devirtualization/IndirectIL.il
+++ b/src/tests/JIT/opt/Devirtualization/IndirectIL.il
@@ -1,0 +1,270 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
+
+.assembly IndirectIL { }
+
+.class public abstract auto ansi sealed beforefieldinit ILTests
+       extends [System.Runtime]System.Object
+{
+  .method public hidebysig static int32  StaticClass() cil managed noinlining aggressiveoptimization
+  {
+    // Code size       12 (0xc)
+    .maxstack  8
+    IL_0000:  ldftn      int32 Cl::B()
+    IL_0006:  calli      int32()
+    IL_000b:  ret
+  } // end of method ILTests::A
+
+  .method public hidebysig static int32  InstanceClass() cil managed noinlining aggressiveoptimization
+  {
+    // Code size       17 (0x11)
+    .maxstack  2
+    .locals init (class Cl V_0)
+    IL_0000:  newobj     instance void Cl::.ctor()
+    IL_0005:  ldftn      instance int32 Cl::A()
+    IL_000b:  calli      instance int32()
+    IL_0010:  ret
+  } // end of method ILTests::B
+
+  .method public hidebysig static int32  InstanceExplicitClass() cil managed noinlining aggressiveoptimization
+  {
+    // Code size       17 (0x11)
+    .maxstack  2
+    .locals init (class Cl V_0)
+    IL_0000:  newobj     instance void Cl::.ctor()
+    IL_0005:  ldftn      instance int32 Cl::A()
+    IL_000b:  calli      explicit instance int32(class Cl)
+    IL_0010:  ret
+  } // end of method ILTests::C
+
+  .method public hidebysig static int32  StaticClassParam() cil managed noinlining aggressiveoptimization
+  {
+    // Code size       15 (0xf)
+    .maxstack  2
+    .locals init (method int32 *(int32) V_0)
+    IL_0000:  ldftn      int32 Cl::D(int32)
+    IL_0006:  stloc.0
+    IL_0007:  ldc.i4.0
+    IL_0008:  ldloc.0
+    IL_0009:  calli      int32(int32)
+    IL_000e:  ret
+  } // end of method ILTests::D
+
+  .method public hidebysig static int32  InstanceClassParam() cil managed noinlining aggressiveoptimization
+  {
+    // Code size       22 (0x16)
+    .maxstack  3
+    .locals init (class Cl V_0,
+             method int32 *(int32) V_1)
+    IL_0000:  newobj     instance void Cl::.ctor()
+    IL_0005:  stloc.0
+    IL_0006:  ldftn      instance int32 Cl::C(int32)
+    IL_000c:  stloc.1
+    IL_000d:  ldloc.0
+    IL_000e:  ldc.i4.0
+    IL_000f:  ldloc.1
+    IL_0010:  calli      instance int32(int32)
+    IL_0015:  ret
+  } // end of method ILTests::E
+
+  .method public hidebysig static int32  InstanceExplicitClassParam() cil managed noinlining aggressiveoptimization
+  {
+    // Code size       22 (0x16)
+    .maxstack  3
+    .locals init (class Cl V_0,
+             method int32 *(int32) V_1)
+    IL_0000:  newobj     instance void Cl::.ctor()
+    IL_0005:  stloc.0
+    IL_0006:  ldftn      instance int32 Cl::C(int32)
+    IL_000c:  stloc.1
+    IL_000d:  ldloc.0
+    IL_000e:  ldc.i4.0
+    IL_000f:  ldloc.1
+    IL_0010:  calli      explicit instance int32(class Cl,int32)
+    IL_0015:  ret
+  } // end of method ILTests::F
+
+  .method public hidebysig static int32  StaticStruct() cil managed noinlining aggressiveoptimization
+  {
+    // Code size       12 (0xc)
+    .maxstack  8
+    IL_0000:  ldftn      int32 St::B()
+    IL_0006:  calli      int32()
+    IL_000b:  ret
+  } // end of method ILTests::G
+
+  .method public hidebysig static int32  InstanceStruct() cil managed noinlining aggressiveoptimization
+  {
+    // Code size       22 (0x16)
+    .maxstack  2
+    .locals init (valuetype St V_0)
+    IL_0000:  ldloca.s   V_0
+    IL_0002:  initobj    St
+    IL_0008:  ldloca.s   V_0
+    IL_000a:  ldftn      instance int32 St::A()
+    IL_0010:  calli      instance int32()
+    IL_0015:  ret
+  } // end of method ILTests::H
+
+  .method public hidebysig static int32  InstanceExplicitStruct() cil managed noinlining aggressiveoptimization
+  {
+    // Code size       22 (0x16)
+    .maxstack  2
+    .locals init (valuetype St V_0)
+    IL_0000:  ldloca.s   V_0
+    IL_0002:  initobj    St
+    IL_0008:  ldloca.s   V_0
+    IL_000a:  ldftn      instance int32 St::A()
+    IL_0010:  calli      explicit instance int32(valuetype St&)
+    IL_0015:  ret
+  } // end of method ILTests::I
+
+  .method public hidebysig static int32  StaticStructParam() cil managed noinlining aggressiveoptimization
+  {
+    // Code size       15 (0xf)
+    .maxstack  2
+    .locals init (method int32 *(int32) V_0)
+    IL_0000:  ldftn      int32 St::D(int32)
+    IL_0006:  stloc.0
+    IL_0007:  ldc.i4.0
+    IL_0008:  ldloc.0
+    IL_0009:  calli      int32(int32)
+    IL_000e:  ret
+  } // end of method ILTests::J
+
+  .method public hidebysig static int32  InstanceStructParam() cil managed noinlining aggressiveoptimization
+  {
+    // Code size       25 (0x19)
+    .maxstack  3
+    .locals init (valuetype St V_0,
+             method int32 *(int32) V_1)
+    IL_0000:  ldloca.s   V_0
+    IL_0002:  initobj    St
+    IL_0008:  ldftn      instance int32 St::C(int32)
+    IL_000e:  stloc.1
+    IL_000f:  ldloca.s   V_0
+    IL_0011:  ldc.i4.0
+    IL_0012:  ldloc.1
+    IL_0013:  calli      instance int32(int32)
+    IL_0018:  ret
+  } // end of method ILTests::K
+
+  .method public hidebysig static int32  InstanceExplicitStructParam() cil managed noinlining aggressiveoptimization
+  {
+    // Code size       25 (0x19)
+    .maxstack  3
+    .locals init (valuetype St V_0,
+             method int32 *(int32) V_1)
+    IL_0000:  ldloca.s   V_0
+    IL_0002:  initobj    St
+    IL_0008:  ldftn      instance int32 St::C(int32)
+    IL_000e:  stloc.1
+    IL_000f:  ldloca.s   V_0
+    IL_0011:  ldc.i4.0
+    IL_0012:  ldloc.1
+    IL_0013:  calli      explicit instance int32(valuetype St&,int32)
+    IL_0018:  ret
+  } // end of method ILTests::L
+
+} // end of class ILTests
+
+.class public auto ansi sealed beforefieldinit Cl
+       extends [System.Runtime]System.Object
+{
+  .method public hidebysig instance int32
+          A() cil managed aggressiveinlining aggressiveoptimization
+  {
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  ldc.i4.1
+    IL_0001:  ret
+  } // end of method Cl::A
+
+  .method public hidebysig static int32  B() cil managed aggressiveinlining aggressiveoptimization
+  {
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  ldc.i4.2
+    IL_0001:  ret
+  } // end of method Cl::B
+
+  .method public hidebysig instance int32
+          C(int32 a) cil managed aggressiveinlining aggressiveoptimization
+  {
+    // Code size       4 (0x4)
+    .maxstack  8
+    IL_0000:  ldc.i4.3
+    IL_0001:  ldarg.1
+    IL_0002:  add
+    IL_0003:  ret
+  } // end of method Cl::C
+
+  .method public hidebysig static int32  D(int32 a) cil managed aggressiveinlining aggressiveoptimization
+  {
+    // Code size       4 (0x4)
+    .maxstack  8
+    IL_0000:  ldc.i4.4
+    IL_0001:  ldarg.0
+    IL_0002:  add
+    IL_0003:  ret
+  } // end of method Cl::D
+
+  .method public hidebysig specialname rtspecialname
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+    IL_0006:  ret
+  } // end of method Cl::.ctor
+
+} // end of class Cl
+
+.class public sequential ansi sealed beforefieldinit St
+       extends [System.Runtime]System.ValueType
+{
+  .pack 0
+  .size 1
+  .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )
+  .method public hidebysig instance int32
+          A() cil managed aggressiveinlining aggressiveoptimization
+  {
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  ldc.i4.1
+    IL_0001:  ret
+  } // end of method St::A
+
+  .method public hidebysig static int32  B() cil managed aggressiveinlining aggressiveoptimization
+  {
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  ldc.i4.2
+    IL_0001:  ret
+  } // end of method St::B
+
+  .method public hidebysig instance int32
+          C(int32 a) cil managed aggressiveinlining aggressiveoptimization
+  {
+    // Code size       4 (0x4)
+    .maxstack  8
+    IL_0000:  ldc.i4.3
+    IL_0001:  ldarg.1
+    IL_0002:  add
+    IL_0003:  ret
+  } // end of method St::C
+
+  .method public hidebysig static int32  D(int32 a) cil managed aggressiveinlining aggressiveoptimization
+  {
+    // Code size       4 (0x4)
+    .maxstack  8
+    IL_0000:  ldc.i4.4
+    IL_0001:  ldarg.0
+    IL_0002:  add
+    IL_0003:  ret
+  } // end of method St::D
+
+} // end of class St

--- a/src/tests/JIT/opt/Devirtualization/IndirectIL.il
+++ b/src/tests/JIT/opt/Devirtualization/IndirectIL.il
@@ -15,7 +15,7 @@
     IL_0000:  ldftn      int32 Cl::B()
     IL_0006:  calli      int32()
     IL_000b:  ret
-  } // end of method ILTests::A
+  } // end of method ILTests::StaticClass
 
   .method public hidebysig static int32  InstanceClass() cil managed noinlining aggressiveoptimization
   {
@@ -26,7 +26,7 @@
     IL_0005:  ldftn      instance int32 Cl::A()
     IL_000b:  calli      instance int32()
     IL_0010:  ret
-  } // end of method ILTests::B
+  } // end of method ILTests::InstanceClass
 
   .method public hidebysig static int32  InstanceExplicitClass() cil managed noinlining aggressiveoptimization
   {
@@ -37,7 +37,7 @@
     IL_0005:  ldftn      instance int32 Cl::A()
     IL_000b:  calli      explicit instance int32(class Cl)
     IL_0010:  ret
-  } // end of method ILTests::C
+  } // end of method ILTests::InstanceExplicitClass
 
   .method public hidebysig static int32  StaticClassParam() cil managed noinlining aggressiveoptimization
   {
@@ -50,7 +50,7 @@
     IL_0008:  ldloc.0
     IL_0009:  calli      int32(int32)
     IL_000e:  ret
-  } // end of method ILTests::D
+  } // end of method ILTests::StaticClassParam
 
   .method public hidebysig static int32  InstanceClassParam() cil managed noinlining aggressiveoptimization
   {
@@ -67,7 +67,7 @@
     IL_000f:  ldloc.1
     IL_0010:  calli      instance int32(int32)
     IL_0015:  ret
-  } // end of method ILTests::E
+  } // end of method ILTests::InstanceClassParam
 
   .method public hidebysig static int32  InstanceExplicitClassParam() cil managed noinlining aggressiveoptimization
   {
@@ -84,7 +84,7 @@
     IL_000f:  ldloc.1
     IL_0010:  calli      explicit instance int32(class Cl,int32)
     IL_0015:  ret
-  } // end of method ILTests::F
+  } // end of method ILTests::InstanceExplicitClassParam
 
   .method public hidebysig static int32  StaticStruct() cil managed noinlining aggressiveoptimization
   {
@@ -93,7 +93,7 @@
     IL_0000:  ldftn      int32 St::B()
     IL_0006:  calli      int32()
     IL_000b:  ret
-  } // end of method ILTests::G
+  } // end of method ILTests::StaticStruct
 
   .method public hidebysig static int32  InstanceStruct() cil managed noinlining aggressiveoptimization
   {
@@ -106,7 +106,7 @@
     IL_000a:  ldftn      instance int32 St::A()
     IL_0010:  calli      instance int32()
     IL_0015:  ret
-  } // end of method ILTests::H
+  } // end of method ILTests::InstanceStruct
 
   .method public hidebysig static int32  InstanceExplicitStruct() cil managed noinlining aggressiveoptimization
   {
@@ -119,7 +119,7 @@
     IL_000a:  ldftn      instance int32 St::A()
     IL_0010:  calli      explicit instance int32(valuetype St&)
     IL_0015:  ret
-  } // end of method ILTests::I
+  } // end of method ILTests::InstanceExplicitStruct
 
   .method public hidebysig static int32  StaticStructParam() cil managed noinlining aggressiveoptimization
   {
@@ -132,7 +132,7 @@
     IL_0008:  ldloc.0
     IL_0009:  calli      int32(int32)
     IL_000e:  ret
-  } // end of method ILTests::J
+  } // end of method ILTests::StaticStructParam
 
   .method public hidebysig static int32  InstanceStructParam() cil managed noinlining aggressiveoptimization
   {
@@ -149,7 +149,7 @@
     IL_0012:  ldloc.1
     IL_0013:  calli      instance int32(int32)
     IL_0018:  ret
-  } // end of method ILTests::K
+  } // end of method ILTests::InstanceStructParam
 
   .method public hidebysig static int32  InstanceExplicitStructParam() cil managed noinlining aggressiveoptimization
   {
@@ -166,8 +166,48 @@
     IL_0012:  ldloc.1
     IL_0013:  calli      explicit instance int32(valuetype St&,int32)
     IL_0018:  ret
-  } // end of method ILTests::L
+  } // end of method ILTests::InstanceExplicitStructParam
 
+    .method public hidebysig static
+        int32 BranchAssign (
+            bool b
+        ) cil managed
+    {
+        // Method begins at RVA 0x2050
+        // Code size 24 (0x18)
+        .maxstack 1
+        .locals init (
+            [0] method int32 *()
+        )
+
+        IL_0000: ldarg.0
+        IL_0001: brfalse.s IL_0011
+
+        IL_0003: ldftn      int32 Cl::B()
+        IL_0009: stloc.0
+        IL_000a: ldloc.0
+        IL_000b: calli int32()
+        IL_0010: ret
+
+        IL_0011: ldloc.0
+        IL_0012: calli int32()
+        IL_0017: ret
+    } // end of method ILTests::BranchAssign
+
+    .method public hidebysig static
+        int32 NoAssign () cil managed
+    {
+        // Method begins at RVA 0x2050
+        // Code size 7 (0x7)
+        .maxstack 1
+        .locals init (
+            [0] method int32 *()
+        )
+
+        IL_0000: ldloc.0
+        IL_0001: calli int32()
+        IL_0006: ret
+    } // end of method ILTests::NoAssign
 } // end of class ILTests
 
 .class public auto ansi sealed beforefieldinit Cl

--- a/src/tests/JIT/opt/Devirtualization/IndirectIL.ilproj
+++ b/src/tests/JIT/opt/Devirtualization/IndirectIL.ilproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RestorePackages>true</RestorePackages>

--- a/src/tests/JIT/opt/Devirtualization/IndirectIL.ilproj
+++ b/src/tests/JIT/opt/Devirtualization/IndirectIL.ilproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <RestorePackages>true</RestorePackages>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/opt/Devirtualization/IndirectNative.cpp
+++ b/src/tests/JIT/opt/Devirtualization/IndirectNative.cpp
@@ -2,19 +2,28 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include <stdint.h>
-#include <platformdefines.h>
 
-extern "C" DLL_EXPORT int32_t STDMETHODCALLTYPE E()
+#ifdef TARGET_WINDOWS
+#define DLL_EXPORT extern "C" __declspec(dllexport)
+#else
+#define DLL_EXPORT extern "C" __attribute((visibility("default")))
+#endif
+
+#ifndef TARGET_WINDOWS
+#define __stdcall
+#endif
+
+DLL_EXPORT int32_t __stdcall E()
 {
     return 4;
 }
 
-extern "C" DLL_EXPORT int32_t STDMETHODCALLTYPE EParams(int32_t a, int32_t b)
+DLL_EXPORT int32_t __stdcall EParams(int32_t a, int32_t b)
 {
     return a + b + 4;
 }
 
-extern "C" DLL_EXPORT int32_t STDMETHODCALLTYPE EPtrs(int32_t* a, int32_t* b)
+DLL_EXPORT int32_t __stdcall EPtrs(int32_t* a, int32_t* b)
 {
     return *a + *b + 4;
 }

--- a/src/tests/JIT/opt/Devirtualization/IndirectNative.cpp
+++ b/src/tests/JIT/opt/Devirtualization/IndirectNative.cpp
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <stint.h>
+#include <xplatform.h>
+#include <platformdefines.h>
+
+extern "C" DLL_EXPORT int32_t STDMETHODCALLTYPE E()
+{
+    return 4;
+}
+
+extern "C" DLL_EXPORT int32_t STDMETHODCALLTYPE EParams(int32_t a, int32_t b)
+{
+    return a + b + 4;
+}
+
+extern "C" DLL_EXPORT int32_t STDMETHODCALLTYPE EPtrs(int32_t* a, int32_t* b)
+{
+    return *a + *b + 4;
+}

--- a/src/tests/JIT/opt/Devirtualization/IndirectNative.cpp
+++ b/src/tests/JIT/opt/Devirtualization/IndirectNative.cpp
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include <stdint.h>
-#include <xplatform.h>
 #include <platformdefines.h>
 
 extern "C" DLL_EXPORT int32_t STDMETHODCALLTYPE E()

--- a/src/tests/JIT/opt/Devirtualization/IndirectNative.cpp
+++ b/src/tests/JIT/opt/Devirtualization/IndirectNative.cpp
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#include <stint.h>
+#include <stdint.h>
 #include <xplatform.h>
 #include <platformdefines.h>
 


### PR DESCRIPTION
Imports indirect calls as direct ones when the target method is known.

Only handles addresses from ldftn as the VM has no way to verify pointers from static readonly fields and crashes on invalid ones.

The helpers currently contain a small dead path that I'll soon use when extending the code to also handle delegates.

Opening as a draft so that the code can be reviewed while I finish the tests.

Fixes #44610