### PR TITLE
[mono][tests] Increase number of nrgctx trampolines to 50000

### DIFF
--- a/src/mono/msbuild/apple/build/AppleBuild.targets
+++ b/src/mono/msbuild/apple/build/AppleBuild.targets
@@ -141,7 +141,7 @@
       <MonoAOTCompilerDefaultAotArguments Include="nrgctx-fetch-trampolines=256" />
       <MonoAOTCompilerDefaultAotArguments Include="ngsharedvt-trampolines=4400" />
       <MonoAOTCompilerDefaultAotArguments Include="nftnptr-arg-trampolines=4000" />
-      <MonoAOTCompilerDefaultAotArguments Include="nrgctx-trampolines=40000" />
+      <MonoAOTCompilerDefaultAotArguments Include="nrgctx-trampolines=50000" />
 
       <MonoAOTCompilerDefaultProcessArguments Include="-O=gsharedvt" />
     </ItemGroup>


### PR DESCRIPTION
This PR should fix https://github.com/dotnet/runtime/issues/85582 by increasing the number of available trampolines for iOS simulators.