### PR TITLE
Servicing docs improvements

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/servicing_pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/servicing_pull_request_template.md
@@ -24,4 +24,4 @@ main PR <!-- Link to PR if any that fixed this in the main branch. -->
 
 # Package authoring signed off?
 
-IMPORTANT: If this change touches code that ships in a NuGet package, please make certain that you have added any necessary [package authoring](~/docs/project/library-servicing.md) and gotten it explicitly reviewed.
+IMPORTANT: If this change touches code that ships in a NuGet package, please make certain that you have added any necessary [package authoring](../../docs/project/library-servicing.md) and gotten it explicitly reviewed.

--- a/.github/PULL_REQUEST_TEMPLATE/servicing_pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/servicing_pull_request_template.md
@@ -24,5 +24,4 @@ main PR <!-- Link to PR if any that fixed this in the main branch. -->
 
 # Package authoring signed off?
 
-
-IMPORTANT: If this change touches code that ships in a NuGet package, please make certain that you have added any necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.
+IMPORTANT: If this change touches code that ships in a NuGet package, please make certain that you have added any necessary [package authoring](~/docs/project/library-servicing.md) and gotten it explicitly reviewed.

--- a/.github/workflows/check-service-labels.yml
+++ b/.github/workflows/check-service-labels.yml
@@ -16,8 +16,9 @@ jobs:
     - name: Check `Servicing-approved` label
       run: |
         echo "Merging permission is enabled for servicing PRs when the `Servicing-approved` label is applied."
-        echo "Rules for applying the label can be found [here](~/docs/project/library-servicing.md)."
+        echo "Rules for applying the label can be found in https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md"
         if [ "${{ contains(github.event.pull_request.labels.*.name, 'Servicing-approved') }}" = "true" ]; then
+          echo "::error 'Servicing-approved' label not applied to the PR yet."
           exit 0
         else
           exit 1

--- a/.github/workflows/check-service-labels.yml
+++ b/.github/workflows/check-service-labels.yml
@@ -19,6 +19,6 @@ jobs:
         if [ "${{ contains(github.event.pull_request.labels.*.name, 'Servicing-approved') }}" = "true" ]; then
           exit 0
         else
-          echo "::error 'Servicing-approved' label not applied to the PR yet. More information: https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md"
+          echo "::error:: 'Servicing-approved' label not applied to the PR yet. More information: https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md"
           exit 1
         fi

--- a/.github/workflows/check-service-labels.yml
+++ b/.github/workflows/check-service-labels.yml
@@ -13,8 +13,10 @@ jobs:
   check-labels:
     runs-on: ubuntu-latest
     steps:
-    - name: Check servicing labels
+    - name: Check `Servicing-approved` label
       run: |
+        echo "Merging permission is enabled for servicing PRs when the `Servicing-approved` label is applied."
+        echo "Rules for applying the label can be found [here](~/docs/project/library-servicing.md)."
         if [ "${{ contains(github.event.pull_request.labels.*.name, 'Servicing-approved') }}" = "true" ]; then
           exit 0
         else

--- a/.github/workflows/check-service-labels.yml
+++ b/.github/workflows/check-service-labels.yml
@@ -16,10 +16,9 @@ jobs:
     - name: Check 'Servicing-approved' label
       run: |
         echo "Merging permission is enabled for servicing PRs when the `Servicing-approved` label is applied."
-        echo "Rules for applying the label can be found in https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md"
         if [ "${{ contains(github.event.pull_request.labels.*.name, 'Servicing-approved') }}" = "true" ]; then
-          echo "::error 'Servicing-approved' label not applied to the PR yet."
           exit 0
         else
+          echo "::error 'Servicing-approved' label not applied to the PR yet. More information: https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md"
           exit 1
         fi

--- a/.github/workflows/check-service-labels.yml
+++ b/.github/workflows/check-service-labels.yml
@@ -13,7 +13,7 @@ jobs:
   check-labels:
     runs-on: ubuntu-latest
     steps:
-    - name: Check `Servicing-approved` label
+    - name: Check 'Servicing-approved' label
       run: |
         echo "Merging permission is enabled for servicing PRs when the `Servicing-approved` label is applied."
         echo "Rules for applying the label can be found in https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md"

--- a/.github/workflows/check-service-labels.yml
+++ b/.github/workflows/check-service-labels.yml
@@ -19,6 +19,6 @@ jobs:
         if [ "${{ contains(github.event.pull_request.labels.*.name, 'Servicing-approved') }}" = "true" ]; then
           exit 0
         else
-          echo "::error:: 'Servicing-approved' label not applied to the PR yet. More information: https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md"
+          echo "::error:: 'Servicing-approved' label not applied to the PR yet. More information: https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md#approval-process"
           exit 1
         fi

--- a/docs/project/library-servicing.md
+++ b/docs/project/library-servicing.md
@@ -49,6 +49,7 @@ For both cases, you must:
 - If the fix is a test-only or infra-only change, the area owner will:
   - Review the PR and sign-off if they approve it.
   - Add the `Servicing-approved` label.
-- The area owner can then merge the PR once the CI looks good (it's either green or the failures are investigated and determined to be unrelated to the PR).
+
+The area owner can then merge the PR once the CI looks good (it's either green or the failures are investigated and determined to be unrelated to the PR).
 
 **Note**: Applying the `Servicing-approved` label ensures the `check-service-labels` CI job passes, which is a mandatory requirement for merging a PR in a servicing branch.

--- a/docs/project/library-servicing.md
+++ b/docs/project/library-servicing.md
@@ -44,7 +44,7 @@ For both cases, you must:
 - Bring it to the attention of the [engineering lead responsible for the area](~/docs/area-owners.md).
 - If the fix is a product change, the area owner will:
   - Add the `Servicing-consider` label.
-  - Request approval to merge this servicing change.
+  - Ask the area owner to champion your PR in the .NET Tactics meeting to request merge approval.
   - If the change is approved, they will replace the `Servicing-consider` label by `Servicing-approved` and sign-off the PR.
 - If the fix is a test-only or infra-only change, the area owner will:
   - Review the PR and sign-off if they approve it.

--- a/docs/project/library-servicing.md
+++ b/docs/project/library-servicing.md
@@ -1,6 +1,6 @@
 # How to service a library
 
-This document provides the steps necessary after modifying a library in a servicing branch.
+This document provides the steps that need to be followed after modifying a library in a servicing branch.
 
 Servicing branches represent shipped versions of .NET, and their name is in the format `release/X.0-staging`. Examples:
 
@@ -41,5 +41,14 @@ All the servicing change must go through an approval process. You have two ways 
 For both cases, you must:
 
 - Fill out the template of the PR description.
-- Add the `servicing-consider` label.
-- Bring it to the attention of the engineering lead responsible for the area, so they consider the fix for servicing.
+- Bring it to the attention of the [engineering lead responsible for the area](~/docs/area-owners.md).
+- If the fix is a product change, the area owner will:
+  - Add the `Servicing-consider` label.
+  - Request approval to merge this servicing change.
+  - If the change is approved, they will replace the `Servicing-consider` label by `Servicing-approved` and sign-off the PR.
+- If the fix is a test-only or infra-only change, the area owner will:
+  - Review the PR and sign-off if they approve it.
+  - Add the `Servicing-approved` label.
+- The area owner can then merge the PR once the CI looks good (it's either green or the failures are investigated and determined to be unrelated to the PR).
+
+**Note**: Applying the `Servicing-approved` label ensures the `check-service-labels` CI job passes, which is a mandatory requirement for merging a PR in a servicing branch.


### PR DESCRIPTION
Adding more details to our servicing documentation, particularly around the check-servicing-labels CI leg.

Starting with the 7.0-staging branch to confirm the CI workflow changes work, then will backport to 7.0, 6.0-staging, 6.0, and finally to main.

Also want to confirm if:
- An "echo" message can show the link to a md file properly.
- The PR template can link to the current branch's doc, instead of the main doc.