### PR TITLE
Add function pointer type support to type loader

### DIFF
--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -1742,7 +1742,7 @@ namespace Internal.Runtime
                 if (((nint)_pFirst & IsRelative) != 0)
                     return (((RelativePointer<MethodTable>*)((nint)_pFirst - IsRelative)) + index)->Value;
 
-                return (MethodTable*)_pFirst + index;
+                return *(MethodTable**)_pFirst + index;
             }
 #if TYPE_LOADER_IMPLEMENTATION
             set

--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -1568,6 +1568,7 @@ namespace Internal.Runtime
             bool fRequiresOptionalFields,
             bool fHasSealedVirtuals,
             bool fHasGenericInfo,
+            int cFunctionPointerTypeParameters,
             bool fHasNonGcStatics,
             bool fHasGcStatics,
             bool fHasThreadStatics)
@@ -1580,6 +1581,7 @@ namespace Internal.Runtime
                 (fHasFinalizer ? sizeof(UIntPtr) : 0) +
                 (fRequiresOptionalFields ? sizeof(IntPtr) : 0) +
                 (fHasSealedVirtuals ? sizeof(IntPtr) : 0) +
+                cFunctionPointerTypeParameters * sizeof(IntPtr) +
                 (fHasGenericInfo ? sizeof(IntPtr)*2 : 0) + // pointers to GenericDefinition and GenericComposition
                 (fHasNonGcStatics ? sizeof(IntPtr) : 0) + // pointer to data
                 (fHasGcStatics ? sizeof(IntPtr) : 0) +  // pointer to data

--- a/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
+++ b/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
@@ -75,6 +75,7 @@ enum EETypeElementType : uint8_t
     ElementType_SzArray = 0x18,
     ElementType_ByRef = 0x19,
     ElementType_Pointer = 0x1A,
+    ElementType_FunctionPointer = 0x1B,
 };
 
 //-------------------------------------------------------------------------------------------------

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -159,7 +159,7 @@ namespace Internal.Runtime.TypeLoader
 
         private void InsertIntoNeedsTypeHandleList(TypeDesc type)
         {
-            if ((type is DefType) || (type is ArrayType) || (type is PointerType) || (type is ByRefType))
+            if ((type is DefType) || (type is ArrayType) || (type is PointerType) || (type is ByRefType) || (type is FunctionPointerType))
             {
                 _typesThatNeedTypeHandles.Add(type);
             }
@@ -233,7 +233,7 @@ namespace Internal.Runtime.TypeLoader
 
                 if (type is ArrayType typeAsArrayType)
                 {
-                    if (typeAsArrayType.IsSzArray && !typeAsArrayType.ElementType.IsPointer)
+                    if (typeAsArrayType.IsSzArray && !typeAsArrayType.ElementType.IsPointer && !typeAsArrayType.ElementType.IsFunctionPointer)
                     {
                         TypeDesc.ComputeTemplate(state);
                         Debug.Assert(state.TemplateType != null && state.TemplateType is ArrayType && !state.TemplateType.RuntimeTypeHandle.IsNull());
@@ -242,9 +242,15 @@ namespace Internal.Runtime.TypeLoader
                     }
                     else
                     {
-                        Debug.Assert(typeAsArrayType.IsMdArray || typeAsArrayType.ElementType.IsPointer);
+                        Debug.Assert(typeAsArrayType.IsMdArray || typeAsArrayType.ElementType.IsPointer || typeAsArrayType.ElementType.IsFunctionPointer);
                     }
                 }
+            }
+            else if (type is FunctionPointerType functionPointerType)
+            {
+                PrepareType(functionPointerType.Signature.ReturnType);
+                foreach (TypeDesc paramType in functionPointerType.Signature)
+                    PrepareType(paramType);
             }
             else
             {
@@ -590,7 +596,7 @@ namespace Internal.Runtime.TypeLoader
         {
             TypeBuilderState state = type.GetTypeBuilderState();
 
-            Debug.Assert(type is DefType || type is ArrayType || type is PointerType || type is ByRefType);
+            Debug.Assert(type is DefType || type is ArrayType || type is PointerType || type is ByRefType || type is FunctionPointerType);
 
             RuntimeTypeHandle rtt = EETypeCreator.CreateEEType(type, state);
 
@@ -843,6 +849,19 @@ namespace Internal.Runtime.TypeLoader
                     }
                 }
             }
+            else if (type is FunctionPointerType)
+            {
+                MethodSignature sig = ((FunctionPointerType)type).Signature;
+                unsafe
+                {
+                    MethodTable* halfBakedMethodTable = state.HalfBakedRuntimeTypeHandle.ToEETypePtr();
+                    halfBakedMethodTable->FunctionPointerReturnType = GetRuntimeTypeHandle(sig.ReturnType).ToEETypePtr();
+                    Debug.Assert(halfBakedMethodTable->NumFunctionPointerParameters == sig.Length);
+                    MethodTableList paramList = halfBakedMethodTable->FunctionPointerParameters;
+                    for (int i = 0; i < sig.Length; i++)
+                        paramList[i] = GetRuntimeTypeHandle(sig[i]).ToEETypePtr();
+                }
+            }
             else
             {
                 Debug.Assert(false);
@@ -942,24 +961,25 @@ namespace Internal.Runtime.TypeLoader
             int newArrayTypesCount = 0;
             int newPointerTypesCount = 0;
             int newByRefTypesCount = 0;
+            int newFunctionPointerTypesCount = 0;
             int[] mdArrayNewTypesCount = null;
 
             for (int i = 0; i < _typesThatNeedTypeHandles.Count; i++)
             {
-                ParameterizedType typeAsParameterizedType = _typesThatNeedTypeHandles[i] as ParameterizedType;
-                if (typeAsParameterizedType == null)
-                    continue;
+                TypeDesc type = _typesThatNeedTypeHandles[i];
 
-                if (typeAsParameterizedType.IsSzArray)
+                if (type.IsSzArray)
                     newArrayTypesCount++;
-                else if (typeAsParameterizedType.IsPointer)
+                else if (type.IsPointer)
                     newPointerTypesCount++;
-                else if (typeAsParameterizedType.IsByRef)
+                else if (type.IsFunctionPointer)
+                    newFunctionPointerTypesCount++;
+                else if (type.IsByRef)
                     newByRefTypesCount++;
-                else if (typeAsParameterizedType.IsMdArray)
+                else if (type.IsMdArray)
                 {
                     mdArrayNewTypesCount ??= new int[MDArray.MaxRank + 1];
-                    mdArrayNewTypesCount[((ArrayType)typeAsParameterizedType).Rank]++;
+                    mdArrayNewTypesCount[((ArrayType)type).Rank]++;
                 }
             }
             // Reserve space in array/pointer cache's so that the actual adding can be fault-free.
@@ -981,6 +1001,7 @@ namespace Internal.Runtime.TypeLoader
 
             TypeSystemContext.PointerTypesCache.Reserve(TypeSystemContext.PointerTypesCache.Count + newPointerTypesCount);
             TypeSystemContext.ByRefTypesCache.Reserve(TypeSystemContext.ByRefTypesCache.Count + newByRefTypesCount);
+            TypeSystemContext.FunctionPointerTypesCache.Reserve(TypeSystemContext.FunctionPointerTypesCache.Count + newFunctionPointerTypesCount);
 
             // Finally, register all generic types and methods atomically with the runtime
             RegisterGenericTypesAndMethods();
@@ -1001,7 +1022,8 @@ namespace Internal.Runtime.TypeLoader
                 {
                     if (_typesThatNeedTypeHandles[i] is FunctionPointerType typeAsFunctionPointerType)
                     {
-                        throw new NotImplementedException();
+                        Debug.Assert(!typeAsFunctionPointerType.RuntimeTypeHandle.IsNull());
+                        TypeSystemContext.FunctionPointerTypesCache.AddOrGetExisting(typeAsFunctionPointerType.RuntimeTypeHandle);
                     }
                     continue;
                 }

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -248,9 +248,9 @@ namespace Internal.Runtime.TypeLoader
             }
             else if (type is FunctionPointerType functionPointerType)
             {
-                PrepareType(functionPointerType.Signature.ReturnType);
+                RegisterForPreparation(functionPointerType.Signature.ReturnType);
                 foreach (TypeDesc paramType in functionPointerType.Signature)
-                    PrepareType(paramType);
+                    RegisterForPreparation(paramType);
             }
             else
             {

--- a/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormat.cs
+++ b/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormat.cs
@@ -203,6 +203,7 @@ namespace Internal.NativeFormat
     {
         Generic                     = 0x1,
         Static                      = 0x2,
+        Unmanaged                   = 0x4,
     };
 
 #if NATIVEFORMAT_PUBLICWRITER

--- a/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormatWriter.cs
+++ b/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormatWriter.cs
@@ -518,6 +518,12 @@ namespace Internal.NativeFormat
             MDArrayTypeSignature sig = new MDArrayTypeSignature(elementType, rank, bounds, lowerBounds);
             return Unify(sig);
         }
+
+        public Vertex GetFunctionPointerTypeSignature(Vertex methodSignature)
+        {
+            FunctionPointerTypeSignature sig = new FunctionPointerTypeSignature(methodSignature);
+            return Unify(sig);
+        }
     }
 
     internal sealed class PlacedVertex : Vertex
@@ -1459,6 +1465,37 @@ namespace Internal.NativeFormat
             }
 
             return true;
+        }
+    }
+
+#if NATIVEFORMAT_PUBLICWRITER
+    public
+#else
+    internal
+#endif
+    class FunctionPointerTypeSignature : Vertex
+    {
+        private Vertex _methodSignature;
+
+        public FunctionPointerTypeSignature(Vertex methodSignature)
+        {
+            _methodSignature = methodSignature;
+        }
+
+        internal override void Save(NativeWriter writer)
+        {
+            writer.WriteUnsigned((uint)TypeSignatureKind.FunctionPointer);
+            _methodSignature.Save(writer);
+        }
+
+        public override int GetHashCode()
+        {
+            return _methodSignature.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is FunctionPointerTypeSignature fnptrSig && _methodSignature.Equals(fnptrSig._methodSignature);
         }
     }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -344,6 +344,8 @@ namespace ILCompiler.DependencyAnalysis
                 methodCallingConvention |= MethodCallingConvention.Generic;
             if (_signature.IsStatic)
                 methodCallingConvention |= MethodCallingConvention.Static;
+            if ((_signature.Flags & MethodSignatureFlags.UnmanagedCallingConventionMask) != 0)
+                methodCallingConvention |= MethodCallingConvention.Unmanaged;
 
             Debug.Assert(_signature.Length == _parametersSig.Length);
 
@@ -407,9 +409,8 @@ namespace ILCompiler.DependencyAnalysis
                 case Internal.TypeSystem.TypeFlags.SignatureMethodVariable:
                     return new NativeLayoutGenericVarSignatureVertexNode(type);
 
-                // TODO Internal.TypeSystem.TypeFlags.FunctionPointer (Runtime parsing also not yet implemented)
                 case Internal.TypeSystem.TypeFlags.FunctionPointer:
-                    throw new NotImplementedException("FunctionPointer signature");
+                    return new NativeLayoutFunctionPointerTypeSignatureVertexNode(factory, type);
 
                 default:
                     {
@@ -464,6 +465,26 @@ namespace ILCompiler.DependencyAnalysis
 
                 Debug.Fail("UNREACHABLE");
                 return null;
+            }
+        }
+
+        private sealed class NativeLayoutFunctionPointerTypeSignatureVertexNode : NativeLayoutTypeSignatureVertexNode
+        {
+            private readonly NativeLayoutMethodSignatureVertexNode _sig;
+
+            public NativeLayoutFunctionPointerTypeSignatureVertexNode(NodeFactory factory, TypeDesc type) : base(type)
+            {
+                _sig = factory.NativeLayout.MethodSignatureVertex(((FunctionPointerType)type).Signature);
+            }
+            public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+            {
+                return new DependencyListEntry[] { new DependencyListEntry(_sig, "Method signature") };
+            }
+            public override Vertex WriteVertex(NodeFactory factory)
+            {
+                Debug.Assert(Marked, "WriteVertex should only happen for marked vertices");
+
+                return GetNativeWriter(factory).GetFunctionPointerTypeSignature(_sig.WriteVertex(factory));
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.NativeLayout.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.NativeLayout.cs
@@ -185,11 +185,19 @@ namespace ILCompiler.DependencyAnalysis
                     type = ((ParameterizedType)type).ParameterType;
                 }
 
-                // We stripped byrefs, pointers and arrays above. If we're left with a function pointer,
-                // we are done. No templates needed for function pointers since their MethodTables
-                // don't carry anything interesting.
                 if (type.IsFunctionPointer)
+                {
+                    MethodSignature sig = ((FunctionPointerType)type).Signature;
+                    foreach (var dependency in TemplateConstructableTypes(sig.ReturnType))
+                        yield return dependency;
+
+                    foreach (var param in sig)
+                        foreach (var dependency in TemplateConstructableTypes(param))
+                            yield return dependency;
+
+                    // Nothing else to do for function pointers
                     yield break;
+                }
 
                 TypeDesc canonicalType = type.ConvertToCanonForm(CanonicalFormKind.Specific);
                 yield return _factory.MaximallyConstructableType(canonicalType);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.NativeLayout.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.NativeLayout.cs
@@ -185,6 +185,12 @@ namespace ILCompiler.DependencyAnalysis
                     type = ((ParameterizedType)type).ParameterType;
                 }
 
+                // We stripped byrefs, pointers and arrays above. If we're left with a function pointer,
+                // we are done. No templates needed for function pointers since their MethodTables
+                // don't carry anything interesting.
+                if (type.IsFunctionPointer)
+                    yield break;
+
                 TypeDesc canonicalType = type.ConvertToCanonForm(CanonicalFormKind.Specific);
                 yield return _factory.MaximallyConstructableType(canonicalType);
 
@@ -236,12 +242,6 @@ namespace ILCompiler.DependencyAnalysis
                 {
                     GenericParameterDesc genericParameter = ((RuntimeDeterminedType)type).RuntimeDeterminedDetailsType;
                     type = _factory.TypeSystemContext.GetSignatureVariable(genericParameter.Index, method: (genericParameter.Kind == GenericParameterKind.Method));
-                }
-
-                if (type.Category == TypeFlags.FunctionPointer)
-                {
-                    // Pretend for now it's an IntPtr, may need to be revisited depending on https://github.com/dotnet/runtime/issues/11354
-                    type = _factory.TypeSystemContext.GetWellKnownType(WellKnownType.IntPtr);
                 }
 
                 return _typeSignatures.GetOrAdd(type);

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
@@ -2459,7 +2459,7 @@ class Generics
             public Type GrabUnmanagedStdcallSuppressGCFnptr() => typeof(delegate* unmanaged[Stdcall, SuppressGCTransition]<T>);
             public Array GetFunctionPointerArray() => new delegate*<T[,]>[1];
             public Array GetFunctionPointerMdArray() => new delegate*<T[,]>[1, 1];
-            public Type GrabManagedFnptrOverAlsoGen() => typeof(delegate*<AlsoGen<T>, MyGen<T>>);
+            public Type GrabManagedFnptrOverAlsoGen() => typeof(delegate*<MyGen<T>, AlsoGen<T>>);
             public Type GrabManagedFnptrOverAlsoAlsoGen() => typeof(delegate*<AlsoAlsoGen<T>, MyGen<T>>);
         }
 
@@ -2520,7 +2520,7 @@ class Generics
 
             {
                 Type t = o.GrabManagedFnptrOverAlsoAlsoGen();
-                if (!t.TypeHandle.Equals(typeof(delegate*<AlsoAlsoGen<Atom>, MyGen<Atom>>)))
+                if (!t.TypeHandle.Equals(typeof(delegate*<AlsoAlsoGen<Atom>, MyGen<Atom>>).TypeHandle))
                     throw new Exception();
             }
         }

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
@@ -55,6 +55,7 @@ class Generics
         TestMDArrayAddressMethod.Run();
         TestNativeLayoutGeneration.Run();
         TestByRefLikeVTables.Run();
+        TestFunctionPointerLoading.Run();
 
         return 100;
     }
@@ -2431,6 +2432,97 @@ class Generics
             RefStruct<string> r = default;
             if (r.ToString() != "System.String")
                 throw new Exception();
+        }
+    }
+
+    class TestFunctionPointerLoading
+    {
+        interface IFace
+        {
+            Type GrabManagedFnptr();
+            Type GrabManagedRefFnptr();
+            Type GrabUnmanagedFnptr();
+            Type GrabUnmanagedStdcallFnptr();
+            Type GrabUnmanagedStdcallSuppressGCFnptr();
+            Array GetFunctionPointerArray();
+            Array GetFunctionPointerMdArray();
+            Type GrabManagedFnptrOverAlsoGen();
+            Type GrabManagedFnptrOverAlsoAlsoGen();
+        }
+
+        unsafe class Gen<T> : IFace
+        {
+            public Type GrabManagedFnptr() => typeof(delegate*<T>);
+            public Type GrabManagedRefFnptr() => typeof(delegate*<ref T>);
+            public Type GrabUnmanagedFnptr() => typeof(delegate* unmanaged<T>);
+            public Type GrabUnmanagedStdcallFnptr() => typeof(delegate* unmanaged[Stdcall]<T>);
+            public Type GrabUnmanagedStdcallSuppressGCFnptr() => typeof(delegate* unmanaged[Stdcall, SuppressGCTransition]<T>);
+            public Array GetFunctionPointerArray() => new delegate*<T[,]>[1];
+            public Array GetFunctionPointerMdArray() => new delegate*<T[,]>[1, 1];
+            public Type GrabManagedFnptrOverAlsoGen() => typeof(delegate*<AlsoGen<T>, MyGen<T>>);
+            public Type GrabManagedFnptrOverAlsoAlsoGen() => typeof(delegate*<AlsoAlsoGen<T>, MyGen<T>>);
+        }
+
+        class MyGen<T> { }
+
+        class AlsoGen<T> { }
+
+        class AlsoAlsoGen<T> { }
+
+        class Atom { }
+
+        static Type s_atomType = typeof(Atom);
+
+        public static void Run()
+        {
+            var o = (IFace)Activator.CreateInstance(typeof(Gen<>).MakeGenericType(s_atomType));
+
+            {
+                Type t = o.GrabManagedFnptr();
+                if (!t.IsFunctionPointer || t.GetFunctionPointerReturnType() != typeof(Atom) || t.IsUnmanagedFunctionPointer)
+                    throw new Exception();
+            }
+
+            {
+                Type t = o.GrabManagedRefFnptr();
+                if (!t.IsFunctionPointer || t.GetFunctionPointerReturnType() != typeof(Atom).MakeByRefType() || t.IsUnmanagedFunctionPointer)
+                    throw new Exception();
+            }
+
+            {
+                Type t = o.GrabUnmanagedFnptr();
+                if (!t.IsFunctionPointer || t.GetFunctionPointerReturnType() != typeof(Atom) || !t.IsUnmanagedFunctionPointer)
+                    throw new Exception();
+
+                if (t != o.GrabUnmanagedStdcallFnptr() || t != o.GrabUnmanagedStdcallSuppressGCFnptr())
+                    throw new Exception();
+            }
+
+            {
+                Array arr = o.GetFunctionPointerArray();
+                if (!arr.GetType().GetElementType().IsFunctionPointer)
+                    throw new Exception();
+            }
+
+            {
+                Array arr = o.GetFunctionPointerMdArray();
+                if (!arr.GetType().GetElementType().IsFunctionPointer)
+                    throw new Exception();
+            }
+
+            {
+                Type t = o.GrabManagedFnptrOverAlsoGen();
+                if (!t.IsFunctionPointer
+                    || t.GetFunctionPointerReturnType().GetGenericTypeDefinition() != typeof(AlsoGen<>)
+                    || t.GetFunctionPointerReturnType().GetGenericArguments()[0] != typeof(Atom))
+                    throw new Exception();
+            }
+
+            {
+                Type t = o.GrabManagedFnptrOverAlsoAlsoGen();
+                if (!t.TypeHandle.Equals(typeof(delegate*<AlsoAlsoGen<Atom>, MyGen<Atom>>)))
+                    throw new Exception();
+            }
         }
     }
 


### PR DESCRIPTION
So that we can create new function pointer types at runtime within the context of `MakeGenericXXX`.

Cc @dotnet/ilc-contrib 