### PR TITLE
Use Ubuntu 22.04 for runtime-dev-innerloop

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -249,6 +249,26 @@ jobs:
         disableClrTest: true
         ${{ insert }}: ${{ parameters.jobParameters }}
 
+# Runtime-dev-innerloop build
+
+- ${{ if containsValue(parameters.platforms, 'linux_x64_dev_innerloop') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: linux
+      archType: x64
+      targetRid: linux-x64
+      platform: linux_x64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: linux_x64_dev_innerloop
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
+
 # Centos 7 x64 Source Build
 
 - ${{ if containsValue(parameters.platforms, 'SourceBuild_centos7_x64') }}:

--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -49,7 +49,7 @@ resources:
         ROOTFS_DIR: /crossrootfs/x86
 
     - container: linux_x64_dev_innerloop
-      image: svencontainers.azurecr.io/s-ubuntu-22.04
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
 
     # CentOS 8 Stream is the closest image to RHEL8, which has the oldest toolsets we support building against
     # for our source-build partners.

--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -48,6 +48,9 @@ resources:
       env:
         ROOTFS_DIR: /crossrootfs/x86
 
+    - container: linux_x64_dev_innerloop
+      image: svencontainers.azurecr.io/s-ubuntu-22.04
+
     # CentOS 8 Stream is the closest image to RHEL8, which has the oldest toolsets we support building against
     # for our source-build partners.
     - container: SourceBuild_linux_x64

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -90,7 +90,7 @@ extends:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           buildConfig: debug
           platforms:
-          - linux_x64
+          - linux_x64_dev_innerloop
           jobParameters:
             testGroup: innerloop
             nameSuffix: Runtime_Release
@@ -111,7 +111,7 @@ extends:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           buildConfig: debug
           platforms:
-          - linux_x64
+          - linux_x64_dev_innerloop
           jobParameters:
             testGroup: innerloop
             nameSuffix: RuntimeFlavor_Mono
@@ -151,7 +151,7 @@ extends:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           buildConfig: debug
           platforms:
-          - linux_x64
+          - linux_x64_dev_innerloop
           jobParameters:
             nameSuffix: Libraries_AllConfigurations
             buildArgs: -subset libs -allconfigurations


### PR DESCRIPTION
This makes the innerloop runs more reflective on a typical dev environment - a recent Ubuntu, and not a cross build. These images don't have `lld` (see https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/865).