### PR TITLE
Delete support for IAT indirecting base type/interfaces

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/DispatchResolve.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/DispatchResolve.cs
@@ -182,7 +182,7 @@ namespace System.Runtime
                 if (i->_usInterfaceMethodSlot == itfSlotNumber)
                 {
                     MethodTable* pCurEntryType =
-                        pTgtType->InterfaceMap[i->_usInterfaceIndex].InterfaceType;
+                        pTgtType->InterfaceMap[i->_usInterfaceIndex];
 
                     if (pCurEntryType == pItfType)
                     {
@@ -250,7 +250,7 @@ namespace System.Runtime
             {
                 StaticVirtualMethodContextSource.None => null,
                 StaticVirtualMethodContextSource.ContextFromThisClass => pTgtType,
-                _ => pTgtType->InterfaceMap[usEncodedValue - StaticVirtualMethodContextSource.ContextFromFirstInterface].InterfaceType
+                _ => pTgtType->InterfaceMap[usEncodedValue - StaticVirtualMethodContextSource.ContextFromFirstInterface]
             };
         }
     }

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/MethodTable.Runtime.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/MethodTable.Runtime.cs
@@ -46,7 +46,7 @@ namespace Internal.Runtime
         }
 
         /// <summary>
-        /// Return true if type is good for simple casting : canonical, no related type via IAT, no generic variance
+        /// Return true if type is good for simple casting : canonical, no generic variance
         /// </summary>
         internal bool SimpleCasting()
         {

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
@@ -55,7 +55,7 @@ namespace System.Runtime
             Debug.Assert(!pTargetType->IsFunctionPointerType, "IsInstanceOfClass called with function pointer MethodTable");
             Debug.Assert(!pTargetType->IsInterface, "IsInstanceOfClass called with interface MethodTable");
 
-            // Quick check if both types are good for simple casting: canonical, no related type via IAT, no generic variance
+            // Quick check if both types are good for simple casting: canonical, no generic variance
             if (Internal.Runtime.MethodTable.BothSimpleCasting(pObjType, pTargetType))
             {
                 // walk the type hierarchy looking for a match
@@ -256,10 +256,10 @@ namespace System.Runtime
             Debug.Assert(pTargetType->IsInterface, "IsInstanceOfInterface called with non-interface MethodTable");
 
             int numInterfaces = pObjType->NumInterfaces;
-            EEInterfaceInfo* interfaceMap = pObjType->InterfaceMap;
+            MethodTable** interfaceMap = pObjType->InterfaceMap;
             for (int i = 0; i < numInterfaces; i++)
             {
-                MethodTable* pInterfaceType = interfaceMap[i].InterfaceType;
+                MethodTable* pInterfaceType = interfaceMap[i];
                 if (pInterfaceType == pTargetType)
                 {
                     return true;
@@ -287,7 +287,7 @@ namespace System.Runtime
 
                 for (int i = 0; i < numInterfaces; i++)
                 {
-                    MethodTable* pInterfaceType = interfaceMap[i].InterfaceType;
+                    MethodTable* pInterfaceType = interfaceMap[i];
 
                     // We can ignore interfaces which are not also marked as having generic variance
                     // unless we're dealing with array covariance.

--- a/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
+++ b/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
@@ -76,7 +76,7 @@ struct DotNetRuntimeDebugHeader
     // This counter can be incremented to indicate breaking changes
     // This field must be encoded little endian, regardless of the typical endianness of
     // the machine
-    const uint16_t MajorVersion = 2;
+    const uint16_t MajorVersion = 3;
 
     // This counter can be incremented to indicate back-compatible changes
     // This field must be encoded little endian, regardless of the typical endianness of
@@ -201,11 +201,7 @@ extern "C" void PopulateDebugHeaders()
     MAKE_DEBUG_FIELD_ENTRY(MethodTable, m_usComponentSize);
     MAKE_DEBUG_FIELD_ENTRY(MethodTable, m_uFlags);
     MAKE_DEBUG_ENTRY(MethodTable, m_pBaseType, offsetof(MethodTable, m_RelatedType) + offsetof(MethodTable::RelatedTypeUnion, m_pBaseType));
-    MAKE_DEBUG_ENTRY(MethodTable, m_ppBaseTypeViaIAT, offsetof(MethodTable, m_RelatedType) + offsetof(MethodTable::RelatedTypeUnion, m_ppBaseTypeViaIAT));
-    MAKE_DEBUG_ENTRY(MethodTable, m_pCanonicalType, offsetof(MethodTable, m_RelatedType) + offsetof(MethodTable::RelatedTypeUnion, m_pCanonicalType));
-    MAKE_DEBUG_ENTRY(MethodTable, m_ppCanonicalTypeViaIAT, offsetof(MethodTable, m_RelatedType) + offsetof(MethodTable::RelatedTypeUnion, m_ppCanonicalTypeViaIAT));
     MAKE_DEBUG_ENTRY(MethodTable, m_pRelatedParameterType, offsetof(MethodTable, m_RelatedType) + offsetof(MethodTable::RelatedTypeUnion, m_pRelatedParameterType));
-    MAKE_DEBUG_ENTRY(MethodTable, m_ppRelatedParameterTypeViaIAT, offsetof(MethodTable, m_RelatedType) + offsetof(MethodTable::RelatedTypeUnion, m_ppRelatedParameterTypeViaIAT));
     MAKE_DEBUG_FIELD_ENTRY(MethodTable, m_VTable);
 
     MAKE_SIZE_ENTRY(StressLog);

--- a/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
+++ b/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
@@ -270,7 +270,6 @@ extern "C" void PopulateDebugHeaders()
     DotNetRuntimeDebugHeader.GlobalEntries = &s_GlobalEntries;
 
     static_assert(MethodTable::Flags::EETypeKindMask         == 0x00030000, "The debugging data contract has a hard coded dependency on this value of MethodTable::Flags. If you change this value you must bump major_version_number.");
-    static_assert(MethodTable::Flags::RelatedTypeViaIATFlag  == 0x00040000, "The debugging data contract has a hard coded dependency on this value of MethodTable::Flags. If you change this value you must bump major_version_number.");
     static_assert(MethodTable::Flags::HasFinalizerFlag       == 0x00100000, "The debugging data contract has a hard coded dependency on this value of MethodTable::Flags. If you change this value you must bump major_version_number.");
     static_assert(MethodTable::Flags::HasPointersFlag        == 0x00200000, "The debugging data contract has a hard coded dependency on this value of MethodTable::Flags. If you change this value you must bump major_version_number.");
     static_assert(MethodTable::Flags::GenericVarianceFlag    == 0x00800000, "The debugging data contract has a hard coded dependency on this value of MethodTable::Flags. If you change this value you must bump major_version_number.");

--- a/src/coreclr/nativeaot/Runtime/MethodTable.cpp
+++ b/src/coreclr/nativeaot/Runtime/MethodTable.cpp
@@ -42,8 +42,7 @@ bool MethodTable::Validate(bool assertOnFail /* default: true */)
         // If the parent type is NULL this had better look like Object.
         if (!IsInterface() && (m_RelatedType.m_pBaseType == NULL))
         {
-            if (IsRelatedTypeViaIAT() ||
-                get_IsValueType() ||
+            if (get_IsValueType() ||
                 HasFinalizer() ||
                 HasReferenceFields() ||
                 HasGenericVariance())
@@ -104,8 +103,5 @@ MethodTable * MethodTable::get_RelatedParameterType()
 {
 	ASSERT(IsParameterizedType());
 
-	if (IsRelatedTypeViaIAT())
-		return *PTR_PTR_EEType(reinterpret_cast<TADDR>(m_RelatedType.m_ppRelatedParameterTypeViaIAT));
-	else
-		return PTR_EEType(reinterpret_cast<TADDR>(m_RelatedType.m_pRelatedParameterType));
+	return PTR_EEType(reinterpret_cast<TADDR>(m_RelatedType.m_pRelatedParameterType));
 }

--- a/src/coreclr/nativeaot/Runtime/forward_declarations.h
+++ b/src/coreclr/nativeaot/Runtime/forward_declarations.h
@@ -47,6 +47,5 @@ namespace rh {
 #endif // FEATURE_RWX_MEMORY
 
 // inc
-FWD_DECL(EEInterfaceInfo)
 FWD_DECL(MethodTable)
 

--- a/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
+++ b/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
@@ -18,27 +18,6 @@ struct EETypeRef;
 #endif
 
 //-------------------------------------------------------------------------------------------------
-// Array of these represents the interfaces implemented by a type
-
-class EEInterfaceInfo
-{
-  public:
-    MethodTable * GetInterfaceEEType()
-    {
-        return ((UIntTarget)m_pInterfaceEEType & ((UIntTarget)1)) ?
-               *(MethodTable**)((UIntTarget)m_ppInterfaceEETypeViaIAT & ~((UIntTarget)1)) :
-               m_pInterfaceEEType;
-    }
-
-  private:
-    union
-    {
-        MethodTable *    m_pInterfaceEEType;         // m_uFlags == InterfaceFlagNormal
-        MethodTable **   m_ppInterfaceEETypeViaIAT;  // m_uFlags == InterfaceViaIATFlag
-    };
-};
-
-//-------------------------------------------------------------------------------------------------
 // The subset of TypeFlags that Redhawk knows about at runtime
 // This should match the TypeFlags enum in the managed type system.
 enum EETypeElementType : uint8_t
@@ -148,7 +127,7 @@ private:
     TgtPTR_Void         m_VTable[];  // make this explicit so the binder gets the right alignment
 
     // after the m_usNumVtableSlots vtable slots, we have m_usNumInterfaces slots of
-    // EEInterfaceInfo, and after that a couple of additional pointers based on whether the type is
+    // MethodTable*, and after that a couple of additional pointers based on whether the type is
     // finalizable (the address of the finalizer code) or has optional fields (pointer to the compacted
     // fields).
 
@@ -159,11 +138,7 @@ private:
         // simplified version of MethodTable. See LimitedEEType definition below.
         EETypeKindMask = 0x00030000,
 
-        // This flag is set when m_pRelatedType is in a different module.  In that case, m_pRelatedType
-        // actually points to a 'fake' MethodTable whose m_pRelatedType field lines up with an IAT slot in this
-        // module, which then points to the desired MethodTable.  In other words, there is an extra indirection
-        // through m_pRelatedType to get to the related type in the other module.
-        RelatedTypeViaIATFlag   = 0x00040000,
+        // Unused = 0x00040000,
 
         IsDynamicTypeFlag       = 0x00080000,
 
@@ -216,9 +191,6 @@ public:
     PTR_PTR_Code get_SlotPtr(uint16_t slotNumber);
 
     Kinds get_Kind();
-
-    bool IsRelatedTypeViaIAT()
-        { return (m_uFlags & RelatedTypeViaIATFlag) != 0; }
 
     bool IsArray()
     {

--- a/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
+++ b/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
@@ -98,15 +98,9 @@ private:
         {
             // Kinds.CanonicalEEType
             MethodTable*     m_pBaseType;
-            MethodTable**    m_ppBaseTypeViaIAT;
-
-            // Kinds.ClonedEEType
-            MethodTable** m_pCanonicalType;
-            MethodTable** m_ppCanonicalTypeViaIAT;
 
             // Kinds.ParameterizedEEType
             MethodTable*  m_pRelatedParameterType;
-            MethodTable** m_ppRelatedParameterTypeViaIAT;
         };
     };
 

--- a/src/coreclr/nativeaot/Runtime/inc/MethodTable.inl
+++ b/src/coreclr/nativeaot/Runtime/inc/MethodTable.inl
@@ -60,10 +60,7 @@ inline bool MethodTable::DacVerifyWorker(MethodTable* pThis)
         // Now on to the next type in the hierarchy.
         //
 
-        if (pCurrentType->IsRelatedTypeViaIAT())
-            pCurrentType = *dac_cast<PTR_PTR_EEType>(reinterpret_cast<TADDR>(pCurrentType->m_RelatedType.m_ppBaseTypeViaIAT));
-        else
-            pCurrentType = dac_cast<PTR_EEType>(reinterpret_cast<TADDR>(pCurrentType->m_RelatedType.m_pBaseType));
+        pCurrentType = dac_cast<PTR_EEType>(reinterpret_cast<TADDR>(pCurrentType->m_RelatedType.m_pBaseType));
 
         if (pCurrentType == NULL)
             break;
@@ -115,7 +112,7 @@ __forceinline uint32_t MethodTable::GetFieldOffset(EETypeField eField)
         ASSERT(GetNumInterfaces() > 0);
         return cbOffset;
     }
-    cbOffset += sizeof(EEInterfaceInfo) * GetNumInterfaces();
+    cbOffset += sizeof(MethodTable*) * GetNumInterfaces();
 
     const uint32_t relativeOrFullPointerOffset =
 #if USE_PORTABLE_HELPERS

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/SharedCodeHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/SharedCodeHelpers.cs
@@ -13,7 +13,7 @@ namespace Internal.Runtime.CompilerHelpers
         public static unsafe MethodTable* GetOrdinalInterface(MethodTable* pType, ushort interfaceIndex)
         {
             Debug.Assert(interfaceIndex <= pType->NumInterfaces);
-            return pType->InterfaceMap[interfaceIndex].InterfaceType;
+            return pType->InterfaceMap[interfaceIndex];
         }
 
         public static unsafe MethodTable* GetCurrentSharedThunkContext()

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/EETypePtr.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/EETypePtr.cs
@@ -444,7 +444,7 @@ namespace System
                 {
                     Debug.Assert((uint)index < _value->NumInterfaces);
 
-                    return new EETypePtr(_value->InterfaceMap[index].InterfaceType);
+                    return new EETypePtr(_value->InterfaceMap[index]);
                 }
             }
         }

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -53,7 +53,7 @@ namespace Internal.Runtime.TypeLoader
 
         public static unsafe void SetInterface(this RuntimeTypeHandle rtth, int interfaceIndex, RuntimeTypeHandle interfaceType)
         {
-            rtth.ToEETypePtr()->InterfaceMap[interfaceIndex].InterfaceType = interfaceType.ToEETypePtr();
+            rtth.ToEETypePtr()->InterfaceMap[interfaceIndex] = interfaceType.ToEETypePtr();
         }
 
         public static unsafe void SetGenericDefinition(this RuntimeTypeHandle rtth, RuntimeTypeHandle genericDefinitionHandle)

--- a/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
@@ -16,15 +16,7 @@ namespace Internal.Runtime
         /// </summary>
         EETypeKindMask = 0x00030000,
 
-        /// <summary>
-        /// This flag is set when m_RelatedType is in a different module.  In that case, _pRelatedType
-        /// actually points to an IAT slot in this module, which then points to the desired MethodTable in the
-        /// other module.  In other words, there is an extra indirection through m_RelatedType to get to
-        /// the related type in the other module.  When this flag is set, it is expected that you use the
-        /// "_ppXxxxViaIAT" member of the RelatedTypeUnion for the particular related type you're
-        /// accessing.
-        /// </summary>
-        RelatedTypeViaIATFlag = 0x00040000,
+        // Unused = 0x00040000,
 
         /// <summary>
         /// This type was dynamically allocated at runtime.
@@ -71,7 +63,7 @@ namespace Internal.Runtime
         /// <summary>
         /// Single mark to check TypeKind and two flags. When non-zero, casting is more complicated.
         /// </summary>
-        ComplexCastingMask = EETypeKindMask | RelatedTypeViaIATFlag | GenericVarianceFlag,
+        ComplexCastingMask = EETypeKindMask | GenericVarianceFlag,
 
         /// <summary>
         /// The _usComponentSize is a number (not holding FlagsEx).

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -738,16 +738,6 @@ namespace ILCompiler.DependencyAnalysis
                 flags |= (uint)EETypeFlags.IDynamicInterfaceCastableFlag;
             }
 
-            ISymbolNode relatedTypeNode = GetRelatedTypeNode(factory);
-
-            // If the related type (base type / array element type / pointee type) is not part of this compilation group, and
-            // the output binaries will be multi-file (not multiple object files linked together), indicate to the runtime
-            // that it should indirect through the import address table
-            if (relatedTypeNode != null && relatedTypeNode.RepresentsIndirectionCell)
-            {
-                flags |= (uint)EETypeFlags.RelatedTypeViaIATFlag;
-            }
-
             if (HasOptionalFields)
             {
                 flags |= (uint)EETypeFlags.OptionalFieldsFlag;
@@ -1074,7 +1064,7 @@ namespace ILCompiler.DependencyAnalysis
 
             foreach (var itf in _type.RuntimeInterfaces)
             {
-                objData.EmitPointerRelocOrIndirectionReference(GetInterfaceTypeNode(factory, itf));
+                objData.EmitPointerReloc(GetInterfaceTypeNode(factory, itf));
             }
         }
 


### PR DESCRIPTION
This is used if we have a SharedLibrary.dll a la .NET Native where a base type/interface of a type could live in a different DLL (e.g. `System.Object`).

SharedLibrary.dll model had a lot of problems around versioning and a "framework-dependent" deployment model like that is unlikely to come back. I think we can start to slowly get rid of and get marginally faster code and less maintenance cost in return.

Cc @dotnet/ilc-contrib 