### PR TITLE
JIT: Create side effect commas as TYP_VOID in block morph

### DIFF
--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -160,7 +160,7 @@ GenTree* MorphInitBlockHelper::Morph()
             commaPool      = commaPool->gtNext;
 
             assert(comma->OperIs(GT_COMMA));
-            comma->gtType        = m_result->TypeGet();
+            comma->gtType        = TYP_VOID;
             comma->AsOp()->gtOp1 = sideEffects;
             comma->AsOp()->gtOp2 = m_result;
             comma->gtFlags       = (sideEffects->gtFlags | m_result->gtFlags) & GTF_ALL_EFFECT;
@@ -169,7 +169,7 @@ GenTree* MorphInitBlockHelper::Morph()
         }
         else
         {
-            m_result = m_comp->gtNewOperNode(GT_COMMA, m_result->TypeGet(), sideEffects, m_result);
+            m_result = m_comp->gtNewOperNode(GT_COMMA, TYP_VOID, sideEffects, m_result);
         }
         INDEBUG(m_result->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED);
 


### PR DESCRIPTION
This code could create IR shapes like

```
COMMA struct
  ...
  ASG struct
    dst
    src
``` 

After liveness that would sometimes result in

```
COMMA struct
  ...
  NOP void
```

which could confuse optimization phases when JitOptRepeat was enabled.

The more canonical shape for these side-effecting GT_COMMA nodes has them TYP_VOID typed as shown by gtExtractSideEffList, so do the same in block morph.

Fix #85037

There are still other cases where we produce the non-canonical typed commas, e.g. `impAssignStruct`. I started trying to fix it but it looks like it will take a larger clean up.