### PR TITLE
[RISC-V] Fixed errors in jit and unwinding

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -5919,7 +5919,7 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* cpBlkNode)
 
     if (size >= 2 * REGSIZE_BYTES)
     {
-        regNumber tempReg2 = rsGetRsvdReg();
+        regNumber tempReg2 = REG_RA;
 
         for (unsigned regSize = 2 * REGSIZE_BYTES; size >= regSize;
              size -= regSize, srcOffset += regSize, dstOffset += regSize)

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -3351,11 +3351,11 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
     if (varTypeIsFloating(op1Type))
     {
         assert(tree->OperIs(GT_LT, GT_LE, GT_EQ, GT_NE, GT_GT, GT_GE));
-        bool      IsUnordered = (tree->gtFlags & GTF_RELOP_NAN_UN) != 0;
+        bool      isUnordered = (tree->gtFlags & GTF_RELOP_NAN_UN) != 0;
         regNumber regOp1      = op1->GetRegNum();
         regNumber regOp2      = op2->GetRegNum();
 
-        if (IsUnordered)
+        if (isUnordered)
         {
             BasicBlock* skipLabel = nullptr;
             if (tree->OperIs(GT_LT))

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -282,6 +282,7 @@ void emitter::emitIns_S_R_R(instruction ins, emitAttr attr, regNumber reg1, regN
     regNumber reg3 = FPbased ? REG_FPBASE : REG_SPBASE;
     regNumber reg2 = offs < 0 ? tmpReg : reg3;
     assert(reg2 != REG_NA && reg2 != codeGen->rsGetRsvdReg());
+    assert(reg1 != codeGen->rsGetRsvdReg());
 
     // regNumber reg2 = reg3;
     offs = offs < 0 ? -offs - 8 : offs;
@@ -365,7 +366,7 @@ void emitter::emitIns_R_S(instruction ins, emitAttr attr, regNumber reg1, int va
             break;
 
         default:
-            NYI_RISCV64("illegal ins within emitIns_S_R!");
+            NYI_RISCV64("illegal ins within emitIns_R_S!");
             return;
 
     } // end switch (ins)

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -502,7 +502,7 @@ void emitter::emitIns_R_I(instruction ins, emitAttr attr, regNumber reg, ssize_t
             assert(isGeneralRegisterOrR0(reg));
             assert(imm >= -1048576 && imm < 1048576);
 
-            code != reg << 7;
+            code |= reg << 7;
             code |= ((imm >> 12) & 0xff) << 12;
             code |= ((imm >> 11) & 0x1) << 20;
             code |= ((imm >> 1) & 0x3ff) << 21;
@@ -3370,7 +3370,7 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
                     }
                     return;
                 case 0x21:            // FCVT.D.S
-                    if (opcode4 == 1) // FCVT.D.S
+                    if (opcode3 == 0) // FCVT.D.S
                     {
                         printf("fcvt.d.s     %s, %s\n", fd, fs1);
                     }

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -913,8 +913,8 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
 #endif // defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
         {
             canPassArgInRegisters = varDscInfo->canEnreg(argType, cSlotsToEnregister);
-#if defined(TARGET_LOONGARCH64)
-            // On LoongArch64, if there aren't any remaining floating-point registers to pass the
+#if defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
+            // On LoongArch64 and RISCV64, if there aren't any remaining floating-point registers to pass the
             // argument,
             // integer registers (if any) are used instead.
             if (!canPassArgInRegisters && varTypeIsFloating(argType))

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -1115,7 +1115,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
                     }
                 }
                 else
-#elif defined(TARGET_RISCV64)
+#elif defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
                 if (varTypeIsStruct(argType))
                 {
                     if (argRegTypeInStruct1 == TYP_UNKNOWN)
@@ -1138,7 +1138,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
                     }
                 }
                 else
-#endif // UNIX_AMD64_ABI, TARGET_RISCV64
+#endif // UNIX_AMD64_ABI, TARGET_LOONGARCH64, TARGET_RISCV64
                 {
                     assert(varTypeUsesFloatReg(argType) || varTypeUsesIntReg(argType));
 

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -913,8 +913,8 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
 #endif // defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
         {
             canPassArgInRegisters = varDscInfo->canEnreg(argType, cSlotsToEnregister);
-#if defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
-            // On LoongArch64 and TARGET_RISCV64 , if there aren't any remaining floating-point registers to pass the
+#if defined(TARGET_LOONGARCH64)
+            // On LoongArch64, if there aren't any remaining floating-point registers to pass the
             // argument,
             // integer registers (if any) are used instead.
             if (!canPassArgInRegisters && varTypeIsFloating(argType))
@@ -960,6 +960,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
             }
             else
 #elif defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
+            unsigned  secondAllocatedRegArgNum = 0;
             if (argRegTypeInStruct1 != TYP_UNKNOWN)
             {
                 firstAllocatedRegArgNum = varDscInfo->allocRegArg(argRegTypeInStruct1, 1);
@@ -1022,7 +1023,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
                     varDsc->lvIs4Field1 = (genTypeSize(argRegTypeInStruct1) == 4) ? 1 : 0;
                     if (argRegTypeInStruct2 != TYP_UNKNOWN)
                     {
-                        unsigned secondAllocatedRegArgNum = varDscInfo->allocRegArg(argRegTypeInStruct2, 1);
+                        secondAllocatedRegArgNum = varDscInfo->allocRegArg(argRegTypeInStruct2, 1);
                         varDsc->SetOtherArgReg(genMapRegArgNumToRegNum(secondAllocatedRegArgNum, argRegTypeInStruct2));
                         varDsc->lvIs4Field2 = (genTypeSize(argRegTypeInStruct2) == 4) ? 1 : 0;
                     }
@@ -1111,6 +1112,29 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
                     {
                         printf(", secondEightByte: %s",
                                getRegName(genMapRegArgNumToRegNum(secondAllocatedRegArgNum, secondEightByteType)));
+                    }
+                }
+                else
+#elif defined(TARGET_RISCV64)
+                if (varTypeIsStruct(argType))
+                {
+                    if (argRegTypeInStruct1 != TYP_UNKNOWN)
+                    {
+                        printf("first: <not used>");
+                    }
+                    else
+                    {
+                        printf("first: %s",
+                               getRegName(genMapRegArgNumToRegNum(firstAllocatedRegArgNum, argRegTypeInStruct1)));
+                    }
+                    if (argRegTypeInStruct2 != TYP_UNKNOWN)
+                    {
+                        printf(", second: <not used>");
+                    }
+                    else
+                    {
+                        printf(", second: %s",
+                               getRegName(genMapRegArgNumToRegNum(secondAllocatedRegArgNum, argRegTypeInStruct2)));
                     }
                 }
                 else

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -1118,7 +1118,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
 #elif defined(TARGET_RISCV64)
                 if (varTypeIsStruct(argType))
                 {
-                    if (argRegTypeInStruct1 != TYP_UNKNOWN)
+                    if (argRegTypeInStruct1 == TYP_UNKNOWN)
                     {
                         printf("first: <not used>");
                     }
@@ -1127,7 +1127,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
                         printf("first: %s",
                                getRegName(genMapRegArgNumToRegNum(firstAllocatedRegArgNum, argRegTypeInStruct1)));
                     }
-                    if (argRegTypeInStruct2 != TYP_UNKNOWN)
+                    if (argRegTypeInStruct2 == TYP_UNKNOWN)
                     {
                         printf(", second: <not used>");
                     }

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -960,7 +960,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
             }
             else
 #elif defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
-            unsigned  secondAllocatedRegArgNum = 0;
+            unsigned secondAllocatedRegArgNum = 0;
             if (argRegTypeInStruct1 != TYP_UNKNOWN)
             {
                 firstAllocatedRegArgNum = varDscInfo->allocRegArg(argRegTypeInStruct1, 1);
@@ -1138,7 +1138,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
                     }
                 }
                 else
-#endif // defined(UNIX_AMD64_ABI)
+#endif // UNIX_AMD64_ABI, TARGET_RISCV64
                 {
                     assert(varTypeUsesFloatReg(argType) || varTypeUsesIntReg(argType));
 

--- a/src/coreclr/jit/scopeinfo.cpp
+++ b/src/coreclr/jit/scopeinfo.cpp
@@ -961,15 +961,11 @@ void CodeGen::psiBegProlog()
                 else
                 {
                     regType = compiler->mangleVarArgsType(lclVarDsc->TypeGet());
-#ifdef TARGET_LOONGARCH64
                     if (emitter::isGeneralRegisterOrR0(lclVarDsc->GetArgReg()) && isFloatRegType(regType))
                     {
-                        // For LoongArch64's ABI, the float args may be passed by integer register.
+                        // For LoongArch64 and RISCV64's ABI, the float args may be passed by integer register.
                         regType = TYP_LONG;
                     }
-#else // TARGET_RISCV64
-// For RV64GC -mabi=lp64d is assumed, so floats are not passed through integer registers.
-#endif
                 }
 #else
                 var_types regType = compiler->mangleVarArgsType(lclVarDsc->TypeGet());

--- a/src/coreclr/jit/unwindriscv64.cpp
+++ b/src/coreclr/jit/unwindriscv64.cpp
@@ -183,7 +183,7 @@ void Compiler::unwindSaveReg(regNumber reg, int offset)
         BYTE x = (BYTE)(reg - REG_F8);
         assert(0 <= x && x <= 0x13);
 
-        pu->AddCode(0xDC | (BYTE)(x >> 3), (BYTE)(x << 4) | (BYTE)(z >> 8), (BYTE)z); // TODO NEED TO CHECK LATER
+        pu->AddCode(0xDC | (BYTE)(x >> 4), (BYTE)(x << 4) | (BYTE)(z >> 8), (BYTE)z);
     }
 }
 
@@ -551,19 +551,19 @@ void DumpUnwindInfo(Compiler*         comp,
                    getRegName(REG_F24 + x, true), getRegName(REG_F24 + x + 1, true), (z + 1) * 8);
         }
 #endif
-        else if (b1 == 0xDC)
+        else if ((b1 & 0xDC) == 0xDC)
         {
-            // save_freg: 11011100 | 0xxxzzzz | zzzzzzzz : save reg f(24 + #X) at [sp + #Z * 8], offset <= 2047
+            // save_freg: 1101110x | xxxxzzzz | zzzzzzzz : save reg f(8 + #X) at [sp + #Z * 8], offset <= 2047
             assert(i + 1 < countOfUnwindCodes);
             b2 = *pUnwindCode++;
             b3 = *pUnwindCode++;
             i += 2;
 
-            x = (DWORD)(b2 >> 4);
-            z = ((DWORD)(b2 & 0xF) << 8) | (DWORD)b3;
+            x = (DWORD)((b1 & 0x1) << 4) | (DWORD)(b2 >> 4);
+            z = ((DWORD)(2 & 0xF) << 8) | (DWORD)b3;
 
             printf("    %02X %02X %02X      save_freg X#%u Z#%u (0x%02X); fsd %s, [sp, #%u]\n", b1, b2, b3, x, z, z,
-                   getRegName(REG_F24 + x), z * 8);
+                   getRegName(REG_F8 + x), z * 8);
         }
 #if 0
         else if (b1 == 0xDE)

--- a/src/coreclr/unwinder/riscv64/unwinder.cpp
+++ b/src/coreclr/unwinder/riscv64/unwinder.cpp
@@ -885,10 +885,10 @@ ExecuteCodes:
         }
 
         //
-        // save_freg (11011100|0xxxzzzz|zzzzzzzz): save reg f(24+#X) at [sp+#Z*8], offset <= 32767
+        // save_freg (1101110x|xxxxzzzz|zzzzzzzz): save reg f(8+#X) at [sp+#Z*8], offset <= 32767
         //
 
-        else if (CurCode == 0xdc) {
+        else if ((CurCode & 0xdc) == 0xdc) {
             if (AccumulatedSaveNexts != 0) {
                 return STATUS_UNWIND_INVALID_SEQUENCE;
             }
@@ -899,7 +899,7 @@ ExecuteCodes:
             Status = RtlpUnwindRestoreFpRegisterRange(
                         ContextRecord,
                         8 * (((NextCode & 0xf) << 8) + NextCode1),
-                        24 + (NextCode >> 4),
+                        8 + (NextCode >> 4) + ((CurCode & 0x1) << 4),
                         1,
                         UnwindParams);
         }


### PR DESCRIPTION
- Fix overwriting RSVD registers and more in JIT
- Fix unwinding `0xdc` type
- Checked some more tests in `JIT/jit64/hfa/` are passed.
- A subtask of https://github.com/dotnet/runtime/issues/84834