### PR TITLE
Revert "SetThreadDpiAwareness for host error dialog"

### DIFF
--- a/src/native/corehost/apphost/apphost.windows.cpp
+++ b/src/native/corehost/apphost/apphost.windows.cpp
@@ -323,20 +323,6 @@ namespace
 
         trace::verbose(_X("Showing error dialog for application: '%s' - error code: 0x%x - url: '%s' - details: %s"), executable_name, error_code, url.c_str(), details.c_str());
 
-        HMODULE user32 = ::LoadLibraryExW(L"user32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
-        if (user32 != nullptr)
-        {
-            using set_thread_dpi = DPI_AWARENESS_CONTEXT(WINAPI*)(DPI_AWARENESS_CONTEXT context);
-            set_thread_dpi set_thread_dpi_func = (set_thread_dpi)::GetProcAddress(user32, "SetThreadDpiAwarenessContext");
-
-            // Since this is only for errors shown when the process is about to exit, we
-            // skip resetting to the previous context to minimize impact on apphost size
-            if (set_thread_dpi_func != nullptr)
-                (void) set_thread_dpi_func(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
-    
-            ::FreeLibrary(user32);
-        }
-
         if (enable_visual_styles())
         {
             // Task dialog requires enabling visual styles


### PR DESCRIPTION
Reverts dotnet/runtime#81930

There is an issue with the Windows TaskDialog where expanding/collapsing the detail area will result in incorrect resizing of the window when the DPI awareness of the process and thread are not the same. Instead of explicitly making the thread starting the dialog DPI aware, we just leave it whatever the process is set to. This means that if the developer specified a manifest that made their application DPI aware, the dialog will be non-blurry, but if the developer did not, it will remain blurry on high DPI.

Fixes https://github.com/dotnet/runtime/issues/85571