### PR TITLE
Optimizations for Ascii.Equals and Ascii.EqualsIgnoreCase

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
@@ -2,12 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
-using System.Text.Unicode;
-using System.Numerics;
+using System.Runtime.Intrinsics.X86;
 
 namespace System.Text
 {
@@ -27,69 +27,55 @@ namespace System.Text
                 return false;
             }
 
+            ref byte currentBytesSearchSpace = ref MemoryMarshal.GetReference(left);
+            ref ushort currentCharsSearchSpace = ref Unsafe.As<char, ushort>(ref MemoryMarshal.GetReference(right));
+            nuint length = (uint)right.Length;
+
             if (!Vector128.IsHardwareAccelerated || right.Length < Vector128<ushort>.Count)
             {
-                for (int i = 0; i < right.Length; i++)
+                for (nuint i = 0; i < length; i++)
                 {
-                    byte b = left[i];
-                    char c = right[i];
+                    byte b = Unsafe.Add(ref currentBytesSearchSpace, i);
+                    ushort c = Unsafe.Add(ref currentCharsSearchSpace, i);
 
-                    if (b != c)
-                    {
-                        return false;
-                    }
-
-                    if (!UnicodeUtility.IsAsciiCodePoint((uint)(b | c)))
+                    if (b != c || !UnicodeUtility.IsAsciiCodePoint((uint)(b | c)))
                     {
                         return false;
                     }
                 }
             }
-            else if (Vector256.IsHardwareAccelerated && right.Length >= Vector256<ushort>.Count)
+            else if (!Vector256.IsHardwareAccelerated || right.Length < Vector256<ushort>.Count)
             {
-                ref ushort currentCharsSearchSpace = ref Unsafe.As<char, ushort>(ref MemoryMarshal.GetReference(right));
-                ref ushort oneVectorAwayFromCharsEnd = ref Unsafe.Add(ref currentCharsSearchSpace, right.Length - Vector256<ushort>.Count);
-                ref byte currentBytesSearchSpace = ref MemoryMarshal.GetReference(left);
-                ref byte oneVectorAwayFromBytesEnd = ref Unsafe.Add(ref currentBytesSearchSpace, left.Length - Vector128<byte>.Count);
+                ref byte oneVectorAwayFromBytesEnd = ref Unsafe.Add(ref currentBytesSearchSpace, length - sizeof(long));
+                ref ushort oneVectorAwayFromCharsEnd = ref Unsafe.Add(ref currentCharsSearchSpace, length - (uint)Vector128<ushort>.Count);
 
-                Vector128<byte> byteValues;
-                Vector256<ushort> charValues;
+                Vector128<ushort> widenedByteValues;
+                Vector128<ushort> charValues;
 
                 // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
                 do
                 {
-                    byteValues = Vector128.LoadUnsafe(ref currentBytesSearchSpace);
-                    charValues = Vector256.LoadUnsafe(ref currentCharsSearchSpace);
-
                     // it's OK to widen the bytes, it's NOT OK to narrow the chars (we could loose some information)
-                    if (Vector256.Equals(Widen(byteValues), charValues) != Vector256<ushort>.AllBitsSet)
+                    widenedByteValues = LoadAndWiden128(ref currentBytesSearchSpace);
+                    charValues = Vector128.LoadUnsafe(ref currentCharsSearchSpace);
+
+                    if (widenedByteValues != charValues || !AllCharsInVectorAreAscii(widenedByteValues | charValues))
                     {
                         return false;
                     }
 
-                    if (byteValues.ExtractMostSignificantBits() != 0 || charValues.AsByte().ExtractMostSignificantBits() != 0)
-                    {
-                        return false;
-                    }
-
-                    currentCharsSearchSpace = ref Unsafe.Add(ref currentCharsSearchSpace, Vector256<ushort>.Count);
-                    currentBytesSearchSpace = ref Unsafe.Add(ref currentBytesSearchSpace, Vector128<byte>.Count);
+                    currentBytesSearchSpace = ref Unsafe.Add(ref currentBytesSearchSpace, sizeof(long));
+                    currentCharsSearchSpace = ref Unsafe.Add(ref currentCharsSearchSpace, Vector128<ushort>.Count);
                 }
                 while (!Unsafe.IsAddressGreaterThan(ref currentCharsSearchSpace, ref oneVectorAwayFromCharsEnd));
 
                 // If any elements remain, process the last vector in the search space.
-                if ((uint)right.Length % Vector256<ushort>.Count != 0)
+                if (length % (uint)Vector128<ushort>.Count != 0)
                 {
-                    byteValues = Vector128.LoadUnsafe(ref oneVectorAwayFromBytesEnd);
-                    charValues = Vector256.LoadUnsafe(ref oneVectorAwayFromCharsEnd);
+                    widenedByteValues = LoadAndWiden128(ref oneVectorAwayFromBytesEnd);
+                    charValues = Vector128.LoadUnsafe(ref oneVectorAwayFromCharsEnd);
 
-                    // it's OK to widen the bytes, it's NOT OK to narrow the chars (we could loose some information)
-                    if (Vector256.Equals(Widen(byteValues), charValues) != Vector256<ushort>.AllBitsSet)
-                    {
-                        return false;
-                    }
-
-                    if (byteValues.ExtractMostSignificantBits() != 0 || charValues.AsByte().ExtractMostSignificantBits() != 0)
+                    if (widenedByteValues != charValues || !AllCharsInVectorAreAscii(widenedByteValues | charValues))
                     {
                         return false;
                     }
@@ -97,49 +83,36 @@ namespace System.Text
             }
             else
             {
-                ref ushort currentCharsSearchSpace = ref Unsafe.As<char, ushort>(ref MemoryMarshal.GetReference(right));
-                ref ushort oneVectorAwayFromCharsEnd = ref Unsafe.Add(ref currentCharsSearchSpace, right.Length - Vector128<ushort>.Count);
-                ref byte currentBytesSearchSpace = ref MemoryMarshal.GetReference(left);
-                ref byte oneVectorAwayFromBytesEnd = ref Unsafe.Add(ref currentBytesSearchSpace, left.Length - Vector64<byte>.Count);
+                ref byte oneVectorAwayFromBytesEnd = ref Unsafe.Add(ref currentBytesSearchSpace, length - (uint)Vector128<byte>.Count);
+                ref ushort oneVectorAwayFromCharsEnd = ref Unsafe.Add(ref currentCharsSearchSpace, length - (uint)Vector256<ushort>.Count);
 
-                Vector64<byte> byteValues;
-                Vector128<ushort> charValues;
+                Vector256<ushort> widenedByteValues;
+                Vector256<ushort> charValues;
 
                 // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
                 do
                 {
-                    byteValues = Vector64.LoadUnsafe(ref currentBytesSearchSpace);
-                    charValues = Vector128.LoadUnsafe(ref currentCharsSearchSpace);
-
                     // it's OK to widen the bytes, it's NOT OK to narrow the chars (we could loose some information)
-                    if (Vector128.Equals(Widen(byteValues), charValues) != Vector128<ushort>.AllBitsSet)
+                    widenedByteValues = LoadAndWiden256(ref currentBytesSearchSpace);
+                    charValues = Vector256.LoadUnsafe(ref currentCharsSearchSpace);
+
+                    if (widenedByteValues != charValues || !AllCharsInVectorAreAscii(widenedByteValues | charValues))
                     {
                         return false;
                     }
 
-                    if (VectorContainsNonAsciiChar(byteValues) | VectorContainsNonAsciiChar(charValues))
-                    {
-                        return false;
-                    }
-
-                    currentBytesSearchSpace = ref Unsafe.Add(ref currentBytesSearchSpace, Vector64<byte>.Count);
-                    currentCharsSearchSpace = ref Unsafe.Add(ref currentCharsSearchSpace, Vector128<ushort>.Count);
+                    currentBytesSearchSpace = ref Unsafe.Add(ref currentBytesSearchSpace, Vector128<byte>.Count);
+                    currentCharsSearchSpace = ref Unsafe.Add(ref currentCharsSearchSpace, Vector256<ushort>.Count);
                 }
-                while (!Unsafe.IsAddressGreaterThan(ref currentCharsSearchSpace, ref oneVectorAwayFromCharsEnd));
+                while (!Unsafe.IsAddressGreaterThan(ref currentBytesSearchSpace, ref oneVectorAwayFromBytesEnd));
 
                 // If any elements remain, process the last vector in the search space.
-                if ((uint)right.Length % Vector128<ushort>.Count != 0)
+                if (length % (uint)Vector256<ushort>.Count != 0)
                 {
-                    charValues = Vector128.LoadUnsafe(ref oneVectorAwayFromCharsEnd);
-                    byteValues = Vector64.LoadUnsafe(ref oneVectorAwayFromBytesEnd);
+                    widenedByteValues = LoadAndWiden256(ref oneVectorAwayFromBytesEnd);
+                    charValues = Vector256.LoadUnsafe(ref oneVectorAwayFromCharsEnd);
 
-                    // it's OK to widen the bytes, it's NOT OK to narrow the chars (we could loose some information)
-                    if (Vector128.Equals(Widen(byteValues), charValues) != Vector128<ushort>.AllBitsSet)
-                    {
-                        return false;
-                    }
-
-                    if (VectorContainsNonAsciiChar(byteValues) || VectorContainsNonAsciiChar(charValues))
+                    if (widenedByteValues != charValues || !AllCharsInVectorAreAscii(widenedByteValues | charValues))
                     {
                         return false;
                     }
@@ -151,7 +124,8 @@ namespace System.Text
 
         /// <inheritdoc cref="Equals(ReadOnlySpan{byte}, ReadOnlySpan{char})"/>
         public static bool Equals(ReadOnlySpan<byte> left, ReadOnlySpan<byte> right)
-            => left.Length == right.Length && Equals<byte>(left, right);
+            => left.Length == right.Length
+            && Equals(ref MemoryMarshal.GetReference(left), ref MemoryMarshal.GetReference(right), (uint)left.Length);
 
         /// <inheritdoc cref="Equals(ReadOnlySpan{byte}, ReadOnlySpan{char})"/>
         public static bool Equals(ReadOnlySpan<char> left, ReadOnlySpan<byte> right)
@@ -159,82 +133,30 @@ namespace System.Text
 
         /// <inheritdoc cref="Equals(ReadOnlySpan{byte}, ReadOnlySpan{char})"/>
         public static bool Equals(ReadOnlySpan<char> left, ReadOnlySpan<char> right)
-            => left.Length == right.Length && Equals<ushort>(MemoryMarshal.Cast<char, ushort>(left), MemoryMarshal.Cast<char, ushort>(right));
+            => left.Length == right.Length
+            && Equals(ref Unsafe.As<char, ushort>(ref MemoryMarshal.GetReference(left)), ref Unsafe.As<char, ushort>(ref MemoryMarshal.GetReference(right)), (uint)left.Length);
 
-        private static bool Equals<T>(ReadOnlySpan<T> left, ReadOnlySpan<T> right) where T : unmanaged, INumberBase<T>
+        private static bool Equals<T>(ref T left, ref T right, nuint length) where T : unmanaged, INumberBase<T>
         {
-            if (!Vector128.IsHardwareAccelerated || right.Length < Vector128<T>.Count)
+            if (!Vector128.IsHardwareAccelerated || length < (uint)Vector128<T>.Count)
             {
-                for (int i = 0; i < right.Length; i++)
+                for (nuint i = 0; i < length; i++)
                 {
-                    uint valueA = uint.CreateTruncating(left[i]);
-                    uint valueB = uint.CreateTruncating(right[i]);
+                    uint valueA = uint.CreateTruncating(Unsafe.Add(ref left, i));
+                    uint valueB = uint.CreateTruncating(Unsafe.Add(ref right, i));
 
-                    if (valueA != valueB)
-                    {
-                        return false;
-                    }
-
-                    if (!UnicodeUtility.IsAsciiCodePoint(valueA | valueB))
+                    if (valueA != valueB || !UnicodeUtility.IsAsciiCodePoint(valueA | valueB))
                     {
                         return false;
                     }
                 }
             }
-            else if (Vector256.IsHardwareAccelerated && right.Length >= Vector256<T>.Count)
+            else if (!Vector256.IsHardwareAccelerated || length < (uint)Vector256<T>.Count)
             {
-                ref T currentLeftSearchSpace = ref MemoryMarshal.GetReference(left);
-                ref T oneVectorAwayFromLeftEnd = ref Unsafe.Add(ref currentLeftSearchSpace, left.Length - Vector256<T>.Count);
-                ref T currentRightSearchSpace = ref MemoryMarshal.GetReference(right);
-                ref T oneVectorAwayFromRightEnd = ref Unsafe.Add(ref currentRightSearchSpace, right.Length - Vector256<T>.Count);
-
-                Vector256<T> leftValues;
-                Vector256<T> rightValues;
-
-                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
-                do
-                {
-                    leftValues = Vector256.LoadUnsafe(ref currentLeftSearchSpace);
-                    rightValues = Vector256.LoadUnsafe(ref currentRightSearchSpace);
-
-                    if (Vector256.Equals(leftValues, rightValues) != Vector256<T>.AllBitsSet)
-                    {
-                        return false;
-                    }
-
-                    if (!AllCharsInVectorAreAscii(leftValues | rightValues))
-                    {
-                        return false;
-                    }
-
-                    currentRightSearchSpace = ref Unsafe.Add(ref currentRightSearchSpace, Vector256<T>.Count);
-                    currentLeftSearchSpace = ref Unsafe.Add(ref currentLeftSearchSpace, Vector256<T>.Count);
-                }
-                while (!Unsafe.IsAddressGreaterThan(ref currentRightSearchSpace, ref oneVectorAwayFromRightEnd));
-
-                // If any elements remain, process the last vector in the search space.
-                if ((uint)right.Length % Vector256<T>.Count != 0)
-                {
-                    rightValues = Vector256.LoadUnsafe(ref oneVectorAwayFromRightEnd);
-                    leftValues = Vector256.LoadUnsafe(ref oneVectorAwayFromLeftEnd);
-
-                    if (Vector256.Equals(leftValues, rightValues) != Vector256<T>.AllBitsSet)
-                    {
-                        return false;
-                    }
-
-                    if (!AllCharsInVectorAreAscii(leftValues | rightValues))
-                    {
-                        return false;
-                    }
-                }
-            }
-            else
-            {
-                ref T currentLeftSearchSpace = ref MemoryMarshal.GetReference(left);
-                ref T oneVectorAwayFromLeftEnd = ref Unsafe.Add(ref currentLeftSearchSpace, left.Length - Vector128<T>.Count);
-                ref T currentRightSearchSpace = ref MemoryMarshal.GetReference(right);
-                ref T oneVectorAwayFromRightEnd = ref Unsafe.Add(ref currentRightSearchSpace, right.Length - Vector128<T>.Count);
+                ref T currentLeftSearchSpace = ref left;
+                ref T oneVectorAwayFromLeftEnd = ref Unsafe.Add(ref currentLeftSearchSpace, length - (uint)Vector128<T>.Count);
+                ref T currentRightSearchSpace = ref right;
+                ref T oneVectorAwayFromRightEnd = ref Unsafe.Add(ref currentRightSearchSpace, length - (uint)Vector128<T>.Count);
 
                 Vector128<T> leftValues;
                 Vector128<T> rightValues;
@@ -245,12 +167,7 @@ namespace System.Text
                     leftValues = Vector128.LoadUnsafe(ref currentLeftSearchSpace);
                     rightValues = Vector128.LoadUnsafe(ref currentRightSearchSpace);
 
-                    if (Vector128.Equals(leftValues, rightValues) != Vector128<T>.AllBitsSet)
-                    {
-                        return false;
-                    }
-
-                    if (!AllCharsInVectorAreAscii(leftValues | rightValues))
+                    if (leftValues != rightValues || !AllCharsInVectorAreAscii(leftValues | rightValues))
                     {
                         return false;
                     }
@@ -261,17 +178,50 @@ namespace System.Text
                 while (!Unsafe.IsAddressGreaterThan(ref currentRightSearchSpace, ref oneVectorAwayFromRightEnd));
 
                 // If any elements remain, process the last vector in the search space.
-                if ((uint)right.Length % Vector128<T>.Count != 0)
+                if (length % (uint)Vector128<T>.Count != 0)
                 {
                     leftValues = Vector128.LoadUnsafe(ref oneVectorAwayFromLeftEnd);
                     rightValues = Vector128.LoadUnsafe(ref oneVectorAwayFromRightEnd);
 
-                    if (Vector128.Equals(leftValues, rightValues) != Vector128<T>.AllBitsSet)
+                    if (leftValues != rightValues || !AllCharsInVectorAreAscii(leftValues | rightValues))
+                    {
+                        return false;
+                    }
+                }
+            }
+            else
+            {
+                ref T currentLeftSearchSpace = ref left;
+                ref T oneVectorAwayFromLeftEnd = ref Unsafe.Add(ref currentLeftSearchSpace, length - (uint)Vector256<T>.Count);
+                ref T currentRightSearchSpace = ref right;
+                ref T oneVectorAwayFromRightEnd = ref Unsafe.Add(ref currentRightSearchSpace, length - (uint)Vector256<T>.Count);
+
+                Vector256<T> leftValues;
+                Vector256<T> rightValues;
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    leftValues = Vector256.LoadUnsafe(ref currentLeftSearchSpace);
+                    rightValues = Vector256.LoadUnsafe(ref currentRightSearchSpace);
+
+                    if (leftValues != rightValues || !AllCharsInVectorAreAscii(leftValues | rightValues))
                     {
                         return false;
                     }
 
-                    if (!AllCharsInVectorAreAscii(leftValues | rightValues))
+                    currentRightSearchSpace = ref Unsafe.Add(ref currentRightSearchSpace, Vector256<T>.Count);
+                    currentLeftSearchSpace = ref Unsafe.Add(ref currentLeftSearchSpace, Vector256<T>.Count);
+                }
+                while (!Unsafe.IsAddressGreaterThan(ref currentRightSearchSpace, ref oneVectorAwayFromRightEnd));
+
+                // If any elements remain, process the last vector in the search space.
+                if (length % (uint)Vector256<T>.Count != 0)
+                {
+                    rightValues = Vector256.LoadUnsafe(ref oneVectorAwayFromRightEnd);
+                    leftValues = Vector256.LoadUnsafe(ref oneVectorAwayFromLeftEnd);
+
+                    if (leftValues != rightValues || !AllCharsInVectorAreAscii(leftValues | rightValues))
                     {
                         return false;
                     }
@@ -325,7 +275,7 @@ namespace System.Text
                 }
 
                 valueA |= 0x20u;
-                if ((uint)(valueA - 'a') > (uint)('z' - 'a'))
+                if (valueA - 'a' > 'z' - 'a')
                 {
                     return false; // not exact match, and first input isn't in [A-Za-z]
                 }
@@ -340,27 +290,29 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Vector128<ushort> Widen(Vector64<byte> bytes)
+        private static Vector256<ushort> LoadAndWiden256(ref byte ptr)
         {
-            if (AdvSimd.IsSupported)
-            {
-                return AdvSimd.ZeroExtendWideningLower(bytes);
-            }
-            else
-            {
-                (Vector64<ushort> lower, Vector64<ushort> upper) = Vector64.Widen(bytes);
-                return Vector128.Create(lower, upper);
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Vector256<ushort> Widen(Vector128<byte> bytes)
-        {
-            (Vector128<ushort> lower, Vector128<ushort> upper) = Vector128.Widen(bytes);
+            (Vector128<ushort> lower, Vector128<ushort> upper) = Vector128.Widen(Vector128.LoadUnsafe(ref ptr));
             return Vector256.Create(lower, upper);
         }
 
-        private static bool VectorContainsNonAsciiChar(Vector64<byte> bytes)
-            => !Utf8Utility.AllBytesInUInt64AreAscii(bytes.AsUInt64().ToScalar());
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector128<ushort> LoadAndWiden128(ref byte ptr)
+        {
+            if (AdvSimd.IsSupported)
+            {
+                return AdvSimd.ZeroExtendWideningLower(Vector64.LoadUnsafe(ref ptr));
+            }
+            else if (Sse2.IsSupported)
+            {
+                Vector128<byte> vec = Vector128.CreateScalarUnsafe(Unsafe.ReadUnaligned<long>(ref ptr)).AsByte();
+                return Sse2.UnpackLow(vec, Vector128<byte>.Zero).AsUInt16();
+            }
+            else
+            {
+                (Vector64<ushort> lower, Vector64<ushort> upper) = Vector64.Widen(Vector64.LoadUnsafe(ref ptr));
+                return Vector128.Create(lower, upper);
+            }
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
@@ -41,7 +41,7 @@ namespace System.Text
         private static bool Equals<TLeft, TRight, TLoader>(ref TLeft left, ref TRight right, nuint length)
             where TLeft : unmanaged, INumberBase<TLeft>
             where TRight : unmanaged, INumberBase<TRight>
-            where TLoader : ILoader<TLeft, TRight>
+            where TLoader : struct, ILoader<TLeft, TRight>
         {
             Debug.Assert(
                 (typeof(TLeft) == typeof(byte) && typeof(TRight) == typeof(byte))
@@ -216,17 +216,9 @@ namespace System.Text
                 Vector128<TRight> leftValues;
                 Vector128<TRight> rightValues;
 
-                Vector128<TRight> loweringMask = typeof(TRight) == typeof(byte)
-                    ? Vector128.Create((byte)0x20).As<byte, TRight>()
-                    : Vector128.Create((ushort)0x20).As<ushort, TRight>();
-
-                Vector128<TRight> vecA = typeof(TRight) == typeof(byte)
-                    ? Vector128.Create((byte)'a').As<byte, TRight>()
-                    : Vector128.Create((ushort)'a').As<ushort, TRight>();
-
-                Vector128<TRight> vecZMinusA = typeof(TRight) == typeof(byte)
-                    ? Vector128.Create((byte)('z' - 'a')).As<byte, TRight>()
-                    : Vector128.Create((ushort)('z' - 'a')).As<ushort, TRight>();
+                Vector128<TRight> loweringMask = Vector128.Create(TRight.CreateTruncating(0x20));
+                Vector128<TRight> vecA = Vector128.Create(TRight.CreateTruncating('a'));
+                Vector128<TRight> vecZMinusA = Vector128.Create(TRight.CreateTruncating(('z' - 'a')));
 
                 // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
                 do
@@ -297,17 +289,9 @@ namespace System.Text
                 Vector256<TRight> leftValues;
                 Vector256<TRight> rightValues;
 
-                Vector256<TRight> loweringMask = typeof(TRight) == typeof(byte)
-                    ? Vector256.Create((byte)0x20).As<byte, TRight>()
-                    : Vector256.Create((ushort)0x20).As<ushort, TRight>();
-
-                Vector256<TRight> vecA = typeof(TRight) == typeof(byte)
-                    ? Vector256.Create((byte)'a').As<byte, TRight>()
-                    : Vector256.Create((ushort)'a').As<ushort, TRight>();
-
-                Vector256<TRight> vecZMinusA = typeof(TRight) == typeof(byte)
-                    ? Vector256.Create((byte)('z' - 'a')).As<byte, TRight>()
-                    : Vector256.Create((ushort)('z' - 'a')).As<ushort, TRight>();
+                Vector256<TRight> loweringMask = Vector256.Create(TRight.CreateTruncating(0x20));
+                Vector256<TRight> vecA = Vector256.Create(TRight.CreateTruncating('a'));
+                Vector256<TRight> vecZMinusA = Vector256.Create(TRight.CreateTruncating(('z' - 'a')));
 
                 // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
                 do
@@ -381,7 +365,7 @@ namespace System.Text
             static abstract Vector256<TRight> Load256(ref TLeft ptr);
         }
 
-        private struct PlainLoader<T> : ILoader<T, T> where T : unmanaged, INumberBase<T>
+        private readonly struct PlainLoader<T> : ILoader<T, T> where T : unmanaged, INumberBase<T>
         {
             public static nuint Count128 => (uint)Vector128<T>.Count;
             public static nuint Count256 => (uint)Vector256<T>.Count;
@@ -389,7 +373,7 @@ namespace System.Text
             public static Vector256<T> Load256(ref T ptr) => Vector256.LoadUnsafe(ref ptr);
         }
 
-        private struct WideningLoader : ILoader<byte, ushort>
+        private readonly struct WideningLoader : ILoader<byte, ushort>
         {
             public static nuint Count128 => sizeof(long);
             public static nuint Count256 => (uint)Vector128<byte>.Count;

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -1471,9 +1471,9 @@ namespace System.Text
             else
             {
                 return
-                    Sse41.IsSupported ? Sse41.TestZ(vector.AsInt16(), Vector128.Create((short)-128)) :
+                    Sse41.IsSupported ? Sse41.TestZ(vector.AsUInt16(), Vector128.Create((ushort)0xFF80)) :
                     AdvSimd.Arm64.IsSupported ? AllCharsInUInt64AreAscii(AdvSimd.Arm64.MaxPairwise(vector.AsUInt16(), vector.AsUInt16()).AsUInt64().ToScalar()) :
-                    (vector.AsUInt16() & Vector128.Create((ushort)(ushort.MaxValue - 127))) == Vector128<ushort>.Zero;
+                    (vector.AsUInt16() & Vector128.Create((ushort)0xFF80)) == Vector128<ushort>.Zero;
             }
         }
 
@@ -1486,7 +1486,7 @@ namespace System.Text
 
             return typeof(T) == typeof(byte)
                 ? Avx.TestZ(vector.AsByte(), Vector256.Create((byte)0x80))
-                : Avx.TestZ(vector.AsInt16(), Vector256.Create((short)-128));
+                : Avx.TestZ(vector.AsUInt16(), Vector256.Create((ushort)0xFF80));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -1481,12 +1481,20 @@ namespace System.Text
         private static bool AllCharsInVectorAreAscii<T>(Vector256<T> vector)
             where T : unmanaged
         {
-            Debug.Assert(Avx.IsSupported);
             Debug.Assert(typeof(T) == typeof(byte) || typeof(T) == typeof(ushort));
 
-            return typeof(T) == typeof(byte)
-                ? Avx.TestZ(vector.AsByte(), Vector256.Create((byte)0x80))
-                : Avx.TestZ(vector.AsUInt16(), Vector256.Create((ushort)0xFF80));
+            if (typeof(T) == typeof(byte))
+            {
+                return
+                    Avx.IsSupported ? Avx.TestZ(vector.AsByte(), Vector256.Create((byte)0x80)) :
+                    vector.AsByte().ExtractMostSignificantBits() == 0;
+            }
+            else
+            {
+                return
+                    Avx.IsSupported ? Avx.TestZ(vector.AsUInt16(), Vector256.Create((ushort)0xFF80)) :
+                    (vector.AsUInt16() & Vector256.Create((ushort)0xFF80)) == Vector256<ushort>.Zero;
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Adresses the open points / comments from https://github.com/dotnet/runtime/pull/84886 (cf. https://github.com/dotnet/runtime/pull/84886#issuecomment-1518242089)

* replaced usage of `Vector64` hw-accelerated intrinsics (instead of sw-fallback), cf. https://github.com/dotnet/runtime/pull/84886#discussion_r1168627003, https://github.com/dotnet/runtime/pull/84886#discussion_r1168629066
* removed bound checks in scalar paths, cf. https://github.com/dotnet/runtime/pull/84886#discussion_r1168566536
* vectorized EqualsIgnoreCase, cf. https://github.com/dotnet/runtime/pull/84886#discussion_r1168586648
* deduplicated the `(byte, char)` and `(byte, byte)` / `(char, char)` variants