### PR TITLE
Make HelixPublishWithArcade Compliant With The TargetOS Lowercasing Policy

### DIFF
--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -84,7 +84,7 @@
 
       <_PropertiesToPass>
         TargetArchitecture=$(TargetArchitecture);
-        TargetOS=$(TargetOS);
+        TargetOS=$(TargetOS.ToLowerInvariant());
         Configuration=$(Configuration);
         Creator=$(_Creator);
         HelixAccessToken=$(_HelixAccessToken);


### PR DESCRIPTION
Fixes #81141. In PR #80164, the build scripts were updated to always require and/or convert the MSBuild `TargetOS` property to lowercase. However, the _helixpublishwitharcade.proj_ file was not included in these efforts, which led to some confusing behavior and misplaced files, as described in issue #81141. This PR addresses and fixes that.