### PR TITLE
Vectorize the CRC64 implementation

### DIFF
--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -1231,6 +1231,7 @@ License for Fast CRC Computation
 --------------------------------------
 
 https://github.com/intel/isa-l/blob/33a2d9484595c2d6516c920ce39a694c144ddf69/crc/crc32_ieee_by4.asm
+https://github.com/intel/isa-l/blob/33a2d9484595c2d6516c920ce39a694c144ddf69/crc/crc64_ecma_norm_by8.asm
 
 Copyright(c) 2011-2015 Intel Corporation All rights reserved.
 

--- a/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
+++ b/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
@@ -21,6 +21,8 @@ System.IO.Hashing.XxHash32</PackageDescription>
              Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))" />
     <Compile Include="System\IO\Hashing\Crc64.cs" />
     <Compile Include="System\IO\Hashing\Crc64.Table.cs" />
+    <Compile Include="System\IO\Hashing\Crc64.Vectorized.cs"
+             Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))" />
     <Compile Include="System\IO\Hashing\XxHash128.cs" />
     <Compile Include="System\IO\Hashing\XxHash3.cs" />
     <Compile Include="System\IO\Hashing\XxHash32.cs" />
@@ -31,6 +33,8 @@ System.IO.Hashing.XxHash32</PackageDescription>
     <Compile Include="System\IO\Hashing\NonCryptographicHashAlgorithm.cs" />
     <Compile Include="System\IO\Hashing\BitOperations.cs"
              Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
+    <Compile Include="System\IO\Hashing\VectorHelper.cs"
+             Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc64.Vectorized.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc64.Vectorized.cs
@@ -1,0 +1,159 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.InteropServices;
+
+namespace System.IO.Hashing
+{
+    public partial class Crc64
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector128<ulong> LoadFromSource(ref byte source, nuint elementOffset)
+        {
+            Vector128<byte> vector = Vector128.LoadUnsafe(ref source, elementOffset);
+
+            if (BitConverter.IsLittleEndian)
+            {
+                // Reverse the byte order.
+
+                // SSSE3 is required to get PSHUFB acceleration for Vector128.Shuffle on x86/x64.
+                // However, the gains from vectorizing the rest of the operations seem to to be
+                // greater than the added cost of emulating the shuffle, so we don't require SSSE3 support.
+                vector = Vector128.Shuffle(vector,
+                    Vector128.Create((byte)0x0F, 0x0E, 0x0D, 0x0C, 0x0B, 0x0A, 0x09, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03,
+                        0x02, 0x01, 0x00));
+            }
+
+            return vector.AsUInt64();
+        }
+
+        // All of these checks except the length check are elided by JIT, so the JITted implementation
+        // will be either a return false or a length check against a constant. This means this method
+        // should be inlined into the caller.
+        private static bool CanBeVectorized(ReadOnlySpan<byte> source) => VectorHelper.IsSupported && source.Length >= Vector128<byte>.Count;
+
+        // Processes the bytes in source in 128 byte chunks using intrinsics, followed by processing 16
+        // byte chunks, and then processing remaining bytes individually. Requires at least 16 bytes of data.
+        // Requires little endian byte order and support for PCLMULQDQ intrinsics on Intel architecture
+        // or AES and AdvSimd intrinsics on ARM architecture. Based on the algorithm put forth in the Intel paper
+        // "Fast CRC Computation for Generic Polynomials Using PCLMULQDQ Instruction" in December, 2009 and the
+        // Intel reference implementation.
+        // https://github.com/intel/isa-l/blob/33a2d9484595c2d6516c920ce39a694c144ddf69/crc/crc64_ecma_norm_by8.asm
+        private static ulong UpdateVectorized(ulong crc, ReadOnlySpan<byte> source)
+        {
+            Debug.Assert(CanBeVectorized(source), "source cannot be vectorized.");
+
+            // Work with a reference to where we're at in the ReadOnlySpan and a local length
+            // to avoid extraneous range checks.
+            ref byte srcRef = ref MemoryMarshal.GetReference(source);
+            int length = source.Length;
+
+            Vector128<ulong> x7; // Accumulator for the new CRC
+            Vector128<ulong> kConstants; // Used to store reused constants
+
+            if (length >= Vector128<byte>.Count * 16) // At least 256 bytes
+            {
+                // Load the first 128 bytes
+                Vector128<ulong> x0 = LoadFromSource(ref srcRef, 0);
+                Vector128<ulong> x1 = LoadFromSource(ref srcRef, 16);
+                Vector128<ulong> x2 = LoadFromSource(ref srcRef, 32);
+                Vector128<ulong> x3 = LoadFromSource(ref srcRef, 48);
+                Vector128<ulong> x4 = LoadFromSource(ref srcRef, 64);
+                Vector128<ulong> x5 = LoadFromSource(ref srcRef, 80);
+                Vector128<ulong> x6 = LoadFromSource(ref srcRef, 96);
+                x7 = LoadFromSource(ref srcRef, 112);
+
+                srcRef = ref Unsafe.Add(ref srcRef, Vector128<byte>.Count * 8);
+                length -= Vector128<byte>.Count * 8;
+
+                // Load and XOR the initial CRC value
+                // CRC value does not need to be byte-reflected, but it needs to be moved to the high part of the register.
+                // because data will be byte-reflected and will align with initial crc at correct place.
+                x0 ^= VectorHelper.ShiftLowerToUpper(Vector128.CreateScalar(crc));
+
+                kConstants = Vector128.Create(0x5cf79dea9ac37d6UL, 0x001067e571d7d5c2UL); // k3, k4
+
+                // Parallel fold blocks of 128
+                do
+                {
+                    Vector128<ulong> y1 = LoadFromSource(ref srcRef, 0);
+                    Vector128<ulong> y2 = LoadFromSource(ref srcRef, 16);
+                    x0 = VectorHelper.FoldPolynomialPair(y1, x0, kConstants);
+                    x1 = VectorHelper.FoldPolynomialPair(y2, x1, kConstants);
+
+                    y1 = LoadFromSource(ref srcRef, 32);
+                    y2 = LoadFromSource(ref srcRef, 48);
+                    x2 = VectorHelper.FoldPolynomialPair(y1, x2, kConstants);
+                    x3 = VectorHelper.FoldPolynomialPair(y2, x3, kConstants);
+
+                    y1 = LoadFromSource(ref srcRef, 64);
+                    y2 = LoadFromSource(ref srcRef, 80);
+                    x4 = VectorHelper.FoldPolynomialPair(y1, x4, kConstants);
+                    x5 = VectorHelper.FoldPolynomialPair(y2, x5, kConstants);
+
+                    y1 = LoadFromSource(ref srcRef, 96);
+                    y2 = LoadFromSource(ref srcRef, 112);
+                    x6 = VectorHelper.FoldPolynomialPair(y1, x6, kConstants);
+                    x7 = VectorHelper.FoldPolynomialPair(y2, x7, kConstants);
+
+                    srcRef = ref Unsafe.Add(ref srcRef, Vector128<byte>.Count * 8);
+                    length -= Vector128<byte>.Count * 8;
+                } while (length >= Vector128<byte>.Count * 8);
+
+                // Fold into 128-bits in x7
+                x7 = VectorHelper.FoldPolynomialPair(x7, x0, Vector128.Create(0xe464f4df5fb60ac1UL, 0xb649c5b35a759cf2UL)); // k9, k10
+                x7 = VectorHelper.FoldPolynomialPair(x7, x1, Vector128.Create(0x9af04e1eff82d0ddUL, 0x6e82e609297f8fe8UL)); // k11, k12
+                x7 = VectorHelper.FoldPolynomialPair(x7, x2, Vector128.Create(0x97c516e98bd2e73UL, 0xb76477b31e22e7bUL)); // k13, k14
+                x7 = VectorHelper.FoldPolynomialPair(x7, x3, Vector128.Create(0x5f6843ca540df020UL, 0xddf4b6981205b83fUL)); // k15, k16
+                x7 = VectorHelper.FoldPolynomialPair(x7, x4, Vector128.Create(0x54819d8713758b2cUL, 0x4a6b90073eb0af5aUL)); // k17, k18
+                x7 = VectorHelper.FoldPolynomialPair(x7, x5, Vector128.Create(0x571bee0a227ef92bUL, 0x44bef2a201b5200cUL)); // k19, k20
+                x7 = VectorHelper.FoldPolynomialPair(x7, x6, Vector128.Create(0x5f5c3c7eb52fab6UL, 0x4eb938a7d257740eUL)); // k1, k2
+            }
+            else
+            {
+                // For shorter sources just load the first vector and XOR with the CRC
+                Debug.Assert(length >= 16);
+
+                x7 = LoadFromSource(ref srcRef, 0);
+
+                // Load and XOR the initial CRC value
+                // CRC value does not need to be byte-reflected, but it needs to be moved to the high part of the register.
+                // because the data will be byte-reflected and will align with initial crc at correct place.
+                x7 ^= VectorHelper.ShiftLowerToUpper(Vector128.CreateScalar(crc));
+
+                srcRef = ref Unsafe.Add(ref srcRef, Vector128<byte>.Count);
+                length -= Vector128<byte>.Count;
+            }
+
+            // Single fold blocks of 16, if any, into x7
+            while (length >= Vector128<byte>.Count)
+            {
+                x7 = VectorHelper.FoldPolynomialPair(LoadFromSource(ref srcRef, 0), x7,
+                    Vector128.Create(0x5f5c3c7eb52fab6UL, 0x4eb938a7d257740eUL)); // k1, k2
+
+                srcRef = ref Unsafe.Add(ref srcRef, Vector128<byte>.Count);
+                length -= Vector128<byte>.Count;
+            }
+
+            // Compute CRC of a 128-bit value and fold to the upper 64-bits
+            x7 = VectorHelper.CarrylessMultiplyLeftUpperRightLower(x7, Vector128.CreateScalar(0x5f5c3c7eb52fab6UL)) ^ // k5
+                 VectorHelper.ShiftLowerToUpper(x7);
+
+            // Barrett reduction
+            kConstants = Vector128.Create(0x578d29d06cc4f872UL, 0x42f0e1eba9ea3693UL); // k7, k8
+            Vector128<ulong> temp = x7;
+            x7 = VectorHelper.CarrylessMultiplyLeftUpperRightLower(x7, kConstants) ^ (x7 & Vector128.Create(0UL, ~0UL));
+            x7 = VectorHelper.CarrylessMultiplyUpper(x7, kConstants);
+            x7 ^= temp;
+
+            // Process the remaining bytes, if any
+            ulong result = x7.GetElement(0);
+            return length > 0
+                ? UpdateScalar(result, MemoryMarshal.CreateReadOnlySpan(ref srcRef, length))
+                : result;
+        }
+    }
+}

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc64.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc64.cs
@@ -167,6 +167,18 @@ namespace System.IO.Hashing
 
         private static ulong Update(ulong crc, ReadOnlySpan<byte> source)
         {
+#if NET7_0_OR_GREATER
+            if (CanBeVectorized(source))
+            {
+                return UpdateVectorized(crc, source);
+            }
+#endif
+
+            return UpdateScalar(crc, source);
+        }
+
+        private static ulong UpdateScalar(ulong crc, ReadOnlySpan<byte> source)
+        {
             ReadOnlySpan<ulong> crcLookup = CrcLookup;
             for (int i = 0; i < source.Length; i++)
             {

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/VectorHelper.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/VectorHelper.cs
@@ -1,0 +1,134 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+using System.Runtime.Intrinsics;
+using Aes = System.Runtime.Intrinsics.Arm.Aes;
+
+namespace System.IO.Hashing
+{
+    // Helpers which provide equivalent intrinsics for Intel and ARM architectures. Should only be used
+    // if the intrinsics are available.
+    internal static class VectorHelper
+    {
+        // Pclmulqdq implies support for SSE2
+        public static bool IsSupported => Pclmulqdq.IsSupported || (Aes.IsSupported && AdvSimd.IsSupported);
+
+        // Performs carryless multiplication of the upper pairs of source and constants and the lower pairs of source and constants,
+        // then folds them into target using carryless addition.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<ulong> FoldPolynomialPair(Vector128<ulong> target, Vector128<ulong> source, Vector128<ulong> constants)
+        {
+            target ^= CarrylessMultiplyUpper(source, constants);
+            target ^= CarrylessMultiplyLower(source, constants);
+
+            return target;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<ulong> CarrylessMultiplyLower(Vector128<ulong> left, Vector128<ulong> right)
+        {
+            if (Pclmulqdq.IsSupported)
+            {
+                return Pclmulqdq.CarrylessMultiply(left, right, 0x00);
+            }
+
+            if (Aes.IsSupported)
+            {
+                return Aes.PolynomialMultiplyWideningLower(left.GetLower(), right.GetLower());
+            }
+
+            ThrowHelper.ThrowUnreachableException();
+            return default;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<ulong> CarrylessMultiplyUpper(Vector128<ulong> left, Vector128<ulong> right)
+        {
+            if (Pclmulqdq.IsSupported)
+            {
+                return Pclmulqdq.CarrylessMultiply(left, right, 0x11);
+            }
+
+            if (Aes.IsSupported)
+            {
+                return Aes.PolynomialMultiplyWideningUpper(left, right);
+            }
+
+            ThrowHelper.ThrowUnreachableException();
+            return default;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<ulong> CarrylessMultiplyLeftUpperRightLower(Vector128<ulong> left, Vector128<ulong> right)
+        {
+            if (Pclmulqdq.IsSupported)
+            {
+                return Pclmulqdq.CarrylessMultiply(left, right, 0x01);
+            }
+
+            if (Aes.IsSupported)
+            {
+                return Aes.PolynomialMultiplyWideningLower(left.GetUpper(), right.GetLower());
+            }
+
+            ThrowHelper.ThrowUnreachableException();
+            return default;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<ulong> CarrylessMultiplyLeftLowerRightUpper(Vector128<ulong> left, Vector128<ulong> right)
+        {
+            if (Pclmulqdq.IsSupported)
+            {
+                return Pclmulqdq.CarrylessMultiply(left, right, 0x10);
+            }
+
+            if (Aes.IsSupported)
+            {
+                return Aes.PolynomialMultiplyWideningLower(left.GetLower(), right.GetUpper());
+            }
+
+            ThrowHelper.ThrowUnreachableException();
+            return default;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<ulong> ShiftRightBytesInVector(Vector128<ulong> operand,
+            [ConstantExpected(Max = (byte)15)] byte numBytesToShift)
+        {
+            if (Sse2.IsSupported)
+            {
+                return Sse2.ShiftRightLogical128BitLane(operand, numBytesToShift);
+            }
+
+            if (AdvSimd.IsSupported)
+            {
+                return AdvSimd.ExtractVector128(operand.AsByte(), Vector128<byte>.Zero, numBytesToShift).AsUInt64();
+            }
+
+            ThrowHelper.ThrowUnreachableException();
+            return default;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<ulong> ShiftLowerToUpper(Vector128<ulong> operand)
+        {
+            if (Sse2.IsSupported)
+            {
+                return Sse2.ShiftLeftLogical128BitLane(operand, 8);
+            }
+
+            if (AdvSimd.IsSupported)
+            {
+                return AdvSimd.ExtractVector128(Vector128<byte>.Zero, operand.AsByte(), 8).AsUInt64();
+            }
+
+            ThrowHelper.ThrowUnreachableException();
+            return default;
+        }
+    }
+}

--- a/src/libraries/System.IO.Hashing/tests/Crc64Tests.cs
+++ b/src/libraries/System.IO.Hashing/tests/Crc64Tests.cs
@@ -69,6 +69,26 @@ namespace System.IO.Hashing.Tests
                     "The quick brown fox jumps over the lazy dog",
                     "The quick brown fox jumps over the lazy dog"u8.ToArray(),
                     "41E05242FFA9883B"),
+                // Test 256 bytes for vector optimizations
+                new TestCase(
+                    "Lorem ipsum 256",
+                    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent non ipsum quis mauris euismod hendrerit id sed lacus. Duis quam neque, porta et volutpat nec, tempor eget nisl. Nunc quis leo quis nisi mattis molestie. Donec a diam velit. Sed a tempus nec."u8.ToArray(),
+                    "DA70046E6B79DD83"),
+                // Test a multiple of 128 bytes greater than 256 bytes + 16 bytes for vector optimizations
+                new TestCase(
+                    "Lorem ipsum 272",
+                    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent non ipsum quis mauris euismod hendrerit id sed lacus. Duis quam neque, porta et volutpat nec, tempor eget nisl. Nunc quis leo quis nisi mattis molestie. Donec a diam velit. Sed a tempus nec1234567890abcdef."u8.ToArray(),
+                    "A94F5E9C5557F65A"),
+                // Test a multiple of 128 bytes greater than 256 bytes for vector optimizations
+                new TestCase(
+                    "Lorem ipsum 384",
+                    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam lobortis non felis et pretium. Suspendisse commodo dignissim sagittis. Etiam vestibulum luctus mollis. Ut finibus, nisl in sodales sagittis, leo mauris sollicitudin odio, id sodales nisl ante vitae quam. Nunc ut mi at lacus ultricies efficitur vitae eu ligula. Donec tincidunt, nisi suscipit facilisis auctor, metus non."u8.ToArray(),
+                    "5768E3F2E9A63829"),
+                // Test data that is > 256 bytes but not a multiple of 16 for vector optimizations
+                new TestCase(
+                     "Lorem ipsum 1001",
+                     "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer ac urna vitae nibh sagittis porttitor et vel ante. Ut molestie sit amet velit ac mattis. Sed ullamcorper nunc non neque imperdiet, vehicula bibendum sapien efficitur. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Suspendisse potenti. Duis sem dui, malesuada non pharetra at, feugiat id mi. Nulla facilisi. Fusce a scelerisque magna. Ut leo justo, auctor quis nisi et, sollicitudin pretium odio. Sed eu nibh mollis, pretium lectus nec, posuere nulla. Morbi ac euismod purus. Morbi rhoncus leo est, at volutpat nunc pretium in. Aliquam erat volutpat. Curabitur eu lacus mollis, varius lectus ut, tincidunt eros. Nullam a velit hendrerit, euismod magna id, fringilla sem. Phasellus scelerisque hendrerit est, vel imperdiet enim auctor a. Aenean vel ultricies nunc. Suspendisse ac tincidunt urna. Nulla tempor dolor ut ligula accumsan, tempus auctor massa gravida. Aenean non odio et augue pellena."u8.ToArray(),
+                     "3ECF3A363FC5BD59"),
             };
 
         protected override NonCryptographicHashAlgorithm CreateInstance() => new Crc64();


### PR DESCRIPTION
This significantly improves performance for System.IO.Hashing.Crc64 for cases where the source span is 16 bytes or larger on Intel x86/x64 and modern ARM architectures. The vectorization change only applies to .NET 7 and later targets of System.IO.Hashing because it uses some Vector128 APIs added in .NET 7.

This is a continuation of work done in #83321 which added vectorization to CRC32.

BenchmarkDotNet=v0.13.2.2052-nightly, OS=Windows 11 (10.0.22621.1631)
Intel Core i7-10850H CPU 2.70GHz, 1 CPU, 12 logical and 6 physical cores
.NET SDK=8.0.100-preview.3.23178.7
  [Host]     : .NET 8.0.0 (8.0.23.17408), X64 RyuJIT AVX2
  Job-FPBBMO : .NET 8.0.0 (42.42.42.42424), X64 RyuJIT AVX2
  Job-FTHZKV : .NET 8.0.0 (42.42.42.42424), X64 RyuJIT AVX2

PowerPlanMode=00000000-0000-0000-0000-000000000000  IterationTime=250.0000 ms  MaxIterationCount=20
MinIterationCount=15  WarmupCount=1

| Method |    Job | BufferSize |         Mean |      Error |     StdDev |       Median |          Min |          Max | Ratio |
|------- |------- |----------- |-------------:|-----------:|-----------:|-------------:|-------------:|-------------:|------:|
| Append | Scalar |         16 |    30.529 ns |  0.3658 ns |  0.3422 ns |    30.656 ns |    29.968 ns |    30.986 ns |  1.00 |
| Append | Vector |         16 |     6.056 ns |  0.0193 ns |  0.0181 ns |     6.046 ns |     6.035 ns |     6.089 ns |  0.20 |
|        |        |            |              |            |            |              |              |              |       |
| Append | Scalar |        256 |   496.097 ns |  2.8740 ns |  2.5477 ns |   496.725 ns |   488.920 ns |   499.684 ns |  1.00 |
| Append | Vector |        256 |    14.741 ns |  0.0614 ns |  0.0512 ns |    14.753 ns |    14.589 ns |    14.798 ns |  0.03 |
|        |        |            |              |            |            |              |              |              |       |
| Append | Scalar |       1024 | 1,986.624 ns | 11.4688 ns | 10.7279 ns | 1,984.088 ns | 1,971.231 ns | 2,004.409 ns |  1.00 |
| Append | Vector |       1024 |    44.201 ns |  0.1042 ns |  0.0924 ns |    44.196 ns |    44.062 ns |    44.413 ns |  0.02 |

BenchmarkDotNet=v0.13.2.2052-nightly, OS=ubuntu 22.04
AWS m6g.xlarge Graviton2
.NET SDK=8.0.100-preview.3.23178.7
  [Host]     : .NET 8.0.0 (8.0.23.17408), Arm64 RyuJIT AdvSIMD
  Job-OYJLBY : .NET 8.0.0 (42.42.42.42424), Arm64 RyuJIT AdvSIMD
  Job-GKZVCN : .NET 8.0.0 (42.42.42.42424), Arm64 RyuJIT AdvSIMD

PowerPlanMode=00000000-0000-0000-0000-000000000000  IterationTime=250.0000 ms  MaxIterationCount=20
MinIterationCount=15  WarmupCount=1

| Method |    Job | BufferSize |        Mean |    Error |   StdDev |      Median |         Min |         Max | Ratio |
|------- |------- |----------- |------------:|---------:|---------:|------------:|------------:|------------:|------:|
| Append | Scalar |         16 |    38.44 ns | 0.003 ns | 0.002 ns |    38.44 ns |    38.43 ns |    38.44 ns |  1.00 |
| Append | Vector |         16 |    13.57 ns | 0.002 ns | 0.002 ns |    13.57 ns |    13.56 ns |    13.57 ns |  0.35 |
|        |        |            |             |          |          |             |             |             |       |
| Append | Scalar |        256 |   619.02 ns | 0.143 ns | 0.133 ns |   619.00 ns |   618.85 ns |   619.35 ns |  1.00 |
| Append | Vector |        256 |    28.70 ns | 0.025 ns | 0.021 ns |    28.70 ns |    28.68 ns |    28.75 ns |  0.05 |
|        |        |            |             |          |          |             |             |             |       |
| Append | Scalar |       1024 | 2,465.47 ns | 0.183 ns | 0.153 ns | 2,465.44 ns | 2,465.18 ns | 2,465.68 ns |  1.00 |
| Append | Vector |       1024 |    79.71 ns | 0.104 ns | 0.097 ns |    79.68 ns |    79.58 ns |    79.93 ns |  0.03 |