### PR TITLE
JIT: fix another case of early flow graph divergence

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9407,9 +9407,11 @@ public:
             return IsInstrumented() && jitFlags->IsSet(JitFlags::JIT_FLAG_BBOPT);
         }
 
-        bool IsInstrumentedOrOptimized() const
+        bool CanBeInstrumentedOrIsOptimized() const
         {
-            return IsInstrumented() || jitFlags->IsSet(JitFlags::JIT_FLAG_BBOPT);
+            return IsInstrumented() || (jitFlags->IsSet(JitFlags::JIT_FLAG_TIER0) &&
+                                        jitFlags->IsSet(JitFlags::JIT_FLAG_BBINSTR_IF_LOOPS)) ||
+                   jitFlags->IsSet(JitFlags::JIT_FLAG_BBOPT);
         }
 
         // true if we should use the PINVOKE_{BEGIN,END} helpers instead of generating

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -1826,7 +1826,7 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
 
                 if ((jmpDist == 0) &&
                     (opcode == CEE_LEAVE || opcode == CEE_LEAVE_S || opcode == CEE_BR || opcode == CEE_BR_S) &&
-                    opts.IsInstrumentedOrOptimized())
+                    opts.CanBeInstrumentedOrIsOptimized())
                 {
                     break; /* NOP */
                 }
@@ -2975,7 +2975,7 @@ unsigned Compiler::fgMakeBasicBlocks(const BYTE* codeAddr, IL_OFFSET codeSize, F
 
                 jmpDist = (sz == 1) ? getI1LittleEndian(codeAddr) : getI4LittleEndian(codeAddr);
 
-                if ((jmpDist == 0) && (opcode == CEE_BR || opcode == CEE_BR_S) && opts.IsInstrumentedOrOptimized())
+                if ((jmpDist == 0) && (opcode == CEE_BR || opcode == CEE_BR_S) && opts.CanBeInstrumentedOrIsOptimized())
                 {
                     continue; /* NOP */
                 }

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -7476,7 +7476,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
             case CEE_BR_S:
                 jmpDist = (sz == 1) ? getI1LittleEndian(codeAddr) : getI4LittleEndian(codeAddr);
 
-                if ((jmpDist == 0) && opts.IsInstrumentedOrOptimized())
+                if ((jmpDist == 0) && opts.CanBeInstrumentedOrIsOptimized())
                 {
                     break; /* NOP */
                 }


### PR DESCRIPTION
The JIT will sometimes decide to instrument a Tier0 method even if `BBINSTR` is not passed by the VM (this is enabled when the VM passes `BBINSTR_IF_LOOPS` so that we can provide some PGO data to OSR methods).

In such cases we build the flow graph and then decide to instrument, so the flow graph shape may differ from the case where we know up front that we are going to instrument or optimize.

Remedy this by also running the early branch to next flow graph opt when a Tier0 JIT is passed `BBINSTR_IF_LOOPS`.

Addresses another case of #85856.