### PR TITLE
Ignore merged test markers for tests without execution script

### DIFF
--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -358,6 +358,13 @@
     <ItemGroup>
       <!-- Exclude WASM support files. They can interfere with our discovery process and create extra work items that don't work. -->
       <_MergedWrapperMarker Include="$(TestBinDir)**\*.MergedTestAssembly" Exclude="$(TestBinDir)**\supportFiles\*.MergedTestAssembly" />
+
+      <_MergedWrapperMarker Update="@(_MergedWrapperMarker.Identity)">
+        <TestExecutionScriptPath>$([System.IO.Path]::ChangeExtension('%(Identity)', '.$(TestScriptExtension)'))</TestExecutionScriptPath>
+      </_MergedWrapperMarker>
+
+      <!-- Exclude merged test wrappers without the test execution script for this target (skipped due to CLRTestTargetUnsupported et al) -->
+      <_MergedWrapperMarker Remove="@(_MergedWrapperMarker.Identity)" Condition="!Exists('%(TestExecutionScriptPath)')" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This delta should fix the remaining issues discussed on the PR thread

https://github.com/dotnet/runtime/pull/85183#issuecomment-1523870971

by filtering out those <code>MergedTestAssembly</code> markers where the entire merged test wrappers got filtered out based on <code>CLRTestTargetUnsupported</code> or a similar property (a recently hit previously unseen case).

Thanks

Tomas

P.S. I'm going to be OOF on vacation Thursday thru Sunday in a recording studio session with my music band. I have validated this PR by putting the commit on top of the above Ivan's PR, please see

https://dev.azure.com/dnceng-public/public/_build/results?buildId=254082&view=results

I likely won't be able to merge this in before I sign off for the rest of the week. Please feel free to do anything with my change, either by merging it in assuming it works or by adding it as an extra commit on top of Ivan's change.