### PR TITLE
init-distro-rid.sh: fix unbound error when VERSION_ID is not defined.

### DIFF
--- a/eng/native/init-distro-rid.sh
+++ b/eng/native/init-distro-rid.sh
@@ -25,7 +25,7 @@ getNonPortableDistroRid()
                 VERSION_ID="${VERSION_ID%.*}"
             fi
 
-            if [[ "${VERSION_ID}" =~ ^([[:digit:]]|\.)+$ ]]; then
+            if [[ "${VERSION_ID:-}" =~ ^([[:digit:]]|\.)+$ ]]; then
                 nonPortableRid="${ID}.${VERSION_ID}-${targetArch}"
             else
                 # Rolling release distros either do not set VERSION_ID, set it as blank or


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/85315.

I verified this locally.

@ViktorHofer ptal.