### PR TITLE
Upgrade System.Reflection.Metadata version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -126,7 +126,7 @@
     <SystemDrawingCommonVersion>7.0.0</SystemDrawingCommonVersion>
     <SystemIOFileSystemAccessControlVersion>5.0.0</SystemIOFileSystemAccessControlVersion>
     <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
-    <SystemReflectionMetadataVersion>6.0.1</SystemReflectionMetadataVersion>
+    <SystemReflectionMetadataVersion>7.0.0</SystemReflectionMetadataVersion>
     <SystemSecurityAccessControlVersion>6.0.0</SystemSecurityAccessControlVersion>
     <SystemSecurityCryptographyCngVersion>5.0.0</SystemSecurityCryptographyCngVersion>
     <SystemSecurityCryptographyOpenSslVersion>5.0.0</SystemSecurityCryptographyOpenSslVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -120,7 +120,7 @@
     <MicrosoftWin32RegistryVersion>5.0.0</MicrosoftWin32RegistryVersion>
     <StyleCopAnalyzersVersion>1.2.0-beta.406</StyleCopAnalyzersVersion>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
-    <SystemCollectionsImmutableVersion>6.0.0</SystemCollectionsImmutableVersion>
+    <SystemCollectionsImmutableVersion>7.0.0</SystemCollectionsImmutableVersion>
     <SystemComponentModelAnnotationsVersion>5.0.0</SystemComponentModelAnnotationsVersion>
     <SystemDataSqlClientVersion>4.8.5</SystemDataSqlClientVersion>
     <SystemDrawingCommonVersion>7.0.0</SystemDrawingCommonVersion>


### PR DESCRIPTION
As a response to #85038, I am upgrading `SystemReflectionMetadataVersion` from 6.0.0 to 7.0.0.

As a side effect of this change, I also need to upgrade `SystemCollectionsImmutableVersion` from 6.0.0. to 7.0.0.

These MSBuild properties are repo-wide. Fortunately, there are only a handful number of references for them. Broadly there are two classes, general-purpose library or tools, and MSBuild Tasks.

These are general-purpose libraries or tools. They could be used in some other contexts (e.g.  ILCompiler.Reflection.ReadyToRun is currently used by ILSpy) and we should check if the upgrade would break those scenarios (We checked that ILSpy can work with the upgrade)

- [x] ILCompiler.Reflection.ReadyToRun.csproj, ILCompiler.Reflection.ReadyToRun.Experimental.pkgproj [@eduardo-vp]
- [ ] ILVerification.csproj, Microsoft.ILVerification.pkgproj [@jkotas] 
- [x] Microsoft.NET.WebAssembly.Webcil.csproj [@lambdageek]

These are all MSBuild tasks, so they probably should have the same constraint and be consistent across. Note that both [dotnet/msbuild](https://github.com/dotnet/msbuild/blob/main/eng/Versions.props) and [dotnet/sdk](https://github.com/dotnet/sdk/blob/003a147e2dfc932efc430ff60f788114f0966510/eng/Versions.props#L31) has already moved on with their upgrade to 7.0.0, and therefore upgrading here is probably the right thing to do to match. @ViktorHofer, do you know who/how to verify if the upgrade is safe for these projects?

- [ ] MonoAOTCompiler.csproj
- [ ] ILCompiler.Build.Tasks.csproj
- [ ] installer.tasks.csproj
- [ ] MonoTargetsTasks.csproj
- [ ] WasmAppBuilder.csproj
- [ ] ILLink.Tasks.csproj

CI validation indicates that this change is safe within this repo, the only failure found in the run are known test failures.

@dotnet/crossgen-contrib for awareness.