### PR TITLE
Use popcount intrinsincs in BitOperations

### DIFF
--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -116,7 +116,7 @@ inline bool genMaxOneBit(T value)
 template <typename T>
 inline bool genExactlyOneBit(T value)
 {
-    return ((value != 0) && genMaxOneBit(value));
+    return BitOperations::PopCount(value) == 1;
 }
 
 /*****************************************************************************

--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -2801,7 +2801,21 @@ uint32_t BitOperations::Log2(uint64_t value)
 uint32_t BitOperations::PopCount(uint32_t value)
 {
 #if defined(_MSC_VER)
-#ifdef HOST_ARM64
+#ifdef HOST_ARM
+    // Inspired by the Stanford Bit Twiddling Hacks by Sean Eron Anderson:
+    // http://graphics.stanford.edu/~seander/bithacks.html
+
+    const uint32_t c1 = 0x55555555u;
+    const uint32_t c2 = 0x33333333u;
+    const uint32_t c3 = 0x0F0F0F0Fu;
+    const uint32_t c4 = 0x01010101u;
+
+    value -= (value >> 1) & c1;
+    value = (value & c2) + ((value >> 2) & c2);
+    value = (((value + (value >> 4)) & c3) * c4) >> 24;
+
+    return value;
+#elif HOST_ARM64
     return _CountOneBits(value);
 #else
     return __popcnt(value);
@@ -2824,7 +2838,21 @@ uint32_t BitOperations::PopCount(uint32_t value)
 uint32_t BitOperations::PopCount(uint64_t value)
 {
 #if defined(_MSC_VER)
-#ifdef HOST_ARM64
+#ifdef HOST_ARM
+    // Inspired by the Stanford Bit Twiddling Hacks by Sean Eron Anderson:
+    // http://graphics.stanford.edu/~seander/bithacks.html
+
+    const uint64_t c1 = 0x5555555555555555ull;
+    const uint64_t c2 = 0x3333333333333333ull;
+    const uint64_t c3 = 0x0F0F0F0F0F0F0F0Full;
+    const uint64_t c4 = 0x0101010101010101ull;
+
+    value -= (value >> 1) & c1;
+    value = (value & c2) + ((value >> 2) & c2);
+    value = (((value + (value >> 4)) & c3) * c4) >> 56;
+
+    return static_cast<uint32_t>(value);
+#elif HOST_ARM64
     return _CountOneBits64(value);
 #elif defined(HOST_64BIT)
     int64_t result = __popcnt64(value);

--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -2801,19 +2801,11 @@ uint32_t BitOperations::Log2(uint64_t value)
 uint32_t BitOperations::PopCount(uint32_t value)
 {
 #if defined(_MSC_VER)
-    // Inspired by the Stanford Bit Twiddling Hacks by Sean Eron Anderson:
-    // http://graphics.stanford.edu/~seander/bithacks.html
-
-    const uint32_t c1 = 0x55555555u;
-    const uint32_t c2 = 0x33333333u;
-    const uint32_t c3 = 0x0F0F0F0Fu;
-    const uint32_t c4 = 0x01010101u;
-
-    value -= (value >> 1) & c1;
-    value = (value & c2) + ((value >> 2) & c2);
-    value = (((value + (value >> 4)) & c3) * c4) >> 24;
-
-    return value;
+#ifdef HOST_ARM64
+    return _CountOneBits(value);
+#else
+    return __popcnt(value);
+#endif
 #else
     int32_t result = __builtin_popcount(value);
     return static_cast<uint32_t>(result);
@@ -2832,19 +2824,14 @@ uint32_t BitOperations::PopCount(uint32_t value)
 uint32_t BitOperations::PopCount(uint64_t value)
 {
 #if defined(_MSC_VER)
-    // Inspired by the Stanford Bit Twiddling Hacks by Sean Eron Anderson:
-    // http://graphics.stanford.edu/~seander/bithacks.html
-
-    const uint64_t c1 = 0x5555555555555555ull;
-    const uint64_t c2 = 0x3333333333333333ull;
-    const uint64_t c3 = 0x0F0F0F0F0F0F0F0Full;
-    const uint64_t c4 = 0x0101010101010101ull;
-
-    value -= (value >> 1) & c1;
-    value = (value & c2) + ((value >> 2) & c2);
-    value = (((value + (value >> 4)) & c3) * c4) >> 56;
-
-    return static_cast<uint32_t>(value);
+#ifdef HOST_ARM64
+    return _CountOneBits64(value);
+#elif defined(HOST_64BIT)
+    int64_t result = __popcnt64(value);
+    return static_cast<uint32_t>(result);
+#else
+    return __popcnt(value >> 32);
+#endif
 #else
     int32_t result = __builtin_popcountll(value);
     return static_cast<uint32_t>(result);

--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -2858,7 +2858,10 @@ uint32_t BitOperations::PopCount(uint64_t value)
     int64_t result = __popcnt64(value);
     return static_cast<uint32_t>(result);
 #else
-    return __popcnt(value >> 32);
+    uint32_t upper = static_cast<uint32_t>(value >> 32);
+    uint32_t lower = static_cast<uint32_t>(value);
+    return __popcnt(upper) + __popcnt(lower);
+
 #endif
 #else
     int32_t result = __builtin_popcountll(value);


### PR DESCRIPTION
I was trying to add this in https://github.com/dotnet/runtime/pull/85842, but thought this should be evaluated separately on how much TP impact it makes.