### PR TITLE
TarEntry: remove some unneeded checks when extracting symbolic and hard links.

### DIFF
--- a/src/libraries/Common/src/System/IO/Archiving.Utils.Unix.cs
+++ b/src/libraries/Common/src/System/IO/Archiving.Utils.Unix.cs
@@ -5,7 +5,9 @@ namespace System.IO
 {
     internal static partial class ArchivingUtils
     {
-        internal static string SanitizeEntryFilePath(string entryPath) => entryPath.Replace('\0', '_');
+#pragma warning disable IDE0060
+        internal static string SanitizeEntryFilePath(string entryPath, bool preserveDriveRoot = false) => entryPath.Replace('\0', '_');
+#pragma warning restore IDE0060
 
         public static unsafe string EntryFromPath(ReadOnlySpan<char> path, bool appendPathSeparator = false)
         {

--- a/src/libraries/Common/src/System/IO/Archiving.Utils.Unix.cs
+++ b/src/libraries/Common/src/System/IO/Archiving.Utils.Unix.cs
@@ -5,7 +5,7 @@ namespace System.IO
 {
     internal static partial class ArchivingUtils
     {
-#pragma warning disable IDE0060
+#pragma warning disable IDE0060 // preserveDriveRoot is unused.
         internal static string SanitizeEntryFilePath(string entryPath, bool preserveDriveRoot = false) => entryPath.Replace('\0', '_');
 #pragma warning restore IDE0060
 

--- a/src/libraries/Common/src/System/IO/Archiving.Utils.Windows.cs
+++ b/src/libraries/Common/src/System/IO/Archiving.Utils.Windows.cs
@@ -13,15 +13,23 @@ namespace System.IO
             "\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F" +
             "\"*:<>?|");
 
-        internal static string SanitizeEntryFilePath(string entryPath)
+        internal static string SanitizeEntryFilePath(string entryPath, bool preserveDriveRoot = false)
         {
+            // When preserveDriveRoot is set, preserve the colon in 'c:\'.
+            int offset = 0;
+            if (preserveDriveRoot && entryPath.Length >= 3 && entryPath[1] == ':' && Path.IsPathFullyQualified(entryPath))
+            {
+                offset = 3;
+            }
+
             // Find the first illegal character in the entry path.
-            int i = entryPath.AsSpan().IndexOfAny(s_illegalChars);
+            int i = entryPath.AsSpan(offset).IndexOfAny(s_illegalChars);
             if (i < 0)
             {
                 // There weren't any characters to sanitize.  Just return the original string.
                 return entryPath;
             }
+            i += offset;
 
             // We found at least one character that needs to be replaced.
             return string.Create(entryPath.Length, (i, entryPath), static (dest, state) =>

--- a/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
+++ b/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
@@ -160,12 +160,6 @@
   <data name="TarGnuFormatExpected" xml:space="preserve">
     <value>Entry '{0}' was expected to be in the GNU format, but did not have the expected version data.</value>
   </data>
-  <data name="TarHardLinkTargetNotExists" xml:space="preserve">
-    <value>Cannot create a hard link '{0}' because the specified target file '{1}' does not exist.</value>
-  </data>
-  <data name="TarHardLinkToDirectoryNotAllowed" xml:space="preserve">
-    <value>Cannot create the hard link '{0}' targeting the directory '{1}'.</value>
-  </data>
   <data name="TarInvalidFormat" xml:space="preserve">
     <value>The archive format is invalid: '{0}'</value>
   </data>
@@ -177,9 +171,6 @@
   </data>
   <data name="TarSizeFieldTooLargeForEntryType" xml:space="preserve">
     <value>The value of the size field for the current entry of type '{0}' is greater than the expected length.</value>
-  </data>
-  <data name="TarSymbolicLinkTargetNotExists" xml:space="preserve">
-    <value>Cannot create the symbolic link '{0}' because the specified target '{1}' does not exist.</value>
   </data>
   <data name="TarUnexpectedMetadataEntry" xml:space="preserve">
     <value>A metadata entry of type '{0}' was unexpectedly found after a metadata entry of type '{1}'.</value>

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -330,7 +330,7 @@ namespace System.Formats.Tar
             Debug.Assert(!string.IsNullOrEmpty(destinationDirectoryPath));
             Debug.Assert(Path.IsPathFullyQualified(destinationDirectoryPath));
 
-            string name = ArchivingUtils.SanitizeEntryFilePath(Name);
+            string name = ArchivingUtils.SanitizeEntryFilePath(Name, preserveDriveRoot: true);
             string? fileDestinationPath = GetFullDestinationPath(
                                                 destinationDirectoryPath,
                                                 Path.IsPathFullyQualified(name) ? name : Path.Join(Path.GetDirectoryName(destinationDirectoryPath), name));
@@ -339,7 +339,7 @@ namespace System.Formats.Tar
                 throw new IOException(SR.Format(SR.TarExtractingResultsFileOutside, name, destinationDirectoryPath));
             }
 
-            string linkName = ArchivingUtils.SanitizeEntryFilePath(LinkName);
+            string linkName = ArchivingUtils.SanitizeEntryFilePath(LinkName, preserveDriveRoot: true);
             string? linkTargetPath = null;
             if (EntryType is TarEntryType.SymbolicLink)
             {

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -339,10 +339,11 @@ namespace System.Formats.Tar
                 throw new IOException(SR.Format(SR.TarExtractingResultsFileOutside, name, destinationDirectoryPath));
             }
 
-            string linkName = ArchivingUtils.SanitizeEntryFilePath(LinkName, preserveDriveRoot: true);
             string? linkTargetPath = null;
             if (EntryType is TarEntryType.SymbolicLink)
             {
+                // LinkName is an absolute path, or path relative to the fileDestinationPath directory.
+                string linkName = ArchivingUtils.SanitizeEntryFilePath(LinkName, preserveDriveRoot: true);
                 if (linkName.Length == 0)
                 {
                     throw new InvalidDataException(SR.TarEntryHardLinkOrSymlinkLinkNameEmpty);
@@ -360,6 +361,8 @@ namespace System.Formats.Tar
             }
             else if (EntryType is TarEntryType.HardLink)
             {
+                // LinkName is path relative to the destinationDirectoryPath.
+                string linkName = ArchivingUtils.SanitizeEntryFilePath(LinkName, preserveDriveRoot: false);
                 if (linkName.Length == 0)
                 {
                     throw new InvalidDataException(SR.TarEntryHardLinkOrSymlinkLinkNameEmpty);

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarFile.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarFile.cs
@@ -185,6 +185,7 @@ namespace System.Formats.Tar
 
             // Rely on Path.GetFullPath for validation of paths
             destinationDirectoryName = Path.GetFullPath(destinationDirectoryName);
+            destinationDirectoryName = PathInternal.EnsureTrailingSeparator(destinationDirectoryName);
 
             ExtractToDirectoryInternal(source, destinationDirectoryName, overwriteFiles, leaveOpen: true);
         }
@@ -229,6 +230,7 @@ namespace System.Formats.Tar
 
             // Rely on Path.GetFullPath for validation of paths
             destinationDirectoryName = Path.GetFullPath(destinationDirectoryName);
+            destinationDirectoryName = PathInternal.EnsureTrailingSeparator(destinationDirectoryName);
 
             return ExtractToDirectoryInternalAsync(source, destinationDirectoryName, overwriteFiles, leaveOpen: true, cancellationToken);
         }
@@ -257,6 +259,7 @@ namespace System.Formats.Tar
             // Rely on Path.GetFullPath for validation of paths
             sourceFileName = Path.GetFullPath(sourceFileName);
             destinationDirectoryName = Path.GetFullPath(destinationDirectoryName);
+            destinationDirectoryName = PathInternal.EnsureTrailingSeparator(destinationDirectoryName);
 
             if (!File.Exists(sourceFileName))
             {
@@ -303,6 +306,7 @@ namespace System.Formats.Tar
             // Rely on Path.GetFullPath for validation of paths
             sourceFileName = Path.GetFullPath(sourceFileName);
             destinationDirectoryName = Path.GetFullPath(destinationDirectoryName);
+            destinationDirectoryName = PathInternal.EnsureTrailingSeparator(destinationDirectoryName);
 
             if (!File.Exists(sourceFileName))
             {

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectory.File.Roundtrip.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectory.File.Roundtrip.cs
@@ -73,7 +73,7 @@ namespace System.Formats.Tar.Tests
             using FileStream archiveStream = File.OpenRead(destinationArchive);
             Exception exception = Assert.Throws<IOException>(() => TarFile.ExtractToDirectory(archiveStream, destinationDirectoryName, overwriteFiles: true));
 
-            Assert.Equal(SR.Format(SR.TarExtractingResultsLinkOutside, symlinkTargetPath, destinationDirectoryName), exception.Message);
+            Assert.Equal(SR.Format(SR.TarExtractingResultsLinkOutside, symlinkTargetPath, $"{destinationDirectoryName}{Path.DirectorySeparatorChar}"), exception.Message);
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectoryAsync.File.Roundtrip.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectoryAsync.File.Roundtrip.cs
@@ -74,7 +74,7 @@ namespace System.Formats.Tar.Tests
             using FileStream archiveStream = File.OpenRead(destinationArchive);
             Exception exception = await Assert.ThrowsAsync<IOException>(() => TarFile.ExtractToDirectoryAsync(archiveStream, destinationDirectoryName, overwriteFiles: true));
 
-            Assert.Equal(SR.Format(SR.TarExtractingResultsLinkOutside, symlinkTargetPath, destinationDirectoryName), exception.Message);
+            Assert.Equal(SR.Format(SR.TarExtractingResultsLinkOutside, symlinkTargetPath, $"{destinationDirectoryName}{Path.DirectorySeparatorChar}"), exception.Message);
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
@@ -318,5 +318,34 @@ namespace System.Formats.Tar.Tests
             Assert.True(File.Exists(filePath), $"{filePath}' does not exist.");
             AssertFileModeEquals(filePath, TestPermission1);
         }
+
+        [Fact]
+        public async Task LinkBeforeTargetAsync()
+        {
+            using TempDirectory source = new TempDirectory();
+            using TempDirectory destination = new TempDirectory();
+
+            string archivePath = Path.Join(source.Path, "archive.tar");
+            using FileStream archiveStream = File.Create(archivePath);
+            using (TarWriter writer = new TarWriter(archiveStream))
+            {
+                PaxTarEntry link = new PaxTarEntry(TarEntryType.SymbolicLink, "link");
+                link.LinkName = "dir/file";
+                writer.WriteEntry(link);
+
+                PaxTarEntry file = new PaxTarEntry(TarEntryType.RegularFile, "dir/file");
+                writer.WriteEntry(file);
+            }
+
+            string filePath = Path.Join(destination.Path, "dir", "file");
+            string linkPath = Path.Join(destination.Path, "link");
+
+            File.WriteAllText(linkPath, "");
+
+            await TarFile.ExtractToDirectoryAsync(archivePath, destination.Path, overwriteFiles: true);
+
+            Assert.True(File.Exists(filePath), $"{filePath}' does not exist.");
+            Assert.True(File.Exists(linkPath), $"{linkPath}' does not exist.");
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/78695.

@dotnet/area-system-io ptal.