### PR TITLE
JIT: Move some BasicBlock methods into block.cpp

### DIFF
--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -1662,3 +1662,102 @@ void BasicBlock::unmarkLoopAlign(Compiler* compiler DEBUG_ARG(const char* reason
         JITDUMP("Unmarking LOOP_ALIGN from " FMT_BB ". Reason= %s.\n", bbNum, reason);
     }
 }
+
+//------------------------------------------------------------------------
+// getCalledCount: get the value used to normalized weights for this method
+//
+// Arguments:
+//    compiler - Compiler instance
+//
+// Notes:
+//   If we don't have profile data then getCalledCount will return BB_UNITY_WEIGHT (100)
+//   otherwise it returns the number of times that profile data says the method was called.
+
+// static
+weight_t BasicBlock::getCalledCount(Compiler* comp)
+{
+    // when we don't have profile data then fgCalledCount will be BB_UNITY_WEIGHT (100)
+    weight_t calledCount = comp->fgCalledCount;
+
+    // If we haven't yet reach the place where we setup fgCalledCount it could still be zero
+    // so return a reasonable value to use until we set it.
+    //
+    if (calledCount == 0)
+    {
+        if (comp->fgIsUsingProfileWeights())
+        {
+            // When we use profile data block counts we have exact counts,
+            // not multiples of BB_UNITY_WEIGHT (100)
+            calledCount = 1;
+        }
+        else
+        {
+            calledCount = comp->fgFirstBB->bbWeight;
+
+            if (calledCount == 0)
+            {
+                calledCount = BB_UNITY_WEIGHT;
+            }
+        }
+    }
+    return calledCount;
+}
+
+//------------------------------------------------------------------------
+// getBBWeight: get the normalized weight of this block
+//
+// Arguments:
+//    compiler - Compiler instance
+//
+// Notes:
+//    with profie data: number of expected executions of this block, given
+//    one call to the method
+//
+weight_t BasicBlock::getBBWeight(Compiler* comp)
+{
+    if (this->bbWeight == BB_ZERO_WEIGHT)
+    {
+        return BB_ZERO_WEIGHT;
+    }
+    else
+    {
+        weight_t calledCount = getCalledCount(comp);
+
+        // Normalize the bbWeights by multiplying by BB_UNITY_WEIGHT and dividing by the calledCount.
+        //
+        weight_t fullResult = this->bbWeight * BB_UNITY_WEIGHT / calledCount;
+
+        return fullResult;
+    }
+}
+
+//------------------------------------------------------------------------
+// bbStackDepthOnEntry: return depth of IL stack at block entry
+//
+unsigned BasicBlock::bbStackDepthOnEntry() const
+{
+    return (bbEntryState ? bbEntryState->esStackDepth : 0);
+}
+
+//------------------------------------------------------------------------
+// bbSetStack: update IL stack for block entry
+//
+// Arguments;
+//   stack - new stack for block
+//
+void BasicBlock::bbSetStack(StackEntry* stack)
+{
+    assert(bbEntryState);
+    assert(stack);
+    bbEntryState->esStack = stack;
+}
+
+//------------------------------------------------------------------------
+// bbStackOnEntry: fetch IL stack for block entry
+//
+StackEntry* BasicBlock::bbStackOnEntry() const
+{
+    assert(bbEntryState);
+    return bbEntryState->esStack;
+}
+

--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -1760,4 +1760,3 @@ StackEntry* BasicBlock::bbStackOnEntry() const
     assert(bbEntryState);
     return bbEntryState->esStack;
 }
-

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -1230,7 +1230,7 @@ struct BasicBlock : private LIR::Range
 #endif // DEBUG
 
     unsigned bbStackDepthOnEntry() const;
-    void bbSetStack(void* stackBuffer);
+    void bbSetStack(StackEntry* stack);
     StackEntry* bbStackOnEntry() const;
 
     // "bbNum" is one-based (for unknown reasons); it is sometimes useful to have the corresponding

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -12505,24 +12505,6 @@ void Compiler::verResetCurrentState(BasicBlock* block, EntryState* destState)
     }
 }
 
-unsigned BasicBlock::bbStackDepthOnEntry() const
-{
-    return (bbEntryState ? bbEntryState->esStackDepth : 0);
-}
-
-void BasicBlock::bbSetStack(void* stackBuffer)
-{
-    assert(bbEntryState);
-    assert(stackBuffer);
-    bbEntryState->esStack = (StackEntry*)stackBuffer;
-}
-
-StackEntry* BasicBlock::bbStackOnEntry() const
-{
-    assert(bbEntryState);
-    return bbEntryState->esStack;
-}
-
 void Compiler::verInitCurrentState()
 {
     // initialize stack info

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -3332,59 +3332,6 @@ unsigned Compiler::lvaLclExactSize(unsigned varNum)
     return lvaGetDesc(varNum)->lvExactSize();
 }
 
-// getCalledCount -- get the value used to normalized weights for this method
-//  if we don't have profile data then getCalledCount will return BB_UNITY_WEIGHT (100)
-//  otherwise it returns the number of times that profile data says the method was called.
-//
-// static
-weight_t BasicBlock::getCalledCount(Compiler* comp)
-{
-    // when we don't have profile data then fgCalledCount will be BB_UNITY_WEIGHT (100)
-    weight_t calledCount = comp->fgCalledCount;
-
-    // If we haven't yet reach the place where we setup fgCalledCount it could still be zero
-    // so return a reasonable value to use until we set it.
-    //
-    if (calledCount == 0)
-    {
-        if (comp->fgIsUsingProfileWeights())
-        {
-            // When we use profile data block counts we have exact counts,
-            // not multiples of BB_UNITY_WEIGHT (100)
-            calledCount = 1;
-        }
-        else
-        {
-            calledCount = comp->fgFirstBB->bbWeight;
-
-            if (calledCount == 0)
-            {
-                calledCount = BB_UNITY_WEIGHT;
-            }
-        }
-    }
-    return calledCount;
-}
-
-// getBBWeight -- get the normalized weight of this block
-weight_t BasicBlock::getBBWeight(Compiler* comp)
-{
-    if (this->bbWeight == BB_ZERO_WEIGHT)
-    {
-        return BB_ZERO_WEIGHT;
-    }
-    else
-    {
-        weight_t calledCount = getCalledCount(comp);
-
-        // Normalize the bbWeights by multiplying by BB_UNITY_WEIGHT and dividing by the calledCount.
-        //
-        weight_t fullResult = this->bbWeight * BB_UNITY_WEIGHT / calledCount;
-
-        return fullResult;
-    }
-}
-
 // LclVarDsc "less" comparer used to compare the weight of two locals, when optimizing for small code.
 class LclVarDsc_SmallCode_Less
 {


### PR DESCRIPTION
Collect up a few `BasicBlock` methods that were scattered about in other files.