### PR TITLE
Fix new warnings found with CA1854 improvement.

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs
@@ -254,8 +254,11 @@ namespace {lc.Namespace}
                 {
                     // this is related to https://github.com/serilog/serilog-extensions-logging/issues/197
                     string name = p.CodeName;
-                    // take the letter casing from the template
-                    lm.TemplateMap.TryGetValue(name, out name);
+                    if (lm.TemplateMap.TryGetValue(name, out string value))
+                    {
+                        // take the letter casing from the template
+                        name = value;
+                    }
 
                     _builder.AppendLine($"                    {nestedIndentation}{index++} => new global::System.Collections.Generic.KeyValuePair<string, object?>(\"{name}\", this.{NormalizeSpecialSymbol(p.CodeName)}),");
                 }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs
@@ -254,11 +254,8 @@ namespace {lc.Namespace}
                 {
                     // this is related to https://github.com/serilog/serilog-extensions-logging/issues/197
                     string name = p.CodeName;
-                    if (lm.TemplateMap.ContainsKey(name))
-                    {
-                        // take the letter casing from the template
-                        name = lm.TemplateMap[name];
-                    }
+                    // take the letter casing from the template
+                    lm.TemplateMap.TryGetValue(name, out name);
 
                     _builder.AppendLine($"                    {nestedIndentation}{index++} => new global::System.Collections.Generic.KeyValuePair<string, object?>(\"{name}\", this.{NormalizeSpecialSymbol(p.CodeName)}),");
                 }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpEndPointManager.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpEndPointManager.cs
@@ -135,9 +135,9 @@ namespace System.Net
             }
 
             Dictionary<int, HttpEndPointListener>? p;
-            if (s_ipEndPoints.ContainsKey(addr))
+            if (s_ipEndPoints.TryGetValue(addr, out Dictionary<int, HttpEndPointListener>? value))
             {
-                p = s_ipEndPoints[addr];
+                p = value;
             }
             else
             {
@@ -146,9 +146,9 @@ namespace System.Net
             }
 
             HttpEndPointListener? epl;
-            if (p.ContainsKey(port))
+            if (p.TryGetValue(port, out HttpEndPointListener? epListener))
             {
-                epl = p[port];
+                epl = epListener;
             }
             else
             {

--- a/src/tools/illink/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -138,8 +138,8 @@ namespace Mono.Linker.Dataflow
 				return;
 			}
 
-			if (knownStacks.ContainsKey (newOffset)) {
-				knownStacks[newOffset] = MergeStack (knownStacks[newOffset], newStack);
+			if (knownStacks.TryGetValue (newOffset, out Stack<StackSlot>? value)) {
+				knownStacks[newOffset] = MergeStack (value, newStack);
 			} else {
 				knownStacks.Add (newOffset, new Stack<StackSlot> (newStack.Reverse ()));
 			}
@@ -292,12 +292,12 @@ namespace Mono.Linker.Dataflow
 			foreach (Instruction operation in methodIL.Instructions) {
 				int curBasicBlock = blockIterator.MoveNext (operation);
 
-				if (knownStacks.ContainsKey (operation.Offset)) {
+				if (knownStacks.TryGetValue (operation.Offset, out Stack<StackSlot>? knownValue)) {
 					if (currentStack == null) {
 						// The stack copy constructor reverses the stack
-						currentStack = new Stack<StackSlot> (knownStacks[operation.Offset].Reverse ());
+						currentStack = new Stack<StackSlot> (knownValue.Reverse ());
 					} else {
-						currentStack = MergeStack (currentStack, knownStacks[operation.Offset]);
+						currentStack = MergeStack (currentStack, knownValue);
 					}
 				}
 


### PR DESCRIPTION
Fix new warnings found in https://github.com/dotnet/runtime/pull/85518/files introduced with [recent improvements](https://github.com/dotnet/roslyn-analyzers/pull/6387) in CA1854  `Prefer a 'TryGetValue' call over a Dictionary indexer access guarded by a 'ContainsKey' check to avoid double lookup`

