### PR TITLE
Save some space in the hwintrinsic and instruction tables

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -2412,7 +2412,7 @@ inline ssize_t emitter::emitGetInsCIdisp(instrDesc* id)
  */
 
 // clang-format off
-const insFlags      CodeGenInterface::instInfo[] =
+const insFlags CodeGenInterface::instInfo[] =
 {
     #define INST0(id, nm, um, mr,                 tt, flags) static_cast<insFlags>(flags),
     #define INST1(id, nm, um, mr,                 tt, flags) static_cast<insFlags>(flags),
@@ -2436,7 +2436,7 @@ const insFlags      CodeGenInterface::instInfo[] =
  */
 
 // clang-format off
-const BYTE          emitter::emitInsModeFmtTab[] =
+const uint8_t emitter::emitInsModeFmtTab[] =
 {
     #define INST0(id, nm, um, mr,                 tt, flags) um,
     #define INST1(id, nm, um, mr,                 tt, flags) um,
@@ -2539,8 +2539,7 @@ bool emitter::emitInsCanOnlyWriteSSE2OrAVXReg(instrDesc* id)
 inline size_t insCode(instruction ins)
 {
     // clang-format off
-    const static
-    size_t          insCodes[] =
+    const static uint32_t insCodes[] =
     {
         #define INST0(id, nm, um, mr,                 tt, flags) mr,
         #define INST1(id, nm, um, mr,                 tt, flags) mr,
@@ -2572,8 +2571,7 @@ inline size_t insCode(instruction ins)
 inline size_t insCodeACC(instruction ins)
 {
     // clang-format off
-    const static
-    size_t          insCodesACC[] =
+    const static uint32_t insCodesACC[] =
     {
         #define INST0(id, nm, um, mr,                 tt, flags)
         #define INST1(id, nm, um, mr,                 tt, flags)
@@ -2605,8 +2603,7 @@ inline size_t insCodeACC(instruction ins)
 inline size_t insCodeRR(instruction ins)
 {
     // clang-format off
-    const static
-    size_t          insCodesRR[] =
+    const static uint32_t insCodesRR[] =
     {
         #define INST0(id, nm, um, mr,                 tt, flags)
         #define INST1(id, nm, um, mr,                 tt, flags)
@@ -2631,8 +2628,7 @@ inline size_t insCodeRR(instruction ins)
 }
 
 // clang-format off
-const static
-size_t          insCodesRM[] =
+const static size_t insCodesRM[] =
 {
     #define INST0(id, nm, um, mr,                 tt, flags)
     #define INST1(id, nm, um, mr,                 tt, flags)
@@ -2671,8 +2667,7 @@ inline size_t insCodeRM(instruction ins)
 }
 
 // clang-format off
-const static
-size_t          insCodesMI[] =
+const static size_t insCodesMI[] =
 {
     #define INST0(id, nm, um, mr,                 tt, flags)
     #define INST1(id, nm, um, mr,                 tt, flags)
@@ -2711,8 +2706,7 @@ inline size_t insCodeMI(instruction ins)
 }
 
 // clang-format off
-const static
-size_t          insCodesMR[] =
+const static uint32_t insCodesMR[] =
 {
     #define INST0(id, nm, um, mr,                 tt, flags)
     #define INST1(id, nm, um, mr,                 tt, flags) mr,
@@ -2863,8 +2857,7 @@ inline size_t insCodeMR(instruction ins)
 }
 
 // clang-format off
-const static
-insTupleType insTupleTypeInfos[] =
+const static insTupleType insTupleTypeInfos[] =
 {
     #define INST0(id, nm, um, mr,                 tt, flags) static_cast<insTupleType>(tt),
     #define INST1(id, nm, um, mr,                 tt, flags) static_cast<insTupleType>(tt),

--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -10,11 +10,29 @@ static const HWIntrinsicInfo hwIntrinsicInfoArray[] = {
 // clang-format off
 #if defined(TARGET_XARCH)
 #define HARDWARE_INTRINSIC(isa, name, size, numarg, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, category, flag) \
-    {NI_##isa##_##name, #name, InstructionSet_##isa, size, numarg, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, category, static_cast<HWIntrinsicFlag>(flag)},
+    { \
+            /* name */ #name, \
+           /* flags */ static_cast<HWIntrinsicFlag>(flag), \
+              /* id */ NI_##isa##_##name, \
+             /* ins */ t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, \
+             /* isa */ InstructionSet_##isa, \
+        /* simdSize */ size, \
+         /* numArgs */ numarg, \
+        /* category */ category \
+    },
 #include "hwintrinsiclistxarch.h"
 #elif defined (TARGET_ARM64)
 #define HARDWARE_INTRINSIC(isa, name, size, numarg, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, category, flag) \
-    {NI_##isa##_##name, #name, InstructionSet_##isa, size, numarg, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, category, static_cast<HWIntrinsicFlag>(flag)},
+    { \
+            /* name */ #name, \
+           /* flags */ static_cast<HWIntrinsicFlag>(flag), \
+              /* id */ NI_##isa##_##name, \
+             /* ins */ t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, \
+             /* isa */ InstructionSet_##isa, \
+        /* simdSize */ size, \
+         /* numArgs */ numarg, \
+        /* category */ category \
+    },
 #include "hwintrinsiclistarm64.h"
 #else
 #error Unsupported platform

--- a/src/coreclr/jit/hwintrinsic.h
+++ b/src/coreclr/jit/hwintrinsic.h
@@ -7,7 +7,7 @@
 #ifdef FEATURE_HW_INTRINSICS
 
 #ifdef TARGET_XARCH
-enum HWIntrinsicCategory : unsigned int
+enum HWIntrinsicCategory : uint8_t
 {
     // Simple SIMD intrinsics
     // - take Vector128/256<T> parameters
@@ -40,10 +40,8 @@ enum HWIntrinsicCategory : unsigned int
     // - have to be addressed specially
     HW_Category_Special
 };
-
 #elif defined(TARGET_ARM64)
-
-enum HWIntrinsicCategory : unsigned int
+enum HWIntrinsicCategory : uint8_t
 {
     // Most of the Arm64 intrinsic fall into SIMD category:
     // - vector or scalar intrinsics that operate on one-or-many SIMD registers
@@ -69,11 +67,9 @@ enum HWIntrinsicCategory : unsigned int
     // - have to be addressed specially
     HW_Category_Special
 };
-
 #else
 #error Unsupported platform
 #endif
-
 enum HWIntrinsicFlag : unsigned int
 {
     HW_Flag_NoFlag = 0,
@@ -194,7 +190,7 @@ enum HWIntrinsicFlag : unsigned int
 
 #if defined(TARGET_XARCH)
 // This mirrors the System.Runtime.Intrinsics.X86.FloatComparisonMode enumeration
-enum class FloatComparisonMode : unsigned char
+enum class FloatComparisonMode : uint8_t
 {
     // _CMP_EQ_OQ
     OrderedEqualNonSignaling = 0,
@@ -293,7 +289,7 @@ enum class FloatComparisonMode : unsigned char
     UnorderedTrueSignaling = 31,
 };
 
-enum class FloatRoundingMode : unsigned char
+enum class FloatRoundingMode : uint8_t
 {
     // _MM_FROUND_TO_NEAREST_INT
     ToNearestInteger = 0x00,
@@ -320,14 +316,17 @@ enum class FloatRoundingMode : unsigned char
 
 struct HWIntrinsicInfo
 {
-    NamedIntrinsic         id;
-    const char*            name;
-    CORINFO_InstructionSet isa;
-    int                    simdSize;
-    int                    numArgs;
-    instruction            ins[10];
-    HWIntrinsicCategory    category;
-    HWIntrinsicFlag        flags;
+    // 32-bit: 36-bytes (34+2 trailing padding)
+    // 64-bit: 40-bytes (38+2 trailing padding)
+
+    const char*            name;        // 4 or 8-bytes
+    HWIntrinsicFlag        flags;       // 4-bytes
+    NamedIntrinsic         id;          // 2-bytes
+    uint16_t               ins[10];     // 10 * 2-bytes
+    uint8_t                isa;         // 1-byte
+    int8_t                 simdSize;    // 1-byte
+    int8_t                 numArgs;     // 1-byte
+    HWIntrinsicCategory    category;    // 1-byte
 
     static const HWIntrinsicInfo& lookup(NamedIntrinsic id);
 
@@ -372,7 +371,8 @@ struct HWIntrinsicInfo
 
     static CORINFO_InstructionSet lookupIsa(NamedIntrinsic id)
     {
-        return lookup(id).isa;
+        uint8_t result = lookup(id).isa;
+        return static_cast<CORINFO_InstructionSet>(result);
     }
 
 #ifdef TARGET_XARCH
@@ -612,7 +612,9 @@ struct HWIntrinsicInfo
             assert(!"Unexpected type");
             return INS_invalid;
         }
-        return lookup(id).ins[type - TYP_BYTE];
+
+        uint16_t result = lookup(id).ins[type - TYP_BYTE];
+        return static_cast<instruction>(result);
     }
 
     static instruction lookupIns(GenTreeHWIntrinsic* intrinsicNode)

--- a/src/coreclr/jit/hwintrinsic.h
+++ b/src/coreclr/jit/hwintrinsic.h
@@ -319,14 +319,14 @@ struct HWIntrinsicInfo
     // 32-bit: 36-bytes (34+2 trailing padding)
     // 64-bit: 40-bytes (38+2 trailing padding)
 
-    const char*            name;        // 4 or 8-bytes
-    HWIntrinsicFlag        flags;       // 4-bytes
-    NamedIntrinsic         id;          // 2-bytes
-    uint16_t               ins[10];     // 10 * 2-bytes
-    uint8_t                isa;         // 1-byte
-    int8_t                 simdSize;    // 1-byte
-    int8_t                 numArgs;     // 1-byte
-    HWIntrinsicCategory    category;    // 1-byte
+    const char*         name;     // 4 or 8-bytes
+    HWIntrinsicFlag     flags;    // 4-bytes
+    NamedIntrinsic      id;       // 2-bytes
+    uint16_t            ins[10];  // 10 * 2-bytes
+    uint8_t             isa;      // 1-byte
+    int8_t              simdSize; // 1-byte
+    int8_t              numArgs;  // 1-byte
+    HWIntrinsicCategory category; // 1-byte
 
     static const HWIntrinsicInfo& lookup(NamedIntrinsic id);
 

--- a/src/coreclr/jit/instr.h
+++ b/src/coreclr/jit/instr.h
@@ -15,7 +15,7 @@
 /*****************************************************************************/
 
 // clang-format off
-enum instruction : unsigned
+enum instruction : uint32_t
 {
 #if defined(TARGET_XARCH)
     #define INST0(id, nm, um, mr,                 tt, flags) INS_##id,
@@ -366,24 +366,24 @@ enum insBarrier : unsigned
 // Represents tupletype attribute of instruction.
 // This is used in determining factor N while calculating compressed displacement in EVEX encoding
 // Reference: Section 2.6.5 in Intel 64 and ia-32 architectures software developer's manual volume 2.
-enum insTupleType : uint32_t
+enum insTupleType : uint16_t
 {
-    INS_TT_NONE             = 0x00000,
-    INS_TT_FULL             = 0x00001,
-    INS_TT_HALF             = 0x00002,
-    INS_TT_IS_BROADCAST     = 0x00003,
-    INS_TT_FULL_MEM         = 0x00010,
-    INS_TT_TUPLE1_SCALAR    = 0x00020,
-    INS_TT_TUPLE1_FIXED     = 0x00040,
-    INS_TT_TUPLE2           = 0x00080,
-    INS_TT_TUPLE4           = 0x00100,
-    INS_TT_TUPLE8           = 0x00200,
-    INS_TT_HALF_MEM         = 0x00400,
-    INS_TT_QUARTER_MEM      = 0x00800,
-    INS_TT_EIGHTH_MEM       = 0x01000,
-    INS_TT_MEM128           = 0x02000,
-    INS_TT_MOVDDUP          = 0x04000,
-    INS_TT_IS_NON_BROADCAST = 0x7FFFC
+    INS_TT_NONE             = 0x0000,
+    INS_TT_FULL             = 0x0001,
+    INS_TT_HALF             = 0x0002,
+    INS_TT_IS_BROADCAST     = 0x0003,
+    INS_TT_FULL_MEM         = 0x0010,
+    INS_TT_TUPLE1_SCALAR    = 0x0020,
+    INS_TT_TUPLE1_FIXED     = 0x0040,
+    INS_TT_TUPLE2           = 0x0080,
+    INS_TT_TUPLE4           = 0x0100,
+    INS_TT_TUPLE8           = 0x0200,
+    INS_TT_HALF_MEM         = 0x0400,
+    INS_TT_QUARTER_MEM      = 0x0800,
+    INS_TT_EIGHTH_MEM       = 0x1000,
+    INS_TT_MEM128           = 0x2000,
+    INS_TT_MOVDDUP          = 0x4000,
+    INS_TT_IS_NON_BROADCAST = 0x8000,
 };
 #endif
 


### PR DESCRIPTION
This saves us `~45kb` in the total size of `clrjit.dll` (went from `~1926kb` to `~1881kb` locally).