### PR TITLE
Fix test execution jobs in the coreclr-release-outerloop-nightly pipeline

### DIFF
--- a/eng/pipelines/coreclr/release-tests.yml
+++ b/eng/pipelines/coreclr/release-tests.yml
@@ -28,6 +28,7 @@ extends:
           # Adding it here will enable it also
           - osx_arm64
           jobParameters:
+            testGroup: outerloop
             isOfficialBuild: false
 
       #


### PR DESCRIPTION
As described in the issue

https://github.com/dotnet/runtime/issues/85263

the <code>coreclr-release-outerloop-nightly</code> pipeline has been malfunctioning for quite a while due to not publishing the native test components. This simple change fixes that - while it doesn't make the pipeline completely green, at least we're now sending the tests to Helix and observing just a couple of remaining test failures.

Thanks

Tomas

/cc @dotnet/runtime-infrastructure 