### PR TITLE
Add PreserveSig support to ComInterfaceGenerator

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -448,46 +449,49 @@ namespace Microsoft.Interop
             // Create the stub.
             var signatureContext = SignatureContext.Create(symbol, DefaultMarshallingInfoParser.Create(environment, generatorDiagnostics, symbol, new InteropAttributeCompilationData(), generatedComAttribute), environment, typeof(VtableIndexStubGenerator).Assembly);
 
-            // Search for the element information for the managed return value.
-            // We need to transform it such that any return type is converted to an out parameter at the end of the parameter list.
-            ImmutableArray<TypePositionInfo> returnSwappedSignatureElements = signatureContext.ElementTypeInformation;
-            for (int i = 0; i < returnSwappedSignatureElements.Length; ++i)
+            if (!symbol.MethodImplementationFlags.HasFlag(MethodImplAttributes.PreserveSig))
             {
-                if (returnSwappedSignatureElements[i].IsManagedReturnPosition)
+                // Search for the element information for the managed return value.
+                // We need to transform it such that any return type is converted to an out parameter at the end of the parameter list.
+                ImmutableArray<TypePositionInfo> returnSwappedSignatureElements = signatureContext.ElementTypeInformation;
+                for (int i = 0; i < returnSwappedSignatureElements.Length; ++i)
                 {
-                    if (returnSwappedSignatureElements[i].ManagedType == SpecialTypeInfo.Void)
+                    if (returnSwappedSignatureElements[i].IsManagedReturnPosition)
                     {
-                        // Return type is void, just remove the element from the signature list.
-                        // We don't introduce an out parameter.
-                        returnSwappedSignatureElements = returnSwappedSignatureElements.RemoveAt(i);
-                    }
-                    else
-                    {
-                        // Convert the current element into an out parameter on the native signature
-                        // while keeping it at the return position in the managed signature.
-                        var managedSignatureAsNativeOut = returnSwappedSignatureElements[i] with
+                        if (returnSwappedSignatureElements[i].ManagedType == SpecialTypeInfo.Void)
                         {
-                            RefKind = RefKind.Out,
-                            RefKindSyntax = SyntaxKind.OutKeyword,
-                            ManagedIndex = TypePositionInfo.ReturnIndex,
-                            NativeIndex = symbol.Parameters.Length
-                        };
-                        returnSwappedSignatureElements = returnSwappedSignatureElements.SetItem(i, managedSignatureAsNativeOut);
+                            // Return type is void, just remove the element from the signature list.
+                            // We don't introduce an out parameter.
+                            returnSwappedSignatureElements = returnSwappedSignatureElements.RemoveAt(i);
+                        }
+                        else
+                        {
+                            // Convert the current element into an out parameter on the native signature
+                            // while keeping it at the return position in the managed signature.
+                            var managedSignatureAsNativeOut = returnSwappedSignatureElements[i] with
+                            {
+                                RefKind = RefKind.Out,
+                                RefKindSyntax = SyntaxKind.OutKeyword,
+                                ManagedIndex = TypePositionInfo.ReturnIndex,
+                                NativeIndex = symbol.Parameters.Length
+                            };
+                            returnSwappedSignatureElements = returnSwappedSignatureElements.SetItem(i, managedSignatureAsNativeOut);
+                        }
+                        break;
                     }
-                    break;
                 }
-            }
 
-            signatureContext = signatureContext with
-            {
-                // Add the HRESULT return value in the native signature.
-                // This element does not have any influence on the managed signature, so don't assign a managed index.
-                ElementTypeInformation = returnSwappedSignatureElements.Add(
-                    new TypePositionInfo(SpecialTypeInfo.Int32, new ManagedHResultExceptionMarshallingInfo())
-                    {
-                        NativeIndex = TypePositionInfo.ReturnIndex
-                    })
-            };
+                signatureContext = signatureContext with
+                {
+                    // Add the HRESULT return value in the native signature.
+                    // This element does not have any influence on the managed signature, so don't assign a managed index.
+                    ElementTypeInformation = returnSwappedSignatureElements.Add(
+                        new TypePositionInfo(SpecialTypeInfo.Int32, new ManagedHResultExceptionMarshallingInfo())
+                        {
+                            NativeIndex = TypePositionInfo.ReturnIndex
+                        })
+                };
+            }
 
             var containingSyntaxContext = new ContainingSyntaxContext(syntax);
 

--- a/src/libraries/System.Runtime.InteropServices/tests/Common/Verifiers/CSharpSourceGeneratorVerifier.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/Common/Verifiers/CSharpSourceGeneratorVerifier.cs
@@ -19,7 +19,7 @@ using Microsoft.CodeAnalysis.Testing.Verifiers;
 namespace Microsoft.Interop.UnitTests.Verifiers
 {
     public static class CSharpSourceGeneratorVerifier<TSourceGenerator>
-        where TSourceGenerator : IIncrementalGenerator, new()
+        where TSourceGenerator : new()
     {
         public static DiagnosticResult Diagnostic(string diagnosticId)
             => new DiagnosticResult(diagnosticId, DiagnosticSeverity.Error);


### PR DESCRIPTION
Add support for PreserveSig and some unit tests that validate the shape of the emitted function pointer signature.

Fixes #85816