### PR TITLE
[NativeAOT] Do not strip exported symbols from executables on Apple platforms

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -336,6 +336,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <_IgnoreLinkerWarnings>false</_IgnoreLinkerWarnings>
       <_IgnoreLinkerWarnings Condition="'$(_IsApplePlatform)' == 'true'">true</_IgnoreLinkerWarnings>
       <StripFlag Condition="'$(_IsApplePlatform)' == 'true' and '$(NativeLib)' == 'Shared'">-x</StripFlag> <!-- keep global symbols in dylib -->
+      <StripFlag Condition="'$(_IsApplePlatform)' == 'true' and '$(NativeLib)' != 'Shared' and '$(IlcExportUnmanagedEntrypoints)' == 'true'">-i -s $(ExportsFile)</StripFlag> <!-- keep global symbols when explicitly specified -->
     </PropertyGroup>
 
     <!-- write linker script for lld (13+) to retain the __modules section -->

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -335,8 +335,8 @@ The .NET Foundation licenses this file to you under the MIT license.
     <PropertyGroup>
       <_IgnoreLinkerWarnings>false</_IgnoreLinkerWarnings>
       <_IgnoreLinkerWarnings Condition="'$(_IsApplePlatform)' == 'true'">true</_IgnoreLinkerWarnings>
-      <StripFlag Condition="'$(_IsApplePlatform)' == 'true' and '$(NativeLib)' == 'Shared'">-x</StripFlag> <!-- keep global symbols in dylib -->
-      <StripFlag Condition="'$(_IsApplePlatform)' == 'true' and '$(NativeLib)' != 'Shared' and '$(IlcExportUnmanagedEntrypoints)' == 'true'">-i -s $(ExportsFile)</StripFlag> <!-- keep global symbols when explicitly specified -->
+      <_StripFlag Condition="'$(_IsApplePlatform)' == 'true' and '$(NativeLib)' == 'Shared'">-x</_StripFlag> <!-- keep global symbols in dylib -->
+      <_StripFlag Condition="'$(_IsApplePlatform)' == 'true' and '$(NativeLib)' != 'Shared' and '$(IlcExportUnmanagedEntrypoints)' == 'true'">-i -s $(ExportsFile)</_StripFlag> <!-- keep global symbols when explicitly specified -->
     </PropertyGroup>
 
     <!-- write linker script for lld (13+) to retain the __modules section -->
@@ -363,7 +363,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <Exec Condition="'$(StripSymbols)' == 'true' and '$(_IsApplePlatform)' == 'true' and '$(NativeLib)' != 'Static'"
       Command="
         dsymutil $(DsymUtilOptions) &quot;$(NativeBinary)&quot; &amp;&amp;
-        strip -no_code_signature_warning $(StripFlag) &quot;$(NativeBinary)&quot;" />
+        strip -no_code_signature_warning $(_StripFlag) &quot;$(NativeBinary)&quot;" />
   </Target>
 
   <Target Name="CreateLib"

--- a/src/tests/nativeaot/GenerateUnmanagedEntryPoints/GenerateUnmanagedEntryPoints.csproj
+++ b/src/tests/nativeaot/GenerateUnmanagedEntryPoints/GenerateUnmanagedEntryPoints.csproj
@@ -4,9 +4,6 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IlcExportUnmanagedEntrypoints>true</IlcExportUnmanagedEntrypoints>
-    
-    <!-- Stripping symbols causes problems for running the test on macOS -->
-    <StripSymbols>false</StripSymbols>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`StripSymbols` project property is now set by default when building with NativeAOT: https://github.com/dotnet/runtime/pull/85139 

However, this breaks a special use case on Apple platforms when an executable dynamically looks-up symbols in the current executable image (self-referencing) reported here: https://github.com/dotnet/runtime/pull/85139#issuecomment-1518543725

This PR:
- fixes this issue by adding a `StripFlag` for this special use case, which will ignore exported symbols when stripping the executable
- reenables stripping in the unit test in question
- renames: `StripFlag` into `_StripFlag` as it is an internal property

cc: @kotlarmilos 
