### PR TITLE
Pass resource item to workload task

### DIFF
--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -148,7 +148,7 @@
     <CreateVisualStudioWorkload BaseIntermediateOutputPath="$(WorkloadIntermediateOutputPath)"
                                 AllowMissingPacks="True"
                                 BaseOutputPath="$(WorkloadOutputPath)"
-                                ComponentResources="$(ComponentResources)"
+                                ComponentResources="@(ComponentResources)"
                                 PackageSource="$(PackageSource)"
                                 ShortNames="@(ShortNames)"
                                 WorkloadManifestPackageFiles="@(ManifestPackages)"


### PR DESCRIPTION
The generated component versions for workloads also reverted to the default manifest version because the resource items were passed as a property instead of an item.

If you look at an official build bin log, you'll notice that the ComponentResources paramater is never set because it's passing an empty property

![image](https://user-images.githubusercontent.com/7409981/234091066-2c9e553b-7f7b-4358-8dc4-86376d91819c.png)

