### PR TITLE
Fix TimeZoneInfo Perf

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -1921,16 +1921,12 @@ namespace System
             // check the cache
             if (cachedData._systemTimeZones != null)
             {
-                if (cachedData._systemTimeZones.TryGetValue(id, out TimeZoneInfo? match))
+                if (cachedData._systemTimeZones.TryGetValue(id, out value))
                 {
-                    if (dstDisabled && match._supportsDaylightSavingTime)
+                    if (dstDisabled && value._supportsDaylightSavingTime)
                     {
                         // we found a cache hit but we want a time zone without DST and this one has DST data
-                        value = CreateCustomTimeZone(match._id, match._baseUtcOffset, match._displayName, match._standardDisplayName);
-                    }
-                    else
-                    {
-                        value = match;
+                        value = CreateCustomTimeZone(value._id, value._baseUtcOffset, value._displayName, value._standardDisplayName);
                     }
 
                     return result;
@@ -1939,16 +1935,12 @@ namespace System
 
             if (cachedData._timeZonesUsingAlternativeIds != null)
             {
-                if (cachedData._timeZonesUsingAlternativeIds.TryGetValue(id, out TimeZoneInfo? match))
+                if (cachedData._timeZonesUsingAlternativeIds.TryGetValue(id, out value))
                 {
-                    if (dstDisabled && match._supportsDaylightSavingTime)
+                    if (dstDisabled && value._supportsDaylightSavingTime)
                     {
                         // we found a cache hit but we want a time zone without DST and this one has DST data
-                        value = CreateCustomTimeZone(match._id, match._baseUtcOffset, match._displayName, match._standardDisplayName);
-                    }
-                    else
-                    {
-                        value = match;
+                        value = CreateCustomTimeZone(value._id, value._baseUtcOffset, value._displayName, value._standardDisplayName);
                     }
 
                     return result;
@@ -1979,7 +1971,7 @@ namespace System
         {
             TimeZoneInfoResult result;
 
-            result = TryGetTimeZoneFromLocalMachine(id, out TimeZoneInfo? match, out e);
+            result = TryGetTimeZoneFromLocalMachine(id, out value, out e);
 
             if (result == TimeZoneInfoResult.Success)
             {
@@ -1992,22 +1984,14 @@ namespace System
                 // uses reference equality with the Utc object.
                 if (!id.Equals(UtcId, StringComparison.OrdinalIgnoreCase))
                 {
-                    cachedData._systemTimeZones.Add(id, match!);
+                    cachedData._systemTimeZones.Add(id, value!);
                 }
 
-                if (dstDisabled && match!._supportsDaylightSavingTime)
+                if (dstDisabled && value!._supportsDaylightSavingTime)
                 {
                     // we found a cache hit but we want a time zone without DST and this one has DST data
-                    value = CreateCustomTimeZone(match._id, match._baseUtcOffset, match._displayName, match._standardDisplayName);
+                    value = CreateCustomTimeZone(value._id, value._baseUtcOffset, value._displayName, value._standardDisplayName);
                 }
-                else
-                {
-                    value = match;
-                }
-            }
-            else
-            {
-                value = null;
             }
 
             return result;

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -127,6 +127,7 @@ namespace System
 
             public Dictionary<string, TimeZoneInfo>? _systemTimeZones;
             public ReadOnlyCollection<TimeZoneInfo>? _readOnlySystemTimeZones;
+            public Dictionary<string, TimeZoneInfo>? _timeZonesUsingAlternativeIds;
             public bool _allSystemTimeZonesRead;
         }
 
@@ -1898,6 +1899,9 @@ namespace System
                             }
                         }
 
+                        cachedData._timeZonesUsingAlternativeIds ??= new Dictionary<string, TimeZoneInfo>(StringComparer.OrdinalIgnoreCase);
+                        cachedData._timeZonesUsingAlternativeIds[id] = zone;
+
                         Debug.Assert(zone != null);
                         value = zone;
                     }
@@ -1926,8 +1930,25 @@ namespace System
                     }
                     else
                     {
-                        value = new TimeZoneInfo(match._id, match._baseUtcOffset, match._displayName, match._standardDisplayName,
-                                              match._daylightDisplayName, match._adjustmentRules, disableDaylightSavingTime: false, match.HasIanaId);
+                        value = match;
+                    }
+
+                    return result;
+                }
+            }
+
+            if (cachedData._timeZonesUsingAlternativeIds != null)
+            {
+                if (cachedData._timeZonesUsingAlternativeIds.TryGetValue(id, out TimeZoneInfo? match))
+                {
+                    if (dstDisabled && match._supportsDaylightSavingTime)
+                    {
+                        // we found a cache hit but we want a time zone without DST and this one has DST data
+                        value = CreateCustomTimeZone(match._id, match._baseUtcOffset, match._displayName, match._standardDisplayName);
+                    }
+                    else
+                    {
+                        value = match;
                     }
 
                     return result;
@@ -1981,8 +2002,7 @@ namespace System
                 }
                 else
                 {
-                    value = new TimeZoneInfo(match!._id, match._baseUtcOffset, match._displayName, match._standardDisplayName,
-                                          match._daylightDisplayName, match._adjustmentRules, disableDaylightSavingTime: false, match.HasIanaId);
+                    value = match;
                 }
             }
             else


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/85432

This change  is addressing multiple performance issues:

The first problem arises when creating a TimeZoneInfo object with an alternative zone ID (like using IANA Id on Windows and Windows Id on Linux) using the FindSystemTimeZoneById method. By default, the object returned by GetSystemTimeZones is cached only for the zone ID that matches the OS we are running on. Thus, when we try to create a new object with an alternative ID, we cannot benefit from the cache, and we always attempt to read the zone from the system. On non-Windows OS, this requires accessing the file system and probing for the zone file. To address this issue, we introduce a cache for the alternative ID.

The second issue concerns the unnecessary creation of new zone objects when requesting them with FindSystemTimeZoneById. Even if we have already created the object and cached it, we still create a new one every time. However, since the zone objects do not have writable properties, there is no need to clone them. Instead, we can return the cached object to avoid the allocation and the validation of the new object.

# Windows 

### Before

```
|         Method |         Mean |      Error |     StdDev |   Gen0 | Allocated |
|--------------- |-------------:|-----------:|-----------:|-------:|----------:|
|    UsingIanaId | 40,061.32 ns | 753.377 ns | 667.849 ns |      - |     312 B |
| UsingWindowsId |     50.31 ns |   1.018 ns |   1.461 ns | 0.0095 |      80 B |

```

### After 

```
|         Method |     Mean |    Error |   StdDev | Allocated |
|--------------- |---------:|---------:|---------:|----------:|
|    UsingIanaId | 34.41 ns | 0.377 ns | 0.315 ns |         - |
| UsingWindowsId | 33.55 ns | 0.462 ns | 0.410 ns |         - |
```

# Linux 

### Before

```
|         Method |       Mean |    Error |   StdDev |   Gen0 | Allocated |
|--------------- |-----------:|---------:|---------:|-------:|----------:|
|    UsingIanaId | 1,429.8 ns | 27.28 ns | 29.19 ns | 0.0095 |      80 B |
| UsingWindowsId |   935.2 ns | 18.36 ns | 21.86 ns | 0.0687 |     576 B |

```

### After

```
|         Method |     Mean |    Error |   StdDev | Allocated |
|--------------- |---------:|---------:|---------:|----------:|
|    UsingIanaId | 31.87 ns | 0.634 ns | 1.143 ns |         - |
| UsingWindowsId | 41.03 ns | 0.838 ns | 1.229 ns |         - |
```