### PR TITLE
Build Mono LLVM legs on the CBL-Mariner images, but run the AOTing steps on CentOS Stream 8 with binutils

### DIFF
--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -67,7 +67,7 @@ resources:
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-gcc12-amd64
 
     - container: linux_x64_llvmaot
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8
 
     - container: browser_wasm
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-webassembly-net8-20230327150025-4404b5c

--- a/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+++ b/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
@@ -58,11 +58,11 @@ steps:
       - ${{ if eq(parameters.runtimeVariant, 'llvmaot') }}:
         - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)MonoAot mono_aot ${{ parameters.buildConfig }} ${{ parameters.archType }}
           displayName: "LLVM AOT compile CoreCLR tests"
-          target: coalsece(parameters.llvmAotStepContainer, parameters.container)
+          target: ${{ coalsece(parameters.llvmAotStepContainer, parameters.container) }}
       - ${{ if eq(parameters.runtimeVariant, 'llvmfullaot') }}:
         - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)MonoAot mono_fullaot ${{ parameters.buildConfig }} ${{ parameters.archType }}
           displayName: "LLVM AOT compile CoreCLR tests"
-          target: coalsece(parameters.llvmAotStepContainer, parameters.container)
+          target: ${{ coalsece(parameters.llvmAotStepContainer, parameters.container) }}
     - ${{ if eq(parameters.archType, 'arm64') }}:
       - ${{ if eq(parameters.runtimeVariant, 'llvmaot') }}:
         - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)MonoAot mono_aot ${{ parameters.buildConfig }} ${{ parameters.archType }}  $(_monoAotCrossCompileArg) /p:RuntimeVariant=llvmfullaot -maxcpucount:2

--- a/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+++ b/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
@@ -58,11 +58,11 @@ steps:
       - ${{ if eq(parameters.runtimeVariant, 'llvmaot') }}:
         - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)MonoAot mono_aot ${{ parameters.buildConfig }} ${{ parameters.archType }}
           displayName: "LLVM AOT compile CoreCLR tests"
-          target: ${{ coalsece(parameters.llvmAotStepContainer, parameters.container) }}
+          target: ${{ coalesce(parameters.llvmAotStepContainer, parameters.container) }}
       - ${{ if eq(parameters.runtimeVariant, 'llvmfullaot') }}:
         - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)MonoAot mono_fullaot ${{ parameters.buildConfig }} ${{ parameters.archType }}
           displayName: "LLVM AOT compile CoreCLR tests"
-          target: ${{ coalsece(parameters.llvmAotStepContainer, parameters.container) }}
+          target: ${{ coalesce(parameters.llvmAotStepContainer, parameters.container) }}
     - ${{ if eq(parameters.archType, 'arm64') }}:
       - ${{ if eq(parameters.runtimeVariant, 'llvmaot') }}:
         - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)MonoAot mono_aot ${{ parameters.buildConfig }} ${{ parameters.archType }}  $(_monoAotCrossCompileArg) /p:RuntimeVariant=llvmfullaot -maxcpucount:2

--- a/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+++ b/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
@@ -14,6 +14,7 @@ parameters:
   nativeAotTest: false
   runtimeFlavor: 'mono'
   runtimeVariant: 'monointerpreter'
+  llvmAotStepContainer: ''
   scenarios:
     - normal
   variables: {}
@@ -57,9 +58,11 @@ steps:
       - ${{ if eq(parameters.runtimeVariant, 'llvmaot') }}:
         - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)MonoAot mono_aot ${{ parameters.buildConfig }} ${{ parameters.archType }}
           displayName: "LLVM AOT compile CoreCLR tests"
+          container: coalsece(parameters.llvmAotStepContainer, parameters.container)
       - ${{ if eq(parameters.runtimeVariant, 'llvmfullaot') }}:
         - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)MonoAot mono_fullaot ${{ parameters.buildConfig }} ${{ parameters.archType }}
           displayName: "LLVM AOT compile CoreCLR tests"
+          container: coalsece(parameters.llvmAotStepContainer, parameters.container)
     - ${{ if eq(parameters.archType, 'arm64') }}:
       - ${{ if eq(parameters.runtimeVariant, 'llvmaot') }}:
         - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)MonoAot mono_aot ${{ parameters.buildConfig }} ${{ parameters.archType }}  $(_monoAotCrossCompileArg) /p:RuntimeVariant=llvmfullaot -maxcpucount:2

--- a/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+++ b/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
@@ -58,11 +58,11 @@ steps:
       - ${{ if eq(parameters.runtimeVariant, 'llvmaot') }}:
         - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)MonoAot mono_aot ${{ parameters.buildConfig }} ${{ parameters.archType }}
           displayName: "LLVM AOT compile CoreCLR tests"
-          container: coalsece(parameters.llvmAotStepContainer, parameters.container)
+          target: coalsece(parameters.llvmAotStepContainer, parameters.container)
       - ${{ if eq(parameters.runtimeVariant, 'llvmfullaot') }}:
         - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)MonoAot mono_fullaot ${{ parameters.buildConfig }} ${{ parameters.archType }}
           displayName: "LLVM AOT compile CoreCLR tests"
-          container: coalsece(parameters.llvmAotStepContainer, parameters.container)
+          target: coalsece(parameters.llvmAotStepContainer, parameters.container)
     - ${{ if eq(parameters.archType, 'arm64') }}:
       - ${{ if eq(parameters.runtimeVariant, 'llvmaot') }}:
         - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)MonoAot mono_aot ${{ parameters.buildConfig }} ${{ parameters.archType }}  $(_monoAotCrossCompileArg) /p:RuntimeVariant=llvmfullaot -maxcpucount:2

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-other.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-other.yml
@@ -287,6 +287,7 @@ jobs:
       extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
       extraStepsParameters:
         creator: dotnet-bot
+        llvmAotStepContainer: linux_x64_llvmaot
       testRunNamePrefixSuffix: Mono_Release
       extraVariablesTemplates:
         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml

--- a/eng/pipelines/runtime-llvm.yml
+++ b/eng/pipelines/runtime-llvm.yml
@@ -176,7 +176,7 @@ extends:
           buildConfig: release
           runtimeFlavor: mono
           platforms:
-          - linux_x64
+          - linux_x64_llvmaot
           # Disabled pending outcome of https://github.com/dotnet/runtime/issues/60234 investigation
           #- linux_arm64
           helixQueueGroup: pr
@@ -202,7 +202,7 @@ extends:
           buildConfig: release
           runtimeFlavor: mono
           platforms:
-          - linux_x64
+          - linux_x64_llvmaot
           - linux_arm64
           helixQueueGroup: pr
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1210,7 +1210,7 @@ extends:
           buildConfig: Release
           runtimeFlavor: mono
           platforms:
-            - linux_x64_llvmaot
+            - linux_x64
             # Disabled pending outcome of https://github.com/dotnet/runtime/issues/60234 investigation
             #- linux_arm64
           variables:
@@ -1233,6 +1233,7 @@ extends:
             extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
             extraStepsParameters:
               creator: dotnet-bot
+              llvmAotStepContainer: linux_x64_llvmaot
             testRunNamePrefixSuffix: Mono_Release
             extraVariablesTemplates:
               - template: /eng/pipelines/common/templates/runtimes/test-variables.yml


### PR DESCRIPTION
We want to move off of using CentOS 7 images for our builds, but Mono's AOT tooling uses binutils tools for its AOT process. We can't built Mono on CentOS Stream 8 images as that introduces too high of a glibc dependency. This PR moves the product build steps to use our CBL-Mariner images that set up the right libc dependency, while setting up the AOT legs to use our CentOS Stream 8 image that provides the binutils tools on a supported base image.

Replaces #84727