### PR TITLE
Make preinitialized delegates reflection-visible

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FrozenObjectNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FrozenObjectNode.cs
@@ -83,6 +83,8 @@ namespace ILCompiler.DependencyAnalysis
                 }
             }
 
+            _data.GetNonRelocationDependencies(ref dependencies, factory);
+
             return dependencies;
         }
 

--- a/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
+++ b/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
@@ -36,6 +36,7 @@ internal class Program
         TestBadClass.Run();
         TestRefs.Run();
         TestDelegate.Run();
+        TestDelegateReflectionVisible.Run();
         TestInitFromOtherClass.Run();
         TestInitFromOtherClassDouble.Run();
         TestDelegateToOtherClass.Run();
@@ -607,6 +608,19 @@ class TestDelegate
         Assert.IsPreinitialized(typeof(TestDelegate));
         Assert.AreEqual(42, s_delegate());
         Assert.AreEqual(2020, s_lambda());
+    }
+}
+
+class TestDelegateReflectionVisible
+{
+    static readonly Action s_a = DelegateTarget;
+
+    static void DelegateTarget() { }
+
+    public static void Run()
+    {
+        Assert.IsPreinitialized(typeof(TestDelegateReflectionVisible));
+        Assert.AreEqual(nameof(DelegateTarget), s_a.Method.Name);
     }
 }
 


### PR DESCRIPTION
Frozen delegate instances were bypassing the callback to metadata manager that lets metadata manager inject reflection dependencies on delegate construction. Introduce a spot for the callback.

Fixes dotnet/aspnetcore#47941.

Cc @dotnet/ilc-contrib 