### PR TITLE
Simplify SelectArrayIterator method

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Select.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Select.cs
@@ -178,15 +178,17 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                if (_state < 1 | _state == _source.Length + 1)
+                TSource[] source = _source;
+                int index = _state - 1;
+                if ((uint)index < (uint)source.Length)
                 {
-                    Dispose();
-                    return false;
+                    _state++;
+                    _current = _selector(source[index]);
+                    return true;
                 }
 
-                int index = _state++ - 1;
-                _current = _selector(_source[index]);
-                return true;
+                Dispose();
+                return false;
             }
 
             public override IEnumerable<TResult2> Select<TResult2>(Func<TResult, TResult2> selector) =>


### PR DESCRIPTION
Happened to look at the current implementation, and the if condition was unnecessarily complex.  Plus this change removes a bounds check as a bonus.