### PR TITLE
Remove cached Type instances

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/MaskedTextProvider.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/MaskedTextProvider.cs
@@ -117,9 +117,6 @@ namespace System.ComponentModel
         private static readonly int s_RESET_ON_LITERALS = BitVector32.CreateMask(s_RESET_ON_PROMPT);
         private static readonly int s_SKIP_SPACE = BitVector32.CreateMask(s_RESET_ON_LITERALS);
 
-        // Type cached to speed up cloning of this object.
-        private static readonly Type s_maskTextProviderType = typeof(MaskedTextProvider);
-
         //// Instance data.
 
         // Bit vector to represent bool variables.
@@ -460,9 +457,8 @@ namespace System.ComponentModel
         public object Clone()
         {
             MaskedTextProvider clonedProvider;
-            Type providerType = GetType();
 
-            if (providerType == s_maskTextProviderType)
+            if (GetType() == typeof(MaskedTextProvider))
             {
                 clonedProvider = new MaskedTextProvider(
                                                         Mask,
@@ -484,7 +480,7 @@ namespace System.ComponentModel
                     AsciiOnly
                 };
 
-                clonedProvider = (Activator.CreateInstance(providerType, parameters) as MaskedTextProvider)!;
+                clonedProvider = (Activator.CreateInstance(GetType(), parameters) as MaskedTextProvider)!;
             }
 
             clonedProvider.ResetOnPrompt = false;

--- a/src/libraries/System.Data.Common/src/System/Data/DataSetUtil.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataSetUtil.cs
@@ -82,24 +82,17 @@ internal static class DataSetUtil
         return InvalidEnumerationValue(typeof(LoadOption), (int)value);
     }
 
-    // only StackOverflowException & ThreadAbortException are sealed classes
-    private static readonly Type s_stackOverflowType = typeof(StackOverflowException);
-    private static readonly Type s_outOfMemoryType = typeof(OutOfMemoryException);
-    private static readonly Type s_threadAbortType = typeof(System.Threading.ThreadAbortException);
-    private static readonly Type s_nullReferenceType = typeof(NullReferenceException);
-    private static readonly Type s_accessViolationType = typeof(AccessViolationException);
-    private static readonly Type s_securityType = typeof(System.Security.SecurityException);
 
     internal static bool IsCatchableExceptionType(Exception e)
     {
         // a 'catchable' exception is defined by what it is not.
-        Type type = e.GetType();
+        // only StackOverflowException & ThreadAbortException are sealed classes
 
-        return ((type != s_stackOverflowType) &&
-                 (type != s_outOfMemoryType) &&
-                 (type != s_threadAbortType) &&
-                 (type != s_nullReferenceType) &&
-                 (type != s_accessViolationType) &&
-                 !s_securityType.IsAssignableFrom(type));
+        return ((e.GetType() != typeof(StackOverflowException)) &&
+                 (e.GetType() != typeof(OutOfMemoryException)) &&
+                 (e.GetType() != typeof(System.Threading.ThreadAbortException)) &&
+                 (e.GetType() != typeof(NullReferenceException)) &&
+                 (e.GetType() != typeof(System.Security.SecurityException)) &&
+                 !typeof(System.Security.SecurityException).IsAssignableFrom(e.GetType()));
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Convert.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Convert.cs
@@ -74,50 +74,8 @@ namespace System
 
     public static partial class Convert
     {
-        // A typeof operation is fairly expensive (does a system call), so we'll cache these here
-        // statically.  These are exactly lined up with the TypeCode, eg. ConvertType[TypeCode.Int16]
-        // will give you the type of an short.
-        internal static readonly Type[] ConvertTypes = {
-            typeof(System.Empty),
-            typeof(object),
-            typeof(System.DBNull),
-            typeof(bool),
-            typeof(char),
-            typeof(sbyte),
-            typeof(byte),
-            typeof(short),
-            typeof(ushort),
-            typeof(int),
-            typeof(uint),
-            typeof(long),
-            typeof(ulong),
-            typeof(float),
-            typeof(double),
-            typeof(decimal),
-            typeof(DateTime),
-            typeof(object), // TypeCode is discontinuous so we need a placeholder.
-            typeof(string)
-        };
-
-        // Need to special case Enum because typecode will be underlying type, e.g. Int32
-        private static readonly Type EnumType = typeof(Enum);
-
         private const int Base64LineBreakPosition = 76;
         private const int Base64VectorizationLengthThreshold = 16;
-
-#if DEBUG
-        static Convert()
-        {
-            Debug.Assert(ConvertTypes != null, "[Convert.cctor]ConvertTypes!=null");
-            Debug.Assert(ConvertTypes.Length == ((int)TypeCode.String + 1), "[Convert.cctor]ConvertTypes.Length == ((int)TypeCode.String + 1)");
-            Debug.Assert(ConvertTypes[(int)TypeCode.Empty] == typeof(System.Empty),
-                            "[Convert.cctor]ConvertTypes[(int)TypeCode.Empty]==typeof(System.Empty)");
-            Debug.Assert(ConvertTypes[(int)TypeCode.String] == typeof(string),
-                            "[Convert.cctor]ConvertTypes[(int)TypeCode.String]==typeof(System.String)");
-            Debug.Assert(ConvertTypes[(int)TypeCode.Int32] == typeof(int),
-                            "[Convert.cctor]ConvertTypes[(int)TypeCode.Int32]==typeof(int)");
-        }
-#endif
 
         // Constant representing the database null value. This value is used in
         // database applications to indicate the absence of a known value. Note
@@ -223,44 +181,44 @@ namespace System
                 return value;
             }
 
-            if (ReferenceEquals(targetType, ConvertTypes[(int)TypeCode.Boolean]))
+            if (ReferenceEquals(targetType, typeof(bool)))
                 return value.ToBoolean(provider);
-            if (ReferenceEquals(targetType, ConvertTypes[(int)TypeCode.Char]))
+            if (ReferenceEquals(targetType, typeof(char)))
                 return value.ToChar(provider);
-            if (ReferenceEquals(targetType, ConvertTypes[(int)TypeCode.SByte]))
+            if (ReferenceEquals(targetType, typeof(sbyte)))
                 return value.ToSByte(provider);
-            if (ReferenceEquals(targetType, ConvertTypes[(int)TypeCode.Byte]))
+            if (ReferenceEquals(targetType, typeof(byte)))
                 return value.ToByte(provider);
-            if (ReferenceEquals(targetType, ConvertTypes[(int)TypeCode.Int16]))
+            if (ReferenceEquals(targetType, typeof(short)))
                 return value.ToInt16(provider);
-            if (ReferenceEquals(targetType, ConvertTypes[(int)TypeCode.UInt16]))
+            if (ReferenceEquals(targetType, typeof(ushort)))
                 return value.ToUInt16(provider);
-            if (ReferenceEquals(targetType, ConvertTypes[(int)TypeCode.Int32]))
+            if (ReferenceEquals(targetType, typeof(int)))
                 return value.ToInt32(provider);
-            if (ReferenceEquals(targetType, ConvertTypes[(int)TypeCode.UInt32]))
+            if (ReferenceEquals(targetType, typeof(uint)))
                 return value.ToUInt32(provider);
-            if (ReferenceEquals(targetType, ConvertTypes[(int)TypeCode.Int64]))
+            if (ReferenceEquals(targetType, typeof(long)))
                 return value.ToInt64(provider);
-            if (ReferenceEquals(targetType, ConvertTypes[(int)TypeCode.UInt64]))
+            if (ReferenceEquals(targetType, typeof(ulong)))
                 return value.ToUInt64(provider);
-            if (ReferenceEquals(targetType, ConvertTypes[(int)TypeCode.Single]))
+            if (ReferenceEquals(targetType, typeof(float)))
                 return value.ToSingle(provider);
-            if (ReferenceEquals(targetType, ConvertTypes[(int)TypeCode.Double]))
+            if (ReferenceEquals(targetType, typeof(double)))
                 return value.ToDouble(provider);
-            if (ReferenceEquals(targetType, ConvertTypes[(int)TypeCode.Decimal]))
+            if (ReferenceEquals(targetType, typeof(decimal)))
                 return value.ToDecimal(provider);
-            if (ReferenceEquals(targetType, ConvertTypes[(int)TypeCode.DateTime]))
+            if (ReferenceEquals(targetType, typeof(DateTime)))
                 return value.ToDateTime(provider);
-            if (ReferenceEquals(targetType, ConvertTypes[(int)TypeCode.String]))
+            if (ReferenceEquals(targetType, typeof(string)))
                 return value.ToString(provider);
-            if (ReferenceEquals(targetType, ConvertTypes[(int)TypeCode.Object]))
+            if (ReferenceEquals(targetType, typeof(object)))
                 return (object)value;
             // Need to special case Enum because typecode will be underlying type, e.g. Int32
-            if (ReferenceEquals(targetType, EnumType))
+            if (ReferenceEquals(targetType, typeof(Enum)))
                 return (Enum)value;
-            if (ReferenceEquals(targetType, ConvertTypes[(int)TypeCode.DBNull]))
+            if (ReferenceEquals(targetType, typeof(DBNull)))
                 throw new InvalidCastException(SR.InvalidCast_DBNull);
-            if (ReferenceEquals(targetType, ConvertTypes[(int)TypeCode.Empty]))
+            if (ReferenceEquals(targetType, typeof(Empty)))
                 throw new InvalidCastException(SR.InvalidCast_Empty);
 
             throw new InvalidCastException(SR.Format(SR.InvalidCast_FromTo, value.GetType().FullName, targetType.FullName));
@@ -295,37 +253,37 @@ namespace System
                 throw new InvalidCastException(SR.InvalidCast_IConvertible);
             }
 
-            if (ReferenceEquals(conversionType, ConvertTypes[(int)TypeCode.Boolean]))
+            if (ReferenceEquals(conversionType, typeof(bool)))
                 return ic.ToBoolean(provider);
-            if (ReferenceEquals(conversionType, ConvertTypes[(int)TypeCode.Char]))
+            if (ReferenceEquals(conversionType, typeof(char)))
                 return ic.ToChar(provider);
-            if (ReferenceEquals(conversionType, ConvertTypes[(int)TypeCode.SByte]))
+            if (ReferenceEquals(conversionType, typeof(sbyte)))
                 return ic.ToSByte(provider);
-            if (ReferenceEquals(conversionType, ConvertTypes[(int)TypeCode.Byte]))
+            if (ReferenceEquals(conversionType, typeof(byte)))
                 return ic.ToByte(provider);
-            if (ReferenceEquals(conversionType, ConvertTypes[(int)TypeCode.Int16]))
+            if (ReferenceEquals(conversionType, typeof(short)))
                 return ic.ToInt16(provider);
-            if (ReferenceEquals(conversionType, ConvertTypes[(int)TypeCode.UInt16]))
+            if (ReferenceEquals(conversionType, typeof(ushort)))
                 return ic.ToUInt16(provider);
-            if (ReferenceEquals(conversionType, ConvertTypes[(int)TypeCode.Int32]))
+            if (ReferenceEquals(conversionType, typeof(int)))
                 return ic.ToInt32(provider);
-            if (ReferenceEquals(conversionType, ConvertTypes[(int)TypeCode.UInt32]))
+            if (ReferenceEquals(conversionType, typeof(uint)))
                 return ic.ToUInt32(provider);
-            if (ReferenceEquals(conversionType, ConvertTypes[(int)TypeCode.Int64]))
+            if (ReferenceEquals(conversionType, typeof(long)))
                 return ic.ToInt64(provider);
-            if (ReferenceEquals(conversionType, ConvertTypes[(int)TypeCode.UInt64]))
+            if (ReferenceEquals(conversionType, typeof(ulong)))
                 return ic.ToUInt64(provider);
-            if (ReferenceEquals(conversionType, ConvertTypes[(int)TypeCode.Single]))
+            if (ReferenceEquals(conversionType, typeof(float)))
                 return ic.ToSingle(provider);
-            if (ReferenceEquals(conversionType, ConvertTypes[(int)TypeCode.Double]))
+            if (ReferenceEquals(conversionType, typeof(double)))
                 return ic.ToDouble(provider);
-            if (ReferenceEquals(conversionType, ConvertTypes[(int)TypeCode.Decimal]))
+            if (ReferenceEquals(conversionType, typeof(decimal)))
                 return ic.ToDecimal(provider);
-            if (ReferenceEquals(conversionType, ConvertTypes[(int)TypeCode.DateTime]))
+            if (ReferenceEquals(conversionType, typeof(DateTime)))
                 return ic.ToDateTime(provider);
-            if (ReferenceEquals(conversionType, ConvertTypes[(int)TypeCode.String]))
+            if (ReferenceEquals(conversionType, typeof(string)))
                 return ic.ToString(provider);
-            if (ReferenceEquals(conversionType, ConvertTypes[(int)TypeCode.Object]))
+            if (ReferenceEquals(conversionType, typeof(object)))
                 return (object)value;
 
             return ic.ToType(conversionType, provider);

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
@@ -141,8 +141,6 @@ namespace System.Resources
         // there yet because CultureInfo's class initializer hasn't finished.  If we move SystemResMgr off of
         // Assembly (or at least make it an internal property) we should be able to circumvent this problem.
 
-        // This is our min required ResourceSet type.
-        private static readonly Type s_minResourceSet = typeof(ResourceSet);
         // These Strings are used to avoid using Reflection in CreateResourceSet.
         internal const string ResReaderTypeName = "System.Resources.ResourceReader";
         internal const string ResSetTypeName = "System.Resources.RuntimeResourceSet";
@@ -212,7 +210,7 @@ namespace System.Resources
             MainAssembly = assembly;
             BaseNameField = baseName;
 
-            if (usingResourceSet != null && (usingResourceSet != s_minResourceSet) && !usingResourceSet.IsSubclassOf(s_minResourceSet))
+            if (usingResourceSet != null && (usingResourceSet != typeof(ResourceSet)) && !usingResourceSet.IsSubclassOf(typeof(ResourceSet)))
                 throw new ArgumentException(SR.Arg_ResMgrNotResSet, nameof(usingResourceSet));
             _userResourceSet = usingResourceSet;
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/BinaryXml/XmlBinaryReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/BinaryXml/XmlBinaryReader.cs
@@ -16,9 +16,6 @@ namespace System.Xml
 {
     internal sealed partial class XmlSqlBinaryReader : XmlReader, IXmlNamespaceResolver
     {
-        internal static readonly Type TypeOfObject = typeof(object);
-        internal static readonly Type TypeOfString = typeof(string);
-
         private static volatile Type?[] s_tokenTypeMap = null!;
 
         private static ReadOnlySpan<byte> XsdKatmaiTimeScaleToValueLengthMap => new byte[8] { // rely on C# compiler optimization to eliminate allocation
@@ -350,7 +347,7 @@ namespace System.Xml
             AddInitNamespace(string.Empty, string.Empty);
             AddInitNamespace(_xml, _xnt.Add(XmlReservedNs.NsXml));
             AddInitNamespace(_xmlns, _nsxmlns);
-            _valueType = TypeOfString;
+            _valueType = typeof(string);
             // init buffer position, etc
             _inStrm = stream;
             if (data != null)
@@ -854,7 +851,7 @@ namespace System.Xml
                     else
                     {
                         _token = BinXmlToken.Error;
-                        _valueType = TypeOfString;
+                        _valueType = typeof(string);
                         _state = ScanState.AttrValPseudoValue;
                     }
                     _qnameOther.Clear();
@@ -2404,7 +2401,7 @@ namespace System.Xml
             _token = BinXmlToken.Attr;
             _nodetype = XmlNodeType.Attribute;
             _state = ScanState.Attr;
-            _valueType = TypeOfObject;
+            _valueType = typeof(object);
             _stringValue = null;
         }
 
@@ -2828,7 +2825,7 @@ namespace System.Xml
 
             ClearAttributes();
             _attrCount = 0;
-            _valueType = TypeOfString;
+            _valueType = typeof(string);
             _stringValue = null;
             _hasTypedValue = false;
 
@@ -2960,7 +2957,7 @@ namespace System.Xml
                 case BinXmlToken.SQL_NCHAR:
                 case BinXmlToken.SQL_NVARCHAR:
                 case BinXmlToken.SQL_NTEXT:
-                    _valueType = TypeOfString;
+                    _valueType = typeof(string);
                     _hasTypedValue = false;
                     break;
                 default:
@@ -3090,7 +3087,7 @@ namespace System.Xml
                 }
             }
             _nodetype = XmlNodeType.Element;
-            _valueType = TypeOfObject;
+            _valueType = typeof(object);
             _posAfterAttrs = _pos;
         }
 
@@ -3308,13 +3305,13 @@ namespace System.Xml
             map[(int)BinXmlToken.SQL_UDT] = TypeOfByteArray;
             map[(int)BinXmlToken.XSD_BINHEX] = TypeOfByteArray;
             map[(int)BinXmlToken.XSD_BASE64] = TypeOfByteArray;
-            map[(int)BinXmlToken.SQL_CHAR] = TypeOfString;
-            map[(int)BinXmlToken.SQL_VARCHAR] = TypeOfString;
-            map[(int)BinXmlToken.SQL_TEXT] = TypeOfString;
-            map[(int)BinXmlToken.SQL_NCHAR] = TypeOfString;
-            map[(int)BinXmlToken.SQL_NVARCHAR] = TypeOfString;
-            map[(int)BinXmlToken.SQL_NTEXT] = TypeOfString;
-            map[(int)BinXmlToken.SQL_UUID] = TypeOfString;
+            map[(int)BinXmlToken.SQL_CHAR] = typeof(string);
+            map[(int)BinXmlToken.SQL_VARCHAR] = typeof(string);
+            map[(int)BinXmlToken.SQL_TEXT] = typeof(string);
+            map[(int)BinXmlToken.SQL_NCHAR] = typeof(string);
+            map[(int)BinXmlToken.SQL_NVARCHAR] = typeof(string);
+            map[(int)BinXmlToken.SQL_NTEXT] = typeof(string);
+            map[(int)BinXmlToken.SQL_UUID] = typeof(string);
             return map;
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/BinaryXml/XmlBinaryReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/BinaryXml/XmlBinaryReader.cs
@@ -3305,13 +3305,14 @@ namespace System.Xml
             map[(int)BinXmlToken.SQL_UDT] = TypeOfByteArray;
             map[(int)BinXmlToken.XSD_BINHEX] = TypeOfByteArray;
             map[(int)BinXmlToken.XSD_BASE64] = TypeOfByteArray;
-            map[(int)BinXmlToken.SQL_CHAR] = typeof(string);
-            map[(int)BinXmlToken.SQL_VARCHAR] = typeof(string);
-            map[(int)BinXmlToken.SQL_TEXT] = typeof(string);
-            map[(int)BinXmlToken.SQL_NCHAR] = typeof(string);
-            map[(int)BinXmlToken.SQL_NVARCHAR] = typeof(string);
-            map[(int)BinXmlToken.SQL_NTEXT] = typeof(string);
-            map[(int)BinXmlToken.SQL_UUID] = typeof(string);
+            Type TypeOfString = typeof(string);
+            map[(int)BinXmlToken.SQL_CHAR] = TypeOfString;
+            map[(int)BinXmlToken.SQL_VARCHAR] = TypeOfString;
+            map[(int)BinXmlToken.SQL_TEXT] = TypeOfString;
+            map[(int)BinXmlToken.SQL_NCHAR] = TypeOfString;
+            map[(int)BinXmlToken.SQL_NVARCHAR] = TypeOfString;
+            map[(int)BinXmlToken.SQL_NTEXT] = TypeOfString;
+            map[(int)BinXmlToken.SQL_UUID] = TypeOfString;
             return map;
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/DataTypeImplementation.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/DataTypeImplementation.cs
@@ -1154,8 +1154,6 @@ namespace System.Xml.Schema
     //Union datatype
     internal sealed class Datatype_union : Datatype_anySimpleType
     {
-        private static readonly Type s_atomicValueType = typeof(object);
-        private static readonly Type s_listValueType = typeof(object[]);
         private readonly XmlSchemaSimpleType[] _types;
 
         internal override XmlValueConverter CreateValueConverter(XmlSchemaType schemaType)
@@ -1190,13 +1188,13 @@ namespace System.Xml.Schema
             return -1;
         }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
+        public override Type ValueType { get { return typeof(object); } }
 
         public override XmlTypeCode TypeCode { get { return XmlTypeCode.AnyAtomicType; } }
 
         internal override FacetsChecker FacetsChecker { get { return unionFacetsChecker; } }
 
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(object[]); } }
 
         internal override RestrictionFlags ValidRestrictionFlags
         {
@@ -1351,9 +1349,6 @@ namespace System.Xml.Schema
     // Primitive datatypes
     internal class Datatype_anySimpleType : DatatypeImplementation
     {
-        private static readonly Type s_atomicValueType = typeof(string);
-        private static readonly Type s_listValueType = typeof(string[]);
-
         internal override XmlValueConverter CreateValueConverter(XmlSchemaType schemaType)
         {
             return XmlUntypedConverter.Untyped;
@@ -1361,11 +1356,11 @@ namespace System.Xml.Schema
 
         internal override FacetsChecker FacetsChecker { get { return miscFacetsChecker; } }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
+        public override Type ValueType { get { return typeof(string); } }
 
         public override XmlTypeCode TypeCode { get { return XmlTypeCode.AnyAtomicType; } }
 
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(string[]); } }
 
         public override XmlTokenizedType TokenizedType { get { return XmlTokenizedType.None; } }
 
@@ -1502,9 +1497,6 @@ namespace System.Xml.Schema
     */
     internal sealed class Datatype_boolean : Datatype_anySimpleType
     {
-        private static readonly Type s_atomicValueType = typeof(bool);
-        private static readonly Type s_listValueType = typeof(bool[]);
-
         internal override XmlValueConverter CreateValueConverter(XmlSchemaType schemaType)
         {
             return XmlBooleanConverter.Create(schemaType!);
@@ -1514,9 +1506,9 @@ namespace System.Xml.Schema
 
         public override XmlTypeCode TypeCode { get { return XmlTypeCode.Boolean; } }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
+        public override Type ValueType { get { return typeof(bool); } }
 
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(bool[]); } }
 
         internal override XmlSchemaWhiteSpace BuiltInWhitespaceFacet { get { return XmlSchemaWhiteSpace.Collapse; } }
 
@@ -1582,9 +1574,6 @@ namespace System.Xml.Schema
     */
     internal class Datatype_float : Datatype_anySimpleType
     {
-        private static readonly Type s_atomicValueType = typeof(float);
-        private static readonly Type s_listValueType = typeof(float[]);
-
         internal override XmlValueConverter CreateValueConverter(XmlSchemaType schemaType)
         {
             return XmlNumeric2Converter.Create(schemaType);
@@ -1594,9 +1583,9 @@ namespace System.Xml.Schema
 
         public override XmlTypeCode TypeCode { get { return XmlTypeCode.Float; } }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
+        public override Type ValueType { get { return typeof(float); } }
 
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(float[]); } }
 
         internal override XmlSchemaWhiteSpace BuiltInWhitespaceFacet { get { return XmlSchemaWhiteSpace.Collapse; } }
 
@@ -1671,9 +1660,6 @@ namespace System.Xml.Schema
     */
     internal class Datatype_double : Datatype_anySimpleType
     {
-        private static readonly Type s_atomicValueType = typeof(double);
-        private static readonly Type s_listValueType = typeof(double[]);
-
         internal override XmlValueConverter CreateValueConverter(XmlSchemaType schemaType)
         {
             return XmlNumeric2Converter.Create(schemaType);
@@ -1683,9 +1669,9 @@ namespace System.Xml.Schema
 
         public override XmlTypeCode TypeCode { get { return XmlTypeCode.Double; } }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
+        public override Type ValueType { get { return typeof(double); } }
 
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(double[]); } }
 
         internal override XmlSchemaWhiteSpace BuiltInWhitespaceFacet { get { return XmlSchemaWhiteSpace.Collapse; } }
 
@@ -1762,8 +1748,6 @@ namespace System.Xml.Schema
     */
     internal class Datatype_decimal : Datatype_anySimpleType
     {
-        private static readonly Type s_atomicValueType = typeof(decimal);
-        private static readonly Type s_listValueType = typeof(decimal[]);
         private static readonly Numeric10FacetsChecker s_numeric10FacetsChecker = new Numeric10FacetsChecker(decimal.MinValue, decimal.MaxValue);
 
         internal override XmlValueConverter CreateValueConverter(XmlSchemaType schemaType)
@@ -1775,9 +1759,9 @@ namespace System.Xml.Schema
 
         public override XmlTypeCode TypeCode { get { return XmlTypeCode.Decimal; } }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
+        public override Type ValueType { get { return typeof(decimal); } }
 
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(decimal[]); } }
 
         internal override XmlSchemaWhiteSpace BuiltInWhitespaceFacet { get { return XmlSchemaWhiteSpace.Collapse; } }
 
@@ -1855,9 +1839,6 @@ namespace System.Xml.Schema
     */
     internal class Datatype_duration : Datatype_anySimpleType
     {
-        private static readonly Type s_atomicValueType = typeof(TimeSpan);
-        private static readonly Type s_listValueType = typeof(TimeSpan[]);
-
         internal override XmlValueConverter CreateValueConverter(XmlSchemaType schemaType)
         {
             return XmlMiscConverter.Create(schemaType);
@@ -1867,9 +1848,9 @@ namespace System.Xml.Schema
 
         public override XmlTypeCode TypeCode { get { return XmlTypeCode.Duration; } }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
+        public override Type ValueType { get { return typeof(TimeSpan); } }
 
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(TimeSpan[]); } }
 
         internal override XmlSchemaWhiteSpace BuiltInWhitespaceFacet { get { return XmlSchemaWhiteSpace.Collapse; } }
 
@@ -2000,8 +1981,6 @@ namespace System.Xml.Schema
 
     internal class Datatype_dateTimeBase : Datatype_anySimpleType
     {
-        private static readonly Type s_atomicValueType = typeof(DateTime);
-        private static readonly Type s_listValueType = typeof(DateTime[]);
         private readonly XsdDateTimeFlags _dateTimeFlags;
 
         internal override XmlValueConverter CreateValueConverter(XmlSchemaType schemaType)
@@ -2018,9 +1997,9 @@ namespace System.Xml.Schema
             _dateTimeFlags = dateTimeFlags;
         }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
+        public override Type ValueType { get { return typeof(DateTime); } }
 
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(DateTime[]); } }
 
         internal override XmlSchemaWhiteSpace BuiltInWhitespaceFacet { get { return XmlSchemaWhiteSpace.Collapse; } }
 
@@ -2399,9 +2378,6 @@ namespace System.Xml.Schema
     */
     internal sealed class Datatype_hexBinary : Datatype_anySimpleType
     {
-        private static readonly Type s_atomicValueType = typeof(byte[]);
-        private static readonly Type s_listValueType = typeof(byte[][]);
-
         internal override XmlValueConverter CreateValueConverter(XmlSchemaType schemaType)
         {
             return XmlMiscConverter.Create(schemaType);
@@ -2411,9 +2387,9 @@ namespace System.Xml.Schema
 
         public override XmlTypeCode TypeCode { get { return XmlTypeCode.HexBinary; } }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
+        public override Type ValueType { get { return typeof(byte[]); } }
 
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(byte[][]); } }
 
         internal override XmlSchemaWhiteSpace BuiltInWhitespaceFacet { get { return XmlSchemaWhiteSpace.Collapse; } }
 
@@ -2500,9 +2476,6 @@ namespace System.Xml.Schema
     */
     internal sealed class Datatype_base64Binary : Datatype_anySimpleType
     {
-        private static readonly Type s_atomicValueType = typeof(byte[]);
-        private static readonly Type s_listValueType = typeof(byte[][]);
-
         internal override XmlValueConverter CreateValueConverter(XmlSchemaType schemaType)
         {
             return XmlMiscConverter.Create(schemaType);
@@ -2512,9 +2485,9 @@ namespace System.Xml.Schema
 
         public override XmlTypeCode TypeCode { get { return XmlTypeCode.Base64Binary; } }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
+        public override Type ValueType { get { return typeof(byte[]); } }
 
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(byte[][]); } }
 
         internal override XmlSchemaWhiteSpace BuiltInWhitespaceFacet { get { return XmlSchemaWhiteSpace.Collapse; } }
 
@@ -2600,9 +2573,6 @@ namespace System.Xml.Schema
     */
     internal sealed class Datatype_anyURI : Datatype_anySimpleType
     {
-        private static readonly Type s_atomicValueType = typeof(Uri);
-        private static readonly Type s_listValueType = typeof(Uri[]);
-
         internal override XmlValueConverter CreateValueConverter(XmlSchemaType schemaType)
         {
             return XmlMiscConverter.Create(schemaType);
@@ -2612,7 +2582,7 @@ namespace System.Xml.Schema
 
         public override XmlTypeCode TypeCode { get { return XmlTypeCode.AnyUri; } }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
+        public override Type ValueType { get { return typeof(Uri); } }
 
         internal override bool HasValueFacets
         {
@@ -2621,7 +2591,7 @@ namespace System.Xml.Schema
                 return true; //Built-in facet to check validity of Uri
             }
         }
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(Uri[]); } }
 
         internal override XmlSchemaWhiteSpace BuiltInWhitespaceFacet { get { return XmlSchemaWhiteSpace.Collapse; } }
 
@@ -2698,9 +2668,6 @@ namespace System.Xml.Schema
     */
     internal sealed class Datatype_QName : Datatype_anySimpleType
     {
-        private static readonly Type s_atomicValueType = typeof(XmlQualifiedName);
-        private static readonly Type s_listValueType = typeof(XmlQualifiedName[]);
-
         internal override XmlValueConverter CreateValueConverter(XmlSchemaType schemaType)
         {
             return XmlMiscConverter.Create(schemaType);
@@ -2725,9 +2692,9 @@ namespace System.Xml.Schema
             }
         }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
+        public override Type ValueType { get { return typeof(XmlQualifiedName); } }
 
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(XmlQualifiedName[]); } }
 
         internal override XmlSchemaWhiteSpace BuiltInWhitespaceFacet { get { return XmlSchemaWhiteSpace.Collapse; } }
 
@@ -3034,9 +3001,6 @@ namespace System.Xml.Schema
     */
     internal sealed class Datatype_NOTATION : Datatype_anySimpleType
     {
-        private static readonly Type s_atomicValueType = typeof(XmlQualifiedName);
-        private static readonly Type s_listValueType = typeof(XmlQualifiedName[]);
-
         internal override XmlValueConverter CreateValueConverter(XmlSchemaType schemaType)
         {
             return XmlMiscConverter.Create(schemaType);
@@ -3061,9 +3025,9 @@ namespace System.Xml.Schema
             }
         }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
+        public override Type ValueType { get { return typeof(XmlQualifiedName); } }
 
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(XmlQualifiedName[]); } }
 
         internal override XmlSchemaWhiteSpace BuiltInWhitespaceFacet { get { return XmlSchemaWhiteSpace.Collapse; } }
 
@@ -3240,8 +3204,6 @@ namespace System.Xml.Schema
     */
     internal class Datatype_long : Datatype_integer
     {
-        private static readonly Type s_atomicValueType = typeof(long);
-        private static readonly Type s_listValueType = typeof(long[]);
         private static readonly Numeric10FacetsChecker s_numeric10FacetsChecker = new Numeric10FacetsChecker(long.MinValue, long.MaxValue);
 
         internal override FacetsChecker FacetsChecker { get { return s_numeric10FacetsChecker; } }
@@ -3261,9 +3223,9 @@ namespace System.Xml.Schema
             return ((long)value1).CompareTo((long)value2);
         }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
+        public override Type ValueType { get { return typeof(long); } }
 
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(long[]); } }
 
         internal override Exception? TryParseValue(string s, XmlNameTable? nameTable, IXmlNamespaceResolver? nsmgr, out object? typedValue)
         {
@@ -3304,8 +3266,6 @@ namespace System.Xml.Schema
     */
     internal class Datatype_int : Datatype_long
     {
-        private static readonly Type s_atomicValueType = typeof(int);
-        private static readonly Type s_listValueType = typeof(int[]);
         private static readonly Numeric10FacetsChecker s_numeric10FacetsChecker = new Numeric10FacetsChecker(int.MinValue, int.MaxValue);
 
         internal override FacetsChecker FacetsChecker { get { return s_numeric10FacetsChecker; } }
@@ -3317,9 +3277,9 @@ namespace System.Xml.Schema
             return ((int)value1).CompareTo((int)value2);
         }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
+        public override Type ValueType { get { return typeof(int); } }
 
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(int[]); } }
 
         internal override Exception? TryParseValue(string s, XmlNameTable? nameTable, IXmlNamespaceResolver? nsmgr, out object? typedValue)
         {
@@ -3361,8 +3321,6 @@ namespace System.Xml.Schema
     */
     internal class Datatype_short : Datatype_int
     {
-        private static readonly Type s_atomicValueType = typeof(short);
-        private static readonly Type s_listValueType = typeof(short[]);
         private static readonly Numeric10FacetsChecker s_numeric10FacetsChecker = new Numeric10FacetsChecker(short.MinValue, short.MaxValue);
 
         internal override FacetsChecker FacetsChecker { get { return s_numeric10FacetsChecker; } }
@@ -3374,9 +3332,9 @@ namespace System.Xml.Schema
             return ((short)value1).CompareTo((short)value2);
         }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
+        public override Type ValueType { get { return typeof(short); } }
 
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(short[]); } }
 
         internal override Exception? TryParseValue(string s, XmlNameTable? nameTable, IXmlNamespaceResolver? nsmgr, out object? typedValue)
         {
@@ -3417,8 +3375,6 @@ namespace System.Xml.Schema
     */
     internal sealed class Datatype_byte : Datatype_short
     {
-        private static readonly Type s_atomicValueType = typeof(sbyte);
-        private static readonly Type s_listValueType = typeof(sbyte[]);
         private static readonly Numeric10FacetsChecker s_numeric10FacetsChecker = new Numeric10FacetsChecker(sbyte.MinValue, sbyte.MaxValue);
 
         internal override FacetsChecker FacetsChecker { get { return s_numeric10FacetsChecker; } }
@@ -3430,9 +3386,9 @@ namespace System.Xml.Schema
             return ((sbyte)value1).CompareTo((sbyte)value2);
         }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
+        public override Type ValueType { get { return typeof(sbyte); } }
 
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(sbyte[]); } }
 
         internal override Exception? TryParseValue(string s, XmlNameTable? nameTable, IXmlNamespaceResolver? nsmgr, out object? typedValue)
         {
@@ -3505,8 +3461,6 @@ namespace System.Xml.Schema
     */
     internal class Datatype_unsignedLong : Datatype_nonNegativeInteger
     {
-        private static readonly Type s_atomicValueType = typeof(ulong);
-        private static readonly Type s_listValueType = typeof(ulong[]);
         private static readonly Numeric10FacetsChecker s_numeric10FacetsChecker = new Numeric10FacetsChecker(ulong.MinValue, ulong.MaxValue);
 
         internal override FacetsChecker FacetsChecker { get { return s_numeric10FacetsChecker; } }
@@ -3518,9 +3472,9 @@ namespace System.Xml.Schema
             return ((ulong)value1).CompareTo((ulong)value2);
         }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
+        public override Type ValueType { get { return typeof(ulong); } }
 
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(ulong[]); } }
 
         internal override Exception? TryParseValue(string s, XmlNameTable? nameTable, IXmlNamespaceResolver? nsmgr, out object? typedValue)
         {
@@ -3561,8 +3515,6 @@ namespace System.Xml.Schema
     */
     internal class Datatype_unsignedInt : Datatype_unsignedLong
     {
-        private static readonly Type s_atomicValueType = typeof(uint);
-        private static readonly Type s_listValueType = typeof(uint[]);
         private static readonly Numeric10FacetsChecker s_numeric10FacetsChecker = new Numeric10FacetsChecker(uint.MinValue, uint.MaxValue);
 
         internal override FacetsChecker FacetsChecker { get { return s_numeric10FacetsChecker; } }
@@ -3574,9 +3526,9 @@ namespace System.Xml.Schema
             return ((uint)value1).CompareTo((uint)value2);
         }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
+        public override Type ValueType { get { return typeof(uint); } }
 
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(uint[]); } }
 
         internal override Exception? TryParseValue(string s, XmlNameTable? nameTable, IXmlNamespaceResolver? nsmgr, out object? typedValue)
         {
@@ -3617,8 +3569,6 @@ namespace System.Xml.Schema
     */
     internal class Datatype_unsignedShort : Datatype_unsignedInt
     {
-        private static readonly Type s_atomicValueType = typeof(ushort);
-        private static readonly Type s_listValueType = typeof(ushort[]);
         private static readonly Numeric10FacetsChecker s_numeric10FacetsChecker = new Numeric10FacetsChecker(ushort.MinValue, ushort.MaxValue);
 
         internal override FacetsChecker FacetsChecker { get { return s_numeric10FacetsChecker; } }
@@ -3630,9 +3580,9 @@ namespace System.Xml.Schema
             return ((ushort)value1).CompareTo((ushort)value2);
         }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
+        public override Type ValueType { get { return typeof(ushort); } }
 
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(ushort[]); } }
 
         internal override Exception? TryParseValue(string s, XmlNameTable? nameTable, IXmlNamespaceResolver? nsmgr, out object? typedValue)
         {
@@ -3672,8 +3622,6 @@ namespace System.Xml.Schema
     */
     internal sealed class Datatype_unsignedByte : Datatype_unsignedShort
     {
-        private static readonly Type s_atomicValueType = typeof(byte);
-        private static readonly Type s_listValueType = typeof(byte[]);
         private static readonly Numeric10FacetsChecker s_numeric10FacetsChecker = new Numeric10FacetsChecker(byte.MinValue, byte.MaxValue);
 
         internal override FacetsChecker FacetsChecker { get { return s_numeric10FacetsChecker; } }
@@ -3685,9 +3633,9 @@ namespace System.Xml.Schema
             return ((byte)value1).CompareTo((byte)value2);
         }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
+        public override Type ValueType { get { return typeof(byte); } }
 
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(byte[]); } }
 
         internal override Exception? TryParseValue(string s, XmlNameTable? nameTable, IXmlNamespaceResolver? nsmgr, out object? typedValue)
         {
@@ -3783,9 +3731,6 @@ namespace System.Xml.Schema
 
     internal sealed class Datatype_QNameXdr : Datatype_anySimpleType
     {
-        private static readonly Type s_atomicValueType = typeof(XmlQualifiedName);
-        private static readonly Type s_listValueType = typeof(XmlQualifiedName[]);
-
         public override XmlTokenizedType TokenizedType { get { return XmlTokenizedType.QName; } }
 
         public override object ParseValue(string s, XmlNameTable? nameTable, IXmlNamespaceResolver? nsmgr)
@@ -3811,9 +3756,9 @@ namespace System.Xml.Schema
             }
         }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
+        public override Type ValueType { get { return typeof(XmlQualifiedName); } }
 
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(XmlQualifiedName[]); } }
     }
 
     internal sealed class Datatype_ENUMERATION : Datatype_NMTOKEN
@@ -3823,12 +3768,9 @@ namespace System.Xml.Schema
 
     internal sealed class Datatype_char : Datatype_anySimpleType
     {
-        private static readonly Type s_atomicValueType = typeof(char);
-        private static readonly Type s_listValueType = typeof(char[]);
+        public override Type ValueType { get { return typeof(char); } }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
-
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(char[]); } }
 
         internal override RestrictionFlags ValidRestrictionFlags { get { return 0; } } //XDR only
 
@@ -3923,12 +3865,9 @@ namespace System.Xml.Schema
 
     internal sealed class Datatype_uuid : Datatype_anySimpleType
     {
-        private static readonly Type s_atomicValueType = typeof(Guid);
-        private static readonly Type s_listValueType = typeof(Guid[]);
+        public override Type ValueType { get { return typeof(Guid); } }
 
-        public override Type ValueType { get { return s_atomicValueType; } }
-
-        internal override Type ListValueType { get { return s_listValueType; } }
+        internal override Type ListValueType { get { return typeof(Guid[]); } }
 
         internal override RestrictionFlags ValidRestrictionFlags { get { return 0; } }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/XmlILOptimizerVisitor.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/XmlILOptimizerVisitor.cs
@@ -5407,7 +5407,7 @@ namespace System.Xml.Xsl.IlGen
                     else if (typTarget == XmlQueryTypeFactory.IntegerX)
                         return this.f.LiteralInt64(value.ValueAsLong);
                     else if (typTarget == XmlQueryTypeFactory.DecimalX)
-                        return this.f.LiteralDecimal((decimal)value.ValueAs(XsltConvert.DecimalType));
+                        return this.f.LiteralDecimal((decimal)value.ValueAs(typeof(decimal)));
                     else if (typTarget == XmlQueryTypeFactory.DoubleX)
                         return this.f.LiteralDouble(value.ValueAsDouble);
                     else if (typTarget == XmlQueryTypeFactory.BooleanX)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryContext.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryContext.cs
@@ -312,7 +312,7 @@ namespace System.Xml.Xsl.Runtime
             objRet = extFunc.Invoke(instance, objActualArgs);
 
             // 2. Convert to IList<XPathItem>
-            if (objRet == null && extFunc.ClrReturnType == XsltConvert.VoidType)
+            if (objRet == null && extFunc.ClrReturnType == typeof(void))
                 return XmlQueryNodeSequence.Empty;
 
             return (IList<XPathItem>)_runtime.ChangeTypeXsltResult(XmlQueryTypeFactory.ItemS, objRet);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryRuntime.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryRuntime.cs
@@ -480,18 +480,18 @@ namespace System.Xml.Xsl.Runtime
             Debug.Assert(XmlILTypeHelper.GetStorageType(xmlType).IsAssignableFrom(value.GetType()),
                          "Values passed to ChangeTypeXsltArgument should be in ILGen's default Clr representation.");
 
-            Debug.Assert(destinationType == XsltConvert.ObjectType || !destinationType.IsAssignableFrom(value.GetType()),
+            Debug.Assert(destinationType == typeof(object) || !destinationType.IsAssignableFrom(value.GetType()),
                          $"No need to call ChangeTypeXsltArgument since value is already assignable to destinationType {destinationType}");
 
             switch (xmlType.TypeCode)
             {
                 case XmlTypeCode.String:
-                    if (destinationType == XsltConvert.DateTimeType)
+                    if (destinationType == typeof(DateTime))
                         value = XsltConvert.ToDateTime((string)value);
                     break;
 
                 case XmlTypeCode.Double:
-                    if (destinationType != XsltConvert.DoubleType)
+                    if (destinationType != typeof(double))
                         value = Convert.ChangeType(value, destinationType, CultureInfo.InvariantCulture);
                     break;
 
@@ -499,11 +499,11 @@ namespace System.Xml.Xsl.Runtime
                     Debug.Assert(xmlType != XmlQueryTypeFactory.Node && xmlType != XmlQueryTypeFactory.NodeS,
                                  "Rtf values should have been eliminated by caller.");
 
-                    if (destinationType == XsltConvert.XPathNodeIteratorType)
+                    if (destinationType == typeof(XPathNodeIterator))
                     {
                         value = new XPathArrayIterator((IList)value);
                     }
-                    else if (destinationType == XsltConvert.XPathNavigatorArrayType)
+                    else if (destinationType == typeof(XPathNavigator[]))
                     {
                         // Copy sequence to XPathNavigator[]
                         IList<XPathNavigator> seq = (IList<XPathNavigator>)value;
@@ -519,7 +519,7 @@ namespace System.Xml.Xsl.Runtime
                 case XmlTypeCode.Item:
                     {
                         // Only typeof(object) is supported as a destination type
-                        if (destinationType != XsltConvert.ObjectType)
+                        if (destinationType != typeof(object))
                             throw new XslTransformException(SR.Xslt_UnsupportedClrType, destinationType.Name);
 
                         // Convert to default, backwards-compatible representation
@@ -579,12 +579,12 @@ namespace System.Xml.Xsl.Runtime
             switch (xmlType.TypeCode)
             {
                 case XmlTypeCode.String:
-                    if (value.GetType() == XsltConvert.DateTimeType)
+                    if (value.GetType() == typeof(DateTime))
                         value = XsltConvert.ToString((DateTime)value);
                     break;
 
                 case XmlTypeCode.Double:
-                    if (value.GetType() != XsltConvert.DoubleType)
+                    if (value.GetType() != typeof(double))
                         value = ((IConvertible)value).ToDouble(null);
 
                     break;
@@ -641,7 +641,7 @@ namespace System.Xml.Xsl.Runtime
                                 break;
 
                             case XmlTypeCode.String:
-                                if (sourceType == XsltConvert.DateTimeType)
+                                if (sourceType == typeof(DateTime))
                                     value = new XmlQueryItemSequence(new XmlAtomicValue(XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.String), XsltConvert.ToString((DateTime)value)));
                                 else
                                     value = new XmlQueryItemSequence(new XmlAtomicValue(XmlSchemaType.GetBuiltInSimpleType(XmlTypeCode.String), value));

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XsltConvert.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XsltConvert.cs
@@ -1,15 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Xml.XPath;
-using System.Xml.Xsl;
-using System.Xml.Schema;
-using System.Diagnostics;
 using System.ComponentModel;
-using System.Reflection;
+using System.Diagnostics;
+using System.Xml.Schema;
+using System.Xml.XPath;
 
 namespace System.Xml.Xsl.Runtime
 {
@@ -25,37 +21,6 @@ namespace System.Xml.Xsl.Runtime
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class XsltConvert
     {
-        internal static readonly Type BooleanType = typeof(bool);
-        internal static readonly Type ByteArrayType = typeof(byte[]);
-        internal static readonly Type ByteType = typeof(byte);
-        internal static readonly Type DateTimeType = typeof(DateTime);
-        internal static readonly Type DecimalType = typeof(decimal);
-        internal static readonly Type DoubleType = typeof(double);
-        internal static readonly Type ICollectionType = typeof(ICollection);
-        internal static readonly Type IEnumerableType = typeof(IEnumerable);
-        internal static readonly Type IListType = typeof(IList);
-        internal static readonly Type Int16Type = typeof(short);
-        internal static readonly Type Int32Type = typeof(int);
-        internal static readonly Type Int64Type = typeof(long);
-        internal static readonly Type IXPathNavigableType = typeof(IXPathNavigable);
-        internal static readonly Type ObjectType = typeof(object);
-        internal static readonly Type SByteType = typeof(sbyte);
-        internal static readonly Type SingleType = typeof(float);
-        internal static readonly Type StringType = typeof(string);
-        internal static readonly Type TimeSpanType = typeof(TimeSpan);
-        internal static readonly Type UInt16Type = typeof(ushort);
-        internal static readonly Type UInt32Type = typeof(uint);
-        internal static readonly Type UInt64Type = typeof(ulong);
-        internal static readonly Type UriType = typeof(Uri);
-        internal static readonly Type VoidType = typeof(void);
-        internal static readonly Type XmlAtomicValueType = typeof(XmlAtomicValue);
-        internal static readonly Type XmlQualifiedNameType = typeof(XmlQualifiedName);
-        internal static readonly Type XPathItemType = typeof(XPathItem);
-        internal static readonly Type XPathNavigatorArrayType = typeof(XPathNavigator[]);
-        internal static readonly Type XPathNavigatorType = typeof(XPathNavigator);
-        internal static readonly Type XPathNodeIteratorType = typeof(XPathNodeIterator);
-
-
         //------------------------------------------------------------------------
         // ToBoolean (internal type to internal type)
         //------------------------------------------------------------------------
@@ -69,11 +34,11 @@ namespace System.Xml.Xsl.Runtime
 
             Type itemType = item.ValueType;
 
-            if (itemType == StringType)
+            if (itemType == typeof(string))
             {
                 return item.Value.Length != 0;
             }
-            else if (itemType == DoubleType)
+            else if (itemType == typeof(double))
             {
                 // (x < 0 || 0 < x)  ==  (x != 0) && !Double.IsNaN(x)
                 double dbl = item.ValueAsDouble;
@@ -81,7 +46,7 @@ namespace System.Xml.Xsl.Runtime
             }
             else
             {
-                Debug.Assert(itemType == BooleanType, $"Unexpected type of atomic sequence {itemType}");
+                Debug.Assert(itemType == typeof(bool), $"Unexpected type of atomic sequence {itemType}");
                 return item.ValueAsBoolean;
             }
         }
@@ -115,17 +80,17 @@ namespace System.Xml.Xsl.Runtime
 
             Type itemType = item.ValueType;
 
-            if (itemType == StringType)
+            if (itemType == typeof(string))
             {
                 return XPathConvert.StringToDouble(item.Value);
             }
-            else if (itemType == DoubleType)
+            else if (itemType == typeof(double))
             {
                 return item.ValueAsDouble;
             }
             else
             {
-                Debug.Assert(itemType == BooleanType, $"Unexpected type of atomic sequence {itemType}");
+                Debug.Assert(itemType == typeof(bool), $"Unexpected type of atomic sequence {itemType}");
                 return item.ValueAsBoolean ? 1d : 0d;
             }
         }
@@ -211,7 +176,7 @@ namespace System.Xml.Xsl.Runtime
             XsltLibrary.CheckXsltValue(item);
 
             // Use XPath 1.0 rules to convert double to string
-            if (!item.IsNode && item.ValueType == DoubleType)
+            if (!item.IsNode && item.ValueType == typeof(double))
                 return XPathConvert.DoubleToString(item.ValueAsDouble);
 
             return item.Value;
@@ -318,7 +283,7 @@ namespace System.Xml.Xsl.Runtime
                             return new XmlAtomicValue(destinationType.SchemaType, ToDouble(value));
 
                         case XmlTypeCode.Decimal:
-                            return new XmlAtomicValue(destinationType.SchemaType, ToDouble((decimal)value.ValueAs(DecimalType, null)));
+                            return new XmlAtomicValue(destinationType.SchemaType, ToDouble((decimal)value.ValueAs(typeof(decimal), null)));
 
                         case XmlTypeCode.Int:
                         case XmlTypeCode.Long:
@@ -382,26 +347,26 @@ namespace System.Xml.Xsl.Runtime
         /// </summary>
         internal static XmlQueryType InferXsltType(Type clrType)
         {
-            if (clrType == BooleanType) return XmlQueryTypeFactory.BooleanX;
-            if (clrType == ByteType) return XmlQueryTypeFactory.DoubleX;
-            if (clrType == DecimalType) return XmlQueryTypeFactory.DoubleX;
-            if (clrType == DateTimeType) return XmlQueryTypeFactory.StringX;
-            if (clrType == DoubleType) return XmlQueryTypeFactory.DoubleX;
-            if (clrType == Int16Type) return XmlQueryTypeFactory.DoubleX;
-            if (clrType == Int32Type) return XmlQueryTypeFactory.DoubleX;
-            if (clrType == Int64Type) return XmlQueryTypeFactory.DoubleX;
-            if (clrType == IXPathNavigableType) return XmlQueryTypeFactory.NodeNotRtf;
-            if (clrType == SByteType) return XmlQueryTypeFactory.DoubleX;
-            if (clrType == SingleType) return XmlQueryTypeFactory.DoubleX;
-            if (clrType == StringType) return XmlQueryTypeFactory.StringX;
-            if (clrType == UInt16Type) return XmlQueryTypeFactory.DoubleX;
-            if (clrType == UInt32Type) return XmlQueryTypeFactory.DoubleX;
-            if (clrType == UInt64Type) return XmlQueryTypeFactory.DoubleX;
-            if (clrType == XPathNavigatorArrayType) return XmlQueryTypeFactory.NodeSDod;
-            if (clrType == XPathNavigatorType) return XmlQueryTypeFactory.NodeNotRtf;
-            if (clrType == XPathNodeIteratorType) return XmlQueryTypeFactory.NodeSDod;
+            if (clrType == typeof(bool)) return XmlQueryTypeFactory.BooleanX;
+            if (clrType == typeof(byte)) return XmlQueryTypeFactory.DoubleX;
+            if (clrType == typeof(decimal)) return XmlQueryTypeFactory.DoubleX;
+            if (clrType == typeof(DateTime)) return XmlQueryTypeFactory.StringX;
+            if (clrType == typeof(double)) return XmlQueryTypeFactory.DoubleX;
+            if (clrType == typeof(short)) return XmlQueryTypeFactory.DoubleX;
+            if (clrType == typeof(int)) return XmlQueryTypeFactory.DoubleX;
+            if (clrType == typeof(long)) return XmlQueryTypeFactory.DoubleX;
+            if (clrType == typeof(IXPathNavigable)) return XmlQueryTypeFactory.NodeNotRtf;
+            if (clrType == typeof(sbyte)) return XmlQueryTypeFactory.DoubleX;
+            if (clrType == typeof(float)) return XmlQueryTypeFactory.DoubleX;
+            if (clrType == typeof(string)) return XmlQueryTypeFactory.StringX;
+            if (clrType == typeof(ushort)) return XmlQueryTypeFactory.DoubleX;
+            if (clrType == typeof(uint)) return XmlQueryTypeFactory.DoubleX;
+            if (clrType == typeof(ulong)) return XmlQueryTypeFactory.DoubleX;
+            if (clrType == typeof(XPathNavigator[])) return XmlQueryTypeFactory.NodeSDod;
+            if (clrType == typeof(XPathNavigator)) return XmlQueryTypeFactory.NodeNotRtf;
+            if (clrType == typeof(XPathNodeIterator)) return XmlQueryTypeFactory.NodeSDod;
             if (clrType.IsEnum) return XmlQueryTypeFactory.DoubleX;
-            if (clrType == VoidType) return XmlQueryTypeFactory.Empty;
+            if (clrType == typeof(void)) return XmlQueryTypeFactory.Empty;
 
             return XmlQueryTypeFactory.ItemS;
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XsltFunctions.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XsltFunctions.cs
@@ -327,17 +327,17 @@ namespace System.Xml.Xsl.Runtime
             else
             {
                 Type itemType = item.ValueType;
-                if (itemType == XsltConvert.StringType)
+                if (itemType == typeof(string))
                 {
                     stringValue = item.Value;
                 }
-                else if (itemType == XsltConvert.DoubleType)
+                else if (itemType == typeof(double))
                 {
                     return item.ValueAsDouble;
                 }
                 else
                 {
-                    Debug.Assert(itemType == XsltConvert.BooleanType, $"Unexpected type of atomic value {itemType}");
+                    Debug.Assert(itemType == typeof(bool), $"Unexpected type of atomic value {itemType}");
                     return item.ValueAsBoolean ? 1d : 0d;
                 }
             }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XsltLibrary.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XsltLibrary.cs
@@ -336,17 +336,17 @@ namespace System.Xml.Xsl.Runtime
             // Faster implementation of Type.GetTypeCode(item.ValueType);
             Debug.Assert(!item.IsNode, "Atomic value expected");
             Type itemType = item.ValueType;
-            if (itemType == XsltConvert.StringType)
+            if (itemType == typeof(string))
             {
                 return TypeCode.String;
             }
-            else if (itemType == XsltConvert.DoubleType)
+            else if (itemType == typeof(double))
             {
                 return TypeCode.Double;
             }
             else
             {
-                Debug.Assert(itemType == XsltConvert.BooleanType, $"Unexpected type of atomic value {itemType}");
+                Debug.Assert(itemType == typeof(bool), $"Unexpected type of atomic value {itemType}");
                 return TypeCode.Boolean;
             }
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/QilGeneratorEnv.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/QilGeneratorEnv.cs
@@ -658,13 +658,13 @@ namespace System.Xml.Xsl.Xslt
                 if (EvaluateFuncCalls)
                 {
                     XPathItem propValue = XsltFunctions.SystemProperty(qname);
-                    if (propValue.ValueType == XsltConvert.StringType)
+                    if (propValue.ValueType == typeof(string))
                     {
                         return _f.String(propValue.Value);
                     }
                     else
                     {
-                        Debug.Assert(propValue.ValueType == XsltConvert.DoubleType);
+                        Debug.Assert(propValue.ValueType == typeof(double));
                         return _f.Double((double)propValue.ValueAsDouble);
                     }
                 }


### PR DESCRIPTION
With #75573, `typeof` is now a constant instead of a call. The workaround to reduce CLR calls should not be necessary now.
Only updating libraries targeting latest .NET version.

There are a lot of instances in `XmlValueConverter`, which is generated by I can't find the generator code.