### PR TITLE
Skip libs native runtime packages build in source-index-stage job

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -51,7 +51,7 @@ extends:
       - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
         - template: /eng/common/templates/job/source-index-stage1.yml
           parameters:
-            sourceIndexBuildCommand: build.cmd -subset libs.sfx+libs.oob -binarylog -os linux -ci
+            sourceIndexBuildCommand: build.cmd -subset libs.sfx+libs.oob -binarylog -os linux -ci /p:SkipLibrariesNativeRuntimePackages=true
 
       #
       # Build CoreCLR

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -51,7 +51,7 @@ extends:
       - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
         - template: /eng/common/templates/job/source-index-stage1.yml
           parameters:
-            sourceIndexBuildCommand: build.cmd -subset libs.native+libs.sfx+libs.oob -binarylog -os linux -ci
+            sourceIndexBuildCommand: build.cmd -subset libs.sfx+libs.oob -binarylog -os linux -ci
 
       #
       # Build CoreCLR

--- a/src/libraries/oob-all.proj
+++ b/src/libraries/oob-all.proj
@@ -13,6 +13,14 @@
                                $(MSBuildThisFileDirectory)*\src\**\*.shproj;
                                shims\src\*.csproj" />
 
+    <!-- During an official build, build the identity package only in the allconfigurations build, otherwise always. -->
+    <ProjectReference Include="$(MSBuildThisFileDirectory)*\pkg\runtime.native.*.proj"
+                      Condition="'$(SkipLibrariesNativeRuntimePackages)' != 'true' and
+                                 (
+                                  '$(BuildingAnOfficialBuildLeg)' != 'true' or
+                                  '$(BuildAllConfigurations)' == 'true'
+                                 )" />
+
     <!-- Build these packages in the allconfigurations leg only. -->
     <ProjectReference Remove="Microsoft.Internal.Runtime.AspNetCore.Transport\src\Microsoft.Internal.Runtime.AspNetCore.Transport.proj;
                               Microsoft.Internal.Runtime.WindowsDesktop.Transport\src\Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj"
@@ -21,10 +29,6 @@
     <!-- Skip these projects during source-build as they rely on external prebuilts. -->
     <ProjectReference Remove="Microsoft.Extensions.DependencyInjection.Specification.Tests\src\Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj"
                       Condition="'$(DotNetBuildFromSource)' == 'true'" />
-
-    <!-- During an official build, build the identity package only in the allconfigurations build, otherwise always. -->
-    <ProjectReference Include="$(MSBuildThisFileDirectory)*\pkg\runtime.native.*.proj"
-                      Condition="'$(BuildingAnOfficialBuildLeg)' != 'true' or '$(BuildAllConfigurations)' == 'true'" />
   </ItemGroup>
 
 </Project>

--- a/src/libraries/oob-src.proj
+++ b/src/libraries/oob-src.proj
@@ -17,8 +17,15 @@
 
     <!-- During an official Build, build the rid specific package matching the OutputRID only outside of an allconfigurations build and only when targeting the CoreCLR runtime.
          The limitation on the CoreCLR runtime is entirely artificial but avoids duplicate assets being publish. -->
-    <ProjectReference Include="$(MSBuildThisFileDirectory)*\pkg\runtime.$(OutputRID).*.proj" Condition="'$(BuildingAnOfficialBuildLeg)' != 'true' or
-                                                                                                        ('$(BuildAllConfigurations)' != 'true' and '$(RuntimeFlavor)' == '$(PrimaryRuntimeFlavor)')" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)*\pkg\runtime.$(OutputRID).*.proj"
+                      Condition="'$(SkipLibrariesNativeRuntimePackages)' != 'true' and
+                                 (
+                                  '$(BuildingAnOfficialBuildLeg)' != 'true' or
+                                  (
+                                   '$(BuildAllConfigurations)' != 'true' and
+                                   '$(RuntimeFlavor)' == '$(PrimaryRuntimeFlavor)'
+                                  )
+                                 )" />
 
     <!-- Don't build task and tools project in the NetCoreAppCurrent vertical. -->
     <ProjectReference Remove="Microsoft.XmlSerializer.Generator\src\Microsoft.XmlSerializer.Generator.csproj" />


### PR DESCRIPTION
Commit 1: [Revert "Fix source-index-stage1 official build](https://github.com/dotnet/runtime/commit/9a1411acb8eecc9dc34b6b029e8a47eba5a55eca)
Commit 2: [Skip libs native runtime packages in source-index-stage job](https://github.com/dotnet/runtime/commit/fb832cf66ca6a8c1af0b3e8149cf51a93796294f)

Fixes official build regression introduced in https://github.com/dotnet/runtime/commit/21fb96b6ee011576d3db184765658bb1bc9c178d

cc @tmds 