### PR TITLE
Keep `this` alive across the native call for VTable-based source-generation

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ManagedToNativeVTableMethodGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ManagedToNativeVTableMethodGenerator.cs
@@ -185,6 +185,16 @@ namespace Microsoft.Interop
             }
 
             tryStatements.AddRange(statements.NotifyForSuccessfulInvoke);
+
+            // GC.KeepAlive(this);
+            tryStatements.Add(
+                ExpressionStatement(
+                    InvocationExpression(
+                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                            ParseTypeName(TypeNames.System_GC),
+                            IdentifierName("KeepAlive")),
+                        ArgumentList(SingletonSeparatedList(Argument(ThisExpression()))))));
+
             tryStatements.AddRange(statements.Unmarshal);
 
             List<StatementSyntax> allStatements = setupStatements;

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ManagedToNativeVTableMethodGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ManagedToNativeVTableMethodGenerator.cs
@@ -186,6 +186,9 @@ namespace Microsoft.Interop
 
             tryStatements.AddRange(statements.NotifyForSuccessfulInvoke);
 
+            // Keep the this object alive across the native call, similar to how we handle marshalling managed delegates.
+            // We do this right after the NotifyForSuccessfulInvoke phase as that phase is where the delegate objects are kept alive.
+            // If we ever move the "this" object handling out of this type, we'll move the handling to be emitted in that phase.
             // GC.KeepAlive(this);
             tryStatements.Add(
                 ExpressionStatement(

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
@@ -51,6 +51,8 @@ namespace Microsoft.Interop
 
         public const string System_Exception = "System.Exception";
 
+        public const string System_GC = "System.GC";
+
         public const string System_Type = "System.Type";
 
         public const string System_Int16 = "System.Int16";


### PR DESCRIPTION
Otherwise another thread can GC the managed object and cause the underlying native memory to be released mid-call.

This PR adds a `GC.KeepAlive(this);` call after the call to native code where we put the `GC.KeepAlive()` calls for marshalling delegates.