### PR TITLE
Fix WaitForExitAsync could return a cancelled task

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessWaitState.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessWaitState.Unix.cs
@@ -548,7 +548,7 @@ namespace System.Diagnostics
                         _waitInProgress = null;
                     }
                 }
-            }, cancellationToken);
+            }, CancellationToken.None);
         }
 
         private void ChildReaped(int exitCode, bool configureConsole)

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessWaitState.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessWaitState.Unix.cs
@@ -548,7 +548,7 @@ namespace System.Diagnostics
                         _waitInProgress = null;
                     }
                 }
-            }, CancellationToken.None);
+            }, CancellationToken.None); // We should avoid this Task.Run being cancelled and the delegate being skipped
         }
 
         private void ChildReaped(int exitCode, bool configureConsole)


### PR DESCRIPTION
Fix #85717. In `WaitForExitAsync`, `Task.Run` being cancelled is unexpected, which makes `waitTask.Wait()` throw.

To reproduce the issue, add a `Thread.Sleep(1000)` before calling `waitTask = WaitForExitAsync(token)` in the implement of `ProcessWaitState.WaitForExit` and run `Process.GetCurrentProcess().WaitForExit(50)`.