### PR TITLE
JIT: Inline static readonly delegates

### DIFF
--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -12005,9 +12005,16 @@ bool CEEInfo::getObjectContent(CORINFO_OBJECT_HANDLE handle, uint8_t* buffer, in
         Object* obj = OBJECTREFToObject(objRef);
         if (objRef->GetMethodTable()->ContainsPointers())
         {
-            // Only allow access to Delegate's IntPtr _methodPtr field
-            if (objRef->GetMethodTable()->IsDelegate() && (bufferSize == TARGET_POINTER_SIZE) &&
-                (valueOffset == TARGET_POINTER_SIZE * 3))
+            // Allow access to Delegate's IntPtr _methodPtr field
+            if (objRef->GetMethodTable()->IsDelegate() &&
+                (bufferSize == TARGET_POINTER_SIZE) && (valueOffset == TARGET_POINTER_SIZE * 3))
+            {
+                memcpy(buffer, (uint8_t*)obj + valueOffset, bufferSize);
+                result = true;
+            }
+            // Also, allow access to RuntimeType's IntPtr m_handle field
+            else if (objRef->GetMethodTable() == g_pRuntimeTypeClass &&
+                (bufferSize == TARGET_POINTER_SIZE) && (valueOffset == TARGET_POINTER_SIZE * 3))
             {
                 memcpy(buffer, (uint8_t*)obj + valueOffset, bufferSize);
                 result = true;


### PR DESCRIPTION
```csharp
static Func<int, int, int> MyFunc { get; } = (x, y) => x + y;

static int Test() => RunFunc(MyFunc);

static int RunFunc(Func<int, int, int> processor)
{
    return processor(10, 20);
}
```
codegen for `Test()` with PGO enabled:
```asm
       mov      eax, 30
       ret      
; Total bytes of code 6
```

Not sure it's super useful (how often developers save delegates to static readonly?) but it's the first case when we can inline a lambda without checks 🙂 

*UPD*: Also, it seems to fold `typeof(T).TypeHandle.Value;` and closes https://github.com/dotnet/runtime/issues/5973
```csharp
static nint Test()
{
    return typeof(int).TypeHandle.Value;
}
```
codegen:
```asm
       mov      rax, 0x7FF7A3C3EA58
       ret 
; Total bytes of code 11
```