### PR TITLE
JIT: fold str[cns] for static readonly (non-frozen)

### DIFF
--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -991,6 +991,9 @@ public:
     // Returns true iff the VN represents a handle constant.
     bool IsVNHandle(ValueNum vn);
 
+    // Returns true iff the VN represents a FieldSeq handle constant.
+    bool IsVNFieldSeqHandle(ValueNum vn);
+
     // Returns true iff the VN represents an object handle constant.
     bool IsVNObjHandle(ValueNum vn);
 


### PR DESCRIPTION
```csharp
static readonly string s_Str = Environment.GetEnvironmentVariable("PATH")!;

[MethodImpl(MethodImplOptions.NoInlining)]
static char Test() => s_Str[10];
```
folds to 
```asm
; Assembly listing for method Program:Test():ushort
       mov      eax, 92
       ret      
; Total bytes of code 6
```
not expecting it to be super useful, but seems like it won't hurt? I just extended existing logic that relied on frozen objects but in this case we can handle any type of object.