### PR TITLE
Emission and reading of custom modifiers

### DIFF
--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -1742,7 +1742,7 @@ namespace Internal.Runtime
                 if (((nint)_pFirst & IsRelative) != 0)
                     return (((RelativePointer<MethodTable>*)((nint)_pFirst - IsRelative)) + index)->Value;
 
-                return *(MethodTable**)_pFirst + index;
+                return *((MethodTable**)_pFirst + index);
             }
 #if TYPE_LOADER_IMPLEMENTATION
             set

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/ModifiedType.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/ModifiedType.NativeAot.cs
@@ -1,20 +1,123 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using System.Reflection.Runtime.General;
+
+using Internal.Metadata.NativeFormat;
+
+using Debug = System.Diagnostics.Debug;
+
 namespace System.Reflection
 {
     internal partial class ModifiedType
     {
-        internal struct TypeSignature
+        internal readonly struct TypeSignature
         {
+            internal readonly MetadataReader Reader;
+            internal readonly Handle Handle;
+            public TypeSignature(MetadataReader reader, Handle handle)
+                => (Reader, Handle) = (reader, handle);
         }
 
-#pragma warning disable IDE0060
-        internal Type GetTypeParameter(Type unmodifiedType, int index) => throw new NotSupportedException();
+        internal Type GetTypeParameter(Type unmodifiedType, int index)
+        {
+            MetadataReader reader = _typeSignature.Reader;
+            Handle handle = _typeSignature.Handle;
 
-        internal SignatureCallingConvention GetCallingConventionFromFunctionPointer() => throw new NotSupportedException();
+            while (handle.HandleType == HandleType.ModifiedType)
+                handle = reader.GetModifiedType(handle.ToModifiedTypeHandle(reader)).Type;
 
-        private Type[] GetCustomModifiers(bool required) => throw new NotSupportedException();
-#pragma warning restore IDE0060
+            if (handle.HandleType == HandleType.TypeSpecification)
+                handle = reader.GetTypeSpecification(handle.ToTypeSpecificationHandle(reader)).Signature;
+
+            switch (handle.HandleType)
+            {
+                case HandleType.SZArraySignature:
+                    Debug.Assert(index == 0);
+                    return Create(unmodifiedType, new TypeSignature(reader, reader.GetSZArraySignature(handle.ToSZArraySignatureHandle(reader)).ElementType));
+                case HandleType.ArraySignature:
+                    Debug.Assert(index == 0);
+                    return Create(unmodifiedType, new TypeSignature(reader, reader.GetArraySignature(handle.ToArraySignatureHandle(reader)).ElementType));
+                case HandleType.PointerSignature:
+                    Debug.Assert(index == 0);
+                    return Create(unmodifiedType, new TypeSignature(reader, reader.GetPointerSignature(handle.ToPointerSignatureHandle(reader)).Type));
+                case HandleType.ByReferenceSignature:
+                    Debug.Assert(index == 0);
+                    return Create(unmodifiedType, new TypeSignature(reader, reader.GetByReferenceSignature(handle.ToByReferenceSignatureHandle(reader)).Type));
+                case HandleType.FunctionPointerSignature:
+                    {
+                        MethodSignature functionSig = reader.GetMethodSignature(
+                            reader.GetFunctionPointerSignature(handle.ToFunctionPointerSignatureHandle(reader)).Signature);
+                        if (index-- == 0)
+                            return Create(unmodifiedType, new TypeSignature(reader, functionSig.ReturnType));
+
+                        Debug.Assert(index <= functionSig.Parameters.Count);
+                        foreach (Handle paramHandle in functionSig.Parameters)
+                            if (index-- == 0)
+                                return Create(unmodifiedType, new TypeSignature(reader, paramHandle));
+                    }
+                    break;
+                case HandleType.TypeInstantiationSignature:
+                    {
+                        TypeInstantiationSignature typeInst =
+                            reader.GetTypeInstantiationSignature(handle.ToTypeInstantiationSignatureHandle(reader));
+                        Debug.Assert(index < typeInst.GenericTypeArguments.Count);
+                        foreach (Handle paramHandle in typeInst.GenericTypeArguments)
+                            if (index-- == 0)
+                                return Create(unmodifiedType, new TypeSignature(reader, paramHandle));
+                    }
+                    break;
+            }
+
+            Debug.Fail(handle.HandleType.ToString());
+            return null;
+        }
+
+        internal SignatureCallingConvention GetCallingConventionFromFunctionPointer()
+        {
+            MetadataReader reader = _typeSignature.Reader;
+            Handle fnPtrTypeSigHandle = reader.GetTypeSpecification(
+                _typeSignature.Handle.ToTypeSpecificationHandle(reader)).Signature;
+            MethodSignatureHandle methodSigHandle = reader.GetFunctionPointerSignature(
+                fnPtrTypeSigHandle.ToFunctionPointerSignatureHandle(reader)).Signature;
+
+            Debug.Assert((int)Internal.Metadata.NativeFormat.SignatureCallingConvention.StdCall == (int)SignatureCallingConvention.StdCall);
+            Debug.Assert((int)Internal.Metadata.NativeFormat.SignatureCallingConvention.Unmanaged == (int)SignatureCallingConvention.Unmanaged);
+            return (SignatureCallingConvention)(reader.GetMethodSignature(methodSigHandle).CallingConvention
+                & Internal.Metadata.NativeFormat.SignatureCallingConvention.UnmanagedCallingConventionMask);
+        }
+
+        private Type[] GetCustomModifiers(bool required)
+        {
+            ArrayBuilder<Type> builder = default;
+
+            MetadataReader reader = _typeSignature.Reader;
+            Handle handle = _typeSignature.Handle;
+
+            while (handle.HandleType == HandleType.ModifiedType)
+            {
+                var modifiedType = reader.GetModifiedType(handle.ToModifiedTypeHandle(reader));
+
+                handle = modifiedType.Type;
+
+                if (modifiedType.IsOptional == required)
+                    continue;
+
+                builder.Add(modifiedType.ModifierType.Resolve(reader, new TypeContext(null, null)));
+            }
+
+            Type[] result = builder.ToArray();
+
+            // We call Reverse for compat with CoreCLR that also reverses these.
+            // ILDasm also reverses these but don't be fooled: you can go to
+            // View -> MetaInfo -> Show to see the file format order in ILDasm.
+            Array.Reverse(result);
+
+            return result;
+        }
+
+        public static Type Create(Type unmodifiedType, MetadataReader reader, Handle typeSignature)
+            => ModifiedType.Create(unmodifiedType, new TypeSignature(reader, typeSignature));
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/FieldInfos/NativeFormat/NativeFormatRuntimeFieldInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/FieldInfos/NativeFormat/NativeFormatRuntimeFieldInfo.cs
@@ -162,6 +162,8 @@ namespace System.Reflection.Runtime.FieldInfos.NativeFormat
 
         protected sealed override int ExplicitLayoutFieldOffsetData => (int)(_field.Offset);
 
+        public sealed override Type GetModifiedFieldType() => ModifiedType.Create(FieldRuntimeType, _reader, FieldTypeHandle);
+
         private Handle FieldTypeHandle => _field.Signature.GetFieldSignature(_reader).Type;
 
         private readonly NativeFormatRuntimeNamedTypeInfo _definingTypeInfo;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/QSignatureTypeHandle.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/QSignatureTypeHandle.cs
@@ -61,5 +61,10 @@ namespace System.Reflection.Runtime.General
             return _handle.GetCustomModifiers((global::Internal.Metadata.NativeFormat.MetadataReader)Reader, typeContext, optional);
 #endif
         }
+
+        internal Type GetModifiedType(TypeContext typeContext)
+        {
+            return ModifiedType.Create(Resolve(typeContext), (global::Internal.Metadata.NativeFormat.MetadataReader)Reader, _handle);
+        }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/ParameterInfos/RuntimeMethodParameterInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/ParameterInfos/RuntimeMethodParameterInfo.cs
@@ -36,6 +36,8 @@ namespace System.Reflection.Runtime.ParameterInfos
             }
         }
 
+        public sealed override Type GetModifiedParameterType() => QualifiedParameterTypeHandle.GetModifiedType(_typeContext);
+
         protected readonly QSignatureTypeHandle QualifiedParameterTypeHandle;
         private readonly TypeContext _typeContext;
         private volatile Type _lazyParameterType;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/PropertyInfos/NativeFormat/NativeFormatRuntimePropertyInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/PropertyInfos/NativeFormat/NativeFormatRuntimePropertyInfo.cs
@@ -75,6 +75,12 @@ namespace System.Reflection.Runtime.PropertyInfos.NativeFormat
             }
         }
 
+        public override Type GetModifiedPropertyType()
+        {
+            return ModifiedType.Create(PropertyType, _reader, _reader.GetPropertySignature(_property.Signature).Type);
+
+        }
+
         public sealed override bool HasSameMetadataDefinitionAs(MemberInfo other)
         {
             ArgumentNullException.ThrowIfNull(other);

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -637,6 +637,24 @@ namespace Internal.Runtime.TypeLoader
             return numSeries;
         }
 
+        public static RuntimeTypeHandle CreateFunctionPointerEEType(uint hashCodeOfNewType, RuntimeTypeHandle returnTypeHandle, RuntimeTypeHandle[] parameterHandles, FunctionPointerType functionPointerType)
+        {
+            TypeBuilderState state = new TypeBuilderState(functionPointerType);
+
+            CreateEETypeWorker(typeof(delegate*<void>).TypeHandle.ToEETypePtr(), hashCodeOfNewType, 0, state);
+            Debug.Assert(!state.HalfBakedRuntimeTypeHandle.IsNull());
+
+            TypeLoaderLogger.WriteLine("Allocated new FUNCTION POINTER type " + functionPointerType.ToString() + " with hashcode value = 0x" + hashCodeOfNewType.LowLevelToString() + " with MethodTable = " + state.HalfBakedRuntimeTypeHandle.ToIntPtr().LowLevelToString());
+
+            state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->FunctionPointerReturnType = returnTypeHandle.ToEETypePtr();
+            Debug.Assert(state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->NumFunctionPointerParameters == parameterHandles.Length);
+            MethodTableList paramList = state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->FunctionPointerParameters;
+            for (int i = 0; i < parameterHandles.Length; i++)
+                paramList[i] = parameterHandles[i].ToEETypePtr();
+
+            return state.HalfBakedRuntimeTypeHandle;
+        }
+
         public static RuntimeTypeHandle CreatePointerEEType(uint hashCodeOfNewType, RuntimeTypeHandle pointeeTypeHandle, TypeDesc pointerType)
         {
             TypeBuilderState state = new TypeBuilderState(pointerType);

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/TypeSystemContext.Runtime.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/TypeSystemContext.Runtime.cs
@@ -162,7 +162,7 @@ namespace Internal.TypeSystem
         internal static FunctionPointerRuntimeTypeHandleHashtable FunctionPointerTypesCache { get; }
             = new FunctionPointerRuntimeTypeHandleHashtable();
 
-        private TypeDesc[] ResolveRuntimeTypeHandlesInternal(RuntimeTypeHandle[] runtimeTypeHandles)
+        public TypeDesc[] ResolveRuntimeTypeHandlesInternal(RuntimeTypeHandle[] runtimeTypeHandles)
         {
             TypeDesc[] TypeDescs = new TypeDesc[runtimeTypeHandles.Length];
             for (int i = 0; i < runtimeTypeHandles.Length; i++)

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/SchemaDef.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/SchemaDef.cs
@@ -558,7 +558,7 @@ class SchemaDef
             name: "MethodInstantiation",
             members: new MemberDef[] {
                 new MemberDef("Method", MethodDefOrRef, MemberDefFlags.RecordRef),
-                new MemberDef("GenericTypeArguments", TypeDefOrRefOrSpec, MemberDefFlags.List | MemberDefFlags.RecordRef),
+                new MemberDef("GenericTypeArguments", TypeDefOrRefOrSpecOrMod, MemberDefFlags.List | MemberDefFlags.RecordRef),
                 // COMPLETENESS: new MemberDef("CustomAttributes", "CustomAttribute", MemberDefFlags.List | MemberDefFlags.RecordRef | MemberDefFlags.Child),
             }
         ),
@@ -674,7 +674,7 @@ class SchemaDef
             name: "TypeInstantiationSignature",
             members: new MemberDef[] {
                 new MemberDef("GenericType", TypeDefOrRefOrSpec, MemberDefFlags.RecordRef),
-                new MemberDef("GenericTypeArguments", TypeDefOrRefOrSpec, MemberDefFlags.List | MemberDefFlags.RecordRef),
+                new MemberDef("GenericTypeArguments", TypeDefOrRefOrSpecOrMod, MemberDefFlags.List | MemberDefFlags.RecordRef),
             }
         ),
         new RecordDef(

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/SchemaDef.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/SchemaDef.cs
@@ -695,7 +695,7 @@ class SchemaDef
         new RecordDef(
             name: "ByReferenceSignature",
             members: new MemberDef[] {
-                new MemberDef("Type", TypeDefOrRefOrSpec, MemberDefFlags.RecordRef),
+                new MemberDef("Type", TypeDefOrRefOrSpecOrMod, MemberDefFlags.RecordRef),
             }
         ),
         new RecordDef(

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/SchemaDef.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/SchemaDef.cs
@@ -686,7 +686,7 @@ class SchemaDef
         new RecordDef(
             name: "ArraySignature",
             members: new MemberDef[] {
-                new MemberDef("ElementType", TypeDefOrRefOrSpec, MemberDefFlags.RecordRef),
+                new MemberDef("ElementType", TypeDefOrRefOrSpecOrMod, MemberDefFlags.RecordRef),
                 new MemberDef("Rank", "int"),
                 new MemberDef("Sizes", "Int32", MemberDefFlags.Array),
                 new MemberDef("LowerBounds", "Int32", MemberDefFlags.Array),

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
@@ -37,7 +37,7 @@ namespace Internal.Metadata.NativeFormat
                 return _handle;
             }
         } // Handle
-        /// One of: TypeDefinition, TypeReference, TypeSpecification
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ModifiedType
 
         public Handle ElementType
         {

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
@@ -4901,7 +4901,7 @@ namespace Internal.Metadata.NativeFormat
         } // Method
 
         internal Handle _method;
-        /// One of: TypeDefinition, TypeReference, TypeSpecification
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ModifiedType
 
         public HandleCollection GenericTypeArguments
         {
@@ -7756,7 +7756,7 @@ namespace Internal.Metadata.NativeFormat
         } // GenericType
 
         internal Handle _genericType;
-        /// One of: TypeDefinition, TypeReference, TypeSpecification
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ModifiedType
 
         public HandleCollection GenericTypeArguments
         {

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
@@ -182,7 +182,7 @@ namespace Internal.Metadata.NativeFormat
                 return _handle;
             }
         } // Handle
-        /// One of: TypeDefinition, TypeReference, TypeSpecification
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ModifiedType
 
         public Handle Type
         {

--- a/src/coreclr/tools/Common/TypeSystem/Common/FieldDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/FieldDesc.cs
@@ -47,6 +47,8 @@ namespace Internal.TypeSystem
         // Get the embedded signature data used to hold custom modifiers and such within a field signature
         public abstract EmbeddedSignatureData[] GetEmbeddedSignatureData();
 
+        public abstract bool HasEmbeddedSignatureData { get; }
+
         public abstract bool IsStatic
         {
             get;

--- a/src/coreclr/tools/Common/TypeSystem/Common/FieldForInstantiatedType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/FieldForInstantiatedType.cs
@@ -54,6 +54,14 @@ namespace Internal.TypeSystem
             return _fieldDef.GetEmbeddedSignatureData();
         }
 
+        public override bool HasEmbeddedSignatureData
+        {
+            get
+            {
+                return _fieldDef.HasEmbeddedSignatureData;
+            }
+        }
+
         public override bool IsStatic
         {
             get

--- a/src/coreclr/tools/Common/TypeSystem/Common/PropertySignature.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/PropertySignature.cs
@@ -11,6 +11,8 @@ namespace Internal.TypeSystem
 
         public readonly TypeDesc ReturnType;
 
+        private readonly EmbeddedSignatureData[] _embeddedSignatureData;
+
         [System.Runtime.CompilerServices.IndexerName("Parameter")]
         public TypeDesc this[int index]
         {
@@ -28,11 +30,20 @@ namespace Internal.TypeSystem
             }
         }
 
-        public PropertySignature(bool isStatic, TypeDesc[] parameters, TypeDesc returnType)
+        public bool HasEmbeddedSignatureData
+        {
+            get
+            {
+                return _embeddedSignatureData != null;
+            }
+        }
+
+        public PropertySignature(bool isStatic, TypeDesc[] parameters, TypeDesc returnType, EmbeddedSignatureData[] embeddedSignatureData)
         {
             IsStatic = isStatic;
             _parameters = parameters;
             ReturnType = returnType;
+            _embeddedSignatureData = embeddedSignatureData;
         }
     }
 }

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
@@ -421,19 +421,10 @@ namespace Internal.TypeSystem.Ecma
 
         public PropertySignature ParsePropertySignature()
         {
-            try
-            {
-                _indexStack = new Stack<int>();
-                _indexStack.Push(0);
-                _embeddedSignatureDataList = new List<EmbeddedSignatureData>();
-                return ParsePropertySignatureInternal();
-            }
-            finally
-            {
-                _indexStack = null;
-                _embeddedSignatureDataList = null;
-            }
-
+            _indexStack = new Stack<int>();
+            _indexStack.Push(0);
+            _embeddedSignatureDataList = new List<EmbeddedSignatureData>();
+            return ParsePropertySignatureInternal();
         }
 
         private PropertySignature ParsePropertySignatureInternal()

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
@@ -421,6 +421,23 @@ namespace Internal.TypeSystem.Ecma
 
         public PropertySignature ParsePropertySignature()
         {
+            try
+            {
+                _indexStack = new Stack<int>();
+                _indexStack.Push(0);
+                _embeddedSignatureDataList = new List<EmbeddedSignatureData>();
+                return ParsePropertySignatureInternal();
+            }
+            finally
+            {
+                _indexStack = null;
+                _embeddedSignatureDataList = null;
+            }
+
+        }
+
+        private PropertySignature ParsePropertySignatureInternal()
+        {
             // As PropertySignature is a struct, we cannot return null
             if (_notFoundBehavior != NotFoundBehavior.Throw)
                 throw new ArgumentException();
@@ -450,7 +467,9 @@ namespace Internal.TypeSystem.Ecma
                 parameters = TypeDesc.EmptyTypes;
             }
 
-            return new PropertySignature(isStatic, parameters, returnType);
+            EmbeddedSignatureData[] embeddedSignatureDataArray = (_embeddedSignatureDataList == null || _embeddedSignatureDataList.Count == 0) ? null : _embeddedSignatureDataList.ToArray();
+
+            return new PropertySignature(isStatic, parameters, returnType, embeddedSignatureDataArray);
         }
 
         public TypeDesc ParseFieldSignature()

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/PInvokeLazyFixupField.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/PInvokeLazyFixupField.cs
@@ -58,6 +58,8 @@ namespace Internal.IL.Stubs
 
         public override EmbeddedSignatureData[] GetEmbeddedSignatureData() => null;
 
+        public override bool HasEmbeddedSignatureData => false;
+
         public override bool HasRva
         {
             get

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/InlineArrayType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/InlineArrayType.cs
@@ -446,6 +446,8 @@ namespace Internal.TypeSystem.Interop
             }
             public override EmbeddedSignatureData[] GetEmbeddedSignatureData() => null;
 
+            public override bool HasEmbeddedSignatureData => false;
+
             public override bool HasRva
             {
                 get

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/NativeStructType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/NativeStructType.cs
@@ -372,6 +372,8 @@ namespace Internal.TypeSystem.Interop
 
             public override EmbeddedSignatureData[] GetEmbeddedSignatureData() => null;
 
+            public override bool HasEmbeddedSignatureData => false;
+
             public override bool HasRva
             {
                 get

--- a/src/coreclr/tools/Common/TypeSystem/MetadataEmitter/TypeSystemMetadataEmitter.cs
+++ b/src/coreclr/tools/Common/TypeSystem/MetadataEmitter/TypeSystemMetadataEmitter.cs
@@ -269,11 +269,10 @@ namespace Internal.TypeSystem
 
         private BlobHandle GetFieldSignatureBlobHandle(FieldDesc field)
         {
-            var embeddedSigData = field.GetEmbeddedSignatureData();
             EmbeddedSignatureDataEmitter signatureDataEmitter;
-            if (embeddedSigData != null && embeddedSigData.Length != 0)
+            if (field.HasEmbeddedSignatureData)
             {
-                signatureDataEmitter = new EmbeddedSignatureDataEmitter(embeddedSigData, this);
+                signatureDataEmitter = new EmbeddedSignatureDataEmitter(field.GetEmbeddedSignatureData(), this);
             }
             else
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FieldMetadataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FieldMetadataNode.cs
@@ -51,6 +51,13 @@ namespace ILCompiler.DependencyAnalysis
                 GenericArgumentDataFlow.ProcessGenericArgumentDataFlow(ref dependencies, factory, new MessageOrigin(_field), ecmaField.FieldType, ecmaField.OwningType);
             }
 
+            if (_field.HasEmbeddedSignatureData)
+            {
+                foreach (var sigData in _field.GetEmbeddedSignatureData())
+                    if (sigData.type != null)
+                        TypeMetadataNode.GetMetadataDependencies(ref dependencies, factory, sigData.type, "Modifier in a field signature");
+            }
+
             return dependencies;
         }
         protected override string GetName(NodeFactory factory)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/MethodMetadataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/MethodMetadataNode.cs
@@ -50,6 +50,13 @@ namespace ILCompiler.DependencyAnalysis
                 TypeMetadataNode.GetMetadataDependencies(ref dependencies, factory, paramType, reason);
             }
 
+            if (sig.HasEmbeddedSignatureData)
+            {
+                foreach (var sigData in sig.GetEmbeddedSignatureData())
+                    if (sigData.type != null)
+                        TypeMetadataNode.GetMetadataDependencies(ref dependencies, factory, sigData.type, "Modifier in a method signature");
+            }
+
             if (_method is EcmaMethod ecmaMethod)
             {
                 DynamicDependencyAttributesOnEntityNode.AddDependenciesDueToDynamicDependencyAttribute(ref dependencies, factory, ecmaMethod);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExternSymbolMappedField.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExternSymbolMappedField.cs
@@ -27,6 +27,7 @@ namespace ILCompiler
 
         public override TypeDesc FieldType => _fieldType;
         public override EmbeddedSignatureData[] GetEmbeddedSignatureData() => null;
+        public override bool HasEmbeddedSignatureData => false;
 
         public override bool IsStatic => true;
 

--- a/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler/Metadata/Transform.Field.cs
+++ b/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler/Metadata/Transform.Field.cs
@@ -78,6 +78,10 @@ namespace ILCompiler.Metadata
                 if (offset >= 0)
                     record.Offset = (uint)offset;
             }
+            else
+            {
+                throw new NotImplementedException();
+            }
         }
 
         private MetadataRecord HandleFieldSignature(Cts.Ecma.EcmaModule module, Ecma.BlobHandle sigBlob)

--- a/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler/Metadata/Transform.Field.cs
+++ b/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler/Metadata/Transform.Field.cs
@@ -47,11 +47,6 @@ namespace ILCompiler.Metadata
         private void InitializeFieldDefinition(Cts.FieldDesc entity, Field record)
         {
             record.Name = HandleString(entity.Name);
-            record.Signature = new FieldSignature
-            {
-                Type = HandleType(entity.FieldType),
-                // TODO: CustomModifiers
-            };
             record.Flags = GetFieldAttributes(entity);
 
             var ecmaField = entity as Cts.Ecma.EcmaField;
@@ -59,6 +54,14 @@ namespace ILCompiler.Metadata
             {
                 Ecma.MetadataReader reader = ecmaField.MetadataReader;
                 Ecma.FieldDefinition fieldDef = reader.GetFieldDefinition(ecmaField.Handle);
+
+                record.Signature = new FieldSignature
+                {
+                    Type = entity.HasEmbeddedSignatureData
+                        ? HandleFieldSignature(ecmaField.Module, fieldDef.Signature)
+                        : HandleType(entity.FieldType),
+                };
+
                 Ecma.ConstantHandle defaultValueHandle = fieldDef.GetDefaultValue();
                 if (!defaultValueHandle.IsNil)
                 {
@@ -75,6 +78,14 @@ namespace ILCompiler.Metadata
                 if (offset >= 0)
                     record.Offset = (uint)offset;
             }
+        }
+
+        private MetadataRecord HandleFieldSignature(Cts.Ecma.EcmaModule module, Ecma.BlobHandle sigBlob)
+        {
+            Ecma.BlobReader reader = module.MetadataReader.GetBlobReader(sigBlob);
+            Ecma.SignatureHeader header = reader.ReadSignatureHeader();
+            Debug.Assert(header.Kind == Ecma.SignatureKind.Field);
+            return HandleType(module, ref reader);
         }
 
         private MemberReference HandleFieldReference(Cts.FieldDesc field)

--- a/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler/Metadata/Transform.Method.cs
+++ b/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler/Metadata/Transform.Method.cs
@@ -61,7 +61,6 @@ namespace ILCompiler.Metadata
         private void InitializeMethodDefinition(Cts.MethodDesc entity, Method record)
         {
             record.Name = HandleString(entity.Name);
-            record.Signature = HandleMethodSignature(entity.Signature);
 
             if (entity.HasInstantiation)
             {
@@ -76,6 +75,11 @@ namespace ILCompiler.Metadata
                 Ecma.MetadataReader reader = ecmaEntity.MetadataReader;
                 Ecma.MethodDefinition methodDef = reader.GetMethodDefinition(ecmaEntity.Handle);
                 Ecma.ParameterHandleCollection paramHandles = methodDef.GetParameters();
+
+                Cts.MethodSignature sig = entity.Signature;
+                record.Signature = sig.HasEmbeddedSignatureData
+                    ? HandleMethodSignature(ecmaEntity.Module, methodDef.Signature)
+                    : HandleMethodSignature(entity.Signature);
 
                 record.Parameters.Capacity = paramHandles.Count;
                 foreach (var paramHandle in paramHandles)
@@ -170,6 +174,37 @@ namespace ILCompiler.Metadata
             return result;
         }
 
+        private MethodSignature HandleMethodSignature(Cts.Ecma.EcmaModule module, Ecma.BlobHandle sigBlobHandle)
+        {
+            Ecma.BlobReader blobReader = module.MetadataReader.GetBlobReader(sigBlobHandle);
+            return HandleMethodSignature(module, ref blobReader);
+        }
+
+        private MethodSignature HandleMethodSignature(Cts.Ecma.EcmaModule module, ref Ecma.BlobReader blobReader)
+        {
+            Ecma.SignatureHeader header = blobReader.ReadSignatureHeader();
+
+            int arity = header.IsGeneric ? blobReader.ReadCompressedInteger() : 0;
+
+            int count = blobReader.ReadCompressedInteger();
+
+            var result = new MethodSignature
+            {
+                CallingConvention = GetSignatureCallingConvention(header),
+                GenericParameterCount = arity,
+                ReturnType = HandleType(module, ref blobReader),
+                // TODO-NICE: VarArgParameters
+            };
+
+            result.Parameters.Capacity = count;
+            for (int i = 0; i < count; i++)
+            {
+                result.Parameters.Add(HandleType(module, ref blobReader));
+            }
+
+            return result;
+        }
+
         private static MethodAttributes GetMethodAttributes(Cts.MethodDesc method)
         {
             var ecmaMethod = method as Cts.Ecma.EcmaMethod;
@@ -203,6 +238,19 @@ namespace ILCompiler.Metadata
             Debug.Assert((int)Cts.MethodSignatureFlags.UnmanagedCallingConventionMask == (int)SignatureCallingConvention.UnmanagedCallingConventionMask);
             SignatureCallingConvention callingConvention = (SignatureCallingConvention)(signature.Flags & Cts.MethodSignatureFlags.UnmanagedCallingConventionMask);
             if ((signature.Flags & Cts.MethodSignatureFlags.Static) == 0)
+            {
+                callingConvention |= SignatureCallingConvention.HasThis;
+            }
+            return callingConvention;
+        }
+
+        private static SignatureCallingConvention GetSignatureCallingConvention(Ecma.SignatureHeader signature)
+        {
+            Debug.Assert((int)Ecma.SignatureCallingConvention.CDecl == (int)SignatureCallingConvention.Cdecl);
+            Debug.Assert((int)Ecma.SignatureCallingConvention.ThisCall == (int)SignatureCallingConvention.ThisCall);
+            Debug.Assert((int)Ecma.SignatureCallingConvention.Unmanaged == (int)SignatureCallingConvention.Unmanaged);
+            SignatureCallingConvention callingConvention = (SignatureCallingConvention)(signature.CallingConvention);
+            if (signature.IsInstance)
             {
                 callingConvention |= SignatureCallingConvention.HasThis;
             }

--- a/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler/Metadata/Transform.Type.cs
+++ b/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler/Metadata/Transform.Type.cs
@@ -376,6 +376,142 @@ namespace ILCompiler.Metadata
                 => entity.GetNestedTypes().GetEnumerator().MoveNext();
         }
 
+        private MetadataRecord HandleType(Cts.Ecma.EcmaModule module, ref Ecma.BlobReader reader)
+        {
+            switch (reader.ReadSignatureTypeCode())
+            {
+                case Ecma.SignatureTypeCode.Void:
+                    return HandleType(module.Context.GetWellKnownType(Cts.WellKnownType.Void));
+                case Ecma.SignatureTypeCode.Boolean:
+                    return HandleType(module.Context.GetWellKnownType(Cts.WellKnownType.Boolean));
+                case Ecma.SignatureTypeCode.SByte:
+                    return HandleType(module.Context.GetWellKnownType(Cts.WellKnownType.SByte));
+                case Ecma.SignatureTypeCode.Byte:
+                    return HandleType(module.Context.GetWellKnownType(Cts.WellKnownType.Byte));
+                case Ecma.SignatureTypeCode.Int16:
+                    return HandleType(module.Context.GetWellKnownType(Cts.WellKnownType.Int16));
+                case Ecma.SignatureTypeCode.UInt16:
+                    return HandleType(module.Context.GetWellKnownType(Cts.WellKnownType.UInt16));
+                case Ecma.SignatureTypeCode.Int32:
+                    return HandleType(module.Context.GetWellKnownType(Cts.WellKnownType.Int32));
+                case Ecma.SignatureTypeCode.UInt32:
+                    return HandleType(module.Context.GetWellKnownType(Cts.WellKnownType.UInt32));
+                case Ecma.SignatureTypeCode.Int64:
+                    return HandleType(module.Context.GetWellKnownType(Cts.WellKnownType.Int64));
+                case Ecma.SignatureTypeCode.UInt64:
+                    return HandleType(module.Context.GetWellKnownType(Cts.WellKnownType.UInt64));
+                case Ecma.SignatureTypeCode.Single:
+                    return HandleType(module.Context.GetWellKnownType(Cts.WellKnownType.Single));
+                case Ecma.SignatureTypeCode.Double:
+                    return HandleType(module.Context.GetWellKnownType(Cts.WellKnownType.Double));
+                case Ecma.SignatureTypeCode.Char:
+                    return HandleType(module.Context.GetWellKnownType(Cts.WellKnownType.Char));
+                case Ecma.SignatureTypeCode.String:
+                    return HandleType(module.Context.GetWellKnownType(Cts.WellKnownType.String));
+                case Ecma.SignatureTypeCode.IntPtr:
+                    return HandleType(module.Context.GetWellKnownType(Cts.WellKnownType.IntPtr));
+                case Ecma.SignatureTypeCode.UIntPtr:
+                    return HandleType(module.Context.GetWellKnownType(Cts.WellKnownType.UIntPtr));
+                case Ecma.SignatureTypeCode.Object:
+                    return HandleType(module.Context.GetWellKnownType(Cts.WellKnownType.Object));
+                case Ecma.SignatureTypeCode.TypeHandle:
+                    return HandleType(module.GetType(reader.ReadTypeHandle()));
+                case Ecma.SignatureTypeCode.SZArray:
+                    return new TypeSpecification
+                    {
+                        Signature = new SZArraySignature()
+                        {
+                            ElementType = HandleType(module, ref reader)
+                        }
+                    };
+                case Ecma.SignatureTypeCode.Array:
+                    {
+                        MetadataRecord elementType = HandleType(module, ref reader);
+                        int rank = reader.ReadCompressedInteger();
+
+                        var boundsCount = reader.ReadCompressedInteger();
+                        for (int i = 0; i < boundsCount; i++)
+                            reader.ReadCompressedInteger();
+                        var lowerBoundsCount = reader.ReadCompressedInteger();
+                        for (int j = 0; j < lowerBoundsCount; j++)
+                            reader.ReadCompressedSignedInteger();
+
+                        return new TypeSpecification
+                        {
+                            Signature = new ArraySignature()
+                            {
+                                ElementType = elementType,
+                                Rank = rank,
+                                // TODO: sizes & lower bounds
+                            }
+                        };
+                    }
+                case Ecma.SignatureTypeCode.ByReference:
+                    return new TypeSpecification
+                    {
+                        Signature = new ByReferenceSignature()
+                        {
+                            Type = HandleType(module, ref reader)
+                        }
+                    };
+                case Ecma.SignatureTypeCode.Pointer:
+                    return new TypeSpecification
+                    {
+                        Signature = new PointerSignature()
+                        {
+                            Type = HandleType(module, ref reader)
+                        }
+                    };
+                case Ecma.SignatureTypeCode.GenericTypeParameter:
+                    return HandleType(module.Context.GetSignatureVariable(reader.ReadCompressedInteger(), false));
+                case Ecma.SignatureTypeCode.GenericMethodParameter:
+                    return HandleType(module.Context.GetSignatureVariable(reader.ReadCompressedInteger(), true));
+                case Ecma.SignatureTypeCode.GenericTypeInstance:
+                    {
+                        var sig = new TypeInstantiationSignature
+                        {
+                            GenericType = HandleType(module, ref reader)
+                        };
+
+                        int count = reader.ReadCompressedInteger();
+                        for (int i = 0; i < count; i++)
+                            sig.GenericTypeArguments.Add(HandleType(module, ref reader));
+
+                        return new TypeSpecification
+                        {
+                            Signature = sig
+                        };
+                    }
+                case Ecma.SignatureTypeCode.TypedReference:
+                    return HandleType(module.Context.GetWellKnownType(Cts.WellKnownType.TypedReference));
+                case Ecma.SignatureTypeCode.FunctionPointer:
+                    return new TypeSpecification
+                    {
+                        Signature = new FunctionPointerSignature
+                        {
+                            Signature = HandleMethodSignature(module, ref reader)
+                        }
+                    };
+                case Ecma.SignatureTypeCode.OptionalModifier:
+                    return new ModifiedType
+                    {
+                        IsOptional = true,
+                        ModifierType = HandleType(module.GetType(reader.ReadTypeHandle())),
+                        Type = HandleType(module, ref reader),
+                    };
+                case Ecma.SignatureTypeCode.RequiredModifier:
+                    return new ModifiedType
+                    {
+                        IsOptional = false,
+                        ModifierType = HandleType(module.GetType(reader.ReadTypeHandle())),
+                        Type = HandleType(module, ref reader),
+                    };
+
+                default:
+                    throw new BadImageFormatException();
+            }
+        }
+
         private static TypeAttributes GetTypeAttributes(Cts.MetadataType type)
         {
             TypeAttributes result;

--- a/src/coreclr/tools/aot/ILCompiler.MetadataTransform/Internal/Metadata/NativeFormat/Writer/NativeFormatWriterGen.cs
+++ b/src/coreclr/tools/aot/ILCompiler.MetadataTransform/Internal/Metadata/NativeFormat/Writer/NativeFormatWriterGen.cs
@@ -151,7 +151,8 @@ namespace Internal.Metadata.NativeFormat.Writer
             Debug.Assert(Type == null ||
                 Type.HandleType == HandleType.TypeDefinition ||
                 Type.HandleType == HandleType.TypeReference ||
-                Type.HandleType == HandleType.TypeSpecification);
+                Type.HandleType == HandleType.TypeSpecification ||
+                Type.HandleType == HandleType.ModifiedType);
             writer.Write(Type);
         } // Save
 

--- a/src/coreclr/tools/aot/ILCompiler.MetadataTransform/Internal/Metadata/NativeFormat/Writer/NativeFormatWriterGen.cs
+++ b/src/coreclr/tools/aot/ILCompiler.MetadataTransform/Internal/Metadata/NativeFormat/Writer/NativeFormatWriterGen.cs
@@ -77,7 +77,8 @@ namespace Internal.Metadata.NativeFormat.Writer
             Debug.Assert(ElementType == null ||
                 ElementType.HandleType == HandleType.TypeDefinition ||
                 ElementType.HandleType == HandleType.TypeReference ||
-                ElementType.HandleType == HandleType.TypeSpecification);
+                ElementType.HandleType == HandleType.TypeSpecification ||
+                ElementType.HandleType == HandleType.ModifiedType);
             writer.Write(ElementType);
             writer.Write(Rank);
             writer.Write(Sizes);

--- a/src/coreclr/tools/aot/ILCompiler.MetadataTransform/Internal/Metadata/NativeFormat/Writer/NativeFormatWriterGen.cs
+++ b/src/coreclr/tools/aot/ILCompiler.MetadataTransform/Internal/Metadata/NativeFormat/Writer/NativeFormatWriterGen.cs
@@ -2994,7 +2994,8 @@ namespace Internal.Metadata.NativeFormat.Writer
             Debug.Assert(GenericTypeArguments.TrueForAll(handle => handle == null ||
                 handle.HandleType == HandleType.TypeDefinition ||
                 handle.HandleType == HandleType.TypeReference ||
-                handle.HandleType == HandleType.TypeSpecification));
+                handle.HandleType == HandleType.TypeSpecification ||
+                handle.HandleType == HandleType.ModifiedType));
             writer.Write(GenericTypeArguments);
         } // Save
 
@@ -4692,7 +4693,8 @@ namespace Internal.Metadata.NativeFormat.Writer
             Debug.Assert(GenericTypeArguments.TrueForAll(handle => handle == null ||
                 handle.HandleType == HandleType.TypeDefinition ||
                 handle.HandleType == HandleType.TypeReference ||
-                handle.HandleType == HandleType.TypeSpecification));
+                handle.HandleType == HandleType.TypeSpecification ||
+                handle.HandleType == HandleType.ModifiedType));
             writer.Write(GenericTypeArguments);
         } // Save
 

--- a/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemField.cs
+++ b/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemField.cs
@@ -32,6 +32,8 @@ namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
 
         public override EmbeddedSignatureData[] GetEmbeddedSignatureData() => _embeddedSignatureData;
 
+        public override bool HasEmbeddedSignatureData => _embeddedSignatureData != null;
+
         public override bool IsStatic => throw new NotImplementedException();
 
         public override bool IsInitOnly => throw new NotImplementedException();

--- a/src/libraries/Common/tests/System/FunctionPointerCallingConventionTests.cs
+++ b/src/libraries/Common/tests/System/FunctionPointerCallingConventionTests.cs
@@ -16,7 +16,6 @@ namespace System.Tests.Types
         [InlineData(true)]
         [InlineData(false)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void ManagedCallingConvention(bool modified)
         {
             Type t = typeof(FunctionPointerHolder).Project();
@@ -38,7 +37,6 @@ namespace System.Tests.Types
         [InlineData(nameof(FunctionPointerHolder.MethodCallConv_Thiscall))]
         [InlineData(nameof(FunctionPointerHolder.MethodCallConv_Fastcall))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void UnmanagedCallConv_Param_Unmodified(string methodName)
         {
             Type t = typeof(FunctionPointerHolder).Project();
@@ -57,7 +55,6 @@ namespace System.Tests.Types
         [InlineData(nameof(FunctionPointerHolder.MethodCallConv_Thiscall), typeof(CallConvThiscall))]
         [InlineData(nameof(FunctionPointerHolder.MethodCallConv_Fastcall), typeof(CallConvFastcall))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void UnmanagedCallConv_Param_Modified(string methodName, Type callingConventionRuntime)
         {
             Type callingConvention = callingConventionRuntime.Project();
@@ -75,7 +72,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void UnmanagedCallConvs_Return_Unmodified()
         {
             Type t = typeof(FunctionPointerHolder).Project();
@@ -96,7 +92,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void UnmanagedCallConvs_Return_Modified()
         {
             Type t = typeof(FunctionPointerHolder).Project();
@@ -124,7 +119,6 @@ namespace System.Tests.Types
         [InlineData(nameof(FunctionPointerHolder.MethodCallConv_Thiscall_SuppressGCTransition))]
         [InlineData(nameof(FunctionPointerHolder.MethodCallConv_Fastcall_SuppressGCTransition))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void UnmanagedCallConv_PhysicalModifiers_Unmodified(string methodName)
         {
             Type t = typeof(FunctionPointerHolder).Project();
@@ -144,7 +138,6 @@ namespace System.Tests.Types
         [InlineData(nameof(FunctionPointerHolder.MethodCallConv_Thiscall_SuppressGCTransition), typeof(CallConvThiscall))]
         [InlineData(nameof(FunctionPointerHolder.MethodCallConv_Fastcall_SuppressGCTransition), typeof(CallConvFastcall))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void UnmanagedCallConv_PhysicalModifiers_Modified(string methodName, Type callingConventionRuntime)
         {
             Type suppressGcTransitionType = typeof(CallConvSuppressGCTransition).Project();
@@ -169,7 +162,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void GenericTypeParameter()
         {
             Type holder = typeof(FunctionPointerHolder).Project();

--- a/src/libraries/Common/tests/System/FunctionPointerEqualityTests.cs
+++ b/src/libraries/Common/tests/System/FunctionPointerEqualityTests.cs
@@ -32,7 +32,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void ObjectEquals_ModifiedTypes()
         {
             Type holder = typeof(FunctionPointerHolder).Project();
@@ -49,7 +48,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void ObjectEquals_OneSideModifiedType()
         {
             Type holder = typeof(FunctionPointerHolder).Project();
@@ -86,7 +84,6 @@ namespace System.Tests.Types
         [InlineData(nameof(FunctionPointerHolder.MethodCallConv_Cdecl), nameof(FunctionPointerHolder.MethodCallConv_Thiscall))]
         [InlineData(nameof(FunctionPointerHolder.MethodCallConv_Cdecl), nameof(FunctionPointerHolder.MethodCallConv_Fastcall))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void CallingConvention_Modified(string methodName1, string methodName2)
         {
             Type t = typeof(FunctionPointerHolder).Project();

--- a/src/libraries/Common/tests/System/FunctionPointerTests.cs
+++ b/src/libraries/Common/tests/System/FunctionPointerTests.cs
@@ -164,7 +164,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void RequiredModifiers()
         {
             Type t = typeof(FunctionPointerHolder).Project();
@@ -190,7 +189,6 @@ namespace System.Tests.Types
             "System.Double(System.String, System.Boolean*&, System.Tests.Types.FunctionPointerTests+FunctionPointerHolder+MyClass, System.Tests.Types.FunctionPointerTests+FunctionPointerHolder+MyStruct&)",
             "String", "Boolean*&", "MyClass", "MyStruct&")]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void MethodInfo(
             string methodName,
             string methodToStringPostfix,
@@ -219,7 +217,6 @@ namespace System.Tests.Types
         [InlineData(nameof(FunctionPointerHolder.Prop_Int), "System.Int32()")]
         [InlineData(nameof(FunctionPointerHolder.Prop_MyClass), "System.Tests.Types.FunctionPointerTests+FunctionPointerHolder+MyClass()")]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void Property(string name, string expectedToString)
         {
             Type t = typeof(FunctionPointerHolder).Project();
@@ -239,7 +236,6 @@ namespace System.Tests.Types
         [InlineData(nameof(FunctionPointerHolder.Field_Int), "System.Int32()")]
         [InlineData(nameof(FunctionPointerHolder.Field_MyClass), "System.Tests.Types.FunctionPointerTests+FunctionPointerHolder+MyClass()")]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void Field(string name, string expectedToString)
         {
             Type t = typeof(FunctionPointerHolder).Project();

--- a/src/libraries/Common/tests/System/ModifiedTypeTests.cs
+++ b/src/libraries/Common/tests/System/ModifiedTypeTests.cs
@@ -18,7 +18,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void TypeMembers()
         {
             FieldInfo fi = typeof(ModifiedTypeHolder).Project().GetField(nameof(ModifiedTypeHolder._volatileInt), Bindings);
@@ -125,7 +124,10 @@ namespace System.Tests.Types
                 Assert.Null(t.DeclaringType);
                 Assert.Null(t.ReflectedType);
                 Assert.Null(t.TypeInitializer);
-                Assert.True(t.MetadataToken != 0);
+
+                if (PlatformDetection.IsMetadataTokenSupported)
+                    Assert.True(t.MetadataToken != 0);
+
                 Assert.False(t.IsNested);
                 Assert.True(t.IsVisible);
             }
@@ -152,7 +154,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void Fields_Modified()
         {
             Type volatileInt = typeof(ModifiedTypeHolder).Project().GetField(nameof(ModifiedTypeHolder._volatileInt), Bindings).GetModifiedFieldType();
@@ -191,7 +192,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void Fields_Generic_Unmodified()
         {
             Type arrayGenericFcnPtr = typeof(ModifiedTypeHolder).Project().GetField(nameof(ModifiedTypeHolder._arrayGenericFcnPtr), Bindings).FieldType;
@@ -213,7 +213,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void Fields_Generic_Modified()
         {
             Type arrayGenericFcnPtr = typeof(ModifiedTypeHolder).Project().GetField(nameof(ModifiedTypeHolder._arrayGenericFcnPtr), Bindings).GetModifiedFieldType();
@@ -237,7 +236,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void Methods_OpenGeneric_Unmodified()
         {
             MethodInfo mi = typeof(ModifiedTypeHolder).Project().GetMethod(nameof(ModifiedTypeHolder.M_ArrayOpenGenericFcnPtr), Bindings);
@@ -261,7 +259,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void Methods_OpenGeneric_Modified()
         {
             MethodInfo mi = typeof(ModifiedTypeHolder).Project().GetMethod(nameof(ModifiedTypeHolder.M_ArrayOpenGenericFcnPtr), Bindings);
@@ -287,7 +284,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void Fields_Unmodified()
         {
             Type volatileInt = typeof(ModifiedTypeHolder).Project().GetField(nameof(ModifiedTypeHolder._volatileInt), Bindings).FieldType;
@@ -320,7 +316,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void Fields_Parameterized_Basic()
         {
             Type ptr_ptr_int = typeof(ModifiedTypeHolder).Project().GetField(nameof(ModifiedTypeHolder._ptr_ptr_int), Bindings).GetModifiedFieldType();
@@ -342,7 +337,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void Fields_Parameterized_FcnPtr()
         {
             Type ptr_fcnPtr = typeof(ModifiedTypeHolder).Project().GetField(nameof(ModifiedTypeHolder._ptr_fcnPtr), Bindings).GetModifiedFieldType();
@@ -374,7 +368,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void Fields_VerifyIdempotency()
         {
             // Call these again to ensure any backing caching strategy works.
@@ -386,7 +379,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void MethodParameters()
         {
             ParameterInfo[] parameters = typeof(ModifiedTypeHolder).Project().GetMethod(nameof(ModifiedTypeHolder.M_P0IntOut), Bindings).GetParameters();
@@ -411,7 +403,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void ConstructorParameters_Unmodified()
         {
             ParameterInfo[] parameters = typeof(ModifiedTypeHolder).Project().GetConstructors()[0].GetParameters();
@@ -425,7 +416,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void ConstructorParameters_Modified()
         {
             ParameterInfo[] parameters = typeof(ModifiedTypeHolder).Project().GetConstructors()[0].GetParameters();
@@ -440,7 +430,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void FunctionPointerParameters_fcnPtrP0Out_Unmodified()
         {
             Type fcnPtr = typeof(ModifiedTypeHolder).Project().GetField(nameof(ModifiedTypeHolder._fcnPtrP0Out), Bindings).GetModifiedFieldType();
@@ -452,7 +441,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void FunctionPointerParameters_fcnPtrP0Out_Modified()
         {
             Type fcnPtr = typeof(ModifiedTypeHolder).Project().GetField(nameof(ModifiedTypeHolder._fcnPtrP0Out), Bindings).FieldType;
@@ -464,7 +452,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void FunctionPointerParameters_fcnPtr_fcnPtrP0Out_Unmodified()
         {
             Type fcnPtr = typeof(ModifiedTypeHolder).Project().GetField(nameof(ModifiedTypeHolder._fcnPtr_fcnPtrP0Out), Bindings).FieldType;
@@ -478,7 +465,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void FunctionPointerParameters_fcnPtr_fcnPtrP0Out_Modified()
         {
             // Modified
@@ -494,7 +480,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void FunctionPointerParameters_fcnPtr_fcnPtrP0Ref_Unmodified()
         {
             Type fcnPtr = typeof(ModifiedTypeHolder).Project().GetField(nameof(ModifiedTypeHolder._fcnPtr_fcnPtrP0Ref), Bindings).FieldType;
@@ -509,7 +494,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void FunctionPointerParameters_fcnPtr_fcnPtrP0Ref_Modified()
         {
             Type fcnPtr = typeof(ModifiedTypeHolder).Project().GetField(nameof(ModifiedTypeHolder._fcnPtr_fcnPtrP0Ref), Bindings).GetModifiedFieldType();
@@ -524,7 +508,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void FunctionPointerParameters_fcnPtr_fcnPtrRetP0Ref_Unmodified()
         {
             Type fcnPtr = typeof(ModifiedTypeHolder).Project().GetField(nameof(ModifiedTypeHolder._fcnPtr_fcnPtrRetP0Out), Bindings).FieldType;
@@ -536,7 +519,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void FunctionPointerParameters_fcnPtr_fcnPtrRetP0Ref_Modified()
         {
             Type fcnPtr = typeof(ModifiedTypeHolder).Project().GetField(nameof(ModifiedTypeHolder._fcnPtr_fcnPtrRetP0Out), Bindings).GetModifiedFieldType();
@@ -549,7 +531,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void FunctionPointerParameters_fcnPtr_complex_Unmodified()
         {
             Type fcnPtr = typeof(ModifiedTypeHolder).Project().GetField(nameof(ModifiedTypeHolder._fcnPtr_complex), Bindings).FieldType;
@@ -574,7 +555,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void FunctionPointerParameters_fcnPtr_complex_Modified()
         {
             Type fcnPtr = typeof(ModifiedTypeHolder).Project().GetField(nameof(ModifiedTypeHolder._fcnPtr_complex), Bindings).GetModifiedFieldType();
@@ -600,7 +580,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void Property_FcnPtr_Complex_Unmodified()
         {
             Type mt = typeof(ModifiedTypeHolder).Project().GetProperty(nameof(ModifiedTypeHolder.Property_FcnPtr_Complex), Bindings).PropertyType;
@@ -618,7 +597,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void Property_FcnPtr_Complex_Modified()
         {
             Type mt = typeof(ModifiedTypeHolder).Project().GetProperty(nameof(ModifiedTypeHolder.Property_FcnPtr_Complex), Bindings).GetModifiedPropertyType();
@@ -637,7 +615,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void MethodWithGenericParameter_Unmodified()
         {
             MethodInfo mi = typeof(GenericWithModifiers).Project().GetMethod(nameof(GenericWithModifiers.MethodWithGenericParameter), Bindings);
@@ -659,7 +636,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void MethodWithGenericParameter_Modified()
         {
             MethodInfo mi = typeof(GenericWithModifiers).Project().GetMethod(nameof(GenericWithModifiers.MethodWithGenericParameter), Bindings);
@@ -683,7 +659,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void GenericMethod_Unmodified()
         {
             MethodInfo mi = typeof(GenericWithModifiers).Project().GetMethod(nameof(GenericWithModifiers.GenericMethod), Bindings);
@@ -697,7 +672,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void GenericMethod_Modified()
         {
             MethodInfo mi = typeof(GenericWithModifiers).Project().GetMethod(nameof(GenericWithModifiers.GenericMethod), Bindings);
@@ -711,7 +685,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static void ParameterConstraints1()
         {
             MethodInfo mi = typeof(ModifiedTypeHolder).Project().GetMethod(nameof(ModifiedTypeHolder.M_GenericWithParameterConstraint1), Bindings);
@@ -737,7 +710,6 @@ namespace System.Tests.Types
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/71095", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/71883", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static void ParameterConstraints2()
         {
             MethodInfo mi = typeof(ModifiedTypeHolder).Project().GetMethod(nameof(ModifiedTypeHolder.M_GenericWithParameterConstraint2), Bindings);

--- a/src/libraries/System.Runtime/tests/default.rd.xml
+++ b/src/libraries/System.Runtime/tests/default.rd.xml
@@ -251,6 +251,12 @@
         </Method>
       </Type>
 
+      <Type Name="System.Tests.Types.ModifiedTypeTests+ModifiedTypeHolder">
+        <Method Name="M_GenericWithParameterConstraint1" Dynamic="Required All">
+          <GenericArgument Name="System.Byte, System.Private.CoreLib" />
+        </Method>
+      </Type>
+
       <Type Name="System.Tests.ArrayTests">
         <Method Name="Sort_Array_Generic" Dynamic="Required All">
           <GenericArgument Name="System.Byte, System.Private.CoreLib" />

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1249,12 +1249,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/DictionaryExpansion/DictionaryExpansion/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/154</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/Casting/Functionpointer/*">
-            <Issue>https://github.com/dotnet/runtime/issues/71883</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/generics/Pointers/Pointers/*">
-            <Issue>https://github.com/dotnet/runtime/issues/71883</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/explicitlayout/Regressions/ASURT/ASURT150271/test3/*">
             <Issue>Won't fix https://github.com/dotnet/corert/issues/2396</Issue>
         </ExcludeList>
@@ -1320,9 +1314,6 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/opt/Regressions/Regression4/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/155: Assembly.Load</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/opt/ValueNumbering/TypeTestFolding/*">
-            <Issue>https://github.com/dotnet/runtime/issues/71883</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/DevDiv_461649/DevDiv_461649/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/155: Reflection emit</Issue>


### PR DESCRIPTION
Fixes #71883.

* Emit custom modifiers to the native metadata format
* Read custom modifiers at runtime
* Bugfix in the type loader