### PR TITLE
Move DispatchMap pointer to MethodTable

### DIFF
--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/TypeManagerHandle.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/TypeManagerHandle.cs
@@ -20,7 +20,6 @@ namespace Internal.Runtime
         {
             public IntPtr OsHandle;
             public IntPtr ReadyToRunHeader;
-            public IntPtr DispatchMap;
         }
 
         public TypeManagerHandle(IntPtr handleValue)
@@ -46,14 +45,6 @@ namespace Internal.Runtime
             get
             {
                 return _handleValue->OsHandle;
-            }
-        }
-
-        public unsafe IntPtr DispatchMap
-        {
-            get
-            {
-                return _handleValue->DispatchMap;
             }
         }
     }

--- a/src/coreclr/nativeaot/Runtime/TypeManager.cpp
+++ b/src/coreclr/nativeaot/Runtime/TypeManager.cpp
@@ -45,7 +45,6 @@ TypeManager::TypeManager(HANDLE osModule, ReadyToRunHeader * pHeader, void** pCl
     int length;
     m_pStaticsGCDataSection = (uint8_t*)GetModuleSection(ReadyToRunSectionType::GCStaticRegion, &length);
     m_pThreadStaticsDataSection = (uint8_t*)GetModuleSection(ReadyToRunSectionType::ThreadStaticRegion, &length);
-    m_pDispatchMapTable = (DispatchMap **)GetModuleSection(ReadyToRunSectionType::InterfaceDispatchTable, &length);
 }
 
 void * TypeManager::GetModuleSection(ReadyToRunSectionType sectionId, int * length)

--- a/src/coreclr/nativeaot/Runtime/TypeManager.h
+++ b/src/coreclr/nativeaot/Runtime/TypeManager.h
@@ -4,14 +4,11 @@
 #include "ModuleHeaders.h"
 #include "ICodeManager.h"
 
-class DispatchMap;
-
 class TypeManager
 {
     // NOTE: Part of this layout is a contract with the managed side in TypeManagerHandle.cs
     HANDLE                      m_osModule;
     ReadyToRunHeader *          m_pHeader;
-    DispatchMap**               m_pDispatchMapTable;
     uint8_t*                    m_pStaticsGCDataSection;
     uint8_t*                    m_pThreadStaticsDataSection;
     void**                      m_pClasslibFunctions;

--- a/src/coreclr/nativeaot/Runtime/inc/ModuleHeaders.h
+++ b/src/coreclr/nativeaot/Runtime/inc/ModuleHeaders.h
@@ -43,7 +43,7 @@ enum class ReadyToRunSectionType
     StringTable                 = 200,
     GCStaticRegion              = 201,
     ThreadStaticRegion          = 202,
-    InterfaceDispatchTable      = 203,
+    // unused                   = 203,
     TypeManagerIndirection      = 204,
     EagerCctor                  = 205,
     FrozenObjectRegion          = 206,

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -155,6 +155,7 @@ namespace Internal.Runtime.TypeLoader
                 int baseSize = 0;
 
                 bool isValueType;
+                bool hasDispatchMap;
                 bool hasFinalizer;
                 bool isNullable;
                 bool isArray;
@@ -172,6 +173,7 @@ namespace Internal.Runtime.TypeLoader
                 baseSize = (int)pTemplateEEType->RawBaseSize;
                 isValueType = pTemplateEEType->IsValueType;
                 hasFinalizer = pTemplateEEType->IsFinalizable;
+                hasDispatchMap = pTemplateEEType->HasDispatchMap;
                 isNullable = pTemplateEEType->IsNullable;
                 flags = pTemplateEEType->Flags;
                 isArray = pTemplateEEType->IsArray;
@@ -225,9 +227,6 @@ namespace Internal.Runtime.TypeLoader
                 if (rareFlags != 0)
                     optionalFields.SetFieldValue(EETypeOptionalFieldTag.RareFlags, rareFlags);
 
-                // Dispatch map is fetched from template type
-                optionalFields.ClearField(EETypeOptionalFieldTag.DispatchMap);
-
                 // Compute size of optional fields encoding
                 cbOptionalFieldsSize = optionalFields.Encode();
 
@@ -251,6 +250,7 @@ namespace Internal.Runtime.TypeLoader
                     int cbEEType = (int)MethodTable.GetSizeofEEType(
                         numVtableSlots,
                         runtimeInterfacesLength,
+                        hasDispatchMap,
                         hasFinalizer,
                         cbOptionalFieldsSize > 0,
                         hasSealedVTable,
@@ -299,6 +299,12 @@ namespace Internal.Runtime.TypeLoader
                     IntPtr* pTemplateVtable = (IntPtr*)((byte*)pTemplateEEType + sizeof(MethodTable));
                     for (int i = 0; i < numVtableSlots; i++)
                         pVtable[i] = pTemplateVtable[i];
+
+                    // Copy dispatch map from the template type
+                    if (hasDispatchMap)
+                    {
+                        pEEType->DispatchMap = pTemplateEEType->DispatchMap;
+                    }
 
                     // Copy Pointer to finalizer method from the template type
                     if (hasFinalizer)

--- a/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
@@ -16,7 +16,10 @@ namespace Internal.Runtime
         /// </summary>
         EETypeKindMask = 0x00030000,
 
-        // Unused = 0x00040000,
+        /// <summary>
+        /// Type has an associated dispatch map.
+        /// </summary>
+        HasDispatchMap = 0x00040000,
 
         /// <summary>
         /// This type was dynamically allocated at runtime.
@@ -177,6 +180,7 @@ namespace Internal.Runtime
         ETF_InterfaceMap,
         ETF_TypeManagerIndirection,
         ETF_WritableData,
+        ETF_DispatchMap,
         ETF_Finalizer,
         ETF_OptionalFieldsPtr,
         ETF_SealedVirtualSlots,
@@ -235,11 +239,6 @@ namespace Internal.Runtime
         /// Extra <c>MethodTable</c> flags not commonly used such as HasClassConstructor
         /// </summary>
         RareFlags,
-
-        /// <summary>
-        /// Index of the dispatch map pointer in the DispatchMap table
-        /// </summary>
-        DispatchMap,
 
         /// <summary>
         /// Padding added to a value type when allocated on the GC heap

--- a/src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
@@ -78,7 +78,7 @@ namespace Internal.Runtime
         StringTable = 200, // Unused
         GCStaticRegion = 201,
         ThreadStaticRegion = 202,
-        InterfaceDispatchTable = 203,
+        // Unused = 203,
         TypeManagerIndirection = 204,
         EagerCctor = 205,
         FrozenObjectRegion = 206,

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CanonicalEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CanonicalEETypeNode.cs
@@ -42,9 +42,6 @@ namespace ILCompiler.DependencyAnalysis
 
             DefType closestDefType = _type.GetClosestDefType();
 
-            if (MightHaveInterfaceDispatchMap(factory))
-                dependencyList.Add(factory.InterfaceDispatchMap(_type), "Canonical interface dispatch map");
-
             dependencyList.Add(factory.VTable(closestDefType), "VTable");
 
             if (_type.IsCanonicalSubtype(CanonicalFormKind.Universal))

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -36,12 +36,6 @@ namespace ILCompiler.DependencyAnalysis
 
             DefType closestDefType = _type.GetClosestDefType();
 
-            if (MightHaveInterfaceDispatchMap(factory))
-            {
-                TypeDesc canonType = _type.ConvertToCanonForm(CanonicalFormKind.Specific);
-                dependencyList.Add(factory.InterfaceDispatchMap(canonType), "Interface dispatch map");
-            }
-
             if (_type.IsArray)
             {
                 // Array MethodTable depends on System.Array's virtuals. Array EETypes don't point to

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -50,7 +50,6 @@ namespace ILCompiler.DependencyAnalysis
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
             var result = new DependencyList();
-            result.Add(factory.InterfaceDispatchMapIndirection(_type), "Interface dispatch map indirection node");
 
             // VTable slots of implemented interfaces are consulted during emission
             foreach (TypeDesc runtimeInterface in _type.RuntimeInterfaces)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -391,11 +391,6 @@ namespace ILCompiler.DependencyAnalysis
                 return new EmbeddedTrimmingDescriptorNode(module);
             });
 
-            _interfaceDispatchMapIndirectionNodes = new NodeCache<TypeDesc, EmbeddedObjectNode>((TypeDesc type) =>
-            {
-                return DispatchMapTable.NewNodeWithSymbol(InterfaceDispatchMap(type));
-            });
-
             _genericCompositions = new NodeCache<Instantiation, GenericCompositionNode>((Instantiation details) =>
             {
                 return new GenericCompositionNode(details);
@@ -757,13 +752,6 @@ namespace ILCompiler.DependencyAnalysis
         internal InterfaceDispatchMapNode InterfaceDispatchMap(TypeDesc type)
         {
             return _interfaceDispatchMaps.GetOrAdd(type);
-        }
-
-        private NodeCache<TypeDesc, EmbeddedObjectNode> _interfaceDispatchMapIndirectionNodes;
-
-        public EmbeddedObjectNode InterfaceDispatchMapIndirection(TypeDesc type)
-        {
-            return _interfaceDispatchMapIndirectionNodes.GetOrAdd(type);
         }
 
         private NodeCache<Instantiation, GenericCompositionNode> _genericCompositions;
@@ -1248,11 +1236,6 @@ namespace ILCompiler.DependencyAnalysis
             "__EagerCctorEnd",
             null);
 
-        public ArrayOfEmbeddedPointersNode<InterfaceDispatchMapNode> DispatchMapTable = new ArrayOfEmbeddedPointersNode<InterfaceDispatchMapNode>(
-            "__DispatchMapTableStart",
-            "__DispatchMapTableEnd",
-            new SortableDependencyNode.ObjectNodeComparer(CompilerComparer.Instance));
-
         public ArrayOfFrozenObjectsNode FrozenSegmentRegion = new ArrayOfFrozenObjectsNode();
 
         internal ModuleInitializerListNode ModuleInitializerList = new ModuleInitializerListNode();
@@ -1276,7 +1259,6 @@ namespace ILCompiler.DependencyAnalysis
             graph.AddRoot(ThreadStaticsRegion, "ThreadStaticsRegion is always generated");
             graph.AddRoot(EagerCctorTable, "EagerCctorTable is always generated");
             graph.AddRoot(TypeManagerIndirection, "TypeManagerIndirection is always generated");
-            graph.AddRoot(DispatchMapTable, "DispatchMapTable is always generated");
             graph.AddRoot(FrozenSegmentRegion, "FrozenSegmentRegion is always generated");
             graph.AddRoot(InterfaceDispatchCellSection, "Interface dispatch cell section is always generated");
             graph.AddRoot(ModuleInitializerList, "Module initializer list is always generated");
@@ -1285,7 +1267,6 @@ namespace ILCompiler.DependencyAnalysis
             ReadyToRunHeader.Add(ReadyToRunSectionType.ThreadStaticRegion, ThreadStaticsRegion, ThreadStaticsRegion.StartSymbol, ThreadStaticsRegion.EndSymbol);
             ReadyToRunHeader.Add(ReadyToRunSectionType.EagerCctor, EagerCctorTable, EagerCctorTable.StartSymbol, EagerCctorTable.EndSymbol);
             ReadyToRunHeader.Add(ReadyToRunSectionType.TypeManagerIndirection, TypeManagerIndirection, TypeManagerIndirection);
-            ReadyToRunHeader.Add(ReadyToRunSectionType.InterfaceDispatchTable, DispatchMapTable, DispatchMapTable.StartSymbol);
             ReadyToRunHeader.Add(ReadyToRunSectionType.FrozenObjectRegion, FrozenSegmentRegion, FrozenSegmentRegion, FrozenSegmentRegion.EndSymbol);
             ReadyToRunHeader.Add(ReadyToRunSectionType.ModuleInitializerList, ModuleInitializerList, ModuleInitializerList, ModuleInitializerList.EndSymbol);
 


### PR DESCRIPTION
Sending this for consideration. The old approach also had an advantage. Wouldn't be the end of the world if we keep that.

Before this PR, accessing dispatch map involved:
* Reading optional fields to find the field with the right tag
* The optional field contained an integer index into a table
* The index was used to index into a dispatch map table to find a pointer to the actual dispatch map
* We then followed the pointer to get to the dispatch map.

The advantage of this scheme is smaller working set (MethodTable is smaller), but this assumes the MethodTable has other optional fields (because we still need a pointer to the optional fields). Turns out most MethodTables only need optional fields pointer because of the dispatch map and if we move them to MethodTable, we no longer need an optional field pointer.

This PR simply moves the dispatch map pointer to MethodTable.

I'm seeing another 15 kB saving on BasicMinimalApi. Plus the code looks simpler.

Cc @dotnet/ilc-contrib 