### PR TITLE
Ensure the insTupleType mask entries stay correct

### DIFF
--- a/src/coreclr/jit/instr.h
+++ b/src/coreclr/jit/instr.h
@@ -371,7 +371,7 @@ enum insTupleType : uint16_t
     INS_TT_NONE             = 0x0000,
     INS_TT_FULL             = 0x0001,
     INS_TT_HALF             = 0x0002,
-    INS_TT_IS_BROADCAST     = 0x0003,
+    INS_TT_IS_BROADCAST     = INS_TT_FULL | INS_TT_HALF,
     INS_TT_FULL_MEM         = 0x0010,
     INS_TT_TUPLE1_SCALAR    = 0x0020,
     INS_TT_TUPLE1_FIXED     = 0x0040,
@@ -383,7 +383,7 @@ enum insTupleType : uint16_t
     INS_TT_EIGHTH_MEM       = 0x1000,
     INS_TT_MEM128           = 0x2000,
     INS_TT_MOVDDUP          = 0x4000,
-    INS_TT_IS_NON_BROADCAST = 0x8000,
+    INS_TT_IS_NON_BROADCAST = ~INS_TT_IS_BROADCAST,
 };
 #endif
 

--- a/src/coreclr/jit/instr.h
+++ b/src/coreclr/jit/instr.h
@@ -371,7 +371,7 @@ enum insTupleType : uint16_t
     INS_TT_NONE             = 0x0000,
     INS_TT_FULL             = 0x0001,
     INS_TT_HALF             = 0x0002,
-    INS_TT_IS_BROADCAST     = INS_TT_FULL | INS_TT_HALF,
+    INS_TT_IS_BROADCAST     = static_cast<uint16_t>(INS_TT_FULL | INS_TT_HALF),
     INS_TT_FULL_MEM         = 0x0010,
     INS_TT_TUPLE1_SCALAR    = 0x0020,
     INS_TT_TUPLE1_FIXED     = 0x0040,
@@ -383,7 +383,7 @@ enum insTupleType : uint16_t
     INS_TT_EIGHTH_MEM       = 0x1000,
     INS_TT_MEM128           = 0x2000,
     INS_TT_MOVDDUP          = 0x4000,
-    INS_TT_IS_NON_BROADCAST = ~INS_TT_IS_BROADCAST,
+    INS_TT_IS_NON_BROADCAST = static_cast<uint16_t>(~INS_TT_IS_BROADCAST),
 };
 #endif
 


### PR DESCRIPTION
Fixes an incorrect change in https://github.com/dotnet/runtime/pull/85853. The value of `INS_TT_IS_NON_BROADCAST` is currently unused, which is why it caused no issues.