### PR TITLE
Retry compat Random.NextSingle in case rounding from double produces 1.0f

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Random.Net5CompatImpl.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Random.Net5CompatImpl.cs
@@ -83,7 +83,17 @@ namespace System
 
             public override double NextDouble() => _prng.Sample();
 
-            public override float NextSingle() => (float)_prng.Sample();
+            public override float NextSingle()
+            {
+                while (true)
+                {
+                    float f = (float)_prng.Sample();
+                    if (f < 1.0f) // reject 1.0f, which is rare but possible due to rounding
+                    {
+                        return f;
+                    }
+                }
+            }
 
             public override void NextBytes(byte[] buffer) => _prng.NextBytes(buffer);
 
@@ -197,7 +207,14 @@ namespace System
             public override float NextSingle()
             {
                 _prng.EnsureInitialized(_seed);
-                return (float)_parent.Sample();
+                while (true)
+                {
+                    float f = (float)_parent.Sample();
+                    if (f < 1.0f) // reject 1.0f, which is rare but possible due to rounding
+                    {
+                        return f;
+                    }
+                }
             }
 
             public override void NextBytes(byte[] buffer)

--- a/src/libraries/System.Runtime.Extensions/tests/System/Random.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Random.cs
@@ -69,13 +69,13 @@ namespace System.Tests
                 Assert.InRange(r.NextInt64(20, 30), 20, 29);
             }
 
-            for (int i = 0; i < 1000; i++)
+            for (int i = 0; i < 5_000_000; i++)
             {
                 float x = r.NextSingle();
                 Assert.True(x >= 0.0 && x < 1.0);
             }
 
-            for (int i = 0; i < 1000; i++)
+            for (int i = 0; i < 5_000_000; i++)
             {
                 double x = r.NextDouble();
                 Assert.True(x >= 0.0 && x < 1.0);
@@ -830,7 +830,7 @@ namespace System.Tests
             AssertExtensions.SequenceEqual(new byte[] { 1, 1, 3, 1, 3, 2, 2 }, buffer);
         }
 
-        private static Random Create(bool derived, bool seeded, int seed = 42) =>
+        private static Random Create(bool derived, bool seeded) =>
             (derived, seeded) switch
             {
                 (false, false) => new Random(),


### PR DESCRIPTION
The compat implementation behind Random just casts a double to a float to produce the result of NextSingle.  Some double values close to 1.0 might round up to 1.0f, which is out of range for NextSingle.  In that case, reject it and retry.  This approach is consistent with how fairness is handled elsewhere in the implementation, and avoids changing the sequence of values returned for a fixed seed in cases where an illegal value wasn't being returned.

Fixes https://github.com/dotnet/runtime/issues/85016