### PR TITLE
Allow set GC configuration in NativeAOT

### DIFF
--- a/src/coreclr/nativeaot/Runtime/GcStressControl.cpp
+++ b/src/coreclr/nativeaot/Runtime/GcStressControl.cpp
@@ -70,12 +70,12 @@ private:
             s_lock.InitNoThrow(CrstGcStressControl);
 
             if (g_pRhConfig->GetGcStressSeed())
-                s_lGcStressRNGSeed = g_pRhConfig->GetGcStressSeed();
+                s_lGcStressRNGSeed = (uint32_t)g_pRhConfig->GetGcStressSeed();
             else
                 s_lGcStressRNGSeed = (uint32_t)PalGetTickCount64();
 
             if (g_pRhConfig->GetGcStressFreqDenom())
-                s_lGcStressFreqDenom = g_pRhConfig->GetGcStressFreqDenom();
+                s_lGcStressFreqDenom = (uint32_t)g_pRhConfig->GetGcStressFreqDenom();
             else
                 s_lGcStressFreqDenom = 10000;
 

--- a/src/coreclr/nativeaot/Runtime/RhConfig.cpp
+++ b/src/coreclr/nativeaot/Runtime/RhConfig.cpp
@@ -24,7 +24,7 @@
 
 #include <string.h>
 
-bool RhConfig::ReadConfigValue(_In_z_ const TCHAR *wszName, uint32_t* pValue, bool decimal)
+bool RhConfig::ReadConfigValue(_In_z_ const TCHAR *wszName, uint64_t* pValue, bool decimal)
 {
     TCHAR wszBuffer[CONFIG_VAL_MAXLEN + 1]; // 8 hex digits plus a nul terminator.
     const uint32_t cchBuffer = sizeof(wszBuffer) / sizeof(wszBuffer[0]);
@@ -47,7 +47,7 @@ bool RhConfig::ReadConfigValue(_In_z_ const TCHAR *wszName, uint32_t* pValue, bo
     if ((cchResult == 0) || (cchResult >= cchBuffer))
         return false; // not found
 
-    uint32_t uiResult = 0;
+    uint64_t uiResult = 0;
 
     for (uint32_t i = 0; i < cchResult; i++)
     {

--- a/src/coreclr/nativeaot/Runtime/RhConfig.cpp
+++ b/src/coreclr/nativeaot/Runtime/RhConfig.cpp
@@ -26,7 +26,7 @@
 
 bool RhConfig::ReadConfigValue(_In_z_ const TCHAR *wszName, uint64_t* pValue, bool decimal)
 {
-    TCHAR wszBuffer[CONFIG_VAL_MAXLEN + 1]; // 8 hex digits plus a nul terminator.
+    TCHAR wszBuffer[CONFIG_VAL_MAXLEN + 1]; // hex digits plus a nul terminator.
     const uint32_t cchBuffer = sizeof(wszBuffer) / sizeof(wszBuffer[0]);
 
     uint32_t cchResult = 0;

--- a/src/coreclr/nativeaot/Runtime/RhConfig.h
+++ b/src/coreclr/nativeaot/Runtime/RhConfig.h
@@ -22,7 +22,7 @@ class RhConfig
 
 #define CONFIG_INI_NOT_AVAIL (void*)0x1  //signal for ini file failed to load
 #define CONFIG_KEY_MAXLEN 50             //arbitrary max length of config keys increase if needed
-#define CONFIG_VAL_MAXLEN 16              //32 bit uint in hex
+#define CONFIG_VAL_MAXLEN 16              //64 bit uint in hex
 
 private:
     struct ConfigPair

--- a/src/coreclr/nativeaot/Runtime/RhConfig.h
+++ b/src/coreclr/nativeaot/Runtime/RhConfig.h
@@ -22,7 +22,7 @@ class RhConfig
 
 #define CONFIG_INI_NOT_AVAIL (void*)0x1  //signal for ini file failed to load
 #define CONFIG_KEY_MAXLEN 50             //arbitrary max length of config keys increase if needed
-#define CONFIG_VAL_MAXLEN 8              //32 bit uint in hex
+#define CONFIG_VAL_MAXLEN 16              //32 bit uint in hex
 
 private:
     struct ConfigPair
@@ -42,14 +42,14 @@ private:
 
 public:
 
-    bool ReadConfigValue(_In_z_ const TCHAR* wszName, uint32_t* pValue, bool decimal = false);
+    bool ReadConfigValue(_In_z_ const TCHAR* wszName, uint64_t* pValue, bool decimal = false);
 
 #define DEFINE_VALUE_ACCESSOR(_name, defaultVal)        \
-    uint32_t Get##_name()                                 \
+    uint64_t Get##_name()                                 \
     {                                                   \
         if (m_uiConfigValuesRead & (1 << RCV_##_name))  \
             return m_uiConfigValues[RCV_##_name];       \
-        uint32_t uiValue;                               \
+        uint64_t uiValue;                               \
         m_uiConfigValues[RCV_##_name] = ReadConfigValue(_T(#_name), &uiValue) ? uiValue : defaultVal; \
         m_uiConfigValuesRead |= 1 << RCV_##_name;       \
         return m_uiConfigValues[RCV_##_name];           \
@@ -111,7 +111,7 @@ private:
 
 
     uint32_t  m_uiConfigValuesRead;
-    uint32_t  m_uiConfigValues[RCV_Count];
+    uint64_t  m_uiConfigValues[RCV_Count];
 };
 
 extern RhConfig * g_pRhConfig;

--- a/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
@@ -1375,7 +1375,7 @@ bool GCToEEInterface::GetBooleanConfigValue(const char* privateKey, const char* 
     const TCHAR* pKey = privateKey;
 #endif
 
-    uint32_t uiValue;
+    uint64_t uiValue;
     if (!g_pRhConfig->ReadConfigValue(pKey, &uiValue))
         return false;
 
@@ -1394,7 +1394,7 @@ bool GCToEEInterface::GetIntConfigValue(const char* privateKey, const char* publ
     const TCHAR* pKey = privateKey;
 #endif
 
-    uint32_t uiValue;
+    uint64_t uiValue;
     if (!g_pRhConfig->ReadConfigValue(pKey, &uiValue))
         return false;
 

--- a/src/coreclr/nativeaot/Runtime/startup.cpp
+++ b/src/coreclr/nativeaot/Runtime/startup.cpp
@@ -132,8 +132,8 @@ static bool InitDLL(HANDLE hPalInstance)
     InitializeYieldProcessorNormalizedCrst();
 
 #ifdef STRESS_LOG
-    uint32_t dwTotalStressLogSize = g_pRhConfig->GetTotalStressLogSize();
-    uint32_t dwStressLogLevel = g_pRhConfig->GetStressLogLevel();
+    uint32_t dwTotalStressLogSize = (uint32_t)g_pRhConfig->GetTotalStressLogSize();
+    uint32_t dwStressLogLevel = (uint32_t)g_pRhConfig->GetStressLogLevel();
 
     unsigned facility = (unsigned)LF_ALL;
     unsigned dwPerThreadChunks = (dwTotalStressLogSize / 24) / STRESSLOG_CHUNK_SIZE;

--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -352,7 +352,7 @@ void InitializeCurrentProcessCpuCount()
     // process affinity and CPU quota limit.
 
     const unsigned int MAX_PROCESSOR_COUNT = 0xffff;
-    uint32_t configValue;
+    uint64_t configValue;
 
     if (g_pRhConfig->ReadConfigValue(_T("PROCESSOR_COUNT"), &configValue, true /* decimal */) &&
         0 < configValue && configValue <= MAX_PROCESSOR_COUNT)

--- a/src/coreclr/nativeaot/Runtime/windows/PalRedhawkMinWin.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/PalRedhawkMinWin.cpp
@@ -70,12 +70,12 @@ void InitializeCurrentProcessCpuCount()
     // process affinity and CPU quota limit.
 
     const unsigned int MAX_PROCESSOR_COUNT = 0xffff;
-    uint32_t configValue;
+    uint64_t configValue;
 
     if (g_pRhConfig->ReadConfigValue(_T("PROCESSOR_COUNT"), &configValue, true /* decimal */) &&
         0 < configValue && configValue <= MAX_PROCESSOR_COUNT)
     {
-        count = configValue;
+        count = (DWORD)configValue;
     }
     else
     {


### PR DESCRIPTION
Currently NativeAOT uses `uint32_t` for storing configuration values. There assumption that configuration would take 8 characters in configuration. If we set value which has 9 characters it would be silently ignored. For example: `$env:DOTNET_GCHeapHardLimit="100000000"` which is 4Gb. On CoreCLR GC uses `uint64_t` so it does not make sense to limit NativeAOT cofiguration to 32-bit values here