### PR TITLE
JIT: enhance SSA checker to check some PHI properties

### DIFF
--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -4205,11 +4205,25 @@ public:
 
     void CheckPhis(BasicBlock* block)
     {
+        Statement* nonPhiStmt = nullptr;
         for (Statement* const stmt : block->Statements())
         {
+            // All PhiDefs should appear before any other statements
+            //
             if (!stmt->IsPhiDefnStmt())
             {
-                break;
+                if (nonPhiStmt == nullptr)
+                {
+                    nonPhiStmt = stmt;
+                }
+                continue;
+            }
+
+            if (nonPhiStmt != nullptr)
+            {
+                SetHasErrors();
+                JITDUMP("[error] " FMT_BB " PhiDef " FMT_STMT " appears after non-PhiDef " FMT_STMT "\n", block->bbNum,
+                        stmt->GetID(), nonPhiStmt->GetID());
             }
 
             GenTree* const phiDefNode = stmt->GetRootNode();


### PR DESCRIPTION
* Ensure PhiArgs have the right local number.
* Ensure PhiArgs have unique `gtPredBB` (for most blocks)

Handler entries may have multiple PhiArgs with the same `gtPredBB`. This is by design, to model exceptional flow from the middle of the block to a handler.

Jump threading relies on there being just a single PhiArg per pred. So exclude handler entry blocks from jump threading.

Prep work for possibly changing SSA to produce one PhiArg per pred, instead of one PhiArg per ssa def.