### PR TITLE
fix: Change severity for SYSLIB1006 to Info instead of warning

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/DiagnosticDescriptors.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/DiagnosticDescriptors.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Extensions.Logging.Generators
             title: new LocalizableResourceString(nameof(SR.ShouldntReuseEventIdsTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.ShouldntReuseEventIdsMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             category: "LoggingGenerator",
-            DiagnosticSeverity.Warning,
+            DiagnosticSeverity.Info,
             isEnabledByDefault: true);
 
         public static DiagnosticDescriptor LoggingMethodMustReturnVoid { get; } = new DiagnosticDescriptor(


### PR DESCRIPTION
Hopefully fixes https://github.com/dotnet/runtime/issues/72263

`EventId` can be the same, let's not warn if it's not the same. 

Documentation link  -> https://learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-7.0#log-event-id

![image](https://user-images.githubusercontent.com/17148381/235443831-fc7e5b26-e99d-4690-ab99-f66f0c7bf909.png)
