### PR TITLE
Exclude the test DevDiv_255294.cmd on Windows arm in issues.targets

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -899,6 +899,13 @@
         </ExcludeList>
     </ItemGroup>
 
+    <!-- Crossgen2 Windows arm32 specific excludes -->
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(TestBuildMode)' == 'crossgen2' or '$(TestBuildMode)' == 'crossgen') and '$(RuntimeFlavor)' == 'coreclr' and '$(TargetsWindows)' == 'true' and ('$(TargetArchitecture)' == 'arm' or '$(AltJitArch)' == 'arm')">
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/DevDiv_255294/DevDiv_255294/*">
+            <Issue>https://github.com/dotnet/runtime/issues/85663</Issue>
+        </ExcludeList>
+    </ItemGroup>
+
     <!-- NativeAOT specific -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TestBuildMode)' == 'nativeaot' and '$(RuntimeFlavor)' == 'coreclr'">
         <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/TypeInitialization/CctorsWithSideEffects/CctorForWrite/*">

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -899,8 +899,8 @@
         </ExcludeList>
     </ItemGroup>
 
-    <!-- Crossgen2 Windows arm32 specific excludes -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(TestBuildMode)' == 'crossgen2' or '$(TestBuildMode)' == 'crossgen') and '$(RuntimeFlavor)' == 'coreclr' and '$(TargetsWindows)' == 'true' and ('$(TargetArchitecture)' == 'arm' or '$(AltJitArch)' == 'arm')">
+    <!-- Crossgen2 arm32/arm64 specific excludes -->
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(TestBuildMode)' == 'crossgen2' or '$(TestBuildMode)' == 'crossgen') and '$(RuntimeFlavor)' == 'coreclr' and ('$(TargetArchitecture)' == 'arm64' or '$(TargetArchitecture)' == 'arm' or '$(AltJitArch)' == 'arm')">
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/DevDiv_255294/DevDiv_255294/*">
             <Issue>https://github.com/dotnet/runtime/issues/85663</Issue>
         </ExcludeList>


### PR DESCRIPTION
This test failure is known and tracked under

https://github.com/dotnet/runtime/issues/85663

I'm adding the issues.targets entry to baseline the failure and make outerloop green again.

Thanks

Tomas