### PR TITLE
Fix Helix command lines error code handling

### DIFF
--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -449,14 +449,21 @@
 
       <!--
         Check both exit codes, the test's and XUnitLogChecker's. If any of them failed, then we return that one, with the
-        test's taking priority (i.e. if the test failed, we return that one regardless of how things went with the log checker.
+        test's taking priority (i.e. if the test failed, we return that one regardless of how things went with the log checker).
         Full description in the reasoning of this is in the comment above about GH issue #85056.
+        Note that you can not use "exit" or the shell will exit and the HelixPostCommands will not run.
       -->
-      <HelixCommandLines Condition="'$(TestWrapperTargetsWindows)' == 'true'" Include="if %25test_exit_code%25 NEQ 0 exit %25test_exit_code%25" />
-      <HelixCommandLines Condition="'$(TestWrapperTargetsWindows)' != 'true'" Include="if [ %24test_exit_code -ne 0 ]%3B then exit %24test_exit_code%3B fi" />
-      <HelixCommandLines Condition="'$(TestWrapperTargetsWindows)' == 'true'" Include="if %25xunitlogchecker_exit_code%25 NEQ 0 exit %25xunitlogchecker_exit_code%25" />
-      <HelixCommandLines Condition="'$(TestWrapperTargetsWindows)' != 'true'" Include="if [ %24xunitlogchecker_exit_code -ne 0 ]%3B then exit %24xunitlogchecker_exit_code%3B fi" />
-      <HelixCommandLines Include="exit 0" />
+
+      <HelixCommandLines Condition="'$(TestWrapperTargetsWindows)' == 'true'" Include="set result_exit_code=0" />
+      <HelixCommandLines Condition="'$(TestWrapperTargetsWindows)' == 'true'" Include="if %25xunitlogchecker_exit_code%25 NEQ 0 set result_exit_code=%25xunitlogchecker_exit_code%25" />
+      <HelixCommandLines Condition="'$(TestWrapperTargetsWindows)' == 'true'" Include="if %25test_exit_code%25 NEQ 0 set result_exit_code=%25test_exit_code%25" />
+      <HelixCommandLines Condition="'$(TestWrapperTargetsWindows)' == 'true'" Include="%25ComSpec%25 /C exit %25result_exit_code%25" />
+
+      <HelixCommandLines Condition="'$(TestWrapperTargetsWindows)' != 'true'" Include="result_exit_code=0" />
+      <HelixCommandLines Condition="'$(TestWrapperTargetsWindows)' != 'true'" Include="if [ %24xunitlogchecker_exit_code -ne 0 ]%3B then result_exit_code=%24xunitlogchecker_exit_code%3B fi" />
+      <HelixCommandLines Condition="'$(TestWrapperTargetsWindows)' != 'true'" Include="if [ %24test_exit_code -ne 0 ]%3B then result_exit_code=%24test_exit_code%3B fi" />
+      <HelixCommandLines Condition="'$(TestWrapperTargetsWindows)' != 'true'" Include="set_return() { return $1; }" />
+      <HelixCommandLines Condition="'$(TestWrapperTargetsWindows)' != 'true'" Include="set_return %24result_exit_code" />
     </ItemGroup>
 
     <Copy SourceFiles="@(ReducedMergedPayloadFilesFinal)" DestinationFiles="@(ReducedMergedPayloadFilesFinal->'$(MergedPayloadsRootDirectory)\$(_MergedWrapperName)\%(FileRelativeToPayloadsRootDirectory)')" Condition="'@(ReducedMergedPayloadFilesFinal)' != ''" />


### PR DESCRIPTION
The `HelixCommandLines` group must not call `exit` on the script or the HelixPostCommands and potentially other injected commands will not run.

Instead, figure out what the exit code should be, and set it properly (as `ERRORLEVEL` on Windows or `$?` on non-Windows).

Fixes #85621