### PR TITLE
Disable crossgen on riscv64

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.props
@@ -11,6 +11,8 @@
     <PublishReadyToRun Condition="'$(TargetOS)' == 'netbsd' or '$(TargetOS)' == 'illumos' or '$(TargetOS)' == 'solaris'">false</PublishReadyToRun>
     <!-- Disable crossgen on FreeBSD when cross building from Linux. -->
     <PublishReadyToRun Condition="'$(TargetOS)'=='freebsd' and '$(CrossBuild)'=='true'">false</PublishReadyToRun>
+    <!-- Disable crossgen on riscv64. -->
+    <PublishReadyToRun Condition="'$(TargetArchitecture)'=='riscv64'">false</PublishReadyToRun>
     <!-- These components are installed by the root shared framework, but not others. -->
     <IncludeWerRelatedKeys>true</IncludeWerRelatedKeys>
     <IncludeBreadcrumbStoreFolder>true</IncludeBreadcrumbStoreFolder>


### PR DESCRIPTION
It's currently unsupported. With `clr+libs+packs`,`PublishReadyToRun` was evaluated as true. With this patch, it builds cleanly:

```sh
$ docker run --rm -v$(pwd):/runtime -e ROOTFS_DIR=/crossrootfs/riscv64 \
     mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-riscv64-20230420175531-3fc5553 \
     /runtime/build.sh clr+libs+packs -cross -a riscv64
...
Build succeeded.
    0 Warning(s)
    0 Error(s)
```