### PR TITLE
[NativeAOT] Use 8.1 atomics, if available, in RhpCheckedXchg/RhpCheckedLockCmpXchg

### DIFF
--- a/src/coreclr/nativeaot/Runtime/AsmOffsets.h
+++ b/src/coreclr/nativeaot/Runtime/AsmOffsets.h
@@ -34,6 +34,13 @@ ASM_CONST(     2,     2, STRING_COMPONENT_SIZE)
 ASM_CONST(     E,    16, STRING_BASE_SIZE)
 ASM_CONST(3FFFFFDF,3FFFFFDF,MAX_STRING_LENGTH)
 
+
+#if defined(HOST_ARM64)
+// Bit position for the ARM64IntrinsicConstants_Atomics flags, to be used with tbz / tbnz instructions
+// ARM64IntrinsicConstants_Atomics = 0x0080
+ASM_CONST(     7,     7, ARM64_ATOMICS_FEATURE_FLAG_BIT)
+#endif
+
 ASM_OFFSET(    0,     0, MethodTable, m_usComponentSize)
 ASM_OFFSET(    0,     0, MethodTable, m_uFlags)
 ASM_OFFSET(    4,     4, MethodTable, m_uBaseSize)

--- a/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
@@ -287,6 +287,11 @@ EXTERN_C void * RhpCheckedXchgAVLocation;
 EXTERN_C void * RhpLockCmpXchg32AVLocation;
 EXTERN_C void * RhpLockCmpXchg64AVLocation;
 
+#if defined(HOST_ARM64) && !defined(LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT)
+EXTERN_C void* RhpCheckedLockCmpXchgAVLocation2;
+EXTERN_C void* RhpCheckedXchgAVLocation2;
+#endif
+
 static bool InWriteBarrierHelper(uintptr_t faultingIP)
 {
 #ifndef USE_PORTABLE_HELPERS
@@ -298,6 +303,10 @@ static bool InWriteBarrierHelper(uintptr_t faultingIP)
         (uintptr_t)&RhpCheckedXchgAVLocation,
         (uintptr_t)&RhpLockCmpXchg32AVLocation,
         (uintptr_t)&RhpLockCmpXchg64AVLocation,
+#if defined(HOST_ARM64) && !defined(LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT)
+        (uintptr_t)&RhpCheckedLockCmpXchgAVLocation2,
+        (uintptr_t)&RhpCheckedXchgAVLocation2,
+#endif
     };
 
     // compare the IP against the list of known possible AV locations in the write barrier helpers

--- a/src/coreclr/nativeaot/Runtime/IntrinsicConstants.h
+++ b/src/coreclr/nativeaot/Runtime/IntrinsicConstants.h
@@ -50,6 +50,11 @@ enum ARM64IntrinsicConstants
     ARM64IntrinsicConstants_Atomics = 0x0080,
     ARM64IntrinsicConstants_Rcpc = 0x0100,
 };
+
+// Bit position for the ARM64IntrinsicConstants_Atomics flags, to be used with tbz / tbnz instructions
+static const int ARM64_ATOMICS_FEATURE_FLAG_BIT = 7;
+static_assert((1 << ARM64_ATOMICS_FEATURE_FLAG_BIT) == ARM64IntrinsicConstants_Atomics, "ARM64_ATOMICS_FEATURE_FLAG_BIT must match with ARM64IntrinsicConstants_Atomics");
+
 #endif //HOST_ARM64
 
 #endif //!INTRINSICCONSTANTS_INCLUDED

--- a/src/coreclr/nativeaot/Runtime/amd64/AsmMacros.inc
+++ b/src/coreclr/nativeaot/Runtime/amd64/AsmMacros.inc
@@ -420,4 +420,3 @@ endif
 ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
 EXTERN g_write_watch_table  : QWORD
 endif
-

--- a/src/coreclr/nativeaot/Runtime/arm64/AsmMacros.h
+++ b/src/coreclr/nativeaot/Runtime/arm64/AsmMacros.h
@@ -81,10 +81,6 @@ TrapThreadsFlags_TrapThreads     equ 2
 TrapThreadsFlags_AbortInProgress_Bit equ 0
 TrapThreadsFlags_TrapThreads_Bit     equ 1
 
-;; Bit position for the ARM64IntrinsicConstants_Atomics flags, to be used with tbz / tbnz instructions
-;; ARM64IntrinsicConstants_Atomics = 0x0080
-ARM64_ATOMICS_FEATURE_FLAG_BIT       equ 7
-
 ;; This must match HwExceptionCode.STATUS_REDHAWK_THREAD_ABORT
 STATUS_REDHAWK_THREAD_ABORT      equ 0x43
 

--- a/src/coreclr/nativeaot/Runtime/arm64/AsmMacros.h
+++ b/src/coreclr/nativeaot/Runtime/arm64/AsmMacros.h
@@ -81,6 +81,10 @@ TrapThreadsFlags_TrapThreads     equ 2
 TrapThreadsFlags_AbortInProgress_Bit equ 0
 TrapThreadsFlags_TrapThreads_Bit     equ 1
 
+;; Bit position for the ARM64IntrinsicConstants_Atomics flags, to be used with tbz / tbnz instructions
+;; ARM64IntrinsicConstants_Atomics = 0x0080
+ARM64_ATOMICS_FEATURE_FLAG_BIT       equ 7
+
 ;; This must match HwExceptionCode.STATUS_REDHAWK_THREAD_ABORT
 STATUS_REDHAWK_THREAD_ABORT      equ 0x43
 
@@ -116,6 +120,7 @@ OFFSETOF__Thread__m_alloc_context__alloc_limit      equ OFFSETOF__Thread__m_rgbA
     EXTERN g_write_watch_table
 #endif
 
+    EXTERN g_cpuFeatures
 
 ;; -----------------------------------------------------------------------------
 ;; Macro used to assign an alternate name to a symbol containing characters normally disallowed in a symbol
@@ -162,6 +167,16 @@ MovInstr SETS "movk"
         adrp $Reg, $Name
         ldr  $Reg, [$Reg, $Name]
     MEND
+
+;; ---------------------------------------------------------------------------- -
+;; Macro for loading a 32bit value of a global variable into a register
+    MACRO
+        PREPARE_EXTERNAL_VAR_INDIRECT_W $Name, $RegNum
+
+        adrp x$RegNum, $Name
+        ldr  w$RegNum, [x$RegNum, $Name]
+    MEND
+
 
 ;; -----------------------------------------------------------------------------
 ;;

--- a/src/coreclr/nativeaot/Runtime/arm64/WriteBarriers.S
+++ b/src/coreclr/nativeaot/Runtime/arm64/WriteBarriers.S
@@ -279,20 +279,26 @@ LEAF_END RhpAssignRef, _TEXT
 //
 // On exit:
 //  x0: original value of objectref
-//  x10, x12, x17: trashed
+//  x10, x12, x16, x17: trashed
 //
     LEAF_ENTRY RhpCheckedLockCmpXchg
 
-#ifdef LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT
+#ifndef LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT
+        PREPARE_EXTERNAL_VAR_INDIRECT_W g_cpuFeatures, 16
+        tbz    w16, #ARM64_ATOMICS_FEATURE_FLAG_BIT, CmpXchgRetry
+#endif
+
         mov    x10, x2
     ALTERNATE_ENTRY RhpCheckedLockCmpXchgAVLocation
         casal  x10, x1, [x0]                  // exchange
         cmp    x2, x10
         bne    CmpXchgNoUpdate
-#else
+
+#ifndef LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT
+        b      DoCardsCmpXchg
 CmpXchgRetry:
         // Check location value is what we expect.
-    ALTERNATE_ENTRY  RhpCheckedLockCmpXchgAVLocation
+    ALTERNATE_ENTRY  RhpCheckedLockCmpXchgAVLocation2
         ldaxr   x10, [x0]
         cmp     x10, x2
         bne     CmpXchgNoUpdate
@@ -302,6 +308,7 @@ CmpXchgRetry:
         cbnz    w12, CmpXchgRetry
 #endif
 
+DoCardsCmpXchg:
         // We have successfully updated the value of the objectref so now we need a GC write barrier.
         // The following barrier code takes the destination in x0 and the value in x1 so the arguments are
         // already correctly set up.
@@ -311,8 +318,11 @@ CmpXchgRetry:
 CmpXchgNoUpdate:
         // x10 still contains the original value.
         mov     x0, x10
+
 #ifndef LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT
+        tbnz    w16, #ARM64_ATOMICS_FEATURE_FLAG_BIT, NoBarrierCmpXchg
         InterlockedOperationBarrier
+NoBarrierCmpXchg:
 #endif
         ret     lr
 
@@ -333,17 +343,23 @@ CmpXchgNoUpdate:
 // On exit:
 //  x0: original value of objectref
 //  x10: trashed
-//  x12, x17: trashed
+//  x12, x16, x17: trashed
 //
     LEAF_ENTRY RhpCheckedXchg, _TEXT
 
-#ifdef LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT
+#ifndef LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT
+        PREPARE_EXTERNAL_VAR_INDIRECT_W g_cpuFeatures, 16
+        tbz    w16, #ARM64_ATOMICS_FEATURE_FLAG_BIT, ExchangeRetry
+#endif
+
     ALTERNATE_ENTRY  RhpCheckedXchgAVLocation
         swpal  x1, x10, [x0]                   // exchange
-#else
+
+#ifndef LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT
+        b      DoCardsXchg
 ExchangeRetry:
         // Read the existing memory location.
-    ALTERNATE_ENTRY  RhpCheckedXchgAVLocation
+    ALTERNATE_ENTRY  RhpCheckedXchgAVLocation2
         ldaxr   x10,  [x0]
 
         // Attempt to update with the new value.
@@ -351,6 +367,7 @@ ExchangeRetry:
         cbnz    w12, ExchangeRetry
 #endif
 
+DoCardsXchg:
         // We have successfully updated the value of the objectref so now we need a GC write barrier.
         // The following barrier code takes the destination in x0 and the value in x1 so the arguments are
         // already correctly set up.
@@ -359,8 +376,11 @@ ExchangeRetry:
 
         // x10 still contains the original value.
         mov     x0, x10
+
 #ifndef LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT
+        tbnz    w16, #ARM64_ATOMICS_FEATURE_FLAG_BIT, NoBarrierXchg
         InterlockedOperationBarrier
+NoBarrierXchg:
 #endif
         ret
 

--- a/src/coreclr/nativeaot/Runtime/arm64/WriteBarriers.S
+++ b/src/coreclr/nativeaot/Runtime/arm64/WriteBarriers.S
@@ -268,6 +268,10 @@ LEAF_END RhpAssignRef, _TEXT
 // - Function "InWriteBarrierHelper" assumes an AV due to passed in null pointer will happen at RhpCheckedLockCmpXchgAVLocation
 // - Function "UnwindSimpleHelperToCaller" assumes no registers were pushed and LR contains the return address
 
+#ifndef LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT
+.arch_extension lse
+#endif
+
 // RhpCheckedLockCmpXchg(Object** dest, Object* value, Object* comparand)
 //
 // Interlocked compare exchange on objectref.
@@ -385,3 +389,7 @@ NoBarrierXchg:
         ret
 
     LEAF_END RhpCheckedXchg, _TEXT
+
+#ifndef LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT
+.arch_extension nolse
+#endif

--- a/src/coreclr/nativeaot/Runtime/arm64/WriteBarriers.S
+++ b/src/coreclr/nativeaot/Runtime/arm64/WriteBarriers.S
@@ -283,6 +283,13 @@ LEAF_END RhpAssignRef, _TEXT
 //
     LEAF_ENTRY RhpCheckedLockCmpXchg
 
+#ifdef LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT
+        mov    x10, x2
+    ALTERNATE_ENTRY RhpCheckedLockCmpXchgAVLocation
+        casal  x10, x1, [x0]                  // exchange
+        cmp    x2, x10
+        bne    CmpXchgNoUpdate
+#else
 CmpXchgRetry:
         // Check location value is what we expect.
     ALTERNATE_ENTRY  RhpCheckedLockCmpXchgAVLocation
@@ -293,6 +300,7 @@ CmpXchgRetry:
         // Current value matches comparand, attempt to update with the new value.
         stlxr   w12, x1, [x0]
         cbnz    w12, CmpXchgRetry
+#endif
 
         // We have successfully updated the value of the objectref so now we need a GC write barrier.
         // The following barrier code takes the destination in x0 and the value in x1 so the arguments are
@@ -303,7 +311,9 @@ CmpXchgRetry:
 CmpXchgNoUpdate:
         // x10 still contains the original value.
         mov     x0, x10
+#ifndef LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT
         InterlockedOperationBarrier
+#endif
         ret     lr
 
     LEAF_END RhpCheckedLockCmpXchg, _TEXT
@@ -327,6 +337,10 @@ CmpXchgNoUpdate:
 //
     LEAF_ENTRY RhpCheckedXchg, _TEXT
 
+#ifdef LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT
+    ALTERNATE_ENTRY  RhpCheckedXchgAVLocation
+        swpal  x1, x10, [x0]                   // exchange
+#else
 ExchangeRetry:
         // Read the existing memory location.
     ALTERNATE_ENTRY  RhpCheckedXchgAVLocation
@@ -335,6 +349,7 @@ ExchangeRetry:
         // Attempt to update with the new value.
         stlxr   w12, x1, [x0]
         cbnz    w12, ExchangeRetry
+#endif
 
         // We have successfully updated the value of the objectref so now we need a GC write barrier.
         // The following barrier code takes the destination in x0 and the value in x1 so the arguments are
@@ -344,7 +359,9 @@ ExchangeRetry:
 
         // x10 still contains the original value.
         mov     x0, x10
+#ifndef LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT
         InterlockedOperationBarrier
+#endif
         ret
 
     LEAF_END RhpCheckedXchg, _TEXT

--- a/src/coreclr/nativeaot/Runtime/arm64/WriteBarriers.asm
+++ b/src/coreclr/nativeaot/Runtime/arm64/WriteBarriers.asm
@@ -294,20 +294,26 @@ NotInHeap
 ;;
 ;; On exit:
 ;;  x0: original value of objectref
-;;  x10, x12, x17: trashed
+;;  x10, x12, x16, x17: trashed
 ;;
     LEAF_ENTRY RhpCheckedLockCmpXchg
 
-#ifdef LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT
+#ifndef LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT
+        PREPARE_EXTERNAL_VAR_INDIRECT_W g_cpuFeatures, 16
+        tbz    x16, #ARM64_ATOMICS_FEATURE_FLAG_BIT, CmpXchgRetry
+#endif
+
         mov    x10, x2
     ALTERNATE_ENTRY RhpCheckedLockCmpXchgAVLocation
         casal  x10, x1, [x0]                  ;; exchange
         cmp    x2, x10
         bne    CmpXchgNoUpdate
-#else
+
+#ifndef LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT
+        b      DoCardsCmpXchg
 CmpXchgRetry
         ;; Check location value is what we expect.
-    ALTERNATE_ENTRY RhpCheckedLockCmpXchgAVLocation
+    ALTERNATE_ENTRY  RhpCheckedLockCmpXchgAVLocation2
         ldaxr   x10, [x0]
         cmp     x10, x2
         bne     CmpXchgNoUpdate
@@ -317,7 +323,8 @@ CmpXchgRetry
         cbnz    w12, CmpXchgRetry
 #endif
 
-        ;; We've successfully updated the value of the objectref so now we need a GC write barrier.
+DoCardsCmpXchg
+        ;; We have successfully updated the value of the objectref so now we need a GC write barrier.
         ;; The following barrier code takes the destination in x0 and the value in x1 so the arguments are
         ;; already correctly set up.
 
@@ -326,8 +333,11 @@ CmpXchgRetry
 CmpXchgNoUpdate
         ;; x10 still contains the original value.
         mov     x0, x10
+
 #ifndef LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT
+        tbnz    x16, #ARM64_ATOMICS_FEATURE_FLAG_BIT, NoBarrierCmpXchg
         InterlockedOperationBarrier
+NoBarrierCmpXchg
 #endif
         ret     lr
 
@@ -348,17 +358,23 @@ CmpXchgNoUpdate
 ;; On exit:
 ;;  x0: original value of objectref
 ;;  x10: trashed
-;;  x12, x17: trashed
+;;  x12, x16, x17: trashed
 ;;
     LEAF_ENTRY RhpCheckedXchg
 
-#ifdef LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT
+#ifndef LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT
+        PREPARE_EXTERNAL_VAR_INDIRECT_W g_cpuFeatures, 16
+        tbz    x16, #ARM64_ATOMICS_FEATURE_FLAG_BIT, ExchangeRetry
+#endif
+
     ALTERNATE_ENTRY  RhpCheckedXchgAVLocation
         swpal  x1, x10, [x0]                   ;; exchange
-#else
+
+#ifndef LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT
+        b      DoCardsXchg
 ExchangeRetry
         ;; Read the existing memory location.
-    ALTERNATE_ENTRY RhpCheckedXchgAVLocation
+    ALTERNATE_ENTRY  RhpCheckedXchgAVLocation2
         ldaxr   x10,  [x0]
 
         ;; Attempt to update with the new value.
@@ -366,7 +382,8 @@ ExchangeRetry
         cbnz    w12, ExchangeRetry
 #endif
 
-        ;; We've successfully updated the value of the objectref so now we need a GC write barrier.
+DoCardsXchg
+        ;; We have successfully updated the value of the objectref so now we need a GC write barrier.
         ;; The following barrier code takes the destination in x0 and the value in x1 so the arguments are
         ;; already correctly set up.
 
@@ -374,8 +391,11 @@ ExchangeRetry
 
         ;; x10 still contains the original value.
         mov     x0, x10
+
 #ifndef LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT
+        tbnz    x16, #ARM64_ATOMICS_FEATURE_FLAG_BIT, NoBarrierXchg
         InterlockedOperationBarrier
+NoBarrierXchg
 #endif
         ret
 

--- a/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosarm64.inc
+++ b/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosarm64.inc
@@ -372,10 +372,6 @@ PTFF_THREAD_ABORT_BIT = 36
 TrapThreadsFlags_AbortInProgress_Bit = 0
 TrapThreadsFlags_TrapThreads_Bit     = 1
 
-// Bit position for the ARM64IntrinsicConstants_Atomics flags, to be used with tbz / tbnz instructions
-// ARM64IntrinsicConstants_Atomics = 0x0080
-ARM64_ATOMICS_FEATURE_FLAG_BIT       = 7
-
 // This must match HwExceptionCode.STATUS_REDHAWK_THREAD_ABORT
 #define STATUS_REDHAWK_THREAD_ABORT     0x43
 

--- a/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosarm64.inc
+++ b/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosarm64.inc
@@ -372,6 +372,10 @@ PTFF_THREAD_ABORT_BIT = 36
 TrapThreadsFlags_AbortInProgress_Bit = 0
 TrapThreadsFlags_TrapThreads_Bit     = 1
 
+// Bit position for the ARM64IntrinsicConstants_Atomics flags, to be used with tbz / tbnz instructions
+// ARM64IntrinsicConstants_Atomics = 0x0080
+ARM64_ATOMICS_FEATURE_FLAG_BIT       = 7
+
 // This must match HwExceptionCode.STATUS_REDHAWK_THREAD_ABORT
 #define STATUS_REDHAWK_THREAD_ABORT     0x43
 


### PR DESCRIPTION
We could, in theory, test for presence of LSE instructions dynamically, - set a global flag early on, and check it when need to do an object exchange. I am not sure if potential improvement could be more than the cost of the check.

When it is guaranteed that LSE is present, it is a trivial change.