### PR TITLE
[RISC-V] Fix build error

### DIFF
--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -1485,6 +1485,9 @@ instruction CodeGen::ins_Move_Extend(var_types srcType, bool srcInReg)
 #elif defined(TARGET_ARM)
     assert(!varTypeIsSIMD(srcType));
     return INS_vmov;
+#elif defined(TARGET_RISCV64)
+    NYI("ins_Move_Extend"); // not used for RISCV64
+    return INS_invalid;
 #else
     NYI("ins_Move_Extend");
 #endif


### PR DESCRIPTION
- Fixed build error due to no return value in non-void function (ins_Move_Extend)
- https://github.com/dotnet/runtime/issues/84834