### PR TITLE
Skip covariant checks for ldelema T[] with T exact

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -7203,6 +7203,13 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     return;
                 }
 
+                if (opts.OptimizationEnabled() && (gtGetArrayElementClassHandle(impStackTop(1).val) == ldelemClsHnd) &&
+                    impIsClassExact(ldelemClsHnd))
+                {
+                    JITDUMP("\nldelema of T[] with T exact: skipping covariant check\n");
+                    goto ARR_LD;
+                }
+
                 GenTree* index = impPopStack().val;
                 GenTree* arr   = impPopStack().val;
 


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/65789

```csharp
public sealed class C
{
    C[] _array;

    C Test() => Volatile.Read(ref _array[0]);
}
```
Was:
```asm
; Assembly listing for method C:Test():C:this
       sub      rsp, 40
       mov      rcx, gword ptr [rcx+08H]
       xor      edx, edx
       mov      r8, 0x7FF85CB4CE28      ; C
       call     CORINFO_HELP_LDELEMA_REF
       mov      rax, gword ptr [rax]
       add      rsp, 40
       ret      
; Total bytes of code 33
```
Now:
```asm
; Assembly listing for method C:Test():C:this
       sub      rsp, 40
       mov      rax, gword ptr [rcx+08H]
       mov      edx, dword ptr [rax+08H]
       test     rdx, rdx
       je       SHORT G_M7456_IG04
       mov      rax, gword ptr [rax+10H]
       add      rsp, 40
       ret      
G_M7456_IG04:
       call     CORINFO_HELP_RNGCHKFAIL
       int3     
; Total bytes of code 31
```