### PR TITLE
Avoid S.R.I.RuntimeInformation package dependency

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -128,7 +128,6 @@
     <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
     <SystemNumericsVectorsVersion>4.5.0</SystemNumericsVectorsVersion>
     <SystemReflectionMetadataVersion>6.0.1</SystemReflectionMetadataVersion>
-    <SystemRuntimeInteropServicesRuntimeInformationVersion>4.3.0</SystemRuntimeInteropServicesRuntimeInformationVersion>
     <SystemSecurityAccessControlVersion>6.0.0</SystemSecurityAccessControlVersion>
     <SystemSecurityCryptographyAlgorithmsVersion>4.3.1</SystemSecurityCryptographyAlgorithmsVersion>
     <SystemSecurityCryptographyCngVersion>5.0.0</SystemSecurityCryptographyCngVersion>

--- a/src/libraries/Microsoft.Extensions.DependencyModel/src/EnvironmentWrapper.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/src/EnvironmentWrapper.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+#if !NETFRAMEWORK
 using System.Runtime.InteropServices;
+#endif
 
 namespace Microsoft.Extensions.DependencyModel
 {
@@ -14,6 +16,11 @@ namespace Microsoft.Extensions.DependencyModel
 
         public object? GetAppContextData(string name) => AppDomain.CurrentDomain.GetData(name);
 
-        public bool IsWindows() => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        public bool IsWindows() =>
+#if NETFRAMEWORK
+            Environment.OSVersion.Platform == PlatformID.Win32NT;
+#else
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+#endif
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyModel/src/Microsoft.Extensions.DependencyModel.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/src/Microsoft.Extensions.DependencyModel.csproj
@@ -41,7 +41,6 @@ By default, the dependency manifest contains information about the application's
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System.Runtime" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="$(SystemRuntimeInteropServicesRuntimeInformationVersion)" />
   </ItemGroup>
   
 </Project>

--- a/src/libraries/Microsoft.Extensions.DependencyModel/src/Resolution/DotNetReferenceAssembliesPathResolver.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/src/Resolution/DotNetReferenceAssembliesPathResolver.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if !NETFRAMEWORK
 using System.Runtime.InteropServices;
+#endif
 
 namespace Microsoft.Extensions.DependencyModel.Resolution
 {
@@ -27,12 +29,21 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
 
         private static string? GetDefaultDotNetReferenceAssembliesPath(IFileSystem fileSystem)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (
+#if NETFRAMEWORK
+                System.Environment.OSVersion.Platform == System.PlatformID.Win32NT
+#else
+                RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+#endif
+                )
             {
                 return null;
             }
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
+            if (
+#if !NETFRAMEWORK
+                RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
+#endif
                 fileSystem.Directory.Exists("/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/xbuild-frameworks"))
             {
                 return "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/xbuild-frameworks";

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceHelpers.cs
@@ -19,7 +19,13 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
         [SupportedOSPlatformGuard("windows")]
         public static bool IsWindowsService()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (
+#if NETFRAMEWORK
+                Environment.OSVersion.Platform != PlatformID.Win32NT
+#else
+                !RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+#endif
+                )
             {
                 return false;
             }

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceLifetimeHostBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceLifetimeHostBuilderExtensions.cs
@@ -106,11 +106,15 @@ namespace Microsoft.Extensions.Hosting
 
         private static void AddWindowsServiceLifetime(IServiceCollection services, Action<WindowsServiceLifetimeOptions> configure)
         {
+#if !NETFRAMEWORK
             Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+#endif
 
             services.AddLogging(logging =>
             {
+#if !NETFRAMEWORK
                 Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+#endif
                 logging.AddEventLog();
             });
             services.AddSingleton<IHostLifetime, WindowsServiceLifetime>();
@@ -129,7 +133,9 @@ namespace Microsoft.Extensions.Hosting
 
             public void Configure(EventLogSettings settings)
             {
+#if !NETFRAMEWORK
                 Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+#endif
 
                 if (string.IsNullOrEmpty(settings.SourceName))
                 {

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
@@ -217,7 +217,13 @@ namespace Microsoft.Extensions.Hosting
             // any trailing directory separator characters. I'm not even sure the casing can ever be different from these APIs, but I think it makes sense to
             // ignore case for Windows path comparisons given the file system is usually (always?) going to be case insensitive for the system path.
             string cwd = Environment.CurrentDirectory;
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || !string.Equals(cwd, Environment.SystemDirectory, StringComparison.OrdinalIgnoreCase))
+            if (
+#if NETFRAMEWORK
+                Environment.OSVersion.Platform != PlatformID.Win32NT ||
+#else
+                !RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
+#endif
+                !string.Equals(cwd, Environment.SystemDirectory, StringComparison.OrdinalIgnoreCase))
             {
                 hostConfigBuilder.AddInMemoryCollection(new[]
                 {
@@ -270,6 +276,8 @@ namespace Microsoft.Extensions.Hosting
                 bool isWindows =
 #if NETCOREAPP
                     OperatingSystem.IsWindows();
+#elif NETFRAMEWORK
+                    Environment.OSVersion.Platform == PlatformID.Win32NT;
 #else
                     RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 #endif

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Microsoft.Extensions.Hosting.csproj
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Microsoft.Extensions.Hosting.csproj
@@ -54,7 +54,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="$(SystemRuntimeInteropServicesRuntimeInformationVersion)" />
     <Reference Include="System.Runtime" />
   </ItemGroup>
 

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
@@ -68,7 +68,13 @@ namespace Microsoft.Extensions.Logging.Console
         [UnsupportedOSPlatformGuard("windows")]
         private static bool DoesConsoleSupportAnsi()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (
+#if NETFRAMEWORK
+                Environment.OSVersion.Platform != PlatformID.Win32NT
+#else
+                !RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+#endif
+                )
             {
                 return true;
             }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Microsoft.Extensions.Logging.Console.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Microsoft.Extensions.Logging.Console.csproj
@@ -64,8 +64,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="$(SystemRuntimeInteropServicesRuntimeInformationVersion)" />
-    <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
     <Reference Include="System.Runtime" />
   </ItemGroup>
 


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/85641

System.Runtime.InteropServices.RuntimeInformation/4.3.0 is being referenced in a few .NET Framework builds. The reference to that package is undesirable as it brings in the entire netstandard1.x dependency graph.

Instead, use System.Environment.OSVersion which returns "Microsoft
Windows NT" on .NET Framework, Mono and .NETCoreApp runtimes.

cc @dotnet/area-dependencymodel @dotnet/area-extensions-hosting @dotnet/area-extensions-logging