### PR TITLE
JIT: ARR_LENGTH(new T[CNS]) --> CNS

### DIFF
--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -70,7 +70,8 @@ RangeCheck::OverflowMap* RangeCheck::GetOverflowMap()
 int RangeCheck::GetArrLength(ValueNum vn)
 {
     ValueNum arrRefVN = m_pCompiler->vnStore->GetArrForLenVn(vn);
-    return m_pCompiler->vnStore->GetNewArrSize(arrRefVN);
+    int      size;
+    return m_pCompiler->vnStore->TryGetNewArrSize(arrRefVN, &size) ? size : 0;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -2440,10 +2440,10 @@ ValueNum ValueNumStore::VNForFunc(var_types typ, VNFunc func, ValueNum arg0VN)
                 {
                     // Constant is INT64, but we need INT32 for GT_ARR_LEN, so make sure it fits
                     ssize_t val = CoercedConstantValue<ssize_t>(funcApp.m_args[1]);
-                    if ((size_t)val <= UINT_MAX)
+                    if ((size_t)val <= INT_MAX)
                     {
                         // Return known length of the array
-                        resultVN = funcApp.m_args[1];
+                        resultVN = VNForIntCon((int)val);
                     }
                 }
             }

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -2438,8 +2438,13 @@ ValueNum ValueNumStore::VNForFunc(var_types typ, VNFunc func, ValueNum arg0VN)
                 // Case 3: ARR_LENGTH(new T[CNS])
                 else if ((funcApp.m_func == VNF_JitNewArr) && IsVNConstant(funcApp.m_args[1]))
                 {
-                    // Return known length of the array
-                    resultVN = funcApp.m_args[1];
+                    // Constant is INT64, but we need INT32 for GT_ARR_LEN, so make sure it fits
+                    ssize_t val = CoercedConstantValue<ssize_t>(funcApp.m_args[1]);
+                    if ((size_t)val <= UINT_MAX)
+                    {
+                        // Return known length of the array
+                        resultVN = funcApp.m_args[1];
+                    }
                 }
             }
         }

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -946,8 +946,8 @@ public:
     // Check if "vn" is "new [] (type handle, size)"
     bool IsVNNewArr(ValueNum vn, VNFuncApp* funcApp);
 
-    // Check if "vn" IsVNNewArr and return <= 0 if arr size cannot be determined, else array size.
-    int GetNewArrSize(ValueNum vn);
+    // Check if "vn" IsVNNewArr and return false if arr size cannot be determined.
+    bool TryGetNewArrSize(ValueNum vn, int* size);
 
     // Check if "vn" is "a.Length" or "a.GetLength(n)"
     bool IsVNArrLen(ValueNum vn);


### PR DESCRIPTION
Quick 5 lines-of-code change to enable `ARR_LENGTH(JitNewArr)` constant folding in VN:

```csharp
int Test()
{
    var a = new int[100];
    return a.Length;
}
```
Current codegen:
```asm
; Method Proga:Test():int:this
       sub      rsp, 40
       mov      rcx, 0xD1FFAB1E      ; int[]
       mov      edx, 100
       call     CORINFO_HELP_NEWARR_1_VC
       mov      eax, dword ptr [rax+08H]
       add      rsp, 40
       ret      
; Total bytes of code: 32
```

New codegen:
```asm
; Method Proga:Test():int:this
       mov      eax, 100
       ret      
; Total bytes of code: 6
```

I recommend enabling "hide whitespaces" for code review since most of the changes are just extra { } block
