### PR TITLE
[wasm] Use monotonic clock in wasm, emscripten has it now

### DIFF
--- a/src/mono/mono/utils/mono-os-mutex.h
+++ b/src/mono/mono/utils/mono-os-mutex.h
@@ -36,7 +36,7 @@
 
 #if !defined(HOST_WIN32)
 
-#if !defined(CLOCK_MONOTONIC) || defined(HOST_DARWIN) || defined(HOST_WASM)
+#if !defined(CLOCK_MONOTONIC) || defined(HOST_DARWIN)
 #define BROKEN_CLOCK_SOURCE
 #endif
 

--- a/src/mono/mono/utils/mono-os-mutex.h
+++ b/src/mono/mono/utils/mono-os-mutex.h
@@ -36,7 +36,7 @@
 
 #if !defined(HOST_WIN32)
 
-#if !defined(CLOCK_MONOTONIC) || defined(HOST_DARWIN)
+#if !defined(CLOCK_MONOTONIC) || defined(HOST_DARWIN) || defined(HOST_WASI)
 #define BROKEN_CLOCK_SOURCE
 #endif
 

--- a/src/mono/mono/utils/mono-time.c
+++ b/src/mono/mono/utils/mono-time.c
@@ -119,9 +119,10 @@ gint64
 mono_msec_boottime (void)
 {
 	/* clock_gettime () is found by configure on Apple builds, but its only present from ios 10, macos 10.12, tvos 10 and watchos 3 */
-#if !defined (TARGET_WASM) && ((defined(HAVE_CLOCK_MONOTONIC_COARSE) || defined(HAVE_CLOCK_MONOTONIC)) && !(defined(TARGET_IOS) || defined(TARGET_OSX) || defined(TARGET_WATCHOS) || defined(TARGET_TVOS)))
+#if ((defined(HAVE_CLOCK_MONOTONIC_COARSE) || defined(HAVE_CLOCK_MONOTONIC)) && !(defined(TARGET_IOS) || defined(TARGET_OSX) || defined(TARGET_WATCHOS) || defined(TARGET_TVOS)))
 	clockid_t clockType =
-#if HAVE_CLOCK_MONOTONIC_COARSE
+	/* emscripten exposes CLOCK_MONOTONIC_COARSE but doesn't implement it */
+#if defined(HAVE_CLOCK_MONOTONIC_COARSE) && !defined(TARGET_WASM)
 	CLOCK_MONOTONIC_COARSE; /* good enough resolution, fastest speed */
 #else
 	CLOCK_MONOTONIC;


### PR DESCRIPTION
emscripten added monotonic clock support (albeit not *coarse* support, despite the symbol existing) at least a year ago, possibly longer. So we can use our common monotonic clock/gettime path on wasm as well, which might fix #85473 (I can't reproduce it locally).