### PR TITLE
JIT: Make optAssertionPropGlobal_RelOp less conservative for side-effects

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3802,8 +3802,8 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
         return nullptr;
     }
 
-    // Bail out if tree is not side effect free.
-    if ((tree->gtFlags & GTF_SIDE_EFFECT) != 0)
+    // Bail out if op1 is not side effect free.
+    if ((tree->gtGetOp1()->gtFlags & GTF_SIDE_EFFECT) != 0)
     {
         return nullptr;
     }

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3802,8 +3802,8 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
         return nullptr;
     }
 
-    // Bail out if op1 is not side effect free.
-    if ((tree->gtGetOp1()->gtFlags & GTF_SIDE_EFFECT) != 0)
+    // Bail out if op1 is not side effect free. Note we'll be bashing it below, unlike op2.
+    if ((op1->gtFlags & GTF_SIDE_EFFECT) != 0)
     {
         return nullptr;
     }


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/85522

```csharp
static int Test(object o)
{
    if (o is string)
        return ((string)o).Length;
    return 0;
}
```
Old codegen:
```asm
; Method Proga:Test(System.Object):int
       mov      rax, rcx
       test     rax, rax
       je       SHORT G_M10539_IG06
       mov      rdx, 0x7FF85AF27778      ; System.String
       cmp      qword ptr [rax], rdx
       jne      SHORT G_M10539_IG06
       mov      rax, 0x7FF85AF27778      ; System.String
       cmp      qword ptr [rcx], rax
       jne      SHORT G_M10539_IG08
       mov      eax, dword ptr [rcx+08H]
       ret      
G_M10539_IG06:  
       xor      eax, eax
       ret      
G_M10539_IG08:  
       int3     
; Total bytes of code: 46
```
New codegen:
```asm
; Method Proga:Test(System.Object):int
       mov      rax, rcx
       test     rax, rax
       je       SHORT G_M10539_IG04
       mov      rdx, 0x7FF85AF37778      ; System.String
       cmp      qword ptr [rax], rdx
       je       SHORT G_M10539_IG06
G_M10539_IG04:
       xor      eax, eax
       ret      
G_M10539_IG06:  
       mov      eax, dword ptr [rcx+08H]
       ret      
; Total bytes of code: 30
```

The problem that for the following tree

![image](https://user-images.githubusercontent.com/523221/235192369-6b632334-bd94-4cd3-bc06-09d12794bc70.png)

Assertprop gives up due to ASG side-effects from the op2 (op1 is side-effect free since it's proved that the address is not null) - it will be preserved just fine