### PR TITLE
[JIT] X64 - Centralize peephole optimization for removing redundant `mov` instructions

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -7373,13 +7373,11 @@ void CodeGen::genIntToIntCast(GenTreeCast* cast)
         case GenIntCastDesc::LOAD_ZERO_EXTEND_INT:
             ins     = INS_mov;
             insSize = 4;
-            canSkip = compiler->opts.OptimizationEnabled() && emit->AreUpper32BitsZero(srcReg);
             break;
         case GenIntCastDesc::SIGN_EXTEND_INT:
         case GenIntCastDesc::LOAD_SIGN_EXTEND_INT:
             ins     = INS_movsxd;
             insSize = 4;
-            canSkip = compiler->opts.OptimizationEnabled() && emit->AreUpper32BitsSignExtended(srcReg);
             break;
 #endif
         case GenIntCastDesc::COPY:

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -594,7 +594,8 @@ bool emitter::AreUpperBitsZero(regNumber reg, emitAttr size)
 // Arguments:
 //    reg - register of interest
 //    size - the size of data that the given register of interest is working with;
-//           remaining upper bits of the register that represent a larger size are the bits that are checked for sign-extended
+//           remaining upper bits of the register that represent a larger size are the bits that are checked for
+//           sign-extended
 //
 // Return Value:
 //    true if previous instruction upper bits are sign-extended.

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -6281,6 +6281,7 @@ bool emitter::IsRedundantMov(
             case INS_movzx:
                 if (AreUpperBitsZero(src, size))
                 {
+                    JITDUMP("\n -- suppressing movzx because upper bits are zero.\n");
                     return true;
                 }
                 break;
@@ -6291,6 +6292,7 @@ bool emitter::IsRedundantMov(
 #endif // TARGET_64BIT
                 if (AreUpperBitsSignExtended(src, size))
                 {
+                    JITDUMP("\n -- suppressing movsx or movsxd because upper bits are sign-extended.\n");
                     return true;
                 }
                 break;
@@ -6299,6 +6301,7 @@ bool emitter::IsRedundantMov(
             case INS_mov:
                 if ((size == EA_4BYTE) && AreUpperBitsZero(src, size))
                 {
+                    JITDUMP("\n -- suppressing mov because upper bits are zero.\n");
                     return true;
                 }
                 break;

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -6264,9 +6264,18 @@ bool emitter::IsRedundantMov(
         return false;
     }
 
+    bool hasSideEffect = HasSideEffect(ins, size);
+
     // Peephole optimization to eliminate redundant 'mov' instructions.
-    if (emitComp->opts.OptimizationEnabled() && (dst == src))
+    if (dst == src)
     {
+        // Check if we are already in the correct register and don't have a side effect
+        if (!hasSideEffect)
+        {
+            JITDUMP("\n -- suppressing mov because src and dst is same register and the mov has no side-effects.\n");
+            return true;
+        }
+
         switch (ins)
         {
             case INS_movzx:
@@ -6297,15 +6306,6 @@ bool emitter::IsRedundantMov(
             default:
                 break;
         }
-    }
-
-    bool hasSideEffect = HasSideEffect(ins, size);
-
-    // Check if we are already in the correct register and don't have a side effect
-    if ((dst == src) && !hasSideEffect)
-    {
-        JITDUMP("\n -- suppressing mov because src and dst is same register and the mov has no side-effects.\n");
-        return true;
     }
 
     // TODO-XArch-CQ: Certain instructions, such as movaps vs movups, are equivalent in

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -510,6 +510,8 @@ bool emitter::IsRexW1EvexInstruction(instruction ins)
 //
 // Arguments:
 //    reg - register of interest
+//    size - the size of data that the given register of interest is working with;
+//           remaining upper bits of the register that represent a larger size are the bits that are checked for zero
 //
 // Return Value:
 //    true if previous instruction zeroed reg's upper bits.
@@ -591,6 +593,8 @@ bool emitter::AreUpperBitsZero(regNumber reg, emitAttr size)
 //
 // Arguments:
 //    reg - register of interest
+//    size - the size of data that the given register of interest is working with;
+//           remaining upper bits of the register that represent a larger size are the bits that are checked for sign-extended
 //
 // Return Value:
 //    true if previous instruction upper bits are sign-extended.

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -622,8 +622,6 @@ bool emitter::AreUpperBitsSignExtended(regNumber reg, emitAttr size)
                 case INS_call:
                     return PEEPHOLE_ABORT;
 
-                case INS_cwde:
-                case INS_cdq:
                 case INS_movsx:
 #ifdef TARGET_64BIT
                 case INS_movsxd:

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -557,7 +557,7 @@ bool emitter::AreUpperBitsZero(regNumber reg, emitAttr size)
                         {
                             result = true;
                         }
-                        else if (size == EA_1BYTE || EA_2BYTE)
+                        else if (size == EA_1BYTE || size == EA_2BYTE)
                         {
                             result = (id->idOpSize() <= size);
                         }
@@ -612,7 +612,6 @@ bool emitter::AreUpperBitsSignExtended(regNumber reg, emitAttr size)
 #ifdef TARGET_64BIT
     if (size == EA_4BYTE)
     {
-
         if (id->idReg1() != reg)
         {
             return false;

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -133,8 +133,10 @@ bool IsRedundantStackMov(instruction ins, insFormat fmt, emitAttr size, regNumbe
 static bool IsJccInstruction(instruction ins);
 static bool IsJmpInstruction(instruction ins);
 
+#ifdef TARGET_64BIT
 bool AreUpperBitsZero(regNumber reg, emitAttr size);
 bool AreUpperBitsSignExtended(regNumber reg, emitAttr size);
+#endif // TARGET_64BIT
 
 bool IsRedundantCmp(emitAttr size, regNumber reg1, regNumber reg2);
 

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -135,10 +135,6 @@ static bool IsJmpInstruction(instruction ins);
 
 bool AreUpperBitsZero(regNumber reg, emitAttr size);
 bool AreUpperBitsSignExtended(regNumber reg, emitAttr size);
-#ifdef TARGET_64BIT
-bool AreUpper32BitsZero(regNumber reg);
-bool AreUpper32BitsSignExtended(regNumber reg);
-#endif // TARGET_64BIT
 
 bool IsRedundantCmp(emitAttr size, regNumber reg1, regNumber reg2);
 

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -133,6 +133,8 @@ bool IsRedundantStackMov(instruction ins, insFormat fmt, emitAttr size, regNumbe
 static bool IsJccInstruction(instruction ins);
 static bool IsJmpInstruction(instruction ins);
 
+bool AreUpperBitsZero(regNumber reg, emitAttr size);
+bool AreUpperBitsSignExtended(regNumber reg, emitAttr size);
 #ifdef TARGET_64BIT
 bool AreUpper32BitsZero(regNumber reg);
 bool AreUpper32BitsSignExtended(regNumber reg);


### PR DESCRIPTION
## Description

This centralizes checking for redundant `mov` instructions.

Depending on what we do for https://github.com/dotnet/runtime/pull/85734 , we need to counter some of the regressions that may occur as a result of not removing `CAST` nodes.

This also includes more peephole optimizations for `movzx`, `movsx` and `movsxd`.