### PR TITLE
Make Guid.HexsToChars aggressively inlined

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -1052,6 +1052,7 @@ namespace System
 
         public static bool operator !=(Guid a, Guid b) => !EqualsCore(a, b);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe int HexsToChars<TChar>(TChar* guidChars, int a, int b) where TChar : unmanaged, IUtfChar<TChar>
         {
             guidChars[0] = TChar.CastFrom(HexConverter.ToCharLower(a >> 4));


### PR DESCRIPTION
To help mono cope with the genericized implementation.  This method is only used when Ssse3 or AdvSimd.Arm64 are not supported, or when formatting the rarely-used "X" format, but currently mono AOT without LLVM doesn't enable those intrinsics.

cc: @vargaz 