### PR TITLE
NativeAOT ComWrappers: fix race condition in when creating native wrapper

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -720,8 +720,18 @@ namespace System.Runtime.InteropServices
                 {
                     if (_rcwCache.TryGetValue(externalComObject, out GCHandle handle))
                     {
-                        retValue = handle.Target;
-                        return true;
+                        object? cachedWrapper = handle.Target;
+                        if (cachedWrapper is not null)
+                        {
+                            retValue = cachedWrapper;
+                            return true;
+                        }
+                        else
+                        {
+                            // The GCHandle has been clear out but the NativeObjectWrapper
+                            // finalizer has not yet run to remove the entry from _rcwCache
+                            _rcwCache.Remove(externalComObject);
+                        }
                     }
 
                     if (wrapperMaybe is not null)
@@ -765,9 +775,21 @@ namespace System.Runtime.InteropServices
 
             using (LockHolder.Hold(_lock))
             {
+                object? cachedWrapper = null;
                 if (_rcwCache.TryGetValue(externalComObject, out var existingHandle))
                 {
-                    retValue = existingHandle.Target;
+                    cachedWrapper = existingHandle.Target;
+                    if (cachedWrapper is null)
+                    {
+                        // The GCHandle has been clear out but the NativeObjectWrapper
+                        // finalizer has not yet run to remove the entry from _rcwCache
+                        _rcwCache.Remove(externalComObject);
+                    }
+                }
+
+                if (cachedWrapper is not null)
+                {
+                    retValue = cachedWrapper;
                 }
                 else
                 {

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -299,6 +299,36 @@ namespace ComWrappersTests
             Assert.NotEqual(trackerObj1, trackerObj3);
         }
 
+        // Make sure that if one wrapper is GCed, another can be created.
+        static void ValidateCreateObjectGcBehavior()
+        {
+            Console.WriteLine($"Running {nameof(ValidateCreateObjectCachingScenario)}...");
+
+            var cw = new TestComWrappers();
+
+            // Get an object from a tracker runtime.
+            IntPtr trackerObjRaw = MockReferenceTrackerRuntime.CreateTrackerObject();
+
+            // Create the first native object wrapper and run the GC.
+            CreateObject();
+            GC.Collect();
+
+            // Try to create another wrapper for the same object. The above GC
+            // may have collected parts of the ComWrapper cache, but this should
+            // still work.
+            CreateObject();
+            ForceGC();
+
+            Marshal.Release(trackerObjRaw);
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            void CreateObject()
+            {
+                var obj = (ITrackerObjectWrapper)cw.GetOrCreateObjectForComInstance(trackerObjRaw, CreateObjectFlags.None);
+                Assert.NotNull(obj);
+            }
+        }
+
         static void ValidateMappingAPIs()
         {
             Console.WriteLine($"Running {nameof(ValidateMappingAPIs)}...");
@@ -777,6 +807,7 @@ namespace ComWrappersTests
                 ValidateCreatingAComInterfaceForObjectAfterTheFirstIsFree();
                 ValidateFallbackQueryInterface();
                 ValidateCreateObjectCachingScenario();
+                ValidateCreateObjectGcBehavior();
                 ValidateMappingAPIs();
                 ValidateWrappersInstanceIsolation();
                 ValidatePrecreatedExternalWrapper();


### PR DESCRIPTION
If a ComWrapper for a native object becomes unrooted, the GCHandle in `_rcwCache` can be nulled out by the GC. If a new wrapper is created using `GetOrCreateObjectForComInstance` before the `NativeObjectWrapper` finializer has a chance to run, a null value could be returned from `GetOrCreateObjectForComInstance`.

This PR adds test that passes on the main branch using CoreCLR but fails under NativeAOT. After this change, the test passes for NativeAOT as well.