### PR TITLE
Allow emitting function pointers in TypeSystemMetadataEmitter

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/MetadataEmitter/TypeSystemMetadataEmitter.cs
+++ b/src/coreclr/tools/Common/TypeSystem/MetadataEmitter/TypeSystemMetadataEmitter.cs
@@ -206,11 +206,6 @@ namespace Internal.TypeSystem
                 return handle;
             }
 
-            if (type.IsFunctionPointer)
-            {
-                throw new ArgumentException("type");
-            }
-
             EntityHandle typeHandle;
 
             if (type.IsTypeDefinition && type is MetadataType metadataType)


### PR DESCRIPTION
This is handled. It's unclear to me why it was disallowed.

Unfortunately, this means `IlcGenerateMstatFile` is going to be completely broken in .NET 8 Preview 4.

Cc @dotnet/ilc-contrib 