### PR TITLE
[release/8.0-preview4] Comment out support for mtag extension in libunwind

### DIFF
--- a/src/native/external/llvm-libunwind/src/DwarfInstructions.hpp
+++ b/src/native/external/llvm-libunwind/src/DwarfInstructions.hpp
@@ -211,7 +211,7 @@ int DwarfInstructions<A, R>::stepWithDwarf(A &addressSpace, pint_t pc,
       // __unw_step_stage2 is not used for cross unwinding, so we use
       // __aarch64__ rather than LIBUNWIND_TARGET_AARCH64 to make sure we are
       // building for AArch64 natively.
-#if defined(__aarch64__)
+#if 0 // defined(__aarch64__)
       if (stage2 && cieInfo.mteTaggedFrame) {
         pint_t sp = registers.getSP();
         pint_t p = sp;


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3424

## Customer Impact

Break in source build caused by recent upgrade of libunwind from libunwind upstream. The update brought it inline assembly code that does not compile with older compilers.

Comment out the offending code since it is not needed for our libunwind use case.

## Testing

Local build

## Risk

Low. The change is effectively reverting recent change.