### PR TITLE
Fix JsonNode.To allocations

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.To.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.To.cs
@@ -21,7 +21,7 @@ namespace System.Text.Json.Nodes
                 WriteTo(writer, options);
             }
 
-            return JsonHelpers.Utf8GetString(output.WrittenMemory.ToArray());
+            return JsonHelpers.Utf8GetString(output.WrittenMemory.Span);
         }
 
         /// <summary>
@@ -51,7 +51,7 @@ namespace System.Text.Json.Nodes
                 WriteTo(writer);
             }
 
-            return JsonHelpers.Utf8GetString(output.WrittenMemory.ToArray());
+            return JsonHelpers.Utf8GetString(output.WrittenMemory.Span);
         }
 
         /// <summary>


### PR DESCRIPTION
`JsonHelpers.Utf8GetString` takes a `ReadOnlySpan<byte>` parameter...