### PR TITLE
Translate AV in RhpByRefAssignRef to NullReferenceException

### DIFF
--- a/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
@@ -285,9 +285,10 @@ EXTERN_C void * RhpCheckedLockCmpXchgAVLocation;
 EXTERN_C void * RhpCheckedXchgAVLocation;
 EXTERN_C void * RhpLockCmpXchg32AVLocation;
 EXTERN_C void * RhpLockCmpXchg64AVLocation;
+EXTERN_C void * RhpByRefAssignRefAVLocation1;
 
 #if !defined(HOST_ARM64)
-EXTERN_C void * RhpByRefAssignRefAVLocation;
+EXTERN_C void * RhpByRefAssignRefAVLocation2;
 #endif
 
 #if defined(HOST_ARM64) && !defined(LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT)
@@ -306,8 +307,9 @@ static bool InWriteBarrierHelper(uintptr_t faultingIP)
         (uintptr_t)&RhpCheckedXchgAVLocation,
         (uintptr_t)&RhpLockCmpXchg32AVLocation,
         (uintptr_t)&RhpLockCmpXchg64AVLocation,
+        (uintptr_t)&RhpByRefAssignRefAVLocation1,
 #if !defined(HOST_ARM64)
-        (uintptr_t)&RhpByRefAssignRefAVLocation,
+        (uintptr_t)&RhpByRefAssignRefAVLocation2,
 #endif
 #if defined(HOST_ARM64) && !defined(LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT)
         (uintptr_t)&RhpCheckedLockCmpXchgAVLocation2,

--- a/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
@@ -286,6 +286,10 @@ EXTERN_C void * RhpCheckedXchgAVLocation;
 EXTERN_C void * RhpLockCmpXchg32AVLocation;
 EXTERN_C void * RhpLockCmpXchg64AVLocation;
 
+#if !defined(HOST_ARM64)
+EXTERN_C void * RhpByRefAssignRefAVLocation;
+#endif
+
 #if defined(HOST_ARM64) && !defined(LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT)
 EXTERN_C void* RhpCheckedLockCmpXchgAVLocation2;
 EXTERN_C void* RhpCheckedXchgAVLocation2;
@@ -302,6 +306,9 @@ static bool InWriteBarrierHelper(uintptr_t faultingIP)
         (uintptr_t)&RhpCheckedXchgAVLocation,
         (uintptr_t)&RhpLockCmpXchg32AVLocation,
         (uintptr_t)&RhpLockCmpXchg64AVLocation,
+#if !defined(HOST_ARM64)
+        (uintptr_t)&RhpByRefAssignRefAVLocation,
+#endif
 #if defined(HOST_ARM64) && !defined(LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT)
         (uintptr_t)&RhpCheckedLockCmpXchgAVLocation2,
         (uintptr_t)&RhpCheckedXchgAVLocation2,

--- a/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.S
+++ b/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.S
@@ -260,8 +260,12 @@ LEAF_END RhpCheckedXchg, _TEXT
 //      rdi, rsi are incremented by 8,
 //      rcx, r10, r11: trashed
 //
+// WARNING: Code in EHHelpers.cpp makes assumptions about write barrier code, in particular:
+// - Function "InWriteBarrierHelper" assumes an AV due to passed in null pointer will happen at RhpByRefAssignRefAVLocation
+// - Function "UnwindSimpleHelperToCaller" assumes the stack contains just the pushed return address
 LEAF_ENTRY RhpByRefAssignRef, _TEXT
     mov     rcx, [rsi]
+ALTERNATE_ENTRY RhpByRefAssignRefAVLocation
     mov     [rdi], rcx
 
     // Check whether the writes were even into the heap. If not there's no card update required.

--- a/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.S
+++ b/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.S
@@ -261,11 +261,12 @@ LEAF_END RhpCheckedXchg, _TEXT
 //      rcx, r10, r11: trashed
 //
 // WARNING: Code in EHHelpers.cpp makes assumptions about write barrier code, in particular:
-// - Function "InWriteBarrierHelper" assumes an AV due to passed in null pointer will happen at RhpByRefAssignRefAVLocation
+// - Function "InWriteBarrierHelper" assumes an AV due to passed in null pointer will happen at RhpByRefAssignRefAVLocation1/2
 // - Function "UnwindSimpleHelperToCaller" assumes the stack contains just the pushed return address
 LEAF_ENTRY RhpByRefAssignRef, _TEXT
+ALTERNATE_ENTRY RhpByRefAssignRefAVLocation1
     mov     rcx, [rsi]
-ALTERNATE_ENTRY RhpByRefAssignRefAVLocation
+ALTERNATE_ENTRY RhpByRefAssignRefAVLocation2
     mov     [rdi], rcx
 
     // Check whether the writes were even into the heap. If not there's no card update required.

--- a/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.asm
+++ b/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.asm
@@ -276,8 +276,12 @@ LEAF_END RhpCheckedXchg, _TEXT
 ;;      rdi, rsi are incremented by 8,
 ;;      rcx, r10, r11: trashed
 ;;
+;; WARNING: Code in EHHelpers.cpp makes assumptions about write barrier code, in particular:
+;; - Function "InWriteBarrierHelper" assumes an AV due to passed in null pointer will happen at RhpByRefAssignRefAVLocation
+;; - Function "UnwindSimpleHelperToCaller" assumes the stack contains just the pushed return address
 LEAF_ENTRY RhpByRefAssignRef, _TEXT
     mov     rcx, [rsi]
+ALTERNATE_ENTRY RhpByRefAssignRefAVLocation
     mov     [rdi], rcx
 
     ;; Check whether the writes were even into the heap. If not there's no card update required.

--- a/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.asm
+++ b/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.asm
@@ -277,11 +277,12 @@ LEAF_END RhpCheckedXchg, _TEXT
 ;;      rcx, r10, r11: trashed
 ;;
 ;; WARNING: Code in EHHelpers.cpp makes assumptions about write barrier code, in particular:
-;; - Function "InWriteBarrierHelper" assumes an AV due to passed in null pointer will happen at RhpByRefAssignRefAVLocation
+;; - Function "InWriteBarrierHelper" assumes an AV due to passed in null pointer will happen at RhpByRefAssignRefAVLocation1/2
 ;; - Function "UnwindSimpleHelperToCaller" assumes the stack contains just the pushed return address
 LEAF_ENTRY RhpByRefAssignRef, _TEXT
+ALTERNATE_ENTRY RhpByRefAssignRefAVLocation1
     mov     rcx, [rsi]
-ALTERNATE_ENTRY RhpByRefAssignRefAVLocation
+ALTERNATE_ENTRY RhpByRefAssignRefAVLocation2
     mov     [rdi], rcx
 
     ;; Check whether the writes were even into the heap. If not there's no card update required.

--- a/src/coreclr/nativeaot/Runtime/arm/WriteBarriers.S
+++ b/src/coreclr/nativeaot/Runtime/arm/WriteBarriers.S
@@ -322,11 +322,15 @@ LEAF_END RhpCheckedXchg, _TEXT
 //      r0, r1 are incremented by 4,
 //      r2, r3: trashed
 //
+// WARNING: Code in EHHelpers.cpp makes assumptions about write barrier code, in particular:
+// - Function "InWriteBarrierHelper" assumes an AV due to passed in null pointer will happen at RhpByRefAssignRefAVLocation
+// - Function "UnwindSimpleHelperToCaller" assumes no registers were pushed and LR contains the return address
 LEAF_ENTRY RhpByRefAssignRef, _TEXT
           // See comment in RhpAssignRef
           dmb
 
           ldr          r2, [r1]
+ALTERNATE_ENTRY RhpByRefAssignRefAVLocation
           str          r2, [r0]
 
           // Check whether the writes were even into the heap. If not there's no card update required.

--- a/src/coreclr/nativeaot/Runtime/arm/WriteBarriers.S
+++ b/src/coreclr/nativeaot/Runtime/arm/WriteBarriers.S
@@ -323,14 +323,15 @@ LEAF_END RhpCheckedXchg, _TEXT
 //      r2, r3: trashed
 //
 // WARNING: Code in EHHelpers.cpp makes assumptions about write barrier code, in particular:
-// - Function "InWriteBarrierHelper" assumes an AV due to passed in null pointer will happen at RhpByRefAssignRefAVLocation
+// - Function "InWriteBarrierHelper" assumes an AV due to passed in null pointer will happen at RhpByRefAssignRefAVLocation1/2
 // - Function "UnwindSimpleHelperToCaller" assumes no registers were pushed and LR contains the return address
 LEAF_ENTRY RhpByRefAssignRef, _TEXT
           // See comment in RhpAssignRef
           dmb
 
+ALTERNATE_ENTRY RhpByRefAssignRefAVLocation1
           ldr          r2, [r1]
-ALTERNATE_ENTRY RhpByRefAssignRefAVLocation
+ALTERNATE_ENTRY RhpByRefAssignRefAVLocation2
           str          r2, [r0]
 
           // Check whether the writes were even into the heap. If not there's no card update required.

--- a/src/coreclr/nativeaot/Runtime/arm64/WriteBarriers.S
+++ b/src/coreclr/nativeaot/Runtime/arm64/WriteBarriers.S
@@ -192,8 +192,12 @@
 //   x15  : trashed
 //   x12, x17  : trashed
 //
+// WARNING: Code in EHHelpers.cpp makes assumptions about write barrier code, in particular:
+// - Function "InWriteBarrierHelper" assumes an AV due to passed in null pointer will happen at RhpByRefAssignRefAVLocation1
+// - Function "UnwindSimpleHelperToCaller" assumes no registers were pushed and LR contains the return address
 LEAF_ENTRY RhpByRefAssignRefArm64, _TEXT
 
+    ALTERNATE_ENTRY RhpByRefAssignRefAVLocation1
         ldr     x15, [x13], 8
         b       C_FUNC(RhpCheckedAssignRefArm64)
 

--- a/src/coreclr/nativeaot/Runtime/arm64/WriteBarriers.asm
+++ b/src/coreclr/nativeaot/Runtime/arm64/WriteBarriers.asm
@@ -206,8 +206,12 @@ INVALIDGCVALUE  EQU 0xCCCCCCCD
 ;;   x15  : trashed
 ;;   x12, x17  : trashed
 ;;
+;; WARNING: Code in EHHelpers.cpp makes assumptions about write barrier code, in particular:
+;; - Function "InWriteBarrierHelper" assumes an AV due to passed in null pointer will happen at RhpByRefAssignRefAVLocation1
+;; - Function "UnwindSimpleHelperToCaller" assumes no registers were pushed and LR contains the return address
     LEAF_ENTRY RhpByRefAssignRefArm64, _TEXT
 
+    ALTERNATE_ENTRY RhpByRefAssignRefAVLocation1
         ldr     x15, [x13], 8
         b       RhpCheckedAssignRefArm64
 

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1204,9 +1204,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/v2.2/ddb/b429039/b429039/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/155: RuntimeHelpers.InitializeArray</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_19444/GitHub_19444/*">
-            <Issue>https://github.com/dotnet/runtimelab/issues/197</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_22583/GitHub_22583/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/155: Type equivalence</Issue>
         </ExcludeList>


### PR DESCRIPTION
Fixes dotnet/runtimelab#197.

Ran into this again when curiosity made my try a newly added JIT test with NativeAOT.

Cc @dotnet/ilc-contrib 