### PR TITLE
Fix cast type to conform to Roslyn API

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/InlinedTypes.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/InlinedTypes.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Interop
                                         GenericName(
                                             Identifier("GetInstance"),
                                             TypeArgumentList(
-                                                SeparatedList<SyntaxNode>(
+                                                SeparatedList<TypeSyntax>(
                                                     new[] { PredefinedType(Token(SyntaxKind.ObjectKeyword)) })))))
                                 .AddArgumentListArguments(
                                     Argument(


### PR DESCRIPTION
The Source-build bootstrapping stage 2 build, which uses a source-built version of the latest SDK to build the product, fails with the following error in the runtime repo:

```
/vmr/src/runtime/artifacts/source-build/self/src/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/InlinedTypes.cs(56,49): error CS1503: Argument 1: cannot convert from 'Microsoft.CodeAnalysis.SeparatedSyntaxList<Microsoft.CodeAnalysis.SyntaxNode>' to 'Microsoft.CodeAnalysis.SeparatedSyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax>' [/vmr/src/runtime/artifacts/source-build/self/src/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.csproj]
```

This is a similar issue to https://github.com/dotnet/roslyn-analyzers/pull/6596. This is fixed by referencing the correct type.

Related to https://github.com/dotnet/source-build/issues/3425