### PR TITLE
Reduce some collection sizes in the System.Collections.Immutable tests.

### DIFF
--- a/src/libraries/System.Collections.Immutable/tests/Frozen/FrozenDictionaryTests.cs
+++ b/src/libraries/System.Collections.Immutable/tests/Frozen/FrozenDictionaryTests.cs
@@ -206,7 +206,7 @@ namespace System.Collections.Frozen.Tests
         }
 
         public static IEnumerable<object[]> LookupItems_AllItemsFoundAsExpected_MemberData() =>
-            from size in new[] { 0, 1, 2, 10, 999, 1024 }
+            from size in new[] { 0, 1, 2, 10, 99 }
             from comparer in new IEqualityComparer<TKey>[] { null, EqualityComparer<TKey>.Default, NonDefaultEqualityComparer<TKey>.Instance }
             from specifySameComparer in new[] { false, true }
             select new object[] { size, comparer, specifySameComparer };

--- a/src/libraries/System.Collections.Immutable/tests/Frozen/FrozenSetTests.cs
+++ b/src/libraries/System.Collections.Immutable/tests/Frozen/FrozenSetTests.cs
@@ -169,7 +169,7 @@ namespace System.Collections.Frozen.Tests
         }
 
         public static IEnumerable<object[]> LookupItems_AllItemsFoundAsExpected_MemberData() =>
-            from size in new[] { 0, 1, 2, 10, 999, 1024 }
+            from size in new[] { 0, 1, 2, 10, 99 }
             from comparer in new IEqualityComparer<T>[] { null, EqualityComparer<T>.Default, NonDefaultEqualityComparer<T>.Instance }
             from specifySameComparer in new[] { false, true }
             select new object[] { size, comparer, specifySameComparer };


### PR DESCRIPTION
The previous sizes caused timeouts when running on wasm+interpreter on CI.