### PR TITLE
Fix add/edit for generic methods scenario

### DIFF
--- a/src/coreclr/vm/methoditer.cpp
+++ b/src/coreclr/vm/methoditer.cpp
@@ -24,7 +24,7 @@ BOOL LoadedMethodDescIterator::Next(
     {
         NOTHROW;
         GC_NOTRIGGER;
-        MODE_PREEMPTIVE;
+        MODE_ANY;
     }
     CONTRACTL_END
 
@@ -203,15 +203,11 @@ MethodDesc *LoadedMethodDescIterator::Current()
         return m_mainMD;
     }
 
-    MethodTable *pMT = m_typeIteratorEntry->GetTypeHandle().GetMethodTable();
+    MethodTable *pMT = m_typeIteratorEntry->GetTypeHandle().GetMethodTable()->GetCanonicalMethodTable();
     PREFIX_ASSUME(pMT != NULL);
-    _ASSERTE(pMT);
-
-    return pMT->GetMethodDescForSlot(m_mainMD->GetSlot());
+    return pMT->GetParallelMethodDesc(m_mainMD);
 }
 
-// Initialize the iterator. It will cover generics + prejitted;
-// but it is not EnC aware.
 void
 LoadedMethodDescIterator::Start(
     AppDomain * pAppDomain,

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -8770,6 +8770,7 @@ namespace
             GC_NOTRIGGER;
             MODE_ANY;
             PRECONDITION(pMT != NULL);
+            PRECONDITION(pMT->IsCanonicalMethodTable());
             PRECONDITION(pDefMD != NULL);
             PRECONDITION(pDefMD->IsEnCAddedMethod());
             PRECONDITION(pDefMD->GetSlot() == MethodTable::NO_SLOT);

--- a/src/coreclr/vm/runtimehandles.cpp
+++ b/src/coreclr/vm/runtimehandles.cpp
@@ -2413,7 +2413,8 @@ FCIMPL2(MethodDesc*, RuntimeMethodHandle::GetMethodFromCanonical, MethodDesc *pM
     REFLECTCLASSBASEREF refType = (REFLECTCLASSBASEREF)ObjectToOBJECTREF(pTypeUNSAFE);
 
     TypeHandle instType = refType->GetType();
-    MethodDesc* pMDescInCanonMT = instType.GetMethodTable()->GetParallelMethodDesc(pMethod);
+    MethodTable* pCanonMT = instType.GetMethodTable()->GetCanonicalMethodTable();
+    MethodDesc* pMDescInCanonMT = pCanonMT->GetParallelMethodDesc(pMethod);
 
     return pMDescInCanonMT;
 }


### PR DESCRIPTION
Ensure the canonical MethodTable is always used.

Fixes #85605 