### PR TITLE
Add request metrics to System.Net.Http

### DIFF
--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -214,6 +214,9 @@ namespace System.Net.Http
         public HttpMessageInvoker(System.Net.Http.HttpMessageHandler handler) { }
         public HttpMessageInvoker(System.Net.Http.HttpMessageHandler handler, bool disposeHandler) { }
         public void Dispose() { }
+#pragma warning disable CS3003 // Type is not CLS-compliant
+        public System.Diagnostics.Metrics.Meter Meter { get { throw null; } set { } }
+#pragma warning restore CS3003 // Type is not CLS-compliant
         protected virtual void Dispose(bool disposing) { }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public virtual System.Net.Http.HttpResponseMessage Send(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) { throw null; }
@@ -263,6 +266,7 @@ namespace System.Net.Http
         [System.ObsoleteAttribute("HttpRequestMessage.Properties has been deprecated. Use Options instead.")]
         public System.Collections.Generic.IDictionary<string, object?> Properties { get { throw null; } }
         public HttpRequestOptions Options { get { throw null; } }
+        public ICollection<KeyValuePair<string, object?>> MetricsTags { get { throw null; } }
         public System.Uri? RequestUri { get { throw null; } set { } }
         public System.Version Version { get { throw null; } set { } }
         public System.Net.Http.HttpVersionPolicy VersionPolicy { get { throw null; } set { } }

--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -53,6 +53,7 @@
     <Compile Include="System\Net\Http\HttpMessageHandler.cs" />
     <Compile Include="System\Net\Http\HttpMessageInvoker.cs" />
     <Compile Include="System\Net\Http\HttpMethod.cs" />
+    <Compile Include="System\Net\Http\HttpMetrics.cs" />
     <Compile Include="System\Net\Http\HttpParseResult.cs" />
     <Compile Include="System\Net\Http\HttpProtocolException.cs" />
     <Compile Include="System\Net\Http\HttpRequestException.cs" />

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -621,7 +621,7 @@ namespace System.Net.Http
                 e = toThrow = CancellationHelper.CreateOperationCanceledException(e, cancellationToken.IsCancellationRequested ? cancellationToken : cts.Token);
             }
 
-            LogRequestFailed(e, telemetryStarted);
+            LogRequestFailed(e, telemetryStarted, out _);
 
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, e);
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpMetrics.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpMetrics.cs
@@ -28,19 +28,37 @@ namespace System.Net.Http
 
         public void RequestStart(HttpRequestMessage request)
         {
-#pragma warning disable SA1129 // Do not use default value type constructor
-            var tags = new TagList();
-#pragma warning restore SA1129 // Do not use default value type constructor
-            InitializeCommonTags(ref tags, request);
-            _currentRequests.Add(1, tags);
+            if (_currentRequests.Enabled)
+            {
+                RequestStartCore(request);
+            }
         }
 
-        public void RequestStop(HttpRequestMessage request, HttpResponseMessage? response, Exception? unhandledException, long startTimestamp, long currentTimestamp)
+        public void RequestStartCore(HttpRequestMessage request)
         {
 #pragma warning disable SA1129 // Do not use default value type constructor
             var tags = new TagList();
 #pragma warning restore SA1129 // Do not use default value type constructor
             InitializeCommonTags(ref tags, request);
+
+            _currentRequests.Add(1, tags);
+        }
+
+        public void RequestStop(HttpRequestMessage request, HttpResponseMessage? response, Exception? unhandledException, long startTimestamp, long currentTimestamp)
+        {
+            if (_currentRequests.Enabled || _requestsDuration.Enabled)
+            {
+                RequestStopCore(request, response, unhandledException, startTimestamp, currentTimestamp);
+            }
+        }
+
+        private void RequestStopCore(HttpRequestMessage request, HttpResponseMessage? response, Exception? unhandledException, long startTimestamp, long currentTimestamp)
+        {
+#pragma warning disable SA1129 // Do not use default value type constructor
+            var tags = new TagList();
+#pragma warning restore SA1129 // Do not use default value type constructor
+            InitializeCommonTags(ref tags, request);
+
             _currentRequests.Add(-1, tags);
 
             if (response is not null)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpMetrics.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpMetrics.cs
@@ -18,12 +18,12 @@ namespace System.Net.Http
 
             _currentRequests = _meter.CreateUpDownCounter<long>(
                 "current-requests",
-                description: "The duration of outbound HTTP requests.");
+                description: "Number of outbound HTTP requests that are currently active on the client.");
 
             _requestsDuration = _meter.CreateHistogram<double>(
                 "request-duration",
                 unit: "s",
-                description: "Number of outbound HTTP requests that are currently active on the client.");
+                description: "The duration of outbound HTTP requests.");
         }
 
         public void RequestStart(HttpRequestMessage request)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpMetrics.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpMetrics.cs
@@ -35,7 +35,7 @@ namespace System.Net.Http
             _currentRequests.Add(1, tags);
         }
 
-        public void RequestStop(HttpRequestMessage request, HttpResponseMessage? response, long startTimestamp, long currentTimestamp)
+        public void RequestStop(HttpRequestMessage request, HttpResponseMessage? response, Exception? unhandledException, long startTimestamp, long currentTimestamp)
         {
 #pragma warning disable SA1129 // Do not use default value type constructor
             var tags = new TagList();
@@ -43,10 +43,14 @@ namespace System.Net.Http
             InitializeCommonTags(ref tags, request);
             _currentRequests.Add(-1, tags);
 
-            if (response != null)
+            if (response is not null)
             {
                 tags.Add("status-code", (int)response.StatusCode); // Boxing?
                 tags.Add("protocol", $"HTTP/{response.Version}"); // Hacky
+            }
+            if (unhandledException is not null)
+            {
+                tags.Add("exception-name", unhandledException.GetType().FullName);
             }
             if (request.HasTags)
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpMetrics.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpMetrics.cs
@@ -1,0 +1,85 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace System.Net.Http
+{
+    internal sealed class HttpMetrics
+    {
+        private readonly Meter _meter;
+        private readonly UpDownCounter<long> _currentRequests;
+        private readonly Histogram<double> _requestsDuration;
+
+        public HttpMetrics(Meter meter)
+        {
+            _meter = meter;
+
+            _currentRequests = _meter.CreateUpDownCounter<long>(
+                "current-requests",
+                description: "The duration of outbound HTTP requests.");
+
+            _requestsDuration = _meter.CreateHistogram<double>(
+                "request-duration",
+                unit: "s",
+                description: "Number of outbound HTTP requests that are currently active on the client.");
+        }
+
+        public void RequestStart(HttpRequestMessage request)
+        {
+#pragma warning disable SA1129 // Do not use default value type constructor
+            var tags = new TagList();
+#pragma warning restore SA1129 // Do not use default value type constructor
+            InitializeCommonTags(ref tags, request);
+            _currentRequests.Add(1, tags);
+        }
+
+        public void RequestStop(HttpRequestMessage request, HttpResponseMessage? response, long startTimestamp, long currentTimestamp)
+        {
+#pragma warning disable SA1129 // Do not use default value type constructor
+            var tags = new TagList();
+#pragma warning restore SA1129 // Do not use default value type constructor
+            InitializeCommonTags(ref tags, request);
+            _currentRequests.Add(-1, tags);
+
+            if (response != null)
+            {
+                tags.Add("status-code", (int)response.StatusCode); // Boxing?
+                tags.Add("protocol", $"HTTP/{response.Version}"); // Hacky
+            }
+            if (request.HasTags)
+            {
+                foreach (var customTag in request.MetricsTags)
+                {
+                    tags.Add(customTag);
+                }
+            }
+            var duration = Stopwatch.GetElapsedTime(startTimestamp, currentTimestamp);
+            _requestsDuration.Record(duration.TotalSeconds, tags);
+        }
+
+        private static void InitializeCommonTags(ref TagList tags, HttpRequestMessage request)
+        {
+            if (request.RequestUri is { } requestUri && requestUri.IsAbsoluteUri)
+            {
+                if (requestUri.Scheme is not null)
+                {
+                    tags.Add("scheme", requestUri.Scheme);
+                }
+                if (requestUri.Host is not null)
+                {
+                    tags.Add("host", requestUri.Host);
+                }
+                // Add port tag when not the default value for the current scheme
+                if (!requestUri.IsDefaultPort)
+                {
+                    tags.Add("port", requestUri.Port);
+                }
+            }
+            tags.Add("method", request.Method.Method);
+        }
+
+        internal bool RequestCountersEnabled() => _currentRequests.Enabled || _requestsDuration.Enabled;
+    }
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
@@ -31,6 +31,7 @@ namespace System.Net.Http
         private HttpVersionPolicy _versionPolicy;
         private HttpContent? _content;
         private HttpRequestOptions? _options;
+        private List<KeyValuePair<string, object?>>? _metricsTags;
 
         public Version Version
         {
@@ -115,6 +116,14 @@ namespace System.Net.Http
         /// Gets the collection of options to configure the HTTP request.
         /// </summary>
         public HttpRequestOptions Options => _options ??= new HttpRequestOptions();
+
+        // TODO: Should tags be defined in a new collection or stashed in HttpRequestOptions?
+        // If tags are stashed in HttpRequestOptions then there should probably be extension methods to interact with them.
+        // If tags are stored in a collection then a custom collection type might be wanted.
+        // An Add(string name, object? value) method for convenience would be nice.
+        public ICollection<KeyValuePair<string, object?>> MetricsTags => _metricsTags ??= new List<KeyValuePair<string, object?>>();
+
+        internal bool HasTags => _metricsTags != null;
 
         public HttpRequestMessage()
             : this(HttpMethod.Get, (Uri?)null)

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpMetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpMetricsTest.cs
@@ -1,0 +1,233 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class HttpMetricsTest
+    {
+        [Fact]
+        public async Task SendAsync_CurrentRequests_Success()
+        {
+            var invoker = new HttpMessageInvoker(new MockHandler());
+            var currentRequestsRecorder = new InstrumentRecorder<long>(invoker.Meter, "current-requests");
+
+            var response = await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get, "https://localhost/test"), CancellationToken.None);
+
+            Assert.Collection(currentRequestsRecorder.GetMeasurements(),
+                m => AssertCurrentRequest(m, 1, "https", "localhost"),
+                m => AssertCurrentRequest(m, -1, "https", "localhost"));
+        }
+
+        [Fact]
+        public void Send_CurrentRequests_Success()
+        {
+            var invoker = new HttpMessageInvoker(new MockHandler());
+            var currentRequestsRecorder = new InstrumentRecorder<long>(invoker.Meter, "current-requests");
+
+            var response = invoker.Send(new HttpRequestMessage(HttpMethod.Get, "https://localhost/test"), CancellationToken.None);
+
+            Assert.Collection(currentRequestsRecorder.GetMeasurements(),
+                m => AssertCurrentRequest(m, 1, "https", "localhost"),
+                m => AssertCurrentRequest(m, -1, "https", "localhost"));
+        }
+
+        [Fact]
+        public async Task SendAsync_RequestDuration_Success()
+        {
+            var invoker = new HttpMessageInvoker(new MockHandler());
+            var currentRequestsRecorder = new InstrumentRecorder<double>(invoker.Meter, "request-duration");
+
+            var response = await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get, "https://localhost/test"), CancellationToken.None);
+
+            Assert.Collection(currentRequestsRecorder.GetMeasurements(),
+                m => AssertRequestDuration(m, "https", "localhost", "HTTP/1.1", 200));
+        }
+
+        [Fact]
+        public async Task SendAsync_RequestDuration_CustomTags()
+        {
+            var invoker = new HttpMessageInvoker(new MockHandler());
+            var currentRequestsRecorder = new InstrumentRecorder<double>(invoker.Meter, "request-duration");
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/test");
+            request.MetricsTags.Add(new KeyValuePair<string, object>("route", "/test"));
+            var response = await invoker.SendAsync(request, CancellationToken.None);
+
+            Assert.Collection(currentRequestsRecorder.GetMeasurements(),
+                m =>
+                {
+                    AssertRequestDuration(m, "http", "localhost", "HTTP/1.1", 200);
+                    Assert.Equal("/test", m.Tags.ToArray().Single(t => t.Key == "route").Value);
+                });
+        }
+
+        private static void AssertCurrentRequest(Measurement<long> measurement, long expectedValue, string scheme, string host, int? port = null)
+        {
+            Assert.Equal(expectedValue, measurement.Value);
+            Assert.Equal(scheme, measurement.Tags.ToArray().Single(t => t.Key == "scheme").Value);
+            Assert.Equal(host, measurement.Tags.ToArray().Single(t => t.Key == "host").Value);
+            if (port is null)
+            {
+                Assert.DoesNotContain(measurement.Tags.ToArray(), t => t.Key == "port");
+            }
+            else
+            {
+                Assert.Equal(port, (int)measurement.Tags.ToArray().Single(t => t.Key == "port").Value);
+            }
+        }
+
+        private static void AssertRequestDuration(Measurement<double> measurement, string scheme, string host, string protocol, int statusCode, int? port = null)
+        {
+            Assert.True(measurement.Value > 0);
+            Assert.Equal(scheme, measurement.Tags.ToArray().Single(t => t.Key == "scheme").Value);
+            Assert.Equal(host, measurement.Tags.ToArray().Single(t => t.Key == "host").Value);
+            if (port is null)
+            {
+                Assert.DoesNotContain(measurement.Tags.ToArray(), t => t.Key == "port");
+            }
+            else
+            {
+                Assert.Equal(port, (int)measurement.Tags.ToArray().Single(t => t.Key == "port").Value);
+            }
+            Assert.Equal(protocol, measurement.Tags.ToArray().Single(t => t.Key == "protocol").Value);
+            Assert.Equal(statusCode, (int)measurement.Tags.ToArray().Single(t => t.Key == "status-code").Value);
+        }
+
+        #region Helpers
+
+        private class MockHandler : HttpMessageHandler
+        {
+            public int DisposeCount { get; private set; }
+            public int SendAsyncCount { get; private set; }
+            public int SendCount { get; private set; }
+
+            public MockHandler()
+            {
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                SendAsyncCount++;
+
+                return Task.FromResult<HttpResponseMessage>(new HttpResponseMessage());
+            }
+
+            protected override HttpResponseMessage Send(HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                SendCount++;
+
+                return new HttpResponseMessage();
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                DisposeCount++;
+                base.Dispose(disposing);
+            }
+        }
+
+        #endregion Helepers
+    }
+
+    // TODO: Remove when Metrics DI intergration package is available https://github.com/dotnet/aspnetcore/issues/47618
+    internal sealed class InstrumentRecorder<T> : IDisposable where T : struct
+    {
+        private readonly object _lock = new object();
+        private readonly string _meterName;
+        private readonly string _instrumentName;
+        private readonly MeterListener _meterListener;
+        private readonly List<Measurement<T>> _values;
+        private readonly List<Action<Measurement<T>>> _callbacks;
+
+        public InstrumentRecorder(Meter meter, string instrumentName, object? state = null) : this(new TestMeterRegistry(new List<Meter> { meter }), meter.Name, instrumentName, state)
+        {
+        }
+
+        public InstrumentRecorder(IMeterRegistry registry, string meterName, string instrumentName, object? state = null)
+        {
+            _meterName = meterName;
+            _instrumentName = instrumentName;
+            _callbacks = new List<Action<Measurement<T>>>();
+            _values = new List<Measurement<T>>();
+            _meterListener = new MeterListener();
+            _meterListener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == _meterName && registry.Contains(instrument.Meter) && instrument.Name == _instrumentName)
+                {
+                    listener.EnableMeasurementEvents(instrument, state);
+                }
+            };
+            _meterListener.SetMeasurementEventCallback<T>(OnMeasurementRecorded);
+            _meterListener.Start();
+        }
+
+        private void OnMeasurementRecorded(Instrument instrument, T measurement, ReadOnlySpan<KeyValuePair<string, object?>> tags, object? state)
+        {
+            lock (_lock)
+            {
+                var m = new Measurement<T>(measurement, tags);
+                _values.Add(m);
+
+                // Should this happen in the lock?
+                // Is there a better way to notify listeners that there are new measurements?
+                foreach (var callback in _callbacks)
+                {
+                    callback(m);
+                }
+            }
+        }
+
+        public void Register(Action<Measurement<T>> callback)
+        {
+            _callbacks.Add(callback);
+        }
+
+        public IReadOnlyList<Measurement<T>> GetMeasurements()
+        {
+            lock (_lock)
+            {
+                return _values.ToArray();
+            }
+        }
+
+        public void Dispose()
+        {
+            _meterListener.Dispose();
+        }
+    }
+
+    internal interface IMeterRegistry
+    {
+        void Add(Meter meter);
+        bool Contains(Meter meter);
+    }
+
+    internal class TestMeterRegistry : IMeterRegistry
+    {
+        private readonly List<Meter> _meters;
+
+        public TestMeterRegistry() : this(new List<Meter>())
+        {
+        }
+
+        public TestMeterRegistry(List<Meter> meters)
+        {
+            _meters = meters;
+        }
+
+        public void Add(Meter meter) => _meters.Add(meter);
+
+        public bool Contains(Meter meter) => _meters.Contains(meter);
+    }
+}

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -183,6 +183,7 @@
     <Compile Include="HttpContentTest.cs" />
     <Compile Include="HttpMessageInvokerTest.cs" />
     <Compile Include="HttpMethodTest.cs" />
+    <Compile Include="HttpMetricsTest.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Http\IdnaProtocolTests.cs"
              Link="Common\System\Net\Http\IdnaProtocolTests.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Http\HttpProtocolTests.cs"

--- a/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -198,6 +198,8 @@
              Link="ProductionCode\System\Net\Http\HttpMessageInvoker.cs" />
     <Compile Include="..\..\src\System\Net\Http\HttpMethod.cs"
              Link="ProductionCode\System\Net\Http\HttpMethod.cs" />
+    <Compile Include="..\..\src\System\Net\Http\HttpMetrics.cs"
+             Link="ProductionCode\System\Net\Http\HttpMetrics.cs" />
     <Compile Include="..\..\src\System\Net\Http\HttpParseResult.cs"
              Link="ProductionCode\System\Net\Http\HttpParseResult.cs" />
     <Compile Include="..\..\src\System\Net\Http\HttpRequestException.cs"


### PR DESCRIPTION
Addresses https://github.com/dotnet/runtime/issues/84978. Work in progress.

Adds:
* [x] `request-duration` counter
* [x] `current-requests` counter
* [x] `HttpMessageInvoker.Meter` property
* [x] `HttpRequestMessage.MetricsTags` property
* [ ] Client connection counters
* [ ] Moves request stop event for counters to response body finished reading/request abort.