### PR TITLE
We should not establish a heap hard limit for 32 bit platforms

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -49693,6 +49693,7 @@ bool gc_heap::compute_hard_limit()
 
 bool gc_heap::compute_memory_settings(bool is_initialization, uint32_t& nhp, uint32_t nhp_from_config, size_t& seg_size_from_config, size_t new_current_total_committed)
 {
+#ifdef HOST_64BIT
     // If the hard limit is specified, the user is saying even if the process is already
     // running in a container, use this limit for the GC heap.
     if (!hard_limit_config_p)
@@ -49716,6 +49717,7 @@ bool gc_heap::compute_memory_settings(bool is_initialization, uint32_t& nhp, uin
     {
         return false;
     }
+#endif //HOST_64BIT
 
 #ifdef USE_REGIONS
     {


### PR DESCRIPTION
This fixed https://github.com/dotnet/runtime/issues/85757, a regression I introduced during the refactoring for #83707, the code to establish a heap hard limit under a container should be excluded for 32-bit platforms.