### PR TITLE
enable ntlm tests on RHEL7 again

### DIFF
--- a/src/libraries/Common/tests/System/Net/Capability.Security.Unix.cs
+++ b/src/libraries/Common/tests/System/Net/Capability.Security.Unix.cs
@@ -9,7 +9,7 @@ namespace System.Net.Test.Common
         {
             // GSS on Linux does not work with OpenSSL 3.0. Fix was submitted to gss-ntlm but it will take a while to make to
             // all supported distributions. The second part of the check should be removed when it does.
-            return Interop.NetSecurityNative.IsNtlmInstalled() && (!PlatformDetection.IsOpenSslSupported || PlatformDetection.OpenSslVersion.Major < 3) && !PlatformDetection.IsRedHatFamily7;
+            return Interop.NetSecurityNative.IsNtlmInstalled() && (!PlatformDetection.IsOpenSslSupported || PlatformDetection.OpenSslVersion.Major < 3);
         }
     }
 }

--- a/src/libraries/System.Net.Security/tests/UnitTests/NegotiateAuthenticationTests.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/NegotiateAuthenticationTests.cs
@@ -10,7 +10,6 @@ using System.Net.Test.Common;
 using System.Security.Principal;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Net.Security.Tests
@@ -87,10 +86,6 @@ namespace System.Net.Security.Tests
         [ConditionalFact(nameof(IsNtlmUnavailable))]
         public void Package_Unsupported_NTLM()
         {
-            if (PlatformDetection.IsRedHatFamily7)
-            {
-                throw new SkipTestException("https://github.com/dotnet/runtime/issues/83540");
-            }
             NegotiateAuthenticationClientOptions clientOptions = new NegotiateAuthenticationClientOptions { Package = "NTLM", Credential = s_testCredentialRight, TargetName = "HTTP/foo" };
             NegotiateAuthentication negotiateAuthentication = new NegotiateAuthentication(clientOptions);
             NegotiateAuthenticationStatusCode statusCode;


### PR DESCRIPTION
it seems like the gss-ntlm package was fixed and published.
This reverts  https://github.com/dotnet/runtime/pull/83559 and fixes #83540.