### PR TITLE
JIT: Fix modelling of exceptions thrown by INDEX_ADDR

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6904,8 +6904,10 @@ ExceptionSetFlags GenTree::OperExceptions(Compiler* comp)
             return ExceptionSetFlags::None;
 
         case GT_BOUNDS_CHECK:
-        case GT_INDEX_ADDR:
             return ExceptionSetFlags::IndexOutOfRangeException;
+
+        case GT_INDEX_ADDR:
+            return ExceptionSetFlags::NullReferenceException | ExceptionSetFlags::IndexOutOfRangeException;
 
         case GT_ARR_INDEX:
         case GT_ARR_OFFSET:

--- a/src/tests/JIT/Regression/JitBlue/Runtime_85645/Runtime_85645.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_85645/Runtime_85645.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_85645
+{
+    [Fact]
+    public static int Test()
+    {
+        try
+        {
+            Bar(null, new int[0]);
+            Console.WriteLine("FAIL: Should have thrown exception");
+            return -1;
+        }
+        catch (NullReferenceException)
+        {
+            Console.WriteLine("PASS: Caught NullReferenceException");
+            return 100;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("FAIL: {0}", ex);
+            return -1;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Bar(int[] a, int[] b)
+    {
+        Consume(a[0], b[0] + 3);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Consume(int a, int b)
+    {
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_85645/Runtime_85645.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_85645/Runtime_85645.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fix #85645

Expect regressions from no longer being able to make profitable reorderings of some call args in MinOpts.