### PR TITLE
Enable Windows Arm64 ASMDIFFS between checked and release build

### DIFF
--- a/eng/pipelines/coreclr/superpmi-asmdiffs-checked-release.yml
+++ b/eng/pipelines/coreclr/superpmi-asmdiffs-checked-release.yml
@@ -22,6 +22,7 @@ extends:
           platforms:
           - windows_x64
           - windows_x86
+          - windows_arm64
           jobParameters:
             uploadAs: 'pipelineArtifacts'
 
@@ -32,6 +33,7 @@ extends:
           platforms:
           - windows_x64
           - windows_x86
+          - windows_arm64
           jobParameters:
             uploadAs: 'pipelineArtifacts'
 
@@ -42,5 +44,6 @@ extends:
           platforms:
           - windows_x64
           - windows_x86
+          - windows_arm64
           helixQueueGroup: ci
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml

--- a/eng/pipelines/coreclr/templates/run-superpmi-asmdiffs-checked-release-job.yml
+++ b/eng/pipelines/coreclr/templates/run-superpmi-asmdiffs-checked-release-job.yml
@@ -98,7 +98,7 @@ jobs:
       displayName: Publish SuperPMI logs
       inputs:
         targetPath: $(SpmiLogsLocation)
-        artifactName: 'SuperPMI_Logs_$(archType)_$(buildConfig)_Attempt$(System.JobAttempt)'
+        artifactName: 'SuperPMI_Logs_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)_Attempt$(System.JobAttempt)'
       condition: always()
       continueOnError: true
 
@@ -106,6 +106,6 @@ jobs:
       displayName: Publish SuperPMI build logs
       inputs:
         targetPath: $(Build.SourcesDirectory)/artifacts/log
-        artifactName: 'SuperPMI_BuildLogs_$(archType)_$(buildConfig)_Attempt$(System.JobAttempt)'
+        artifactName: 'SuperPMI_BuildLogs_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)_Attempt$(System.JobAttempt)'
       condition: always()
       continueOnError: true


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/61335 enabled Windows x64 and x86. Add support for Windows Arm64.