### PR TITLE
Add GenericTypeParameterBuilder implementation and save a generic type into assembly.

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeTypeBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeTypeBuilder.cs
@@ -491,14 +491,11 @@ namespace System.Reflection.Emit
             int[]? interfaceTokens = null;
             if (interfaces != null)
             {
+                interfaceTokens = new int[interfaces.Length + 1];
                 for (i = 0; i < interfaces.Length; i++)
                 {
                     // cannot contain null in the interface list
                     ArgumentNullException.ThrowIfNull(interfaces[i], nameof(interfaces));
-                }
-                interfaceTokens = new int[interfaces.Length + 1];
-                for (i = 0; i < interfaces.Length; i++)
-                {
                     interfaceTokens[i] = m_module.GetTypeTokenInternal(interfaces[i]);
                 }
             }
@@ -1144,15 +1141,18 @@ namespace System.Reflection.Emit
 
         protected override GenericTypeParameterBuilder[] DefineGenericParametersCore(params string[] names)
         {
-            for (int i = 0; i < names.Length; i++)
-                ArgumentNullException.ThrowIfNull(names[i], nameof(names));
-
             if (m_inst != null)
+            {
                 throw new InvalidOperationException();
+            }
 
             m_inst = new RuntimeGenericTypeParameterBuilder[names.Length];
             for (int i = 0; i < names.Length; i++)
-                m_inst[i] = new RuntimeGenericTypeParameterBuilder(new RuntimeTypeBuilder(names[i], i, this));
+            {
+                string name = names[i];
+                ArgumentNullException.ThrowIfNull(name, nameof(names));
+                m_inst[i] = new RuntimeGenericTypeParameterBuilder(new RuntimeTypeBuilder(name, i, this));
+            }
 
             return m_inst;
         }

--- a/src/libraries/System.Reflection.Emit/src/System.Reflection.Emit.csproj
+++ b/src/libraries/System.Reflection.Emit/src/System.Reflection.Emit.csproj
@@ -8,6 +8,7 @@
     <Compile Include="System\Reflection\Emit\CustomAttributeWrapper.cs" />
     <Compile Include="System\Reflection\Emit\AssemblyBuilderImpl.cs" />
     <Compile Include="System\Reflection\Emit\FieldBuilderImpl.cs" />
+    <Compile Include="System\Reflection\Emit\GenericTypeParameterBuilderImpl.cs" />
     <Compile Include="System\Reflection\Emit\MethodBuilderImpl.cs" />
     <Compile Include="System\Reflection\Emit\ModuleBuilderImpl.cs" />
     <Compile Include="System\Reflection\Emit\ParameterBuilderImpl.cs" />

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/GenericTypeParameterBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/GenericTypeParameterBuilderImpl.cs
@@ -13,7 +13,7 @@ namespace System.Reflection.Emit
         private readonly TypeBuilderImpl _type;
         private readonly int _genParamPosition;
         private GenericParameterAttributes _genParamAttributes;
-        private bool _isGenericType;
+        private bool _isGenericMethodParameter;
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
         private Type? _parent;
 
@@ -25,7 +25,7 @@ namespace System.Reflection.Emit
             _name = name;
             _genParamPosition = genParamPosition;
             _type = typeBuilder;
-            _isGenericType = true;
+            _isGenericMethodParameter = false;
         }
 
         protected override void SetBaseTypeConstraintCore([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type? baseTypeConstraint)
@@ -59,8 +59,8 @@ namespace System.Reflection.Emit
 
         public override Type[] GetGenericParameterConstraints() =>
             _interfaces == null ? EmptyTypes : _interfaces.ToArray();
-        public override bool IsGenericTypeParameter => _isGenericType;
-        public override bool IsGenericMethodParameter => !_isGenericType;
+        public override bool IsGenericTypeParameter => !_isGenericMethodParameter;
+        public override bool IsGenericMethodParameter => _isGenericMethodParameter;
         public override int GenericParameterPosition => _genParamPosition;
         public override GenericParameterAttributes GenericParameterAttributes => _genParamAttributes;
         public override string Name => _name;

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/GenericTypeParameterBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/GenericTypeParameterBuilderImpl.cs
@@ -1,0 +1,148 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+namespace System.Reflection.Emit
+{
+    internal sealed class GenericTypeParameterBuilderImpl : GenericTypeParameterBuilder
+    {
+        private readonly string _name;
+        private readonly TypeBuilderImpl _type;
+        private readonly int _genParamPosition;
+        private GenericParameterAttributes _genParamAttributes;
+        private bool _isGenericType;
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+        private Type? _parent;
+
+        internal List<CustomAttributeWrapper>? _customAttributes;
+        internal List<Type>? _interfaces;
+
+        internal GenericTypeParameterBuilderImpl(string name, int genParamPosition, TypeBuilderImpl typeBuilder)
+        {
+            _name = name;
+            _genParamPosition = genParamPosition;
+            _type = typeBuilder;
+            _isGenericType = true;
+        }
+
+        protected override void SetBaseTypeConstraintCore([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type? baseTypeConstraint)
+        {
+            _parent = baseTypeConstraint;
+
+            if (_parent != null)
+            {
+                _interfaces ??= new List<Type>();
+                _interfaces.Add(_parent);
+            }
+        }
+
+        protected override void SetCustomAttributeCore(ConstructorInfo con, ReadOnlySpan<byte> binaryAttribute)
+        {
+            _customAttributes ??= new List<CustomAttributeWrapper>();
+            _customAttributes.Add(new CustomAttributeWrapper(con, binaryAttribute));
+        }
+
+        protected override void SetGenericParameterAttributesCore(GenericParameterAttributes genericParameterAttributes) =>
+            _genParamAttributes = genericParameterAttributes;
+
+        protected override void SetInterfaceConstraintsCore(params Type[]? interfaceConstraints)
+        {
+            if (interfaceConstraints != null)
+            {
+                _interfaces ??= new List<Type>(interfaceConstraints.Length);
+                _interfaces.AddRange(interfaceConstraints);
+            }
+        }
+        public override Type[] GetGenericParameterConstraints() =>
+            _interfaces == null ? EmptyTypes : _interfaces.ToArray();
+        public override bool IsGenericTypeParameter => _isGenericType;
+        public override bool IsGenericMethodParameter => !_isGenericType;
+        public override int GenericParameterPosition => _genParamPosition;
+        public override GenericParameterAttributes GenericParameterAttributes => _genParamAttributes;
+        public override string Name => _name;
+        public override Module Module => _type.Module;
+        public override Assembly Assembly => _type.Assembly;
+        public override string? FullName => null;
+        public override string? Namespace => null;
+        public override string? AssemblyQualifiedName => null;
+        public override Type UnderlyingSystemType => this;
+        public override bool IsGenericTypeDefinition => false;
+        public override bool IsGenericType => false;
+        public override bool IsGenericParameter => true;
+        public override bool IsConstructedGenericType => false;
+        public override bool ContainsGenericParameters => _type.ContainsGenericParameters;
+        public override MethodBase? DeclaringMethod => throw new NotImplementedException();
+        public override Type? BaseType => _parent;
+        public override RuntimeTypeHandle TypeHandle => throw new NotSupportedException();
+        public override Guid GUID => throw new NotSupportedException();
+        protected override bool IsArrayImpl() => false;
+        protected override bool IsByRefImpl() => false;
+        protected override bool IsPointerImpl() => false;
+        protected override bool IsPrimitiveImpl() => false;
+        protected override bool IsCOMObjectImpl() => false;
+        protected override bool HasElementTypeImpl() => false;
+        protected override TypeAttributes GetAttributeFlagsImpl() => TypeAttributes.Public;
+        public override Type GetElementType() => throw new NotSupportedException();
+        public override object[] GetCustomAttributes(bool inherit) => throw new NotSupportedException();
+        public override object[] GetCustomAttributes(Type attributeType, bool inherit) => throw new NotSupportedException();
+        public override bool IsDefined(Type attributeType, bool inherit) => throw new NotSupportedException();
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+        protected override ConstructorInfo GetConstructorImpl(BindingFlags bindingAttr, Binder? binder, CallingConventions callConvention, Type[] types, ParameterModifier[]? modifiers) => throw new NotSupportedException();
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+        public override ConstructorInfo[] GetConstructors(BindingFlags bindingAttr) => throw new NotSupportedException();
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
+        protected override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder? binder, CallingConventions callConvention, Type[]? types, ParameterModifier[]? modifiers) => throw new NotSupportedException();
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
+        public override MethodInfo[] GetMethods(BindingFlags bindingAttr) => throw new NotSupportedException();
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)]
+        public override FieldInfo GetField(string name, BindingFlags bindingAttr) => throw new NotSupportedException();
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)]
+        public override FieldInfo[] GetFields(BindingFlags bindingAttr) => throw new NotSupportedException();
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+        public override Type GetInterface(string name, bool ignoreCase) => throw new NotSupportedException();
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+        public override Type[] GetInterfaces() => throw new NotSupportedException();
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents)]
+        public override EventInfo GetEvent(string name, BindingFlags bindingAttr) => throw new NotSupportedException();
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents)]
+        public override EventInfo[] GetEvents() => throw new NotSupportedException();
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
+        protected override PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr, Binder? binder, Type? returnType, Type[]? types, ParameterModifier[]? modifiers) => throw new NotSupportedException();
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
+        public override PropertyInfo[] GetProperties(BindingFlags bindingAttr) => throw new NotSupportedException();
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicNestedTypes | DynamicallyAccessedMemberTypes.NonPublicNestedTypes)]
+        public override Type[] GetNestedTypes(BindingFlags bindingAttr) => throw new NotSupportedException();
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicNestedTypes | DynamicallyAccessedMemberTypes.NonPublicNestedTypes)]
+        public override Type GetNestedType(string name, BindingFlags bindingAttr) => throw new NotSupportedException();
+
+        [DynamicallyAccessedMembers(TypeBuilderImpl.GetAllMembers)]
+        public override MemberInfo[] GetMember(string name, MemberTypes type, BindingFlags bindingAttr) => throw new NotSupportedException();
+
+        public override InterfaceMapping GetInterfaceMap([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] Type interfaceType) => throw new NotSupportedException();
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents)]
+        public override EventInfo[] GetEvents(BindingFlags bindingAttr) => throw new NotSupportedException();
+
+        [DynamicallyAccessedMembers(TypeBuilderImpl.GetAllMembers)]
+        public override MemberInfo[] GetMembers(BindingFlags bindingAttr) => throw new NotSupportedException();
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+        public override object InvokeMember(string name, BindingFlags invokeAttr, Binder? binder, object? target, object?[]? args, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParameters) => throw new NotSupportedException();
+    }
+}

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/GenericTypeParameterBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/GenericTypeParameterBuilderImpl.cs
@@ -56,6 +56,7 @@ namespace System.Reflection.Emit
                 _interfaces.AddRange(interfaceConstraints);
             }
         }
+
         public override Type[] GetGenericParameterConstraints() =>
             _interfaces == null ? EmptyTypes : _interfaces.ToArray();
         public override bool IsGenericTypeParameter => _isGenericType;
@@ -91,55 +92,38 @@ namespace System.Reflection.Emit
         public override bool IsDefined(Type attributeType, bool inherit) => throw new NotSupportedException();
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
         protected override ConstructorInfo GetConstructorImpl(BindingFlags bindingAttr, Binder? binder, CallingConventions callConvention, Type[] types, ParameterModifier[]? modifiers) => throw new NotSupportedException();
-
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
         public override ConstructorInfo[] GetConstructors(BindingFlags bindingAttr) => throw new NotSupportedException();
-
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
         protected override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder? binder, CallingConventions callConvention, Type[]? types, ParameterModifier[]? modifiers) => throw new NotSupportedException();
-
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
         public override MethodInfo[] GetMethods(BindingFlags bindingAttr) => throw new NotSupportedException();
-
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)]
         public override FieldInfo GetField(string name, BindingFlags bindingAttr) => throw new NotSupportedException();
-
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)]
         public override FieldInfo[] GetFields(BindingFlags bindingAttr) => throw new NotSupportedException();
-
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
         public override Type GetInterface(string name, bool ignoreCase) => throw new NotSupportedException();
-
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
         public override Type[] GetInterfaces() => throw new NotSupportedException();
-
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents)]
         public override EventInfo GetEvent(string name, BindingFlags bindingAttr) => throw new NotSupportedException();
-
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents)]
         public override EventInfo[] GetEvents() => throw new NotSupportedException();
-
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
         protected override PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr, Binder? binder, Type? returnType, Type[]? types, ParameterModifier[]? modifiers) => throw new NotSupportedException();
-
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
         public override PropertyInfo[] GetProperties(BindingFlags bindingAttr) => throw new NotSupportedException();
-
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicNestedTypes | DynamicallyAccessedMemberTypes.NonPublicNestedTypes)]
         public override Type[] GetNestedTypes(BindingFlags bindingAttr) => throw new NotSupportedException();
-
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicNestedTypes | DynamicallyAccessedMemberTypes.NonPublicNestedTypes)]
         public override Type GetNestedType(string name, BindingFlags bindingAttr) => throw new NotSupportedException();
-
         [DynamicallyAccessedMembers(TypeBuilderImpl.GetAllMembers)]
         public override MemberInfo[] GetMember(string name, MemberTypes type, BindingFlags bindingAttr) => throw new NotSupportedException();
-
         public override InterfaceMapping GetInterfaceMap([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] Type interfaceType) => throw new NotSupportedException();
-
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents)]
         public override EventInfo[] GetEvents(BindingFlags bindingAttr) => throw new NotSupportedException();
-
         [DynamicallyAccessedMembers(TypeBuilderImpl.GetAllMembers)]
         public override MemberInfo[] GetMembers(BindingFlags bindingAttr) => throw new NotSupportedException();
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
@@ -18,6 +18,7 @@ namespace System.Reflection.Emit
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
         private Type? _typeParent;
         private readonly TypeBuilderImpl? _declaringType;
+        private GenericTypeParameterBuilderImpl[]? _typeParameters;
         private TypeAttributes _attributes;
         private PackingSize _packingSize;
         private int _typeSize;
@@ -65,24 +66,45 @@ namespace System.Reflection.Emit
         internal ModuleBuilderImpl GetModuleBuilder() => _module;
         protected override PackingSize PackingSizeCore => _packingSize;
         protected override int SizeCore => _typeSize;
+
         protected override void AddInterfaceImplementationCore([DynamicallyAccessedMembers((DynamicallyAccessedMemberTypes.All))] Type interfaceType)
         {
             _interfaces ??= new List<Type>();
             _interfaces.Add(interfaceType);
         }
+
         [return: DynamicallyAccessedMembers((DynamicallyAccessedMemberTypes)(-1))]
         protected override TypeInfo CreateTypeInfoCore() => throw new NotImplementedException();
         protected override ConstructorBuilder DefineConstructorCore(MethodAttributes attributes, CallingConventions callingConvention, Type[]? parameterTypes, Type[][]? requiredCustomModifiers, Type[][]? optionalCustomModifiers) => throw new NotImplementedException();
         protected override ConstructorBuilder DefineDefaultConstructorCore(MethodAttributes attributes) => throw new NotImplementedException();
         protected override EventBuilder DefineEventCore(string name, EventAttributes attributes, Type eventtype) => throw new NotImplementedException();
+
         protected override FieldBuilder DefineFieldCore(string fieldName, Type type, Type[]? requiredCustomModifiers, Type[]? optionalCustomModifiers, FieldAttributes attributes)
         {
             var field = new FieldBuilderImpl(this, fieldName, type, attributes);
             _fieldDefinitions.Add(field);
             return field;
         }
-        protected override GenericTypeParameterBuilder[] DefineGenericParametersCore(params string[] names) => throw new NotImplementedException();
+
+        protected override GenericTypeParameterBuilder[] DefineGenericParametersCore(params string[] names)
+        {
+            if (_typeParameters != null)
+                throw new InvalidOperationException();
+
+            _typeParameters = new GenericTypeParameterBuilderImpl[names.Length];
+
+            for (int i = 0; i < names.Length; i++)
+            {
+                string name = names[i];
+                ArgumentNullException.ThrowIfNull(name, nameof(names));
+                _typeParameters[i] = new GenericTypeParameterBuilderImpl(name, i, this);
+            }
+
+            return _typeParameters;
+        }
+
         protected override FieldBuilder DefineInitializedDataCore(string name, byte[] data, FieldAttributes attributes) => throw new NotImplementedException();
+
         protected override MethodBuilder DefineMethodCore(string name, MethodAttributes attributes, CallingConventions callingConvention, Type? returnType, Type[]? returnTypeRequiredCustomModifiers, Type[]? returnTypeOptionalCustomModifiers, Type[]? parameterTypes, Type[][]? parameterTypeRequiredCustomModifiers, Type[][]? parameterTypeOptionalCustomModifiers)
         {
             MethodBuilderImpl methodBuilder = new(name, attributes, callingConvention, returnType, parameterTypes, _module, this);
@@ -91,6 +113,7 @@ namespace System.Reflection.Emit
         }
 
         protected override void DefineMethodOverrideCore(MethodInfo methodInfoBody, MethodInfo methodInfoDeclaration) => throw new NotImplementedException();
+
         protected override TypeBuilder DefineNestedTypeCore(string name, TypeAttributes attr,
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type? parent, Type[]? interfaces, PackingSize packSize, int typeSize)
         {
@@ -102,7 +125,7 @@ namespace System.Reflection.Emit
         protected override PropertyBuilder DefinePropertyCore(string name, PropertyAttributes attributes, CallingConventions callingConvention, Type returnType, Type[]? returnTypeRequiredCustomModifiers, Type[]? returnTypeOptionalCustomModifiers, Type[]? parameterTypes, Type[][]? parameterTypeRequiredCustomModifiers, Type[][]? parameterTypeOptionalCustomModifiers) => throw new NotImplementedException();
         protected override ConstructorBuilder DefineTypeInitializerCore() => throw new NotImplementedException();
         protected override FieldBuilder DefineUninitializedDataCore(string name, int size, FieldAttributes attributes) => throw new NotImplementedException();
-        protected override bool IsCreatedCore() => throw new NotImplementedException();
+        protected override bool IsCreatedCore() => false;
         protected override void SetCustomAttributeCore(ConstructorInfo con, ReadOnlySpan<byte> binaryAttribute)
         {
             // Handle pseudo custom attributes
@@ -217,6 +240,9 @@ namespace System.Reflection.Emit
         public override string Name => _name;
         public override Type? DeclaringType => _declaringType;
         public override Type? ReflectedType => _declaringType;
+        public override bool IsGenericTypeDefinition => IsGenericType;
+        public override bool IsGenericType => _typeParameters != null;
+        public override Type[] GenericTypeParameters => _typeParameters ?? EmptyTypes;
         public override bool IsDefined(Type attributeType, bool inherit) => throw new NotImplementedException();
         public override object[] GetCustomAttributes(bool inherit) => throw new NotImplementedException();
         public override object[] GetCustomAttributes(Type attributeType, bool inherit) => throw new NotImplementedException();

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
@@ -242,7 +242,9 @@ namespace System.Reflection.Emit
         public override Type? ReflectedType => _declaringType;
         public override bool IsGenericTypeDefinition => IsGenericType;
         public override bool IsGenericType => _typeParameters != null;
+        // Not returning a copy for compat with existing runtime behavior
         public override Type[] GenericTypeParameters => _typeParameters ?? EmptyTypes;
+        public override Type[] GetGenericArguments() => _typeParameters ?? EmptyTypes;
         public override bool IsDefined(Type attributeType, bool inherit) => throw new NotImplementedException();
         public override object[] GetCustomAttributes(bool inherit) => throw new NotImplementedException();
         public override object[] GetCustomAttributes(Type attributeType, bool inherit) => throw new NotImplementedException();

--- a/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveWithVariousMembersTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveWithVariousMembersTests.cs
@@ -166,10 +166,9 @@ namespace System.Reflection.Emit.Tests
                 typeParams[1].SetCustomAttribute(new CustomAttributeBuilder(typeof(DynamicallyAccessedMembersAttribute).GetConstructor(
                     new Type[] { typeof(DynamicallyAccessedMemberTypes) }), new object[] { DynamicallyAccessedMemberTypes.PublicProperties }));
                 typeParams[2].SetBaseTypeConstraint(typeof(EmptyTestClass));
-                typeParams[2].SetGenericParameterAttributes(GenericParameterAttributes.ReferenceTypeConstraint);
+                typeParams[2].SetGenericParameterAttributes(GenericParameterAttributes.VarianceMask);
                 saveMethod.Invoke(assemblyBuilder, new object[] { file.Path });
-                // internal interface TestInterface<TFirst, [DynamicallyAccessedMembers(/*Could not decode attribute arguments.*/)] TSecond, TThird>
-                // where TFirst : IAccess, INoMethod where TThird : class, EmptyTestClass
+
                 Assembly assemblyFromDisk = AssemblyTools.LoadAssemblyFromPath(file.Path);
                 Type testType = assemblyFromDisk.Modules.First().GetTypes()[0];
                 Type[] genericTypeParams = testType.GetGenericArguments();
@@ -184,9 +183,11 @@ namespace System.Reflection.Emit.Tests
                 Assert.Equal(typeof(IAccess).FullName, constraints[0].FullName);
                 Assert.Equal(typeof(INoMethod).FullName, constraints[1].FullName);
                 Assert.Empty(genericTypeParams[1].GetTypeInfo().GetGenericParameterConstraints());
-                Assert.Equal(typeof(EmptyTestClass).FullName, genericTypeParams[2].GetTypeInfo().GetGenericParameterConstraints()[0].FullName);
+                Type[] constraints2 = genericTypeParams[2].GetTypeInfo().GetGenericParameterConstraints();
+                Assert.Equal(1, constraints2.Length);
+                Assert.Equal(typeof(EmptyTestClass).FullName, constraints2[0].FullName);
                 Assert.Equal(GenericParameterAttributes.None, genericTypeParams[0].GenericParameterAttributes);
-                Assert.Equal(GenericParameterAttributes.ReferenceTypeConstraint, genericTypeParams[2].GenericParameterAttributes);
+                Assert.Equal(GenericParameterAttributes.VarianceMask, genericTypeParams[2].GenericParameterAttributes);
 
                 IList<CustomAttributeData> attributes = genericTypeParams[1].GetCustomAttributesData();
                 Assert.Equal(1, attributes.Count);

--- a/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveWithVariousMembersTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveWithVariousMembersTests.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Reflection.Emit.Tests
@@ -101,7 +100,6 @@ namespace System.Reflection.Emit.Tests
             {
                 AssemblyBuilder assemblyBuilder = AssemblyTools.PopulateAssemblyBuilderAndSaveMethod(
                     s_assemblyName, null, typeof(string), out MethodInfo saveMethod);
-
                 ModuleBuilder mb = assemblyBuilder.DefineDynamicModule("My Module");
                 TypeBuilder tb = mb.DefineType("TestInterface", TypeAttributes.Interface | TypeAttributes.Abstract);
                 tb.DefineMethod("TestMethod", MethodAttributes.Public);
@@ -131,7 +129,6 @@ namespace System.Reflection.Emit.Tests
             {
                 AssemblyBuilder assemblyBuilder = AssemblyTools.PopulateAssemblyBuilderAndSaveMethod(
                     s_assemblyName, null, typeof(string), out MethodInfo saveMethod);
-
                 ModuleBuilder mb = assemblyBuilder.DefineDynamicModule("My Module");
                 TypeBuilder tb = mb.DefineType("TestInterface", TypeAttributes.Interface | TypeAttributes.Abstract, null, new Type[] { typeof(IOneMethod)});
                 tb.AddInterfaceImplementation(typeof(INoMethod));
@@ -151,6 +148,51 @@ namespace System.Reflection.Emit.Tests
                 Assert.Equal(1, iOneMethod.GetMethods().Length);
                 Assert.Empty(iNoMethod.GetMethods());
                 Assert.NotNull(testType.GetNestedType("NestedType", BindingFlags.NonPublic));
+            }
+        }
+
+        [Fact]
+        public void SaveGenericTypeParametersForAType()
+        {
+            using (TempFile file = TempFile.Create())
+            {
+                AssemblyBuilder assemblyBuilder = AssemblyTools.PopulateAssemblyBuilderAndSaveMethod(
+                    s_assemblyName, null, typeof(string), out MethodInfo saveMethod);
+                ModuleBuilder mb = assemblyBuilder.DefineDynamicModule("My Module");
+                TypeBuilder tb = mb.DefineType("TestInterface", TypeAttributes.Interface | TypeAttributes.Abstract);
+                string[] typeParamNames = new string[] { "TFirst", "TSecond", "TThird" };
+                GenericTypeParameterBuilder[] typeParams = tb.DefineGenericParameters(typeParamNames);
+                typeParams[0].SetInterfaceConstraints(new Type[] { typeof(IAccess), typeof(INoMethod)});
+                typeParams[1].SetCustomAttribute(new CustomAttributeBuilder(typeof(DynamicallyAccessedMembersAttribute).GetConstructor(
+                    new Type[] { typeof(DynamicallyAccessedMemberTypes) }), new object[] { DynamicallyAccessedMemberTypes.PublicProperties }));
+                typeParams[2].SetBaseTypeConstraint(typeof(EmptyTestClass));
+                typeParams[2].SetGenericParameterAttributes(GenericParameterAttributes.ReferenceTypeConstraint);
+                saveMethod.Invoke(assemblyBuilder, new object[] { file.Path });
+                // internal interface TestInterface<TFirst, [DynamicallyAccessedMembers(/*Could not decode attribute arguments.*/)] TSecond, TThird>
+                // where TFirst : IAccess, INoMethod where TThird : class, EmptyTestClass
+                Assembly assemblyFromDisk = AssemblyTools.LoadAssemblyFromPath(file.Path);
+                Type testType = assemblyFromDisk.Modules.First().GetTypes()[0];
+                Type[] genericTypeParams = testType.GetGenericArguments();
+                
+                Assert.Equal(3, genericTypeParams.Length);
+                Assert.Equal("TFirst", genericTypeParams[0].Name);
+                Assert.Equal("TSecond", genericTypeParams[1].Name);
+                Assert.Equal("TThird", genericTypeParams[2].Name);
+
+                Type[] constraints = genericTypeParams[0].GetTypeInfo().GetGenericParameterConstraints();
+                Assert.Equal(2, constraints.Length);
+                Assert.Equal(typeof(IAccess).FullName, constraints[0].FullName);
+                Assert.Equal(typeof(INoMethod).FullName, constraints[1].FullName);
+                Assert.Empty(genericTypeParams[1].GetTypeInfo().GetGenericParameterConstraints());
+                Assert.Equal(typeof(EmptyTestClass).FullName, genericTypeParams[2].GetTypeInfo().GetGenericParameterConstraints()[0].FullName);
+                Assert.Equal(GenericParameterAttributes.None, genericTypeParams[0].GenericParameterAttributes);
+                Assert.Equal(GenericParameterAttributes.ReferenceTypeConstraint, genericTypeParams[2].GenericParameterAttributes);
+
+                IList<CustomAttributeData> attributes = genericTypeParams[1].GetCustomAttributesData();
+                Assert.Equal(1, attributes.Count);
+                Assert.Equal("DynamicallyAccessedMembersAttribute", attributes[0].AttributeType.Name);
+                Assert.Equal(DynamicallyAccessedMemberTypes.PublicProperties, (DynamicallyAccessedMemberTypes)attributes[0].ConstructorArguments[0].Value);
+                Assert.Empty(genericTypeParams[0].GetCustomAttributesData());
             }
         }
     }


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/62956

AssemblyBuilder.Save generic type parameters support
- Add GenericTypeParameterBuilder implementation 
- Support saving generic type parameters with its constraints for a type