### PR TITLE
Set .env variables in corerun prior to CLR init

### DIFF
--- a/src/coreclr/hosts/corerun/corerun.cpp
+++ b/src/coreclr/hosts/corerun/corerun.cpp
@@ -247,7 +247,9 @@ static int run(const configuration& config)
     // Check if debugger attach scenario was requested.
     if (config.wait_to_debug)
         wait_for_debugger();
-
+    
+    config.dotenv_configuration.load_into_current_process();
+    
     string_t exe_path = pal::get_exe_path();
 
     // Determine the managed application's path.
@@ -302,8 +304,6 @@ static int run(const configuration& config)
             return -1;
         }
     }
-
-    config.dotenv_configuration.load_into_current_process();
 
     actions.before_coreclr_load();
 


### PR DESCRIPTION
While playing with the dotnet `corerun.exe` host I have noticed that the user supplied `.env` file through the `-e` argument is not processed by corerun.

I launched `corerun.exe` by first supplying the path of `CORE_LIBRARIES` as an environmental variable:

```
> SET CORE_LIBRARIES=C:\\Program Files\\dotnet\\shared\\Microsoft.NETCore.App\\7.0.0
> corerun.exe ./SampleProgram.dll
```

This worked fine, however - when placing the variables inside an `.env` file as described in the usage prompt:
> -e, --env - path to a .env file with environment variables that corerun should set.

```
// core.env file
CORE_LIBRARIES=C:\\Program Files\\dotnet\\shared\\Microsoft.NETCore.App\\7.0.0
```
and passing the file through the `-e` argument I noticed that I received the following exception:

```
Unhandled exception. System.IO.FileNotFoundException: Could not load file or assembly 'System.Runtime, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The system cannot find the file specified.
File name: 'System.Runtime, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
```

This exception indicated that the CLR could not load the necessary core libraries. The reason behind this is simply because the path to the core_libraries is set prior to the `.env` file variables being injected into the corerun process at the following code:
```Cpp
string_t core_libs = pal::getenv(envvar::coreLibraries); // envvar::coreLibraries is not set at this point
```

This is a simple fix to this issue.