### PR TITLE
Zip.Unix: don't hang when creating zip file from directory with named pipe.

### DIFF
--- a/src/libraries/Common/src/System/IO/Archiving.Utils.cs
+++ b/src/libraries/Common/src/System/IO/Archiving.Utils.cs
@@ -26,9 +26,9 @@ namespace System.IO
             }
         }
 
-        public static bool IsDirEmpty(DirectoryInfo possiblyEmptyDir)
+        public static bool IsDirEmpty(string directoryFullName)
         {
-            using (IEnumerator<string> enumerator = Directory.EnumerateFileSystemEntries(possiblyEmptyDir.FullName).GetEnumerator())
+            using (IEnumerator<string> enumerator = Directory.EnumerateFileSystemEntries(directoryFullName).GetEnumerator())
                 return !enumerator.MoveNext();
         }
 

--- a/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
+++ b/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
@@ -244,7 +244,7 @@
     <value>A metadata entry of type '{0}' was unexpectedly found after a metadata entry of type '{1}'.</value>
   </data>
   <data name="TarUnsupportedFile" xml:space="preserve">
-    <value>The file '{0}' is a type of file not supported for tar archiving.</value>
+    <value>The file type of '{0}' is not supported for tar archiving.</value>
   </data>
   <data name="UnauthorizedAccess_IODenied_NoPathName" xml:space="preserve">
     <value>Access to the path is denied.</value>

--- a/src/libraries/System.IO.Compression.ZipFile/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.Compression.ZipFile/src/Resources/Strings.resx
@@ -100,6 +100,6 @@
     <value>Access to the path '{0}' is denied.</value>
   </data>
   <data name="ZipUnsupportedFile" xml:space="preserve">
-    <value>The file '{0}' is a type of file not supported for zip archiving.</value>
+    <value>The file type of '{0}' is not supported for zip archiving.</value>
   </data>
 </root>

--- a/src/libraries/System.IO.Compression.ZipFile/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.Compression.ZipFile/src/Resources/Strings.resx
@@ -99,4 +99,7 @@
   <data name="UnauthorizedAccess_IODenied_Path" xml:space="preserve">
     <value>Access to the path '{0}' is denied.</value>
   </data>
+  <data name="ZipUnsupportedFile" xml:space="preserve">
+    <value>The file '{0}' is a type of file not supported for zip archiving.</value>
+  </data>
 </root>

--- a/src/libraries/System.IO.Compression.ZipFile/src/System.IO.Compression.ZipFile.csproj
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System.IO.Compression.ZipFile.csproj
@@ -20,9 +20,11 @@
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'windows'">
     <Compile Include="$(CommonPath)System\IO\Archiving.Utils.Windows.cs"
              Link="Common\System\IO\Archiving.Utils.Windows.cs" />
+    <Compile Include="System\IO\Compression\ZipFile.Create.Windows.cs" />
   </ItemGroup>
   <!-- Unix specific files -->
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == ''">
+    <Compile Include="System\IO\Compression\ZipFile.Create.Unix.cs" />
     <Compile Include="System\IO\Compression\ZipFileExtensions.ZipArchive.Create.Unix.cs" />
     <Compile Include="$(CommonPath)System\IO\Compression\ZipArchiveEntryConstants.Unix.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\Interop.IOErrors.cs"

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.Unix.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.Unix.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Enumeration;
+
+namespace System.IO.Compression
+{
+    public static partial class ZipFile
+    {
+        private static FileSystemEnumerable<(string, CreateEntryType)> CreateEnumerableForCreate(string directoryFullPath)
+            => new FileSystemEnumerable<(string, CreateEntryType)>(directoryFullPath,
+                static (ref FileSystemEntry entry) =>
+                    {
+                        string fullPath = entry.ToFullPath();
+
+                        int type;
+                        if (entry.IsDirectory) // entry is a directory, or a link to a directory.
+                        {
+                            type = Interop.Sys.FileTypes.S_IFDIR;
+                        }
+                        else
+                        {
+                            // Use 'stat' to follow links.
+                            Interop.CheckIo(Interop.Sys.Stat(fullPath, out Interop.Sys.FileStatus status), fullPath);
+                            type = (status.Mode & Interop.Sys.FileTypes.S_IFMT);
+                        }
+
+                        return type switch
+                        {
+                            Interop.Sys.FileTypes.S_IFREG => (fullPath, CreateEntryType.File),
+                            Interop.Sys.FileTypes.S_IFDIR => (fullPath, CreateEntryType.Directory),
+                            _                             => (fullPath, CreateEntryType.Unsupported)
+                        };
+                    },
+                    new EnumerationOptions { RecurseSubdirectories = true, AttributesToSkip = 0, IgnoreInaccessible = false });
+    }
+}

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.Windows.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.Windows.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Enumeration;
+
+namespace System.IO.Compression
+{
+    public static partial class ZipFile
+    {
+        private static FileSystemEnumerable<(string, CreateEntryType)> CreateEnumerableForCreate(string directoryFullPath)
+            => new FileSystemEnumerable<(string, CreateEntryType)>(directoryFullPath,
+                static (ref FileSystemEntry entry) => (entry.ToFullPath(), entry.IsDirectory ? CreateEntryType.Directory : CreateEntryType.File),
+                new EnumerationOptions { RecurseSubdirectories = true, AttributesToSkip = 0, IgnoreInaccessible = false });
+    }
+}

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Unix.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Unix.cs
@@ -184,7 +184,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)] // browser doesn't have libc mkfifo.
+        [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser & ~TestPlatforms.tvOS & ~TestPlatforms.iOS)] // browser doesn't have libc mkfifo. tvOS/iOS return an error for mkfifo.
         [SkipOnPlatform(TestPlatforms.LinuxBionic, "Bionic is not normal Linux, has no normal file permissions")]
         public void ZipNamedPipeIsNotSupported()
         {

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Unix.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Unix.cs
@@ -184,7 +184,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)] // browser doesn't have libc mkfifo.
         [SkipOnPlatform(TestPlatforms.LinuxBionic, "Bionic is not normal Linux, has no normal file permissions")]
         public void ZipNamedPipeIsNotSupported()
         {

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Unix.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Unix.cs
@@ -184,9 +184,9 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser & ~TestPlatforms.tvOS & ~TestPlatforms.iOS)]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
         [SkipOnPlatform(TestPlatforms.LinuxBionic, "Bionic is not normal Linux, has no normal file permissions")]
-        public async Task CanZipNamedPipe()
+        public void ZipNamedPipeIsNotSupported()
         {
             string destPath = Path.Combine(TestDirectory, "dest.zip");
 
@@ -195,29 +195,7 @@ namespace System.IO.Compression.Tests
             Directory.CreateDirectory(subFolderPath); // mandatory before calling mkfifo
             Assert.Equal(0, mkfifo(fifoPath, 438 /* 666 in octal */));
 
-            byte[] contentBytes = { 1, 2, 3, 4, 5 };
-
-            await Task.WhenAll(
-                Task.Run(() =>
-                {
-                    using FileStream fs = new (fifoPath, FileMode.Open, FileAccess.Write, FileShare.Read, bufferSize: 0);
-                    foreach (byte content in contentBytes)
-                    {
-                        fs.WriteByte(content);
-                    }
-                }),
-                Task.Run(() =>
-                {
-                    ZipFile.CreateFromDirectory(subFolderPath, destPath);
-
-                    using ZipArchive zippedFolder = ZipFile.OpenRead(destPath);
-                    using Stream unzippedPipe = zippedFolder.Entries.Single().Open();
-
-                    byte[] readBytes = new byte[contentBytes.Length];
-                    Assert.Equal(contentBytes.Length, unzippedPipe.Read(readBytes));
-                    Assert.Equal<byte>(contentBytes, readBytes);
-                    Assert.Equal(0, unzippedPipe.Read(readBytes)); // EOF
-                }));
+            Assert.Throws<IOException>(() => ZipFile.CreateFromDirectory(subFolderPath, destPath));
         }
 
         private static string GetExpectedPermissions(string expectedPermissions)


### PR DESCRIPTION
When we open the named pipe for reading, that call will block indefinitely when there is no writer to provide data.

And if we manage to read data from a pipe, that data was probably meant for someone else.

Rather than opening named pipes, throw an IOException indicating they are not supported.

And like the named pipes, this also treat character devices, block devices, and sockets as unsupported types.

Fixes https://github.com/dotnet/runtime/issues/85097.

@dotnet/area-system-io ptal.