### PR TITLE
SPMI: Always add authenticated pip feed for test job runs

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -653,6 +653,7 @@ jobs:
         inputs:
           artifactFeeds: public/dotnet-public-pypi
           onlyAddExtraIndex: false
+        condition: always()
 
       # Ensure the Python azure-storage-blob package is installed before doing the upload.
       - script: $(PipScript) install --user --upgrade pip && $(PipScript) install --user azure.storage.blob==12.5.0 --force-reinstall


### PR DESCRIPTION
We always try to upload the collections for the tests, even on failures, so we should also add the authed feed on failures.

cc @dotnet/jit-contrib 