### PR TITLE
Remove AO from a couple of SpanHelpers methods

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -342,7 +342,6 @@ namespace System
 
         // IndexOfNullByte processes memory in aligned chunks, and thus it won't crash even if it accesses memory beyond the null terminator.
         // This behavior is an implementation detail of the runtime and callers outside System.Private.CoreLib must not depend on it.
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         internal static unsafe int IndexOfNullByte(byte* searchSpace)
         {
             const int Length = int.MaxValue;
@@ -789,7 +788,6 @@ namespace System
             return i * 8 + LocateFirstFoundByte(candidate);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe int SequenceCompareTo(ref byte first, int firstLength, ref byte second, int secondLength)
         {
             Debug.Assert(firstLength >= 0);

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -355,7 +355,6 @@ namespace System
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe int SequenceCompareTo(ref char first, int firstLength, ref char second, int secondLength)
         {
             Debug.Assert(firstLength >= 0);

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -422,7 +422,6 @@ namespace System
 
         // IndexOfNullCharacter processes memory in aligned chunks, and thus it won't crash even if it accesses memory beyond the null terminator.
         // This behavior is an implementation detail of the runtime and callers outside System.Private.CoreLib must not depend on it.
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe int IndexOfNullCharacter(char* searchSpace)
         {
             const char value = '\0';

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -1315,7 +1315,6 @@ namespace System
             return NonPackedContainsValueType(ref searchSpace, value, length);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         internal static bool NonPackedContainsValueType<T>(ref T searchSpace, T value, int length) where T : struct, INumber<T>
         {
             Debug.Assert(length >= 0, "Expected non-negative length");
@@ -1463,7 +1462,6 @@ namespace System
             return NonPackedIndexOfValueType<TValue, TNegator>(ref searchSpace, value, length);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         internal static int NonPackedIndexOfValueType<TValue, TNegator>(ref TValue searchSpace, TValue value, int length)
             where TValue : struct, INumber<TValue>
             where TNegator : struct, INegator<TValue>
@@ -1621,7 +1619,6 @@ namespace System
         }
 
         // having INumber<T> constraint here allows to use == operator and get better perf compared to .Equals
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         internal static int NonPackedIndexOfAnyValueType<TValue, TNegator>(ref TValue searchSpace, TValue value0, TValue value1, int length)
             where TValue : struct, INumber<TValue>
             where TNegator : struct, INegator<TValue>
@@ -1797,7 +1794,6 @@ namespace System
             return NonPackedIndexOfAnyValueType<TValue, TNegator>(ref searchSpace, value0, value1, value2, length);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         internal static int NonPackedIndexOfAnyValueType<TValue, TNegator>(ref TValue searchSpace, TValue value0, TValue value1, TValue value2, int length)
             where TValue : struct, INumber<TValue>
             where TNegator : struct, INegator<TValue>
@@ -1958,7 +1954,6 @@ namespace System
         internal static int IndexOfAnyExceptValueType<T>(ref T searchSpace, T value0, T value1, T value2, T value3, int length) where T : struct, INumber<T>
             => IndexOfAnyValueType<T, Negate<T>>(ref searchSpace, value0, value1, value2, value3, length);
 
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         private static int IndexOfAnyValueType<TValue, TNegator>(ref TValue searchSpace, TValue value0, TValue value1, TValue value2, TValue value3, int length)
             where TValue : struct, INumber<TValue>
             where TNegator : struct, INegator<TValue>
@@ -2087,7 +2082,6 @@ namespace System
         internal static int IndexOfAnyExceptValueType<T>(ref T searchSpace, T value0, T value1, T value2, T value3, T value4, int length) where T : struct, INumber<T>
             => IndexOfAnyValueType<T, Negate<T>>(ref searchSpace, value0, value1, value2, value3, value4, length);
 
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         private static int IndexOfAnyValueType<TValue, TNegator>(ref TValue searchSpace, TValue value0, TValue value1, TValue value2, TValue value3, TValue value4, int length)
             where TValue : struct, INumber<TValue>
             where TNegator : struct, INegator<TValue>
@@ -2219,7 +2213,6 @@ namespace System
         internal static int LastIndexOfAnyExceptValueType<T>(ref T searchSpace, T value, int length) where T : struct, INumber<T>
             => LastIndexOfValueType<T, Negate<T>>(ref searchSpace, value, length);
 
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         private static int LastIndexOfValueType<TValue, TNegator>(ref TValue searchSpace, TValue value, int length)
             where TValue : struct, INumber<TValue>
             where TNegator : struct, INegator<TValue>
@@ -2354,7 +2347,6 @@ namespace System
         internal static int LastIndexOfAnyExceptValueType<T>(ref T searchSpace, T value0, T value1, int length) where T : struct, INumber<T>
             => LastIndexOfAnyValueType<T, Negate<T>>(ref searchSpace, value0, value1, length);
 
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         private static int LastIndexOfAnyValueType<TValue, TNegator>(ref TValue searchSpace, TValue value0, TValue value1, int length)
             where TValue : struct, INumber<TValue>
             where TNegator : struct, INegator<TValue>
@@ -2510,7 +2502,6 @@ namespace System
         internal static int LastIndexOfAnyExceptValueType<T>(ref T searchSpace, T value0, T value1, T value2, int length) where T : struct, INumber<T>
             => LastIndexOfAnyValueType<T, Negate<T>>(ref searchSpace, value0, value1, value2, length);
 
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         private static int LastIndexOfAnyValueType<TValue, TNegator>(ref TValue searchSpace, TValue value0, TValue value1, TValue value2, int length)
             where TValue : struct, INumber<TValue>
             where TNegator : struct, INegator<TValue>
@@ -2667,7 +2658,6 @@ namespace System
         internal static int LastIndexOfAnyExceptValueType<T>(ref T searchSpace, T value0, T value1, T value2, T value3, int length) where T : struct, INumber<T>
             => LastIndexOfAnyValueType<T, Negate<T>>(ref searchSpace, value0, value1, value2, value3, length);
 
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         private static int LastIndexOfAnyValueType<TValue, TNegator>(ref TValue searchSpace, TValue value0, TValue value1, TValue value2, TValue value3, int length)
             where TValue : struct, INumber<TValue>
             where TNegator : struct, INegator<TValue>
@@ -2882,7 +2872,6 @@ namespace System
         internal static int LastIndexOfAnyExceptValueType<T>(ref T searchSpace, T value0, T value1, T value2, T value3, T value4, int length) where T : struct, INumber<T>
             => LastIndexOfAnyValueType<T, Negate<T>>(ref searchSpace, value0, value1, value2, value3, value4, length);
 
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         private static int LastIndexOfAnyValueType<TValue, TNegator>(ref TValue searchSpace, TValue value0, TValue value1, TValue value2, TValue value3, TValue value4, int length)
             where TValue : struct, INumber<TValue>
             where TNegator : struct, INegator<TValue>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/85791 (removes a couple of methods jitted during Hello World start).
```
   3: JIT compiled System.SpanHelpers:IndexOfNullCharacter(ulong) [Tier1, IL size=805, code size=391]
   9: JIT compiled System.SpanHelpers:IndexOfNullByte(ulong) [Tier1, IL size=844, code size=459]
  25: JIT compiled System.SpanHelpers:SequenceCompareTo(byref,int,byref,int) [Tier1, IL size=568, code size=329]
```


I don't see a good reason for these to have [AO], R2R'd versions look good enough to me (SSE based):

<details>
  <summary>R2R codegen:</summary>

```asm
; Assembly listing for method System.SpanHelpers:IndexOfNullCharacter(ulong):int
; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
; ReadyToRun compilation
; optimized code
; rsp based frame
; fully interruptible
; No PGO data
; 0 inlinees with PGO data; 3 single block inlinees; 0 inlinees without PGO data

G_M000_IG01:                ;; offset=0000H
       sub      rsp, 40
       vzeroupper

G_M000_IG02:                ;; offset=0007H
       xor      eax, eax
       mov      edx, 0x7FFFFFFF
       test     cl, 1
       jne      SHORT G_M000_IG04

G_M000_IG03:                ;; offset=0013H
       mov      edx, ecx
       neg      edx
       mov      r8d, edx
       shr      r8d, 31
       add      edx, r8d
       sar      edx, 1
       and      rdx, 7

G_M000_IG04:                ;; offset=0027H
       cmp      rdx, 4
       jl       SHORT G_M000_IG06

G_M000_IG05:                ;; offset=002DH
       cmp      word  ptr [rcx+2*rax], 0
       je       G_M000_IG21
       cmp      word  ptr [rcx+2*rax+02H], 0
       je       G_M000_IG20
       cmp      word  ptr [rcx+2*rax+04H], 0
       je       G_M000_IG19
       cmp      word  ptr [rcx+2*rax+06H], 0
       je       G_M000_IG18
       add      rax, 4
       add      rdx, -4
       cmp      rdx, 4
       jge      SHORT G_M000_IG05

G_M000_IG06:                ;; offset=006AH
       test     rdx, rdx
       jle      SHORT G_M000_IG08

G_M000_IG07:                ;; offset=006FH
       cmp      word  ptr [rcx+2*rax], 0
       je       G_M000_IG21
       inc      rax
       dec      rdx
       test     rdx, rdx
       jg       SHORT G_M000_IG07

G_M000_IG08:                ;; offset=0085H
       cmp      rax, 0x7FFFFFFF
       jge      G_M000_IG22
       lea      rdx, [rcx+2*rax]
       test     dl, 31
       je       SHORT G_M000_IG11

G_M000_IG09:                ;; offset=009AH
       vxorps   xmm0, xmm0, xmm0
       vpcmpeqw xmm0, xmm0, xmmword ptr [rcx+2*rax]
       vpmovmskb edx, xmm0
       test     edx, edx
       jne      SHORT G_M000_IG10
       add      rax, 8
       jmp      SHORT G_M000_IG11

G_M000_IG10:                ;; offset=00B1H
       xor      ecx, ecx
       tzcnt    ecx, edx
       shr      ecx, 1
       mov      edx, ecx
       add      eax, edx
       jmp      G_M000_IG21

G_M000_IG11:                ;; offset=00C2H
       mov      rdx, rax
       neg      rdx
       add      rdx, 0x7FFFFFFF
       and      rdx, -16
       jle      SHORT G_M000_IG13

G_M000_IG12:                ;; offset=00D5H
       vxorps   ymm0, ymm0, ymm0
       vpcmpeqw ymm0, ymm0, ymmword ptr [rcx+2*rax]
       vpmovmskb r8d, ymm0
       test     r8d, r8d
       jne      SHORT G_M000_IG15
       add      rax, 16
       add      rdx, -16
       test     rdx, rdx
       jg       SHORT G_M000_IG12

G_M000_IG13:                ;; offset=00F4H
       mov      r8, rax
       neg      r8
       add      r8, 0x7FFFFFFF
       and      r8, -8
       jle      SHORT G_M000_IG17

G_M000_IG14:                ;; offset=0107H
       vxorps   xmm0, xmm0, xmm0
       vpcmpeqw xmm0, xmm0, xmmword ptr [rcx+2*rax]
       vpmovmskb edx, xmm0
       test     edx, edx
       jne      SHORT G_M000_IG16
       add      rax, 8
       jmp      SHORT G_M000_IG17

G_M000_IG15:                ;; offset=011EH
       xor      edx, edx
       tzcnt    edx, r8d
       shr      edx, 1
       mov      ecx, edx
       add      eax, ecx
       jmp      SHORT G_M000_IG21

G_M000_IG16:                ;; offset=012DH
       tzcnt    edx, edx
       shr      edx, 1
       add      eax, edx
       jmp      SHORT G_M000_IG21

G_M000_IG17:                ;; offset=0137H
       cmp      rax, 0x7FFFFFFF
       jge      SHORT G_M000_IG22
       mov      rdx, rax
       neg      rdx
       add      rdx, 0x7FFFFFFF
       jmp      G_M000_IG04

G_M000_IG18:                ;; offset=0151H
       add      eax, 3
       jmp      SHORT G_M000_IG21

G_M000_IG19:                ;; offset=0156H
       add      eax, 2
       jmp      SHORT G_M000_IG21

G_M000_IG20:                ;; offset=015BH
       inc      eax

G_M000_IG21:                ;; offset=015DH
       vzeroupper
       add      rsp, 40
       ret

G_M000_IG22:                ;; offset=0165H
       call     [System.SpanHelpers:ThrowMustBeNullTerminatedString()]
       int3

; Total bytes of code 364



; Assembly listing for method System.SpanHelpers:IndexOfNullByte(ulong):int
; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
; ReadyToRun compilation
; optimized code
; rsp based frame
; fully interruptible
; No PGO data
; 0 inlinees with PGO data; 3 single block inlinees; 0 inlinees without PGO data

G_M000_IG01:                ;; offset=0000H
       sub      rsp, 40
       vzeroupper

G_M000_IG02:                ;; offset=0007H
       xor      eax, eax
       mov      edx, ecx
       and      edx, 15
       neg      edx
       add      edx, 16
       and      edx, 15

G_M000_IG03:                ;; offset=0016H
       cmp      rdx, 8
       jb       SHORT G_M000_IG05

G_M000_IG04:                ;; offset=001CH
       add      rdx, -8
       cmp      byte  ptr [rcx+rax], 0
       je       G_M000_IG19
       cmp      byte  ptr [rcx+rax+01H], 0
       je       G_M000_IG20
       cmp      byte  ptr [rcx+rax+02H], 0
       je       G_M000_IG21
       cmp      byte  ptr [rcx+rax+03H], 0
       je       G_M000_IG22
       cmp      byte  ptr [rcx+rax+04H], 0
       je       G_M000_IG23
       cmp      byte  ptr [rcx+rax+05H], 0
       je       G_M000_IG24
       cmp      byte  ptr [rcx+rax+06H], 0
       je       G_M000_IG25
       cmp      byte  ptr [rcx+rax+07H], 0
       je       G_M000_IG26
       add      rax, 8
       cmp      rdx, 8
       jae      SHORT G_M000_IG04

G_M000_IG05:                ;; offset=0081H
       cmp      rdx, 4
       jb       SHORT G_M000_IG07

G_M000_IG06:                ;; offset=0087H
       add      rdx, -4
       cmp      byte  ptr [rcx+rax], 0
       je       G_M000_IG19
       cmp      byte  ptr [rcx+rax+01H], 0
       je       G_M000_IG20
       cmp      byte  ptr [rcx+rax+02H], 0
       je       G_M000_IG21
       cmp      byte  ptr [rcx+rax+03H], 0
       je       G_M000_IG22
       add      rax, 4

G_M000_IG07:                ;; offset=00BAH
       test     rdx, rdx
       je       SHORT G_M000_IG09

G_M000_IG08:                ;; offset=00BFH
       dec      rdx
       cmp      byte  ptr [rcx+rax], 0
       je       G_M000_IG19
       inc      rax
       test     rdx, rdx
       jne      SHORT G_M000_IG08

G_M000_IG09:                ;; offset=00D4H
       cmp      rax, 0x7FFFFFFF
       jae      G_M000_IG28
       mov      edx, ecx
       add      rdx, rax
       test     dl, 31
       je       SHORT G_M000_IG11

G_M000_IG10:                ;; offset=00EAH
       vxorps   xmm0, xmm0, xmm0
       vpcmpeqb xmm0, xmm0, xmmword ptr [rcx+rax]
       vpmovmskb edx, xmm0
       test     edx, edx
       jne      SHORT G_M000_IG16
       add      rax, 16

G_M000_IG11:                ;; offset=00FFH
       mov      edx, eax
       neg      edx
       add      edx, 0x7FFFFFFF
       and      edx, -32
       cmp      rdx, rax
       jbe      SHORT G_M000_IG13

G_M000_IG12:                ;; offset=0111H
       vxorps   ymm0, ymm0, ymm0
       vpcmpeqb ymm0, ymm0, ymmword ptr [rcx+rax]
       vpmovmskb r8d, ymm0
       test     r8d, r8d
       jne      SHORT G_M000_IG17
       add      rax, 32
       cmp      rdx, rax
       ja       SHORT G_M000_IG12

G_M000_IG13:                ;; offset=012CH
       mov      edx, eax
       neg      edx
       add      edx, 0x7FFFFFFF
       and      edx, -16
       mov      r8d, edx
       cmp      r8, rax
       jbe      SHORT G_M000_IG15

G_M000_IG14:                ;; offset=0141H
       vxorps   xmm0, xmm0, xmm0
       vpcmpeqb xmm0, xmm0, xmmword ptr [rcx+rax]
       vpmovmskb edx, xmm0
       test     edx, edx
       jne      SHORT G_M000_IG18
       add      rax, 16

G_M000_IG15:                ;; offset=0156H
       cmp      rax, 0x7FFFFFFF
       jae      SHORT G_M000_IG28
       mov      rdx, rax
       neg      rdx
       add      rdx, 0x7FFFFFFF
       jmp      G_M000_IG03

G_M000_IG16:                ;; offset=0170H
       tzcnt    edx, edx
       add      eax, edx
       jmp      SHORT G_M000_IG27

G_M000_IG17:                ;; offset=0178H
       xor      edx, edx
       tzcnt    edx, r8d
       add      eax, edx
       jmp      SHORT G_M000_IG27

G_M000_IG18:                ;; offset=0183H
       tzcnt    edx, edx
       add      eax, edx
       jmp      SHORT G_M000_IG27

G_M000_IG19:                ;; offset=018BH
       jmp      SHORT G_M000_IG27

G_M000_IG20:                ;; offset=018DH
       inc      eax
       jmp      SHORT G_M000_IG27

G_M000_IG21:                ;; offset=0191H
       add      eax, 2
       jmp      SHORT G_M000_IG27

G_M000_IG22:                ;; offset=0196H
       add      eax, 3
       jmp      SHORT G_M000_IG27

G_M000_IG23:                ;; offset=019BH
       add      eax, 4
       jmp      SHORT G_M000_IG27

G_M000_IG24:                ;; offset=01A0H
       add      eax, 5
       jmp      SHORT G_M000_IG27

G_M000_IG25:                ;; offset=01A5H
       add      eax, 6
       jmp      SHORT G_M000_IG27

G_M000_IG26:                ;; offset=01AAH
       add      eax, 7

G_M000_IG27:                ;; offset=01ADH
       vzeroupper
       add      rsp, 40
       ret

G_M000_IG28:                ;; offset=01B5H
       call     [System.SpanHelpers:ThrowMustBeNullTerminatedString()]
       int3

; Total bytes of code 444
```

</details>