### PR TITLE
Fix Diagnostic port suspension message doesn't report expected port name

### DIFF
--- a/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
@@ -313,7 +313,7 @@ ds_rt_server_log_pause_message (void)
 	uint32_t port_suspended = ds_rt_config_value_get_default_port_suspend();
 
 	printf("The runtime has been configured to pause during startup and is awaiting a Diagnostics IPC ResumeStartup command from a Diagnostic Port.\n");
-	printf("%s=\"%s\"\n", diagPortsName, ports == nullptr ? "" : ports);
+	printf("DOTNET_%s=\"%s\"\n", diagPortsName, ports == nullptr ? "" : ports);
 	printf("DOTNET_DefaultDiagnosticPortSuspend=%u\n", port_suspended);
 	fflush(stdout);
 }

--- a/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
@@ -302,7 +302,7 @@ ds_rt_server_log_pause_message (void)
 {
 	STATIC_CONTRACT_NOTHROW;
 
-	const char diagPortsName[] = "DOTNET_DiagnosticPorts";
+	const char diagPortsName[] = "DiagnosticPorts";
 	CLRConfigNoCache diagPorts = CLRConfigNoCache::Get(diagPortsName);
 	LPCSTR ports = nullptr;
 	if (diagPorts.IsSet())


### PR DESCRIPTION
Fixes #75581

I repo’d #75581 on Windows and verified this works. Apparently, the static member function CLRConfigNoCache::Get from the header ‘src/coreclr/inc/clrconfignocache.h’ first copies the prefix “DOTNET_” to a char array and then appends “DOTNET_ DiagnosticPorts” resulting in “DOTNET_DOTNET_ DiagnosticPorts” which when passed to getenv() returns null because it doesn’t exist in the environment table. This works by instead appending “DiagnosticPorts” resulting in “DOTNET_ DiagnosticPorts” which does exist in the environment table.