### PR TITLE
[wasm] GenerateWasmBootJson - close file handles

### DIFF
--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/GenerateWasmBootJson.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/GenerateWasmBootJson.cs
@@ -290,7 +290,8 @@ public class GenerateWasmBootJson : Task
             foreach (var configExtension in Extensions)
             {
                 var key = configExtension.GetMetadata("key");
-                var config = (Dictionary<string, object>)configSerializer.ReadObject(File.OpenRead(configExtension.ItemSpec));
+                using var fs = File.OpenRead(configExtension.ItemSpec);
+                var config = (Dictionary<string, object>)configSerializer.ReadObject(fs);
                 result.extensions[key] = config;
             }
         }


### PR DESCRIPTION
Close files opened with `File.OpenRead` by utilizing the `using` pattern.

### Background
- this was found when looking at the test failures mentioned in https://github.com/dotnet/aspnetcore/pull/47540#issuecomment-1525958042 .

The hypothesis is that the following operations happen in order:
1. `GenerateBlazorBootExtensionJson` calls `File.Create` to create `obj/Release/net8.0/blazor.publish.boot-extension.json`, and the file handle is closed
2. `GenerateWasmBootJson` opens the same file with `File.OpenRead` but does *not* close it
3. `GenerateBlazorBootExtensionJson` runs again as part of the nested build, but fails because (2) left the file open

```
The "GenerateBlazorBootExtensionJson" task failed unexpectedly. [/datadisks/disk1/work/B95509FE/w/998E08AE/e/Templates/BaseFolder/AspNet.hhjg2t3oatk0/Client/AspNet.hhjg2t3oatk0.Client.csproj]
System.IO.IOException: The process cannot access the file '/datadisks/disk1/work/B95509FE/w/998E08AE/e/Templates/BaseFolder/AspNet.hhjg2t3oatk0/Client/obj/Release/net8.0/blazor.publish.boot-extension.json' because it is being used by another process. [/datadisks/disk1/work/B95509FE/w/998E08AE/e/Templates/BaseFolder/AspNet.hhjg2t3oatk0/Client/AspNet.hhjg2t3oatk0.Client.csproj]
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Init(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Int64& fileLength, UnixFileMode& filePermissions) [/datadisks/disk1/work/B95509FE/w/998E08AE/e/Templates/BaseFolder/AspNet.hhjg2t3oatk0/Client/AspNet.hhjg2t3oatk0.Client.csproj]
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, UnixFileMode openPermissions, Int64& fileLength, UnixFileMode& filePermissions, Func`4 createOpenException) [/datadisks/disk1/work/B95509FE/w/998E08AE/e/Templates/BaseFolder/AspNet.hhjg2t3oatk0/Client/AspNet.hhjg2t3oatk0.Client.csproj]
   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode) [/datadisks/disk1/work/B95509FE/w/998E08AE/e/Templates/BaseFolder/AspNet.hhjg2t3oatk0/Client/AspNet.hhjg2t3oatk0.Client.csproj]
   at System.IO.File.Create(String path) [/datadisks/disk1/work/B95509FE/w/998E08AE/e/Templates/BaseFolder/AspNet.hhjg2t3oatk0/Client/AspNet.hhjg2t3oatk0.Client.csproj]
   at Microsoft.NET.Sdk.BlazorWebAssembly.GenerateBlazorBootExtensionJson.Execute() [/datadisks/disk1/work/B95509FE/w/998E08AE/e/Templates/BaseFolder/AspNet.hhjg2t3oatk0/Client/AspNet.hhjg2t3oatk0.Client.csproj]
   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute() [/datadisks/disk1/work/B95509FE/w/998E08AE/e/Templates/BaseFolder/AspNet.hhjg2t3oatk0/Client/AspNet.hhjg2t3oatk0.Client.csproj]
   at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask) [/datadisks/disk1/work/B95509FE/w/998E08AE/e/Templates/BaseFolder/AspNet.hhjg2t3oatk0/Client/AspNet.hhjg2t3oatk0.Client.csproj]
```