### PR TITLE
Move assignment rationalization to before the late helper expansion phases

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5047,10 +5047,10 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         DoPhase(this, PHASE_EXPAND_TLS, &Compiler::fgExpandThreadLocalAccess);
     }
 
+    DoPhase(this, PHASE_RATIONALIZE_ASSIGNMENTS, &Compiler::fgRationalizeAssignments);
+
     // Insert GC Polls
     DoPhase(this, PHASE_INSERT_GC_POLLS, &Compiler::fgInsertGCPolls);
-
-    DoPhase(this, PHASE_RATIONALIZE_ASSIGNMENTS, &Compiler::fgRationalizeAssignments);
 
     if (opts.OptimizationEnabled())
     {

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5031,6 +5031,8 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     optLoopTableValid         = false;
     optLoopsRequirePreHeaders = false;
 
+    DoPhase(this, PHASE_RATIONALIZE_ASSIGNMENTS, &Compiler::fgRationalizeAssignments);
+
 #ifdef DEBUG
     DoPhase(this, PHASE_STRESS_SPLIT_TREE, &Compiler::StressSplitTree);
 #endif
@@ -5046,8 +5048,6 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         // Currently this is only applicable for Windows
         DoPhase(this, PHASE_EXPAND_TLS, &Compiler::fgExpandThreadLocalAccess);
     }
-
-    DoPhase(this, PHASE_RATIONALIZE_ASSIGNMENTS, &Compiler::fgRationalizeAssignments);
 
     // Insert GC Polls
     DoPhase(this, PHASE_INSERT_GC_POLLS, &Compiler::fgInsertGCPolls);

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5050,6 +5050,8 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     // Insert GC Polls
     DoPhase(this, PHASE_INSERT_GC_POLLS, &Compiler::fgInsertGCPolls);
 
+    DoPhase(this, PHASE_RATIONALIZE_ASSIGNMENTS, &Compiler::fgRationalizeAssignments);
+
     if (opts.OptimizationEnabled())
     {
         // Optimize boolean conditions
@@ -5068,8 +5070,6 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     // Determine start of cold region if we are hot/cold splitting
     //
     DoPhase(this, PHASE_DETERMINE_FIRST_COLD_BLOCK, &Compiler::fgDetermineFirstColdBlock);
-
-    DoPhase(this, PHASE_RATIONALIZE_ASSIGNMENTS, &Compiler::fgRationalizeAssignments);
 
 #ifdef DEBUG
     // Stash the current estimate of the function's size if necessary.

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2839,6 +2839,12 @@ public:
 
     GenTreeIndir* gtNewIndir(var_types typ, GenTree* addr, GenTreeFlags indirFlags = GTF_EMPTY);
 
+    GenTreeBlk* gtNewStoreBlkNode(
+        ClassLayout* layout, GenTree* addr, GenTree* data, GenTreeFlags indirFlags = GTF_EMPTY);
+
+    GenTreeStoreInd* gtNewStoreIndNode(
+        var_types type, GenTree* addr, GenTree* data, GenTreeFlags indirFlags = GTF_EMPTY);
+
     GenTree* gtNewLoadValueNode(
         var_types type, ClassLayout* layout, GenTree* addr, GenTreeFlags indirFlags = GTF_EMPTY);
 
@@ -2850,6 +2856,14 @@ public:
     GenTree* gtNewLoadValueNode(var_types type, GenTree* addr, GenTreeFlags indirFlags = GTF_EMPTY)
     {
         return gtNewLoadValueNode(type, nullptr, addr, indirFlags);
+    }
+
+    GenTree* gtNewStoreValueNode(
+        var_types type, ClassLayout* layout, GenTree* addr, GenTree* data, GenTreeFlags indirFlags = GTF_EMPTY);
+
+    GenTree* gtNewStoreValueNode(ClassLayout* layout, GenTree* addr, GenTree* data, GenTreeFlags indirFlags = GTF_EMPTY)
+    {
+        return gtNewStoreValueNode(layout->GetType(), layout, addr, data, indirFlags);
     }
 
     GenTree* gtNewNullCheck(GenTree* addr, BasicBlock* basicBlock);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2536,6 +2536,7 @@ public:
                                                   void*                   compileTimeHandle);
 
     GenTreeLclVar* gtNewLclvNode(unsigned lnum, var_types type DEBUGARG(IL_OFFSET offs = BAD_IL_OFFSET));
+    GenTreeLclVar* gtNewLclVarNode(unsigned lclNum, var_types type = TYP_UNDEF);
     GenTreeLclVar* gtNewLclLNode(unsigned lnum, var_types type DEBUGARG(IL_OFFSET offs = BAD_IL_OFFSET));
 
     GenTreeLclFld* gtNewLclVarAddrNode(unsigned lclNum, var_types type = TYP_I_IMPL);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2963,6 +2963,9 @@ public:
 
     void gtPrepareCost(GenTree* tree);
     bool gtIsLikelyRegVar(GenTree* tree);
+    void gtGetLclVarNodeCost(GenTreeLclVar* node, int* pCostEx, int* pCostSz, bool isLikelyRegVar);
+    void gtGetLclFldNodeCost(GenTreeLclFld* node, int* pCostEx, int* pCostSz);
+    bool gtGetIndNodeCost(GenTreeIndir* node, int* pCostEx, int* pCostSz);
 
     // Returns true iff the secondNode can be swapped with firstNode.
     bool gtCanSwapOrder(GenTree* firstNode, GenTree* secondNode);

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1230,6 +1230,7 @@ inline void GenTree::SetOper(genTreeOps oper, ValueNumberUpdate vnUpdate)
             break;
 #endif
         case GT_LCL_FLD:
+        case GT_STORE_LCL_FLD:
             AsLclFld()->SetLclOffs(0);
             AsLclFld()->SetLayout(nullptr);
             break;

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -514,10 +514,8 @@ GenTree* DecomposeLongs::DecomposeStoreLclFld(LIR::Use& use)
     loStore->gtFlags |= GTF_VAR_USEASG;
 
     // Create the store for the upper half of the GT_LONG and insert it after the low store.
-    GenTreeLclFld* hiStore = m_compiler->gtNewLclFldNode(loStore->GetLclNum(), TYP_INT, loStore->GetLclOffs() + 4);
-    hiStore->SetOper(GT_STORE_LCL_FLD);
-    hiStore->gtOp1 = value->gtOp2;
-    hiStore->gtFlags |= (GTF_VAR_DEF | GTF_VAR_USEASG);
+    GenTreeLclFld* hiStore =
+        m_compiler->gtNewStoreLclFldNode(loStore->GetLclNum(), TYP_INT, loStore->GetLclOffs() + 4, value->gtOp2);
 
     Range().InsertAfter(loStore, hiStore);
 

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -3445,24 +3445,14 @@ bool Compiler::fgBlockEndFavorsTailDuplication(BasicBlock* block, unsigned lclNu
     while (count < limit)
     {
         count++;
+        unsigned storeLclNum;
         GenTree* const tree = stmt->GetRootNode();
-        if (tree->OperIs(GT_ASG) && !tree->OperIsBlkOp())
+        if (tree->OperIsStoreLcl(&storeLclNum) && (storeLclNum == lclNum) && !tree->OperIsBlkOp())
         {
-            GenTree* const op1 = tree->AsOp()->gtOp1;
-
-            if (op1->IsLocal())
+            GenTree* const data = tree->Data();
+            if (data->OperIsArrLength() || data->OperIsConst() || data->OperIsCompare())
             {
-                const unsigned op1LclNum = op1->AsLclVarCommon()->GetLclNum();
-
-                if (op1LclNum == lclNum)
-                {
-                    GenTree* const op2 = tree->AsOp()->gtOp2;
-
-                    if (op2->OperIsArrLength() || op2->OperIsConst() || op2->OperIsCompare())
-                    {
-                        return true;
-                    }
-                }
+                return true;
             }
         }
 
@@ -3616,36 +3606,29 @@ bool Compiler::fgBlockIsGoodTailDuplicationCandidate(BasicBlock* target, unsigne
     // Otherwise check the first stmt.
     // Verify the branch is just a simple local compare.
     //
+    unsigned storeLclNum;
     GenTree* const firstTree = firstStmt->GetRootNode();
-
-    if (firstTree->gtOper != GT_ASG)
+    if (!firstTree->OperIsStoreLclVar(&storeLclNum))
     {
         return false;
     }
 
-    GenTree* const lhs = firstTree->AsOp()->gtOp1;
-    if (!lhs->OperIs(GT_LCL_VAR))
-    {
-        return false;
-    }
-
-    const unsigned lhsLcl = lhs->AsLclVarCommon()->GetLclNum();
-    if (lhsLcl != *lclNum)
+    if (storeLclNum != *lclNum)
     {
         return false;
     }
 
     // Could allow unary here too...
     //
-    GenTree* const rhs = firstTree->AsOp()->gtOp2;
-    if (!rhs->OperIsBinary())
+    GenTree* const data = firstTree->Data();
+    if (!data->OperIsBinary())
     {
         return false;
     }
 
     // op1 must be some combinations of casts of local or constant
     // (or unary)
-    op1 = rhs->AsOp()->gtOp1;
+    op1 = data->AsOp()->gtOp1;
     while (op1->gtOper == GT_CAST)
     {
         op1 = op1->AsOp()->gtOp1;
@@ -3658,7 +3641,7 @@ bool Compiler::fgBlockIsGoodTailDuplicationCandidate(BasicBlock* target, unsigne
 
     // op2 must be some combinations of casts of local or constant
     // (or unary)
-    op2 = rhs->AsOp()->gtOp2;
+    op2 = data->AsOp()->gtOp2;
 
     // A binop may not actually have an op2.
     //

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -3445,7 +3445,7 @@ bool Compiler::fgBlockEndFavorsTailDuplication(BasicBlock* block, unsigned lclNu
     while (count < limit)
     {
         count++;
-        unsigned storeLclNum;
+        unsigned       storeLclNum;
         GenTree* const tree = stmt->GetRootNode();
         if (tree->OperIsStoreLcl(&storeLclNum) && (storeLclNum == lclNum) && !tree->OperIsBlkOp())
         {
@@ -3606,7 +3606,7 @@ bool Compiler::fgBlockIsGoodTailDuplicationCandidate(BasicBlock* target, unsigne
     // Otherwise check the first stmt.
     // Verify the branch is just a simple local compare.
     //
-    unsigned storeLclNum;
+    unsigned       storeLclNum;
     GenTree* const firstTree = firstStmt->GetRootNode();
     if (!firstTree->OperIsStoreLclVar(&storeLclNum))
     {

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -2979,6 +2979,7 @@ GenTree* Compiler::fgRationalizeAssignment(GenTreeOp* assignment)
     {
         store->SetReverseOp();
     }
+    store->CopyRawCosts(assignment);
 
     if (storeOp == GT_STOREIND)
     {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -730,12 +730,15 @@ ClassLayout* GenTree::GetLayout(Compiler* compiler) const
     switch (OperGet())
     {
         case GT_LCL_VAR:
+        case GT_STORE_LCL_VAR:
             return compiler->lvaGetDesc(AsLclVar())->GetLayout();
 
         case GT_LCL_FLD:
+        case GT_STORE_LCL_FLD:
             return AsLclFld()->GetLayout();
 
         case GT_BLK:
+        case GT_STORE_BLK:
             return AsBlk()->GetLayout();
 
         case GT_COMMA:

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -4175,6 +4175,176 @@ bool Compiler::gtIsLikelyRegVar(GenTree* tree)
 }
 
 //------------------------------------------------------------------------
+// gtGetLclVarNodeCost: Calculate the cost for a local variable node.
+//
+// Used for both uses and defs. Only the node's own cost is calculated.
+//
+// Arguments:
+//    node           - The node in question
+//    pCostEx        - [out] parameter for the execution cost
+//    pCostSz        - [out] parameter for the size cost
+//    isLikelyRegVar - Is the local likely to end up enregistered
+//
+void Compiler::gtGetLclVarNodeCost(GenTreeLclVar* node, int* pCostEx, int* pCostSz, bool isLikelyRegVar)
+{
+    int costEx;
+    int costSz;
+    if (isLikelyRegVar)
+    {
+        costEx = 1;
+        costSz = 1;
+        /* Sign-extend and zero-extend are more expensive to load */
+        if (lvaGetDesc(node)->lvNormalizeOnLoad())
+        {
+            costEx += 1;
+            costSz += 1;
+        }
+    }
+    else
+    {
+        costEx = IND_COST_EX;
+        costSz = 2;
+
+        // Some types are more expensive to load than others.
+        if (varTypeIsSmall(node))
+        {
+            costEx += 1;
+            costSz += 1;
+        }
+        else if (node->TypeIs(TYP_STRUCT))
+        {
+            costEx += 2 * IND_COST_EX;
+            costSz += 2 * 2;
+        }
+    }
+#if defined(TARGET_AMD64)
+    // increase costSz for floating point locals
+    if (varTypeIsFloating(node))
+    {
+        costSz += 1;
+        if (!isLikelyRegVar)
+        {
+            costSz += 1;
+        }
+    }
+#endif
+
+    *pCostEx = costEx;
+    *pCostSz = costSz;
+}
+
+//------------------------------------------------------------------------
+// gtGetLclFldNodeCost: Calculate the cost for a local field node.
+//
+// Used for both uses and defs. Only the node's own cost is calculated.
+//
+// Arguments:
+//    node           - The node in question
+//    pCostEx        - [out] parameter for the execution cost
+//    pCostSz        - [out] parameter for the size cost
+//
+void Compiler::gtGetLclFldNodeCost(GenTreeLclFld* node, int* pCostEx, int* pCostSz)
+{
+    int costEx = IND_COST_EX;
+    int costSz = 4;
+    if (varTypeIsSmall(node->TypeGet()))
+    {
+        costEx += 1;
+        costSz += 1;
+    }
+    else if (node->TypeIs(TYP_STRUCT))
+    {
+        costEx += 2 * IND_COST_EX;
+        costSz += 2 * 2;
+    }
+
+    *pCostEx = costEx;
+    *pCostSz = costSz;
+}
+
+//------------------------------------------------------------------------
+// gtGetLclFldNodeCost: Calculate the cost for a primitive indir node.
+//
+// Used for both loads and stores.
+//
+// Arguments:
+//    node           - The node in question
+//    pCostEx        - [out] parameter for the execution cost
+//    pCostSz        - [out] parameter for the size cost
+//
+// Return Value:
+//    Whether the cost calculated includes that of the node's address.
+//
+bool Compiler::gtGetIndNodeCost(GenTreeIndir* node, int* pCostEx, int* pCostSz)
+{
+    assert(node->isIndir());
+
+    // Indirections have a costEx of IND_COST_EX.
+    int  costEx           = IND_COST_EX;
+    int  costSz           = 2;
+    bool includesAddrCost = false;
+
+    // If we have to sign-extend or zero-extend, bump the cost.
+    if (varTypeIsSmall(node))
+    {
+        costEx += 1;
+        costSz += 1;
+    }
+
+#ifdef TARGET_ARM
+    if (varTypeIsFloating(node))
+    {
+        costSz += 2;
+    }
+#endif // TARGET_ARM
+
+    // Can we form an addressing mode with this indirection?
+    GenTree* addr = node->Addr();
+
+    if (addr->gtEffectiveVal()->OperIs(GT_ADD))
+    {
+        // See if we can form a complex addressing mode.
+        bool doAddrMode = true;
+
+        // TODO-1stClassStructs: delete once IND<struct> nodes are no more.
+        if (node->TypeGet() == TYP_STRUCT)
+        {
+            doAddrMode = false;
+        }
+#ifdef TARGET_ARM64
+        if (node->IsVolatile())
+        {
+            // For volatile store/loads when address is contained we always emit `dmb`
+            // if it's not - we emit one-way barriers i.e. ldar/stlr
+            doAddrMode = false;
+        }
+#endif // TARGET_ARM64
+        if (doAddrMode && gtMarkAddrMode(addr, &costEx, &costSz, node->TypeGet()))
+        {
+            includesAddrCost = true;
+        }
+    }
+    else if (gtIsLikelyRegVar(addr))
+    {
+        // Indirection of an enregister LCL_VAR, don't increase costEx/costSz.
+        includesAddrCost = true;
+    }
+#ifdef TARGET_XARCH
+    else if (addr->IsCnsIntOrI())
+    {
+        // Indirection of a CNS_INT, subtract 1 from costEx makes costEx 3 for x86 and 4 for amd64.
+        costEx += (addr->GetCostEx() - 1);
+        costSz += addr->GetCostSz();
+        includesAddrCost = true;
+    }
+#endif
+
+    *pCostEx = costEx;
+    *pCostSz = costSz;
+    return includesAddrCost;
+}
+
+//------------------------------------------------------------------------
 // gtCanSwapOrder: Returns true iff the secondNode can be swapped with firstNode.
 //
 // Arguments:
@@ -5066,61 +5236,12 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
 
             case GT_LCL_VAR:
                 level = 1;
-                if (gtIsLikelyRegVar(tree))
-                {
-                    costEx = 1;
-                    costSz = 1;
-                    /* Sign-extend and zero-extend are more expensive to load */
-                    if (lvaTable[tree->AsLclVar()->GetLclNum()].lvNormalizeOnLoad())
-                    {
-                        costEx += 1;
-                        costSz += 1;
-                    }
-                }
-                else
-                {
-                    costEx = IND_COST_EX;
-                    costSz = 2;
-
-                    // Some types are more expensive to load than others.
-                    if (varTypeIsSmall(tree->TypeGet()))
-                    {
-                        costEx += 1;
-                        costSz += 1;
-                    }
-                    else if (tree->TypeIs(TYP_STRUCT))
-                    {
-                        costEx += 2 * IND_COST_EX;
-                        costSz += 2 * 2;
-                    }
-                }
-#if defined(TARGET_AMD64)
-                // increase costSz for floating point locals
-                if (isflt)
-                {
-                    costSz += 1;
-                    if (!gtIsLikelyRegVar(tree))
-                    {
-                        costSz += 1;
-                    }
-                }
-#endif
+                gtGetLclVarNodeCost(tree->AsLclVar(), &costEx, &costSz, gtIsLikelyRegVar(tree));
                 break;
 
             case GT_LCL_FLD:
                 level  = 1;
-                costEx = IND_COST_EX;
-                costSz = 4;
-                if (varTypeIsSmall(tree->TypeGet()))
-                {
-                    costEx += 1;
-                    costSz += 1;
-                }
-                else if (tree->TypeIs(TYP_STRUCT))
-                {
-                    costEx += 2 * IND_COST_EX;
-                    costSz += 2 * 2;
-                }
+                gtGetLclFldNodeCost(tree->AsLclFld(), &costEx, &costSz);
                 break;
 
             case GT_LCL_ADDR:
@@ -5148,9 +5269,6 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
 
     if (kind & GTK_SMPOP)
     {
-        int      lvlb; // preference for op2
-        unsigned lvl2; // scratch variable
-
         GenTree* op1 = tree->AsOp()->gtOp1;
         GenTree* op2 = tree->gtGetOp2IfPresent();
 
@@ -5401,78 +5519,52 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                     break;
 
                 case GT_IND:
-                {
-                    /* An indirection should always have a non-zero level.
-                     * Only constant leaf nodes have level 0.
-                     */
-
+                    // An indirection should always have a non-zero level.
+                    // Only constant leaf nodes have level 0.
                     if (level == 0)
                     {
                         level = 1;
                     }
 
-                    /* Indirections have a costEx of IND_COST_EX */
-                    costEx = IND_COST_EX;
-                    costSz = 2;
-
-                    /* If we have to sign-extend or zero-extend, bump the cost */
-                    if (varTypeIsSmall(tree->TypeGet()))
+                    if (gtGetIndNodeCost(tree->AsIndir(), &costEx, &costSz))
                     {
-                        costEx += 1;
-                        costSz += 1;
+                        goto DONE;
+                    }
+                    break;
+
+                case GT_STORE_LCL_VAR:
+                    if (gtIsLikelyRegVar(tree))
+                    {
+                        // Store to an enregistered local.
+                        costEx = op1->GetCostEx();
+                        costSz = max(3, op1->GetCostSz()); // 3 is an estimate for a reg-reg move.
+                        goto DONE;
                     }
 
+                    gtGetLclVarNodeCost(tree->AsLclVar(), &costEx, &costSz, /* isLikelyRegVar */ false);
+                    goto SET_LCL_STORE_COSTS;
+
+                case GT_STORE_LCL_FLD:
+                    gtGetLclFldNodeCost(tree->AsLclFld(), &costEx, &costSz);
+
+                SET_LCL_STORE_COSTS:
+                    costEx += 1;
+                    costSz += 1;
 #ifdef TARGET_ARM
                     if (isflt)
                     {
                         costSz += 2;
                     }
 #endif // TARGET_ARM
-
-                    // Can we form an addressing mode with this indirection?
-                    GenTree* addr = op1->gtEffectiveVal();
-
-                    if (addr->OperIs(GT_ADD))
+#ifndef TARGET_64BIT
+                    if (tree->TypeIs(TYP_LONG))
                     {
-                        // See if we can form a complex addressing mode.
-                        bool doAddrMode = true;
-
-                        // TODO-1stClassStructs: Always do this, but first make sure it's done in Lowering as well.
-                        if (tree->TypeGet() == TYP_STRUCT)
-                        {
-                            doAddrMode = false;
-                        }
-#ifdef TARGET_ARM64
-                        if (tree->AsIndir()->IsVolatile())
-                        {
-                            // For volatile store/loads when address is contained we always emit `dmb`
-                            // if it's not - we emit one-way barriers i.e. ldar/stlr
-                            doAddrMode = false;
-                        }
-#endif // TARGET_ARM64
-                        if (doAddrMode && gtMarkAddrMode(op1, &costEx, &costSz, tree->TypeGet()))
-                        {
-                            goto DONE;
-                        }
+                        // Operations on longs are more expensive.
+                        costEx += 3;
+                        costSz += 3;
                     }
-                    else if (gtIsLikelyRegVar(op1))
-                    {
-                        /* Indirection of an enregister LCL_VAR, don't increase costEx/costSz */
-                        goto DONE;
-                    }
-#ifdef TARGET_XARCH
-                    else if (op1->IsCnsIntOrI())
-                    {
-                        // Indirection of a CNS_INT, subtract 1 from costEx
-                        // makes costEx 3 for x86 and 4 for amd64
-                        //
-                        costEx += (op1->GetCostEx() - 1);
-                        costSz += op1->GetCostSz();
-                        goto DONE;
-                    }
-#endif
-                }
-                break;
+#endif // !TARGET_64BIT
+                    break;
 
                 default:
                     break;
@@ -5483,8 +5575,9 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
         }
 
         /* Binary operator - check for certain special cases */
-
-        lvlb = 0;
+        bool includeOp1Cost = true;
+        bool includeOp2Cost = true;
+        bool allowReversal  = true;
 
         /* Default Binary ops have a cost of 1,1 */
         costEx = 1;
@@ -5504,6 +5597,9 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
             costSz += 3;
         }
 #endif
+        level          = gtSetEvalOrder(op1);
+        unsigned lvl2  = gtSetEvalOrder(op2);
+
         switch (oper)
         {
             case GT_MOD:
@@ -5539,7 +5635,7 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                     costSz += 2;
 
                     // Encourage the first operand to be evaluated (into EAX/EDX) first */
-                    lvlb -= 3;
+                    level += 3;
                 }
                 break;
 
@@ -5569,7 +5665,7 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                     {
                         /* We use imulEAX for TYP_LONG and overflow multiplications */
                         // Encourage the first operand to be evaluated (into EAX/EDX) first */
-                        lvlb -= 4;
+                        level += 4;
 
                         /* The 64-bit imul instruction costs more */
                         costEx += 4;
@@ -5596,141 +5692,6 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                 }
                 break;
 
-            case GT_BOUNDS_CHECK:
-                costEx = 4; // cmp reg,reg and jae throw (not taken)
-                costSz = 7; // jump to cold section
-                break;
-
-            case GT_COMMA:
-
-                /* Comma tosses the result of the left operand */
-                gtSetEvalOrder(op1);
-                level = gtSetEvalOrder(op2);
-
-                /* GT_COMMA cost is the sum of op1 and op2 costs */
-                costEx = (op1->GetCostEx() + op2->GetCostEx());
-                costSz = (op1->GetCostSz() + op2->GetCostSz());
-
-                goto DONE;
-
-            case GT_INDEX_ADDR:
-                costEx = 6; // cmp reg,reg; jae throw; mov reg, [addrmode]  (not taken)
-                costSz = 9; // jump to cold section
-                break;
-
-            case GT_ASG:
-                /* Assignments need a bit of special handling */
-                /* Process the target */
-                level = gtSetEvalOrder(op1);
-
-                if (gtIsLikelyRegVar(op1))
-                {
-                    assert(lvlb == 0);
-                    lvl2 = gtSetEvalOrder(op2);
-
-                    /* Assignment to an enregistered LCL_VAR */
-                    costEx = op2->GetCostEx();
-                    costSz = max(3, op2->GetCostSz()); // 3 is an estimate for a reg-reg assignment
-                    goto DONE_OP1_AFTER_COST;
-                }
-                goto DONE_OP1;
-
-            default:
-                break;
-        }
-
-        /* Process the sub-operands */
-
-        level = gtSetEvalOrder(op1);
-        if (lvlb < 0)
-        {
-            level -= lvlb; // lvlb is negative, so this increases level
-            lvlb = 0;
-        }
-
-    DONE_OP1:
-        assert(lvlb >= 0);
-        lvl2 = gtSetEvalOrder(op2) + lvlb;
-
-        costEx += (op1->GetCostEx() + op2->GetCostEx());
-        costSz += (op1->GetCostSz() + op2->GetCostSz());
-
-    DONE_OP1_AFTER_COST:
-
-        bool bReverseInAssignment = false;
-        if (oper == GT_ASG && (!optValnumCSE_phase || optCSE_canSwap(op1, op2)))
-        {
-            switch (op1->OperGet())
-            {
-                case GT_IND:
-                case GT_BLK:
-                {
-                    // In an ASG(IND(addr), ...), the "IND" is a pure syntactical element,
-                    // the actual indirection will only be realized at the point of the ASG
-                    // itself. As such, we can discard any side effects "induced" by it in
-                    // this logic.
-                    //
-                    GenTree* op1Addr = op1->AsIndir()->Addr();
-
-                    if (op1Addr->IsInvariant())
-                    {
-                        bReverseInAssignment = true;
-                        tree->gtFlags |= GTF_REVERSE_OPS;
-                        break;
-                    }
-                    if (op1Addr->gtFlags & GTF_ALL_EFFECT)
-                    {
-                        break;
-                    }
-
-                    // In case op2 assigns to a local var that is used in op1, we have to evaluate op1 first.
-                    if (op2->gtFlags & GTF_ASG)
-                    {
-                        break;
-                    }
-
-                    // If op2 is simple then evaluate op1 first
-                    if (op2->OperKind() & GTK_LEAF)
-                    {
-                        break;
-                    }
-                }
-                    // fall through and set GTF_REVERSE_OPS
-                    FALLTHROUGH;
-
-                case GT_LCL_VAR:
-                case GT_LCL_FLD:
-                    // Note that for local stores, liveness depends on seeing the defs and
-                    // uses in correct order, and so we MUST reverse the ASG in that case.
-                    bReverseInAssignment = true;
-                    tree->gtFlags |= GTF_REVERSE_OPS;
-                    break;
-
-                default:
-                    break;
-            }
-        }
-        else if (GenTree::OperIsCompare(oper))
-        {
-            /* Float compares remove both operands from the FP stack */
-            /* Also FP comparison uses EAX for flags */
-
-            if (varTypeIsFloating(op1->TypeGet()))
-            {
-                level++;
-                lvl2++;
-            }
-            if ((tree->gtFlags & GTF_RELOP_JMP_USED) == 0)
-            {
-                /* Using a setcc instruction is more expensive */
-                costEx += 3;
-            }
-        }
-
-        /* Check for other interesting cases */
-
-        switch (oper)
-        {
             case GT_LSH:
             case GT_RSH:
             case GT_RSZ:
@@ -5755,15 +5716,50 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                 }
                 break;
 
+            case GT_EQ:
+            case GT_NE:
+            case GT_LT:
+            case GT_LE:
+            case GT_GE:
+            case GT_GT:
+                /* Float compares remove both operands from the FP stack */
+                /* Also FP comparison uses EAX for flags */
+
+                if (varTypeIsFloating(op1->TypeGet()))
+                {
+                    level++;
+                    lvl2++;
+                }
+                if ((tree->gtFlags & GTF_RELOP_JMP_USED) == 0)
+                {
+                    /* Using a setcc instruction is more expensive */
+                    costEx += 3;
+                }
+                break;
+
+            case GT_BOUNDS_CHECK:
+                costEx = 4; // cmp reg,reg and jae throw (not taken)
+                costSz = 7; // jump to cold section
+                // Bounds check nodes used to not be binary, thus GTF_REVERSE_OPS was not enabled for them. This
+                // condition preserves that behavior. Additionally, CQ analysis shows that enabling GTF_REVERSE_OPS
+                // for these nodes leads to mixed results at best.
+                allowReversal = false;
+                break;
+
             case GT_INTRINSIC:
+                // We do not swap operand execution order for intrinsics that are implemented by user calls because
+                // of trickiness around ensuring the execution order does not change during rationalization.
+                if (IsIntrinsicImplementedByUserCall(tree->AsIntrinsic()->gtIntrinsicName))
+                {
+                    allowReversal = false;
+                }
 
                 switch (tree->AsIntrinsic()->gtIntrinsicName)
                 {
                     case NI_System_Math_Atan2:
                     case NI_System_Math_Pow:
-                        // These math intrinsics are actually implemented by user calls.
-                        // Increase the Sethi 'complexity' by two to reflect the argument
-                        // register requirement.
+                        // These math intrinsics are actually implemented by user calls. Increase the
+                        // Sethi 'complexity' by two to reflect the argument register requirement.
                         level += 2;
                         break;
 
@@ -5776,11 +5772,156 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                         assert(!"Unknown binary GT_INTRINSIC operator");
                         break;
                 }
+                break;
 
+            case GT_COMMA:
+                /* Comma tosses the result of the left operand */
+                level = lvl2;
+                /* GT_COMMA cost is the sum of op1 and op2 costs */
+                costEx = (op1->GetCostEx() + op2->GetCostEx());
+                costSz = (op1->GetCostSz() + op2->GetCostSz());
+                goto DONE;
+
+            case GT_INDEX_ADDR:
+                costEx = 6; // cmp reg,reg; jae throw; mov reg, [addrmode]  (not taken)
+                costSz = 9; // jump to cold section
+                break;
+
+            case GT_STORE_BLK:
+                // We estimate the cost of a GT_STORE_BLK to be two stores.
+                costEx += 2 * IND_COST_EX;
+                costSz += 2 * 2;
+                goto SET_INDIRECT_STORE_ORDER;
+
+            case GT_STOREIND:
+                if (gtGetIndNodeCost(tree->AsIndir(), &costEx, &costSz))
+                {
+                    includeOp1Cost = false;
+                }
+
+                costEx += 1;
+                costSz += 1;
+#ifndef TARGET_64BIT
+                if (tree->TypeIs(TYP_LONG))
+                {
+                    // Operations on longs are more expensive.
+                    costEx += 3;
+                    costSz += 3;
+                }
+#endif // !TARGET_64BIT
+
+            SET_INDIRECT_STORE_ORDER:
+                // TODO-ASG-Cleanup: this logic emulates the ASG case below. See how of much of it can be deleted.
+                if (!optValnumCSE_phase || optCSE_canSwap(op1, op2))
+                {
+                    if (op1->IsInvariant())
+                    {
+                        allowReversal = false;
+                        tree->SetReverseOp();
+                        break;
+                    }
+                    if ((op1->gtFlags & GTF_ALL_EFFECT) != 0)
+                    {
+                        break;
+                    }
+
+                    // In case op2 assigns to a local var that is used in op1, we have to evaluate op1 first.
+                    if ((op2->gtFlags & GTF_ASG) != 0)
+                    {
+                        // TODO-ASG-Cleanup: move this guard to "gtCanSwapOrder".
+                        allowReversal = false;
+                        break;
+                    }
+
+                    // If op2 is simple then evaluate op1 first
+                    if (op2->OperIsLeaf())
+                    {
+                        break;
+                    }
+
+                    allowReversal = false;
+                    tree->SetReverseOp();
+                }
+                break;
+
+            case GT_ASG:
+                /* Assignments need a bit of special handling */
+                if (gtIsLikelyRegVar(op1))
+                {
+                    /* Assignment to an enregistered LCL_VAR */
+                    costEx         = op2->GetCostEx();
+                    costSz         = max(3, op2->GetCostSz()); // 3 is an estimate for a reg-reg assignment
+                    includeOp1Cost = false;
+                    includeOp2Cost = false;
+                }
+
+                if (!optValnumCSE_phase || optCSE_canSwap(op1, op2))
+                {
+                    switch (op1->OperGet())
+                    {
+                        case GT_IND:
+                        case GT_BLK:
+                        {
+                            // In an ASG(IND(addr), ...), the "IND" is a pure syntactical element,
+                            // the actual indirection will only be realized at the point of the ASG
+                            // itself. As such, we can discard any side effects "induced" by it in
+                            // this logic.
+                            //
+                            GenTree* op1Addr = op1->AsIndir()->Addr();
+
+                            if (op1Addr->IsInvariant())
+                            {
+                                allowReversal = false;
+                                tree->gtFlags |= GTF_REVERSE_OPS;
+                                break;
+                            }
+                            if (op1Addr->gtFlags & GTF_ALL_EFFECT)
+                            {
+                                break;
+                            }
+
+                            // In case op2 assigns to a local var that is used in op1, we have to evaluate op1 first.
+                            if (op2->gtFlags & GTF_ASG)
+                            {
+                                break;
+                            }
+
+                            // If op2 is simple then evaluate op1 first
+                            if (op2->OperKind() & GTK_LEAF)
+                            {
+                                break;
+                            }
+                        }
+                            // fall through and set GTF_REVERSE_OPS
+                            FALLTHROUGH;
+
+                        case GT_LCL_VAR:
+                        case GT_LCL_FLD:
+                            // Note that for local stores, liveness depends on seeing the defs and
+                            // uses in correct order, and so we MUST reverse the ASG in that case.
+                            allowReversal = false;
+                            tree->gtFlags |= GTF_REVERSE_OPS;
+                            break;
+
+                        default:
+                            break;
+                    }
+                }
                 break;
 
             default:
                 break;
+        }
+
+        if (includeOp1Cost)
+        {
+            costEx += op1->GetCostEx();
+            costSz += op1->GetCostSz();
+        }
+        if (includeOp2Cost)
+        {
+            costEx += op2->GetCostEx();
+            costSz += op2->GetCostSz();
         }
 
         /* We need to evaluate constants later as many places in codegen
@@ -5796,50 +5937,12 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
             lvl2++;
         }
 
-        /* We try to swap operands if the second one is more expensive */
-        bool     tryToSwap;
-        GenTree* opA;
-        GenTree* opB;
-
-        if (tree->gtFlags & GTF_REVERSE_OPS)
+        // We try to swap operands if the second one is more expensive.
+        // Don't swap anything if we're in linear order; we're really just interested in the costs.
+        bool tryToSwap = false;
+        if (allowReversal && (fgOrder != FGOrderLinear))
         {
-            opA = op2;
-            opB = op1;
-        }
-        else
-        {
-            opA = op1;
-            opB = op2;
-        }
-
-        if (fgOrder == FGOrderLinear)
-        {
-            // Don't swap anything if we're in linear order; we're really just interested in the costs.
-            tryToSwap = false;
-        }
-        else if (bReverseInAssignment)
-        {
-            // Assignments are special, we want the reverseops flags
-            // so if possible it was set above.
-            tryToSwap = false;
-        }
-        else if ((oper == GT_INTRINSIC) && IsIntrinsicImplementedByUserCall(tree->AsIntrinsic()->gtIntrinsicName))
-        {
-            // We do not swap operand execution order for intrinsics that are implemented by user calls
-            // because of trickiness around ensuring the execution order does not change during rationalization.
-            tryToSwap = false;
-        }
-        else if (oper == GT_BOUNDS_CHECK)
-        {
-            // Bounds check nodes used to not be binary, thus GTF_REVERSE_OPS was
-            // not enabled for them. This condition preserves that behavior.
-            // Additionally, CQ analysis shows that enabling GTF_REVERSE_OPS
-            // for these nodes leads to mixed results at best.
-            tryToSwap = false;
-        }
-        else
-        {
-            if (tree->gtFlags & GTF_REVERSE_OPS)
+            if (tree->IsReverseOp())
             {
                 tryToSwap = (level > lvl2);
             }
@@ -5849,8 +5952,7 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
             }
 
             // Try to force extra swapping when in the stress mode:
-            if (compStressCompile(STRESS_REVERSE_FLAG, 60) && ((tree->gtFlags & GTF_REVERSE_OPS) == 0) &&
-                !op2->OperIsConst())
+            if (compStressCompile(STRESS_REVERSE_FLAG, 60) && !tree->IsReverseOp() && !op2->OperIsConst())
             {
                 tryToSwap = true;
             }
@@ -5858,7 +5960,7 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
 
         if (tryToSwap)
         {
-            bool canSwap = gtCanSwapOrder(opA, opB);
+            bool canSwap = tree->IsReverseOp() ? gtCanSwapOrder(op2, op1) : gtCanSwapOrder(op1, op2);
 
             if (canSwap)
             {
@@ -5898,30 +6000,17 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                         break;
 
                     default:
-
-                        /* Mark the operand's evaluation order to be swapped */
-                        if (tree->gtFlags & GTF_REVERSE_OPS)
-                        {
-                            tree->gtFlags &= ~GTF_REVERSE_OPS;
-                        }
-                        else
-                        {
-                            tree->gtFlags |= GTF_REVERSE_OPS;
-                        }
-
+                        // Mark the operand's evaluation order to be swapped.
+                        tree->gtFlags ^= GTF_REVERSE_OPS;
                         break;
                 }
             }
         }
 
         /* Swap the level counts */
-        if (tree->gtFlags & GTF_REVERSE_OPS)
+        if (tree->IsReverseOp())
         {
-            unsigned tmpl;
-
-            tmpl  = level;
-            level = lvl2;
-            lvl2  = tmpl;
+            std::swap(level, lvl2);
         }
 
         /* Compute the sethi number for this binary operator */

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -10680,12 +10680,11 @@ void Compiler::gtDispNode(GenTree* tree, IndentStack* indentStack, _In_ _In_opt_
         /* First print the flags associated with the node */
         switch (tree->gtOper)
         {
-            case GT_LEA:
             case GT_BLK:
+            case GT_IND:
+            case GT_STOREIND:
             case GT_STORE_BLK:
             case GT_STORE_DYN_BLK:
-
-            case GT_IND:
                 // We prefer printing V or U
                 if ((tree->gtFlags & (GTF_IND_VOLATILE | GTF_IND_UNALIGNED)) == 0)
                 {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -4131,7 +4131,7 @@ void Compiler::gtPrepareCost(GenTree* tree)
 
 bool Compiler::gtIsLikelyRegVar(GenTree* tree)
 {
-    if (tree->gtOper != GT_LCL_VAR)
+    if (!tree->OperIsScalarLocal())
     {
         return false;
     }
@@ -7767,6 +7767,23 @@ GenTreeLclVar* Compiler::gtNewLclvNode(unsigned lnum, var_types type DEBUGARG(IL
     // assert(lnum < lvaCount);
 
     return node;
+}
+
+GenTreeLclVar* Compiler::gtNewLclVarNode(unsigned lclNum, var_types type)
+{
+    LclVarDsc* varDsc = lvaGetDesc(lclNum);
+    if (type == TYP_UNDEF)
+    {
+        type = varDsc->lvNormalizeOnLoad() ? varDsc->TypeGet() : genActualType(varDsc);
+    }
+
+    GenTreeLclVar* lclVar = gtNewLclvNode(lclNum, type);
+    if (varDsc->IsAddressExposed())
+    {
+        lclVar->gtFlags |= GTF_GLOB_REF;
+    }
+
+    return lclVar;
 }
 
 GenTreeLclVar* Compiler::gtNewLclLNode(unsigned lnum, var_types type DEBUGARG(IL_OFFSET offs))

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -5240,7 +5240,7 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                 break;
 
             case GT_LCL_FLD:
-                level  = 1;
+                level = 1;
                 gtGetLclFldNodeCost(tree->AsLclFld(), &costEx, &costSz);
                 break;
 
@@ -5597,8 +5597,8 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
             costSz += 3;
         }
 #endif
-        level          = gtSetEvalOrder(op1);
-        unsigned lvl2  = gtSetEvalOrder(op2);
+        level         = gtSetEvalOrder(op1);
+        unsigned lvl2 = gtSetEvalOrder(op2);
 
         switch (oper)
         {

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1789,6 +1789,8 @@ public:
     // The returned pointer might be nullptr if the node is not binary, or if non-null op2 is not required.
     inline GenTree* gtGetOp2IfPresent() const;
 
+    inline GenTree* GetStoreDestination() const;
+
     inline GenTree*& Data();
 
     bool TryGetUse(GenTree* operand, GenTree*** pUse);
@@ -9257,6 +9259,12 @@ inline GenTree* GenTree::gtGetOp2IfPresent() const
     assert((op2 != nullptr) || !RequiresNonNullOp2(gtOper));
 
     return op2;
+}
+
+inline GenTree* GenTree::GetStoreDestination() const // TODO-ASG: delete.
+{
+    assert(OperIs(GT_ASG) || OperIsStore());
+    return OperIs(GT_ASG) ? gtGetOp1() : this;
 }
 
 inline GenTree*& GenTree::Data()

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1692,6 +1692,9 @@ public:
         return OperIs(GT_JCC, GT_SETCC, GT_SELECTCC);
     }
 
+    bool OperIsStoreLclVar(unsigned* pLclNum);
+    bool OperIsStoreLcl(unsigned* pLclNum);
+
 #ifdef DEBUG
     static const GenTreeDebugOperKind gtDebugOperKindTable[];
 
@@ -8839,6 +8842,40 @@ inline bool GenTree::OperIsInitBlkOp()
 inline bool GenTree::OperIsCopyBlkOp()
 {
     return OperIsBlkOp() && !OperIsInitBlkOp();
+}
+
+inline bool GenTree::OperIsStoreLclVar(unsigned* pLclNum) // TODO-ASG: delete.
+{
+    if (OperIs(GT_STORE_LCL_VAR))
+    {
+        *pLclNum = AsLclVar()->GetLclNum();
+        return true;
+    }
+    if (OperIs(GT_ASG) && gtGetOp1()->OperIs(GT_LCL_VAR))
+    {
+        *pLclNum = gtGetOp1()->AsLclVar()->GetLclNum();
+        return true;
+    }
+
+    *pLclNum = BAD_VAR_NUM;
+    return false;
+}
+
+inline bool GenTree::OperIsStoreLcl(unsigned* pLclNum) // TODO-ASG: delete.
+{
+    if (OperIsLocalStore())
+    {
+        *pLclNum = AsLclVarCommon()->GetLclNum();
+        return true;
+    }
+    if (OperIs(GT_ASG) && gtGetOp1()->OperIsLocal())
+    {
+        *pLclNum = gtGetOp1()->AsLclVarCommon()->GetLclNum();
+        return true;
+    }
+
+    *pLclNum = BAD_VAR_NUM;
+    return false;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1789,7 +1789,7 @@ public:
     // The returned pointer might be nullptr if the node is not binary, or if non-null op2 is not required.
     inline GenTree* gtGetOp2IfPresent() const;
 
-    inline GenTree* GetStoreDestination() const;
+    inline GenTree* GetStoreDestination();
 
     inline GenTree*& Data();
 
@@ -9261,7 +9261,7 @@ inline GenTree* GenTree::gtGetOp2IfPresent() const
     return op2;
 }
 
-inline GenTree* GenTree::GetStoreDestination() const // TODO-ASG: delete.
+inline GenTree* GenTree::GetStoreDestination() // TODO-ASG: delete.
 {
     assert(OperIs(GT_ASG) || OperIsStore());
     return OperIs(GT_ASG) ? gtGetOp1() : this;

--- a/src/coreclr/jit/helperexpansion.cpp
+++ b/src/coreclr/jit/helperexpansion.cpp
@@ -186,15 +186,10 @@ bool Compiler::fgExpandRuntimeLookupsForCall(BasicBlock** pBlock, Statement* stm
 
     // Mostly for Tier0: if the current statement is ASG(LCL, RuntimeLookup)
     // we can drop it and use that LCL as the destination
-    if (stmt->GetRootNode()->OperIs(GT_ASG))
+    if (stmt->GetRootNode()->OperIs(GT_STORE_LCL_VAR) && (stmt->GetRootNode()->AsLclVar()->Data() == *callUse))
     {
-        GenTree* lhs = stmt->GetRootNode()->gtGetOp1();
-        GenTree* rhs = stmt->GetRootNode()->gtGetOp2();
-        if (lhs->OperIs(GT_LCL_VAR) && rhs == *callUse)
-        {
-            rtLookupLcl = gtClone(lhs)->AsLclVar();
-            fgRemoveStmt(block, stmt);
-        }
+        rtLookupLcl = gtNewLclVarNode(stmt->GetRootNode()->AsLclVar()->GetLclNum());
+        fgRemoveStmt(block, stmt);
     }
 
     // Grab a temp to store result (it's assigned from either fastPathBb or fallbackBb)
@@ -285,12 +280,12 @@ bool Compiler::fgExpandRuntimeLookupsForCall(BasicBlock** pBlock, Statement* stm
         fgNewBBFromTreeAfter(BBJ_COND, prevBb, gtNewOperNode(GT_JTRUE, TYP_VOID, nullcheckOp), debugInfo);
 
     // Fallback basic block
-    GenTree*    asgFallbackValue = gtNewAssignNode(gtClone(rtLookupLcl), call);
-    BasicBlock* fallbackBb       = fgNewBBFromTreeAfter(BBJ_NONE, nullcheckBb, asgFallbackValue, debugInfo, true);
+    GenTree*    fallbackValueDef = gtNewStoreLclVarNode(rtLookupLcl->GetLclNum(), call);
+    BasicBlock* fallbackBb       = fgNewBBFromTreeAfter(BBJ_NONE, nullcheckBb, fallbackValueDef, debugInfo, true);
 
     // Fast-path basic block
-    GenTree*    asgFastpathValue = gtNewAssignNode(gtClone(rtLookupLcl), fastPathValueClone);
-    BasicBlock* fastPathBb       = fgNewBBFromTreeAfter(BBJ_ALWAYS, nullcheckBb, asgFastpathValue, debugInfo);
+    GenTree*    fastpathValueDef = gtNewStoreLclVarNode(rtLookupLcl->GetLclNum(), fastPathValueClone);
+    BasicBlock* fastPathBb       = fgNewBBFromTreeAfter(BBJ_ALWAYS, nullcheckBb, fastpathValueDef, debugInfo);
 
     BasicBlock* sizeCheckBb = nullptr;
     if (needsSizeCheck)
@@ -565,15 +560,14 @@ bool Compiler::fgExpandThreadLocalAccessForCall(BasicBlock** pBlock, Statement* 
     // Cache the tls value
     unsigned tlsLclNum         = lvaGrabTemp(true DEBUGARG("TLS access"));
     lvaTable[tlsLclNum].lvType = TYP_I_IMPL;
-    GenTree* defTlsLclValue    = gtNewLclvNode(tlsLclNum, TYP_I_IMPL);
-    GenTree* useTlsLclValue    = gtCloneExpr(defTlsLclValue); // Create a use for tlsLclValue
-    GenTree* asgTlsValue       = gtNewAssignNode(defTlsLclValue, tlsValue);
+    GenTree* tlsValueDef       = gtNewStoreLclVarNode(tlsLclNum, tlsValue);
+    GenTree* tlsLclValueUse    = gtNewLclVarNode(tlsLclNum);
 
     // Create tree for "maxThreadStaticBlocks = tls[offsetOfMaxThreadStaticBlocks]"
     GenTree* offsetOfMaxThreadStaticBlocks =
         gtNewIconNode(threadStaticBlocksInfo.offsetOfMaxThreadStaticBlocks, TYP_I_IMPL);
     GenTree* maxThreadStaticBlocksRef =
-        gtNewOperNode(GT_ADD, TYP_I_IMPL, gtCloneExpr(useTlsLclValue), offsetOfMaxThreadStaticBlocks);
+        gtNewOperNode(GT_ADD, TYP_I_IMPL, gtCloneExpr(tlsLclValueUse), offsetOfMaxThreadStaticBlocks);
     GenTree* maxThreadStaticBlocksValue =
         gtNewIndir(TYP_INT, maxThreadStaticBlocksRef, GTF_IND_NONFAULTING | GTF_IND_INVARIANT);
 
@@ -585,7 +579,7 @@ bool Compiler::fgExpandThreadLocalAccessForCall(BasicBlock** pBlock, Statement* 
     // Create tree for "threadStaticBlockBase = tls[offsetOfThreadStaticBlocks]"
     GenTree* offsetOfThreadStaticBlocks = gtNewIconNode(threadStaticBlocksInfo.offsetOfThreadStaticBlocks, TYP_I_IMPL);
     GenTree* threadStaticBlocksRef =
-        gtNewOperNode(GT_ADD, TYP_I_IMPL, gtCloneExpr(useTlsLclValue), offsetOfThreadStaticBlocks);
+        gtNewOperNode(GT_ADD, TYP_I_IMPL, gtCloneExpr(tlsLclValueUse), offsetOfThreadStaticBlocks);
     GenTree* threadStaticBlocksValue =
         gtNewIndir(TYP_I_IMPL, threadStaticBlocksRef, GTF_IND_NONFAULTING | GTF_IND_INVARIANT);
 
@@ -599,14 +593,13 @@ bool Compiler::fgExpandThreadLocalAccessForCall(BasicBlock** pBlock, Statement* 
     // Cache the threadStaticBlock value
     unsigned threadStaticBlockBaseLclNum         = lvaGrabTemp(true DEBUGARG("ThreadStaticBlockBase access"));
     lvaTable[threadStaticBlockBaseLclNum].lvType = TYP_I_IMPL;
-    GenTree* defThreadStaticBlockBaseLclValue    = gtNewLclvNode(threadStaticBlockBaseLclNum, TYP_I_IMPL);
-    GenTree* useThreadStaticBlockBaseLclValue =
-        gtCloneExpr(defThreadStaticBlockBaseLclValue); // StaticBlockBaseLclValue that will be used
-    GenTree* asgThreadStaticBlockBase = gtNewAssignNode(defThreadStaticBlockBaseLclValue, typeThreadStaticBlockValue);
+    GenTree* threadStaticBlockBaseDef =
+        gtNewStoreLclVarNode(threadStaticBlockBaseLclNum, typeThreadStaticBlockValue);
+    GenTree* threadStaticBlockBaseLclValueUse = gtNewLclVarNode(threadStaticBlockBaseLclNum);
 
     // Create tree for "if (threadStaticBlockValue != nullptr)"
     GenTree* threadStaticBlockNullCond =
-        gtNewOperNode(GT_NE, TYP_INT, useThreadStaticBlockBaseLclValue, gtNewIconNode(0, TYP_I_IMPL));
+        gtNewOperNode(GT_NE, TYP_INT, threadStaticBlockBaseLclValueUse, gtNewIconNode(0, TYP_I_IMPL));
     threadStaticBlockNullCond = gtNewOperNode(GT_JTRUE, TYP_VOID, threadStaticBlockNullCond);
 
     // prevBb (BBJ_NONE):                                               [weight: 1.0]
@@ -633,26 +626,26 @@ bool Compiler::fgExpandThreadLocalAccessForCall(BasicBlock** pBlock, Statement* 
     //      use(threadStaticBlockBase);
 
     // maxThreadStaticBlocksCondBB
-    BasicBlock* maxThreadStaticBlocksCondBB = fgNewBBFromTreeAfter(BBJ_COND, prevBb, asgTlsValue, debugInfo);
+    BasicBlock* maxThreadStaticBlocksCondBB = fgNewBBFromTreeAfter(BBJ_COND, prevBb, tlsValueDef, debugInfo);
 
     fgInsertStmtAfter(maxThreadStaticBlocksCondBB, maxThreadStaticBlocksCondBB->firstStmt(),
                       fgNewStmtFromTree(maxThreadStaticBlocksCond));
 
     // threadStaticBlockNullCondBB
     BasicBlock* threadStaticBlockNullCondBB =
-        fgNewBBFromTreeAfter(BBJ_COND, maxThreadStaticBlocksCondBB, asgThreadStaticBlockBase, debugInfo);
+        fgNewBBFromTreeAfter(BBJ_COND, maxThreadStaticBlocksCondBB, threadStaticBlockBaseDef, debugInfo);
     fgInsertStmtAfter(threadStaticBlockNullCondBB, threadStaticBlockNullCondBB->firstStmt(),
                       fgNewStmtFromTree(threadStaticBlockNullCond));
 
     // fallbackBb
-    GenTree*    asgFallbackValue = gtNewAssignNode(gtClone(threadStaticBlockLcl), call);
+    GenTree*    fallbackValueDef = gtNewStoreLclVarNode(threadStaticBlockLclNum, call);
     BasicBlock* fallbackBb =
-        fgNewBBFromTreeAfter(BBJ_ALWAYS, threadStaticBlockNullCondBB, asgFallbackValue, debugInfo, true);
+        fgNewBBFromTreeAfter(BBJ_ALWAYS, threadStaticBlockNullCondBB, fallbackValueDef, debugInfo, true);
 
     // fastPathBb
-    GenTree* asgFastPathValue =
-        gtNewAssignNode(gtClone(threadStaticBlockLcl), gtCloneExpr(useThreadStaticBlockBaseLclValue));
-    BasicBlock* fastPathBb = fgNewBBFromTreeAfter(BBJ_ALWAYS, fallbackBb, asgFastPathValue, debugInfo, true);
+    GenTree* fastPathValueDef =
+        gtNewStoreLclVarNode(threadStaticBlockLclNum, gtCloneExpr(threadStaticBlockBaseLclValueUse));
+    BasicBlock* fastPathBb = fgNewBBFromTreeAfter(BBJ_ALWAYS, fallbackBb, fastPathValueDef, debugInfo, true);
 
     //
     // Update preds in all new blocks

--- a/src/coreclr/jit/helperexpansion.cpp
+++ b/src/coreclr/jit/helperexpansion.cpp
@@ -593,8 +593,7 @@ bool Compiler::fgExpandThreadLocalAccessForCall(BasicBlock** pBlock, Statement* 
     // Cache the threadStaticBlock value
     unsigned threadStaticBlockBaseLclNum         = lvaGrabTemp(true DEBUGARG("ThreadStaticBlockBase access"));
     lvaTable[threadStaticBlockBaseLclNum].lvType = TYP_I_IMPL;
-    GenTree* threadStaticBlockBaseDef =
-        gtNewStoreLclVarNode(threadStaticBlockBaseLclNum, typeThreadStaticBlockValue);
+    GenTree* threadStaticBlockBaseDef = gtNewStoreLclVarNode(threadStaticBlockBaseLclNum, typeThreadStaticBlockValue);
     GenTree* threadStaticBlockBaseLclValueUse = gtNewLclVarNode(threadStaticBlockBaseLclNum);
 
     // Create tree for "if (threadStaticBlockValue != nullptr)"

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -8264,8 +8264,6 @@ void Lowering::TryRetypingFloatingPointStoreToIntegerStore(GenTree* store)
             if (store->OperIs(GT_STORE_LCL_VAR))
             {
                 store->SetOper(GT_STORE_LCL_FLD);
-                store->AsLclFld()->SetLclOffs(0);
-                store->AsLclFld()->SetLayout(nullptr);
             }
             store->ChangeType(type);
         }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -7909,32 +7909,28 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
 
             // Either or both of the array and index arguments may have been spilled to temps by `fgMorphArgs`. Copy
             // the spill trees as well if necessary.
-            GenTreeOp* argSetup = nullptr;
+            GenTree* argSetup = nullptr;
             for (CallArg& arg : call->gtArgs.EarlyArgs())
             {
-                GenTree* const argNode = arg.GetEarlyNode();
-                if (argNode->OperGet() != GT_ASG)
+                if (arg.GetLateNode() == nullptr)
                 {
                     continue;
                 }
 
-                assert(argNode != arr);
-                assert(argNode != index);
+                GenTree* const setupArgNode = arg.GetEarlyNode();
+                assert((setupArgNode != arr) && (setupArgNode != index));
 
-                GenTree* op1 = argSetup;
-                if (op1 == nullptr)
+                if (argSetup == nullptr)
                 {
-                    op1 = gtNewNothingNode();
+                    argSetup = setupArgNode;
+                }
+                else
+                {
+                    argSetup = new (this, GT_COMMA) GenTreeOp(GT_COMMA, TYP_VOID, argSetup, setupArgNode);
 #if DEBUG
-                    op1->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
+                    argSetup->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
 #endif // DEBUG
                 }
-
-                argSetup = new (this, GT_COMMA) GenTreeOp(GT_COMMA, TYP_VOID, op1, argNode);
-
-#if DEBUG
-                argSetup->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
-#endif // DEBUG
             }
 
 #ifdef DEBUG
@@ -7948,11 +7944,18 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
             fgWalkTreePost(&value, resetMorphedFlag);
 #endif // DEBUG
 
-            GenTree* const arrIndexAddr = gtNewArrayIndexAddr(arr, index, TYP_REF, NO_CLASS_HANDLE);
-            GenTree* const arrIndex     = gtNewIndexIndir(arrIndexAddr->AsIndexAddr());
-            GenTree* const arrStore     = gtNewAssignNode(arrIndex, value);
+            GenTree* indexAddr = gtNewArrayIndexAddr(arr, index, TYP_REF, NO_CLASS_HANDLE);
+            GenTree* store;
+            if (compAssignmentRationalized)
+            {
+                store = gtNewStoreIndNode(TYP_REF, indexAddr, value);
+            }
+            else
+            {
+                store = gtNewAssignNode(gtNewIndir(TYP_REF, indexAddr), value);
+            }
 
-            GenTree* result = fgMorphTree(arrStore);
+            GenTree* result = fgMorphTree(store);
             if (argSetup != nullptr)
             {
                 result = new (this, GT_COMMA) GenTreeOp(GT_COMMA, TYP_VOID, argSetup, result);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11665,6 +11665,10 @@ GenTree* Compiler::fgMorphSmpOpOptional(GenTreeOp* tree, bool* optAssertionPropD
     switch (oper)
     {
         case GT_ASG:
+        case GT_STOREIND:
+        case GT_STORE_BLK:
+        case GT_STORE_LCL_VAR:
+        case GT_STORE_LCL_FLD:
             // Make sure we're allowed to do this.
             if (optValnumCSE_phase)
             {
@@ -11690,6 +11694,11 @@ GenTree* Compiler::fgMorphSmpOpOptional(GenTreeOp* tree, bool* optAssertionPropD
                 {
                     return fgMorphInitBlock(tree);
                 }
+            }
+
+            if (!tree->OperIs(GT_ASG))
+            {
+                break;
             }
 
             if (typ == TYP_LONG)

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -1552,7 +1552,7 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
 
         if (addrSpillStore != nullptr)
         {
-            result       = m_comp->gtNewOperNode(GT_COMMA, TYP_VOID, addrSpillStore, storeOneFld);
+            result         = m_comp->gtNewOperNode(GT_COMMA, TYP_VOID, addrSpillStore, storeOneFld);
             addrSpillStore = nullptr;
         }
         else if (result != nullptr)

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -9,7 +9,7 @@ public:
     static GenTree* MorphInitBlock(Compiler* comp, GenTree* tree);
 
 protected:
-    MorphInitBlockHelper(Compiler* comp, GenTree* asg, bool initBlock);
+    MorphInitBlockHelper(Compiler* comp, GenTree* store, bool initBlock);
 
     GenTree* Morph();
 
@@ -36,9 +36,9 @@ protected:
     Compiler* m_comp;
     bool      m_initBlock;
 
-    GenTreeOp* m_asg = nullptr;
-    GenTree*   m_dst = nullptr;
-    GenTree*   m_src = nullptr;
+    GenTree* m_asg = nullptr;
+    GenTree* m_dst = nullptr;
+    GenTree* m_src = nullptr;
 
     unsigned             m_blockSize          = 0;
     ClassLayout*         m_blockLayout        = nullptr;
@@ -93,21 +93,12 @@ GenTree* MorphInitBlockHelper::MorphInitBlock(Compiler* comp, GenTree* tree)
 // Notes:
 //    Most class members are initialized via in-class member initializers.
 //
-MorphInitBlockHelper::MorphInitBlockHelper(Compiler* comp, GenTree* asg, bool initBlock = true)
+MorphInitBlockHelper::MorphInitBlockHelper(Compiler* comp, GenTree* store, bool initBlock = true)
     : m_comp(comp), m_initBlock(initBlock)
 {
-    assert(asg->OperIs(GT_ASG));
-#if defined(DEBUG)
-    if (m_initBlock)
-    {
-        assert(asg->OperIsInitBlkOp());
-    }
-    else
-    {
-        assert(asg->OperIsCopyBlkOp());
-    }
-#endif // DEBUG
-    m_asg = asg->AsOp();
+    assert(store->OperIs(GT_ASG) || store->OperIsStore());
+    assert((m_initBlock == store->OperIsInitBlkOp()) && (!m_initBlock == store->OperIsCopyBlkOp()));
+    m_asg = store;
 }
 
 //------------------------------------------------------------------------
@@ -188,15 +179,16 @@ GenTree* MorphInitBlockHelper::Morph()
 //
 void MorphInitBlockHelper::PrepareDst()
 {
-    m_dst = m_asg->gtGetOp1();
+    m_dst = m_asg->GetStoreDestination();
 
     // Commas cannot be destinations.
     assert(!m_dst->OperIs(GT_COMMA));
 
+    // TODO-ASG: delete this retyping.
     if (m_asg->TypeGet() != m_dst->TypeGet())
     {
-        assert(!m_initBlock && "the asg type should be final for an init block.");
-        JITDUMP("changing type of assignment from %-6s to %-6s\n", varTypeName(m_asg->TypeGet()),
+        assert(!m_initBlock && "the store type should be final for an init block.");
+        JITDUMP("changing type of store from %-6s to %-6s\n", varTypeName(m_asg->TypeGet()),
                 varTypeName(m_dst->TypeGet()));
 
         m_asg->ChangeType(m_dst->TypeGet());
@@ -218,7 +210,7 @@ void MorphInitBlockHelper::PrepareDst()
     else
     {
         assert(m_dst == m_dst->gtEffectiveVal() && "the commas were skipped in MorphBlock");
-        assert(m_dst->OperIs(GT_IND, GT_BLK) && (!m_dst->OperIs(GT_IND) || !m_dst->TypeIs(TYP_STRUCT)));
+        assert(m_dst->OperIsIndir() && (!m_dst->isIndir() || !m_dst->TypeIs(TYP_STRUCT)));
     }
 
     if (m_dst->TypeIs(TYP_STRUCT))
@@ -290,7 +282,7 @@ void MorphInitBlockHelper::PropagateExpansionAssertions()
 //
 void MorphInitBlockHelper::PrepareSrc()
 {
-    m_src = m_asg->gtGetOp2();
+    m_src = m_asg->Data();
 }
 
 //------------------------------------------------------------------------
@@ -330,7 +322,8 @@ void MorphInitBlockHelper::MorphStructCases()
 
         if (m_dstVarDsc != nullptr)
         {
-            if (m_dst->OperIs(GT_LCL_FLD))
+            // TODO-ASG: delete the GT_LCL_FLD check on "m_dst".
+            if (m_dst->OperIs(GT_LCL_FLD, GT_STORE_LCL_FLD))
             {
                 m_comp->lvaSetVarDoNotEnregister(m_dstLclNum DEBUGARG(DoNotEnregisterReason::LocalField));
             }
@@ -454,7 +447,6 @@ void MorphInitBlockHelper::TryInitFieldByField()
 
         LclVarDsc* fieldDesc = m_comp->lvaGetDesc(fieldLclNum);
         var_types  fieldType = fieldDesc->TypeGet();
-        GenTree*   dest      = m_comp->gtNewLclvNode(fieldLclNum, fieldType);
 
         GenTree* src;
         switch (fieldType)
@@ -470,7 +462,7 @@ void MorphInitBlockHelper::TryInitFieldByField()
                 FALLTHROUGH;
             case TYP_INT:
             {
-                int64_t mask = (int64_t(1) << (genTypeSize(dest->TypeGet()) * 8)) - 1;
+                int64_t mask = (int64_t(1) << (genTypeSize(fieldType) * 8)) - 1;
                 src          = m_comp->gtNewIconNode(static_cast<int32_t>(initPattern & mask));
                 break;
             }
@@ -508,20 +500,20 @@ void MorphInitBlockHelper::TryInitFieldByField()
                 unreached();
         }
 
-        GenTree* asg = m_comp->gtNewAssignNode(dest, src);
+        GenTree* store = m_comp->gtNewTempAssign(fieldLclNum, src);
 
         if (m_comp->optLocalAssertionProp)
         {
-            m_comp->optAssertionGen(asg);
+            m_comp->optAssertionGen(store);
         }
 
         if (tree != nullptr)
         {
-            tree = m_comp->gtNewOperNode(GT_COMMA, TYP_VOID, tree, asg);
+            tree = m_comp->gtNewOperNode(GT_COMMA, TYP_VOID, tree, store);
         }
         else
         {
-            tree = asg;
+            tree = store;
         }
     }
 
@@ -556,14 +548,25 @@ void MorphInitBlockHelper::TryPrimitiveInit()
             m_src->BashToZeroConst(lclVarType);
         }
 
-        m_dst->ChangeType(m_dstVarDsc->lvNormalizeOnLoad() ? lclVarType : genActualType(lclVarType));
-        m_dst->ChangeOper(GT_LCL_VAR);
-        m_dst->AsLclVar()->SetLclNum(m_dstLclNum);
-        m_dst->gtFlags |= GTF_VAR_DEF;
+        if (m_asg->OperIs(GT_ASG))
+        {
+            m_dst->ChangeType(m_dstVarDsc->lvNormalizeOnLoad() ? lclVarType : genActualType(lclVarType));
+            m_dst->ChangeOper(GT_LCL_VAR);
+            m_dst->AsLclVar()->SetLclNum(m_dstLclNum);
+            m_dst->gtFlags |= GTF_VAR_DEF;
 
-        m_asg->ChangeType(m_dst->TypeGet());
-        m_asg->gtOp1             = m_dst;
-        m_asg->gtOp2             = m_src;
+            m_asg->ChangeType(m_dst->TypeGet());
+            m_asg->gtOp1             = m_dst;
+            m_asg->gtOp2             = m_src;
+        }
+        else
+        {
+            m_asg->ChangeType(m_dstVarDsc->lvNormalizeOnLoad() ? lclVarType : genActualType(lclVarType));
+            m_asg->ChangeOper(GT_STORE_LCL_VAR);
+            m_asg->AsLclVar()->SetLclNum(m_dstLclNum);
+            m_asg->gtFlags |= GTF_VAR_DEF;
+        }
+
         m_result                 = m_asg;
         m_transformationDecision = BlockTransformation::OneAsgBlock;
     }
@@ -586,41 +589,41 @@ void MorphInitBlockHelper::TryPrimitiveInit()
 //   We have a tree like the following (note that location-valued commas are
 //   illegal, so there cannot be a comma on the left):
 //
-//            ASG
-//          /     \.
-//        IND   COMMA
-//         |      /  \.
-//         B     C    D
+//            ASG               STOREIND
+//          /     \             /      \.
+//        IND   COMMA    or    B      COMMA
+//         |      /  \                 /  \.
+//         B     C    D               C    D
 //
-//   We'd like downstream code to just see and be expand ASG(IND(B), D).
+//   We'd like downstream code to just see and expand ASG(IND(B), D).
 //   We will produce:
 //
-//       COMMA
-//       /   \.
-//     ASG   COMMA
-//    /  \    /  \.
-//   tmp  B  C   ASG
-//              /  \.
-//            IND   D
+//       COMMA                                  COMMA
+//       /   \.                               /       \.
+//     ASG   COMMA             STORE_LCL_VAR<tmp>    COMMA
+//    /  \    /  \.      or           /              /   \.
+//   tmp  B  C   ASG                 B              C  STOREIND
+//              /  \.                                   /  \.
+//            IND   D                                 tmp   D
 //             |
 //            tmp
 //
-//   If the ASG has GTF_REVERSE_OPS then we will produce:
+//   If the store has GTF_REVERSE_OPS then we will produce:
 //
-//      COMMA
-//      /   \.
-//     C    ASG
-//         /  \.
-//       IND   D
+//      COMMA                   COMMA
+//      /   \.                  /   \.
+//     C    ASG          or    C   STOREIND
+//         /  \.                    /  \.
+//       IND   D                   B    D
 //        |
 //        B
 //
 //   While keeping the GTF_REVERSE_OPS.
 //
 //   Note that the final resulting tree is created in the caller since it also
-//   needs to propagate side effect flags from the decomposed assignment to all
-//   the created commas. Therefore this function just returns a linked list of
-//   the side effects to be used for that purpose.
+//   needs to propagate side effect flags from the decomposed store to all the
+//   created commas. Therefore this function just returns a linked list of the
+//   side effects to be used for that purpose.
 //
 GenTree* MorphInitBlockHelper::EliminateCommas(GenTree** commaPool)
 {
@@ -638,44 +641,43 @@ GenTree* MorphInitBlockHelper::EliminateCommas(GenTree** commaPool)
         *commaPool    = comma;
     };
 
-    GenTree* lhs = m_asg->gtGetOp1();
-    assert(lhs->OperIsIndir() || lhs->OperIsLocal());
-
-    GenTree* rhs = m_asg->gtGetOp2();
+    GenTree* dst = m_asg->GetStoreDestination();
+    GenTree* src = m_asg->Data();
+    assert(dst->OperIsIndir() || dst->OperIsLocal());
 
     if (m_asg->IsReverseOp())
     {
-        while (rhs->OperIs(GT_COMMA))
+        while (src->OperIs(GT_COMMA))
         {
-            addComma(rhs);
-            rhs = rhs->gtGetOp2();
+            addComma(src);
+            src = src->gtGetOp2();
         }
     }
     else
     {
-        if (lhs->OperIsIndir() && rhs->OperIs(GT_COMMA))
+        if (dst->OperIsIndir() && src->OperIs(GT_COMMA))
         {
-            GenTree* addr = lhs->gtGetOp1();
-            if (((addr->gtFlags & GTF_ALL_EFFECT) != 0) || (((rhs->gtFlags & GTF_ASG) != 0) && !addr->IsInvariant()))
+            GenTree* addr = dst->AsIndir()->Addr();
+            if (((addr->gtFlags & GTF_ALL_EFFECT) != 0) || (((src->gtFlags & GTF_ASG) != 0) && !addr->IsInvariant()))
             {
                 unsigned lhsAddrLclNum = m_comp->lvaGrabTemp(true DEBUGARG("Block morph LHS addr"));
 
                 addSideEffect(m_comp->gtNewTempAssign(lhsAddrLclNum, addr));
-                lhs->AsUnOp()->gtOp1 = m_comp->gtNewLclvNode(lhsAddrLclNum, genActualType(addr));
-                m_comp->gtUpdateNodeSideEffects(lhs);
+                dst->AsUnOp()->gtOp1 = m_comp->gtNewLclvNode(lhsAddrLclNum, genActualType(addr));
+                m_comp->gtUpdateNodeSideEffects(dst);
             }
         }
 
-        while (rhs->OperIs(GT_COMMA))
+        while (src->OperIs(GT_COMMA))
         {
-            addComma(rhs);
-            rhs = rhs->gtGetOp2();
+            addComma(src);
+            src = src->gtGetOp2();
         }
     }
 
     if (sideEffects != nullptr)
     {
-        m_asg->gtOp2 = rhs;
+        m_asg->Data() = src;
         m_comp->gtUpdateNodeSideEffects(m_asg);
     }
 
@@ -752,7 +754,7 @@ MorphCopyBlockHelper::MorphCopyBlockHelper(Compiler* comp, GenTree* asg) : Morph
 //
 void MorphCopyBlockHelper::PrepareSrc()
 {
-    m_src = m_asg->gtGetOp2();
+    m_src = m_asg->Data();
 
     if (m_src->IsLocal())
     {
@@ -762,7 +764,7 @@ void MorphCopyBlockHelper::PrepareSrc()
         m_srcVarDsc    = m_comp->lvaGetDesc(m_srcLclNum);
     }
 
-    // Verify that the types on the LHS and RHS match.
+    // Verify that the types of the store and data match.
     assert(m_dst->TypeGet() == m_src->TypeGet());
     if (m_dst->TypeIs(TYP_STRUCT))
     {
@@ -777,7 +779,7 @@ void MorphCopyBlockHelper::TrySpecialCases()
 {
     if (m_src->IsMultiRegNode())
     {
-        assert(m_dst->OperIs(GT_LCL_VAR));
+        assert(m_dst->OperIsScalarLocal());
 
         m_dstVarDsc->lvIsMultiRegRet = true;
 
@@ -785,7 +787,7 @@ void MorphCopyBlockHelper::TrySpecialCases()
         m_transformationDecision = BlockTransformation::SkipMultiRegSrc;
         m_result                 = m_asg;
     }
-    else if (m_src->IsCall() && m_dst->OperIs(GT_LCL_VAR) && m_dstVarDsc->CanBeReplacedWithItsField(m_comp))
+    else if (m_src->IsCall() && m_dst->OperIsScalarLocal() && m_dstVarDsc->CanBeReplacedWithItsField(m_comp))
     {
         JITDUMP("Not morphing a single reg call return\n");
         m_transformationDecision = BlockTransformation::SkipSingleRegCallSrc;
@@ -863,7 +865,8 @@ void MorphCopyBlockHelper::MorphStructCases()
 
     // If either src or dest is a reg-sized non-field-addressed struct, keep the copyBlock;
     // this will avoid having to DNER the enregisterable local when creating LCL_FLD nodes.
-    if ((m_dst->OperIs(GT_LCL_VAR) && m_dstVarDsc->lvRegStruct) ||
+    // TODO-ASG: delete the GT_LCL_VAR check on "m_dst".
+    if ((m_dst->OperIs(GT_STORE_LCL_VAR, GT_LCL_VAR) && m_dstVarDsc->lvRegStruct) ||
         (m_src->OperIs(GT_LCL_VAR) && m_srcVarDsc->lvRegStruct))
     {
         requiresCopyBlock = true;
@@ -1065,7 +1068,8 @@ void MorphCopyBlockHelper::MorphStructCases()
     //
     if (!m_dstDoFldAsg && (m_dstVarDsc != nullptr) && !m_dstSingleLclVarAsg)
     {
-        if (m_dst->OperIs(GT_LCL_FLD))
+        // TODO-ASG: delete the GT_LCL_FLD check on "m_dst".
+        if (m_dst->OperIs(GT_LCL_FLD, GT_STORE_LCL_FLD))
         {
             m_comp->lvaSetVarDoNotEnregister(m_dstLclNum DEBUGARG(DoNotEnregisterReason::LocalField));
         }
@@ -1107,10 +1111,10 @@ void MorphCopyBlockHelper::TryPrimitiveCopy()
     }
 
     var_types asgType = TYP_UNDEF;
-    assert((m_src == m_src->gtEffectiveVal()) && (m_dst == m_dst->gtEffectiveVal()));
 
     // Can we use the LHS local directly?
-    if (m_dst->OperIs(GT_LCL_FLD))
+    // TODO-ASG: delete the GT_LCL_FLD check on "m_dst".
+    if (m_dst->OperIs(GT_LCL_FLD, GT_STORE_LCL_FLD))
     {
         if (m_blockSize == genTypeSize(m_dstVarDsc))
         {
@@ -1139,30 +1143,31 @@ void MorphCopyBlockHelper::TryPrimitiveCopy()
         return;
     }
 
-    auto doRetypeNode = [asgType](GenTree* op, LclVarDsc* varDsc) {
+    auto doRetypeNode = [asgType](GenTree* op, LclVarDsc* varDsc, bool isUse) {
         if (op->OperIsIndir())
         {
-            op->SetOper(GT_IND);
+            op->SetOper(isUse ? GT_IND : GT_STOREIND);
             op->ChangeType(asgType);
         }
         else if (varDsc->TypeGet() == asgType)
         {
-            op->SetOper(GT_LCL_VAR);
+            op->SetOper(isUse ? GT_LCL_VAR : GT_STORE_LCL_VAR);
             op->ChangeType(varDsc->lvNormalizeOnLoad() ? varDsc->TypeGet() : genActualType(varDsc));
             op->gtFlags &= ~GTF_VAR_USEASG;
         }
         else
         {
-            if (op->OperIs(GT_LCL_VAR))
+            if (op->OperIsScalarLocal())
             {
-                op->SetOper(GT_LCL_FLD);
+                op->SetOper(isUse ? GT_LCL_FLD : GT_STORE_LCL_FLD);
             }
             op->ChangeType(asgType);
         }
     };
 
-    doRetypeNode(m_dst, m_dstVarDsc);
-    doRetypeNode(m_src, m_srcVarDsc);
+    doRetypeNode(m_dst, m_dstVarDsc, /* isUse */ m_asg->OperIs(GT_ASG));
+    doRetypeNode(m_src, m_srcVarDsc, /* isUse */ true);
+    // TODO-ASG: delete.
     m_asg->ChangeType(asgType);
 
     m_result                 = m_asg;
@@ -1184,7 +1189,7 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
     GenTree* addrSpill     = nullptr;
     unsigned addrSpillTemp = BAD_VAR_NUM;
 
-    GenTree* addrSpillAsg = nullptr;
+    GenTree* addrSpillStore = nullptr;
 
     unsigned fieldCnt = 0;
 
@@ -1290,15 +1295,13 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
         addrSpillTemp = m_comp->lvaGrabTemp(true DEBUGARG("BlockOp address local"));
 
         LclVarDsc* addrSpillDsc = m_comp->lvaGetDesc(addrSpillTemp);
-        addrSpillDsc->lvType    = TYP_BYREF;
-
-        GenTreeLclVar* addrSpillNode = m_comp->gtNewLclvNode(addrSpillTemp, TYP_BYREF);
-        addrSpillAsg                 = m_comp->gtNewAssignNode(addrSpillNode, addrSpill);
+        addrSpillDsc->lvType    = TYP_BYREF; // TODO-ASG: zero-diff quirk, delete.
+        addrSpillStore          = m_comp->gtNewTempAssign(addrSpillTemp, addrSpill);
     }
 
     // We may have allocated a temp above, and that may have caused the lvaTable to be expanded.
     // So, beyond this point we cannot rely on the old values of 'm_srcVarDsc' and 'm_dstVarDsc'.
-
+    bool useAsg = m_asg->OperIs(GT_ASG);
     for (unsigned i = 0; i < fieldCnt; ++i)
     {
         GenTree* dstFld;
@@ -1511,25 +1514,25 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
         assert(srcFld != nullptr);
         noway_assert(dstFld->TypeGet() == srcFld->TypeGet());
 
-        GenTreeOp* asgOneFld = m_comp->gtNewAssignNode(dstFld, srcFld);
+        GenTreeOp* storeOneFld = m_comp->gtNewAssignNode(dstFld, srcFld);
 
         if (m_comp->optLocalAssertionProp)
         {
-            m_comp->optAssertionGen(asgOneFld);
+            m_comp->optAssertionGen(storeOneFld);
         }
 
-        if (addrSpillAsg != nullptr)
+        if (addrSpillStore != nullptr)
         {
-            result       = m_comp->gtNewOperNode(GT_COMMA, TYP_VOID, addrSpillAsg, asgOneFld)->AsOp();
-            addrSpillAsg = nullptr;
+            result       = m_comp->gtNewOperNode(GT_COMMA, TYP_VOID, addrSpillStore, storeOneFld);
+            addrSpillStore = nullptr;
         }
         else if (result != nullptr)
         {
-            result = m_comp->gtNewOperNode(GT_COMMA, TYP_VOID, result, asgOneFld)->AsOp();
+            result = m_comp->gtNewOperNode(GT_COMMA, TYP_VOID, result, storeOneFld);
         }
         else
         {
-            result = asgOneFld;
+            result = storeOneFld;
         }
     }
 


### PR DESCRIPTION
And adapt more common code to work with store nodes, notably, block morphing and costing. The latter had to be refactored quite substantially to avoid regressing TP.