### PR TITLE
Comment out support for mtag extension in libunwind

### DIFF
--- a/src/native/external/libunwind-version.txt
+++ b/src/native/external/libunwind-version.txt
@@ -18,6 +18,3 @@ Apply https://github.com/libunwind/libunwind/pull/416
 
 For LoongArch64:
 Apply https://github.com/libunwind/libunwind/pull/316 and https://github.com/libunwind/libunwind/pull/322
-
-Build Break on arm64 with old clang
-https://github.com/dotnet/runtime/pull/85431/commits/0ee8827547405408b37d1aae2a83629c1632eea8

--- a/src/native/external/libunwind-version.txt
+++ b/src/native/external/libunwind-version.txt
@@ -18,3 +18,6 @@ Apply https://github.com/libunwind/libunwind/pull/416
 
 For LoongArch64:
 Apply https://github.com/libunwind/libunwind/pull/316 and https://github.com/libunwind/libunwind/pull/322
+
+Build Break on arm64 with old clang
+https://github.com/dotnet/runtime/pull/85431/commits/0ee8827547405408b37d1aae2a83629c1632eea8

--- a/src/native/external/llvm-libunwind-version.txt
+++ b/src/native/external/llvm-libunwind-version.txt
@@ -2,3 +2,5 @@ v16.0.2
 https://github.com/llvm/llvm-project/releases/tag/llvmorg-16.0.2
 
 Apply https://github.com/dotnet/runtime/commit/1bafb60792b91747d9c2a9dd38461cf090a987a4
+Apply https://github.com/dotnet/runtime/commit/0ee8827547405408b37d1aae2a83629c1632eea8
+

--- a/src/native/external/llvm-libunwind/src/DwarfInstructions.hpp
+++ b/src/native/external/llvm-libunwind/src/DwarfInstructions.hpp
@@ -211,7 +211,7 @@ int DwarfInstructions<A, R>::stepWithDwarf(A &addressSpace, pint_t pc,
       // __unw_step_stage2 is not used for cross unwinding, so we use
       // __aarch64__ rather than LIBUNWIND_TARGET_AARCH64 to make sure we are
       // building for AArch64 natively.
-#if defined(__aarch64__)
+#if 0 // defined(__aarch64__)
       if (stage2 && cieInfo.mteTaggedFrame) {
         pint_t sp = registers.getSP();
         pint_t p = sp;


### PR DESCRIPTION
Porting the fix from 
[[release/8.0-preview4] Comment out support for mtag extension in libunwind](https://github.com/dotnet/runtime/pull/85431)