### PR TITLE
Disable foreground-shutdown test on Windows

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -239,6 +239,9 @@
 
     <!-- Windows all architecture excludes -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TargetsWindows)' == 'true' and '$(RuntimeFlavor)' == 'coreclr'">
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/regressions/2164/foreground-shutdown/*">
+            <Issue>https://github.com/dotnet/runtime/issues/84006</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- Windows x64 specific excludes -->


### PR DESCRIPTION
This test has failed across many configurations, but apparently only on Windows. Tracked by https://github.com/dotnet/runtime/issues/84006, https://github.com/dotnet/runtime/issues/83658.