### PR TITLE
JIT: assert if we see schema mismatches with dynamic pgo data

### DIFF
--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -3297,6 +3297,15 @@ void EfficientEdgeCountReconstructor::Prepare()
 //
 void EfficientEdgeCountReconstructor::Solve()
 {
+    // If we have dynamic PGO data, we don't expect to see any mismatches,
+    // since the schema we got from the runtime should have come from the
+    // exact same JIT and IL, created in an earlier tier.
+    //
+    if (m_comp->fgPgoSource == ICorJitInfo::PgoSource::Dynamic)
+    {
+        assert(!m_mismatch);
+    }
+
     // If issues arose earlier, then don't try solving.
     //
     if (m_badcode || m_mismatch || m_allWeightsZero)


### PR DESCRIPTION
When the profile data comes from dynamic PGO, the spanning tree encoded in the schema produced by an earlier tier should exactly match the spanning tree for the current jit attempt, since the JIT and method IL are identical.

(This is not the case for static PGO; that schema may have come from a different JIT and/or different version of IL).

Note in release modes we won't assert; instead, we will silently throw the PGO data away.

Follow-on change to #85805 to catch more issues like #85799.