### PR TITLE
Add IPC commands to enable and disable PerfMaps/JitDumps

### DIFF
--- a/src/coreclr/inc/CrstTypes.def
+++ b/src/coreclr/inc/CrstTypes.def
@@ -402,7 +402,7 @@ End
 
 // Used to synchronize all rejit information stored in a given AppDomain.
 Crst CodeVersioning
-    AcquiredBefore LoaderHeap SingleUseLock DeadlockDetection JumpStubCache DebuggerController FuncPtrStubs
+    AcquiredBefore LoaderHeap SingleUseLock DeadlockDetection JumpStubCache DebuggerController FuncPtrStubs PerfMap
     AcquiredAfter ReJITGlobalRequest ThreadStore GlobalStrLiteralMap SystemDomain DebuggerMutex MethodDescBackpatchInfoTracker
                 ReadyToRunEntryPointToMethodDescMap ClassInit AppDomainCache TypeIDMap FusionAppCtx COMWrapperCache InteropData
 End
@@ -580,4 +580,8 @@ End
 
 Crst StaticBoxInit
     AcquiredBefore LoaderHeap FrozenObjectHeap AssemblyLoader
+End
+
+Crst PerfMap
+    AcquiredAfter CodeVersioning AssemblyList
 End

--- a/src/coreclr/inc/crsttypes_generated.h
+++ b/src/coreclr/inc/crsttypes_generated.h
@@ -94,47 +94,48 @@ enum CrstType
     CrstObjectList = 76,
     CrstPEImage = 77,
     CrstPendingTypeLoadEntry = 78,
-    CrstPgoData = 79,
-    CrstPinnedByrefValidation = 80,
-    CrstPinnedHeapHandleTable = 81,
-    CrstProfilerGCRefDataFreeList = 82,
-    CrstProfilingAPIStatus = 83,
-    CrstRCWCache = 84,
-    CrstRCWCleanupList = 85,
-    CrstReadyToRunEntryPointToMethodDescMap = 86,
-    CrstReflection = 87,
-    CrstReJITGlobalRequest = 88,
-    CrstRetThunkCache = 89,
-    CrstSavedExceptionInfo = 90,
-    CrstSaveModuleProfileData = 91,
-    CrstSecurityStackwalkCache = 92,
-    CrstSigConvert = 93,
-    CrstSingleUseLock = 94,
-    CrstSpecialStatics = 95,
-    CrstStackSampler = 96,
-    CrstStaticBoxInit = 97,
-    CrstStressLog = 98,
-    CrstStubCache = 99,
-    CrstStubDispatchCache = 100,
-    CrstStubUnwindInfoHeapSegments = 101,
-    CrstSyncBlockCache = 102,
-    CrstSyncHashLock = 103,
-    CrstSystemBaseDomain = 104,
-    CrstSystemDomain = 105,
-    CrstSystemDomainDelayedUnloadList = 106,
-    CrstThreadIdDispenser = 107,
-    CrstThreadStore = 108,
-    CrstTieredCompilation = 109,
-    CrstTypeEquivalenceMap = 110,
-    CrstTypeIDMap = 111,
-    CrstUMEntryThunkCache = 112,
-    CrstUMEntryThunkFreeListLock = 113,
-    CrstUniqueStack = 114,
-    CrstUnresolvedClassLock = 115,
-    CrstUnwindInfoTableLock = 116,
-    CrstVSDIndirectionCellLock = 117,
-    CrstWrapperTemplate = 118,
-    kNumberOfCrstTypes = 119
+    CrstPerfMap = 79,
+    CrstPgoData = 80,
+    CrstPinnedByrefValidation = 81,
+    CrstPinnedHeapHandleTable = 82,
+    CrstProfilerGCRefDataFreeList = 83,
+    CrstProfilingAPIStatus = 84,
+    CrstRCWCache = 85,
+    CrstRCWCleanupList = 86,
+    CrstReadyToRunEntryPointToMethodDescMap = 87,
+    CrstReflection = 88,
+    CrstReJITGlobalRequest = 89,
+    CrstRetThunkCache = 90,
+    CrstSavedExceptionInfo = 91,
+    CrstSaveModuleProfileData = 92,
+    CrstSecurityStackwalkCache = 93,
+    CrstSigConvert = 94,
+    CrstSingleUseLock = 95,
+    CrstSpecialStatics = 96,
+    CrstStackSampler = 97,
+    CrstStaticBoxInit = 98,
+    CrstStressLog = 99,
+    CrstStubCache = 100,
+    CrstStubDispatchCache = 101,
+    CrstStubUnwindInfoHeapSegments = 102,
+    CrstSyncBlockCache = 103,
+    CrstSyncHashLock = 104,
+    CrstSystemBaseDomain = 105,
+    CrstSystemDomain = 106,
+    CrstSystemDomainDelayedUnloadList = 107,
+    CrstThreadIdDispenser = 108,
+    CrstThreadStore = 109,
+    CrstTieredCompilation = 110,
+    CrstTypeEquivalenceMap = 111,
+    CrstTypeIDMap = 112,
+    CrstUMEntryThunkCache = 113,
+    CrstUMEntryThunkFreeListLock = 114,
+    CrstUniqueStack = 115,
+    CrstUnresolvedClassLock = 116,
+    CrstUnwindInfoTableLock = 117,
+    CrstVSDIndirectionCellLock = 118,
+    CrstWrapperTemplate = 119,
+    kNumberOfCrstTypes = 120
 };
 
 #endif // __CRST_TYPES_INCLUDED
@@ -147,7 +148,7 @@ int g_rgCrstLevelMap[] =
 {
     10,         // CrstAppDomainCache
     3,          // CrstArgBasedStubCache
-    0,          // CrstAssemblyList
+    3,          // CrstAssemblyList
     12,         // CrstAssemblyLoader
     4,          // CrstAvailableClass
     5,          // CrstAvailableParamTypes
@@ -224,6 +225,7 @@ int g_rgCrstLevelMap[] =
     2,          // CrstObjectList
     5,          // CrstPEImage
     19,         // CrstPendingTypeLoadEntry
+    0,          // CrstPerfMap
     4,          // CrstPgoData
     0,          // CrstPinnedByrefValidation
     14,         // CrstPinnedHeapHandleTable
@@ -348,6 +350,7 @@ LPCSTR g_rgCrstNameMap[] =
     "CrstObjectList",
     "CrstPEImage",
     "CrstPendingTypeLoadEntry",
+    "CrstPerfMap",
     "CrstPgoData",
     "CrstPinnedByrefValidation",
     "CrstPinnedHeapHandleTable",

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.h
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.h
@@ -258,6 +258,20 @@ ds_rt_set_environment_variable (const ep_char16_t *name, const ep_char16_t *valu
     return 0xffff;
 }
 
+static
+uint32_t
+ds_rt_enable_perfmap (uint32_t type)
+{
+    return DS_IPC_E_NOTSUPPORTED;
+}
+
+static
+uint32_t
+ds_rt_disable_perfmap ()
+{
+    return DS_IPC_E_NOTSUPPORTED;
+}
+
 /*
 * DiagnosticServer.
 */

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.h
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.h
@@ -267,7 +267,7 @@ ds_rt_enable_perfmap (uint32_t type)
 
 static
 uint32_t
-ds_rt_disable_perfmap ()
+ds_rt_disable_perfmap (void)
 {
     return DS_IPC_E_NOTSUPPORTED;
 }

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -540,6 +540,11 @@ PALAPI
 PAL_PerfJitDump_Start(const char* path);
 
 PALIMPORT
+bool
+PALAPI
+PAL_PerfJitDump_IsStarted();
+
+PALIMPORT
 int
 PALAPI
 // Log a method to the jitdump file.

--- a/src/coreclr/pal/src/misc/perfjitdump.cpp
+++ b/src/coreclr/pal/src/misc/perfjitdump.cpp
@@ -248,7 +248,7 @@ exit:
             size_t itemsWritten = 0;
 
             if (result != 0)
-                return FatalError(false);
+                return FatalError();
 
             if (!enabled)
                 goto exit;
@@ -268,7 +268,7 @@ exit:
                     if (errno == EINTR)
                         continue;
 
-                    return FatalError(true);
+                    return FatalError();
                 }
 
                 // Detect unexpected failure cases.

--- a/src/coreclr/pal/src/misc/perfjitdump.cpp
+++ b/src/coreclr/pal/src/misc/perfjitdump.cpp
@@ -380,6 +380,13 @@ PAL_PerfJitDump_Start(const char* path)
     return GetState().Start(path);
 }
 
+bool
+PALAPI
+PAL_PerfJitDump_IsStarted()
+{
+    return GetState().enabled;
+}
+
 int
 PALAPI
 PAL_PerfJitDump_LogMethod(void* pCode, size_t codeSize, const char* symbol, void* debugInfo, void* unwindInfo)
@@ -401,6 +408,13 @@ PALAPI
 PAL_PerfJitDump_Start(const char* path)
 {
     return 0;
+}
+
+bool
+PALAPI
+PAL_PerfJitDump_IsStarted()
+{
+    return false;
 }
 
 int

--- a/src/coreclr/pal/src/misc/perfjitdump.cpp
+++ b/src/coreclr/pal/src/misc/perfjitdump.cpp
@@ -139,17 +139,15 @@ struct PerfJitDumpState
         enabled(false),
         fd(-1),
         mmapAddr(MAP_FAILED),
-        mutex(PTHREAD_MUTEX_INITIALIZER),
         codeIndex(0)
     {}
 
     volatile bool enabled;
     int fd;
     void *mmapAddr;
-    pthread_mutex_t mutex;
     volatile uint64_t codeIndex;
 
-    int FatalError(bool locked)
+    int FatalError()
     {
         enabled = false;
 
@@ -165,11 +163,6 @@ struct PerfJitDumpState
             fd = -1;
         }
 
-        if (locked)
-        {
-            pthread_mutex_unlock(&mutex);
-        }
-
         return -1;
     }
 
@@ -180,10 +173,8 @@ struct PerfJitDumpState
         // Write file header
         FileHeader header;
 
-        result = pthread_mutex_lock(&mutex);
-
         if (result != 0)
-            return FatalError(false);
+            return FatalError();
 
         if (enabled)
             goto exit;
@@ -193,39 +184,37 @@ struct PerfJitDumpState
         result = snprintf(jitdumpPath, sizeof(jitdumpPath), "%s/jit-%i.dump", path, getpid());
 
         if (result >= PATH_MAX)
-            return FatalError(true);
+            return FatalError();
 
         result = open(jitdumpPath, O_CREAT|O_TRUNC|O_RDWR|O_CLOEXEC, S_IRUSR|S_IWUSR );
 
         if (result == -1)
-            return FatalError(true);
+            return FatalError();
 
         fd = result;
 
         result = write(fd, &header, sizeof(FileHeader));
 
         if (result == -1)
-            return FatalError(true);
+            return FatalError();
 
         result = fsync(fd);
 
         if (result == -1)
-            return FatalError(true);
+            return FatalError();
 
         // mmap jitdump file
         // this is a marker for perf inject to find the jitdumpfile
         mmapAddr = mmap(nullptr, sizeof(FileHeader), PROT_READ | PROT_EXEC, MAP_PRIVATE, fd, 0);
 
         if (mmapAddr == MAP_FAILED)
-            return FatalError(true);
+            return FatalError();
 
         enabled = true;
 
 exit:
-        result = pthread_mutex_unlock(&mutex);
-
         if (result != 0)
-            return FatalError(false);
+            return FatalError();
 
         return 0;
     }
@@ -257,8 +246,6 @@ exit:
             size_t itemsCount = sizeof(items) / sizeof(items[0]);
 
             size_t itemsWritten = 0;
-
-            result = pthread_mutex_lock(&mutex);
 
             if (result != 0)
                 return FatalError(false);
@@ -312,10 +299,8 @@ exit:
             } while (true);
 
 exit:
-            result = pthread_mutex_unlock(&mutex);
-
             if (result != 0)
-                return FatalError(false);
+                return FatalError();
         }
         return 0;
     }
@@ -328,11 +313,8 @@ exit:
         {
             enabled = false;
 
-            // Lock the mutex
-            result = pthread_mutex_lock(&mutex);
-
             if (result != 0)
-                return FatalError(false);
+                return FatalError();
 
             if (!enabled)
                 goto exit;
@@ -340,24 +322,22 @@ exit:
             result = munmap(mmapAddr, sizeof(FileHeader));
 
             if (result == -1)
-                return FatalError(true);
+                return FatalError();
 
             mmapAddr = MAP_FAILED;
 
             result = fsync(fd);
 
             if (result == -1)
-                return FatalError(true);
+                return FatalError();
 
             result = close(fd);
 
             if (result == -1)
-                return FatalError(true);
+                return FatalError();
 
             fd = -1;
 exit:
-            result = pthread_mutex_unlock(&mutex);
-
             if (result != 0)
                 return -1;
         }

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1242,7 +1242,7 @@ void STDMETHODCALLTYPE EEShutDownHelper(BOOL fIsDllUnloading)
 
 #ifdef FEATURE_PERFMAP
         // Flush and close the perf map file.
-        PerfMap::Destroy();
+        PerfMap::Disable();
 #endif
 
         ceeInf.JitProcessShutdownWork();  // Do anything JIT-related that needs to happen at shutdown.

--- a/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
@@ -13,6 +13,9 @@
 #include <eventpipe/ds-process-protocol.h>
 #include <eventpipe/ds-profiler-protocol.h>
 #include <eventpipe/ds-dump-protocol.h>
+#ifdef FEATURE_PERFMAP
+#include "perfmap.h"
+#endif
 
 #undef DS_LOG_ALWAYS_0
 #define DS_LOG_ALWAYS_0(msg) STRESS_LOG0(LF_DIAGNOSTICS_PORT, LL_ALWAYS, msg "\n")
@@ -290,6 +293,40 @@ uint32_t
 ds_rt_set_environment_variable (const ep_char16_t *name, const ep_char16_t *value)
 {
 	return SetEnvironmentVariableW(reinterpret_cast<LPCWSTR>(name), reinterpret_cast<LPCWSTR>(value)) ? S_OK : HRESULT_FROM_WIN32(GetLastError());
+}
+
+static
+uint32_t
+ds_rt_enable_perfmap (uint32_t type)
+{
+	LIMITED_METHOD_CONTRACT;
+
+#ifdef FEATURE_PERFMAP
+	PerfMap::PerfMapType perfMapType = (PerfMap::PerfMapType)type;
+	if (perfMapType == PerfMap::PerfMapType::DISABLED || perfMapType > PerfMap::PerfMapType::JITDUMP)
+	{
+		return DS_IPC_E_INVALIDARG;
+	}
+
+	PerfMap::Enable(perfMapType, true);
+
+    return DS_IPC_S_OK;
+#else // FEATURE_PERFMAP
+    return DS_IPC_E_NOTSUPPORTED;
+#endif // FEATURE_PERFMAP
+}
+
+static
+uint32_t
+ds_rt_disable_perfmap ()
+{
+	LIMITED_METHOD_CONTRACT;
+#ifdef FEATURE_PERFMAP
+	PerfMap::Disable();
+	return DS_IPC_S_OK;
+#else // FEATURE_PERFMAP
+	return DS_IPC_E_NOTSUPPORTED;
+#endif // FEATURE_PERFMAP
 }
 
 /*

--- a/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
@@ -318,7 +318,7 @@ ds_rt_enable_perfmap (uint32_t type)
 
 static
 uint32_t
-ds_rt_disable_perfmap ()
+ds_rt_disable_perfmap (void)
 {
 	LIMITED_METHOD_CONTRACT;
 #ifdef FEATURE_PERFMAP

--- a/src/coreclr/vm/perfmap.cpp
+++ b/src/coreclr/vm/perfmap.cpp
@@ -20,48 +20,56 @@
 #define FMT_CODE_ADDR "%p"
 
 Volatile<bool> PerfMap::s_enabled = false;
-PerfMap * PerfMap::s_Current = nullptr;
+VolatilePtr<PerfMap> PerfMap::s_Current = nullptr;
 bool PerfMap::s_ShowOptimizationTiers = false;
 unsigned PerfMap::s_StubsMapped = 0;
-
-enum 
-{
-    DISABLED,
-    ALL,
-    JITDUMP,
-    PERFMAP
-};
+CrstStatic PerfMap::s_csPerfMap;
 
 // Initialize the map for the process - called from EEStartupHelper.
 void PerfMap::Initialize()
 {
     LIMITED_METHOD_CONTRACT;
 
-    // Only enable the map if requested.
-    if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_PerfMapEnabled) == ALL || CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_PerfMapEnabled) == PERFMAP)
+    s_csPerfMap.Init(CrstPerfMap);
+
+    PerfMapType perfMapType = (PerfMapType)CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_PerfMapEnabled);
+    PerfMap::Enable(perfMapType, false);
+}
+
+void PerfMap::Enable(PerfMapType type, bool sendExisting)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    if (type == PerfMapType::DISABLED)
     {
-        // Get the current process id.
-        int currentPid = GetCurrentProcessId();
-
-        // Create the map.
-        s_Current = new PerfMap(currentPid);
-
-        int signalNum = (int) CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_PerfMapIgnoreSignal);
-
-        if (signalNum > 0)
-        {
-            PAL_IgnoreProfileSignal(signalNum);
-        }
-
-        if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_PerfMapShowOptimizationTiers) != 0)
-        {
-            s_ShowOptimizationTiers = true;
-        }
-
-        s_enabled = true;
+        return;
     }
 
-    if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_PerfMapEnabled) == ALL || CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_PerfMapEnabled) == JITDUMP)
+    {
+        CrstHolder ch(&(s_csPerfMap));
+
+        if (s_Current == nullptr && (type == PerfMapType::ALL || type == PerfMapType::PERFMAP))
+        {
+            s_Current = new PerfMap();
+            int signalNum = (int) CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_PerfMapIgnoreSignal);
+
+            if (signalNum > 0)
+            {
+                PAL_IgnoreProfileSignal(signalNum);
+            }
+
+            if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_PerfMapShowOptimizationTiers) != 0)
+            {
+                s_ShowOptimizationTiers = true;
+            }
+
+            int currentPid = GetCurrentProcessId();
+            s_Current->OpenFileForPid(currentPid);
+            s_enabled = true;
+        }
+    }
+
+    if (!PAL_PerfJitDump_IsStarted() && (type == PerfMapType::ALL || type == PerfMapType::JITDUMP))
     {   
         const char* jitdumpPath;
         char jitdumpPathBuffer[4096];
@@ -86,29 +94,121 @@ void PerfMap::Initialize()
         
         s_enabled = true;
     }
+
+    if (sendExisting)
+    {
+        if (type == PerfMapType::ALL || type == PerfMapType::JITDUMP)
+        {
+            AppDomain::AssemblyIterator assemblyIterator = GetAppDomain()->IterateAssembliesEx(
+                (AssemblyIterationFlags)(kIncludeLoaded | kIncludeExecution));
+            CollectibleAssemblyHolder<DomainAssembly *> pDomainAssembly;
+            while (assemblyIterator.Next(pDomainAssembly.This()))
+            {
+                CollectibleAssemblyHolder<Assembly *> pAssembly = pDomainAssembly->GetAssembly();
+                PerfMap::LogImageLoad(pAssembly->GetPEAssembly());
+
+                Module *pModule = pAssembly->GetModule();
+                if (pModule->IsReadyToRun())
+                {
+                    ReadyToRunInfo::MethodIterator mi(pModule->GetReadyToRunInfo());
+
+                    while (mi.Next())
+                    {
+                        // Call GetMethodDesc_NoRestore instead of GetMethodDesc to avoid restoring methods.
+                        MethodDesc *hotDesc = (MethodDesc *)mi.GetMethodDesc_NoRestore();
+                        if (hotDesc != nullptr && hotDesc->GetNativeCode() != NULL)
+                        {
+                            PerfMap::LogPreCompiledMethod(hotDesc, hotDesc->GetNativeCode());
+                        }
+                    }
+                }
+            }
+        }
+
+        {
+            CodeVersionManager::LockHolder codeVersioningLockHolder;
+
+            EEJitManager::CodeHeapIterator heapIterator(nullptr);
+            while (heapIterator.Next())
+            {
+                MethodDesc * pMethod = heapIterator.GetMethod();
+                if (pMethod == nullptr)
+                {
+                    continue;
+                }
+
+                PCODE codeStart = PINSTRToPCODE(heapIterator.GetMethodCode());
+                NativeCodeVersion nativeCodeVersion;
+#ifdef FEATURE_CODE_VERSIONING
+                nativeCodeVersion = pMethod->GetCodeVersionManager()->GetNativeCodeVersion(pMethod, codeStart);;
+                if (nativeCodeVersion.IsNull() && codeStart != pMethod->GetNativeCode())
+                {
+                    continue;
+                }
+#else // FEATURE_CODE_VERSIONING
+                if (codeStart != pMethod->GetNativeCode())
+                {
+                    continue;
+                }
+#endif // FEATURE_CODE_VERSIONING
+
+                EECodeInfo codeInfo(codeStart);
+                IJitManager::MethodRegionInfo methodRegionInfo;
+                codeInfo.GetMethodRegionInfo(&methodRegionInfo);
+                _ASSERTE(methodRegionInfo.hotStartAddress == codeStart);
+                    
+                PrepareCodeConfig config(!nativeCodeVersion.IsNull() ? nativeCodeVersion : NativeCodeVersion(pMethod), FALSE, FALSE);
+                PerfMap::LogJITCompiledMethod(pMethod, codeStart, methodRegionInfo.hotSize, &config);
+            }
+        }
+    }
 }
 
-// Destroy the map for the process - called from EEShutdownHelper.
-void PerfMap::Destroy()
+// Disable the map for the process - called from EEShutdownHelper.
+void PerfMap::Disable()
 {
     LIMITED_METHOD_CONTRACT;
 
     if (s_enabled)
     {
+        CrstHolder ch(&(s_csPerfMap));
+
         s_enabled = false;
+        if (s_Current != nullptr)
+        {
+            delete s_Current;
+            s_Current = nullptr;
+        }
+
         // PAL_PerfJitDump_Finish is lock protected and can safely be called multiple times
         PAL_PerfJitDump_Finish();
     }
 }
 
 // Construct a new map for the process.
-PerfMap::PerfMap(int pid)
+PerfMap::PerfMap()
 {
     LIMITED_METHOD_CONTRACT;
 
     // Initialize with no failures.
     m_ErrorEncountered = false;
+    m_PerfInfo = nullptr;
+}
 
+// Clean-up resources.
+PerfMap::~PerfMap()
+{
+    LIMITED_METHOD_CONTRACT;
+
+    delete m_FileStream;
+    m_FileStream = nullptr;
+
+    delete m_PerfInfo;
+    m_PerfInfo = nullptr;
+}
+
+void PerfMap::OpenFileForPid(int pid)
+{
     // Build the path to the map file on disk.
     WCHAR tempPath[MAX_LONGPATH+1];
     if(!GetTempPathW(MAX_LONGPATH, tempPath))
@@ -124,32 +224,6 @@ PerfMap::PerfMap(int pid)
     OpenFile(path);
 
     m_PerfInfo = new PerfInfo(pid);
-}
-
-// Construct a new map without a specified file name.
-// Used for offline creation of NGEN map files.
-PerfMap::PerfMap()
-  : m_FileStream(nullptr)
-  , m_PerfInfo(nullptr)
-{
-    LIMITED_METHOD_CONTRACT;
-
-    // Initialize with no failures.
-    m_ErrorEncountered = false;
-
-    s_StubsMapped = 0;
-}
-
-// Clean-up resources.
-PerfMap::~PerfMap()
-{
-    LIMITED_METHOD_CONTRACT;
-
-    delete m_FileStream;
-    m_FileStream = nullptr;
-
-    delete m_PerfInfo;
-    m_PerfInfo = nullptr;
 }
 
 // Open the specified destination map file.
@@ -174,6 +248,9 @@ void PerfMap::OpenFile(SString& path)
 void PerfMap::WriteLine(SString& line)
 {
     STANDARD_VM_CONTRACT;
+#ifdef _DEBUG
+    _ASSERTE(s_csPerfMap.OwnedByCurrentThread());
+#endif
 
     if (m_FileStream == nullptr || m_ErrorEncountered)
     {
@@ -202,6 +279,8 @@ void PerfMap::WriteLine(SString& line)
 
 void PerfMap::LogImageLoad(PEAssembly * pPEAssembly)
 {
+    CrstHolder ch(&(s_csPerfMap));
+
     if (s_enabled && s_Current != nullptr)
     {
         s_Current->LogImage(pPEAssembly);
@@ -235,8 +314,6 @@ void PerfMap::LogImage(PEAssembly * pPEAssembly)
     EX_CATCH{} EX_END_CATCH(SwallowAllExceptions);
 }
 
-
-// Log a method to the map.
 void PerfMap::LogJITCompiledMethod(MethodDesc * pMethod, PCODE pCode, size_t codeSize, PrepareCodeConfig *pConfig)
 {
     LIMITED_METHOD_CONTRACT;
@@ -276,10 +353,13 @@ void PerfMap::LogJITCompiledMethod(MethodDesc * pMethod, PCODE pCode, size_t cod
         SString line;
         line.Printf(FMT_CODE_ADDR " %x %s\n", pCode, codeSize, name.GetUTF8());
 
-        // Write the line.
-        if(s_Current != nullptr)
         {
-            s_Current->WriteLine(line);
+            CrstHolder ch(&(s_csPerfMap));
+
+            if(s_Current != nullptr)
+            {
+                s_Current->WriteLine(line);
+            }
         }
         PAL_PerfJitDump_LogMethod((void*)pCode, codeSize, name.GetUTF8(), nullptr, nullptr);
     }
@@ -364,10 +444,13 @@ void PerfMap::LogStubs(const char* stubType, const char* stubOwner, PCODE pCode,
         SString line;
         line.Printf(FMT_CODE_ADDR " %x %s\n", pCode, codeSize, name.GetUTF8());
 
-        // Write the line.
-        if(s_Current != nullptr)
         {
-            s_Current->WriteLine(line);
+            CrstHolder ch(&(s_csPerfMap));
+
+            if(s_Current != nullptr)
+            {
+                s_Current->WriteLine(line);
+            }
         }
         PAL_PerfJitDump_LogMethod((void*)pCode, codeSize, name.GetUTF8(), nullptr, nullptr);
     }

--- a/src/coreclr/vm/perfmap.h
+++ b/src/coreclr/vm/perfmap.h
@@ -19,13 +19,15 @@ private:
     static Volatile<bool> s_enabled;
 
     // The one and only PerfMap for the process.
-    static PerfMap * s_Current;
+    static VolatilePtr<PerfMap> s_Current;
 
     // Indicates whether optimization tiers should be shown for methods in perf maps
     static bool s_ShowOptimizationTiers;
 
     // Set to true if an error is encountered when writing to the file.
     static unsigned s_StubsMapped;
+
+    static CrstStatic s_csPerfMap;
 
     // The file stream to write the map to.
     CFileStream * m_FileStream;
@@ -37,19 +39,14 @@ private:
     bool m_ErrorEncountered;
 
     // Construct a new map for the specified pid.
-    PerfMap(int pid);
+    PerfMap();
+
+    void OpenFileForPid(int pid);
 
     // Write a line to the map file.
     void WriteLine(SString & line);
 
 protected:
-    // Construct a new map without a specified file name.
-    // Used for offline creation of NGEN map files.
-    PerfMap();
-
-    // Clean-up resources.
-    ~PerfMap();
-
     // Open the perf map file for write.
     void OpenFile(SString& path);
 
@@ -63,13 +60,32 @@ protected:
     static void GetNativeImageSignature(PEAssembly * pPEAssembly, CHAR * pszSig, unsigned int nSigSize);
 
 public:
+    // Clean-up resources.
+    ~PerfMap();
+
+    enum class PerfMapType
+    {
+        DISABLED = 0,
+        ALL      = 1,
+        JITDUMP  = 2,
+        PERFMAP  = 3
+    };
+
+    static bool IsEnabled()
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        return s_enabled;
+    }
+
     // Initialize the map for the current process.
     static void Initialize();
+
+    static void Enable(PerfMapType type, bool sendExisting);
 
     // Log a native image load to the map.
     static void LogImageLoad(PEAssembly * pPEAssembly);
 
-    // Log a JIT compiled method to the map.
     static void LogJITCompiledMethod(MethodDesc * pMethod, PCODE pCode, size_t codeSize, PrepareCodeConfig *pConfig);
 
     // Log a pre-compiled method to the map.
@@ -79,6 +95,6 @@ public:
     static void LogStubs(const char* stubType, const char* stubOwner, PCODE pCode, size_t codeSize);
 
     // Close the map and flush any remaining data.
-    static void Destroy();
+    static void Disable();
 };
 #endif // PERFPID_H

--- a/src/coreclr/vm/perfmap.h
+++ b/src/coreclr/vm/perfmap.h
@@ -19,7 +19,7 @@ private:
     static Volatile<bool> s_enabled;
 
     // The one and only PerfMap for the process.
-    static VolatilePtr<PerfMap> s_Current;
+    static PerfMap * s_Current;
 
     // Indicates whether optimization tiers should be shown for methods in perf maps
     static bool s_ShowOptimizationTiers;
@@ -33,7 +33,7 @@ private:
     CFileStream * m_FileStream;
 
     // The perfinfo file to log images to.
-    PerfInfo* m_PerfInfo;
+    PerfInfo * m_PerfInfo;
 
     // Set to true if an error is encountered when writing to the file.
     bool m_ErrorEncountered;

--- a/src/mono/mono/eventpipe/ds-rt-mono.h
+++ b/src/mono/mono/eventpipe/ds-rt-mono.h
@@ -234,7 +234,7 @@ ds_rt_enable_perfmap (uint32_t type)
 
 static
 uint32_t
-ds_rt_disable_perfmap ()
+ds_rt_disable_perfmap (void)
 {
 	return DS_IPC_E_NOTSUPPORTED;
 }

--- a/src/mono/mono/eventpipe/ds-rt-mono.h
+++ b/src/mono/mono/eventpipe/ds-rt-mono.h
@@ -225,6 +225,20 @@ ds_rt_set_environment_variable (const ep_char16_t *name, const ep_char16_t *valu
 	return success ? DS_IPC_S_OK : DS_IPC_E_FAIL;
 }
 
+static
+uint32_t
+ds_rt_enable_perfmap (uint32_t type)
+{
+	return DS_IPC_E_NOTSUPPORTED;
+}
+
+static
+uint32_t
+ds_rt_disable_perfmap ()
+{
+	return DS_IPC_E_NOTSUPPORTED;
+}
+
 /*
 * DiagnosticServer.
 */

--- a/src/native/eventpipe/ds-process-protocol.c
+++ b/src/native/eventpipe/ds-process-protocol.c
@@ -819,7 +819,7 @@ process_protocol_helper_enable_perfmap (
 	}
 
 	ds_ipc_result_t ipc_result;
-	ipc_result = ds_rt_enable_perfmap (payload->value);
+	ipc_result = ds_rt_enable_perfmap (payload->perfMapType);
 	if (ipc_result != DS_IPC_S_OK) {
 		ds_ipc_message_send_error (stream, ipc_result);
 		ep_raise_error ();

--- a/src/native/eventpipe/ds-process-protocol.c
+++ b/src/native/eventpipe/ds-process-protocol.c
@@ -79,6 +79,18 @@ process_protocol_helper_set_environment_variable (
 
 static
 bool
+process_protocol_helper_enable_perfmap (
+	DiagnosticsIpcMessage *message,
+	DiagnosticsIpcStream *stream);
+
+static
+bool
+process_protocol_helper_disable_perfmap (
+	DiagnosticsIpcMessage *message,
+	DiagnosticsIpcStream *stream);
+
+static
+bool
 process_protocol_helper_unknown_command (
 	DiagnosticsIpcMessage *message,
 	DiagnosticsIpcStream *stream);
@@ -745,6 +757,121 @@ ep_on_error:
 	ep_exit_error_handler ();
 }
 
+DiagnosticsEnablePerfmapPayload *
+ds_enable_perfmap_payload_alloc (void)
+{
+	return ep_rt_object_alloc (DiagnosticsEnablePerfmapPayload);
+}
+
+void
+ds_enable_perfmap_payload_free (DiagnosticsEnablePerfmapPayload *payload)
+{
+	ep_return_void_if_nok (payload != NULL);
+	ep_rt_byte_array_free (payload->incoming_buffer);
+	ep_rt_object_free (payload);
+}
+
+static
+uint8_t *
+enable_perfmap_command_try_parse_payload (
+	uint8_t *buffer,
+	uint16_t buffer_len)
+{
+	EP_ASSERT (buffer != NULL);
+
+	uint8_t * buffer_cursor = buffer;
+	uint32_t buffer_cursor_len = buffer_len;
+
+	DiagnosticsEnablePerfmapPayload *instance = ds_enable_perfmap_payload_alloc ();
+	ep_raise_error_if_nok (instance != NULL);
+
+	instance->incoming_buffer = buffer;
+
+	if (!ds_ipc_message_try_parse_uint32_t (&buffer_cursor, &buffer_cursor_len, &instance->value))
+		ep_raise_error ();
+
+ep_on_exit:
+	return (uint8_t *)instance;
+
+ep_on_error:
+	ds_enable_perfmap_payload_free (instance);
+	instance = NULL;
+	ep_exit_error_handler ();
+}
+
+static
+bool
+process_protocol_helper_enable_perfmap (
+	DiagnosticsIpcMessage *message,
+	DiagnosticsIpcStream *stream)
+{
+	EP_ASSERT (message != NULL);
+	EP_ASSERT (stream != NULL);
+
+	if (!stream)
+		return false;
+
+	bool result = false;
+	DiagnosticsEnablePerfmapPayload *payload = (DiagnosticsEnablePerfmapPayload *)ds_ipc_message_try_parse_payload (message, enable_perfmap_command_try_parse_payload);
+	if (!payload) {
+		ds_ipc_message_send_error (stream, DS_IPC_E_BAD_ENCODING);
+		ep_raise_error ();
+	}
+
+	ds_ipc_result_t ipc_result;
+	ipc_result = ds_rt_enable_perfmap (payload->value);
+	if (ipc_result != DS_IPC_S_OK) {
+		ds_ipc_message_send_error (stream, ipc_result);
+		ep_raise_error ();
+	} else {
+		ds_ipc_message_send_success (stream, ipc_result);
+	}
+
+	result = true;
+
+ep_on_exit:
+	ds_enable_perfmap_payload_free (payload);
+	ds_ipc_stream_free (stream);
+	return result;
+
+ep_on_error:
+	EP_ASSERT (!result);
+	ep_exit_error_handler ();
+}
+
+static
+bool
+process_protocol_helper_disable_perfmap (
+	DiagnosticsIpcMessage *message,
+	DiagnosticsIpcStream *stream)
+{
+	EP_ASSERT (message != NULL);
+	EP_ASSERT (stream != NULL);
+
+	if (!stream)
+		return false;
+
+	bool result = false;
+	ds_ipc_result_t ipc_result;
+	ipc_result = ds_rt_disable_perfmap ();
+	if (ipc_result != DS_IPC_S_OK) {
+		ds_ipc_message_send_error (stream, ipc_result);
+		ep_raise_error ();
+	} else {
+		ds_ipc_message_send_success (stream, ipc_result);
+	}
+
+	result = true;
+
+ep_on_exit:
+	ds_ipc_stream_free (stream);
+	return result;
+
+ep_on_error:
+	EP_ASSERT (!result);
+	ep_exit_error_handler ();
+}
+
 static
 bool
 process_protocol_helper_unknown_command (
@@ -782,6 +909,12 @@ ds_process_protocol_helper_handle_ipc_message (
 		break;
 	case DS_PROCESS_COMMANDID_GET_PROCESS_INFO_2:
 		result = process_protocol_helper_get_process_info_2 (message, stream);
+		break;
+	case DS_PROCESS_COMMANDID_ENABLE_PERFMAP:
+		result = process_protocol_helper_enable_perfmap (message, stream);
+		break;
+	case DS_PROCESS_COMMANDID_DISABLE_PERFMAP:
+		result = process_protocol_helper_disable_perfmap (message, stream);
 		break;
 	default:
 		result = process_protocol_helper_unknown_command (message, stream);

--- a/src/native/eventpipe/ds-process-protocol.c
+++ b/src/native/eventpipe/ds-process-protocol.c
@@ -787,7 +787,7 @@ enable_perfmap_command_try_parse_payload (
 
 	instance->incoming_buffer = buffer;
 
-	if (!ds_ipc_message_try_parse_uint32_t (&buffer_cursor, &buffer_cursor_len, &instance->value))
+	if (!ds_ipc_message_try_parse_uint32_t (&buffer_cursor, &buffer_cursor_len, &instance->perfMapType))
 		ep_raise_error ();
 
 ep_on_exit:

--- a/src/native/eventpipe/ds-process-protocol.h
+++ b/src/native/eventpipe/ds-process-protocol.h
@@ -185,10 +185,10 @@ struct _DiagnosticsEnablePerfmapPayload {
 #endif
 
 DiagnosticsEnablePerfmapPayload *
-ds_set_generate_perfmap_payload_alloc (void);
+ds_enable_perfmap_payload_alloc (void);
 
 void
-ds_set_generate_perfmap_payload_free (DiagnosticsEnablePerfmapPayload *payload);
+ds_enable_perfmap_payload_free (DiagnosticsEnablePerfmapPayload *payload);
 
 /*
  * DiagnosticsProcessProtocolHelper.

--- a/src/native/eventpipe/ds-process-protocol.h
+++ b/src/native/eventpipe/ds-process-protocol.h
@@ -175,7 +175,7 @@ struct _DiagnosticsEnablePerfmapPayload_Internal {
 #endif
 	uint8_t * incoming_buffer;
 
-	uint32_t value;
+	uint32_t perfMapType;
 };
 
 #if !defined(DS_INLINE_GETTER_SETTER) && !defined(DS_IMPL_PROCESS_PROTOCOL_GETTER_SETTER)

--- a/src/native/eventpipe/ds-process-protocol.h
+++ b/src/native/eventpipe/ds-process-protocol.h
@@ -165,6 +165,32 @@ void
 ds_set_environment_variable_payload_free (DiagnosticsSetEnvironmentVariablePayload *payload);
 
 /*
+* DiagnosticsEnablePerfmapPayload
+*/
+
+#if defined(DS_INLINE_GETTER_SETTER) || defined(DS_IMPL_PROCESS_PROTOCOL_GETTER_SETTER)
+struct _DiagnosticsEnablePerfmapPayload {
+#else
+struct _DiagnosticsEnablePerfmapPayload_Internal {
+#endif
+	uint8_t * incoming_buffer;
+
+	uint32_t value;
+};
+
+#if !defined(DS_INLINE_GETTER_SETTER) && !defined(DS_IMPL_PROCESS_PROTOCOL_GETTER_SETTER)
+struct _DiagnosticsEnablePerfmapPayload {
+	uint8_t _internal [sizeof (struct _DiagnosticsSetEnvironmentVariablePayload_Internal)];
+};
+#endif
+
+DiagnosticsEnablePerfmapPayload *
+ds_set_generate_perfmap_payload_alloc (void);
+
+void
+ds_set_generate_perfmap_payload_free (DiagnosticsEnablePerfmapPayload *payload);
+
+/*
  * DiagnosticsProcessProtocolHelper.
  */
 

--- a/src/native/eventpipe/ds-process-protocol.h
+++ b/src/native/eventpipe/ds-process-protocol.h
@@ -180,7 +180,7 @@ struct _DiagnosticsEnablePerfmapPayload_Internal {
 
 #if !defined(DS_INLINE_GETTER_SETTER) && !defined(DS_IMPL_PROCESS_PROTOCOL_GETTER_SETTER)
 struct _DiagnosticsEnablePerfmapPayload {
-	uint8_t _internal [sizeof (struct _DiagnosticsSetEnvironmentVariablePayload_Internal)];
+	uint8_t _internal [sizeof (struct _DiagnosticsEnablePerfmapPayload_Internal)];
 };
 #endif
 

--- a/src/native/eventpipe/ds-rt.h
+++ b/src/native/eventpipe/ds-rt.h
@@ -116,7 +116,7 @@ ds_rt_enable_perfmap (uint32_t type);
 
 static
 uint32_t
-ds_rt_disable_perfmap ();
+ds_rt_disable_perfmap (void);
 
 /*
 * DiagnosticServer.

--- a/src/native/eventpipe/ds-rt.h
+++ b/src/native/eventpipe/ds-rt.h
@@ -110,6 +110,14 @@ ds_rt_get_environment_variable (const ep_char16_t *name,
 								uint32_t *valueLengthOut,
 								ep_char16_t *valueBuffer);
 
+static
+uint32_t
+ds_rt_enable_perfmap (uint32_t type);
+
+static
+uint32_t
+ds_rt_disable_perfmap ();
+
 /*
 * DiagnosticServer.
 */

--- a/src/native/eventpipe/ds-types.h
+++ b/src/native/eventpipe/ds-types.h
@@ -23,6 +23,7 @@ typedef struct _DiagnosticsGenerateCoreDumpCommandPayload DiagnosticsGenerateCor
 typedef struct _DiagnosticsGenerateCoreDumpResponsePayload DiagnosticsGenerateCoreDumpResponsePayload;
 typedef struct _DiagnosticsSetEnvironmentVariablePayload DiagnosticsSetEnvironmentVariablePayload;
 typedef struct _DiagnosticsGetEnvironmentVariablePayload DiagnosticsGetEnvironmentVariablePayload;
+typedef struct _DiagnosticsEnablePerfmapPayload DiagnosticsEnablePerfmapPayload;
 typedef struct _DiagnosticsIpcHeader DiagnosticsIpcHeader;
 typedef struct _DiagnosticsIpcMessage DiagnosticsIpcMessage;
 typedef struct _DiagnosticsListenPort DiagnosticsListenPort;
@@ -71,7 +72,9 @@ typedef enum {
 	DS_PROCESS_COMMANDID_RESUME_RUNTIME = 0x01,
 	DS_PROCESS_COMMANDID_GET_PROCESS_ENV = 0x02,
 	DS_PROCESS_COMMANDID_SET_ENV_VAR = 0x03,
-	DS_PROCESS_COMMANDID_GET_PROCESS_INFO_2 = 0x04
+	DS_PROCESS_COMMANDID_GET_PROCESS_INFO_2 = 0x04,
+	DS_PROCESS_COMMANDID_ENABLE_PERFMAP = 0x05,
+	DS_PROCESS_COMMANDID_DISABLE_PERFMAP = 0x06
 	// future
 } DiagnosticsProcessCommandId;
 


### PR DESCRIPTION
Runtime side of the fix for #83056

Adds IPC commands to enable or disable perfmaps. If enabled after process start we will emit all known methods in to the files similar to rundown.

We do not have a mechanism to iterate through existing stubs so if enabled after process start we won't emit any stub information for existing stubs, but that matches rundown behavior and should be ok.