### PR TITLE
Revert "[NativeAOT] Do not strip exported symbols from executables on Apple platforms (#85293)"

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -335,8 +335,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <PropertyGroup>
       <_IgnoreLinkerWarnings>false</_IgnoreLinkerWarnings>
       <_IgnoreLinkerWarnings Condition="'$(_IsApplePlatform)' == 'true'">true</_IgnoreLinkerWarnings>
-      <_StripFlag Condition="'$(_IsApplePlatform)' == 'true' and '$(NativeLib)' == 'Shared'">-x</_StripFlag> <!-- keep global symbols in dylib -->
-      <_StripFlag Condition="'$(_IsApplePlatform)' == 'true' and '$(NativeLib)' != 'Shared' and '$(IlcExportUnmanagedEntrypoints)' == 'true'">-i -s $(ExportsFile)</_StripFlag> <!-- keep global symbols when explicitly specified -->
+      <StripFlag Condition="'$(_IsApplePlatform)' == 'true' and '$(NativeLib)' == 'Shared'">-x</StripFlag> <!-- keep global symbols in dylib -->
     </PropertyGroup>
 
     <!-- write linker script for lld (13+) to retain the __modules section -->
@@ -363,7 +362,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <Exec Condition="'$(StripSymbols)' == 'true' and '$(_IsApplePlatform)' == 'true' and '$(NativeLib)' != 'Static'"
       Command="
         dsymutil $(DsymUtilOptions) &quot;$(NativeBinary)&quot; &amp;&amp;
-        strip -no_code_signature_warning $(_StripFlag) &quot;$(NativeBinary)&quot;" />
+        strip -no_code_signature_warning $(StripFlag) &quot;$(NativeBinary)&quot;" />
   </Target>
 
   <Target Name="CreateLib"

--- a/src/tests/nativeaot/GenerateUnmanagedEntryPoints/GenerateUnmanagedEntryPoints.csproj
+++ b/src/tests/nativeaot/GenerateUnmanagedEntryPoints/GenerateUnmanagedEntryPoints.csproj
@@ -4,6 +4,9 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IlcExportUnmanagedEntrypoints>true</IlcExportUnmanagedEntrypoints>
+    
+    <!-- Stripping symbols causes problems for running the test on macOS -->
+    <StripSymbols>false</StripSymbols>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This reverts commit 32ecd85d057f4c49e7972ee44c314e1ad7392192.