### PR TITLE
Add introspection for readelf

### DIFF
--- a/eng/native/configuretools.cmake
+++ b/eng/native/configuretools.cmake
@@ -53,6 +53,7 @@ if(NOT WIN32 AND NOT CLR_CMAKE_TARGET_BROWSER AND NOT CLR_CMAKE_TARGET_WASI)
 
   if(NOT CLR_CMAKE_TARGET_APPLE AND (NOT CLR_CMAKE_TARGET_ANDROID OR CROSS_ROOTFS))
     locate_toolchain_exec(objdump CMAKE_OBJDUMP YES)
+    locate_toolchain_exec(readelf CMAKE_READELF YES)
 
     unset(CMAKE_OBJCOPY CACHE)
     locate_toolchain_exec(objcopy CMAKE_OBJCOPY NO)

--- a/eng/native/genmoduleindex.sh
+++ b/eng/native/genmoduleindex.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 if [[ "$#" -lt 2 ]]; then
-  echo "Usage: genmoduleindex.sh ModuleBinaryFile IndexHeaderFile"
+  echo "Usage: genmoduleindex.sh ModuleBinaryFile IndexHeaderFile readelfBinaryPath"
   exit 1
 fi
 
@@ -25,16 +25,18 @@ function printIdAsBinary() {
 
 case "$(uname -s)" in
 Darwin)
-  cmd="dwarfdump -u $1"
+  cmd="dwarfdump"
+  arg="-u"
   pattern='^UUID: ([0-9A-Fa-f\-]+)';;
 *)
-  cmd="readelf -n $1"
+  cmd="$3"
+  arg="-n"
   pattern='^[[:space:]]*Build ID: ([0-9A-Fa-f\-]+)';;
 esac
 
-while read -r line; do
+"$cmd" "$arg" "$1" | while read -r line; do
   if [[ "$line" =~ $pattern ]]; then
     printIdAsBinary "${BASH_REMATCH[1]//-/}"
     break
   fi
-done < <(eval "$cmd") > "$2"
+done > "$2"

--- a/src/coreclr/debug/runtimeinfo/CMakeLists.txt
+++ b/src/coreclr/debug/runtimeinfo/CMakeLists.txt
@@ -15,7 +15,7 @@ function(generate_module_index Target ModuleIndexFile)
 
     add_custom_command(
         OUTPUT ${ModuleIndexFile}
-        COMMAND ${CLR_ENG_NATIVE_DIR}/genmoduleindex${scriptExt} $<TARGET_FILE:${Target}> ${ModuleIndexFile}
+        COMMAND ${CLR_ENG_NATIVE_DIR}/genmoduleindex${scriptExt} $<TARGET_FILE:${Target}> ${ModuleIndexFile} ${CMAKE_READELF}
         DEPENDS ${Target}
         COMMENT "Generating ${Target} module index file -> ${ModuleIndexFile}"
     )


### PR DESCRIPTION
Just like `CMAKE_NM`, which is used by `verify-entrypoints.sh`, introspect `CMAKE_READELF` for `genmoduleindex.sh`.

I saw some warnings in [riscv64 logs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=251104&view=logs&jobId=61a6c216-902b-58a9-7a66-2fc8440918c9&j=61a6c216-902b-58a9-7a66-2fc8440918c9&t=e3de8ff2-0932-5298-3d8c-422e717b2560) in @clamp03's PR https://github.com/dotnet/runtime/pull/85289. Those warnings are reported by binutils readelf, which doesn't seem to handle DWARF 5 very well:

```sh
2023-04-25T06:24:05.8822869Z [ 96%] Generating coreclr module index file -> /__w/1/s/artifacts/obj/coreclr/linux.riscv64.Checked/debug/runtimeinfo/runtimemoduleindex.h
2023-04-25T06:24:05.9454927Z readelf: Warning: Unrecognized form: 0x23
2023-04-25T06:24:05.9574180Z readelf: Warning: Unrecognized form: 0x22
2023-04-25T06:24:05.9574395Z readelf: Warning: Unrecognized form: 0x22
...
2023-04-25T06:24:05.9575038Z readelf: Warning: Bogus end-of-siblings marker detected at offset 5131 in .debug_info section
2023-04-25T06:24:05.9575305Z readelf: Warning: Unrecognized form: 0x22
2023-04-25T06:24:05.9575728Z readelf: Warning: Bogus end-of-siblings marker detected at offset 5147 in .debug_info section
2023-04-25T06:24:05.9576205Z readelf: Warning: Bogus end-of-siblings marker detected at offset 5156 in .debug_info section
2023-04-25T06:24:05.9577004Z readelf: Warning: Further warnings about bogus end-of-sibling markers suppressed
2023-04-25T06:24:05.9577299Z readelf: Warning: Unrecognized form: 0x23
2023-04-25T06:24:05.9577497Z readelf: Warning: Unrecognized form: 0x22
2023-04-25T06:24:05.9577714Z readelf: Warning: Unrecognized form: 0x22
```

With this change, the script uses `llvm-readelf-15` in that container (matching the exact toolchain in use) and reports no warning. 

Also removed the usage of `eval` in the script while I was at it.