### PR TITLE
Delete `arrayArgumentsFound` logic from type loader

### DIFF
--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.ConstructedGenericTypesLookup.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.ConstructedGenericTypesLookup.cs
@@ -91,20 +91,13 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
-        internal abstract class GenericTypeLookupData
-        {
-            internal abstract int LookupHashCode();
-            internal abstract bool MatchParsedEntry(RuntimeTypeHandle tentativeType);
-            internal abstract bool MatchGenericTypeEntry(GenericTypeEntry entry);
-        }
-
-        internal class HandleBasedGenericTypeLookup : GenericTypeLookupData
+        internal struct GenericTypeLookupData
         {
             private DefType _typeToLookup;
             private RuntimeTypeHandle _genericTypeDefinitionHandle;
             private RuntimeTypeHandle[] _genericTypeArgumentHandles;
 
-            internal HandleBasedGenericTypeLookup(DefType typeToLookup)
+            internal GenericTypeLookupData(DefType typeToLookup)
             {
                 Debug.Assert(typeToLookup != null);
                 _typeToLookup = typeToLookup;
@@ -112,7 +105,7 @@ namespace Internal.Runtime.TypeLoader
                 // _genericTypeArgumentHandles not initialized here to avoid allocation of new array (and it's not used if we initialize _typeToLookup).
             }
 
-            internal HandleBasedGenericTypeLookup(RuntimeTypeHandle genericTypeDefinitionHandle, RuntimeTypeHandle[] genericTypeArgumentHandles)
+            internal GenericTypeLookupData(RuntimeTypeHandle genericTypeDefinitionHandle, RuntimeTypeHandle[] genericTypeArgumentHandles)
             {
                 Debug.Assert(genericTypeArgumentHandles != null);
                 _typeToLookup = null;
@@ -120,12 +113,12 @@ namespace Internal.Runtime.TypeLoader
                 _genericTypeArgumentHandles = genericTypeArgumentHandles;
             }
 
-            internal override int LookupHashCode()
+            internal int LookupHashCode()
             {
                 return _typeToLookup != null ? _typeToLookup.GetHashCode() : TypeHashingAlgorithms.ComputeGenericInstanceHashCode(_genericTypeDefinitionHandle.GetHashCode(), _genericTypeArgumentHandles);
             }
 
-            internal override bool MatchParsedEntry(RuntimeTypeHandle tentativeType)
+            internal bool MatchParsedEntry(RuntimeTypeHandle tentativeType)
             {
                 RuntimeTypeHandle parsedTypeDefinitionHandle = RuntimeAugments.GetGenericDefinition(tentativeType);
                 if (!parsedTypeDefinitionHandle.Equals(_genericTypeDefinitionHandle))
@@ -144,7 +137,7 @@ namespace Internal.Runtime.TypeLoader
                 return true;
             }
 
-            internal override bool MatchGenericTypeEntry(GenericTypeEntry entry)
+            internal bool MatchGenericTypeEntry(GenericTypeEntry entry)
             {
                 if (!entry._genericTypeDefinitionHandle.Equals(_genericTypeDefinitionHandle))
                     return false;
@@ -219,7 +212,7 @@ namespace Internal.Runtime.TypeLoader
 
         public bool TryLookupConstructedGenericTypeForComponents(RuntimeTypeHandle genericTypeDefinitionHandle, RuntimeTypeHandle[] genericTypeArgumentHandles, out RuntimeTypeHandle runtimeTypeHandle)
         {
-            return TryLookupConstructedGenericTypeForComponents(new HandleBasedGenericTypeLookup(genericTypeDefinitionHandle, genericTypeArgumentHandles), out runtimeTypeHandle);
+            return TryLookupConstructedGenericTypeForComponents(new GenericTypeLookupData(genericTypeDefinitionHandle, genericTypeArgumentHandles), out runtimeTypeHandle);
         }
 
         public bool TryLookupConstructedLazyDictionaryForContext(IntPtr context, IntPtr signature, out IntPtr dictionary)

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/TypeDesc.Runtime.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/TypeDesc.Runtime.cs
@@ -77,23 +77,16 @@ namespace Internal.TypeSystem
                         // Generic type. First make sure we have type handles for the arguments, then check
                         // the instantiation.
                         bool argumentsRegistered = true;
-                        bool arrayArgumentsFound = false;
                         for (int i = 0; i < instantiation.Length; i++)
                         {
                             if (!instantiation[i].RetrieveRuntimeTypeHandleIfPossible())
                             {
                                 argumentsRegistered = false;
-                                arrayArgumentsFound = arrayArgumentsFound || (instantiation[i] is ArrayType);
                             }
                         }
 
                         RuntimeTypeHandle rtth;
-
-                        // If at least one of the arguments is not known to the runtime, we take a slower
-                        // path to compare the current type we need a handle for to the list of generic
-                        // types statically available, by loading them as DefTypes and doing a DefType comparaison
-                        if ((argumentsRegistered && TypeLoaderEnvironment.Instance.TryLookupConstructedGenericTypeForComponents(new TypeLoaderEnvironment.HandleBasedGenericTypeLookup(typeAsDefType), out rtth)) ||
-                            (arrayArgumentsFound && TypeLoaderEnvironment.Instance.TryLookupConstructedGenericTypeForComponents(new TypeLoaderEnvironment.DefTypeBasedGenericTypeLookup(typeAsDefType), out rtth)))
+                        if (argumentsRegistered && TypeLoaderEnvironment.Instance.TryLookupConstructedGenericTypeForComponents(new TypeLoaderEnvironment.HandleBasedGenericTypeLookup(typeAsDefType), out rtth))
                         {
                             typeAsDefType.SetRuntimeTypeHandleUnsafe(rtth);
                             return true;

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/TypeDesc.Runtime.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/TypeDesc.Runtime.cs
@@ -86,7 +86,7 @@ namespace Internal.TypeSystem
                         }
 
                         RuntimeTypeHandle rtth;
-                        if (argumentsRegistered && TypeLoaderEnvironment.Instance.TryLookupConstructedGenericTypeForComponents(new TypeLoaderEnvironment.HandleBasedGenericTypeLookup(typeAsDefType), out rtth))
+                        if (argumentsRegistered && TypeLoaderEnvironment.Instance.TryLookupConstructedGenericTypeForComponents(new TypeLoaderEnvironment.GenericTypeLookupData(typeAsDefType), out rtth))
                         {
                             typeAsDefType.SetRuntimeTypeHandleUnsafe(rtth);
                             return true;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ArrayMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ArrayMapNode.cs
@@ -57,16 +57,6 @@ namespace ILCompiler.DependencyAnalysis
 
                 var arrayType = (ArrayType)type;
 
-                // This optimization is not compatible with canInlineTypeCheck on JIT/EE interface returning
-                // CORINFO_INLINE_TYPECHECK_PASS unconditionally.
-                //
-                // If we're generating a template for this type, we can skip generating the hashtable entry
-                // since the type loader can just create this type at runtime if something needs it. It's
-                // okay to have multiple EETypes for the same array type.
-                // var canonArrayType = arrayType.ConvertToCanonForm(CanonicalFormKind.Specific);
-                // if (arrayType != canonArrayType && factory.NativeLayout.TemplateTypeLayout(canonArrayType).Marked)
-                //     continue;
-
                 // Look at the constructed type symbol. If a constructed type wasn't emitted, then the array map entry isn't valid for use
                 IEETypeNode arrayTypeSymbol = factory.ConstructedTypeSymbol(arrayType);
 


### PR DESCRIPTION
I think this was handling a situation where we're trying to find an existing `MethodTable` for `Foo<SomeType[]>` and such `MethodTable` does statically exist but we didn't have a mapping table entry for `SomeType[]` and we couldn't get a `MethodTable` for it, even though it statically exists in the image. Since the compiler optimization to skip emitting this mapping got commented out, it wasn't actually possible to end up in a situation where we wouldn't know how to find a `MethodTable` for an existing array at runtime. We therefore don't need the slow path that tries to find the type without having `MethodTable`s for all generic arguments.

Related to #85507.

Cc @dotnet/ilc-contrib 