### PR TITLE
Fix typo in SafeHandle.cs

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeHandle.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeHandle.cs
@@ -256,7 +256,7 @@ namespace System.Runtime.InteropServices
 
             // If we get here we successfully decremented the ref count. Additionally we
             // may have decremented it to zero and set the handle state as closed. In
-            // this case (providng we own the handle) we will call the ReleaseHandle
+            // this case (providing we own the handle) we will call the ReleaseHandle
             // method on the SafeHandle subclass.
             if (performRelease)
             {


### PR DESCRIPTION
Fixes #85593 
Change `providng` to `providing` in a comment.