### PR TITLE
Replace InvariantCulture comparison with Ordinal

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -403,7 +403,7 @@ namespace System.Text.Json
 #if NETCOREAPP
             int iPos = message.AsSpan().LastIndexOf(" LineNumber: ");
 #else
-            int iPos = message.LastIndexOf(" LineNumber: ", StringComparison.InvariantCulture);
+            int iPos = message.LastIndexOf(" LineNumber: ", StringComparison.Ordinal);
 #endif
             if (iPos >= 0)
             {


### PR DESCRIPTION
In .NET Core path the comparison is ordinal. Update the .NET Framework path to also use an Ordinal comparison.