### PR TITLE
Eliminate cancellation deadlock in RateLimiter implementations

### DIFF
--- a/src/libraries/System.Threading.RateLimiting/src/Properties/InternalsVisibleTo.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/Properties/InternalsVisibleTo.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("System.Threading.RateLimiting.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001004b86c4cb78549b34bab61a3b1800e23bfeb5b3ec390074041536a7e3cbd97f5f04cf0f857155a8928eaa29ebfd11cfbbad3ba70efea7bda3226c6a8d370a4cd303f714486b6ebc225985a638471e6ef571cc92a4613c00b8fa65d61ccee0cbe5f36330c9a01f4183559f1bef24cc2917c6d913e3a541333a1d05d9bed22b38cb")]

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
@@ -396,10 +396,10 @@ namespace System.Threading.RateLimiting
                 // is going to invoke the callback synchronously, but this does not create
                 // a deadlock because lock are reentrant
                 if (cancellationToken.CanBeCanceled)
-#if NETCOREAPP || NETSTANDARD2_1
-                    _cancellationTokenRegistration = cancellationToken.UnsafeRegister(Cancel, this) ;
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+                    _cancellationTokenRegistration = cancellationToken.UnsafeRegister(Cancel, this);
 #else
-                    _cancellationTokenRegistration = cancellationToken.Register(Cancel, this) ;
+                    _cancellationTokenRegistration = cancellationToken.Register(Cancel, this);
 #endif
             }
 

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
@@ -132,7 +132,7 @@ namespace System.Threading.RateLimiting
                 return new ValueTask<RateLimitLease>(SuccessfulLease);
             }
 
-            using var disposer = new RequestRegistration.Disposer();
+            using var disposer = default(RequestRegistration.Disposer);
 
             // Perf: Check SemaphoreSlim implementation instead of locking
             lock (Lock)
@@ -218,7 +218,7 @@ namespace System.Threading.RateLimiting
 
         private void Release(int releaseCount)
         {
-            using var disposer = new RequestRegistration.Disposer();
+            using var disposer = default(RequestRegistration.Disposer);
             lock (Lock)
             {
                 if (_disposed)
@@ -295,7 +295,7 @@ namespace System.Threading.RateLimiting
                 return;
             }
 
-            using var disposer = new RequestRegistration.Disposer();
+            using var disposer = default(RequestRegistration.Disposer);
             lock (Lock)
             {
                 if (_disposed)

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
@@ -396,7 +396,11 @@ namespace System.Threading.RateLimiting
                 // is going to invoke the callback synchronously, but this does not create
                 // a deadlock because lock are reentrant
                 if (cancellationToken.CanBeCanceled)
+#if NETCOREAPP || NETSTANDARD2_1
                     _cancellationTokenRegistration = cancellationToken.UnsafeRegister(Cancel, this) ;
+#else
+                    _cancellationTokenRegistration = cancellationToken.Register(Cancel, this) ;
+#endif
             }
 
             public int Count { get; }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
@@ -132,6 +132,8 @@ namespace System.Threading.RateLimiting
                 return new ValueTask<RateLimitLease>(SuccessfulLease);
             }
 
+            using var disposer = new RequestRegistration.Disposer();
+
             // Perf: Check SemaphoreSlim implementation instead of locking
             lock (Lock)
             {
@@ -152,7 +154,7 @@ namespace System.Threading.RateLimiting
                             RequestRegistration oldestRequest = _queue.DequeueHead();
                             _queueCount -= oldestRequest.Count;
                             Debug.Assert(_queueCount >= 0);
-                            if (!oldestRequest.Tcs.TrySetResult(FailedLease))
+                            if (!oldestRequest.TrySetResult(FailedLease))
                             {
                                 // Updating queue count is handled by the cancellation code
                                 _queueCount += oldestRequest.Count;
@@ -161,7 +163,7 @@ namespace System.Threading.RateLimiting
                             {
                                 Interlocked.Increment(ref _failedLeasesCount);
                             }
-                            oldestRequest.CancellationTokenRegistration.Dispose();
+                            disposer.Add(oldestRequest);
                         }
                         while (_options.QueueLimit - _queueCount < permitCount);
                     }
@@ -173,22 +175,12 @@ namespace System.Threading.RateLimiting
                     }
                 }
 
-                CancelQueueState tcs = new CancelQueueState(permitCount, this, cancellationToken);
-                CancellationTokenRegistration ctr = default;
-                if (cancellationToken.CanBeCanceled)
-                {
-                    ctr = cancellationToken.Register(static obj =>
-                    {
-                        ((CancelQueueState)obj!).TrySetCanceled();
-                    }, tcs);
-                }
-
-                RequestRegistration request = new RequestRegistration(permitCount, tcs, ctr);
+                var request = new RequestRegistration(permitCount, this, cancellationToken);
                 _queue.EnqueueTail(request);
                 _queueCount += permitCount;
                 Debug.Assert(_queueCount <= _options.QueueLimit);
 
-                return new ValueTask<RateLimitLease>(request.Tcs.Task);
+                return new ValueTask<RateLimitLease>(request.Task);
             }
         }
 
@@ -226,6 +218,7 @@ namespace System.Threading.RateLimiting
 
         private void Release(int releaseCount)
         {
+            using var disposer = new RequestRegistration.Disposer();
             lock (Lock)
             {
                 if (_disposed)
@@ -245,13 +238,13 @@ namespace System.Threading.RateLimiting
 
                     // Request was handled already, either via cancellation or being kicked from the queue due to a newer request being queued.
                     // We just need to remove the item and let the next queued item be considered for completion.
-                    if (nextPendingRequest.Tcs.Task.IsCompleted)
+                    if (nextPendingRequest.Task.IsCompleted)
                     {
                         nextPendingRequest =
                             _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
                             ? _queue.DequeueHead()
                             : _queue.DequeueTail();
-                        nextPendingRequest.CancellationTokenRegistration.Dispose();
+                        disposer.Add(nextPendingRequest);
                     }
                     else if (_permitCount >= nextPendingRequest.Count)
                     {
@@ -266,7 +259,7 @@ namespace System.Threading.RateLimiting
 
                         ConcurrencyLease lease = nextPendingRequest.Count == 0 ? SuccessfulLease : new ConcurrencyLease(true, this, nextPendingRequest.Count);
                         // Check if request was canceled
-                        if (!nextPendingRequest.Tcs.TrySetResult(lease))
+                        if (!nextPendingRequest.TrySetResult(lease))
                         {
                             // Queued item was canceled so add count back
                             _permitCount += nextPendingRequest.Count;
@@ -277,7 +270,7 @@ namespace System.Threading.RateLimiting
                         {
                             Interlocked.Increment(ref _successfulLeasesCount);
                         }
-                        nextPendingRequest.CancellationTokenRegistration.Dispose();
+                        disposer.Add(nextPendingRequest);
                         Debug.Assert(_queueCount >= 0);
                     }
                     else
@@ -302,6 +295,7 @@ namespace System.Threading.RateLimiting
                 return;
             }
 
+            using var disposer = new RequestRegistration.Disposer();
             lock (Lock)
             {
                 if (_disposed)
@@ -314,8 +308,8 @@ namespace System.Threading.RateLimiting
                     RequestRegistration next = _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
                         ? _queue.DequeueHead()
                         : _queue.DequeueTail();
-                    next.CancellationTokenRegistration.Dispose();
-                    next.Tcs.TrySetResult(FailedLease);
+                    disposer.Add(next);
+                    next.TrySetResult(FailedLease);
                 }
             }
         }
@@ -383,49 +377,64 @@ namespace System.Threading.RateLimiting
             }
         }
 
-        private readonly struct RequestRegistration
+        private sealed class RequestRegistration : TaskCompletionSource<RateLimitLease>
         {
-            public RequestRegistration(int requestedCount, TaskCompletionSource<RateLimitLease> tcs,
-                CancellationTokenRegistration cancellationTokenRegistration)
+            private readonly CancellationToken _cancellationToken;
+            private CancellationTokenRegistration _cancellationTokenRegistration;
+
+            // this field is used only by the disposal mechanics and never shared between threads
+            private RequestRegistration? _next;
+
+            public RequestRegistration(int permitCount, ConcurrencyLimiter limiter, CancellationToken cancellationToken)
+                : base(limiter, TaskCreationOptions.RunContinuationsAsynchronously)
             {
-                Count = requestedCount;
-                // Perf: Use AsyncOperation<TResult> instead
-                Tcs = tcs;
-                CancellationTokenRegistration = cancellationTokenRegistration;
+                Count = permitCount;
+                _cancellationToken = cancellationToken;
+
+                // RequestRegistration objects are created while the limiter lock is held
+                // if cancellationToken fires before or while the lock is held, UnsafeRegister
+                // is going to invoke the callback synchronously, but this does not create
+                // a deadlock because lock are reentrant
+                if (cancellationToken.CanBeCanceled)
+                    _cancellationTokenRegistration = cancellationToken.UnsafeRegister(Cancel, this) ;
             }
 
             public int Count { get; }
 
-            public TaskCompletionSource<RateLimitLease> Tcs { get; }
-
-            public CancellationTokenRegistration CancellationTokenRegistration { get; }
-        }
-
-        private sealed class CancelQueueState : TaskCompletionSource<RateLimitLease>
-        {
-            private readonly int _permitCount;
-            private readonly ConcurrencyLimiter _limiter;
-            private readonly CancellationToken _cancellationToken;
-
-            public CancelQueueState(int permitCount, ConcurrencyLimiter limiter, CancellationToken cancellationToken)
-                : base(TaskCreationOptions.RunContinuationsAsynchronously)
+            private static void Cancel(object? state)
             {
-                _permitCount = permitCount;
-                _limiter = limiter;
-                _cancellationToken = cancellationToken;
+                if (state is RequestRegistration registration && registration.TrySetCanceled(registration._cancellationToken))
+                {
+                    var limiter = (ConcurrencyLimiter)registration.Task.AsyncState!;
+                    lock (limiter.Lock)
+                    {
+                        limiter._queueCount -= registration.Count;
+                    }
+                }
             }
 
-            public new bool TrySetCanceled()
+            /// <summary>
+            /// Collects registrations to dispose outside the limiter lock to avoid deadlock.
+            /// </summary>
+            public struct Disposer : IDisposable
             {
-                if (TrySetCanceled(_cancellationToken))
+                private RequestRegistration? _next;
+
+                public void Add(RequestRegistration request)
                 {
-                    lock (_limiter.Lock)
-                    {
-                        _limiter._queueCount -= _permitCount;
-                    }
-                    return true;
+                    request._next = _next;
+                    _next = request;
                 }
-                return false;
+
+                public void Dispose()
+                {
+                    for (var current = _next; current is not null; current = current._next)
+                    {
+                        current._cancellationTokenRegistration.Dispose();
+                    }
+
+                    _next = null;
+                }
             }
         }
     }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
@@ -157,7 +157,7 @@ namespace System.Threading.RateLimiting
                                 // Updating queue count is handled by the cancellation/cleanup code
                                 Interlocked.Increment(ref _failedLeasesCount);
                             }
-                            disposer.Add(oldestRequest);
+                            disposer.CleanupAndAdd(oldestRequest);
                             Debug.Assert(_queueCount >= 0);
                         }
                         while (_options.QueueLimit - _queueCount < permitCount);
@@ -249,7 +249,7 @@ namespace System.Threading.RateLimiting
                             _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
                             ? _queue.DequeueHead()
                             : _queue.DequeueTail();
-                        disposer.Add(nextPendingRequest);
+                        disposer.CleanupAndAdd(nextPendingRequest);
                         continue;
                     }
 
@@ -279,7 +279,7 @@ namespace System.Threading.RateLimiting
                         {
                             Interlocked.Increment(ref _successfulLeasesCount);
                         }
-                        disposer.Add(nextPendingRequest);
+                        disposer.CleanupAndAdd(nextPendingRequest);
                         Debug.Assert(_queueCount >= 0);
                     }
                     else
@@ -317,7 +317,7 @@ namespace System.Threading.RateLimiting
                     RequestRegistration next = _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
                         ? _queue.DequeueHead()
                         : _queue.DequeueTail();
-                    disposer.Add(next);
+                    disposer.CleanupAndAdd(next);
                     next.TrySetResult(FailedLease);
                 }
                 Debug.Assert(_queueCount == 0);
@@ -443,7 +443,7 @@ namespace System.Threading.RateLimiting
             {
                 private RequestRegistration? _next;
 
-                public void Add(RequestRegistration request)
+                public void CleanupAndAdd(RequestRegistration request)
                 {
                     request.Cleanup();
                     request._next = _next;

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
@@ -448,10 +448,10 @@ namespace System.Threading.RateLimiting
                 // is going to invoke the callback synchronously, but this does not create
                 // a deadlock because lock are reentrant
                 if (cancellationToken.CanBeCanceled)
-#if NETCOREAPP || NETSTANDARD2_1
-                    _cancellationTokenRegistration = cancellationToken.UnsafeRegister(Cancel, this) ;
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+                    _cancellationTokenRegistration = cancellationToken.UnsafeRegister(Cancel, this);
 #else
-                    _cancellationTokenRegistration = cancellationToken.Register(Cancel, this) ;
+                    _cancellationTokenRegistration = cancellationToken.Register(Cancel, this);
 #endif
             }
 

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
@@ -151,6 +151,7 @@ namespace System.Threading.RateLimiting
                 return new ValueTask<RateLimitLease>(SuccessfulLease);
             }
 
+            using var disposer = new RequestRegistration.Disposer();
             lock (Lock)
             {
                 if (TryLeaseUnsynchronized(permitCount, out RateLimitLease? lease))
@@ -170,7 +171,7 @@ namespace System.Threading.RateLimiting
                             RequestRegistration oldestRequest = _queue.DequeueHead();
                             _queueCount -= oldestRequest.Count;
                             Debug.Assert(_queueCount >= 0);
-                            if (!oldestRequest.Tcs.TrySetResult(FailedLease))
+                            if (!oldestRequest.TrySetResult(FailedLease))
                             {
                                 _queueCount += oldestRequest.Count;
                             }
@@ -178,7 +179,7 @@ namespace System.Threading.RateLimiting
                             {
                                 Interlocked.Increment(ref _failedLeasesCount);
                             }
-                            oldestRequest.CancellationTokenRegistration.Dispose();
+                            disposer.Add(oldestRequest);
                         }
                         while (_options.QueueLimit - _queueCount < permitCount);
                     }
@@ -190,22 +191,12 @@ namespace System.Threading.RateLimiting
                     }
                 }
 
-                CancelQueueState tcs = new CancelQueueState(permitCount, this, cancellationToken);
-                CancellationTokenRegistration ctr = default;
-                if (cancellationToken.CanBeCanceled)
-                {
-                    ctr = cancellationToken.Register(static obj =>
-                    {
-                        ((CancelQueueState)obj!).TrySetCanceled();
-                    }, tcs);
-                }
-
-                RequestRegistration registration = new RequestRegistration(permitCount, tcs, ctr);
+                var registration = new RequestRegistration(permitCount, this, cancellationToken);
                 _queue.EnqueueTail(registration);
                 _queueCount += permitCount;
                 Debug.Assert(_queueCount <= _options.QueueLimit);
 
-                return new ValueTask<RateLimitLease>(registration.Tcs.Task);
+                return new ValueTask<RateLimitLease>(registration.Task);
             }
         }
 
@@ -280,6 +271,8 @@ namespace System.Threading.RateLimiting
         // Used in tests that test behavior with specific time intervals
         private void ReplenishInternal(long nowTicks)
         {
+            using var disposer = new RequestRegistration.Disposer();
+
             // Method is re-entrant (from Timer), lock to avoid multiple simultaneous replenishes
             lock (Lock)
             {
@@ -315,13 +308,13 @@ namespace System.Threading.RateLimiting
 
                     // Request was handled already, either via cancellation or being kicked from the queue due to a newer request being queued.
                     // We just need to remove the item and let the next queued item be considered for completion.
-                    if (nextPendingRequest.Tcs.Task.IsCompleted)
+                    if (nextPendingRequest.Task.IsCompleted)
                     {
                         nextPendingRequest =
                             _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
                             ? _queue.DequeueHead()
                             : _queue.DequeueTail();
-                        nextPendingRequest.CancellationTokenRegistration.Dispose();
+                        disposer.Add(nextPendingRequest);
                     }
                     else if (_permitCount >= nextPendingRequest.Count)
                     {
@@ -335,7 +328,7 @@ namespace System.Threading.RateLimiting
                         _permitCount -= nextPendingRequest.Count;
                         Debug.Assert(_permitCount >= 0);
 
-                        if (!nextPendingRequest.Tcs.TrySetResult(SuccessfulLease))
+                        if (!nextPendingRequest.TrySetResult(SuccessfulLease))
                         {
                             // Queued item was canceled so add count back
                             _permitCount += nextPendingRequest.Count;
@@ -346,7 +339,7 @@ namespace System.Threading.RateLimiting
                         {
                             Interlocked.Increment(ref _successfulLeasesCount);
                         }
-                        nextPendingRequest.CancellationTokenRegistration.Dispose();
+                        disposer.Add(nextPendingRequest);
                         Debug.Assert(_queueCount >= 0);
                     }
                     else
@@ -372,6 +365,7 @@ namespace System.Threading.RateLimiting
                 return;
             }
 
+            using var disposer = new RequestRegistration.Disposer();
             lock (Lock)
             {
                 if (_disposed)
@@ -385,8 +379,8 @@ namespace System.Threading.RateLimiting
                     RequestRegistration next = _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
                         ? _queue.DequeueHead()
                         : _queue.DequeueTail();
-                    next.CancellationTokenRegistration.Dispose();
-                    next.Tcs.TrySetResult(FailedLease);
+                    disposer.Add(next);
+                    next.TrySetResult(FailedLease);
                 }
             }
         }
@@ -435,48 +429,64 @@ namespace System.Threading.RateLimiting
             }
         }
 
-        private readonly struct RequestRegistration
+        private sealed class RequestRegistration : TaskCompletionSource<RateLimitLease>
         {
-            public RequestRegistration(int permitCount, TaskCompletionSource<RateLimitLease> tcs, CancellationTokenRegistration cancellationTokenRegistration)
+            private readonly CancellationToken _cancellationToken;
+            private CancellationTokenRegistration _cancellationTokenRegistration;
+
+            // this field is used only by the disposal mechanics and never shared between threads
+            private RequestRegistration? _next;
+
+            public RequestRegistration(int permitCount, FixedWindowRateLimiter limiter, CancellationToken cancellationToken)
+                : base(limiter, TaskCreationOptions.RunContinuationsAsynchronously)
             {
                 Count = permitCount;
-                // Use VoidAsyncOperationWithData<T> instead
-                Tcs = tcs;
-                CancellationTokenRegistration = cancellationTokenRegistration;
+                _cancellationToken = cancellationToken;
+
+                // RequestRegistration objects are created while the limiter lock is held
+                // if cancellationToken fires before or while the lock is held, UnsafeRegister
+                // is going to invoke the callback synchronously, but this does not create
+                // a deadlock because lock are reentrant
+                if (cancellationToken.CanBeCanceled)
+                    _cancellationTokenRegistration = cancellationToken.UnsafeRegister(Cancel, this) ;
             }
 
             public int Count { get; }
 
-            public TaskCompletionSource<RateLimitLease> Tcs { get; }
-
-            public CancellationTokenRegistration CancellationTokenRegistration { get; }
-        }
-
-        private sealed class CancelQueueState : TaskCompletionSource<RateLimitLease>
-        {
-            private readonly int _permitCount;
-            private readonly FixedWindowRateLimiter _limiter;
-            private readonly CancellationToken _cancellationToken;
-
-            public CancelQueueState(int permitCount, FixedWindowRateLimiter limiter, CancellationToken cancellationToken)
-                : base(TaskCreationOptions.RunContinuationsAsynchronously)
+            private static void Cancel(object? state)
             {
-                _permitCount = permitCount;
-                _limiter = limiter;
-                _cancellationToken = cancellationToken;
+                if (state is RequestRegistration registration && registration.TrySetCanceled(registration._cancellationToken))
+                {
+                    var limiter = (FixedWindowRateLimiter)registration.Task.AsyncState!;
+                    lock (limiter.Lock)
+                    {
+                        limiter._queueCount -= registration.Count;
+                    }
+                }
             }
 
-            public new bool TrySetCanceled()
+            /// <summary>
+            /// Collects registrations to dispose outside the limiter lock to avoid deadlock.
+            /// </summary>
+            public struct Disposer : IDisposable
             {
-                if (TrySetCanceled(_cancellationToken))
+                private RequestRegistration? _next;
+
+                public void Add(RequestRegistration request)
                 {
-                    lock (_limiter.Lock)
-                    {
-                        _limiter._queueCount -= _permitCount;
-                    }
-                    return true;
+                    request._next = _next;
+                    _next = request;
                 }
-                return false;
+
+                public void Dispose()
+                {
+                    for (var current = _next; current is not null; current = current._next)
+                    {
+                        current._cancellationTokenRegistration.Dispose();
+                    }
+
+                    _next = null;
+                }
             }
         }
     }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
@@ -448,7 +448,11 @@ namespace System.Threading.RateLimiting
                 // is going to invoke the callback synchronously, but this does not create
                 // a deadlock because lock are reentrant
                 if (cancellationToken.CanBeCanceled)
+#if NETCOREAPP || NETSTANDARD2_1
                     _cancellationTokenRegistration = cancellationToken.UnsafeRegister(Cancel, this) ;
+#else
+                    _cancellationTokenRegistration = cancellationToken.Register(Cancel, this) ;
+#endif
             }
 
             public int Count { get; }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
@@ -151,7 +151,7 @@ namespace System.Threading.RateLimiting
                 return new ValueTask<RateLimitLease>(SuccessfulLease);
             }
 
-            using var disposer = new RequestRegistration.Disposer();
+            using var disposer = default(RequestRegistration.Disposer);
             lock (Lock)
             {
                 if (TryLeaseUnsynchronized(permitCount, out RateLimitLease? lease))
@@ -271,7 +271,7 @@ namespace System.Threading.RateLimiting
         // Used in tests that test behavior with specific time intervals
         private void ReplenishInternal(long nowTicks)
         {
-            using var disposer = new RequestRegistration.Disposer();
+            using var disposer = default(RequestRegistration.Disposer);
 
             // Method is re-entrant (from Timer), lock to avoid multiple simultaneous replenishes
             lock (Lock)
@@ -365,7 +365,7 @@ namespace System.Threading.RateLimiting
                 return;
             }
 
-            using var disposer = new RequestRegistration.Disposer();
+            using var disposer = default(RequestRegistration.Disposer);
             lock (Lock)
             {
                 if (_disposed)

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
@@ -174,7 +174,7 @@ namespace System.Threading.RateLimiting
                                 // Updating queue count is handled by the cancellation/cleanup code
                                 Interlocked.Increment(ref _failedLeasesCount);
                             }
-                            disposer.Add(oldestRequest);
+                            disposer.CleanupAndAdd(oldestRequest);
                             Debug.Assert(_queueCount >= 0);
                         }
                         while (_options.QueueLimit - _queueCount < permitCount);
@@ -310,7 +310,7 @@ namespace System.Threading.RateLimiting
                             _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
                             ? _queue.DequeueHead()
                             : _queue.DequeueTail();
-                        disposer.Add(nextPendingRequest);
+                        disposer.CleanupAndAdd(nextPendingRequest);
                     }
                     else if (_permitCount >= nextPendingRequest.Count)
                     {
@@ -333,7 +333,7 @@ namespace System.Threading.RateLimiting
                         {
                             Interlocked.Increment(ref _successfulLeasesCount);
                         }
-                        disposer.Add(nextPendingRequest);
+                        disposer.CleanupAndAdd(nextPendingRequest);
                         Debug.Assert(_queueCount >= 0);
                     }
                     else
@@ -373,7 +373,7 @@ namespace System.Threading.RateLimiting
                     RequestRegistration next = _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
                         ? _queue.DequeueHead()
                         : _queue.DequeueTail();
-                    disposer.Add(next);
+                    disposer.CleanupAndAdd(next);
                     next.TrySetResult(FailedLease);
                 }
                 Debug.Assert(_queueCount == 0);
@@ -480,7 +480,7 @@ namespace System.Threading.RateLimiting
             {
                 private RequestRegistration? _next;
 
-                public void Add(RequestRegistration request)
+                public void CleanupAndAdd(RequestRegistration request)
                 {
                     request.Cleanup();
                     request._next = _next;

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
@@ -169,17 +169,13 @@ namespace System.Threading.RateLimiting
                         do
                         {
                             RequestRegistration oldestRequest = _queue.DequeueHead();
-                            _queueCount -= oldestRequest.Count;
-                            Debug.Assert(_queueCount >= 0);
-                            if (!oldestRequest.TrySetResult(FailedLease))
+                            if (oldestRequest.TrySetResult(FailedLease))
                             {
-                                _queueCount += oldestRequest.Count;
-                            }
-                            else
-                            {
+                                // Updating queue count is handled by the cancellation/cleanup code
                                 Interlocked.Increment(ref _failedLeasesCount);
                             }
                             disposer.Add(oldestRequest);
+                            Debug.Assert(_queueCount >= 0);
                         }
                         while (_options.QueueLimit - _queueCount < permitCount);
                     }
@@ -324,7 +320,7 @@ namespace System.Threading.RateLimiting
                             ? _queue.DequeueHead()
                             : _queue.DequeueTail();
 
-                        _queueCount -= nextPendingRequest.Count;
+                        // Updating queue count is handled by the cancellation/cleanup code
                         _permitCount -= nextPendingRequest.Count;
                         Debug.Assert(_permitCount >= 0);
 
@@ -332,8 +328,6 @@ namespace System.Threading.RateLimiting
                         {
                             // Queued item was canceled so add count back
                             _permitCount += nextPendingRequest.Count;
-                            // Updating queue count is handled by the cancellation code
-                            _queueCount += nextPendingRequest.Count;
                         }
                         else
                         {
@@ -382,6 +376,7 @@ namespace System.Threading.RateLimiting
                     disposer.Add(next);
                     next.TrySetResult(FailedLease);
                 }
+                Debug.Assert(_queueCount == 0);
             }
         }
 
@@ -455,17 +450,26 @@ namespace System.Threading.RateLimiting
 #endif
             }
 
-            public int Count { get; }
+            /// <remarks>
+            /// This property is only accessed under limiter lock.
+            /// </remarks>
+            public int Count { get; private set; }
 
             private static void Cancel(object? state)
             {
                 if (state is RequestRegistration registration && registration.TrySetCanceled(registration._cancellationToken))
                 {
-                    var limiter = (FixedWindowRateLimiter)registration.Task.AsyncState!;
-                    lock (limiter.Lock)
-                    {
-                        limiter._queueCount -= registration.Count;
-                    }
+                    registration.Cleanup();
+                }
+            }
+
+            private void Cleanup()
+            {
+                var limiter = (FixedWindowRateLimiter)Task.AsyncState!;
+                lock (limiter.Lock)
+                {
+                    limiter._queueCount -= Count;
+                    Count = 0;
                 }
             }
 
@@ -478,6 +482,7 @@ namespace System.Threading.RateLimiting
 
                 public void Add(RequestRegistration request)
                 {
+                    request.Cleanup();
                     request._next = _next;
                     _next = request;
                 }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
@@ -461,10 +461,10 @@ namespace System.Threading.RateLimiting
                 // is going to invoke the callback synchronously, but this does not create
                 // a deadlock because lock are reentrant
                 if (cancellationToken.CanBeCanceled)
-#if NETCOREAPP || NETSTANDARD2_1
-                    _cancellationTokenRegistration = cancellationToken.UnsafeRegister(Cancel, this) ;
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+                    _cancellationTokenRegistration = cancellationToken.UnsafeRegister(Cancel, this);
 #else
-                    _cancellationTokenRegistration = cancellationToken.Register(Cancel, this) ;
+                    _cancellationTokenRegistration = cancellationToken.Register(Cancel, this);
 #endif
             }
 

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
@@ -163,6 +163,7 @@ namespace System.Threading.RateLimiting
                 return new ValueTask<RateLimitLease>(SuccessfulLease);
             }
 
+            using var disposer = new RequestRegistration.Disposer();
             lock (Lock)
             {
                 if (TryLeaseUnsynchronized(permitCount, out RateLimitLease? lease))
@@ -182,7 +183,7 @@ namespace System.Threading.RateLimiting
                             RequestRegistration oldestRequest = _queue.DequeueHead();
                             _queueCount -= oldestRequest.Count;
                             Debug.Assert(_queueCount >= 0);
-                            if (!oldestRequest.Tcs.TrySetResult(FailedLease))
+                            if (!oldestRequest.TrySetResult(FailedLease))
                             {
                                 _queueCount += oldestRequest.Count;
                             }
@@ -190,7 +191,7 @@ namespace System.Threading.RateLimiting
                             {
                                 Interlocked.Increment(ref _failedLeasesCount);
                             }
-                            oldestRequest.CancellationTokenRegistration.Dispose();
+                            disposer.Add(oldestRequest);
                         }
                         while (_options.QueueLimit - _queueCount < permitCount);
                     }
@@ -202,22 +203,12 @@ namespace System.Threading.RateLimiting
                     }
                 }
 
-                CancelQueueState tcs = new CancelQueueState(permitCount, this, cancellationToken);
-                CancellationTokenRegistration ctr = default;
-                if (cancellationToken.CanBeCanceled)
-                {
-                    ctr = cancellationToken.Register(static obj =>
-                    {
-                        ((CancelQueueState)obj!).TrySetCanceled();
-                    }, tcs);
-                }
-
-                RequestRegistration registration = new RequestRegistration(permitCount, tcs, ctr);
+                var registration = new RequestRegistration(permitCount, this, cancellationToken);
                 _queue.EnqueueTail(registration);
                 _queueCount += permitCount;
                 Debug.Assert(_queueCount <= _options.QueueLimit);
 
-                return new ValueTask<RateLimitLease>(registration.Tcs.Task);
+                return new ValueTask<RateLimitLease>(registration.Task);
             }
         }
 
@@ -286,6 +277,8 @@ namespace System.Threading.RateLimiting
         // Used in tests that test behavior with specific time intervals
         private void ReplenishInternal(long nowTicks)
         {
+            using var disposer = new RequestRegistration.Disposer();
+
             // Method is re-entrant (from Timer), lock to avoid multiple simultaneous replenishes
             lock (Lock)
             {
@@ -325,13 +318,13 @@ namespace System.Threading.RateLimiting
 
                     // Request was handled already, either via cancellation or being kicked from the queue due to a newer request being queued.
                     // We just need to remove the item and let the next queued item be considered for completion.
-                    if (nextPendingRequest.Tcs.Task.IsCompleted)
+                    if (nextPendingRequest.Task.IsCompleted)
                     {
                         nextPendingRequest =
                             _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
                             ? _queue.DequeueHead()
                             : _queue.DequeueTail();
-                        nextPendingRequest.CancellationTokenRegistration.Dispose();
+                        disposer.Add(nextPendingRequest);
                     }
                     // If we have enough permits after replenishing to serve the queued requests
                     else if (_permitCount >= nextPendingRequest.Count)
@@ -347,7 +340,7 @@ namespace System.Threading.RateLimiting
                         _requestsPerSegment[_currentSegmentIndex] += nextPendingRequest.Count;
                         Debug.Assert(_permitCount >= 0);
 
-                        if (!nextPendingRequest.Tcs.TrySetResult(SuccessfulLease))
+                        if (!nextPendingRequest.TrySetResult(SuccessfulLease))
                         {
                             // Queued item was canceled so add count back
                             _permitCount += nextPendingRequest.Count;
@@ -359,7 +352,7 @@ namespace System.Threading.RateLimiting
                         {
                             Interlocked.Increment(ref _successfulLeasesCount);
                         }
-                        nextPendingRequest.CancellationTokenRegistration.Dispose();
+                        disposer.Add(nextPendingRequest);
                         Debug.Assert(_queueCount >= 0);
                     }
                     else
@@ -385,6 +378,7 @@ namespace System.Threading.RateLimiting
                 return;
             }
 
+            using var disposer = new RequestRegistration.Disposer();
             lock (Lock)
             {
                 if (_disposed)
@@ -398,8 +392,8 @@ namespace System.Threading.RateLimiting
                     RequestRegistration next = _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
                         ? _queue.DequeueHead()
                         : _queue.DequeueTail();
-                    next.CancellationTokenRegistration.Dispose();
-                    next.Tcs.TrySetResult(FailedLease);
+                    disposer.Add(next);
+                    next.TrySetResult(FailedLease);
                 }
             }
         }
@@ -448,48 +442,64 @@ namespace System.Threading.RateLimiting
             }
         }
 
-        private readonly struct RequestRegistration
+        private sealed class RequestRegistration : TaskCompletionSource<RateLimitLease>
         {
-            public RequestRegistration(int permitCount, TaskCompletionSource<RateLimitLease> tcs, CancellationTokenRegistration cancellationTokenRegistration)
+            private readonly CancellationToken _cancellationToken;
+            private CancellationTokenRegistration _cancellationTokenRegistration;
+
+            // this field is used only by the disposal mechanics and never shared between threads
+            private RequestRegistration? _next;
+
+            public RequestRegistration(int permitCount, SlidingWindowRateLimiter limiter, CancellationToken cancellationToken)
+                : base(limiter, TaskCreationOptions.RunContinuationsAsynchronously)
             {
                 Count = permitCount;
-                // Use VoidAsyncOperationWithData<T> instead
-                Tcs = tcs;
-                CancellationTokenRegistration = cancellationTokenRegistration;
+                _cancellationToken = cancellationToken;
+
+                // RequestRegistration objects are created while the limiter lock is held
+                // if cancellationToken fires before or while the lock is held, UnsafeRegister
+                // is going to invoke the callback synchronously, but this does not create
+                // a deadlock because lock are reentrant
+                if (cancellationToken.CanBeCanceled)
+                    _cancellationTokenRegistration = cancellationToken.UnsafeRegister(Cancel, this) ;
             }
 
             public int Count { get; }
 
-            public TaskCompletionSource<RateLimitLease> Tcs { get; }
-
-            public CancellationTokenRegistration CancellationTokenRegistration { get; }
-        }
-
-        private sealed class CancelQueueState : TaskCompletionSource<RateLimitLease>
-        {
-            private readonly int _permitCount;
-            private readonly SlidingWindowRateLimiter _limiter;
-            private readonly CancellationToken _cancellationToken;
-
-            public CancelQueueState(int permitCount, SlidingWindowRateLimiter limiter, CancellationToken cancellationToken)
-                : base(TaskCreationOptions.RunContinuationsAsynchronously)
+            private static void Cancel(object? state)
             {
-                _permitCount = permitCount;
-                _limiter = limiter;
-                _cancellationToken = cancellationToken;
+                if (state is RequestRegistration registration && registration.TrySetCanceled(registration._cancellationToken))
+                {
+                    var limiter = (SlidingWindowRateLimiter)registration.Task.AsyncState!;
+                    lock (limiter.Lock)
+                    {
+                        limiter._queueCount -= registration.Count;
+                    }
+                }
             }
 
-            public new bool TrySetCanceled()
+            /// <summary>
+            /// Collects registrations to dispose outside the limiter lock to avoid deadlock.
+            /// </summary>
+            public struct Disposer : IDisposable
             {
-                if (TrySetCanceled(_cancellationToken))
+                private RequestRegistration? _next;
+
+                public void Add(RequestRegistration request)
                 {
-                    lock (_limiter.Lock)
-                    {
-                        _limiter._queueCount -= _permitCount;
-                    }
-                    return true;
+                    request._next = _next;
+                    _next = request;
                 }
-                return false;
+
+                public void Dispose()
+                {
+                    for (var current = _next; current is not null; current = current._next)
+                    {
+                        current._cancellationTokenRegistration.Dispose();
+                    }
+
+                    _next = null;
+                }
             }
         }
     }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
@@ -461,7 +461,11 @@ namespace System.Threading.RateLimiting
                 // is going to invoke the callback synchronously, but this does not create
                 // a deadlock because lock are reentrant
                 if (cancellationToken.CanBeCanceled)
+#if NETCOREAPP || NETSTANDARD2_1
                     _cancellationTokenRegistration = cancellationToken.UnsafeRegister(Cancel, this) ;
+#else
+                    _cancellationTokenRegistration = cancellationToken.Register(Cancel, this) ;
+#endif
             }
 
             public int Count { get; }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
@@ -163,7 +163,7 @@ namespace System.Threading.RateLimiting
                 return new ValueTask<RateLimitLease>(SuccessfulLease);
             }
 
-            using var disposer = new RequestRegistration.Disposer();
+            using var disposer = default(RequestRegistration.Disposer);
             lock (Lock)
             {
                 if (TryLeaseUnsynchronized(permitCount, out RateLimitLease? lease))
@@ -277,7 +277,7 @@ namespace System.Threading.RateLimiting
         // Used in tests that test behavior with specific time intervals
         private void ReplenishInternal(long nowTicks)
         {
-            using var disposer = new RequestRegistration.Disposer();
+            using var disposer = default(RequestRegistration.Disposer);
 
             // Method is re-entrant (from Timer), lock to avoid multiple simultaneous replenishes
             lock (Lock)
@@ -378,7 +378,7 @@ namespace System.Threading.RateLimiting
                 return;
             }
 
-            using var disposer = new RequestRegistration.Disposer();
+            using var disposer = default(RequestRegistration.Disposer);
             lock (Lock)
             {
                 if (_disposed)

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
@@ -186,7 +186,7 @@ namespace System.Threading.RateLimiting
                                 // Updating queue count is handled by the cancellation/cleanup code
                                 Interlocked.Increment(ref _failedLeasesCount);
                             }
-                            disposer.Add(oldestRequest);
+                            disposer.CleanupAndAdd(oldestRequest);
                             Debug.Assert(_queueCount >= 0);
                         }
                         while (_options.QueueLimit - _queueCount < permitCount);
@@ -320,7 +320,7 @@ namespace System.Threading.RateLimiting
                             _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
                             ? _queue.DequeueHead()
                             : _queue.DequeueTail();
-                        disposer.Add(nextPendingRequest);
+                        disposer.CleanupAndAdd(nextPendingRequest);
                     }
                     // If we have enough permits after replenishing to serve the queued requests
                     else if (_permitCount >= nextPendingRequest.Count)
@@ -346,7 +346,7 @@ namespace System.Threading.RateLimiting
                         {
                             Interlocked.Increment(ref _successfulLeasesCount);
                         }
-                        disposer.Add(nextPendingRequest);
+                        disposer.CleanupAndAdd(nextPendingRequest);
                         Debug.Assert(_queueCount >= 0);
                     }
                     else
@@ -386,7 +386,7 @@ namespace System.Threading.RateLimiting
                     RequestRegistration next = _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
                         ? _queue.DequeueHead()
                         : _queue.DequeueTail();
-                    disposer.Add(next);
+                    disposer.CleanupAndAdd(next);
                     next.TrySetResult(FailedLease);
                 }
                 Debug.Assert(_queueCount == 0);
@@ -493,7 +493,7 @@ namespace System.Threading.RateLimiting
             {
                 private RequestRegistration? _next;
 
-                public void Add(RequestRegistration request)
+                public void CleanupAndAdd(RequestRegistration request)
                 {
                     request.Cleanup();
                     request._next = _next;

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
@@ -463,10 +463,10 @@ namespace System.Threading.RateLimiting
                 // is going to invoke the callback synchronously, but this does not create
                 // a deadlock because lock are reentrant
                 if (cancellationToken.CanBeCanceled)
-#if NETCOREAPP || NETSTANDARD2_1
-                    _cancellationTokenRegistration = cancellationToken.UnsafeRegister(Cancel, this) ;
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+                    _cancellationTokenRegistration = cancellationToken.UnsafeRegister(Cancel, this);
 #else
-                    _cancellationTokenRegistration = cancellationToken.Register(Cancel, this) ;
+                    _cancellationTokenRegistration = cancellationToken.Register(Cancel, this);
 #endif
             }
 

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
@@ -463,7 +463,11 @@ namespace System.Threading.RateLimiting
                 // is going to invoke the callback synchronously, but this does not create
                 // a deadlock because lock are reentrant
                 if (cancellationToken.CanBeCanceled)
+#if NETCOREAPP || NETSTANDARD2_1
                     _cancellationTokenRegistration = cancellationToken.UnsafeRegister(Cancel, this) ;
+#else
+                    _cancellationTokenRegistration = cancellationToken.Register(Cancel, this) ;
+#endif
             }
 
             public int Count { get; }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
@@ -156,6 +156,7 @@ namespace System.Threading.RateLimiting
                 return new ValueTask<RateLimitLease>(SuccessfulLease);
             }
 
+            using var disposer = new RequestRegistration.Disposer();
             lock (Lock)
             {
                 if (TryLeaseUnsynchronized(tokenCount, out RateLimitLease? lease))
@@ -175,7 +176,7 @@ namespace System.Threading.RateLimiting
                             RequestRegistration oldestRequest = _queue.DequeueHead();
                             _queueCount -= oldestRequest.Count;
                             Debug.Assert(_queueCount >= 0);
-                            if (!oldestRequest.Tcs.TrySetResult(FailedLease))
+                            if (!oldestRequest.TrySetResult(FailedLease))
                             {
                                 // Updating queue count is handled by the cancellation code
                                 _queueCount += oldestRequest.Count;
@@ -184,7 +185,7 @@ namespace System.Threading.RateLimiting
                             {
                                 Interlocked.Increment(ref _failedLeasesCount);
                             }
-                            oldestRequest.CancellationTokenRegistration.Dispose();
+                            disposer.Add(oldestRequest);
                         }
                         while (_options.QueueLimit - _queueCount < tokenCount);
                     }
@@ -196,22 +197,12 @@ namespace System.Threading.RateLimiting
                     }
                 }
 
-                CancelQueueState tcs = new CancelQueueState(tokenCount, this, cancellationToken);
-                CancellationTokenRegistration ctr = default;
-                if (cancellationToken.CanBeCanceled)
-                {
-                    ctr = cancellationToken.Register(static obj =>
-                    {
-                        ((CancelQueueState)obj!).TrySetCanceled();
-                    }, tcs);
-                }
-
-                RequestRegistration registration = new RequestRegistration(tokenCount, tcs, ctr);
+                var registration = new RequestRegistration(tokenCount, this, cancellationToken);
                 _queue.EnqueueTail(registration);
                 _queueCount += tokenCount;
                 Debug.Assert(_queueCount <= _options.QueueLimit);
 
-                return new ValueTask<RateLimitLease>(registration.Tcs.Task);
+                return new ValueTask<RateLimitLease>(registration.Task);
             }
         }
 
@@ -288,6 +279,8 @@ namespace System.Threading.RateLimiting
         // Used in tests to avoid dealing with real time
         private void ReplenishInternal(long nowTicks)
         {
+            using var disposer = new RequestRegistration.Disposer();
+
             // method is re-entrant (from Timer), lock to avoid multiple simultaneous replenishes
             lock (Lock)
             {
@@ -330,13 +323,13 @@ namespace System.Threading.RateLimiting
 
                     // Request was handled already, either via cancellation or being kicked from the queue due to a newer request being queued.
                     // We just need to remove the item and let the next queued item be considered for completion.
-                    if (nextPendingRequest.Tcs.Task.IsCompleted)
+                    if (nextPendingRequest.Task.IsCompleted)
                     {
                         nextPendingRequest =
                             _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
                             ? queue.DequeueHead()
                             : queue.DequeueTail();
-                        nextPendingRequest.CancellationTokenRegistration.Dispose();
+                        disposer.Add(nextPendingRequest);
                     }
                     else if (_tokenCount >= nextPendingRequest.Count)
                     {
@@ -350,7 +343,7 @@ namespace System.Threading.RateLimiting
                         _tokenCount -= nextPendingRequest.Count;
                         Debug.Assert(_tokenCount >= 0);
 
-                        if (!nextPendingRequest.Tcs.TrySetResult(SuccessfulLease))
+                        if (!nextPendingRequest.TrySetResult(SuccessfulLease))
                         {
                             // Queued item was canceled so add count back
                             _tokenCount += nextPendingRequest.Count;
@@ -361,7 +354,7 @@ namespace System.Threading.RateLimiting
                         {
                             Interlocked.Increment(ref _successfulLeasesCount);
                         }
-                        nextPendingRequest.CancellationTokenRegistration.Dispose();
+                        disposer.Add(nextPendingRequest);
                         Debug.Assert(_queueCount >= 0);
                     }
                     else
@@ -387,6 +380,7 @@ namespace System.Threading.RateLimiting
                 return;
             }
 
+            using var disposer = new RequestRegistration.Disposer();
             lock (Lock)
             {
                 if (_disposed)
@@ -400,8 +394,8 @@ namespace System.Threading.RateLimiting
                     RequestRegistration next = _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
                         ? _queue.DequeueHead()
                         : _queue.DequeueTail();
-                    next.CancellationTokenRegistration.Dispose();
-                    next.Tcs.TrySetResult(FailedLease);
+                    disposer.Add(next);
+                    next.TrySetResult(FailedLease);
                 }
             }
         }
@@ -450,48 +444,64 @@ namespace System.Threading.RateLimiting
             }
         }
 
-        private readonly struct RequestRegistration
+        private sealed class RequestRegistration : TaskCompletionSource<RateLimitLease>
         {
-            public RequestRegistration(int tokenCount, TaskCompletionSource<RateLimitLease> tcs, CancellationTokenRegistration cancellationTokenRegistration)
+            private readonly CancellationToken _cancellationToken;
+            private CancellationTokenRegistration _cancellationTokenRegistration;
+
+            // this field is used only by the disposal mechanics and never shared between threads
+            private RequestRegistration? _next;
+
+            public RequestRegistration(int permitCount, TokenBucketRateLimiter limiter, CancellationToken cancellationToken)
+                : base(limiter, TaskCreationOptions.RunContinuationsAsynchronously)
             {
-                Count = tokenCount;
-                // Use VoidAsyncOperationWithData<T> instead
-                Tcs = tcs;
-                CancellationTokenRegistration = cancellationTokenRegistration;
+                Count = permitCount;
+                _cancellationToken = cancellationToken;
+
+                // RequestRegistration objects are created while the limiter lock is held
+                // if cancellationToken fires before or while the lock is held, UnsafeRegister
+                // is going to invoke the callback synchronously, but this does not create
+                // a deadlock because lock are reentrant
+                if (cancellationToken.CanBeCanceled)
+                    _cancellationTokenRegistration = cancellationToken.UnsafeRegister(Cancel, this) ;
             }
 
             public int Count { get; }
 
-            public TaskCompletionSource<RateLimitLease> Tcs { get; }
-
-            public CancellationTokenRegistration CancellationTokenRegistration { get; }
-        }
-
-        private sealed class CancelQueueState : TaskCompletionSource<RateLimitLease>
-        {
-            private readonly int _tokenCount;
-            private readonly TokenBucketRateLimiter _limiter;
-            private readonly CancellationToken _cancellationToken;
-
-            public CancelQueueState(int tokenCount, TokenBucketRateLimiter limiter, CancellationToken cancellationToken)
-                : base(TaskCreationOptions.RunContinuationsAsynchronously)
+            private static void Cancel(object? state)
             {
-                _tokenCount = tokenCount;
-                _limiter = limiter;
-                _cancellationToken = cancellationToken;
+                if (state is RequestRegistration registration && registration.TrySetCanceled(registration._cancellationToken))
+                {
+                    var limiter = (TokenBucketRateLimiter)registration.Task.AsyncState!;
+                    lock (limiter.Lock)
+                    {
+                        limiter._queueCount -= registration.Count;
+                    }
+                }
             }
 
-            public new bool TrySetCanceled()
+            /// <summary>
+            /// Collects registrations to dispose outside the limiter lock to avoid deadlock.
+            /// </summary>
+            public struct Disposer : IDisposable
             {
-                if (TrySetCanceled(_cancellationToken))
+                private RequestRegistration? _next;
+
+                public void Add(RequestRegistration request)
                 {
-                    lock (_limiter.Lock)
-                    {
-                        _limiter._queueCount -= _tokenCount;
-                    }
-                    return true;
+                    request._next = _next;
+                    _next = request;
                 }
-                return false;
+
+                public void Dispose()
+                {
+                    for (var current = _next; current is not null; current = current._next)
+                    {
+                        current._cancellationTokenRegistration.Dispose();
+                    }
+
+                    _next = null;
+                }
             }
         }
     }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
@@ -156,7 +156,7 @@ namespace System.Threading.RateLimiting
                 return new ValueTask<RateLimitLease>(SuccessfulLease);
             }
 
-            using var disposer = new RequestRegistration.Disposer();
+            using var disposer = default(RequestRegistration.Disposer);
             lock (Lock)
             {
                 if (TryLeaseUnsynchronized(tokenCount, out RateLimitLease? lease))
@@ -279,7 +279,7 @@ namespace System.Threading.RateLimiting
         // Used in tests to avoid dealing with real time
         private void ReplenishInternal(long nowTicks)
         {
-            using var disposer = new RequestRegistration.Disposer();
+            using var disposer = default(RequestRegistration.Disposer);
 
             // method is re-entrant (from Timer), lock to avoid multiple simultaneous replenishes
             lock (Lock)
@@ -380,7 +380,7 @@ namespace System.Threading.RateLimiting
                 return;
             }
 
-            using var disposer = new RequestRegistration.Disposer();
+            using var disposer = default(RequestRegistration.Disposer);
             lock (Lock)
             {
                 if (_disposed)

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
@@ -179,7 +179,7 @@ namespace System.Threading.RateLimiting
                                 // Updating queue count is handled by the cancellation/cleanup code
                                 Interlocked.Increment(ref _failedLeasesCount);
                             }
-                            disposer.Add(oldestRequest);
+                            disposer.CleanupAndAdd(oldestRequest);
                             Debug.Assert(_queueCount >= 0);
                         }
                         while (_options.QueueLimit - _queueCount < tokenCount);
@@ -324,7 +324,7 @@ namespace System.Threading.RateLimiting
                             _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
                             ? queue.DequeueHead()
                             : queue.DequeueTail();
-                        disposer.Add(nextPendingRequest);
+                        disposer.CleanupAndAdd(nextPendingRequest);
                     }
                     else if (_tokenCount >= nextPendingRequest.Count)
                     {
@@ -347,7 +347,7 @@ namespace System.Threading.RateLimiting
                         {
                             Interlocked.Increment(ref _successfulLeasesCount);
                         }
-                        disposer.Add(nextPendingRequest);
+                        disposer.CleanupAndAdd(nextPendingRequest);
                         Debug.Assert(_queueCount >= 0);
                     }
                     else
@@ -387,7 +387,7 @@ namespace System.Threading.RateLimiting
                     RequestRegistration next = _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
                         ? _queue.DequeueHead()
                         : _queue.DequeueTail();
-                    disposer.Add(next);
+                    disposer.CleanupAndAdd(next);
                     next.TrySetResult(FailedLease);
                 }
                 Debug.Assert(_queueCount == 0);
@@ -494,7 +494,7 @@ namespace System.Threading.RateLimiting
             {
                 private RequestRegistration? _next;
 
-                public void Add(RequestRegistration request)
+                public void CleanupAndAdd(RequestRegistration request)
                 {
                     request.Cleanup();
                     request._next = _next;

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
@@ -174,18 +174,13 @@ namespace System.Threading.RateLimiting
                         do
                         {
                             RequestRegistration oldestRequest = _queue.DequeueHead();
-                            _queueCount -= oldestRequest.Count;
-                            Debug.Assert(_queueCount >= 0);
-                            if (!oldestRequest.TrySetResult(FailedLease))
+                            if (oldestRequest.TrySetResult(FailedLease))
                             {
-                                // Updating queue count is handled by the cancellation code
-                                _queueCount += oldestRequest.Count;
-                            }
-                            else
-                            {
+                                // Updating queue count is handled by the cancellation/cleanup code
                                 Interlocked.Increment(ref _failedLeasesCount);
                             }
                             disposer.Add(oldestRequest);
+                            Debug.Assert(_queueCount >= 0);
                         }
                         while (_options.QueueLimit - _queueCount < tokenCount);
                     }
@@ -339,7 +334,7 @@ namespace System.Threading.RateLimiting
                             ? queue.DequeueHead()
                             : queue.DequeueTail();
 
-                        _queueCount -= nextPendingRequest.Count;
+                        // Updating queue count is handled by the cancellation/cleanup code
                         _tokenCount -= nextPendingRequest.Count;
                         Debug.Assert(_tokenCount >= 0);
 
@@ -347,8 +342,6 @@ namespace System.Threading.RateLimiting
                         {
                             // Queued item was canceled so add count back
                             _tokenCount += nextPendingRequest.Count;
-                            // Updating queue count is handled by the cancellation code
-                            _queueCount += nextPendingRequest.Count;
                         }
                         else
                         {
@@ -397,6 +390,7 @@ namespace System.Threading.RateLimiting
                     disposer.Add(next);
                     next.TrySetResult(FailedLease);
                 }
+                Debug.Assert(_queueCount == 0);
             }
         }
 
@@ -470,17 +464,26 @@ namespace System.Threading.RateLimiting
 #endif
             }
 
-            public int Count { get; }
+            /// <remarks>
+            /// This property is only accessed under limiter lock.
+            /// </remarks>
+            public int Count { get; private set; }
 
             private static void Cancel(object? state)
             {
                 if (state is RequestRegistration registration && registration.TrySetCanceled(registration._cancellationToken))
                 {
-                    var limiter = (TokenBucketRateLimiter)registration.Task.AsyncState!;
-                    lock (limiter.Lock)
-                    {
-                        limiter._queueCount -= registration.Count;
-                    }
+                    registration.Cleanup();
+                }
+            }
+
+            private void Cleanup()
+            {
+                var limiter = (TokenBucketRateLimiter)Task.AsyncState!;
+                lock (limiter.Lock)
+                {
+                    limiter._queueCount -= Count;
+                    Count = 0;
                 }
             }
 
@@ -493,6 +496,7 @@ namespace System.Threading.RateLimiting
 
                 public void Add(RequestRegistration request)
                 {
+                    request.Cleanup();
                     request._next = _next;
                     _next = request;
                 }


### PR DESCRIPTION
In `System.Threading.RateLimiting.ConcurrencyLimiter` and the other three implementations using a synchronously locked deque, there is a deadlock between an outstanding wait-for-lease operation being canceled by user and releasing an existing lease. The internal `Release()` method has to clean up wait-for-lease operations in some circumstances. This involves disposing the operation's `CancellationTokenRegistration`, which blocks if the registered callback is already running. This callback can be invoked on another thread if the external cancellation token fires. It locks the rate limiter to return the operation's permits to the rate limiter. If the external cancellation token fires after `Release()` runs but before it disposes of the `CancellationTokenRegistration`, there will be a deadlock as `Release()` holds the lock while waiting for the callback to complete while the callback blocks on the lock to return its permits.

This change eliminates this deadlock by moving the cleanup of any wait-for-lease operations in `Release()` outside the lock.
It also combines the private struct `RequestRegistration` with the private class `CancelQueueState` as they are used only together, increasing the size of the deque element for no discernible gain.