### PR TITLE
JIT: properly scrub SSA from return address buffers

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1184,6 +1184,12 @@ public:
 
     SsaDefArray<LclSsaVarDsc> lvPerSsaData;
 
+    // True if ssaNum is a viable ssaNum for this local.
+    bool IsValidSsaNum(unsigned ssaNum) const
+    {
+        return lvPerSsaData.IsValidSsaNum(ssaNum);
+    }
+
     // Returns the address of the per-Ssa data for the given ssaNum (which is required
     // not to be the SsaConfig::RESERVED_SSA_NUM, which indicates that the variable is
     // not an SSA variable).

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -11440,20 +11440,31 @@ static const char* InsCflagsToString(insCflags flags)
 //
 void Compiler::gtDispSsaName(unsigned lclNum, unsigned ssaNum, bool isDef)
 {
-    if (ssaNum != SsaConfig::RESERVED_SSA_NUM)
+    if (ssaNum == SsaConfig::RESERVED_SSA_NUM)
     {
-        if (isDef)
+        return;
+    }
+
+    LclVarDsc* const lclDsc  = lvaGetDesc(lclNum);
+    bool const       isValid = lclDsc->IsValidSsaNum(ssaNum);
+
+    if (isDef)
+    {
+        if (!isValid)
         {
-            unsigned oldDefSsaNum = lvaGetDesc(lclNum)->GetPerSsaData(ssaNum)->GetUseDefSsaNum();
-            if (oldDefSsaNum != SsaConfig::RESERVED_SSA_NUM)
-            {
-                printf("ud:%d->%d", oldDefSsaNum, ssaNum);
-                return;
-            }
+            printf("?d:%d", ssaNum);
+            return;
         }
 
-        printf("%s:%d", isDef ? "d" : "u", ssaNum);
+        unsigned oldDefSsaNum = lclDsc->GetPerSsaData(ssaNum)->GetUseDefSsaNum();
+        if (oldDefSsaNum != SsaConfig::RESERVED_SSA_NUM)
+        {
+            printf("ud:%d->%d", oldDefSsaNum, ssaNum);
+            return;
+        }
     }
+
+    printf("%s%s:%d", isValid ? "" : "?", isDef ? "d" : "u", ssaNum);
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1955,6 +1955,11 @@ public:
         return OperIsLocal(OperGet());
     }
 
+    bool IsAnyLocal() const
+    {
+        return OperIsAnyLocal(OperGet());
+    }
+
     bool IsLclVarAddr() const;
 
     // Returns "true" iff 'this' is a GT_LCL_FLD or GT_STORE_LCL_FLD on which the type

--- a/src/coreclr/jit/ssabuilder.cpp
+++ b/src/coreclr/jit/ssabuilder.cpp
@@ -110,7 +110,7 @@ void Compiler::fgResetForSsa()
         {
             for (GenTree* const tree : stmt->TreeList())
             {
-                if (tree->IsLocal())
+                if (tree->IsAnyLocal())
                 {
                     tree->AsLclVarCommon()->SetSsaNum(SsaConfig::RESERVED_SSA_NUM);
                 }


### PR DESCRIPTION
These can be in SSA and were not getting their SSA numbers cleaned by `fgResetForSsa`, so in repeat mode they might trigger SSA check failures.

Also changed it so you can dump the SSA number without triggering an assert.

Fixes #85629