### PR TITLE
Unroll StringBuilder.Append for const string

### DIFF
--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -1125,6 +1125,20 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
                                 break;
                             }
 
+                            case NI_System_SpanHelpers_SequenceEqual:
+                            case NI_System_Buffer_Memmove:
+                            {
+                                if (FgStack::IsConstArgument(pushedStack.Top(), impInlineInfo))
+                                {
+                                    // Constant (at its call-site) argument feeds the Memmove/Memcmp length argument.
+                                    // We most likely will be able to unroll it.
+                                    // It is important to only raise this hint for constant arguments, if it's just a
+                                    // constant in the inlinee itself then we don't need to inline it for unrolling.
+                                    compInlineResult->Note(InlineObservation::CALLSITE_UNROLLABLE_MEMOP);
+                                }
+                                break;
+                            }
+
                             case NI_System_Span_get_Item:
                             case NI_System_ReadOnlySpan_get_Item:
                             {

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3795,8 +3795,12 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
             case NI_System_SpanHelpers_SequenceEqual:
             case NI_System_Buffer_Memmove:
             {
-                // We'll try to unroll this in lower for constant input.
-                isSpecial = true;
+                if (sig->sigInst.methInstCount == 0)
+                {
+                    // We'll try to unroll this in lower for constant input.
+                    isSpecial = true;
+                }
+                // The generic version is also marked as [Intrinsic] just as a hint for the inliner
                 break;
             }
 

--- a/src/coreclr/jit/inline.def
+++ b/src/coreclr/jit/inline.def
@@ -180,6 +180,7 @@ INLINE_OBSERVATION(FOLDABLE_EXPR,             int,    "foldable binary expressio
 INLINE_OBSERVATION(FOLDABLE_EXPR_UN,          int,    "foldable unary expression",            INFORMATION, CALLSITE)
 INLINE_OBSERVATION(FOLDABLE_BRANCH,           int,    "foldable branch",                      INFORMATION, CALLSITE)
 INLINE_OBSERVATION(FOLDABLE_SWITCH,           int,    "foldable switch",                      INFORMATION, CALLSITE)
+INLINE_OBSERVATION(UNROLLABLE_MEMOP,          int,    "unrollable memmove/memcmp",            INFORMATION, CALLSITE)
 INLINE_OBSERVATION(DIV_BY_CNS,                int,    "dividy by const",                      INFORMATION, CALLSITE)
 INLINE_OBSERVATION(CONSTANT_ARG_FEEDS_TEST,   bool,   "constant argument feeds test",         INFORMATION, CALLSITE)
 INLINE_OBSERVATION(DEPTH,                     int,    "depth",                                INFORMATION, CALLSITE)

--- a/src/coreclr/jit/inlinepolicy.cpp
+++ b/src/coreclr/jit/inlinepolicy.cpp
@@ -1317,6 +1317,10 @@ void ExtendedDefaultPolicy::NoteBool(InlineObservation obs, bool value)
             m_FoldableSwitch++;
             break;
 
+        case InlineObservation::CALLSITE_UNROLLABLE_MEMOP:
+            m_UnrollableMemop++;
+            break;
+
         case InlineObservation::CALLEE_HAS_SWITCH:
             m_Switch++;
             break;
@@ -1409,7 +1413,7 @@ void ExtendedDefaultPolicy::NoteInt(InlineObservation obs, int value)
                     // in prejit-root mode.
                     bbLimit += 5 + m_Switch * 10;
                 }
-                bbLimit += m_FoldableBranch + m_FoldableSwitch * 10;
+                bbLimit += m_FoldableBranch + m_FoldableSwitch * 10 + m_UnrollableMemop * 2;
 
                 if ((unsigned)value > bbLimit)
                 {
@@ -1715,6 +1719,13 @@ double ExtendedDefaultPolicy::DetermineMultiplier()
             break;
     }
 
+    if (m_UnrollableMemop > 0)
+    {
+        multiplier += m_UnrollableMemop;
+        JITDUMP("\nInline candidate has %d unrollable memory operations.  Multiplier increased to %g.",
+                m_UnrollableMemop, multiplier);
+    }
+
     if (m_FoldableSwitch > 0)
     {
         multiplier += 6.0;
@@ -1841,6 +1852,7 @@ void ExtendedDefaultPolicy::OnDumpXml(FILE* file, unsigned indent) const
     XATTR_I4(m_FoldableExprUn)
     XATTR_I4(m_FoldableBranch)
     XATTR_I4(m_FoldableSwitch)
+    XATTR_I4(m_UnrollableMemop)
     XATTR_I4(m_Switch)
     XATTR_I4(m_DivByCns)
     XATTR_B(m_ReturnsStructByValue)

--- a/src/coreclr/jit/inlinepolicy.h
+++ b/src/coreclr/jit/inlinepolicy.h
@@ -216,6 +216,7 @@ public:
         , m_FoldableExprUn(0)
         , m_FoldableBranch(0)
         , m_FoldableSwitch(0)
+        , m_UnrollableMemop(0)
         , m_Switch(0)
         , m_DivByCns(0)
         , m_ReturnsStructByValue(false)
@@ -268,6 +269,7 @@ protected:
     unsigned m_FoldableExprUn;
     unsigned m_FoldableBranch;
     unsigned m_FoldableSwitch;
+    unsigned m_UnrollableMemop;
     unsigned m_Switch;
     unsigned m_DivByCns;
     bool     m_ReturnsStructByValue : 1;

--- a/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
@@ -345,6 +345,7 @@ namespace System
 
 #if !MONO // Mono BulkMoveWithWriteBarrier is in terms of elements (not bytes) and takes a type handle.
 
+        [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe void Memmove<T>(ref T destination, ref T source, nuint elementCount)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -730,7 +730,7 @@ namespace System.Text
         {
             if (value is not null)
             {
-                Append(valueCount: value.Length, value: ref value.GetRawStringData());
+                Append(ref value.GetRawStringData(), value.Length);
             }
 
             return this;
@@ -2115,19 +2115,10 @@ namespace System.Text
 
                 if (((uint)chunkLength + (uint)valueCount) <= (uint)chunkChars.Length)
                 {
-                    ref char destination = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(chunkChars), chunkLength);
-                    if (valueCount <= 2)
-                    {
-                        destination = value;
-                        if (valueCount == 2)
-                        {
-                            Unsafe.Add(ref destination, 1) = Unsafe.Add(ref value, 1);
-                        }
-                    }
-                    else
-                    {
-                        Buffer.Memmove(ref destination, ref value, (nuint)valueCount);
-                    }
+                    Buffer.Memmove(
+                        destination: ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(chunkChars), chunkLength),
+                        source: ref value,
+                        elementCount: (nuint)valueCount);
 
                     m_ChunkLength = chunkLength + valueCount;
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -728,7 +728,7 @@ namespace System.Text
         /// <param name="value">The string to append.</param>
         public StringBuilder Append(string? value)
         {
-            if (value != null)
+            if (value is not null)
             {
                 Append(ref value.GetRawStringData(), value.Length);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -728,7 +728,7 @@ namespace System.Text
         /// <param name="value">The string to append.</param>
         public StringBuilder Append(string? value)
         {
-            if (value is not null)
+            if (value != null)
             {
                 Append(ref value.GetRawStringData(), value.Length);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -2126,8 +2126,7 @@ namespace System.Text
                     }
                     else
                     {
-                        // Use intrinsic so the JIT can unroll for constant length
-                        Buffer.Memmove(ref Unsafe.As<char, byte>(ref destination), ref Unsafe.As<char, byte>(ref value), (nuint)valueCount * 2);
+                        Buffer.Memmove(ref destination, ref value, (nuint)valueCount);
                     }
 
                     m_ChunkLength = chunkLength + valueCount;


### PR DESCRIPTION
Buffer.Memmove is now being unrolled for constant lengths. If we simplify Append(ref char, int) a bit, the JIT can inline it.
As a result, this allows the methods StringBuilder.Append(string) and StringBuilder.AppendLine() to be able to be unrolled.
I didn't seem to need to add any AggressiveInlining attribute, so I left it out.

**Const string example**

```csharp
public static void Example(StringBuilder stringBuilder)
{
    stringBuilder.Append("1234567890abcdefghijklmnopqrstuvwxyzåäö");
}
```

Before:
```assembly
; Method Program:Example(System.Text.StringBuilder)
G_M35345_IG01:  ;; offset=0000H
       sub      rsp, 40
						;; size=4 bbWeight=1 PerfScore 0.25

G_M35345_IG02:  ;; offset=0004H
       cmp      byte  ptr [rcx], cl
       mov      rdx, 0x154802028D8      ; '1'
       add      rdx, 12
       mov      r8d, 39
       call     [System.Text.StringBuilder:Append(byref,int):this]
       nop      
						;; size=29 bbWeight=1 PerfScore 7.00

G_M35345_IG03:  ;; offset=0021H
       add      rsp, 40
       ret      
						;; size=5 bbWeight=1 PerfScore 1.25
; Total bytes of code: 38
```

After:

```assembly
; Method Program:Example(System.Text.StringBuilder)
G_M35345_IG01:  ;; offset=0000H
       sub      rsp, 40
       vzeroupper 
						;; size=7 bbWeight=1 PerfScore 1.25

G_M35345_IG02:  ;; offset=0007H
       mov      rdx, 0x18C802028D8      ; '1'
       add      rdx, 12
       mov      r8, gword ptr [rcx+08H]
       mov      eax, dword ptr [rcx+18H]
       lea      r9d, [rax+27H]
       cmp      dword ptr [r8+08H], r9d
       jb       SHORT G_M35345_IG04
						;; size=31 bbWeight=1 PerfScore 9.00

G_M35345_IG03:  ;; offset=0026H
       movsxd   r9, eax
       lea      r8, bword ptr [r8+2*r9+10H]
       vmovdqu  ymm0, ymmword ptr [rdx]
       vmovdqu  ymm1, ymmword ptr [rdx+20H]
       vmovdqu  xmm2, xmmword ptr [rdx+3EH]
       vmovdqu  ymmword ptr [r8], ymm0
       vmovdqu  ymmword ptr [r8+20H], ymm1
       vmovdqu  xmmword ptr [r8+3EH], xmm2
       add      eax, 39
       mov      dword ptr [rcx+18H], eax
       jmp      SHORT G_M35345_IG05
						;; size=47 bbWeight=0.50 PerfScore 12.25

G_M35345_IG04:  ;; offset=0055H
       mov      r8d, 39
       call     [System.Text.StringBuilder:AppendWithExpansion(byref,int):this]
						;; size=12 bbWeight=0.50 PerfScore 1.62

G_M35345_IG05:  ;; offset=0061H
       nop      
						;; size=1 bbWeight=1 PerfScore 0.25

G_M35345_IG06:  ;; offset=0062H
       add      rsp, 40
       ret      
						;; size=5 bbWeight=1 PerfScore 1.25
; Total bytes of code: 103
```

**AppendLine example**

```csharp
public static void Example(StringBuilder stringBuilder)
{
    stringBuilder.AppendLine();
}
```

Before:
```assembly
; Method Program:Example(System.Text.StringBuilder)
G_M35345_IG01:  ;; offset=0000H
       sub      rsp, 40
						;; size=4 bbWeight=1 PerfScore 0.25

G_M35345_IG02:  ;; offset=0004H
       cmp      byte  ptr [rcx], cl
       mov      rdx, 0x195802028D8      ; '  '
       add      rdx, 12
       mov      r8d, 2
       call     [System.Text.StringBuilder:Append(byref,int):this]
       nop      
						;; size=29 bbWeight=1 PerfScore 7.00

G_M35345_IG03:  ;; offset=0021H
       add      rsp, 40
       ret      
						;; size=5 bbWeight=1 PerfScore 1.25
; Total bytes of code: 38
```

After:
```assembly
; Method Program:Example(System.Text.StringBuilder)
G_M35345_IG01:  ;; offset=0000H
       sub      rsp, 40
						;; size=4 bbWeight=1 PerfScore 0.25

G_M35345_IG02:  ;; offset=0004H
       mov      rdx, 0x17C002028D8      ; '  '
       add      rdx, 12
       mov      r8, gword ptr [rcx+08H]
       mov      eax, dword ptr [rcx+18H]
       lea      r9d, [rax+02H]
       cmp      dword ptr [r8+08H], r9d
       jb       SHORT G_M35345_IG04
						;; size=31 bbWeight=1 PerfScore 9.00

G_M35345_IG03:  ;; offset=0023H
       movsxd   r9, eax
       lea      r8, bword ptr [r8+2*r9+10H]
       mov      r9d, dword ptr [rdx]
       mov      dword ptr [r8], r9d
       add      eax, 2
       mov      dword ptr [rcx+18H], eax
       jmp      SHORT G_M35345_IG05
						;; size=22 bbWeight=0.50 PerfScore 3.75

G_M35345_IG04:  ;; offset=0039H
       mov      r8d, 2
       call     [System.Text.StringBuilder:AppendWithExpansion(byref,int):this]
						;; size=12 bbWeight=0.50 PerfScore 1.62

G_M35345_IG05:  ;; offset=0045H
       nop      
						;; size=1 bbWeight=1 PerfScore 0.25

G_M35345_IG06:  ;; offset=0046H
       add      rsp, 40
       ret      
						;; size=5 bbWeight=1 PerfScore 1.25
; Total bytes of code: 75
```

@EgorBo can you please take a look at this