### PR TITLE
[release/6.0] Fix createdump arg parsing for signal-based exceptions

### DIFF
--- a/src/coreclr/debug/createdump/createdump.h
+++ b/src/coreclr/debug/createdump/createdump.h
@@ -103,7 +103,7 @@ typedef struct
     int Pid;
     int CrashThread;
     int Signal;
-#if defined(HOST_UNIX) && !defined(HOST_OSX)
+#if defined(HOST_UNIX)
     int SignalCode;
     int SignalErrno;
     void* SignalAddress;

--- a/src/coreclr/debug/createdump/main.cpp
+++ b/src/coreclr/debug/createdump/main.cpp
@@ -54,7 +54,7 @@ int __cdecl main(const int argc, const char* argv[])
     options.Signal = 0;
     options.CrashThread = 0;
     options.Pid = 0;
-#if defined(HOST_UNIX) && !defined(HOST_OSX)
+#if defined(HOST_UNIX)
     options.SignalCode = 0;
     options.SignalErrno = 0;
     options.SignalAddress = nullptr;
@@ -140,7 +140,6 @@ int __cdecl main(const int argc, const char* argv[])
             {
                 options.Signal = atoi(*++argv);
             }
-#ifndef HOST_OSX
             else if (strcmp(*argv, "--code") == 0)
             {
                 options.SignalCode = atoi(*++argv);
@@ -153,7 +152,6 @@ int __cdecl main(const int argc, const char* argv[])
             {
                 options.SignalAddress = (void*)atoll(*++argv);
             }
-#endif
 #endif
             else if ((strcmp(*argv, "-d") == 0) || (strcmp(*argv, "--diag") == 0))
             {
@@ -264,5 +262,3 @@ trace_verbose_printf(const char* format, ...)
         va_end(args);
     }
 }
-
-


### PR DESCRIPTION
Backport of #85422 to release/7.0-staging

Handle NT_SIGINFO parameters on macOS for hardware-signal based exceptions.

/cc @hoyosjs

## Customer Impact

This was a regression w.r.t 7.0.4 and 6.0.15. The regression caused no dumps or crash reports to be generated for crashes on hardware exceptions.

## Testing

Testing in automation to be added out of band. Reported scenarios validated manually.

## Risk

Low risk - linux uses the same parsing logic, and the values don't get used if not needed (macOS doesn't try to use the values).
