### PR TITLE
Update createdumpwindows to not appear to succeed after getting ERROR_PARTIAL_COPY 5 times

### DIFF
--- a/src/coreclr/debug/createdump/createdumpwindows.cpp
+++ b/src/coreclr/debug/createdump/createdumpwindows.cpp
@@ -63,9 +63,10 @@ CreateDump(const CreateDumpOptions& options)
         printf_error("Invalid dump path '%s' - %s\n", dumpPath.c_str(), GetLastErrorString().c_str());
         goto exit;
     }
-
+    
+    int retryCount = 5;
     // Retry the write dump on ERROR_PARTIAL_COPY
-    for (int i = 0; i < 5; i++)
+    for (int i = 0; i <= retryCount; i++)
     {
         if (MiniDumpWriteDump(hProcess, pid, hFile, options.MinidumpType, NULL, NULL, NULL))
         {
@@ -75,10 +76,14 @@ CreateDump(const CreateDumpOptions& options)
         else
         {
             int err = GetLastError();
-            if (err != ERROR_PARTIAL_COPY)
+            if (err != ERROR_PARTIAL_COPY || i == retryCount)
             {
                 printf_error("MiniDumpWriteDump - %s\n", GetLastErrorString().c_str());
                 break;
+            }
+            else
+            {
+                 printf_error("Retry %d of MiniDumpWriteDump due to - %s\n", i, GetLastErrorString().c_str());
             }
         }
     }

--- a/src/coreclr/debug/createdump/createdumpwindows.cpp
+++ b/src/coreclr/debug/createdump/createdumpwindows.cpp
@@ -64,7 +64,7 @@ CreateDump(const CreateDumpOptions& options)
         goto exit;
     }
     
-    int retryCount = 5;
+    int retryCount = 10;
     // Retry the write dump on ERROR_PARTIAL_COPY
     for (int i = 0; i <= retryCount; i++)
     {


### PR DESCRIPTION
create dump has same bug as documented and fixed in dotnet-dump (https://github.com/dotnet/diagnostics/issues/3829).

Updates the `CreateDump` function to report the `ERROR_PARTIAL_COPY` if it fails on the final retry

I can create an issue in the runtime repository if necessary for the PR.