### PR TITLE
[release/6.0-staging] Make WindowsServiceLifetime gracefully stop 

### DIFF
--- a/eng/testing/xunit/xunit.targets
+++ b/eng/testing/xunit/xunit.targets
@@ -4,6 +4,11 @@
     <PackageReference Include="NETStandard.Library" Version="$(NetStandardLibraryVersion)" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <AutoGenerateBindingRedirects Condition="'$(AutoGenerateBindingRedirects)' == ''">true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType Condition="'$(GenerateBindingRedirectsOutputType)' == ''">true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
+
   <!-- Run target (F5) support. -->
   <PropertyGroup>
     <RunWorkingDirectory>$(OutDir)</RunWorkingDirectory>

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.QueryServiceStatusEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.QueryServiceStatusEx.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Advapi32
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct SERVICE_STATUS_PROCESS
+        {
+            public int dwServiceType;
+            public int dwCurrentState;
+            public int dwControlsAccepted;
+            public int dwWin32ExitCode;
+            public int dwServiceSpecificExitCode;
+            public int dwCheckPoint;
+            public int dwWaitHint;
+            public int dwProcessId;
+            public int dwServiceFlags;
+        }
+
+        private const int SC_STATUS_PROCESS_INFO = 0;
+
+        [LibraryImport(Libraries.Advapi32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static unsafe partial bool QueryServiceStatusEx(SafeServiceHandle serviceHandle, int InfoLevel, SERVICE_STATUS_PROCESS* pStatus, int cbBufSize, out int pcbBytesNeeded);
+
+        internal static unsafe bool QueryServiceStatusEx(SafeServiceHandle serviceHandle, SERVICE_STATUS_PROCESS* pStatus) => QueryServiceStatusEx(serviceHandle, SC_STATUS_PROCESS_INFO, pStatus, sizeof(SERVICE_STATUS_PROCESS), out _);
+    }
+}

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.QueryServiceStatusEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.QueryServiceStatusEx.cs
@@ -25,9 +25,9 @@ internal static partial class Interop
 
         private const int SC_STATUS_PROCESS_INFO = 0;
 
-        [LibraryImport(Libraries.Advapi32, SetLastError = true)]
+        [DllImport(Libraries.Advapi32, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static unsafe partial bool QueryServiceStatusEx(SafeServiceHandle serviceHandle, int InfoLevel, SERVICE_STATUS_PROCESS* pStatus, int cbBufSize, out int pcbBytesNeeded);
+        private static unsafe extern bool QueryServiceStatusEx(SafeServiceHandle serviceHandle, int InfoLevel, SERVICE_STATUS_PROCESS* pStatus, int cbBufSize, out int pcbBytesNeeded);
 
         internal static unsafe bool QueryServiceStatusEx(SafeServiceHandle serviceHandle, SERVICE_STATUS_PROCESS* pStatus) => QueryServiceStatusEx(serviceHandle, SC_STATUS_PROCESS_INFO, pStatus, sizeof(SERVICE_STATUS_PROCESS), out _);
     }

--- a/src/libraries/Common/src/Interop/Windows/Interop.Errors.cs
+++ b/src/libraries/Common/src/Interop/Windows/Interop.Errors.cs
@@ -63,6 +63,8 @@ internal static partial class Interop
         internal const int ERROR_IO_PENDING = 0x3E5;
         internal const int ERROR_NO_TOKEN = 0x3f0;
         internal const int ERROR_SERVICE_DOES_NOT_EXIST = 0x424;
+        internal const int ERROR_EXCEPTION_IN_SERVICE = 0x428;
+        internal const int ERROR_PROCESS_ABORTED = 0x42B;
         internal const int ERROR_NO_UNICODE_TRANSLATION = 0x459;
         internal const int ERROR_DLL_INIT_FAILED = 0x45A;
         internal const int ERROR_COUNTER_TIMEOUT = 0x461;

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/Microsoft.Extensions.Hosting.WindowsServices.csproj
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/Microsoft.Extensions.Hosting.WindowsServices.csproj
@@ -4,7 +4,8 @@
     <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
     <PackageDescription>.NET hosting infrastructure for Windows Services.</PackageDescription>
-    <ServicingVersion>1</ServicingVersion>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>2</ServicingVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceLifetime.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
 {
     public class WindowsServiceLifetime : ServiceBase, IHostLifetime
     {
-        private readonly TaskCompletionSource<object?> _delayStart = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
-        private readonly TaskCompletionSource<object?> _serviceDispatcherStopped = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<object> _delayStart = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<object> _serviceDispatcherStopped = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly ManualResetEventSlim _delayStop = new ManualResetEventSlim();
         private readonly HostOptions _hostOptions;
         private bool _serviceStopRequested;

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceLifetime.cs
@@ -12,9 +12,11 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
 {
     public class WindowsServiceLifetime : ServiceBase, IHostLifetime
     {
-        private readonly TaskCompletionSource<object> _delayStart = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<object?> _delayStart = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<object?> _serviceDispatcherStopped = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly ManualResetEventSlim _delayStop = new ManualResetEventSlim();
         private readonly HostOptions _hostOptions;
+        private bool _serviceStopRequested;
 
         public WindowsServiceLifetime(IHostEnvironment environment, IHostApplicationLifetime applicationLifetime, ILoggerFactory loggerFactory, IOptions<HostOptions> optionsAccessor)
             : this(environment, applicationLifetime, loggerFactory, optionsAccessor, Options.Options.Create(new WindowsServiceLifetimeOptions()))
@@ -73,19 +75,30 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
             {
                 Run(this); // This blocks until the service is stopped.
                 _delayStart.TrySetException(new InvalidOperationException("Stopped without starting"));
+                _serviceDispatcherStopped.TrySetResult(null);
             }
             catch (Exception ex)
             {
                 _delayStart.TrySetException(ex);
+                _serviceDispatcherStopped.TrySetException(ex);
             }
         }
 
-        public Task StopAsync(CancellationToken cancellationToken)
+        /// <summary>
+        /// Called from <see cref="IHost.StopAsync"/> to stop the service if not already stopped, and wait for the service dispatcher to exit.
+        /// Once this method returns the service is stopped and the process can be terminated at any time.
+        /// </summary>
+        public async Task StopAsync(CancellationToken cancellationToken)
         {
-            // Avoid deadlock where host waits for StopAsync before firing ApplicationStopped,
-            // and Stop waits for ApplicationStopped.
-            Task.Run(Stop, CancellationToken.None);
-            return Task.CompletedTask;
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!_serviceStopRequested)
+            {
+                await Task.Run(Stop, cancellationToken).ConfigureAwait(false);
+            }
+
+            // When the underlying service is stopped this will cause the ServiceBase.Run method to complete and return, which completes _serviceDispatcherStopped.
+            await _serviceDispatcherStopped.Task.ConfigureAwait(false);
         }
 
         // Called by base.Run when the service is ready to start.
@@ -95,18 +108,28 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
             base.OnStart(args);
         }
 
-        // Called by base.Stop. This may be called multiple times by service Stop, ApplicationStopping, and StopAsync.
-        // That's OK because StopApplication uses a CancellationTokenSource and prevents any recursion.
+        /// <summary>
+        /// Executes when a Stop command is sent to the service by the Service Control Manager (SCM).
+        /// Triggers <see cref="IHostApplicationLifetime.ApplicationStopping"/> and waits for <see cref="IHostApplicationLifetime.ApplicationStopped"/>.
+        /// Shortly after this method returns, the Service will be marked as stopped in SCM and the process may exit at any point.
+        /// </summary>
         protected override void OnStop()
         {
+            _serviceStopRequested = true;
             ApplicationLifetime.StopApplication();
             // Wait for the host to shutdown before marking service as stopped.
             _delayStop.Wait(_hostOptions.ShutdownTimeout);
             base.OnStop();
         }
 
+        /// <summary>
+        /// Executes when a Shutdown command is sent to the service by the Service Control Manager (SCM).
+        /// Triggers <see cref="IHostApplicationLifetime.ApplicationStopping"/> and waits for <see cref="IHostApplicationLifetime.ApplicationStopped"/>.
+        /// Shortly after this method returns, the Service will be marked as stopped in SCM and the process may exit at any point.
+        /// </summary>
         protected override void OnShutdown()
         {
+            _serviceStopRequested = true;
             ApplicationLifetime.StopApplication();
             // Wait for the host to shutdown before marking service as stopped.
             _delayStop.Wait(_hostOptions.ShutdownTimeout);

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/Microsoft.Extensions.Hosting.WindowsServices.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/Microsoft.Extensions.Hosting.WindowsServices.Tests.csproj
@@ -2,9 +2,8 @@
 
   <PropertyGroup>
     <!-- Use "$(NetCoreAppCurrent)-windows" to avoid PlatformNotSupportedExceptions from ServiceController. -->
-    <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetFrameworkMinimum)</TargetFrameworks> 
+    <TargetFrameworks>$(NetCoreAppCurrent)-windows;net461</TargetFrameworks> 
     <EnableDefaultItems>true</EnableDefaultItems>
-    <EnableLibraryImportGenerator>true</EnableLibraryImportGenerator>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
   </PropertyGroup>

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/Microsoft.Extensions.Hosting.WindowsServices.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/Microsoft.Extensions.Hosting.WindowsServices.Tests.csproj
@@ -1,12 +1,47 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetCoreAppCurrent);net461</TargetFrameworks>
+    <!-- Use "$(NetCoreAppCurrent)-windows" to avoid PlatformNotSupportedExceptions from ServiceController. -->
+    <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetFrameworkMinimum)</TargetFrameworks> 
     <EnableDefaultItems>true</EnableDefaultItems>
+    <EnableLibraryImportGenerator>true</EnableLibraryImportGenerator>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\src\Microsoft.Extensions.Hosting.WindowsServices.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="$(LibrariesProjectRoot)System.ServiceProcess.ServiceController\src\Microsoft\Win32\SafeHandles\SafeServiceHandle.cs"
+             Link="Microsoft\Win32\SafeHandles\SafeServiceHandle.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs"
+             Link="Common\Interop\Windows\Interop.Errors.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs"
+             Link="Common\Interop\Windows\Interop.Libraries.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.ServiceProcessOptions.cs"
+             Link="Common\Interop\Windows\Interop.ServiceProcessOptions.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CloseServiceHandle.cs"
+             Link="Common\Interop\Windows\Interop.CloseServiceHandle.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.CreateService.cs"
+             Link="Common\Interop\Windows\Interop.CreateService.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.DeleteService.cs"
+             Link="Common\Interop\Windows\Interop.DeleteService.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.OpenService.cs"
+             Link="Common\Interop\Windows\Interop.OpenService.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.OpenSCManager.cs"
+             Link="Common\Interop\Windows\Interop.OpenSCManager.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.QueryServiceStatus.cs"
+             Link="Common\Interop\Windows\Interop.QueryServiceStatus.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.QueryServiceStatusEx.cs"
+             Link="Common\Interop\Windows\Interop.QueryServiceStatusEx.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Advapi32\Interop.SERVICE_STATUS.cs"
+             Link="Common\Interop\Windows\Interop.SERVICE_STATUS.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <Reference Include="System.ServiceProcess" />
   </ItemGroup>
 
 </Project>

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/UseWindowsServiceTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/UseWindowsServiceTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Reflection;
 using System.ServiceProcess;
+using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting.Internal;
 using Microsoft.Extensions.Hosting.WindowsServices;
@@ -16,6 +17,8 @@ namespace Microsoft.Extensions.Hosting
 {
     public class UseWindowsServiceTests
     {
+        private static bool IsRemoteExecutorSupportedAndPrivilegedProcess => RemoteExecutor.IsSupported && AdminHelpers.IsProcessElevated;
+
         private static MethodInfo? _addWindowsServiceLifetimeMethod = null;
 
         [Fact]
@@ -32,7 +35,7 @@ namespace Microsoft.Extensions.Hosting
         }
         }
 
-        [ConditionalFact(typeof(AdminHelpers), nameof(AdminHelpers.IsProcessElevated))]
+        [ConditionalFact(nameof(IsRemoteExecutorSupportedAndPrivilegedProcess))]
         public void CanCreateService()
         {
             using var serviceTester = WindowsServiceTester.Create(() =>

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/UseWindowsServiceTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/UseWindowsServiceTests.cs
@@ -27,12 +27,12 @@ namespace Microsoft.Extensions.Hosting
 
             using (host)
             {
-                var lifetime = host.Services.GetRequiredService<IHostLifetime>();
-                Assert.IsType<ConsoleLifetime>(lifetime);
-            }
+            var lifetime = host.Services.GetRequiredService<IHostLifetime>();
+            Assert.IsType<ConsoleLifetime>(lifetime);
+        }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPrivilegedProcess))]
+        [ConditionalFact(typeof(AdminHelpers), nameof(AdminHelpers.IsProcessElevated))]
         public void CanCreateService()
         {
             using var serviceTester = WindowsServiceTester.Create(() =>

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/UseWindowsServiceTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/UseWindowsServiceTests.cs
@@ -1,14 +1,23 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Reflection;
+using System.ServiceProcess;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting.Internal;
+using Microsoft.Extensions.Hosting.WindowsServices;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.EventLog;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Microsoft.Extensions.Hosting
 {
     public class UseWindowsServiceTests
     {
+        private static MethodInfo? _addWindowsServiceLifetimeMethod = null;
+
         [Fact]
         public void DefaultsToOffOutsideOfService()
         {
@@ -21,6 +30,26 @@ namespace Microsoft.Extensions.Hosting
                 var lifetime = host.Services.GetRequiredService<IHostLifetime>();
                 Assert.IsType<ConsoleLifetime>(lifetime);
             }
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPrivilegedProcess))]
+        public void CanCreateService()
+        {
+            using var serviceTester = WindowsServiceTester.Create(() =>
+            {
+                using IHost host = new HostBuilder()
+                    .UseWindowsService()
+                    .Build();
+                host.Run();
+            });
+
+            serviceTester.Start();
+            serviceTester.WaitForStatus(ServiceControllerStatus.Running);
+            serviceTester.Stop();
+            serviceTester.WaitForStatus(ServiceControllerStatus.Stopped);
+
+            var status = serviceTester.QueryServiceStatus();
+            Assert.Equal(0, status.win32ExitCode);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/UseWindowsServiceTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/UseWindowsServiceTests.cs
@@ -17,9 +17,7 @@ namespace Microsoft.Extensions.Hosting
 {
     public class UseWindowsServiceTests
     {
-        private static bool IsRemoteExecutorSupportedAndPrivilegedProcess => RemoteExecutor.IsSupported && AdminHelpers.IsProcessElevated;
-
-        private static MethodInfo? _addWindowsServiceLifetimeMethod = null;
+        private static bool IsRemoteExecutorSupportedAndPrivilegedProcess => RemoteExecutor.IsSupported && AdminHelpers.IsProcessElevated();
 
         [Fact]
         public void DefaultsToOffOutsideOfService()

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/WindowsServiceLifetimeTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/WindowsServiceLifetimeTests.cs
@@ -1,0 +1,338 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.ServiceProcess;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting.Internal;
+using Microsoft.Extensions.Hosting.WindowsServices;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Microsoft.Extensions.Hosting
+{
+    public class WindowsServiceLifetimeTests
+    {
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPrivilegedProcess))]
+        public void ServiceStops()
+        {
+            using var serviceTester = WindowsServiceTester.Create(async () =>
+            {
+                var applicationLifetime = new ApplicationLifetime(NullLogger<ApplicationLifetime>.Instance);
+                using var lifetime = new WindowsServiceLifetime(
+                    new HostingEnvironment(), 
+                    applicationLifetime,
+                    NullLoggerFactory.Instance,
+                    new OptionsWrapper<HostOptions>(new HostOptions()));
+
+                await lifetime.WaitForStartAsync(CancellationToken.None);
+                
+                // would normally occur here, but WindowsServiceLifetime does not depend on it.
+                // applicationLifetime.NotifyStarted();
+                
+                // will be signaled by WindowsServiceLifetime when SCM stops the service.
+                applicationLifetime.ApplicationStopping.WaitHandle.WaitOne();
+
+                // required by WindowsServiceLifetime to identify that app has stopped.
+                applicationLifetime.NotifyStopped();
+
+                await lifetime.StopAsync(CancellationToken.None);
+            });
+
+            serviceTester.Start();
+            serviceTester.WaitForStatus(ServiceControllerStatus.Running);
+
+            var statusEx = serviceTester.QueryServiceStatusEx();
+            var serviceProcess = Process.GetProcessById(statusEx.dwProcessId);
+
+            serviceTester.Stop();
+            serviceTester.WaitForStatus(ServiceControllerStatus.Stopped);
+            
+            serviceProcess.WaitForExit();
+
+            var status = serviceTester.QueryServiceStatus();
+            Assert.Equal(0, status.win32ExitCode);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPrivilegedProcess))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework is missing the fix from https://github.com/dotnet/corefx/commit/3e68d791066ad0fdc6e0b81828afbd9df00dd7f8")]
+        public void ExceptionOnStartIsPropagated()
+        {
+            using var serviceTester = WindowsServiceTester.Create(async () =>
+            {
+                using (var lifetime = ThrowingWindowsServiceLifetime.Create(throwOnStart: new Exception("Should be thrown")))
+                {
+                    Assert.Equal(lifetime.ThrowOnStart,
+                            await Assert.ThrowsAsync<Exception>(async () => 
+                                await lifetime.WaitForStartAsync(CancellationToken.None)));
+                }
+            });
+
+            serviceTester.Start();
+
+            serviceTester.WaitForStatus(ServiceControllerStatus.Stopped);
+            var status = serviceTester.QueryServiceStatus();
+            Assert.Equal(Interop.Errors.ERROR_EXCEPTION_IN_SERVICE, status.win32ExitCode);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPrivilegedProcess))]
+        public void ExceptionOnStopIsPropagated()
+        {
+            using var serviceTester = WindowsServiceTester.Create(async () =>
+            {
+                using (var lifetime = ThrowingWindowsServiceLifetime.Create(throwOnStop: new Exception("Should be thrown")))
+                {
+                    await lifetime.WaitForStartAsync(CancellationToken.None);
+                    lifetime.ApplicationLifetime.NotifyStopped();
+                    Assert.Equal(lifetime.ThrowOnStop,
+                            await Assert.ThrowsAsync<Exception>( async () => 
+                                await lifetime.StopAsync(CancellationToken.None)));
+                }
+            });
+
+            serviceTester.Start();
+
+            serviceTester.WaitForStatus(ServiceControllerStatus.Stopped);
+            var status = serviceTester.QueryServiceStatus();
+            Assert.Equal(Interop.Errors.ERROR_PROCESS_ABORTED, status.win32ExitCode);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPrivilegedProcess))]
+        public void CancelStopAsync()
+        {
+            using var serviceTester = WindowsServiceTester.Create(async () =>
+            {
+                var applicationLifetime = new ApplicationLifetime(NullLogger<ApplicationLifetime>.Instance);
+                using var lifetime = new WindowsServiceLifetime(
+                    new HostingEnvironment(), 
+                    applicationLifetime,
+                    NullLoggerFactory.Instance,
+                    new OptionsWrapper<HostOptions>(new HostOptions()));
+                await lifetime.WaitForStartAsync(CancellationToken.None);
+                
+                await Assert.ThrowsAsync<OperationCanceledException>(async () => await lifetime.StopAsync(new CancellationToken(true)));
+            });
+
+            serviceTester.Start();
+
+            serviceTester.WaitForStatus(ServiceControllerStatus.Stopped);
+            var status = serviceTester.QueryServiceStatus();
+            Assert.Equal(Interop.Errors.ERROR_PROCESS_ABORTED, status.win32ExitCode);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPrivilegedProcess))]
+        public void ServiceCanStopItself()
+        {
+            using (var serviceTester = WindowsServiceTester.Create(async () =>
+            {
+                FileLogger.InitializeForTestCase(nameof(ServiceCanStopItself));
+                using IHost host = new HostBuilder()
+                    .ConfigureServices(services =>
+                    {
+                        services.AddHostedService<LoggingBackgroundService>();
+                        services.AddSingleton<IHostLifetime, LoggingWindowsServiceLifetime>();
+                    })
+                    .Build();
+
+                var applicationLifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+                applicationLifetime.ApplicationStarted.Register(() => FileLogger.Log($"lifetime started"));
+                applicationLifetime.ApplicationStopping.Register(() => FileLogger.Log($"lifetime stopping"));
+                applicationLifetime.ApplicationStopped.Register(() => FileLogger.Log($"lifetime stopped"));
+
+                FileLogger.Log("host.Start()");
+                host.Start();
+
+                FileLogger.Log("host.Stop()");
+                await host.StopAsync();
+                FileLogger.Log("host.Stop() complete");
+            }))
+            {
+                FileLogger.DeleteLog(nameof(ServiceCanStopItself));
+
+                // service should start cleanly
+                serviceTester.Start();
+                
+                // service will proceed to stopped without any error
+                serviceTester.WaitForStatus(ServiceControllerStatus.Stopped);
+            
+                var status = serviceTester.QueryServiceStatus();
+                Assert.Equal(0, status.win32ExitCode);
+
+            }
+
+            var logText = FileLogger.ReadLog(nameof(ServiceCanStopItself));
+            Assert.Equal("""
+                host.Start()
+                WindowsServiceLifetime.OnStart
+                BackgroundService.StartAsync
+                lifetime started
+                host.Stop()
+                lifetime stopping
+                BackgroundService.StopAsync
+                lifetime stopped
+                WindowsServiceLifetime.OnStop
+                host.Stop() complete
+
+                """, logText);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPrivilegedProcess))]
+        public void ServiceSequenceIsCorrect()
+        {
+            using (var serviceTester = WindowsServiceTester.Create(() =>
+            {
+                FileLogger.InitializeForTestCase(nameof(ServiceSequenceIsCorrect));
+                using IHost host = new HostBuilder()
+                    .ConfigureServices(services =>
+                    {
+                        services.AddHostedService<LoggingBackgroundService>();
+                        services.AddSingleton<IHostLifetime, LoggingWindowsServiceLifetime>();
+                    })
+                    .Build();
+
+                var applicationLifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+                applicationLifetime.ApplicationStarted.Register(() => FileLogger.Log($"lifetime started"));
+                applicationLifetime.ApplicationStopping.Register(() => FileLogger.Log($"lifetime stopping"));
+                applicationLifetime.ApplicationStopped.Register(() => FileLogger.Log($"lifetime stopped"));
+
+                FileLogger.Log("host.Run()");
+                host.Run();
+                FileLogger.Log("host.Run() complete");
+            }))
+            {
+
+                FileLogger.DeleteLog(nameof(ServiceSequenceIsCorrect));
+
+                serviceTester.Start();
+                serviceTester.WaitForStatus(ServiceControllerStatus.Running);
+
+                var statusEx = serviceTester.QueryServiceStatusEx();
+                var serviceProcess = Process.GetProcessById(statusEx.dwProcessId);
+
+                // Give a chance for all asynchronous "started" events to be raised, these happen after the service status changes to started 
+                Thread.Sleep(1000);
+
+                serviceTester.Stop();
+                serviceTester.WaitForStatus(ServiceControllerStatus.Stopped);
+                
+                var status = serviceTester.QueryServiceStatus();
+                Assert.Equal(0, status.win32ExitCode);
+
+            }
+
+            var logText = FileLogger.ReadLog(nameof(ServiceSequenceIsCorrect));
+            Assert.Equal("""
+                host.Run()
+                WindowsServiceLifetime.OnStart
+                BackgroundService.StartAsync
+                lifetime started
+                WindowsServiceLifetime.OnStop
+                lifetime stopping
+                BackgroundService.StopAsync
+                lifetime stopped
+                host.Run() complete
+
+                """, logText);
+
+        }
+
+        public class LoggingWindowsServiceLifetime : WindowsServiceLifetime
+        {
+            public LoggingWindowsServiceLifetime(IHostEnvironment environment, IHostApplicationLifetime applicationLifetime, ILoggerFactory loggerFactory, IOptions<HostOptions> optionsAccessor) :
+                base(environment, applicationLifetime, loggerFactory, optionsAccessor)
+            { }
+
+            protected override void OnStart(string[] args)
+            {
+                FileLogger.Log("WindowsServiceLifetime.OnStart");
+                base.OnStart(args);
+            }
+
+            protected override void OnStop()
+            {
+                FileLogger.Log("WindowsServiceLifetime.OnStop");
+                base.OnStop();
+            }
+        }
+
+        public class ThrowingWindowsServiceLifetime : WindowsServiceLifetime
+        {
+            public static ThrowingWindowsServiceLifetime Create(Exception throwOnStart = null, Exception throwOnStop = null) => 
+                    new ThrowingWindowsServiceLifetime(
+                        new HostingEnvironment(), 
+                        new ApplicationLifetime(NullLogger<ApplicationLifetime>.Instance),
+                        NullLoggerFactory.Instance,
+                        new OptionsWrapper<HostOptions>(new HostOptions()))
+                    {
+                        ThrowOnStart = throwOnStart,
+                        ThrowOnStop = throwOnStop
+                    };
+
+            public ThrowingWindowsServiceLifetime(IHostEnvironment environment, ApplicationLifetime applicationLifetime, ILoggerFactory loggerFactory, IOptions<HostOptions> optionsAccessor) :
+                base(environment, applicationLifetime, loggerFactory, optionsAccessor)
+            { 
+                ApplicationLifetime = applicationLifetime;
+            }
+
+            public ApplicationLifetime ApplicationLifetime { get; }
+
+            public Exception ThrowOnStart { get; set; }
+            protected override void OnStart(string[] args)
+            {
+                if (ThrowOnStart != null)
+                {
+                    throw ThrowOnStart;
+                }
+                base.OnStart(args);
+            }
+
+            public Exception ThrowOnStop { get; set; }
+            protected override void OnStop()
+            {
+                if (ThrowOnStop != null)
+                {
+                    throw ThrowOnStop;
+                }
+                base.OnStop();
+            }
+        }
+
+        public class LoggingBackgroundService : BackgroundService
+        {
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+            protected override async Task ExecuteAsync(CancellationToken stoppingToken) => FileLogger.Log("BackgroundService.ExecuteAsync");
+            public override async Task StartAsync(CancellationToken stoppingToken) => FileLogger.Log("BackgroundService.StartAsync");
+            public override async Task StopAsync(CancellationToken stoppingToken) => FileLogger.Log("BackgroundService.StopAsync");
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+        }
+
+        static class FileLogger
+        {
+            static string _fileName;
+
+            public static void InitializeForTestCase(string testCaseName)
+            {
+                Assert.Null(_fileName);
+                _fileName = GetLogForTestCase(testCaseName);
+            }
+
+            private static string GetLogForTestCase(string testCaseName) => Path.Combine(AppContext.BaseDirectory, $"{testCaseName}.log");
+            public static void DeleteLog(string testCaseName) => File.Delete(GetLogForTestCase(testCaseName));
+            public static string ReadLog(string testCaseName) => File.ReadAllText(GetLogForTestCase(testCaseName));
+            public static void Log(string message)
+            {
+                Assert.NotNull(_fileName);
+                lock (_fileName)
+                {
+                    File.AppendAllText(_fileName, message + Environment.NewLine);
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/WindowsServiceLifetimeTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/WindowsServiceLifetimeTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Extensions.Hosting
 {
     public class WindowsServiceLifetimeTests
     {
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPrivilegedProcess))]
+        [ConditionalFact(typeof(AdminHelpers), nameof(AdminHelpers.IsProcessElevated))]
         public void ServiceStops()
         {
             using var serviceTester = WindowsServiceTester.Create(async () =>
@@ -60,7 +60,7 @@ namespace Microsoft.Extensions.Hosting
             Assert.Equal(0, status.win32ExitCode);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPrivilegedProcess))]
+        [ConditionalFact(typeof(AdminHelpers), nameof(AdminHelpers.IsProcessElevated))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework is missing the fix from https://github.com/dotnet/corefx/commit/3e68d791066ad0fdc6e0b81828afbd9df00dd7f8")]
         public void ExceptionOnStartIsPropagated()
         {
@@ -81,7 +81,7 @@ namespace Microsoft.Extensions.Hosting
             Assert.Equal(Interop.Errors.ERROR_EXCEPTION_IN_SERVICE, status.win32ExitCode);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPrivilegedProcess))]
+        [ConditionalFact(typeof(AdminHelpers), nameof(AdminHelpers.IsProcessElevated))]
         public void ExceptionOnStopIsPropagated()
         {
             using var serviceTester = WindowsServiceTester.Create(async () =>
@@ -103,7 +103,7 @@ namespace Microsoft.Extensions.Hosting
             Assert.Equal(Interop.Errors.ERROR_PROCESS_ABORTED, status.win32ExitCode);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPrivilegedProcess))]
+        [ConditionalFact(typeof(AdminHelpers), nameof(AdminHelpers.IsProcessElevated))]
         public void CancelStopAsync()
         {
             using var serviceTester = WindowsServiceTester.Create(async () =>
@@ -126,7 +126,7 @@ namespace Microsoft.Extensions.Hosting
             Assert.Equal(Interop.Errors.ERROR_PROCESS_ABORTED, status.win32ExitCode);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPrivilegedProcess))]
+        [ConditionalFact(typeof(AdminHelpers), nameof(AdminHelpers.IsProcessElevated))]
         public void ServiceCanStopItself()
         {
             using (var serviceTester = WindowsServiceTester.Create(async () =>
@@ -182,7 +182,7 @@ namespace Microsoft.Extensions.Hosting
                 """, logText);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPrivilegedProcess))]
+        [ConditionalFact(typeof(AdminHelpers), nameof(AdminHelpers.IsProcessElevated))]
         public void ServiceSequenceIsCorrect()
         {
             using (var serviceTester = WindowsServiceTester.Create(() =>

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/WindowsServiceLifetimeTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/WindowsServiceLifetimeTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.Hosting
 {
     public class WindowsServiceLifetimeTests
     {
-        private static bool IsRemoteExecutorSupportedAndPrivilegedProcess => RemoteExecutor.IsSupported && AdminHelpers.IsProcessElevated;
+        private static bool IsRemoteExecutorSupportedAndPrivilegedProcess => RemoteExecutor.IsSupported && AdminHelpers.IsProcessElevated();
 
         [ConditionalFact(nameof(IsRemoteExecutorSupportedAndPrivilegedProcess))]
         public void ServiceStops()
@@ -179,19 +179,18 @@ namespace Microsoft.Extensions.Hosting
             }
 
             var logText = FileLogger.ReadLog(nameof(ServiceCanStopItself));
-            Assert.Equal("""
-                host.Start()
-                WindowsServiceLifetime.OnStart
-                BackgroundService.StartAsync
-                lifetime started
-                host.Stop()
-                lifetime stopping
-                BackgroundService.StopAsync
-                lifetime stopped
-                WindowsServiceLifetime.OnStop
-                host.Stop() complete
-
-                """, logText);
+            Assert.Equal(
+@"host.Start()
+WindowsServiceLifetime.OnStart
+BackgroundService.StartAsync
+lifetime started
+host.Stop()
+lifetime stopping
+BackgroundService.StopAsync
+lifetime stopped
+WindowsServiceLifetime.OnStop
+host.Stop() complete
+", logText);
         }
 
         [ConditionalFact(nameof(IsRemoteExecutorSupportedAndPrivilegedProcess))]
@@ -239,18 +238,17 @@ namespace Microsoft.Extensions.Hosting
             }
 
             var logText = FileLogger.ReadLog(nameof(ServiceSequenceIsCorrect));
-            Assert.Equal("""
-                host.Run()
-                WindowsServiceLifetime.OnStart
-                BackgroundService.StartAsync
-                lifetime started
-                WindowsServiceLifetime.OnStop
-                lifetime stopping
-                BackgroundService.StopAsync
-                lifetime stopped
-                host.Run() complete
-
-                """, logText);
+            Assert.Equal(
+@"host.Run()
+WindowsServiceLifetime.OnStart
+BackgroundService.StartAsync
+lifetime started
+WindowsServiceLifetime.OnStop
+lifetime stopping
+BackgroundService.StopAsync
+lifetime stopped
+host.Run() complete
+", logText);
 
         }
 

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/WindowsServiceLifetimeTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/WindowsServiceLifetimeTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.ServiceProcess;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting.Internal;
 using Microsoft.Extensions.Hosting.WindowsServices;
@@ -19,23 +20,25 @@ namespace Microsoft.Extensions.Hosting
 {
     public class WindowsServiceLifetimeTests
     {
-        [ConditionalFact(typeof(AdminHelpers), nameof(AdminHelpers.IsProcessElevated))]
+        private static bool IsRemoteExecutorSupportedAndPrivilegedProcess => RemoteExecutor.IsSupported && AdminHelpers.IsProcessElevated;
+
+        [ConditionalFact(nameof(IsRemoteExecutorSupportedAndPrivilegedProcess))]
         public void ServiceStops()
         {
             using var serviceTester = WindowsServiceTester.Create(async () =>
             {
                 var applicationLifetime = new ApplicationLifetime(NullLogger<ApplicationLifetime>.Instance);
                 using var lifetime = new WindowsServiceLifetime(
-                    new HostingEnvironment(), 
+                    new HostingEnvironment(),
                     applicationLifetime,
                     NullLoggerFactory.Instance,
                     new OptionsWrapper<HostOptions>(new HostOptions()));
 
                 await lifetime.WaitForStartAsync(CancellationToken.None);
-                
+
                 // would normally occur here, but WindowsServiceLifetime does not depend on it.
                 // applicationLifetime.NotifyStarted();
-                
+
                 // will be signaled by WindowsServiceLifetime when SCM stops the service.
                 applicationLifetime.ApplicationStopping.WaitHandle.WaitOne();
 
@@ -53,14 +56,14 @@ namespace Microsoft.Extensions.Hosting
 
             serviceTester.Stop();
             serviceTester.WaitForStatus(ServiceControllerStatus.Stopped);
-            
+
             serviceProcess.WaitForExit();
 
             var status = serviceTester.QueryServiceStatus();
             Assert.Equal(0, status.win32ExitCode);
         }
 
-        [ConditionalFact(typeof(AdminHelpers), nameof(AdminHelpers.IsProcessElevated))]
+        [ConditionalFact(nameof(IsRemoteExecutorSupportedAndPrivilegedProcess))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework is missing the fix from https://github.com/dotnet/corefx/commit/3e68d791066ad0fdc6e0b81828afbd9df00dd7f8")]
         public void ExceptionOnStartIsPropagated()
         {
@@ -69,7 +72,7 @@ namespace Microsoft.Extensions.Hosting
                 using (var lifetime = ThrowingWindowsServiceLifetime.Create(throwOnStart: new Exception("Should be thrown")))
                 {
                     Assert.Equal(lifetime.ThrowOnStart,
-                            await Assert.ThrowsAsync<Exception>(async () => 
+                            await Assert.ThrowsAsync<Exception>(async () =>
                                 await lifetime.WaitForStartAsync(CancellationToken.None)));
                 }
             });
@@ -81,7 +84,7 @@ namespace Microsoft.Extensions.Hosting
             Assert.Equal(Interop.Errors.ERROR_EXCEPTION_IN_SERVICE, status.win32ExitCode);
         }
 
-        [ConditionalFact(typeof(AdminHelpers), nameof(AdminHelpers.IsProcessElevated))]
+        [ConditionalFact(nameof(IsRemoteExecutorSupportedAndPrivilegedProcess))]
         public void ExceptionOnStopIsPropagated()
         {
             using var serviceTester = WindowsServiceTester.Create(async () =>
@@ -91,7 +94,7 @@ namespace Microsoft.Extensions.Hosting
                     await lifetime.WaitForStartAsync(CancellationToken.None);
                     lifetime.ApplicationLifetime.NotifyStopped();
                     Assert.Equal(lifetime.ThrowOnStop,
-                            await Assert.ThrowsAsync<Exception>( async () => 
+                            await Assert.ThrowsAsync<Exception>(async () =>
                                 await lifetime.StopAsync(CancellationToken.None)));
                 }
             });
@@ -103,19 +106,19 @@ namespace Microsoft.Extensions.Hosting
             Assert.Equal(Interop.Errors.ERROR_PROCESS_ABORTED, status.win32ExitCode);
         }
 
-        [ConditionalFact(typeof(AdminHelpers), nameof(AdminHelpers.IsProcessElevated))]
+        [ConditionalFact(nameof(IsRemoteExecutorSupportedAndPrivilegedProcess))]
         public void CancelStopAsync()
         {
             using var serviceTester = WindowsServiceTester.Create(async () =>
             {
                 var applicationLifetime = new ApplicationLifetime(NullLogger<ApplicationLifetime>.Instance);
                 using var lifetime = new WindowsServiceLifetime(
-                    new HostingEnvironment(), 
+                    new HostingEnvironment(),
                     applicationLifetime,
                     NullLoggerFactory.Instance,
                     new OptionsWrapper<HostOptions>(new HostOptions()));
                 await lifetime.WaitForStartAsync(CancellationToken.None);
-                
+
                 await Assert.ThrowsAsync<OperationCanceledException>(async () => await lifetime.StopAsync(new CancellationToken(true)));
             });
 
@@ -126,7 +129,7 @@ namespace Microsoft.Extensions.Hosting
             Assert.Equal(Interop.Errors.ERROR_PROCESS_ABORTED, status.win32ExitCode);
         }
 
-        [ConditionalFact(typeof(AdminHelpers), nameof(AdminHelpers.IsProcessElevated))]
+        [ConditionalFact(nameof(IsRemoteExecutorSupportedAndPrivilegedProcess))]
         public void ServiceCanStopItself()
         {
             using (var serviceTester = WindowsServiceTester.Create(async () =>
@@ -166,10 +169,10 @@ namespace Microsoft.Extensions.Hosting
 
                 // service should start cleanly
                 serviceTester.Start();
-                
+
                 // service will proceed to stopped without any error
                 serviceTester.WaitForStatus(ServiceControllerStatus.Stopped);
-            
+
                 var status = serviceTester.QueryServiceStatus();
                 Assert.Equal(0, status.win32ExitCode);
 
@@ -191,7 +194,7 @@ namespace Microsoft.Extensions.Hosting
                 """, logText);
         }
 
-        [ConditionalFact(typeof(AdminHelpers), nameof(AdminHelpers.IsProcessElevated))]
+        [ConditionalFact(nameof(IsRemoteExecutorSupportedAndPrivilegedProcess))]
         public void ServiceSequenceIsCorrect()
         {
             using (var serviceTester = WindowsServiceTester.Create(() =>
@@ -229,7 +232,7 @@ namespace Microsoft.Extensions.Hosting
 
                 serviceTester.Stop();
                 serviceTester.WaitForStatus(ServiceControllerStatus.Stopped);
-                
+
                 var status = serviceTester.QueryServiceStatus();
                 Assert.Equal(0, status.win32ExitCode);
 
@@ -272,9 +275,9 @@ namespace Microsoft.Extensions.Hosting
 
         public class ThrowingWindowsServiceLifetime : WindowsServiceLifetime
         {
-            public static ThrowingWindowsServiceLifetime Create(Exception throwOnStart = null, Exception throwOnStop = null) => 
+            public static ThrowingWindowsServiceLifetime Create(Exception throwOnStart = null, Exception throwOnStop = null) =>
                     new ThrowingWindowsServiceLifetime(
-                        new HostingEnvironment(), 
+                        new HostingEnvironment(),
                         new ApplicationLifetime(NullLogger<ApplicationLifetime>.Instance),
                         NullLoggerFactory.Instance,
                         new OptionsWrapper<HostOptions>(new HostOptions()))
@@ -285,7 +288,7 @@ namespace Microsoft.Extensions.Hosting
 
             public ThrowingWindowsServiceLifetime(IHostEnvironment environment, ApplicationLifetime applicationLifetime, ILoggerFactory loggerFactory, IOptions<HostOptions> optionsAccessor) :
                 base(environment, applicationLifetime, loggerFactory, optionsAccessor)
-            { 
+            {
                 ApplicationLifetime = applicationLifetime;
             }
 

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/WindowsServiceTester.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/WindowsServiceTester.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Extensions.Hosting
             { }
         }
 
-        public TimeSpan WaitForStatusTimeout { get; set; } = TimeSpan.FromSeconds(30);
+        public static TimeSpan WaitForStatusTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
         public new void WaitForStatus(ServiceControllerStatus desiredStatus) =>
             WaitForStatus(desiredStatus, WaitForStatusTimeout);

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/WindowsServiceTester.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/WindowsServiceTester.cs
@@ -1,0 +1,158 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.ServiceProcess;
+using System.Threading.Tasks;
+using Microsoft.DotNet.RemoteExecutor;
+using Microsoft.Win32.SafeHandles;
+using Xunit;
+
+namespace Microsoft.Extensions.Hosting
+{
+    public class WindowsServiceTester : ServiceController
+    {
+        private WindowsServiceTester(SafeServiceHandle serviceHandle, RemoteInvokeHandle remoteInvokeHandle, string serviceName) : base(serviceName)
+        {
+            _serviceHandle = serviceHandle;
+            _remoteInvokeHandle = remoteInvokeHandle;
+        }
+
+        private SafeServiceHandle _serviceHandle;
+        private RemoteInvokeHandle _remoteInvokeHandle;
+
+        public new void Start()
+        {
+            Start(Array.Empty<string>());
+        }
+
+        public new void Start(string[] args)
+        {
+            base.Start(args);
+
+            // get the process
+            _remoteInvokeHandle.Process.Dispose();
+            _remoteInvokeHandle.Process = null;
+
+            var statusEx = QueryServiceStatusEx();
+            try
+            {
+                _remoteInvokeHandle.Process = Process.GetProcessById(statusEx.dwProcessId);
+                // fetch the process handle so that we can get the exit code later.
+                var _ = _remoteInvokeHandle.Process.SafeHandle;
+            }
+            catch (ArgumentException)
+            { }
+        }
+
+        public TimeSpan WaitForStatusTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+        public new void WaitForStatus(ServiceControllerStatus desiredStatus) =>
+            WaitForStatus(desiredStatus, WaitForStatusTimeout);
+
+        public new void WaitForStatus(ServiceControllerStatus desiredStatus, TimeSpan timeout)
+        {
+            base.WaitForStatus(desiredStatus, timeout);
+
+            Assert.Equal(Status, desiredStatus);
+        }
+
+        // the following overloads are necessary to ensure the compiler will produce the correct signature from a lambda.
+        public static WindowsServiceTester Create(Func<Task> serviceMain, [CallerMemberName] string serviceName = null) => Create(RemoteExecutor.Invoke(serviceMain, remoteInvokeOptions), serviceName);
+        
+        public static WindowsServiceTester Create(Func<Task<int>> serviceMain, [CallerMemberName] string serviceName = null) => Create(RemoteExecutor.Invoke(serviceMain, remoteInvokeOptions), serviceName);
+
+        public static WindowsServiceTester Create(Func<int> serviceMain, [CallerMemberName] string serviceName = null) => Create(RemoteExecutor.Invoke(serviceMain, remoteInvokeOptions), serviceName);
+        
+        public static WindowsServiceTester Create(Action serviceMain, [CallerMemberName] string serviceName = null) => Create(RemoteExecutor.Invoke(serviceMain, remoteInvokeOptions), serviceName);
+
+        private static RemoteInvokeOptions remoteInvokeOptions = new RemoteInvokeOptions() { Start = false };
+
+        private static WindowsServiceTester Create(RemoteInvokeHandle remoteInvokeHandle, string serviceName)
+        {
+            // create remote executor commandline arguments
+            var startInfo = remoteInvokeHandle.Process.StartInfo;
+            string commandLine = startInfo.FileName + " " + startInfo.Arguments;
+
+            // install the service
+            using (var serviceManagerHandle = new SafeServiceHandle(Interop.Advapi32.OpenSCManager(null, null, Interop.Advapi32.ServiceControllerOptions.SC_MANAGER_ALL)))
+            {
+                if (serviceManagerHandle.IsInvalid)
+                {
+                    throw new InvalidOperationException();
+                }
+
+                // delete existing service if it exists
+                using (var existingServiceHandle = new SafeServiceHandle(Interop.Advapi32.OpenService(serviceManagerHandle, serviceName, Interop.Advapi32.ServiceAccessOptions.ACCESS_TYPE_ALL)))
+                {
+                    if (!existingServiceHandle.IsInvalid)
+                    {
+                        Interop.Advapi32.DeleteService(existingServiceHandle);
+                    }
+                }
+
+                var serviceHandle = new SafeServiceHandle(
+                    Interop.Advapi32.CreateService(serviceManagerHandle,
+                    serviceName,
+                    $"{nameof(WindowsServiceTester)} {serviceName} test service",
+                    Interop.Advapi32.ServiceAccessOptions.ACCESS_TYPE_ALL,
+                    Interop.Advapi32.ServiceTypeOptions.SERVICE_WIN32_OWN_PROCESS,
+                    (int)ServiceStartMode.Manual,
+                    Interop.Advapi32.ServiceStartErrorModes.ERROR_CONTROL_NORMAL,
+                    commandLine,
+                    loadOrderGroup: null,
+                    pTagId: IntPtr.Zero,
+                    dependencies: null,
+                    servicesStartName: null,
+                    password: null));
+
+                if (serviceHandle.IsInvalid)
+                {
+                    throw new Win32Exception();
+                }
+
+                return new WindowsServiceTester(serviceHandle, remoteInvokeHandle, serviceName);
+            }
+        }
+
+        internal unsafe Interop.Advapi32.SERVICE_STATUS QueryServiceStatus()
+        {
+            Interop.Advapi32.SERVICE_STATUS status = default;
+            bool success = Interop.Advapi32.QueryServiceStatus(_serviceHandle, &status);
+            if (!success)
+            {
+                throw new Win32Exception();
+            }
+            return status;
+        }
+
+        internal unsafe Interop.Advapi32.SERVICE_STATUS_PROCESS QueryServiceStatusEx()
+        {
+            Interop.Advapi32.SERVICE_STATUS_PROCESS status = default;
+            bool success = Interop.Advapi32.QueryServiceStatusEx(_serviceHandle, &status);
+            if (!success)
+            {
+                throw new Win32Exception();
+            }
+            return status;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (_remoteInvokeHandle != null)
+            {
+                _remoteInvokeHandle.Dispose();               
+            }
+
+            if (!_serviceHandle.IsInvalid)
+            {
+                // delete the temporary test service
+                Interop.Advapi32.DeleteService(_serviceHandle);
+                _serviceHandle.Close();
+            }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/WindowsServiceTester.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/test/WindowsServiceTester.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Extensions.Hosting
                     serviceName,
                     $"{nameof(WindowsServiceTester)} {serviceName} test service",
                     Interop.Advapi32.ServiceAccessOptions.ACCESS_TYPE_ALL,
-                    Interop.Advapi32.ServiceTypeOptions.SERVICE_WIN32_OWN_PROCESS,
+                    Interop.Advapi32.ServiceTypeOptions.SERVICE_TYPE_WIN32_OWN_PROCESS,
                     (int)ServiceStartMode.Manual,
                     Interop.Advapi32.ServiceStartErrorModes.ERROR_CONTROL_NORMAL,
                     commandLine,

--- a/src/libraries/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
+++ b/src/libraries/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
@@ -6,7 +6,7 @@
     <NoTargetsDoNotReferenceOutputAssemblies>false</NoTargetsDoNotReferenceOutputAssemblies>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <ServicingVersion>5</ServicingVersion>
+    <ServicingVersion>6</ServicingVersion>
     <!-- This is a meta package and doesn't contain any libs. -->
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <PackageDescription>This Windows Compatibility Pack provides access to APIs that were previously available only for .NET Framework. It can be used from both .NET Core as well as .NET Standard.</PackageDescription>

--- a/src/libraries/System.ServiceProcess.ServiceController/src/System.ServiceProcess.ServiceController.csproj
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System.ServiceProcess.ServiceController.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <!-- If you enable GeneratePackageOnBuild for this package and bump ServicingVersion, make sure to also bump ServicingVersion in Microsoft.Windows.Compatibility.csproj once for the next release. -->
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <ServicingVersion>0</ServicingVersion>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>1</ServicingVersion>
     <PackageDescription>Provides the System.ServiceProcess.ServiceContainer class, which allows you to connect to a running or stopped service, manipulate it, or get information about it.
 
 Commonly Used Types:

--- a/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
@@ -31,6 +31,7 @@ namespace System.ServiceProcess
         private bool _commandPropsFrozen;  // set to true once we've use the Can... properties.
         private bool _disposed;
         private bool _initialized;
+        private object _stopLock = new object();
         private EventLog? _eventLog;
 
         /// <summary>
@@ -505,27 +506,34 @@ namespace System.ServiceProcess
         // This is a problem when multiple services are hosted in a single process.
         private unsafe void DeferredStop()
         {
-            fixed (SERVICE_STATUS* pStatus = &_status)
+            lock(_stopLock)
             {
-                int previousState = _status.currentState;
+                // never call SetServiceStatus again after STATE_STOPPED is set.
+                if (_status.currentState != ServiceControlStatus.STATE_STOPPED)
+                {
+                    fixed (SERVICE_STATUS* pStatus = &_status)
+                    {
+                        int previousState = _status.currentState;
 
-                _status.checkPoint = 0;
-                _status.waitHint = 0;
-                _status.currentState = ServiceControlStatus.STATE_STOP_PENDING;
-                SetServiceStatus(_statusHandle, pStatus);
-                try
-                {
-                    OnStop();
-                    WriteLogEntry(SR.StopSuccessful);
-                    _status.currentState = ServiceControlStatus.STATE_STOPPED;
-                    SetServiceStatus(_statusHandle, pStatus);
-                }
-                catch (Exception e)
-                {
-                    _status.currentState = previousState;
-                    SetServiceStatus(_statusHandle, pStatus);
-                    WriteLogEntry(SR.Format(SR.StopFailed, e), EventLogEntryType.Error);
-                    throw;
+                        _status.checkPoint = 0;
+                        _status.waitHint = 0;
+                        _status.currentState = ServiceControlStatus.STATE_STOP_PENDING;
+                        SetServiceStatus(_statusHandle, pStatus);
+                        try
+                        {
+                            OnStop();
+                            WriteLogEntry(SR.StopSuccessful);
+                            _status.currentState = ServiceControlStatus.STATE_STOPPED;
+                            SetServiceStatus(_statusHandle, pStatus);
+                        }
+                        catch (Exception e)
+                        {
+                            _status.currentState = previousState;
+                            SetServiceStatus(_statusHandle, pStatus);
+                            WriteLogEntry(SR.Format(SR.StopFailed, e), EventLogEntryType.Error);
+                            throw;
+                        }
+                    }
                 }
             }
         }
@@ -537,14 +545,17 @@ namespace System.ServiceProcess
                 OnShutdown();
                 WriteLogEntry(SR.ShutdownOK);
 
-                if (_status.currentState == ServiceControlStatus.STATE_PAUSED || _status.currentState == ServiceControlStatus.STATE_RUNNING)
+                lock(_stopLock)
                 {
-                    fixed (SERVICE_STATUS* pStatus = &_status)
+                    if (_status.currentState == ServiceControlStatus.STATE_PAUSED || _status.currentState == ServiceControlStatus.STATE_RUNNING)
                     {
-                        _status.checkPoint = 0;
-                        _status.waitHint = 0;
-                        _status.currentState = ServiceControlStatus.STATE_STOPPED;
-                        SetServiceStatus(_statusHandle, pStatus);
+                        fixed (SERVICE_STATUS* pStatus = &_status)
+                        {
+                            _status.checkPoint = 0;
+                            _status.waitHint = 0;
+                            _status.currentState = ServiceControlStatus.STATE_STOPPED;
+                            SetServiceStatus(_statusHandle, pStatus);
+                        }
                     }
                 }
             }
@@ -672,7 +683,7 @@ namespace System.ServiceProcess
         {
             if (!_initialized)
             {
-                //Cannot register the service with NT service manatger if the object has been disposed, since finalization has been suppressed.
+                //Cannot register the service with NT service manager if the object has been disposed, since finalization has been suppressed.
                 if (_disposed)
                     throw new ObjectDisposedException(GetType().Name);
 
@@ -935,8 +946,14 @@ namespace System.ServiceProcess
                 if (!statusOK)
                 {
                     WriteLogEntry(SR.Format(SR.StartFailed, new Win32Exception().Message), EventLogEntryType.Error);
-                    _status.currentState = ServiceControlStatus.STATE_STOPPED;
-                    SetServiceStatus(_statusHandle, pStatus);
+                    lock (_stopLock)
+                    {
+                        if (_status.currentState != ServiceControlStatus.STATE_STOPPED)
+                        {
+                            _status.currentState = ServiceControlStatus.STATE_STOPPED;
+                            SetServiceStatus(_statusHandle, pStatus);
+                        }
+                    }
                 }
             }
         }

--- a/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
@@ -506,7 +506,7 @@ namespace System.ServiceProcess
         // This is a problem when multiple services are hosted in a single process.
         private unsafe void DeferredStop()
         {
-            lock(_stopLock)
+            lock (_stopLock)
             {
                 // never call SetServiceStatus again after STATE_STOPPED is set.
                 if (_status.currentState != ServiceControlStatus.STATE_STOPPED)
@@ -545,7 +545,7 @@ namespace System.ServiceProcess
                 OnShutdown();
                 WriteLogEntry(SR.ShutdownOK);
 
-                lock(_stopLock)
+                lock (_stopLock)
                 {
                     if (_status.currentState == ServiceControlStatus.STATE_PAUSED || _status.currentState == ServiceControlStatus.STATE_RUNNING)
                     {


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/83892
Fixes https://github.com/dotnet/runtime/issues/62579 on 6.0

## Description 
Windows services implemented with Microsoft.Extensions.Hosting.WindowsServices would not gracefully stop - due to exit without reporting STOPPED status - resulting in an error in Service Control Manager.  If the service had configured error handling this would also cause the service to restart rather than stay stopped.  In some cases the service would crash with on stop as well - generating WER dumps.

The clean exit without reporting STOPPED was caused because nothing held up the main routine from exiting before SCM was notified that the service was stopped.  This race condition was always present, but has gotten worse over the past two releases as we made the runtime faster - effectively giving the background thread less time to complete and report it's stop.

The AV was caused by a double call to stop the service -- once happening when handing the SCM Stop request, and again from hosting when shutting down the application lifetime.  This double call was violating the constraint of SetServiceStatus:
> The first call to the function in the SERVICE_STOPPED state closes the RPC context handle and any subsequent calls can cause the process to crash.

We've avoided calling stop twice and also guarded against user's calling ServiceBase.Stop when the service is already stopping.

## Customer Impact
Not all shutdown logic is allowed to run - which could result in data loss.  Customers receive error reports about their services.  Services may restart when intended to stop.

## Testing
Fix has been made in main for a month and validated on nightly builds by customers.  We added numerous automated test cases to cover this scenario and cover the overall lifetime sequence.  We also tested the service stop logic manually and through system shutdown (note that this bug still exists which causes problems on shutdown

## Risk
Risk is low, but not zero due to the size of the change and the addition of cross-thread synchronization and locking.  We've tried to mitigate this through lots of automated and manual testing.  We also kept the locking to a minimum and run no user code under the added lock.  Probably the biggest risk here is that we didn't completely fix everything folks care about in this path.  For example: https://github.com/dotnet/runtime/issues/83093/

Note the changes to ServiceBase are not strictly required - which is good because we cannot change that type on .NETFramework where this same package is supported.