### PR TITLE
Skip ProcessStartInfoTests.TestWindowStyle if COM interop is not supported

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.Windows.cs
@@ -82,9 +82,10 @@ namespace System.Diagnostics.Tests
         [InlineData(ProcessWindowStyle.Maximized, false)]
         public void TestWindowStyle(ProcessWindowStyle windowStyle, bool useShellExecute)
         {
-            if (useShellExecute && !PlatformDetection.SupportsComInterop)
+            if (useShellExecute && PlatformDetection.IsMonoRuntime)
             {
-                throw new SkipTestException("ShellExecute uses COM interop which is not supported by this platform/runtime.");
+                // https://github.com/dotnet/runtime/issues/34360
+                throw new SkipTestException("ShellExecute tries to set STA COM apartment state which is not implemented by Mono.");
             }
 
             // "x y" where x is the expected dwFlags & 0x1 result and y is the wShowWindow value

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.Windows.cs
@@ -4,6 +4,7 @@
 using System.IO;
 using System.Security;
 using Microsoft.DotNet.RemoteExecutor;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Diagnostics.Tests
@@ -81,6 +82,11 @@ namespace System.Diagnostics.Tests
         [InlineData(ProcessWindowStyle.Maximized, false)]
         public void TestWindowStyle(ProcessWindowStyle windowStyle, bool useShellExecute)
         {
+            if (useShellExecute && !PlatformDetection.SupportsComInterop)
+            {
+                throw new SkipTestException("ShellExecute uses COM interop which is not supported by this platform/runtime.");
+            }
+
             // "x y" where x is the expected dwFlags & 0x1 result and y is the wShowWindow value
             (int expectedDwFlag, int expectedWindowFlag) = windowStyle switch
             {


### PR DESCRIPTION
This happens on e.g. Mono and results in this exception:

```
    System.Diagnostics.Tests.ProcessStartInfoTests.TestWindowStyle(windowStyle: Normal, useShellExecute: True) [FAIL]
      System.PlatformNotSupportedException : COM Interop is not supported on this platform.
      Stack Trace:
        /_/src/mono/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs(262,0): at System.Threading.Thread.SetApartmentStateUnchecked(ApartmentState state, Boolean throwOnError)
        /_/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs(521,0): at System.Threading.Thread.SetApartmentState(ApartmentState state, Boolean throwOnError)
        /_/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs(499,0): at System.Threading.Thread.SetApartmentState(ApartmentState state)
        /_/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Win32.cs(177,0): at System.Diagnostics.Process.ShellExecuteHelper.ShellExecuteOnSTAThread()
        /_/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Win32.cs(74,0): at System.Diagnostics.Process.StartWithShellExecuteEx(ProcessStartInfo startInfo)
        /_/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Win32.cs(25,0): at System.Diagnostics.Process.StartCore(ProcessStartInfo startInfo)
        /_/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs(1282,0): at System.Diagnostics.Process.Start()
        /_/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.Windows.cs(108,0): at System.Diagnostics.Tests.ProcessStartInfoTests.TestWindowStyle(ProcessWindowStyle windowStyle, Boolean useShellExecute)
        /_/src/mono/System.Private.CoreLib/src/System/Reflection/MethodInvoker.Mono.cs(30,0): at System.Reflection.MethodInvoker.InterpretedInvoke(Object obj, IntPtr* args)
        /_/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodInvoker.cs(59,0): at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
```