### PR TITLE
Update KnownILCompilerPack to support iOS runtime identifiers

### DIFF
--- a/eng/targetingpacks.targets
+++ b/eng/targetingpacks.targets
@@ -58,7 +58,7 @@
                          ILCompilerPackNamePattern="runtime.**RID**.Microsoft.DotNet.ILCompiler"
                          TargetFramework="$(NetCoreAppCurrent)"
                          ILCompilerPackVersion="$(ProductVersion)"
-                         ILCompilerRuntimeIdentifiers="linux-musl-x64;linux-x64;win-x64;linux-arm;linux-arm64;linux-musl-arm;linux-musl-arm64;osx-arm64;osx-x64;win-arm;win-arm64;win-x86"
+                         ILCompilerRuntimeIdentifiers="linux-musl-x64;linux-x64;win-x64;linux-arm;linux-arm64;linux-musl-arm;linux-musl-arm64;osx-arm64;osx-x64;win-arm;win-arm64;win-x86;maccatalyst-x64;maccatalyst-arm64;ios-arm64;iossimulator-arm64;iossimulator-x64;tvos-arm64;tvossimulator-arm64;tvossimulator-x64"
                          Condition="'@(KnownILCompilerPack)' == '' or !@(KnownILCompilerPack->AnyHaveMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR updates the `KnownILCompilerPack` to support iOS RiDs. Draft PR should identify if there are any additional changes needed for full integration with the SDK/Installer and internal build tasks for targeting iOS platforms.

Follow-up Installer change which allows iOS RiDs https://github.com/dotnet/installer/compare/main...kotlarmilos:installer:feature/ios-with-nativeaot. 

/cc: @akoeplinger @ivanpovazan 