### PR TITLE
[JIT] X64 Fix - Handle 'imul' instruction variants to determine if a register was written to

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -662,6 +662,120 @@ bool emitter::emitIsInstrWritingToReg(instrDesc* id, regNumber reg)
         case INS_call:
             return true;
 
+        case INS_imul_AX:
+            if (reg == REG_RAX)
+            {
+                return true;
+            }
+            break;
+
+        case INS_imul_BP:
+            if (reg == REG_RBP)
+            {
+                return true;
+            }
+            break;
+
+        case INS_imul_BX:
+            if (reg == REG_RBX)
+            {
+                return true;
+            }
+            break;
+
+        case INS_imul_CX:
+            if (reg == REG_RCX)
+            {
+                return true;
+            }
+            break;
+
+        case INS_imul_DI:
+            if (reg == REG_RDI)
+            {
+                return true;
+            }
+            break;
+
+        case INS_imul_DX:
+            if (reg == REG_RDX)
+            {
+                return true;
+            }
+            break;
+
+        case INS_imul_SI:
+            if (reg == REG_RSI)
+            {
+                return true;
+            }
+            break;
+
+        case INS_imul_SP:
+            if (reg == REG_RSP)
+            {
+                return true;
+            }
+            break;
+
+#ifdef TARGET_AMD64
+        case INS_imul_08:
+            if (reg == REG_R8)
+            {
+                return true;
+            }
+            break;
+
+        case INS_imul_09:
+            if (reg == REG_R9)
+            {
+                return true;
+            }
+            break;
+
+        case INS_imul_10:
+            if (reg == REG_R10)
+            {
+                return true;
+            }
+            break;
+
+        case INS_imul_11:
+            if (reg == REG_R11)
+            {
+                return true;
+            }
+            break;
+
+        case INS_imul_12:
+            if (reg == REG_R12)
+            {
+                return true;
+            }
+            break;
+
+        case INS_imul_13:
+            if (reg == REG_R13)
+            {
+                return true;
+            }
+            break;
+
+        case INS_imul_14:
+            if (reg == REG_R14)
+            {
+                return true;
+            }
+            break;
+
+        case INS_imul_15:
+            if (reg == REG_R15)
+            {
+                return true;
+            }
+            break;
+#endif // TARGET_AMD64
+
         // These always write to RAX and RDX.
         case INS_idiv:
         case INS_div:

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -663,118 +663,28 @@ bool emitter::emitIsInstrWritingToReg(instrDesc* id, regNumber reg)
             return true;
 
         case INS_imul_AX:
-            if (reg == REG_RAX)
-            {
-                return true;
-            }
-            break;
-
         case INS_imul_BP:
-            if (reg == REG_RBP)
-            {
-                return true;
-            }
-            break;
-
         case INS_imul_BX:
-            if (reg == REG_RBX)
-            {
-                return true;
-            }
-            break;
-
         case INS_imul_CX:
-            if (reg == REG_RCX)
-            {
-                return true;
-            }
-            break;
-
         case INS_imul_DI:
-            if (reg == REG_RDI)
-            {
-                return true;
-            }
-            break;
-
         case INS_imul_DX:
-            if (reg == REG_RDX)
-            {
-                return true;
-            }
-            break;
-
         case INS_imul_SI:
-            if (reg == REG_RSI)
-            {
-                return true;
-            }
-            break;
-
         case INS_imul_SP:
-            if (reg == REG_RSP)
-            {
-                return true;
-            }
-            break;
-
 #ifdef TARGET_AMD64
         case INS_imul_08:
-            if (reg == REG_R8)
-            {
-                return true;
-            }
-            break;
-
         case INS_imul_09:
-            if (reg == REG_R9)
-            {
-                return true;
-            }
-            break;
-
         case INS_imul_10:
-            if (reg == REG_R10)
-            {
-                return true;
-            }
-            break;
-
         case INS_imul_11:
-            if (reg == REG_R11)
-            {
-                return true;
-            }
-            break;
-
         case INS_imul_12:
-            if (reg == REG_R12)
-            {
-                return true;
-            }
-            break;
-
         case INS_imul_13:
-            if (reg == REG_R13)
-            {
-                return true;
-            }
-            break;
-
         case INS_imul_14:
-            if (reg == REG_R14)
-            {
-                return true;
-            }
-            break;
-
         case INS_imul_15:
-            if (reg == REG_R15)
+#endif // TARGET_AMD64
+            if (reg == inst3opImulReg(ins))
             {
                 return true;
             }
             break;
-#endif // TARGET_AMD64
 
         // These always write to RAX and RDX.
         case INS_idiv:

--- a/src/tests/JIT/Regression/JitBlue/Runtime_85602/Runtime_85602.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_85602/Runtime_85602.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Test
+{
+    public class C0
+    {
+        public C0(ulong f0, sbyte f1, byte f2, ulong f3, ulong f4, int f5, short f6)
+        {
+        }
+    }
+
+    // This is trying to verify that we eliminate 'mov' instructions correctly.
+    public class Program
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static ulong Consume(ulong x) { return x; }
+
+        public static ushort s_1;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static ulong M0()
+        {
+            ulong var0 = ~(ulong)(uint)(-15356 * (2637600427U % (byte)((2147483647 ^ (4167361218894137384UL * (ushort)(-(ushort)(-(ushort)(128 * (5114990800133743712L % (byte)((byte)(-(byte)(-(byte)(-(byte)~(byte)(-2 % (short)((short)~(short)(-(short)(-90400400 - (-(0 | ~~(int)(32766 & (uint)(-~(uint)(-(uint)(629572031969723397L ^ (sbyte)(1UL * (byte)(8945663325738713761L / ((-(long)(127 / (sbyte)((sbyte)(-23817 % (ushort)((ushort)~M1(new C0(8144643251292930980UL, -118, 183, 18446744073709551614UL, 1827525571111008345UL, 1751590714, -32653)) | 1)) | 1))) | 1))))))))))) | 1))))) | 1))))))) | 1)));
+            return Program.Consume(var0);
+        }
+
+        public static ushort M1(C0 argThis)
+        {
+            return s_1;
+        }
+    }
+
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        var result = Test.Program.M0();
+        if (result != 18446744069414922151)
+        {
+            return 0;
+        }
+        return 100;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_85602/Runtime_85602.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_85602/Runtime_85602.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/85602

There were `imul` variants that refer to which register is implicitly being written to. We needed to handle these cases for `emitIsInstrWritingToReg`.

Local diffs - Windows x64:
**-60 bytes** improvement
No regressions.