### PR TITLE
[Wasm.Build.Tests] Fixup wildcard matching for runtime packs (take two)

### DIFF
--- a/eng/testing/tests.browser.targets
+++ b/eng/testing/tests.browser.targets
@@ -286,6 +286,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <_RuntimePackNugetAvailable Include="$(LibrariesShippingPackagesDir)Microsoft.NETCore.App.Runtime.Mono.$(RuntimeIdentifier).*$(PackageVersionForWorkloadManifests).nupkg" />
       <_RuntimePackNugetAvailable Include="$(LibrariesShippingPackagesDir)Microsoft.NETCore.App.Runtime.Mono.*.$(RuntimeIdentifier).*$(PackageVersionForWorkloadManifests).nupkg" />
       <_RuntimePackNugetAvailable Remove="@(_RuntimePackNugetAvailable)" Condition="$([System.String]::new('%(_RuntimePackNugetAvailable.FileName)').EndsWith('.symbols'))" />
     </ItemGroup>


### PR DESCRIPTION
Try to fix [Log](https://dev.azure.com/dnceng-public/public/_build/results?buildId=252978&view=logs&j=1fa93050-f528-55d3-a351-f8bf9ce5adbf&t=d9dc6d3d-3442-5b70-1296-5b62e29ea209)

```
/__w/1/s/eng/testing/tests.browser.targets(293,5): 
error : Expected to find either one or three in /__w/1/s/artifacts/packages/Release/Shipping/:  
[/__w/1/s/src/mono/wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj]
##[error]eng/testing/tests.browser.targets(293,5): error : (NETCORE_ENGINEERING_TELEMETRY=Build) Expected to find either one or three in /__w/1/s/artifacts/packages/Release/Shipping/: 
```

After https://github.com/dotnet/runtime/pull/85286