### PR TITLE
Fix source-index-stage1 official build

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -51,7 +51,7 @@ extends:
       - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
         - template: /eng/common/templates/job/source-index-stage1.yml
           parameters:
-            sourceIndexBuildCommand: build.cmd -subset libs.sfx+libs.oob -binarylog -os linux -ci
+            sourceIndexBuildCommand: build.cmd -subset libs.native+libs.sfx+libs.oob -binarylog -os linux -ci
 
       #
       # Build CoreCLR


### PR DESCRIPTION
With https://github.com/dotnet/runtime/commit/21fb96b6ee011576d3db184765658bb1bc9c178d, the libs.native subset is now required to be built as well for the source-index-stage1 leg.