### PR TITLE
Fix simd12_t size

### DIFF
--- a/src/coreclr/jit/simd.h
+++ b/src/coreclr/jit/simd.h
@@ -55,7 +55,7 @@ struct simd8_t
 };
 static_assert_no_msg(sizeof(simd8_t) == 8);
 
-#include "pshpack4.h"
+#include <pshpack4.h>
 struct simd12_t
 {
     union {

--- a/src/coreclr/jit/simd.h
+++ b/src/coreclr/jit/simd.h
@@ -53,7 +53,9 @@ struct simd8_t
         return {};
     }
 };
+static_assert_no_msg(sizeof(simd8_t) == 8);
 
+#include "pshpack4.h"
 struct simd12_t
 {
     union {
@@ -109,6 +111,8 @@ struct simd12_t
         return {};
     }
 };
+#include <poppack.h>
+static_assert_no_msg(sizeof(simd12_t) == 12);
 
 struct simd16_t
 {
@@ -161,6 +165,7 @@ struct simd16_t
         return {};
     }
 };
+static_assert_no_msg(sizeof(simd16_t) == 16);
 
 #if defined(TARGET_XARCH)
 struct simd32_t
@@ -215,6 +220,7 @@ struct simd32_t
         return {};
     }
 };
+static_assert_no_msg(sizeof(simd32_t) == 32);
 
 struct simd64_t
 {
@@ -269,6 +275,7 @@ struct simd64_t
         return {};
     }
 };
+static_assert_no_msg(sizeof(simd64_t) == 64);
 
 typedef simd64_t simd_t;
 #else


### PR DESCRIPTION
`sizeof(simd12_t)` used to return 16 - that could produce some garbage values in upper 4 bytes, e.g.:
```csharp
public Vector3 Test() => Vector3.Reflect(
    new Vector3(3.0f, 1.0f, 1.0f), 
    new Vector3(3.0f, 1.0f, 1.0f));
```
```diff
; Method Program:Test():System.Numerics.Vector3:this
G_M16498_IG01:
       vzeroupper 
						;; size=3 bbWeight=1 PerfScore 1.00

G_M16498_IG02:
       vmovups  xmm0, xmmword ptr [reloc @RWD00]
       vmovups  xmm1, xmmword ptr [reloc @RWD00]
       vdpps    xmm0, xmm0, xmm1, 127
       vmulps   xmm0, xmm0, xmm1
       vmovups  xmm1, xmmword ptr [reloc @RWD16]
       vmulps   xmm0, xmm0, xmm1
       vmovups  xmm1, xmmword ptr [reloc @RWD00]
       vsubps   xmm0, xmm1, xmm0
       vmovsd   qword ptr [rdx], xmm0
       vextractps dword ptr [rdx+08H], xmm0, 2
       mov      rax, rdx
						;; size=64 bbWeight=1 PerfScore 39.25

G_M16498_IG03:
       ret      
						;; size=1 bbWeight=1 PerfScore 1.00
-RWD00  	dq	3F80000040400000h, DDDDDDDD3F800000h
+RWD00  	dq	3F80000040400000h, 000000003F800000h
-RWD16  	dq	4000000040000000h, DDDDDDDD40000000h
+RWD16  	dq	4000000040000000h, 0000000040000000h
; Total bytes of code: 68
```

so I applied the #include "pshpack4.h" fix @tannergooding suggested