### PR TITLE
[browser][mt] Thread affinity for HTTP and WS

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/X509ResourceClient.cs
+++ b/src/libraries/Common/src/System/Net/Http/X509ResourceClient.cs
@@ -60,7 +60,7 @@ namespace System.Net.Http
 
             try
             {
-                ret = await s_downloadBytes(uri, cts?.Token ?? default, async).ConfigureAwait(false);
+                ret = await s_downloadBytes(uri, cts?.Token ?? default, async).ConfigureAwait(OperatingSystem.IsBrowser());
                 return ret;
             }
             catch { }
@@ -163,7 +163,7 @@ namespace System.Net.Http
                     if (async)
                     {
                         Task sendTask = (Task)sendAsyncMethod.Invoke(httpClient, new object[] { requestMessage, cancellationToken })!;
-                        await sendTask.ConfigureAwait(false);
+                        await sendTask.ConfigureAwait(OperatingSystem.IsBrowser());
                         responseMessage = taskOfHttpResponseMessageResultProp.GetValue(sendTask)!;
                     }
                     else
@@ -207,7 +207,7 @@ namespace System.Net.Http
                         if (async)
                         {
                             Task sendTask = (Task)sendAsyncMethod.Invoke(httpClient, new object[] { requestMessage, cancellationToken })!;
-                            await sendTask.ConfigureAwait(false);
+                            await sendTask.ConfigureAwait(OperatingSystem.IsBrowser());
                             responseMessage = taskOfHttpResponseMessageResultProp.GetValue(sendTask)!;
                         }
                         else
@@ -229,7 +229,7 @@ namespace System.Net.Http
                     var result = new MemoryStream();
                     if (async)
                     {
-                        await responseStream.CopyToAsync(result).ConfigureAwait(false);
+                        await responseStream.CopyToAsync(result).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     else
                     {

--- a/src/libraries/Common/src/System/Net/StreamBuffer.cs
+++ b/src/libraries/Common/src/System/Net/StreamBuffer.cs
@@ -170,7 +170,7 @@ namespace System.IO
                 }
 
                 buffer = buffer.Slice(bytesWritten);
-                await _writeTaskSource.WaitAsync(cancellationToken).ConfigureAwait(false);
+                await _writeTaskSource.WaitAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -243,7 +243,7 @@ namespace System.IO
             if (wait)
             {
                 Debug.Assert(bytesRead == 0);
-                await _readTaskSource.WaitAsync(cancellationToken).ConfigureAwait(false);
+                await _readTaskSource.WaitAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 (wait, bytesRead) = TryReadFromBuffer(buffer.Span);
                 Debug.Assert(!wait);
             }

--- a/src/libraries/Common/src/System/Threading/AsyncOverSyncWithIoCancellation.cs
+++ b/src/libraries/Common/src/System/Threading/AsyncOverSyncWithIoCancellation.cs
@@ -76,7 +76,7 @@ namespace System.Threading
             // Register for cancellation, perform the work, and clean up. Even though we're in an async method, awaits _must not_ be used inside
             // the using block, or else the I/O cancellation could both not work and negatively interact with I/O on another thread.  The func
             // _must_ be invoked on the same thread that invoked RegisterCancellation, with no intervening work.
-            await using (workItem.RegisterCancellation(cancellationToken).ConfigureAwait(false))
+            await using (workItem.RegisterCancellation(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser()))
             {
                 try
                 {
@@ -116,7 +116,7 @@ namespace System.Threading
             // Register for cancellation, perform the work, and clean up. Even though we're in an async method, awaits _must not_ be used inside
             // the using block, or else the I/O cancellation could both not work and negatively interact with I/O on another thread.  The func
             // _must_ be invoked on the same thread that invoked RegisterCancellation, with no intervening work.
-            await using (workItem.RegisterCancellation(cancellationToken).ConfigureAwait(false))
+            await using (workItem.RegisterCancellation(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser()))
             {
                 try
                 {
@@ -188,13 +188,13 @@ namespace System.Threading
                 // Then we need to dispose of the registration.  Upon Dispose returning, we know that
                 // either the synchronous invocation of the callback completed or that the callback
                 // will never be invoked.
-                await CancellationRegistration.DisposeAsync().ConfigureAwait(false);
+                await CancellationRegistration.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
                 // Now that we know the synchronous callback has quiesced, check to see whether it scheduled
                 // asynchronous work.  If it did, wait for that work to complete.
                 if (WorkItem.CallbackCompleted is Task t)
                 {
-                    await t.ConfigureAwait(false);
+                    await t.ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
         }

--- a/src/libraries/Common/src/System/Threading/Tasks/TaskCompletionSourceWithCancellation.cs
+++ b/src/libraries/Common/src/System/Threading/Tasks/TaskCompletionSourceWithCancellation.cs
@@ -18,7 +18,7 @@ namespace System.Threading.Tasks
         {
             using (cancellationToken.UnsafeRegister(static (s, cancellationToken) => ((TaskCompletionSourceWithCancellation<T>)s!).TrySetCanceled(cancellationToken), this))
             {
-                return await Task.ConfigureAwait(false);
+                return await Task.ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 

--- a/src/libraries/Microsoft.Bcl.TimeProvider/src/System/Threading/Tasks/TimeProviderTaskExtensions.cs
+++ b/src/libraries/Microsoft.Bcl.TimeProvider/src/System/Threading/Tasks/TimeProviderTaskExtensions.cs
@@ -212,7 +212,7 @@ namespace System.Threading.Tasks
 #else
         public static async Task<TResult> WaitAsync<TResult>(this Task<TResult> task, TimeSpan timeout, TimeProvider timeProvider, CancellationToken cancellationToken = default)
         {
-            await ((Task)task).WaitAsync(timeout, timeProvider, cancellationToken).ConfigureAwait(false);
+            await ((Task)task).WaitAsync(timeout, timeProvider, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             return task.Result;
         }
 #endif // NET8_0_OR_GREATER

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/DistributedCacheExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/DistributedCacheExtensions.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Extensions.Caching.Distributed
         /// <returns>A task that gets the string value from the stored cache key.</returns>
         public static async Task<string?> GetStringAsync(this IDistributedCache cache, string key, CancellationToken token = default(CancellationToken))
         {
-            byte[]? data = await cache.GetAsync(key, token).ConfigureAwait(false);
+            byte[]? data = await cache.GetAsync(key, token).ConfigureAwait(OperatingSystem.IsBrowser());
             if (data == null)
             {
                 return null;

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/MemoryCacheExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/MemoryCacheExtensions.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Extensions.Caching.Memory
             {
                 using ICacheEntry entry = cache.CreateEntry(key);
 
-                result = await factory(entry).ConfigureAwait(false);
+                result = await factory(entry).ConfigureAwait(OperatingSystem.IsBrowser());
                 entry.Value = result;
             }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
             static async ValueTask Await(int i, ValueTask vt, List<object> toDispose)
             {
-                await vt.ConfigureAwait(false);
+                await vt.ConfigureAwait(OperatingSystem.IsBrowser());
                 // vt is acting on the disposable at index i,
                 // decrement it and move to the next iteration
                 i--;
@@ -160,7 +160,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     object disposable = toDispose[i];
                     if (disposable is IAsyncDisposable asyncDisposable)
                     {
-                        await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                        await asyncDisposable.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     else
                     {

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Extensions.Hosting
                 var tcs = new TaskCompletionSource<object>();
                 using CancellationTokenRegistration registration = cancellationToken.Register(s => ((TaskCompletionSource<object>)s!).SetCanceled(), tcs);
                 // Do not await the _executeTask because cancelling it will throw an OperationCanceledException which we are explicitly ignoring
-                await Task.WhenAny(_executeTask, tcs.Task).ConfigureAwait(false);
+                await Task.WhenAny(_executeTask, tcs.Task).ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
         }

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Extensions.Hosting.Internal
             using var combinedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _applicationLifetime.ApplicationStopping);
             CancellationToken combinedCancellationToken = combinedCancellationTokenSource.Token;
 
-            await _hostLifetime.WaitForStartAsync(combinedCancellationToken).ConfigureAwait(false);
+            await _hostLifetime.WaitForStartAsync(combinedCancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
             combinedCancellationToken.ThrowIfCancellationRequested();
             _hostedServices = Services.GetRequiredService<IEnumerable<IHostedService>>();
@@ -72,7 +72,7 @@ namespace Microsoft.Extensions.Hosting.Internal
             {
                 Task tasks = Task.WhenAll(_hostedServices.Select(async service =>
                 {
-                    await service.StartAsync(combinedCancellationToken).ConfigureAwait(false);
+                    await service.StartAsync(combinedCancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
                     if (service is BackgroundService backgroundService)
                     {
@@ -82,7 +82,7 @@ namespace Microsoft.Extensions.Hosting.Internal
 
                 try
                 {
-                    await tasks.ConfigureAwait(false);
+                    await tasks.ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 catch (Exception ex)
                 {
@@ -96,7 +96,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                     try
                     {
                         // Fire IHostedService.Start
-                        await hostedService.StartAsync(combinedCancellationToken).ConfigureAwait(false);
+                        await hostedService.StartAsync(combinedCancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
                         if (hostedService is BackgroundService backgroundService)
                         {
@@ -145,7 +145,7 @@ namespace Microsoft.Extensions.Hosting.Internal
 
             try
             {
-                await backgroundTask.ConfigureAwait(false);
+                await backgroundTask.ConfigureAwait(OperatingSystem.IsBrowser());
             }
             catch (Exception ex)
             {
@@ -185,11 +185,11 @@ namespace Microsoft.Extensions.Hosting.Internal
 
                     if (_options.ServicesStopConcurrently)
                     {
-                        Task tasks = Task.WhenAll(hostedServices.Select(async service => await service.StopAsync(token).ConfigureAwait(false)));
+                        Task tasks = Task.WhenAll(hostedServices.Select(async service => await service.StopAsync(token).ConfigureAwait(OperatingSystem.IsBrowser())));
 
                         try
                         {
-                            await tasks.ConfigureAwait(false);
+                            await tasks.ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                         catch (Exception ex)
                         {
@@ -202,7 +202,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                         {
                             try
                             {
-                                await hostedService.StopAsync(token).ConfigureAwait(false);
+                                await hostedService.StopAsync(token).ConfigureAwait(OperatingSystem.IsBrowser());
                             }
                             catch (Exception ex)
                             {
@@ -217,7 +217,7 @@ namespace Microsoft.Extensions.Hosting.Internal
 
                 try
                 {
-                    await _hostLifetime.StopAsync(token).ConfigureAwait(false);
+                    await _hostLifetime.StopAsync(token).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 catch (Exception ex)
                 {
@@ -253,25 +253,25 @@ namespace Microsoft.Extensions.Hosting.Internal
             if (ReferenceEquals(_hostEnvironment.ContentRootFileProvider, _defaultProvider))
             {
                 // Dispose the content provider
-                await DisposeAsync(_hostEnvironment.ContentRootFileProvider).ConfigureAwait(false);
+                await DisposeAsync(_hostEnvironment.ContentRootFileProvider).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             else
             {
                 // In the rare case that the user replaced the ContentRootFileProvider, dispose it and the one
                 // we originally created
-                await DisposeAsync(_hostEnvironment.ContentRootFileProvider).ConfigureAwait(false);
-                await DisposeAsync(_defaultProvider).ConfigureAwait(false);
+                await DisposeAsync(_hostEnvironment.ContentRootFileProvider).ConfigureAwait(OperatingSystem.IsBrowser());
+                await DisposeAsync(_defaultProvider).ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             // Dispose the service provider
-            await DisposeAsync(Services).ConfigureAwait(false);
+            await DisposeAsync(Services).ConfigureAwait(OperatingSystem.IsBrowser());
 
             static async ValueTask DisposeAsync(object o)
             {
                 switch (o)
                 {
                     case IAsyncDisposable asyncDisposable:
-                        await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                        await asyncDisposable.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
                     case IDisposable disposable:
                         disposable.Dispose();

--- a/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingHttpMessageHandler.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingHttpMessageHandler.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Extensions.Http.Logging
                 // not really anything to surround.
                 Log.RequestStart(_logger, request, shouldRedactHeaderValue);
                 var stopwatch = ValueStopwatch.StartNew();
-                HttpResponseMessage response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                HttpResponseMessage response = await base.SendAsync(request, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 Log.RequestEnd(_logger, response, stopwatch.GetElapsedTime(), shouldRedactHeaderValue);
 
                 return response;

--- a/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingScopeHttpMessageHandler.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingScopeHttpMessageHandler.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Extensions.Http.Logging
                 using (Log.BeginRequestPipelineScope(_logger, request))
                 {
                     Log.RequestPipelineStart(_logger, request, shouldRedactHeaderValue);
-                    HttpResponseMessage response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                    HttpResponseMessage response = await base.SendAsync(request, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     Log.RequestPipelineEnd(_logger, response, stopwatch.GetElapsedTime(), shouldRedactHeaderValue);
 
                     return response;

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbDataSource.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbDataSource.cs
@@ -36,12 +36,12 @@ namespace System.Data.Common
 
             try
             {
-                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 return connection;
             }
             catch
             {
-                await connection.DisposeAsync().ConfigureAwait(false);
+                await connection.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 throw;
             }
         }
@@ -80,7 +80,7 @@ namespace System.Data.Common
 
         public async ValueTask DisposeAsync()
         {
-            await DisposeAsyncCore().ConfigureAwait(false);
+            await DisposeAsyncCore().ConfigureAwait(OperatingSystem.IsBrowser());
 
             Dispose(disposing: false);
             GC.SuppressFinalize(this);
@@ -134,18 +134,18 @@ namespace System.Data.Common
 
             public override async Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
             {
-                await _connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                await _connection.OpenAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
                 try
                 {
                     return await _wrappedCommand.ExecuteNonQueryAsync(cancellationToken)
-                        .ConfigureAwait(false);
+                        .ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 finally
                 {
                     try
                     {
-                        await _connection.CloseAsync().ConfigureAwait(false);
+                        await _connection.CloseAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     catch (Exception e)
                     {
@@ -187,18 +187,18 @@ namespace System.Data.Common
 
             public override async Task<object?> ExecuteScalarAsync(CancellationToken cancellationToken)
             {
-                await _connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                await _connection.OpenAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
                 try
                 {
                     return await _wrappedCommand.ExecuteScalarAsync(cancellationToken)
-                        .ConfigureAwait(false);
+                        .ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 finally
                 {
                     try
                     {
-                        await _connection.CloseAsync().ConfigureAwait(false);
+                        await _connection.CloseAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     catch (Exception e)
                     {
@@ -241,20 +241,20 @@ namespace System.Data.Common
                 CommandBehavior behavior,
                 CancellationToken cancellationToken)
             {
-                await _connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                await _connection.OpenAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
                 try
                 {
                     return await _wrappedCommand.ExecuteReaderAsync(
                             behavior | CommandBehavior.CloseConnection,
                             cancellationToken)
-                        .ConfigureAwait(false);
+                        .ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 catch
                 {
                     try
                     {
-                        await _connection.CloseAsync().ConfigureAwait(false);
+                        await _connection.CloseAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     catch (Exception e)
                     {
@@ -322,8 +322,8 @@ namespace System.Data.Common
             {
                 var connection = _wrappedCommand.Connection;
 
-                await _wrappedCommand.DisposeAsync().ConfigureAwait(false);
-                await connection!.DisposeAsync().ConfigureAwait(false);
+                await _wrappedCommand.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+                await connection!.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             // In most case, preparation doesn't make sense on a connectionless command since prepared statements are
@@ -393,18 +393,18 @@ namespace System.Data.Common
 
             public override async Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
             {
-                await _connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                await _connection.OpenAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
                 try
                 {
                     return await _wrappedBatch.ExecuteNonQueryAsync(cancellationToken)
-                        .ConfigureAwait(false);
+                        .ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 finally
                 {
                     try
                     {
-                        await _connection.CloseAsync().ConfigureAwait(false);
+                        await _connection.CloseAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     catch (Exception e)
                     {
@@ -446,18 +446,18 @@ namespace System.Data.Common
 
             public override async Task<object?> ExecuteScalarAsync(CancellationToken cancellationToken)
             {
-                await _connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                await _connection.OpenAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
                 try
                 {
                     return await _wrappedBatch.ExecuteScalarAsync(cancellationToken)
-                        .ConfigureAwait(false);
+                        .ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 finally
                 {
                     try
                     {
-                        await _connection.CloseAsync().ConfigureAwait(false);
+                        await _connection.CloseAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     catch (Exception e)
                     {
@@ -500,20 +500,20 @@ namespace System.Data.Common
                 CommandBehavior behavior,
                 CancellationToken cancellationToken)
             {
-                await _connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                await _connection.OpenAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
                 try
                 {
                     return await _wrappedBatch.ExecuteReaderAsync(
                             behavior | CommandBehavior.CloseConnection,
                             cancellationToken)
-                        .ConfigureAwait(false);
+                        .ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 catch
                 {
                     try
                     {
-                        await _connection.CloseAsync().ConfigureAwait(false);
+                        await _connection.CloseAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     catch (Exception e)
                     {
@@ -551,8 +551,8 @@ namespace System.Data.Common
             {
                 var connection = _wrappedBatch.Connection;
 
-                await _wrappedBatch.DisposeAsync().ConfigureAwait(false);
-                await connection!.DisposeAsync().ConfigureAwait(false);
+                await _wrappedBatch.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+                await connection!.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             // In most case, preparation doesn't make sense on a connectionless command since prepared statements are

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/AsyncStreamReader.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/AsyncStreamReader.cs
@@ -92,7 +92,7 @@ namespace System.Diagnostics
             {
                 try
                 {
-                    int bytesRead = await _stream.ReadAsync(new Memory<byte>(_byteBuffer), _cts.Token).ConfigureAwait(false);
+                    int bytesRead = await _stream.ReadAsync(new Memory<byte>(_byteBuffer), _cts.Token).ConfigureAwait(OperatingSystem.IsBrowser());
                     if (bytesRead == 0)
                         break;
 

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -1534,7 +1534,7 @@ namespace System.Diagnostics
                 // exception up to the user
                 if (HasExited)
                 {
-                    await WaitUntilOutputEOF(cancellationToken).ConfigureAwait(false);
+                    await WaitUntilOutputEOF(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     return;
                 }
 
@@ -1557,12 +1557,12 @@ namespace System.Diagnostics
                     // CASE 1.1 & CASE 3.1: Process exits or is canceled here
                     using (cancellationToken.UnsafeRegister(static (s, cancellationToken) => ((TaskCompletionSource)s!).TrySetCanceled(cancellationToken), tcs))
                     {
-                        await tcs.Task.ConfigureAwait(false);
+                        await tcs.Task.ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                 }
 
                 // Wait until output streams have been drained
-                await WaitUntilOutputEOF(cancellationToken).ConfigureAwait(false);
+                await WaitUntilOutputEOF(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             finally
             {
@@ -1573,12 +1573,12 @@ namespace System.Diagnostics
             {
                 if (_output is not null)
                 {
-                    await _output.EOF.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    await _output.EOF.WaitAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
 
                 if (_error is not null)
                 {
-                    await _error.EOF.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    await _error.EOF.WaitAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
         }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessWaitState.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessWaitState.Unix.cs
@@ -534,7 +534,7 @@ namespace System.Diagnostics
                         // Wait
                         try
                         {
-                            await Task.Delay(pollingIntervalMs, cancellationToken).ConfigureAwait(false);
+                            await Task.Delay(pollingIntervalMs, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                             pollingIntervalMs = Math.Min(pollingIntervalMs * 2, MaxPollingIntervalMs);
                         }
                         catch (OperationCanceledException) { }

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
@@ -344,7 +344,7 @@ namespace System.DirectoryServices.Protocols
                     {
                         try
                         {
-                            DirectoryResponse response = await vt.ConfigureAwait(false);
+                            DirectoryResponse response = await vt.ConfigureAwait(OperatingSystem.IsBrowser());
                             requestState._response = response;
                         }
                         catch (Exception e)
@@ -1414,7 +1414,7 @@ namespace System.DirectoryServices.Protocols
                     {
                         break;
                     }
-                    await Task.Delay(Math.Min(iterationDelay, 100)).ConfigureAwait(false);
+                    await Task.Delay(Math.Min(iterationDelay, 100)).ConfigureAwait(OperatingSystem.IsBrowser());
                     if (iterationDelay < 100)
                     {
                         iterationDelay *= 2;

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/SubReadStream.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/SubReadStream.cs
@@ -163,7 +163,7 @@ namespace System.Formats.Tar
                 buffer = buffer.Slice(0, (int)(_endInSuperStream - _positionInSuperStream));
             }
 
-            int ret = await _superStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            int ret = await _superStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
             _positionInSuperStream += ret;
             return ret;

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -552,12 +552,12 @@ namespace System.Formats.Tar
 
             // Rely on FileStream's ctor for further checking destinationFileName parameter
             FileStream fs = new FileStream(destinationFileName, CreateFileStreamOptions(isAsync: true));
-            await using (fs.ConfigureAwait(false))
+            await using (fs.ConfigureAwait(OperatingSystem.IsBrowser()))
             {
                 if (DataStream != null)
                 {
                     // Important: The DataStream will be written from its current position
-                    await DataStream.CopyToAsync(fs, cancellationToken).ConfigureAwait(false);
+                    await DataStream.CopyToAsync(fs, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarFile.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarFile.cs
@@ -364,9 +364,9 @@ namespace System.Formats.Tar
             };
             // Throws if the destination file exists
             FileStream archive = new(destinationFileName, options);
-            await using (archive.ConfigureAwait(false))
+            await using (archive.ConfigureAwait(OperatingSystem.IsBrowser()))
             {
-                await CreateFromDirectoryInternalAsync(sourceDirectoryName, archive, includeBaseDirectory, leaveOpen: false, cancellationToken).ConfigureAwait(false);
+                await CreateFromDirectoryInternalAsync(sourceDirectoryName, archive, includeBaseDirectory, leaveOpen: false, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -378,7 +378,7 @@ namespace System.Formats.Tar
             cancellationToken.ThrowIfCancellationRequested();
 
             TarWriter writer = new TarWriter(destination, TarEntryFormat.Pax, leaveOpen);
-            await using (writer.ConfigureAwait(false))
+            await using (writer.ConfigureAwait(OperatingSystem.IsBrowser()))
             {
                 DirectoryInfo di = new(sourceDirectoryName);
                 string basePath = GetBasePathForCreateFromDirectory(di, includeBaseDirectory);
@@ -386,7 +386,7 @@ namespace System.Formats.Tar
                 bool skipBaseDirRecursion = false;
                 if (includeBaseDirectory)
                 {
-                    await writer.WriteEntryAsync(di.FullName, GetEntryNameForBaseDirectory(di.Name), cancellationToken).ConfigureAwait(false);
+                    await writer.WriteEntryAsync(di.FullName, GetEntryNameForBaseDirectory(di.Name), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     skipBaseDirRecursion = (di.Attributes & FileAttributes.ReparsePoint) != 0;
                 }
 
@@ -398,7 +398,7 @@ namespace System.Formats.Tar
 
                 foreach (FileSystemInfo file in GetFileSystemEnumerationForCreation(sourceDirectoryName))
                 {
-                    await writer.WriteEntryAsync(file.FullName, GetEntryNameForFileSystemInfo(file, basePath.Length), cancellationToken).ConfigureAwait(false);
+                    await writer.WriteEntryAsync(file.FullName, GetEntryNameForFileSystemInfo(file, basePath.Length), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
         }
@@ -472,9 +472,9 @@ namespace System.Formats.Tar
                 Options = FileOptions.Asynchronous,
             };
             FileStream archive = new(sourceFileName, options);
-            await using (archive.ConfigureAwait(false))
+            await using (archive.ConfigureAwait(OperatingSystem.IsBrowser()))
             {
-                await ExtractToDirectoryInternalAsync(archive, destinationDirectoryName, overwriteFiles, leaveOpen: false, cancellationToken).ConfigureAwait(false);
+                await ExtractToDirectoryInternalAsync(archive, destinationDirectoryName, overwriteFiles, leaveOpen: false, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -487,14 +487,14 @@ namespace System.Formats.Tar
 
             SortedDictionary<string, UnixFileMode>? pendingModes = TarHelpers.CreatePendingModesDictionary();
             TarReader reader = new TarReader(source, leaveOpen);
-            await using (reader.ConfigureAwait(false))
+            await using (reader.ConfigureAwait(OperatingSystem.IsBrowser()))
             {
                 TarEntry? entry;
-                while ((entry = await reader.GetNextEntryAsync(cancellationToken: cancellationToken).ConfigureAwait(false)) != null)
+                while ((entry = await reader.GetNextEntryAsync(cancellationToken: cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser())) != null)
                 {
                     if (entry.EntryType is not TarEntryType.GlobalExtendedAttributes)
                     {
-                        await entry.ExtractRelativeToDirectoryAsync(destinationDirectoryPath, overwriteFiles, pendingModes, cancellationToken).ConfigureAwait(false);
+                        await entry.ExtractRelativeToDirectoryAsync(destinationDirectoryPath, overwriteFiles, pendingModes, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                 }
             }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -45,12 +45,12 @@ namespace System.Formats.Tar
             byte[] rented = ArrayPool<byte>.Shared.Rent(minimumLength: TarHelpers.RecordSize);
             Memory<byte> buffer = rented.AsMemory(0, TarHelpers.RecordSize); // minimumLength means the array could've been larger
 
-            await archiveStream.ReadExactlyAsync(buffer, cancellationToken).ConfigureAwait(false);
+            await archiveStream.ReadExactlyAsync(buffer, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
             TarHeader? header = TryReadAttributes(initialFormat, buffer.Span);
             if (header != null && processDataBlock)
             {
-                await header.ProcessDataBlockAsync(archiveStream, copyData, cancellationToken).ConfigureAwait(false);
+                await header.ProcessDataBlockAsync(archiveStream, copyData, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             ArrayPool<byte>.Shared.Return(rented);
@@ -247,10 +247,10 @@ namespace System.Formats.Tar
             switch (_typeFlag)
             {
                 case TarEntryType.ExtendedAttributes or TarEntryType.GlobalExtendedAttributes:
-                    await ReadExtendedAttributesBlockAsync(archiveStream, cancellationToken).ConfigureAwait(false);
+                    await ReadExtendedAttributesBlockAsync(archiveStream, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     break;
                 case TarEntryType.LongLink or TarEntryType.LongPath:
-                    await ReadGnuLongPathDataBlockAsync(archiveStream, cancellationToken).ConfigureAwait(false);
+                    await ReadGnuLongPathDataBlockAsync(archiveStream, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     break;
                 case TarEntryType.BlockDevice:
                 case TarEntryType.CharacterDevice:
@@ -273,10 +273,10 @@ namespace System.Formats.Tar
                 case TarEntryType.SparseFile: // Contains portion of a file
                 case TarEntryType.TapeVolume: // Might contain data
                 default: // Unrecognized entry types could potentially have a data section
-                    _dataStream = await GetDataStreamAsync(archiveStream, copyData, _size, cancellationToken).ConfigureAwait(false);
+                    _dataStream = await GetDataStreamAsync(archiveStream, copyData, _size, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     if (_dataStream is SeekableSubReadStream)
                     {
-                        await TarHelpers.AdvanceStreamAsync(archiveStream, _size, cancellationToken).ConfigureAwait(false);
+                        await TarHelpers.AdvanceStreamAsync(archiveStream, _size, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     else if (_dataStream is SubReadStream)
                     {
@@ -292,7 +292,7 @@ namespace System.Formats.Tar
             {
                 if (_size > 0)
                 {
-                    await TarHelpers.SkipBlockAlignmentPaddingAsync(archiveStream, _size, cancellationToken).ConfigureAwait(false);
+                    await TarHelpers.SkipBlockAlignmentPaddingAsync(archiveStream, _size, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
 
                 if (archiveStream.CanSeek)
@@ -343,7 +343,7 @@ namespace System.Formats.Tar
             if (copyData)
             {
                 MemoryStream copiedData = new MemoryStream();
-                await TarHelpers.CopyBytesAsync(archiveStream, copiedData, size, cancellationToken).ConfigureAwait(false);
+                await TarHelpers.CopyBytesAsync(archiveStream, copiedData, size, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 // Reset position pointer so the user can do the first DataStream read from the beginning
                 copiedData.Position = 0;
                 return copiedData;
@@ -597,7 +597,7 @@ namespace System.Formats.Tar
                 byte[] buffer = ArrayPool<byte>.Shared.Rent((int)_size);
                 Memory<byte> memory = buffer.AsMemory(0, (int)_size);
 
-                await archiveStream.ReadExactlyAsync(memory, cancellationToken).ConfigureAwait(false);
+                await archiveStream.ReadExactlyAsync(memory, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 ReadExtendedAttributesFromBuffer(memory.Span, _name);
 
                 ArrayPool<byte>.Shared.Return(buffer);
@@ -668,7 +668,7 @@ namespace System.Formats.Tar
                 byte[] buffer = ArrayPool<byte>.Shared.Rent((int)_size);
                 Memory<byte> memory = buffer.AsMemory(0, (int)_size);
 
-                await archiveStream.ReadExactlyAsync(memory, cancellationToken).ConfigureAwait(false);
+                await archiveStream.ReadExactlyAsync(memory, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 ReadGnuLongPathDataFromBuffer(memory.Span);
 
                 ArrayPool<byte>.Shared.Return(buffer);

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -45,11 +45,11 @@ namespace System.Formats.Tar
 
             WriteV7FieldsToBuffer(buffer.Span);
 
-            await archiveStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+            await archiveStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
             if (_dataStream != null)
             {
-                await WriteDataAsync(archiveStream, _dataStream, _size, cancellationToken).ConfigureAwait(false);
+                await WriteDataAsync(archiveStream, _dataStream, _size, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -84,11 +84,11 @@ namespace System.Formats.Tar
 
             WriteUstarFieldsToBuffer(buffer.Span);
 
-            await archiveStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+            await archiveStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
             if (_dataStream != null)
             {
-                await WriteDataAsync(archiveStream, _dataStream, _size, cancellationToken).ConfigureAwait(false);
+                await WriteDataAsync(archiveStream, _dataStream, _size, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -162,11 +162,11 @@ namespace System.Formats.Tar
             _size = GetTotalDataBytesToWrite();
             CollectExtendedAttributesFromStandardFieldsIfNeeded();
             // And pass the attributes to the preceding extended attributes header for writing
-            await extendedAttributesHeader.WriteAsPaxExtendedAttributesAsync(archiveStream, buffer, ExtendedAttributes, isGea: false, globalExtendedAttributesEntryNumber: -1, cancellationToken).ConfigureAwait(false);
+            await extendedAttributesHeader.WriteAsPaxExtendedAttributesAsync(archiveStream, buffer, ExtendedAttributes, isGea: false, globalExtendedAttributesEntryNumber: -1, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
             buffer.Span.Clear(); // Reset it to reuse it
             // Second, we write this header as a normal one
-            await WriteAsPaxInternalAsync(archiveStream, buffer, cancellationToken).ConfigureAwait(false);
+            await WriteAsPaxInternalAsync(archiveStream, buffer, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         // Writes the current header as a Gnu entry into the archive stream.
@@ -203,7 +203,7 @@ namespace System.Formats.Tar
             if (_linkName != null && Encoding.UTF8.GetByteCount(_linkName) > FieldLengths.LinkName)
             {
                 TarHeader longLinkHeader = GetGnuLongMetadataHeader(TarEntryType.LongLink, _linkName);
-                await longLinkHeader.WriteAsGnuInternalAsync(archiveStream, buffer, cancellationToken).ConfigureAwait(false);
+                await longLinkHeader.WriteAsGnuInternalAsync(archiveStream, buffer, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 buffer.Span.Clear(); // Reset it to reuse it
             }
 
@@ -211,12 +211,12 @@ namespace System.Formats.Tar
             if (Encoding.UTF8.GetByteCount(_name) > FieldLengths.Name)
             {
                 TarHeader longPathHeader = GetGnuLongMetadataHeader(TarEntryType.LongPath, _name);
-                await longPathHeader.WriteAsGnuInternalAsync(archiveStream, buffer, cancellationToken).ConfigureAwait(false);
+                await longPathHeader.WriteAsGnuInternalAsync(archiveStream, buffer, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 buffer.Span.Clear(); // Reset it to reuse it
             }
 
             // Third, we write this header as a normal one
-            await WriteAsGnuInternalAsync(archiveStream, buffer, cancellationToken).ConfigureAwait(false);
+            await WriteAsGnuInternalAsync(archiveStream, buffer, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         // Creates and returns a GNU long metadata header, with the specified long text written into its data stream.
@@ -257,11 +257,11 @@ namespace System.Formats.Tar
 
             WriteAsGnuSharedInternal(buffer.Span);
 
-            await archiveStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+            await archiveStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
             if (_dataStream != null)
             {
-                await WriteDataAsync(archiveStream, _dataStream, _size, cancellationToken).ConfigureAwait(false);
+                await WriteDataAsync(archiveStream, _dataStream, _size, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -331,11 +331,11 @@ namespace System.Formats.Tar
 
             WriteAsPaxSharedInternal(buffer.Span);
 
-            await archiveStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+            await archiveStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
             if (_dataStream != null)
             {
-                await WriteDataAsync(archiveStream, _dataStream, _size, cancellationToken).ConfigureAwait(false);
+                await WriteDataAsync(archiveStream, _dataStream, _size, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -628,7 +628,7 @@ namespace System.Formats.Tar
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            await dataStream.CopyToAsync(archiveStream, cancellationToken).ConfigureAwait(false); // The data gets copied from the current position
+            await dataStream.CopyToAsync(archiveStream, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser()); // The data gets copied from the current position
 
             int paddingAfterData = TarHelpers.CalculatePadding(actualLength);
             if (paddingAfterData != 0)
@@ -636,7 +636,7 @@ namespace System.Formats.Tar
                 byte[] buffer = ArrayPool<byte>.Shared.Rent(paddingAfterData);
                 Array.Clear(buffer, 0, paddingAfterData);
 
-                await archiveStream.WriteAsync(buffer.AsMemory(0, paddingAfterData), cancellationToken).ConfigureAwait(false);
+                await archiveStream.WriteAsync(buffer.AsMemory(0, paddingAfterData), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
                 ArrayPool<byte>.Shared.Return(buffer);
             }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
@@ -84,7 +84,7 @@ namespace System.Formats.Tar
                 while (bytesToDiscard > 0)
                 {
                     int currentLengthToRead = (int)Math.Min(MaxBufferLength, bytesToDiscard);
-                    await archiveStream.ReadExactlyAsync(buffer, 0, currentLengthToRead, cancellationToken).ConfigureAwait(false);
+                    await archiveStream.ReadExactlyAsync(buffer, 0, currentLengthToRead, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     bytesToDiscard -= currentLengthToRead;
                 }
                 ArrayPool<byte>.Shared.Return(buffer);
@@ -115,8 +115,8 @@ namespace System.Formats.Tar
             {
                 int currentLengthToRead = (int)Math.Min(MaxBufferLength, bytesToCopy);
                 Memory<byte> memory = buffer.AsMemory(0, currentLengthToRead);
-                await origin.ReadExactlyAsync(buffer, 0, currentLengthToRead, cancellationToken).ConfigureAwait(false);
-                await destination.WriteAsync(memory, cancellationToken).ConfigureAwait(false);
+                await origin.ReadExactlyAsync(buffer, 0, currentLengthToRead, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
+                await destination.WriteAsync(memory, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 bytesToCopy -= currentLengthToRead;
             }
             ArrayPool<byte>.Shared.Return(buffer);
@@ -302,7 +302,7 @@ namespace System.Formats.Tar
             cancellationToken.ThrowIfCancellationRequested();
 
             int bytesToSkip = CalculatePadding(size);
-            await AdvanceStreamAsync(archiveStream, bytesToSkip, cancellationToken).ConfigureAwait(false);
+            await AdvanceStreamAsync(archiveStream, bytesToSkip, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             return bytesToSkip;
         }
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarReader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarReader.cs
@@ -88,11 +88,11 @@ namespace System.Formats.Tar
                     {
                         foreach (Stream s in _dataStreamsToDispose)
                         {
-                            await s.DisposeAsync().ConfigureAwait(false);
+                            await s.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                     }
 
-                    await _archiveStream.DisposeAsync().ConfigureAwait(false);
+                    await _archiveStream.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
         }
@@ -270,20 +270,20 @@ namespace System.Formats.Tar
                     if (dataStream.Position < (_previouslyReadEntry._header._size - 1))
                     {
                         long bytesToSkip = _previouslyReadEntry._header._size - dataStream.Position;
-                        await TarHelpers.AdvanceStreamAsync(_archiveStream, bytesToSkip, cancellationToken).ConfigureAwait(false);
+                        await TarHelpers.AdvanceStreamAsync(_archiveStream, bytesToSkip, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                         dataStream.HasReachedEnd = true; // Now the pointer is beyond the limit, so any read attempts should throw
                     }
                 }
-                await TarHelpers.SkipBlockAlignmentPaddingAsync(_archiveStream, _previouslyReadEntry._header._size, cancellationToken).ConfigureAwait(false);
+                await TarHelpers.SkipBlockAlignmentPaddingAsync(_archiveStream, _previouslyReadEntry._header._size, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
         // Asynchronously retrieves the next entry if one is found.
         private async ValueTask<TarEntry?> GetNextEntryInternalAsync(bool copyData, CancellationToken cancellationToken)
         {
-            await AdvanceDataStreamIfNeededAsync(cancellationToken).ConfigureAwait(false);
+            await AdvanceDataStreamIfNeededAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
-            TarHeader? header = await TryGetNextEntryHeaderAsync(copyData, cancellationToken).ConfigureAwait(false);
+            TarHeader? header = await TryGetNextEntryHeaderAsync(copyData, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             if (header != null)
             {
                 TarEntry entry = header._format switch
@@ -360,7 +360,7 @@ namespace System.Formats.Tar
 
             Debug.Assert(!_reachedEndMarkers);
 
-            TarHeader? header = await TarHeader.TryGetNextHeaderAsync(_archiveStream, copyData, TarEntryFormat.Unknown, processDataBlock: true, cancellationToken).ConfigureAwait(false);
+            TarHeader? header = await TarHeader.TryGetNextHeaderAsync(_archiveStream, copyData, TarEntryFormat.Unknown, processDataBlock: true, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             if (header == null)
             {
                 return null;
@@ -371,7 +371,7 @@ namespace System.Formats.Tar
             // PAX metadata
             if (header._typeFlag is TarEntryType.ExtendedAttributes)
             {
-                TarHeader? mainHeader = await TryProcessExtendedAttributesHeaderAsync(header, copyData, cancellationToken).ConfigureAwait(false);
+                TarHeader? mainHeader = await TryProcessExtendedAttributesHeaderAsync(header, copyData, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 if (mainHeader == null)
                 {
                     return null;
@@ -381,7 +381,7 @@ namespace System.Formats.Tar
             // GNU metadata
             else if (header._typeFlag is TarEntryType.LongLink or TarEntryType.LongPath)
             {
-                TarHeader? mainHeader = await TryProcessGnuMetadataHeaderAsync(header, copyData, cancellationToken).ConfigureAwait(false);
+                TarHeader? mainHeader = await TryProcessGnuMetadataHeaderAsync(header, copyData, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 if (mainHeader == null)
                 {
                     return null;
@@ -431,7 +431,7 @@ namespace System.Formats.Tar
 
             // Don't process the data block of the actual entry just yet, because there's a slim chance
             // that the extended attributes contain a size that we need to override in the header
-            TarHeader? actualHeader = await TarHeader.TryGetNextHeaderAsync(_archiveStream, copyData, TarEntryFormat.Pax, processDataBlock: false, cancellationToken).ConfigureAwait(false);
+            TarHeader? actualHeader = await TarHeader.TryGetNextHeaderAsync(_archiveStream, copyData, TarEntryFormat.Pax, processDataBlock: false, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             if (actualHeader == null)
             {
                 return null;
@@ -544,7 +544,7 @@ namespace System.Formats.Tar
             cancellationToken.ThrowIfCancellationRequested();
 
             // Get the second entry, which is the actual entry
-            TarHeader? secondHeader = await TarHeader.TryGetNextHeaderAsync(_archiveStream, copyData, TarEntryFormat.Gnu, processDataBlock: true, cancellationToken).ConfigureAwait(false);
+            TarHeader? secondHeader = await TarHeader.TryGetNextHeaderAsync(_archiveStream, copyData, TarEntryFormat.Gnu, processDataBlock: true, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             if (secondHeader == null)
             {
                 return null;
@@ -563,7 +563,7 @@ namespace System.Formats.Tar
                 (header._typeFlag is TarEntryType.LongPath && secondHeader._typeFlag is TarEntryType.LongLink))
             {
                 // Get the third entry, which is the actual entry
-                TarHeader? thirdHeader = await TarHeader.TryGetNextHeaderAsync(_archiveStream, copyData, TarEntryFormat.Gnu, processDataBlock: true, cancellationToken).ConfigureAwait(false);
+                TarHeader? thirdHeader = await TarHeader.TryGetNextHeaderAsync(_archiveStream, copyData, TarEntryFormat.Gnu, processDataBlock: true, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 if (thirdHeader == null)
                 {
                     return null;

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
@@ -115,12 +115,12 @@ namespace System.Formats.Tar
 
                 if (_wroteEntries)
                 {
-                    await WriteFinalRecordsAsync().ConfigureAwait(false);
+                    await WriteFinalRecordsAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
 
                 if (!_leaveOpen)
                 {
-                    await _archiveStream.DisposeAsync().ConfigureAwait(false);
+                    await _archiveStream.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
         }
@@ -176,10 +176,10 @@ namespace System.Formats.Tar
 
             TarEntry entry = ConstructEntryForWriting(fullPath, entryName, FileOptions.Asynchronous);
 
-            await WriteEntryAsync(entry, cancellationToken).ConfigureAwait(false);
+            await WriteEntryAsync(entry, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             if (entry._header._dataStream != null)
             {
-                await entry._header._dataStream.DisposeAsync().ConfigureAwait(false);
+                await entry._header._dataStream.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -330,7 +330,7 @@ namespace System.Formats.Tar
                 TarEntryFormat.Gnu => entry._header.WriteAsGnuAsync(_archiveStream, buffer, cancellationToken),
                 _ => throw new InvalidDataException(SR.Format(SR.TarInvalidFormat, Format)),
             };
-            await task.ConfigureAwait(false);
+            await task.ConfigureAwait(OperatingSystem.IsBrowser());
 
             _wroteEntries = true;
 
@@ -358,7 +358,7 @@ namespace System.Formats.Tar
             byte[] twoEmptyRecords = ArrayPool<byte>.Shared.Rent(TwoRecordSize);
             Array.Clear(twoEmptyRecords, 0, TwoRecordSize);
 
-            await _archiveStream.WriteAsync(twoEmptyRecords.AsMemory(0, TwoRecordSize), cancellationToken: default).ConfigureAwait(false);
+            await _archiveStream.WriteAsync(twoEmptyRecords.AsMemory(0, TwoRecordSize), cancellationToken: default).ConfigureAwait(OperatingSystem.IsBrowser());
 
             ArrayPool<byte>.Shared.Return(twoEmptyRecords);
         }

--- a/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/BrotliStream.cs
+++ b/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/BrotliStream.cs
@@ -103,12 +103,12 @@ namespace System.IO.Compression
                 {
                     if (_mode == CompressionMode.Compress)
                     {
-                        await WriteAsyncMemoryCore(ReadOnlyMemory<byte>.Empty, CancellationToken.None, isFinalBlock: true).ConfigureAwait(false);
+                        await WriteAsyncMemoryCore(ReadOnlyMemory<byte>.Empty, CancellationToken.None, isFinalBlock: true).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
 
                     if (!_leaveOpen)
                     {
-                        await _stream.DisposeAsync().ConfigureAwait(false);
+                        await _stream.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                 }
             }

--- a/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliStream.Decompress.cs
+++ b/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliStream.Decompress.cs
@@ -151,7 +151,7 @@ namespace System.IO.Compression
                     int bytesWritten;
                     while (!TryDecompress(buffer.Span, out bytesWritten))
                     {
-                        int bytesRead = await _stream.ReadAsync(_buffer.AsMemory(_bufferCount), cancellationToken).ConfigureAwait(false);
+                        int bytesRead = await _stream.ReadAsync(_buffer.AsMemory(_bufferCount), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                         if (bytesRead <= 0)
                         {
                             if (s_useStrictValidation && _nonEmptyInput && !buffer.IsEmpty)

--- a/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/enc/BrotliStream.Compress.cs
+++ b/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/enc/BrotliStream.Compress.cs
@@ -153,7 +153,7 @@ namespace System.IO.Compression
                     if (bytesConsumed > 0)
                         buffer = buffer.Slice(bytesConsumed);
                     if (bytesWritten > 0)
-                        await _stream.WriteAsync(new ReadOnlyMemory<byte>(_buffer, 0, bytesWritten), cancellationToken).ConfigureAwait(false);
+                        await _stream.WriteAsync(new ReadOnlyMemory<byte>(_buffer, 0, bytesWritten), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             finally
@@ -223,10 +223,10 @@ namespace System.IO.Compression
                     if (lastResult == OperationStatus.InvalidData)
                         throw new InvalidDataException(SR.BrotliStream_Compress_InvalidData);
                     if (bytesWritten > 0)
-                        await _stream.WriteAsync(output.Slice(0, bytesWritten), cancellationToken).ConfigureAwait(false);
+                        await _stream.WriteAsync(output.Slice(0, bytesWritten), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
 
-                await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                await _stream.FlushAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             finally
             {

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateManaged/DeflateManagedStream.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateManaged/DeflateManagedStream.cs
@@ -206,7 +206,7 @@ namespace System.IO.Compression
             {
                 while (true)
                 {
-                    int bytesRead = await readTask.ConfigureAwait(false);
+                    int bytesRead = await readTask.ConfigureAwait(OperatingSystem.IsBrowser());
                     EnsureNotDisposed();
 
                     if (bytesRead <= 0)

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -186,7 +186,7 @@ namespace System.IO.Compression
                     Debug.Assert(_deflater != null && _buffer != null);
 
                     // Compress any bytes left:
-                    await WriteDeflaterOutputAsync(cancellationToken).ConfigureAwait(false);
+                    await WriteDeflaterOutputAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
                     // Pull out any bytes left inside deflater:
                     bool flushSuccessful;
@@ -196,13 +196,13 @@ namespace System.IO.Compression
                         flushSuccessful = _deflater.Flush(_buffer, out compressedBytes);
                         if (flushSuccessful)
                         {
-                            await _stream.WriteAsync(new ReadOnlyMemory<byte>(_buffer, 0, compressedBytes), cancellationToken).ConfigureAwait(false);
+                            await _stream.WriteAsync(new ReadOnlyMemory<byte>(_buffer, 0, compressedBytes), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                         Debug.Assert(flushSuccessful == (compressedBytes > 0));
                     } while (flushSuccessful);
 
                     // Always flush on the underlying stream
-                    await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                    await _stream.FlushAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 finally
                 {
@@ -421,7 +421,7 @@ namespace System.IO.Compression
                         // data to proceed, read some to populate it.
                         if (_inflater.NeedsInput())
                         {
-                            int n = await _stream.ReadAsync(new Memory<byte>(_buffer, 0, _buffer.Length), cancellationToken).ConfigureAwait(false);
+                            int n = await _stream.ReadAsync(new Memory<byte>(_buffer, 0, _buffer.Length), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                             if (n <= 0)
                             {
                                 // - Inflater didn't return any data although a non-empty output buffer was passed by the caller.
@@ -631,7 +631,7 @@ namespace System.IO.Compression
             if (_wroteBytes)
             {
                 // Compress any bytes left
-                await WriteDeflaterOutputAsync(default).ConfigureAwait(false);
+                await WriteDeflaterOutputAsync(default).ConfigureAwait(OperatingSystem.IsBrowser());
 
                 // Pull out any bytes left inside deflater:
                 bool finished;
@@ -641,7 +641,7 @@ namespace System.IO.Compression
                     finished = _deflater.Finish(_buffer, out compressedBytes);
 
                     if (compressedBytes > 0)
-                        await _stream.WriteAsync(new ReadOnlyMemory<byte>(_buffer, 0, compressedBytes)).ConfigureAwait(false);
+                        await _stream.WriteAsync(new ReadOnlyMemory<byte>(_buffer, 0, compressedBytes)).ConfigureAwait(OperatingSystem.IsBrowser());
                 } while (!finished);
             }
             else
@@ -716,7 +716,7 @@ namespace System.IO.Compression
                 // Same logic as Dispose(true), except with async counterparts.
                 try
                 {
-                    await PurgeBuffersAsync().ConfigureAwait(false);
+                    await PurgeBuffersAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 finally
                 {
@@ -728,7 +728,7 @@ namespace System.IO.Compression
                     try
                     {
                         if (!_leaveOpen && stream != null)
-                            await stream.DisposeAsync().ConfigureAwait(false);
+                            await stream.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     finally
                     {
@@ -802,13 +802,13 @@ namespace System.IO.Compression
                 AsyncOperationStarting();
                 try
                 {
-                    await WriteDeflaterOutputAsync(cancellationToken).ConfigureAwait(false);
+                    await WriteDeflaterOutputAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
                     Debug.Assert(_deflater != null);
                     // Pass new bytes through deflater
                     _deflater.SetInput(buffer);
 
-                    await WriteDeflaterOutputAsync(cancellationToken).ConfigureAwait(false);
+                    await WriteDeflaterOutputAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
                     _wroteBytes = true;
                 }
@@ -830,7 +830,7 @@ namespace System.IO.Compression
                 int compressedBytes = _deflater.GetDeflateOutput(_buffer);
                 if (compressedBytes > 0)
                 {
-                    await _stream.WriteAsync(new ReadOnlyMemory<byte>(_buffer, 0, compressedBytes), cancellationToken).ConfigureAwait(false);
+                    await _stream.WriteAsync(new ReadOnlyMemory<byte>(_buffer, 0, compressedBytes), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
         }
@@ -899,7 +899,7 @@ namespace System.IO.Compression
                         int bytesRead = _deflateStream._inflater.Inflate(_arrayPoolBuffer, 0, _arrayPoolBuffer.Length);
                         if (bytesRead > 0)
                         {
-                            await _destination.WriteAsync(new ReadOnlyMemory<byte>(_arrayPoolBuffer, 0, bytesRead), _cancellationToken).ConfigureAwait(false);
+                            await _destination.WriteAsync(new ReadOnlyMemory<byte>(_arrayPoolBuffer, 0, bytesRead), _cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                         else if (_deflateStream._inflater.NeedsInput())
                         {
@@ -909,7 +909,7 @@ namespace System.IO.Compression
                     }
 
                     // Now, use the source stream's CopyToAsync to push directly to our inflater via this helper stream
-                    await _deflateStream._stream.CopyToAsync(this, _arrayPoolBuffer.Length, _cancellationToken).ConfigureAwait(false);
+                    await _deflateStream._stream.CopyToAsync(this, _arrayPoolBuffer.Length, _cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     if (s_useStrictValidation && !_deflateStream._inflater.Finished())
                     {
                         ThrowTruncatedInvalidData();
@@ -996,7 +996,7 @@ namespace System.IO.Compression
                     int bytesRead = _deflateStream._inflater.Inflate(new Span<byte>(_arrayPoolBuffer));
                     if (bytesRead > 0)
                     {
-                        await _destination.WriteAsync(new ReadOnlyMemory<byte>(_arrayPoolBuffer, 0, bytesRead), cancellationToken).ConfigureAwait(false);
+                        await _destination.WriteAsync(new ReadOnlyMemory<byte>(_arrayPoolBuffer, 0, bytesRead), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     else if (_deflateStream._inflater.NeedsInput())
                     {

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -1258,7 +1258,7 @@ namespace System.IO.Compression
                         _usedZip64inLH = _entry.WriteLocalFileHeader(isEmptyFile: false);
                     }
 
-                    await _crcSizeStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+                    await _crcSizeStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     _position += buffer.Length;
                 }
             }

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipCustomStreams.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipCustomStreams.cs
@@ -356,7 +356,7 @@ namespace System.IO.Compression
                     buffer = buffer.Slice(0, (int)(_endInSuperStream - _positionInSuperStream));
                 }
 
-                int ret = await _superStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+                int ret = await _superStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
                 _positionInSuperStream += ret;
                 return ret;
@@ -569,7 +569,7 @@ namespace System.IO.Compression
 
                 _checksum = Crc32Helper.UpdateCrc32(_checksum, buffer.Span);
 
-                await _baseStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+                await _baseStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 _position += buffer.Length;
             }
         }

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/NonCryptographicHashAlgorithm.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/NonCryptographicHashAlgorithm.cs
@@ -157,9 +157,9 @@ namespace System.IO.Hashing
             while (true)
             {
 #if NETCOREAPP
-                int read = await stream.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false);
+                int read = await stream.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 #else
-                int read = await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+                int read = await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 #endif
 
                 if (read == 0)

--- a/src/libraries/System.Memory.Data/src/System/BinaryData.cs
+++ b/src/libraries/System.Memory.Data/src/System/BinaryData.cs
@@ -185,7 +185,7 @@ namespace System
             {
                 if (async)
                 {
-                    await stream.CopyToAsync(memoryStream, bufferSize, cancellationToken).ConfigureAwait(false);
+                    await stream.CopyToAsync(memoryStream, bufferSize, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 else
                 {

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.cs
@@ -81,7 +81,7 @@ namespace System.Net.Http.Json
             {
                 try
                 {
-                    using HttpResponseMessage response = await responseTask.ConfigureAwait(false);
+                    using HttpResponseMessage response = await responseTask.ConfigureAwait(OperatingSystem.IsBrowser());
                     response.EnsureSuccessStatusCode();
 
                     Debug.Assert(client.MaxResponseContentBufferSize is > 0 and <= int.MaxValue);
@@ -94,14 +94,14 @@ namespace System.Net.Http.Json
 
                     try
                     {
-                        using Stream contentStream = await HttpContentJsonExtensions.GetContentStreamAsync(response.Content, linkedCTS?.Token ?? cancellationToken).ConfigureAwait(false);
+                        using Stream contentStream = await HttpContentJsonExtensions.GetContentStreamAsync(response.Content, linkedCTS?.Token ?? cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
                         // If ResponseHeadersRead wasn't used, HttpClient will have already buffered the whole response upfront. No need to check the limit again.
                         Stream readStream = usingResponseHeadersRead
                             ? new LengthLimitReadStream(contentStream, (int)client.MaxResponseContentBufferSize)
                             : contentStream;
 
-                        return await deserializeMethod(readStream, jsonOptions, linkedCTS?.Token ?? cancellationToken).ConfigureAwait(false);
+                        return await deserializeMethod(readStream, jsonOptions, linkedCTS?.Token ?? cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     catch (OperationCanceledException oce) when ((linkedCTS?.Token.IsCancellationRequested == true) && !cancellationToken.IsCancellationRequested)
                     {

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpContentJsonExtensions.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpContentJsonExtensions.cs
@@ -89,9 +89,9 @@ namespace System.Net.Http.Json
         [RequiresDynamicCode(SerializationDynamicCodeMessage)]
         private static async Task<object?> ReadFromJsonAsyncCore(HttpContent content, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken)
         {
-            using (Stream contentStream = await GetContentStreamAsync(content, cancellationToken).ConfigureAwait(false))
+            using (Stream contentStream = await GetContentStreamAsync(content, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser()))
             {
-                return await JsonSerializer.DeserializeAsync(contentStream, type, options ?? JsonHelpers.s_defaultSerializerOptions, cancellationToken).ConfigureAwait(false);
+                return await JsonSerializer.DeserializeAsync(contentStream, type, options ?? JsonHelpers.s_defaultSerializerOptions, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -99,9 +99,9 @@ namespace System.Net.Http.Json
         [RequiresDynamicCode(SerializationDynamicCodeMessage)]
         private static async Task<T?> ReadFromJsonAsyncCore<T>(HttpContent content, JsonSerializerOptions? options, CancellationToken cancellationToken)
         {
-            using (Stream contentStream = await GetContentStreamAsync(content, cancellationToken).ConfigureAwait(false))
+            using (Stream contentStream = await GetContentStreamAsync(content, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser()))
             {
-                return await JsonSerializer.DeserializeAsync<T>(contentStream, options ?? JsonHelpers.s_defaultSerializerOptions, cancellationToken).ConfigureAwait(false);
+                return await JsonSerializer.DeserializeAsync<T>(contentStream, options ?? JsonHelpers.s_defaultSerializerOptions, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -127,23 +127,23 @@ namespace System.Net.Http.Json
 
         private static async Task<object?> ReadFromJsonAsyncCore(HttpContent content, Type type, JsonSerializerContext context, CancellationToken cancellationToken)
         {
-            using (Stream contentStream = await GetContentStreamAsync(content, cancellationToken).ConfigureAwait(false))
+            using (Stream contentStream = await GetContentStreamAsync(content, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser()))
             {
-                return await JsonSerializer.DeserializeAsync(contentStream, type, context, cancellationToken).ConfigureAwait(false);
+                return await JsonSerializer.DeserializeAsync(contentStream, type, context, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
         private static async Task<T?> ReadFromJsonAsyncCore<T>(HttpContent content, JsonTypeInfo<T> jsonTypeInfo, CancellationToken cancellationToken)
         {
-            using (Stream contentStream = await GetContentStreamAsync(content, cancellationToken).ConfigureAwait(false))
+            using (Stream contentStream = await GetContentStreamAsync(content, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser()))
             {
-                return await JsonSerializer.DeserializeAsync(contentStream, jsonTypeInfo, cancellationToken).ConfigureAwait(false);
+                return await JsonSerializer.DeserializeAsync(contentStream, jsonTypeInfo, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
         internal static async ValueTask<Stream> GetContentStreamAsync(HttpContent content, CancellationToken cancellationToken)
         {
-            Stream contentStream = await ReadHttpContentStreamAsync(content, cancellationToken).ConfigureAwait(false);
+            Stream contentStream = await ReadHttpContentStreamAsync(content, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
             // Wrap content stream into a transcoding stream that buffers the data transcoded from the sourceEncoding to utf-8.
             if (JsonHelpers.GetEncoding(content) is Encoding sourceEncoding && sourceEncoding != Encoding.UTF8)

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.cs
@@ -80,7 +80,7 @@ namespace System.Net.Http.Json
                 {
                     if (async)
                     {
-                        await JsonSerializer.SerializeAsync(transcodingStream, Value, ObjectType, _jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
+                        await JsonSerializer.SerializeAsync(transcodingStream, Value, ObjectType, _jsonSerializerOptions, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     else
                     {
@@ -93,7 +93,7 @@ namespace System.Net.Http.Json
                     // buffers should be empty as we expect JsonSerializer to emit only well-formed UTF-8 data.
                     if (async)
                     {
-                        await transcodingStream.DisposeAsync().ConfigureAwait(false);
+                        await transcodingStream.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     else
                     {
@@ -105,11 +105,11 @@ namespace System.Net.Http.Json
 
                 using (TranscodingWriteStream transcodingStream = new TranscodingWriteStream(targetStream, targetEncoding))
                 {
-                    await JsonSerializer.SerializeAsync(transcodingStream, Value, ObjectType, _jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
+                    await JsonSerializer.SerializeAsync(transcodingStream, Value, ObjectType, _jsonSerializerOptions, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     // The transcoding streams use Encoders and Decoders that have internal buffers. We need to flush these
                     // when there is no more data to be written. Stream.FlushAsync isn't suitable since it's
                     // acceptable to Flush a Stream (multiple times) prior to completion.
-                    await transcodingStream.FinalWriteAsync(cancellationToken).ConfigureAwait(false);
+                    await transcodingStream.FinalWriteAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
 #endif
             }
@@ -117,7 +117,7 @@ namespace System.Net.Http.Json
             {
                 if (async)
                 {
-                    await JsonSerializer.SerializeAsync(targetStream, Value, ObjectType, _jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
+                    await JsonSerializer.SerializeAsync(targetStream, Value, ObjectType, _jsonSerializerOptions, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 else
                 {

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContentOfT.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContentOfT.cs
@@ -59,7 +59,7 @@ namespace System.Net.Http.Json
                 {
                     if (async)
                     {
-                        await JsonSerializer.SerializeAsync(transcodingStream, _typedValue, _typeInfo, cancellationToken).ConfigureAwait(false);
+                        await JsonSerializer.SerializeAsync(transcodingStream, _typedValue, _typeInfo, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     else
                     {
@@ -72,7 +72,7 @@ namespace System.Net.Http.Json
                     // buffers should be empty as we expect JsonSerializer to emit only well-formed UTF-8 data.
                     if (async)
                     {
-                        await transcodingStream.DisposeAsync().ConfigureAwait(false);
+                        await transcodingStream.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     else
                     {
@@ -84,11 +84,11 @@ namespace System.Net.Http.Json
 
                 using (TranscodingWriteStream transcodingStream = new TranscodingWriteStream(targetStream, targetEncoding))
                 {
-                    await JsonSerializer.SerializeAsync(transcodingStream, _typedValue, _typeInfo, cancellationToken).ConfigureAwait(false);
+                    await JsonSerializer.SerializeAsync(transcodingStream, _typedValue, _typeInfo, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     // The transcoding streams use Encoders and Decoders that have internal buffers. We need to flush these
                     // when there is no more data to be written. Stream.FlushAsync isn't suitable since it's
                     // acceptable to Flush a Stream (multiple times) prior to completion.
-                    await transcodingStream.FinalWriteAsync(cancellationToken).ConfigureAwait(false);
+                    await transcodingStream.FinalWriteAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
 #endif
             }
@@ -96,7 +96,7 @@ namespace System.Net.Http.Json
             {
                 if (async)
                 {
-                    await JsonSerializer.SerializeAsync(targetStream, _typedValue, _typeInfo, cancellationToken).ConfigureAwait(false);
+                    await JsonSerializer.SerializeAsync(targetStream, _typedValue, _typeInfo, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 else
                 {

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/LengthLimitReadStream.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/LengthLimitReadStream.cs
@@ -61,7 +61,7 @@ namespace System.Net.Http.Json
 
             async ValueTask<int> Core(ValueTask<int> readTask)
             {
-                int read = await readTask.ConfigureAwait(false);
+                int read = await readTask.ConfigureAwait(OperatingSystem.IsBrowser());
                 CheckLengthLimit(read);
                 return read;
             }
@@ -69,7 +69,7 @@ namespace System.Net.Http.Json
 #else
         public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            int read = await _innerStream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+            int read = await _innerStream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             CheckLengthLimit(read);
             return read;
         }

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/TranscodingReadStream.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/TranscodingReadStream.cs
@@ -116,7 +116,7 @@ namespace System.Net.Http.Json
             // Only read more content from the input stream if we have exhausted all the buffered chars.
             if (_charBuffer.Count == 0)
             {
-                int bytesRead = await ReadInputChars(cancellationToken).ConfigureAwait(false);
+                int bytesRead = await ReadInputChars(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 shouldFlushEncoder = bytesRead == 0 && _byteBuffer.Count == 0;
             }
 
@@ -170,7 +170,7 @@ namespace System.Net.Http.Json
             int offset = _byteBuffer.Count;
             int count = _byteBuffer.Array.Length - _byteBuffer.Count;
 
-            int bytesRead = await _stream.ReadAsync(_byteBuffer.Array, offset, count, cancellationToken).ConfigureAwait(false);
+            int bytesRead = await _stream.ReadAsync(_byteBuffer.Array, offset, count, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
             _byteBuffer = new ArraySegment<byte>(_byteBuffer.Array, 0, offset + bytesRead);
 

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/TranscodingWriteStream.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/TranscodingWriteStream.cs
@@ -103,7 +103,7 @@ namespace System.Net.Http.Json
 
                 _charsDecoded += charsDecoded;
                 bufferSegment = bufferSegment.Slice(bytesDecoded);
-                await WriteBufferAsync(cancellationToken).ConfigureAwait(false);
+                await WriteBufferAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -118,7 +118,7 @@ namespace System.Net.Http.Json
                 _encoder.Convert(_charBuffer, charsWritten, _charsDecoded - charsWritten, byteBuffer, byteIndex: 0, byteBuffer.Length,
                     flush: false, out int charsEncoded, out int bytesUsed, out encoderCompleted);
 
-                await _stream.WriteAsync(byteBuffer, 0, bytesUsed, cancellationToken).ConfigureAwait(false);
+                await _stream.WriteAsync(byteBuffer, 0, bytesUsed, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 charsWritten += charsEncoded;
             }
 
@@ -150,7 +150,7 @@ namespace System.Net.Http.Json
                 _encoder.Convert(Array.Empty<char>(), 0, 0, byteBuffer, 0, byteBuffer.Length,
                     flush: true, out _, out int bytesUsed, out encoderCompleted);
 
-                await _stream.WriteAsync(byteBuffer, 0, bytesUsed, cancellationToken).ConfigureAwait(false);
+                await _stream.WriteAsync(byteBuffer, 0, bytesUsed, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             ArrayPool<byte>.Shared.Return(byteBuffer);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
@@ -146,7 +146,7 @@ namespace System.Net.Http
             try
             {
                 response = async ?
-                    await _innerHandler.SendAsync(request, cancellationToken).ConfigureAwait(false) :
+                    await _innerHandler.SendAsync(request, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser()) :
                     _innerHandler.Send(request, cancellationToken);
                 return response;
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -185,7 +185,7 @@ namespace System.Net.Http
             try
             {
                 // Wait for the response message and make sure it completed successfully.
-                response = await base.SendAsync(request, cts.Token).ConfigureAwait(false);
+                response = await base.SendAsync(request, cts.Token).ConfigureAwait(OperatingSystem.IsBrowser());
                 ThrowForNullResponse(response);
                 response.EnsureSuccessStatusCode();
 
@@ -199,12 +199,12 @@ namespace System.Net.Http
 
                 // Since the underlying byte[] will never be exposed, we use an ArrayPool-backed
                 // stream to which we copy all of the data from the response.
-                using Stream responseStream = c.TryReadAsStream() ?? await c.ReadAsStreamAsync(cts.Token).ConfigureAwait(false);
+                using Stream responseStream = c.TryReadAsStream() ?? await c.ReadAsStreamAsync(cts.Token).ConfigureAwait(OperatingSystem.IsBrowser());
                 using var buffer = new HttpContent.LimitArrayPoolWriteStream(_maxResponseContentBufferSize, (int)c.Headers.ContentLength.GetValueOrDefault());
 
                 try
                 {
-                    await responseStream.CopyToAsync(buffer, cts.Token).ConfigureAwait(false);
+                    await responseStream.CopyToAsync(buffer, cts.Token).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 catch (Exception e) when (HttpContent.StreamCopyExceptionNeedsWrapping(e))
                 {
@@ -260,7 +260,7 @@ namespace System.Net.Http
             try
             {
                 // Wait for the response message and make sure it completed successfully.
-                response = await base.SendAsync(request, cts.Token).ConfigureAwait(false);
+                response = await base.SendAsync(request, cts.Token).ConfigureAwait(OperatingSystem.IsBrowser());
                 ThrowForNullResponse(response);
                 response.EnsureSuccessStatusCode();
 
@@ -284,10 +284,10 @@ namespace System.Net.Http
                     new HttpContent.LimitMemoryStream(_maxResponseContentBufferSize, (int)contentLength.GetValueOrDefault()) :
                     new HttpContent.LimitArrayPoolWriteStream(_maxResponseContentBufferSize);
 
-                using Stream responseStream = c.TryReadAsStream() ?? await c.ReadAsStreamAsync(cts.Token).ConfigureAwait(false);
+                using Stream responseStream = c.TryReadAsStream() ?? await c.ReadAsStreamAsync(cts.Token).ConfigureAwait(OperatingSystem.IsBrowser());
                 try
                 {
-                    await responseStream.CopyToAsync(buffer, cts.Token).ConfigureAwait(false);
+                    await responseStream.CopyToAsync(buffer, cts.Token).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 catch (Exception e) when (HttpContent.StreamCopyExceptionNeedsWrapping(e))
                 {
@@ -338,12 +338,12 @@ namespace System.Net.Http
             try
             {
                 // Wait for the response message and make sure it completed successfully.
-                response = await base.SendAsync(request, cts.Token).ConfigureAwait(false);
+                response = await base.SendAsync(request, cts.Token).ConfigureAwait(OperatingSystem.IsBrowser());
                 ThrowForNullResponse(response);
                 response.EnsureSuccessStatusCode();
 
                 HttpContent c = response.Content;
-                return c.TryReadAsStream() ?? await c.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+                return c.TryReadAsStream() ?? await c.ReadAsStreamAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             catch (Exception e)
             {
@@ -527,7 +527,7 @@ namespace System.Net.Http
                 try
                 {
                     // Wait for the send request to complete, getting back the response.
-                    response = await base.SendAsync(request, cts.Token).ConfigureAwait(false);
+                    response = await base.SendAsync(request, cts.Token).ConfigureAwait(OperatingSystem.IsBrowser());
                     ThrowForNullResponse(response);
 
                     // Buffer the response content if we've been asked to.
@@ -539,7 +539,7 @@ namespace System.Net.Http
                             responseContentTelemetryStarted = true;
                         }
 
-                        await response.Content.LoadIntoBufferAsync(_maxResponseContentBufferSize, cts.Token).ConfigureAwait(false);
+                        await response.Content.LoadIntoBufferAsync(_maxResponseContentBufferSize, cts.Token).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
 
                     return response;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpContent.cs
@@ -395,7 +395,7 @@ namespace System.Net.Http
             {
                 try
                 {
-                    await copyTask.ConfigureAwait(false);
+                    await copyTask.ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 catch (Exception e) when (StreamCopyExceptionNeedsWrapping(e))
                 {
@@ -511,7 +511,7 @@ namespace System.Net.Http
         {
             try
             {
-                await serializeToStreamTask.ConfigureAwait(false);
+                await serializeToStreamTask.ConfigureAwait(OperatingSystem.IsBrowser());
             }
             catch (Exception e)
             {
@@ -828,7 +828,7 @@ namespace System.Net.Http
 
         private static async Task<TResult> WaitAndReturnAsync<TState, TResult>(Task waitTask, TState state, Func<TState, TResult> returnFunc)
         {
-            await waitTask.ConfigureAwait(false);
+            await waitTask.ConfigureAwait(OperatingSystem.IsBrowser());
             return returnFunc(state);
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpMessageInvoker.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpMessageInvoker.cs
@@ -83,7 +83,7 @@ namespace System.Net.Http
                 HttpResponseMessage? response = null;
                 try
                 {
-                    response = await handler.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                    response = await handler.SendAsync(request, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     return response;
                 }
                 catch (Exception ex) when (LogRequestFailed(ex, telemetryStarted: true))

--- a/src/libraries/System.Net.Http/src/System/Net/Http/MultipartContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/MultipartContent.cs
@@ -209,7 +209,7 @@ namespace System.Net.Http
             try
             {
                 // Write start boundary.
-                await EncodeStringToStreamAsync(stream, "--" + _boundary + CrLf, cancellationToken).ConfigureAwait(false);
+                await EncodeStringToStreamAsync(stream, "--" + _boundary + CrLf, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
                 // Write each nested content.
                 var output = new MemoryStream();
@@ -221,13 +221,13 @@ namespace System.Net.Http
                     output.SetLength(0);
                     SerializeHeadersToStream(output, content, writeDivider: contentIndex != 0);
                     output.Position = 0;
-                    await output.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
+                    await output.CopyToAsync(stream, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
-                    await content.CopyToAsync(stream, context, cancellationToken).ConfigureAwait(false);
+                    await content.CopyToAsync(stream, context, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
 
                 // Write footer boundary.
-                await EncodeStringToStreamAsync(stream, CrLf + "--" + _boundary + "--" + CrLf, cancellationToken).ConfigureAwait(false);
+                await EncodeStringToStreamAsync(stream, CrLf + "--" + _boundary + "--" + CrLf, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             catch (Exception ex)
             {
@@ -273,7 +273,7 @@ namespace System.Net.Http
                     Stream readStream;
                     if (async)
                     {
-                        readStream = nestedContent.TryReadAsStream() ?? await nestedContent.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+                        readStream = nestedContent.TryReadAsStream() ?? await nestedContent.ReadAsStreamAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     else
                     {
@@ -291,7 +291,7 @@ namespace System.Net.Http
 
 #pragma warning disable CA2016
                         // Do not pass a cancellationToken to base.CreateContentReadStreamAsync() as it would trigger an infinite loop => StackOverflow
-                        return async ? await base.CreateContentReadStreamAsync().ConfigureAwait(false) : base.CreateContentReadStream(cancellationToken);
+                        return async ? await base.CreateContentReadStreamAsync().ConfigureAwait(OperatingSystem.IsBrowser()) : base.CreateContentReadStream(cancellationToken);
 #pragma warning restore CA2016
                     }
                     streams[streamIndex++] = readStream;
@@ -448,7 +448,7 @@ namespace System.Net.Http
             {
                 foreach (Stream s in _streams)
                 {
-                    await s.DisposeAsync().ConfigureAwait(false);
+                    await s.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
 
@@ -549,7 +549,7 @@ namespace System.Net.Http
                 {
                     if (_current != null)
                     {
-                        int bytesRead = await _current.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+                        int bytesRead = await _current.ReadAsync(buffer, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                         if (bytesRead != 0)
                         {
                             _position += bytesRead;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/StreamToStreamCopy.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/StreamToStreamCopy.cs
@@ -79,7 +79,7 @@ namespace System.Net.Http
 
                         static async Task DisposeSourceAsync(Task copyTask, Stream source)
                         {
-                            await copyTask.ConfigureAwait(false);
+                            await copyTask.ConfigureAwait(OperatingSystem.IsBrowser());
                             DisposeSource(source);
                         }
                 }

--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/ClientWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/ClientWebSocket.cs
@@ -127,7 +127,7 @@ namespace System.Net.WebSockets
 
             try
             {
-                await _innerWebSocket.ConnectAsync(uri, invoker, cancellationToken, Options).ConfigureAwait(false);
+                await _innerWebSocket.ConnectAsync(uri, invoker, cancellationToken, Options).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             catch
             {

--- a/src/libraries/System.Private.CoreLib/src/System/CodeDom/Compiler/IndentedTextWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/CodeDom/Compiler/IndentedTextWriter.cs
@@ -78,7 +78,7 @@ namespace System.CodeDom.Compiler
             {
                 for (int i = 0; i < _indentLevel; i++)
                 {
-                    await _writer.WriteAsync(_tabString).ConfigureAwait(false);
+                    await _writer.WriteAsync(_tabString).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 _tabsPending = false;
             }
@@ -170,8 +170,8 @@ namespace System.CodeDom.Compiler
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task WriteAsync(char value)
         {
-            await OutputTabsAsync().ConfigureAwait(false);
-            await _writer.WriteAsync(value).ConfigureAwait(false);
+            await OutputTabsAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+            await _writer.WriteAsync(value).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         /// <summary>
@@ -185,8 +185,8 @@ namespace System.CodeDom.Compiler
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task WriteAsync(char[] buffer, int index, int count)
         {
-            await OutputTabsAsync().ConfigureAwait(false);
-            await _writer.WriteAsync(buffer, index, count).ConfigureAwait(false);
+            await OutputTabsAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+            await _writer.WriteAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         /// <summary>
@@ -197,8 +197,8 @@ namespace System.CodeDom.Compiler
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task WriteAsync(string? value)
         {
-            await OutputTabsAsync().ConfigureAwait(false);
-            await _writer.WriteAsync(value).ConfigureAwait(false);
+            await OutputTabsAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+            await _writer.WriteAsync(value).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         /// <summary>
@@ -210,8 +210,8 @@ namespace System.CodeDom.Compiler
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task WriteAsync(ReadOnlyMemory<char> buffer, CancellationToken cancellationToken = default)
         {
-            await OutputTabsAsync().ConfigureAwait(false);
-            await _writer.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+            await OutputTabsAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+            await _writer.WriteAsync(buffer, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         /// <summary>
@@ -223,8 +223,8 @@ namespace System.CodeDom.Compiler
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task WriteAsync(StringBuilder? value, CancellationToken cancellationToken = default)
         {
-            await OutputTabsAsync().ConfigureAwait(false);
-            await _writer.WriteAsync(value, cancellationToken).ConfigureAwait(false);
+            await OutputTabsAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+            await _writer.WriteAsync(value, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         public void WriteLineNoTabs(string? s)
@@ -351,8 +351,8 @@ namespace System.CodeDom.Compiler
         /// <inheritdoc/>
         public override async Task WriteLineAsync()
         {
-            await OutputTabsAsync().ConfigureAwait(false);
-            await _writer.WriteLineAsync().ConfigureAwait(false);
+            await OutputTabsAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+            await _writer.WriteLineAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             _tabsPending = true;
         }
 
@@ -364,8 +364,8 @@ namespace System.CodeDom.Compiler
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task WriteLineAsync(char value)
         {
-            await OutputTabsAsync().ConfigureAwait(false);
-            await _writer.WriteLineAsync(value).ConfigureAwait(false);
+            await OutputTabsAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+            await _writer.WriteLineAsync(value).ConfigureAwait(OperatingSystem.IsBrowser());
             _tabsPending = true;
         }
 
@@ -379,8 +379,8 @@ namespace System.CodeDom.Compiler
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task WriteLineAsync(char[] buffer, int index, int count)
         {
-            await OutputTabsAsync().ConfigureAwait(false);
-            await _writer.WriteLineAsync(buffer, index, count).ConfigureAwait(false);
+            await OutputTabsAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+            await _writer.WriteLineAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
             _tabsPending = true;
         }
 
@@ -392,8 +392,8 @@ namespace System.CodeDom.Compiler
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task WriteLineAsync(string? value)
         {
-            await OutputTabsAsync().ConfigureAwait(false);
-            await _writer.WriteLineAsync(value).ConfigureAwait(false);
+            await OutputTabsAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+            await _writer.WriteLineAsync(value).ConfigureAwait(OperatingSystem.IsBrowser());
             _tabsPending = true;
         }
 
@@ -406,8 +406,8 @@ namespace System.CodeDom.Compiler
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task WriteLineAsync(ReadOnlyMemory<char> buffer, CancellationToken cancellationToken = default)
         {
-            await OutputTabsAsync().ConfigureAwait(false);
-            await _writer.WriteLineAsync(buffer, cancellationToken).ConfigureAwait(false);
+            await OutputTabsAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+            await _writer.WriteLineAsync(buffer, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             _tabsPending = true;
         }
 
@@ -420,8 +420,8 @@ namespace System.CodeDom.Compiler
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task WriteLineAsync(StringBuilder? value, CancellationToken cancellationToken = default)
         {
-            await OutputTabsAsync().ConfigureAwait(false);
-            await _writer.WriteLineAsync(value, cancellationToken).ConfigureAwait(false);
+            await OutputTabsAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+            await _writer.WriteLineAsync(value, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             _tabsPending = true;
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
@@ -519,7 +519,7 @@ namespace System.IO
 
         public override async ValueTask DisposeAsync()
         {
-            await _strategy.DisposeAsync().ConfigureAwait(false);
+            await _strategy.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
             // For compatibility, derived classes must only call base.DisposeAsync(),
             // otherwise we would end up calling Dispose twice (one from base.DisposeAsync() and one from here).

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
@@ -105,9 +105,9 @@ namespace System.IO
                 try
                 {
                     int bytesRead;
-                    while ((bytesRead = await source.ReadAsync(new Memory<byte>(buffer), cancellationToken).ConfigureAwait(false)) != 0)
+                    while ((bytesRead = await source.ReadAsync(new Memory<byte>(buffer), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser())) != 0)
                     {
-                        await destination.WriteAsync(new ReadOnlyMemory<byte>(buffer, 0, bytesRead), cancellationToken).ConfigureAwait(false);
+                        await destination.WriteAsync(new ReadOnlyMemory<byte>(buffer, 0, bytesRead), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                 }
                 finally
@@ -321,7 +321,7 @@ namespace System.IO
             {
                 try
                 {
-                    int result = await readTask.ConfigureAwait(false);
+                    int result = await readTask.ConfigureAwait(OperatingSystem.IsBrowser());
                     new ReadOnlySpan<byte>(localBuffer, 0, result).CopyTo(localDestination.Span);
                     return result;
                 }
@@ -432,7 +432,7 @@ namespace System.IO
             int totalRead = 0;
             while (totalRead < minimumBytes)
             {
-                int read = await ReadAsync(buffer.Slice(totalRead), cancellationToken).ConfigureAwait(false);
+                int read = await ReadAsync(buffer.Slice(totalRead), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 if (read == 0)
                 {
                     if (throwOnEndOfStream)
@@ -753,7 +753,7 @@ namespace System.IO
         {
             try
             {
-                await writeTask.ConfigureAwait(false);
+                await writeTask.ConfigureAwait(OperatingSystem.IsBrowser());
             }
             finally
             {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
@@ -905,7 +905,7 @@ namespace System.IO
 
         private async Task<string?> ReadLineAsyncInternal(CancellationToken cancellationToken)
         {
-            if (_charPos == _charLen && (await ReadBufferAsync(cancellationToken).ConfigureAwait(false)) == 0)
+            if (_charPos == _charLen && (await ReadBufferAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser())) == 0)
             {
                 return null;
             }
@@ -943,7 +943,7 @@ namespace System.IO
                     // If we found '\r', consume any immediately following '\n'.
                     if (matchedChar == '\r')
                     {
-                        if (charPos < charLen || (await ReadBufferAsync(cancellationToken).ConfigureAwait(false)) > 0)
+                        if (charPos < charLen || (await ReadBufferAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser())) > 0)
                         {
                             if (_charBuffer[_charPos] == '\n')
                             {
@@ -971,7 +971,7 @@ namespace System.IO
                 charBuffer.AsSpan(charPos, charLen - charPos).CopyTo(arrayPoolBuffer.AsSpan(arrayPoolBufferPos));
                 arrayPoolBufferPos += charLen - charPos;
             }
-            while (await ReadBufferAsync(cancellationToken).ConfigureAwait(false) > 0);
+            while (await ReadBufferAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser()) > 0);
 
             if (arrayPoolBuffer is not null)
             {
@@ -1040,7 +1040,7 @@ namespace System.IO
                 int tmpCharPos = _charPos;
                 sb.Append(_charBuffer, tmpCharPos, _charLen - tmpCharPos);
                 _charPos = _charLen;  // We consumed these characters
-                await ReadBufferAsync(cancellationToken).ConfigureAwait(false);
+                await ReadBufferAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             } while (_charLen > 0);
 
             return sb.ToString();
@@ -1096,7 +1096,7 @@ namespace System.IO
 
         internal override async ValueTask<int> ReadAsyncInternal(Memory<char> buffer, CancellationToken cancellationToken)
         {
-            if (_charPos == _charLen && (await ReadBufferAsync(cancellationToken).ConfigureAwait(false)) == 0)
+            if (_charPos == _charLen && (await ReadBufferAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser())) == 0)
             {
                 return 0;
             }
@@ -1139,7 +1139,7 @@ namespace System.IO
                         {
                             Debug.Assert(_bytePos <= _encoding.Preamble.Length, "possible bug in _compressPreamble.  Are two threads using this StreamReader at the same time?");
                             int tmpBytePos = _bytePos;
-                            int len = await tmpStream.ReadAsync(new Memory<byte>(tmpByteBuffer, tmpBytePos, tmpByteBuffer.Length - tmpBytePos), cancellationToken).ConfigureAwait(false);
+                            int len = await tmpStream.ReadAsync(new Memory<byte>(tmpByteBuffer, tmpBytePos, tmpByteBuffer.Length - tmpBytePos), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                             Debug.Assert(len >= 0, "Stream.Read returned a negative number!  This is a bug in your stream class.");
 
                             if (len == 0)
@@ -1175,7 +1175,7 @@ namespace System.IO
                         {
                             Debug.Assert(_bytePos == 0, "_bytePos can be non zero only when we are trying to _checkPreamble.  Are two threads using this StreamReader at the same time?");
 
-                            _byteLen = await tmpStream.ReadAsync(new Memory<byte>(tmpByteBuffer), cancellationToken).ConfigureAwait(false);
+                            _byteLen = await tmpStream.ReadAsync(new Memory<byte>(tmpByteBuffer), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
                             Debug.Assert(_byteLen >= 0, "Stream.Read returned a negative number!  This is a bug in your stream class.");
 
@@ -1334,7 +1334,7 @@ namespace System.IO
                 {
                     Debug.Assert(_bytePos <= _encoding.Preamble.Length, "possible bug in _compressPreamble. Are two threads using this StreamReader at the same time?");
                     int tmpBytePos = _bytePos;
-                    int len = await tmpStream.ReadAsync(tmpByteBuffer.AsMemory(tmpBytePos), cancellationToken).ConfigureAwait(false);
+                    int len = await tmpStream.ReadAsync(tmpByteBuffer.AsMemory(tmpBytePos), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     Debug.Assert(len >= 0, "Stream.Read returned a negative number!  This is a bug in your stream class.");
 
                     if (len == 0)
@@ -1348,7 +1348,7 @@ namespace System.IO
                 else
                 {
                     Debug.Assert(_bytePos == 0, "_bytePos can be non zero only when we are trying to _checkPreamble. Are two threads using this StreamReader at the same time?");
-                    _byteLen = await tmpStream.ReadAsync(new Memory<byte>(tmpByteBuffer), cancellationToken).ConfigureAwait(false);
+                    _byteLen = await tmpStream.ReadAsync(new Memory<byte>(tmpByteBuffer), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     Debug.Assert(_byteLen >= 0, "Stream.Read returned a negative number!  Bug in stream class.");
 
                     if (_byteLen == 0)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamWriter.cs
@@ -246,7 +246,7 @@ namespace System.IO
             {
                 if (!_disposed)
                 {
-                    await FlushAsync().ConfigureAwait(false);
+                    await FlushAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             finally
@@ -633,7 +633,7 @@ namespace System.IO
         {
             if (_charPos == _charLen)
             {
-                await FlushAsyncInternal(flushStream: false, flushEncoder: false).ConfigureAwait(false);
+                await FlushAsyncInternal(flushStream: false, flushEncoder: false).ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             _charBuffer[_charPos++] = value;
@@ -644,7 +644,7 @@ namespace System.IO
                 {
                     if (_charPos == _charLen)
                     {
-                        await FlushAsyncInternal(flushStream: false, flushEncoder: false).ConfigureAwait(false);
+                        await FlushAsyncInternal(flushStream: false, flushEncoder: false).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
 
                     _charBuffer[_charPos++] = CoreNewLine[i];
@@ -653,7 +653,7 @@ namespace System.IO
 
             if (_autoFlush)
             {
-                await FlushAsyncInternal(flushStream: true, flushEncoder: false).ConfigureAwait(false);
+                await FlushAsyncInternal(flushStream: true, flushEncoder: false).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -741,7 +741,7 @@ namespace System.IO
             {
                 if (_charPos == _charLen)
                 {
-                    await FlushAsyncInternal(flushStream: false, flushEncoder: false, cancellationToken).ConfigureAwait(false);
+                    await FlushAsyncInternal(flushStream: false, flushEncoder: false, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
 
                 int n = Math.Min(_charLen - _charPos, source.Length - copied);
@@ -758,7 +758,7 @@ namespace System.IO
                 {
                     if (_charPos == _charLen)
                     {
-                        await FlushAsyncInternal(flushStream: false, flushEncoder: false, cancellationToken).ConfigureAwait(false);
+                        await FlushAsyncInternal(flushStream: false, flushEncoder: false, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
 
                     _charBuffer[_charPos++] = CoreNewLine[i];
@@ -767,7 +767,7 @@ namespace System.IO
 
             if (_autoFlush)
             {
-                await FlushAsyncInternal(flushStream: true, flushEncoder: false, cancellationToken).ConfigureAwait(false);
+                await FlushAsyncInternal(flushStream: true, flushEncoder: false, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -933,7 +933,7 @@ namespace System.IO
                     byte[] preamble = _encoding.GetPreamble();
                     if (preamble.Length > 0)
                     {
-                        await _stream.WriteAsync(new ReadOnlyMemory<byte>(preamble), cancellationToken).ConfigureAwait(false);
+                        await _stream.WriteAsync(new ReadOnlyMemory<byte>(preamble), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                 }
 
@@ -943,7 +943,7 @@ namespace System.IO
                 _charPos = 0;
                 if (count > 0)
                 {
-                    await _stream.WriteAsync(new ReadOnlyMemory<byte>(byteBuffer, 0, count), cancellationToken).ConfigureAwait(false);
+                    await _stream.WriteAsync(new ReadOnlyMemory<byte>(byteBuffer, 0, count), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
 
                 // By definition, calling Flush should flush the stream, but this is
@@ -951,7 +951,7 @@ namespace System.IO
                 // Services guys have some perf tests where flushing needlessly hurts.
                 if (flushStream)
                 {
-                    await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                    await _stream.FlushAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
@@ -245,7 +245,7 @@ namespace System.IO
             try
             {
                 int len;
-                while ((len = await ReadAsyncInternal(chars, cancellationToken).ConfigureAwait(false)) != 0)
+                while ((len = await ReadAsyncInternal(chars, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser())) != 0)
                 {
                     sb.Append(chars, 0, len);
                 }
@@ -315,7 +315,7 @@ namespace System.IO
             int n = 0, i;
             do
             {
-                i = await ReadAsyncInternal(buffer.Slice(n), cancellationToken).ConfigureAwait(false);
+                i = await ReadAsyncInternal(buffer.Slice(n), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 n += i;
             } while (i > 0 && n < buffer.Length);
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextWriter.cs
@@ -546,7 +546,7 @@ namespace System.IO
             {
                 foreach (ReadOnlyMemory<char> chunk in sb.GetChunks())
                 {
-                    await WriteAsync(chunk, ct).ConfigureAwait(false);
+                    await WriteAsync(chunk, ct).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
         }
@@ -609,9 +609,9 @@ namespace System.IO
             {
                 foreach (ReadOnlyMemory<char> chunk in sb.GetChunks())
                 {
-                    await WriteAsync(chunk, ct).ConfigureAwait(false);
+                    await WriteAsync(chunk, ct).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
-                await WriteAsync(CoreNewLine, ct).ConfigureAwait(false);
+                await WriteAsync(CoreNewLine, ct).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/TranscodingStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/TranscodingStream.cs
@@ -152,11 +152,11 @@ namespace System.Text
                 Stream innerStream = _innerStream;
                 _innerStream = null!;
 
-                await innerStream.WriteAsync(pendingData.AsMemory()).ConfigureAwait(false);
+                await innerStream.WriteAsync(pendingData.AsMemory()).ConfigureAwait(OperatingSystem.IsBrowser());
 
                 if (!_leaveOpen)
                 {
-                    await innerStream.DisposeAsync().ConfigureAwait(false);
+                    await innerStream.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
         }
@@ -401,7 +401,7 @@ namespace System.Text
                             // a larger-than-expected array, but our worst-case expansion calculations
                             // performed earlier didn't take that into account.
 
-                            int innerBytesReadJustNow = await _innerStream.ReadAsync(rentedBytes.AsMemory(0, DefaultReadByteBufferSize), cancellationToken).ConfigureAwait(false);
+                            int innerBytesReadJustNow = await _innerStream.ReadAsync(rentedBytes.AsMemory(0, DefaultReadByteBufferSize), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                             isEofReached = (innerBytesReadJustNow == 0);
 
                             // Convert bytes [inner] -> chars, then convert chars -> bytes [this].
@@ -594,7 +594,7 @@ namespace System.Text
                                 out encoderFinished);
 
                             decodedChars = decodedChars.Slice(charsConsumed);
-                            await _innerStream.WriteAsync(new ReadOnlyMemory<byte>(scratchBytes, 0, bytesWritten), cancellationToken).ConfigureAwait(false);
+                            await _innerStream.WriteAsync(new ReadOnlyMemory<byte>(scratchBytes, 0, bytesWritten), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                         } while (!encoderFinished);
                     } while (!decoderFinished);
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -730,7 +730,7 @@ namespace System.Threading
 
             // The waiter had already been removed, which means it's already completed or is about to
             // complete, so let it, and don't return until it does.
-            return await asyncWaiter.ConfigureAwait(false);
+            return await asyncWaiter.ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         // TODO https://github.com/dotnet/runtime/issues/22144: Replace with official nothrow await solution once available.

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskAsyncEnumerableExtensions.ToBlockingEnumerable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskAsyncEnumerableExtensions.ToBlockingEnumerable.cs
@@ -41,7 +41,7 @@ namespace System.Threading.Tasks
 
                     if (!moveNextTask.IsCompleted)
                     {
-                        (mres ??= new ManualResetEventWithAwaiterSupport()).Wait(moveNextTask.ConfigureAwait(false).GetAwaiter());
+                        (mres ??= new ManualResetEventWithAwaiterSupport()).Wait(moveNextTask.ConfigureAwait(OperatingSystem.IsBrowser()).GetAwaiter());
                         Debug.Assert(moveNextTask.IsCompleted);
                     }
 
@@ -59,7 +59,7 @@ namespace System.Threading.Tasks
 
                 if (!disposeTask.IsCompleted)
                 {
-                    (mres ?? new ManualResetEventWithAwaiterSupport()).Wait(disposeTask.ConfigureAwait(false).GetAwaiter());
+                    (mres ?? new ManualResetEventWithAwaiterSupport()).Wait(disposeTask.ConfigureAwait(OperatingSystem.IsBrowser()).GetAwaiter());
                     Debug.Assert(disposeTask.IsCompleted);
                 }
 

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBaseWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBaseWriter.cs
@@ -374,7 +374,7 @@ namespace System.Xml
 
         private async Task WriteEndAttributeAsyncImpl()
         {
-            await FlushBase64Async().ConfigureAwait(false);
+            await FlushBase64Async().ConfigureAwait(OperatingSystem.IsBrowser());
             try
             {
                 if (_isXmlAttribute)
@@ -416,7 +416,7 @@ namespace System.Xml
                 }
                 else
                 {
-                    await _writer.WriteEndAttributeAsync().ConfigureAwait(false);
+                    await _writer.WriteEndAttributeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             finally
@@ -544,14 +544,14 @@ namespace System.Xml
 
         private async Task StartElementAndWriteStartElementAsync(string? prefix, string localName, string? namespaceUri)
         {
-            prefix = await StartElementAsync(prefix, localName, namespaceUri, null).ConfigureAwait(false);
-            await _writer.WriteStartElementAsync(prefix, localName).ConfigureAwait(false);
+            prefix = await StartElementAsync(prefix, localName, namespaceUri, null).ConfigureAwait(OperatingSystem.IsBrowser());
+            await _writer.WriteStartElementAsync(prefix, localName).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         private async Task<string> StartElementAsync(string? prefix, string localName, string? ns, XmlDictionaryString? xNs)
         {
-            await FlushBase64Async().ConfigureAwait(false);
-            await AutoCompleteAsync(WriteState.Element).ConfigureAwait(false);
+            await FlushBase64Async().ConfigureAwait(OperatingSystem.IsBrowser());
+            await AutoCompleteAsync(WriteState.Element).ConfigureAwait(OperatingSystem.IsBrowser());
             Element element = EnterScope();
             if (ns == null)
             {
@@ -641,18 +641,18 @@ namespace System.Xml
         private async Task WriteEndElementAsyncImpl()
         {
             if (_writeState == WriteState.Attribute)
-                await WriteEndAttributeAsync().ConfigureAwait(false);
+                await WriteEndAttributeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
             FlushBase64();
             if (_writeState == WriteState.Element)
             {
                 _nsMgr.DeclareNamespaces(_writer);
-                await _writer.WriteEndStartElementAsync(true).ConfigureAwait(false);
+                await _writer.WriteEndStartElementAsync(true).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             else
             {
                 Element element = _elements![_depth];
-                await _writer.WriteEndElementAsync(element.Prefix, element.LocalName!).ConfigureAwait(false);
+                await _writer.WriteEndElementAsync(element.Prefix, element.LocalName!).ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             ExitScope();
@@ -722,7 +722,7 @@ namespace System.Xml
 
         protected async Task StartContentAsync()
         {
-            await FlushElementAsync().ConfigureAwait(false);
+            await FlushElementAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             if (_depth == 0)
                 throw new InvalidOperationException(SR.XmlIllegalOutsideRoot);
         }
@@ -783,7 +783,7 @@ namespace System.Xml
         {
             if (_writeState == WriteState.Element)
             {
-                await EndStartElementAsync().ConfigureAwait(false);
+                await EndStartElementAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
             _writeState = writeState;
         }
@@ -1547,8 +1547,8 @@ namespace System.Xml
                     }
                     if (!_isXmlnsAttribute)
                     {
-                        await StartContentAsync().ConfigureAwait(false);
-                        await _writer.WriteBase64TextAsync(_trailBytes, _trailByteCount, buffer, offset, actualByteCount - _trailByteCount).ConfigureAwait(false);
+                        await StartContentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+                        await _writer.WriteBase64TextAsync(_trailBytes, _trailByteCount, buffer, offset, actualByteCount - _trailByteCount).ConfigureAwait(OperatingSystem.IsBrowser());
                         EndContent();
                     }
                     _trailByteCount = (totalByteCount - actualByteCount);
@@ -1766,8 +1766,8 @@ namespace System.Xml
 
             if (!_isXmlnsAttribute)
             {
-                await StartContentAsync().ConfigureAwait(false);
-                await _writer.WriteBase64TextAsync(_trailBytes, _trailByteCount, _trailBytes, 0, 0).ConfigureAwait(false);
+                await StartContentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+                await _writer.WriteBase64TextAsync(_trailBytes, _trailByteCount, _trailBytes, 0, 0).ConfigureAwait(OperatingSystem.IsBrowser());
                 EndContent();
             }
             _trailByteCount = 0;

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlStreamNodeWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlStreamNodeWriter.cs
@@ -97,7 +97,7 @@ namespace System.Xml
             }
             else
             {
-                await FlushBufferAsync().ConfigureAwait(false);
+                await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 offset = 0;
             }
 #if DEBUG
@@ -145,7 +145,7 @@ namespace System.Xml
 
         private async Task FlushBufferAndWriteByteAsync(byte b)
         {
-            await FlushBufferAsync().ConfigureAwait(false);
+            await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             _buffer[_offset++] = b;
         }
 
@@ -191,7 +191,7 @@ namespace System.Xml
 
         private async Task FlushAndWriteBytesAsync(byte b1, byte b2)
         {
-            await FlushBufferAsync().ConfigureAwait(false);
+            await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             _buffer[_offset++] = b1;
             _buffer[_offset++] = b2;
         }
@@ -420,8 +420,8 @@ namespace System.Xml
 
         public override async Task FlushAsync()
         {
-            await FlushBufferAsync().ConfigureAwait(false);
-            await OutputStream.FlushAsync().ConfigureAwait(false);
+            await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+            await OutputStream.FlushAsync().ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         public override void Close()

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlUTF8TextWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlUTF8TextWriter.cs
@@ -173,12 +173,12 @@ namespace System.Xml
 
         public override async Task WriteStartElementAsync(string? prefix, string localName)
         {
-            await WriteByteAsync('<').ConfigureAwait(false);
+            await WriteByteAsync('<').ConfigureAwait(OperatingSystem.IsBrowser());
             if (!string.IsNullOrEmpty(prefix))
             {
                 // This method calls into unsafe method which cannot run asyncly.
                 WritePrefix(prefix);
-                await WriteByteAsync(':').ConfigureAwait(false);
+                await WriteByteAsync(':').ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             // This method calls into unsafe method which cannot run asyncly.
@@ -217,11 +217,11 @@ namespace System.Xml
         {
             if (!isEmpty)
             {
-                await WriteByteAsync('>').ConfigureAwait(false);
+                await WriteByteAsync('>').ConfigureAwait(OperatingSystem.IsBrowser());
             }
             else
             {
-                await WriteBytesAsync('/', '>').ConfigureAwait(false);
+                await WriteBytesAsync('/', '>').ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -239,14 +239,14 @@ namespace System.Xml
 
         public override async Task WriteEndElementAsync(string? prefix, string localName)
         {
-            await WriteBytesAsync('<', '/').ConfigureAwait(false);
+            await WriteBytesAsync('<', '/').ConfigureAwait(OperatingSystem.IsBrowser());
             if (!string.IsNullOrEmpty(prefix))
             {
                 WritePrefix(prefix);
-                await WriteByteAsync(':').ConfigureAwait(false);
+                await WriteByteAsync(':').ConfigureAwait(OperatingSystem.IsBrowser());
             }
             WriteLocalName(localName);
-            await WriteByteAsync('>').ConfigureAwait(false);
+            await WriteByteAsync('>').ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         public override void WriteEndElement(byte[] prefixBuffer, int prefixOffset, int prefixLength, byte[] localNameBuffer, int localNameOffset, int localNameLength)
@@ -337,7 +337,7 @@ namespace System.Xml
 
         public override async Task WriteEndAttributeAsync()
         {
-            await WriteByteAsync('"').ConfigureAwait(false);
+            await WriteByteAsync('"').ConfigureAwait(OperatingSystem.IsBrowser());
             _inAttribute = false;
         }
 
@@ -640,10 +640,10 @@ namespace System.Xml
         {
             if (trailByteCount > 0)
             {
-                await InternalWriteBase64TextAsync(trailBytes, 0, trailByteCount).ConfigureAwait(false);
+                await InternalWriteBase64TextAsync(trailBytes, 0, trailByteCount).ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
-            await InternalWriteBase64TextAsync(buffer, offset, count).ConfigureAwait(false);
+            await InternalWriteBase64TextAsync(buffer, offset, count).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         private void InternalWriteBase64Text(byte[] buffer, int offset, int count)
@@ -673,7 +673,7 @@ namespace System.Xml
                 int byteCount = Math.Min(bufferLength / 4 * 3, count - count % 3);
                 int charCount = byteCount / 3 * 4;
                 int charOffset;
-                BytesWithOffset bufferResult = await GetBufferAsync(charCount).ConfigureAwait(false);
+                BytesWithOffset bufferResult = await GetBufferAsync(charCount).ConfigureAwait(OperatingSystem.IsBrowser());
                 byte[] chars = bufferResult.Bytes;
                 charOffset = bufferResult.Offset;
                 Advance(encoding.GetChars(buffer, offset, byteCount, chars, charOffset));
@@ -683,7 +683,7 @@ namespace System.Xml
             if (count > 0)
             {
                 int charOffset;
-                BytesWithOffset bufferResult = await GetBufferAsync(4).ConfigureAwait(false);
+                BytesWithOffset bufferResult = await GetBufferAsync(4).ConfigureAwait(OperatingSystem.IsBrowser());
                 byte[] chars = bufferResult.Bytes;
                 charOffset = bufferResult.Offset;
                 Advance(encoding.GetChars(buffer, offset, count, chars, charOffset));

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XContainer.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XContainer.cs
@@ -859,14 +859,14 @@ namespace System.Xml.Linq
             {
                 cancellationToken.ThrowIfCancellationRequested();
             }
-            while (await cr.ReadContentFromAsync(this, r).ConfigureAwait(false) && await r.ReadAsync().ConfigureAwait(false));
+            while (await cr.ReadContentFromAsync(this, r).ConfigureAwait(OperatingSystem.IsBrowser()) && await r.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser()));
         }
 
         internal async Task ReadContentFromAsync(XmlReader r, LoadOptions o, CancellationToken cancellationToken)
         {
             if ((o & (LoadOptions.SetBaseUri | LoadOptions.SetLineInfo)) == 0)
             {
-                await ReadContentFromAsync(r, cancellationToken).ConfigureAwait(false);
+                await ReadContentFromAsync(r, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 return;
             }
             if (r.ReadState != ReadState.Interactive) throw new InvalidOperationException(SR.InvalidOperation_ExpectedInteractive);
@@ -876,7 +876,7 @@ namespace System.Xml.Linq
             {
                 cancellationToken.ThrowIfCancellationRequested();
             }
-            while (await cr.ReadContentFromContainerAsync(this, r).ConfigureAwait(false) && await r.ReadAsync().ConfigureAwait(false));
+            while (await cr.ReadContentFromContainerAsync(this, r).ConfigureAwait(OperatingSystem.IsBrowser()) && await r.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser()));
         }
 
         private sealed class ContentReader
@@ -965,7 +965,7 @@ namespace System.Xml.Linq
                             {
                                 e.AppendAttributeSkipNotify(new XAttribute(
                                     _aCache.Get(r.Prefix.Length == 0 ? string.Empty : r.NamespaceURI).GetName(r.LocalName),
-                                    await r.GetValueAsync().ConfigureAwait(false)));
+                                    await r.GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser())));
                             } while (r.MoveToNextAttribute());
                             r.MoveToElement();
                         }
@@ -983,19 +983,19 @@ namespace System.Xml.Linq
                     case XmlNodeType.Text:
                     case XmlNodeType.SignificantWhitespace:
                     case XmlNodeType.Whitespace:
-                        _currentContainer.AddStringSkipNotify(await r.GetValueAsync().ConfigureAwait(false));
+                        _currentContainer.AddStringSkipNotify(await r.GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser()));
                         break;
                     case XmlNodeType.CDATA:
-                        _currentContainer.AddNodeSkipNotify(new XCData(await r.GetValueAsync().ConfigureAwait(false)));
+                        _currentContainer.AddNodeSkipNotify(new XCData(await r.GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser())));
                         break;
                     case XmlNodeType.Comment:
-                        _currentContainer.AddNodeSkipNotify(new XComment(await r.GetValueAsync().ConfigureAwait(false)));
+                        _currentContainer.AddNodeSkipNotify(new XComment(await r.GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser())));
                         break;
                     case XmlNodeType.ProcessingInstruction:
-                        _currentContainer.AddNodeSkipNotify(new XProcessingInstruction(r.Name, await r.GetValueAsync().ConfigureAwait(false)));
+                        _currentContainer.AddNodeSkipNotify(new XProcessingInstruction(r.Name, await r.GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser())));
                         break;
                     case XmlNodeType.DocumentType:
-                        _currentContainer.AddNodeSkipNotify(new XDocumentType(r.LocalName, r.GetAttribute("PUBLIC"), r.GetAttribute("SYSTEM"), await r.GetValueAsync().ConfigureAwait(false)));
+                        _currentContainer.AddNodeSkipNotify(new XDocumentType(r.LocalName, r.GetAttribute("PUBLIC"), r.GetAttribute("SYSTEM"), await r.GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser())));
                         break;
                     case XmlNodeType.EntityReference:
                         if (!r.CanResolveEntity) throw new InvalidOperationException(SR.InvalidOperation_UnresolvedEntityReference);
@@ -1147,7 +1147,7 @@ namespace System.Xml.Linq
                                 {
                                     XAttribute a = new XAttribute(
                                         _aCache.Get(r.Prefix.Length == 0 ? string.Empty : r.NamespaceURI).GetName(r.LocalName),
-                                        await r.GetValueAsync().ConfigureAwait(false));
+                                        await r.GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser()));
                                     if (_lineInfo != null && _lineInfo.HasLineInfo())
                                     {
                                         a.SetLineInfo(_lineInfo.LineNumber, _lineInfo.LinePosition);
@@ -1192,24 +1192,24 @@ namespace System.Xml.Linq
                         if ((_baseUri != null && _baseUri != baseUri) ||
                             (_lineInfo != null && _lineInfo.HasLineInfo()))
                         {
-                            newNode = new XText(await r.GetValueAsync().ConfigureAwait(false));
+                            newNode = new XText(await r.GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser()));
                         }
                         else
                         {
-                            _currentContainer.AddStringSkipNotify(await r.GetValueAsync().ConfigureAwait(false));
+                            _currentContainer.AddStringSkipNotify(await r.GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser()));
                         }
                         break;
                     case XmlNodeType.CDATA:
-                        newNode = new XCData(await r.GetValueAsync().ConfigureAwait(false));
+                        newNode = new XCData(await r.GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser()));
                         break;
                     case XmlNodeType.Comment:
-                        newNode = new XComment(await r.GetValueAsync().ConfigureAwait(false));
+                        newNode = new XComment(await r.GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser()));
                         break;
                     case XmlNodeType.ProcessingInstruction:
-                        newNode = new XProcessingInstruction(r.Name, await r.GetValueAsync().ConfigureAwait(false));
+                        newNode = new XProcessingInstruction(r.Name, await r.GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser()));
                         break;
                     case XmlNodeType.DocumentType:
-                        newNode = new XDocumentType(r.LocalName, r.GetAttribute("PUBLIC"), r.GetAttribute("SYSTEM"), await r.GetValueAsync().ConfigureAwait(false));
+                        newNode = new XDocumentType(r.LocalName, r.GetAttribute("PUBLIC"), r.GetAttribute("SYSTEM"), await r.GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser()));
                         break;
                     case XmlNodeType.EntityReference:
                         if (!r.CanResolveEntity) throw new InvalidOperationException(SR.InvalidOperation_UnresolvedEntityReference);
@@ -1337,7 +1337,7 @@ namespace System.Xml.Linq
                         tWrite = writer.WriteStringAsync(stringContent);
                     }
 
-                    await tWrite.ConfigureAwait(false);
+                    await tWrite.ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 else
                 {
@@ -1345,7 +1345,7 @@ namespace System.Xml.Linq
                     do
                     {
                         n = n.next!;
-                        await n.WriteToAsync(writer, cancellationToken).ConfigureAwait(false);
+                        await n.WriteToAsync(writer, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     } while (n != content);
                 }
             }

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XDocument.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XDocument.cs
@@ -300,7 +300,7 @@ namespace System.Xml.Linq
 
             using (XmlReader r = XmlReader.Create(stream, rs))
             {
-                return await LoadAsync(r, options, cancellationToken).ConfigureAwait(false);
+                return await LoadAsync(r, options, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -383,7 +383,7 @@ namespace System.Xml.Linq
 
             using (XmlReader r = XmlReader.Create(textReader, rs))
             {
-                return await LoadAsync(r, options, cancellationToken).ConfigureAwait(false);
+                return await LoadAsync(r, options, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -464,11 +464,11 @@ namespace System.Xml.Linq
         {
             if (reader.ReadState == ReadState.Initial)
             {
-                await reader.ReadAsync().ConfigureAwait(false);
+                await reader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             XDocument d = InitLoad(reader, options);
-            await d.ReadContentFromAsync(reader, options, cancellationToken).ConfigureAwait(false);
+            await d.ReadContentFromAsync(reader, options, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
             if (!reader.EOF) throw new InvalidOperationException(SR.InvalidOperation_ExpectedEndOfFile);
             if (d.Root == null) throw new InvalidOperationException(SR.InvalidOperation_MissingRoot);
@@ -635,10 +635,10 @@ namespace System.Xml.Linq
             }
 
             XmlWriter w = XmlWriter.Create(stream, ws);
-            await using (w.ConfigureAwait(false))
+            await using (w.ConfigureAwait(OperatingSystem.IsBrowser()))
             {
-                await WriteToAsync(w, cancellationToken).ConfigureAwait(false);
-                await w.FlushAsync().ConfigureAwait(false);
+                await WriteToAsync(w, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
+                await w.FlushAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -709,10 +709,10 @@ namespace System.Xml.Linq
             ws.Async = true;
 
             XmlWriter w = XmlWriter.Create(textWriter, ws);
-            await using (w.ConfigureAwait(false))
+            await using (w.ConfigureAwait(OperatingSystem.IsBrowser()))
             {
-                await WriteToAsync(w, cancellationToken).ConfigureAwait(false);
-                await w.FlushAsync().ConfigureAwait(false);
+                await WriteToAsync(w, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
+                await w.FlushAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -847,10 +847,10 @@ namespace System.Xml.Linq
             {
                 tStart = writer.WriteStartDocumentAsync();
             }
-            await tStart.ConfigureAwait(false);
+            await tStart.ConfigureAwait(OperatingSystem.IsBrowser());
 
-            await WriteContentToAsync(writer, cancellationToken).ConfigureAwait(false);
-            await writer.WriteEndDocumentAsync().ConfigureAwait(false);
+            await WriteContentToAsync(writer, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
+            await writer.WriteEndDocumentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         internal override void AddAttribute(XAttribute a)

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XElement.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XElement.cs
@@ -163,7 +163,7 @@ namespace System.Xml.Linq
         internal static async Task<XElement> CreateAsync(XmlReader r, CancellationToken cancellationToken)
         {
             XElement xe = new XElement(default(AsyncConstructionSentry));
-            await xe.ReadElementFromAsync(r, LoadOptions.None, cancellationToken).ConfigureAwait(false);
+            await xe.ReadElementFromAsync(r, LoadOptions.None, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             return xe;
         }
 
@@ -687,7 +687,7 @@ namespace System.Xml.Linq
 
             using (XmlReader r = XmlReader.Create(stream, rs))
             {
-                return await LoadAsync(r, options, cancellationToken).ConfigureAwait(false);
+                return await LoadAsync(r, options, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -769,7 +769,7 @@ namespace System.Xml.Linq
 
             using (XmlReader r = XmlReader.Create(textReader, rs))
             {
-                return await LoadAsync(r, options, cancellationToken).ConfigureAwait(false);
+                return await LoadAsync(r, options, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -844,13 +844,13 @@ namespace System.Xml.Linq
 
         private static async Task<XElement> LoadAsyncInternal(XmlReader reader, LoadOptions options, CancellationToken cancellationToken)
         {
-            if (await reader.MoveToContentAsync().ConfigureAwait(false) != XmlNodeType.Element) throw new InvalidOperationException(SR.Format(SR.InvalidOperation_ExpectedNodeType, XmlNodeType.Element, reader.NodeType));
+            if (await reader.MoveToContentAsync().ConfigureAwait(OperatingSystem.IsBrowser()) != XmlNodeType.Element) throw new InvalidOperationException(SR.Format(SR.InvalidOperation_ExpectedNodeType, XmlNodeType.Element, reader.NodeType));
 
             XElement e = new XElement(default(AsyncConstructionSentry));
-            await e.ReadElementFromAsync(reader, options, cancellationToken).ConfigureAwait(false);
+            await e.ReadElementFromAsync(reader, options, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
             cancellationToken.ThrowIfCancellationRequested();
-            await reader.MoveToContentAsync().ConfigureAwait(false);
+            await reader.MoveToContentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
             if (!reader.EOF) throw new InvalidOperationException(SR.InvalidOperation_ExpectedEndOfFile);
             return e;
@@ -1085,9 +1085,9 @@ namespace System.Xml.Linq
             ws.Async = true;
 
             XmlWriter w = XmlWriter.Create(stream, ws);
-            await using (w.ConfigureAwait(false))
+            await using (w.ConfigureAwait(OperatingSystem.IsBrowser()))
             {
-                await SaveAsync(w, cancellationToken).ConfigureAwait(false);
+                await SaveAsync(w, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -1147,9 +1147,9 @@ namespace System.Xml.Linq
             ws.Async = true;
 
             XmlWriter w = XmlWriter.Create(textWriter, ws);
-            await using (w.ConfigureAwait(false))
+            await using (w.ConfigureAwait(OperatingSystem.IsBrowser()))
             {
-                await SaveAsync(w, cancellationToken).ConfigureAwait(false);
+                await SaveAsync(w, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -1186,12 +1186,12 @@ namespace System.Xml.Linq
 
         private async Task SaveAsyncInternal(XmlWriter writer, CancellationToken cancellationToken)
         {
-            await writer.WriteStartDocumentAsync().ConfigureAwait(false);
+            await writer.WriteStartDocumentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
-            await WriteToAsync(writer, cancellationToken).ConfigureAwait(false);
+            await WriteToAsync(writer, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
             cancellationToken.ThrowIfCancellationRequested();
-            await writer.WriteEndDocumentAsync().ConfigureAwait(false);
+            await writer.WriteEndDocumentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         /// <summary>
@@ -2032,13 +2032,13 @@ namespace System.Xml.Linq
             if (!r.IsEmptyElement)
             {
                 cancellationTokentoken.ThrowIfCancellationRequested();
-                await r.ReadAsync().ConfigureAwait(false);
+                await r.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
-                await ReadContentFromAsync(r, o, cancellationTokentoken).ConfigureAwait(false);
+                await ReadContentFromAsync(r, o, cancellationTokentoken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             cancellationTokentoken.ThrowIfCancellationRequested();
-            await r.ReadAsync().ConfigureAwait(false);
+            await r.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         /// <summary>

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XLinq.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XLinq.cs
@@ -257,10 +257,10 @@ namespace System.Xml.Linq
                 XElement? current = n as XElement;
                 if (current != null)
                 {
-                    await WriteStartElementAsync(current, cancellationToken).ConfigureAwait(false);
+                    await WriteStartElementAsync(current, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     if (current.content == null)
                     {
-                        await WriteEndElementAsync(cancellationToken).ConfigureAwait(false);
+                        await WriteEndElementAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     else
                     {
@@ -268,8 +268,8 @@ namespace System.Xml.Linq
                         if (s != null)
                         {
                             cancellationToken.ThrowIfCancellationRequested();
-                            await _writer.WriteStringAsync(s).ConfigureAwait(false);
-                            await WriteFullEndElementAsync(cancellationToken).ConfigureAwait(false);
+                            await _writer.WriteStringAsync(s).ConfigureAwait(OperatingSystem.IsBrowser());
+                            await WriteFullEndElementAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                         else
                         {
@@ -280,12 +280,12 @@ namespace System.Xml.Linq
                 }
                 else
                 {
-                    await n.WriteToAsync(_writer, cancellationToken).ConfigureAwait(false);
+                    await n.WriteToAsync(_writer, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 while (n != root && n == n.parent!.content)
                 {
                     n = n.parent;
-                    await WriteFullEndElementAsync(cancellationToken).ConfigureAwait(false);
+                    await WriteFullEndElementAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 if (n == root) break;
                 n = n.next!;
@@ -350,7 +350,7 @@ namespace System.Xml.Linq
         private async Task WriteEndElementAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await _writer.WriteEndElementAsync().ConfigureAwait(false);
+            await _writer.WriteEndElementAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             _resolver.PopScope();
         }
 
@@ -363,7 +363,7 @@ namespace System.Xml.Linq
         private async Task WriteFullEndElementAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await _writer.WriteFullEndElementAsync().ConfigureAwait(false);
+            await _writer.WriteFullEndElementAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             _resolver.PopScope();
         }
 
@@ -390,7 +390,7 @@ namespace System.Xml.Linq
         {
             PushElement(e);
             XNamespace ns = e.Name.Namespace;
-            await _writer.WriteStartElementAsync(GetPrefixOfNamespace(ns, true), e.Name.LocalName, ns.NamespaceName).ConfigureAwait(false);
+            await _writer.WriteStartElementAsync(GetPrefixOfNamespace(ns, true), e.Name.LocalName, ns.NamespaceName).ConfigureAwait(OperatingSystem.IsBrowser());
             XAttribute? a = e.lastAttr;
             if (a != null)
             {
@@ -401,7 +401,7 @@ namespace System.Xml.Linq
                     string localName = a.Name.LocalName;
                     string namespaceName = ns.NamespaceName;
                     cancellationToken.ThrowIfCancellationRequested();
-                    await _writer.WriteAttributeStringAsync(GetPrefixOfNamespace(ns, false), localName, namespaceName.Length == 0 && localName == "xmlns" ? XNamespace.xmlnsPrefixNamespace : namespaceName, a.Value).ConfigureAwait(false);
+                    await _writer.WriteAttributeStringAsync(GetPrefixOfNamespace(ns, false), localName, namespaceName.Length == 0 && localName == "xmlns" ? XNamespace.xmlnsPrefixNamespace : namespaceName, a.Value).ConfigureAwait(OperatingSystem.IsBrowser());
                 } while (a != e.lastAttr);
             }
         }

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XNode.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XNode.cs
@@ -499,7 +499,7 @@ namespace System.Xml.Linq
                     ret = new XDocumentType(name, publicId, systemId, internalSubset);
                     break;
                 case XmlNodeType.Element:
-                    return await XElement.CreateAsync(reader, cancellationToken).ConfigureAwait(false);
+                    return await XElement.CreateAsync(reader, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 case XmlNodeType.ProcessingInstruction:
                     var target = reader.Name;
                     var data = reader.Value;
@@ -511,7 +511,7 @@ namespace System.Xml.Linq
             }
 
             cancellationToken.ThrowIfCancellationRequested();
-            await reader.ReadAsync().ConfigureAwait(false);
+            await reader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
             return ret;
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/AsyncHelper.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/AsyncHelper.cs
@@ -33,7 +33,7 @@ namespace System.Xml
 
         private static async Task CallVoidFuncWhenFinishCoreAsync<TArg>(this Task task, Action<TArg> func, TArg arg)
         {
-            await task.ConfigureAwait(false);
+            await task.ConfigureAwait(OperatingSystem.IsBrowser());
             func(arg);
         }
 
@@ -46,7 +46,7 @@ namespace System.Xml
 
         private static async Task<bool> ReturnTrueTaskWhenFinishCoreAsync(this Task task)
         {
-            await task.ConfigureAwait(false);
+            await task.ConfigureAwait(OperatingSystem.IsBrowser());
             return true;
         }
 
@@ -59,8 +59,8 @@ namespace System.Xml
 
         private static async Task CallTaskFuncWhenFinishCoreAsync<TArg>(Task task, Func<TArg, Task> func, TArg arg)
         {
-            await task.ConfigureAwait(false);
-            await func(arg).ConfigureAwait(false);
+            await task.ConfigureAwait(OperatingSystem.IsBrowser());
+            await func(arg).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         public static Task<bool> CallBoolTaskFuncWhenFinishAsync<TArg>(this Task task, Func<TArg, Task<bool>> func, TArg arg)
@@ -72,8 +72,8 @@ namespace System.Xml
 
         private static async Task<bool> CallBoolTaskFuncWhenFinishCoreAsync<TArg>(this Task task, Func<TArg, Task<bool>> func, TArg arg)
         {
-            await task.ConfigureAwait(false);
-            return await func(arg).ConfigureAwait(false);
+            await task.ConfigureAwait(OperatingSystem.IsBrowser());
+            return await func(arg).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         public static Task<bool> ContinueBoolTaskFuncWhenFalseAsync<TArg>(this Task<bool> task, Func<TArg, Task<bool>> func, TArg arg)
@@ -90,10 +90,10 @@ namespace System.Xml
 
         private static async Task<bool> ContinueBoolTaskFuncWhenFalseCoreAsync<TArg>(Task<bool> task, Func<TArg, Task<bool>> func, TArg arg)
         {
-            if (await task.ConfigureAwait(false))
+            if (await task.ConfigureAwait(OperatingSystem.IsBrowser()))
                 return true;
             else
-                return await func(arg).ConfigureAwait(false);
+                return await func(arg).ConfigureAwait(OperatingSystem.IsBrowser());
         }
     }
 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Base64EncoderAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Base64EncoderAsync.cs
@@ -42,7 +42,7 @@ namespace System.Xml
 
                     // encode the left-over buffer and write out
                     int leftOverChars = Convert.ToBase64CharArray(_leftOverBytes!, 0, 3, _charsLine, 0);
-                    await WriteCharsAsync(_charsLine, 0, leftOverChars).ConfigureAwait(false);
+                    await WriteCharsAsync(_charsLine, 0, leftOverChars).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
 
                 // store new left-over buffer
@@ -67,7 +67,7 @@ namespace System.Xml
                         chunkSize = endIndex - index;
                     }
                     int charCount = Convert.ToBase64CharArray(buffer, index, chunkSize, _charsLine, 0);
-                    await WriteCharsAsync(_charsLine, 0, charCount).ConfigureAwait(false);
+                    await WriteCharsAsync(_charsLine, 0, charCount).ConfigureAwait(OperatingSystem.IsBrowser());
 
                     index += chunkSize;
                 }
@@ -79,7 +79,7 @@ namespace System.Xml
             if (_leftOverBytesCount > 0)
             {
                 int leftOverChars = Convert.ToBase64CharArray(_leftOverBytes!, 0, _leftOverBytesCount, _charsLine, 0);
-                await WriteCharsAsync(_charsLine, 0, leftOverChars).ConfigureAwait(false);
+                await WriteCharsAsync(_charsLine, 0, leftOverChars).ConfigureAwait(OperatingSystem.IsBrowser());
                 _leftOverBytesCount = 0;
             }
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/BinHexEncoderAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/BinHexEncoderAsync.cs
@@ -24,7 +24,7 @@ namespace System.Xml
                 {
                     int cnt = (count < CharsChunkSize / 2) ? count : CharsChunkSize / 2;
                     HexConverter.EncodeToUtf16(buffer.AsSpan(index, cnt), chars);
-                    await writer.WriteRawAsync(chars, 0, cnt * 2).ConfigureAwait(false);
+                    await writer.WriteRawAsync(chars, 0, cnt * 2).ConfigureAwait(OperatingSystem.IsBrowser());
                     index += cnt;
                     count -= cnt;
                 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/ReadContentAsBinaryHelperAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/ReadContentAsBinaryHelperAsync.cs
@@ -25,7 +25,7 @@ namespace System.Xml
                     {
                         throw _reader.CreateReadContentAsException(nameof(ReadContentAsBase64));
                     }
-                    if (!await InitAsync().ConfigureAwait(false))
+                    if (!await InitAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         return 0;
                     }
@@ -35,7 +35,7 @@ namespace System.Xml
                     if (_decoder == _base64Decoder)
                     {
                         // read more binary data
-                        return await ReadContentAsBinaryAsync(buffer, index, count).ConfigureAwait(false);
+                        return await ReadContentAsBinaryAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     break;
                 case State.InReadElementContent:
@@ -51,7 +51,7 @@ namespace System.Xml
             InitBase64Decoder();
 
             // read more binary data
-            return await ReadContentAsBinaryAsync(buffer, index, count).ConfigureAwait(false);
+            return await ReadContentAsBinaryAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         internal async Task<int> ReadContentAsBinHexAsync(byte[] buffer, int index, int count) // only ever awaited, so no need to separate out argument handling
@@ -69,7 +69,7 @@ namespace System.Xml
                     {
                         throw _reader.CreateReadContentAsException(nameof(ReadContentAsBinHex));
                     }
-                    if (!await InitAsync().ConfigureAwait(false))
+                    if (!await InitAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         return 0;
                     }
@@ -79,7 +79,7 @@ namespace System.Xml
                     if (_decoder == _binHexDecoder)
                     {
                         // read more binary data
-                        return await ReadContentAsBinaryAsync(buffer, index, count).ConfigureAwait(false);
+                        return await ReadContentAsBinaryAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     break;
                 case State.InReadElementContent:
@@ -95,7 +95,7 @@ namespace System.Xml
             InitBinHexDecoder();
 
             // read more binary data
-            return await ReadContentAsBinaryAsync(buffer, index, count).ConfigureAwait(false);
+            return await ReadContentAsBinaryAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         internal async Task<int> ReadElementContentAsBase64Async(byte[] buffer, int index, int count) // only ever awaited, so no need to separate out argument handling
@@ -113,7 +113,7 @@ namespace System.Xml
                     {
                         throw _reader.CreateReadElementContentAsException(nameof(ReadElementContentAsBase64));
                     }
-                    if (!await InitOnElementAsync().ConfigureAwait(false))
+                    if (!await InitOnElementAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         return 0;
                     }
@@ -125,7 +125,7 @@ namespace System.Xml
                     if (_decoder == _base64Decoder)
                     {
                         // read more binary data
-                        return await ReadElementContentAsBinaryAsync(buffer, index, count).ConfigureAwait(false);
+                        return await ReadElementContentAsBinaryAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     break;
                 default:
@@ -139,7 +139,7 @@ namespace System.Xml
             InitBase64Decoder();
 
             // read more binary data
-            return await ReadElementContentAsBinaryAsync(buffer, index, count).ConfigureAwait(false);
+            return await ReadElementContentAsBinaryAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         internal async Task<int> ReadElementContentAsBinHexAsync(byte[] buffer, int index, int count) // only ever awaited, so no need to separate out argument handling
@@ -157,7 +157,7 @@ namespace System.Xml
                     {
                         throw _reader.CreateReadElementContentAsException(nameof(ReadElementContentAsBinHex));
                     }
-                    if (!await InitOnElementAsync().ConfigureAwait(false))
+                    if (!await InitOnElementAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         return 0;
                     }
@@ -169,7 +169,7 @@ namespace System.Xml
                     if (_decoder == _binHexDecoder)
                     {
                         // read more binary data
-                        return await ReadElementContentAsBinaryAsync(buffer, index, count).ConfigureAwait(false);
+                        return await ReadElementContentAsBinaryAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     break;
                 default:
@@ -183,14 +183,14 @@ namespace System.Xml
             InitBinHexDecoder();
 
             // read more binary data
-            return await ReadElementContentAsBinaryAsync(buffer, index, count).ConfigureAwait(false);
+            return await ReadElementContentAsBinaryAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         internal async Task FinishAsync()
         {
             if (_state != State.None)
             {
-                while (await MoveToNextContentNodeAsync(true).ConfigureAwait(false))
+                while (await MoveToNextContentNodeAsync(true).ConfigureAwait(OperatingSystem.IsBrowser()))
                     ;
                 if (_state == State.InReadElementContent)
                 {
@@ -199,7 +199,7 @@ namespace System.Xml
                         throw new XmlException(SR.Xml_InvalidNodeType, _reader.NodeType.ToString(), _reader as IXmlLineInfo);
                     }
                     // move off the EndElement
-                    await _reader.ReadAsync().ConfigureAwait(false);
+                    await _reader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             Reset();
@@ -209,7 +209,7 @@ namespace System.Xml
         private async Task<bool> InitAsync()
         {
             // make sure we are on a content node
-            if (!await MoveToNextContentNodeAsync(false).ConfigureAwait(false))
+            if (!await MoveToNextContentNodeAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()))
             {
                 return false;
             }
@@ -225,21 +225,21 @@ namespace System.Xml
             bool isEmpty = _reader.IsEmptyElement;
 
             // move to content or off the empty element
-            await _reader.ReadAsync().ConfigureAwait(false);
+            await _reader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             if (isEmpty)
             {
                 return false;
             }
 
             // make sure we are on a content node
-            if (!await MoveToNextContentNodeAsync(false).ConfigureAwait(false))
+            if (!await MoveToNextContentNodeAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()))
             {
                 if (_reader.NodeType != XmlNodeType.EndElement)
                 {
                     throw new XmlException(SR.Xml_InvalidNodeType, _reader.NodeType.ToString(), _reader as IXmlLineInfo);
                 }
                 // move off end element
-                await _reader.ReadAsync().ConfigureAwait(false);
+                await _reader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 return false;
             }
             _state = State.InReadElementContent;
@@ -275,7 +275,7 @@ namespace System.Xml
                             return _decoder.DecodedCount;
                         }
                         Debug.Assert(_valueOffset == _valueChunkLength);
-                        if ((_valueChunkLength = await _reader.ReadValueChunkAsync(_valueChunk!, 0, ChunkSize).ConfigureAwait(false)) == 0)
+                        if ((_valueChunkLength = await _reader.ReadValueChunkAsync(_valueChunk!, 0, ChunkSize).ConfigureAwait(OperatingSystem.IsBrowser())) == 0)
                         {
                             break;
                         }
@@ -285,7 +285,7 @@ namespace System.Xml
                 else
                 {
                     // read what is reader.Value
-                    string value = await _reader.GetValueAsync().ConfigureAwait(false);
+                    string value = await _reader.GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     int decodedCharsCount = _decoder.Decode(value, _valueOffset, value.Length - _valueOffset);
                     _valueOffset += decodedCharsCount;
 
@@ -298,7 +298,7 @@ namespace System.Xml
                 _valueOffset = 0;
 
                 // move to next textual node in the element content; throw on sub elements
-                if (!await MoveToNextContentNodeAsync(true).ConfigureAwait(false))
+                if (!await MoveToNextContentNodeAsync(true).ConfigureAwait(OperatingSystem.IsBrowser()))
                 {
                     _isEnd = true;
                     return _decoder.DecodedCount;
@@ -313,7 +313,7 @@ namespace System.Xml
                 return 0;
             }
             // read binary
-            int decoded = await ReadContentAsBinaryAsync(buffer, index, count).ConfigureAwait(false);
+            int decoded = await ReadContentAsBinaryAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
             if (decoded > 0)
             {
                 return decoded;
@@ -326,7 +326,7 @@ namespace System.Xml
             }
 
             // move off the EndElement
-            await _reader.ReadAsync().ConfigureAwait(false);
+            await _reader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             _state = State.None;
             return 0;
         }
@@ -364,7 +364,7 @@ namespace System.Xml
                         return false;
                 }
                 moveIfOnContentNode = false;
-            } while (await _reader.ReadAsync().ConfigureAwait(false));
+            } while (await _reader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser()));
             return false;
         }
     }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlCharCheckingReaderAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlCharCheckingReaderAsync.cs
@@ -35,13 +35,13 @@ namespace System.Xml
                     _state = State.Interactive;
                     if (_readBinaryHelper != null)
                     {
-                        await _readBinaryHelper.FinishAsync().ConfigureAwait(false);
+                        await _readBinaryHelper.FinishAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     _state = State.Interactive;
                     goto case State.Interactive;
 
                 case State.Interactive:
-                    if (!await base.reader.ReadAsync().ConfigureAwait(false))
+                    if (!await base.reader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         return false;
                     }
@@ -61,19 +61,19 @@ namespace System.Xml
                     case XmlNodeType.Comment:
                         if (_ignoreComments)
                         {
-                            return await ReadAsync().ConfigureAwait(false);
+                            return await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                         break;
                     case XmlNodeType.Whitespace:
                         if (_ignoreWhitespace)
                         {
-                            return await ReadAsync().ConfigureAwait(false);
+                            return await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                         break;
                     case XmlNodeType.ProcessingInstruction:
                         if (_ignorePis)
                         {
-                            return await ReadAsync().ConfigureAwait(false);
+                            return await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                         break;
                     case XmlNodeType.DocumentType:
@@ -83,7 +83,7 @@ namespace System.Xml
                         }
                         else if (_dtdProcessing == DtdProcessing.Ignore)
                         {
-                            return await ReadAsync().ConfigureAwait(false);
+                            return await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                         break;
                 }
@@ -117,7 +117,7 @@ namespace System.Xml
                     case XmlNodeType.CDATA:
                         if (_checkCharacters)
                         {
-                            CheckCharacters(await base.reader.GetValueAsync().ConfigureAwait(false));
+                            CheckCharacters(await base.reader.GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser()));
                         }
                         break;
 
@@ -132,7 +132,7 @@ namespace System.Xml
                     case XmlNodeType.ProcessingInstruction:
                         if (_ignorePis)
                         {
-                            return await ReadAsync().ConfigureAwait(false);
+                            return await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                         if (_checkCharacters)
                         {
@@ -144,7 +144,7 @@ namespace System.Xml
                     case XmlNodeType.Comment:
                         if (_ignoreComments)
                         {
-                            return await ReadAsync().ConfigureAwait(false);
+                            return await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                         if (_checkCharacters)
                         {
@@ -159,7 +159,7 @@ namespace System.Xml
                         }
                         else if (_dtdProcessing == DtdProcessing.Ignore)
                         {
-                            return await ReadAsync().ConfigureAwait(false);
+                            return await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                         if (_checkCharacters)
                         {
@@ -187,18 +187,18 @@ namespace System.Xml
                     case XmlNodeType.Whitespace:
                         if (_ignoreWhitespace)
                         {
-                            return await ReadAsync().ConfigureAwait(false);
+                            return await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                         if (_checkCharacters)
                         {
-                            CheckWhitespace(await base.reader.GetValueAsync().ConfigureAwait(false));
+                            CheckWhitespace(await base.reader.GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser()));
                         }
                         break;
 
                     case XmlNodeType.SignificantWhitespace:
                         if (_checkCharacters)
                         {
-                            CheckWhitespace(await base.reader.GetValueAsync().ConfigureAwait(false));
+                            CheckWhitespace(await base.reader.GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser()));
                         }
                         break;
 
@@ -232,7 +232,7 @@ namespace System.Xml
                 {
                     _readBinaryHelper = null;
                     _state = State.InReadBinary;
-                    return await base.ReadContentAsBase64Async(buffer, index, count).ConfigureAwait(false);
+                    return await base.ReadContentAsBase64Async(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 // the wrapped reader cannot read chunks or we are on an element where we should check characters or ignore whitespace
                 else
@@ -245,7 +245,7 @@ namespace System.Xml
                 // forward calls into wrapped reader
                 if (_readBinaryHelper == null)
                 {
-                    return await base.ReadContentAsBase64Async(buffer, index, count).ConfigureAwait(false);
+                    return await base.ReadContentAsBase64Async(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
 
@@ -253,7 +253,7 @@ namespace System.Xml
             _state = State.Interactive;
 
             // call to the helper
-            int readCount = await _readBinaryHelper.ReadContentAsBase64Async(buffer, index, count).ConfigureAwait(false);
+            int readCount = await _readBinaryHelper.ReadContentAsBase64Async(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
 
             // turn on InReadBinary in again and return
             _state = State.InReadBinary;
@@ -275,7 +275,7 @@ namespace System.Xml
                 {
                     _readBinaryHelper = null;
                     _state = State.InReadBinary;
-                    return await base.ReadContentAsBinHexAsync(buffer, index, count).ConfigureAwait(false);
+                    return await base.ReadContentAsBinHexAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 // the wrapped reader cannot read chunks or we are on an element where we should check characters or ignore whitespace
                 else
@@ -288,7 +288,7 @@ namespace System.Xml
                 // forward calls into wrapped reader
                 if (_readBinaryHelper == null)
                 {
-                    return await base.ReadContentAsBinHexAsync(buffer, index, count).ConfigureAwait(false);
+                    return await base.ReadContentAsBinHexAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
 
@@ -296,7 +296,7 @@ namespace System.Xml
             _state = State.Interactive;
 
             // call to the helper
-            int readCount = await _readBinaryHelper.ReadContentAsBinHexAsync(buffer, index, count).ConfigureAwait(false);
+            int readCount = await _readBinaryHelper.ReadContentAsBinHexAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
 
             // turn on InReadBinary in again and return
             _state = State.InReadBinary;
@@ -328,7 +328,7 @@ namespace System.Xml
                     {
                         _readBinaryHelper = null;
                         _state = State.InReadBinary;
-                        return await base.ReadElementContentAsBase64Async(buffer, index, count).ConfigureAwait(false);
+                        return await base.ReadElementContentAsBase64Async(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     // the wrapped reader cannot read chunks or we are on an element where we should check characters or ignore whitespace
                     else
@@ -341,7 +341,7 @@ namespace System.Xml
                     // forward calls into wrapped reader
                     if (_readBinaryHelper == null)
                     {
-                        return await base.ReadElementContentAsBase64Async(buffer, index, count).ConfigureAwait(false);
+                        return await base.ReadElementContentAsBase64Async(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                 }
 
@@ -349,7 +349,7 @@ namespace System.Xml
                 _state = State.Interactive;
 
                 // call to the helper
-                int readCount = await _readBinaryHelper.ReadElementContentAsBase64Async(buffer, index, count).ConfigureAwait(false);
+                int readCount = await _readBinaryHelper.ReadElementContentAsBase64Async(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
 
                 // turn on InReadBinary in again and return
                 _state = State.InReadBinary;
@@ -382,7 +382,7 @@ namespace System.Xml
                     {
                         _readBinaryHelper = null;
                         _state = State.InReadBinary;
-                        return await base.ReadElementContentAsBinHexAsync(buffer, index, count).ConfigureAwait(false);
+                        return await base.ReadElementContentAsBinHexAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     // the wrapped reader cannot read chunks or we are on an element where we should check characters or ignore whitespace
                     else
@@ -395,7 +395,7 @@ namespace System.Xml
                     // forward calls into wrapped reader
                     if (_readBinaryHelper == null)
                     {
-                        return await base.ReadElementContentAsBinHexAsync(buffer, index, count).ConfigureAwait(false);
+                        return await base.ReadElementContentAsBinHexAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                 }
 
@@ -403,7 +403,7 @@ namespace System.Xml
                 _state = State.Interactive;
 
                 // call to the helper
-                int readCount = await _readBinaryHelper.ReadElementContentAsBinHexAsync(buffer, index, count).ConfigureAwait(false);
+                int readCount = await _readBinaryHelper.ReadElementContentAsBinHexAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
 
                 // turn on InReadBinary in again and return
                 _state = State.InReadBinary;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlCharCheckingWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlCharCheckingWriterAsync.cs
@@ -112,12 +112,12 @@ namespace System.Xml
                 int i;
                 while ((i = text.IndexOf("]]>", StringComparison.Ordinal)) >= 0)
                 {
-                    await writer.WriteCDataAsync(text.Substring(0, i + 2)).ConfigureAwait(false);
+                    await writer.WriteCDataAsync(text.Substring(0, i + 2)).ConfigureAwait(OperatingSystem.IsBrowser());
                     text = text.Substring(i + 2);
                 }
             }
 
-            await writer.WriteCDataAsync(text).ConfigureAwait(false);
+            await writer.WriteCDataAsync(text).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         public override Task WriteCommentAsync(string? text)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriterAsync.cs
@@ -37,26 +37,26 @@ namespace System.Xml
             if (!_omitXmlDeclaration && !_autoXmlDeclaration)
             {
                 if (_trackTextContent && _inTextContent) { ChangeTextContentMark(false); }
-                await RawTextAsync("<?xml version=\"").ConfigureAwait(false);
+                await RawTextAsync("<?xml version=\"").ConfigureAwait(OperatingSystem.IsBrowser());
 
                 // Version
-                await RawTextAsync("1.0").ConfigureAwait(false);
+                await RawTextAsync("1.0").ConfigureAwait(OperatingSystem.IsBrowser());
 
                 // Encoding
                 if (_encoding != null)
                 {
-                    await RawTextAsync("\" encoding=\"").ConfigureAwait(false);
-                    await RawTextAsync(_encoding.WebName).ConfigureAwait(false);
+                    await RawTextAsync("\" encoding=\"").ConfigureAwait(OperatingSystem.IsBrowser());
+                    await RawTextAsync(_encoding.WebName).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
 
                 // Standalone
                 if (standalone != XmlStandalone.Omit)
                 {
-                    await RawTextAsync("\" standalone=\"").ConfigureAwait(false);
-                    await RawTextAsync(standalone == XmlStandalone.Yes ? "yes" : "no").ConfigureAwait(false);
+                    await RawTextAsync("\" standalone=\"").ConfigureAwait(OperatingSystem.IsBrowser());
+                    await RawTextAsync(standalone == XmlStandalone.Yes ? "yes" : "no").ConfigureAwait(OperatingSystem.IsBrowser());
                 }
 
-                await RawTextAsync("\"?>").ConfigureAwait(false);
+                await RawTextAsync("\"?>").ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -76,7 +76,7 @@ namespace System.Xml
         {
             try
             {
-                await FlushBufferAsync().ConfigureAwait(false);
+                await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
             finally
             {
@@ -87,7 +87,7 @@ namespace System.Xml
                 {
                     try
                     {
-                        await _stream.FlushAsync().ConfigureAwait(false);
+                        await _stream.FlushAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     finally
                     {
@@ -95,7 +95,7 @@ namespace System.Xml
                         {
                             if (_closeOutput)
                             {
-                                await _stream.DisposeAsync().ConfigureAwait(false);
+                                await _stream.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                             }
                         }
                         finally
@@ -108,7 +108,7 @@ namespace System.Xml
                 {
                     try
                     {
-                        await _writer.FlushAsync().ConfigureAwait(false);
+                        await _writer.FlushAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     finally
                     {
@@ -116,7 +116,7 @@ namespace System.Xml
                         {
                             if (_closeOutput)
                             {
-                                await _writer.DisposeAsync().ConfigureAwait(false);
+                                await _writer.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                             }
                         }
                         finally
@@ -136,23 +136,23 @@ namespace System.Xml
 
             if (_trackTextContent && _inTextContent) { ChangeTextContentMark(false); }
 
-            await RawTextAsync("<!DOCTYPE ").ConfigureAwait(false);
-            await RawTextAsync(name).ConfigureAwait(false);
+            await RawTextAsync("<!DOCTYPE ").ConfigureAwait(OperatingSystem.IsBrowser());
+            await RawTextAsync(name).ConfigureAwait(OperatingSystem.IsBrowser());
             if (pubid != null)
             {
-                await RawTextAsync(" PUBLIC \"").ConfigureAwait(false);
-                await RawTextAsync(pubid).ConfigureAwait(false);
-                await RawTextAsync("\" \"").ConfigureAwait(false);
+                await RawTextAsync(" PUBLIC \"").ConfigureAwait(OperatingSystem.IsBrowser());
+                await RawTextAsync(pubid).ConfigureAwait(OperatingSystem.IsBrowser());
+                await RawTextAsync("\" \"").ConfigureAwait(OperatingSystem.IsBrowser());
                 if (sysid != null)
                 {
-                    await RawTextAsync(sysid).ConfigureAwait(false);
+                    await RawTextAsync(sysid).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 _bufChars[_bufPos++] = (char)'"';
             }
             else if (sysid != null)
             {
-                await RawTextAsync(" SYSTEM \"").ConfigureAwait(false);
-                await RawTextAsync(sysid).ConfigureAwait(false);
+                await RawTextAsync(" SYSTEM \"").ConfigureAwait(OperatingSystem.IsBrowser());
+                await RawTextAsync(sysid).ConfigureAwait(OperatingSystem.IsBrowser());
                 _bufChars[_bufPos++] = (char)'"';
             }
             else
@@ -163,7 +163,7 @@ namespace System.Xml
             if (subset != null)
             {
                 _bufChars[_bufPos++] = (char)'[';
-                await RawTextAsync(subset).ConfigureAwait(false);
+                await RawTextAsync(subset).ConfigureAwait(OperatingSystem.IsBrowser());
                 _bufChars[_bufPos++] = (char)']';
             }
 
@@ -306,9 +306,9 @@ namespace System.Xml
             CheckAsyncCall();
             Debug.Assert(prefix != null && namespaceName != null);
 
-            await WriteStartNamespaceDeclarationAsync(prefix).ConfigureAwait(false);
-            await WriteStringAsync(namespaceName).ConfigureAwait(false);
-            await WriteEndNamespaceDeclarationAsync().ConfigureAwait(false);
+            await WriteStartNamespaceDeclarationAsync(prefix).ConfigureAwait(OperatingSystem.IsBrowser());
+            await WriteStringAsync(namespaceName).ConfigureAwait(OperatingSystem.IsBrowser());
+            await WriteEndNamespaceDeclarationAsync().ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         internal override async Task WriteStartNamespaceDeclarationAsync(string prefix)
@@ -325,12 +325,12 @@ namespace System.Xml
 
             if (prefix.Length == 0)
             {
-                await RawTextAsync("xmlns=\"").ConfigureAwait(false);
+                await RawTextAsync("xmlns=\"").ConfigureAwait(OperatingSystem.IsBrowser());
             }
             else
             {
-                await RawTextAsync("xmlns:").ConfigureAwait(false);
-                await RawTextAsync(prefix).ConfigureAwait(false);
+                await RawTextAsync("xmlns:").ConfigureAwait(OperatingSystem.IsBrowser());
+                await RawTextAsync(prefix).ConfigureAwait(OperatingSystem.IsBrowser());
                 _bufChars[_bufPos++] = (char)'=';
                 _bufChars[_bufPos++] = (char)'"';
             }
@@ -383,7 +383,7 @@ namespace System.Xml
                 _bufChars[_bufPos++] = (char)'[';
             }
 
-            await WriteCDataSectionAsync(text).ConfigureAwait(false);
+            await WriteCDataSectionAsync(text).ConfigureAwait(OperatingSystem.IsBrowser());
 
             _bufChars[_bufPos++] = (char)']';
             _bufChars[_bufPos++] = (char)']';
@@ -406,7 +406,7 @@ namespace System.Xml
             _bufChars[_bufPos++] = (char)'-';
             _bufChars[_bufPos++] = (char)'-';
 
-            await WriteCommentOrPiAsync(text, '-').ConfigureAwait(false);
+            await WriteCommentOrPiAsync(text, '-').ConfigureAwait(OperatingSystem.IsBrowser());
 
             _bufChars[_bufPos++] = (char)'-';
             _bufChars[_bufPos++] = (char)'-';
@@ -424,12 +424,12 @@ namespace System.Xml
 
             _bufChars[_bufPos++] = (char)'<';
             _bufChars[_bufPos++] = (char)'?';
-            await RawTextAsync(name).ConfigureAwait(false);
+            await RawTextAsync(name).ConfigureAwait(OperatingSystem.IsBrowser());
 
             if (text.Length > 0)
             {
                 _bufChars[_bufPos++] = (char)' ';
-                await WriteCommentOrPiAsync(text, '?').ConfigureAwait(false);
+                await WriteCommentOrPiAsync(text, '?').ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             _bufChars[_bufPos++] = (char)'?';
@@ -445,12 +445,12 @@ namespace System.Xml
             if (_trackTextContent && _inTextContent) { ChangeTextContentMark(false); }
 
             _bufChars[_bufPos++] = (char)'&';
-            await RawTextAsync(name).ConfigureAwait(false);
+            await RawTextAsync(name).ConfigureAwait(OperatingSystem.IsBrowser());
             _bufChars[_bufPos++] = (char)';';
 
             if (_bufPos > _bufLen)
             {
-                await FlushBufferAsync().ConfigureAwait(false);
+                await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             _textPos = _bufPos;
@@ -473,12 +473,12 @@ namespace System.Xml
             _bufChars[_bufPos++] = (char)'&';
             _bufChars[_bufPos++] = (char)'#';
             _bufChars[_bufPos++] = (char)'x';
-            await RawTextAsync(strVal).ConfigureAwait(false);
+            await RawTextAsync(strVal).ConfigureAwait(OperatingSystem.IsBrowser());
             _bufChars[_bufPos++] = (char)';';
 
             if (_bufPos > _bufLen)
             {
-                await FlushBufferAsync().ConfigureAwait(false);
+                await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             _textPos = _bufPos;
@@ -534,7 +534,7 @@ namespace System.Xml
             _bufChars[_bufPos++] = (char)'&';
             _bufChars[_bufPos++] = (char)'#';
             _bufChars[_bufPos++] = (char)'x';
-            await RawTextAsync(surrogateChar.ToString("X", NumberFormatInfo.InvariantInfo)).ConfigureAwait(false);
+            await RawTextAsync(surrogateChar.ToString("X", NumberFormatInfo.InvariantInfo)).ConfigureAwait(OperatingSystem.IsBrowser());
             _bufChars[_bufPos++] = (char)';';
             _textPos = _bufPos;
         }
@@ -573,7 +573,7 @@ namespace System.Xml
 
             if (_trackTextContent && _inTextContent) { ChangeTextContentMark(false); }
 
-            await WriteRawWithCharCheckingAsync(buffer, index, count).ConfigureAwait(false);
+            await WriteRawWithCharCheckingAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
 
             _textPos = _bufPos;
         }
@@ -587,7 +587,7 @@ namespace System.Xml
 
             if (_trackTextContent && _inTextContent) { ChangeTextContentMark(false); }
 
-            await WriteRawWithCharCheckingAsync(data).ConfigureAwait(false);
+            await WriteRawWithCharCheckingAsync(data).ConfigureAwait(OperatingSystem.IsBrowser());
 
             _textPos = _bufPos;
         }
@@ -596,16 +596,16 @@ namespace System.Xml
         public override async Task FlushAsync()
         {
             CheckAsyncCall();
-            await FlushBufferAsync().ConfigureAwait(false);
-            await FlushEncoderAsync().ConfigureAwait(false);
+            await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+            await FlushEncoderAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
             if (_stream != null)
             {
-                await _stream.FlushAsync().ConfigureAwait(false);
+                await _stream.FlushAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
             else if (_writer != null)
             {
-                await _writer.FlushAsync().ConfigureAwait(false);
+                await _writer.FlushAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -642,14 +642,14 @@ namespace System.Xml
                             }
                             Debug.Assert(_textContentMarks![0] == 1);
                         }
-                        await EncodeCharsAsync(1, _bufPos, true).ConfigureAwait(false);
+                        await EncodeCharsAsync(1, _bufPos, true).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     else
                     {
                         if (_bufPos - 1 > 0)
                         {
                             // Write text to TextWriter
-                            await _writer!.WriteAsync(_bufChars.AsMemory(1, _bufPos - 1)).ConfigureAwait(false);
+                            await _writer!.WriteAsync(_bufChars.AsMemory(1, _bufPos - 1)).ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                     }
                 }
@@ -691,13 +691,13 @@ namespace System.Xml
                 _bufBytesUsed += bEnc;
                 if (_bufBytesUsed >= (_bufBytes.Length - 16))
                 {
-                    await _stream!.WriteAsync(_bufBytes.AsMemory(0, _bufBytesUsed)).ConfigureAwait(false);
+                    await _stream!.WriteAsync(_bufBytes.AsMemory(0, _bufBytesUsed)).ConfigureAwait(OperatingSystem.IsBrowser());
                     _bufBytesUsed = 0;
                 }
             }
             if (writeAllToStream && _bufBytesUsed > 0)
             {
-                await _stream!.WriteAsync(_bufBytes.AsMemory(0, _bufBytesUsed)).ConfigureAwait(false);
+                await _stream!.WriteAsync(_bufBytes.AsMemory(0, _bufBytesUsed)).ConfigureAwait(OperatingSystem.IsBrowser());
                 _bufBytesUsed = 0;
             }
         }
@@ -884,7 +884,7 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0);
         }
@@ -909,7 +909,7 @@ namespace System.Xml
         private async Task _WriteAttributeTextBlockAsync(string text, int curIndex, int leftCount)
         {
             int writeLen;
-            await FlushBufferAsync().ConfigureAwait(false);
+            await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             do
             {
                 writeLen = WriteAttributeTextBlockNoFlush(text, curIndex, leftCount);
@@ -917,7 +917,7 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0);
         }
@@ -1097,13 +1097,13 @@ namespace System.Xml
                 if (needWriteNewLine)
                 {
                     //hit WriteNewLine
-                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
                     curIndex++;
                     leftCount--;
                 }
                 else if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0 || needWriteNewLine);
         }
@@ -1137,13 +1137,13 @@ namespace System.Xml
 
             if (newLine)
             {
-                await RawTextAsync(_newLineChars).ConfigureAwait(false);
+                await RawTextAsync(_newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
                 curIndex++;
                 leftCount--;
             }
             else
             {
-                await FlushBufferAsync().ConfigureAwait(false);
+                await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             do
@@ -1154,13 +1154,13 @@ namespace System.Xml
                 if (needWriteNewLine)
                 {
                     //hit WriteNewLine
-                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
                     curIndex++;
                     leftCount--;
                 }
                 else if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0 || needWriteNewLine);
         }
@@ -1319,7 +1319,7 @@ namespace System.Xml
             Debug.Assert(text3 != null || (text4 == null));
 
             // Write out the remainder of the first string
-            await FlushBufferAsync().ConfigureAwait(false);
+            await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             int writeLen;
             do
             {
@@ -1328,14 +1328,14 @@ namespace System.Xml
                 leftCount1 -= writeLen;
                 if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0);
 
             // If there are additional strings, write them out as well
             if (text2 != null)
             {
-                await RawTextAsync(text2, text3, text4).ConfigureAwait(false);
+                await RawTextAsync(text2, text3, text4).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -1495,13 +1495,13 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (needWriteNewLine)
                 {
-                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
                     curIndex++;
                     leftCount--;
                 }
                 else if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0 || needWriteNewLine);
         }
@@ -1519,13 +1519,13 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (needWriteNewLine)
                 {
-                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
                     curIndex++;
                     leftCount--;
                 }
                 else if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0 || needWriteNewLine);
         }
@@ -1690,7 +1690,7 @@ namespace System.Xml
             {
                 if (_bufPos >= _bufLen)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 return;
             }
@@ -1706,13 +1706,13 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (needWriteNewLine)
                 {
-                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
                     curIndex++;
                     leftCount--;
                 }
                 else if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0 || needWriteNewLine);
         }
@@ -1874,7 +1874,7 @@ namespace System.Xml
             {
                 if (_bufPos >= _bufLen)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 return;
             }
@@ -1890,13 +1890,13 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (needWriteNewLine)
                 {
-                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
                     curIndex++;
                     leftCount--;
                 }
                 else if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0 || needWriteNewLine);
         }
@@ -1911,9 +1911,9 @@ namespace System.Xml
             // Add indentation
             if (!_mixedContent && base._textPos != base._bufPos)
             {
-                await WriteIndentAsync().ConfigureAwait(false);
+                await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
-            await base.WriteDocTypeAsync(name, pubid, sysid, subset).ConfigureAwait(false);
+            await base.WriteDocTypeAsync(name, pubid, sysid, subset).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         public override async Task WriteStartElementAsync(string? prefix, string localName, string? ns)
@@ -1924,12 +1924,12 @@ namespace System.Xml
             // Add indentation
             if (!_mixedContent && base._textPos != base._bufPos)
             {
-                await WriteIndentAsync().ConfigureAwait(false);
+                await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
             _indentLevel++;
             _mixedContentStack.PushBit(_mixedContent);
 
-            await base.WriteStartElementAsync(prefix, localName, ns).ConfigureAwait(false);
+            await base.WriteStartElementAsync(prefix, localName, ns).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         internal override async Task WriteEndElementAsync(string prefix, string localName, string ns)
@@ -1942,12 +1942,12 @@ namespace System.Xml
                 // There was content, so try to indent
                 if (base._textPos != base._bufPos)
                 {
-                    await WriteIndentAsync().ConfigureAwait(false);
+                    await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             _mixedContent = _mixedContentStack.PopBit();
 
-            await base.WriteEndElementAsync(prefix, localName, ns).ConfigureAwait(false);
+            await base.WriteEndElementAsync(prefix, localName, ns).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         internal override async Task WriteFullEndElementAsync(string prefix, string localName, string ns)
@@ -1960,12 +1960,12 @@ namespace System.Xml
                 // There was content, so try to indent
                 if (base._textPos != base._bufPos)
                 {
-                    await WriteIndentAsync().ConfigureAwait(false);
+                    await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             _mixedContent = _mixedContentStack.PopBit();
 
-            await base.WriteFullEndElementAsync(prefix, localName, ns).ConfigureAwait(false);
+            await base.WriteFullEndElementAsync(prefix, localName, ns).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         // Same as base class, plus possible indentation.
@@ -1975,10 +1975,10 @@ namespace System.Xml
             // Add indentation
             if (_newLineOnAttributes)
             {
-                await WriteIndentAsync().ConfigureAwait(false);
+                await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
-            await base.WriteStartAttributeAsync(prefix, localName, ns).ConfigureAwait(false);
+            await base.WriteStartAttributeAsync(prefix, localName, ns).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         // Same as base class, plus possible indentation.
@@ -1988,10 +1988,10 @@ namespace System.Xml
             // Add indentation
             if (_newLineOnAttributes)
             {
-                await WriteIndentAsync().ConfigureAwait(false);
+                await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
-            await base.WriteStartNamespaceDeclarationAsync(prefix).ConfigureAwait(false);
+            await base.WriteStartNamespaceDeclarationAsync(prefix).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         public override Task WriteCDataAsync(string? text)
@@ -2006,10 +2006,10 @@ namespace System.Xml
             CheckAsyncCall();
             if (!_mixedContent && base._textPos != base._bufPos)
             {
-                await WriteIndentAsync().ConfigureAwait(false);
+                await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
-            await base.WriteCommentAsync(text).ConfigureAwait(false);
+            await base.WriteCommentAsync(text).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         public override async Task WriteProcessingInstructionAsync(string target, string? text)
@@ -2017,10 +2017,10 @@ namespace System.Xml
             CheckAsyncCall();
             if (!_mixedContent && base._textPos != base._bufPos)
             {
-                await WriteIndentAsync().ConfigureAwait(false);
+                await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
-            await base.WriteProcessingInstructionAsync(target, text).ConfigureAwait(false);
+            await base.WriteProcessingInstructionAsync(target, text).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         public override Task WriteEntityRefAsync(string name)
@@ -2090,10 +2090,10 @@ namespace System.Xml
         private async Task WriteIndentAsync()
         {
             CheckAsyncCall();
-            await RawTextAsync(base._newLineChars).ConfigureAwait(false);
+            await RawTextAsync(base._newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
             for (int i = _indentLevel; i > 0; i--)
             {
-                await RawTextAsync(_indentChars).ConfigureAwait(false);
+                await RawTextAsync(_indentChars).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
     }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGeneratorAsync.ttinclude
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGeneratorAsync.ttinclude
@@ -38,26 +38,26 @@ namespace System.Xml
             if (!_omitXmlDeclaration && !_autoXmlDeclaration)
             {<# /* Code block is to squash extra line. */
 #><#= SetTextContentMark(4, 1, false) #>
-                await RawTextAsync("<?xml version=\"").ConfigureAwait(false);
+                await RawTextAsync("<?xml version=\"").ConfigureAwait(OperatingSystem.IsBrowser());
 
                 // Version
-                await RawTextAsync("1.0").ConfigureAwait(false);
+                await RawTextAsync("1.0").ConfigureAwait(OperatingSystem.IsBrowser());
 
                 // Encoding
                 if (_encoding != null)
                 {
-                    await RawTextAsync("\" encoding=\"").ConfigureAwait(false);
-                    await RawTextAsync(_encoding.WebName).ConfigureAwait(false);
+                    await RawTextAsync("\" encoding=\"").ConfigureAwait(OperatingSystem.IsBrowser());
+                    await RawTextAsync(_encoding.WebName).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
 
                 // Standalone
                 if (standalone != XmlStandalone.Omit)
                 {
-                    await RawTextAsync("\" standalone=\"").ConfigureAwait(false);
-                    await RawTextAsync(standalone == XmlStandalone.Yes ? "yes" : "no").ConfigureAwait(false);
+                    await RawTextAsync("\" standalone=\"").ConfigureAwait(OperatingSystem.IsBrowser());
+                    await RawTextAsync(standalone == XmlStandalone.Yes ? "yes" : "no").ConfigureAwait(OperatingSystem.IsBrowser());
                 }
 
-                await RawTextAsync("\"?>").ConfigureAwait(false);
+                await RawTextAsync("\"?>").ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -77,7 +77,7 @@ namespace System.Xml
         {
             try
             {
-                await FlushBufferAsync().ConfigureAwait(false);
+                await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
             finally
             {
@@ -88,7 +88,7 @@ namespace System.Xml
                 {
                     try
                     {
-                        await _stream.FlushAsync().ConfigureAwait(false);
+                        await _stream.FlushAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     finally
                     {
@@ -96,7 +96,7 @@ namespace System.Xml
                         {
                             if (_closeOutput)
                             {
-                                await _stream.DisposeAsync().ConfigureAwait(false);
+                                await _stream.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                             }
                         }
                         finally
@@ -110,7 +110,7 @@ namespace System.Xml
                 {
                     try
                     {
-                        await _writer.FlushAsync().ConfigureAwait(false);
+                        await _writer.FlushAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     finally
                     {
@@ -118,7 +118,7 @@ namespace System.Xml
                         {
                             if (_closeOutput)
                             {
-                                await _writer.DisposeAsync().ConfigureAwait(false);
+                                await _writer.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                             }
                         }
                         finally
@@ -139,23 +139,23 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            await RawTextAsync("<!DOCTYPE ").ConfigureAwait(false);
-            await RawTextAsync(name).ConfigureAwait(false);
+            await RawTextAsync("<!DOCTYPE ").ConfigureAwait(OperatingSystem.IsBrowser());
+            await RawTextAsync(name).ConfigureAwait(OperatingSystem.IsBrowser());
             if (pubid != null)
             {
-                await RawTextAsync(" PUBLIC \"").ConfigureAwait(false);
-                await RawTextAsync(pubid).ConfigureAwait(false);
-                await RawTextAsync("\" \"").ConfigureAwait(false);
+                await RawTextAsync(" PUBLIC \"").ConfigureAwait(OperatingSystem.IsBrowser());
+                await RawTextAsync(pubid).ConfigureAwait(OperatingSystem.IsBrowser());
+                await RawTextAsync("\" \"").ConfigureAwait(OperatingSystem.IsBrowser());
                 if (sysid != null)
                 {
-                    await RawTextAsync(sysid).ConfigureAwait(false);
+                    await RawTextAsync(sysid).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'"';
             }
             else if (sysid != null)
             {
-                await RawTextAsync(" SYSTEM \"").ConfigureAwait(false);
-                await RawTextAsync(sysid).ConfigureAwait(false);
+                await RawTextAsync(" SYSTEM \"").ConfigureAwait(OperatingSystem.IsBrowser());
+                await RawTextAsync(sysid).ConfigureAwait(OperatingSystem.IsBrowser());
                 <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'"';
             }
             else
@@ -166,7 +166,7 @@ namespace System.Xml
             if (subset != null)
             {
                 <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'[';
-                await RawTextAsync(subset).ConfigureAwait(false);
+                await RawTextAsync(subset).ConfigureAwait(OperatingSystem.IsBrowser());
                 <#= BufferName #>[_bufPos++] = (<#= BufferType #>)']';
             }
 
@@ -309,9 +309,9 @@ namespace System.Xml
             CheckAsyncCall();
             Debug.Assert(prefix != null && namespaceName != null);
 
-            await WriteStartNamespaceDeclarationAsync(prefix).ConfigureAwait(false);
-            await WriteStringAsync(namespaceName).ConfigureAwait(false);
-            await WriteEndNamespaceDeclarationAsync().ConfigureAwait(false);
+            await WriteStartNamespaceDeclarationAsync(prefix).ConfigureAwait(OperatingSystem.IsBrowser());
+            await WriteStringAsync(namespaceName).ConfigureAwait(OperatingSystem.IsBrowser());
+            await WriteEndNamespaceDeclarationAsync().ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         internal override async Task WriteStartNamespaceDeclarationAsync(string prefix)
@@ -328,12 +328,12 @@ namespace System.Xml
 
             if (prefix.Length == 0)
             {
-                await RawTextAsync("xmlns=\"").ConfigureAwait(false);
+                await RawTextAsync("xmlns=\"").ConfigureAwait(OperatingSystem.IsBrowser());
             }
             else
             {
-                await RawTextAsync("xmlns:").ConfigureAwait(false);
-                await RawTextAsync(prefix).ConfigureAwait(false);
+                await RawTextAsync("xmlns:").ConfigureAwait(OperatingSystem.IsBrowser());
+                await RawTextAsync(prefix).ConfigureAwait(OperatingSystem.IsBrowser());
                 <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'=';
                 <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'"';
             }
@@ -385,7 +385,7 @@ namespace System.Xml
                 <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'[';
             }
 
-            await WriteCDataSectionAsync(text).ConfigureAwait(false);
+            await WriteCDataSectionAsync(text).ConfigureAwait(OperatingSystem.IsBrowser());
 
             <#= BufferName #>[_bufPos++] = (<#= BufferType #>)']';
             <#= BufferName #>[_bufPos++] = (<#= BufferType #>)']';
@@ -408,7 +408,7 @@ namespace System.Xml
             <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'-';
             <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'-';
 
-            await WriteCommentOrPiAsync(text, '-').ConfigureAwait(false);
+            await WriteCommentOrPiAsync(text, '-').ConfigureAwait(OperatingSystem.IsBrowser());
 
             <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'-';
             <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'-';
@@ -426,12 +426,12 @@ namespace System.Xml
 
             <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'<';
             <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'?';
-            await RawTextAsync(name).ConfigureAwait(false);
+            await RawTextAsync(name).ConfigureAwait(OperatingSystem.IsBrowser());
 
             if (text.Length > 0)
             {
                 <#= BufferName #>[_bufPos++] = (<#= BufferType #>)' ';
-                await WriteCommentOrPiAsync(text, '?').ConfigureAwait(false);
+                await WriteCommentOrPiAsync(text, '?').ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'?';
@@ -447,12 +447,12 @@ namespace System.Xml
 #><#= SetTextContentMark(3, false) #>
 
             <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'&';
-            await RawTextAsync(name).ConfigureAwait(false);
+            await RawTextAsync(name).ConfigureAwait(OperatingSystem.IsBrowser());
             <#= BufferName #>[_bufPos++] = (<#= BufferType #>)';';
 
             if (_bufPos > _bufLen)
             {
-                await FlushBufferAsync().ConfigureAwait(false);
+                await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             _textPos = _bufPos;
@@ -475,12 +475,12 @@ namespace System.Xml
             <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'&';
             <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'#';
             <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'x';
-            await RawTextAsync(strVal).ConfigureAwait(false);
+            await RawTextAsync(strVal).ConfigureAwait(OperatingSystem.IsBrowser());
             <#= BufferName #>[_bufPos++] = (<#= BufferType #>)';';
 
             if (_bufPos > _bufLen)
             {
-                await FlushBufferAsync().ConfigureAwait(false);
+                await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             _textPos = _bufPos;
@@ -533,7 +533,7 @@ namespace System.Xml
             <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'&';
             <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'#';
             <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'x';
-            await RawTextAsync(surrogateChar.ToString("X", NumberFormatInfo.InvariantInfo)).ConfigureAwait(false);
+            await RawTextAsync(surrogateChar.ToString("X", NumberFormatInfo.InvariantInfo)).ConfigureAwait(OperatingSystem.IsBrowser());
             <#= BufferName #>[_bufPos++] = (<#= BufferType #>)';';
             _textPos = _bufPos;
         }
@@ -572,7 +572,7 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            await WriteRawWithCharCheckingAsync(buffer, index, count).ConfigureAwait(false);
+            await WriteRawWithCharCheckingAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
 
             _textPos = _bufPos;
         }
@@ -586,7 +586,7 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            await WriteRawWithCharCheckingAsync(data).ConfigureAwait(false);
+            await WriteRawWithCharCheckingAsync(data).ConfigureAwait(OperatingSystem.IsBrowser());
 
             _textPos = _bufPos;
         }
@@ -595,19 +595,19 @@ namespace System.Xml
         public override async Task FlushAsync()
         {
             CheckAsyncCall();
-            await FlushBufferAsync().ConfigureAwait(false);
+            await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 <# if (WriterType == RawTextWriterType.Encoded) { #>
-            await FlushEncoderAsync().ConfigureAwait(false);
+            await FlushEncoderAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 <# } #>
 
             if (_stream != null)
             {
-                await _stream.FlushAsync().ConfigureAwait(false);
+                await _stream.FlushAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 <# if (WriterType == RawTextWriterType.Encoded) { #>
             else if (_writer != null)
             {
-                await _writer.FlushAsync().ConfigureAwait(false);
+                await _writer.FlushAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 <# } #>
         }
@@ -627,7 +627,7 @@ namespace System.Xml
                     if (_bufPos - 1 > 0)
                     {
                         Debug.Assert(_stream != null);
-                        await _stream.WriteAsync(_bufBytes.AsMemory(1, _bufPos - 1)).ConfigureAwait(false);
+                        await _stream.WriteAsync(_bufBytes.AsMemory(1, _bufPos - 1)).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
 <# } else { #>
                     Debug.Assert(_stream != null || _writer != null);
@@ -652,14 +652,14 @@ namespace System.Xml
                             }
                             Debug.Assert(_textContentMarks[0] == 1);
                         }
-                        await EncodeCharsAsync(1, _bufPos, true).ConfigureAwait(false);
+                        await EncodeCharsAsync(1, _bufPos, true).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     else
                     {
                         if (_bufPos - 1 > 0)
                         {
                             // Write text to TextWriter
-                            await _writer.WriteAsync(<#= BufferName #>.AsMemory(1, _bufPos - 1)).ConfigureAwait(false);
+                            await _writer.WriteAsync(<#= BufferName #>.AsMemory(1, _bufPos - 1)).ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                     }
 <# } #>
@@ -715,13 +715,13 @@ namespace System.Xml
                 _bufBytesUsed += bEnc;
                 if (_bufBytesUsed >= (_bufBytes.Length - 16))
                 {
-                    await _stream.WriteAsync(_bufBytes.AsMemory(0, _bufBytesUsed)).ConfigureAwait(false);
+                    await _stream.WriteAsync(_bufBytes.AsMemory(0, _bufBytesUsed)).ConfigureAwait(OperatingSystem.IsBrowser());
                     _bufBytesUsed = 0;
                 }
             }
             if (writeAllToStream && _bufBytesUsed > 0)
             {
-                await _stream.WriteAsync(_bufBytes.AsMemory(0, _bufBytesUsed)).ConfigureAwait(false);
+                await _stream.WriteAsync(_bufBytes.AsMemory(0, _bufBytesUsed)).ConfigureAwait(OperatingSystem.IsBrowser());
                 _bufBytesUsed = 0;
             }
         }
@@ -897,7 +897,7 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0);
         }
@@ -922,7 +922,7 @@ namespace System.Xml
         private async Task _WriteAttributeTextBlockAsync(string text, int curIndex, int leftCount)
         {
             int writeLen;
-            await FlushBufferAsync().ConfigureAwait(false);
+            await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             do
             {
                 writeLen = WriteAttributeTextBlockNoFlush(text, curIndex, leftCount);
@@ -930,7 +930,7 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0);
         }
@@ -1096,13 +1096,13 @@ namespace System.Xml
                 if (needWriteNewLine)
                 {
                     //hit WriteNewLine
-                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
                     curIndex++;
                     leftCount--;
                 }
                 else if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0 || needWriteNewLine);
         }
@@ -1136,13 +1136,13 @@ namespace System.Xml
 
             if (newLine)
             {
-                await RawTextAsync(_newLineChars).ConfigureAwait(false);
+                await RawTextAsync(_newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
                 curIndex++;
                 leftCount--;
             }
             else
             {
-                await FlushBufferAsync().ConfigureAwait(false);
+                await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             do
@@ -1153,13 +1153,13 @@ namespace System.Xml
                 if (needWriteNewLine)
                 {
                     //hit WriteNewLine
-                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
                     curIndex++;
                     leftCount--;
                 }
                 else if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0 || needWriteNewLine);
         }
@@ -1304,7 +1304,7 @@ namespace System.Xml
             Debug.Assert(text3 != null || (text4 == null));
 
             // Write out the remainder of the first string
-            await FlushBufferAsync().ConfigureAwait(false);
+            await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             int writeLen = 0;
             do
             {
@@ -1313,14 +1313,14 @@ namespace System.Xml
                 leftCount1 -= writeLen;
                 if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0);
 
             // If there are additional strings, write them out as well
             if (text2 != null)
             {
-                await RawTextAsync(text2, text3, text4).ConfigureAwait(false);
+                await RawTextAsync(text2, text3, text4).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -1466,13 +1466,13 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (needWriteNewLine)
                 {
-                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
                     curIndex++;
                     leftCount--;
                 }
                 else if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0 || needWriteNewLine);
         }
@@ -1490,13 +1490,13 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (needWriteNewLine)
                 {
-                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
                     curIndex++;
                     leftCount--;
                 }
                 else if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0 || needWriteNewLine);
         }
@@ -1647,7 +1647,7 @@ namespace System.Xml
             {
                 if (_bufPos >= _bufLen)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 return;
             }
@@ -1663,13 +1663,13 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (needWriteNewLine)
                 {
-                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
                     curIndex++;
                     leftCount--;
                 }
                 else if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0 || needWriteNewLine);
         }
@@ -1817,7 +1817,7 @@ namespace System.Xml
             {
                 if (_bufPos >= _bufLen)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 return;
             }
@@ -1833,13 +1833,13 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (needWriteNewLine)
                 {
-                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
                     curIndex++;
                     leftCount--;
                 }
                 else if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0 || needWriteNewLine);
         }
@@ -1854,9 +1854,9 @@ namespace System.Xml
             // Add indentation
             if (!_mixedContent && base._textPos != base._bufPos)
             {
-                await WriteIndentAsync().ConfigureAwait(false);
+                await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
-            await base.WriteDocTypeAsync(name, pubid, sysid, subset).ConfigureAwait(false);
+            await base.WriteDocTypeAsync(name, pubid, sysid, subset).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         public override async Task WriteStartElementAsync(string prefix, string localName, string ns)
@@ -1867,12 +1867,12 @@ namespace System.Xml
             // Add indentation
             if (!_mixedContent && base._textPos != base._bufPos)
             {
-                await WriteIndentAsync().ConfigureAwait(false);
+                await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
             _indentLevel++;
             _mixedContentStack.PushBit(_mixedContent);
 
-            await base.WriteStartElementAsync(prefix, localName, ns).ConfigureAwait(false);
+            await base.WriteStartElementAsync(prefix, localName, ns).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         internal override async Task WriteEndElementAsync(string prefix, string localName, string ns)
@@ -1885,12 +1885,12 @@ namespace System.Xml
                 // There was content, so try to indent
                 if (base._textPos != base._bufPos)
                 {
-                    await WriteIndentAsync().ConfigureAwait(false);
+                    await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             _mixedContent = _mixedContentStack.PopBit();
 
-            await base.WriteEndElementAsync(prefix, localName, ns).ConfigureAwait(false);
+            await base.WriteEndElementAsync(prefix, localName, ns).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         internal override async Task WriteFullEndElementAsync(string prefix, string localName, string ns)
@@ -1903,12 +1903,12 @@ namespace System.Xml
                 // There was content, so try to indent
                 if (base._textPos != base._bufPos)
                 {
-                    await WriteIndentAsync().ConfigureAwait(false);
+                    await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             _mixedContent = _mixedContentStack.PopBit();
 
-            await base.WriteFullEndElementAsync(prefix, localName, ns).ConfigureAwait(false);
+            await base.WriteFullEndElementAsync(prefix, localName, ns).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         // Same as base class, plus possible indentation.
@@ -1918,10 +1918,10 @@ namespace System.Xml
             // Add indentation
             if (_newLineOnAttributes)
             {
-                await WriteIndentAsync().ConfigureAwait(false);
+                await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
-            await base.WriteStartAttributeAsync(prefix, localName, ns).ConfigureAwait(false);
+            await base.WriteStartAttributeAsync(prefix, localName, ns).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         // Same as base class, plus possible indentation.
@@ -1931,10 +1931,10 @@ namespace System.Xml
             // Add indentation
             if (_newLineOnAttributes)
             {
-                await WriteIndentAsync().ConfigureAwait(false);
+                await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
-            await base.WriteStartNamespaceDeclarationAsync(prefix).ConfigureAwait(false);
+            await base.WriteStartNamespaceDeclarationAsync(prefix).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         public override Task WriteCDataAsync(string text)
@@ -1949,10 +1949,10 @@ namespace System.Xml
             CheckAsyncCall();
             if (!_mixedContent && base._textPos != base._bufPos)
             {
-                await WriteIndentAsync().ConfigureAwait(false);
+                await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
-            await base.WriteCommentAsync(text).ConfigureAwait(false);
+            await base.WriteCommentAsync(text).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         public override async Task WriteProcessingInstructionAsync(string target, string text)
@@ -1960,10 +1960,10 @@ namespace System.Xml
             CheckAsyncCall();
             if (!_mixedContent && base._textPos != base._bufPos)
             {
-                await WriteIndentAsync().ConfigureAwait(false);
+                await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
-            await base.WriteProcessingInstructionAsync(target, text).ConfigureAwait(false);
+            await base.WriteProcessingInstructionAsync(target, text).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         public override Task WriteEntityRefAsync(string name)
@@ -2033,10 +2033,10 @@ namespace System.Xml
         private async Task WriteIndentAsync()
         {
             CheckAsyncCall();
-            await RawTextAsync(base._newLineChars).ConfigureAwait(false);
+            await RawTextAsync(base._newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
             for (int i = _indentLevel; i > 0; i--)
             {
-                await RawTextAsync(_indentChars).ConfigureAwait(false);
+                await RawTextAsync(_indentChars).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
     }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawWriterAsync.cs
@@ -194,11 +194,11 @@ namespace System.Xml
         {
             if (prefix.Length != 0)
             {
-                await WriteStringAsync(prefix).ConfigureAwait(false);
-                await WriteStringAsync(":").ConfigureAwait(false);
+                await WriteStringAsync(prefix).ConfigureAwait(OperatingSystem.IsBrowser());
+                await WriteStringAsync(":").ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
-            await WriteStringAsync(localName).ConfigureAwait(false);
+            await WriteStringAsync(localName).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         // This method must be called instead of WriteStartAttribute() for namespaces.

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlReaderAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlReaderAsync.cs
@@ -27,7 +27,7 @@ namespace System.Xml
             {
                 throw CreateReadContentAsException(nameof(ReadContentAsObject));
             }
-            return await InternalReadContentAsStringAsync().ConfigureAwait(false);
+            return await InternalReadContentAsStringAsync().ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         // Concatenates values of textual nodes of the current content, ignoring comments and PIs, expanding entity references,
@@ -50,7 +50,7 @@ namespace System.Xml
                 throw CreateReadContentAsException(nameof(ReadContentAs));
             }
 
-            string strContentValue = await InternalReadContentAsStringAsync().ConfigureAwait(false);
+            string strContentValue = await InternalReadContentAsStringAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             if (returnType == typeof(string))
             {
                 return strContentValue;
@@ -73,10 +73,10 @@ namespace System.Xml
         // Returns the content of the current element as the most appropriate type. Moves to the node following the element's end tag.
         public virtual async Task<object> ReadElementContentAsObjectAsync()
         {
-            if (await SetupReadElementContentAsXxxAsync("ReadElementContentAsObject").ConfigureAwait(false))
+            if (await SetupReadElementContentAsXxxAsync("ReadElementContentAsObject").ConfigureAwait(OperatingSystem.IsBrowser()))
             {
-                object value = await ReadContentAsObjectAsync().ConfigureAwait(false);
-                await FinishReadElementContentAsXxxAsync().ConfigureAwait(false);
+                object value = await ReadContentAsObjectAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+                await FinishReadElementContentAsXxxAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 return value;
             }
             return string.Empty;
@@ -85,10 +85,10 @@ namespace System.Xml
         // Returns the content of the current element as a string. Moves to the node following the element's end tag.
         public virtual async Task<string> ReadElementContentAsStringAsync()
         {
-            if (await SetupReadElementContentAsXxxAsync("ReadElementContentAsString").ConfigureAwait(false))
+            if (await SetupReadElementContentAsXxxAsync("ReadElementContentAsString").ConfigureAwait(OperatingSystem.IsBrowser()))
             {
-                string value = await ReadContentAsStringAsync().ConfigureAwait(false);
-                await FinishReadElementContentAsXxxAsync().ConfigureAwait(false);
+                string value = await ReadContentAsStringAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+                await FinishReadElementContentAsXxxAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 return value;
             }
             return string.Empty;
@@ -97,10 +97,10 @@ namespace System.Xml
         // Returns the content of the current element as the requested type. Moves to the node following the element's end tag.
         public virtual async Task<object> ReadElementContentAsAsync(Type returnType, IXmlNamespaceResolver namespaceResolver)
         {
-            if (await SetupReadElementContentAsXxxAsync("ReadElementContentAs").ConfigureAwait(false))
+            if (await SetupReadElementContentAsXxxAsync("ReadElementContentAs").ConfigureAwait(OperatingSystem.IsBrowser()))
             {
-                object value = await ReadContentAsAsync(returnType, namespaceResolver).ConfigureAwait(false);
-                await FinishReadElementContentAsXxxAsync().ConfigureAwait(false);
+                object value = await ReadContentAsAsync(returnType, namespaceResolver).ConfigureAwait(OperatingSystem.IsBrowser());
+                await FinishReadElementContentAsXxxAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 return value;
             }
             return returnType == typeof(string) ? string.Empty : XmlUntypedConverter.Untyped.ChangeType(string.Empty, returnType, namespaceResolver);
@@ -171,7 +171,7 @@ namespace System.Xml
                     case XmlNodeType.EndEntity:
                         return NodeType;
                 }
-            } while (await ReadAsync().ConfigureAwait(false));
+            } while (await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser()));
             return NodeType;
         }
 
@@ -184,7 +184,7 @@ namespace System.Xml
             }
             if (NodeType != XmlNodeType.Attribute && NodeType != XmlNodeType.Element)
             {
-                await ReadAsync().ConfigureAwait(false);
+                await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 return string.Empty;
             }
 
@@ -200,7 +200,7 @@ namespace System.Xml
 
                 if (NodeType == XmlNodeType.Element)
                 {
-                    await WriteNodeAsync(xtw, false).ConfigureAwait(false);
+                    await WriteNodeAsync(xtw, false).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
 
@@ -211,7 +211,7 @@ namespace System.Xml
         private async Task WriteNodeAsync(XmlTextWriter xtw, bool defattr)
         {
             int d = NodeType == XmlNodeType.None ? -1 : Depth;
-            while (await ReadAsync().ConfigureAwait(false) && d < Depth)
+            while (await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser()) && d < Depth)
             {
                 switch (NodeType)
                 {
@@ -225,11 +225,11 @@ namespace System.Xml
                         }
                         break;
                     case XmlNodeType.Text:
-                        xtw.WriteString(await GetValueAsync().ConfigureAwait(false));
+                        xtw.WriteString(await GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser()));
                         break;
                     case XmlNodeType.Whitespace:
                     case XmlNodeType.SignificantWhitespace:
-                        xtw.WriteWhitespace(await GetValueAsync().ConfigureAwait(false));
+                        xtw.WriteWhitespace(await GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser()));
                         break;
                     case XmlNodeType.CDATA:
                         xtw.WriteCData(Value);
@@ -254,7 +254,7 @@ namespace System.Xml
             }
             if (d == Depth && NodeType == XmlNodeType.EndElement)
             {
-                await ReadAsync().ConfigureAwait(false);
+                await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -267,7 +267,7 @@ namespace System.Xml
             }
             if (NodeType != XmlNodeType.Attribute && NodeType != XmlNodeType.Element)
             {
-                await ReadAsync().ConfigureAwait(false);
+                await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 return string.Empty;
             }
 
@@ -301,18 +301,18 @@ namespace System.Xml
             {
                 int depth = Depth;
 
-                while (await ReadAsync().ConfigureAwait(false) && depth < Depth)
+                while (await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser()) && depth < Depth)
                 {
                     // Nothing, just read on
                 }
 
                 // consume end tag
                 if (NodeType == XmlNodeType.EndElement)
-                    return await ReadAsync().ConfigureAwait(false);
+                    return await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
             else
             {
-                return await ReadAsync().ConfigureAwait(false);
+                return await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             return false;
@@ -335,12 +335,12 @@ namespace System.Xml
                         // merge text content
                         if (value.Length == 0)
                         {
-                            value = await GetValueAsync().ConfigureAwait(false);
+                            value = await GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                         else
                         {
                             sb ??= new StringBuilder().Append(value);
-                            sb.Append(await GetValueAsync().ConfigureAwait(false));
+                            sb.Append(await GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser()));
                         }
                         break;
                     case XmlNodeType.ProcessingInstruction:
@@ -358,7 +358,7 @@ namespace System.Xml
                     default:
                         goto ReturnContent;
                 }
-            } while (AttributeCount != 0 ? ReadAttributeValue() : await ReadAsync().ConfigureAwait(false));
+            } while (AttributeCount != 0 ? ReadAttributeValue() : await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser()));
 
         ReturnContent:
             return sb == null ? value : sb.ToString();
@@ -374,7 +374,7 @@ namespace System.Xml
             bool isEmptyElement = IsEmptyElement;
 
             // move to content or beyond the empty element
-            await ReadAsync().ConfigureAwait(false);
+            await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
             if (isEmptyElement)
             {
@@ -384,7 +384,7 @@ namespace System.Xml
             XmlNodeType nodeType = NodeType;
             if (nodeType == XmlNodeType.EndElement)
             {
-                await ReadAsync().ConfigureAwait(false);
+                await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 return false;
             }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlSubtreeReaderAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlSubtreeReaderAsync.cs
@@ -52,7 +52,7 @@ namespace System.Xml
                         }
                         Debug.Assert(reader.NodeType == XmlNodeType.Element && !reader.IsEmptyElement);
                     }
-                    if (await reader.ReadAsync().ConfigureAwait(false))
+                    if (await reader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         ProcessNamespaces();
                         return true;
@@ -79,19 +79,19 @@ namespace System.Xml
 
                 case State.ReadElementContentAsBase64:
                 case State.ReadElementContentAsBinHex:
-                    if (!await FinishReadElementContentAsBinaryAsync().ConfigureAwait(false))
+                    if (!await FinishReadElementContentAsBinaryAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         return false;
                     }
-                    return await ReadAsync().ConfigureAwait(false);
+                    return await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
                 case State.ReadContentAsBase64:
                 case State.ReadContentAsBinHex:
-                    if (!await FinishReadContentAsBinaryAsync().ConfigureAwait(false))
+                    if (!await FinishReadContentAsBinaryAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         return false;
                     }
-                    return await ReadAsync().ConfigureAwait(false);
+                    return await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
                 default:
                     Debug.Fail($"Unexpected state {_state}");
@@ -104,7 +104,7 @@ namespace System.Xml
             switch (_state)
             {
                 case State.Initial:
-                    await ReadAsync().ConfigureAwait(false);
+                    await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     return;
 
                 case State.Interactive:
@@ -117,11 +117,11 @@ namespace System.Xml
                         if (reader.NodeType == XmlNodeType.Element && !reader.IsEmptyElement)
                         {
                             // we are on root of the subtree -> skip to the end element and set to Eof state
-                            if (await reader.ReadAsync().ConfigureAwait(false))
+                            if (await reader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                             {
                                 while (reader.NodeType != XmlNodeType.EndElement && reader.Depth > _initialDepth)
                                 {
-                                    await reader.SkipAsync().ConfigureAwait(false);
+                                    await reader.SkipAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                                 }
                             }
                         }
@@ -137,7 +137,7 @@ namespace System.Xml
                     {
                         _nsManager.PopScope();
                     }
-                    await reader.SkipAsync().ConfigureAwait(false);
+                    await reader.SkipAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     ProcessNamespaces();
 
                     Debug.Assert(reader.Depth >= _initialDepth);
@@ -158,17 +158,17 @@ namespace System.Xml
 
                 case State.ReadElementContentAsBase64:
                 case State.ReadElementContentAsBinHex:
-                    if (await FinishReadElementContentAsBinaryAsync().ConfigureAwait(false))
+                    if (await FinishReadElementContentAsBinaryAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
-                        await SkipAsync().ConfigureAwait(false);
+                        await SkipAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     break;
 
                 case State.ReadContentAsBase64:
                 case State.ReadContentAsBinHex:
-                    if (await FinishReadContentAsBinaryAsync().ConfigureAwait(false))
+                    if (await FinishReadContentAsBinaryAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
-                        await SkipAsync().ConfigureAwait(false);
+                        await SkipAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     break;
 
@@ -186,7 +186,7 @@ namespace System.Xml
             try
             {
                 InitReadContentAsType("ReadContentAsObject");
-                object value = await reader.ReadContentAsObjectAsync().ConfigureAwait(false);
+                object value = await reader.ReadContentAsObjectAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 FinishReadContentAsType();
                 return value;
             }
@@ -202,7 +202,7 @@ namespace System.Xml
             try
             {
                 InitReadContentAsType("ReadContentAsString");
-                string value = await reader.ReadContentAsStringAsync().ConfigureAwait(false);
+                string value = await reader.ReadContentAsStringAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 FinishReadContentAsType();
                 return value;
             }
@@ -218,7 +218,7 @@ namespace System.Xml
             try
             {
                 InitReadContentAsType("ReadContentAs");
-                object value = await reader.ReadContentAsAsync(returnType, namespaceResolver).ConfigureAwait(false);
+                object value = await reader.ReadContentAsAsync(returnType, namespaceResolver).ConfigureAwait(OperatingSystem.IsBrowser());
                 FinishReadContentAsType();
                 return value;
             }
@@ -280,7 +280,7 @@ namespace System.Xml
                             goto case XmlNodeType.Text;
                         case XmlNodeType.Text:
                             Debug.Assert(AttributeCount > 0);
-                            return await reader.ReadContentAsBase64Async(buffer, index, count).ConfigureAwait(false);
+                            return await reader.ReadContentAsBase64Async(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
                         default:
                             Debug.Fail($"Unexpected state {_state}");
                             return 0;
@@ -291,7 +291,7 @@ namespace System.Xml
                     goto case State.ReadContentAsBase64;
 
                 case State.ReadContentAsBase64:
-                    int read = await reader.ReadContentAsBase64Async(buffer, index, count).ConfigureAwait(false);
+                    int read = await reader.ReadContentAsBase64Async(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
                     if (read == 0)
                     {
                         _state = State.Interactive;
@@ -323,14 +323,14 @@ namespace System.Xml
                 case State.Interactive:
                 case State.PopNamespaceScope:
                 case State.ClearNsAttributes:
-                    if (!await InitReadElementContentAsBinaryAsync(State.ReadElementContentAsBase64).ConfigureAwait(false))
+                    if (!await InitReadElementContentAsBinaryAsync(State.ReadElementContentAsBase64).ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         return 0;
                     }
                     goto case State.ReadElementContentAsBase64;
 
                 case State.ReadElementContentAsBase64:
-                    int read = await reader.ReadContentAsBase64Async(buffer, index, count).ConfigureAwait(false);
+                    int read = await reader.ReadContentAsBase64Async(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
                     if (read > 0 || count == 0)
                     {
                         return read;
@@ -352,7 +352,7 @@ namespace System.Xml
                     }
                     else
                     {
-                        await ReadAsync().ConfigureAwait(false);
+                        await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     return 0;
 
@@ -418,7 +418,7 @@ namespace System.Xml
                             goto case XmlNodeType.Text;
                         case XmlNodeType.Text:
                             Debug.Assert(AttributeCount > 0);
-                            return await reader.ReadContentAsBinHexAsync(buffer, index, count).ConfigureAwait(false);
+                            return await reader.ReadContentAsBinHexAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
                         default:
                             Debug.Fail($"Unexpected state {_state}");
                             return 0;
@@ -429,7 +429,7 @@ namespace System.Xml
                     goto case State.ReadContentAsBinHex;
 
                 case State.ReadContentAsBinHex:
-                    int read = await reader.ReadContentAsBinHexAsync(buffer, index, count).ConfigureAwait(false);
+                    int read = await reader.ReadContentAsBinHexAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
                     if (read == 0)
                     {
                         _state = State.Interactive;
@@ -461,13 +461,13 @@ namespace System.Xml
                 case State.Interactive:
                 case State.PopNamespaceScope:
                 case State.ClearNsAttributes:
-                    if (!await InitReadElementContentAsBinaryAsync(State.ReadElementContentAsBinHex).ConfigureAwait(false))
+                    if (!await InitReadElementContentAsBinaryAsync(State.ReadElementContentAsBinHex).ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         return 0;
                     }
                     goto case State.ReadElementContentAsBinHex;
                 case State.ReadElementContentAsBinHex:
-                    int read = await reader.ReadContentAsBinHexAsync(buffer, index, count).ConfigureAwait(false);
+                    int read = await reader.ReadContentAsBinHexAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
                     if (read > 0 || count == 0)
                     {
                         return read;
@@ -489,7 +489,7 @@ namespace System.Xml
                     }
                     else
                     {
-                        await ReadAsync().ConfigureAwait(false);
+                        await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     return 0;
 
@@ -565,7 +565,7 @@ namespace System.Xml
             bool isEmpty = IsEmptyElement;
 
             // move to content or off the empty element
-            if (!await ReadAsync().ConfigureAwait(false) || isEmpty)
+            if (!await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser()) || isEmpty)
             {
                 return false;
             }
@@ -577,7 +577,7 @@ namespace System.Xml
                 case XmlNodeType.EndElement:
                     // pop scope & move off end element
                     ProcessNamespaces();
-                    await ReadAsync().ConfigureAwait(false);
+                    await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     return false;
             }
 
@@ -593,11 +593,11 @@ namespace System.Xml
             byte[] bytes = new byte[256];
             if (_state == State.ReadElementContentAsBase64)
             {
-                while (await reader.ReadContentAsBase64Async(bytes, 0, 256).ConfigureAwait(false) > 0) ;
+                while (await reader.ReadContentAsBase64Async(bytes, 0, 256).ConfigureAwait(OperatingSystem.IsBrowser()) > 0) ;
             }
             else
             {
-                while (await reader.ReadContentAsBinHexAsync(bytes, 0, 256).ConfigureAwait(false) > 0) ;
+                while (await reader.ReadContentAsBinHexAsync(bytes, 0, 256).ConfigureAwait(OperatingSystem.IsBrowser()) > 0) ;
             }
 
             if (NodeType != XmlNodeType.EndElement)
@@ -617,7 +617,7 @@ namespace System.Xml
                 return false;
             }
             // move off end element
-            return await ReadAsync().ConfigureAwait(false);
+            return await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         private async Task<bool> FinishReadContentAsBinaryAsync()
@@ -627,11 +627,11 @@ namespace System.Xml
             byte[] bytes = new byte[256];
             if (_state == State.ReadContentAsBase64)
             {
-                while (await reader.ReadContentAsBase64Async(bytes, 0, 256).ConfigureAwait(false) > 0) ;
+                while (await reader.ReadContentAsBase64Async(bytes, 0, 256).ConfigureAwait(OperatingSystem.IsBrowser()) > 0) ;
             }
             else
             {
-                while (await reader.ReadContentAsBinHexAsync(bytes, 0, 256).ConfigureAwait(false) > 0) ;
+                while (await reader.ReadContentAsBinHexAsync(bytes, 0, 256).ConfigureAwait(OperatingSystem.IsBrowser()) > 0) ;
             }
 
             _state = State.Interactive;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplAsync.cs
@@ -43,12 +43,12 @@ namespace System.Xml
             {
                 if (_parsingFunction == ParsingFunction.PartialTextValue)
                 {
-                    await FinishPartialValueAsync().ConfigureAwait(false);
+                    await FinishPartialValueAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     _parsingFunction = _nextParsingFunction;
                 }
                 else
                 {
-                    await FinishOtherValueIteratorAsync().ConfigureAwait(false);
+                    await FinishOtherValueIteratorAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             return _curNode.StringValue;
@@ -74,7 +74,7 @@ namespace System.Xml
 
         private async Task FinishInitUriStringAsync()
         {
-            Stream stream = (Stream)(await _laterInitParam!.inputUriResolver!.GetEntityAsync(_laterInitParam.inputbaseUri!, string.Empty, typeof(Stream)).ConfigureAwait(false));
+            Stream stream = (Stream)(await _laterInitParam!.inputUriResolver!.GetEntityAsync(_laterInitParam.inputbaseUri!, string.Empty, typeof(Stream)).ConfigureAwait(OperatingSystem.IsBrowser()));
 
             if (stream == null)
             {
@@ -92,14 +92,14 @@ namespace System.Xml
             {
                 // init ParsingState
                 Debug.Assert(_reportedBaseUri != null);
-                await InitStreamInputAsync(_laterInitParam.inputbaseUri, _reportedBaseUri, stream, null, 0, enc).ConfigureAwait(false);
+                await InitStreamInputAsync(_laterInitParam.inputbaseUri, _reportedBaseUri, stream, null, 0, enc).ConfigureAwait(OperatingSystem.IsBrowser());
 
                 _reportedEncoding = _ps.encoding;
 
                 // parse DTD
                 if (_laterInitParam.inputContext != null && _laterInitParam.inputContext.HasDtdInfo)
                 {
-                    await ProcessDtdFromParserContextAsync(_laterInitParam.inputContext).ConfigureAwait(false);
+                    await ProcessDtdFromParserContextAsync(_laterInitParam.inputContext).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             catch
@@ -123,14 +123,14 @@ namespace System.Xml
 
             // init ParsingState
             Debug.Assert(_reportedBaseUri != null);
-            await InitStreamInputAsync(_laterInitParam.inputbaseUri, _reportedBaseUri, _laterInitParam!.inputStream!, _laterInitParam.inputBytes, _laterInitParam.inputByteCount, enc).ConfigureAwait(false);
+            await InitStreamInputAsync(_laterInitParam.inputbaseUri, _reportedBaseUri, _laterInitParam!.inputStream!, _laterInitParam.inputBytes, _laterInitParam.inputByteCount, enc).ConfigureAwait(OperatingSystem.IsBrowser());
 
             _reportedEncoding = _ps.encoding;
 
             // parse DTD
             if (_laterInitParam.inputContext != null && _laterInitParam.inputContext.HasDtdInfo)
             {
-                await ProcessDtdFromParserContextAsync(_laterInitParam.inputContext).ConfigureAwait(false);
+                await ProcessDtdFromParserContextAsync(_laterInitParam.inputContext).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             _laterInitParam = null;
         }
@@ -138,14 +138,14 @@ namespace System.Xml
         private async Task FinishInitTextReaderAsync()
         {
             // init ParsingState
-            await InitTextReaderInputAsync(_reportedBaseUri!, _laterInitParam!.inputTextReader!).ConfigureAwait(false);
+            await InitTextReaderInputAsync(_reportedBaseUri!, _laterInitParam!.inputTextReader!).ConfigureAwait(OperatingSystem.IsBrowser());
 
             _reportedEncoding = _ps.encoding;
 
             // parse DTD
             if (_laterInitParam.inputContext != null && _laterInitParam.inputContext.HasDtdInfo)
             {
-                await ProcessDtdFromParserContextAsync(_laterInitParam.inputContext).ConfigureAwait(false);
+                await ProcessDtdFromParserContextAsync(_laterInitParam.inputContext).ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             _laterInitParam = null;
@@ -284,8 +284,8 @@ namespace System.Xml
 
         private async Task<bool> _ReadAsync_SwitchToInteractiveXmlDecl(Task<bool> task)
         {
-            bool result = await task.ConfigureAwait(false);
-            return await ReadAsync_SwitchToInteractiveXmlDecl_Helper(result).ConfigureAwait(false);
+            bool result = await task.ConfigureAwait(OperatingSystem.IsBrowser());
+            return await ReadAsync_SwitchToInteractiveXmlDecl_Helper(result).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         private Task<bool> ReadAsync_SwitchToInteractiveXmlDecl_Helper(bool finish)
@@ -327,16 +327,16 @@ namespace System.Xml
                         FinishIncrementalRead();
                         break;
                     case ParsingFunction.PartialTextValue:
-                        await SkipPartialTextValueAsync().ConfigureAwait(false);
+                        await SkipPartialTextValueAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
                     case ParsingFunction.InReadValueChunk:
-                        await FinishReadValueChunkAsync().ConfigureAwait(false);
+                        await FinishReadValueChunkAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
                     case ParsingFunction.InReadContentAsBinary:
-                        await FinishReadContentAsBinaryAsync().ConfigureAwait(false);
+                        await FinishReadContentAsBinaryAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
                     case ParsingFunction.InReadElementContentAsBinary:
-                        await FinishReadElementContentAsBinaryAsync().ConfigureAwait(false);
+                        await FinishReadElementContentAsBinaryAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
                 }
             }
@@ -352,7 +352,7 @@ namespace System.Xml
                     int initialDepth = _index;
                     _parsingMode = ParsingMode.SkipContent;
                     // skip content
-                    while (await _outerReader.ReadAsync().ConfigureAwait(false) && _index > initialDepth) ;
+                    while (await _outerReader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser()) && _index > initialDepth) ;
                     Debug.Assert(_curNode.type == XmlNodeType.EndElement);
                     Debug.Assert(_parsingFunction != ParsingFunction.Eof);
                     _parsingMode = ParsingMode.Full;
@@ -362,13 +362,13 @@ namespace System.Xml
                     goto case XmlNodeType.Element;
             }
             // move to following sibling node
-            await _outerReader.ReadAsync().ConfigureAwait(false);
+            await _outerReader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             return;
         }
 
         private async Task<int> ReadContentAsBase64_AsyncHelper(Task<bool> task, byte[] buffer, int index, int count)
         {
-            bool result = await task.ConfigureAwait(false);
+            bool result = await task.ConfigureAwait(OperatingSystem.IsBrowser());
             if (!result)
             {
                 return 0;
@@ -379,7 +379,7 @@ namespace System.Xml
                 InitBase64Decoder();
 
                 // read binary data
-                return await ReadContentAsBinaryAsync(buffer, index, count).ConfigureAwait(false);
+                return await ReadContentAsBinaryAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -455,7 +455,7 @@ namespace System.Xml
                 if (_incReadDecoder == _binHexDecoder)
                 {
                     // read more binary data
-                    return await ReadContentAsBinaryAsync(buffer, index, count).ConfigureAwait(false);
+                    return await ReadContentAsBinaryAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             // first call of ReadContentAsBinHex -> initialize (move to first text child (for elements) and initialize incremental read state)
@@ -474,7 +474,7 @@ namespace System.Xml
                     throw CreateReadContentAsException(nameof(ReadContentAsBinHex));
                 }
 
-                if (!await InitReadContentAsBinaryAsync().ConfigureAwait(false))
+                if (!await InitReadContentAsBinaryAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                 {
                     return 0;
                 }
@@ -484,12 +484,12 @@ namespace System.Xml
             InitBinHexDecoder();
 
             // read binary data
-            return await ReadContentAsBinaryAsync(buffer, index, count).ConfigureAwait(false);
+            return await ReadContentAsBinaryAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         private async Task<int> ReadElementContentAsBase64Async_Helper(Task<bool> task, byte[] buffer, int index, int count)
         {
-            bool result = await task.ConfigureAwait(false);
+            bool result = await task.ConfigureAwait(OperatingSystem.IsBrowser());
             if (!result)
             {
                 return 0;
@@ -500,7 +500,7 @@ namespace System.Xml
                 InitBase64Decoder();
 
                 // read binary data
-                return await ReadElementContentAsBinaryAsync(buffer, index, count).ConfigureAwait(false);
+                return await ReadElementContentAsBinaryAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -576,7 +576,7 @@ namespace System.Xml
                 if (_incReadDecoder == _binHexDecoder)
                 {
                     // read more binary data
-                    return await ReadElementContentAsBinaryAsync(buffer, index, count).ConfigureAwait(false);
+                    return await ReadElementContentAsBinaryAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             // first call of ReadContentAsBinHex -> initialize
@@ -594,7 +594,7 @@ namespace System.Xml
                 {
                     throw CreateReadElementContentAsException(nameof(ReadElementContentAsBinHex));
                 }
-                if (!await InitReadElementContentAsBinaryAsync().ConfigureAwait(false))
+                if (!await InitReadElementContentAsBinaryAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                 {
                     return 0;
                 }
@@ -604,7 +604,7 @@ namespace System.Xml
             InitBinHexDecoder();
 
             // read binary data
-            return await ReadElementContentAsBinaryAsync(buffer, index, count).ConfigureAwait(false);
+            return await ReadElementContentAsBinaryAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         // Iterates over Value property and copies it into the provided buffer
@@ -681,7 +681,7 @@ namespace System.Xml
                 while (readCount < count && !endOfValue)
                 {
                     int orChars = 0;
-                    var tuple_0 = await ParseTextAsync(orChars).ConfigureAwait(false);
+                    var tuple_0 = await ParseTextAsync(orChars).ConfigureAwait(OperatingSystem.IsBrowser());
                     startPos = tuple_0.Item1;
                     endPos = tuple_0.Item2;
 
@@ -730,7 +730,7 @@ namespace System.Xml
         {
             CheckAsyncCall();
 
-            var tuple_1 = await this.ParseNumericCharRefAsync(true, internalSubsetBuilder).ConfigureAwait(false);
+            var tuple_1 = await this.ParseNumericCharRefAsync(true, internalSubsetBuilder).ConfigureAwait(OperatingSystem.IsBrowser());
             return tuple_1.Item2;
         }
 
@@ -747,12 +747,12 @@ namespace System.Xml
             {
                 ParsingMode pm = _parsingMode;
                 _parsingMode = ParsingMode.SkipNode;
-                await ParsePIAsync(null).ConfigureAwait(false);
+                await ParsePIAsync(null).ConfigureAwait(OperatingSystem.IsBrowser());
                 _parsingMode = pm;
             }
             else
             {
-                await ParsePIAsync(sb).ConfigureAwait(false);
+                await ParsePIAsync(sb).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -767,7 +767,7 @@ namespace System.Xml
                 {
                     ParsingMode savedParsingMode = _parsingMode;
                     _parsingMode = ParsingMode.SkipNode;
-                    await ParseCDataOrCommentAsync(XmlNodeType.Comment).ConfigureAwait(false);
+                    await ParseCDataOrCommentAsync(XmlNodeType.Comment).ConfigureAwait(OperatingSystem.IsBrowser());
                     _parsingMode = savedParsingMode;
                 }
                 else
@@ -775,7 +775,7 @@ namespace System.Xml
                     NodeData originalCurNode = _curNode;
 
                     _curNode = AddNode(_index + _attrCount + 1, _index);
-                    await ParseCDataOrCommentAsync(XmlNodeType.Comment).ConfigureAwait(false);
+                    await ParseCDataOrCommentAsync(XmlNodeType.Comment).ConfigureAwait(OperatingSystem.IsBrowser());
                     _curNode.CopyTo(0, sb);
 
                     _curNode = originalCurNode;
@@ -808,7 +808,7 @@ namespace System.Xml
 
                     return (entityId, false);
                 }
-                retValue = await PushExternalEntityAsync(entity).ConfigureAwait(false);
+                retValue = await PushExternalEntityAsync(entity).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             else
             {
@@ -838,7 +838,7 @@ namespace System.Xml
             {
                 _ps.baseUri = _xmlResolver!.ResolveUri(null, _ps.baseUriStr);
             }
-            await PushExternalEntityOrSubsetAsync(publicId, systemId, _ps.baseUri, null).ConfigureAwait(false);
+            await PushExternalEntityOrSubsetAsync(publicId, systemId, _ps.baseUri, null).ConfigureAwait(OperatingSystem.IsBrowser());
 
             _ps.entity = null;
             _ps.entityId = 0;
@@ -847,9 +847,9 @@ namespace System.Xml
             int initialPos = _ps.charPos;
             if (_v1Compat)
             {
-                await EatWhitespacesAsync(null).ConfigureAwait(false);
+                await EatWhitespacesAsync(null).ConfigureAwait(OperatingSystem.IsBrowser());
             }
-            if (!await ParseXmlDeclarationAsync(true).ConfigureAwait(false))
+            if (!await ParseXmlDeclarationAsync(true).ConfigureAwait(OperatingSystem.IsBrowser()))
             {
                 _ps.charPos = initialPos;
             }
@@ -911,7 +911,7 @@ namespace System.Xml
             if (_ps.bytesUsed < 4 && _ps.bytes.Length - _ps.bytesUsed > 0)
             {
                 int bytesToRead = Math.Min(4, _ps.bytes.Length - _ps.bytesUsed);
-                int read = await stream.ReadAtLeastAsync(_ps.bytes.AsMemory(_ps.bytesUsed), bytesToRead, throwOnEndOfStream: false).ConfigureAwait(false);
+                int read = await stream.ReadAtLeastAsync(_ps.bytes.AsMemory(_ps.bytesUsed), bytesToRead, throwOnEndOfStream: false).ConfigureAwait(OperatingSystem.IsBrowser());
                 if (read < bytesToRead)
                 {
                     _ps.isStreamEof = true;
@@ -932,7 +932,7 @@ namespace System.Xml
 
             // decode first characters
             _ps.appendMode = true;
-            await ReadDataAsync().ConfigureAwait(false);
+            await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser());
         }
         private Task<int> InitTextReaderInputAsync(string baseUriStr, TextReader input)
         {
@@ -1124,7 +1124,7 @@ namespace System.Xml
                     // read new bytes
                     if (_ps.bytePos == _ps.bytesUsed && _ps.bytes!.Length - _ps.bytesUsed > 0)
                     {
-                        int read = await _ps.stream.ReadAsync(_ps.bytes.AsMemory(_ps.bytesUsed)).ConfigureAwait(false);
+                        int read = await _ps.stream.ReadAsync(_ps.bytes.AsMemory(_ps.bytesUsed)).ConfigureAwait(OperatingSystem.IsBrowser());
                         if (read == 0)
                         {
                             _ps.isStreamEof = true;
@@ -1140,13 +1140,13 @@ namespace System.Xml
                 if (charsRead == 0 && _ps.bytePos != originalBytePos)
                 {
                     // GetChars consumed some bytes but it was not enough bytes to form a character -> try again
-                    return await ReadDataAsync().ConfigureAwait(false);
+                    return await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             else if (_ps.textReader != null)
             {
                 // read chars
-                charsRead = await _ps.textReader.ReadAsync(_ps.chars.AsMemory(_ps.charsUsed, _ps.chars.Length - _ps.charsUsed - 1)).ConfigureAwait(false);
+                charsRead = await _ps.textReader.ReadAsync(_ps.chars.AsMemory(_ps.charsUsed, _ps.chars.Length - _ps.charsUsed - 1)).ConfigureAwait(OperatingSystem.IsBrowser());
                 _ps.charsUsed += charsRead;
             }
             else
@@ -1170,7 +1170,7 @@ namespace System.Xml
         {
             while (_ps.charsUsed - _ps.charPos < 6)
             {  // minimum "<?xml "
-                if (await ReadDataAsync().ConfigureAwait(false) == 0)
+                if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     goto NoXmlDecl;
                 }
@@ -1200,7 +1200,7 @@ namespace System.Xml
             while (true)
             {
                 int originalSbLen = sb.Length;
-                int wsCount = await EatWhitespacesAsync(xmlDeclState == 0 ? null : sb).ConfigureAwait(false);
+                int wsCount = await EatWhitespacesAsync(xmlDeclState == 0 ? null : sb).ConfigureAwait(OperatingSystem.IsBrowser());
 
                 // end of xml declaration
                 if (_ps.chars[_ps.charPos] == '?')
@@ -1244,12 +1244,12 @@ namespace System.Xml
                             }
                             if (_ps.decoder is SafeAsciiDecoder)
                             {
-                                await SwitchEncodingToUTF8Async().ConfigureAwait(false);
+                                await SwitchEncodingToUTF8Async().ConfigureAwait(OperatingSystem.IsBrowser());
                             }
                         }
                         else
                         {
-                            await SwitchEncodingAsync(encoding).ConfigureAwait(false);
+                            await SwitchEncodingAsync(encoding).ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                         _ps.appendMode = false;
                         return true;
@@ -1270,7 +1270,7 @@ namespace System.Xml
                 }
 
                 // read attribute name
-                int nameEndPos = await ParseNameAsync().ConfigureAwait(false);
+                int nameEndPos = await ParseNameAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
                 NodeData? attr = null;
                 switch (_ps.chars.AsSpan(_ps.charPos, nameEndPos - _ps.charPos))
@@ -1318,7 +1318,7 @@ namespace System.Xml
                 // parse equals and quote char;
                 if (_ps.chars[_ps.charPos] != '=')
                 {
-                    await EatWhitespacesAsync(sb).ConfigureAwait(false);
+                    await EatWhitespacesAsync(sb).ConfigureAwait(OperatingSystem.IsBrowser());
                     if (_ps.chars[_ps.charPos] != '=')
                     {
                         ThrowUnexpectedToken("=");
@@ -1330,7 +1330,7 @@ namespace System.Xml
                 char quoteChar = _ps.chars[_ps.charPos];
                 if (quoteChar != '"' && quoteChar != '\'')
                 {
-                    await EatWhitespacesAsync(sb).ConfigureAwait(false);
+                    await EatWhitespacesAsync(sb).ConfigureAwait(OperatingSystem.IsBrowser());
                     quoteChar = _ps.chars[_ps.charPos];
                     if (quoteChar != '"' && quoteChar != '\'')
                     {
@@ -1417,7 +1417,7 @@ namespace System.Xml
                 }
                 else if (pos == _ps.charsUsed)
                 {
-                    if (await ReadDataAsync().ConfigureAwait(false) != 0)
+                    if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) != 0)
                     {
                         goto Continue;
                     }
@@ -1432,7 +1432,7 @@ namespace System.Xml
                 }
 
             ReadData:
-                if (_ps.isEof || await ReadDataAsync().ConfigureAwait(false) == 0)
+                if (_ps.isEof || await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     Throw(SR.Xml_UnexpectedEOF1);
                 }
@@ -1457,7 +1457,7 @@ namespace System.Xml
             }
             if (_ps.decoder is SafeAsciiDecoder)
             {
-                await SwitchEncodingToUTF8Async().ConfigureAwait(false);
+                await SwitchEncodingToUTF8Async().ConfigureAwait(OperatingSystem.IsBrowser());
             }
             _ps.appendMode = false;
             return false;
@@ -1623,7 +1623,7 @@ namespace System.Xml
                     _fragmentType = XmlNodeType.Element;
                 }
 
-                var tuple_3 = await HandleEntityReferenceAsync(false, EntityExpandType.OnlyGeneral).ConfigureAwait(false);
+                var tuple_3 = await HandleEntityReferenceAsync(false, EntityExpandType.OnlyGeneral).ConfigureAwait(OperatingSystem.IsBrowser());
 
                 switch (tuple_3.Item2)
                 {
@@ -1633,18 +1633,18 @@ namespace System.Xml
                         {
                             _parsingFunction = _nextParsingFunction;
                         }
-                        await ParseEntityReferenceAsync().ConfigureAwait(false);
+                        await ParseEntityReferenceAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         return true;
                     case EntityType.CharacterDec:
                     case EntityType.CharacterHex:
                     case EntityType.CharacterNamed:
-                        if (await ParseTextAsync().ConfigureAwait(false))
+                        if (await ParseTextAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                         {
                             return true;
                         }
-                        return await ParseDocumentContentAsync().ConfigureAwait(false);
+                        return await ParseDocumentContentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     default:
-                        return await ParseDocumentContentAsync().ConfigureAwait(false);
+                        return await ParseDocumentContentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
         }
@@ -1675,7 +1675,7 @@ namespace System.Xml
 
         private async Task<bool> _ParseDocumentContentAsync_WhiteSpace(Task<bool> task)
         {
-            if (await task.ConfigureAwait(false))
+            if (await task.ConfigureAwait(OperatingSystem.IsBrowser()))
             {
                 if (_fragmentType == XmlNodeType.None && _curNode.type == XmlNodeType.Text)
                 {
@@ -1683,15 +1683,15 @@ namespace System.Xml
                 }
                 return true;
             }
-            return await ParseDocumentContentAsync().ConfigureAwait(false);
+            return await ParseDocumentContentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         private async Task<bool> ParseDocumentContentAsync_ReadData(bool needMoreChars)
         {
             // read new characters into the buffer
-            if (await ReadDataAsync().ConfigureAwait(false) != 0)
+            if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) != 0)
             {
-                return await ParseDocumentContentAsync().ConfigureAwait(false);
+                return await ParseDocumentContentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
             else
             {
@@ -1707,7 +1707,7 @@ namespace System.Xml
                         SetupEndEntityNodeInContent();
                         return true;
                     }
-                    return await ParseDocumentContentAsync().ConfigureAwait(false);
+                    return await ParseDocumentContentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 Debug.Assert(_index == 0);
 
@@ -1828,7 +1828,7 @@ namespace System.Xml
         private async Task<bool> ParseElementContent_ReadData()
         {
             // read new characters into the buffer
-            if (await ReadDataAsync().ConfigureAwait(false) == 0)
+            if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
             {
                 if (_ps.charsUsed - _ps.charPos != 0)
                 {
@@ -1849,7 +1849,7 @@ namespace System.Xml
                     return true;
                 }
             }
-            return await ParseElementContentAsync().ConfigureAwait(false);
+            return await ParseElementContentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         // Parses the element start tag
@@ -1940,10 +1940,10 @@ namespace System.Xml
 
         private async Task _ParseElementAsync_ContinueWithSetElement(Task<(int, int)> task)
         {
-            var tuple_4 = await task.ConfigureAwait(false);
+            var tuple_4 = await task.ConfigureAwait(OperatingSystem.IsBrowser());
             int colonPos = tuple_4.Item1;
             int pos = tuple_4.Item2;
-            await ParseElementAsync_SetElement(colonPos, pos).ConfigureAwait(false);
+            await ParseElementAsync_SetElement(colonPos, pos).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         private Task ParseElementAsync_SetElement(int colonPos, int pos)
@@ -2049,12 +2049,12 @@ namespace System.Xml
 
         private async Task ParseElementAsync_ReadData(int pos)
         {
-            if (await ReadDataAsync().ConfigureAwait(false) == 0)
+            if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
             {
                 Throw(pos, SR.Xml_UnexpectedEOF, ">");
             }
 
-            await ParseElementAsync_NoAttributes().ConfigureAwait(false);
+            await ParseElementAsync_NoAttributes().ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         private Task ParseEndElementAsync()
@@ -2074,8 +2074,8 @@ namespace System.Xml
 
         private async Task _ParseEndElmentAsync()
         {
-            await ParseEndElmentAsync_PrepareData().ConfigureAwait(false);
-            await ParseEndElementAsync_CheckNameAndParse().ConfigureAwait(false);
+            await ParseEndElmentAsync_PrepareData().ConfigureAwait(OperatingSystem.IsBrowser());
+            await ParseEndElementAsync_CheckNameAndParse().ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         private async Task ParseEndElmentAsync_PrepareData()
@@ -2088,7 +2088,7 @@ namespace System.Xml
 
             while (_ps.charsUsed - _ps.charPos < prefLen + locLen + 1)
             {
-                if (await ReadDataAsync().ConfigureAwait(false) == 0)
+                if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     break;
                 }
@@ -2163,7 +2163,7 @@ namespace System.Xml
         {
             while (true)
             {
-                await task.ConfigureAwait(false);
+                await task.ConfigureAwait(OperatingSystem.IsBrowser());
                 switch (_parseEndElement_NextFunc)
                 {
                     case ParseEndElementParseFunction.CheckEndTag:
@@ -2269,7 +2269,7 @@ namespace System.Xml
 
         private async Task ParseEndElementAsync_ReadData()
         {
-            if (await ReadDataAsync().ConfigureAwait(false) == 0)
+            if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
             {
                 ThrowUnclosedElements();
             }
@@ -2283,7 +2283,7 @@ namespace System.Xml
             {
                 // parse the bad name
 
-                var tuple_5 = await ParseQNameAsync().ConfigureAwait(false);
+                var tuple_5 = await ParseQNameAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
                 int endPos = tuple_5.Item2;
 
@@ -2458,7 +2458,7 @@ namespace System.Xml
 
                         // else fallback to full name parsing routine
 
-                        var tuple_6 = await ParseQNameAsync().ConfigureAwait(false);
+                        var tuple_6 = await ParseQNameAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         colonPos = tuple_6.Item1;
 
                         pos = tuple_6.Item2;
@@ -2468,7 +2468,7 @@ namespace System.Xml
                 }
                 else if (pos + 1 >= _ps.charsUsed)
                 {
-                    var tuple_7 = await ParseQNameAsync().ConfigureAwait(false);
+                    var tuple_7 = await ParseQNameAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     colonPos = tuple_7.Item1;
 
                     pos = tuple_7.Item2;
@@ -2487,7 +2487,7 @@ namespace System.Xml
                 if (chars[pos] != '=')
                 {
                     _ps.charPos = pos;
-                    await EatWhitespacesAsync(null).ConfigureAwait(false);
+                    await EatWhitespacesAsync(null).ConfigureAwait(OperatingSystem.IsBrowser());
                     pos = _ps.charPos;
                     if (chars[pos] != '=')
                     {
@@ -2500,7 +2500,7 @@ namespace System.Xml
                 if (quoteChar != '"' && quoteChar != '\'')
                 {
                     _ps.charPos = pos;
-                    await EatWhitespacesAsync(null).ConfigureAwait(false);
+                    await EatWhitespacesAsync(null).ConfigureAwait(OperatingSystem.IsBrowser());
                     pos = _ps.charPos;
                     quoteChar = chars[pos];
                     if (quoteChar != '"' && quoteChar != '\'')
@@ -2536,7 +2536,7 @@ namespace System.Xml
                 }
                 else
                 {
-                    await ParseAttributeValueSlowAsync(pos, quoteChar, attr).ConfigureAwait(false);
+                    await ParseAttributeValueSlowAsync(pos, quoteChar, attr).ConfigureAwait(OperatingSystem.IsBrowser());
                     pos = _ps.charPos;
                     chars = _ps.chars;
                 }
@@ -2567,7 +2567,7 @@ namespace System.Xml
 
             ReadData:
                 _ps.lineNo -= lineNoDelta;
-                if (await ReadDataAsync().ConfigureAwait(false) != 0)
+                if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) != 0)
                 {
                     pos = _ps.charPos;
                     chars = _ps.chars;
@@ -2699,7 +2699,7 @@ namespace System.Xml
                             int enclosingEntityId = _ps.entityId;
                             LineInfo entityLineInfo = new LineInfo(_ps.lineNo, _ps.LinePos + 1);
 
-                            var tuple_8 = await HandleEntityReferenceAsync(true, EntityExpandType.All).ConfigureAwait(false);
+                            var tuple_8 = await HandleEntityReferenceAsync(true, EntityExpandType.All).ConfigureAwait(OperatingSystem.IsBrowser());
                             pos = tuple_8.Item1;
 
                             switch (tuple_8.Item2)
@@ -2725,7 +2725,7 @@ namespace System.Xml
 
                                         // parse entity name
                                         _ps.charPos++;
-                                        string entityName = await ParseEntityNameAsync().ConfigureAwait(false);
+                                        string entityName = await ParseEntityNameAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
                                         // construct entity reference chunk
                                         NodeData entityChunk = new NodeData();
@@ -2748,7 +2748,7 @@ namespace System.Xml
                                     else
                                     {
                                         _ps.charPos++;
-                                        await ParseEntityNameAsync().ConfigureAwait(false);
+                                        await ParseEntityNameAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                                     }
                                     pos = _ps.charPos;
                                     break;
@@ -2818,7 +2818,7 @@ namespace System.Xml
 
             ReadData:
                 // read new characters into the buffer
-                if (await ReadDataAsync().ConfigureAwait(false) == 0)
+                if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     if (_ps.charsUsed - _ps.charPos > 0)
                     {
@@ -2956,7 +2956,7 @@ namespace System.Xml
                 (int, int, int, bool) tuple_9;
                 do
                 {
-                    tuple_9 = await ParseTextAsync(orChars).ConfigureAwait(false);
+                    tuple_9 = await ParseTextAsync(orChars).ConfigureAwait(OperatingSystem.IsBrowser());
                     orChars = tuple_9.Item3;
                 } while (!tuple_9.Item4);
 
@@ -2969,7 +2969,7 @@ namespace System.Xml
             parseTask = ParseTextAsync(orChars).AsTask();
 
         Parse:
-            var tuple_10 = await parseTask.ConfigureAwait(false);
+            var tuple_10 = await parseTask.ConfigureAwait(OperatingSystem.IsBrowser());
             startPos = tuple_10.Item1;
             endPos = tuple_10.Item2;
             orChars = tuple_10.Item3;
@@ -3004,7 +3004,7 @@ namespace System.Xml
                             _stringBuilder.Append(_ps.chars, startPos, endPos - startPos);
                         }
 
-                        tuple_11 = await ParseTextAsync(orChars).ConfigureAwait(false);
+                        tuple_11 = await ParseTextAsync(orChars).ConfigureAwait(OperatingSystem.IsBrowser());
                         startPos = tuple_11.Item1;
                         endPos = tuple_11.Item2;
                         orChars = tuple_11.Item3;
@@ -3050,7 +3050,7 @@ namespace System.Xml
                     }
                     do
                     {
-                        var tuple_12 = await ParseTextAsync(orChars).ConfigureAwait(false);
+                        var tuple_12 = await ParseTextAsync(orChars).ConfigureAwait(OperatingSystem.IsBrowser());
                         startPos = tuple_12.Item1;
                         endPos = tuple_12.Item2;
                         orChars = tuple_12.Item3;
@@ -3074,7 +3074,7 @@ namespace System.Xml
                             (int, int, int, bool) tuple_13;
                             do
                             {
-                                tuple_13 = await ParseTextAsync(orChars).ConfigureAwait(false);
+                                tuple_13 = await ParseTextAsync(orChars).ConfigureAwait(OperatingSystem.IsBrowser());
                                 orChars = tuple_13.Item3;
                             } while (!tuple_13.Item4);
                         }
@@ -3095,7 +3095,7 @@ namespace System.Xml
             }
 
         IgnoredNode:
-            return await ParseTextAsync_IgnoreNode().ConfigureAwait(false);
+            return await ParseTextAsync_IgnoreNode().ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         private Task<bool> ParseTextAsync_IgnoreNode()
@@ -3208,7 +3208,7 @@ namespace System.Xml
         {
             while (true)
             {
-                await task.ConfigureAwait(false);
+                await task.ConfigureAwait(OperatingSystem.IsBrowser());
 
                 int outOrChars = _lastParseTextState.outOrChars;
                 char[] chars = _lastParseTextState.chars;
@@ -3377,7 +3377,7 @@ namespace System.Xml
                     return _parseText_dummyTask.Result;
                 }
 
-                var tuple_14 = await HandleEntityReferenceAsync(false, EntityExpandType.All).ConfigureAwait(false);
+                var tuple_14 = await HandleEntityReferenceAsync(false, EntityExpandType.All).ConfigureAwait(OperatingSystem.IsBrowser());
                 pos = tuple_14.Item1;
 
                 switch (tuple_14.Item2)
@@ -3439,7 +3439,7 @@ namespace System.Xml
                 }
             }
             int offset = pos - _ps.charPos;
-            if (await ZeroEndingStreamAsync(pos).ConfigureAwait(false))
+            if (await ZeroEndingStreamAsync(pos).ConfigureAwait(OperatingSystem.IsBrowser()))
             {
                 chars = _ps.chars;
                 pos = _ps.charPos + offset;
@@ -3464,7 +3464,7 @@ namespace System.Xml
                 return _parseText_dummyTask.Result;
             }
             // read new characters into the buffer
-            if (await ReadDataAsync().ConfigureAwait(false) == 0)
+            if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
             {
                 if (_ps.charsUsed - _ps.charPos > 0)
                 {
@@ -3536,7 +3536,7 @@ namespace System.Xml
             int endPos;
             int orChars = 0;
 
-            var tuple_15 = await ParseTextAsync(orChars).ConfigureAwait(false);
+            var tuple_15 = await ParseTextAsync(orChars).ConfigureAwait(OperatingSystem.IsBrowser());
             startPos = tuple_15.Item1;
             endPos = tuple_15.Item2;
             orChars = tuple_15.Item3;
@@ -3545,7 +3545,7 @@ namespace System.Xml
             {
                 _stringBuilder.Append(_ps.chars, startPos, endPos - startPos);
 
-                tuple_15 = await ParseTextAsync(orChars).ConfigureAwait(false);
+                tuple_15 = await ParseTextAsync(orChars).ConfigureAwait(OperatingSystem.IsBrowser());
                 startPos = tuple_15.Item1;
                 endPos = tuple_15.Item2;
                 orChars = tuple_15.Item3;
@@ -3567,7 +3567,7 @@ namespace System.Xml
                 case ParsingFunction.InReadValueChunk:
                     if (_incReadState == IncrementalReadState.ReadValueChunk_OnPartialValue)
                     {
-                        await FinishPartialValueAsync().ConfigureAwait(false);
+                        await FinishPartialValueAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         _incReadState = IncrementalReadState.ReadValueChunk_OnCachedValue;
                     }
                     else
@@ -3584,7 +3584,7 @@ namespace System.Xml
                     switch (_incReadState)
                     {
                         case IncrementalReadState.ReadContentAsBinary_OnPartialValue:
-                            await FinishPartialValueAsync().ConfigureAwait(false);
+                            await FinishPartialValueAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                             _incReadState = IncrementalReadState.ReadContentAsBinary_OnCachedValue;
                             break;
                         case IncrementalReadState.ReadContentAsBinary_OnCachedValue:
@@ -3615,7 +3615,7 @@ namespace System.Xml
             (int, int, int, bool) tuple_16;
             do
             {
-                tuple_16 = await ParseTextAsync(orChars).ConfigureAwait(false);
+                tuple_16 = await ParseTextAsync(orChars).ConfigureAwait(OperatingSystem.IsBrowser());
                 orChars = tuple_16.Item3;
             } while (!tuple_16.Item4);
         }
@@ -3647,7 +3647,7 @@ namespace System.Xml
             if (_incReadState == IncrementalReadState.ReadContentAsBinary_OnPartialValue)
             {
                 Debug.Assert((_index > 0) ? _nextParsingFunction == ParsingFunction.ElementContent : _nextParsingFunction == ParsingFunction.DocumentContent);
-                await SkipPartialTextValueAsync().ConfigureAwait(false);
+                await SkipPartialTextValueAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
             else
             {
@@ -3656,20 +3656,20 @@ namespace System.Xml
             }
             if (_incReadState != IncrementalReadState.ReadContentAsBinary_End)
             {
-                while (await MoveToNextContentNodeAsync(true).ConfigureAwait(false)) ;
+                while (await MoveToNextContentNodeAsync(true).ConfigureAwait(OperatingSystem.IsBrowser())) ;
             }
         }
 
         private async Task FinishReadElementContentAsBinaryAsync()
         {
-            await FinishReadContentAsBinaryAsync().ConfigureAwait(false);
+            await FinishReadContentAsBinaryAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
             if (_curNode.type != XmlNodeType.EndElement)
             {
                 Throw(SR.Xml_InvalidNodeType, _curNode.type.ToString());
             }
             // move off the end element
-            await _outerReader.ReadAsync().ConfigureAwait(false);
+            await _outerReader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         private async Task<bool> ParseRootLevelWhitespaceAsync()
@@ -3680,8 +3680,8 @@ namespace System.Xml
 
             if (nodeType == XmlNodeType.None)
             {
-                await EatWhitespacesAsync(null).ConfigureAwait(false);
-                if (_ps.chars[_ps.charPos] == '<' || _ps.charsUsed - _ps.charPos == 0 || await ZeroEndingStreamAsync(_ps.charPos).ConfigureAwait(false))
+                await EatWhitespacesAsync(null).ConfigureAwait(OperatingSystem.IsBrowser());
+                if (_ps.chars[_ps.charPos] == '<' || _ps.charsUsed - _ps.charPos == 0 || await ZeroEndingStreamAsync(_ps.charPos).ConfigureAwait(OperatingSystem.IsBrowser()))
                 {
                     return false;
                 }
@@ -3689,8 +3689,8 @@ namespace System.Xml
             else
             {
                 _curNode.SetLineInfo(_ps.LineNo, _ps.LinePos);
-                await EatWhitespacesAsync(_stringBuilder).ConfigureAwait(false);
-                if (_ps.chars[_ps.charPos] == '<' || _ps.charsUsed - _ps.charPos == 0 || await ZeroEndingStreamAsync(_ps.charPos).ConfigureAwait(false))
+                await EatWhitespacesAsync(_stringBuilder).ConfigureAwait(OperatingSystem.IsBrowser());
+                if (_ps.chars[_ps.charPos] == '<' || _ps.charsUsed - _ps.charPos == 0 || await ZeroEndingStreamAsync(_ps.charPos).ConfigureAwait(OperatingSystem.IsBrowser()))
                 {
                     if (_stringBuilder.Length > 0)
                     {
@@ -3719,7 +3719,7 @@ namespace System.Xml
             _ps.charPos++;
 
             _curNode.SetLineInfo(_ps.LineNo, _ps.LinePos);
-            _curNode.SetNamedNode(XmlNodeType.EntityReference, await ParseEntityNameAsync().ConfigureAwait(false));
+            _curNode.SetNamedNode(XmlNodeType.EntityReference, await ParseEntityNameAsync().ConfigureAwait(OperatingSystem.IsBrowser()));
         }
 
         private async Task<(int, EntityType)> HandleEntityReferenceAsync(bool isInAttributeValue, EntityExpandType expandType)
@@ -3730,7 +3730,7 @@ namespace System.Xml
 
             if (_ps.charPos + 1 == _ps.charsUsed)
             {
-                if (await ReadDataAsync().ConfigureAwait(false) == 0)
+                if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     Throw(SR.Xml_UnexpectedEOF1);
                 }
@@ -3741,7 +3741,7 @@ namespace System.Xml
             {
                 EntityType entityType;
 
-                var tuple_17 = await ParseNumericCharRefAsync(expandType != EntityExpandType.OnlyGeneral, null).ConfigureAwait(false);
+                var tuple_17 = await ParseNumericCharRefAsync(expandType != EntityExpandType.OnlyGeneral, null).ConfigureAwait(OperatingSystem.IsBrowser());
                 entityType = tuple_17.Item1;
 
                 charRefEndPos = tuple_17.Item2;
@@ -3754,7 +3754,7 @@ namespace System.Xml
             else
             {
                 // named character reference
-                charRefEndPos = await ParseNamedCharRefAsync(expandType != EntityExpandType.OnlyGeneral, null).ConfigureAwait(false);
+                charRefEndPos = await ParseNamedCharRefAsync(expandType != EntityExpandType.OnlyGeneral, null).ConfigureAwait(OperatingSystem.IsBrowser());
                 if (charRefEndPos >= 0)
                 {
                     return (charRefEndPos, EntityType.CharacterNamed);
@@ -3776,7 +3776,7 @@ namespace System.Xml
                 int savedLinePos = _ps.LinePos;
                 try
                 {
-                    endPos = await ParseNameAsync().ConfigureAwait(false);
+                    endPos = await ParseNameAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 catch (XmlException)
                 {
@@ -3796,7 +3796,7 @@ namespace System.Xml
                 _ps.charPos = endPos + 1;
                 charRefEndPos = -1;
 
-                EntityType entType = await HandleGeneralEntityReferenceAsync(entityName, isInAttributeValue, false, entityLinePos).ConfigureAwait(false);
+                EntityType entType = await HandleGeneralEntityReferenceAsync(entityName, isInAttributeValue, false, entityLinePos).ConfigureAwait(OperatingSystem.IsBrowser());
                 _reportedBaseUri = _ps.baseUriStr;
                 _reportedEncoding = _ps.encoding;
 
@@ -3812,7 +3812,7 @@ namespace System.Xml
 
             if (_dtdInfo == null && _fragmentParserContext != null && _fragmentParserContext.HasDtdInfo && _dtdProcessing == DtdProcessing.Parse)
             {
-                await ParseDtdFromParserContextAsync().ConfigureAwait(false);
+                await ParseDtdFromParserContextAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             if (_dtdInfo == null ||
@@ -3864,7 +3864,7 @@ namespace System.Xml
                 {
                     if (pushFakeEntityIfNullResolver)
                     {
-                        await PushExternalEntityAsync(entity).ConfigureAwait(false);
+                        await PushExternalEntityAsync(entity).ConfigureAwait(OperatingSystem.IsBrowser());
                         _curNode.entityId = _ps.entityId;
                         return EntityType.FakeExpanded;
                     }
@@ -3872,7 +3872,7 @@ namespace System.Xml
                 }
                 else
                 {
-                    await PushExternalEntityAsync(entity).ConfigureAwait(false);
+                    await PushExternalEntityAsync(entity).ConfigureAwait(OperatingSystem.IsBrowser());
                     _curNode.entityId = _ps.entityId;
                     return EntityType.Expanded;
                 }
@@ -3908,7 +3908,7 @@ namespace System.Xml
             Debug.Assert(_stringBuilder.Length == 0);
 
             // parse target name
-            int nameEndPos = await ParseNameAsync().ConfigureAwait(false);
+            int nameEndPos = await ParseNameAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             string target = _nameTable.Add(_ps.chars, _ps.charPos, nameEndPos - _ps.charPos);
 
             if (string.Equals(target, "xml", StringComparison.OrdinalIgnoreCase))
@@ -3932,11 +3932,11 @@ namespace System.Xml
             // check mandatory whitespace
             char ch = _ps.chars[_ps.charPos];
             Debug.Assert(_ps.charPos < _ps.charsUsed);
-            if (await EatWhitespacesAsync(piInDtdStringBuilder).ConfigureAwait(false) == 0)
+            if (await EatWhitespacesAsync(piInDtdStringBuilder).ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
             {
                 if (_ps.charsUsed - _ps.charPos < 2)
                 {
-                    await ReadDataAsync().ConfigureAwait(false);
+                    await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 if (ch != '?' || _ps.chars[_ps.charPos + 1] != '>')
                 {
@@ -3947,7 +3947,7 @@ namespace System.Xml
             // scan processing instruction value
             int startPos, endPos;
 
-            var tuple_18 = await ParsePIValueAsync().ConfigureAwait(false);
+            var tuple_18 = await ParsePIValueAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             startPos = tuple_18.Item1;
             endPos = tuple_18.Item2;
 
@@ -3979,7 +3979,7 @@ namespace System.Xml
                         (int, int, bool) tuple_19;
                         do
                         {
-                            tuple_19 = await ParsePIValueAsync().ConfigureAwait(false);
+                            tuple_19 = await ParsePIValueAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         } while (!tuple_19.Item3);
 
                         return false;
@@ -3998,7 +3998,7 @@ namespace System.Xml
                 {
                     sb.Append(_ps.chars, startPos, endPos - startPos);
 
-                    tuple_20 = await ParsePIValueAsync().ConfigureAwait(false);
+                    tuple_20 = await ParsePIValueAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     startPos = tuple_20.Item1;
                     endPos = tuple_20.Item2;
                 } while (!tuple_20.Item3);
@@ -4022,7 +4022,7 @@ namespace System.Xml
             // read new characters into the buffer
             if (_ps.charsUsed - _ps.charPos < 2)
             {
-                if (await ReadDataAsync().ConfigureAwait(false) == 0)
+                if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     Throw(_ps.charsUsed, SR.Xml_UnexpectedEOF, "PI");
                 }
@@ -4175,13 +4175,13 @@ namespace System.Xml
             {
                 ParsingMode oldParsingMode = _parsingMode;
                 _parsingMode = ParsingMode.SkipNode;
-                await ParseCDataOrCommentAsync(XmlNodeType.Comment).ConfigureAwait(false);
+                await ParseCDataOrCommentAsync(XmlNodeType.Comment).ConfigureAwait(OperatingSystem.IsBrowser());
                 _parsingMode = oldParsingMode;
                 return false;
             }
             else
             {
-                await ParseCDataOrCommentAsync(XmlNodeType.Comment).ConfigureAwait(false);
+                await ParseCDataOrCommentAsync(XmlNodeType.Comment).ConfigureAwait(OperatingSystem.IsBrowser());
                 return true;
             }
         }
@@ -4201,7 +4201,7 @@ namespace System.Xml
                 _curNode.SetLineInfo(_ps.LineNo, _ps.LinePos);
                 Debug.Assert(_stringBuilder.Length == 0);
 
-                var tuple_21 = await ParseCDataOrCommentTupleAsync(type).ConfigureAwait(false);
+                var tuple_21 = await ParseCDataOrCommentTupleAsync(type).ConfigureAwait(OperatingSystem.IsBrowser());
                 startPos = tuple_21.Item1;
                 endPos = tuple_21.Item2;
 
@@ -4217,7 +4217,7 @@ namespace System.Xml
                     {
                         _stringBuilder.Append(_ps.chars, startPos, endPos - startPos);
 
-                        tuple_22 = await ParseCDataOrCommentTupleAsync(type).ConfigureAwait(false);
+                        tuple_22 = await ParseCDataOrCommentTupleAsync(type).ConfigureAwait(OperatingSystem.IsBrowser());
                         startPos = tuple_22.Item1;
                         endPos = tuple_22.Item2;
                     } while (!tuple_22.Item3);
@@ -4232,7 +4232,7 @@ namespace System.Xml
                 (int, int, bool) tuple_23;
                 do
                 {
-                    tuple_23 = await ParseCDataOrCommentTupleAsync(type).ConfigureAwait(false);
+                    tuple_23 = await ParseCDataOrCommentTupleAsync(type).ConfigureAwait(OperatingSystem.IsBrowser());
                 } while (!tuple_23.Item3);
             }
         }
@@ -4247,7 +4247,7 @@ namespace System.Xml
             if (_ps.charsUsed - _ps.charPos < 3)
             {
                 // read new characters into the buffer
-                if (await ReadDataAsync().ConfigureAwait(false) == 0)
+                if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     Throw(SR.Xml_UnexpectedEOF, (type == XmlNodeType.Comment) ? "Comment" : "CDATA");
                 }
@@ -4416,7 +4416,7 @@ namespace System.Xml
             // parse 'DOCTYPE'
             while (_ps.charsUsed - _ps.charPos < 8)
             {
-                if (await ReadDataAsync().ConfigureAwait(false) == 0)
+                if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     Throw(SR.Xml_UnexpectedEOF, "DOCTYPE");
                 }
@@ -4441,14 +4441,14 @@ namespace System.Xml
 
             _ps.charPos += 8;
 
-            await EatWhitespacesAsync(null).ConfigureAwait(false);
+            await EatWhitespacesAsync(null).ConfigureAwait(OperatingSystem.IsBrowser());
 
             // Parse DTD
             if (_dtdProcessing == DtdProcessing.Parse)
             {
                 _curNode.SetLineInfo(_ps.LineNo, _ps.LinePos);
 
-                await ParseDtdAsync().ConfigureAwait(false);
+                await ParseDtdAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
                 _nextParsingFunction = _parsingFunction;
                 _parsingFunction = ParsingFunction.ResetAttributesRootLevel;
@@ -4459,7 +4459,7 @@ namespace System.Xml
             {
                 Debug.Assert(_dtdProcessing == DtdProcessing.Ignore);
 
-                await SkipDtdAsync().ConfigureAwait(false);
+                await SkipDtdAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 return false;
             }
         }
@@ -4468,7 +4468,7 @@ namespace System.Xml
         {
             IDtdParser dtdParser = DtdParser.Create();
 
-            _dtdInfo = await dtdParser.ParseInternalDtdAsync(new DtdParserProxy(this), true).ConfigureAwait(false);
+            _dtdInfo = await dtdParser.ParseInternalDtdAsync(new DtdParserProxy(this), true).ConfigureAwait(OperatingSystem.IsBrowser());
 
             if ((_validatingReaderCompatFlag || !_v1Compat) && (_dtdInfo.HasDefaultAttributes || _dtdInfo.HasNonCDataAttributes))
             {
@@ -4484,14 +4484,14 @@ namespace System.Xml
 
             // parse dtd name
 
-            var tuple_24 = await ParseQNameAsync().ConfigureAwait(false);
+            var tuple_24 = await ParseQNameAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
             int pos = tuple_24.Item2;
 
             _ps.charPos = pos;
 
             // check whitespace
-            await EatWhitespacesAsync(null).ConfigureAwait(false);
+            await EatWhitespacesAsync(null).ConfigureAwait(OperatingSystem.IsBrowser());
 
             // PUBLIC Id
             if (_ps.chars[_ps.charPos] == 'P')
@@ -4499,7 +4499,7 @@ namespace System.Xml
                 // make sure we have enough characters
                 while (_ps.charsUsed - _ps.charPos < 6)
                 {
-                    if (await ReadDataAsync().ConfigureAwait(false) == 0)
+                    if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                     {
                         Throw(SR.Xml_UnexpectedEOF1);
                     }
@@ -4512,31 +4512,31 @@ namespace System.Xml
                 _ps.charPos += 6;
 
                 // check whitespace
-                if (await EatWhitespacesAsync(null).ConfigureAwait(false) == 0)
+                if (await EatWhitespacesAsync(null).ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     ThrowExpectingWhitespace(_ps.charPos);
                 }
 
                 // parse PUBLIC value
-                await SkipPublicOrSystemIdLiteralAsync().ConfigureAwait(false);
+                await SkipPublicOrSystemIdLiteralAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
                 // check whitespace
-                if (await EatWhitespacesAsync(null).ConfigureAwait(false) == 0)
+                if (await EatWhitespacesAsync(null).ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     ThrowExpectingWhitespace(_ps.charPos);
                 }
 
                 // parse SYSTEM value
-                await SkipPublicOrSystemIdLiteralAsync().ConfigureAwait(false);
+                await SkipPublicOrSystemIdLiteralAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
-                await EatWhitespacesAsync(null).ConfigureAwait(false);
+                await EatWhitespacesAsync(null).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             else if (_ps.chars[_ps.charPos] == 'S')
             {
                 // make sure we have enough characters
                 while (_ps.charsUsed - _ps.charPos < 6)
                 {
-                    if (await ReadDataAsync().ConfigureAwait(false) == 0)
+                    if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                     {
                         Throw(SR.Xml_UnexpectedEOF1);
                     }
@@ -4549,15 +4549,15 @@ namespace System.Xml
                 _ps.charPos += 6;
 
                 // check whitespace
-                if (await EatWhitespacesAsync(null).ConfigureAwait(false) == 0)
+                if (await EatWhitespacesAsync(null).ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     ThrowExpectingWhitespace(_ps.charPos);
                 }
 
                 // parse SYSTEM value
-                await SkipPublicOrSystemIdLiteralAsync().ConfigureAwait(false);
+                await SkipPublicOrSystemIdLiteralAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
-                await EatWhitespacesAsync(null).ConfigureAwait(false);
+                await EatWhitespacesAsync(null).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             else if (_ps.chars[_ps.charPos] != '[' && _ps.chars[_ps.charPos] != '>')
             {
@@ -4569,9 +4569,9 @@ namespace System.Xml
             {
                 _ps.charPos++;
 
-                await SkipUntilAsync(']', true).ConfigureAwait(false);
+                await SkipUntilAsync(']', true).ConfigureAwait(OperatingSystem.IsBrowser());
 
-                await EatWhitespacesAsync(null).ConfigureAwait(false);
+                await EatWhitespacesAsync(null).ConfigureAwait(OperatingSystem.IsBrowser());
                 if (_ps.chars[_ps.charPos] != '>')
                 {
                     ThrowUnexpectedToken(">");
@@ -4779,7 +4779,7 @@ namespace System.Xml
 
             ReadData:
                 // read new characters into the buffer
-                if (await ReadDataAsync().ConfigureAwait(false) == 0)
+                if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     if (_ps.charsUsed - _ps.charPos > 0)
                     {
@@ -4877,7 +4877,7 @@ namespace System.Xml
                     wsCount += tmp3;
                 }
 
-                if (await ReadDataAsync().ConfigureAwait(false) == 0)
+                if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     if (_ps.charsUsed - _ps.charPos == 0)
                     {
@@ -4913,7 +4913,7 @@ namespace System.Xml
                 {
                     case -2:
                         // read new characters in the buffer
-                        if (await ReadDataAsync().ConfigureAwait(false) == 0)
+                        if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                         {
                             Throw(SR.Xml_UnexpectedEOF);
                         }
@@ -4947,7 +4947,7 @@ namespace System.Xml
                         return -1;
                     case -2:
                         // read new characters in the buffer
-                        if (await ReadDataAsync().ConfigureAwait(false) == 0)
+                        if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                         {
                             return -1;
                         }
@@ -4965,7 +4965,7 @@ namespace System.Xml
 
         private async Task<int> ParseNameAsync()
         {
-            var tuple_25 = await ParseQNameAsync(false, 0).ConfigureAwait(false);
+            var tuple_25 = await ParseQNameAsync(false, 0).ConfigureAwait(OperatingSystem.IsBrowser());
             return tuple_25.Item2;
         }
 
@@ -4993,7 +4993,7 @@ namespace System.Xml
             {
                 if (pos + 1 >= _ps.charsUsed)
                 {
-                    var tuple_27 = await ReadDataInNameAsync(pos).ConfigureAwait(false);
+                    var tuple_27 = await ReadDataInNameAsync(pos).ConfigureAwait(OperatingSystem.IsBrowser());
                     pos = tuple_27.Item1;
 
                     if (tuple_27.Item2)
@@ -5045,7 +5045,7 @@ namespace System.Xml
             // end of buffer
             else if (pos == _ps.charsUsed)
             {
-                var tuple_28 = await ReadDataInNameAsync(pos).ConfigureAwait(false);
+                var tuple_28 = await ReadDataInNameAsync(pos).ConfigureAwait(OperatingSystem.IsBrowser());
                 pos = tuple_28.Item1;
 
                 if (tuple_28.Item2)
@@ -5065,7 +5065,7 @@ namespace System.Xml
         private async Task<(int, bool)> ReadDataInNameAsync(int pos)
         {
             int offset = pos - _ps.charPos;
-            bool newDataRead = (await ReadDataAsync().ConfigureAwait(false) != 0);
+            bool newDataRead = (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) != 0);
             pos = _ps.charPos + offset;
 
             return (pos, newDataRead);
@@ -5076,7 +5076,7 @@ namespace System.Xml
             int endPos;
             try
             {
-                endPos = await ParseNameAsync().ConfigureAwait(false);
+                endPos = await ParseNameAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
             catch (XmlException)
             {
@@ -5107,7 +5107,7 @@ namespace System.Xml
                 try
                 {
                     uri = _xmlResolver!.ResolveUri(baseUri, publicId);
-                    if (await OpenAndPushAsync(uri).ConfigureAwait(false))
+                    if (await OpenAndPushAsync(uri).ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         return;
                     }
@@ -5122,7 +5122,7 @@ namespace System.Xml
             uri = _xmlResolver!.ResolveUri(baseUri, systemId);
             try
             {
-                if (await OpenAndPushAsync(uri).ConfigureAwait(false))
+                if (await OpenAndPushAsync(uri).ConfigureAwait(OperatingSystem.IsBrowser()))
                 {
                     return;
                 }
@@ -5163,28 +5163,28 @@ namespace System.Xml
             // First try to get the data as a TextReader
             if (_xmlResolver.SupportsType(uri, typeof(TextReader)))
             {
-                TextReader textReader = (TextReader)await _xmlResolver.GetEntityAsync(uri, null, typeof(TextReader)).ConfigureAwait(false);
+                TextReader textReader = (TextReader)await _xmlResolver.GetEntityAsync(uri, null, typeof(TextReader)).ConfigureAwait(OperatingSystem.IsBrowser());
                 if (textReader == null)
                 {
                     return false;
                 }
 
                 PushParsingState();
-                await InitTextReaderInputAsync(uri.ToString(), uri, textReader).ConfigureAwait(false);
+                await InitTextReaderInputAsync(uri.ToString(), uri, textReader).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             else
             {
                 // Then try get it as a Stream
                 Debug.Assert(_xmlResolver.SupportsType(uri, typeof(Stream)), "Stream must always be a supported type in XmlResolver");
 
-                Stream stream = (Stream)await _xmlResolver.GetEntityAsync(uri, null, typeof(Stream)).ConfigureAwait(false);
+                Stream stream = (Stream)await _xmlResolver.GetEntityAsync(uri, null, typeof(Stream)).ConfigureAwait(OperatingSystem.IsBrowser());
                 if (stream == null)
                 {
                     return false;
                 }
 
                 PushParsingState();
-                await InitStreamInputAsync(uri, stream, null).ConfigureAwait(false);
+                await InitStreamInputAsync(uri, stream, null).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             return true;
         }
@@ -5204,7 +5204,7 @@ namespace System.Xml
                 {
                     entityBaseUri = _xmlResolver!.ResolveUri(null, entity.BaseUriString);
                 }
-                await PushExternalEntityOrSubsetAsync(entity.PublicId, entity.SystemId, entityBaseUri, entity.Name).ConfigureAwait(false);
+                await PushExternalEntityOrSubsetAsync(entity.PublicId, entity.SystemId, entityBaseUri, entity.Name).ConfigureAwait(OperatingSystem.IsBrowser());
 
                 RegisterEntity(entity);
 
@@ -5212,9 +5212,9 @@ namespace System.Xml
                 int initialPos = _ps.charPos;
                 if (_v1Compat)
                 {
-                    await EatWhitespacesAsync(null).ConfigureAwait(false);
+                    await EatWhitespacesAsync(null).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
-                if (!await ParseXmlDeclarationAsync(true).ConfigureAwait(false))
+                if (!await ParseXmlDeclarationAsync(true).ConfigureAwait(OperatingSystem.IsBrowser()))
                 {
                     _ps.charPos = initialPos;
                 }
@@ -5242,7 +5242,7 @@ namespace System.Xml
         // Note that this method calls ReadData() which may change the value of ps.chars and ps.charPos.
         private async Task<bool> ZeroEndingStreamAsync(int pos)
         {
-            if (_v1Compat && pos == _ps.charsUsed - 1 && _ps.chars[pos] == (char)0 && await ReadDataAsync().ConfigureAwait(false) == 0 && _ps.isStreamEof)
+            if (_v1Compat && pos == _ps.charsUsed - 1 && _ps.chars[pos] == (char)0 && await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0 && _ps.isStreamEof)
             {
                 _ps.charsUsed--;
                 return true;
@@ -5257,7 +5257,7 @@ namespace System.Xml
             IDtdParser dtdParser = DtdParser.Create();
 
             // Parse DTD
-            _dtdInfo = await dtdParser.ParseFreeFloatingDtdAsync(_fragmentParserContext.BaseURI, _fragmentParserContext.DocTypeName, _fragmentParserContext.PublicId, _fragmentParserContext.SystemId, _fragmentParserContext.InternalSubset, new DtdParserProxy(this)).ConfigureAwait(false);
+            _dtdInfo = await dtdParser.ParseFreeFloatingDtdAsync(_fragmentParserContext.BaseURI, _fragmentParserContext.DocTypeName, _fragmentParserContext.PublicId, _fragmentParserContext.SystemId, _fragmentParserContext.InternalSubset, new DtdParserProxy(this)).ConfigureAwait(OperatingSystem.IsBrowser());
 
             if ((_validatingReaderCompatFlag || !_v1Compat) && (_dtdInfo.HasDefaultAttributes || _dtdInfo.HasNonCDataAttributes))
             {
@@ -5280,7 +5280,7 @@ namespace System.Xml
 
             if (!XmlReader.IsTextualNode(_curNode.type))
             {
-                if (!await MoveToNextContentNodeAsync(false).ConfigureAwait(false))
+                if (!await MoveToNextContentNodeAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()))
                 {
                     return false;
                 }
@@ -5299,21 +5299,21 @@ namespace System.Xml
             bool isEmpty = _curNode.IsEmptyElement;
 
             // move to content or off the empty element
-            await _outerReader.ReadAsync().ConfigureAwait(false);
+            await _outerReader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             if (isEmpty)
             {
                 return false;
             }
 
             // make sure we are on a content node
-            if (!await MoveToNextContentNodeAsync(false).ConfigureAwait(false))
+            if (!await MoveToNextContentNodeAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()))
             {
                 if (_curNode.type != XmlNodeType.EndElement)
                 {
                     Throw(SR.Xml_InvalidNodeType, _curNode.type.ToString());
                 }
                 // move off end element
-                await _outerReader.ReadAsync().ConfigureAwait(false);
+                await _outerReader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 return false;
             }
             SetupReadContentAsBinaryState(ParsingFunction.InReadElementContentAsBinary);
@@ -5350,7 +5350,7 @@ namespace System.Xml
                         return false;
                 }
                 moveIfOnContentNode = false;
-            } while (await _outerReader.ReadAsync().ConfigureAwait(false));
+            } while (await _outerReader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser()));
             return false;
         }
 
@@ -5402,7 +5402,7 @@ namespace System.Xml
                         // store current line info and parse more text
                         _incReadLineInfo.Set(_ps.LineNo, _ps.LinePos);
 
-                        var tuple_36 = await ParseTextAsync(orChars).ConfigureAwait(false);
+                        var tuple_36 = await ParseTextAsync(orChars).ConfigureAwait(OperatingSystem.IsBrowser());
                         startPos = tuple_36.Item1;
                         endPos = tuple_36.Item2;
 
@@ -5438,7 +5438,7 @@ namespace System.Xml
                 _nextParsingFunction = _nextNextParsingFunction;
 
                 // move to next textual node in the element content; throw on sub elements
-                if (!await MoveToNextContentNodeAsync(true).ConfigureAwait(false))
+                if (!await MoveToNextContentNodeAsync(true).ConfigureAwait(OperatingSystem.IsBrowser()))
                 {
                     SetupReadContentAsBinaryState(tmp);
                     _incReadState = IncrementalReadState.ReadContentAsBinary_End;
@@ -5455,7 +5455,7 @@ namespace System.Xml
             {
                 return 0;
             }
-            int decoded = await ReadContentAsBinaryAsync(buffer, index, count).ConfigureAwait(false);
+            int decoded = await ReadContentAsBinaryAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
             if (decoded > 0)
             {
                 return decoded;
@@ -5473,7 +5473,7 @@ namespace System.Xml
             Debug.Assert(_parsingFunction != ParsingFunction.InReadElementContentAsBinary);
 
             // move off the EndElement
-            await _outerReader.ReadAsync().ConfigureAwait(false);
+            await _outerReader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             return 0;
         }
     }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriterAsync.cs
@@ -36,26 +36,26 @@ namespace System.Xml
             // Output xml declaration only if user allows it and it was not already output
             if (!_omitXmlDeclaration && !_autoXmlDeclaration)
             {
-                await RawTextAsync("<?xml version=\"").ConfigureAwait(false);
+                await RawTextAsync("<?xml version=\"").ConfigureAwait(OperatingSystem.IsBrowser());
 
                 // Version
-                await RawTextAsync("1.0").ConfigureAwait(false);
+                await RawTextAsync("1.0").ConfigureAwait(OperatingSystem.IsBrowser());
 
                 // Encoding
                 if (_encoding != null)
                 {
-                    await RawTextAsync("\" encoding=\"").ConfigureAwait(false);
-                    await RawTextAsync(_encoding.WebName).ConfigureAwait(false);
+                    await RawTextAsync("\" encoding=\"").ConfigureAwait(OperatingSystem.IsBrowser());
+                    await RawTextAsync(_encoding.WebName).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
 
                 // Standalone
                 if (standalone != XmlStandalone.Omit)
                 {
-                    await RawTextAsync("\" standalone=\"").ConfigureAwait(false);
-                    await RawTextAsync(standalone == XmlStandalone.Yes ? "yes" : "no").ConfigureAwait(false);
+                    await RawTextAsync("\" standalone=\"").ConfigureAwait(OperatingSystem.IsBrowser());
+                    await RawTextAsync(standalone == XmlStandalone.Yes ? "yes" : "no").ConfigureAwait(OperatingSystem.IsBrowser());
                 }
 
-                await RawTextAsync("\"?>").ConfigureAwait(false);
+                await RawTextAsync("\"?>").ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -75,7 +75,7 @@ namespace System.Xml
         {
             try
             {
-                await FlushBufferAsync().ConfigureAwait(false);
+                await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
             finally
             {
@@ -86,7 +86,7 @@ namespace System.Xml
                 {
                     try
                     {
-                        await _stream.FlushAsync().ConfigureAwait(false);
+                        await _stream.FlushAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     finally
                     {
@@ -94,7 +94,7 @@ namespace System.Xml
                         {
                             if (_closeOutput)
                             {
-                                await _stream.DisposeAsync().ConfigureAwait(false);
+                                await _stream.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                             }
                         }
                         finally
@@ -112,23 +112,23 @@ namespace System.Xml
             CheckAsyncCall();
             Debug.Assert(name != null && name.Length > 0);
 
-            await RawTextAsync("<!DOCTYPE ").ConfigureAwait(false);
-            await RawTextAsync(name).ConfigureAwait(false);
+            await RawTextAsync("<!DOCTYPE ").ConfigureAwait(OperatingSystem.IsBrowser());
+            await RawTextAsync(name).ConfigureAwait(OperatingSystem.IsBrowser());
             if (pubid != null)
             {
-                await RawTextAsync(" PUBLIC \"").ConfigureAwait(false);
-                await RawTextAsync(pubid).ConfigureAwait(false);
-                await RawTextAsync("\" \"").ConfigureAwait(false);
+                await RawTextAsync(" PUBLIC \"").ConfigureAwait(OperatingSystem.IsBrowser());
+                await RawTextAsync(pubid).ConfigureAwait(OperatingSystem.IsBrowser());
+                await RawTextAsync("\" \"").ConfigureAwait(OperatingSystem.IsBrowser());
                 if (sysid != null)
                 {
-                    await RawTextAsync(sysid).ConfigureAwait(false);
+                    await RawTextAsync(sysid).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 _bufBytes[_bufPos++] = (byte)'"';
             }
             else if (sysid != null)
             {
-                await RawTextAsync(" SYSTEM \"").ConfigureAwait(false);
-                await RawTextAsync(sysid).ConfigureAwait(false);
+                await RawTextAsync(" SYSTEM \"").ConfigureAwait(OperatingSystem.IsBrowser());
+                await RawTextAsync(sysid).ConfigureAwait(OperatingSystem.IsBrowser());
                 _bufBytes[_bufPos++] = (byte)'"';
             }
             else
@@ -139,7 +139,7 @@ namespace System.Xml
             if (subset != null)
             {
                 _bufBytes[_bufPos++] = (byte)'[';
-                await RawTextAsync(subset).ConfigureAwait(false);
+                await RawTextAsync(subset).ConfigureAwait(OperatingSystem.IsBrowser());
                 _bufBytes[_bufPos++] = (byte)']';
             }
 
@@ -272,9 +272,9 @@ namespace System.Xml
             CheckAsyncCall();
             Debug.Assert(prefix != null && namespaceName != null);
 
-            await WriteStartNamespaceDeclarationAsync(prefix).ConfigureAwait(false);
-            await WriteStringAsync(namespaceName).ConfigureAwait(false);
-            await WriteEndNamespaceDeclarationAsync().ConfigureAwait(false);
+            await WriteStartNamespaceDeclarationAsync(prefix).ConfigureAwait(OperatingSystem.IsBrowser());
+            await WriteStringAsync(namespaceName).ConfigureAwait(OperatingSystem.IsBrowser());
+            await WriteEndNamespaceDeclarationAsync().ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         internal override async Task WriteStartNamespaceDeclarationAsync(string prefix)
@@ -289,12 +289,12 @@ namespace System.Xml
 
             if (prefix.Length == 0)
             {
-                await RawTextAsync("xmlns=\"").ConfigureAwait(false);
+                await RawTextAsync("xmlns=\"").ConfigureAwait(OperatingSystem.IsBrowser());
             }
             else
             {
-                await RawTextAsync("xmlns:").ConfigureAwait(false);
-                await RawTextAsync(prefix).ConfigureAwait(false);
+                await RawTextAsync("xmlns:").ConfigureAwait(OperatingSystem.IsBrowser());
+                await RawTextAsync(prefix).ConfigureAwait(OperatingSystem.IsBrowser());
                 _bufBytes[_bufPos++] = (byte)'=';
                 _bufBytes[_bufPos++] = (byte)'"';
             }
@@ -341,7 +341,7 @@ namespace System.Xml
                 _bufBytes[_bufPos++] = (byte)'[';
             }
 
-            await WriteCDataSectionAsync(text).ConfigureAwait(false);
+            await WriteCDataSectionAsync(text).ConfigureAwait(OperatingSystem.IsBrowser());
 
             _bufBytes[_bufPos++] = (byte)']';
             _bufBytes[_bufPos++] = (byte)']';
@@ -362,7 +362,7 @@ namespace System.Xml
             _bufBytes[_bufPos++] = (byte)'-';
             _bufBytes[_bufPos++] = (byte)'-';
 
-            await WriteCommentOrPiAsync(text, '-').ConfigureAwait(false);
+            await WriteCommentOrPiAsync(text, '-').ConfigureAwait(OperatingSystem.IsBrowser());
 
             _bufBytes[_bufPos++] = (byte)'-';
             _bufBytes[_bufPos++] = (byte)'-';
@@ -378,12 +378,12 @@ namespace System.Xml
 
             _bufBytes[_bufPos++] = (byte)'<';
             _bufBytes[_bufPos++] = (byte)'?';
-            await RawTextAsync(name).ConfigureAwait(false);
+            await RawTextAsync(name).ConfigureAwait(OperatingSystem.IsBrowser());
 
             if (text.Length > 0)
             {
                 _bufBytes[_bufPos++] = (byte)' ';
-                await WriteCommentOrPiAsync(text, '?').ConfigureAwait(false);
+                await WriteCommentOrPiAsync(text, '?').ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             _bufBytes[_bufPos++] = (byte)'?';
@@ -397,12 +397,12 @@ namespace System.Xml
             Debug.Assert(name != null && name.Length > 0);
 
             _bufBytes[_bufPos++] = (byte)'&';
-            await RawTextAsync(name).ConfigureAwait(false);
+            await RawTextAsync(name).ConfigureAwait(OperatingSystem.IsBrowser());
             _bufBytes[_bufPos++] = (byte)';';
 
             if (_bufPos > _bufLen)
             {
-                await FlushBufferAsync().ConfigureAwait(false);
+                await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             _textPos = _bufPos;
@@ -423,12 +423,12 @@ namespace System.Xml
             _bufBytes[_bufPos++] = (byte)'&';
             _bufBytes[_bufPos++] = (byte)'#';
             _bufBytes[_bufPos++] = (byte)'x';
-            await RawTextAsync(strVal).ConfigureAwait(false);
+            await RawTextAsync(strVal).ConfigureAwait(OperatingSystem.IsBrowser());
             _bufBytes[_bufPos++] = (byte)';';
 
             if (_bufPos > _bufLen)
             {
-                await FlushBufferAsync().ConfigureAwait(false);
+                await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             _textPos = _bufPos;
@@ -478,7 +478,7 @@ namespace System.Xml
             _bufBytes[_bufPos++] = (byte)'&';
             _bufBytes[_bufPos++] = (byte)'#';
             _bufBytes[_bufPos++] = (byte)'x';
-            await RawTextAsync(surrogateChar.ToString("X", NumberFormatInfo.InvariantInfo)).ConfigureAwait(false);
+            await RawTextAsync(surrogateChar.ToString("X", NumberFormatInfo.InvariantInfo)).ConfigureAwait(OperatingSystem.IsBrowser());
             _bufBytes[_bufPos++] = (byte)';';
             _textPos = _bufPos;
         }
@@ -513,7 +513,7 @@ namespace System.Xml
             Debug.Assert(index >= 0);
             Debug.Assert(count >= 0 && index + count <= buffer.Length);
 
-            await WriteRawWithCharCheckingAsync(buffer, index, count).ConfigureAwait(false);
+            await WriteRawWithCharCheckingAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
 
             _textPos = _bufPos;
         }
@@ -525,7 +525,7 @@ namespace System.Xml
             CheckAsyncCall();
             Debug.Assert(data != null);
 
-            await WriteRawWithCharCheckingAsync(data).ConfigureAwait(false);
+            await WriteRawWithCharCheckingAsync(data).ConfigureAwait(OperatingSystem.IsBrowser());
 
             _textPos = _bufPos;
         }
@@ -534,11 +534,11 @@ namespace System.Xml
         public override async Task FlushAsync()
         {
             CheckAsyncCall();
-            await FlushBufferAsync().ConfigureAwait(false);
+            await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
             if (_stream != null)
             {
-                await _stream.FlushAsync().ConfigureAwait(false);
+                await _stream.FlushAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -556,7 +556,7 @@ namespace System.Xml
                     if (_bufPos - 1 > 0)
                     {
                         Debug.Assert(_stream != null);
-                        await _stream.WriteAsync(_bufBytes.AsMemory(1, _bufPos - 1)).ConfigureAwait(false);
+                        await _stream.WriteAsync(_bufBytes.AsMemory(1, _bufPos - 1)).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                 }
             }
@@ -754,7 +754,7 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0);
         }
@@ -779,7 +779,7 @@ namespace System.Xml
         private async Task _WriteAttributeTextBlockAsync(string text, int curIndex, int leftCount)
         {
             int writeLen;
-            await FlushBufferAsync().ConfigureAwait(false);
+            await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             do
             {
                 writeLen = WriteAttributeTextBlockNoFlush(text, curIndex, leftCount);
@@ -787,7 +787,7 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0);
         }
@@ -966,13 +966,13 @@ namespace System.Xml
                 if (needWriteNewLine)
                 {
                     //hit WriteNewLine
-                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
                     curIndex++;
                     leftCount--;
                 }
                 else if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0 || needWriteNewLine);
         }
@@ -1006,13 +1006,13 @@ namespace System.Xml
 
             if (newLine)
             {
-                await RawTextAsync(_newLineChars).ConfigureAwait(false);
+                await RawTextAsync(_newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
                 curIndex++;
                 leftCount--;
             }
             else
             {
-                await FlushBufferAsync().ConfigureAwait(false);
+                await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             do
@@ -1023,13 +1023,13 @@ namespace System.Xml
                 if (needWriteNewLine)
                 {
                     //hit WriteNewLine
-                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
                     curIndex++;
                     leftCount--;
                 }
                 else if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0 || needWriteNewLine);
         }
@@ -1187,7 +1187,7 @@ namespace System.Xml
             Debug.Assert(text3 != null || (text4 == null));
 
             // Write out the remainder of the first string
-            await FlushBufferAsync().ConfigureAwait(false);
+            await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             int writeLen;
             do
             {
@@ -1196,14 +1196,14 @@ namespace System.Xml
                 leftCount1 -= writeLen;
                 if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0);
 
             // If there are additional strings, write them out as well
             if (text2 != null)
             {
-                await RawTextAsync(text2, text3, text4).ConfigureAwait(false);
+                await RawTextAsync(text2, text3, text4).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -1362,13 +1362,13 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (needWriteNewLine)
                 {
-                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
                     curIndex++;
                     leftCount--;
                 }
                 else if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0 || needWriteNewLine);
         }
@@ -1386,13 +1386,13 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (needWriteNewLine)
                 {
-                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
                     curIndex++;
                     leftCount--;
                 }
                 else if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0 || needWriteNewLine);
         }
@@ -1556,7 +1556,7 @@ namespace System.Xml
             {
                 if (_bufPos >= _bufLen)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 return;
             }
@@ -1572,13 +1572,13 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (needWriteNewLine)
                 {
-                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
                     curIndex++;
                     leftCount--;
                 }
                 else if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0 || needWriteNewLine);
         }
@@ -1739,7 +1739,7 @@ namespace System.Xml
             {
                 if (_bufPos >= _bufLen)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 return;
             }
@@ -1755,13 +1755,13 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (needWriteNewLine)
                 {
-                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
                     curIndex++;
                     leftCount--;
                 }
                 else if (writeLen >= 0)
                 {
-                    await FlushBufferAsync().ConfigureAwait(false);
+                    await FlushBufferAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             } while (writeLen >= 0 || needWriteNewLine);
         }
@@ -1776,9 +1776,9 @@ namespace System.Xml
             // Add indentation
             if (!_mixedContent && base._textPos != base._bufPos)
             {
-                await WriteIndentAsync().ConfigureAwait(false);
+                await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
-            await base.WriteDocTypeAsync(name, pubid, sysid, subset).ConfigureAwait(false);
+            await base.WriteDocTypeAsync(name, pubid, sysid, subset).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         public override async Task WriteStartElementAsync(string? prefix, string localName, string? ns)
@@ -1789,12 +1789,12 @@ namespace System.Xml
             // Add indentation
             if (!_mixedContent && base._textPos != base._bufPos)
             {
-                await WriteIndentAsync().ConfigureAwait(false);
+                await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
             _indentLevel++;
             _mixedContentStack.PushBit(_mixedContent);
 
-            await base.WriteStartElementAsync(prefix, localName, ns).ConfigureAwait(false);
+            await base.WriteStartElementAsync(prefix, localName, ns).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         internal override async Task WriteEndElementAsync(string prefix, string localName, string ns)
@@ -1807,12 +1807,12 @@ namespace System.Xml
                 // There was content, so try to indent
                 if (base._textPos != base._bufPos)
                 {
-                    await WriteIndentAsync().ConfigureAwait(false);
+                    await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             _mixedContent = _mixedContentStack.PopBit();
 
-            await base.WriteEndElementAsync(prefix, localName, ns).ConfigureAwait(false);
+            await base.WriteEndElementAsync(prefix, localName, ns).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         internal override async Task WriteFullEndElementAsync(string prefix, string localName, string ns)
@@ -1825,12 +1825,12 @@ namespace System.Xml
                 // There was content, so try to indent
                 if (base._textPos != base._bufPos)
                 {
-                    await WriteIndentAsync().ConfigureAwait(false);
+                    await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             _mixedContent = _mixedContentStack.PopBit();
 
-            await base.WriteFullEndElementAsync(prefix, localName, ns).ConfigureAwait(false);
+            await base.WriteFullEndElementAsync(prefix, localName, ns).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         // Same as base class, plus possible indentation.
@@ -1840,10 +1840,10 @@ namespace System.Xml
             // Add indentation
             if (_newLineOnAttributes)
             {
-                await WriteIndentAsync().ConfigureAwait(false);
+                await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
-            await base.WriteStartAttributeAsync(prefix, localName, ns).ConfigureAwait(false);
+            await base.WriteStartAttributeAsync(prefix, localName, ns).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         // Same as base class, plus possible indentation.
@@ -1853,10 +1853,10 @@ namespace System.Xml
             // Add indentation
             if (_newLineOnAttributes)
             {
-                await WriteIndentAsync().ConfigureAwait(false);
+                await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
-            await base.WriteStartNamespaceDeclarationAsync(prefix).ConfigureAwait(false);
+            await base.WriteStartNamespaceDeclarationAsync(prefix).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         public override Task WriteCDataAsync(string? text)
@@ -1871,10 +1871,10 @@ namespace System.Xml
             CheckAsyncCall();
             if (!_mixedContent && base._textPos != base._bufPos)
             {
-                await WriteIndentAsync().ConfigureAwait(false);
+                await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
-            await base.WriteCommentAsync(text).ConfigureAwait(false);
+            await base.WriteCommentAsync(text).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         public override async Task WriteProcessingInstructionAsync(string target, string? text)
@@ -1882,10 +1882,10 @@ namespace System.Xml
             CheckAsyncCall();
             if (!_mixedContent && base._textPos != base._bufPos)
             {
-                await WriteIndentAsync().ConfigureAwait(false);
+                await WriteIndentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
-            await base.WriteProcessingInstructionAsync(target, text).ConfigureAwait(false);
+            await base.WriteProcessingInstructionAsync(target, text).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         public override Task WriteEntityRefAsync(string name)
@@ -1955,10 +1955,10 @@ namespace System.Xml
         private async Task WriteIndentAsync()
         {
             CheckAsyncCall();
-            await RawTextAsync(base._newLineChars).ConfigureAwait(false);
+            await RawTextAsync(base._newLineChars).ConfigureAwait(OperatingSystem.IsBrowser());
             for (int i = _indentLevel; i > 0; i--)
             {
-                await RawTextAsync(_indentChars).ConfigureAwait(false);
+                await RawTextAsync(_indentChars).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
     }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlValidatingReaderImplAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlValidatingReaderImplAsync.cs
@@ -29,7 +29,7 @@ namespace System.Xml
             switch (_parsingFunction)
             {
                 case ParsingFunction.Read:
-                    if (await _coreReader.ReadAsync().ConfigureAwait(false))
+                    if (await _coreReader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         ProcessCoreReaderEvent();
                         return true;
@@ -41,7 +41,7 @@ namespace System.Xml
                     }
                 case ParsingFunction.ParseDtdFromContext:
                     _parsingFunction = ParsingFunction.Read;
-                    await ParseDtdFromParserContextAsync().ConfigureAwait(false);
+                    await ParseDtdFromParserContextAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     goto case ParsingFunction.Read;
                 case ParsingFunction.Error:
                 case ParsingFunction.ReaderClosed:
@@ -59,11 +59,11 @@ namespace System.Xml
                     }
                 case ParsingFunction.ResolveEntityInternally:
                     _parsingFunction = ParsingFunction.Read;
-                    await ResolveEntityInternallyAsync().ConfigureAwait(false);
+                    await ResolveEntityInternallyAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     goto case ParsingFunction.Read;
                 case ParsingFunction.InReadBinaryContent:
                     _parsingFunction = ParsingFunction.Read;
-                    await _readBinaryHelper!.FinishAsync().ConfigureAwait(false);
+                    await _readBinaryHelper!.FinishAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     goto case ParsingFunction.Read;
                 default:
                     Debug.Fail($"Unexpected parsing function {_parsingFunction}");
@@ -88,7 +88,7 @@ namespace System.Xml
             _parsingFunction = ParsingFunction.Read;
 
             // call to the helper
-            int readCount = await _readBinaryHelper!.ReadContentAsBase64Async(buffer, index, count).ConfigureAwait(false);
+            int readCount = await _readBinaryHelper!.ReadContentAsBase64Async(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
 
             // setup parsingFunction
             _parsingFunction = ParsingFunction.InReadBinaryContent;
@@ -112,7 +112,7 @@ namespace System.Xml
             _parsingFunction = ParsingFunction.Read;
 
             // call to the helper
-            int readCount = await _readBinaryHelper!.ReadContentAsBinHexAsync(buffer, index, count).ConfigureAwait(false);
+            int readCount = await _readBinaryHelper!.ReadContentAsBinHexAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
 
             // setup parsingFunction
             _parsingFunction = ParsingFunction.InReadBinaryContent;
@@ -136,7 +136,7 @@ namespace System.Xml
             _parsingFunction = ParsingFunction.Read;
 
             // call to the helper
-            int readCount = await _readBinaryHelper!.ReadElementContentAsBase64Async(buffer, index, count).ConfigureAwait(false);
+            int readCount = await _readBinaryHelper!.ReadElementContentAsBase64Async(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
 
             // setup parsingFunction
             _parsingFunction = ParsingFunction.InReadBinaryContent;
@@ -160,7 +160,7 @@ namespace System.Xml
             _parsingFunction = ParsingFunction.Read;
 
             // call to the helper
-            int readCount = await _readBinaryHelper!.ReadElementContentAsBinHexAsync(buffer, index, count).ConfigureAwait(false);
+            int readCount = await _readBinaryHelper!.ReadElementContentAsBinHexAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
 
             // setup parsingFunction
             _parsingFunction = ParsingFunction.InReadBinaryContent;
@@ -183,7 +183,7 @@ namespace System.Xml
 
             IDtdParser dtdParser = DtdParser.Create();
             XmlTextReaderImpl.DtdParserProxy proxy = new XmlTextReaderImpl.DtdParserProxy(_coreReaderImpl);
-            IDtdInfo dtdInfo = await dtdParser.ParseFreeFloatingDtdAsync(_parserContext.BaseURI, _parserContext.DocTypeName, _parserContext.PublicId, _parserContext.SystemId, _parserContext.InternalSubset, proxy).ConfigureAwait(false);
+            IDtdInfo dtdInfo = await dtdParser.ParseFreeFloatingDtdAsync(_parserContext.BaseURI, _parserContext.DocTypeName, _parserContext.PublicId, _parserContext.SystemId, _parserContext.InternalSubset, proxy).ConfigureAwait(OperatingSystem.IsBrowser());
             _coreReaderImpl.SetDtdInfo(dtdInfo);
 
             ValidateDtd();
@@ -194,7 +194,7 @@ namespace System.Xml
             Debug.Assert(_coreReader.NodeType == XmlNodeType.EntityReference);
             int initialDepth = _coreReader.Depth;
             _outerReader.ResolveEntity();
-            while (await _outerReader.ReadAsync().ConfigureAwait(false) && _coreReader.Depth > initialDepth) ;
+            while (await _outerReader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser()) && _coreReader.Depth > initialDepth) ;
         }
     }
 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriterAsync.cs
@@ -36,10 +36,10 @@ namespace System.Xml
                 // auto-close all elements
                 while (_elemTop > 0)
                 {
-                    await WriteEndElementAsync().ConfigureAwait(false);
+                    await WriteEndElementAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 State prevState = _currentState;
-                await AdvanceStateAsync(Token.EndDocument).ConfigureAwait(false);
+                await AdvanceStateAsync(Token.EndDocument).ConfigureAwait(OperatingSystem.IsBrowser());
 
                 if (prevState != State.AfterRootEle)
                 {
@@ -47,7 +47,7 @@ namespace System.Xml
                 }
                 if (_rawWriter == null)
                 {
-                    await _writer.WriteEndDocumentAsync().ConfigureAwait(false);
+                    await _writer.WriteEndDocumentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             catch
@@ -73,7 +73,7 @@ namespace System.Xml
                     throw new InvalidOperationException(SR.Xml_DtdNotAllowedInFragment);
                 }
 
-                await AdvanceStateAsync(Token.Dtd).ConfigureAwait(false);
+                await AdvanceStateAsync(Token.Dtd).ConfigureAwait(OperatingSystem.IsBrowser());
                 if (_dtdWritten)
                 {
                     _currentState = State.Error;
@@ -115,7 +115,7 @@ namespace System.Xml
                 }
 
                 // write doctype
-                await _writer.WriteDocTypeAsync(name, pubid, sysid, subset).ConfigureAwait(false);
+                await _writer.WriteDocTypeAsync(name, pubid, sysid, subset).ConfigureAwait(OperatingSystem.IsBrowser());
                 _dtdWritten = true;
             }
             catch
@@ -142,7 +142,7 @@ namespace System.Xml
         {
             try
             {
-                await task.ConfigureAwait(false);
+                await task.ConfigureAwait(OperatingSystem.IsBrowser());
             }
             catch
             {
@@ -168,8 +168,8 @@ namespace System.Xml
         {
             try
             {
-                await task.ConfigureAwait(false);
-                await nextTaskFun(arg).ConfigureAwait(false);
+                await task.ConfigureAwait(OperatingSystem.IsBrowser());
+                await nextTaskFun(arg).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             catch
             {
@@ -267,8 +267,8 @@ namespace System.Xml
         {
             try
             {
-                await task.ConfigureAwait(false);
-                await WriteStartElementAsync_NoAdvanceState(prefix, localName, ns).ConfigureAwait(false);
+                await task.ConfigureAwait(OperatingSystem.IsBrowser());
+                await WriteStartElementAsync_NoAdvanceState(prefix, localName, ns).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             catch
             {
@@ -310,7 +310,7 @@ namespace System.Xml
         {
             try
             {
-                await t.ConfigureAwait(false);
+                await t.ConfigureAwait(OperatingSystem.IsBrowser());
                 WriteStartElementAsync_FinishWrite(prefix, localName, ns);
             }
             catch
@@ -602,8 +602,8 @@ namespace System.Xml
         {
             try
             {
-                await task.ConfigureAwait(false);
-                await WriteStartAttributeAsync_NoAdvanceState(prefix, localName, namespaceName).ConfigureAwait(false);
+                await task.ConfigureAwait(OperatingSystem.IsBrowser());
+                await WriteStartAttributeAsync_NoAdvanceState(prefix, localName, namespaceName).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             catch
             {
@@ -664,20 +664,20 @@ namespace System.Xml
                             {
                                 if (_rawWriter.SupportsNamespaceDeclarationInChunks)
                                 {
-                                    await _rawWriter.WriteStartNamespaceDeclarationAsync(string.Empty).ConfigureAwait(false);
-                                    await _attrValueCache.ReplayAsync(_rawWriter).ConfigureAwait(false);
-                                    await _rawWriter.WriteEndNamespaceDeclarationAsync().ConfigureAwait(false);
+                                    await _rawWriter.WriteStartNamespaceDeclarationAsync(string.Empty).ConfigureAwait(OperatingSystem.IsBrowser());
+                                    await _attrValueCache.ReplayAsync(_rawWriter).ConfigureAwait(OperatingSystem.IsBrowser());
+                                    await _rawWriter.WriteEndNamespaceDeclarationAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                                 }
                                 else
                                 {
-                                    await _rawWriter.WriteNamespaceDeclarationAsync(string.Empty, value).ConfigureAwait(false);
+                                    await _rawWriter.WriteNamespaceDeclarationAsync(string.Empty, value).ConfigureAwait(OperatingSystem.IsBrowser());
                                 }
                             }
                             else
                             {
-                                await _writer.WriteStartAttributeAsync(string.Empty, "xmlns", XmlReservedNs.NsXmlNs).ConfigureAwait(false);
-                                await _attrValueCache.ReplayAsync(_writer).ConfigureAwait(false);
-                                await _writer.WriteEndAttributeAsync().ConfigureAwait(false);
+                                await _writer.WriteStartAttributeAsync(string.Empty, "xmlns", XmlReservedNs.NsXmlNs).ConfigureAwait(OperatingSystem.IsBrowser());
+                                await _attrValueCache.ReplayAsync(_writer).ConfigureAwait(OperatingSystem.IsBrowser());
+                                await _writer.WriteEndAttributeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                             }
                         }
 
@@ -701,20 +701,20 @@ namespace System.Xml
                             {
                                 if (_rawWriter.SupportsNamespaceDeclarationInChunks)
                                 {
-                                    await _rawWriter.WriteStartNamespaceDeclarationAsync(_curDeclPrefix).ConfigureAwait(false);
-                                    await _attrValueCache.ReplayAsync(_rawWriter).ConfigureAwait(false);
-                                    await _rawWriter.WriteEndNamespaceDeclarationAsync().ConfigureAwait(false);
+                                    await _rawWriter.WriteStartNamespaceDeclarationAsync(_curDeclPrefix).ConfigureAwait(OperatingSystem.IsBrowser());
+                                    await _attrValueCache.ReplayAsync(_rawWriter).ConfigureAwait(OperatingSystem.IsBrowser());
+                                    await _rawWriter.WriteEndNamespaceDeclarationAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                                 }
                                 else
                                 {
-                                    await _rawWriter.WriteNamespaceDeclarationAsync(_curDeclPrefix, value).ConfigureAwait(false);
+                                    await _rawWriter.WriteNamespaceDeclarationAsync(_curDeclPrefix, value).ConfigureAwait(OperatingSystem.IsBrowser());
                                 }
                             }
                             else
                             {
-                                await _writer.WriteStartAttributeAsync("xmlns", _curDeclPrefix, XmlReservedNs.NsXmlNs).ConfigureAwait(false);
-                                await _attrValueCache.ReplayAsync(_writer).ConfigureAwait(false);
-                                await _writer.WriteEndAttributeAsync().ConfigureAwait(false);
+                                await _writer.WriteStartAttributeAsync("xmlns", _curDeclPrefix, XmlReservedNs.NsXmlNs).ConfigureAwait(OperatingSystem.IsBrowser());
+                                await _attrValueCache.ReplayAsync(_writer).ConfigureAwait(OperatingSystem.IsBrowser());
+                                await _writer.WriteEndAttributeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                             }
                         }
                         _curDeclPrefix = null;
@@ -735,16 +735,16 @@ namespace System.Xml
                         {
                             throw new ArgumentException(SR.Format(SR.Xml_InvalidXmlSpace, value));
                         }
-                        await _writer.WriteStartAttributeAsync("xml", "space", XmlReservedNs.NsXml).ConfigureAwait(false);
-                        await _attrValueCache.ReplayAsync(_writer).ConfigureAwait(false);
-                        await _writer.WriteEndAttributeAsync().ConfigureAwait(false);
+                        await _writer.WriteStartAttributeAsync("xml", "space", XmlReservedNs.NsXml).ConfigureAwait(OperatingSystem.IsBrowser());
+                        await _attrValueCache.ReplayAsync(_writer).ConfigureAwait(OperatingSystem.IsBrowser());
+                        await _writer.WriteEndAttributeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
                     case SpecialAttribute.XmlLang:
                         value = _attrValueCache.StringValue;
                         _elemScopeStack[_elemTop].xmlLang = value;
-                        await _writer.WriteStartAttributeAsync("xml", "lang", XmlReservedNs.NsXml).ConfigureAwait(false);
-                        await _attrValueCache.ReplayAsync(_writer).ConfigureAwait(false);
-                        await _writer.WriteEndAttributeAsync().ConfigureAwait(false);
+                        await _writer.WriteStartAttributeAsync("xml", "lang", XmlReservedNs.NsXml).ConfigureAwait(OperatingSystem.IsBrowser());
+                        await _attrValueCache.ReplayAsync(_writer).ConfigureAwait(OperatingSystem.IsBrowser());
+                        await _writer.WriteEndAttributeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
                 }
                 _specAttr = SpecialAttribute.No;
@@ -763,8 +763,8 @@ namespace System.Xml
             {
                 text ??= string.Empty;
 
-                await AdvanceStateAsync(Token.CData).ConfigureAwait(false);
-                await _writer.WriteCDataAsync(text).ConfigureAwait(false);
+                await AdvanceStateAsync(Token.CData).ConfigureAwait(OperatingSystem.IsBrowser());
+                await _writer.WriteCDataAsync(text).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             catch
             {
@@ -779,8 +779,8 @@ namespace System.Xml
             {
                 text ??= string.Empty;
 
-                await AdvanceStateAsync(Token.Comment).ConfigureAwait(false);
-                await _writer.WriteCommentAsync(text).ConfigureAwait(false);
+                await AdvanceStateAsync(Token.Comment).ConfigureAwait(OperatingSystem.IsBrowser());
+                await _writer.WriteCommentAsync(text).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             catch
             {
@@ -812,22 +812,22 @@ namespace System.Xml
                     }
 
                     _xmlDeclFollows = true;
-                    await AdvanceStateAsync(Token.PI).ConfigureAwait(false);
+                    await AdvanceStateAsync(Token.PI).ConfigureAwait(OperatingSystem.IsBrowser());
 
                     if (_rawWriter != null)
                     {
                         // Translate PI into an xml declaration
-                        await _rawWriter.WriteXmlDeclarationAsync(text).ConfigureAwait(false);
+                        await _rawWriter.WriteXmlDeclarationAsync(text).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     else
                     {
-                        await _writer.WriteProcessingInstructionAsync(name, text).ConfigureAwait(false);
+                        await _writer.WriteProcessingInstructionAsync(name, text).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                 }
                 else
                 {
-                    await AdvanceStateAsync(Token.PI).ConfigureAwait(false);
-                    await _writer.WriteProcessingInstructionAsync(name, text).ConfigureAwait(false);
+                    await AdvanceStateAsync(Token.PI).ConfigureAwait(OperatingSystem.IsBrowser());
+                    await _writer.WriteProcessingInstructionAsync(name, text).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             catch
@@ -849,14 +849,14 @@ namespace System.Xml
 
                 CheckNCName(name);
 
-                await AdvanceStateAsync(Token.Text).ConfigureAwait(false);
+                await AdvanceStateAsync(Token.Text).ConfigureAwait(OperatingSystem.IsBrowser());
                 if (SaveAttrValue)
                 {
                     _attrValueCache!.WriteEntityRef(name);
                 }
                 else
                 {
-                    await _writer.WriteEntityRefAsync(name).ConfigureAwait(false);
+                    await _writer.WriteEntityRefAsync(name).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             catch
@@ -875,14 +875,14 @@ namespace System.Xml
                     throw new ArgumentException(SR.Xml_InvalidSurrogateMissingLowChar);
                 }
 
-                await AdvanceStateAsync(Token.Text).ConfigureAwait(false);
+                await AdvanceStateAsync(Token.Text).ConfigureAwait(OperatingSystem.IsBrowser());
                 if (SaveAttrValue)
                 {
                     _attrValueCache!.WriteCharEntity(ch);
                 }
                 else
                 {
-                    await _writer.WriteCharEntityAsync(ch).ConfigureAwait(false);
+                    await _writer.WriteCharEntityAsync(ch).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             catch
@@ -901,14 +901,14 @@ namespace System.Xml
                     throw XmlConvert.CreateInvalidSurrogatePairException(lowChar, highChar);
                 }
 
-                await AdvanceStateAsync(Token.Text).ConfigureAwait(false);
+                await AdvanceStateAsync(Token.Text).ConfigureAwait(OperatingSystem.IsBrowser());
                 if (SaveAttrValue)
                 {
                     _attrValueCache!.WriteSurrogateCharEntity(lowChar, highChar);
                 }
                 else
                 {
-                    await _writer.WriteSurrogateCharEntityAsync(lowChar, highChar).ConfigureAwait(false);
+                    await _writer.WriteSurrogateCharEntityAsync(lowChar, highChar).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             catch
@@ -929,14 +929,14 @@ namespace System.Xml
                     throw new ArgumentException(SR.Xml_NonWhitespace);
                 }
 
-                await AdvanceStateAsync(Token.Whitespace).ConfigureAwait(false);
+                await AdvanceStateAsync(Token.Whitespace).ConfigureAwait(OperatingSystem.IsBrowser());
                 if (SaveAttrValue)
                 {
                     _attrValueCache!.WriteWhitespace(ws);
                 }
                 else
                 {
-                    await _writer.WriteWhitespaceAsync(ws).ConfigureAwait(false);
+                    await _writer.WriteWhitespaceAsync(ws).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             catch
@@ -998,8 +998,8 @@ namespace System.Xml
         {
             try
             {
-                await task.ConfigureAwait(false);
-                await WriteStringAsync_NoAdvanceState(text).ConfigureAwait(false);
+                await task.ConfigureAwait(OperatingSystem.IsBrowser());
+                await WriteStringAsync_NoAdvanceState(text).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             catch
             {
@@ -1017,14 +1017,14 @@ namespace System.Xml
                 ArgumentOutOfRangeException.ThrowIfNegative(count);
                 ArgumentOutOfRangeException.ThrowIfGreaterThan(count, buffer.Length - index);
 
-                await AdvanceStateAsync(Token.Text).ConfigureAwait(false);
+                await AdvanceStateAsync(Token.Text).ConfigureAwait(OperatingSystem.IsBrowser());
                 if (SaveAttrValue)
                 {
                     _attrValueCache!.WriteChars(buffer, index, count);
                 }
                 else
                 {
-                    await _writer.WriteCharsAsync(buffer, index, count).ConfigureAwait(false);
+                    await _writer.WriteCharsAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             catch
@@ -1043,14 +1043,14 @@ namespace System.Xml
                 ArgumentOutOfRangeException.ThrowIfNegative(count);
                 ArgumentOutOfRangeException.ThrowIfGreaterThan(count, buffer.Length - index);
 
-                await AdvanceStateAsync(Token.RawData).ConfigureAwait(false);
+                await AdvanceStateAsync(Token.RawData).ConfigureAwait(OperatingSystem.IsBrowser());
                 if (SaveAttrValue)
                 {
                     _attrValueCache!.WriteRaw(buffer, index, count);
                 }
                 else
                 {
-                    await _writer.WriteRawAsync(buffer, index, count).ConfigureAwait(false);
+                    await _writer.WriteRawAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             catch
@@ -1069,14 +1069,14 @@ namespace System.Xml
                     return;
                 }
 
-                await AdvanceStateAsync(Token.RawData).ConfigureAwait(false);
+                await AdvanceStateAsync(Token.RawData).ConfigureAwait(OperatingSystem.IsBrowser());
                 if (SaveAttrValue)
                 {
                     _attrValueCache!.WriteRaw(data);
                 }
                 else
                 {
-                    await _writer.WriteRawAsync(data).ConfigureAwait(false);
+                    await _writer.WriteRawAsync(data).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             catch
@@ -1117,8 +1117,8 @@ namespace System.Xml
         {
             try
             {
-                await task.ConfigureAwait(false);
-                await _writer.WriteBase64Async(buffer, index, count).ConfigureAwait(false);
+                await task.ConfigureAwait(OperatingSystem.IsBrowser());
+                await _writer.WriteBase64Async(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             catch
             {
@@ -1131,7 +1131,7 @@ namespace System.Xml
         {
             try
             {
-                await _writer.FlushAsync().ConfigureAwait(false);
+                await _writer.FlushAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
             catch
             {
@@ -1150,7 +1150,7 @@ namespace System.Xml
                 }
                 CheckNCName(localName);
 
-                await AdvanceStateAsync(Token.Text).ConfigureAwait(false);
+                await AdvanceStateAsync(Token.Text).ConfigureAwait(OperatingSystem.IsBrowser());
                 string? prefix = string.Empty;
                 if (ns != null && ns.Length != 0)
                 {
@@ -1171,14 +1171,14 @@ namespace System.Xml
                 {
                     if (prefix.Length != 0)
                     {
-                        await WriteStringAsync(prefix).ConfigureAwait(false);
-                        await WriteStringAsync(":").ConfigureAwait(false);
+                        await WriteStringAsync(prefix).ConfigureAwait(OperatingSystem.IsBrowser());
+                        await WriteStringAsync(":").ConfigureAwait(OperatingSystem.IsBrowser());
                     }
-                    await WriteStringAsync(localName).ConfigureAwait(false);
+                    await WriteStringAsync(localName).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 else
                 {
-                    await _rawWriter.WriteQualifiedNameAsync(prefix, localName, ns).ConfigureAwait(false);
+                    await _rawWriter.WriteQualifiedNameAsync(prefix, localName, ns).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             catch
@@ -1196,8 +1196,8 @@ namespace System.Xml
             }
             try
             {
-                await AdvanceStateAsync(Token.Text).ConfigureAwait(false);
-                await base.WriteBinHexAsync(buffer, index, count).ConfigureAwait(false);
+                await AdvanceStateAsync(Token.Text).ConfigureAwait(OperatingSystem.IsBrowser());
+                await base.WriteBinHexAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             catch
             {
@@ -1210,7 +1210,7 @@ namespace System.Xml
         {
             try
             {
-                await AdvanceStateAsync(Token.StartDocument).ConfigureAwait(false);
+                await AdvanceStateAsync(Token.StartDocument).ConfigureAwait(OperatingSystem.IsBrowser());
 
                 if (_conformanceLevel == ConformanceLevel.Auto)
                 {
@@ -1226,13 +1226,13 @@ namespace System.Xml
                 {
                     if (!_xmlDeclFollows)
                     {
-                        await _rawWriter.WriteXmlDeclarationAsync(standalone).ConfigureAwait(false);
+                        await _rawWriter.WriteXmlDeclarationAsync(standalone).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                 }
                 else
                 {
                     // We do not pass the standalone value here
-                    await _writer.WriteStartDocumentAsync().ConfigureAwait(false);
+                    await _writer.WriteStartDocumentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             catch
@@ -1258,7 +1258,7 @@ namespace System.Xml
 
         private async Task _AdvanceStateAsync_ReturnWhenFinish(Task task, State newState)
         {
-            await task.ConfigureAwait(false);
+            await task.ConfigureAwait(OperatingSystem.IsBrowser());
             _currentState = newState;
         }
 
@@ -1277,9 +1277,9 @@ namespace System.Xml
 
         private async Task _AdvanceStateAsync_ContinueWhenFinish(Task task, State newState, Token token)
         {
-            await task.ConfigureAwait(false);
+            await task.ConfigureAwait(OperatingSystem.IsBrowser());
             _currentState = newState;
-            await AdvanceStateAsync(token).ConfigureAwait(false);
+            await AdvanceStateAsync(token).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         // Advance the state machine
@@ -1399,7 +1399,7 @@ namespace System.Xml
             {
                 if (_nsStack[i].kind == NamespaceKind.NeedToWrite)
                 {
-                    await _nsStack[i].WriteDeclAsync(_writer, _rawWriter).ConfigureAwait(false);
+                    await _nsStack[i].WriteDeclAsync(_writer, _rawWriter).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
 
@@ -1428,7 +1428,7 @@ namespace System.Xml
                     {
                         while (_currentState != State.Error && _elemTop > 0)
                         {
-                            await WriteEndElementAsync().ConfigureAwait(false);
+                            await WriteEndElementAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                     }
                     else
@@ -1438,7 +1438,7 @@ namespace System.Xml
                             //finish the start element tag '>'
                             try
                             {
-                                await AdvanceStateAsync(Token.EndElement).ConfigureAwait(false);
+                                await AdvanceStateAsync(Token.EndElement).ConfigureAwait(OperatingSystem.IsBrowser());
                             }
                             catch
                             {
@@ -1450,10 +1450,10 @@ namespace System.Xml
 
                     if (InBase64 && _rawWriter != null)
                     {
-                        await _rawWriter.WriteEndBase64Async().ConfigureAwait(false);
+                        await _rawWriter.WriteEndBase64Async().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
 
-                    await _writer.FlushAsync().ConfigureAwait(false);
+                    await _writer.FlushAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 finally
                 {
@@ -1461,11 +1461,11 @@ namespace System.Xml
                     {
                         if (_rawWriter != null)
                         {
-                            await _rawWriter.DisposeAsyncCore(WriteState).ConfigureAwait(false);
+                            await _rawWriter.DisposeAsyncCore(WriteState).ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                         else
                         {
-                            await _writer.DisposeAsync().ConfigureAwait(false);
+                            await _writer.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                     }
                     finally

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriterHelpersAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriterHelpersAsync.cs
@@ -32,20 +32,20 @@ namespace System.Xml
                 Debug.Assert(kind == NamespaceKind.NeedToWrite);
                 if (null != rawWriter)
                 {
-                    await rawWriter.WriteNamespaceDeclarationAsync(prefix, namespaceUri).ConfigureAwait(false);
+                    await rawWriter.WriteNamespaceDeclarationAsync(prefix, namespaceUri).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 else
                 {
                     if (prefix.Length == 0)
                     {
-                        await writer.WriteStartAttributeAsync(string.Empty, "xmlns", XmlReservedNs.NsXmlNs).ConfigureAwait(false);
+                        await writer.WriteStartAttributeAsync(string.Empty, "xmlns", XmlReservedNs.NsXmlNs).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                     else
                     {
-                        await writer.WriteStartAttributeAsync("xmlns", prefix, XmlReservedNs.NsXmlNs).ConfigureAwait(false);
+                        await writer.WriteStartAttributeAsync("xmlns", prefix, XmlReservedNs.NsXmlNs).ConfigureAwait(OperatingSystem.IsBrowser());
                     }
-                    await writer.WriteStringAsync(namespaceUri).ConfigureAwait(false);
-                    await writer.WriteEndAttributeAsync().ConfigureAwait(false);
+                    await writer.WriteStringAsync(namespaceUri).ConfigureAwait(OperatingSystem.IsBrowser());
+                    await writer.WriteEndAttributeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
         }
@@ -56,7 +56,7 @@ namespace System.Xml
             {
                 if (_singleStringValue != null)
                 {
-                    await writer.WriteStringAsync(_singleStringValue).ConfigureAwait(false);
+                    await writer.WriteStringAsync(_singleStringValue).ConfigureAwait(OperatingSystem.IsBrowser());
                     return;
                 }
 
@@ -67,34 +67,34 @@ namespace System.Xml
                     switch (item.type)
                     {
                         case ItemType.EntityRef:
-                            await writer.WriteEntityRefAsync((string)item.data).ConfigureAwait(false);
+                            await writer.WriteEntityRefAsync((string)item.data).ConfigureAwait(OperatingSystem.IsBrowser());
                             break;
                         case ItemType.CharEntity:
-                            await writer.WriteCharEntityAsync((char)item.data).ConfigureAwait(false);
+                            await writer.WriteCharEntityAsync((char)item.data).ConfigureAwait(OperatingSystem.IsBrowser());
                             break;
                         case ItemType.SurrogateCharEntity:
                             char[] chars = (char[])item.data;
-                            await writer.WriteSurrogateCharEntityAsync(chars[0], chars[1]).ConfigureAwait(false);
+                            await writer.WriteSurrogateCharEntityAsync(chars[0], chars[1]).ConfigureAwait(OperatingSystem.IsBrowser());
                             break;
                         case ItemType.Whitespace:
-                            await writer.WriteWhitespaceAsync((string)item.data).ConfigureAwait(false);
+                            await writer.WriteWhitespaceAsync((string)item.data).ConfigureAwait(OperatingSystem.IsBrowser());
                             break;
                         case ItemType.String:
-                            await writer.WriteStringAsync((string)item.data).ConfigureAwait(false);
+                            await writer.WriteStringAsync((string)item.data).ConfigureAwait(OperatingSystem.IsBrowser());
                             break;
                         case ItemType.StringChars:
                             bufChunk = (BufferChunk)item.data;
-                            await writer.WriteCharsAsync(bufChunk.buffer, bufChunk.index, bufChunk.count).ConfigureAwait(false);
+                            await writer.WriteCharsAsync(bufChunk.buffer, bufChunk.index, bufChunk.count).ConfigureAwait(OperatingSystem.IsBrowser());
                             break;
                         case ItemType.Raw:
-                            await writer.WriteRawAsync((string)item.data).ConfigureAwait(false);
+                            await writer.WriteRawAsync((string)item.data).ConfigureAwait(OperatingSystem.IsBrowser());
                             break;
                         case ItemType.RawChars:
                             bufChunk = (BufferChunk)item.data;
-                            await writer.WriteCharsAsync(bufChunk.buffer, bufChunk.index, bufChunk.count).ConfigureAwait(false);
+                            await writer.WriteCharsAsync(bufChunk.buffer, bufChunk.index, bufChunk.count).ConfigureAwait(OperatingSystem.IsBrowser());
                             break;
                         case ItemType.ValueString:
-                            await writer.WriteStringAsync((string)item.data).ConfigureAwait(false);
+                            await writer.WriteStringAsync((string)item.data).ConfigureAwait(OperatingSystem.IsBrowser());
                             break;
                         default:
                             Debug.Fail("Unexpected ItemType value.");

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWriterAsync.cs
@@ -76,9 +76,9 @@ namespace System.Xml
 
         private async Task WriteAttributeStringAsyncHelper(Task task, string? value)
         {
-            await task.ConfigureAwait(false);
-            await WriteStringAsync(value).ConfigureAwait(false);
-            await WriteEndAttributeAsync().ConfigureAwait(false);
+            await task.ConfigureAwait(OperatingSystem.IsBrowser());
+            await WriteStringAsync(value).ConfigureAwait(OperatingSystem.IsBrowser());
+            await WriteEndAttributeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         // Writes the start of an attribute.
@@ -222,10 +222,10 @@ namespace System.Xml
                 {
                     throw new ArgumentException(SR.Format(SR.Xml_UndefNamespace, ns));
                 }
-                await WriteStringAsync(prefix).ConfigureAwait(false);
-                await WriteStringAsync(":").ConfigureAwait(false);
+                await WriteStringAsync(prefix).ConfigureAwait(OperatingSystem.IsBrowser());
+                await WriteStringAsync(":").ConfigureAwait(OperatingSystem.IsBrowser());
             }
-            await WriteStringAsync(localName).ConfigureAwait(false);
+            await WriteStringAsync(localName).ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         // XmlReader Helper Methods
@@ -242,7 +242,7 @@ namespace System.Xml
                 {
                     if (reader.MoveToFirstAttribute())
                     {
-                        await WriteAttributesAsync(reader, defattr).ConfigureAwait(false);
+                        await WriteAttributesAsync(reader, defattr).ConfigureAwait(OperatingSystem.IsBrowser());
                         reader.MoveToElement();
                     }
                 }
@@ -258,19 +258,19 @@ namespace System.Xml
                         // If either of these is true and defattr=false, we should not write the attribute out
                         if (defattr || !reader.IsDefaultInternal)
                         {
-                            await WriteStartAttributeAsync(reader.Prefix, reader.LocalName, reader.NamespaceURI).ConfigureAwait(false);
+                            await WriteStartAttributeAsync(reader.Prefix, reader.LocalName, reader.NamespaceURI).ConfigureAwait(OperatingSystem.IsBrowser());
                             while (reader.ReadAttributeValue())
                             {
                                 if (reader.NodeType == XmlNodeType.EntityReference)
                                 {
-                                    await WriteEntityRefAsync(reader.Name).ConfigureAwait(false);
+                                    await WriteEntityRefAsync(reader.Name).ConfigureAwait(OperatingSystem.IsBrowser());
                                 }
                                 else
                                 {
-                                    await WriteStringAsync(reader.Value).ConfigureAwait(false);
+                                    await WriteStringAsync(reader.Value).ConfigureAwait(OperatingSystem.IsBrowser());
                                 }
                             }
-                            await WriteEndAttributeAsync().ConfigureAwait(false);
+                            await WriteEndAttributeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                     }
                     while (reader.MoveToNextAttribute());
@@ -305,11 +305,11 @@ namespace System.Xml
                 switch (reader.NodeType)
                 {
                     case XmlNodeType.Element:
-                        await WriteStartElementAsync(reader.Prefix, reader.LocalName, reader.NamespaceURI).ConfigureAwait(false);
-                        await WriteAttributesAsync(reader, defattr).ConfigureAwait(false);
+                        await WriteStartElementAsync(reader.Prefix, reader.LocalName, reader.NamespaceURI).ConfigureAwait(OperatingSystem.IsBrowser());
+                        await WriteAttributesAsync(reader, defattr).ConfigureAwait(OperatingSystem.IsBrowser());
                         if (reader.IsEmptyElement)
                         {
-                            await WriteEndElementAsync().ConfigureAwait(false);
+                            await WriteEndElementAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                         break;
                     case XmlNodeType.Text:
@@ -319,37 +319,37 @@ namespace System.Xml
                             int read;
                             while ((read = reader.ReadValueChunk(_writeNodeBuffer, 0, WriteNodeBufferSize)) > 0)
                             {
-                                await WriteCharsAsync(_writeNodeBuffer, 0, read).ConfigureAwait(false);
+                                await WriteCharsAsync(_writeNodeBuffer, 0, read).ConfigureAwait(OperatingSystem.IsBrowser());
                             }
                         }
                         else
                         {
-                            await WriteStringAsync(reader.Value).ConfigureAwait(false);
+                            await WriteStringAsync(reader.Value).ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                         break;
                     case XmlNodeType.Whitespace:
                     case XmlNodeType.SignificantWhitespace:
-                        await WriteWhitespaceAsync(reader.Value).ConfigureAwait(false);
+                        await WriteWhitespaceAsync(reader.Value).ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
                     case XmlNodeType.CDATA:
-                        await WriteCDataAsync(reader.Value).ConfigureAwait(false);
+                        await WriteCDataAsync(reader.Value).ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
                     case XmlNodeType.EntityReference:
-                        await WriteEntityRefAsync(reader.Name).ConfigureAwait(false);
+                        await WriteEntityRefAsync(reader.Name).ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
                     case XmlNodeType.XmlDeclaration:
                     case XmlNodeType.ProcessingInstruction:
-                        await WriteProcessingInstructionAsync(reader.Name, reader.Value).ConfigureAwait(false);
+                        await WriteProcessingInstructionAsync(reader.Name, reader.Value).ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
                     case XmlNodeType.DocumentType:
-                        await WriteDocTypeAsync(reader.Name, reader.GetAttribute("PUBLIC"), reader.GetAttribute("SYSTEM"), reader.Value).ConfigureAwait(false);
+                        await WriteDocTypeAsync(reader.Name, reader.GetAttribute("PUBLIC"), reader.GetAttribute("SYSTEM"), reader.Value).ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
 
                     case XmlNodeType.Comment:
-                        await WriteCommentAsync(reader.Value).ConfigureAwait(false);
+                        await WriteCommentAsync(reader.Value).ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
                     case XmlNodeType.EndElement:
-                        await WriteFullEndElementAsync().ConfigureAwait(false);
+                        await WriteFullEndElementAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
                 }
             } while (reader.Read() && (d < reader.Depth || (d == reader.Depth && reader.NodeType == XmlNodeType.EndElement)));
@@ -367,11 +367,11 @@ namespace System.Xml
                 switch (reader.NodeType)
                 {
                     case XmlNodeType.Element:
-                        await WriteStartElementAsync(reader.Prefix, reader.LocalName, reader.NamespaceURI).ConfigureAwait(false);
-                        await WriteAttributesAsync(reader, defattr).ConfigureAwait(false);
+                        await WriteStartElementAsync(reader.Prefix, reader.LocalName, reader.NamespaceURI).ConfigureAwait(OperatingSystem.IsBrowser());
+                        await WriteAttributesAsync(reader, defattr).ConfigureAwait(OperatingSystem.IsBrowser());
                         if (reader.IsEmptyElement)
                         {
-                            await WriteEndElementAsync().ConfigureAwait(false);
+                            await WriteEndElementAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                         break;
                     case XmlNodeType.Text:
@@ -379,43 +379,43 @@ namespace System.Xml
                         {
                             _writeNodeBuffer ??= new char[WriteNodeBufferSize];
                             int read;
-                            while ((read = await reader.ReadValueChunkAsync(_writeNodeBuffer, 0, WriteNodeBufferSize).ConfigureAwait(false)) > 0)
+                            while ((read = await reader.ReadValueChunkAsync(_writeNodeBuffer, 0, WriteNodeBufferSize).ConfigureAwait(OperatingSystem.IsBrowser())) > 0)
                             {
-                                await WriteCharsAsync(_writeNodeBuffer, 0, read).ConfigureAwait(false);
+                                await WriteCharsAsync(_writeNodeBuffer, 0, read).ConfigureAwait(OperatingSystem.IsBrowser());
                             }
                         }
                         else
                         {
                             //reader.Value may block on Text or WhiteSpace node, use GetValueAsync
-                            await WriteStringAsync(await reader.GetValueAsync().ConfigureAwait(false)).ConfigureAwait(false);
+                            await WriteStringAsync(await reader.GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser())).ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                         break;
                     case XmlNodeType.Whitespace:
                     case XmlNodeType.SignificantWhitespace:
-                        await WriteWhitespaceAsync(await reader.GetValueAsync().ConfigureAwait(false)).ConfigureAwait(false);
+                        await WriteWhitespaceAsync(await reader.GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser())).ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
                     case XmlNodeType.CDATA:
-                        await WriteCDataAsync(reader.Value).ConfigureAwait(false);
+                        await WriteCDataAsync(reader.Value).ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
                     case XmlNodeType.EntityReference:
-                        await WriteEntityRefAsync(reader.Name).ConfigureAwait(false);
+                        await WriteEntityRefAsync(reader.Name).ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
                     case XmlNodeType.XmlDeclaration:
                     case XmlNodeType.ProcessingInstruction:
-                        await WriteProcessingInstructionAsync(reader.Name, reader.Value).ConfigureAwait(false);
+                        await WriteProcessingInstructionAsync(reader.Name, reader.Value).ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
                     case XmlNodeType.DocumentType:
-                        await WriteDocTypeAsync(reader.Name, reader.GetAttribute("PUBLIC"), reader.GetAttribute("SYSTEM"), reader.Value).ConfigureAwait(false);
+                        await WriteDocTypeAsync(reader.Name, reader.GetAttribute("PUBLIC"), reader.GetAttribute("SYSTEM"), reader.Value).ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
 
                     case XmlNodeType.Comment:
-                        await WriteCommentAsync(reader.Value).ConfigureAwait(false);
+                        await WriteCommentAsync(reader.Value).ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
                     case XmlNodeType.EndElement:
-                        await WriteFullEndElementAsync().ConfigureAwait(false);
+                        await WriteFullEndElementAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
                 }
-            } while (await reader.ReadAsync().ConfigureAwait(false) && (d < reader.Depth || (d == reader.Depth && reader.NodeType == XmlNodeType.EndElement)));
+            } while (await reader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser()) && (d < reader.Depth || (d == reader.Depth && reader.NodeType == XmlNodeType.EndElement)));
         }
 
         // Copies the current node from the given XPathNavigator to the writer (including child nodes).
@@ -438,7 +438,7 @@ namespace System.Xml
                     switch (nodeType)
                     {
                         case XPathNodeType.Element:
-                            await WriteStartElementAsync(navigator.Prefix, navigator.LocalName, navigator.NamespaceURI).ConfigureAwait(false);
+                            await WriteStartElementAsync(navigator.Prefix, navigator.LocalName, navigator.NamespaceURI).ConfigureAwait(OperatingSystem.IsBrowser());
 
                             // Copy attributes
                             if (navigator.MoveToFirstAttribute())
@@ -448,10 +448,10 @@ namespace System.Xml
                                     IXmlSchemaInfo? schemaInfo = navigator.SchemaInfo;
                                     if (defattr || (schemaInfo == null || !schemaInfo.IsDefault))
                                     {
-                                        await WriteStartAttributeAsync(navigator.Prefix, navigator.LocalName, navigator.NamespaceURI).ConfigureAwait(false);
+                                        await WriteStartAttributeAsync(navigator.Prefix, navigator.LocalName, navigator.NamespaceURI).ConfigureAwait(OperatingSystem.IsBrowser());
                                         // copy string value to writer
-                                        await WriteStringAsync(navigator.Value).ConfigureAwait(false);
-                                        await WriteEndAttributeAsync().ConfigureAwait(false);
+                                        await WriteStringAsync(navigator.Value).ConfigureAwait(OperatingSystem.IsBrowser());
+                                        await WriteEndAttributeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                                     }
                                 } while (navigator.MoveToNextAttribute());
                                 navigator.MoveToParent();
@@ -460,7 +460,7 @@ namespace System.Xml
                             // Copy namespaces
                             if (navigator.MoveToFirstNamespace(XPathNamespaceScope.Local))
                             {
-                                await WriteLocalNamespacesAsync(navigator).ConfigureAwait(false);
+                                await WriteLocalNamespacesAsync(navigator).ConfigureAwait(OperatingSystem.IsBrowser());
                                 navigator.MoveToParent();
                             }
                             mayHaveChildren = true;
@@ -469,20 +469,20 @@ namespace System.Xml
                             // do nothing on root level attribute
                             break;
                         case XPathNodeType.Text:
-                            await WriteStringAsync(navigator.Value).ConfigureAwait(false);
+                            await WriteStringAsync(navigator.Value).ConfigureAwait(OperatingSystem.IsBrowser());
                             break;
                         case XPathNodeType.SignificantWhitespace:
                         case XPathNodeType.Whitespace:
-                            await WriteWhitespaceAsync(navigator.Value).ConfigureAwait(false);
+                            await WriteWhitespaceAsync(navigator.Value).ConfigureAwait(OperatingSystem.IsBrowser());
                             break;
                         case XPathNodeType.Root:
                             mayHaveChildren = true;
                             break;
                         case XPathNodeType.Comment:
-                            await WriteCommentAsync(navigator.Value).ConfigureAwait(false);
+                            await WriteCommentAsync(navigator.Value).ConfigureAwait(OperatingSystem.IsBrowser());
                             break;
                         case XPathNodeType.ProcessingInstruction:
-                            await WriteProcessingInstructionAsync(navigator.LocalName, navigator.Value).ConfigureAwait(false);
+                            await WriteProcessingInstructionAsync(navigator.LocalName, navigator.Value).ConfigureAwait(OperatingSystem.IsBrowser());
                             break;
                         case XPathNodeType.Namespace:
                             // do nothing on root level namespace
@@ -506,11 +506,11 @@ namespace System.Xml
                         {
                             if (navigator.IsEmptyElement)
                             {
-                                await WriteEndElementAsync().ConfigureAwait(false);
+                                await WriteEndElementAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                             }
                             else
                             {
-                                await WriteFullEndElementAsync().ConfigureAwait(false);
+                                await WriteFullEndElementAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                             }
                         }
                     }
@@ -536,7 +536,7 @@ namespace System.Xml
 
                         // EndElement
                         if (navigator.NodeType == XPathNodeType.Element)
-                            await WriteFullEndElementAsync().ConfigureAwait(false);
+                            await WriteFullEndElementAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                 }
             }
@@ -547,12 +547,12 @@ namespace System.Xml
         // Writes out an attribute with the specified name, namespace URI, and string value.
         public async Task WriteElementStringAsync(string? prefix, string localName, string? ns, string value)
         {
-            await WriteStartElementAsync(prefix, localName, ns).ConfigureAwait(false);
+            await WriteStartElementAsync(prefix, localName, ns).ConfigureAwait(OperatingSystem.IsBrowser());
             if (!string.IsNullOrEmpty(value))
             {
-                await WriteStringAsync(value).ConfigureAwait(false);
+                await WriteStringAsync(value).ConfigureAwait(OperatingSystem.IsBrowser());
             }
-            await WriteEndElementAsync().ConfigureAwait(false);
+            await WriteEndElementAsync().ConfigureAwait(OperatingSystem.IsBrowser());
         }
 
         // Copy local namespaces on the navigator's current node to the raw writer. The namespaces are returned by the navigator in reversed order.
@@ -564,22 +564,22 @@ namespace System.Xml
 
             if (nsNav.MoveToNextNamespace(XPathNamespaceScope.Local))
             {
-                await WriteLocalNamespacesAsync(nsNav).ConfigureAwait(false);
+                await WriteLocalNamespacesAsync(nsNav).ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             if (prefix.Length == 0)
             {
-                await WriteAttributeStringAsync(string.Empty, "xmlns", XmlReservedNs.NsXmlNs, ns).ConfigureAwait(false);
+                await WriteAttributeStringAsync(string.Empty, "xmlns", XmlReservedNs.NsXmlNs, ns).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             else
             {
-                await WriteAttributeStringAsync("xmlns", prefix, XmlReservedNs.NsXmlNs, ns).ConfigureAwait(false);
+                await WriteAttributeStringAsync("xmlns", prefix, XmlReservedNs.NsXmlNs, ns).ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
         public async ValueTask DisposeAsync()
         {
-            await DisposeAsyncCore().ConfigureAwait(false);
+            await DisposeAsyncCore().ConfigureAwait(OperatingSystem.IsBrowser());
             Dispose(false);
             GC.SuppressFinalize(this);
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XsdCachingReaderAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XsdCachingReaderAsync.cs
@@ -39,7 +39,7 @@ namespace System.Xml
 
                 case CachingReaderState.Record:
                     ValidatingReaderNodeData? recordedNode = null;
-                    if (await _coreReader.ReadAsync().ConfigureAwait(false))
+                    if (await _coreReader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         switch (_coreReader.NodeType)
                         {
@@ -61,7 +61,7 @@ namespace System.Xml
                             case XmlNodeType.Whitespace:
                             case XmlNodeType.SignificantWhitespace:
                                 recordedNode = AddContent(_coreReader.NodeType);
-                                recordedNode.SetItemData(await _coreReader.GetValueAsync().ConfigureAwait(false));
+                                recordedNode.SetItemData(await _coreReader.GetValueAsync().ConfigureAwait(OperatingSystem.IsBrowser()));
                                 recordedNode.SetLineInfo(_lineInfo);
                                 recordedNode.Depth = _coreReader.Depth;
                                 break;
@@ -85,7 +85,7 @@ namespace System.Xml
                         _cacheHandler(this);
                         if (_coreReader.NodeType != XmlNodeType.Element || _readAhead)
                         { //Only when coreReader not positioned on Element node, read ahead, otherwise it is on the next element node already, since this was not cached
-                            return await _coreReader.ReadAsync().ConfigureAwait(false);
+                            return await _coreReader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         }
                         return true;
                     }
@@ -112,10 +112,10 @@ namespace System.Xml
                     if (_coreReader.NodeType != XmlNodeType.EndElement && !_readAhead)
                     { //will be true for IsDefault cases where we peek only one node ahead
                         int startDepth = _coreReader.Depth - 1;
-                        while (await _coreReader.ReadAsync().ConfigureAwait(false) && _coreReader.Depth > startDepth)
+                        while (await _coreReader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser()) && _coreReader.Depth > startDepth)
                             ;
                     }
-                    await _coreReader.ReadAsync().ConfigureAwait(false);
+                    await _coreReader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     _cacheState = CachingReaderState.ReaderClosed;
                     _cacheHandler(this);
                     break;
@@ -126,7 +126,7 @@ namespace System.Xml
 
                 default:
                     Debug.Assert(_cacheState == CachingReaderState.Replay);
-                    await ReadAsync().ConfigureAwait(false);
+                    await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     break;
             }
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XsdValidatingReaderAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XsdValidatingReaderAsync.cs
@@ -46,7 +46,7 @@ namespace System.Xml
                 throw CreateReadContentAsException(nameof(ReadContentAsString));
             }
 
-            object typedValue = await InternalReadContentAsObjectAsync().ConfigureAwait(false);
+            object typedValue = await InternalReadContentAsObjectAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             XmlSchemaType? xmlType = NodeType == XmlNodeType.Attribute ? AttributeXmlType : ElementXmlType;
             try
             {
@@ -82,7 +82,7 @@ namespace System.Xml
 
             string originalStringValue;
 
-            var tuple_0 = await InternalReadContentAsObjectTupleAsync(false).ConfigureAwait(false);
+            var tuple_0 = await InternalReadContentAsObjectTupleAsync(false).ConfigureAwait(OperatingSystem.IsBrowser());
             originalStringValue = tuple_0.Item1;
 
             object typedValue = tuple_0.Item2;
@@ -127,7 +127,7 @@ namespace System.Xml
                 throw CreateReadElementContentAsException(nameof(ReadElementContentAsObject));
             }
 
-            var tuple_1 = await InternalReadElementContentAsObjectAsync(true).ConfigureAwait(false);
+            var tuple_1 = await InternalReadElementContentAsObjectAsync(true).ConfigureAwait(OperatingSystem.IsBrowser());
 
             return tuple_1.Item2;
         }
@@ -141,7 +141,7 @@ namespace System.Xml
 
             XmlSchemaType xmlType;
 
-            var content = await InternalReadElementContentAsObjectAsync().ConfigureAwait(false);
+            var content = await InternalReadElementContentAsObjectAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             xmlType = content.Item1;
 
             object typedValue = content.Item2;
@@ -182,7 +182,7 @@ namespace System.Xml
             XmlSchemaType xmlType;
             string originalStringValue;
 
-            var content = await InternalReadElementContentAsObjectTupleAsync(false).ConfigureAwait(false);
+            var content = await InternalReadElementContentAsObjectTupleAsync(false).ConfigureAwait(OperatingSystem.IsBrowser());
             xmlType = content.Item1;
             originalStringValue = content.Item2;
 
@@ -247,9 +247,9 @@ namespace System.Xml
 
         private async Task<bool> _ReadAsync_Read(Task<bool> task)
         {
-            if (await task.ConfigureAwait(false))
+            if (await task.ConfigureAwait(OperatingSystem.IsBrowser()))
             {
-                await ProcessReaderEventAsync().ConfigureAwait(false);
+                await ProcessReaderEventAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 return true;
             }
             else
@@ -279,7 +279,7 @@ namespace System.Xml
 
         private async Task<bool> _ReadAsync_ReadAhead(Task task)
         {
-            await task.ConfigureAwait(false);
+            await task.ConfigureAwait(OperatingSystem.IsBrowser());
             _validationState = ValidatingReaderState.Read;
             return true;
         }
@@ -362,7 +362,7 @@ namespace System.Xml
                         callSkipToEndElem = false;
                     }
 
-                    await _coreReader.SkipAsync().ConfigureAwait(false);
+                    await _coreReader.SkipAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     _validationState = ValidatingReaderState.ReadAhead;
                     if (callSkipToEndElem)
                     {
@@ -376,7 +376,7 @@ namespace System.Xml
                     goto case XmlNodeType.Element;
             }
             // For all other NodeTypes Skip() same as Read()
-            await ReadAsync().ConfigureAwait(false);
+            await ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             return;
         }
 
@@ -399,7 +399,7 @@ namespace System.Xml
 
             // call to the helper
             Debug.Assert(_readBinaryHelper != null);
-            int readCount = await _readBinaryHelper.ReadContentAsBase64Async(buffer, index, count).ConfigureAwait(false);
+            int readCount = await _readBinaryHelper.ReadContentAsBase64Async(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
 
             // set OnReadBinaryContent state again and return
             _savedState = _validationState;
@@ -426,7 +426,7 @@ namespace System.Xml
 
             // call to the helper
             Debug.Assert(_readBinaryHelper != null);
-            int readCount = await _readBinaryHelper.ReadContentAsBinHexAsync(buffer, index, count).ConfigureAwait(false);
+            int readCount = await _readBinaryHelper.ReadContentAsBinHexAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
 
             // set OnReadBinaryContent state again and return
             _savedState = _validationState;
@@ -453,7 +453,7 @@ namespace System.Xml
 
             // call to the helper
             Debug.Assert(_readBinaryHelper != null);
-            int readCount = await _readBinaryHelper.ReadElementContentAsBase64Async(buffer, index, count).ConfigureAwait(false);
+            int readCount = await _readBinaryHelper.ReadElementContentAsBase64Async(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
 
             // set OnReadBinaryContent state again and return
             _savedState = _validationState;
@@ -480,7 +480,7 @@ namespace System.Xml
 
             // call to the helper
             Debug.Assert(_readBinaryHelper != null);
-            int readCount = await _readBinaryHelper.ReadElementContentAsBinHexAsync(buffer, index, count).ConfigureAwait(false);
+            int readCount = await _readBinaryHelper.ReadElementContentAsBinHexAsync(buffer, index, count).ConfigureAwait(OperatingSystem.IsBrowser());
 
             // set OnReadBinaryContent state again and return
             _savedState = _validationState;
@@ -546,7 +546,7 @@ namespace System.Xml
                 {
                     // If its not empty schema, then parse else ignore
                     _inlineSchemaParser = new Parser(SchemaType.XSD, _coreReaderNameTable, _validator.SchemaSet.GetSchemaNames(_coreReaderNameTable), _validationEvent);
-                    await _inlineSchemaParser.StartParsingAsync(_coreReader, null).ConfigureAwait(false);
+                    await _inlineSchemaParser.StartParsingAsync(_coreReader, null).ConfigureAwait(OperatingSystem.IsBrowser());
                     _inlineSchemaParser.ParseReaderNode();
                     _validationState = ValidatingReaderState.ParseInlineSchema;
                 }
@@ -615,7 +615,7 @@ namespace System.Xml
                 _validator.ValidateEndOfAttributes(_xmlSchemaInfo);
                 if (_coreReader.IsEmptyElement)
                 {
-                    await ProcessEndElementEventAsync().ConfigureAwait(false);
+                    await ProcessEndElementEventAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
 
                 _validationState = ValidatingReaderState.ClearAttributes;
@@ -635,7 +635,7 @@ namespace System.Xml
                 Debug.Assert(_cachingReader != null);
                 _cachingReader.RecordTextNode(_xmlSchemaInfo.XmlType!.ValueConverter.ToString(_atomicValue), _originalAtomicValueString, depth + 1, 0, 0);
                 _cachingReader.RecordEndElementNode();
-                await _cachingReader.SetToReplayModeAsync().ConfigureAwait(false);
+                await _cachingReader.SetToReplayModeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 _replayCache = true;
             }
             else if (_manageNamespaces)
@@ -648,7 +648,7 @@ namespace System.Xml
         private async Task ProcessInlineSchemaAsync()
         {
             Debug.Assert(_inlineSchemaParser != null);
-            if (await _coreReader.ReadAsync().ConfigureAwait(false))
+            if (await _coreReader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
             {
                 if (_coreReader.NodeType == XmlNodeType.Element)
                 {
@@ -678,7 +678,7 @@ namespace System.Xml
 
         private async Task<object> InternalReadContentAsObjectAsync(bool unwrapTypedValue)
         {
-            var content = await InternalReadContentAsObjectTupleAsync(unwrapTypedValue).ConfigureAwait(false);
+            var content = await InternalReadContentAsObjectTupleAsync(unwrapTypedValue).ConfigureAwait(OperatingSystem.IsBrowser());
             return content.Item2;
         }
 
@@ -728,7 +728,7 @@ namespace System.Xml
                 if (_validator.CurrentContentType == XmlSchemaContentType.TextOnly)
                 {
                     // if current element is of simple type
-                    object? value = ReturnBoxedValue(await ReadTillEndElementAsync().ConfigureAwait(false), _xmlSchemaInfo.XmlType!, unwrapTypedValue);
+                    object? value = ReturnBoxedValue(await ReadTillEndElementAsync().ConfigureAwait(OperatingSystem.IsBrowser()), _xmlSchemaInfo.XmlType!, unwrapTypedValue);
                     Debug.Assert(value != null);
 
                     Debug.Assert(_originalAtomicValueString != null);
@@ -745,7 +745,7 @@ namespace System.Xml
                     }
                     else
                     {
-                        originalStringValue = await InternalReadContentAsStringAsync().ConfigureAwait(false);
+                        originalStringValue = await InternalReadContentAsStringAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
 
                     return (originalStringValue, originalStringValue);
@@ -760,7 +760,7 @@ namespace System.Xml
 
         private async Task<(XmlSchemaType, object)> InternalReadElementContentAsObjectAsync(bool unwrapTypedValue)
         {
-            var content = await InternalReadElementContentAsObjectTupleAsync(unwrapTypedValue).ConfigureAwait(false);
+            var content = await InternalReadElementContentAsObjectTupleAsync(unwrapTypedValue).ConfigureAwait(OperatingSystem.IsBrowser());
 
             return (content.Item1, content.Item3);
         }
@@ -787,13 +787,13 @@ namespace System.Xml
                 Debug.Assert(_originalAtomicValueString != null);
                 originalString = _originalAtomicValueString;
                 xmlType = ElementXmlType; // Set this for default values
-                await this.ReadAsync().ConfigureAwait(false);
+                await this.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
                 return (xmlType!, originalString, typedValue);
             }
 
             // move to content and read typed value
-            await this.ReadAsync().ConfigureAwait(false);
+            await this.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
             if (this.NodeType == XmlNodeType.EndElement)
             {
@@ -827,7 +827,7 @@ namespace System.Xml
             }
             else
             {
-                var content = await InternalReadContentAsObjectTupleAsync(unwrapTypedValue).ConfigureAwait(false);
+                var content = await InternalReadContentAsObjectTupleAsync(unwrapTypedValue).ConfigureAwait(OperatingSystem.IsBrowser());
                 originalString = content.Item1;
 
                 typedValue = content.Item2;
@@ -842,7 +842,7 @@ namespace System.Xml
             xmlType = ElementXmlType; // Set this as we are moving ahead to the next node
 
             // move to next node
-            await this.ReadAsync().ConfigureAwait(false);
+            await this.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
             return (xmlType!, originalString, typedValue);
         }
@@ -851,7 +851,7 @@ namespace System.Xml
         {
             if (_atomicValue == null)
             {
-                while (await _coreReader.ReadAsync().ConfigureAwait(false))
+                while (await _coreReader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                 {
                     if (_replayCache)
                     {
@@ -862,7 +862,7 @@ namespace System.Xml
                     switch (_coreReader.NodeType)
                     {
                         case XmlNodeType.Element:
-                            await ProcessReaderEventAsync().ConfigureAwait(false);
+                            await ProcessReaderEventAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                             goto breakWhile;
 
                         case XmlNodeType.Text:

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/DtdParserAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/DtdParserAsync.cs
@@ -24,14 +24,14 @@ namespace System.Xml
         async Task<IDtdInfo> IDtdParser.ParseInternalDtdAsync(IDtdParserAdapter adapter, bool saveInternalSubset)
         {
             Initialize(adapter);
-            await ParseAsync(saveInternalSubset).ConfigureAwait(false);
+            await ParseAsync(saveInternalSubset).ConfigureAwait(OperatingSystem.IsBrowser());
             return _schemaInfo;
         }
 
         async Task<IDtdInfo> IDtdParser.ParseFreeFloatingDtdAsync(string baseUri, string docTypeName, string publicId, string systemId, string internalSubset, IDtdParserAdapter adapter)
         {
             InitializeFreeFloatingDtd(baseUri, docTypeName, publicId, systemId, internalSubset, adapter);
-            await ParseAsync(false).ConfigureAwait(false);
+            await ParseAsync(false).ConfigureAwait(OperatingSystem.IsBrowser());
             return _schemaInfo;
         }
         #endregion
@@ -44,11 +44,11 @@ namespace System.Xml
         {
             if (_freeFloatingDtd)
             {
-                await ParseFreeFloatingDtdAsync().ConfigureAwait(false);
+                await ParseFreeFloatingDtdAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
             else
             {
-                await ParseInDocumentDtdAsync(saveInternalSubset).ConfigureAwait(false);
+                await ParseInDocumentDtdAsync(saveInternalSubset).ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             _schemaInfo.Finish();
@@ -76,21 +76,21 @@ namespace System.Xml
             _nextScanningFunction = ScanningFunction.Doctype1;
 
             // doctype name
-            if (await GetTokenAsync(false).ConfigureAwait(false) != Token.QName)
+            if (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()) != Token.QName)
             {
                 OnUnexpectedError();
             }
             _schemaInfo.DocTypeName = GetNameQualified(true);
 
             // SYSTEM or PUBLIC id
-            Token token = await GetTokenAsync(false).ConfigureAwait(false);
+            Token token = await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser());
             if (token == Token.SYSTEM || token == Token.PUBLIC)
             {
-                var tuple_0 = await ParseExternalIdAsync(token, Token.DOCTYPE).ConfigureAwait(false);
+                var tuple_0 = await ParseExternalIdAsync(token, Token.DOCTYPE).ConfigureAwait(OperatingSystem.IsBrowser());
                 _publicId = tuple_0.Item1;
                 _systemId = tuple_0.Item2;
 
-                token = await GetTokenAsync(false).ConfigureAwait(false);
+                token = await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             switch (token)
@@ -101,7 +101,7 @@ namespace System.Xml
                         SaveParsingBuffer(); // this will cause saving the internal subset right from the point after '['
                         _internalSubsetValueSb = new StringBuilder();
                     }
-                    await ParseInternalSubsetAsync().ConfigureAwait(false);
+                    await ParseInternalSubsetAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     break;
                 case Token.GreaterThan:
                     break;
@@ -113,7 +113,7 @@ namespace System.Xml
 
             if (_systemId != null && _systemId.Length > 0)
             {
-                await ParseExternalSubsetAsync().ConfigureAwait(false);
+                await ParseExternalSubsetAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -122,13 +122,13 @@ namespace System.Xml
             if (_hasFreeFloatingInternalSubset)
             {
                 LoadParsingBuffer();
-                await ParseInternalSubsetAsync().ConfigureAwait(false);
+                await ParseInternalSubsetAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 SaveParsingBuffer();
             }
 
             if (_systemId != null && _systemId.Length > 0)
             {
-                await ParseExternalSubsetAsync().ConfigureAwait(false);
+                await ParseExternalSubsetAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             }
         }
 
@@ -143,7 +143,7 @@ namespace System.Xml
             Debug.Assert(_externalEntitiesDepth == 0);
 
             // push external subset
-            if (!await _readerAdapter.PushExternalSubsetAsync(_systemId, _publicId).ConfigureAwait(false))
+            if (!await _readerAdapter.PushExternalSubsetAsync(_systemId, _publicId).ConfigureAwait(OperatingSystem.IsBrowser()))
             {
                 return;
             }
@@ -158,7 +158,7 @@ namespace System.Xml
             LoadParsingBuffer();
 
             // parse
-            await ParseSubsetAsync().ConfigureAwait(false);
+            await ParseSubsetAsync().ConfigureAwait(OperatingSystem.IsBrowser());
 
 #if DEBUG
             Debug.Assert(_readerAdapter.EntityStackLength == 0 ||
@@ -171,32 +171,32 @@ namespace System.Xml
             int startTagEntityId;
             while (true)
             {
-                Token token = await GetTokenAsync(false).ConfigureAwait(false);
+                Token token = await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser());
                 startTagEntityId = _currentEntityId;
                 switch (token)
                 {
                     case Token.AttlistDecl:
-                        await ParseAttlistDeclAsync().ConfigureAwait(false);
+                        await ParseAttlistDeclAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
 
                     case Token.ElementDecl:
-                        await ParseElementDeclAsync().ConfigureAwait(false);
+                        await ParseElementDeclAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
 
                     case Token.EntityDecl:
-                        await ParseEntityDeclAsync().ConfigureAwait(false);
+                        await ParseEntityDeclAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
 
                     case Token.NotationDecl:
-                        await ParseNotationDeclAsync().ConfigureAwait(false);
+                        await ParseNotationDeclAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
 
                     case Token.Comment:
-                        await ParseCommentAsync().ConfigureAwait(false);
+                        await ParseCommentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
 
                     case Token.PI:
-                        await ParsePIAsync().ConfigureAwait(false);
+                        await ParsePIAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         break;
 
                     case Token.CondSectionStart:
@@ -204,7 +204,7 @@ namespace System.Xml
                         {
                             Throw(_curPos - 3, SR.Xml_InvalidConditionalSection); // 3==strlen("<![")
                         }
-                        await ParseCondSectionAsync().ConfigureAwait(false);
+                        await ParseCondSectionAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                         startTagEntityId = _currentEntityId;
                         break;
                     case Token.CondSectionEnd:
@@ -237,7 +237,7 @@ namespace System.Xml
                                 _internalSubsetValueSb = null;
                             }
                             // check '>'
-                            if (await GetTokenAsync(false).ConfigureAwait(false) != Token.GreaterThan)
+                            if (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()) != Token.GreaterThan)
                             {
                                 ThrowUnexpectedToken(_curPos, ">");
                             }
@@ -288,7 +288,7 @@ namespace System.Xml
 
         private async Task ParseAttlistDeclAsync()
         {
-            if (await GetTokenAsync(true).ConfigureAwait(false) != Token.QName)
+            if (await GetTokenAsync(true).ConfigureAwait(OperatingSystem.IsBrowser()) != Token.QName)
             {
                 goto UnexpectedError;
             }
@@ -308,7 +308,7 @@ namespace System.Xml
             SchemaAttDef? attrDef = null;
             while (true)
             {
-                switch (await GetTokenAsync(false).ConfigureAwait(false))
+                switch (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()))
                 {
                     case Token.QName:
                         XmlQualifiedName attrName = GetNameQualified(true);
@@ -344,8 +344,8 @@ namespace System.Xml
 
                 bool attrDefAlreadyExists = (elementDecl.GetAttDef(attrDef.Name) != null);
 
-                await ParseAttlistTypeAsync(attrDef, elementDecl, attrDefAlreadyExists).ConfigureAwait(false);
-                await ParseAttlistDefaultAsync(attrDef, attrDefAlreadyExists).ConfigureAwait(false);
+                await ParseAttlistTypeAsync(attrDef, elementDecl, attrDefAlreadyExists).ConfigureAwait(OperatingSystem.IsBrowser());
+                await ParseAttlistDefaultAsync(attrDef, attrDefAlreadyExists).ConfigureAwait(OperatingSystem.IsBrowser());
 
                 // check xml:space and xml:lang
                 if (attrDef.Prefix.Length > 0 && attrDef.Prefix.Equals("xml"))
@@ -396,7 +396,7 @@ namespace System.Xml
 
         private async Task ParseAttlistTypeAsync(SchemaAttDef attrDef, SchemaElementDecl elementDecl, bool ignoreErrors)
         {
-            Token token = await GetTokenAsync(true).ConfigureAwait(false);
+            Token token = await GetTokenAsync(true).ConfigureAwait(OperatingSystem.IsBrowser());
 
             if (token != Token.CDATA)
             {
@@ -445,13 +445,13 @@ namespace System.Xml
                     }
                 }
 
-                if (await GetTokenAsync(true).ConfigureAwait(false) != Token.LeftParen)
+                if (await GetTokenAsync(true).ConfigureAwait(OperatingSystem.IsBrowser()) != Token.LeftParen)
                 {
                     goto UnexpectedError;
                 }
 
                 // parse notation list
-                if (await GetTokenAsync(false).ConfigureAwait(false) != Token.Name)
+                if (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()) != Token.Name)
                 {
                     goto UnexpectedError;
                 }
@@ -468,10 +468,10 @@ namespace System.Xml
                     }
                     attrDef.AddValue(notationName);
 
-                    switch (await GetTokenAsync(false).ConfigureAwait(false))
+                    switch (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         case Token.Or:
-                            if (await GetTokenAsync(false).ConfigureAwait(false) != Token.Name)
+                            if (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()) != Token.Name)
                             {
                                 goto UnexpectedError;
                             }
@@ -489,16 +489,16 @@ namespace System.Xml
                 attrDef.SchemaType = XmlSchemaType.GetBuiltInSimpleType(attrDef.Datatype.TypeCode);
 
                 // parse nmtoken list
-                if (await GetTokenAsync(false).ConfigureAwait(false) != Token.Nmtoken)
+                if (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()) != Token.Nmtoken)
                     goto UnexpectedError;
                 attrDef.AddValue(GetNameString());
 
                 while (true)
                 {
-                    switch (await GetTokenAsync(false).ConfigureAwait(false))
+                    switch (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         case Token.Or:
-                            if (await GetTokenAsync(false).ConfigureAwait(false) != Token.Nmtoken)
+                            if (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()) != Token.Nmtoken)
                                 goto UnexpectedError;
                             string nmtoken = GetNmtokenString();
                             if (_validate && !_v1Compat && attrDef.Values != null && attrDef.Values.Contains(nmtoken) && !ignoreErrors)
@@ -525,7 +525,7 @@ namespace System.Xml
 
         private async Task ParseAttlistDefaultAsync(SchemaAttDef attrDef, bool ignoreErrors)
         {
-            switch (await GetTokenAsync(true).ConfigureAwait(false))
+            switch (await GetTokenAsync(true).ConfigureAwait(OperatingSystem.IsBrowser()))
             {
                 case Token.REQUIRED:
                     attrDef.Presence = SchemaDeclBase.Use.Required;
@@ -535,7 +535,7 @@ namespace System.Xml
                     return;
                 case Token.FIXED:
                     attrDef.Presence = SchemaDeclBase.Use.Fixed;
-                    if (await GetTokenAsync(true).ConfigureAwait(false) != Token.Literal)
+                    if (await GetTokenAsync(true).ConfigureAwait(OperatingSystem.IsBrowser()) != Token.Literal)
                     {
                         goto UnexpectedError;
                     }
@@ -573,7 +573,7 @@ namespace System.Xml
         private async Task ParseElementDeclAsync()
         {
             // element name
-            if (await GetTokenAsync(true).ConfigureAwait(false) != Token.QName)
+            if (await GetTokenAsync(true).ConfigureAwait(OperatingSystem.IsBrowser()) != Token.QName)
             {
                 goto UnexpectedError;
             }
@@ -604,7 +604,7 @@ namespace System.Xml
             elementDecl.IsDeclaredInExternal = !ParsingInternalSubset;
 
             // content spec
-            switch (await GetTokenAsync(true).ConfigureAwait(false))
+            switch (await GetTokenAsync(true).ConfigureAwait(OperatingSystem.IsBrowser()))
             {
                 case Token.EMPTY:
                     elementDecl.ContentValidator = ContentValidator.Empty;
@@ -614,7 +614,7 @@ namespace System.Xml
                     break;
                 case Token.LeftParen:
                     int startParenEntityId = _currentEntityId;
-                    switch (await GetTokenAsync(false).ConfigureAwait(false))
+                    switch (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         case Token.PCDATA:
                             {
@@ -622,7 +622,7 @@ namespace System.Xml
                                 pcv.Start();
                                 pcv.OpenGroup();
 
-                                await ParseElementMixedContentAsync(pcv, startParenEntityId).ConfigureAwait(false);
+                                await ParseElementMixedContentAsync(pcv, startParenEntityId).ConfigureAwait(OperatingSystem.IsBrowser());
 
                                 elementDecl.ContentValidator = pcv.Finish(true);
                                 break;
@@ -634,7 +634,7 @@ namespace System.Xml
                                 pcv.Start();
                                 pcv.OpenGroup();
 
-                                await ParseElementOnlyContentAsync(pcv, startParenEntityId).ConfigureAwait(false);
+                                await ParseElementOnlyContentAsync(pcv, startParenEntityId).ConfigureAwait(OperatingSystem.IsBrowser());
 
                                 elementDecl.ContentValidator = pcv.Finish(true);
                                 break;
@@ -647,7 +647,7 @@ namespace System.Xml
                     goto UnexpectedError;
             }
 
-            if (await GetTokenAsync(false).ConfigureAwait(false) != Token.GreaterThan)
+            if (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()) != Token.GreaterThan)
             {
                 ThrowUnexpectedToken(_curPos, ">");
             }
@@ -666,11 +666,11 @@ namespace System.Xml
         RecursiveCall:
 
         Loop:
-            switch (await GetTokenAsync(false).ConfigureAwait(false))
+            switch (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()))
             {
                 case Token.QName:
                     pcv.AddName(GetNameQualified(true), null);
-                    await ParseHowManyAsync(pcv).ConfigureAwait(false);
+                    await ParseHowManyAsync(pcv).ConfigureAwait(OperatingSystem.IsBrowser());
                     break;
                 case Token.LeftParen:
                     pcv.OpenGroup();
@@ -695,7 +695,7 @@ namespace System.Xml
             }
 
         ReturnFromRecursiveCall:
-            switch (await GetTokenAsync(false).ConfigureAwait(false))
+            switch (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()))
             {
                 case Token.Comma:
                     if (currentFrame.parsingSchema == Token.Or)
@@ -719,7 +719,7 @@ namespace System.Xml
                     {
                         SendValidationEvent(_curPos, XmlSeverityType.Error, SR.Sch_ParEntityRefNesting, string.Empty);
                     }
-                    await ParseHowManyAsync(pcv).ConfigureAwait(false);
+                    await ParseHowManyAsync(pcv).ConfigureAwait(OperatingSystem.IsBrowser());
                     goto Return;
                 case Token.GreaterThan:
                     Throw(_curPos, SR.Xml_InvalidContentModel);
@@ -749,7 +749,7 @@ namespace System.Xml
 
         private async Task ParseHowManyAsync(ParticleContentValidator pcv)
         {
-            switch (await GetTokenAsync(false).ConfigureAwait(false))
+            switch (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()))
             {
                 case Token.Star:
                     pcv.AddStar();
@@ -773,7 +773,7 @@ namespace System.Xml
 
             while (true)
             {
-                switch (await GetTokenAsync(false).ConfigureAwait(false))
+                switch (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()))
                 {
                     case Token.RightParen:
                         pcv.CloseGroup();
@@ -781,7 +781,7 @@ namespace System.Xml
                         {
                             SendValidationEvent(_curPos, XmlSeverityType.Error, SR.Sch_ParEntityRefNesting, string.Empty);
                         }
-                        if (await GetTokenAsync(false).ConfigureAwait(false) == Token.Star && hasNames)
+                        if (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()) == Token.Star && hasNames)
                         {
                             pcv.AddStar();
                         }
@@ -808,7 +808,7 @@ namespace System.Xml
                             }
                         }
 
-                        if (await GetTokenAsync(false).ConfigureAwait(false) != Token.QName)
+                        if (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()) != Token.QName)
                         {
                             goto default;
                         }
@@ -842,11 +842,11 @@ namespace System.Xml
             SchemaEntity? entity;
 
             // get entity name and type
-            switch (await GetTokenAsync(true).ConfigureAwait(false))
+            switch (await GetTokenAsync(true).ConfigureAwait(OperatingSystem.IsBrowser()))
             {
                 case Token.Percent:
                     isParamEntity = true;
-                    if (await GetTokenAsync(true).ConfigureAwait(false) != Token.Name)
+                    if (await GetTokenAsync(true).ConfigureAwait(OperatingSystem.IsBrowser()) != Token.Name)
                     {
                         goto UnexpectedError;
                     }
@@ -880,7 +880,7 @@ namespace System.Xml
                     goto UnexpectedError;
             }
 
-            Token token = await GetTokenAsync(true).ConfigureAwait(false);
+            Token token = await GetTokenAsync(true).ConfigureAwait(OperatingSystem.IsBrowser());
             switch (token)
             {
                 case Token.PUBLIC:
@@ -888,7 +888,7 @@ namespace System.Xml
                     string? systemId;
                     string? publicId;
 
-                    var tuple_1 = await ParseExternalIdAsync(token, Token.EntityDecl).ConfigureAwait(false);
+                    var tuple_1 = await ParseExternalIdAsync(token, Token.EntityDecl).ConfigureAwait(OperatingSystem.IsBrowser());
                     publicId = tuple_1.Item1;
                     systemId = tuple_1.Item2;
 
@@ -896,7 +896,7 @@ namespace System.Xml
                     entity.Url = systemId;
                     entity.Pubid = publicId;
 
-                    if (await GetTokenAsync(false).ConfigureAwait(false) == Token.NData)
+                    if (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()) == Token.NData)
                     {
                         if (isParamEntity)
                         {
@@ -907,7 +907,7 @@ namespace System.Xml
                             Throw(_curPos - 5, SR.Xml_ExpectingWhiteSpace, "NDATA");
                         }
 
-                        if (await GetTokenAsync(true).ConfigureAwait(false) != Token.Name)
+                        if (await GetTokenAsync(true).ConfigureAwait(OperatingSystem.IsBrowser()) != Token.Name)
                         {
                             goto UnexpectedError;
                         }
@@ -929,7 +929,7 @@ namespace System.Xml
                     goto UnexpectedError;
             }
 
-            if (await GetTokenAsync(false).ConfigureAwait(false) == Token.GreaterThan)
+            if (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()) == Token.GreaterThan)
             {
                 entity.ParsingInProgress = false;
                 return;
@@ -942,7 +942,7 @@ namespace System.Xml
         private async Task ParseNotationDeclAsync()
         {
             // notation name
-            if (await GetTokenAsync(true).ConfigureAwait(false) != Token.Name)
+            if (await GetTokenAsync(true).ConfigureAwait(OperatingSystem.IsBrowser()) != Token.Name)
             {
                 OnUnexpectedError();
             }
@@ -966,12 +966,12 @@ namespace System.Xml
             }
 
             // public / system id
-            Token token = await GetTokenAsync(true).ConfigureAwait(false);
+            Token token = await GetTokenAsync(true).ConfigureAwait(OperatingSystem.IsBrowser());
             if (token == Token.SYSTEM || token == Token.PUBLIC)
             {
                 string? notationPublicId, notationSystemId;
 
-                var tuple_2 = await ParseExternalIdAsync(token, Token.NOTATION).ConfigureAwait(false);
+                var tuple_2 = await ParseExternalIdAsync(token, Token.NOTATION).ConfigureAwait(OperatingSystem.IsBrowser());
                 notationPublicId = tuple_2.Item1;
                 notationSystemId = tuple_2.Item2;
 
@@ -986,7 +986,7 @@ namespace System.Xml
                 OnUnexpectedError();
             }
 
-            if (await GetTokenAsync(false).ConfigureAwait(false) != Token.GreaterThan)
+            if (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()) != Token.GreaterThan)
                 OnUnexpectedError();
         }
 
@@ -998,12 +998,12 @@ namespace System.Xml
                 if (SaveInternalSubsetValue)
                 {
                     Debug.Assert(_internalSubsetValueSb != null);
-                    await _readerAdapter.ParseCommentAsync(_internalSubsetValueSb).ConfigureAwait(false);
+                    await _readerAdapter.ParseCommentAsync(_internalSubsetValueSb).ConfigureAwait(OperatingSystem.IsBrowser());
                     _internalSubsetValueSb.Append("-->");
                 }
                 else
                 {
-                    await _readerAdapter.ParseCommentAsync(null).ConfigureAwait(false);
+                    await _readerAdapter.ParseCommentAsync(null).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             catch (XmlException e)
@@ -1026,12 +1026,12 @@ namespace System.Xml
             if (SaveInternalSubsetValue)
             {
                 Debug.Assert(_internalSubsetValueSb != null);
-                await _readerAdapter.ParsePIAsync(_internalSubsetValueSb).ConfigureAwait(false);
+                await _readerAdapter.ParsePIAsync(_internalSubsetValueSb).ConfigureAwait(OperatingSystem.IsBrowser());
                 _internalSubsetValueSb.Append("?>");
             }
             else
             {
-                await _readerAdapter.ParsePIAsync(null).ConfigureAwait(false);
+                await _readerAdapter.ParsePIAsync(null).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             LoadParsingBuffer();
         }
@@ -1040,10 +1040,10 @@ namespace System.Xml
         {
             int csEntityId = _currentEntityId;
 
-            switch (await GetTokenAsync(false).ConfigureAwait(false))
+            switch (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()))
             {
                 case Token.INCLUDE:
-                    if (await GetTokenAsync(false).ConfigureAwait(false) != Token.LeftBracket)
+                    if (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()) != Token.LeftBracket)
                     {
                         goto default;
                     }
@@ -1068,7 +1068,7 @@ namespace System.Xml
                     _condSectionDepth++;
                     break;
                 case Token.IGNORE:
-                    if (await GetTokenAsync(false).ConfigureAwait(false) != Token.LeftBracket)
+                    if (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()) != Token.LeftBracket)
                     {
                         goto default;
                     }
@@ -1077,7 +1077,7 @@ namespace System.Xml
                         SendValidationEvent(_curPos, XmlSeverityType.Error, SR.Sch_ParEntityRefNesting, string.Empty);
                     }
                     // the content of the ignore section is parsed & skipped by scanning function
-                    if (await GetTokenAsync(false).ConfigureAwait(false) != Token.CondSectionEnd)
+                    if (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()) != Token.CondSectionEnd)
                     {
                         goto default;
                     }
@@ -1101,7 +1101,7 @@ namespace System.Xml
             publicId = null;
             systemId = null;
 
-            if (await GetTokenAsync(true).ConfigureAwait(false) != Token.Literal)
+            if (await GetTokenAsync(true).ConfigureAwait(OperatingSystem.IsBrowser()) != Token.Literal)
             {
                 ThrowUnexpectedToken(_curPos, "\"", "'");
             }
@@ -1138,7 +1138,7 @@ namespace System.Xml
                     _literalLineInfo.linePos++;
                     _readerAdapter.OnPublicId(publicId, keywordLineInfo, _literalLineInfo);
 
-                    if (await GetTokenAsync(false).ConfigureAwait(false) == Token.Literal)
+                    if (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()) == Token.Literal)
                     {
                         if (!_whitespaceSeen)
                         {
@@ -1155,7 +1155,7 @@ namespace System.Xml
                 }
                 else
                 {
-                    if (await GetTokenAsync(false).ConfigureAwait(false) == Token.Literal)
+                    if (await GetTokenAsync(false).ConfigureAwait(OperatingSystem.IsBrowser()) == Token.Literal)
                     {
                         if (!_whitespaceSeen)
                         {
@@ -1237,7 +1237,7 @@ namespace System.Xml
                             }
                             else
                             {
-                                await HandleEntityReferenceAsync(true, false, false).ConfigureAwait(false);
+                                await HandleEntityReferenceAsync(true, false, false).ConfigureAwait(OperatingSystem.IsBrowser());
                             }
                             continue;
                         }
@@ -1251,36 +1251,36 @@ namespace System.Xml
                     SwitchAgain:
                         switch (_scanningFunction)
                         {
-                            case ScanningFunction.Name: return await ScanNameExpectedAsync().ConfigureAwait(false);
-                            case ScanningFunction.QName: return await ScanQNameExpectedAsync().ConfigureAwait(false);
-                            case ScanningFunction.Nmtoken: return await ScanNmtokenExpectedAsync().ConfigureAwait(false);
-                            case ScanningFunction.SubsetContent: return await ScanSubsetContentAsync().ConfigureAwait(false);
-                            case ScanningFunction.Doctype1: return await ScanDoctype1Async().ConfigureAwait(false);
+                            case ScanningFunction.Name: return await ScanNameExpectedAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+                            case ScanningFunction.QName: return await ScanQNameExpectedAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+                            case ScanningFunction.Nmtoken: return await ScanNmtokenExpectedAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+                            case ScanningFunction.SubsetContent: return await ScanSubsetContentAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+                            case ScanningFunction.Doctype1: return await ScanDoctype1Async().ConfigureAwait(OperatingSystem.IsBrowser());
                             case ScanningFunction.Doctype2: return ScanDoctype2();
-                            case ScanningFunction.Element1: return await ScanElement1Async().ConfigureAwait(false);
-                            case ScanningFunction.Element2: return await ScanElement2Async().ConfigureAwait(false);
-                            case ScanningFunction.Element3: return await ScanElement3Async().ConfigureAwait(false);
+                            case ScanningFunction.Element1: return await ScanElement1Async().ConfigureAwait(OperatingSystem.IsBrowser());
+                            case ScanningFunction.Element2: return await ScanElement2Async().ConfigureAwait(OperatingSystem.IsBrowser());
+                            case ScanningFunction.Element3: return await ScanElement3Async().ConfigureAwait(OperatingSystem.IsBrowser());
                             case ScanningFunction.Element4: return ScanElement4();
                             case ScanningFunction.Element5: return ScanElement5();
                             case ScanningFunction.Element6: return ScanElement6();
                             case ScanningFunction.Element7: return ScanElement7();
-                            case ScanningFunction.Attlist1: return await ScanAttlist1Async().ConfigureAwait(false);
-                            case ScanningFunction.Attlist2: return await ScanAttlist2Async().ConfigureAwait(false);
+                            case ScanningFunction.Attlist1: return await ScanAttlist1Async().ConfigureAwait(OperatingSystem.IsBrowser());
+                            case ScanningFunction.Attlist2: return await ScanAttlist2Async().ConfigureAwait(OperatingSystem.IsBrowser());
                             case ScanningFunction.Attlist3: return ScanAttlist3();
                             case ScanningFunction.Attlist4: return ScanAttlist4();
                             case ScanningFunction.Attlist5: return ScanAttlist5();
-                            case ScanningFunction.Attlist6: return await ScanAttlist6Async().ConfigureAwait(false);
+                            case ScanningFunction.Attlist6: return await ScanAttlist6Async().ConfigureAwait(OperatingSystem.IsBrowser());
                             case ScanningFunction.Attlist7: return ScanAttlist7();
-                            case ScanningFunction.Notation1: return await ScanNotation1Async().ConfigureAwait(false);
-                            case ScanningFunction.SystemId: return await ScanSystemIdAsync().ConfigureAwait(false);
-                            case ScanningFunction.PublicId1: return await ScanPublicId1Async().ConfigureAwait(false);
-                            case ScanningFunction.PublicId2: return await ScanPublicId2Async().ConfigureAwait(false);
-                            case ScanningFunction.Entity1: return await ScanEntity1Async().ConfigureAwait(false);
-                            case ScanningFunction.Entity2: return await ScanEntity2Async().ConfigureAwait(false);
-                            case ScanningFunction.Entity3: return await ScanEntity3Async().ConfigureAwait(false);
-                            case ScanningFunction.CondSection1: return await ScanCondSection1Async().ConfigureAwait(false);
+                            case ScanningFunction.Notation1: return await ScanNotation1Async().ConfigureAwait(OperatingSystem.IsBrowser());
+                            case ScanningFunction.SystemId: return await ScanSystemIdAsync().ConfigureAwait(OperatingSystem.IsBrowser());
+                            case ScanningFunction.PublicId1: return await ScanPublicId1Async().ConfigureAwait(OperatingSystem.IsBrowser());
+                            case ScanningFunction.PublicId2: return await ScanPublicId2Async().ConfigureAwait(OperatingSystem.IsBrowser());
+                            case ScanningFunction.Entity1: return await ScanEntity1Async().ConfigureAwait(OperatingSystem.IsBrowser());
+                            case ScanningFunction.Entity2: return await ScanEntity2Async().ConfigureAwait(OperatingSystem.IsBrowser());
+                            case ScanningFunction.Entity3: return await ScanEntity3Async().ConfigureAwait(OperatingSystem.IsBrowser());
+                            case ScanningFunction.CondSection1: return await ScanCondSection1Async().ConfigureAwait(OperatingSystem.IsBrowser());
                             case ScanningFunction.CondSection2: return ScanCondSection2();
-                            case ScanningFunction.CondSection3: return await ScanCondSection3Async().ConfigureAwait(false);
+                            case ScanningFunction.CondSection3: return await ScanCondSection3Async().ConfigureAwait(OperatingSystem.IsBrowser());
                             case ScanningFunction.ClosingTag: return ScanClosingTag();
                             case ScanningFunction.ParamEntitySpace:
                                 _whitespaceSeen = true;
@@ -1292,7 +1292,7 @@ namespace System.Xml
                         }
                 }
             ReadData:
-                if (_readerAdapter.IsEof || await ReadDataAsync().ConfigureAwait(false) == 0)
+                if (_readerAdapter.IsEof || await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     if (HandleEntityEnd(false))
                     {
@@ -1468,7 +1468,7 @@ namespace System.Xml
                         break;
                 }
             ReadData:
-                if (await ReadDataAsync().ConfigureAwait(false) == 0)
+                if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     Throw(_charsUsed, SR.Xml_IncompleteDtdContent);
                 }
@@ -1477,21 +1477,21 @@ namespace System.Xml
 
         private async Task<Token> ScanNameExpectedAsync()
         {
-            await ScanNameAsync().ConfigureAwait(false);
+            await ScanNameAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             _scanningFunction = _nextScanningFunction;
             return Token.Name;
         }
 
         private async Task<Token> ScanQNameExpectedAsync()
         {
-            await ScanQNameAsync().ConfigureAwait(false);
+            await ScanQNameAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             _scanningFunction = _nextScanningFunction;
             return Token.QName;
         }
 
         private async Task<Token> ScanNmtokenExpectedAsync()
         {
-            await ScanNmtokenAsync().ConfigureAwait(false);
+            await ScanNmtokenAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             _scanningFunction = _nextScanningFunction;
             return Token.Nmtoken;
         }
@@ -1501,7 +1501,7 @@ namespace System.Xml
             switch (_chars[_curPos])
             {
                 case 'P':
-                    if (!await EatPublicKeywordAsync().ConfigureAwait(false))
+                    if (!await EatPublicKeywordAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         Throw(_curPos, SR.Xml_ExpectExternalOrClose);
                     }
@@ -1509,7 +1509,7 @@ namespace System.Xml
                     _scanningFunction = ScanningFunction.PublicId1;
                     return Token.PUBLIC;
                 case 'S':
-                    if (!await EatSystemKeywordAsync().ConfigureAwait(false))
+                    if (!await EatSystemKeywordAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         Throw(_curPos, SR.Xml_ExpectExternalOrClose);
                     }
@@ -1570,7 +1570,7 @@ namespace System.Xml
                         break;
                 }
             ReadData:
-                if (await ReadDataAsync().ConfigureAwait(false) == 0)
+                if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     Throw(_curPos, SR.Xml_IncompleteDtdContent);
                 }
@@ -1583,7 +1583,7 @@ namespace System.Xml
             {
                 while (_charsUsed - _curPos < 7)
                 {
-                    if (await ReadDataAsync().ConfigureAwait(false) == 0)
+                    if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                     {
                         Throw(_curPos, SR.Xml_IncompleteDtdContent);
                     }
@@ -1617,7 +1617,7 @@ namespace System.Xml
                     _scanningFunction = ScanningFunction.SubsetContent;
                     return Token.GreaterThan;
                 default:
-                    await ScanQNameAsync().ConfigureAwait(false);
+                    await ScanQNameAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     _scanningFunction = ScanningFunction.Element4;
                     return Token.QName;
             }
@@ -1636,7 +1636,7 @@ namespace System.Xml
                     {
                         Throw(_curPos, SR.Xml_ExpectingWhiteSpace, ParseUnexpectedToken(_curPos));
                     }
-                    await ScanQNameAsync().ConfigureAwait(false);
+                    await ScanQNameAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     _scanningFunction = ScanningFunction.Attlist2;
                     return Token.QName;
             }
@@ -1767,7 +1767,7 @@ namespace System.Xml
                 }
 
             ReadData:
-                if (await ReadDataAsync().ConfigureAwait(false) == 0)
+                if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     Throw(_curPos, SR.Xml_IncompleteDtdContent);
                 }
@@ -1782,7 +1782,7 @@ namespace System.Xml
                 {
                     case '"':
                     case '\'':
-                        await ScanLiteralAsync(LiteralType.AttributeValue).ConfigureAwait(false);
+                        await ScanLiteralAsync(LiteralType.AttributeValue).ConfigureAwait(OperatingSystem.IsBrowser());
                         _scanningFunction = ScanningFunction.Attlist1;
                         return Token.Literal;
                     case '#':
@@ -1834,7 +1834,7 @@ namespace System.Xml
                         break;
                 }
             ReadData:
-                if (await ReadDataAsync().ConfigureAwait(false) == 0)
+                if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     Throw(_curPos, SR.Xml_IncompleteDtdContent);
                 }
@@ -1957,7 +1957,7 @@ namespace System.Xml
                             _curPos++;
                             continue;
                         }
-                        await HandleEntityReferenceAsync(true, true, literalType == LiteralType.AttributeValue).ConfigureAwait(false);
+                        await HandleEntityReferenceAsync(true, true, literalType == LiteralType.AttributeValue).ConfigureAwait(OperatingSystem.IsBrowser());
                         _tokenStartPos = _curPos;
                         continue;
                     // general entity reference
@@ -1975,7 +1975,7 @@ namespace System.Xml
                         if (_chars[_curPos + 1] == '#')
                         {
                             SaveParsingBuffer();
-                            int endPos = await _readerAdapter.ParseNumericCharRefAsync(SaveInternalSubsetValue ? _internalSubsetValueSb : null).ConfigureAwait(false);
+                            int endPos = await _readerAdapter.ParseNumericCharRefAsync(SaveInternalSubsetValue ? _internalSubsetValueSb : null).ConfigureAwait(OperatingSystem.IsBrowser());
                             LoadParsingBuffer();
                             _stringBuilder.Append(_chars, _curPos, endPos - _curPos);
                             _readerAdapter.CurrentPosition = endPos;
@@ -1989,7 +1989,7 @@ namespace System.Xml
                             SaveParsingBuffer();
                             if (literalType == LiteralType.AttributeValue)
                             {
-                                int endPos = await _readerAdapter.ParseNamedCharRefAsync(true, SaveInternalSubsetValue ? _internalSubsetValueSb : null).ConfigureAwait(false);
+                                int endPos = await _readerAdapter.ParseNamedCharRefAsync(true, SaveInternalSubsetValue ? _internalSubsetValueSb : null).ConfigureAwait(OperatingSystem.IsBrowser());
                                 LoadParsingBuffer();
 
                                 if (endPos >= 0)
@@ -2002,14 +2002,14 @@ namespace System.Xml
                                 }
                                 else
                                 {
-                                    await HandleEntityReferenceAsync(false, true, true).ConfigureAwait(false);
+                                    await HandleEntityReferenceAsync(false, true, true).ConfigureAwait(OperatingSystem.IsBrowser());
                                     _tokenStartPos = _curPos;
                                 }
                                 continue;
                             }
                             else
                             {
-                                int endPos = await _readerAdapter.ParseNamedCharRefAsync(false, null).ConfigureAwait(false);
+                                int endPos = await _readerAdapter.ParseNamedCharRefAsync(false, null).ConfigureAwait(OperatingSystem.IsBrowser());
                                 LoadParsingBuffer();
 
                                 if (endPos >= 0)
@@ -2062,7 +2062,7 @@ namespace System.Xml
                 Debug.Assert(_curPos - _tokenStartPos == 0);
 
                 // read new characters into the buffer
-                if (_readerAdapter.IsEof || await ReadDataAsync().ConfigureAwait(false) == 0)
+                if (_readerAdapter.IsEof || await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     if (literalType == LiteralType.SystemOrPublicID || !HandleEntityEnd(true))
                     {
@@ -2078,7 +2078,7 @@ namespace System.Xml
             switch (_chars[_curPos])
             {
                 case 'P':
-                    if (!await EatPublicKeywordAsync().ConfigureAwait(false))
+                    if (!await EatPublicKeywordAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         Throw(_curPos, SR.Xml_ExpectExternalOrClose);
                     }
@@ -2086,7 +2086,7 @@ namespace System.Xml
                     _scanningFunction = ScanningFunction.PublicId1;
                     return Token.PUBLIC;
                 case 'S':
-                    if (!await EatSystemKeywordAsync().ConfigureAwait(false))
+                    if (!await EatSystemKeywordAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         Throw(_curPos, SR.Xml_ExpectExternalOrClose);
                     }
@@ -2106,7 +2106,7 @@ namespace System.Xml
                 ThrowUnexpectedToken(_curPos, "\"", "'");
             }
 
-            await ScanLiteralAsync(LiteralType.SystemOrPublicID).ConfigureAwait(false);
+            await ScanLiteralAsync(LiteralType.SystemOrPublicID).ConfigureAwait(OperatingSystem.IsBrowser());
 
             _scanningFunction = _nextScanningFunction;
             return Token.Literal;
@@ -2123,7 +2123,7 @@ namespace System.Xml
             }
             else
             {
-                await ScanNameAsync().ConfigureAwait(false);
+                await ScanNameAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 _scanningFunction = ScanningFunction.Entity2;
                 return Token.Name;
             }
@@ -2134,7 +2134,7 @@ namespace System.Xml
             switch (_chars[_curPos])
             {
                 case 'P':
-                    if (!await EatPublicKeywordAsync().ConfigureAwait(false))
+                    if (!await EatPublicKeywordAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         Throw(_curPos, SR.Xml_ExpectExternalOrClose);
                     }
@@ -2142,7 +2142,7 @@ namespace System.Xml
                     _scanningFunction = ScanningFunction.PublicId1;
                     return Token.PUBLIC;
                 case 'S':
-                    if (!await EatSystemKeywordAsync().ConfigureAwait(false))
+                    if (!await EatSystemKeywordAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         Throw(_curPos, SR.Xml_ExpectExternalOrClose);
                     }
@@ -2152,7 +2152,7 @@ namespace System.Xml
 
                 case '"':
                 case '\'':
-                    await ScanLiteralAsync(LiteralType.EntityReplText).ConfigureAwait(false);
+                    await ScanLiteralAsync(LiteralType.EntityReplText).ConfigureAwait(OperatingSystem.IsBrowser());
                     _scanningFunction = ScanningFunction.ClosingTag;
                     return Token.Literal;
                 default:
@@ -2167,7 +2167,7 @@ namespace System.Xml
             {
                 while (_charsUsed - _curPos < 5)
                 {
-                    if (await ReadDataAsync().ConfigureAwait(false) == 0)
+                    if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                     {
                         goto End;
                     }
@@ -2193,7 +2193,7 @@ namespace System.Xml
                 ThrowUnexpectedToken(_curPos, "\"", "'");
             }
 
-            await ScanLiteralAsync(LiteralType.SystemOrPublicID).ConfigureAwait(false);
+            await ScanLiteralAsync(LiteralType.SystemOrPublicID).ConfigureAwait(OperatingSystem.IsBrowser());
 
             _scanningFunction = ScanningFunction.PublicId2;
             return Token.Literal;
@@ -2207,7 +2207,7 @@ namespace System.Xml
                 return Token.None;
             }
 
-            await ScanLiteralAsync(LiteralType.SystemOrPublicID).ConfigureAwait(false);
+            await ScanLiteralAsync(LiteralType.SystemOrPublicID).ConfigureAwait(OperatingSystem.IsBrowser());
             _scanningFunction = _nextScanningFunction;
 
             return Token.Literal;
@@ -2260,7 +2260,7 @@ namespace System.Xml
                         return Token.None;
                 }
             ReadData:
-                if (await ReadDataAsync().ConfigureAwait(false) == 0)
+                if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     Throw(_curPos, SR.Xml_IncompleteDtdContent);
                 }
@@ -2372,7 +2372,7 @@ namespace System.Xml
 
             ReadData:
                 // read new characters into the buffer
-                if (_readerAdapter.IsEof || await ReadDataAsync().ConfigureAwait(false) == 0)
+                if (_readerAdapter.IsEof || await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     if (HandleEntityEnd(false))
                     {
@@ -2409,7 +2409,7 @@ namespace System.Xml
                 {
                     if (_curPos + 1 >= _charsUsed)
                     {
-                        if (await ReadDataInNameAsync().ConfigureAwait(false))
+                        if (await ReadDataInNameAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                         {
                             continue;
                         }
@@ -2455,7 +2455,7 @@ namespace System.Xml
                 // end of buffer
                 else if (_curPos == _charsUsed)
                 {
-                    if (await ReadDataInNameAsync().ConfigureAwait(false))
+                    if (await ReadDataInNameAsync().ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         goto ContinueName;
                     }
@@ -2474,7 +2474,7 @@ namespace System.Xml
         {
             int offset = _curPos - _tokenStartPos;
             _curPos = _tokenStartPos;
-            bool newDataRead = (await ReadDataAsync().ConfigureAwait(false) != 0);
+            bool newDataRead = (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) != 0);
             _tokenStartPos = _curPos;
             _curPos += offset;
             return newDataRead;
@@ -2509,7 +2509,7 @@ namespace System.Xml
 
                 int len = _curPos - _tokenStartPos;
                 _curPos = _tokenStartPos;
-                if (await ReadDataAsync().ConfigureAwait(false) == 0)
+                if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     if (len > 0)
                     {
@@ -2529,7 +2529,7 @@ namespace System.Xml
             Debug.Assert(_chars[_curPos] == 'P');
             while (_charsUsed - _curPos < 6)
             {
-                if (await ReadDataAsync().ConfigureAwait(false) == 0)
+                if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     return false;
                 }
@@ -2548,7 +2548,7 @@ namespace System.Xml
             Debug.Assert(_chars[_curPos] == 'S');
             while (_charsUsed - _curPos < 6)
             {
-                if (await ReadDataAsync().ConfigureAwait(false) == 0)
+                if (await ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser()) == 0)
                 {
                     return false;
                 }
@@ -2568,7 +2568,7 @@ namespace System.Xml
         private async Task<int> ReadDataAsync()
         {
             SaveParsingBuffer();
-            int charsRead = await _readerAdapter.ReadDataAsync().ConfigureAwait(false);
+            int charsRead = await _readerAdapter.ReadDataAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             LoadParsingBuffer();
             return charsRead;
         }
@@ -2607,7 +2607,7 @@ namespace System.Xml
             int newEntityId;
             if (entity.IsExternal)
             {
-                var tuple_3 = await _readerAdapter.PushEntityAsync(entity).ConfigureAwait(false);
+                var tuple_3 = await _readerAdapter.PushEntityAsync(entity).ConfigureAwait(OperatingSystem.IsBrowser());
                 newEntityId = tuple_3.Item1;
 
                 if (!tuple_3.Item2)
@@ -2623,7 +2623,7 @@ namespace System.Xml
                     return false;
                 }
 
-                var tuple_4 = await _readerAdapter.PushEntityAsync(entity).ConfigureAwait(false);
+                var tuple_4 = await _readerAdapter.PushEntityAsync(entity).ConfigureAwait(OperatingSystem.IsBrowser());
                 newEntityId = tuple_4.Item1;
 
                 if (!tuple_4.Item2)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/ParserAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/ParserAsync.cs
@@ -28,7 +28,7 @@ namespace System.Xml.Schema
             {
                 _isProcessNamespaces = false;
             }
-            while (reader.NodeType != XmlNodeType.Element && await reader.ReadAsync().ConfigureAwait(false)) { }
+            while (reader.NodeType != XmlNodeType.Element && await reader.ReadAsync().ConfigureAwait(OperatingSystem.IsBrowser())) { }
 
             _markupDepth = int.MaxValue;
             _schemaXmlDepth = reader.Depth;

--- a/src/libraries/System.Private.Xml/src/System/Xml/XmlDownloadManagerAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XmlDownloadManagerAsync.cs
@@ -40,7 +40,7 @@ namespace System.Xml
                 }
 #pragma warning restore CA1416
 
-                using (Stream respStream = await client.GetStreamAsync(uri).ConfigureAwait(false))
+                using (Stream respStream = await client.GetStreamAsync(uri).ConfigureAwait(OperatingSystem.IsBrowser()))
                 {
                     var result = new MemoryStream();
                     respStream.CopyTo(result);

--- a/src/libraries/System.Private.Xml/src/System/Xml/XmlUrlResolverAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XmlUrlResolverAsync.cs
@@ -13,7 +13,7 @@ namespace System.Xml
         {
             if (ofObjectToReturn == null || ofObjectToReturn == typeof(System.IO.Stream) || ofObjectToReturn == typeof(object))
             {
-                return await XmlDownloadManager.GetStreamAsync(absoluteUri, _credentials, _proxy).ConfigureAwait(false);
+                return await XmlDownloadManager.GetStreamAsync(absoluteUri, _credentials, _proxy).ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             throw new XmlException(SR.Xml_UnsupportedClass, string.Empty);

--- a/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/CoseMessage.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/CoseMessage.cs
@@ -473,9 +473,9 @@ namespace System.Security.Cryptography.Cose
             byte[] contentBuffer = ArrayPool<byte>.Shared.Rent(4096);
             int bytesRead;
 #if NETSTANDARD2_0 || NETFRAMEWORK
-            while ((bytesRead = await content.ReadAsync(contentBuffer, 0, contentBuffer.Length, cancellationToken).ConfigureAwait(false)) > 0)
+            while ((bytesRead = await content.ReadAsync(contentBuffer, 0, contentBuffer.Length, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser())) > 0)
 #else
-            while ((bytesRead = await content.ReadAsync(contentBuffer, cancellationToken).ConfigureAwait(false)) > 0)
+            while ((bytesRead = await content.ReadAsync(contentBuffer, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser())) > 0)
 #endif
             {
                 hasher.AppendData(contentBuffer, 0, bytesRead);

--- a/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/CoseMultiSignMessage.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/CoseMultiSignMessage.cs
@@ -285,7 +285,7 @@ namespace System.Security.Cryptography.Cose
             CancellationToken cancellationToken)
         {
             byte[] buffer = new byte[expectedSize];
-            int bytesWritten = await CreateCoseMultiSignMessageAsync(content, buffer, signer, protectedHeaders, unprotectedHeaders, associatedData, cancellationToken).ConfigureAwait(false);
+            int bytesWritten = await CreateCoseMultiSignMessageAsync(content, buffer, signer, protectedHeaders, unprotectedHeaders, associatedData, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
             Debug.Assert(buffer.Length == bytesWritten);
             return buffer;
@@ -413,7 +413,7 @@ namespace System.Security.Cryptography.Cose
             CoseHelpers.WriteHeaderMap(buffer.AsSpan(protectedMapBytesWritten), writer, unprotectedHeaders, isProtected: false, null);
             CoseHelpers.WriteContent(writer, default, isDetached: true);
 
-            await WriteSignatureAsync(writer, signer, buffer, buffer.AsMemory(0, protectedMapBytesWritten), associatedData, content, cancellationToken).ConfigureAwait(false);
+            await WriteSignatureAsync(writer, signer, buffer, buffer.AsMemory(0, protectedMapBytesWritten), associatedData, content, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
             writer.WriteEndArray();
             return writer.Encode(buffer);
@@ -490,7 +490,7 @@ namespace System.Security.Cryptography.Cose
             using (IncrementalHash hasher = IncrementalHash.CreateHash(hashAlgorithm))
             {
                 // We can use the whole buffer at this point as the space for bodyProtected and signProtected is consumed.
-                await AppendToBeSignedAsync(buffer, hasher, SigStructureContext.Signature, bodyProtected, buffer.AsMemory(start, signProtectedBytesWritten), associatedData, contentStream, cancellationToken).ConfigureAwait(false);
+                await AppendToBeSignedAsync(buffer, hasher, SigStructureContext.Signature, bodyProtected, buffer.AsMemory(start, signProtectedBytesWritten), associatedData, contentStream, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 CoseHelpers.WriteSignature(buffer, hasher, writer, signer);
             }
 
@@ -873,7 +873,7 @@ namespace System.Security.Cryptography.Cose
 
             using (IncrementalHash hasher = IncrementalHash.CreateHash(signer.HashAlgorithm))
             {
-                await AppendToBeSignedAsync(buffer, hasher, SigStructureContext.Signature, _protectedHeaderAsBstr, encodedSignProtected, associatedData, content, cancellationToken).ConfigureAwait(false);
+                await AppendToBeSignedAsync(buffer, hasher, SigStructureContext.Signature, _protectedHeaderAsBstr, encodedSignProtected, associatedData, content, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 bytesWritten = CoseHelpers.SignHash(signer, hasher, buffer);
 
                 byte[] signature = buffer.AsSpan(0, bytesWritten).ToArray();

--- a/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/CoseSign1Message.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/CoseSign1Message.cs
@@ -235,7 +235,7 @@ namespace System.Security.Cryptography.Cose
         private static async Task<byte[]> SignAsyncCore(int expectedSize, Stream content, CoseSigner signer, ReadOnlyMemory<byte> associatedData, CancellationToken cancellationToken)
         {
             byte[] buffer = new byte[expectedSize];
-            int bytesWritten = await CreateCoseSign1MessageAsync(content, buffer, signer, associatedData, cancellationToken).ConfigureAwait(false);
+            int bytesWritten = await CreateCoseSign1MessageAsync(content, buffer, signer, associatedData, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
             Debug.Assert(buffer.Length == bytesWritten);
             return buffer;
@@ -355,7 +355,7 @@ namespace System.Security.Cryptography.Cose
 
             using (IncrementalHash hasher = IncrementalHash.CreateHash(signer.HashAlgorithm))
             {
-                await AppendToBeSignedAsync(buffer, hasher, SigStructureContext.Signature1, buffer.AsMemory(0, protectedMapBytesWritten), ReadOnlyMemory<byte>.Empty, associatedData, content, cancellationToken).ConfigureAwait(false);
+                await AppendToBeSignedAsync(buffer, hasher, SigStructureContext.Signature1, buffer.AsMemory(0, protectedMapBytesWritten), ReadOnlyMemory<byte>.Empty, associatedData, content, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 CoseHelpers.WriteSignature(buffer, hasher, writer, signer);
             }
 
@@ -729,7 +729,7 @@ namespace System.Security.Cryptography.Cose
                     contentLength: 0);
                 byte[] buffer = ArrayPool<byte>.Shared.Rent(bufferLength);
 
-                await AppendToBeSignedAsync(buffer, hasher, SigStructureContext.Signature1, _protectedHeaderAsBstr, ReadOnlyMemory<byte>.Empty, associatedData, content, cancellationToken).ConfigureAwait(false);
+                await AppendToBeSignedAsync(buffer, hasher, SigStructureContext.Signature1, _protectedHeaderAsBstr, ReadOnlyMemory<byte>.Empty, associatedData, content, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 bool retVal = VerifyHash(key, hasher, hashAlgorithm, keyType, padding);
 
                 ArrayPool<byte>.Shared.Return(buffer, clearArray: true);

--- a/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/CoseSignature.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/CoseSignature.cs
@@ -406,7 +406,7 @@ namespace System.Security.Cryptography.Cose
 
                 try
                 {
-                    await CoseMessage.AppendToBeSignedAsync(buffer, hasher, SigStructureContext.Signature, Message.RawProtectedHeaders, _encodedSignProtectedHeaders, associatedData, content, cancellationToken).ConfigureAwait(false);
+                    await CoseMessage.AppendToBeSignedAsync(buffer, hasher, SigStructureContext.Signature, Message.RawProtectedHeaders, _encodedSignProtectedHeaders, associatedData, content, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     return VerifyHash(key, hasher, hashAlgorithm, keyType, padding);
                 }
                 finally

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CryptoStream.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CryptoStream.cs
@@ -146,7 +146,7 @@ namespace System.Security.Cryptography
                 byte[] finalBytes = _transform.TransformFinalBlock(_inputBuffer!, 0, _inputBufferIndex);
                 if (useAsync)
                 {
-                    await _stream.WriteAsync(new ReadOnlyMemory<byte>(finalBytes), cancellationToken).ConfigureAwait(false);
+                    await _stream.WriteAsync(new ReadOnlyMemory<byte>(finalBytes), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 else
                 {
@@ -159,14 +159,14 @@ namespace System.Security.Cryptography
             {
                 if (!innerCryptoStream.HasFlushedFinalBlock)
                 {
-                    await innerCryptoStream.FlushFinalBlockAsync(useAsync, cancellationToken).ConfigureAwait(false);
+                    await innerCryptoStream.FlushFinalBlockAsync(useAsync, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             else
             {
                 if (useAsync)
                 {
-                    await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                    await _stream.FlushAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 else
                 {
@@ -237,10 +237,10 @@ namespace System.Security.Cryptography
             // async requests outstanding, we will block the application's main
             // thread if it does a second IO request until the first one completes.
 
-            await AsyncActiveSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            await AsyncActiveSemaphore.WaitAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             try
             {
-                return await ReadAsyncCore(buffer, cancellationToken, useAsync: true).ConfigureAwait(false);
+                return await ReadAsyncCore(buffer, cancellationToken, useAsync: true).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             finally
             {
@@ -348,7 +348,7 @@ namespace System.Security.Cryptography
                         // Read into our temporary input buffer, leaving enough room at the beginning for any existing data
                         // we have in _inputBuffer.
                         bytesRead = useAsync ?
-                            await _stream.ReadAsync(new Memory<byte>(tempInputBuffer, _inputBufferIndex, numWholeBlocksInBytes - _inputBufferIndex), cancellationToken).ConfigureAwait(false) :
+                            await _stream.ReadAsync(new Memory<byte>(tempInputBuffer, _inputBufferIndex, numWholeBlocksInBytes - _inputBufferIndex), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser()) :
                             _stream.Read(tempInputBuffer, _inputBufferIndex, numWholeBlocksInBytes - _inputBufferIndex);
                         eof = bytesRead == 0;
 
@@ -425,7 +425,7 @@ namespace System.Security.Cryptography
                     while (_inputBufferIndex < _inputBlockSize)
                     {
                         bytesRead = useAsync ?
-                            await _stream.ReadAsync(new Memory<byte>(_inputBuffer, _inputBufferIndex, _inputBlockSize - _inputBufferIndex), cancellationToken).ConfigureAwait(false) :
+                            await _stream.ReadAsync(new Memory<byte>(_inputBuffer, _inputBufferIndex, _inputBlockSize - _inputBufferIndex), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser()) :
                             _stream.Read(_inputBuffer, _inputBufferIndex, _inputBlockSize - _inputBufferIndex);
                         if (bytesRead <= 0)
                         {
@@ -476,10 +476,10 @@ namespace System.Security.Cryptography
             // async requests outstanding, we will block the application's main
             // thread if it does a second IO request until the first one completes.
 
-            await AsyncActiveSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            await AsyncActiveSemaphore.WaitAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             try
             {
-                await WriteAsyncCore(buffer, cancellationToken, useAsync: true).ConfigureAwait(false);
+                await WriteAsyncCore(buffer, cancellationToken, useAsync: true).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             finally
             {
@@ -570,7 +570,7 @@ namespace System.Security.Cryptography
                 numOutputBytes = _transform.TransformBlock(_inputBuffer, 0, _inputBlockSize, _outputBuffer, 0);
                 // write out the bytes we just got
                 if (useAsync)
-                    await _stream.WriteAsync(new ReadOnlyMemory<byte>(_outputBuffer, 0, numOutputBytes), cancellationToken).ConfigureAwait(false);
+                    await _stream.WriteAsync(new ReadOnlyMemory<byte>(_outputBuffer, 0, numOutputBytes), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 else
                     _stream.Write(_outputBuffer, 0, numOutputBytes);
 
@@ -599,7 +599,7 @@ namespace System.Security.Cryptography
 
                             if (useAsync)
                             {
-                                await _stream.WriteAsync(new ReadOnlyMemory<byte>(tempOutputBuffer, 0, numOutputBytes), cancellationToken).ConfigureAwait(false);
+                                await _stream.WriteAsync(new ReadOnlyMemory<byte>(tempOutputBuffer, 0, numOutputBytes), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                             }
                             else
                             {
@@ -626,7 +626,7 @@ namespace System.Security.Cryptography
                         numOutputBytes = TransformBlock(_transform, buffer.Slice(currentInputIndex, _inputBlockSize), _outputBuffer, 0);
 
                         if (useAsync)
-                            await _stream.WriteAsync(new ReadOnlyMemory<byte>(_outputBuffer, 0, numOutputBytes), cancellationToken).ConfigureAwait(false);
+                            await _stream.WriteAsync(new ReadOnlyMemory<byte>(_outputBuffer, 0, numOutputBytes), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                         else
                             _stream.Write(_outputBuffer, 0, numOutputBytes);
 
@@ -727,8 +727,8 @@ namespace System.Security.Cryptography
                 int bytesRead;
                 do
                 {
-                    bytesRead = await ReadAsync(rentedBuffer.AsMemory(0, bufferSize), cancellationToken).ConfigureAwait(false);
-                    await destination.WriteAsync(rentedBuffer.AsMemory(0, bytesRead), cancellationToken).ConfigureAwait(false);
+                    bytesRead = await ReadAsync(rentedBuffer.AsMemory(0, bufferSize), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
+                    await destination.WriteAsync(rentedBuffer.AsMemory(0, bytesRead), cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 } while (bytesRead > 0);
             }
             finally
@@ -811,12 +811,12 @@ namespace System.Security.Cryptography
             {
                 if (!_finalBlockTransformed)
                 {
-                    await FlushFinalBlockAsync(useAsync: true, default).ConfigureAwait(false);
+                    await FlushFinalBlockAsync(useAsync: true, default).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
 
                 if (!_leaveOpen)
                 {
-                    await _stream.DisposeAsync().ConfigureAwait(false);
+                    await _stream.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
             }
             finally

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashAlgorithm.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashAlgorithm.cs
@@ -135,7 +135,7 @@ namespace System.Security.Cryptography
             int clearLimit = 0;
             int bytesRead;
 
-            while ((bytesRead = await inputStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false)) > 0)
+            while ((bytesRead = await inputStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser())) > 0)
             {
                 if (bytesRead > clearLimit)
                 {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/LiteHashProvider.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/LiteHashProvider.cs
@@ -151,7 +151,7 @@ namespace System.Security.Cryptography
 
                 try
                 {
-                    while ((read = await source.ReadAsync(rented, cancellationToken).ConfigureAwait(false)) > 0)
+                    while ((read = await source.ReadAsync(rented, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser())) > 0)
                     {
                         maxRead = Math.Max(maxRead, read);
                         hash.Append(rented.AsSpan(0, read));
@@ -173,7 +173,7 @@ namespace System.Security.Cryptography
             CancellationToken cancellationToken) where T : ILiteHash
         {
             byte[] result = new byte[hash.HashSizeInBytes];
-            int written = await ProcessStreamAsync(hash, source, result, cancellationToken).ConfigureAwait(false);
+            int written = await ProcessStreamAsync(hash, source, result, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
             Debug.Assert(written == result.Length);
             return result;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.Parse.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.Parse.cs
@@ -213,7 +213,7 @@ namespace System.Text.Json
             JsonDocumentOptions options = default,
             CancellationToken cancellationToken = default)
         {
-            ArraySegment<byte> drained = await ReadToEndAsync(utf8Json, cancellationToken).ConfigureAwait(false);
+            ArraySegment<byte> drained = await ReadToEndAsync(utf8Json, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             Debug.Assert(drained.Array != null);
             try
             {
@@ -862,7 +862,7 @@ namespace System.Text.Json
                         written,
                         utf8BomLength - written,
 #endif
-                        cancellationToken).ConfigureAwait(false);
+                        cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
                     written += lastRead;
                 } while (lastRead > 0 && written < utf8BomLength);
@@ -893,7 +893,7 @@ namespace System.Text.Json
                         written,
                         rented.Length - written,
 #endif
-                        cancellationToken).ConfigureAwait(false);
+                        cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
                     written += lastRead;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.ReadHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.ReadHelper.cs
@@ -35,7 +35,7 @@ namespace System.Text.Json.Serialization.Metadata
             {
                 while (true)
                 {
-                    bufferState = await bufferState.ReadFromStreamAsync(utf8Json, cancellationToken).ConfigureAwait(false);
+                    bufferState = await bufferState.ReadFromStreamAsync(utf8Json, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                     T? value = ContinueDeserialize(ref bufferState, ref jsonReaderState, ref readStack);
 
                     if (bufferState.IsFinalBlock)
@@ -100,7 +100,7 @@ namespace System.Text.Json.Serialization.Metadata
             {
                 do
                 {
-                    bufferState = await bufferState.ReadFromStreamAsync(utf8Json, cancellationToken, fillBuffer: false).ConfigureAwait(false);
+                    bufferState = await bufferState.ReadFromStreamAsync(utf8Json, cancellationToken, fillBuffer: false).ConfigureAwait(OperatingSystem.IsBrowser());
                     queueTypeInfo.ContinueDeserialize(
                         ref bufferState,
                         ref jsonReaderState,
@@ -128,7 +128,7 @@ namespace System.Text.Json.Serialization.Metadata
 
         internal sealed override async ValueTask<object?> DeserializeAsObjectAsync(Stream utf8Json, CancellationToken cancellationToken)
         {
-            T? result = await DeserializeAsync(utf8Json, cancellationToken).ConfigureAwait(false);
+            T? result = await DeserializeAsync(utf8Json, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             return result;
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.WriteHelpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.WriteHelpers.cs
@@ -93,7 +93,7 @@ namespace System.Text.Json.Serialization.Metadata
                     Utf8JsonWriterCache.ReturnWriter(writer);
                 }
 
-                await bufferWriter.WriteToStreamAsync(utf8Json, cancellationToken).ConfigureAwait(false);
+                await bufferWriter.WriteToStreamAsync(utf8Json, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             else if (
 #if NETCOREAPP
@@ -104,7 +104,7 @@ namespace System.Text.Json.Serialization.Metadata
                 Options.TryGetPolymorphicTypeInfoForRootType(rootValue, out JsonTypeInfo? derivedTypeInfo))
             {
                 Debug.Assert(typeof(T) == typeof(object));
-                await derivedTypeInfo.SerializeAsObjectAsync(utf8Json, rootValue, cancellationToken).ConfigureAwait(false);
+                await derivedTypeInfo.SerializeAsObjectAsync(utf8Json, rootValue, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             else
             {
@@ -139,7 +139,7 @@ namespace System.Text.Json.Serialization.Metadata
                             }
                             else
                             {
-                                await bufferWriter.WriteToStreamAsync(utf8Json, cancellationToken).ConfigureAwait(false);
+                                await bufferWriter.WriteToStreamAsync(utf8Json, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                                 bufferWriter.Clear();
                             }
                         }
@@ -151,7 +151,7 @@ namespace System.Text.Json.Serialization.Metadata
                             {
                                 try
                                 {
-                                    await state.PendingTask.ConfigureAwait(false);
+                                    await state.PendingTask.ConfigureAwait(OperatingSystem.IsBrowser());
                                 }
                                 catch
                                 {
@@ -163,7 +163,7 @@ namespace System.Text.Json.Serialization.Metadata
                             // Dispose any pending async disposables (currently these can only be completed IAsyncEnumerators).
                             if (state.CompletedAsyncDisposables?.Count > 0)
                             {
-                                await state.DisposeCompletedAsyncDisposables().ConfigureAwait(false);
+                                await state.DisposeCompletedAsyncDisposables().ConfigureAwait(OperatingSystem.IsBrowser());
                             }
                         }
 
@@ -172,7 +172,7 @@ namespace System.Text.Json.Serialization.Metadata
                 catch
                 {
                     // On exception, walk the WriteStack for any orphaned disposables and try to dispose them.
-                    await state.DisposePendingDisposablesOnExceptionAsync().ConfigureAwait(false);
+                    await state.DisposePendingDisposablesOnExceptionAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     throw;
                 }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadBufferState.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadBufferState.cs
@@ -54,7 +54,7 @@ namespace System.Text.Json.Serialization
 #else
                     bufferState._buffer, bufferState._count, bufferState._buffer.Length - bufferState._count,
 #endif
-                    cancellationToken).ConfigureAwait(false);
+                    cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 
                 if (bytesRead == 0)
                 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -284,7 +284,7 @@ namespace System.Text.Json
             {
                 try
                 {
-                    await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                    await asyncDisposable.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 catch (Exception e)
                 {
@@ -347,12 +347,12 @@ namespace System.Text.Json
         {
             Exception? exception = null;
 
-            exception = await DisposeFrame(Current.CollectionEnumerator, Current.AsyncDisposable, exception).ConfigureAwait(false);
+            exception = await DisposeFrame(Current.CollectionEnumerator, Current.AsyncDisposable, exception).ConfigureAwait(OperatingSystem.IsBrowser());
 
             int stackSize = Math.Max(_count, _continuationCount);
             for (int i = 0; i < stackSize - 1; i++)
             {
-                exception = await DisposeFrame(_stack[i].CollectionEnumerator, _stack[i].AsyncDisposable, exception).ConfigureAwait(false);
+                exception = await DisposeFrame(_stack[i].CollectionEnumerator, _stack[i].AsyncDisposable, exception).ConfigureAwait(OperatingSystem.IsBrowser());
             }
 
             if (exception is not null)
@@ -372,7 +372,7 @@ namespace System.Text.Json
                     }
                     else if (asyncDisposable is not null)
                     {
-                        await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                        await asyncDisposable.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                     }
                 }
                 catch (Exception e)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
@@ -386,7 +386,7 @@ namespace System.Text.Json
                 }
             }
 
-            await FlushAsync().ConfigureAwait(false);
+            await FlushAsync().ConfigureAwait(OperatingSystem.IsBrowser());
             ResetHelper();
 
             _stream = null;
@@ -419,20 +419,20 @@ namespace System.Text.Json
                     BytesPending = 0;
 
 #if NETCOREAPP
-                    await _stream.WriteAsync(_arrayBufferWriter.WrittenMemory, cancellationToken).ConfigureAwait(false);
+                    await _stream.WriteAsync(_arrayBufferWriter.WrittenMemory, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 #else
                     Debug.Assert(_arrayBufferWriter.WrittenMemory.Length == _arrayBufferWriter.WrittenCount);
                     bool result = MemoryMarshal.TryGetArray(_arrayBufferWriter.WrittenMemory, out ArraySegment<byte> underlyingBuffer);
                     Debug.Assert(result);
                     Debug.Assert(underlyingBuffer.Offset == 0);
                     Debug.Assert(_arrayBufferWriter.WrittenCount == underlyingBuffer.Count);
-                    await _stream.WriteAsync(underlyingBuffer.Array, underlyingBuffer.Offset, underlyingBuffer.Count, cancellationToken).ConfigureAwait(false);
+                    await _stream.WriteAsync(underlyingBuffer.Array, underlyingBuffer.Offset, underlyingBuffer.Count, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
 #endif
 
                     BytesCommitted += _arrayBufferWriter.WrittenCount;
                     _arrayBufferWriter.Clear();
                 }
-                await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                await _stream.FlushAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             else
             {

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelReader.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelReader.cs
@@ -78,7 +78,7 @@ namespace System.Threading.Channels
             {
                 while (true)
                 {
-                    if (!await WaitToReadAsync(ct).ConfigureAwait(false))
+                    if (!await WaitToReadAsync(ct).ConfigureAwait(OperatingSystem.IsBrowser()))
                     {
                         throw new ChannelClosedException();
                     }

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelReader.netcoreapp.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelReader.netcoreapp.cs
@@ -17,7 +17,7 @@ namespace System.Threading.Channels
         /// <returns>The created async enumerable.</returns>
         public virtual async IAsyncEnumerable<T> ReadAllAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
-            while (await WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+            while (await WaitToReadAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser()))
             {
                 while (TryRead(out T? item))
                 {

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelWriter.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/ChannelWriter.cs
@@ -53,7 +53,7 @@ namespace System.Threading.Channels
 
         private async ValueTask WriteAsyncCore(T innerItem, CancellationToken ct)
         {
-            while (await WaitToWriteAsync(ct).ConfigureAwait(false))
+            while (await WaitToWriteAsync(ct).ConfigureAwait(OperatingSystem.IsBrowser()))
             {
                 if (TryWrite(innerItem))
                 {

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedPartitionedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedPartitionedRateLimiter.cs
@@ -88,7 +88,7 @@ namespace System.Threading.RateLimiting
                 Exception? exception = null;
                 try
                 {
-                    lease = await _limiters[i].AcquireAsync(resource, permitCount, cancellationToken).ConfigureAwait(false);
+                    lease = await _limiters[i].AcquireAsync(resource, permitCount, cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 catch (Exception ex)
                 {

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/DefaultPartitionedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/DefaultPartitionedRateLimiter.cs
@@ -57,7 +57,7 @@ namespace System.Threading.RateLimiting
             {
                 try
                 {
-                    await Heartbeat().ConfigureAwait(false);
+                    await Heartbeat().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 // TODO: Can we log to EventSource or somewhere? Maybe dispatch throwing the exception so it is at least an unhandled exception?
                 catch { }
@@ -146,12 +146,12 @@ namespace System.Threading.RateLimiting
         {
             bool alreadyDisposed = CommonDispose();
 
-            await _timerTask.ConfigureAwait(false);
+            await _timerTask.ConfigureAwait(OperatingSystem.IsBrowser());
             _cachedLimiters.Clear();
 
             if (alreadyDisposed)
             {
-                await _disposeComplete.Task.ConfigureAwait(false);
+                await _disposeComplete.Task.ConfigureAwait(OperatingSystem.IsBrowser());
                 return;
             }
 
@@ -160,7 +160,7 @@ namespace System.Threading.RateLimiting
             {
                 try
                 {
-                    await limiter.Value.Value.DisposeAsync().ConfigureAwait(false);
+                    await limiter.Value.Value.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 catch (Exception ex)
                 {
@@ -264,7 +264,7 @@ namespace System.Threading.RateLimiting
             {
                 try
                 {
-                    await limiter.DisposeAsync().ConfigureAwait(false);
+                    await limiter.DisposeAsync().ConfigureAwait(OperatingSystem.IsBrowser());
                 }
                 catch (Exception ex)
                 {

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.T.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.T.cs
@@ -111,7 +111,7 @@ namespace System.Threading.RateLimiting
         public async ValueTask DisposeAsync()
         {
             // Perform async cleanup.
-            await DisposeAsyncCore().ConfigureAwait(false);
+            await DisposeAsyncCore().ConfigureAwait(OperatingSystem.IsBrowser());
 
             // Dispose of unmanaged resources.
             Dispose(false);

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimiter.cs
@@ -115,7 +115,7 @@ namespace System.Threading.RateLimiting
         public async ValueTask DisposeAsync()
         {
             // Perform async cleanup.
-            await DisposeAsyncCore().ConfigureAwait(false);
+            await DisposeAsyncCore().ConfigureAwait(OperatingSystem.IsBrowser());
 
             // Dispose of unmanaged resources.
             Dispose(false);

--- a/src/libraries/System.Threading.Tasks.Dataflow/src/Base/DataflowBlock.IAsyncEnumerable.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/Base/DataflowBlock.IAsyncEnumerable.cs
@@ -25,7 +25,7 @@ namespace System.Threading.Tasks.Dataflow
 
             static async IAsyncEnumerable<TOutput> Core(IReceivableSourceBlock<TOutput> source, [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                while (await source.OutputAvailableAsync(cancellationToken).ConfigureAwait(false))
+                while (await source.OutputAvailableAsync(cancellationToken).ConfigureAwait(OperatingSystem.IsBrowser()))
                 {
                     while (source.TryReceive(out TOutput? item))
                     {

--- a/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/TransformManyBlock.IAsyncEnumerable.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/TransformManyBlock.IAsyncEnumerable.cs
@@ -48,7 +48,7 @@ namespace System.Threading.Tasks.Dataflow
         // Note:
         // Enumerating the IAsyncEnumerable is done with ConfigureAwait(true), using the default behavior of
         // paying attention to the current context/scheduler. This makes it so that the enumerable code runs on the target scheduler.
-        // For this to work correctly, there can't be any ConfigureAwait(false) in the same method prior to
+        // For this to work correctly, there can't be any ConfigureAwait(OperatingSystem.IsBrowser()) in the same method prior to
         // these await foreach loops, nor in the call chain prior to the method invocation.
 
         /// <summary>Processes the message with a user-provided transform function that returns an async enumerable.</summary>
@@ -60,7 +60,7 @@ namespace System.Threading.Tasks.Dataflow
             {
                 // Run the user transform and store the results.
                 IAsyncEnumerable<TOutput> outputItems = transformFunction(messageWithId.Key);
-                await StoreOutputItemsAsync(messageWithId, outputItems).ConfigureAwait(false);
+                await StoreOutputItemsAsync(messageWithId, outputItems).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             catch (Exception exc)
             {
@@ -95,12 +95,12 @@ namespace System.Threading.Tasks.Dataflow
             // The reordering buffer will handle all details, including bounding.
             if (_reorderingBuffer is not null)
             {
-                await StoreOutputItemsReorderedAsync(messageWithId.Value, outputItems).ConfigureAwait(false);
+                await StoreOutputItemsReorderedAsync(messageWithId.Value, outputItems).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             // Otherwise, output the data directly.
             else if (outputItems is not null)
             {
-                await StoreOutputItemsNonReorderedWithIterationAsync(outputItems).ConfigureAwait(false);
+                await StoreOutputItemsNonReorderedWithIterationAsync(outputItems).ConfigureAwait(OperatingSystem.IsBrowser());
             }
             else if (_target.IsBounded)
             {
@@ -146,7 +146,7 @@ namespace System.Threading.Tasks.Dataflow
                 // If this is the next item, we can output it now.
                 if (_reorderingBuffer.IsNext(id))
                 {
-                    await StoreOutputItemsNonReorderedWithIterationAsync(item).ConfigureAwait(false);
+                    await StoreOutputItemsNonReorderedWithIterationAsync(item).ConfigureAwait(OperatingSystem.IsBrowser());
                     // here itemCopy remains null, so that base.AddItem will finish our interactions with the reordering buffer
                 }
                 else


### PR DESCRIPTION
Keep HTTP and WS on the same thread where it was initiated in the browser.
Because the JavaScript objects and the network sessions are bound to particular web worker. 

Luckily the `OperatingSystem.IsBrowser()` is a constant and so it should be eliminated by IL linker or JIT.