### PR TITLE
Fix invalid "double.ToString" behavior with two section separators

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
@@ -3446,11 +3446,6 @@ namespace System
                     }
                 }
             }
-
-            if (number.IsNegative && (section == 0) && (number.Scale == 0) && (vlb.Length > 0))
-            {
-                vlb.Insert(0, info.NegativeSignTChar<TChar>());
-            }
         }
 
         private static void FormatCurrency<TChar>(ref ValueListBuilder<TChar> vlb, ref NumberBuffer number, int nMaxDigits, NumberFormatInfo info) where TChar : unmanaged, IUtfChar<TChar>

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
@@ -3165,15 +3165,6 @@ namespace System
                     number.Scale += scaleAdjust;
                     int pos = scientific ? digitCount : number.Scale + digitCount - decimalPos;
                     RoundNumber(ref number, pos, isCorrectlyRounded: false);
-                    if (dig[0] == 0)
-                    {
-                        src = FindSection(format, 2);
-                        if (src != section)
-                        {
-                            section = src;
-                            continue;
-                        }
-                    }
                 }
                 else
                 {

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.cs
@@ -781,9 +781,10 @@ namespace System.Tests
         {
             yield return new object[] { -4567.0, "G", null, "-4567" };
             yield return new object[] { -4567.89101, "G", null, "-4567.89101" };
-            yield return new object[] { -0.001, "+0.00;-0.00", null, "+0.00" };
+            yield return new object[] { -0.001, "+0.00;-0.00", null, "-0.00" };
             yield return new object[] { -0.0, string.Empty, null, "-0" };
             yield return new object[] { -0.0, "#", null, "" };
+            yield return new object[] { 0.0, "+0.00;-0.00", null, "+0.00" };
             yield return new object[] { 0.0, "G", null, "0" };
             yield return new object[] { 4567.0, "G", null, "4567" };
             yield return new object[] { 4567.89101, "G", null, "4567.89101" };

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.cs
@@ -823,7 +823,6 @@ namespace System.Tests
                 yield return testData;
             }
 
-
             yield return new object[] { double.MinValue, "G", null, "-1.7976931348623157E+308" };
             yield return new object[] { double.MaxValue, "G", null, "1.7976931348623157E+308" };
 
@@ -838,39 +837,32 @@ namespace System.Tests
             yield return new object[] { 32.5, "N100", invariantFormat, "32.5000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" };
         }
 
-        [Fact]
-        public static void Test_ToString_NotNetFramework()
+        [Theory]
+        [MemberData(nameof(ToString_TestData_NotNetFramework))]
+        public static void Test_ToString_NotNetFramework(double d, string format, IFormatProvider provider, string expected)
         {
             using (new ThreadCultureChange(CultureInfo.InvariantCulture))
             {
-                foreach (object[] testdata in ToString_TestData_NotNetFramework())
+                bool isDefaultProvider = (provider == null || provider == NumberFormatInfo.CurrentInfo);
+                if (string.IsNullOrEmpty(format) || format.ToUpperInvariant() == "G")
                 {
-                    ToString((double)testdata[0], (string)testdata[1], (IFormatProvider)testdata[2], (string)testdata[3]);
+                    if (isDefaultProvider)
+                    {
+                        Assert.Equal(expected, d.ToString());
+                        Assert.Equal(expected, d.ToString((IFormatProvider)null));
+                    }
+                    Assert.Equal(expected, d.ToString(provider));
                 }
-            }
-        }
-
-        private static void ToString(double d, string format, IFormatProvider provider, string expected)
-        {
-            bool isDefaultProvider = (provider == null || provider == NumberFormatInfo.CurrentInfo);
-            if (string.IsNullOrEmpty(format) || format.ToUpperInvariant() == "G")
-            {
                 if (isDefaultProvider)
                 {
-                    Assert.Equal(expected, d.ToString());
-                    Assert.Equal(expected, d.ToString((IFormatProvider)null));
+                    Assert.Equal(expected, d.ToString(format.ToUpperInvariant()), true);
+                    Assert.Equal(expected, d.ToString(format.ToLowerInvariant()), true);
+                    Assert.Equal(expected, d.ToString(format.ToUpperInvariant(), null), true);
+                    Assert.Equal(expected, d.ToString(format.ToLowerInvariant(), null), true);
                 }
-                Assert.Equal(expected, d.ToString(provider));
+                Assert.Equal(expected, d.ToString(format.ToUpperInvariant(), provider), true);
+                Assert.Equal(expected, d.ToString(format.ToLowerInvariant(), provider), true);
             }
-            if (isDefaultProvider)
-            {
-                Assert.Equal(expected.Replace('e', 'E'), d.ToString(format.ToUpperInvariant())); // If format is upper case, then exponents are printed in upper case
-                Assert.Equal(expected.Replace('E', 'e'), d.ToString(format.ToLowerInvariant())); // If format is lower case, then exponents are printed in upper case
-                Assert.Equal(expected.Replace('e', 'E'), d.ToString(format.ToUpperInvariant(), null));
-                Assert.Equal(expected.Replace('E', 'e'), d.ToString(format.ToLowerInvariant(), null));
-            }
-            Assert.Equal(expected.Replace('e', 'E'), d.ToString(format.ToUpperInvariant(), provider));
-            Assert.Equal(expected.Replace('E', 'e'), d.ToString(format.ToLowerInvariant(), provider));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.cs
@@ -781,6 +781,9 @@ namespace System.Tests
         {
             yield return new object[] { -4567.0, "G", null, "-4567" };
             yield return new object[] { -4567.89101, "G", null, "-4567.89101" };
+            yield return new object[] { -0.001, "+0.00;-0.00", null, "+0.00" };
+            yield return new object[] { -0.0, string.Empty, null, "-0" };
+            yield return new object[] { -0.0, "#", null, "" };
             yield return new object[] { 0.0, "G", null, "0" };
             yield return new object[] { 4567.0, "G", null, "4567" };
             yield return new object[] { 4567.89101, "G", null, "4567.89101" };

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.cs
@@ -859,13 +859,13 @@ namespace System.Tests
                 }
                 if (isDefaultProvider)
                 {
-                    Assert.Equal(expected, d.ToString(format.ToUpperInvariant()), true);
-                    Assert.Equal(expected, d.ToString(format.ToLowerInvariant()), true);
-                    Assert.Equal(expected, d.ToString(format.ToUpperInvariant(), null), true);
-                    Assert.Equal(expected, d.ToString(format.ToLowerInvariant(), null), true);
+                    Assert.Equal(expected, d.ToString(format.ToUpperInvariant()), ignoreCase: true);
+                    Assert.Equal(expected, d.ToString(format.ToLowerInvariant()), ignoreCase: true);
+                    Assert.Equal(expected, d.ToString(format.ToUpperInvariant(), null), ignoreCase: true);
+                    Assert.Equal(expected, d.ToString(format.ToLowerInvariant(), null), ignoreCase: true);
                 }
-                Assert.Equal(expected, d.ToString(format.ToUpperInvariant(), provider), true);
-                Assert.Equal(expected, d.ToString(format.ToLowerInvariant(), provider), true);
+                Assert.Equal(expected, d.ToString(format.ToUpperInvariant(), provider), ignoreCase: true);
+                Assert.Equal(expected, d.ToString(format.ToLowerInvariant(), provider), ignoreCase: true);
             }
         }
 

--- a/src/libraries/System.Runtime/tests/System/HalfTests.cs
+++ b/src/libraries/System.Runtime/tests/System/HalfTests.cs
@@ -1008,13 +1008,13 @@ namespace System.Tests
                 }
                 if (isDefaultProvider)
                 {
-                    Assert.Equal(expected, h.ToString(format.ToUpperInvariant()), true);
-                    Assert.Equal(expected, h.ToString(format.ToLowerInvariant()), true);
-                    Assert.Equal(expected, h.ToString(format.ToUpperInvariant(), null), true);
-                    Assert.Equal(expected, h.ToString(format.ToLowerInvariant(), null), true);
+                    Assert.Equal(expected, h.ToString(format.ToUpperInvariant()), ignoreCase: true);
+                    Assert.Equal(expected, h.ToString(format.ToLowerInvariant()), ignoreCase: true);
+                    Assert.Equal(expected, h.ToString(format.ToUpperInvariant(), null), ignoreCase: true);
+                    Assert.Equal(expected, h.ToString(format.ToLowerInvariant(), null), ignoreCase: true);
                 }
-                Assert.Equal(expected, h.ToString(format.ToUpperInvariant(), provider), true);
-                Assert.Equal(expected, h.ToString(format.ToLowerInvariant(), provider), true);
+                Assert.Equal(expected, h.ToString(format.ToUpperInvariant(), provider), ignoreCase: true);
+                Assert.Equal(expected, h.ToString(format.ToLowerInvariant(), provider), ignoreCase: true);
             }
         }
 

--- a/src/libraries/System.Runtime/tests/System/SingleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/SingleTests.cs
@@ -798,13 +798,13 @@ namespace System.Tests
                 }
                 if (isDefaultProvider)
                 {
-                    Assert.Equal(expected, f.ToString(format.ToUpperInvariant()), true);
-                    Assert.Equal(expected, f.ToString(format.ToLowerInvariant()), true);
-                    Assert.Equal(expected, f.ToString(format.ToUpperInvariant(), null), true);
-                    Assert.Equal(expected, f.ToString(format.ToLowerInvariant(), null), true);
+                    Assert.Equal(expected, f.ToString(format.ToUpperInvariant()), ignoreCase: true);
+                    Assert.Equal(expected, f.ToString(format.ToLowerInvariant()), ignoreCase: true);
+                    Assert.Equal(expected, f.ToString(format.ToUpperInvariant(), null), ignoreCase: true);
+                    Assert.Equal(expected, f.ToString(format.ToLowerInvariant(), null), ignoreCase: true);
                 }
-                Assert.Equal(expected, f.ToString(format.ToUpperInvariant(), provider), true);
-                Assert.Equal(expected, f.ToString(format.ToLowerInvariant(), provider), true);
+                Assert.Equal(expected, f.ToString(format.ToUpperInvariant(), provider), ignoreCase: true);
+                Assert.Equal(expected, f.ToString(format.ToLowerInvariant(), provider), ignoreCase: true);
             }
         }
 

--- a/src/libraries/System.Runtime/tests/System/SingleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/SingleTests.cs
@@ -720,6 +720,9 @@ namespace System.Tests
         {
             yield return new object[] { -4567.0f, "G", null, "-4567" };
             yield return new object[] { -4567.89101f, "G", null, "-4567.891" };
+            yield return new object[] { -0.001f, "+0.00;-0.00", null, "-0.00" };
+            yield return new object[] { -0.0f, string.Empty, null, "-0" };
+            yield return new object[] { -0.0f, "#", null, "" };
             yield return new object[] { 0.0f, "G", null, "0" };
             yield return new object[] { 4567.0f, "G", null, "4567" };
             yield return new object[] { 4567.89101f, "G", null, "4567.891" };
@@ -777,39 +780,32 @@ namespace System.Tests
             yield return new object[] { 32.5f, "N100", invariantFormat, "32.5000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" };
         }
 
-        [Fact]
-        public static void Test_ToString_NotNetFramework()
+        [Theory]
+        [MemberData(nameof(ToString_TestData_NotNetFramework))]
+        public static void Test_ToString_NotNetFramework(float f, string format, IFormatProvider provider, string expected)
         {
             using (new ThreadCultureChange(CultureInfo.InvariantCulture))
             {
-                foreach (object[] testdata in ToString_TestData_NotNetFramework())
+                bool isDefaultProvider = provider == null;
+                if (string.IsNullOrEmpty(format) || format.ToUpperInvariant() == "G")
                 {
-                    ToStringTest((float)testdata[0], (string)testdata[1], (IFormatProvider)testdata[2], (string)testdata[3]);
+                    if (isDefaultProvider)
+                    {
+                        Assert.Equal(expected, f.ToString());
+                        Assert.Equal(expected, f.ToString((IFormatProvider)null));
+                    }
+                    Assert.Equal(expected, f.ToString(provider));
                 }
-            }
-        }
-
-        private static void ToStringTest(float f, string format, IFormatProvider provider, string expected)
-        {
-            bool isDefaultProvider = provider == null;
-            if (string.IsNullOrEmpty(format) || format.ToUpperInvariant() == "G")
-            {
                 if (isDefaultProvider)
                 {
-                    Assert.Equal(expected, f.ToString());
-                    Assert.Equal(expected, f.ToString((IFormatProvider)null));
+                    Assert.Equal(expected, f.ToString(format.ToUpperInvariant()), true);
+                    Assert.Equal(expected, f.ToString(format.ToLowerInvariant()), true);
+                    Assert.Equal(expected, f.ToString(format.ToUpperInvariant(), null), true);
+                    Assert.Equal(expected, f.ToString(format.ToLowerInvariant(), null), true);
                 }
-                Assert.Equal(expected, f.ToString(provider));
+                Assert.Equal(expected, f.ToString(format.ToUpperInvariant(), provider), true);
+                Assert.Equal(expected, f.ToString(format.ToLowerInvariant(), provider), true);
             }
-            if (isDefaultProvider)
-            {
-                Assert.Equal(expected.Replace('e', 'E'), f.ToString(format.ToUpperInvariant())); // If format is upper case, then exponents are printed in upper case
-                Assert.Equal(expected.Replace('E', 'e'), f.ToString(format.ToLowerInvariant())); // If format is lower case, then exponents are printed in lower case
-                Assert.Equal(expected.Replace('e', 'E'), f.ToString(format.ToUpperInvariant(), null));
-                Assert.Equal(expected.Replace('E', 'e'), f.ToString(format.ToLowerInvariant(), null));
-            }
-            Assert.Equal(expected.Replace('e', 'E'), f.ToString(format.ToUpperInvariant(), provider));
-            Assert.Equal(expected.Replace('E', 'e'), f.ToString(format.ToLowerInvariant(), provider));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #70460 