### PR TITLE
[native-library] If a dllimport is specified with an absolute path, look for it first

### DIFF
--- a/src/mono/mono/metadata/native-library.c
+++ b/src/mono/mono/metadata/native-library.c
@@ -532,14 +532,22 @@ netcore_probe_for_module (MonoImage *image, const char *file_name, int flags, Mo
 	// If the difference becomes a problem, overhaul this algorithm to match theirs exactly
 
 	ERROR_DECL (bad_image_error);
+	gboolean probe_first_without_prepend = FALSE;
 
 #if defined(HOST_ANDROID)
 	// On Android, try without any path additions first. It is sensitive to probing that will always miss
     // and lookup for some libraries is required to use a relative path
-	module = netcore_probe_for_module_variations (NULL, file_name, lflags, error);
-	if (!module && !is_ok (error) && mono_error_get_error_code (error) == MONO_ERROR_BAD_IMAGE)
-		mono_error_move (bad_image_error, error);
+	probe_first_without_prepend = TRUE;
+#else
+	if (file_name != NULL && g_path_is_absolute (file_name))
+		probe_first_without_prepend = TRUE;
 #endif
+
+	if (module == NULL && probe_first_without_prepend) {
+		module = netcore_probe_for_module_variations (NULL, file_name, lflags, error);
+		if (!module && !is_ok (error) && mono_error_get_error_code (error) == MONO_ERROR_BAD_IMAGE)
+			mono_error_move (bad_image_error, error);
+	}
 
 	// Check the NATIVE_DLL_SEARCH_DIRECTORIES
 	for (int i = 0; i < pinvoke_search_directories_count && module == NULL; ++i) {
@@ -563,15 +571,13 @@ netcore_probe_for_module (MonoImage *image, const char *file_name, int flags, Mo
 		g_free (mdirname);
 	}
 
-#if !defined(HOST_ANDROID)
-	// Try without any path additions
-	if (module == NULL)
+	// Try without any path additions, if we didn't try it already
+	if (module == NULL && !probe_first_without_prepend)
 	{
 		module = netcore_probe_for_module_variations (NULL, file_name, lflags, error);
 		if (!module && !is_ok (error) && mono_error_get_error_code (error) == MONO_ERROR_BAD_IMAGE)
 			mono_error_move (bad_image_error, error);
 	}
-#endif
 
 	// TODO: Pass remaining flags on to LoadLibraryEx on Windows where appropriate, see https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.dllimportsearchpath?view=netcore-3.1
 


### PR DESCRIPTION
The unmanaged native library probing documentation says to try absolute paths without variations

https://learn.microsoft.com/en-us/dotnet/core/dependency-loading/default-probing#unmanaged-native-library-probing