### PR TITLE
[mono] Invoke AssemblyLoad hooks from RuntimeAssemblyBuilder:.ctor ()…

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -722,6 +722,11 @@ namespace System.Runtime.Loader
             return InvokeResolveEvent(AssemblyResolve, assembly, assemblyFullName);
         }
 
+        internal static void InvokeAssemblyLoadEvent(Assembly assembly)
+        {
+            AssemblyLoad?.Invoke(AppDomain.CurrentDomain, new AssemblyLoadEventArgs(assembly));
+        }
+
         [UnconditionalSuppressMessage("SingleFile", "IL3000: Avoid accessing Assembly file path when publishing as a single file",
             Justification = "The code handles the Assembly.Location equals null")]
         private static RuntimeAssembly? InvokeResolveEvent(ResolveEventHandler? eventHandler, RuntimeAssembly? assembly, string name)

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeAssemblyBuilder.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeAssemblyBuilder.Mono.cs
@@ -256,6 +256,8 @@ namespace System.Reflection.Emit
             // Netcore only allows one module per assembly
             manifest_module = new RuntimeModuleBuilder(this, "RefEmit_InMemoryManifestModule");
             modules = new RuntimeModuleBuilder[] { manifest_module };
+
+            AssemblyLoadContext.InvokeAssemblyLoadEvent (this);
         }
 
         public override bool ReflectionOnly

--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -571,6 +571,10 @@ mono_domain_fire_assembly_load_event (MonoDomain *domain, MonoAssembly *assembly
 	if (!method)
 		goto exit;
 
+	if (assembly->dynamic)
+		/* Called by RuntimeAssemblyBuilder:.ctor () after the manifest module has been created */
+		goto exit;
+
 	MonoReflectionAssemblyHandle assembly_handle;
 	assembly_handle = mono_assembly_get_object_handle (assembly, error);
 	goto_if_nok (error, exit);


### PR DESCRIPTION
… instead from native code.

The call from native code is made before the manifest module was created, causing errors if the hook tried to access Assembly.ManifestModule.

Fixes https://github.com/dotnet/runtime/issues/84771.