### PR TITLE
Fix the reverse of genCodeForJumpCompare for LoongArch64 and RISCV64.

### DIFF
--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -4357,6 +4357,12 @@ void CodeGen::genCodeForJumpCompare(GenTreeOp* tree)
 
     bool IsUnsigned = (cond & GenCondition::Unsigned) != 0;
 
+    if (tree->gtFlags & GTF_JCMP_EQ)
+    {
+        GenCondition condReverse(static_cast<GenCondition::Code>(cond));
+        cond = GenCondition::Reverse(condReverse).GetCode();
+    }
+
     emitAttr  cmpSize = EA_ATTR(genTypeSize(op1Type));
     regNumber regOp1  = op1->GetRegNum();
 

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -3597,6 +3597,12 @@ void CodeGen::genCodeForJumpCompare(GenTreeOp* tree)
     emitAttr  cmpSize    = EA_ATTR(genTypeSize(op1Type));
     regNumber regOp1     = op1->GetRegNum();
 
+    if (tree->gtFlags & GTF_JCMP_EQ)
+    {
+        GenCondition condReverse(static_cast<GenCondition::Code>(cond));
+        cond = GenCondition::Reverse(condReverse).GetCode();
+    }
+
     if (varTypeIsFloating(op1Type))
     {
         NYI_RISCV64("genCodeForJumpCompare floating-----unimplemented on RISCV64 yet----");


### PR DESCRIPTION
This PR is part of the issue https://github.com/dotnet/runtime/issues/69705 to amend the LA's port.

Fix the reverse of genCodeForJumpCompare for LoongArch64 and RISCV64.