### PR TITLE
ProcessTests: allow WorkingSet to be zero just after launching the process.

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -776,7 +776,7 @@ namespace System.Diagnostics.Tests
             }
 
             // On recent Linux kernels (6.2+) working set can be zero just after the process started.
-            RetryHelper.Execute(() =>
+            ExecuteWithRetryOnLinux(() =>
             {
                 try
                 {
@@ -841,7 +841,7 @@ namespace System.Diagnostics.Tests
             }
 
             // On recent Linux kernels (6.2+) working set can be zero just after the process started.
-            RetryHelper.Execute(() =>
+            ExecuteWithRetryOnLinux(() =>
             {
                 try
                 {
@@ -2053,7 +2053,7 @@ namespace System.Diagnostics.Tests
             }
 
             // On recent Linux kernels (6.2+) working set can be zero just after the process started.
-            RetryHelper.Execute(() =>
+            ExecuteWithRetryOnLinux(() =>
             {
                 try
                 {
@@ -2131,7 +2131,7 @@ namespace System.Diagnostics.Tests
             }
 
             // On recent Linux kernels (6.2+) working set can be zero just after the process started.
-            RetryHelper.Execute(() =>
+            ExecuteWithRetryOnLinux(() =>
             {
                 try
                 {
@@ -2738,6 +2738,18 @@ namespace System.Diagnostics.Tests
             }
 
             return secureString;
+        }
+
+        private static void ExecuteWithRetryOnLinux(Action test)
+        {
+            if (OperatingSystem.IsLinux())
+            {
+                RetryHelper.Execute(test, retryWhen: ex => ex is XunitException);
+            }
+            else
+            {
+                test();
+            }
         }
     }
 }

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -2049,6 +2049,7 @@ namespace System.Diagnostics.Tests
 #pragma warning disable 0618
                 Assert.Equal(0, _process.PeakWorkingSet);
 #pragma warning restore 0618
+                return;
             }
 
             // On recent Linux kernels (6.2+) working set can be zero just after the process started.

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -769,7 +769,25 @@ namespace System.Diagnostics.Tests
         {
             CreateDefaultProcess();
 
-            AssertNonZeroAllZeroDarwin(_process.PeakWorkingSet64);
+            if (OperatingSystem.IsMacOS())
+            {
+                Assert.Equal(0, _process.PeakWorkingSet64);
+                return;
+            }
+
+            // On recent Linux kernels (6.2+) working set can be zero just after the process started.
+            RetryHelper.Execute(() =>
+            {
+                try
+                {
+                    Assert.NotEqual(0, _process.PeakWorkingSet64);
+                }
+                catch
+                {
+                    _process.Refresh();
+                    throw;
+                }
+            });
         }
 
         [Fact]
@@ -822,7 +840,19 @@ namespace System.Diagnostics.Tests
                 return;
             }
 
-            Assert.InRange(_process.WorkingSet64, 1, long.MaxValue);
+            // On recent Linux kernels (6.2+) working set can be zero just after the process started.
+            RetryHelper.Execute(() =>
+            {
+                try
+                {
+                    Assert.InRange(_process.WorkingSet64, 1, long.MaxValue);
+                }
+                catch
+                {
+                    _process.Refresh();
+                    throw;
+                }
+            });
         }
 
         [Fact]
@@ -2014,9 +2044,28 @@ namespace System.Diagnostics.Tests
         {
             CreateDefaultProcess();
 
+            if (OperatingSystem.IsMacOS())
+            {
 #pragma warning disable 0618
-            AssertNonZeroAllZeroDarwin(_process.PeakWorkingSet);
+                Assert.Equal(0, _process.PeakWorkingSet);
 #pragma warning restore 0618
+            }
+
+            // On recent Linux kernels (6.2+) working set can be zero just after the process started.
+            RetryHelper.Execute(() =>
+            {
+                try
+                {
+#pragma warning disable 0618
+                    Assert.NotEqual(0, _process.PeakWorkingSet);
+#pragma warning restore 0618
+                }
+                catch
+                {
+                    _process.Refresh();
+                    throw;
+                }
+            });
         }
 
         [Fact]
@@ -2080,9 +2129,21 @@ namespace System.Diagnostics.Tests
                 return;
             }
 
+            // On recent Linux kernels (6.2+) working set can be zero just after the process started.
+            RetryHelper.Execute(() =>
+            {
+                try
+                {
 #pragma warning disable 0618
-            Assert.InRange(_process.WorkingSet, 1, int.MaxValue);
+                    Assert.InRange(_process.WorkingSet, 1, int.MaxValue);
 #pragma warning restore 0618
+                }
+                catch
+                {
+                    _process.Refresh();
+                    throw;
+                }
+            });
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/83129.

The WorkingSet tests fail on Fedora 38+ because a zero working set value is observed just after the process start.

@dotnet/area-system-diagnostics-process ptal.

cc @omajid 