### PR TITLE
[wasm] Wasm.Build.Tests - Override KnownWebAssemblySdkPack to 8.0.0-dev

### DIFF
--- a/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
+++ b/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Workload.Build.Tasks
             string bundledVersions = Directory.EnumerateFiles(targetPath, @"Microsoft.NETCoreSdk.BundledVersions.props", SearchOption.AllDirectories).Single();
 
             string nupkgName = "Microsoft.NET.Sdk.WebAssembly.Pack";
-            string nupkg = Directory.EnumerateFiles(localNugetsPath, $"{nupkgName}.*.nupkg").Single();
+            string nupkg = Directory.EnumerateFiles(localNuGetsPath, $"{nupkgName}.*.nupkg").Single();
             string nupkgVersion = Path.GetFileNameWithoutExtension(nupkg).Substring(nupkgName.Length + 1);
 
             var document = XDocument.Load(bundledVersions);

--- a/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
+++ b/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
@@ -139,12 +139,14 @@ namespace Microsoft.Workload.Build.Tasks
 
         private static void OverrideWebAssemblySdkPack(string targetPath, string localNuGetsPath)
         {
-            string bundledVersions = Directory.EnumerateFiles(targetPath, @"Microsoft.NETCoreSdk.BundledVersions.props", SearchOption.AllDirectories).Single();
-
             string nupkgName = "Microsoft.NET.Sdk.WebAssembly.Pack";
-            string nupkg = Directory.EnumerateFiles(localNuGetsPath, $"{nupkgName}.*.nupkg").Single();
+            string? nupkg = Directory.EnumerateFiles(localNuGetsPath, $"{nupkgName}.*.nupkg").FirstOrDefault();
+            if (nupkg == null)
+                return;
+
             string nupkgVersion = Path.GetFileNameWithoutExtension(nupkg).Substring(nupkgName.Length + 1);
 
+            string bundledVersions = Directory.EnumerateFiles(targetPath, @"Microsoft.NETCoreSdk.BundledVersions.props", SearchOption.AllDirectories).Single();
             var document = XDocument.Load(bundledVersions);
             if (document != null)
             {

--- a/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
+++ b/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
@@ -117,6 +117,8 @@ namespace Microsoft.Workload.Build.Tasks
                     if (!ExecuteInternal(req) && !req.IgnoreErrors)
                         return false;
 
+                    OverrideWebAssemblySdkPack(req.TargetPath);
+
                     File.WriteAllText(req.StampPath, string.Empty);
                 }
 
@@ -131,6 +133,19 @@ namespace Microsoft.Workload.Build.Tasks
             {
                 if (!string.IsNullOrEmpty(_tempDir) && Directory.Exists(_tempDir))
                     Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+
+        private static void OverrideWebAssemblySdkPack(string targetPath)
+        {
+            string path = Directory.EnumerateFiles(targetPath, @"Microsoft.NETCoreSdk.BundledVersions.props", SearchOption.AllDirectories).Single();
+
+            var document = XDocument.Load(path);
+            if (document != null)
+            {
+                var element = document.Descendants("KnownWebAssemblySdkPack").First(e => e.Attribute("TargetFramework")?.Value == "net8.0");
+                element.SetAttributeValue("WebAssemblySdkPackVersion", "8.0.0-dev");
+                document.Save(path);
             }
         }
 


### PR DESCRIPTION
Override version of `KnownWebAssemblySdkPack` in `Microsoft.NETCoreSdk.BundledVersions.props` to point to local built package