### PR TITLE
refactor the g_SyncBlockCacheInstance for aligned

### DIFF
--- a/src/coreclr/vm/syncblk.cpp
+++ b/src/coreclr/vm/syncblk.cpp
@@ -464,7 +464,11 @@ void SyncBlockCache::Init()
 {
     CONTRACTL
     {
-        WRAPPER_NO_CONTRACT;
+        CONSTRUCTOR_CHECK;
+        THROWS;
+        GC_NOTRIGGER;
+        MODE_ANY;
+        INJECT_FAULT(COMPlusThrowOM());
     }
     CONTRACTL_END;
 
@@ -494,7 +498,10 @@ void SyncBlockCache::Destroy()
 {
     CONTRACTL
     {
-        WRAPPER_NO_CONTRACT;
+        DESTRUCTOR_CHECK;
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
     }
     CONTRACTL_END;
 

--- a/src/coreclr/vm/syncblk.cpp
+++ b/src/coreclr/vm/syncblk.cpp
@@ -480,7 +480,7 @@ void SyncBlockCache::Init()
     // g_criticalSection, which means all functions that enter it will become
     // GC_TRIGGERS.  (This includes all uses of LockHolder around SyncBlockCache::GetSyncBlockCache().
     // So be sure to update the contracts if you remove this flag.
-    ::new (&m_CacheLock) Crst(CrstSyncBlockCache, (CrstFlags) (CRST_UNSAFE_ANYMODE | CRST_DEBUGGER_THREAD));
+    m_CacheLock.Init(CrstSyncBlockCache, (CrstFlags) (CRST_UNSAFE_ANYMODE | CRST_DEBUGGER_THREAD));
 
     m_FreeCount = 0;
     m_ActiveCount = 0;
@@ -509,6 +509,8 @@ void SyncBlockCache::Destroy()
     m_FreeBlockList = NULL;
     //<TODO>@todo we can clear this fast too I guess</TODO>
     m_pCleanupBlockList = NULL;
+
+    m_CacheLock.Destroy();
 
     // destruct all arrays
     while (m_SyncBlocks)

--- a/src/coreclr/vm/syncblk.cpp
+++ b/src/coreclr/vm/syncblk.cpp
@@ -47,7 +47,7 @@ class  SyncBlockArray
 };
 
 // For in-place constructor
-BYTE g_SyncBlockCacheInstance[sizeof(SyncBlockCache)];
+BYTE DECLSPEC_ALIGN(sizeof(void*)) g_SyncBlockCacheInstance[sizeof(SyncBlockCache)];
 
 SPTR_IMPL (SyncBlockCache, SyncBlockCache, s_pSyncBlockCache);
 

--- a/src/coreclr/vm/syncblk.h
+++ b/src/coreclr/vm/syncblk.h
@@ -1309,7 +1309,7 @@ class SyncBlockCache
   private:
     PTR_SLink   m_pCleanupBlockList;    // list of sync blocks that need cleanup
     SLink*      m_FreeBlockList;        // list of free sync blocks
-    Crst        m_CacheLock;            // cache lock
+    CrstStatic  m_CacheLock;            // cache lock
     DWORD       m_FreeCount;            // count of active sync blocks
     DWORD       m_ActiveCount;          // number active
     SyncBlockArray *m_SyncBlocks;       // Array of new SyncBlocks.

--- a/src/coreclr/vm/syncblk.h
+++ b/src/coreclr/vm/syncblk.h
@@ -1356,8 +1356,9 @@ class SyncBlockCache
         LIMITED_METHOD_CONTRACT;
     }
 
-    SyncBlockCache();
-    ~SyncBlockCache();
+    // Note: No constructors/destructors - global instance
+    void Init();
+    void Destroy();
 
     static void Attach();
     static void Detach();

--- a/src/coreclr/vm/syncblk.h
+++ b/src/coreclr/vm/syncblk.h
@@ -1345,17 +1345,6 @@ class SyncBlockCache
     SPTR_DECL(SyncBlockCache, s_pSyncBlockCache);
     static SyncBlockCache*& GetSyncBlockCache();
 
-    void *operator new(size_t size, void *pInPlace)
-    {
-        LIMITED_METHOD_CONTRACT;
-        return pInPlace;
-    }
-
-    void operator delete(void *p)
-    {
-        LIMITED_METHOD_CONTRACT;
-    }
-
     // Note: No constructors/destructors - global instance
     void Init();
     void Destroy();


### PR DESCRIPTION
Add aligned attribute for g_SyncBlockCacheInstance to avoid unaligned accessing error on some CPUs.

This PR is also part of the issue https://github.com/dotnet/runtime/issues/69705 to amend the LA's port.