### PR TITLE
Fix perf regressions in Utf8Formatter for integers

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/StandardFormat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/StandardFormat.cs
@@ -40,6 +40,9 @@ namespace System.Buffers
         /// </summary>
         public bool HasPrecision => _precision != NoPrecision;
 
+        /// <summary>Gets the precision if one was specified; otherwise, 0.</summary>
+        internal byte PrecisionOrZero => _precision != NoPrecision ? _precision : (byte)0;
+
         /// <summary>
         /// true if the StandardFormat == default(StandardFormat)
         /// </summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
+
 namespace System.Buffers.Text
 {
     /// <summary>
@@ -30,7 +32,7 @@ namespace System.Buffers.Text
         /// <cref>System.FormatException</cref> if the format is not valid for this data type.
         /// </exceptions>
         public static bool TryFormat(byte value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) =>
-            FormattingHelpers.TryFormat(value, destination, out bytesWritten, format);
+            TryFormat((uint)value, destination, out bytesWritten, format);
 
         /// <summary>
         /// Formats an SByte as a UTF8 string.
@@ -55,7 +57,7 @@ namespace System.Buffers.Text
         /// </exceptions>
         [CLSCompliant(false)]
         public static bool TryFormat(sbyte value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) =>
-            FormattingHelpers.TryFormat(value, destination, out bytesWritten, format);
+            TryFormat(value, 0xFF, destination, out bytesWritten, format);
 
         /// <summary>
         /// Formats a Unt16 as a UTF8 string.
@@ -80,7 +82,7 @@ namespace System.Buffers.Text
         /// </exceptions>
         [CLSCompliant(false)]
         public static bool TryFormat(ushort value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) =>
-            FormattingHelpers.TryFormat(value, destination, out bytesWritten, format);
+            TryFormat((uint)value, destination, out bytesWritten, format);
 
         /// <summary>
         /// Formats an Int16 as a UTF8 string.
@@ -104,7 +106,7 @@ namespace System.Buffers.Text
         /// <cref>System.FormatException</cref> if the format is not valid for this data type.
         /// </exceptions>
         public static bool TryFormat(short value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) =>
-            FormattingHelpers.TryFormat(value, destination, out bytesWritten, format);
+            TryFormat(value, 0xFFFF, destination, out bytesWritten, format);
 
         /// <summary>
         /// Formats a UInt32 as a UTF8 string.
@@ -127,9 +129,38 @@ namespace System.Buffers.Text
         /// <exceptions>
         /// <cref>System.FormatException</cref> if the format is not valid for this data type.
         /// </exceptions>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        public static bool TryFormat(uint value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) =>
-            FormattingHelpers.TryFormat(value, destination, out bytesWritten, format);
+        public static bool TryFormat(uint value, Span<byte> destination, out int bytesWritten, StandardFormat format = default)
+        {
+            if (format.IsDefault)
+            {
+                return Number.TryUInt32ToDecStr(value, destination, out bytesWritten);
+            }
+
+            switch (format.Symbol | 0x20)
+            {
+                case 'd':
+                    return Number.TryUInt32ToDecStr(value, format.PrecisionOrZero, destination, out bytesWritten);
+
+                case 'x':
+                    return Number.TryInt32ToHexStr((int)value, Number.GetHexBase(format.Symbol), format.PrecisionOrZero, destination, out bytesWritten);
+
+                case 'n':
+                    return FormattingHelpers.TryFormat(value, destination, out bytesWritten, format);
+
+                case 'g' or 'r':
+                    if (format.HasPrecision)
+                    {
+                        ThrowGWithPrecisionNotSupported();
+                    }
+                    goto case 'd';
+
+                default:
+                    ThrowHelper.ThrowFormatException_BadFormatSpecifier();
+                    goto case 'd';
+            }
+        }
 
         /// <summary>
         /// Formats an Int32 as a UTF8 string.
@@ -153,7 +184,43 @@ namespace System.Buffers.Text
         /// <cref>System.FormatException</cref> if the format is not valid for this data type.
         /// </exceptions>
         public static bool TryFormat(int value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) =>
-            FormattingHelpers.TryFormat(value, destination, out bytesWritten, format);
+            TryFormat(value, ~0, destination, out bytesWritten, format);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryFormat(int value, int hexMask, Span<byte> destination, out int bytesWritten, StandardFormat format = default)
+        {
+            if (format.IsDefault)
+            {
+                return value >= 0 ?
+                    Number.TryUInt32ToDecStr((uint)value, destination, out bytesWritten) :
+                    Number.TryNegativeInt32ToDecStr(value, format.PrecisionOrZero, "-"u8, destination, out bytesWritten);
+            }
+
+            switch (format.Symbol | 0x20)
+            {
+                case 'd':
+                    return value >= 0 ?
+                        Number.TryUInt32ToDecStr((uint)value, format.PrecisionOrZero, destination, out bytesWritten) :
+                        Number.TryNegativeInt32ToDecStr(value, format.PrecisionOrZero, "-"u8, destination, out bytesWritten);
+
+                case 'x':
+                    return Number.TryInt32ToHexStr(value & hexMask, Number.GetHexBase(format.Symbol), format.PrecisionOrZero, destination, out bytesWritten);
+
+                case 'n':
+                    return FormattingHelpers.TryFormat(value, destination, out bytesWritten, format);
+
+                case 'g' or 'r':
+                    if (format.HasPrecision)
+                    {
+                        ThrowGWithPrecisionNotSupported();
+                    }
+                    goto case 'd';
+
+                default:
+                    ThrowHelper.ThrowFormatException_BadFormatSpecifier();
+                    goto case 'd';
+            }
+        }
 
         /// <summary>
         /// Formats a UInt64 as a UTF8 string.
@@ -176,9 +243,38 @@ namespace System.Buffers.Text
         /// <exceptions>
         /// <cref>System.FormatException</cref> if the format is not valid for this data type.
         /// </exceptions>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        public static bool TryFormat(ulong value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) =>
-            FormattingHelpers.TryFormat(value, destination, out bytesWritten, format);
+        public static bool TryFormat(ulong value, Span<byte> destination, out int bytesWritten, StandardFormat format = default)
+        {
+            if (format.IsDefault)
+            {
+                return Number.TryUInt64ToDecStr(value, destination, out bytesWritten);
+            }
+
+            switch (format.Symbol | 0x20)
+            {
+                case 'd':
+                    return Number.TryUInt64ToDecStr(value, format.PrecisionOrZero, destination, out bytesWritten);
+
+                case 'x':
+                    return Number.TryInt64ToHexStr((long)value, Number.GetHexBase(format.Symbol), format.PrecisionOrZero, destination, out bytesWritten);
+
+                case 'n':
+                    return FormattingHelpers.TryFormat(value, destination, out bytesWritten, format);
+
+                case 'g' or 'r':
+                    if (format.HasPrecision)
+                    {
+                        ThrowGWithPrecisionNotSupported();
+                    }
+                    goto case 'd';
+
+                default:
+                    ThrowHelper.ThrowFormatException_BadFormatSpecifier();
+                    goto case 'd';
+            }
+        }
 
         /// <summary>
         /// Formats an Int64 as a UTF8 string.
@@ -201,7 +297,44 @@ namespace System.Buffers.Text
         /// <exceptions>
         /// <cref>System.FormatException</cref> if the format is not valid for this data type.
         /// </exceptions>
-        public static bool TryFormat(long value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) =>
-            FormattingHelpers.TryFormat(value, destination, out bytesWritten, format);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryFormat(long value, Span<byte> destination, out int bytesWritten, StandardFormat format = default)
+        {
+            if (format.IsDefault)
+            {
+                return value >= 0 ?
+                    Number.TryUInt64ToDecStr((ulong)value, destination, out bytesWritten) :
+                    Number.TryNegativeInt64ToDecStr(value, format.PrecisionOrZero, "-"u8, destination, out bytesWritten);
+            }
+
+            switch (format.Symbol | 0x20)
+            {
+                case 'd':
+                    return value >= 0 ?
+                        Number.TryUInt64ToDecStr((ulong)value, format.PrecisionOrZero, destination, out bytesWritten) :
+                        Number.TryNegativeInt64ToDecStr(value, format.PrecisionOrZero, "-"u8, destination, out bytesWritten);
+
+                case 'x':
+                    return Number.TryInt64ToHexStr(value, Number.GetHexBase(format.Symbol), format.PrecisionOrZero, destination, out bytesWritten);
+
+                case 'n':
+                    return FormattingHelpers.TryFormat(value, destination, out bytesWritten, format);
+
+                case 'g' or 'r':
+                    if (format.HasPrecision)
+                    {
+                        ThrowGWithPrecisionNotSupported();
+                    }
+                    goto case 'd';
+
+                default:
+                    ThrowHelper.ThrowFormatException_BadFormatSpecifier();
+                    goto case 'd';
+            }
+        }
+
+        private static void ThrowGWithPrecisionNotSupported() =>
+            // With a precision, 'G' can produce exponential format, even for integers.
+            throw new NotSupportedException(SR.Argument_GWithPrecisionNotSupported);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
@@ -907,7 +907,7 @@ namespace System
             }
         }
 
-        private static char GetHexBase(char fmt)
+        internal static char GetHexBase(char fmt)
         {
             // The fmt-(X-A+10) hack has the effect of dictating whether we produce uppercase or lowercase
             // hex numbers for a-f. 'X' as the fmt code produces uppercase. 'x' as the format code produces lowercase.
@@ -1675,7 +1675,7 @@ namespace System
             return result;
         }
 
-        private static unsafe bool TryNegativeInt32ToDecStr<TChar>(int value, int digits, ReadOnlySpan<TChar> sNegative, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
+        internal static unsafe bool TryNegativeInt32ToDecStr<TChar>(int value, int digits, ReadOnlySpan<TChar> sNegative, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             Debug.Assert(value < 0);
@@ -1724,7 +1724,7 @@ namespace System
             return result;
         }
 
-        private static unsafe bool TryInt32ToHexStr<TChar>(int value, char hexBase, int digits, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
+        internal static unsafe bool TryInt32ToHexStr<TChar>(int value, char hexBase, int digits, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
 
@@ -1999,7 +1999,7 @@ namespace System
             return result;
         }
 
-        private static unsafe bool TryUInt32ToDecStr<TChar>(uint value, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
+        internal static unsafe bool TryUInt32ToDecStr<TChar>(uint value, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
 
@@ -2019,7 +2019,7 @@ namespace System
             return false;
         }
 
-        private static unsafe bool TryUInt32ToDecStr<TChar>(uint value, int digits, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
+        internal static unsafe bool TryUInt32ToDecStr<TChar>(uint value, int digits, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
 
@@ -2108,7 +2108,7 @@ namespace System
             return result;
         }
 
-        private static unsafe bool TryNegativeInt64ToDecStr<TChar>(long value, int digits, ReadOnlySpan<TChar> sNegative, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
+        internal static unsafe bool TryNegativeInt64ToDecStr<TChar>(long value, int digits, ReadOnlySpan<TChar> sNegative, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             Debug.Assert(value < 0);
@@ -2157,7 +2157,7 @@ namespace System
             return result;
         }
 
-        private static unsafe bool TryInt64ToHexStr<TChar>(long value, char hexBase, int digits, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
+        internal static unsafe bool TryInt64ToHexStr<TChar>(long value, char hexBase, int digits, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
 
@@ -2427,7 +2427,7 @@ namespace System
             return result;
         }
 
-        private static unsafe bool TryUInt64ToDecStr<TChar>(ulong value, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
+        internal static unsafe bool TryUInt64ToDecStr<TChar>(ulong value, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
 
@@ -2448,7 +2448,7 @@ namespace System
             return false;
         }
 
-        private static unsafe bool TryUInt64ToDecStr<TChar>(ulong value, int digits, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
+        internal static unsafe bool TryUInt64ToDecStr<TChar>(ulong value, int digits, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
         {
             int countedDigits = FormattingHelpers.CountDigits(value);
             int bufferLength = Math.Max(digits, countedDigits);


### PR DESCRIPTION
When I added UTF8 support to the core numeric types, I also just routed Utf8Formatter to use the public TryFormat API on each type.  That, however, regressed some microbenchmarks due to a) going from `StandardFormat` to a `ReadOnlySpan<char>` format and then parsing it back out and b) removing some of the inlining that was there previously.  This change puts back into Utf8Formatter.TryFormat the handling of the format and then delegating to the relevant helpers that already exist rather than always going through the public entrypoint (it doesn't do so for 'n', but that's also much rarer to use on a hot path and is also in general more expensive).

```C#
private byte[] _buffer = new byte[100];

[Benchmark]
[Arguments(42)]
public bool TryFormatInt32_Default(int value) => Utf8Formatter.TryFormat(value, _buffer, out _);

[Benchmark]
[Arguments(123L)]
public bool TryFormatInt64_Default(long value) => Utf8Formatter.TryFormat(value, _buffer, out _);

[Benchmark]
[Arguments(12345UL)]
public bool TryFormatUInt64_Default(ulong value) => Utf8Formatter.TryFormat(value, _buffer, out _);

[Benchmark]
[Arguments(42)]
public bool TryFormatInt32_D2(int value) => Utf8Formatter.TryFormat(value, _buffer, out _, new StandardFormat('D', 2));

[Benchmark]
[Arguments(0x1234UL)]
public bool TryFormatUInt64_X4(ulong value) => Utf8Formatter.TryFormat(value, _buffer, out _, new StandardFormat('X', 4));

[Benchmark]
[Arguments(long.MinValue)]
public bool TryFormatInt64_X(long value) => Utf8Formatter.TryFormat(value, _buffer, out _, new StandardFormat('X'));
```

|                  Method |  Runtime |                value |      Mean |     Error |    StdDev | Ratio | Code Size |
|------------------------ |--------- |--------------------- |----------:|----------:|----------:|------:|----------:|
|        TryFormatInt64_X |     main | -9223372036854775808 | 29.905 ns | 0.6288 ns | 1.0154 ns |  1.51 |   2,545 B |
|        TryFormatInt64_X |       pr | -9223372036854775808 | 13.156 ns | 0.2904 ns | 0.4607 ns |  0.67 |     210 B |
|        TryFormatInt64_X | .NET 7.0 | -9223372036854775808 | 19.803 ns | 0.4241 ns | 0.6082 ns |  1.00 |     294 B |
|                         |          |                      |           |           |           |       |           |
|  TryFormatInt64_Default |     main |                  123 | 10.610 ns | 0.1336 ns | 0.1250 ns |  1.62 |     974 B |
|  TryFormatInt64_Default |       pr |                  123 |  8.754 ns | 0.1467 ns | 0.1225 ns |  1.34 |   1,167 B |
|  TryFormatInt64_Default | .NET 7.0 |                  123 |  6.558 ns | 0.1536 ns | 0.1508 ns |  1.00 |     829 B |
|                         |          |                      |           |           |           |       |           |
| TryFormatUInt64_Default |     main |                12345 | 10.376 ns | 0.2275 ns | 0.2337 ns |  1.41 |     608 B |
| TryFormatUInt64_Default |       pr |                12345 |  5.027 ns | 0.0532 ns | 0.0498 ns |  0.68 |     318 B |
| TryFormatUInt64_Default | .NET 7.0 |                12345 |  7.379 ns | 0.0931 ns | 0.0825 ns |  1.00 |     458 B |
|                         |          |                      |           |           |           |       |           |
|  TryFormatInt32_Default |     main |                   42 |  9.973 ns | 0.0832 ns | 0.0737 ns |  1.78 |     964 B |
|  TryFormatInt32_Default |       pr |                   42 |  2.933 ns | 0.0472 ns | 0.0442 ns |  0.52 |     348 B |
|  TryFormatInt32_Default | .NET 7.0 |                   42 |  5.609 ns | 0.0647 ns | 0.0574 ns |  1.00 |     829 B |
|                         |          |                      |           |           |           |       |           |
|       TryFormatInt32_D2 |     main |                   42 | 20.623 ns | 0.1623 ns | 0.1518 ns |  3.26 |   2,438 B |
|       TryFormatInt32_D2 |       pr |                   42 |  4.125 ns | 0.1098 ns | 0.0917 ns |  0.65 |     573 B |
|       TryFormatInt32_D2 | .NET 7.0 |                   42 |  6.340 ns | 0.0438 ns | 0.0366 ns |  1.00 |     581 B |
|                         |          |                      |           |           |           |       |           |
|      TryFormatUInt64_X4 |     main |                 4660 | 21.726 ns | 0.4386 ns | 0.3662 ns |  3.69 |   2,030 B |
|      TryFormatUInt64_X4 |       pr |                 4660 |  6.411 ns | 0.0568 ns | 0.0474 ns |  1.09 |     257 B |
|      TryFormatUInt64_X4 | .NET 7.0 |                 4660 |  5.841 ns | 0.1648 ns | 0.1897 ns |  1.00 |     290 B |