### PR TITLE
[release/6.0-staging] Skip DllImportSearchPathsTest on wasm

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2409,6 +2409,9 @@
         <ExcludeList Include = "$(XunitTestBinBase)/baseservices/threading/paramthreadstart/ThreadStartBool_1/**">
             <Issue>https://github.com/dotnet/runtime/issues/41193</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/DllImportSearchPaths/DllImportSearchPathsTest/**">
+            <Issue>Loads an assembly from file</Issue>
+        </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/Interop/NativeLibrary/Callback/CallbackStressTest_TargetUnix/**">
             <Issue>https://github.com/dotnet/runtime/issues/41519</Issue>
         </ExcludeList>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/84724

cc @carlossanlop 