### PR TITLE
Ensure zroSimd12Elm3 is explicitly nulled out

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -85,6 +85,7 @@ CodeGen::CodeGen(Compiler* theCompiler) : CodeGenInterface(theCompiler)
     negBitmaskDbl  = nullptr;
     absBitmaskFlt  = nullptr;
     absBitmaskDbl  = nullptr;
+    zroSimd12Elm3  = nullptr;
     u8ToDblBitmask = nullptr;
 #endif // defined(TARGET_XARCH)
 

--- a/src/coreclr/jit/simdcodegenxarch.cpp
+++ b/src/coreclr/jit/simdcodegenxarch.cpp
@@ -548,7 +548,7 @@ void CodeGen::genSimd12UpperClear(regNumber tgtReg)
             zroSimd12Elm3 = GetEmitter()->emitSimd16Const(constValue);
         }
 
-        GetEmitter()->emitIns_SIMD_R_R_C(INS_andpd, EA_16BYTE, tgtReg, tgtReg, zroSimd12Elm3, 0);
+        GetEmitter()->emitIns_SIMD_R_R_C(INS_andps, EA_16BYTE, tgtReg, tgtReg, zroSimd12Elm3, 0);
     }
 }
 


### PR DESCRIPTION
Not doing this meant you could get non-determinstic bits in some scenarios, leading to sporadic failure