### PR TITLE
Made FormattedLogValues public

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/FormattedLogValues.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/FormattedLogValues.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.Logging
     /// LogValues to enable formatting options supported by <see cref="string.Format(IFormatProvider, string, object?)"/>.
     /// This also enables using {NamedformatItem} in the format string.
     /// </summary>
-    internal readonly struct FormattedLogValues : IReadOnlyList<KeyValuePair<string, object?>>
+    public readonly struct FormattedLogValues : IReadOnlyList<KeyValuePair<string, object?>>
     {
         internal const int MaxCachedFormatters = 1024;
         private const string NullFormat = "[null]";


### PR DESCRIPTION
Resolves #67577. Reverts https://github.com/dotnet/extensions/pull/513 which made it internal.

Made struct `src/libraries/Microsoft.Extensions.Logging.Abstractions/src/FormattedLogValues` public again to simplify mocking and other kinds of testing. See #67577 for more details and examples.