### PR TITLE
Directory.Build.props: don't overwrite PackageOS from source-build.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -207,7 +207,7 @@
 
     <!-- source-build sets PackageOS to build with non-portable rid packages that were source-built previously. -->
     <PackageRID Condition="'$(PackageOS)' != ''">$(PackageOS)-$(TargetArchitecture)</PackageRID>
-    <PackageRID>$(_packageOS)-$(TargetArchitecture)</PackageRID>
+    <PackageRID Condition="'$(PackageRID)' == ''">$(_packageOS)-$(TargetArchitecture)</PackageRID>
   </PropertyGroup>
 
   <!-- ToolsRID is used for packages needed on the build host. -->


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/pull/82832#issuecomment-1522292421.

@MichaelSimons @ViktorHofer ptal.