### PR TITLE
Change default CFB feedback size for DES.Create()

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DES/DesTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DES/DesTests.cs
@@ -22,6 +22,7 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             {
                 Assert.Equal(64, des.KeySize);
                 Assert.Equal(64, des.BlockSize);
+                Assert.Equal(8, des.FeedbackSize);
                 Assert.Equal(CipherMode.CBC, des.Mode);
                 Assert.Equal(PaddingMode.PKCS7, des.Padding);
             }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DESCryptoServiceProvider.Unix.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DESCryptoServiceProvider.Unix.cs
@@ -17,7 +17,6 @@ namespace System.Security.Cryptography
         {
             // This class wraps DES
             _impl = DES.Create();
-            _impl.FeedbackSize = 8;
         }
 
         public override int BlockSize

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DesImplementation.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DesImplementation.cs
@@ -10,6 +10,14 @@ namespace System.Security.Cryptography
     {
         private const int BitsPerByte = 8;
 
+        public DesImplementation()
+        {
+            // Default CFB to CFB8. .NET Framework uses 8 as the default for DESCryptoServiceProvider which
+            // was used for DES.Create(), and .NET doesn't support anything other than 8 for the feedback size for DES,
+            // so also default it to the only value that works.
+            FeedbackSizeValue = 8;
+        }
+
         public override ICryptoTransform CreateDecryptor()
         {
             return CreateTransform(Key, IV, encrypting: false);

--- a/src/libraries/System.Security.Cryptography/tests/DESTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/DESTests.cs
@@ -19,6 +19,15 @@ namespace System.Security.Cryptography.Tests
             }
         }
 
+        [Fact]
+        public static void DesDerivedFeedbackSize()
+        {
+            using (DES des = new DESMinimal())
+            {
+                Assert.Equal(64, des.FeedbackSize);
+            }
+        }
+
         private class DESLegalSizesBreaker : DESMinimal
         {
             public DESLegalSizesBreaker()


### PR DESCRIPTION
The previous default value, 64, doesn't work for DES because .NET only supports CFB8 for DES. Further, this more closely aligns the behavior of DES.Create() from .NET Framework to .NET, as DESCryptoServiceProvider also had a default feedback size of 8.

This change sets the default feedback size to 8, which is the only value that worked anyway, so it isn't a breaking change.

Types derived from DES will continue to have a default feedback size of 64, which is the default value for .NET Framework derived types. We are only changing the default for DESImplementation returned by DES.Create().

Fixes #85079.