### PR TITLE
Add Base64.IsValid and allow Base64.DecodeXx methods to skip whitespace

### DIFF
--- a/src/libraries/System.Memory/tests/Base64/Base64DecoderUnitTests.cs
+++ b/src/libraries/System.Memory/tests/Base64/Base64DecoderUnitTests.cs
@@ -1,12 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
 using System.Text;
 using Xunit;
 
 namespace System.Buffers.Text.Tests
 {
-    public class Base64DecoderUnitTests
+    public class Base64DecoderUnitTests : Base64TestBase
     {
         [Fact]
         public void BasicDecoding()
@@ -157,7 +158,7 @@ namespace System.Buffers.Text.Tests
 
                 Span<byte> decodedBytes = new byte[3];
                 int consumed, written;
-                if (numBytes % 4 == 0)
+                if (numBytes >= 8)
                 {
                     Assert.True(OperationStatus.DestinationTooSmall ==
                         Base64.DecodeFromUtf8(source, decodedBytes, out consumed, out written), "Number of Input Bytes: " + numBytes);
@@ -373,7 +374,9 @@ namespace System.Buffers.Text.Tests
                 for (int i = 0; i < invalidBytes.Length; i++)
                 {
                     // Don't test padding (byte 61 i.e. '='), which is tested in DecodingInvalidBytesPadding
-                    if (invalidBytes[i] == Base64TestHelper.EncodingPad)
+                    // Don't test chars to be ignored (spaces: 9, 10, 13, 32 i.e. '\n', '\t', '\r', ' ')
+                    if (invalidBytes[i] == Base64TestHelper.EncodingPad
+                        || Base64TestHelper.IsByteToBeIgnored(invalidBytes[i]))
                         continue;
 
                     // replace one byte with an invalid input
@@ -568,7 +571,9 @@ namespace System.Buffers.Text.Tests
                     Span<byte> buffer = "2222PPPP"u8.ToArray(); // valid input
 
                     // Don't test padding (byte 61 i.e. '='), which is tested in DecodeInPlaceInvalidBytesPadding
-                    if (invalidBytes[i] == Base64TestHelper.EncodingPad)
+                    // Don't test chars to be ignored (spaces: 9, 10, 13, 32 i.e. '\n', '\t', '\r', ' ')
+                    if (invalidBytes[i] == Base64TestHelper.EncodingPad
+                        || Base64TestHelper.IsByteToBeIgnored(invalidBytes[i]))
                         continue;
 
                     // replace one byte with an invalid input
@@ -594,7 +599,7 @@ namespace System.Buffers.Text.Tests
             {
                 Span<byte> buffer = "2222PPP"u8.ToArray(); // incomplete input
                 Assert.Equal(OperationStatus.InvalidData, Base64.DecodeFromUtf8InPlace(buffer, out int bytesWritten));
-                Assert.Equal(0, bytesWritten);
+                Assert.Equal(3, bytesWritten);
             }
         }
 
@@ -667,5 +672,96 @@ namespace System.Buffers.Text.Tests
             }
         }
 
+        [Theory]
+        [MemberData(nameof(ValidBase64Strings_WithCharsThatMustBeIgnored))]
+        public void BasicDecodingIgnoresCharsToBeIgnoredAsConvertToBase64Does(string utf8WithCharsToBeIgnored, byte[] expectedBytes)
+        {
+            byte[] utf8BytesWithByteToBeIgnored = UTF8Encoding.UTF8.GetBytes(utf8WithCharsToBeIgnored);
+            byte[] resultBytes = new byte[5];
+            OperationStatus result = Base64.DecodeFromUtf8(utf8BytesWithByteToBeIgnored, resultBytes, out int bytesConsumed, out int bytesWritten);
+
+            // Control value from Convert.FromBase64String
+            byte[] stringBytes = Convert.FromBase64String(utf8WithCharsToBeIgnored);
+
+            Assert.Equal(OperationStatus.Done, result);
+            Assert.Equal(utf8WithCharsToBeIgnored.Length, bytesConsumed);
+            Assert.Equal(expectedBytes.Length, bytesWritten);
+            Assert.True(expectedBytes.SequenceEqual(resultBytes));
+            Assert.True(stringBytes.SequenceEqual(resultBytes));
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidBase64Strings_WithCharsThatMustBeIgnored))]
+        public void DecodeInPlaceIgnoresCharsToBeIgnoredAsConvertToBase64Does(string utf8WithCharsToBeIgnored, byte[] expectedBytes)
+        {
+            Span<byte> utf8BytesWithByteToBeIgnored = UTF8Encoding.UTF8.GetBytes(utf8WithCharsToBeIgnored);
+            OperationStatus result = Base64.DecodeFromUtf8InPlace(utf8BytesWithByteToBeIgnored, out int bytesWritten);
+            Span<byte> bytesOverwritten = utf8BytesWithByteToBeIgnored.Slice(0, bytesWritten);
+            byte[] resultBytesArray = bytesOverwritten.ToArray();
+
+            // Control value from Convert.FromBase64String
+            byte[] stringBytes = Convert.FromBase64String(utf8WithCharsToBeIgnored);
+
+            Assert.Equal(OperationStatus.Done, result);
+            Assert.Equal(expectedBytes.Length, bytesWritten);
+            Assert.True(expectedBytes.SequenceEqual(resultBytesArray));
+            Assert.True(stringBytes.SequenceEqual(resultBytesArray));
+        }
+
+        [Theory]
+        [MemberData(nameof(StringsOnlyWithCharsToBeIgnored))]
+        public void BasicDecodingWithOnlyCharsToBeIgnored(string utf8WithCharsToBeIgnored)
+        {
+            byte[] utf8BytesWithByteToBeIgnored = UTF8Encoding.UTF8.GetBytes(utf8WithCharsToBeIgnored);
+            byte[] resultBytes = new byte[5];
+            OperationStatus result = Base64.DecodeFromUtf8(utf8BytesWithByteToBeIgnored, resultBytes, out int bytesConsumed, out int bytesWritten);
+
+            Assert.Equal(OperationStatus.Done, result);
+            Assert.Equal(0, bytesWritten);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringsOnlyWithCharsToBeIgnored))]
+        public void DecodingInPlaceWithOnlyCharsToBeIgnored(string utf8WithCharsToBeIgnored)
+        {
+            Span<byte> utf8BytesWithByteToBeIgnored = UTF8Encoding.UTF8.GetBytes(utf8WithCharsToBeIgnored);
+            OperationStatus result = Base64.DecodeFromUtf8InPlace(utf8BytesWithByteToBeIgnored, out int bytesWritten);
+
+            Assert.Equal(OperationStatus.Done, result);
+            Assert.Equal(0, bytesWritten);
+        }
+
+        [Theory]
+        [InlineData("AQ==", 4, 1)]
+        [InlineData("AQ== ", 5, 1)]
+        [InlineData("AQ==  ", 6, 1)]
+        [InlineData("AQ==   ", 7, 1)]
+        [InlineData("AQ==    ", 8, 1)]
+        [InlineData("AQ==     ", 9, 1)]
+        [InlineData("AQ==\n", 5, 1)]
+        [InlineData("AQ==\n\n", 6, 1)]
+        [InlineData("AQ==\n\n\n", 7, 1)]
+        [InlineData("AQ==\n\n\n\n", 8, 1)]
+        [InlineData("AQ==\n\n\n\n\n", 9, 1)]
+        [InlineData("AQ==\t", 5, 1)]
+        [InlineData("AQ==\t\t", 6, 1)]
+        [InlineData("AQ==\t\t\t", 7, 1)]
+        [InlineData("AQ==\t\t\t\t", 8, 1)]
+        [InlineData("AQ==\t\t\t\t\t", 9, 1)]
+        [InlineData("AQ==\r", 5, 1)]
+        [InlineData("AQ==\r\r", 6, 1)]
+        [InlineData("AQ==\r\r\r", 7, 1)]
+        [InlineData("AQ==\r\r\r\r", 8, 1)]
+        [InlineData("AQ==\r\r\r\r\r", 9, 1)]
+        public void BasicDecodingWithExtraWhitespaceShouldBeCountedInConsumedBytes(string inputString, int expectedConsumed, int expectedWritten)
+        {
+            Span<byte> source = Encoding.ASCII.GetBytes(inputString);
+            Span<byte> decodedBytes = new byte[Base64.GetMaxDecodedFromUtf8Length(source.Length)];
+
+            Assert.Equal(OperationStatus.Done, Base64.DecodeFromUtf8(source, decodedBytes, out int consumed, out int decodedByteCount));
+            Assert.Equal(expectedConsumed, consumed);
+            Assert.Equal(expectedWritten, decodedByteCount);
+            Assert.True(Base64TestHelper.VerifyDecodingCorrectness(expectedConsumed, expectedWritten, source, decodedBytes));
+        }
     }
 }

--- a/src/libraries/System.Memory/tests/Base64/Base64DecoderUnitTests.cs
+++ b/src/libraries/System.Memory/tests/Base64/Base64DecoderUnitTests.cs
@@ -375,9 +375,11 @@ namespace System.Buffers.Text.Tests
                 {
                     // Don't test padding (byte 61 i.e. '='), which is tested in DecodingInvalidBytesPadding
                     // Don't test chars to be ignored (spaces: 9, 10, 13, 32 i.e. '\n', '\t', '\r', ' ')
-                    if (invalidBytes[i] == Base64TestHelper.EncodingPad
-                        || Base64TestHelper.IsByteToBeIgnored(invalidBytes[i]))
+                    if (invalidBytes[i] == Base64TestHelper.EncodingPad ||
+                        Base64TestHelper.IsByteToBeIgnored(invalidBytes[i]))
+                    {
                         continue;
+                    }
 
                     // replace one byte with an invalid input
                     source[j] = invalidBytes[i];
@@ -572,9 +574,11 @@ namespace System.Buffers.Text.Tests
 
                     // Don't test padding (byte 61 i.e. '='), which is tested in DecodeInPlaceInvalidBytesPadding
                     // Don't test chars to be ignored (spaces: 9, 10, 13, 32 i.e. '\n', '\t', '\r', ' ')
-                    if (invalidBytes[i] == Base64TestHelper.EncodingPad
-                        || Base64TestHelper.IsByteToBeIgnored(invalidBytes[i]))
+                    if (invalidBytes[i] == Base64TestHelper.EncodingPad ||
+                        Base64TestHelper.IsByteToBeIgnored(invalidBytes[i]))
+                    {
                         continue;
+                    }
 
                     // replace one byte with an invalid input
                     buffer[j] = invalidBytes[i];

--- a/src/libraries/System.Memory/tests/Base64/Base64TestBase.cs
+++ b/src/libraries/System.Memory/tests/Base64/Base64TestBase.cs
@@ -1,0 +1,111 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.utf8Bytes, utf8Bytes.Length
+
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Buffers.Text.Tests
+{
+    public class Base64TestBase
+    {
+        public static IEnumerable<object[]> ValidBase64Strings_WithCharsThatMustBeIgnored()
+        {
+            // Create a Base64 string
+            string text = "a b c";
+            byte[] utf8Bytes = Encoding.UTF8.GetBytes(text);
+            string base64Utf8String = Convert.ToBase64String(utf8Bytes);
+
+            // Split the base64 string in half
+            int stringLength = base64Utf8String.Length / 2;
+            string firstSegment = base64Utf8String.Substring(0, stringLength);
+            string secondSegment = base64Utf8String.Substring(stringLength, stringLength);
+
+            // Insert ignored chars between the base 64 string
+            // One will have 1 char, another will have 3
+
+            // Line feed
+            yield return new object[] { GetBase64StringWithPassedCharInsertedInTheMiddle(Convert.ToChar(9), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedInTheMiddle(Convert.ToChar(9), 3), utf8Bytes };
+
+            // Horizontal tab
+            yield return new object[] { GetBase64StringWithPassedCharInsertedInTheMiddle(Convert.ToChar(10), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedInTheMiddle(Convert.ToChar(10), 3), utf8Bytes };
+
+            // Carriage return
+            yield return new object[] { GetBase64StringWithPassedCharInsertedInTheMiddle(Convert.ToChar(13), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedInTheMiddle(Convert.ToChar(13), 3), utf8Bytes };
+
+            // Space
+            yield return new object[] { GetBase64StringWithPassedCharInsertedInTheMiddle(Convert.ToChar(32), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedInTheMiddle(Convert.ToChar(32), 3), utf8Bytes };
+
+            string GetBase64StringWithPassedCharInsertedInTheMiddle(char charToInsert, int numberOfTimesToInsert) => $"{firstSegment}{new string(charToInsert, numberOfTimesToInsert)}{secondSegment}";
+
+            // Insert ignored chars at the start of the base 64 string
+            // One will have 1 char, another will have 3
+
+            // Line feed
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheStart(Convert.ToChar(9), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheStart(Convert.ToChar(9), 3), utf8Bytes };
+
+            // Horizontal tab
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheStart(Convert.ToChar(10), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheStart(Convert.ToChar(10), 3), utf8Bytes };
+
+            // Carriage return
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheStart(Convert.ToChar(13), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheStart(Convert.ToChar(13), 3), utf8Bytes };
+
+            // Space
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheStart(Convert.ToChar(32), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheStart(Convert.ToChar(32), 3), utf8Bytes };
+
+            string GetBase64StringWithPassedCharInsertedAtTheStart(char charToInsert, int numberOfTimesToInsert) => $"{new string(charToInsert, numberOfTimesToInsert)}{firstSegment}{secondSegment}";
+
+            // Insert ignored chars at the end of the base 64 string
+            // One will have 1 char, another will have 3
+            // Whitespace after end/padding is not included in consumed bytes
+
+            // Line feed
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheEnd(Convert.ToChar(9), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheEnd(Convert.ToChar(9), 3), utf8Bytes };
+
+            // Horizontal tab
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheEnd(Convert.ToChar(10), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheEnd(Convert.ToChar(10), 3), utf8Bytes };
+
+            // Carriage return
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheEnd(Convert.ToChar(13), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheEnd(Convert.ToChar(13), 3), utf8Bytes };
+
+            // Space
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheEnd(Convert.ToChar(32), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheEnd(Convert.ToChar(32), 3), utf8Bytes };
+
+            string GetBase64StringWithPassedCharInsertedAtTheEnd(char charToInsert, int numberOfTimesToInsert) => $"{firstSegment}{secondSegment}{new string(charToInsert, numberOfTimesToInsert)}";
+        }
+
+        public static IEnumerable<object[]> StringsOnlyWithCharsToBeIgnored()
+        {
+            // One will have 1 char, another will have 3
+
+            // Line feed
+            yield return new object[] { GetRepeatedChar(Convert.ToChar(9), 1) };
+            yield return new object[] { GetRepeatedChar(Convert.ToChar(9), 3) };
+
+            // Horizontal tab
+            yield return new object[] { GetRepeatedChar(Convert.ToChar(10), 1) };
+            yield return new object[] { GetRepeatedChar(Convert.ToChar(10), 3) };
+
+            // Carriage return
+            yield return new object[] { GetRepeatedChar(Convert.ToChar(13), 1) };
+            yield return new object[] { GetRepeatedChar(Convert.ToChar(13), 3) };
+
+            // Space
+            yield return new object[] { GetRepeatedChar(Convert.ToChar(32), 1) };
+            yield return new object[] { GetRepeatedChar(Convert.ToChar(32), 3) };
+
+            string GetRepeatedChar(char charToInsert, int numberOfTimesToInsert) => new string(charToInsert, numberOfTimesToInsert);
+        }
+    }
+}

--- a/src/libraries/System.Memory/tests/Base64/Base64TestHelper.cs
+++ b/src/libraries/System.Memory/tests/Base64/Base64TestHelper.cs
@@ -44,6 +44,20 @@ namespace System.Buffers.Text.Tests
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         };
 
+        public static bool IsByteToBeIgnored(byte charByte)
+        {
+            switch (charByte)
+            {
+                case 9: // Line feed
+                case 10: // Horizontal tab
+                case 13: // Carriage return
+                case 32: // Space
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
         public const byte EncodingPad = (byte)'=';      // '=', for padding
         public const sbyte InvalidByte = -1;            // Designating -1 for invalid bytes in the decoding map
 

--- a/src/libraries/System.Memory/tests/Base64/Base64TestHelper.cs
+++ b/src/libraries/System.Memory/tests/Base64/Base64TestHelper.cs
@@ -44,19 +44,7 @@ namespace System.Buffers.Text.Tests
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         };
 
-        public static bool IsByteToBeIgnored(byte charByte)
-        {
-            switch (charByte)
-            {
-                case 9: // Line feed
-                case 10: // Horizontal tab
-                case 13: // Carriage return
-                case 32: // Space
-                    return true;
-                default:
-                    return false;
-            }
-        }
+        public static bool IsByteToBeIgnored(byte charByte) => charByte is (byte)' ' or (byte)'\t' or (byte)'\r' or (byte)'\n';
 
         public const byte EncodingPad = (byte)'=';      // '=', for padding
         public const sbyte InvalidByte = -1;            // Designating -1 for invalid bytes in the decoding map

--- a/src/libraries/System.Memory/tests/Base64/Base64ValidationUnitTests.cs
+++ b/src/libraries/System.Memory/tests/Base64/Base64ValidationUnitTests.cs
@@ -1,0 +1,339 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace System.Buffers.Text.Tests
+{
+    public class Base64ValidationUnitTests : Base64TestBase
+    {
+        [Fact]
+        public void BasicValidationBytes()
+        {
+            var rnd = new Random(42);
+            for (int i = 0; i < 10; i++)
+            {
+                int numBytes;
+                do
+                {
+                    numBytes = rnd.Next(100, 1000 * 1000);
+                } while (numBytes % 4 != 0);    // ensure we have a valid length
+
+                Span<byte> source = new byte[numBytes];
+                Base64TestHelper.InitializeDecodableBytes(source, numBytes);
+
+                Assert.True(Base64.IsValid(source));
+                Assert.True(Base64.IsValid(source, out int decodedLength));
+                Assert.True(decodedLength > 0);
+            }
+        }
+
+        [Fact]
+        public void BasicValidationChars()
+        {
+            var rnd = new Random(42);
+            for (int i = 0; i < 10; i++)
+            {
+                int numBytes;
+                do
+                {
+                    numBytes = rnd.Next(100, 1000 * 1000);
+                } while (numBytes % 4 != 0);    // ensure we have a valid length
+
+                Span<byte> source = new byte[numBytes];
+                Base64TestHelper.InitializeDecodableBytes(source, numBytes);
+                Span<char> chars = source
+                    .ToArray()
+                    .Select(Convert.ToChar)
+                    .ToArray()
+                    .AsSpan();
+
+                Assert.True(Base64.IsValid(chars));
+                Assert.True(Base64.IsValid(chars, out int decodedLength));
+                Assert.True(decodedLength > 0);
+            }
+        }
+
+        [Fact]
+        public void BasicValidationInvalidInputLengthBytes()
+        {
+            var rnd = new Random(42);
+            for (int i = 0; i < 10; i++)
+            {
+                int numBytes;
+                do
+                {
+                    numBytes = rnd.Next(100, 1000 * 1000);
+                } while (numBytes % 4 == 0);    // ensure we have a invalid length
+
+                Span<byte> source = new byte[numBytes];
+
+                Assert.False(Base64.IsValid(source));
+                Assert.False(Base64.IsValid(source, out int decodedLength));
+                Assert.Equal(0, decodedLength);
+            }
+        }
+
+        [Fact]
+        public void BasicValidationInvalidInputLengthChars()
+        {
+            var rnd = new Random(42);
+            for (int i = 0; i < 10; i++)
+            {
+                int numBytes;
+                do
+                {
+                    numBytes = rnd.Next(100, 1000 * 1000);
+                } while (numBytes % 4 == 0);    // ensure we have a invalid length
+
+                Span<char> source = new char[numBytes];
+
+                Assert.False(Base64.IsValid(source));
+                Assert.False(Base64.IsValid(source, out int decodedLength));
+                Assert.Equal(0, decodedLength);
+            }
+        }
+
+        [Fact]
+        public void ValidateEmptySpanBytes()
+        {
+            Span<byte> source = Span<byte>.Empty;
+
+            Assert.True(Base64.IsValid(source));
+            Assert.True(Base64.IsValid(source, out int decodedLength));
+            Assert.Equal(0, decodedLength);
+        }
+
+        [Fact]
+        public void ValidateEmptySpanChars()
+        {
+            Span<char> source = Span<char>.Empty;
+
+            Assert.True(Base64.IsValid(source));
+            Assert.True(Base64.IsValid(source, out int decodedLength));
+            Assert.Equal(0, decodedLength);
+        }
+
+        [Fact]
+        public void ValidateGuidBytes()
+        {
+            Span<byte> source = new byte[24];
+            Span<byte> decodedBytes = Guid.NewGuid().ToByteArray();
+            Base64.EncodeToUtf8(decodedBytes, source, out int _, out int _);
+
+            Assert.True(Base64.IsValid(source));
+            Assert.True(Base64.IsValid(source, out int decodedLength));
+            Assert.True(decodedLength > 0);
+        }
+
+        [Fact]
+        public void ValidateGuidChars()
+        {
+            Span<byte> source = new byte[24];
+            Span<byte> decodedBytes = Guid.NewGuid().ToByteArray();
+            Base64.EncodeToUtf8(decodedBytes, source, out int _, out int _);
+            Span<char> chars = source
+                .ToArray()
+                .Select(Convert.ToChar)
+                .ToArray()
+                .AsSpan();
+
+            Assert.True(Base64.IsValid(chars));
+            Assert.True(Base64.IsValid(chars, out int decodedLength));
+            Assert.True(decodedLength > 0);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidBase64Strings_WithCharsThatMustBeIgnored))]
+        public void ValidateBytesIgnoresCharsToBeIgnoredBytes(string utf8WithByteToBeIgnored, byte[] expectedBytes)
+        {
+            byte[] utf8BytesWithByteToBeIgnored = UTF8Encoding.UTF8.GetBytes(utf8WithByteToBeIgnored);
+
+            Assert.True(Base64.IsValid(utf8BytesWithByteToBeIgnored));
+            Assert.True(Base64.IsValid(utf8BytesWithByteToBeIgnored, out int decodedLength));
+            Assert.Equal(expectedBytes.Length, decodedLength);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidBase64Strings_WithCharsThatMustBeIgnored))]
+        public void ValidateBytesIgnoresCharsToBeIgnoredChars(string utf8WithByteToBeIgnored, byte[] expectedBytes)
+        {
+            ReadOnlySpan<char> utf8BytesWithByteToBeIgnored = utf8WithByteToBeIgnored.ToArray();
+
+            Assert.True(Base64.IsValid(utf8BytesWithByteToBeIgnored));
+            Assert.True(Base64.IsValid(utf8BytesWithByteToBeIgnored, out int decodedLength));
+            Assert.Equal(expectedBytes.Length, decodedLength);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringsOnlyWithCharsToBeIgnored))]
+        public void ValidateWithOnlyCharsToBeIgnoredBytes(string utf8WithByteToBeIgnored)
+        {
+            byte[] utf8BytesWithByteToBeIgnored = UTF8Encoding.UTF8.GetBytes(utf8WithByteToBeIgnored);
+
+            Assert.True(Base64.IsValid(utf8BytesWithByteToBeIgnored));
+            Assert.True(Base64.IsValid(utf8BytesWithByteToBeIgnored, out int decodedLength));
+            Assert.Equal(0, decodedLength);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringsOnlyWithCharsToBeIgnored))]
+        public void ValidateWithOnlyCharsToBeIgnoredChars(string utf8WithByteToBeIgnored)
+        {
+            ReadOnlySpan<char> utf8BytesWithByteToBeIgnored = utf8WithByteToBeIgnored.ToArray();
+
+            Assert.True(Base64.IsValid(utf8BytesWithByteToBeIgnored));
+            Assert.True(Base64.IsValid(utf8BytesWithByteToBeIgnored, out int decodedLength));
+            Assert.Equal(0, decodedLength);
+        }
+
+        [Theory]
+        [InlineData("YQ==", 1)]
+        [InlineData("YWI=", 2)]
+        [InlineData("YWJj", 3)]
+        [InlineData(" YWI=", 2)]
+        [InlineData("Y WI=", 2)]
+        [InlineData("YW I=", 2)]
+        [InlineData("YWI =", 2)]
+        [InlineData("YWI= ", 2)]
+        [InlineData(" YQ==", 1)]
+        [InlineData("Y Q==", 1)]
+        [InlineData("YQ ==", 1)]
+        [InlineData("YQ= =", 1)]
+        [InlineData("YQ== ", 1)]
+        public void ValidateWithPaddingReturnsCorrectCountBytes(string utf8WithByteToBeIgnored, int expectedLength)
+        {
+            byte[] utf8BytesWithByteToBeIgnored = UTF8Encoding.UTF8.GetBytes(utf8WithByteToBeIgnored);
+
+            Assert.True(Base64.IsValid(utf8BytesWithByteToBeIgnored));
+            Assert.True(Base64.IsValid(utf8BytesWithByteToBeIgnored, out int decodedLength));
+            Assert.Equal(expectedLength, decodedLength);
+        }
+
+        [Theory]
+        [InlineData("YQ==", 1)]
+        [InlineData("YWI=", 2)]
+        [InlineData("YWJj", 3)]
+        [InlineData(" YWI=", 2)]
+        [InlineData("Y WI=", 2)]
+        [InlineData("YW I=", 2)]
+        [InlineData("YWI =", 2)]
+        [InlineData("YWI= ", 2)]
+        [InlineData(" YQ==", 1)]
+        [InlineData("Y Q==", 1)]
+        [InlineData("YQ ==", 1)]
+        [InlineData("YQ= =", 1)]
+        [InlineData("YQ== ", 1)]
+        public void ValidateWithPaddingReturnsCorrectCountChars(string utf8WithByteToBeIgnored, int expectedLength)
+        {
+            ReadOnlySpan<char> utf8BytesWithByteToBeIgnored = utf8WithByteToBeIgnored.ToArray();
+
+            Assert.True(Base64.IsValid(utf8BytesWithByteToBeIgnored));
+            Assert.True(Base64.IsValid(utf8BytesWithByteToBeIgnored, out int decodedLength));
+            Assert.Equal(expectedLength, decodedLength);
+        }
+
+        [Theory]
+        [InlineData("YQ==", 1)]
+        [InlineData("YWI=", 2)]
+        [InlineData("YWJj", 3)]
+        public void DecodeEmptySpan(string utf8WithByteToBeIgnored, int expectedLength)
+        {
+            ReadOnlySpan<char> utf8BytesWithByteToBeIgnored = utf8WithByteToBeIgnored.ToArray();
+
+            Assert.True(Base64.IsValid(utf8BytesWithByteToBeIgnored));
+            Assert.True(Base64.IsValid(utf8BytesWithByteToBeIgnored, out int decodedLength));
+            Assert.Equal(expectedLength, decodedLength);
+        }
+
+        [Theory]
+        [InlineData("YWJ")]
+        [InlineData("YW")]
+        [InlineData("Y")]
+        public void InvalidSizeBytes(string utf8WithByteToBeIgnored)
+        {
+            byte[] utf8BytesWithByteToBeIgnored = UTF8Encoding.UTF8.GetBytes(utf8WithByteToBeIgnored);
+
+            Assert.False(Base64.IsValid(utf8BytesWithByteToBeIgnored));
+            Assert.False(Base64.IsValid(utf8BytesWithByteToBeIgnored, out int decodedLength));
+            Assert.Equal(0, decodedLength);
+        }
+
+        [Theory]
+        [InlineData("YWJ")]
+        [InlineData("YW")]
+        [InlineData("Y")]
+        public void InvalidSizeChars(string utf8WithByteToBeIgnored)
+        {
+            byte[] utf8BytesWithByteToBeIgnored = UTF8Encoding.UTF8.GetBytes(utf8WithByteToBeIgnored);
+
+            Assert.False(Base64.IsValid(utf8BytesWithByteToBeIgnored));
+            Assert.False(Base64.IsValid(utf8BytesWithByteToBeIgnored, out int decodedLength));
+            Assert.Equal(0, decodedLength);
+        }
+
+        [Theory]
+        [InlineData("YQ===")]
+        [InlineData("YQ=a=")]
+        [InlineData("YWI=a")]
+        [InlineData(" aYWI=a")]
+        [InlineData("a YWI=a")]
+        [InlineData("aY WI=a")]
+        [InlineData("aYW I=a")]
+        [InlineData("aYWI =a")]
+        [InlineData("aYWI= a")]
+        [InlineData("a YQ==a")]
+        [InlineData("aY Q==a")]
+        [InlineData("aYQ ==a")]
+        [InlineData("aYQ= =a")]
+        [InlineData("aYQ== a")]
+        [InlineData("aYQ==a ")]
+        public void InvalidBase64Bytes(string utf8WithByteToBeIgnored)
+        {
+            byte[] utf8BytesWithByteToBeIgnored = UTF8Encoding.UTF8.GetBytes(utf8WithByteToBeIgnored);
+
+            Assert.False(Base64.IsValid(utf8BytesWithByteToBeIgnored));
+            Assert.False(Base64.IsValid(utf8BytesWithByteToBeIgnored, out int decodedLength));
+            Assert.Equal(0, decodedLength);
+        }
+
+        [Theory]
+        [InlineData("YQ===")]
+        [InlineData("YQ=a=")]
+        [InlineData("YWI=a")]
+        [InlineData("a YWI=a")]
+        [InlineData("aY WI=a")]
+        [InlineData("aYW I=a")]
+        [InlineData("aYWI =a")]
+        [InlineData("aYWI= a")]
+        [InlineData("a YQ==a")]
+        [InlineData("aY Q==a")]
+        [InlineData("aYQ ==a")]
+        [InlineData("aYQ= =a")]
+        [InlineData("aYQ== a")]
+        [InlineData("aYQ==a ")]
+        [InlineData("a")]
+        [InlineData(" a")]
+        [InlineData("  a")]
+        [InlineData("   a")]
+        [InlineData("    a")]
+        [InlineData("a ")]
+        [InlineData("a  ")]
+        [InlineData("a   ")]
+        [InlineData("a    ")]
+        [InlineData(" a ")]
+        [InlineData("  a  ")]
+        [InlineData("   a   ")]
+        [InlineData("    a    ")]
+        public void InvalidBase64Chars(string utf8WithByteToBeIgnored)
+        {
+            byte[] utf8BytesWithByteToBeIgnored = UTF8Encoding.UTF8.GetBytes(utf8WithByteToBeIgnored);
+
+            Assert.False(Base64.IsValid(utf8BytesWithByteToBeIgnored));
+            Assert.False(Base64.IsValid(utf8BytesWithByteToBeIgnored, out int decodedLength));
+            Assert.Equal(0, decodedLength);
+        }
+    }
+}

--- a/src/libraries/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/libraries/System.Memory/tests/System.Memory.Tests.csproj
@@ -272,6 +272,8 @@
     <Compile Include="Base64\Base64DecoderUnitTests.cs" />
     <Compile Include="Base64\Base64EncoderUnitTests.cs" />
     <Compile Include="Base64\Base64TestHelper.cs" />
+    <Compile Include="Base64\Base64TestBase.cs" />
+    <Compile Include="Base64\Base64ValidationUnitTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\Buffers\NativeMemoryManager.cs"

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -123,6 +123,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Base64.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Base64Encoder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Base64Decoder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Base64Validator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\FormattingHelpers.CountDigits.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Utf8Constants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Utf8Formatter\FormattingHelpers.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
@@ -585,10 +585,10 @@ namespace System.Buffers.Text
             }
         }
 
-        private const uint EncodingPad = '='; // '=', for padding
+        internal const uint EncodingPad = '='; // '=', for padding
 
         private const int MaximumEncodeLength = (int.MaxValue / 4) * 3; // 1610612733
 
-        private static ReadOnlySpan<byte> EncodingMap => "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"u8;
+        internal static ReadOnlySpan<byte> EncodingMap => "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"u8;
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Validator.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Validator.cs
@@ -1,0 +1,154 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Buffers.Text
+{
+    public static partial class Base64
+    {
+        /// <summary>
+        /// Validates the span of UTF-8 encoded text represented as base64 into binary data.
+        /// </summary>
+        /// <param name="base64Text">The input span which contains UTF-8 encoded text in base64 that needs to be validated.</param>
+        /// <returns>true if <paramref name="base64Text"/> is decodable; otherwise, false.</returns>
+        public static bool IsValid(ReadOnlySpan<char> base64Text) =>
+            IsValid<char, Base64CharValidatable>(base64Text, out _);
+
+        /// <summary>
+        /// Validates the span of UTF-8 encoded text represented as base64 into binary data.
+        /// </summary>
+        /// <param name="base64Text">The input span which contains UTF-8 encoded text in base64 that needs to be validated.</param>
+        /// <param name="decodedLength">The maximum length (in bytes) if you were to decode the base 64 encoded text <paramref name="base64Text"/> within a byte span.</param>
+        /// <returns>true if <paramref name="base64Text"/> is decodable; otherwise, false.</returns>
+        public static bool IsValid(ReadOnlySpan<char> base64Text, out int decodedLength) =>
+            IsValid<char, Base64CharValidatable>(base64Text, out decodedLength);
+
+        /// <summary>
+        /// Validates the span of UTF-8 encoded text represented as base64 into binary data.
+        /// </summary>
+        /// <param name="base64TextUtf8">The input span which contains UTF-8 encoded text in base64 that needs to be validated.</param>
+        /// <returns>true if <paramref name="base64TextUtf8"/> is decodable; otherwise, false.</returns>
+        public static bool IsValid(ReadOnlySpan<byte> base64TextUtf8) =>
+            IsValid<byte, Base64ByteValidatable>(base64TextUtf8, out _);
+
+        /// <summary>
+        /// Validates the span of UTF-8 encoded text represented as base64 into binary data.
+        /// </summary>
+        /// <param name="base64TextUtf8">The input span which contains UTF-8 encoded text in base64 that needs to be validated.</param>
+        /// <param name="decodedLength">The maximum length (in bytes) if you were to decode the base 64 encoded text <paramref name="base64TextUtf8"/> within a byte span.</param>
+        /// <returns>true if <paramref name="base64TextUtf8"/> is decodable; otherwise, false.</returns>
+        public static bool IsValid(ReadOnlySpan<byte> base64TextUtf8, out int decodedLength) =>
+            IsValid<byte, Base64ByteValidatable>(base64TextUtf8, out decodedLength);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsValid<T, TBase64Validatable>(ReadOnlySpan<T> base64Text, out int decodedLength)
+            where TBase64Validatable : IBase64Validatable<T>
+        {
+            if (base64Text.IsEmpty)
+            {
+                decodedLength = 0;
+                return true;
+            }
+
+            int length = 0;
+            bool isPaddingFound = false;
+
+            while (true)
+            {
+                int index = TBase64Validatable.IndexOfAnyExcept(base64Text);
+                if ((uint)index >= (uint)base64Text.Length)
+                {
+                    length += base64Text.Length;
+                    break;
+                }
+
+                length += index;
+
+                T charToValidate = base64Text[index];
+                base64Text = base64Text.Slice(index + 1);
+
+                if (TBase64Validatable.IsWhitespace(charToValidate))
+                {
+                    continue;
+                }
+
+                if (!TBase64Validatable.IsEncodingPad(charToValidate))
+                {
+                    // Invalid char was found.
+                    decodedLength = 0;
+                    return false;
+                }
+
+                // Encoding pad found, determine if padding is valid below.
+                isPaddingFound = true;
+                break;
+            }
+
+            int paddingCount = 0;
+
+            if (isPaddingFound)
+            {
+                paddingCount = 1;
+
+                foreach (T charToValidateInPadding in base64Text)
+                {
+                    if (TBase64Validatable.IsEncodingPad(charToValidateInPadding))
+                    {
+                        // There can be at most 2 padding chars.
+                        if (paddingCount >= 2)
+                        {
+                            decodedLength = 0;
+                            return false;
+                        }
+
+                        paddingCount++;
+                    }
+                    else if (!TBase64Validatable.IsWhitespace(charToValidateInPadding))
+                    {
+                        // Invalid char was found.
+                        decodedLength = 0;
+                        return false;
+                    }
+                }
+
+                length += paddingCount;
+            }
+
+            if (length % 4 != 0)
+            {
+                decodedLength = 0;
+                return false;
+            }
+
+            // Remove padding to get exact length.
+            decodedLength = (int)((uint)length / 4 * 3) - paddingCount;
+            return true;
+        }
+
+        internal interface IBase64Validatable<T>
+        {
+            static abstract int IndexOfAnyExcept(ReadOnlySpan<T> span);
+            static abstract bool IsWhitespace(T value);
+            static abstract bool IsEncodingPad(T value);
+        }
+
+        internal readonly struct Base64CharValidatable : IBase64Validatable<char>
+        {
+            private static readonly SearchValues<char> s_validBase64Chars = SearchValues.Create("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/");
+
+            public static int IndexOfAnyExcept(ReadOnlySpan<char> span) => span.IndexOfAnyExcept(s_validBase64Chars);
+            public static bool IsWhitespace(char value) => Base64.IsWhitespace(value);
+            public static bool IsEncodingPad(char value) => value == Base64.EncodingPad;
+        }
+
+        internal readonly struct Base64ByteValidatable : IBase64Validatable<byte>
+        {
+            private static readonly SearchValues<byte> s_validBase64Chars = SearchValues.Create(Base64.EncodingMap);
+
+            public static int IndexOfAnyExcept(ReadOnlySpan<byte> span) => span.IndexOfAnyExcept(s_validBase64Chars);
+            public static bool IsWhitespace(byte value) => Base64.IsWhitespace(value);
+            public static bool IsEncodingPad(byte value) => value == Base64.EncodingPad;
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Validator.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Validator.cs
@@ -5,37 +5,51 @@ namespace System.Buffers.Text
 {
     public static partial class Base64
     {
-        /// <summary>
-        /// Validates the span of UTF-8 encoded text represented as base64 into binary data.
-        /// </summary>
-        /// <param name="base64Text">The input span which contains UTF-8 encoded text in base64 that needs to be validated.</param>
-        /// <returns>true if <paramref name="base64Text"/> is decodable; otherwise, false.</returns>
+        /// <summary>Validates that the specified span of text is comprised of valid base-64 encoded data.</summary>
+        /// <param name="base64Text">A span of text to validate.</param>
+        /// <returns><see langword="true"/> if <paramref name="base64Text"/> contains a valid, decodable sequence of base-64 encoded data; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// If the method returns <see langword="true"/>, the same text passed to <see cref="Convert.FromBase64String(string)"/> and
+        /// <see cref="Convert.TryFromBase64Chars"/> would successfully decode (in the case
+        /// of <see cref="Convert.TryFromBase64Chars"/> assuming sufficient output space). Any amount of whitespace is allowed anywhere in the input,
+        /// where whitespace is defined as the characters ' ', '\t', '\r', or '\n'.
+        /// </remarks>
         public static bool IsValid(ReadOnlySpan<char> base64Text) =>
             IsValid<char, Base64CharValidatable>(base64Text, out _);
 
-        /// <summary>
-        /// Validates the span of UTF-8 encoded text represented as base64 into binary data.
-        /// </summary>
-        /// <param name="base64Text">The input span which contains UTF-8 encoded text in base64 that needs to be validated.</param>
-        /// <param name="decodedLength">The maximum length (in bytes) if you were to decode the base 64 encoded text <paramref name="base64Text"/> within a byte span.</param>
-        /// <returns>true if <paramref name="base64Text"/> is decodable; otherwise, false.</returns>
+        /// <summary>Validates that the specified span of text is comprised of valid base-64 encoded data.</summary>
+        /// <param name="base64Text">A span of text to validate.</param>
+        /// <param name="decodedLength">If the method returns true, the number of decoded bytes that will result from decoding the input text.</param>
+        /// <returns><see langword="true"/> if <paramref name="base64Text"/> contains a valid, decodable sequence of base-64 encoded data; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// If the method returns <see langword="true"/>, the same text passed to <see cref="Convert.FromBase64String(string)"/> and
+        /// <see cref="Convert.TryFromBase64Chars"/> would successfully decode (in the case
+        /// of <see cref="Convert.TryFromBase64Chars"/> assuming sufficient output space). Any amount of whitespace is allowed anywhere in the input,
+        /// where whitespace is defined as the characters ' ', '\t', '\r', or '\n'.
+        /// </remarks>
         public static bool IsValid(ReadOnlySpan<char> base64Text, out int decodedLength) =>
             IsValid<char, Base64CharValidatable>(base64Text, out decodedLength);
 
-        /// <summary>
-        /// Validates the span of UTF-8 encoded text represented as base64 into binary data.
-        /// </summary>
-        /// <param name="base64TextUtf8">The input span which contains UTF-8 encoded text in base64 that needs to be validated.</param>
-        /// <returns>true if <paramref name="base64TextUtf8"/> is decodable; otherwise, false.</returns>
+        /// <summary>Validates that the specified span of UTF8 text is comprised of valid base-64 encoded data.</summary>
+        /// <param name="base64TextUtf8">A span of UTF8 text to validate.</param>
+        /// <returns><see langword="true"/> if <paramref name="base64TextUtf8"/> contains a valid, decodable sequence of base-64 encoded data; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// If the method returns <see langword="true"/>, the same text passed to <see cref="DecodeFromUtf8"/> and
+        /// <see cref="DecodeFromUtf8InPlace"/> would successfully decode. Any amount of whitespace is allowed anywhere in the input,
+        /// where whitespace is defined as the characters ' ', '\t', '\r', or '\n' (as bytes).
+        /// </remarks>
         public static bool IsValid(ReadOnlySpan<byte> base64TextUtf8) =>
             IsValid<byte, Base64ByteValidatable>(base64TextUtf8, out _);
 
-        /// <summary>
-        /// Validates the span of UTF-8 encoded text represented as base64 into binary data.
-        /// </summary>
-        /// <param name="base64TextUtf8">The input span which contains UTF-8 encoded text in base64 that needs to be validated.</param>
-        /// <param name="decodedLength">The maximum length (in bytes) if you were to decode the base 64 encoded text <paramref name="base64TextUtf8"/> within a byte span.</param>
-        /// <returns>true if <paramref name="base64TextUtf8"/> is decodable; otherwise, false.</returns>
+        /// <summary>Validates that the specified span of UTF8 text is comprised of valid base-64 encoded data.</summary>
+        /// <param name="base64TextUtf8">A span of UTF8 text to validate.</param>
+        /// <param name="decodedLength">If the method returns true, the number of decoded bytes that will result from decoding the input UTF8 text.</param>
+        /// <returns><see langword="true"/> if <paramref name="base64TextUtf8"/> contains a valid, decodable sequence of base-64 encoded data; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// If the method returns <see langword="true"/>, the same text passed to <see cref="DecodeFromUtf8"/> and
+        /// <see cref="DecodeFromUtf8InPlace"/> would successfully decode. Any amount of whitespace is allowed anywhere in the input,
+        /// where whitespace is defined as the characters ' ', '\t', '\r', or '\n' (as bytes).
+        /// </remarks>
         public static bool IsValid(ReadOnlySpan<byte> base64TextUtf8, out int decodedLength) =>
             IsValid<byte, Base64ByteValidatable>(base64TextUtf8, out decodedLength);
 
@@ -117,14 +131,14 @@ namespace System.Buffers.Text
             return false;
         }
 
-        internal interface IBase64Validatable<T>
+        private interface IBase64Validatable<T>
         {
             static abstract int IndexOfAnyExcept(ReadOnlySpan<T> span);
             static abstract bool IsWhiteSpace(T value);
             static abstract bool IsEncodingPad(T value);
         }
 
-        internal readonly struct Base64CharValidatable : IBase64Validatable<char>
+        private readonly struct Base64CharValidatable : IBase64Validatable<char>
         {
             private static readonly SearchValues<char> s_validBase64Chars = SearchValues.Create("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/");
 
@@ -133,7 +147,7 @@ namespace System.Buffers.Text
             public static bool IsEncodingPad(char value) => value == EncodingPad;
         }
 
-        internal readonly struct Base64ByteValidatable : IBase64Validatable<byte>
+        private readonly struct Base64ByteValidatable : IBase64Validatable<byte>
         {
             private static readonly SearchValues<byte> s_validBase64Chars = SearchValues.Create(EncodingMap);
 

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -7342,6 +7342,10 @@ namespace System.Buffers.Text
         public static System.Buffers.OperationStatus EncodeToUtf8InPlace(System.Span<byte> buffer, int dataLength, out int bytesWritten) { throw null; }
         public static int GetMaxDecodedFromUtf8Length(int length) { throw null; }
         public static int GetMaxEncodedToUtf8Length(int length) { throw null; }
+        public static bool IsValid(System.ReadOnlySpan<char> base64Text) { throw null; }
+        public static bool IsValid(System.ReadOnlySpan<char> base64Text, out int decodedLength) { throw null; }
+        public static bool IsValid(System.ReadOnlySpan<byte> base64TextUtf8) { throw null; }
+        public static bool IsValid(System.ReadOnlySpan<byte> base64TextUtf8, out int decodedLength) { throw null; }
     }
 }
 namespace System.CodeDom.Compiler


### PR DESCRIPTION
Cherrypicks, addresses merge conflicts, and squashes the commits from @heathbm in https://github.com/dotnet/runtime/pull/79334, then adds an additional commit to clean up a few things in the src.

Fixes https://github.com/dotnet/runtime/issues/76020
cc: @gfoidl, @MihaZupan, @tarekgh 

@bartonjs, I looked at PemEncoding.TryFind, which is what drove us to add the decodingLength outs to IsValid, but it seems that implementation also needs to be able to find a base64-encoded value within the region rather than validating the whole thing?