### PR TITLE
[LoongArch64] Implements the emitter::emitDispIns.

### DIFF
--- a/src/coreclr/jit/emitloongarch64.cpp
+++ b/src/coreclr/jit/emitloongarch64.cpp
@@ -2652,8 +2652,8 @@ void emitter::emitJumpDistBind()
     }
     if (EMIT_INSTLIST_VERBOSE)
     {
-        printf("\nInstruction list before jump distance binding:(LA64 don't supports)\n\n");
-        // emitDispIGlist(true);
+        printf("\nInstruction list before jump distance binding:\n\n");
+        emitDispIGlist(true);
     }
 #endif
 
@@ -5949,7 +5949,7 @@ void emitter::emitDispInsHex(instrDesc* id, BYTE* code, size_t sz)
 /*****************************************************************************
  *
  * For LoongArch64, the `emitter::emitDispIns` only supports
- * the `COMPlus_JitDump` and `DOTNET_JitDump`.
+ * the `DOTNET_JitDump`.
  */
 void emitter::emitDispIns(
     instrDesc* id, bool isNew, bool doffs, bool asmfm, unsigned offset, BYTE* pCode, size_t sz, insGroup* ig)
@@ -5958,7 +5958,7 @@ void emitter::emitDispIns(
     {
         BYTE* addr = emitCodeBlock + offset + writeableOffset;
 
-        unsigned int size = id->idCodeSize();
+        int size = id->idCodeSize();
         while (size > 0)
         {
             emitDisInsName(*(code_t*)addr, addr, id);

--- a/src/coreclr/jit/emitloongarch64.cpp
+++ b/src/coreclr/jit/emitloongarch64.cpp
@@ -2661,8 +2661,8 @@ void emitter::emitJumpDistBind()
     }
     if (EMIT_INSTLIST_VERBOSE)
     {
-        printf("\nInstruction list before jump distance binding:\n\n");
-        emitDispIGlist(true);
+        printf("\nInstruction list before jump distance binding:(LA64 don't supports)\n\n");
+        // emitDispIGlist(true);
     }
 #endif
 

--- a/src/coreclr/jit/emitloongarch64.cpp
+++ b/src/coreclr/jit/emitloongarch64.cpp
@@ -5960,13 +5960,26 @@ void emitter::emitDispInsHex(instrDesc* id, BYTE* code, size_t sz)
     }
 }
 
+/*****************************************************************************
+ *
+ * For LoongArch64, the `emitter::emitDispIns` only supports
+ * the `COMPlus_JitDump` and `DOTNET_JitDump`.
+ */
 void emitter::emitDispIns(
     instrDesc* id, bool isNew, bool doffs, bool asmfm, unsigned offset, BYTE* pCode, size_t sz, insGroup* ig)
 {
-    // LA implements this similar by `emitter::emitDisInsName`.
-    // For LA maybe the `emitDispIns` is over complicate.
-    // The `emitter::emitDisInsName` is focused on the most important for debugging.
-    NYI_LOONGARCH64("LA not used the emitter::emitDispIns");
+    if (ig)
+    {
+        BYTE* addr = emitCodeBlock + offset + writeableOffset;
+
+        unsigned int size = id->idCodeSize();
+        while (size > 0)
+        {
+            emitDisInsName(*(code_t*)addr, addr, id);
+            addr += 4;
+            size -= 4;
+        }
+    }
 }
 
 /*****************************************************************************

--- a/src/coreclr/jit/emitloongarch64.h
+++ b/src/coreclr/jit/emitloongarch64.h
@@ -20,14 +20,9 @@ struct CnsVal
 };
 
 #ifdef DEBUG
-
 /************************************************************************/
 /*             Debug-only routines to display instructions              */
 /************************************************************************/
-
-const char* emitFPregName(unsigned reg, bool varName = true);
-const char* emitVectorRegName(regNumber reg);
-
 void emitDisInsName(code_t code, const BYTE* addr, instrDesc* id);
 #endif // DEBUG
 


### PR DESCRIPTION
This PR is part of the issue https://github.com/dotnet/runtime/issues/69705 to amend the LA's port.

Implements the emitter::emitDispIns for LoongArch64
.