### PR TITLE
JIT: Allow spill-at-single-def for pure defs

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -3423,15 +3423,11 @@ void LinearScan::spillInterval(Interval* interval, RefPosition* fromRefPosition 
         }
     }
 
-    // Only handle the singledef intervals whose firstRefPosition is RefTypeDef and is not yet marked as spillAfter.
-    // The singledef intervals whose firstRefPositions are already marked as spillAfter, no need to mark them as
-    // singleDefSpill because they will always get spilled at firstRefPosition.
-    // This helps in spilling the singleDef at definition
+    // Only handle the singledef intervals whose firstRefPosition is RefTypeDef.
     //
     // Note: Only mark "singleDefSpill" for those intervals who ever get spilled. The intervals that are never spilled
     // will not be marked as "singleDefSpill" and hence won't get spilled at the first definition.
-    if (interval->isSingleDef && RefTypeIsDef(interval->firstRefPosition->refType) &&
-        !interval->firstRefPosition->spillAfter)
+    if (interval->isSingleDef && RefTypeIsDef(interval->firstRefPosition->refType))
     {
         // TODO-CQ: Check if it is beneficial to spill at def, meaning, if it is a hot block don't worry about
         // doing the spill. Another option is to track number of refpositions and a interval has more than X
@@ -6280,6 +6276,11 @@ void LinearScan::resolveLocalRef(BasicBlock* block, GenTreeLclVar* treeNode, Ref
         varDsc->SetRegNum(REG_STK);
         interval->physReg = REG_NA;
         writeLocalReg(treeNode->AsLclVar(), interval->varNum, REG_NA);
+
+        if (currentRefPosition->singleDefSpill)
+        {
+            varDsc->lvSpillAtSingleDef = true;
+        }
     }
     else // Not reload and Not pure-def that's spillAfter
     {


### PR DESCRIPTION
Allow the spill-at-single-def logic to kick in for defs without subsequent uses before the spill.

I noticed this while working on #85105. My PR affected the IR in the following way:
```diff
@@ -2,7 +2,19 @@ STMT00001 ( 0x007[E-] ... 0x008 )
                [000006] -A---------                         ▌  ASG       struct (copy)
                [000005] D------N---                         ├──▌  LCL_VAR   struct<System.ReadOnlySpan`1, 8> V02 loc0         
                [000004] -----------                         └──▌  LCL_VAR   struct<System.ReadOnlySpan`1, 8> V01 arg1          (last use)
-*** NYI: Conservatively marked as read-back
+Processing block operation [000006] that involves replacements
+
+Local V01 should not be enregistered because: was accessed as a local field
+Struct operation is not fully covered by replaced fields. Keeping struct operation.
+New statement:
+STMT00001 ( 0x007[E-] ... 0x008 )
+               [000517] -A---------                         ▌  COMMA     struct
+               [000516] -A---------                         ├──▌  ASG       int   
+               [000514] D------N---                         │  ├──▌  LCL_VAR   int    V36 tmp29        
+               [000515] -----------                         │  └──▌  LCL_FLD   int    V01 arg1         [+4]
+               [000006] -A---------                         └──▌  ASG       struct (copy)
+               [000005] D------N---                            ├──▌  LCL_VAR   struct<System.ReadOnlySpan`1, 8> V02 loc0         
+               [000004] -----------                            └──▌  LCL_VAR   struct<System.ReadOnlySpan`1, 8> V01 arg1          (last use)
 STMT00002 ( 0x009[E-] ... 0x013 )
                [000013] -----------                         ▌  JTRUE     void  
                [000012] -----------                         └──▌  LE        int   
@@ -14,15 +26,11 @@ Processing use [000009] of V02.[004..008)
   ..replaced with promoted lcl V36
 New statement:
 STMT00002 ( 0x009[E-] ... 0x013 )
-               [000013] -A---------                         ▌  JTRUE     void  
-               [000012] -A---------                         └──▌  LE        int   
+               [000013] -----------                         ▌  JTRUE     void  
+               [000012] -----------                         └──▌  LE        int   
                [000007] -----------                            ├──▌  LCL_VAR   int    V03 loc1         
-               [000011] -A---------                            └──▌  SUB       int   
-               [000518] -A---------                               ├──▌  COMMA     int   
-               [000517] -A---------                               │  ├──▌  ASG       int   
-               [000515] D------N---                               │  │  ├──▌  LCL_VAR   int    V36 tmp29        
-               [000516] -----------                               │  │  └──▌  LCL_FLD   int    V02 loc0         [+4]
-               [000514] -----------                               │  └──▌  LCL_VAR   int    V36 tmp29        
+               [000011] -----------                            └──▌  SUB       int   
+               [000518] -----------                               ├──▌  LCL_VAR   int    V36 tmp29        
                [000010] -----------                               └──▌  CNS_INT   int    4
 STMT00020 ( 0x015[E-] ... 0x01D )
                [000123] -A-XG------                         ▌  ASG       int   
@@ -30,3 +38,4 @@ STMT00020 ( 0x015[E-] ... 0x01D )
                [000119] -----------                         │  └──▌  LCL_VAR   ref    V00 arg0          (last use)
                [000121] -----------                         └──▌  LCL_FLD   int    V02 loc0         [+4] (last use)
 Processing use [000121] of V02.[004..008)
```

I.e. the ASG `[000516]` is placed more eagerly than before (where it was `[000517]`) and farther away from its use. This unexpectedly lead to the spill-at-single-def logic no longer kicking in -- the eager assignment is a "pure def" as the comment in LSRA calls it, and has `spillAfter == true`, so the logic to mark the def with `singleDefSpill ` was not kicking in.