### PR TITLE
The AllocationTick threshold is computed by a Poisson process with a 100 KB mean.

### DIFF
--- a/src/coreclr/gc/gcconfig.h
+++ b/src/coreclr/gc/gcconfig.h
@@ -137,7 +137,9 @@ public:
     INT_CONFIG   (GCConserveMem,             "GCConserveMemory",          "System.GC.ConserveMemory",          0,                  "Specifies how hard GC should try to conserve memory - values 0-9")                       \
     INT_CONFIG   (GCWriteBarrier,            "GCWriteBarrier",            NULL,                                0,                  "Specifies whether GC should use more precise but slower write barrier")                  \
     STRING_CONFIG(GCName,                    "GCName",                    "System.GC.Name",                                        "Specifies the path of the standalone GC implementation.")                                \
-    INT_CONFIG   (GCSpinCountUnit,           "GCSpinCountUnit",           0,                                   0,                  "Specifies the spin count unit used by the GC.")
+    INT_CONFIG   (GCSpinCountUnit,           "GCSpinCountUnit",           0,                                   0,                  "Specifies the spin count unit used by the GC.")                                          \
+    INT_CONFIG   (AllocationTickMode,        "GCAllocationTickMode",      "GCAllocationTickMode",              0,                  "Specifies the AllocationTick mode (0=fixed, 1=variable, 2=Poisson+AC, 3=Poisson in AC")
+
 // This class is responsible for retreiving configuration information
 // for how the GC should operate.
 class GCConfig

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -2967,6 +2967,10 @@ private:
                           uint64_t* available_page_file=NULL);
     PER_HEAP_METHOD size_t generation_size (int gen_number);
     PER_HEAP_ISOLATED_METHOD size_t get_total_survived_size();
+    PER_HEAP_METHOD size_t get_alloc_current_threshold (int gen_number);
+    PER_HEAP_METHOD size_t get_alloc_next_threshold (int gen_number);
+    PER_HEAP_METHOD bool is_alloc_beyond_threshold (int gen_number, size_t size);
+    PER_HEAP_METHOD size_t compute_alloc_threshold ();
     PER_HEAP_METHOD bool update_alloc_info (int gen_number,
                             size_t allocated_size,
                             size_t* etw_allocation_amount);
@@ -3853,8 +3857,13 @@ private:
 #endif //HEAP_ANALYZE
 
     PER_HEAP_FIELD_DIAG_ONLY gen_to_condemn_tuning gen_to_condemn_reasons;
+    PER_HEAP_FIELD_DIAG_ONLY uint64_t etw_allocationTickMode;
     PER_HEAP_FIELD_DIAG_ONLY size_t etw_allocation_running_amount[total_oh_count];
+    // it is needed to know what will be the next threshold after the running one
+    // to compute the limit of an allocation context: if it is smaller than this
+    // next threshold, then the limit is adjusted to the next threshold
     PER_HEAP_FIELD_DIAG_ONLY size_t etw_allocation_running_threshold[total_oh_count];
+    PER_HEAP_FIELD_DIAG_ONLY size_t etw_allocation_next_threshold[total_oh_count];
     PER_HEAP_FIELD_DIAG_ONLY uint64_t total_alloc_bytes_soh;
     PER_HEAP_FIELD_DIAG_ONLY uint64_t total_alloc_bytes_uoh;
 

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -3854,6 +3854,7 @@ private:
 
     PER_HEAP_FIELD_DIAG_ONLY gen_to_condemn_tuning gen_to_condemn_reasons;
     PER_HEAP_FIELD_DIAG_ONLY size_t etw_allocation_running_amount[total_oh_count];
+    PER_HEAP_FIELD_DIAG_ONLY size_t etw_allocation_running_threshold[total_oh_count];
     PER_HEAP_FIELD_DIAG_ONLY uint64_t total_alloc_bytes_soh;
     PER_HEAP_FIELD_DIAG_ONLY uint64_t total_alloc_bytes_uoh;
 


### PR DESCRIPTION
The fixed 100 KB threshold to trigger the AllocationTick event does not allow good ways to estimate the real allocations. The main issue is not really the sampling by itself but the fact that it is not possible to upscale the sampled size in order to get back sizes with the same order of magnitude than the real ones. Also, keeping the relative size differences between allocated types is important.

As a solution, it is possible to a [Poisson process](https://en.wikipedia.org/wiki/Poisson_point_process#Interpreted_as_a_counting_process) because each sample we take has no influence on any other sample. The samples are exponentially distributed in a Poisson process, meaning that the possibility of the next sample happening is calculated by the exponential cumulative distribution function CDF = (1 - e^(-lambda*x)).

In our context, it means that we need to compute x (= the allocated size to wait for the next sample) based on the mean of the distribution (lambda would the odds to sample a byte - in our case 1/100.000 for the current 100 KB threshold). With this sampling, it is possible to upscale/estimate the "real" allocated sizes based on the sampled size with the following formula: 
`upscaled size = sampled size / (1 - e^(- average size / 100.000))`


3 additional threshold sampling scenarios are implemented to compare them against the fixed 100 KB one:
- 100 KB +/- 50KB random
- exponential 
- exponential triggered within an allocation context
The last one seems to provide the best results once upscaled.
Note that using the Poisson process to upscale the current fixed scenario gives better results than the simple upscaling mechanism based on the per type allocation size / total allocated size.

Relates to https://github.com/dotnet/runtime/issues/49424.