### PR TITLE
Fix physical promotion scenario name and a couple of bugs

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -583,8 +583,8 @@ jobs:
             - jitpartialcompilation
             - jitpartialcompilation_pgo
             - jitobjectstackallocation
-            - jitgeneralizedpromotion
-            - jitgeneralizedpromotion_full
+            - jitphysicalpromotion
+            - jitphysicalpromotion_full
 
         ${{ if in(parameters.testGroup, 'jit-cfg') }}:
           scenarios:

--- a/src/coreclr/jit/promotion.cpp
+++ b/src/coreclr/jit/promotion.cpp
@@ -1099,12 +1099,11 @@ public:
 
                 if (srcDsc->lvPromoted)
                 {
-                    unsigned   fieldLcl    = m_compiler->lvaGetFieldLocal(srcDsc, srcOffs);
-                    LclVarDsc* fieldLclDsc = m_compiler->lvaGetDesc(fieldLcl);
+                    unsigned fieldLcl = m_compiler->lvaGetFieldLocal(srcDsc, srcOffs);
 
-                    if (fieldLclDsc->lvType == rep->AccessType)
+                    if ((fieldLcl != BAD_VAR_NUM) && (m_compiler->lvaGetDesc(fieldLcl)->lvType == rep->AccessType))
                     {
-                        srcFld = m_compiler->gtNewLclvNode(fieldLcl, fieldLclDsc->lvType);
+                        srcFld = m_compiler->gtNewLclvNode(fieldLcl, rep->AccessType);
                     }
                 }
 
@@ -1300,6 +1299,11 @@ public:
                     // Overlap with last entry starting before offs.
                     firstIndex--;
                 }
+            }
+            else if (firstIndex >= replacements.size())
+            {
+                // Starts after last replacement ends.
+                return false;
             }
 
             const Replacement& first = replacements[firstIndex];

--- a/src/coreclr/jit/promotion.cpp
+++ b/src/coreclr/jit/promotion.cpp
@@ -1299,11 +1299,11 @@ public:
                     // Overlap with last entry starting before offs.
                     firstIndex--;
                 }
-            }
-            else if (firstIndex >= replacements.size())
-            {
-                // Starts after last replacement ends.
-                return false;
+                else if (firstIndex >= replacements.size())
+                {
+                    // Starts after last replacement ends.
+                    return false;
+                }
             }
 
             const Replacement& first = replacements[firstIndex];


### PR DESCRIPTION
This was renamed but I forgot to update these occurrences. The result is that runtime-jit-experimental is not actually running with physical promotion enabled (but the stress jobs do).

cc @dotnet/jit-contrib PTAL @AndyAyersMS 

Fix #85403