### PR TITLE
Convert JIT/CodeGenBringUpTests to a merged test group

### DIFF
--- a/docs/design/coreclr/jit/porting-ryujit.md
+++ b/docs/design/coreclr/jit/porting-ryujit.md
@@ -59,10 +59,13 @@ There are several steps to follow to port the JIT (some of which can be be done 
 * Implement the basic instruction encodings. Test them using a method like `CodeGen::genArm64EmitterUnitTests()`.
 * Implement the bare minimum to get the compiler building and generating code for very simple operations, like addition.
 * Focus on the CodeGenBringUpTests (src\tests\JIT\CodeGenBringUpTests), starting with the simple ones.
-  These are designed such that for a test `XXX.cs`, there is a single interesting function named `XXX` to compile
-  (that is, the name of the source file is the same as the name of the interesting function. This was done to make
-  the scripts to invoke these tests very simple.). Set `DOTNET_AltJit=XXX` so the new JIT only attempts to
-  compile that one function.
+  * These are designed such that for a test `XXX.cs`, there is a single interesting function named `XXX` to compile
+    (that is, the name of the source file is the same as the name of the interesting function. This was done to make
+    the scripts to invoke these tests very simple.). Set `DOTNET_AltJit=XXX` so the new JIT only attempts to
+    compile that one function.
+  * Merged test groups interfere with the simplicity of these tests by removing the entry point from each individual
+    test and creating a single wrapper that calls all of the tests in a single process. To restore the
+    old behavior, build the tests with the environment variable `BuildAsStandalone` set to `true`.
 * Use `DOTNET_JitDisasm` to see the generated code for functions, even if the code isn't run.
 
 ## Expand test coverage

--- a/src/tests/JIT/CodeGenBringUpTests/Add1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Add1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_Add1
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_Add1
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static int Add1(int x) { return x+1; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int y = Add1(1);
         if (y == 2) return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/Add1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Add1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Add1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Add1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Add1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Add1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Add1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Add1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/And1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/And1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_And1
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_And1
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static int And1(int x) { return x & 1; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int y = And1(17);
         if (y == 1) return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/And1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/And1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/And1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/And1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/And1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/And1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/And1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/And1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AndRef.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/AndRef.cs
@@ -6,9 +6,9 @@
 using System;
 using System.Runtime.CompilerServices;
 
-class child
+public class child
 {
-    static int Main()
+    public static int Main()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/AndRef.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/AndRef.cs
@@ -5,10 +5,12 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class child
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/AndRef_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AndRef_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AndRef_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AndRef_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AndRef_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AndRef_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AndRef_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AndRef_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Args4.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Args4.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_Args4
 {
     const int Pass = 100;
@@ -16,7 +17,8 @@ public class BringUpTest_Args4
         return a+b+c+d;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int y = Args4(1,2,3,4);
         if (y == 10) return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/Args4_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Args4_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Args4_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Args4_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Args4_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Args4_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Args4_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Args4_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Args5.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Args5.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_Args5
 {
     const int Pass = 100;
@@ -16,7 +17,8 @@ public class BringUpTest_Args5
         return a+b+c+d+e;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int y = Args5(1,2,3,4,5);
         if (y == 15) return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/Args5_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Args5_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Args5_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Args5_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Args5_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Args5_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Args5_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Args5_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Array1.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class BringUpTest_Array1
 {
@@ -16,7 +17,8 @@ public class BringUpTest_Array1
         a[1] = 5;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int[] a = {1, 2, 3, 4};
         Array1(a);

--- a/src/tests/JIT/CodeGenBringUpTests/Array1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Array1.cs
@@ -16,7 +16,7 @@ public class BringUpTest_Array1
         a[1] = 5;
     }
 
-    static int Main()
+    public static int Main()
     {
         int[] a = {1, 2, 3, 4};
         Array1(a);

--- a/src/tests/JIT/CodeGenBringUpTests/Array1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array2.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Array2.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class BringUpTest_Array2
 {
@@ -16,7 +17,8 @@ public class BringUpTest_Array2
         return a[1];
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int[] a = {1, 2, 3, 4};
         if (Array2(a) != 2) return Fail;

--- a/src/tests/JIT/CodeGenBringUpTests/Array2.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Array2.cs
@@ -16,7 +16,7 @@ public class BringUpTest_Array2
         return a[1];
     }
 
-    static int Main()
+    public static int Main()
     {
         int[] a = {1, 2, 3, 4};
         if (Array2(a) != 2) return Fail;

--- a/src/tests/JIT/CodeGenBringUpTests/Array2_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array2_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array2_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array2_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array2_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array2_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array2_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array2_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array3.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Array3.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class BringUpTest_Array3
 {
@@ -18,7 +19,8 @@ public class BringUpTest_Array3
         return a[1];
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         if (Array3() != 5) return Fail;
         return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/Array3.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Array3.cs
@@ -18,7 +18,7 @@ public class BringUpTest_Array3
         return a[1];
     }
 
-    static int Main()
+    public static int Main()
     {
         if (Array3() != 5) return Fail;
         return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/Array3_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array3_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array3_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array3_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array3_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array3_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array3_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array3_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array4.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Array4.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class BringUpTest_Array4
 {
@@ -16,7 +17,8 @@ public class BringUpTest_Array4
         return a[i];
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         if (Array4(1) != 2) return Fail;
         return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/Array4.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Array4.cs
@@ -16,7 +16,7 @@ public class BringUpTest_Array4
         return a[i];
     }
 
-    static int Main()
+    public static int Main()
     {
         if (Array4(1) != 2) return Fail;
         return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/Array4_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array4_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array4_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array4_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array4_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array4_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array4_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array4_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayExc.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayExc.cs
@@ -17,7 +17,7 @@ public class BringUpTest_ArrayExc
         return a[5];
     }
 
-    static int Main()
+    public static int Main()
     {
         try
         {

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayExc.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayExc.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class BringUpTest_ArrayExc
 {
@@ -17,7 +18,8 @@ public class BringUpTest_ArrayExc
         return a[5];
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayExc_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayExc_d.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayExc_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayExc_do.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayExc_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayExc_r.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayExc_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayExc_ro.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayJagged.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayJagged.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class BringUpTest_ArrayJagged
 {
@@ -19,7 +20,8 @@ public class BringUpTest_ArrayJagged
         return a[1][i];
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         if (ArrayJagged(1) != 3) return Fail;
         return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayJagged.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayJagged.cs
@@ -19,7 +19,7 @@ public class BringUpTest_ArrayJagged
         return a[1][i];
     }
 
-    static int Main()
+    public static int Main()
     {
         if (ArrayJagged(1) != 3) return Fail;
         return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayJagged_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayJagged_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayJagged_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayJagged_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayJagged_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayJagged_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayJagged_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayJagged_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayMD1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayMD1.cs
@@ -17,7 +17,7 @@ public class BringUpTest_ArrayMD1
         return a[0, 1];
     }
 
-    static int Main()
+    public static int Main()
     {
         if (ArrayMD1() != 2) return Fail;
         return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayMD1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayMD1.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class BringUpTest_ArrayMD1
 {
@@ -17,7 +18,8 @@ public class BringUpTest_ArrayMD1
         return a[0, 1];
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         if (ArrayMD1() != 2) return Fail;
         return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayMD1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayMD1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayMD1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayMD1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayMD1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayMD1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayMD1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayMD1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayMD2.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayMD2.cs
@@ -18,7 +18,7 @@ public class BringUpTest_ArrayMD2
         return a[x, y];
     }
 
-    static int Main()
+    public static int Main()
     {
         if (ArrayMD2(1, 1) != 42) return Fail;
         return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayMD2.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayMD2.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class BringUpTest_ArrayMD2
 {
@@ -18,7 +19,8 @@ public class BringUpTest_ArrayMD2
         return a[x, y];
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         if (ArrayMD2(1, 1) != 42) return Fail;
         return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayMD2_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayMD2_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayMD2_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayMD2_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayMD2_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayMD2_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayMD2_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayMD2_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayObj.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayObj.cs
@@ -27,7 +27,7 @@ public class BringUpTest_ArrayObj
         return a[i].field;
     }
 
-    static int Main()
+    public static int Main()
     {
         if (ArrayObj(1) != 1) return Fail;
         return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayObj.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayObj.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class BringUpTest_ArrayObj
 {
@@ -27,7 +28,8 @@ public class BringUpTest_ArrayObj
         return a[i].field;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         if (ArrayObj(1) != 1) return Fail;
         return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayObj_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayObj_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayObj_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayObj_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayObj_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayObj_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayObj_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayObj_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AsgAdd1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgAdd1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_AsgAdd1
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_AsgAdd1
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static int AsgAdd1(int x) { x += 1; return x; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         if (AsgAdd1(0) == 1) return Pass;
         else return Fail;

--- a/src/tests/JIT/CodeGenBringUpTests/AsgAdd1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgAdd1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AsgAdd1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgAdd1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AsgAdd1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgAdd1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AsgAdd1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgAdd1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AsgAnd1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgAnd1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_AsgAnd1
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_AsgAnd1
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static int AsgAnd1(int x) { x &= 3; return x; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         if (AsgAnd1(0xf) == 3) return Pass;
         else return Fail;

--- a/src/tests/JIT/CodeGenBringUpTests/AsgAnd1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgAnd1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AsgAnd1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgAnd1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AsgAnd1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgAnd1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AsgAnd1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgAnd1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AsgOr1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgOr1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_AsgOr1
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_AsgOr1
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static int AsgOr1(int x) { x |= 0xa; return x; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         if (AsgOr1(4) == 0xe) return Pass;
         else return Fail;

--- a/src/tests/JIT/CodeGenBringUpTests/AsgOr1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgOr1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AsgOr1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgOr1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AsgOr1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgOr1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AsgOr1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgOr1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AsgSub1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgSub1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_AsgSub1
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_AsgSub1
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static int AsgSub1(int x) { x -= 1; return x; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         if (AsgSub1(1) == 0) return Pass;
         else return Fail;

--- a/src/tests/JIT/CodeGenBringUpTests/AsgSub1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgSub1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AsgSub1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgSub1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AsgSub1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgSub1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AsgSub1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgSub1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AsgXor1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgXor1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_AsgXor1
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_AsgXor1
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static int AsgXor1(int x) { x ^= 0xf; return x; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         if (AsgXor1(13) == 2) return Pass;
         else return Fail;

--- a/src/tests/JIT/CodeGenBringUpTests/AsgXor1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgXor1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AsgXor1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgXor1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AsgXor1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgXor1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/AsgXor1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/AsgXor1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/BinaryRMW.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/BinaryRMW.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_BinaryRMW
 {
     const int Pass = 100;
@@ -17,7 +18,8 @@ public class BringUpTest_BinaryRMW
         x |= 2;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int x = 12;
         BinaryRMW(ref x, 17);

--- a/src/tests/JIT/CodeGenBringUpTests/BinaryRMW.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/BinaryRMW.cs
@@ -12,7 +12,7 @@ public class BringUpTest_BinaryRMW
     const int Fail = -1;
 
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
-    public static void BinaryRMW(ref int x, int y)
+    internal static void BinaryRMW(ref int x, int y)
     {
         x += y;
         x |= 2;

--- a/src/tests/JIT/CodeGenBringUpTests/BinaryRMW_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/BinaryRMW_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/BinaryRMW_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/BinaryRMW_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/BinaryRMW_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/BinaryRMW_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/BinaryRMW_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/BinaryRMW_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Call1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Call1.cs
@@ -12,9 +12,9 @@ public class BringUpTest_Call1
     const int Fail = -1;
 
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
-    public static void  M() { Console.WriteLine("Hello"); }
+    internal static void  M() { Console.WriteLine("Hello"); }
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
-    public static void  Call1()
+    internal static void  Call1()
     {
         M();
     }

--- a/src/tests/JIT/CodeGenBringUpTests/Call1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Call1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_Call1
 {
     const int Pass = 100;
@@ -17,7 +18,8 @@ public class BringUpTest_Call1
     {
         M();
     }
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         Call1();
         return 100;

--- a/src/tests/JIT/CodeGenBringUpTests/Call1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Call1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Call1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Call1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Call1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Call1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Call1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Call1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/CastThenBinop.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/CastThenBinop.cs
@@ -3,6 +3,7 @@
 //
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 // Test for https://github.com/dotnet/runtime/issues/13816
 public class Test_CastThenBinop
@@ -50,7 +51,8 @@ public class Test_CastThenBinop
         return (ushort)(_xorLeft ^ (long)_xorRight);
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/CastThenBinop.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/CastThenBinop.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/CnsBool.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/CnsBool.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_CnsBool
 {
     const int Pass = 100;
@@ -22,7 +23,8 @@ public class BringUpTest_CnsBool
        return true;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         bool b = CnsBool(false);
         if (b) return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/CnsBool_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/CnsBool_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/CnsBool_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/CnsBool_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/CnsBool_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/CnsBool_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/CnsBool_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/CnsBool_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/CnsLng1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/CnsLng1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_CnsLng1
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_CnsLng1
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static long CnsLng1() { return 1; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         long y = CnsLng1();
         if (y == 1) return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/CnsLng1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/CnsLng1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/CnsLng1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/CnsLng1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/CnsLng1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/CnsLng1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/CnsLng1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/CnsLng1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblAdd.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/DblAdd.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_DblAdd
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_DblAdd
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static double DblAdd(double x, double y) { return x+y; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         double y = DblAdd(1d, 1d);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/DblAddConst.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/DblAddConst.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_DblAddConst
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_DblAddConst
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static double DblAddConst(double x) { return x+1; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         double y = DblAddConst(13d);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/DblAddConst_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblAddConst_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblAddConst_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblAddConst_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblAddConst_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblAddConst_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblAddConst_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblAddConst_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblAdd_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblAdd_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblAdd_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblAdd_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblAdd_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblAdd_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblAdd_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblAdd_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblArea.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/DblArea.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_DblArea
 {
     const int Pass = 100;
@@ -26,7 +27,8 @@ public class BringUpTest_DblArea
     }
 
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         double y = DblArea(3d, 4d, 5d);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/DblArea_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblArea_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblArea_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblArea_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblArea_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblArea_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblArea_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblArea_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblArray.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/DblArray.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_DblArray
 {
     const int Pass = 100;
@@ -21,7 +22,8 @@ public class BringUpTest_DblArray
        return sum / len; 
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         double []arr = new double[] {1f,2f,3f,4f,5f};
         double y = DblArray(arr, arr.Length);

--- a/src/tests/JIT/CodeGenBringUpTests/DblArray_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblArray_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblArray_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblArray_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblArray_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblArray_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblArray_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblArray_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblAvg2.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/DblAvg2.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_DblAvg2
 {
     const int Pass = 100;
@@ -17,7 +18,8 @@ public class BringUpTest_DblAvg2
        return z; 
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         double y = DblAvg2(5f, 7f);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/DblAvg2_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblAvg2_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblAvg2_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblAvg2_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblAvg2_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblAvg2_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblAvg2_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblAvg2_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblAvg6.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/DblAvg6.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_DblAvg6
 {
     const int Pass = 100;
@@ -17,7 +18,8 @@ public class BringUpTest_DblAvg6
        return z; 
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         double y = DblAvg6(1d, 2d, 3d, 4d, 5d, 6d);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/DblAvg6_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblAvg6_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblAvg6_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblAvg6_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblAvg6_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblAvg6_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblAvg6_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblAvg6_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblCall1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/DblCall1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_DblCall1
 {
     const int Pass = 100;
@@ -20,7 +21,8 @@ public class BringUpTest_DblCall1
         return zero;
     }
                                        
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         double y = DblCall1(-1d);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/DblCall1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblCall1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblCall1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblCall1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblCall1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblCall1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblCall1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblCall1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblCall2.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/DblCall2.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_DblCall2
 {
     const int Pass = 100;
@@ -23,7 +24,8 @@ public class BringUpTest_DblCall2
         return DblAvg2(DblAvg2(a, b), DblAvg2(c, d));
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         double y = DblCall2(1d, 2d, 3d, 4d);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/DblCall2_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblCall2_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblCall2_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblCall2_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblCall2_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblCall2_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblCall2_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblCall2_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblDist.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/DblDist.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_DblDist
 {
     const int Pass = 100;
@@ -24,7 +25,8 @@ public class BringUpTest_DblDist
        return z; 
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         double y = DblDist(5f, 7f, 2f, 3f);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/DblDist_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblDist_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblDist_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblDist_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblDist_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblDist_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblDist_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblDist_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblDiv.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/DblDiv.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_DblDiv
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_DblDiv
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static double DblDiv(double x, double y) { return x/y; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         double y = DblDiv(81d, 3d);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/DblDivConst.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/DblDivConst.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_DblDivConst
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_DblDivConst
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static double DblDivConst(double x) { return x/2; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         double y = DblDivConst(5d);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/DblDivConst_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblDivConst_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblDivConst_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblDivConst_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblDivConst_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblDivConst_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblDivConst_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblDivConst_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblDiv_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblDiv_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblDiv_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblDiv_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblDiv_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblDiv_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblDiv_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblDiv_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblFillArray.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/DblFillArray.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_DblFillArray
 {
     const int Pass = 100;
@@ -29,7 +30,8 @@ public class BringUpTest_DblFillArray
        return end-start;
     }    
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         double []arr = new double[5];
         if (DblFillArray(arr, 0, arr.Length, 1f) != arr.Length) return Fail;

--- a/src/tests/JIT/CodeGenBringUpTests/DblFillArray_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblFillArray_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblFillArray_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblFillArray_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblFillArray_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblFillArray_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblFillArray_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblFillArray_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblMul.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/DblMul.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_DblMul
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_DblMul
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static double DblMul(double x, double y) { return x*y; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         double y = DblMul(17d, 9d);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/DblMulConst.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/DblMulConst.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_DblMulConst
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_DblMulConst
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static double DblMulConst(double r) { return 3.14d *r*r; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         double y = DblMulConst(10d);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/DblMulConst_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblMulConst_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblMulConst_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblMulConst_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblMulConst_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblMulConst_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblMulConst_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblMulConst_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblMul_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblMul_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblMul_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblMul_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblMul_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblMul_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblMul_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblMul_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblNeg.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/DblNeg.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_DblNeg
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_DblNeg
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static double DblNeg(double x) { return -x; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         double y = DblNeg(-1f);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/DblNeg_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblNeg_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblNeg_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblNeg_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblNeg_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblNeg_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblNeg_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblNeg_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblRem.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/DblRem.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_DblRem
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_DblRem
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static double DblRem(double x, double y) { return x%y; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         double y = DblRem(81f, 45f);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/DblRem_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblRem_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblRem_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblRem_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblRem_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblRem_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblRem_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblRem_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblRoots.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/DblRoots.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_DblRoots
 {
     const int Pass = 100;
@@ -18,7 +19,8 @@ public class BringUpTest_DblRoots
        return ; 
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         double x1 = 0;
         double x2 = 0;

--- a/src/tests/JIT/CodeGenBringUpTests/DblRoots.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/DblRoots.cs
@@ -12,7 +12,7 @@ public class BringUpTest_DblRoots
     const int Fail = -1;
 
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
-    public static void DblRoots(double a, double b, double c, ref double r1, ref double r2) 
+    internal static void DblRoots(double a, double b, double c, ref double r1, ref double r2) 
     { 
        r1 = (-b + Math.Sqrt(b*b - 4*a*c))/(2*a);
        r2 = (-b - Math.Sqrt(b*b - 4*a*c))/(2*a);

--- a/src/tests/JIT/CodeGenBringUpTests/DblRoots_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblRoots_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblRoots_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblRoots_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblRoots_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblRoots_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblRoots_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblRoots_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblSub.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/DblSub.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_DblSub
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_DblSub
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static Double DblSub(Double x, Double y) { return x-y; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         Double y = DblSub(17d, 9d);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/DblSubConst.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/DblSubConst.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_DblSubConst
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_DblSubConst
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static double DblSubConst(double x) { return x-1d; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         double y = DblSubConst(1d);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/DblSubConst_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblSubConst_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblSubConst_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblSubConst_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblSubConst_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblSubConst_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblSubConst_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblSubConst_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblSub_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblSub_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblSub_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblSub_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblSub_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblSub_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblSub_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblSub_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblVar.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/DblVar.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_DblVar
 {
     const int Pass = 100;
@@ -17,7 +18,8 @@ public class BringUpTest_DblVar
        return z; 
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         double y = DblVar(1d, 1d);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/DblVar_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblVar_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblVar_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblVar_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblVar_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblVar_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DblVar_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DblVar_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Directory.Build.props
+++ b/src/tests/JIT/CodeGenBringUpTests/Directory.Build.props
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="..\..\Directory.Merged.props" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
+
+  <PropertyGroup>
+    <RunAnalyzers>true</RunAnalyzers>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+  </PropertyGroup>
+</Project>

--- a/src/tests/JIT/CodeGenBringUpTests/DivConst.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/DivConst.cs
@@ -187,7 +187,7 @@ class Point
     public int Y;
 }
 
-static class DivProgram
+public static class DivProgram
 {
     public static int Main()
     {

--- a/src/tests/JIT/CodeGenBringUpTests/DivConst.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/DivConst.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 static class DivConst
 {
@@ -189,7 +190,8 @@ class Point
 
 public static class DivProgram
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/DivConst_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DivConst_d.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DivConst_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DivConst_do.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DivConst_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DivConst_r.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/DivConst_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/DivConst_ro.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Eq1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Eq1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_Eq1
 {
     const int Pass = 100;
@@ -16,7 +17,8 @@ public class BringUpTest_Eq1
         return x == 1;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         bool y = Eq1(1);
         if (y == true) return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/Eq1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Eq1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Eq1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Eq1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Eq1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Eq1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Eq1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Eq1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPAdd.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPAdd.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPAdd
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_FPAdd
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static float FPAdd(float x, float y) { return x+y; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         float y = FPAdd(1f, 1f);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/FPAddConst.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPAddConst.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPAddConst
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_FPAddConst
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static float FPAddConst(float x) { return x+1; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         float y = FPAddConst(1f);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/FPAddConst_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPAddConst_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPAddConst_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPAddConst_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPAddConst_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPAddConst_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPAddConst_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPAddConst_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPAdd_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPAdd_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPAdd_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPAdd_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPAdd_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPAdd_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPAdd_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPAdd_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPArea.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPArea.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPArea
 {
     const int Pass = 100;
@@ -25,7 +26,8 @@ public class BringUpTest_FPArea
     }
 
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         float y = FPArea(3f, 4f, 5f);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/FPArea_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPArea_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPArea_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPArea_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPArea_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPArea_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPArea_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPArea_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPArray.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPArray.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPArray
 {
     const int Pass = 100;
@@ -21,7 +22,8 @@ public class BringUpTest_FPArray
        return sum / len; 
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         float []arr = new float[] {1f,2f,3f,4f,5f};
         float y = FPArray(arr, arr.Length);

--- a/src/tests/JIT/CodeGenBringUpTests/FPArray_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPArray_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPArray_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPArray_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPArray_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPArray_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPArray_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPArray_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPAvg2.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPAvg2.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPAvg2
 {
     const int Pass = 100;
@@ -17,7 +18,8 @@ public class BringUpTest_FPAvg2
        return z; 
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         float y = FPAvg2(5f, 7f);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/FPAvg2_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPAvg2_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPAvg2_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPAvg2_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPAvg2_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPAvg2_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPAvg2_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPAvg2_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPAvg6.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPAvg6.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPAvg6
 {
     const int Pass = 100;
@@ -17,7 +18,8 @@ public class BringUpTest_FPAvg6
        return z; 
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         float y = FPAvg6(1f, 2f, 3f, 4f, 5f, 6f);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/FPAvg6_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPAvg6_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPAvg6_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPAvg6_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPAvg6_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPAvg6_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPAvg6_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPAvg6_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPCall1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPCall1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPCall1
 {
     const int Pass = 100;
@@ -20,7 +21,8 @@ public class BringUpTest_FPCall1
         return zero;
     }
                                        
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         float y = FPCall1(-1f);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/FPCall1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPCall1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPCall1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPCall1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPCall1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPCall1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPCall1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPCall1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPCall2.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPCall2.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPCall2
 {
     const int Pass = 100;
@@ -27,7 +28,8 @@ public class BringUpTest_FPCall2
         return FPAvg2(FPAvg2(a, b), FPAvg2(c, d));
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         float y = FPCall2(1f, 2f, 3f, 4f);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/FPCall2_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPCall2_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPCall2_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPCall2_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPCall2_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPCall2_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPCall2_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPCall2_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvDbl2Lng.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvDbl2Lng.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPConvDbl2Lng
 {
     const int Pass = 100;
@@ -17,7 +18,8 @@ public class BringUpTest_FPConvDbl2Lng
     public static UInt64 FPConvDbl2Lng(float x) { return (UInt64) x; }
 
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int result = Fail;
         long x = FPConvDbl2Lng(3294168832d);

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvDbl2Lng_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvDbl2Lng_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvDbl2Lng_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvDbl2Lng_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvDbl2Lng_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvDbl2Lng_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvDbl2Lng_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvDbl2Lng_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvF2F.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvF2F.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPConvF2F
 {
     const int Pass = 100;
@@ -16,7 +17,8 @@ public class BringUpTest_FPConvF2F
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static float FPConvF2F(double x) { return (float) x; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int result = Fail;
         double x = FPConvF2F(3f);

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvF2F_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvF2F_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvF2F_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvF2F_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvF2F_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvF2F_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvF2F_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvF2F_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvF2I.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvF2I.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPConvF2I
 {
     const int Pass = 100;
@@ -17,7 +18,8 @@ public class BringUpTest_FPConvF2I
     public static byte FPConvF2I(double x) { return (byte) x; }
 
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int result = Fail;
         int x = FPConvF2I(3.14f);

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvF2I_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvF2I_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvF2I_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvF2I_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvF2I_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvF2I_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvF2I_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvF2I_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvF2Lng.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvF2Lng.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPConvF2Lng
 {
     const int Pass = 100;
@@ -17,7 +18,8 @@ public class BringUpTest_FPConvF2Lng
     public static UInt64 FPConvF2Lng(double x) { return (UInt64) x; }
 
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int result = Fail;
         long x = FPConvF2Lng(3294168832f);

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvF2Lng_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvF2Lng_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvF2Lng_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvF2Lng_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvF2Lng_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvF2Lng_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvF2Lng_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvF2Lng_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvI2F.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvI2F.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPConvI2F
 {
     const int Pass = 100;
@@ -28,7 +29,8 @@ public class BringUpTest_FPConvI2F
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static float FPConvI2F(Int16 x) { return (float)x; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int result = Fail;
         float x = FPConvI2F((int)3);

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvI2F_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvI2F_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvI2F_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvI2F_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvI2F_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvI2F_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPConvI2F_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPConvI2F_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPDist.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPDist.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPDist
 {
     const int Pass = 100;
@@ -17,7 +18,8 @@ public class BringUpTest_FPDist
        return z; 
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         float y = FPDist(5f, 7f, 2f, 3f);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/FPDist_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPDist_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPDist_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPDist_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPDist_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPDist_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPDist_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPDist_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPDiv.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPDiv.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPDiv
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_FPDiv
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static float FPDiv(float x, float y) { return x/y; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         float y = FPDiv(81f, 3f);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/FPDivConst.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPDivConst.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPDivConst
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_FPDivConst
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static float FPDivConst(float x) { return 1/x; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         float y = FPDivConst(5f);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/FPDivConst_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPDivConst_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPDivConst_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPDivConst_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPDivConst_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPDivConst_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPDivConst_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPDivConst_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPDiv_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPDiv_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPDiv_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPDiv_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPDiv_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPDiv_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPDiv_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPDiv_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPError.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPError.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPError
 {
     const int Pass = 100;
@@ -15,7 +16,8 @@ public class BringUpTest_FPError
          return x - (x/y)*y;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         float y = FPError(81f, 16f);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/FPError_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPError_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPError_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPError_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPError_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPError_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPError_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPError_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPFillArray.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPFillArray.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPFillArray
 {
     const int Pass = 100;
@@ -29,7 +30,8 @@ public class BringUpTest_FPFillArray
        return end-start;
     }    
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         float []arr = new float[5];
         if (FPFillArray(arr, 0, arr.Length, 1f) != arr.Length) return Fail;

--- a/src/tests/JIT/CodeGenBringUpTests/FPFillArray_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPFillArray_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPFillArray_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPFillArray_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPFillArray_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPFillArray_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPFillArray_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPFillArray_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPMath.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPMath.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPMath
 {
     const int Pass = 100;
@@ -25,7 +26,8 @@ public class BringUpTest_FPMath
 
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int result = FPMath();
 

--- a/src/tests/JIT/CodeGenBringUpTests/FPMath_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPMath_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPMath_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPMath_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPMath_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPMath_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPMath_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPMath_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPMul.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPMul.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPMul
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_FPMul
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static float FPMul(float x, float y) { return x*y; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         float y = FPMul(7f, 9f);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/FPMulConst.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPMulConst.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPMulConst
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_FPMulConst
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static float FPMulConst(float r) { return 3.14f *r*r; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         float y = FPMulConst(10f);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/FPMulConst_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPMulConst_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPMulConst_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPMulConst_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPMulConst_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPMulConst_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPMulConst_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPMulConst_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPMul_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPMul_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPMul_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPMul_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPMul_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPMul_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPMul_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPMul_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPNeg.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPNeg.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPNeg
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_FPNeg
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static float FPNeg(float x) { return -x; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         float y = FPNeg(-1f);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/FPNeg_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPNeg_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPNeg_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPNeg_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPNeg_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPNeg_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPNeg_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPNeg_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPRem.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPRem.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPRem
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_FPRem
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static float FPRem(float x, float y) { return x%y; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         float y = FPRem(81f, 16f);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/FPRem_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPRem_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPRem_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPRem_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPRem_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPRem_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPRem_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPRem_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPRoots.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPRoots.cs
@@ -12,7 +12,7 @@ public class BringUpTest_FPRoots
     const int Fail = -1;
 
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
-    public static void FPRoots(float a, float b, float c, ref float r1, ref float r2) 
+    internal static void FPRoots(float a, float b, float c, ref float r1, ref float r2) 
     { 
        r1 = (-b + (float)Math.Sqrt((double)(b*b - 4*a*c)))/(2*a);
        r2  = (-b - (float)Math.Sqrt((double)(b*b - 4*a*c)))/(2*a);

--- a/src/tests/JIT/CodeGenBringUpTests/FPRoots.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPRoots.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPRoots
 {
     const int Pass = 100;
@@ -20,7 +21,8 @@ public class BringUpTest_FPRoots
        return ; 
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         float x1 = 0;
         float x2 = 0;

--- a/src/tests/JIT/CodeGenBringUpTests/FPRoots_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPRoots_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPRoots_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPRoots_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPRoots_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPRoots_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPRoots_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPRoots_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPSmall.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPSmall.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPSmall
 {
     const int Pass = 100;
@@ -21,7 +22,8 @@ public class BringUpTest_FPSmall
        return result;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         float y = FPSmall(3f, 2f);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/FPSmall_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPSmall_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPSmall_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPSmall_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPSmall_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPSmall_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPSmall_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPSmall_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPSub.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPSub.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPSub
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_FPSub
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static float FPSub(float x, float y) { return x-y; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         float y = FPSub(17f, 9f);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/FPSubConst.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPSubConst.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPSubConst
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_FPSubConst
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static float FPSubConst(float x) { return x-1; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         float y = FPSubConst(1f);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/FPSubConst_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPSubConst_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPSubConst_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPSubConst_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPSubConst_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPSubConst_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPSubConst_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPSubConst_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPSub_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPSub_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPSub_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPSub_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPSub_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPSub_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPSub_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPSub_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPVar.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FPVar.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FPVar
 {
     const int Pass = 100;
@@ -17,7 +18,8 @@ public class BringUpTest_FPVar
        return z; 
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         float y = FPVar(1f, 1f);
         Console.WriteLine(y);

--- a/src/tests/JIT/CodeGenBringUpTests/FPVar_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPVar_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPVar_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPVar_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPVar_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPVar_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FPVar_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FPVar_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FactorialRec.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FactorialRec.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FactorialRec
 {
     const int Pass = 100;
@@ -24,7 +25,8 @@ public class BringUpTest_FactorialRec
         return result;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int s = FactorialRec(5);
         if (s != 120) return Fail;

--- a/src/tests/JIT/CodeGenBringUpTests/FactorialRec_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FactorialRec_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FactorialRec_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FactorialRec_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FactorialRec_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FactorialRec_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FactorialRec_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FactorialRec_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FibLoop.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FibLoop.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FibLoop
 {
     const int Pass = 100;
@@ -25,7 +26,8 @@ public class BringUpTest_FibLoop
         return curr;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int y = FibLoop(7);
         if (y == 13) return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/FibLoop_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FibLoop_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FibLoop_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FibLoop_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FibLoop_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FibLoop_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FibLoop_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FibLoop_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FiboRec.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/FiboRec.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_FiboRec
 {
     const int Pass = 100;
@@ -21,7 +22,8 @@ public class BringUpTest_FiboRec
         return a;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int y = FiboRec(0, 1, 7);
         if (y == 13) return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/FiboRec_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FiboRec_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FiboRec_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FiboRec_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FiboRec_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FiboRec_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/FiboRec_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/FiboRec_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Gcd.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Gcd.cs
@@ -12,7 +12,7 @@ public class BringUpTest_Gcd
     const int Fail = -1;
 
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
-    public static void print(int a, int b)
+    internal static void print(int a, int b)
     {
          Console.WriteLine("GCD: " + a + "," + b);
     }

--- a/src/tests/JIT/CodeGenBringUpTests/Gcd.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Gcd.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_Gcd
 {
     const int Pass = 100;
@@ -32,7 +33,8 @@ public class BringUpTest_Gcd
     }
 
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int s = Gcd(36, 81);
         Console.WriteLine("GCD is " + s);

--- a/src/tests/JIT/CodeGenBringUpTests/Gcd_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Gcd_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Gcd_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Gcd_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Gcd_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Gcd_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Gcd_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Gcd_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Ge1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Ge1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_Ge1
 {
     const int Pass = 100;
@@ -16,7 +17,8 @@ public class BringUpTest_Ge1
         return x >= 1;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         bool y = Ge1(1);
         if (y == true) return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/Ge1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Ge1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Ge1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Ge1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Ge1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Ge1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Ge1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Ge1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Gt1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Gt1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_Gt1
 {
     const int Pass = 100;
@@ -16,7 +17,8 @@ public class BringUpTest_Gt1
         return x > 1;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         bool y = Gt1(1);
         if (y == false) return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/Gt1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Gt1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Gt1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Gt1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Gt1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Gt1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Gt1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Gt1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Ind1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Ind1.cs
@@ -12,7 +12,7 @@ public class BringUpTest_Ind1
     const int Fail = -1;
 
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
-    public static void Ind1(ref int x) { x = 1; return; }
+    internal static void Ind1(ref int x) { x = 1; return; }
 
     [Fact]
     public static int TestEntryPoint()

--- a/src/tests/JIT/CodeGenBringUpTests/Ind1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Ind1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_Ind1
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_Ind1
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static void Ind1(ref int x) { x = 1; return; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int y = 0;
         Ind1(ref y);

--- a/src/tests/JIT/CodeGenBringUpTests/Ind1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Ind1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Ind1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Ind1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Ind1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Ind1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Ind1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Ind1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/InitObj.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/InitObj.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public struct MyClass
 {
@@ -28,7 +29,8 @@ public class BringUpTest_InitObj
     }
 
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         if (InitObj())
         {

--- a/src/tests/JIT/CodeGenBringUpTests/InitObj_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/InitObj_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/InitObj_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/InitObj_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/InitObj_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/InitObj_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/InitObj_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/InitObj_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/InstanceCalls.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/InstanceCalls.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class MiscMethods
 {
@@ -130,7 +131,8 @@ public class BringUpTest_InstanceCalls
     }
 
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         MiscMethods m = new MiscMethods(10,20);
         if (!m.InstanceCalls(m)) return Fail;

--- a/src/tests/JIT/CodeGenBringUpTests/InstanceCalls_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/InstanceCalls_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/InstanceCalls_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/InstanceCalls_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/InstanceCalls_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/InstanceCalls_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/InstanceCalls_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/InstanceCalls_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/IntArraySum.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/IntArraySum.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_IntArraySum
 {
     const int Pass = 100;
@@ -20,7 +21,8 @@ public class BringUpTest_IntArraySum
     }
 
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int [] a = new int[5] {1, 2, 3, 4, 5};
         int result = IntArraySum(a, a.Length);

--- a/src/tests/JIT/CodeGenBringUpTests/IntArraySum_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/IntArraySum_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/IntArraySum_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/IntArraySum_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/IntArraySum_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/IntArraySum_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/IntArraySum_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/IntArraySum_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/IntConv.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/IntConv.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_IntConv
 {
     const int Pass = 100;
@@ -31,7 +32,8 @@ public class BringUpTest_IntConv
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static UInt32 IntConv(long x) { return (UInt32)x; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         long x = IntConv((int)3);
         Console.WriteLine(x);

--- a/src/tests/JIT/CodeGenBringUpTests/IntConv_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/IntConv_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/IntConv_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/IntConv_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/IntConv_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/IntConv_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/IntConv_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/IntConv_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JIT.CodeGenBringUpTests.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JIT.CodeGenBringUpTests.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <MergedWrapperProjectReference Include="**/*.??proj" />
+    <MergedWrapperProjectReference Remove="$(MSBuildThisFileFullPath)" />
+  </ItemGroup>
+
+  <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
+</Project>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrue1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrue1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_JTrue1
 {
     const int Pass = 100;
@@ -18,7 +19,8 @@ public class BringUpTest_JTrue1
         return 0;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int y = JTrue1(1);
         if (y == 2) return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/JTrue1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrue1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrue1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrue1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrue1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrue1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrue1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrue1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueEqDbl.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueEqDbl.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_JTrueEqDbl
 {
     const int Pass = 100;
@@ -22,7 +23,8 @@ public class BringUpTest_JTrueEqDbl
         return returnValue;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int returnValue = Pass;
 

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueEqDbl_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueEqDbl_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueEqDbl_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueEqDbl_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueEqDbl_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueEqDbl_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueEqDbl_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueEqDbl_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueEqFP.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueEqFP.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_JTrueEqFP
 {
     const int Pass = 100;
@@ -22,7 +23,8 @@ public class BringUpTest_JTrueEqFP
         return returnValue;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int returnValue = Pass;
 

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueEqFP_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueEqFP_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueEqFP_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueEqFP_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueEqFP_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueEqFP_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueEqFP_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueEqFP_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueEqInt1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueEqInt1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_JTrueEqInt1
 {
     const int Pass = 100;
@@ -32,7 +33,8 @@ public class BringUpTest_JTrueEqInt1
         return returnValue;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int returnValue = Pass;
 

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueEqInt1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueEqInt1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueEqInt1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueEqInt1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueEqInt1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueEqInt1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueEqInt1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueEqInt1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGeDbl.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGeDbl.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_JTrueGeDbl
 {
     const int Pass = 100;
@@ -24,7 +25,8 @@ public class BringUpTest_JTrueGeDbl
         return returnValue;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int returnValue = Pass;
 

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGeDbl_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGeDbl_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGeDbl_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGeDbl_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGeDbl_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGeDbl_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGeDbl_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGeDbl_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGeFP.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGeFP.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_JTrueGeFP
 {
     const int Pass = 100;
@@ -24,7 +25,8 @@ public class BringUpTest_JTrueGeFP
         return returnValue;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int returnValue = Pass;
 

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGeFP_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGeFP_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGeFP_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGeFP_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGeFP_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGeFP_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGeFP_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGeFP_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGeInt1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGeInt1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_JTrueGeInt1
 {
     const int Pass = 100;
@@ -35,7 +36,8 @@ public class BringUpTest_JTrueGeInt1
         return returnValue;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int returnValue = Pass;
 

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGeInt1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGeInt1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGeInt1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGeInt1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGeInt1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGeInt1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGeInt1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGeInt1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGtDbl.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGtDbl.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_JTrueGtDbl
 {
     const int Pass = 100;
@@ -23,7 +24,8 @@ public class BringUpTest_JTrueGtDbl
         return returnValue;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int returnValue = Pass;
 

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGtDbl_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGtDbl_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGtDbl_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGtDbl_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGtDbl_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGtDbl_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGtDbl_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGtDbl_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGtFP.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGtFP.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_JTrueGtFP
 {
     const int Pass = 100;
@@ -23,7 +24,8 @@ public class BringUpTest_JTrueGtFP
         return returnValue;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int returnValue = Pass;
 

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGtFP_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGtFP_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGtFP_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGtFP_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGtFP_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGtFP_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGtFP_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGtFP_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGtInt1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGtInt1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_JTrueGtInt1
 {
     const int Pass = 100;
@@ -36,7 +37,8 @@ public class BringUpTest_JTrueGtInt1
         return returnValue;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int returnValue = Pass;
 

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGtInt1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGtInt1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGtInt1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGtInt1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGtInt1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGtInt1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueGtInt1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueGtInt1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLeDbl.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLeDbl.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_JTrueLeDbl
 {
     const int Pass = 100;
@@ -24,7 +25,8 @@ public class BringUpTest_JTrueLeDbl
         return returnValue;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int returnValue = Pass;
 

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLeDbl_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLeDbl_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLeDbl_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLeDbl_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLeDbl_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLeDbl_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLeDbl_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLeDbl_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLeFP.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLeFP.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_JTrueLeFP
 {
     const int Pass = 100;
@@ -24,7 +25,8 @@ public class BringUpTest_JTrueLeFP
         return returnValue;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int returnValue = Pass;
 

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLeFP_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLeFP_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLeFP_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLeFP_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLeFP_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLeFP_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLeFP_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLeFP_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLeInt1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLeInt1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_JTrueLeInt1
 {
     const int Pass = 100;
@@ -35,7 +36,8 @@ public class BringUpTest_JTrueLeInt1
         return returnValue;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int returnValue = Pass;
 

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLeInt1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLeInt1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLeInt1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLeInt1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLeInt1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLeInt1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLeInt1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLeInt1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLtDbl.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLtDbl.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_JTrueLtDbl
 {
     const int Pass = 100;
@@ -25,7 +26,8 @@ public class BringUpTest_JTrueLtDbl
         return returnValue;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int returnValue = Pass;
 

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLtDbl_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLtDbl_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLtDbl_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLtDbl_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLtDbl_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLtDbl_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLtDbl_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLtDbl_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLtFP.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLtFP.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_JTrueLtFP
 {
     const int Pass = 100;
@@ -25,7 +26,8 @@ public class BringUpTest_JTrueLtFP
         return returnValue;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int returnValue = Pass;
 

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLtFP_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLtFP_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLtFP_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLtFP_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLtFP_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLtFP_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLtFP_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLtFP_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLtInt1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLtInt1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_JTrueLtInt1
 {
     const int Pass = 100;
@@ -36,7 +37,8 @@ public class BringUpTest_JTrueLtInt1
         return returnValue;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int returnValue = Pass;
 

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLtInt1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLtInt1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLtInt1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLtInt1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLtInt1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLtInt1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueLtInt1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueLtInt1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueNeDbl.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueNeDbl.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_JTrueNeDbl
 {
     const int Pass = 100;
@@ -33,7 +34,8 @@ public class BringUpTest_JTrueNeDbl
         return returnValue;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int returnValue = Pass;
 

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueNeDbl_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueNeDbl_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueNeDbl_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueNeDbl_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueNeDbl_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueNeDbl_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueNeDbl_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueNeDbl_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueNeFP.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueNeFP.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_JTrueNeFP
 {
     const int Pass = 100;
@@ -33,7 +34,8 @@ public class BringUpTest_JTrueNeFP
         return returnValue;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int returnValue = Pass;
 

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueNeFP_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueNeFP_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueNeFP_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueNeFP_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueNeFP_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueNeFP_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueNeFP_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueNeFP_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueNeInt1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueNeInt1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_JTrueNeInt1
 {
     const int Pass = 100;
@@ -45,7 +46,8 @@ public class BringUpTest_JTrueNeInt1
         return returnValue;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int returnValue = Pass;
 

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueNeInt1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueNeInt1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueNeInt1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueNeInt1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueNeInt1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueNeInt1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/JTrueNeInt1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/JTrueNeInt1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Jmp1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Jmp1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_Jmp1
 {
     const int Pass = 100;
@@ -24,7 +25,8 @@ L3:
         return x+1;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int y = Jmp1(1);
         if (y == 4) return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/Jmp1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Jmp1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Jmp1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Jmp1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Jmp1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Jmp1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Jmp1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Jmp1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Le1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Le1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_Le1
 {
     const int Pass = 100;
@@ -16,7 +17,8 @@ public class BringUpTest_Le1
         return x <= 1;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         bool y = Le1(1);
         if (y == true) return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/Le1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Le1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Le1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Le1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Le1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Le1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Le1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Le1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LeftShift.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/LeftShift.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_LeftShift
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_LeftShift
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static int LeftShift(int x, int y) { return x << y; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int y = LeftShift(12, 3);
         if (y == 96) return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/LeftShift_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LeftShift_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LeftShift_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LeftShift_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LeftShift_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LeftShift_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LeftShift_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LeftShift_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LngConv.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/LngConv.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_LngConv
 {
     const int Pass = 100;
@@ -45,7 +46,8 @@ public class BringUpTest_LngConv
     }
 
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int a;
         UInt32 b;

--- a/src/tests/JIT/CodeGenBringUpTests/LngConv_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LngConv_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LngConv_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LngConv_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LngConv_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LngConv_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LngConv_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LngConv_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Localloc.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Localloc.cs
@@ -12,7 +12,7 @@ public class BringUpTest_Localloc
     const int Fail = -1;
 
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
-    public static unsafe void Localloc()
+    internal static unsafe void Localloc()
     {
         byte* a = stackalloc byte[5];
         byte i;
@@ -29,7 +29,7 @@ public class BringUpTest_Localloc
 
 
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
-    public static unsafe void Localloc(byte n)
+    internal static unsafe void Localloc(byte n)
     {
         byte* a = stackalloc byte[n];
         *a = 0;

--- a/src/tests/JIT/CodeGenBringUpTests/Localloc.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Localloc.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_Localloc
 {
     const int Pass = 100;
@@ -46,7 +47,8 @@ public class BringUpTest_Localloc
     }
 
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int ret = Pass;
         Localloc();

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocB_N.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocB_N.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_LocallocB_N
 {
     const int Pass = 100;
@@ -34,7 +35,8 @@ public class BringUpTest_LocallocB_N
         return -1;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int ret;
 

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocB_N_PSP.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocB_N_PSP.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_LocallocB_N_PSP
 {
     const int Pass = 100;
@@ -43,7 +44,8 @@ public class BringUpTest_LocallocB_N_PSP
         return -1;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int ret;
 

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocB_N_PSP_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocB_N_PSP_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocB_N_PSP_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocB_N_PSP_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocB_N_PSP_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocB_N_PSP_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocB_N_PSP_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocB_N_PSP_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocB_N_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocB_N_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocB_N_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocB_N_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocB_N_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocB_N_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocB_N_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocB_N_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_LocallocCnstB1
 {
     const int Pass = 100;
@@ -33,7 +34,8 @@ public class BringUpTest_LocallocCnstB1
         return -1;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int ret;
 

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB117.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB117.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_LocallocCnstB117
 {
     const int Pass = 100;
@@ -33,7 +34,8 @@ public class BringUpTest_LocallocCnstB117
         return -1;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int ret;
 

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB117_PSP.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB117_PSP.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_LocallocCnstB117_PSP
 {
     const int Pass = 100;
@@ -43,7 +44,8 @@ public class BringUpTest_LocallocCnstB117_PSP
         return -1;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int ret;
 

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB117_PSP_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB117_PSP_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB117_PSP_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB117_PSP_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB117_PSP_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB117_PSP_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB117_PSP_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB117_PSP_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB117_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB117_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB117_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB117_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB117_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB117_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB117_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB117_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB1_PSP.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB1_PSP.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_LocallocCnstB1_PSP
 {
     const int Pass = 100;
@@ -43,7 +44,8 @@ public class BringUpTest_LocallocCnstB1_PSP
         return -1;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int ret;
 

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB1_PSP_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB1_PSP_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB1_PSP_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB1_PSP_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB1_PSP_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB1_PSP_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB1_PSP_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB1_PSP_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB32_Loop.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB32_Loop.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_LocallocCnstB32_Loop
 {
     const int Pass = 100;
@@ -35,7 +36,8 @@ public class BringUpTest_LocallocCnstB32_Loop
         return -1;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int ret;
 

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB32_Loop_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB32_Loop_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB32_Loop_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB32_Loop_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB32_Loop_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB32_Loop_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB32_Loop_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB32_Loop_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_LocallocCnstB5
 {
     const int Pass = 100;
@@ -33,7 +34,8 @@ public class BringUpTest_LocallocCnstB5
         return -1;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int ret;
 

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5001.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5001.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_LocallocCnstB5001
 {
     const int Pass = 100;
@@ -33,7 +34,8 @@ public class BringUpTest_LocallocCnstB5001
         return -1;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int ret;
 

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5001_PSP.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5001_PSP.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_LocallocCnstB5001_PSP
 {
     const int Pass = 100;
@@ -43,7 +44,8 @@ public class BringUpTest_LocallocCnstB5001_PSP
         return -1;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int ret;
 

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5001_PSP_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5001_PSP_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5001_PSP_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5001_PSP_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5001_PSP_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5001_PSP_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5001_PSP_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5001_PSP_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5001_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5001_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5001_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5001_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5001_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5001_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5001_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5001_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5_PSP.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5_PSP.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_LocallocCnstB5_PSP
 {
     const int Pass = 100;
@@ -43,7 +44,8 @@ public class BringUpTest_LocallocCnstB5_PSP
         return -1;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int ret;
 

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5_PSP_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5_PSP_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5_PSP_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5_PSP_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5_PSP_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5_PSP_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5_PSP_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5_PSP_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocCnstB5_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocLarge.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocLarge.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Threading;
+using Xunit;
 
 public class ThreadData
 {
@@ -60,7 +61,8 @@ public class BringUpTest_LocallocLarge
         return ok;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         for (int j = 2; j < 1024 * 100; j += 331)
         {

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocLarge_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocLarge_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocLarge_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocLarge_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocLarge_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocLarge_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LocallocLarge_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LocallocLarge_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Localloc_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Localloc_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Localloc_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Localloc_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Localloc_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Localloc_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Localloc_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Localloc_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LongArgsAndReturn.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/LongArgsAndReturn.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 
 public class BringUpTest_LongArgsAndReturn
@@ -20,7 +21,8 @@ public class BringUpTest_LongArgsAndReturn
     }
 
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         long m = LongArgsAndReturn(10L, 20L);
         if (m != 20L) return Fail;

--- a/src/tests/JIT/CodeGenBringUpTests/LongArgsAndReturn_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LongArgsAndReturn_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LongArgsAndReturn_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LongArgsAndReturn_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LongArgsAndReturn_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LongArgsAndReturn_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/LongArgsAndReturn_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/LongArgsAndReturn_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Lt1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Lt1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_Lt1
 {
     const int Pass = 100;
@@ -16,7 +17,8 @@ public class BringUpTest_Lt1
         return x < 1;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         bool y = Lt1(1);
         if (y == false) return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/Lt1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Lt1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Lt1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Lt1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Lt1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Lt1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Lt1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Lt1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ModConst.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/ModConst.cs
@@ -173,7 +173,7 @@ static class ModConst
     }
 }
 
-static class ModProgram
+public static class ModProgram
 {
     public static int Main()
     {

--- a/src/tests/JIT/CodeGenBringUpTests/ModConst.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/ModConst.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 static class ModConst
 {
@@ -175,7 +176,8 @@ static class ModConst
 
 public static class ModProgram
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/ModConst_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ModConst_d.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ModConst_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ModConst_do.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ModConst_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ModConst_r.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ModConst_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ModConst_ro.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Ne1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Ne1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_Ne1
 {
     const int Pass = 100;
@@ -16,7 +17,8 @@ public class BringUpTest_Ne1
         return x != 1;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         bool y = Ne1(1);
         if (y == false) return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/Ne1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Ne1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Ne1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Ne1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Ne1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Ne1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Ne1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Ne1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/NegRMW.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/NegRMW.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_NegRMW
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_NegRMW
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static void NegRMW(ref int x) { x = -x; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int x = 12;
         NegRMW(ref x);

--- a/src/tests/JIT/CodeGenBringUpTests/NegRMW.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/NegRMW.cs
@@ -12,7 +12,7 @@ public class BringUpTest_NegRMW
     const int Fail = -1;
 
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
-    public static void NegRMW(ref int x) { x = -x; }
+    internal static void NegRMW(ref int x) { x = -x; }
 
     [Fact]
     public static int TestEntryPoint()

--- a/src/tests/JIT/CodeGenBringUpTests/NegRMW_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/NegRMW_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/NegRMW_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/NegRMW_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/NegRMW_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/NegRMW_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/NegRMW_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/NegRMW_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/NestedCall.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/NestedCall.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_NestedCall
 {
     const int Pass = 100;
@@ -23,7 +24,8 @@ public class BringUpTest_NestedCall
         return c;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int y = NestedCall(2, 3);
         if (y == 97) return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/NestedCall_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/NestedCall_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/NestedCall_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/NestedCall_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/NestedCall_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/NestedCall_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/NestedCall_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/NestedCall_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/NotAndNeg.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/NotAndNeg.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_NotAndNeg
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_NotAndNeg
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static int NotAndNeg(int x, int y) { return -x ^ ~y; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int y = NotAndNeg(1, 0);
         if (y == 0) return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/NotAndNeg_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/NotAndNeg_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/NotAndNeg_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/NotAndNeg_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/NotAndNeg_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/NotAndNeg_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/NotAndNeg_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/NotAndNeg_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/NotRMW.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/NotRMW.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_NotRMW
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_NotRMW
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static void NotRMW(ref int x) { x = ~x; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int x = -1;
         NotRMW(ref x);

--- a/src/tests/JIT/CodeGenBringUpTests/NotRMW.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/NotRMW.cs
@@ -12,7 +12,7 @@ public class BringUpTest_NotRMW
     const int Fail = -1;
 
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
-    public static void NotRMW(ref int x) { x = ~x; }
+    internal static void NotRMW(ref int x) { x = ~x; }
 
     [Fact]
     public static int TestEntryPoint()

--- a/src/tests/JIT/CodeGenBringUpTests/NotRMW_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/NotRMW_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/NotRMW_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/NotRMW_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/NotRMW_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/NotRMW_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/NotRMW_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/NotRMW_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ObjAlloc.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/ObjAlloc.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class Point
 {
@@ -39,7 +40,8 @@ public class BringUpTest_ObjAlloc
     }
 
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         Point obj = ObjAlloc();
         if (obj == null) return Fail;

--- a/src/tests/JIT/CodeGenBringUpTests/ObjAlloc_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ObjAlloc_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ObjAlloc_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ObjAlloc_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ObjAlloc_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ObjAlloc_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ObjAlloc_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ObjAlloc_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/OpMembersOfStructLocal.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/OpMembersOfStructLocal.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public struct Point
 {
@@ -267,7 +268,8 @@ public class BringUpTest_OpMembersOfStructLocal
     }
     
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {       
        return OpMembersOfStructLocal();
     }

--- a/src/tests/JIT/CodeGenBringUpTests/OpMembersOfStructLocal_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/OpMembersOfStructLocal_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/OpMembersOfStructLocal_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/OpMembersOfStructLocal_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/OpMembersOfStructLocal_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/OpMembersOfStructLocal_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/OpMembersOfStructLocal_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/OpMembersOfStructLocal_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Or1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Or1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_Or1
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_Or1
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static int Or1(int x) { return x | 0xa; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int y = Or1(4);
         if (y == 14) return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/Or1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Or1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Or1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Or1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Or1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Or1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Or1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Or1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/OrRef.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/OrRef.cs
@@ -6,9 +6,9 @@
 using System;
 using System.Runtime.CompilerServices;
 
-class child
+public class child
 {
-    static int Main()
+    public static int Main()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/OrRef.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/OrRef.cs
@@ -5,10 +5,12 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class child
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/OrRef_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/OrRef_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/OrRef_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/OrRef_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/OrRef_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/OrRef_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/OrRef_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/OrRef_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/RecursiveTailCall.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/RecursiveTailCall.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public struct Struct1
 {
@@ -130,7 +131,8 @@ public class Test_RecursiveTailCall
         return TestStackParam(i1 - 1, i2, i3, i4);
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/RecursiveTailCall_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/RecursiveTailCall_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/RecursiveTailCall_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/RecursiveTailCall_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/RecursiveTailCall_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/RecursiveTailCall_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/RecursiveTailCall_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/RecursiveTailCall_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/RightShiftRef.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/RightShiftRef.cs
@@ -12,7 +12,7 @@ public class BringUpTest_RightShiftRef
     const int Fail = -1;
 
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
-    public static void RightShiftRef(ref int x, int y) { x >>= y; }
+    internal static void RightShiftRef(ref int x, int y) { x >>= y; }
 
     [Fact]
     public static int TestEntryPoint()

--- a/src/tests/JIT/CodeGenBringUpTests/RightShiftRef.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/RightShiftRef.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_RightShiftRef
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_RightShiftRef
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static void RightShiftRef(ref int x, int y) { x >>= y; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int x = 36;
         RightShiftRef(ref x, 3);

--- a/src/tests/JIT/CodeGenBringUpTests/RightShiftRef_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/RightShiftRef_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/RightShiftRef_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/RightShiftRef_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/RightShiftRef_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/RightShiftRef_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/RightShiftRef_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/RightShiftRef_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Rotate.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Rotate.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class Test_Rotate
 {
@@ -233,7 +234,8 @@ public class Test_Rotate
         usfield = k;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/Rotate_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Rotate_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Rotate_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Rotate_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Rotate_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Rotate_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Rotate_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Rotate_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Shift.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Shift.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class Test_Shift
 {
@@ -51,7 +52,8 @@ public class Test_Shift
         return x;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/Shift_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Shift_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Shift_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Shift_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Shift_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Shift_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Shift_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Shift_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/StaticCalls.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/StaticCalls.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class BringUpTest_StaticCalls
 {
@@ -175,7 +176,8 @@ public class BringUpTest_StaticCalls
         return result;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int y = StaticCalls();      
         return y;        

--- a/src/tests/JIT/CodeGenBringUpTests/StaticCalls.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/StaticCalls.cs
@@ -93,12 +93,6 @@ public class BringUpTest_StaticCalls
     }
 
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
-    public static void Print(int s)
-    {
-       Console.WriteLine(s);
-    }
-
-    [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static int StaticCalls()
     {
         int a = 1;

--- a/src/tests/JIT/CodeGenBringUpTests/StaticCalls_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/StaticCalls_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/StaticCalls_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/StaticCalls_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/StaticCalls_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/StaticCalls_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/StaticCalls_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/StaticCalls_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/StaticValueField.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/StaticValueField.cs
@@ -3,6 +3,7 @@
 //
 
 using System;
+using Xunit;
 struct TestValue
 {
   public int a;
@@ -26,7 +27,8 @@ public class StaticValueField
     sField = v;
   }
 
-  public static int Main()
+  [Fact]
+  public static int TestEntryPoint()
   {
     Init();
     if (sField.a == 100

--- a/src/tests/JIT/CodeGenBringUpTests/StaticValueField.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/StaticValueField.cs
@@ -18,7 +18,7 @@ public class StaticValueField
   const int Pass = 100;
   const int Fail = -1;
   static TestValue sField;
-  public static void Init()
+  internal static void Init()
   {
     TestValue v = new TestValue();
     v.a = 100;

--- a/src/tests/JIT/CodeGenBringUpTests/StaticValueField.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/StaticValueField.cs
@@ -12,7 +12,7 @@ struct TestValue
 
 // This test stores a primitive (no-GC fields) value type to a static field
 // and checks if the contents are correct.
-class StaticValueField
+public class StaticValueField
 {
   const int Pass = 100;
   const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/StaticValueField_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/StaticValueField_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/StaticValueField_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/StaticValueField_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/StaticValueField_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/StaticValueField_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/StaticValueField_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/StaticValueField_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/StructFldAddr.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/StructFldAddr.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public struct Rational
 {
@@ -29,7 +30,8 @@ public class BringUpTest_StructFldAddr
         return rp.a.num + rp.b.num;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         Rational a = new Rational();
         Rational b = new Rational();

--- a/src/tests/JIT/CodeGenBringUpTests/StructFldAddr_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/StructFldAddr_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/StructFldAddr_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/StructFldAddr_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/StructFldAddr_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/StructFldAddr_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/StructFldAddr_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/StructFldAddr_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/StructInstMethod.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/StructInstMethod.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public struct Point
 {
@@ -86,7 +87,8 @@ public class BringUpTest_StructInstMethod
     }
 
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         Point p = new Point(10, 20, 30);
         if (p.StructInstMethod()) return Fail;

--- a/src/tests/JIT/CodeGenBringUpTests/StructInstMethod_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/StructInstMethod_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/StructInstMethod_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/StructInstMethod_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/StructInstMethod_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/StructInstMethod_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/StructInstMethod_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/StructInstMethod_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/StructReturn.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/StructReturn.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 // int
 public struct MyStructInt1
@@ -335,7 +336,8 @@ public class BringUpTest_StructReturn
     }
 
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         // int
         MyStructInt1 sI1 = returnMyStructInt1(100);

--- a/src/tests/JIT/CodeGenBringUpTests/StructReturn_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/StructReturn_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/StructReturn_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/StructReturn_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/StructReturn_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/StructReturn_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/StructReturn_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/StructReturn_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Sub1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Sub1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_Sub1
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_Sub1
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static int Sub1(int x) { return x - 1; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int y = Sub1(1);
         if (y == 0) return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/Sub1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Sub1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Sub1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Sub1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Sub1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Sub1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Sub1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Sub1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/SubRef.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/SubRef.cs
@@ -6,9 +6,9 @@
 using System;
 using System.Runtime.CompilerServices;
 
-class child
+public class child
 {
-    static int Main()
+    public static int Main()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/SubRef.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/SubRef.cs
@@ -5,10 +5,12 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class child
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/SubRef_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/SubRef_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/SubRef_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/SubRef_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/SubRef_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/SubRef_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/SubRef_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/SubRef_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Swap.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Swap.cs
@@ -12,7 +12,7 @@ public class BringUpTest_Swap
     const int Fail = -1;
 
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
-    public static void Swap(ref int a, ref int b)
+    internal static void Swap(ref int a, ref int b)
     {
       int t = a;
       a = b;

--- a/src/tests/JIT/CodeGenBringUpTests/Swap.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Swap.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_Swap
 {
     const int Pass = 100;
@@ -19,7 +20,8 @@ public class BringUpTest_Swap
     }
 
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int a = 10, b= 20;
         Console.WriteLine("Before swap: " + a + "," + b);

--- a/src/tests/JIT/CodeGenBringUpTests/Swap_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Swap_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Swap_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Swap_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Swap_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Swap_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Swap_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Swap_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Switch.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Switch.cs
@@ -3,7 +3,7 @@
 //
 
 using System;
-class SwitchTest
+public class SwitchTest
 {
  const int Pass = 100;
  const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/Switch.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Switch.cs
@@ -3,12 +3,14 @@
 //
 
 using System;
+using Xunit;
 public class SwitchTest
 {
  const int Pass = 100;
  const int Fail = -1;
 
- public static int Main()
+ [Fact]
+ public static int TestEntryPoint()
  {
   int sum =0;
   for(int i=2; i < 5; i++) {

--- a/src/tests/JIT/CodeGenBringUpTests/Switch_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Switch_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Switch_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Switch_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Switch_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Switch_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Switch_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Switch_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/UDivConst.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/UDivConst.cs
@@ -101,7 +101,7 @@ static class UDivConst
     }
 }
 
-static class UDivProgram
+public static class UDivProgram
 {
     public static int Main()
     {

--- a/src/tests/JIT/CodeGenBringUpTests/UDivConst.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/UDivConst.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 static class UDivConst
 {
@@ -103,7 +104,8 @@ static class UDivConst
 
 public static class UDivProgram
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/UDivConst_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/UDivConst_d.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/UDivConst_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/UDivConst_do.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/UDivConst_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/UDivConst_r.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/UDivConst_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/UDivConst_ro.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/UModConst.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/UModConst.cs
@@ -101,7 +101,7 @@ static class UModConst
     }
 }
 
-static class UModProgram
+public static class UModProgram
 {
     public static int Main()
     {

--- a/src/tests/JIT/CodeGenBringUpTests/UModConst.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/UModConst.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 static class UModConst
 {
@@ -103,7 +104,8 @@ static class UModConst
 
 public static class UModProgram
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/UModConst_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/UModConst_d.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/UModConst_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/UModConst_do.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/UModConst_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/UModConst_r.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/UModConst_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/UModConst_ro.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Unbox.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Unbox.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class BringUpTest_Unbox
 {
@@ -17,7 +18,8 @@ public class BringUpTest_Unbox
         return (int)o;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int r = 3;
         object o = r;

--- a/src/tests/JIT/CodeGenBringUpTests/Unbox_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Unbox_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Unbox_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Unbox_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Unbox_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Unbox_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Unbox_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Unbox_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Xor1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/Xor1.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 public class BringUpTest_Xor1
 {
     const int Pass = 100;
@@ -13,7 +14,8 @@ public class BringUpTest_Xor1
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static int Xor1(int x) { return x ^ 15; }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int y = Xor1(13);
         if (y == 2) return Pass;

--- a/src/tests/JIT/CodeGenBringUpTests/Xor1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Xor1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Xor1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Xor1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Xor1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Xor1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Xor1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Xor1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/XorRef.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/XorRef.cs
@@ -6,9 +6,9 @@
 using System;
 using System.Runtime.CompilerServices;
 
-class child
+public class child
 {
-    static int Main()
+    public static int Main()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/XorRef.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/XorRef.cs
@@ -5,10 +5,12 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class child
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/XorRef_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/XorRef_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/XorRef_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/XorRef_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/XorRef_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/XorRef_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/XorRef_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/XorRef_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/addref.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/addref.cs
@@ -6,9 +6,9 @@
 using System;
 using System.Runtime.CompilerServices;
 
-class child
+public class child
 {
-    static int Main()
+    public static int Main()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/addref.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/addref.cs
@@ -5,10 +5,12 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class child
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/addref_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/addref_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/addref_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/addref_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/addref_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/addref_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/addref_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/addref_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/div1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/div1.cs
@@ -6,9 +6,9 @@
 using System;
 using System.Runtime.CompilerServices;
 
-class child
+public class child
 {
-    static int Main()
+    public static int Main()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/div1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/div1.cs
@@ -5,10 +5,12 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class child
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/div1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/div1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/div1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/div1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/div1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/div1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/div1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/div1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/div2.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/div2.cs
@@ -7,9 +7,9 @@
 using System;
 using System.Runtime.CompilerServices;
 
-class child
+public class child
 {
-    static int Main()
+    public static int Main()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/div2.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/div2.cs
@@ -6,10 +6,12 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class child
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/div2_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/div2_d.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/div2_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/div2_do.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/div2_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/div2_r.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/div2_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/div2_ro.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/divref.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/divref.cs
@@ -5,10 +5,12 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class child
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int b = 5;
         const int Pass = 100;

--- a/src/tests/JIT/CodeGenBringUpTests/divref.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/divref.cs
@@ -6,9 +6,9 @@
 using System;
 using System.Runtime.CompilerServices;
 
-class child
+public class child
 {
-    static int Main()
+    public static int Main()
     {
         int b = 5;
         const int Pass = 100;

--- a/src/tests/JIT/CodeGenBringUpTests/divref_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/divref_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/divref_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/divref_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/divref_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/divref_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/divref_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/divref_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/mul1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/mul1.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Text;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 struct vc
 {
@@ -20,7 +21,8 @@ public class child
     const int Pass = 100;
     const int Fail = -1;
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int result = mul1(3, 7);
         if (result == 21)

--- a/src/tests/JIT/CodeGenBringUpTests/mul1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/mul1.cs
@@ -15,12 +15,12 @@ struct vc
     public vc (int xx, int yy, int zz) { x = xx; y = yy; z = zz; }
 }
 
-class child
+public class child
 {
     const int Pass = 100;
     const int Fail = -1;
 
-    static int Main()
+    public static int Main()
     {
         int result = mul1(3, 7);
         if (result == 21)

--- a/src/tests/JIT/CodeGenBringUpTests/mul1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/mul1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/mul1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/mul1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/mul1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/mul1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/mul1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/mul1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/mul2.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/mul2.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Text;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 struct vc
 {
@@ -20,7 +21,8 @@ public class child
     const int Pass = 100;
     const int Fail = -1;
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int result = mul2(3);
         if (result == 15)

--- a/src/tests/JIT/CodeGenBringUpTests/mul2.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/mul2.cs
@@ -15,12 +15,12 @@ struct vc
     public vc (int xx, int yy, int zz) { x = xx; y = yy; z = zz; }
 }
 
-class child
+public class child
 {
     const int Pass = 100;
     const int Fail = -1;
 
-    static int Main()
+    public static int Main()
     {
         int result = mul2(3);
         if (result == 15)

--- a/src/tests/JIT/CodeGenBringUpTests/mul2_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/mul2_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/mul2_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/mul2_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/mul2_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/mul2_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/mul2_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/mul2_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/mul3.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/mul3.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Text;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 struct vc
 {
@@ -20,7 +21,8 @@ public class child
     const int Pass = 100;
     const int Fail = -1;
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int result=  mul3(3);
         if (result == 15369)

--- a/src/tests/JIT/CodeGenBringUpTests/mul3.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/mul3.cs
@@ -15,12 +15,12 @@ struct vc
     public vc (int xx, int yy, int zz) { x = xx; y = yy; z = zz; }
 }
 
-class child
+public class child
 {
     const int Pass = 100;
     const int Fail = -1;
 
-    static int Main()
+    public static int Main()
     {
         int result=  mul3(3);
         if (result == 15369)

--- a/src/tests/JIT/CodeGenBringUpTests/mul3_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/mul3_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/mul3_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/mul3_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/mul3_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/mul3_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/mul3_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/mul3_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/mul4.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/mul4.cs
@@ -15,12 +15,12 @@ struct vc
     public vc (int xx, int yy, int zz) { x = xx; y = yy; z = zz; }
 }
 
-class child
+public class child
 {
     const int Pass = 100;
     const int Fail = -1;
 
-    static int Main()
+    public static int Main()
     {
         int a = 2;
         int result = mul4(ref a);

--- a/src/tests/JIT/CodeGenBringUpTests/mul4.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/mul4.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Text;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 struct vc
 {
@@ -20,7 +21,8 @@ public class child
     const int Pass = 100;
     const int Fail = -1;
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int a = 2;
         int result = mul4(ref a);

--- a/src/tests/JIT/CodeGenBringUpTests/mul4_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/mul4_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/mul4_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/mul4_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/mul4_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/mul4_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/mul4_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/mul4_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/rem1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/rem1.cs
@@ -6,9 +6,9 @@
 using System;
 using System.Runtime.CompilerServices;
 
-class child
+public class child
 {
-    static int Main()
+    public static int Main()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/rem1.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/rem1.cs
@@ -5,10 +5,12 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class child
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         const int Pass = 100;
         const int Fail = -1;

--- a/src/tests/JIT/CodeGenBringUpTests/rem1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/rem1_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/rem1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/rem1_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/rem1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/rem1_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/rem1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/rem1_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/struct16args.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/struct16args.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public struct Point
 {
@@ -669,7 +670,8 @@ public class BringUpTest_struct16args
         return Pass;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {       
        int i0 = 2;
        int i1 = 3;

--- a/src/tests/JIT/CodeGenBringUpTests/struct16args_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/struct16args_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/struct16args_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/struct16args_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/struct16args_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/struct16args_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/struct16args_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/struct16args_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
See https://github.com/markples/utils/tree/for-PR-dotnet-runtime-85847-others for ILTransform tool.  As usual, I recommend viewing the commit list since it partitions the changes in a more readable way and paying more attention to manual changes.

pre-merge:
- [x] update porting-ryujit.md
- [x] validation that codegenbringup scenarios still work
- [x] outerloop, extra-platforms, gcstress
