### PR TITLE
[mono][interp] Fix il_offset of inserted instructions

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -146,6 +146,7 @@ interp_insert_ins_bb (TransformData *td, InterpBasicBlock *bb, InterpInst *prev_
 	else
 		new_inst->next->prev = new_inst;
 
+	new_inst->il_offset = -1;
 	return new_inst;
 }
 
@@ -10863,6 +10864,9 @@ retry:
 
 	generate_code (td, method, header, generic_context, error);
 	goto_if_nok (error, exit);
+
+	// Any newly created instructions will have undefined il_offset
+	td->current_il_offset = -1;
 
 	g_assert (td->inline_depth == 0);
 


### PR DESCRIPTION
After the original codegen happens, where instructions have the associated il_offset set, we might still generate new instruction as part of various optimizations. They would have the associated il_offset of the end of the method which is incorrect and was screwing up mapping from native_offset to il_offset.

Fixes https://github.com/dotnet/runtime/issues/85055