### PR TITLE
Fix compiling errors within LoongArch64 and RISCV64 for `ins_Move_Extend`.

### DIFF
--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -1485,11 +1485,9 @@ instruction CodeGen::ins_Move_Extend(var_types srcType, bool srcInReg)
 #elif defined(TARGET_ARM)
     assert(!varTypeIsSIMD(srcType));
     return INS_vmov;
-#elif defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
-    NYI("ins_Move_Extend"); // not used for LA64 and RISCV64.
-    return INS_invalid;
 #else
     NYI("ins_Move_Extend");
+    return INS_invalid;
 #endif
 }
 

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -1485,6 +1485,9 @@ instruction CodeGen::ins_Move_Extend(var_types srcType, bool srcInReg)
 #elif defined(TARGET_ARM)
     assert(!varTypeIsSIMD(srcType));
     return INS_vmov;
+#elif defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
+    NYI("ins_Move_Extend"); // not used for LA64 and RISCV64.
+    return INS_invalid;
 #else
     NYI("ins_Move_Extend");
 #endif


### PR DESCRIPTION
This PR is part of the issue https://github.com/dotnet/runtime/issues/69705 to amend the LA's port.

Fix compiling errors within LoongArch64 and RISCV64 for `ins_Move_Extend`.

As RISCV64 #85232 is just a duplication of this PR, addding RISCV64 also.