### PR TITLE
Remove Vector<T> fallbacks for Vector128<T>

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -355,10 +355,6 @@ namespace System
                 // Avx2 branch also operates on Sse2 sizes, so check is combined.
                 lengthToExamine = UnalignedCountVector128(searchSpace);
             }
-            else if (Vector.IsHardwareAccelerated)
-            {
-                lengthToExamine = UnalignedCountVector(searchSpace);
-            }
         SequentialScan:
             while (lengthToExamine >= 8)
             {
@@ -517,32 +513,6 @@ namespace System
                     }
                 }
             }
-            else if (Vector.IsHardwareAccelerated)
-            {
-                if (offset < (nuint)(uint)Length)
-                {
-                    lengthToExamine = GetByteVectorSpanLength(offset, Length);
-
-                    while (lengthToExamine > offset)
-                    {
-                        Vector<byte> matches = Vector.Equals(Vector<byte>.Zero, Vector.Load(searchSpace + offset));
-                        if (Vector<byte>.Zero.Equals(matches))
-                        {
-                            offset += (nuint)Vector<byte>.Count;
-                            continue;
-                        }
-
-                        // Find offset of first match and add to current offset
-                        return (int)offset + LocateFirstFoundByte(matches);
-                    }
-
-                    if (offset < (nuint)(uint)Length)
-                    {
-                        lengthToExamine = ((nuint)(uint)Length - offset);
-                        goto SequentialScan;
-                    }
-                }
-            }
 
             ThrowMustBeNullTerminatedString();
         Found: // Workaround for https://github.com/dotnet/runtime/issues/8795
@@ -690,34 +660,6 @@ namespace System
                     goto NotEqual;
                 }
             }
-            else if (Vector.IsHardwareAccelerated && length >= (nuint)Vector<byte>.Count)
-            {
-                nuint offset = 0;
-                nuint lengthToExamine = length - (nuint)Vector<byte>.Count;
-                // Unsigned, so it shouldn't have overflowed larger than length (rather than negative)
-                Debug.Assert(lengthToExamine < length);
-                if (lengthToExamine > 0)
-                {
-                    do
-                    {
-                        if (LoadVector(ref first, offset) != LoadVector(ref second, offset))
-                        {
-                            goto NotEqual;
-                        }
-                        offset += (nuint)Vector<byte>.Count;
-                    } while (lengthToExamine > offset);
-                }
-
-                // Do final compare as Vector<byte>.Count from end rather than start
-                if (LoadVector(ref first, lengthToExamine) == LoadVector(ref second, lengthToExamine))
-                {
-                    // C# compiler inverts this test, making the outer goto the conditional jmp.
-                    goto Equal;
-                }
-
-                // This becomes a conditional jmp forward to not favor it.
-                goto NotEqual;
-            }
 
 #if TARGET_64BIT
             if (Vector128.IsHardwareAccelerated)
@@ -765,27 +707,6 @@ namespace System
             // - exceptions are conditional forwards jmps and not predicted
         NotEqual:
             return false;
-        }
-
-        // Vector sub-search adapted from https://github.com/aspnet/KestrelHttpServer/pull/1138
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int LocateFirstFoundByte(Vector<byte> match)
-        {
-            var vector64 = Vector.AsVectorUInt64(match);
-            ulong candidate = 0;
-            int i = 0;
-            // Pattern unrolled by jit https://github.com/dotnet/coreclr/pull/8001
-            for (; i < Vector<ulong>.Count; i++)
-            {
-                candidate = vector64[i];
-                if (candidate != 0)
-                {
-                    break;
-                }
-            }
-
-            // Single LEA instruction with jitted const (using function result)
-            return i * 8 + LocateFirstFoundByte(candidate);
         }
 
         public static unsafe int SequenceCompareTo(ref byte first, int firstLength, ref byte second, int secondLength)
@@ -903,22 +824,6 @@ namespace System
                     {
                         // All matched
                         goto Equal;
-                    }
-                    goto BytewiseCheck;
-                }
-            }
-            else if (Vector.IsHardwareAccelerated)
-            {
-                if (lengthToExamine > (nuint)Vector<byte>.Count)
-                {
-                    lengthToExamine -= (nuint)Vector<byte>.Count;
-                    while (lengthToExamine > offset)
-                    {
-                        if (LoadVector(ref first, offset) != LoadVector(ref second, offset))
-                        {
-                            goto BytewiseCheck;
-                        }
-                        offset += (nuint)Vector<byte>.Count;
                     }
                     goto BytewiseCheck;
                 }
@@ -1044,31 +949,6 @@ namespace System
             return i + uint.TrailingZeroCount(mask);
         }
 
-        // Vector sub-search adapted from https://github.com/aspnet/KestrelHttpServer/pull/1138
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int LocateLastFoundByte(Vector<byte> match)
-        {
-            var vector64 = Vector.AsVectorUInt64(match);
-            ulong candidate = 0;
-            int i = Vector<ulong>.Count - 1;
-
-            // This pattern is only unrolled by the Jit if the limit is Vector<T>.Count
-            // As such, we need a dummy iteration variable for that condition to be satisfied
-            for (int j = 0; j < Vector<ulong>.Count; j++)
-            {
-                candidate = vector64[i];
-                if (candidate != 0)
-                {
-                    break;
-                }
-
-                i--;
-            }
-
-            // Single LEA instruction with jitted const (using function result)
-            return i * 8 + LocateLastFoundByte(candidate);
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int LocateFirstFoundByte(ulong match)
             => BitOperations.TrailingZeroCount(match) >> 3;
@@ -1098,10 +978,6 @@ namespace System
             => Unsafe.ReadUnaligned<nuint>(ref Unsafe.AddByteOffset(ref start, offset));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Vector<byte> LoadVector(ref byte start, nuint offset)
-            => Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref start, offset));
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Vector128<byte> LoadVector128(ref byte start, nuint offset)
             => Unsafe.ReadUnaligned<Vector128<byte>>(ref Unsafe.AddByteOffset(ref start, offset));
 
@@ -1110,23 +986,12 @@ namespace System
             => Unsafe.ReadUnaligned<Vector256<byte>>(ref Unsafe.AddByteOffset(ref start, offset));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static nuint GetByteVectorSpanLength(nuint offset, int length)
-            => (nuint)(uint)((length - (int)offset) & ~(Vector<byte>.Count - 1));
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static nuint GetByteVector128SpanLength(nuint offset, int length)
             => (nuint)(uint)((length - (int)offset) & ~(Vector128<byte>.Count - 1));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static nuint GetByteVector256SpanLength(nuint offset, int length)
             => (nuint)(uint)((length - (int)offset) & ~(Vector256<byte>.Count - 1));
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe nuint UnalignedCountVector(byte* searchSpace)
-        {
-            nint unaligned = (nint)searchSpace & (Vector<byte>.Count - 1);
-            return (nuint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
-        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe nuint UnalignedCountVector128(byte* searchSpace)

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -355,6 +355,13 @@ namespace System
                 // Avx2 branch also operates on Sse2 sizes, so check is combined.
                 lengthToExamine = UnalignedCountVector128(searchSpace);
             }
+#if MONO
+            else if (Vector.IsHardwareAccelerated)
+            {
+                lengthToExamine = UnalignedCountVector(searchSpace);
+            }
+#endif
+
         SequentialScan:
             while (lengthToExamine >= 8)
             {
@@ -513,6 +520,34 @@ namespace System
                     }
                 }
             }
+#if MONO
+            else if (Vector.IsHardwareAccelerated)
+            {
+                if (offset < (nuint)(uint)Length)
+                {
+                    lengthToExamine = GetByteVectorSpanLength(offset, Length);
+
+                    while (lengthToExamine > offset)
+                    {
+                        Vector<byte> matches = Vector.Equals(Vector<byte>.Zero, Vector.Load(searchSpace + offset));
+                        if (Vector<byte>.Zero.Equals(matches))
+                        {
+                            offset += (nuint)Vector<byte>.Count;
+                            continue;
+                        }
+
+                        // Find offset of first match and add to current offset
+                        return (int)offset + LocateFirstFoundByte(matches);
+                    }
+
+                    if (offset < (nuint)(uint)Length)
+                    {
+                        lengthToExamine = ((nuint)(uint)Length - offset);
+                        goto SequentialScan;
+                    }
+                }
+            }
+#endif
 
             ThrowMustBeNullTerminatedString();
         Found: // Workaround for https://github.com/dotnet/runtime/issues/8795
@@ -660,6 +695,36 @@ namespace System
                     goto NotEqual;
                 }
             }
+#if MONO
+            else if (Vector.IsHardwareAccelerated && length >= (nuint)Vector<byte>.Count)
+            {
+                nuint offset = 0;
+                nuint lengthToExamine = length - (nuint)Vector<byte>.Count;
+                // Unsigned, so it shouldn't have overflowed larger than length (rather than negative)
+                Debug.Assert(lengthToExamine < length);
+                if (lengthToExamine > 0)
+                {
+                    do
+                    {
+                        if (LoadVector(ref first, offset) != LoadVector(ref second, offset))
+                        {
+                            goto NotEqual;
+                        }
+                        offset += (nuint)Vector<byte>.Count;
+                    } while (lengthToExamine > offset);
+                }
+
+                // Do final compare as Vector<byte>.Count from end rather than start
+                if (LoadVector(ref first, lengthToExamine) == LoadVector(ref second, lengthToExamine))
+                {
+                    // C# compiler inverts this test, making the outer goto the conditional jmp.
+                    goto Equal;
+                }
+
+                // This becomes a conditional jmp forward to not favor it.
+                goto NotEqual;
+            }
+#endif
 
 #if TARGET_64BIT
             if (Vector128.IsHardwareAccelerated)
@@ -828,6 +893,24 @@ namespace System
                     goto BytewiseCheck;
                 }
             }
+#if MONO
+            else if (Vector.IsHardwareAccelerated)
+            {
+                if (lengthToExamine > (nuint)Vector<byte>.Count)
+                {
+                    lengthToExamine -= (nuint)Vector<byte>.Count;
+                    while (lengthToExamine > offset)
+                    {
+                        if (LoadVector(ref first, offset) != LoadVector(ref second, offset))
+                        {
+                            goto BytewiseCheck;
+                        }
+                        offset += (nuint)Vector<byte>.Count;
+                    }
+                    goto BytewiseCheck;
+                }
+            }
+#endif
 
             if (lengthToExamine > (nuint)sizeof(nuint))
             {
@@ -948,6 +1031,69 @@ namespace System
             mask = ~mask;
             return i + uint.TrailingZeroCount(mask);
         }
+
+#if MONO
+        // Vector sub-search adapted from https://github.com/aspnet/KestrelHttpServer/pull/1138
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int LocateFirstFoundByte(Vector<byte> match)
+        {
+            var vector64 = Vector.AsVectorUInt64(match);
+            ulong candidate = 0;
+            int i = 0;
+            // Pattern unrolled by jit https://github.com/dotnet/coreclr/pull/8001
+            for (; i < Vector<ulong>.Count; i++)
+            {
+                candidate = vector64[i];
+                if (candidate != 0)
+                {
+                    break;
+                }
+            }
+
+            // Single LEA instruction with jitted const (using function result)
+            return i * 8 + LocateFirstFoundByte(candidate);
+        }
+
+        // Vector sub-search adapted from https://github.com/aspnet/KestrelHttpServer/pull/1138
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int LocateLastFoundByte(Vector<byte> match)
+        {
+            var vector64 = Vector.AsVectorUInt64(match);
+            ulong candidate = 0;
+            int i = Vector<ulong>.Count - 1;
+
+            // This pattern is only unrolled by the Jit if the limit is Vector<T>.Count
+            // As such, we need a dummy iteration variable for that condition to be satisfied
+            for (int j = 0; j < Vector<ulong>.Count; j++)
+            {
+                candidate = vector64[i];
+                if (candidate != 0)
+                {
+                    break;
+                }
+
+                i--;
+            }
+
+            // Single LEA instruction with jitted const (using function result)
+            return i * 8 + LocateLastFoundByte(candidate);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector<byte> LoadVector(ref byte start, nuint offset)
+            => Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref start, offset));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static nuint GetByteVectorSpanLength(nuint offset, int length)
+            => (nuint)(uint)((length - (int)offset) & ~(Vector<byte>.Count - 1));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe nuint UnalignedCountVector(byte* searchSpace)
+        {
+            nint unaligned = (nint)searchSpace & (Vector<byte>.Count - 1);
+            return (nuint)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
+        }
+#endif
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int LocateFirstFoundByte(ulong match)

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -439,11 +439,6 @@ namespace System
                 // Needs to be double length to allow us to align the data first.
                 lengthToExamine = UnalignedCountVector128(searchSpace);
             }
-            else if (Vector.IsHardwareAccelerated)
-            {
-                // Needs to be double length to allow us to align the data first.
-                lengthToExamine = UnalignedCountVector(searchSpace);
-            }
 
         SequentialScan:
             // In the non-vector case lengthToExamine is the total length.
@@ -603,40 +598,6 @@ namespace System
                     }
                 }
             }
-            else if (Vector.IsHardwareAccelerated)
-            {
-                if (offset < length)
-                {
-                    Debug.Assert(length - offset >= Vector<ushort>.Count);
-
-                    lengthToExamine = GetCharVectorSpanLength(offset, length);
-
-                    if (lengthToExamine > 0)
-                    {
-                        do
-                        {
-                            Debug.Assert(lengthToExamine >= Vector<ushort>.Count);
-
-                            var matches = Vector.Equals(Vector<ushort>.Zero, *(Vector<ushort>*)(searchSpace + (nuint)offset));
-                            if (Vector<ushort>.Zero.Equals(matches))
-                            {
-                                offset += Vector<ushort>.Count;
-                                lengthToExamine -= Vector<ushort>.Count;
-                                continue;
-                            }
-
-                            // Find offset of first match
-                            return (int)(offset + LocateFirstFoundChar(matches));
-                        } while (lengthToExamine > 0);
-                    }
-
-                    if (offset < length)
-                    {
-                        lengthToExamine = length - offset;
-                        goto SequentialScan;
-                    }
-                }
-            }
 
             ThrowMustBeNullTerminatedString();
         Found3:
@@ -649,42 +610,9 @@ namespace System
             return (int)(offset);
         }
 
-        // Vector sub-search adapted from https://github.com/aspnet/KestrelHttpServer/pull/1138
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int LocateFirstFoundChar(Vector<ushort> match)
-        {
-            var vector64 = Vector.AsVectorUInt64(match);
-            ulong candidate = 0;
-            int i = 0;
-            // Pattern unrolled by jit https://github.com/dotnet/coreclr/pull/8001
-            for (; i < Vector<ulong>.Count; i++)
-            {
-                candidate = vector64[i];
-                if (candidate != 0)
-                {
-                    break;
-                }
-            }
-
-            // Single LEA instruction with jitted const (using function result)
-            return i * 4 + LocateFirstFoundChar(candidate);
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int LocateFirstFoundChar(ulong match)
             => BitOperations.TrailingZeroCount(match) >> 4;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Vector<ushort> LoadVector(ref char start, nint offset)
-            => Unsafe.ReadUnaligned<Vector<ushort>>(ref Unsafe.As<char, byte>(ref Unsafe.Add(ref start, offset)));
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Vector<ushort> LoadVector(ref char start, nuint offset)
-            => Unsafe.ReadUnaligned<Vector<ushort>>(ref Unsafe.As<char, byte>(ref Unsafe.Add(ref start, (nint)offset)));
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static nint GetCharVectorSpanLength(nint offset, nint length)
-            => (length - offset) & ~(Vector<ushort>.Count - 1);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static nint GetCharVector128SpanLength(nint offset, nint length)
@@ -693,13 +621,6 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static nint GetCharVector256SpanLength(nint offset, nint length)
             => (length - offset) & ~(Vector256<ushort>.Count - 1);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe nint UnalignedCountVector(char* searchSpace)
-        {
-            const int ElementsPerByte = sizeof(ushort) / sizeof(byte);
-            return (nint)(uint)(-(int)searchSpace / ElementsPerByte) & (Vector<ushort>.Count - 1);
-        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe nint UnalignedCountVector128(char* searchSpace)

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -439,6 +439,13 @@ namespace System
                 // Needs to be double length to allow us to align the data first.
                 lengthToExamine = UnalignedCountVector128(searchSpace);
             }
+#if MONO
+            else if (Vector.IsHardwareAccelerated)
+            {
+                // Needs to be double length to allow us to align the data first.
+                lengthToExamine = UnalignedCountVector(searchSpace);
+            }
+#endif
 
         SequentialScan:
             // In the non-vector case lengthToExamine is the total length.
@@ -598,6 +605,42 @@ namespace System
                     }
                 }
             }
+#if MONO
+            else if (Vector.IsHardwareAccelerated)
+            {
+                if (offset < length)
+                {
+                    Debug.Assert(length - offset >= Vector<ushort>.Count);
+
+                    lengthToExamine = GetCharVectorSpanLength(offset, length);
+
+                    if (lengthToExamine > 0)
+                    {
+                        do
+                        {
+                            Debug.Assert(lengthToExamine >= Vector<ushort>.Count);
+
+                            var matches = Vector.Equals(Vector<ushort>.Zero, *(Vector<ushort>*)(searchSpace + (nuint)offset));
+                            if (Vector<ushort>.Zero.Equals(matches))
+                            {
+                                offset += Vector<ushort>.Count;
+                                lengthToExamine -= Vector<ushort>.Count;
+                                continue;
+                            }
+
+                            // Find offset of first match
+                            return (int)(offset + LocateFirstFoundChar(matches));
+                        } while (lengthToExamine > 0);
+                    }
+
+                    if (offset < length)
+                    {
+                        lengthToExamine = length - offset;
+                        goto SequentialScan;
+                    }
+                }
+            }
+#endif
 
             ThrowMustBeNullTerminatedString();
         Found3:
@@ -609,6 +652,48 @@ namespace System
         Found:
             return (int)(offset);
         }
+
+#if MONO
+        // Vector sub-search adapted from https://github.com/aspnet/KestrelHttpServer/pull/1138
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int LocateFirstFoundChar(Vector<ushort> match)
+        {
+            var vector64 = Vector.AsVectorUInt64(match);
+            ulong candidate = 0;
+            int i = 0;
+            // Pattern unrolled by jit https://github.com/dotnet/coreclr/pull/8001
+            for (; i < Vector<ulong>.Count; i++)
+            {
+                candidate = vector64[i];
+                if (candidate != 0)
+                {
+                    break;
+                }
+            }
+
+            // Single LEA instruction with jitted const (using function result)
+            return i * 4 + LocateFirstFoundChar(candidate);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector<ushort> LoadVector(ref char start, nint offset)
+            => Unsafe.ReadUnaligned<Vector<ushort>>(ref Unsafe.As<char, byte>(ref Unsafe.Add(ref start, offset)));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector<ushort> LoadVector(ref char start, nuint offset)
+            => Unsafe.ReadUnaligned<Vector<ushort>>(ref Unsafe.As<char, byte>(ref Unsafe.Add(ref start, (nint)offset)));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static nint GetCharVectorSpanLength(nint offset, nint length)
+            => (length - offset) & ~(Vector<ushort>.Count - 1);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe nint UnalignedCountVector(char* searchSpace)
+        {
+            const int ElementsPerByte = sizeof(ushort) / sizeof(byte);
+            return (nint)(uint)(-(int)searchSpace / ElementsPerByte) & (Vector<ushort>.Count - 1);
+        }
+#endif
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int LocateFirstFoundChar(ulong match)


### PR DESCRIPTION
I believe the only reason we were keeping these around were some mono platforms that accelerated `Vector<T>` but not `Vector128<T>`...

@fanyang-mono, @radekdoulik, are we able to remove these now?