### PR TITLE
[wasm] Disable `Wasm.Build.Tests.Blazor.BuildPublishTests.BugRegression_60479_WithRazorClassLib`

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
@@ -174,7 +174,7 @@ public class BuildPublishTests : BuildTestBase
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/70762")]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/85354")]
     public void BugRegression_60479_WithRazorClassLib()
     {
         string id = $"blz_razor_lib_top_{Path.GetRandomFileName()}";

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
@@ -174,6 +174,7 @@ public class BuildPublishTests : BuildTestBase
     }
 
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/70762")]
     public void BugRegression_60479_WithRazorClassLib()
     {
         string id = $"blz_razor_lib_top_{Path.GetRandomFileName()}";


### PR DESCRIPTION
Reported in https://github.com/dotnet/runtime/issues/85354

It's needed only for webcil, but IMO we don't have a way to do it.