### PR TITLE
Add `count` and `sum` to Histogram for System.Diagnostics.Metrics

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Aggregator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Aggregator.cs
@@ -30,12 +30,16 @@ namespace System.Diagnostics.Metrics
 
     internal sealed class HistogramStatistics : IAggregationStatistics
     {
-        internal HistogramStatistics(QuantileValue[] quantiles)
+        internal HistogramStatistics(QuantileValue[] quantiles, int count, double sum)
         {
             Quantiles = quantiles;
+            Count = count;
+            Sum = sum;
         }
 
         public QuantileValue[] Quantiles { get; }
+        public int Count { get; }
+        public double Sum { get; }
     }
 
     internal sealed class LabeledAggregationStatistics

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
@@ -118,12 +118,12 @@ namespace System.Diagnostics.Metrics
             WriteEvent(5, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, lastValue);
         }
 
-        [Event(6, Keywords = Keywords.TimeSeriesValues)]
+        [Event(6, Keywords = Keywords.TimeSeriesValues, Version=1)]
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
                             Justification = "This calls WriteEvent with all primitive arguments which is safe. Primitives are always serialized properly.")]
-        public void HistogramValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string quantiles)
+        public void HistogramValuePublished(string sessionId, string meterName, string? meterVersion, string instrumentName, string? unit, string tags, string quantiles, int count, double sum)
         {
-            WriteEvent(6, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, quantiles);
+            WriteEvent(6, sessionId, meterName, meterVersion ?? "", instrumentName, unit ?? "", tags, quantiles, count, sum);
         }
 
         // Sent when we begin to monitor the value of a intrument, either because new session filter arguments changed subscriptions
@@ -435,7 +435,7 @@ namespace System.Diagnostics.Metrics
                 }
                 else if (stats.AggregationStatistics is HistogramStatistics histogramStats)
                 {
-                    Log.HistogramValuePublished(sessionId, instrument.Meter.Name, instrument.Meter.Version, instrument.Name, instrument.Unit, FormatTags(stats.Labels), FormatQuantiles(histogramStats.Quantiles));
+                    Log.HistogramValuePublished(sessionId, instrument.Meter.Name, instrument.Meter.Version, instrument.Name, instrument.Unit, FormatTags(stats.Labels), FormatQuantiles(histogramStats.Quantiles), histogramStats.Count, histogramStats.Sum);
                 }
             }
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ExponentialHistogramTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ExponentialHistogramTests.cs
@@ -287,6 +287,8 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.Equal(1, stats.Quantiles.Length);
             Assert.Equal(0.5, stats.Quantiles[0].Quantile);
             Assert.Equal(-3, stats.Quantiles[0].Value);
+            Assert.Equal(5, stats.Count);
+            Assert.Equal(-15, stats.Sum);
         }
 
         [Fact]
@@ -306,6 +308,8 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.Equal(1, stats.Quantiles.Length);
             Assert.Equal(0.5, stats.Quantiles[0].Quantile);
             Assert.Equal(0, stats.Quantiles[0].Value);
+            Assert.Equal(5, stats.Count);
+            Assert.Equal(0, stats.Sum);
         }
 
         [Fact]
@@ -325,6 +329,8 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.Equal(1, stats.Quantiles.Length);
             Assert.Equal(0.5, stats.Quantiles[0].Quantile);
             Assert.Equal(-0.5, stats.Quantiles[0].Value);
+            Assert.Equal(5, stats.Count);
+            Assert.Equal(99825.1769, stats.Sum);
         }
 
         [Fact]
@@ -346,6 +352,26 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.Equal(100, stats.Quantiles[0].Value);
             Assert.Equal(1, stats.Quantiles[1].Quantile);
             Assert.Equal(100, stats.Quantiles[1].Value);
+            Assert.Equal(1, stats.Count);
+            Assert.Equal(100, stats.Sum);
+        }
+
+        [Fact]
+        public void FilterOnlyNaNAndInfinities()
+        {
+            QuantileAggregation quantiles = new QuantileAggregation(0, 1);
+            ExponentialHistogramAggregator aggregator = new ExponentialHistogramAggregator(quantiles);
+
+            aggregator.Update(double.NaN);
+            aggregator.Update(-double.NaN);
+            aggregator.Update(double.PositiveInfinity);
+            aggregator.Update(double.NegativeInfinity);
+            var stats = (HistogramStatistics)aggregator.Collect();
+
+            Assert.NotNull(stats);
+            Assert.Equal(0, stats.Quantiles.Length);
+            Assert.Equal(0, stats.Count);
+            Assert.Equal(0, stats.Sum);
         }
     }
 }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ExponentialHistogramTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ExponentialHistogramTests.cs
@@ -31,6 +31,8 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.Equal(3, stats.Quantiles[0].Value);
             Assert.Equal(0.95, stats.Quantiles[1].Quantile);
             Assert.Equal(5, stats.Quantiles[1].Value);
+            Assert.Equal(5, stats.Count);
+            Assert.Equal(15, stats.Sum);
         }
 
         [Fact]
@@ -49,6 +51,8 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.Equal(1, stats.Quantiles[0].Value);
             Assert.Equal(1.0, stats.Quantiles[1].Quantile);
             Assert.Equal(5, stats.Quantiles[1].Value);
+            Assert.Equal(5, stats.Count);
+            Assert.Equal(15, stats.Sum);
         }
 
         [Fact]
@@ -63,6 +67,8 @@ namespace System.Diagnostics.Metrics.Tests
             aggregator.Update(5);
             var stats = (HistogramStatistics)aggregator.Collect();
             Assert.Equal(0, stats.Quantiles.Length);
+            Assert.Equal(5, stats.Count);
+            Assert.Equal(15, stats.Sum);
         }
 
         [Fact]
@@ -81,6 +87,8 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.Equal(1, stats.Quantiles[0].Value);
             Assert.Equal(100, stats.Quantiles[1].Quantile);
             Assert.Equal(5, stats.Quantiles[1].Value);
+            Assert.Equal(5, stats.Count);
+            Assert.Equal(15, stats.Sum);
         }
 
         [Fact]
@@ -99,6 +107,8 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.Equal(1, stats.Quantiles[0].Value);
             Assert.Equal(0.9, stats.Quantiles[1].Quantile);
             Assert.Equal(5, stats.Quantiles[1].Value);
+            Assert.Equal(5, stats.Count);
+            Assert.Equal(15, stats.Sum);
         }
 
         [Fact]
@@ -121,6 +131,8 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.Equal(0.5, stats.Quantiles[0].Quantile);
             Assert.Equal(100, stats.Quantiles[0].Value);
             Assert.True(Math.Abs(100.01 - stats.Quantiles[0].Value) <= 100.01 * quantiles.MaxRelativeError);
+            Assert.Equal(10, stats.Count);
+            Assert.Equal(950.22, stats.Sum);
         }
 
         [Fact]
@@ -146,6 +158,8 @@ namespace System.Diagnostics.Metrics.Tests
             //At default error of 0.001 result of 100 would be acceptable, but with higher precision it is not
             Assert.True(100 < stats.Quantiles[0].Value);
             Assert.True(Math.Abs(100.01 - stats.Quantiles[0].Value) <= 100.01 * quantiles.MaxRelativeError);
+            Assert.Equal(10, stats.Count);
+            Assert.Equal(950.22, stats.Sum);
         }
 
         [Fact]
@@ -157,6 +171,8 @@ namespace System.Diagnostics.Metrics.Tests
 
             Assert.NotNull(stats);
             Assert.Equal(0, stats.Quantiles.Length);
+            Assert.Equal(0, stats.Count);
+            Assert.Equal(0, stats.Sum);
         }
 
         [Fact]
@@ -171,6 +187,8 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.Equal(1, stats.Quantiles.Length);
             Assert.Equal(0.5, stats.Quantiles[0].Quantile);
             Assert.Equal(99, stats.Quantiles[0].Value);
+            Assert.Equal(1, stats.Count);
+            Assert.Equal(99, stats.Sum);
         }
 
         [Fact]
@@ -188,6 +206,8 @@ namespace System.Diagnostics.Metrics.Tests
 
             Assert.NotNull(stats);
             Assert.Equal(0, stats.Quantiles.Length);
+            Assert.Equal(0, stats.Count);
+            Assert.Equal(0, stats.Sum);
         }
 
         [Fact]
@@ -198,6 +218,8 @@ namespace System.Diagnostics.Metrics.Tests
             var stats = (HistogramStatistics)aggregator.Collect();
             Assert.NotNull(stats);
             Assert.Equal(0, stats.Quantiles.Length);
+            Assert.Equal(0, stats.Count);
+            Assert.Equal(0, stats.Sum);
 
             aggregator.Update(1);
             aggregator.Update(2);
@@ -210,6 +232,8 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.Equal(1, stats.Quantiles.Length);
             Assert.Equal(0.5, stats.Quantiles[0].Quantile);
             Assert.Equal(3, stats.Quantiles[0].Value);
+            Assert.Equal(5, stats.Count);
+            Assert.Equal(15, stats.Sum);
         }
 
         [Fact]
@@ -228,6 +252,8 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.Equal(1, stats.Quantiles.Length);
             Assert.Equal(0.5, stats.Quantiles[0].Quantile);
             Assert.Equal(3, stats.Quantiles[0].Value);
+            Assert.Equal(5, stats.Count);
+            Assert.Equal(15, stats.Sum);
 
             aggregator.Update(9);
             aggregator.Update(8);
@@ -240,6 +266,8 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.Equal(1, stats.Quantiles.Length);
             Assert.Equal(0.5, stats.Quantiles[0].Quantile);
             Assert.Equal(7, stats.Quantiles[0].Value);
+            Assert.Equal(5, stats.Count);
+            Assert.Equal(35, stats.Sum);
         }
 
         [Fact]

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
@@ -59,7 +59,7 @@ namespace System.Diagnostics.Metrics.Tests
             AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
             AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("", "10"), ("7", "17"));
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "9", "18");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
             AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("-33", "-33"), ("-40", "-73"));
             AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "-11"), ("-11", "-22"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
@@ -100,7 +100,7 @@ namespace System.Diagnostics.Metrics.Tests
             AssertCounterEventsPresent(events, meter.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"));
             AssertCounterEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "", og.Unit, "9", "18", "27");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", h.Unit, "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
             AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, ("33", "33"), ("40", "73"));
             AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
@@ -155,7 +155,7 @@ namespace System.Diagnostics.Metrics.Tests
                 AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
                 AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("", "10"), ("7", "17"));
                 AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "9", "18");
-                AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
+                AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
                 AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("33", "33"), ("40", "73"));
                 AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "-11"), ("-11", "-22"));
                 AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
@@ -211,7 +211,7 @@ namespace System.Diagnostics.Metrics.Tests
             AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
             AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("", "10"), ("7", "17"));
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "9", "18");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
             AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("-33", "-33"), ("-40", "-73"));
             AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "11"), ("11", "22"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
@@ -287,8 +287,8 @@ namespace System.Diagnostics.Metrics.Tests
             AssertCounterEventsPresent(events, meter.Name, oc.Name, "Color=blue,Size=4", "", ("", "20"), ("14", "34"));
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "Color=red,Size=19", "", "9", "18");
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "Color=blue,Size=4", "", "18", "36");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Size=123", "", "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Size=124", "", "0.5=20;0.95=20;0.99=20", "0.5=27;0.95=27;0.99=27");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Size=123", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Size=124", "", ("0.5=20;0.95=20;0.99=20", "1", "20"), ("0.5=27;0.95=27;0.99=27", "1", "27"));
             AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "Color=red", "", ("-33", "-33"), ("40", "7"));
             AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "Color=blue", "", ("-34", "-34"), ("41", "7"));
             AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "Color=red,Size=19", "", ("", "-11"), ("-11", "-22"));
@@ -441,7 +441,7 @@ namespace System.Diagnostics.Metrics.Tests
             AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("0", "5"), ("12", "17"));
             AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("",  "17"), ("0", "17"), ("14", "31"), ("0", "31"));
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "18", "", "36", "");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", "0.5=19;0.95=19;0.99=19", "", "0.5=26;0.95=26;0.99=26", "");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("", "0", "0"), ("0.5=26;0.95=26;0.99=26", "1", "26"), ("", "0", "0"));
             AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("33", "33"), ("0", "33"), ("40", "73"));
             AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "22"), ("0", "22"), ("22", "44"), ("0", "44"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 5);
@@ -487,7 +487,7 @@ namespace System.Diagnostics.Metrics.Tests
             AssertCounterEventsPresent(events, meter.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"));
             AssertCounterEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "", og.Unit, "9", "18", "27");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", h.Unit, "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
             AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", udc.Unit, ("33", "33"), ("40", "73"));
             AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
@@ -535,7 +535,7 @@ namespace System.Diagnostics.Metrics.Tests
             AssertCounterEventsPresent(events, meterA.Name, c.Name, "", c.Unit, ("5", "5"), ("12", "17"));
             AssertCounterEventsPresent(events, meterA.Name, oc.Name, "", oc.Unit, ("", "10"), ("7", "17"), ("7", "24"));
             AssertGaugeEventsPresent(events, meterA.Name, og.Name, "", og.Unit, "9", "18", "27");
-            AssertHistogramEventsPresent(events, meterB.Name, h.Name, "", h.Unit, "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26", "0.5=21;0.95=21;0.99=21");
+            AssertHistogramEventsPresent(events, meterB.Name, h.Name, "", h.Unit, ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"), ("0.5=21;0.95=21;0.99=21", "1", "21"));
             AssertUpDownCounterEventsPresent(events, meterA.Name, udc.Name, "", udc.Unit, ("33", "33"), ("40", "73"));
             AssertUpDownCounterEventsPresent(events, meterA.Name, oudc.Name, "", oudc.Unit, ("", "11"), ("11", "22"), ("11", "33"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 4);
@@ -701,8 +701,8 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, h);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Color=red", "", "0.5=5;0.95=5;0.99=5", "0.5=12;0.95=12;0.99=12");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Color=blue", "", "0.5=6;0.95=6;0.99=6", "0.5=13;0.95=13;0.99=13");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Color=red", "", ("0.5=5;0.95=5;0.99=5", "1", "5"), ("0.5=12;0.95=12;0.99=12", "1", "12"));
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Color=blue", "", ("0.5=6;0.95=6;0.99=6", "1", "6"), ("0.5=13;0.95=13;0.99=13", "1", "13"));
             AssertHistogramLimitPresent(events);
             AssertHistogramEventsNotPresent(events, meter.Name, h.Name, "Color=green");
             AssertHistogramEventsNotPresent(events, meter.Name, h.Name, "Color=yellow");
@@ -771,7 +771,7 @@ namespace System.Diagnostics.Metrics.Tests
             AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
             AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("", "10"), ("7", "17"));
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "9", "18");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
             AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("33", "33"), ("40", "73"));
             AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "11"), ("11", "22"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
@@ -798,7 +798,7 @@ namespace System.Diagnostics.Metrics.Tests
             AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", ("5", "5"), ("12", "17"));
             AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", ("", "31"), ("7", "38"));
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "36", "45");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", ("0.5=19;0.95=19;0.99=19", "1", "19"), ("0.5=26;0.95=26;0.99=26", "1", "26"));
             AssertUpDownCounterEventsPresent(events, meter.Name, udc.Name, "", "", ("33", "33"), ("40", "73"));
             AssertUpDownCounterEventsPresent(events, meter.Name, oudc.Name, "", "", ("", "44"), ("11", "55"));
             AssertCollectStartStopEventsPresent(events, IntervalSecs, 3);
@@ -835,8 +835,8 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, h);
             AssertInitialEnumerationCompleteEventPresent(events);
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Color=red", "", "0.5=5;0.95=5;0.99=5", "0.5=12;0.95=12;0.99=12");
-            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Color=blue", "", "0.5=6;0.95=6;0.99=6", "0.5=13;0.95=13;0.99=13");
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Color=red", "", ("0.5=5;0.95=5;0.99=5", "1", "5"), ("0.5=12;0.95=12;0.99=12", "1", "12"));
+            AssertHistogramEventsPresent(events, meter.Name, h.Name, "Color=blue", "", ("0.5=6;0.95=6;0.99=6", "1", "6"), ("0.5=13;0.95=13;0.99=13", "1", "13"));
             AssertHistogramLimitPresent(events);
             AssertTimeSeriesLimitNotPresent(events);
             AssertHistogramEventsNotPresent(events, meter.Name, h.Name, "Color=green");
@@ -1016,7 +1016,7 @@ namespace System.Diagnostics.Metrics.Tests
         }
 
         private void AssertHistogramEventsPresent(EventWrittenEventArgs[] events, string meterName, string instrumentName, string tags,
-            string expectedUnit, params string[] expectedQuantiles)
+            string expectedUnit, params (string, string, string)[] expected)
         {
             var counterEvents = events.Where(e => e.EventName == "HistogramValuePublished").Select(e =>
                 new
@@ -1026,14 +1026,18 @@ namespace System.Diagnostics.Metrics.Tests
                     InstrumentName = e.Payload[3].ToString(),
                     Unit = e.Payload[4].ToString(),
                     Tags = e.Payload[5].ToString(),
-                    Quantiles = (string)e.Payload[6]
+                    Quantiles = (string)e.Payload[6],
+                    Count = e.Payload[7].ToString(),
+                    Sum = e.Payload[8].ToString()
                 }).ToArray();
             var filteredEvents = counterEvents.Where(e => e.MeterName == meterName && e.InstrumentName == instrumentName && e.Tags == tags).ToArray();
-            Assert.True(filteredEvents.Length >= expectedQuantiles.Length);
-            for (int i = 0; i < expectedQuantiles.Length; i++)
+            Assert.True(filteredEvents.Length >= expected.Length);
+            for (int i = 0; i < expected.Length; i++)
             {
                 Assert.Equal(filteredEvents[i].Unit, expectedUnit);
-                Assert.Equal(expectedQuantiles[i], filteredEvents[i].Quantiles);
+                Assert.Equal(expected[i].Item1, filteredEvents[i].Quantiles);
+                Assert.Equal(expected[i].Item2, filteredEvents[i].Count);
+                Assert.Equal(expected[i].Item3, filteredEvents[i].Sum);
             }
         }
 


### PR DESCRIPTION
For each collection, this publishes the count and sum in addition to the existing quantiles information. This will be consumed by `dotnet-monitor` and `dotnet-counters`. This also includes updates to the testing to check for the expected counts/sums.

@wiktork @noahfalk