### PR TITLE
[NodeJS] Enable wasm exception handling for unit tests

### DIFF
--- a/eng/testing/WasmRunnerAOTTemplate.sh
+++ b/eng/testing/WasmRunnerAOTTemplate.sh
@@ -35,7 +35,7 @@ fi
 
 if [[ "$XHARNESS_COMMAND" == "test" ]]; then
 	if [[ -z "$JS_ENGINE_ARGS" ]]; then
-		JS_ENGINE_ARGS="--engine-arg=--stack-trace-limit=1000"
+		JS_ENGINE_ARGS="--engine-arg=--stack-trace-limit=1000 --engine-arg=--experimental-wasm-eh"
 	fi
 
 	if [[ -z "$JS_ENGINE" ]]; then

--- a/eng/testing/WasmRunnerTemplate.cmd
+++ b/eng/testing/WasmRunnerTemplate.cmd
@@ -45,7 +45,7 @@ if /I [%XHARNESS_COMMAND%] == [test] (
     )
 
     if [%JS_ENGINE_ARGS%] == [] (
-        set "JS_ENGINE_ARGS=--engine-arg^=--stack-trace-limit^=1000"
+        set "JS_ENGINE_ARGS=--engine-arg^=--stack-trace-limit^=1000 --engine-arg^=--experimental-wasm-eh"
     )
 ) else (
     if [%BROWSER_PATH%] == [] if not [%HELIX_CORRELATION_PAYLOAD%] == [] (

--- a/eng/testing/WasmRunnerTemplate.sh
+++ b/eng/testing/WasmRunnerTemplate.sh
@@ -47,7 +47,7 @@ if [[ "$XHARNESS_COMMAND" == "test" ]]; then
 	fi
 
 	if [[ -z "$JS_ENGINE_ARGS" ]]; then
-		JS_ENGINE_ARGS="--engine-arg=--stack-trace-limit=1000"
+		JS_ENGINE_ARGS="--engine-arg=--stack-trace-limit=1000 --engine-arg=--experimental-wasm-eh"
 	fi
 fi
 


### PR DESCRIPTION
In order to fix [Log](https://helixre107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-pull-85313-merge-636fc6d7697e4497a1/WasmTestOnNodeJS-System.Runtime.InteropServices.JavaScript.Tests/1/console.4f7489fb.log?helixlogtype=result)

```
CompileError: WebAssembly.instantiate(): unexpected section <Tag> (enable with --experimental-wasm-eh) @+16822
```

@radekdoulik do we need to do something about console host and the template too ?