### PR TITLE
Delete `GT_CNS_LNG`

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1224,7 +1224,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
                     }
                     else if (op2->gtOper == GT_CNS_LNG)
                     {
-                        assertion.op2.lconVal = op2->AsLngCon()->gtLconVal;
+                        assertion.op2.lconVal = op2->AsIntCon()->gtLconVal;
                     }
                     else
                     {
@@ -1473,7 +1473,7 @@ bool Compiler::optIsTreeKnownIntValue(bool vnBased, GenTree* tree, ssize_t* pCon
         // overlapping gtIconVal.
         else if (tree->OperGet() == GT_CNS_LNG)
         {
-            *pConstant = tree->AsLngCon()->gtLconVal;
+            *pConstant = tree->AsIntCon()->gtLconVal;
             *pFlags    = tree->GetIconHandleFlag();
             return true;
         }

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1114,7 +1114,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
                 assertion.op2.kind = O2K_CONST_INT;
             }
 
-            if (op2->gtOper != GT_CNS_INT)
+            if (!op2->IsCnsIntOrI())
             {
                 goto DONE_ASSERTION; // Don't make an assertion
             }
@@ -1200,7 +1200,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
                     assertion.op2.lconVal = 0;
                     assertion.op2.vn      = optConservativeNormalVN(op2);
 
-                    if (op2->gtOper == GT_CNS_INT)
+                    if (op2->IsCnsIntOrI())
                     {
                         ssize_t iconVal = op2->AsIntCon()->gtIconVal;
 
@@ -1462,7 +1462,7 @@ bool Compiler::optIsTreeKnownIntValue(bool vnBased, GenTree* tree, ssize_t* pCon
     // Is Local assertion prop?
     if (!vnBased)
     {
-        if (tree->OperGet() == GT_CNS_INT)
+        if (tree->IsCnsIntOrI())
         {
             *pConstant = tree->AsIntCon()->IconValue();
             *pFlags    = tree->GetIconHandleFlag();
@@ -2180,13 +2180,13 @@ AssertionInfo Compiler::optAssertionGenJtrue(GenTree* tree)
     }
 
     // Look for a call to an IsInstanceOf helper compared to a nullptr
-    if ((op2->gtOper != GT_CNS_INT) && (op1->gtOper == GT_CNS_INT))
+    if (!op2->IsCnsIntOrI() && op1->IsCnsIntOrI())
     {
         std::swap(op1, op2);
     }
     // Validate op1 and op2
     if ((op1->gtOper != GT_CALL) || (op1->AsCall()->gtCallType != CT_HELPER) || (op1->TypeGet() != TYP_REF) || // op1
-        (op2->gtOper != GT_CNS_INT) || (op2->AsIntCon()->gtIconVal != 0))                                      // op2
+        !op2->IsCnsIntOrI() || (op2->AsIntCon()->gtIconVal != 0))                                              // op2
     {
         return NO_ASSERTION_INDEX;
     }
@@ -4040,7 +4040,7 @@ GenTree* Compiler::optAssertionPropLocal_RelOp(ASSERT_VALARG_TP assertions, GenT
     }
 
     // For Local AssertionProp we only can fold when op2 is a GT_CNS_INT
-    if (op2->gtOper != GT_CNS_INT)
+    if (!op2->IsCnsIntOrI())
     {
         return nullptr;
     }

--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -43,7 +43,7 @@ Documentation for VS debugger format specifiers: https://docs.microsoft.com/en-u
     <DisplayString>{gtTreeID, d}: [{gtOper,en}, {gtType,en}]</DisplayString>
   </Type>
   <Type Name="GenTreeIntCon">
-    <DisplayString>{gtTreeID, d}: [IntCon={((GenTreeIntCon*)this)-&gt;gtIconVal, d}]</DisplayString>
+    <DisplayString>{gtTreeID, d}: [IntCon={((GenTreeIntCon*)this)-&gt;gtLconVal, d}]</DisplayString>
   </Type>
   <Type Name="GenTreeDblCon">
     <DisplayString>{gtTreeID, d}: [DblCon={((GenTreeDblCon*)this)-&gt;gtDconVal, g}]</DisplayString>
@@ -53,9 +53,6 @@ Documentation for VS debugger format specifiers: https://docs.microsoft.com/en-u
   </Type>
   <Type Name="GenTreeVecCon">
     <DisplayString>CNS_VEC</DisplayString>
-  </Type>
-  <Type Name="GenTreeLngCon">
-    <DisplayString>{gtTreeID, d}: [LngCon={((GenTreeLngCon*)this)-&gt;gtLconVal, l}]</DisplayString>
   </Type>
   <Type Name="GenTreeOp">
     <DisplayString Condition="this->gtOper==GT_CAST">{gtTreeID, d}: [{((GenTreeCast*)this)-&gt;gtCastType,en} &lt;- {((GenTreeUnOp*)this)-&gt;gtOp1-&gt;gtType,en}]</DisplayString>

--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -43,7 +43,7 @@ Documentation for VS debugger format specifiers: https://docs.microsoft.com/en-u
     <DisplayString>{gtTreeID, d}: [{gtOper,en}, {gtType,en}]</DisplayString>
   </Type>
   <Type Name="GenTreeIntCon">
-    <DisplayString>{gtTreeID, d}: [IntCon={((GenTreeIntCon*)this)-&gt;gtLconVal, d}]</DisplayString>
+    <DisplayString>{gtTreeID, d}: [IntCon={((GenTreeIntCon*)this)-&gt;m_value, d}]</DisplayString>
   </Type>
   <Type Name="GenTreeDblCon">
     <DisplayString>{gtTreeID, d}: [DblCon={((GenTreeDblCon*)this)-&gt;gtDconVal, g}]</DisplayString>

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -233,8 +233,8 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
         {
             // relocatable values tend to come down as a CNS_INT of native int type
             // so the line between these two opcodes is kind of blurry
-            GenTreeIntConCommon* con    = tree->AsIntConCommon();
-            ssize_t              cnsVal = con->IconValue();
+            GenTreeIntCon* con    = tree->AsIntCon();
+            ssize_t        cnsVal = con->IconValue();
 
             emitAttr attr = emitActualTypeSize(targetType);
 
@@ -937,7 +937,7 @@ void CodeGen::genCodeForShiftLong(GenTree* tree)
 
     assert(shiftBy->isContainedIntOrIImmed());
 
-    unsigned count = (unsigned)shiftBy->AsIntConCommon()->IconValue();
+    unsigned count = (unsigned)shiftBy->AsIntCon()->IconValue();
 
     regNumber regResult = (oper == GT_LSH_HI) ? regHi : regLo;
 

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -397,7 +397,7 @@ void CodeGen::genLclHeap(GenTree* tree)
         assert(size->isContained());
 
         // If amount is zero then return null in regCnt
-        size_t amount = size->AsIntCon()->gtIconVal;
+        size_t amount = size->AsIntCon()->IconValue();
         if (amount == 0)
         {
             instGen_Set_Reg_To_Zero(EA_PTRSIZE, regCnt);
@@ -436,7 +436,7 @@ void CodeGen::genLclHeap(GenTree* tree)
     if (size->IsCnsIntOrI())
     {
         // 'amount' is the total number of bytes to localloc to properly STACK_ALIGN
-        target_size_t amount = (target_size_t)size->AsIntCon()->gtIconVal;
+        target_size_t amount = (target_size_t)size->AsIntCon()->IconValue();
         amount               = AlignUp(amount, STACK_ALIGN);
 
         // For small allocations we will generate up to four push instructions (either 2 or 4, exactly,

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2649,7 +2649,7 @@ void CodeGen::genCodeForBinary(GenTreeOp* tree)
         opt = ShiftOpToInsOpts(op2->gtOper);
 
         emit->emitIns_R_R_R_I(ins, emitActualTypeSize(tree), targetReg, a->GetRegNum(), b->GetRegNum(),
-                              c->AsIntConCommon()->IconValue(), opt);
+                              c->AsIntCon()->IconValue(), opt);
 
         genProduceReg(tree);
         return;
@@ -3423,7 +3423,7 @@ void CodeGen::genCodeForNegNot(GenTree* tree)
                 GenTree* b   = op1->gtGetOp2();
                 genConsumeRegs(op1);
                 GetEmitter()->emitIns_R_R_I(ins, emitActualTypeSize(tree), targetReg, a->GetRegNum(),
-                                            b->AsIntConCommon()->IntegralValue(), ShiftOpToInsOpts(oper));
+                                            b->AsIntCon()->IntegralValue(), ShiftOpToInsOpts(oper));
             }
             break;
 
@@ -3892,7 +3892,7 @@ void CodeGen::genLockedInstructions(GenTreeOp* treeNode)
                 {
                     // Even though INS_add is specified here, the encoder will choose either
                     // an INS_add or an INS_sub and encode the immediate as a positive value
-                    genInstrWithConstant(INS_add, dataSize, storeDataReg, loadReg, data->AsIntConCommon()->IconValue(),
+                    genInstrWithConstant(INS_add, dataSize, storeDataReg, loadReg, data->AsIntCon()->IconValue(),
                                          REG_NA);
                 }
                 else
@@ -4021,7 +4021,7 @@ void CodeGen::genCodeForCmpXchg(GenTreeCmpXchg* treeNode)
             else
             {
                 GetEmitter()->emitIns_R_I(INS_cmp, emitActualTypeSize(treeNode), targetReg,
-                                          comparand->AsIntConCommon()->IconValue());
+                                          comparand->AsIntCon()->IconValue());
                 GetEmitter()->emitIns_J(INS_bne, labelCompareFail);
             }
         }
@@ -4559,7 +4559,7 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
 
         if (op2->isContainedIntOrIImmed())
         {
-            GenTreeIntConCommon* intConst = op2->AsIntConCommon();
+            GenTreeIntCon* intConst = op2->AsIntCon();
 
             regNumber op1Reg = op1->GetRegNum();
 
@@ -4599,8 +4599,7 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
                                 assert(shiftOp2->isContained());
 
                                 emit->emitIns_R_R_I(ins, cmpSize, op1->GetRegNum(), shiftOp1->GetRegNum(),
-                                                    shiftOp2->AsIntConCommon()->IntegralValue(),
-                                                    ShiftOpToInsOpts(oper));
+                                                    shiftOp2->AsIntCon()->IntegralValue(), ShiftOpToInsOpts(oper));
                             }
                             break;
 
@@ -4621,7 +4620,7 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
                     assert(op2->gtGetOp2()->isContained());
 
                     emit->emitIns_R_R_I(ins, cmpSize, op1->GetRegNum(), op2->gtGetOp1()->GetRegNum(),
-                                        op2->gtGetOp2()->AsIntConCommon()->IntegralValue(), ShiftOpToInsOpts(oper));
+                                        op2->gtGetOp2()->AsIntCon()->IntegralValue(), ShiftOpToInsOpts(oper));
                     break;
 
                 default:
@@ -4687,7 +4686,7 @@ void CodeGen::genCodeForCCMP(GenTreeCCMP* ccmp)
 
     if (op2->isContainedIntOrIImmed())
     {
-        GenTreeIntConCommon* intConst = op2->AsIntConCommon();
+        GenTreeIntCon* intConst = op2->AsIntCon();
         emit->emitIns_R_I_FLAGS_COND(INS_ccmp, cmpSize, srcReg1, (int)intConst->IconValue(), ccmp->gtFlagsVal, insCond);
     }
     else

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -3066,7 +3066,7 @@ void CodeGen::genLclHeap(GenTree* tree)
         assert(size->isContained());
 
         // If amount is zero then return null in targetReg
-        amount = size->AsIntCon()->gtIconVal;
+        amount = size->AsIntCon()->IconValue();
         if (amount == 0)
         {
             instGen_Set_Reg_To_Zero(EA_PTRSIZE, targetReg);

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -4864,12 +4864,11 @@ void CodeGen::genCodeForJumpCompare(GenTreeOpCC* tree)
 
     if (tree->OperIs(GT_JTEST))
     {
-        ssize_t compareImm = op2->AsIntCon()->IconValue();
-
-        assert(isPow2(((size_t)compareImm)));
+        uint64_t compareImm = op2->AsIntCon()->IntegralValueUnsigned();
+        assert(isPow2(compareImm));
 
         instruction ins = (cc.GetCode() == GenCondition::EQ) ? INS_tbz : INS_tbnz;
-        int         imm = genLog2((size_t)compareImm);
+        int         imm = genLog2(compareImm);
 
         GetEmitter()->emitIns_J_R_I(ins, attr, compiler->compCurBB->GetJumpDest(), reg, imm);
     }

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -858,7 +858,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
         {
 #ifdef TARGET_ARM64
             assert(source->IsCnsIntOrI());
-            assert(source->AsIntConCommon()->IconValue() == 0);
+            assert(source->AsIntCon()->IconValue() == 0);
 
             emit->emitIns_S_R(storeIns, storeAttr, REG_ZR, varNumOut, argOffsetOut);
 #else  // !TARGET_ARM64
@@ -4699,7 +4699,7 @@ void CodeGen::genLeaInstruction(GenTreeAddrMode* lea)
                 {
                     // Handle LEA with "contained" BFIZ
                     assert(scale == 0);
-                    scale = (DWORD)index->gtGetOp2()->AsIntConCommon()->IconValue();
+                    scale = (DWORD)index->gtGetOp2()->AsIntCon()->IconValue();
                     index = index->gtGetOp1()->gtGetOp1();
                 }
                 else if (index->OperIs(GT_CAST))

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -1580,7 +1580,7 @@ void CodeGen::genCodeForShift(GenTree* tree)
     else
     {
         unsigned immWidth   = emitter::getBitWidth(size); // For ARM64, immWidth will be set to 32 or 64
-        unsigned shiftByImm = (unsigned)shiftBy->AsIntCon()->gtIconVal & (immWidth - 1);
+        unsigned shiftByImm = (unsigned)shiftBy->AsIntCon()->IconValue() & (immWidth - 1);
         GetEmitter()->emitIns_R_R_I(ins, size, dstReg, operand->GetRegNum(), shiftByImm);
     }
 

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -857,7 +857,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
         if (source->isContained())
         {
 #ifdef TARGET_ARM64
-            assert(source->OperGet() == GT_CNS_INT);
+            assert(source->IsCnsIntOrI());
             assert(source->AsIntConCommon()->IconValue() == 0);
 
             emit->emitIns_S_R(storeIns, storeAttr, REG_ZR, varNumOut, argOffsetOut);

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -7471,7 +7471,7 @@ const char* CodeGen::siStackVarName(size_t offs, size_t size, unsigned reg, unsi
 //
 GenTreeIntCon CodeGen::intForm(var_types type, ssize_t value)
 {
-    GenTreeIntCon i(type, value);
+    GenTreeIntCon i(type, value, nullptr);
     i.SetRegNum(REG_NA);
     return i;
 }

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1113,10 +1113,10 @@ AGAIN:
 
     /* Check for an addition of a constant */
 
-    if (op2->IsIntCnsFitsInI32() && (op2->gtType != TYP_REF) && FitsIn<INT32>(cns + op2->AsIntConCommon()->IconValue()))
+    if (op2->IsIntCnsFitsInI32() && (op2->gtType != TYP_REF) && FitsIn<INT32>(cns + op2->AsIntCon()->IconValue()))
     {
         // We should not be building address modes out of non-foldable constants
-        if (!op2->AsIntConCommon()->ImmedValCanBeFolded(compiler, addr->OperGet()))
+        if (!op2->AsIntCon()->ImmedValCanBeFolded(compiler, addr->OperGet()))
         {
             assert(compiler->opts.compReloc);
             return false;
@@ -1124,7 +1124,7 @@ AGAIN:
 
         /* We're adding a constant */
 
-        cns += op2->AsIntConCommon()->IconValue();
+        cns += op2->AsIntCon()->IconValue();
 
 #if defined(TARGET_ARMARCH) || defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
         if (cns == 0)
@@ -1386,7 +1386,7 @@ FOUND_AM:
             }
             else if (index->IsIntCnsFitsInI32())
             {
-                ssize_t constantIndex = index->AsIntConCommon()->IconValue() * indexScale;
+                ssize_t constantIndex = index->AsIntCon()->IconValue() * indexScale;
                 if (constantIndex == 0)
                 {
                     // while scale is a non-zero constant, the actual index is zero so drop it

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -4730,7 +4730,7 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
     if (treeNode->IsReuseRegVal())
     {
         // For now, this is only used for constant nodes.
-        assert((treeNode->OperGet() == GT_CNS_INT) || (treeNode->OperGet() == GT_CNS_DBL));
+        assert((treeNode->IsCnsIntOrI()) || (treeNode->OperGet() == GT_CNS_DBL));
         JITDUMP("  TreeNode is marked ReuseReg\n");
         return;
     }
@@ -5280,7 +5280,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
         // If it is contained then source must be the integer constant zero
         if (source->isContained())
         {
-            assert(source->OperGet() == GT_CNS_INT);
+            assert(source->IsCnsIntOrI());
             assert(source->AsIntConCommon()->IconValue() == 0);
 
             emit->emitIns_S_R(storeIns, storeAttr, REG_R0, varNumOut, argOffsetOut);

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -1936,7 +1936,7 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* lclNode)
             }
             else if (data->IsIntegralConst())
             {
-                ssize_t imm = data->AsIntConCommon()->IconValue();
+                ssize_t imm = data->AsIntCon()->IconValue();
                 emit->emitIns_I_la(EA_PTRSIZE, REG_R21, imm);
                 dataReg = REG_R21;
             }
@@ -5281,7 +5281,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
         if (source->isContained())
         {
             assert(source->IsCnsIntOrI());
-            assert(source->AsIntConCommon()->IconValue() == 0);
+            assert(source->AsIntCon()->IconValue() == 0);
 
             emit->emitIns_S_R(storeIns, storeAttr, REG_R0, varNumOut, argOffsetOut);
         }
@@ -5758,8 +5758,8 @@ void CodeGen::genRangeCheck(GenTree* oper)
     genConsumeRegs(arrIndex);
     genConsumeRegs(arrLen);
 
-    emitter*             emit     = GetEmitter();
-    GenTreeIntConCommon* intConst = nullptr;
+    emitter*       emit     = GetEmitter();
+    GenTreeIntCon* intConst = nullptr;
     if (arrIndex->isContainedIntOrIImmed())
     {
         src1 = arrLen;
@@ -5767,7 +5767,7 @@ void CodeGen::genRangeCheck(GenTree* oper)
         reg1 = REG_R21;
         reg2 = src1->GetRegNum();
 
-        intConst    = src2->AsIntConCommon();
+        intConst    = src2->AsIntCon();
         ssize_t imm = intConst->IconValue();
         if (imm == INT64_MAX)
         {
@@ -5788,7 +5788,7 @@ void CodeGen::genRangeCheck(GenTree* oper)
         if (src2->isContainedIntOrIImmed())
         {
             reg2        = REG_R21;
-            ssize_t imm = src2->AsIntConCommon()->IconValue();
+            ssize_t imm = src2->AsIntCon()->IconValue();
             emit->emitIns_I_la(EA_PTRSIZE, REG_R21, imm);
         }
         else

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -2083,7 +2083,7 @@ void CodeGen::genLclHeap(GenTree* tree)
         assert(size->isContained());
 
         // If amount is zero then return null in targetReg
-        amount = size->AsIntCon()->gtIconVal;
+        amount = size->AsIntCon()->IconValue();
         if (amount == 0)
         {
             instGen_Set_Reg_To_Zero(EA_PTRSIZE, targetReg);
@@ -2472,7 +2472,7 @@ void CodeGen::genCodeForDivMod(GenTreeOp* tree)
         // Check divisorOp first as we can always allow it to be a contained immediate
         if (divisorOp->isContainedIntOrIImmed())
         {
-            ssize_t intConst = (int)(divisorOp->AsIntCon()->gtIconVal);
+            ssize_t intConst = (int)(divisorOp->AsIntCon()->IconValue());
             divisorReg       = emitter::isGeneralRegister(divisorReg) ? divisorReg : REG_R21;
             emit->emitIns_I_la(EA_PTRSIZE, divisorReg, intConst);
         }
@@ -3939,7 +3939,7 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
 
         if (op2->isContainedIntOrIImmed())
         {
-            ssize_t imm = op2->AsIntCon()->gtIconVal;
+            ssize_t imm = op2->AsIntCon()->IconValue();
 
             switch (cmpSize)
             {
@@ -4178,7 +4178,7 @@ void CodeGen::genCodeForJumpCompare(GenTreeOpCC* tree)
 
     if (op2->isContainedIntOrIImmed())
     {
-        ssize_t imm = op2->AsIntCon()->gtIconVal;
+        ssize_t imm = op2->AsIntCon()->IconValue();
 
         if (imm)
         {
@@ -5883,7 +5883,7 @@ void CodeGen::genCodeForShift(GenTree* tree)
     }
     else
     {
-        unsigned shiftByImm = (unsigned)shiftBy->AsIntCon()->gtIconVal;
+        unsigned shiftByImm = (unsigned)shiftBy->AsIntCon()->IconValue();
 
         // should check shiftByImm for loongarch32-ins.
         unsigned immWidth = emitter::getBitWidth(size); // For LOONGARCH64, immWidth will be set to 32 or 64

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -1712,7 +1712,7 @@ void CodeGen::genLclHeap(GenTree* tree)
         assert(size->isContained());
 
         // If amount is zero then return null in targetReg
-        amount = size->AsIntCon()->gtIconVal;
+        amount = size->AsIntCon()->IconValue();
         if (amount == 0)
         {
             instGen_Set_Reg_To_Zero(EA_PTRSIZE, targetReg);
@@ -2100,7 +2100,7 @@ void CodeGen::genCodeForDivMod(GenTreeOp* tree)
             assert(typeSize >= genTypeSize(genActualType(src1->TypeGet())) &&
                    typeSize >= genTypeSize(genActualType(divisorOp->TypeGet())));
 
-            // ssize_t intConstValue = divisorOp->AsIntCon()->gtIconVal;
+            // ssize_t intConstValue = divisorOp->AsIntCon()->IconValue();
             regNumber   reg1       = src1->GetRegNum();
             regNumber   divisorReg = divisorOp->GetRegNum();
             instruction ins;
@@ -2108,7 +2108,7 @@ void CodeGen::genCodeForDivMod(GenTreeOp* tree)
             // Check divisorOp first as we can always allow it to be a contained immediate
             if (divisorOp->isContainedIntOrIImmed())
             {
-                ssize_t intConst = (int)(divisorOp->AsIntCon()->gtIconVal);
+                ssize_t intConst = (int)(divisorOp->AsIntCon()->IconValue());
                 divisorReg       = rsGetRsvdReg();
                 emit->emitLoadImmediate(EA_PTRSIZE, divisorReg, intConst);
             }
@@ -2122,7 +2122,7 @@ void CodeGen::genCodeForDivMod(GenTreeOp* tree)
                 if (src1->isContainedIntOrIImmed())
                 {
                     assert(!divisorOp->isContainedIntOrIImmed());
-                    ssize_t intConst = (int)(src1->AsIntCon()->gtIconVal);
+                    ssize_t intConst = (int)(src1->AsIntCon()->IconValue());
                     reg1             = rsGetRsvdReg();
                     emit->emitLoadImmediate(EA_PTRSIZE, reg1, intConst);
                 }
@@ -2147,7 +2147,7 @@ void CodeGen::genCodeForDivMod(GenTreeOp* tree)
                 //
                 if (divisorOp->IsCnsIntOrI())
                 {
-                    ssize_t intConstValue = divisorOp->AsIntCon()->gtIconVal;
+                    ssize_t intConstValue = divisorOp->AsIntCon()->IconValue();
                     // assert(intConstValue != 0); // already checked above by IsIntegralConst(0)
                     if (intConstValue != -1)
                     {
@@ -3579,7 +3579,7 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
 
         if (op2->isContainedIntOrIImmed())
         {
-            ssize_t imm = op2->AsIntCon()->gtIconVal;
+            ssize_t imm = op2->AsIntCon()->IconValue();
 
             switch (cmpSize)
             {
@@ -3815,7 +3815,7 @@ void CodeGen::genCodeForJumpCompare(GenTreeOpCC* tree)
 
     if (op2->isContainedIntOrIImmed())
     {
-        ssize_t imm = op2->AsIntCon()->gtIconVal;
+        ssize_t imm = op2->AsIntCon()->IconValue();
         if (imm)
         {
             assert(regOp1 != REG_R0);
@@ -5561,7 +5561,7 @@ void CodeGen::genCodeForShift(GenTree* tree)
         }
         else
         {
-            unsigned shiftByImm = (unsigned)shiftBy->AsIntCon()->gtIconVal;
+            unsigned shiftByImm = (unsigned)shiftBy->AsIntCon()->IconValue();
             if (shiftByImm >= 32 && shiftByImm < 64)
             {
                 immWidth = 64;
@@ -5591,7 +5591,7 @@ void CodeGen::genCodeForShift(GenTree* tree)
         else
         {
             instruction ins        = genGetInsForOper(tree);
-            unsigned    shiftByImm = (unsigned)shiftBy->AsIntCon()->gtIconVal;
+            unsigned    shiftByImm = (unsigned)shiftBy->AsIntCon()->IconValue();
 
             // should check shiftByImm for riscv64-ins.
             unsigned immWidth = emitter::getBitWidth(size); // For RISCV64, immWidth will be set to 32 or 64

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -1578,7 +1578,7 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* lclNode)
             }
             else if (data->IsIntegralConst())
             {
-                ssize_t imm = data->AsIntConCommon()->IconValue();
+                ssize_t imm = data->AsIntCon()->IconValue();
                 emit->emitLoadImmediate(EA_PTRSIZE, rsGetRsvdReg(), imm);
                 dataReg = rsGetRsvdReg();
             }
@@ -5047,7 +5047,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
         if (source->isContained())
         {
             assert(source->IsCnsIntOrI());
-            assert(source->AsIntConCommon()->IconValue() == 0);
+            assert(source->AsIntCon()->IconValue() == 0);
             emit->emitIns_S_R(storeIns, storeAttr, REG_R0, varNumOut, argOffsetOut);
         }
         else

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -4511,7 +4511,7 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
     if (treeNode->IsReuseRegVal())
     {
         // For now, this is only used for constant nodes.
-        assert((treeNode->OperGet() == GT_CNS_INT) || (treeNode->OperGet() == GT_CNS_DBL));
+        assert((treeNode->IsCnsIntOrI()) || (treeNode->OperGet() == GT_CNS_DBL));
         JITDUMP("  TreeNode is marked ReuseReg\n");
         return;
     }
@@ -5046,7 +5046,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
         // If it is contained then source must be the integer constant zero
         if (source->isContained())
         {
-            assert(source->OperGet() == GT_CNS_INT);
+            assert(source->IsCnsIntOrI());
             assert(source->AsIntConCommon()->IconValue() == 0);
             emit->emitIns_S_R(storeIns, storeAttr, REG_R0, varNumOut, argOffsetOut);
         }

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -843,7 +843,7 @@ void CodeGen::genCodeForLongUMod(GenTreeOp* node)
     assert(dividendHi->isUsedFromReg());
 
     GenTree* const divisor = node->gtOp2;
-    assert(divisor->gtSkipReloadOrCopy()->OperGet() == GT_CNS_INT);
+    assert(divisor->gtSkipReloadOrCopy()->IsCnsIntOrI());
     assert(divisor->gtSkipReloadOrCopy()->isUsedFromReg());
     assert(divisor->gtSkipReloadOrCopy()->AsIntCon()->gtIconVal >= 2);
     assert(divisor->gtSkipReloadOrCopy()->AsIntCon()->gtIconVal <= 0x3fffffff);

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -845,8 +845,8 @@ void CodeGen::genCodeForLongUMod(GenTreeOp* node)
     GenTree* const divisor = node->gtOp2;
     assert(divisor->gtSkipReloadOrCopy()->IsCnsIntOrI());
     assert(divisor->gtSkipReloadOrCopy()->isUsedFromReg());
-    assert(divisor->gtSkipReloadOrCopy()->AsIntCon()->gtIconVal >= 2);
-    assert(divisor->gtSkipReloadOrCopy()->AsIntCon()->gtIconVal <= 0x3fffffff);
+    assert(divisor->gtSkipReloadOrCopy()->AsIntCon()->IconValue() >= 2);
+    assert(divisor->gtSkipReloadOrCopy()->AsIntCon()->IconValue() <= 0x3fffffff);
 
     // dividendLo must be in RAX; dividendHi must be in RDX
     genCopyRegIfNeeded(dividendLo, REG_EAX);
@@ -2788,7 +2788,7 @@ void CodeGen::genLclHeap(GenTree* tree)
     size_t amount = 0;
     if (size->IsCnsIntOrI() && size->isContained())
     {
-        amount = size->AsIntCon()->gtIconVal;
+        amount = size->AsIntCon()->IconValue();
         assert((amount > 0) && (amount <= UINT_MAX));
 
         // 'amount' is the total number of bytes to localloc to properly STACK_ALIGN
@@ -5308,10 +5308,10 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
         noway_assert(EA_ATTR(genTypeSize(targetType)) == EA_PTRSIZE);
 #if TARGET_64BIT
         emit->emitIns_R_C(ins_Load(TYP_I_IMPL), EA_PTRSIZE, tree->GetRegNum(), FLD_GLOBAL_GS,
-                          (int)addr->AsIntCon()->gtIconVal);
+                          (int)addr->AsIntCon()->IconValue());
 #else
         emit->emitIns_R_C(ins_Load(TYP_I_IMPL), EA_PTRSIZE, tree->GetRegNum(), FLD_GLOBAL_FS,
-                          (int)addr->AsIntCon()->gtIconVal);
+                          (int)addr->AsIntCon()->IconValue());
 #endif
     }
     else
@@ -5542,7 +5542,7 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
                             ssize_t        ival = op2->IconValue();
 
                             assert((ival >= 0) && (ival <= 255));
-                            op2->gtIconVal = static_cast<int8_t>(ival);
+                            op2->SetIconValue(static_cast<int8_t>(ival));
                             break;
                         }
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -11186,7 +11186,6 @@ public:
             case GT_FTN_ADDR:
             case GT_RET_EXPR:
             case GT_CNS_INT:
-            case GT_CNS_LNG:
             case GT_CNS_DBL:
             case GT_CNS_STR:
             case GT_CNS_VEC:

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -3711,7 +3711,7 @@ inline void Compiler::LoopDsc::VERIFY_lpIterTree() const
     assert(value->OperIs(GT_ADD, GT_SUB, GT_MUL, GT_RSH, GT_LSH));
     assert(value->AsOp()->gtOp1->OperGet() == GT_LCL_VAR);
     assert(value->AsOp()->gtOp1->AsLclVar()->GetLclNum() == lpIterTree->AsLclVar()->GetLclNum());
-    assert(value->AsOp()->gtOp2->OperGet() == GT_CNS_INT);
+    assert(value->AsOp()->gtOp2->IsCnsIntOrI());
 #endif
 }
 

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1797,15 +1797,6 @@ inline void GenTree::SetOper(genTreeOps oper, ValueNumberUpdate vnUpdate)
     assert(GenTree::s_gtNodeSizes[oper] == TREE_NODE_SZ_SMALL || GenTree::s_gtNodeSizes[oper] == TREE_NODE_SZ_LARGE);
     assert(GenTree::s_gtNodeSizes[oper] == TREE_NODE_SZ_SMALL || (gtDebugFlags & GTF_DEBUG_NODE_LARGE));
 
-#if defined(HOST_64BIT) && !defined(TARGET_64BIT)
-    if (gtOper == GT_CNS_LNG && oper == GT_CNS_INT)
-    {
-        // When casting from LONG to INT, we need to force cast of the value,
-        // if the host architecture represents INT and LONG with the same data size.
-        AsIntCon()->gtLconVal = (INT64)(INT32)AsIntCon()->gtLconVal;
-    }
-#endif // defined(HOST_64BIT) && !defined(TARGET_64BIT)
-
     SetOperRaw(oper);
 
 #ifdef DEBUG
@@ -3729,7 +3720,7 @@ inline int Compiler::LoopDsc::lpIterConst() const
 {
     VERIFY_lpIterTree();
     GenTree* value = lpIterTree->AsLclVar()->Data();
-    return (int)value->AsOp()->gtOp2->AsIntCon()->gtIconVal;
+    return (int)value->AsOp()->gtOp2->AsIntCon()->IconValue();
 }
 
 //-----------------------------------------------------------------------------
@@ -3860,7 +3851,7 @@ inline int Compiler::LoopDsc::lpConstLimit() const
 
     GenTree* limit = lpLimit();
     assert(limit->OperIsConst());
-    return (int)limit->AsIntCon()->gtIconVal;
+    return (int)limit->AsIntCon()->IconValue();
 }
 
 //-----------------------------------------------------------------------------

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1888,7 +1888,7 @@ inline void GenTree::ChangeOper(genTreeOps oper, ValueNumberUpdate vnUpdate)
 // BashToConst: Bash the node to a constant one.
 //
 // The function will infer the node's new oper from the type: GT_CNS_INT
-// or GT_CNS_LNG for integers and GC types, GT_CNS_DBL for floats/doubles.
+// for integers and GC types, GT_CNS_DBL for floats/doubles.
 //
 // The type is inferred from "value"'s type ("T") unless an explicit
 // one is provided via the second argument, in which case it is checked
@@ -1935,7 +1935,7 @@ void GenTree::BashToConst(T value, var_types type /* = TYP_UNDEF */)
     }
     else
     {
-        oper = (type == TYP_LONG) ? GT_CNS_NATIVELONG : GT_CNS_INT;
+        oper = GT_CNS_INT;
     }
 
     SetOper(oper);
@@ -1945,25 +1945,15 @@ void GenTree::BashToConst(T value, var_types type /* = TYP_UNDEF */)
     switch (oper)
     {
         case GT_CNS_INT:
-#if !defined(TARGET_64BIT)
-            assert(type != TYP_LONG);
-#endif
             assert(varTypeIsIntegral(type) || varTypeIsGC(type));
             if (genTypeSize(type) <= genTypeSize(TYP_INT))
             {
                 assert(FitsIn<int32_t>(value));
             }
 
-            AsIntCon()->SetIconValue(static_cast<ssize_t>(value));
+            AsIntCon()->SetIntegralValue(static_cast<int64_t>(value));
             AsIntCon()->gtFieldSeq = nullptr;
             break;
-
-#if !defined(TARGET_64BIT)
-        case GT_CNS_LNG:
-            assert(type == TYP_LONG);
-            AsIntCon()->SetLngValue(static_cast<int64_t>(value));
-            break;
-#endif
 
         case GT_CNS_DBL:
             assert(varTypeIsFloating(type));
@@ -4435,7 +4425,6 @@ void GenTree::VisitOperands(TVisitor visitor)
         case GT_FTN_ADDR:
         case GT_RET_EXPR:
         case GT_CNS_INT:
-        case GT_CNS_LNG:
         case GT_CNS_DBL:
         case GT_CNS_STR:
         case GT_CNS_VEC:

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1802,7 +1802,7 @@ inline void GenTree::SetOper(genTreeOps oper, ValueNumberUpdate vnUpdate)
     {
         // When casting from LONG to INT, we need to force cast of the value,
         // if the host architecture represents INT and LONG with the same data size.
-        AsLngCon()->gtLconVal = (INT64)(INT32)AsLngCon()->gtLconVal;
+        AsIntCon()->gtLconVal = (INT64)(INT32)AsIntCon()->gtLconVal;
     }
 #endif // defined(HOST_64BIT) && !defined(TARGET_64BIT)
 
@@ -1970,7 +1970,7 @@ void GenTree::BashToConst(T value, var_types type /* = TYP_UNDEF */)
 #if !defined(TARGET_64BIT)
         case GT_CNS_LNG:
             assert(type == TYP_LONG);
-            AsLngCon()->SetLngValue(static_cast<int64_t>(value));
+            AsIntCon()->SetLngValue(static_cast<int64_t>(value));
             break;
 #endif
 

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -179,7 +179,7 @@ GenTree* DecomposeLongs::DecomposeNode(GenTree* tree)
             nextNode = DecomposeCast(use);
             break;
 
-        case GT_CNS_LNG:
+        case GT_CNS_INT:
             nextNode = DecomposeCnsLng(use);
             break;
 
@@ -656,7 +656,7 @@ GenTree* DecomposeLongs::DecomposeCast(LIR::Use& use)
 }
 
 //------------------------------------------------------------------------
-// DecomposeCnsLng: Decompose GT_CNS_LNG.
+// DecomposeCnsLng: Decompose GT_CNS_INT.
 //
 // Arguments:
 //    use - the LIR::Use object for the def that needs to be decomposed.
@@ -667,7 +667,7 @@ GenTree* DecomposeLongs::DecomposeCast(LIR::Use& use)
 GenTree* DecomposeLongs::DecomposeCnsLng(LIR::Use& use)
 {
     assert(use.IsInitialized());
-    assert(use.Def()->OperGet() == GT_CNS_LNG);
+    assert(use.Def()->OperGet() == GT_CNS_INT);
 
     GenTree* tree  = use.Def();
     INT32    loVal = tree->AsIntCon()->LoVal();

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -670,8 +670,8 @@ GenTree* DecomposeLongs::DecomposeCnsLng(LIR::Use& use)
     assert(use.Def()->OperGet() == GT_CNS_LNG);
 
     GenTree* tree  = use.Def();
-    INT32    loVal = tree->AsLngCon()->LoVal();
-    INT32    hiVal = tree->AsLngCon()->HiVal();
+    INT32    loVal = tree->AsIntCon()->LoVal();
+    INT32    hiVal = tree->AsIntCon()->HiVal();
 
     GenTree* loResult = tree;
     loResult->BashToConst(loVal);

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -1059,7 +1059,7 @@ GenTree* DecomposeLongs::DecomposeShift(LIR::Use& use)
     {
         // Reduce count modulo 64 to match behavior found in the shift helpers,
         // Compiler::gtFoldExpr and ValueNumStore::EvalOpIntegral.
-        unsigned int count = shiftByOp->AsIntCon()->gtIconVal & 0x3F;
+        unsigned int count = shiftByOp->AsIntCon()->IconValue() & 0x3F;
         Range().Remove(shiftByOp);
 
         if (count == 0)
@@ -1416,7 +1416,7 @@ GenTree* DecomposeLongs::DecomposeRotate(LIR::Use& use)
         oper = GT_RSH_LO;
     }
 
-    unsigned count = (unsigned)rotateByOp->AsIntCon()->gtIconVal;
+    unsigned count = (unsigned)rotateByOp->AsIntCon()->IconValue();
     Range().Remove(rotateByOp);
 
     // Make sure the rotate amount is between 0 and 63.
@@ -1659,8 +1659,8 @@ GenTree* DecomposeLongs::DecomposeUMod(LIR::Use& use)
 
     assert(loOp2->IsCnsIntOrI());
     assert(hiOp2->IsCnsIntOrI());
-    assert((loOp2->AsIntCon()->gtIconVal >= 2) && (loOp2->AsIntCon()->gtIconVal <= 0x3fffffff));
-    assert(hiOp2->AsIntCon()->gtIconVal == 0);
+    assert((loOp2->AsIntCon()->IconValue() >= 2) && (loOp2->AsIntCon()->IconValue() <= 0x3fffffff));
+    assert(hiOp2->AsIntCon()->IconValue() == 0);
 
     // Get rid of op2's hi part. We don't need it.
     Range().Remove(hiOp2);

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -1657,8 +1657,8 @@ GenTree* DecomposeLongs::DecomposeUMod(LIR::Use& use)
     GenTree* loOp2 = op2->gtGetOp1();
     GenTree* hiOp2 = op2->gtGetOp2();
 
-    assert(loOp2->OperGet() == GT_CNS_INT);
-    assert(hiOp2->OperGet() == GT_CNS_INT);
+    assert(loOp2->IsCnsIntOrI());
+    assert(hiOp2->IsCnsIntOrI());
     assert((loOp2->AsIntCon()->gtIconVal >= 2) && (loOp2->AsIntCon()->gtIconVal <= 0x3fffffff));
     assert(hiOp2->AsIntCon()->gtIconVal == 0);
 

--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -517,7 +517,7 @@ GenTree* Compiler::optFindNullCheckToFold(GenTree* tree, LocalNumberToNullCheckT
 
     if ((addr->OperGet() == GT_ADD) && addr->gtGetOp2()->IsCnsIntOrI())
     {
-        offsetValue += addr->gtGetOp2()->AsIntConCommon()->IconValue();
+        offsetValue += addr->gtGetOp2()->AsIntCon()->IconValue();
         addr = addr->gtGetOp1();
     }
 
@@ -601,7 +601,7 @@ GenTree* Compiler::optFindNullCheckToFold(GenTree* tree, LocalNumberToNullCheckT
             (additionOp1->AsLclVarCommon()->GetLclNum() == nullCheckAddress->AsLclVarCommon()->GetLclNum()) &&
             (additionOp2->IsCnsIntOrI()))
         {
-            offsetValue += additionOp2->AsIntConCommon()->IconValue();
+            offsetValue += additionOp2->AsIntCon()->IconValue();
             nullCheckTree = commaOp1EffectiveValue;
         }
     }

--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -8073,10 +8073,10 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
     assert(!src->isContained() || src->isContainedIntOrIImmed());
 
     // find immed (if any) - it cannot be a dst
-    GenTreeIntConCommon* intConst = nullptr;
+    GenTreeIntCon* intConst = nullptr;
     if (src->isContainedIntOrIImmed())
     {
-        intConst = src->AsIntConCommon();
+        intConst = src->AsIntCon();
     }
 
     if (intConst)
@@ -8098,8 +8098,8 @@ regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, 
 
     // find immed (if any) - it cannot be a dst
     // Only one src can be an int.
-    GenTreeIntConCommon* intConst  = nullptr;
-    GenTree*             nonIntReg = nullptr;
+    GenTreeIntCon* intConst  = nullptr;
+    GenTree*       nonIntReg = nullptr;
 
     if (varTypeIsFloating(dst))
     {
@@ -8116,7 +8116,7 @@ regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, 
         // Check src2 first as we can always allow it to be a contained immediate
         if (src2->isContainedIntOrIImmed())
         {
-            intConst  = src2->AsIntConCommon();
+            intConst  = src2->AsIntCon();
             nonIntReg = src1;
         }
         // Only for commutative operations do we check src1 and allow it to be a contained immediate
@@ -8129,7 +8129,7 @@ regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, 
             if (src1->isContainedIntOrIImmed())
             {
                 assert(!src2->isContainedIntOrIImmed());
-                intConst  = src1->AsIntConCommon();
+                intConst  = src1->AsIntCon();
                 nonIntReg = src2;
             }
         }

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -14220,10 +14220,10 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
     assert(!src->isContained() || src->isContainedIntOrIImmed());
 
     // find immed (if any) - it cannot be a dst
-    GenTreeIntConCommon* intConst = nullptr;
+    GenTreeIntCon* intConst = nullptr;
     if (src->isContainedIntOrIImmed())
     {
-        intConst = src->AsIntConCommon();
+        intConst = src->AsIntCon();
     }
 
     if (intConst)
@@ -14248,8 +14248,8 @@ regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, 
 
     // find immed (if any) - it cannot be a dst
     // Only one src can be an int.
-    GenTreeIntConCommon* intConst  = nullptr;
-    GenTree*             nonIntReg = nullptr;
+    GenTreeIntCon* intConst  = nullptr;
+    GenTree*       nonIntReg = nullptr;
 
     if (varTypeIsFloating(dst))
     {
@@ -14266,7 +14266,7 @@ regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, 
         // Check src2 first as we can always allow it to be a contained immediate
         if (src2->isContainedIntOrIImmed())
         {
-            intConst  = src2->AsIntConCommon();
+            intConst  = src2->AsIntCon();
             nonIntReg = src1;
         }
         // Only for commutative operations do we check src1 and allow it to be a contained immediate
@@ -14279,7 +14279,7 @@ regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, 
             if (src1->isContainedIntOrIImmed())
             {
                 assert(!src2->isContainedIntOrIImmed());
-                intConst  = src1->AsIntConCommon();
+                intConst  = src1->AsIntCon();
                 nonIntReg = src2;
             }
         }

--- a/src/coreclr/jit/emitloongarch64.cpp
+++ b/src/coreclr/jit/emitloongarch64.cpp
@@ -6249,8 +6249,8 @@ regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, 
 
     // find immed (if any) - it cannot be a dst
     // Only one src can be an int.
-    GenTreeIntConCommon* intConst  = nullptr;
-    GenTree*             nonIntReg = nullptr;
+    GenTreeIntCon* intConst  = nullptr;
+    GenTree*       nonIntReg = nullptr;
 
     bool needCheckOv = dst->gtOverflowEx();
 
@@ -6269,7 +6269,7 @@ regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, 
         // Check src2 first as we can always allow it to be a contained immediate
         if (src2->isContainedIntOrIImmed())
         {
-            intConst  = src2->AsIntConCommon();
+            intConst  = src2->AsIntCon();
             nonIntReg = src1;
         }
         // Only for commutative operations do we check src1 and allow it to be a contained immediate
@@ -6282,7 +6282,7 @@ regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, 
             if (src1->isContainedIntOrIImmed())
             {
                 assert(!src2->isContainedIntOrIImmed());
-                intConst  = src1->AsIntConCommon();
+                intConst  = src1->AsIntCon();
                 nonIntReg = src2;
             }
         }

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -4089,8 +4089,8 @@ regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, 
 
     // find immed (if any) - it cannot be a dst
     // Only one src can be an int.
-    GenTreeIntConCommon* intConst  = nullptr;
-    GenTree*             nonIntReg = nullptr;
+    GenTreeIntCon* intConst  = nullptr;
+    GenTree*       nonIntReg = nullptr;
 
     bool needCheckOv = dst->gtOverflowEx();
 
@@ -4109,7 +4109,7 @@ regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, 
         // Check src2 first as we can always allow it to be a contained immediate
         if (src2->isContainedIntOrIImmed())
         {
-            intConst  = src2->AsIntConCommon();
+            intConst  = src2->AsIntCon();
             nonIntReg = src1;
         }
         // Only for commutative operations do we check src1 and allow it to be a contained immediate
@@ -4122,7 +4122,7 @@ regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, 
             if (src1->isContainedIntOrIImmed())
             {
                 assert(!src2->isContainedIntOrIImmed());
-                intConst  = src1->AsIntConCommon();
+                intConst  = src1->AsIntCon();
                 nonIntReg = src2;
             }
         }

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -4673,7 +4673,7 @@ void emitter::emitHandleMemOp(GenTreeIndir* indir, instrDesc* id, insFormat fmt,
     else if ((memBase != nullptr) && memBase->IsCnsIntOrI() && memBase->isContained())
     {
         // Absolute addresses marked as contained should fit within the base of addr mode.
-        assert(memBase->AsIntConCommon()->FitsInAddrBase(emitComp));
+        assert(memBase->AsIntCon()->FitsInAddrBase(emitComp));
 
         // If we reach here, either:
         // - we are not generating relocatable code, (typically the non-AOT JIT case)
@@ -4684,9 +4684,9 @@ void emitter::emitHandleMemOp(GenTreeIndir* indir, instrDesc* id, insFormat fmt,
         //   be contained.
         //
         assert(!emitComp->opts.compReloc || memBase->IsIconHandle() || memBase->IsIntegralConst(0) ||
-               memBase->AsIntConCommon()->FitsInAddrBase(emitComp));
+               memBase->AsIntCon()->FitsInAddrBase(emitComp));
 
-        if (memBase->AsIntConCommon()->AddrNeedsReloc(emitComp))
+        if (memBase->AsIntCon()->AddrNeedsReloc(emitComp))
         {
             id->idSetIsDspReloc();
         }
@@ -4698,7 +4698,7 @@ void emitter::emitHandleMemOp(GenTreeIndir* indir, instrDesc* id, insFormat fmt,
         id->idInsFmt(emitMapFmtForIns(fmt, ins));
 
         // Absolute address must have already been set in the instrDesc constructor.
-        assert(emitGetInsAmdAny(id) == memBase->AsIntConCommon()->IconValue());
+        assert(emitGetInsAmdAny(id) == memBase->AsIntCon()->IconValue());
     }
     else
     {
@@ -4851,7 +4851,7 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
     {
         if (data->isContainedIntOrIImmed())
         {
-            emitIns_C_I(ins, attr, addr->AsClsVar()->gtClsVarHnd, 0, (int)data->AsIntConCommon()->IconValue());
+            emitIns_C_I(ins, attr, addr->AsClsVar()->gtClsVarHnd, 0, (int)data->AsIntCon()->IconValue());
         }
 #if defined(FEATURE_HW_INTRINSICS)
         else if (data->OperIsHWIntrinsic() && data->isContained())
@@ -4869,7 +4869,7 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
             {
                 assert(numArgs == 2);
 
-                int icon = static_cast<int>(hwintrinsic->Op(2)->AsIntConCommon()->IconValue());
+                int icon = static_cast<int>(hwintrinsic->Op(2)->AsIntCon()->IconValue());
                 emitIns_C_R_I(ins, attr, addr->AsClsVar()->gtClsVarHnd, 0, op1->GetRegNum(), icon);
             }
         }
@@ -4889,7 +4889,7 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
 
         if (data->isContainedIntOrIImmed())
         {
-            emitIns_S_I(ins, attr, varNode->GetLclNum(), offset, (int)data->AsIntConCommon()->IconValue());
+            emitIns_S_I(ins, attr, varNode->GetLclNum(), offset, (int)data->AsIntCon()->IconValue());
         }
 #if defined(FEATURE_HW_INTRINSICS)
         else if (data->OperIsHWIntrinsic() && data->isContained())
@@ -4907,7 +4907,7 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
             {
                 assert(numArgs == 2);
 
-                int icon = static_cast<int>(hwintrinsic->Op(2)->AsIntConCommon()->IconValue());
+                int icon = static_cast<int>(hwintrinsic->Op(2)->AsIntCon()->IconValue());
                 emitIns_S_R_I(ins, attr, varNode->GetLclNum(), offset, op1->GetRegNum(), icon);
             }
         }
@@ -4929,7 +4929,7 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
 
     if (data->isContainedIntOrIImmed())
     {
-        int icon = (int)data->AsIntConCommon()->IconValue();
+        int icon = (int)data->AsIntCon()->IconValue();
         id       = emitNewInstrAmdCns(attr, offset, icon);
         id->idIns(ins);
         emitHandleMemOp(mem, id, emitInsModeFormat(ins, IF_ARD_CNS), ins);
@@ -4956,7 +4956,7 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
         else
         {
             assert(numArgs == 2);
-            int icon = static_cast<int>(hwintrinsic->Op(2)->AsIntConCommon()->IconValue());
+            int icon = static_cast<int>(hwintrinsic->Op(2)->AsIntCon()->IconValue());
 
             id = emitNewInstrAmdCns(attr, offset, icon);
             id->idIns(ins);
@@ -5001,7 +5001,7 @@ void emitter::emitInsStoreLcl(instruction ins, emitAttr attr, GenTreeLclVarCommo
 
     if (data->isContainedIntOrIImmed())
     {
-        emitIns_S_I(ins, attr, varNode->GetLclNum(), 0, (int)data->AsIntConCommon()->IconValue());
+        emitIns_S_I(ins, attr, varNode->GetLclNum(), 0, (int)data->AsIntCon()->IconValue());
     }
     else
     {
@@ -5169,7 +5169,7 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
                             // src is an contained immediate
                             // dst is a class static variable
                             emitIns_C_I(ins, attr, memBase->AsClsVar()->gtClsVarHnd, 0,
-                                        (int)src->AsIntConCommon()->IconValue());
+                                        (int)src->AsIntCon()->IconValue());
                         }
                         else
                         {
@@ -5195,7 +5195,7 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
                         assert(otherOp == nullptr);
                         assert(src->IsCnsIntOrI());
 
-                        id = emitNewInstrAmdCns(attr, memIndir->Offset(), (int)src->AsIntConCommon()->IconValue());
+                        id = emitNewInstrAmdCns(attr, memIndir->Offset(), (int)src->AsIntCon()->IconValue());
                     }
                     else
                     {
@@ -5278,7 +5278,7 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
                             assert(cnsOp == src);
                             assert(otherOp == nullptr);
 
-                            sz = emitInsSizeAM(id, insCodeMI(ins), (int)src->AsIntConCommon()->IconValue());
+                            sz = emitInsSizeAM(id, insCodeMI(ins), (int)src->AsIntCon()->IconValue());
                         }
                         else
                         {
@@ -5359,7 +5359,7 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
 
                 // src is an contained immediate
                 // dst is a stack based local variable
-                emitIns_S_I(ins, attr, varNum, offset, (int)src->AsIntConCommon()->IconValue());
+                emitIns_S_I(ins, attr, varNum, offset, (int)src->AsIntCon()->IconValue());
             }
             else
             {
@@ -5380,7 +5380,7 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
         if (src->IsCnsIntOrI())
         {
             assert(!dst->isContained());
-            GenTreeIntConCommon* intCns = src->AsIntConCommon();
+            GenTreeIntCon* intCns = src->AsIntCon();
             emitIns_R_I(ins, attr, dst->GetRegNum(), intCns->IconValue());
         }
         else
@@ -5450,8 +5450,8 @@ void emitter::emitInsRMW(instruction ins, emitAttr attr, GenTreeStoreInd* storeI
 
     if (src->isContainedIntOrIImmed())
     {
-        GenTreeIntConCommon* intConst = src->AsIntConCommon();
-        int                  iconVal  = (int)intConst->IconValue();
+        GenTreeIntCon* intConst = src->AsIntCon();
+        int            iconVal  = (int)intConst->IconValue();
         switch (ins)
         {
             case INS_rcl_N:

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -386,7 +386,7 @@ void Compiler::fgDumpTree(FILE* fgxFile, GenTree* const tree)
     }
     else if (tree->IsCnsIntOrI())
     {
-        fprintf(fgxFile, "%d", tree->AsIntCon()->gtIconVal);
+        fprintf(fgxFile, "%d", tree->AsIntCon()->IconValue());
     }
     else if (tree->IsCnsFltOrDbl())
     {

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -661,7 +661,7 @@ private:
             GenTree*    condTree = tree->AsOp()->gtOp1;
             assert(tree == block->lastStmt()->GetRootNode());
 
-            if (condTree->OperGet() == GT_CNS_INT)
+            if (condTree->IsCnsIntOrI())
             {
                 JITDUMP(" ... found foldable jtrue at [%06u] in " FMT_BB "\n", m_compiler->dspTreeID(tree),
                         block->bbNum);

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -921,7 +921,7 @@ bool Compiler::fgAddrCouldBeNull(GenTree* addr)
                 GenTree* cns1Tree = addr->AsOp()->gtOp1;
                 if (!cns1Tree->IsIconHandle())
                 {
-                    if (!fgIsBigOffset(cns1Tree->AsIntCon()->gtIconVal))
+                    if (!fgIsBigOffset(cns1Tree->AsIntCon()->IconValue()))
                     {
                         // Op1 was an ordinary small constant
                         return fgAddrCouldBeNull(addr->AsOp()->gtOp2);
@@ -936,7 +936,7 @@ bool Compiler::fgAddrCouldBeNull(GenTree* addr)
                         // Is this an addition of a handle and constant
                         if (!cns2Tree->IsIconHandle())
                         {
-                            if (!fgIsBigOffset(cns2Tree->AsIntCon()->gtIconVal))
+                            if (!fgIsBigOffset(cns2Tree->AsIntCon()->IconValue()))
                             {
                                 // Op2 was an ordinary small constant
                                 return false; // we can't have a null address
@@ -954,7 +954,7 @@ bool Compiler::fgAddrCouldBeNull(GenTree* addr)
                     // Is this an addition of a small constant
                     if (!cns2Tree->IsIconHandle())
                     {
-                        if (!fgIsBigOffset(cns2Tree->AsIntCon()->gtIconVal))
+                        if (!fgIsBigOffset(cns2Tree->AsIntCon()->IconValue()))
                         {
                             // Op2 was an ordinary small constant
                             return fgAddrCouldBeNull(addr->AsOp()->gtOp1);

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -916,7 +916,7 @@ bool Compiler::fgAddrCouldBeNull(GenTree* addr)
             return !addr->IsHelperCall() || !s_helperCallProperties.NonNullReturn(addr->AsCall()->GetHelperNum());
 
         case GT_ADD:
-            if (addr->AsOp()->gtOp1->gtOper == GT_CNS_INT)
+            if (addr->AsOp()->gtOp1->IsCnsIntOrI())
             {
                 GenTree* cns1Tree = addr->AsOp()->gtOp1;
                 if (!cns1Tree->IsIconHandle())
@@ -930,7 +930,7 @@ bool Compiler::fgAddrCouldBeNull(GenTree* addr)
                 else // Op1 was a handle represented as a constant
                 {
                     // Is Op2 also a constant?
-                    if (addr->AsOp()->gtOp2->gtOper == GT_CNS_INT)
+                    if (addr->AsOp()->gtOp2->IsCnsIntOrI())
                     {
                         GenTree* cns2Tree = addr->AsOp()->gtOp2;
                         // Is this an addition of a handle and constant
@@ -948,7 +948,7 @@ bool Compiler::fgAddrCouldBeNull(GenTree* addr)
             else
             {
                 // Op1 is not a constant. What about Op2?
-                if (addr->AsOp()->gtOp2->gtOper == GT_CNS_INT)
+                if (addr->AsOp()->gtOp2->IsCnsIntOrI())
                 {
                     GenTree* cns2Tree = addr->AsOp()->gtOp2;
                     // Is this an addition of a small constant
@@ -1012,7 +1012,7 @@ GenTree* Compiler::fgOptimizeDelegateConstructor(GenTreeCall*            call,
         assert(targetMethod->AsCall()->gtArgs.CountArgs() == 3);
         GenTree* handleNode = targetMethod->AsCall()->gtArgs.GetArgByIndex(2)->GetNode();
 
-        if (handleNode->OperGet() == GT_CNS_INT)
+        if (handleNode->IsCnsIntOrI())
         {
             // it's a ldvirtftn case, fetch the methodhandle off the helper for ldvirtftn. It's the 3rd arg
             targetMethodHnd = CORINFO_METHOD_HANDLE(handleNode->AsIntCon()->gtCompileTimeHandle);
@@ -1050,7 +1050,7 @@ GenTree* Compiler::fgOptimizeDelegateConstructor(GenTreeCall*            call,
 
         // This could be any of CORINFO_HELP_RUNTIMEHANDLE_(METHOD|CLASS)(_LOG?)
         GenTree* tokenNode = runtimeLookupCall->gtArgs.GetArgByIndex(1)->GetNode();
-        noway_assert(tokenNode->OperGet() == GT_CNS_INT);
+        noway_assert(tokenNode->IsCnsIntOrI());
         targetMethodHnd = CORINFO_METHOD_HANDLE(tokenNode->AsIntCon()->gtCompileTimeHandle);
     }
 

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -2161,7 +2161,7 @@ private:
     // Return Value:
     //    The new merged return block.
     //
-    BasicBlock* CreateReturnBB(unsigned index, GenTreeIntConCommon* returnConst = nullptr)
+    BasicBlock* CreateReturnBB(unsigned index, GenTreeIntCon* returnConst = nullptr)
     {
         BasicBlock* newReturnBB = comp->fgNewBBinRegion(BBJ_RETURN);
         comp->fgReturnCount++;
@@ -2285,7 +2285,7 @@ private:
             // Check to see if this is a constant return so that we can search
             // for and/or create a constant return block for it.
 
-            GenTreeIntConCommon* retConst = GetReturnConst(returnBlock);
+            GenTreeIntCon* retConst = GetReturnConst(returnBlock);
             if (retConst != nullptr)
             {
                 // We have a constant.  Now find or create a corresponding return block.
@@ -2386,7 +2386,7 @@ private:
 
     //------------------------------------------------------------------------
     // GetReturnConst: If the given block returns an integral constant, return the
-    //     GenTreeIntConCommon that represents the constant.
+    //     GenTreeIntCon that represents the constant.
     //
     // Arguments:
     //    returnBlock - Block whose return value is to be inspected.
@@ -2395,7 +2395,7 @@ private:
     //    GenTreeIntCommon that is the argument of `returnBlock`'s `GT_RETURN` if
     //    such exists; nullptr otherwise.
     //
-    static GenTreeIntConCommon* GetReturnConst(BasicBlock* returnBlock)
+    static GenTreeIntCon* GetReturnConst(BasicBlock* returnBlock)
     {
         Statement* lastStmt = returnBlock->lastStmt();
         if (lastStmt == nullptr)
@@ -2415,7 +2415,7 @@ private:
             return nullptr;
         }
 
-        return retExpr->AsIntConCommon();
+        return retExpr->AsIntCon();
     }
 
     //------------------------------------------------------------------------
@@ -2433,7 +2433,7 @@ private:
     // Return Value:
     //    A block that returns the same constant, if one is found; otherwise nullptr.
     //
-    BasicBlock* FindConstReturnBlock(GenTreeIntConCommon* constExpr, unsigned searchLimit, unsigned* index)
+    BasicBlock* FindConstReturnBlock(GenTreeIntCon* constExpr, unsigned searchLimit, unsigned* index)
     {
         INT64 constVal = constExpr->IntegralValue();
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -7399,7 +7399,7 @@ GenTreeQmark* Compiler::gtNewQmarkNode(var_types type, GenTree* cond, GenTreeCol
 GenTreeIntCon* Compiler::gtNewIconNode(ssize_t value, var_types type)
 {
     assert(genActualType(type) == type);
-    return new (this, GT_CNS_INT) GenTreeIntCon(type, value);
+    return new (this, GT_CNS_INT) GenTreeIntCon(type, value, nullptr);
 }
 
 GenTreeIntCon* Compiler::gtNewIconNode(unsigned fieldOffset, FieldSeq* fieldSeq)
@@ -7632,7 +7632,7 @@ GenTreeIntCon* Compiler::gtNewStringLiteralLength(GenTreeStrCon* node)
 
 GenTree* Compiler::gtNewLconNode(int64_t value)
 {
-    GenTree* node = new (this, GT_CNS_NATIVELONG) GenTreeIntCon(value);
+    GenTree* node = new (this, GT_CNS_NATIVELONG) GenTreeIntCon(TYP_LONG, value, nullptr);
 
     return node;
 }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6091,7 +6091,7 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
             if (call->gtCallType == CT_INDIRECT)
             {
                 // pinvoke-calli cookie is a constant, or constant indirection
-                assert(call->gtCallCookie == nullptr || call->gtCallCookie->gtOper == GT_CNS_INT ||
+                assert(call->gtCallCookie == nullptr || call->gtCallCookie->IsCnsIntOrI() ||
                        call->gtCallCookie->gtOper == GT_IND);
 
                 GenTree* indirect = call->gtCallAddr;
@@ -6823,7 +6823,7 @@ bool GenTree::OperRequiresCallFlag(Compiler* comp) const
             // could mark the trees just before argument processing, but it would require a full
             // tree walk of the argument tree, so we just do it when morphing, instead, even though we'll
             // mark non-argument trees (that will still get converted to calls, anyway).
-            return (this->TypeGet() == TYP_LONG) && (gtGetOp2()->OperGet() != GT_CNS_INT);
+            return (this->TypeGet() == TYP_LONG) && !gtGetOp2()->IsIntegralConst();
 #endif // FEATURE_FIXED_OUT_ARGS && !TARGET_64BIT
 
         default:
@@ -8764,7 +8764,7 @@ void GenTreeOp::CheckDivideByConstOptimized(Compiler* comp)
         // Now set DONT_CSE on the GT_CNS_INT divisor, note that
         // with ValueNumbering we can have a non GT_CNS_INT divisor
         GenTree* divisor = gtGetOp2()->gtEffectiveVal(/*commaOnly*/ true);
-        if (divisor->OperIs(GT_CNS_INT))
+        if (divisor->IsCnsIntOrI())
         {
             divisor->gtFlags |= GTF_DONT_CSE;
         }
@@ -14033,7 +14033,7 @@ CORINFO_CLASS_HANDLE Compiler::gtGetHelperArgClassHandle(GenTree* tree)
     }
 
     // The handle could be a literal constant
-    if ((tree->OperGet() == GT_CNS_INT) && (tree->TypeGet() == TYP_I_IMPL))
+    if (tree->IsCnsIntOrI() && (tree->TypeGet() == TYP_I_IMPL))
     {
         assert(tree->IsIconHandle(GTF_ICON_CLASS_HDL));
         result = (CORINFO_CLASS_HANDLE)tree->AsIntCon()->gtCompileTimeHandle;
@@ -14052,7 +14052,7 @@ CORINFO_CLASS_HANDLE Compiler::gtGetHelperArgClassHandle(GenTree* tree)
         {
             GenTree* handleTreeInternal = tree->AsOp()->gtOp1;
 
-            if ((handleTreeInternal->OperGet() == GT_CNS_INT) && (handleTreeInternal->TypeGet() == TYP_I_IMPL))
+            if (handleTreeInternal->IsCnsIntOrI() && (handleTreeInternal->TypeGet() == TYP_I_IMPL))
             {
                 // These handle constants should be class handles.
                 assert(handleTreeInternal->IsIconHandle(GTF_ICON_CLASS_HDL));
@@ -17318,7 +17318,7 @@ Compiler::TypeProducerKind Compiler::gtGetTypeProducerKind(GenTree* tree)
     {
         return TPK_GetType;
     }
-    else if ((tree->gtOper == GT_CNS_INT) && (tree->AsIntCon()->gtIconVal == 0))
+    else if ((tree->IsCnsIntOrI()) && (tree->AsIntCon()->gtIconVal == 0))
     {
         return TPK_Null;
     }
@@ -18978,7 +18978,7 @@ void GenTreeArrAddr::ParseArrayAddress(Compiler* comp, GenTree** pArr, ValueNum*
                 {
                     // If the other arg is an int constant, and is a "not-a-field", choose
                     // that as the multiplier, thus preserving constant index offsets...
-                    if (tree->AsOp()->gtOp2->OperGet() == GT_CNS_INT &&
+                    if (tree->AsOp()->gtOp2->IsCnsIntOrI() &&
                         tree->AsOp()->gtOp2->AsIntCon()->gtFieldSeq == nullptr)
                     {
                         assert(!tree->AsOp()->gtOp2->AsIntCon()->ImmedValNeedsReloc(comp));

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2693,7 +2693,7 @@ AGAIN:
         switch (oper)
         {
             case GT_CNS_INT:
-                if (op1->AsIntCon()->gtIconVal == op2->AsIntCon()->gtIconVal)
+                if (op1->AsIntCon()->IconValue() == op2->AsIntCon()->IconValue())
                 {
                     return true;
                 }
@@ -2719,7 +2719,7 @@ AGAIN:
 #if 0
             // TODO-CQ: Enable this in the future
         case GT_CNS_LNG:
-            if  (op1->AsIntCon()->gtLconVal == op2->AsIntCon()->gtLconVal)
+            if  (op1->AsIntCon()->IntegralValue() == op2->AsIntCon()->IntegralValue())
                 return true;
             break;
 
@@ -3229,10 +3229,10 @@ AGAIN:
                 break;
 
             case GT_CNS_INT:
-                add = tree->AsIntCon()->gtIconVal;
+                add = tree->AsIntCon()->IconValue();
                 break;
             case GT_CNS_LNG:
-                bits = (UINT64)tree->AsIntCon()->gtLconVal;
+                bits = (UINT64)tree->AsIntCon()->IntegralValue();
 #ifdef HOST_64BIT
                 add = bits;
 #else // 32-bit host
@@ -8574,7 +8574,7 @@ void GenTreeIntCon::FixupInitBlkValue(var_types type)
     unsigned size = genTypeSize(type);
     if (size > 1)
     {
-        size_t cns = gtIconVal;
+        size_t cns = IconValue();
         cns        = cns & 0xFF;
         cns |= cns << 8;
         if (size >= 4)
@@ -8594,7 +8594,7 @@ void GenTreeIntCon::FixupInitBlkValue(var_types type)
             assert(!varTypeIsGC(type) || (cns == 0));
         }
 
-        gtIconVal = cns;
+        SetIconValue(cns);
     }
 }
 
@@ -8792,7 +8792,7 @@ GenTree* Compiler::gtNewPutArgReg(var_types type, GenTree* arg, regNumber argReg
         node->AsMultiRegOp()->gtOtherReg = REG_NEXT(argReg);
     }
 #else
-    node          = gtNewOperNode(GT_PUTARG_REG, type, arg);
+    node = gtNewOperNode(GT_PUTARG_REG, type, arg);
 #endif
     node->SetRegNum(argReg);
 
@@ -8823,7 +8823,7 @@ GenTree* Compiler::gtNewBitCastNode(var_types type, GenTree* arg)
     // A BITCAST could be a MultiRegOp on arm since we could move a double register to two int registers.
     node = new (this, GT_BITCAST) GenTreeMultiRegOp(GT_BITCAST, type, arg, nullptr);
 #else
-    node          = gtNewOperNode(GT_BITCAST, type, arg);
+    node = gtNewOperNode(GT_BITCAST, type, arg);
 #endif
 
     return node;
@@ -8926,7 +8926,7 @@ GenTree* Compiler::gtClone(GenTree* tree, bool complexOK)
 #if defined(LATE_DISASM)
             if (tree->IsIconHandle())
             {
-                copy = gtNewIconHandleNode(tree->AsIntCon()->gtIconVal, tree->gtFlags, tree->AsIntCon()->gtFieldSeq);
+                copy = gtNewIconHandleNode(tree->AsIntCon()->IconValue(), tree->gtFlags, tree->AsIntCon()->gtFieldSeq);
                 copy->AsIntCon()->gtCompileTimeHandle = tree->AsIntCon()->gtCompileTimeHandle;
                 copy->gtType                          = tree->gtType;
             }
@@ -8934,13 +8934,13 @@ GenTree* Compiler::gtClone(GenTree* tree, bool complexOK)
 #endif
             {
                 copy = new (this, GT_CNS_INT)
-                    GenTreeIntCon(tree->gtType, tree->AsIntCon()->gtIconVal, tree->AsIntCon()->gtFieldSeq);
+                    GenTreeIntCon(tree->gtType, tree->AsIntCon()->IconValue(), tree->AsIntCon()->gtFieldSeq);
                 copy->AsIntCon()->gtCompileTimeHandle = tree->AsIntCon()->gtCompileTimeHandle;
             }
             break;
 
         case GT_CNS_LNG:
-            copy = gtNewLconNode(tree->AsIntCon()->gtLconVal);
+            copy = gtNewLconNode(tree->AsIntCon()->IntegralValue());
             break;
 
         case GT_CNS_DBL:
@@ -9112,14 +9112,14 @@ GenTree* Compiler::gtCloneExpr(
                 if (tree->IsIconHandle())
                 {
                     copy =
-                        gtNewIconHandleNode(tree->AsIntCon()->gtIconVal, tree->gtFlags, tree->AsIntCon()->gtFieldSeq);
+                        gtNewIconHandleNode(tree->AsIntCon()->IconValue(), tree->gtFlags, tree->AsIntCon()->gtFieldSeq);
                     copy->AsIntCon()->gtCompileTimeHandle = tree->AsIntCon()->gtCompileTimeHandle;
                     copy->gtType                          = tree->gtType;
                 }
                 else
 #endif
                 {
-                    copy = gtNewIconNode(tree->AsIntCon()->gtIconVal, tree->gtType);
+                    copy = gtNewIconNode(tree->AsIntCon()->IconValue(), tree->gtType);
 #ifdef DEBUG
                     copy->AsIntCon()->gtTargetHandle = tree->AsIntCon()->gtTargetHandle;
 #endif
@@ -9129,7 +9129,7 @@ GenTree* Compiler::gtCloneExpr(
                 goto DONE;
 
             case GT_CNS_LNG:
-                copy = gtNewLconNode(tree->AsIntCon()->gtLconVal);
+                copy = gtNewLconNode(tree->AsIntCon()->IntegralValue());
                 goto DONE;
 
             case GT_CNS_DBL:
@@ -11827,20 +11827,20 @@ void Compiler::gtDispConst(GenTree* tree)
         case GT_CNS_INT:
             if (tree->IsIconHandle(GTF_ICON_STR_HDL))
             {
-                printf(" 0x%X [ICON_STR_HDL]", dspPtr(tree->AsIntCon()->gtIconVal));
+                printf(" 0x%X [ICON_STR_HDL]", dspPtr(tree->AsIntCon()->IconValue()));
             }
             else if (tree->IsIconHandle(GTF_ICON_OBJ_HDL))
             {
-                eePrintObjectDescription(" ", (CORINFO_OBJECT_HANDLE)tree->AsIntCon()->gtIconVal);
+                eePrintObjectDescription(" ", (CORINFO_OBJECT_HANDLE)tree->AsIntCon()->IconValue());
             }
             else
             {
                 ssize_t dspIconVal =
-                    tree->IsIconHandle() ? dspPtr(tree->AsIntCon()->gtIconVal) : tree->AsIntCon()->gtIconVal;
+                    tree->IsIconHandle() ? dspPtr(tree->AsIntCon()->IconValue()) : tree->AsIntCon()->IconValue();
 
                 if (tree->TypeGet() == TYP_REF)
                 {
-                    if (tree->AsIntCon()->gtIconVal == 0)
+                    if (tree->AsIntCon()->IconValue() == 0)
                     {
                         printf(" null");
                     }
@@ -11850,12 +11850,12 @@ void Compiler::gtDispConst(GenTree* tree)
                         printf(" 0x%llx", dspIconVal);
                     }
                 }
-                else if ((tree->AsIntCon()->gtIconVal > -1000) && (tree->AsIntCon()->gtIconVal < 1000))
+                else if ((tree->AsIntCon()->IconValue() > -1000) && (tree->AsIntCon()->IconValue() < 1000))
                 {
                     printf(" %ld", dspIconVal);
                 }
 #ifdef TARGET_64BIT
-                else if ((tree->AsIntCon()->gtIconVal & 0xFFFFFFFF00000000LL) != 0)
+                else if ((tree->AsIntCon()->IconValue() & 0xFFFFFFFF00000000LL) != 0)
                 {
                     if (dspIconVal >= 0)
                     {
@@ -11962,7 +11962,7 @@ void Compiler::gtDispConst(GenTree* tree)
             break;
 
         case GT_CNS_LNG:
-            printf(" 0x%016I64x", tree->AsIntCon()->gtLconVal);
+            printf(" 0x%016I64x", tree->AsIntCon()->IntegralValue());
             break;
 
         case GT_CNS_DBL:
@@ -17312,7 +17312,7 @@ Compiler::TypeProducerKind Compiler::gtGetTypeProducerKind(GenTree* tree)
     {
         return TPK_GetType;
     }
-    else if ((tree->IsCnsIntOrI()) && (tree->AsIntCon()->gtIconVal == 0))
+    else if ((tree->IsCnsIntOrI()) && (tree->AsIntCon()->IconValue() == 0))
     {
         return TPK_Null;
     }
@@ -18948,9 +18948,9 @@ void GenTreeArrAddr::ParseArrayAddress(Compiler* comp, GenTree** pArr, ValueNum*
         {
             case GT_CNS_INT:
                 assert(!tree->AsIntCon()->ImmedValNeedsReloc(comp));
-                // TODO-CrossBitness: we wouldn't need the cast below if GenTreeIntCon::gtIconVal had target_ssize_t
+                // TODO-CrossBitness: we wouldn't need the cast below if GenTreeIntCon::IconValue() had target_ssize_t
                 // type.
-                *pOffset += (inputMul * (target_ssize_t)(tree->AsIntCon()->gtIconVal));
+                *pOffset += (inputMul * (target_ssize_t)(tree->AsIntCon()->IconValue()));
                 return;
 
             case GT_ADD:
@@ -18975,7 +18975,7 @@ void GenTreeArrAddr::ParseArrayAddress(Compiler* comp, GenTree** pArr, ValueNum*
                     if (tree->AsOp()->gtOp2->IsCnsIntOrI() && tree->AsOp()->gtOp2->AsIntCon()->gtFieldSeq == nullptr)
                     {
                         assert(!tree->AsOp()->gtOp2->AsIntCon()->ImmedValNeedsReloc(comp));
-                        // TODO-CrossBitness: we wouldn't need the cast below if GenTreeIntCon::gtIconVal had
+                        // TODO-CrossBitness: we wouldn't need the cast below if GenTreeIntCon::IconValue() had
                         // target_ssize_t type.
                         subMul   = (target_ssize_t)tree->AsOp()->gtOp2->AsIntCon()->IconValue();
                         nonConst = tree->AsOp()->gtOp1;
@@ -18983,7 +18983,7 @@ void GenTreeArrAddr::ParseArrayAddress(Compiler* comp, GenTree** pArr, ValueNum*
                     else
                     {
                         assert(!tree->AsOp()->gtOp1->AsIntCon()->ImmedValNeedsReloc(comp));
-                        // TODO-CrossBitness: we wouldn't need the cast below if GenTreeIntCon::gtIconVal had
+                        // TODO-CrossBitness: we wouldn't need the cast below if GenTreeIntCon::IconValue() had
                         // target_ssize_t type.
                         subMul   = (target_ssize_t)tree->AsOp()->gtOp1->AsIntCon()->IconValue();
                         nonConst = tree->AsOp()->gtOp2;
@@ -18992,7 +18992,7 @@ void GenTreeArrAddr::ParseArrayAddress(Compiler* comp, GenTree** pArr, ValueNum*
                 else if (tree->AsOp()->gtOp2->IsCnsIntOrI())
                 {
                     assert(!tree->AsOp()->gtOp2->AsIntCon()->ImmedValNeedsReloc(comp));
-                    // TODO-CrossBitness: we wouldn't need the cast below if GenTreeIntCon::gtIconVal had
+                    // TODO-CrossBitness: we wouldn't need the cast below if GenTreeIntCon::IconValue() had
                     // target_ssize_t type.
                     subMul   = (target_ssize_t)tree->AsOp()->gtOp2->AsIntCon()->IconValue();
                     nonConst = tree->AsOp()->gtOp1;
@@ -19011,7 +19011,8 @@ void GenTreeArrAddr::ParseArrayAddress(Compiler* comp, GenTree** pArr, ValueNum*
                 if (tree->AsOp()->gtOp2->IsCnsIntOrI())
                 {
                     assert(!tree->AsOp()->gtOp2->AsIntCon()->ImmedValNeedsReloc(comp));
-                    // TODO-CrossBitness: we wouldn't need the cast below if GenTreeIntCon::gtIconVal had target_ssize_t
+                    // TODO-CrossBitness: we wouldn't need the cast below if GenTreeIntCon::IconValue() had
+                    // target_ssize_t
                     // type.
                     target_ssize_t shiftVal = (target_ssize_t)tree->AsOp()->gtOp2->AsIntCon()->IconValue();
                     target_ssize_t subMul   = target_ssize_t{1} << shiftVal;
@@ -19580,7 +19581,7 @@ bool GenTree::isRMWHWIntrinsic(Compiler* comp)
                 return true;
             }
 
-            uint8_t                 control  = static_cast<uint8_t>(op4->AsIntCon()->gtIconVal);
+            uint8_t                 control  = static_cast<uint8_t>(op4->AsIntCon()->IconValue());
             const TernaryLogicInfo& info     = TernaryLogicInfo::lookup(control);
             TernaryLogicUseFlags    useFlags = info.GetAllUseFlags();
 
@@ -20081,7 +20082,7 @@ GenTree* Compiler::gtNewSimdBinOpNode(
 
             if (op2->IsCnsIntOrI())
             {
-                op2->AsIntCon()->gtIconVal &= shiftCountMask;
+                op2->AsIntCon()->SetIconValue(op2->AsIntCon()->IconValue() & shiftCountMask);
             }
             else
             {
@@ -20197,7 +20198,7 @@ GenTree* Compiler::gtNewSimdBinOpNode(
 
                 if (op2->IsCnsIntOrI())
                 {
-                    ssize_t shiftCount = op2->AsIntCon()->gtIconVal;
+                    ssize_t shiftCount = op2->AsIntCon()->IconValue();
                     ssize_t mask       = 255 >> shiftCount;
 
                     maskAmountOp = gtNewIconNode(mask, type);
@@ -20800,7 +20801,7 @@ GenTree* Compiler::gtNewSimdBinOpNode(
 
             if (op2->IsCnsIntOrI())
             {
-                op2->AsIntCon()->gtIconVal &= shiftCountMask;
+                op2->AsIntCon()->SetIconValue(op2->AsIntCon()->IconValue() & shiftCountMask);
 
                 if ((simdSize == 8) && varTypeIsLong(simdBaseType))
                 {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -5122,7 +5122,7 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
             {
                 GenTreeIntCon* con            = tree->AsIntCon();
                 bool           iconNeedsReloc = con->ImmedValNeedsReloc(this);
-                INT64          imm            = con->LngValue();
+                INT64          imm            = con->IntegralValue();
                 emitAttr       size           = EA_SIZE(emitActualTypeSize(tree));
 
                 if (iconNeedsReloc)

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -14429,12 +14429,12 @@ GenTree* Compiler::gtFoldBoxNullable(GenTree* tree)
     GenTree*       op;
     GenTree*       cons;
 
-    if (op1->IsCnsIntOrI())
+    if (op1->IsIntegralConst())
     {
         op   = op2;
         cons = op1;
     }
-    else if (op2->IsCnsIntOrI())
+    else if (op2->IsIntegralConst())
     {
         op   = op1;
         cons = op2;
@@ -14444,9 +14444,7 @@ GenTree* Compiler::gtFoldBoxNullable(GenTree* tree)
         return tree;
     }
 
-    ssize_t const val = cons->AsIntCon()->IconValue();
-
-    if (val != 0)
+    if (cons->AsIntCon()->IntegralValue() != 0)
     {
         return tree;
     }

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1197,7 +1197,7 @@ public:
 
     bool IsConstInitVal() const
     {
-        return IsCnsIntOrI() || (OperIsInitVal() && gtGetOp1()->IsCnsIntOrI());
+        return IsIntegralConst() || (OperIsInitVal() && gtGetOp1()->IsIntegralConst());
     }
 
     bool OperIsBlkOp();
@@ -2208,7 +2208,9 @@ public:
 
     bool IsIconHandle() const
     {
-        return (IsCnsIntOrI()) && ((gtFlags & GTF_ICON_HDL_MASK) != 0);
+        bool isIconHandle = IsIntegralConst() && ((gtFlags & GTF_ICON_HDL_MASK) != 0);
+        assert(!isIconHandle || varTypeIsI(this));
+        return isIconHandle;
     }
 
     bool IsIconHandle(GenTreeFlags handleType) const
@@ -2216,7 +2218,7 @@ public:
         // check that handleType is one of the valid GTF_ICON_* values
         assert((handleType & GTF_ICON_HDL_MASK) != 0);
         assert((handleType & ~GTF_ICON_HDL_MASK) == 0);
-        return IsCnsIntOrI() && ((gtFlags & GTF_ICON_HDL_MASK) == handleType);
+        return IsIntegralConst() && ((gtFlags & GTF_ICON_HDL_MASK) == handleType);
     }
 
     template <typename... T>
@@ -2229,7 +2231,7 @@ public:
     // For non-icon handle trees, returns GTF_EMPTY.
     GenTreeFlags GetIconHandleFlag() const
     {
-        return (IsCnsIntOrI()) ? (gtFlags & GTF_ICON_HDL_MASK) : GTF_EMPTY;
+        return IsIntegralConst() ? (gtFlags & GTF_ICON_HDL_MASK) : GTF_EMPTY;
     }
 
     // Mark this node as no longer being a handle; clear its GTF_ICON_*_HDL bits.

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -3120,6 +3120,22 @@ public:
         m_value = value;
     }
 
+    uint64_t IntegralValueUnsigned() const
+    {
+        return Is32BitConst() ? static_cast<uint32_t>(m_value) : m_value;
+    }
+
+    void SetIntegralValueUnsigned(uint64_t value)
+    {
+        if (Is32BitConst())
+        {
+            assert(FitsIn<uint32_t>(value));
+            value = static_cast<int32_t>(value);
+        }
+
+        m_value = value;
+    }
+
     //------------------------------------------------------------------------
     // SetValueTruncating: Set the value, truncating to TYP_INT if necessary.
     //
@@ -3148,14 +3164,12 @@ public:
         static_assert_no_msg(
             (std::is_same<T, int32_t>::value || std::is_same<T, int64_t>::value || std::is_same<T, ssize_t>::value));
 
-        if (TypeIs(TYP_LONG))
+        if (Is32BitConst())
         {
-            SetLngValue(value);
+            value = static_cast<int32_t>(value);
         }
-        else
-        {
-            SetIconValue(static_cast<int32_t>(value));
-        }
+
+        SetIntegralValue(value);
     }
 
     int LoVal() const
@@ -3178,6 +3192,16 @@ public:
     bool FitsInAddrBase(Compiler* comp);
     bool AddrNeedsReloc(Compiler* comp);
 #endif
+
+private:
+    bool Is32BitConst() const
+    {
+#ifdef TARGET_64BIT
+        return TypeIs(TYP_INT);
+#else
+        return !TypeIs(TYP_LONG);
+#endif
+    }
 };
 
 // node representing a read from a physical register

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -3072,16 +3072,8 @@ public:
     size_t gtTargetHandle = 0;
 #endif
 
-    GenTreeIntCon(var_types type, ssize_t value, FieldSeq* fieldSeq = nullptr DEBUGARG(bool largeNode = false))
-        : GenTree(GT_CNS_INT, type DEBUGARG(largeNode))
-        , m_value(value)
-        , gtFieldSeq(fieldSeq)
-    {
-    }
-
-    GenTreeIntCon(int64_t value)
-        : GenTree(GT_CNS_NATIVELONG, TYP_LONG DEBUGARG(/* largeNode */ false))
-        , m_value(value)
+    GenTreeIntCon(var_types type, int64_t value, FieldSeq* fieldSeq DEBUGARG(bool largeNode = false))
+        : GenTree(GT_CNS_INT, type DEBUGARG(largeNode)), m_value(value), gtFieldSeq(fieldSeq)
     {
     }
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1197,7 +1197,7 @@ public:
 
     bool IsConstInitVal() const
     {
-        return (gtOper == GT_CNS_INT) || (OperIsInitVal() && (gtGetOp1()->gtOper == GT_CNS_INT));
+        return IsCnsIntOrI() || (OperIsInitVal() && gtGetOp1()->IsCnsIntOrI());
     }
 
     bool OperIsBlkOp();
@@ -2208,7 +2208,7 @@ public:
 
     bool IsIconHandle() const
     {
-        return (gtOper == GT_CNS_INT) && ((gtFlags & GTF_ICON_HDL_MASK) != 0);
+        return (IsCnsIntOrI()) && ((gtFlags & GTF_ICON_HDL_MASK) != 0);
     }
 
     bool IsIconHandle(GenTreeFlags handleType) const
@@ -2216,7 +2216,7 @@ public:
         // check that handleType is one of the valid GTF_ICON_* values
         assert((handleType & GTF_ICON_HDL_MASK) != 0);
         assert((handleType & ~GTF_ICON_HDL_MASK) == 0);
-        return (gtOper == GT_CNS_INT) && ((gtFlags & GTF_ICON_HDL_MASK) == handleType);
+        return IsCnsIntOrI() && ((gtFlags & GTF_ICON_HDL_MASK) == handleType);
     }
 
     template <typename... T>
@@ -2229,13 +2229,13 @@ public:
     // For non-icon handle trees, returns GTF_EMPTY.
     GenTreeFlags GetIconHandleFlag() const
     {
-        return (gtOper == GT_CNS_INT) ? (gtFlags & GTF_ICON_HDL_MASK) : GTF_EMPTY;
+        return (IsCnsIntOrI()) ? (gtFlags & GTF_ICON_HDL_MASK) : GTF_EMPTY;
     }
 
     // Mark this node as no longer being a handle; clear its GTF_ICON_*_HDL bits.
     void ClearIconHandleMask()
     {
-        assert(gtOper == GT_CNS_INT);
+        assert(IsCnsIntOrI());
         gtFlags &= ~GTF_ICON_HDL_MASK;
     }
 
@@ -3232,13 +3232,13 @@ inline void GenTreeIntConCommon::SetLngValue(INT64 val)
 
 inline ssize_t GenTreeIntConCommon::IconValue() const
 {
-    assert(gtOper == GT_CNS_INT); //  We should never see a GT_CNS_LNG for a 64-bit target!
+    assert(IsCnsIntOrI()); //  We should never see a GT_CNS_LNG for a 64-bit target!
     return AsIntCon()->gtIconVal;
 }
 
 inline void GenTreeIntConCommon::SetIconValue(ssize_t val)
 {
-    assert(gtOper == GT_CNS_INT); //  We should never see a GT_CNS_LNG for a 64-bit target!
+    assert(IsCnsIntOrI()); //  We should never see a GT_CNS_LNG for a 64-bit target!
     AsIntCon()->gtIconVal = val;
 }
 
@@ -8881,9 +8881,8 @@ inline bool GenTree::OperIsCopyBlkOp()
 //    long constants in a target-independent way.
 
 inline bool GenTree::IsIntegralConst(ssize_t constVal) const
-
 {
-    if ((gtOper == GT_CNS_INT) && (AsIntConCommon()->IconValue() == constVal))
+    if (IsCnsIntOrI() && (AsIntConCommon()->IconValue() == constVal))
     {
         return true;
     }
@@ -9728,7 +9727,7 @@ inline bool GenTree::IsIntegralConst() const
 #ifdef TARGET_64BIT
     return IsCnsIntOrI();
 #else  // !TARGET_64BIT
-    return ((gtOper == GT_CNS_INT) || (gtOper == GT_CNS_LNG));
+    return (IsCnsIntOrI() || (gtOper == GT_CNS_LNG));
 #endif // !TARGET_64BIT
 }
 

--- a/src/coreclr/jit/gentreeopsdef.h
+++ b/src/coreclr/jit/gentreeopsdef.h
@@ -12,16 +12,6 @@ enum genTreeOps : BYTE
 #include "gtlist.h"
 
     GT_COUNT,
-
-#ifdef TARGET_64BIT
-    // GT_CNS_NATIVELONG is the gtOper symbol for GT_CNS_LNG or GT_CNS_INT, depending on the target.
-    // For the 64-bit targets we will only use GT_CNS_INT as it used to represent all the possible sizes
-    GT_CNS_NATIVELONG = GT_CNS_INT,
-#else
-    // For the 32-bit targets we use a GT_CNS_LNG to hold a 64-bit integer constant and GT_CNS_INT for all others.
-    // In the future when we retarget the JIT for x86 we should consider eliminating GT_CNS_LNG
-    GT_CNS_NATIVELONG = GT_CNS_LNG,
-#endif
 };
 
 /*****************************************************************************/

--- a/src/coreclr/jit/gtlist.h
+++ b/src/coreclr/jit/gtlist.h
@@ -43,7 +43,7 @@ GTNODE(RET_EXPR         , GenTreeRetExpr     ,0,0,GTK_LEAF|DBK_NOTLIR)  // Place
 //-----------------------------------------------------------------------------
 
 GTNODE(CNS_INT          , GenTreeIntCon      ,0,0,GTK_LEAF)
-GTNODE(CNS_LNG          , GenTreeLngCon      ,0,0,GTK_LEAF)
+GTNODE(CNS_LNG          , GenTreeIntCon      ,0,0,GTK_LEAF)
 GTNODE(CNS_DBL          , GenTreeDblCon      ,0,0,GTK_LEAF)
 GTNODE(CNS_STR          , GenTreeStrCon      ,0,0,GTK_LEAF)
 GTNODE(CNS_VEC          , GenTreeVecCon      ,0,0,GTK_LEAF)

--- a/src/coreclr/jit/gtlist.h
+++ b/src/coreclr/jit/gtlist.h
@@ -43,7 +43,6 @@ GTNODE(RET_EXPR         , GenTreeRetExpr     ,0,0,GTK_LEAF|DBK_NOTLIR)  // Place
 //-----------------------------------------------------------------------------
 
 GTNODE(CNS_INT          , GenTreeIntCon      ,0,0,GTK_LEAF)
-GTNODE(CNS_LNG          , GenTreeIntCon      ,0,0,GTK_LEAF)
 GTNODE(CNS_DBL          , GenTreeDblCon      ,0,0,GTK_LEAF)
 GTNODE(CNS_STR          , GenTreeStrCon      ,0,0,GTK_LEAF)
 GTNODE(CNS_VEC          , GenTreeVecCon      ,0,0,GTK_LEAF)

--- a/src/coreclr/jit/gtstructs.h
+++ b/src/coreclr/jit/gtstructs.h
@@ -55,7 +55,7 @@ GTSTRUCT_2(Val         , GT_END_LFIN, GT_JMP)
 #else
 GTSTRUCT_1(Val         , GT_JMP)
 #endif
-GTSTRUCT_2(IntCon      , GT_CNS_INT, GT_CNS_LNG)
+GTSTRUCT_1(IntCon      , GT_CNS_INT)
 GTSTRUCT_1(DblCon      , GT_CNS_DBL)
 GTSTRUCT_1(StrCon      , GT_CNS_STR)
 GTSTRUCT_1(VecCon      , GT_CNS_VEC)

--- a/src/coreclr/jit/gtstructs.h
+++ b/src/coreclr/jit/gtstructs.h
@@ -44,7 +44,7 @@
 //
 // The "SPECIAL" variants indicate that some or all of the allowed opers exist elsewhere. This is
 // used in the DEBUGGABLE_GENTREE implementation when determining which vtable pointer to use for
-// a given oper. For example, IntConCommon (for the GenTreeIntConCommon type) allows opers
+// a given oper. For example, IntConCommon (for the GenTreeIntCon type) allows opers
 // for all its subtypes. The "SPECIAL" version is attached to the supertypes. "N" is always
 // considered "special".
 
@@ -55,9 +55,7 @@ GTSTRUCT_2(Val         , GT_END_LFIN, GT_JMP)
 #else
 GTSTRUCT_1(Val         , GT_JMP)
 #endif
-GTSTRUCT_2_SPECIAL(IntConCommon, GT_CNS_INT, GT_CNS_LNG)
-GTSTRUCT_1(IntCon      , GT_CNS_INT)
-GTSTRUCT_1(LngCon      , GT_CNS_LNG)
+GTSTRUCT_2(IntCon      , GT_CNS_INT, GT_CNS_LNG)
 GTSTRUCT_1(DblCon      , GT_CNS_DBL)
 GTSTRUCT_1(StrCon      , GT_CNS_STR)
 GTSTRUCT_1(VecCon      , GT_CNS_VEC)

--- a/src/coreclr/jit/hwintrinsicarm64.cpp
+++ b/src/coreclr/jit/hwintrinsicarm64.cpp
@@ -714,7 +714,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
                         for (uint32_t index = 0; index < sig->numArgs; index++)
                         {
-                            cnsVal = static_cast<uint8_t>(impPopStack().val->AsIntConCommon()->IntegralValue());
+                            cnsVal = static_cast<uint8_t>(impPopStack().val->AsIntCon()->IntegralValue());
                             vecCon->gtSimdVal.u8[simdLength - 1 - index] = cnsVal;
                         }
                         break;
@@ -727,7 +727,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
                         for (uint32_t index = 0; index < sig->numArgs; index++)
                         {
-                            cnsVal = static_cast<uint16_t>(impPopStack().val->AsIntConCommon()->IntegralValue());
+                            cnsVal = static_cast<uint16_t>(impPopStack().val->AsIntCon()->IntegralValue());
                             vecCon->gtSimdVal.u16[simdLength - 1 - index] = cnsVal;
                         }
                         break;
@@ -740,7 +740,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
                         for (uint32_t index = 0; index < sig->numArgs; index++)
                         {
-                            cnsVal = static_cast<uint32_t>(impPopStack().val->AsIntConCommon()->IntegralValue());
+                            cnsVal = static_cast<uint32_t>(impPopStack().val->AsIntCon()->IntegralValue());
                             vecCon->gtSimdVal.u32[simdLength - 1 - index] = cnsVal;
                         }
                         break;
@@ -753,7 +753,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
                         for (uint32_t index = 0; index < sig->numArgs; index++)
                         {
-                            cnsVal = static_cast<uint64_t>(impPopStack().val->AsIntConCommon()->IntegralValue());
+                            cnsVal = static_cast<uint64_t>(impPopStack().val->AsIntCon()->IntegralValue());
                             vecCon->gtSimdVal.u64[simdLength - 1 - index] = cnsVal;
                         }
                         break;

--- a/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
@@ -638,7 +638,7 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
                 if (intrin.op3->isContainedFltOrDblImmed())
                 {
                     assert(intrin.op2->isContainedIntOrIImmed());
-                    assert(intrin.op2->AsIntCon()->gtIconVal == 0);
+                    assert(intrin.op2->AsIntCon()->IconValue() == 0);
 
                     const double dataValue = intrin.op3->AsDblCon()->DconValue();
                     GetEmitter()->emitIns_R_F(INS_fmov, emitSize, targetReg, dataValue, opt);
@@ -701,8 +701,8 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
                     GetEmitter()->emitIns_Mov(INS_mov, emitTypeSize(node), targetReg, op1Reg, /* canSkip */ true);
                 }
 
-                const int resultIndex = (int)intrin.op2->AsIntCon()->gtIconVal;
-                const int valueIndex  = (int)intrin.op4->AsIntCon()->gtIconVal;
+                const int resultIndex = (int)intrin.op2->AsIntCon()->IconValue();
+                const int valueIndex  = (int)intrin.op4->AsIntCon()->IconValue();
                 GetEmitter()->emitIns_R_R_I_I(ins, emitSize, targetReg, op3Reg, resultIndex, valueIndex, opt);
             }
             break;
@@ -859,7 +859,7 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
                     if (intrin.op1->isContainedIntOrIImmed())
                     {
                         // movi/movni reg, #imm8
-                        const ssize_t dataValue = intrin.op1->AsIntCon()->gtIconVal;
+                        const ssize_t dataValue = intrin.op1->AsIntCon()->IconValue();
                         GetEmitter()->emitIns_R_I(INS_movi, emitSize, targetReg, dataValue, opt);
                     }
                     else
@@ -924,7 +924,7 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
                 }
                 else if (intrin.op1->isContainedIntOrIImmed())
                 {
-                    const ssize_t dataValue = intrin.op1->AsIntCon()->gtIconVal;
+                    const ssize_t dataValue = intrin.op1->AsIntCon()->IconValue();
                     GetEmitter()->emitIns_R_I(INS_movi, emitSize, targetReg, dataValue, opt);
                 }
                 else if (GetEmitter()->IsMovInstruction(ins))

--- a/src/coreclr/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/jit/hwintrinsicxarch.cpp
@@ -3393,7 +3393,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
             if (op4->IsIntegralConst())
             {
-                uint8_t                 control  = static_cast<uint8_t>(op4->AsIntCon()->gtIconVal);
+                uint8_t                 control  = static_cast<uint8_t>(op4->AsIntCon()->IconValue());
                 const TernaryLogicInfo& info     = TernaryLogicInfo::lookup(control);
                 TernaryLogicUseFlags    useFlags = info.GetAllUseFlags();
 
@@ -3702,7 +3702,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                                     *val2 = gtNewZeroConNode(retType);
                                 }
 
-                                op4->AsIntCon()->gtIconVal = static_cast<uint8_t>(~0xAA);
+                                op4->AsIntCon()->SetIconValue(static_cast<uint8_t>(~0xAA));
                                 break;
                             }
 
@@ -3760,7 +3760,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                                     *val1 = gtNewZeroConNode(retType);
                                 }
 
-                                op4->AsIntCon()->gtIconVal = static_cast<uint8_t>(~0xCC | 0xAA);
+                                op4->AsIntCon()->SetIconValue(static_cast<uint8_t>(~0xCC | 0xAA));
                             }
                             break;
                         }
@@ -3803,7 +3803,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                                 *val1 = gtNewZeroConNode(retType);
                             }
 
-                            op4->AsIntCon()->gtIconVal = static_cast<uint8_t>(~(0xCC & 0xAA));
+                            op4->AsIntCon()->SetIconValue(static_cast<uint8_t>(~(0xCC & 0xAA)));
                             break;
                         }
 
@@ -3845,7 +3845,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                                 *val1 = gtNewZeroConNode(retType);
                             }
 
-                            op4->AsIntCon()->gtIconVal = static_cast<uint8_t>(~(0xCC | 0xAA));
+                            op4->AsIntCon()->SetIconValue(static_cast<uint8_t>(~(0xCC | 0xAA)));
                             break;
                         }
 
@@ -3887,7 +3887,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                                 *val1 = gtNewZeroConNode(retType);
                             }
 
-                            op4->AsIntCon()->gtIconVal = static_cast<uint8_t>(~(0xCC ^ 0xAA));
+                            op4->AsIntCon()->SetIconValue(static_cast<uint8_t>(~(0xCC ^ 0xAA)));
                             break;
                         }
 

--- a/src/coreclr/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/jit/hwintrinsicxarch.cpp
@@ -1549,7 +1549,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
                         for (uint32_t index = 0; index < sig->numArgs; index++)
                         {
-                            cnsVal = static_cast<uint8_t>(impPopStack().val->AsIntConCommon()->IntegralValue());
+                            cnsVal = static_cast<uint8_t>(impPopStack().val->AsIntCon()->IntegralValue());
                             vecCon->gtSimdVal.u8[simdLength - 1 - index] = cnsVal;
                         }
                         break;
@@ -1562,7 +1562,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
                         for (uint32_t index = 0; index < sig->numArgs; index++)
                         {
-                            cnsVal = static_cast<uint16_t>(impPopStack().val->AsIntConCommon()->IntegralValue());
+                            cnsVal = static_cast<uint16_t>(impPopStack().val->AsIntCon()->IntegralValue());
                             vecCon->gtSimdVal.u16[simdLength - 1 - index] = cnsVal;
                         }
                         break;
@@ -1575,7 +1575,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
                         for (uint32_t index = 0; index < sig->numArgs; index++)
                         {
-                            cnsVal = static_cast<uint32_t>(impPopStack().val->AsIntConCommon()->IntegralValue());
+                            cnsVal = static_cast<uint32_t>(impPopStack().val->AsIntCon()->IntegralValue());
                             vecCon->gtSimdVal.u32[simdLength - 1 - index] = cnsVal;
                         }
                         break;
@@ -1588,7 +1588,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
                         for (uint32_t index = 0; index < sig->numArgs; index++)
                         {
-                            cnsVal = static_cast<uint64_t>(impPopStack().val->AsIntConCommon()->IntegralValue());
+                            cnsVal = static_cast<uint64_t>(impPopStack().val->AsIntCon()->IntegralValue());
                             vecCon->gtSimdVal.u64[simdLength - 1 - index] = cnsVal;
                         }
                         break;

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -6908,7 +6908,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 assertImp(op1->TypeIs(TYP_REF));
 
                 // Check for null pointer - in the inliner case we simply abort.
-                if (compIsForInlining() && op1->IsCnsIntOrI())
+                if (compIsForInlining() && op1->IsIntegralConst())
                 {
                     compInlineResult->NoteFatal(InlineObservation::CALLEE_HAS_NULL_FOR_LDELEM);
                     return;

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -7159,7 +7159,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
                 /* Special case: "int+0", "int-0", "int*1", "int/1" */
 
-                if (op2->gtOper == GT_CNS_INT)
+                if (op2->IsCnsIntOrI())
                 {
                     if ((op2->IsIntegralConst(0) && (oper == GT_ADD || oper == GT_SUB)) ||
                         (op2->IsIntegralConst(1) && (oper == GT_MUL || oper == GT_DIV)))
@@ -7376,7 +7376,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 /* Try to fold the really simple cases like 'iconst *, ifne/ifeq'*/
                 /* Don't make any blocks unreachable in import only mode */
 
-                if (op1->gtOper == GT_CNS_INT)
+                if (op1->IsCnsIntOrI())
                 {
                     /* gtFoldExpr() should prevent this as we don't want to make any blocks
                        unreachable under compDbgCode */
@@ -7638,7 +7638,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 assertImp(genActualTypeIsIntOrI(op1->TypeGet()));
 
                 // Fold Switch for GT_CNS_INT
-                if (opts.OptimizationEnabled() && (op1->gtOper == GT_CNS_INT))
+                if (opts.OptimizationEnabled() && op1->IsCnsIntOrI())
                 {
                     // Find the jump target
                     size_t       switchVal = (size_t)op1->AsIntCon()->gtIconVal;
@@ -7880,7 +7880,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 {
                     op2 = op1->AsOp()->gtOp2;
 
-                    if (op2->gtOper == GT_CNS_INT)
+                    if (op2->IsCnsIntOrI())
                     {
                         ssize_t ival = op2->AsIntCon()->gtIconVal;
                         ssize_t mask, umask;
@@ -12737,7 +12737,7 @@ void Compiler::impInlineRecordArgInfo(InlineInfo*   pInlineInfo,
     if (impIsInvariant(curArgVal))
     {
         inlCurArgInfo->argIsInvariant = true;
-        if (inlCurArgInfo->argIsThis && (curArgVal->gtOper == GT_CNS_INT) && (curArgVal->AsIntCon()->gtIconVal == 0))
+        if (inlCurArgInfo->argIsThis && curArgVal->IsCnsIntOrI() && (curArgVal->AsIntCon()->gtIconVal == 0))
         {
             // Abort inlining at this call site
             inlineResult->NoteFatal(InlineObservation::CALLSITE_ARG_HAS_NULL_THIS);
@@ -13643,7 +13643,7 @@ bool Compiler::impCanSkipCovariantStoreCheck(GenTree* value, GenTree* array)
     }
 
     // Check for assignment of NULL.
-    if (value->OperIs(GT_CNS_INT))
+    if (value->IsCnsIntOrI())
     {
         assert(value->gtType == TYP_REF);
         if (value->AsIntCon()->gtIconVal == 0)

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -7382,7 +7382,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                        unreachable under compDbgCode */
                     assert(!opts.compDbgCode);
 
-                    BBjumpKinds foldedJumpKind = (BBjumpKinds)(op1->AsIntCon()->gtIconVal ? BBJ_ALWAYS : BBJ_NONE);
+                    BBjumpKinds foldedJumpKind = (BBjumpKinds)(op1->AsIntCon()->IconValue() ? BBJ_ALWAYS : BBJ_NONE);
                     // BBJ_COND: normal case
                     // foldedJumpKind: this can happen if we are reimporting the block for the second time
                     assertImp(block->KindIs(BBJ_COND, foldedJumpKind)); // normal case
@@ -7641,7 +7641,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 if (opts.OptimizationEnabled() && op1->IsCnsIntOrI())
                 {
                     // Find the jump target
-                    size_t       switchVal = (size_t)op1->AsIntCon()->gtIconVal;
+                    size_t       switchVal = (size_t)op1->AsIntCon()->IconValue();
                     unsigned     jumpCnt   = block->GetJumpSwt()->bbsCount;
                     BasicBlock** jumpTab   = block->GetJumpSwt()->bbsDstTab;
                     bool         foundVal  = false;
@@ -7882,7 +7882,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
                     if (op2->IsCnsIntOrI())
                     {
-                        ssize_t ival = op2->AsIntCon()->gtIconVal;
+                        ssize_t ival = op2->AsIntCon()->IconValue();
                         ssize_t mask, umask;
 
                         switch (lclTyp)
@@ -12737,7 +12737,7 @@ void Compiler::impInlineRecordArgInfo(InlineInfo*   pInlineInfo,
     if (impIsInvariant(curArgVal))
     {
         inlCurArgInfo->argIsInvariant = true;
-        if (inlCurArgInfo->argIsThis && curArgVal->IsCnsIntOrI() && (curArgVal->AsIntCon()->gtIconVal == 0))
+        if (inlCurArgInfo->argIsThis && curArgVal->IsCnsIntOrI() && (curArgVal->AsIntCon()->IconValue() == 0))
         {
             // Abort inlining at this call site
             inlineResult->NoteFatal(InlineObservation::CALLSITE_ARG_HAS_NULL_THIS);
@@ -13646,7 +13646,7 @@ bool Compiler::impCanSkipCovariantStoreCheck(GenTree* value, GenTree* array)
     if (value->IsCnsIntOrI())
     {
         assert(value->gtType == TYP_REF);
-        if (value->AsIntCon()->gtIconVal == 0)
+        if (value->AsIntCon()->IconValue() == 0)
         {
             JITDUMP("\nstelem of null: skipping covariant store check\n");
             return true;

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -10271,7 +10271,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         break;
                     }
 
-                    ClassLayout* layout = typGetBlkLayout(static_cast<unsigned>(op3->AsIntConCommon()->IconValue()));
+                    ClassLayout* layout = typGetBlkLayout(static_cast<unsigned>(op3->AsIntCon()->IconValue()));
 
                     if (opcode == CEE_INITBLK)
                     {

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -229,7 +229,6 @@ void Compiler::impSaveStackState(SavedStack* savePtr, bool copy)
                 switch (tree->gtOper)
                 {
                     case GT_CNS_INT:
-                    case GT_CNS_LNG:
                     case GT_CNS_DBL:
                     case GT_CNS_STR:
                     case GT_CNS_VEC:

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -2048,7 +2048,7 @@ GenTree* Compiler::impInitializeArrayIntrinsic(CORINFO_SIG_INFO* sig)
             return nullptr;
         }
 
-        numElements = S_SIZE_T(arrayLengthNode->AsIntCon()->gtIconVal);
+        numElements = S_SIZE_T(arrayLengthNode->AsIntCon()->IconValue());
 
         if (!info.compCompHnd->isSDArray(arrayClsHnd))
         {

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -698,7 +698,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
         {
             cookieConst = cookie->AsOp()->gtOp1;
         }
-        assert(cookieConst->gtOper == GT_CNS_INT);
+        assert(cookieConst->IsCnsIntOrI());
 
         // Setting GTF_DONT_CSE on the GT_CNS_INT as well as on the GT_IND (if it exists) will ensure that
         // we won't allow this tree to participate in any CSE logic
@@ -1809,7 +1809,7 @@ GenTree* Compiler::impInitializeArrayIntrinsic(CORINFO_SIG_INFO* sig)
     }
 
     // Check for constant
-    if (fieldTokenNode->gtOper != GT_CNS_INT)
+    if (!fieldTokenNode->IsCnsIntOrI())
     {
         return nullptr;
     }
@@ -2043,7 +2043,7 @@ GenTree* Compiler::impInitializeArrayIntrinsic(CORINFO_SIG_INFO* sig)
         //
         // This optimization is only valid for a constant array size.
         //
-        if (arrayLengthNode->gtOper != GT_CNS_INT)
+        if (!arrayLengthNode->IsCnsIntOrI())
         {
             return nullptr;
         }
@@ -2151,7 +2151,7 @@ GenTree* Compiler::impCreateSpanIntrinsic(CORINFO_SIG_INFO* sig)
     }
 
     // Check for constant
-    if (fieldTokenNode->gtOper != GT_CNS_INT)
+    if (!fieldTokenNode->IsCnsIntOrI())
     {
         return nullptr;
     }

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -1474,18 +1474,18 @@ var_types Compiler::impImportJitTestLabelMark(int numArgs)
         StackEntry se  = impPopStack();
         GenTree*   val = se.val;
         assert(val->IsCnsIntOrI());
-        tlAndN.m_tl = (TestLabel)val->AsIntConCommon()->IconValue();
+        tlAndN.m_tl = (TestLabel)val->AsIntCon()->IconValue();
     }
     else if (numArgs == 3)
     {
         StackEntry se  = impPopStack();
         GenTree*   val = se.val;
         assert(val->IsCnsIntOrI());
-        tlAndN.m_num = val->AsIntConCommon()->IconValue();
+        tlAndN.m_num = val->AsIntCon()->IconValue();
         se           = impPopStack();
         val          = se.val;
         assert(val->IsCnsIntOrI());
-        tlAndN.m_tl = (TestLabel)val->AsIntConCommon()->IconValue();
+        tlAndN.m_tl = (TestLabel)val->AsIntCon()->IconValue();
     }
     else
     {
@@ -3643,7 +3643,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                         {
                             // `rank` is guaranteed to be <=32 (see MAX_RANK in vm\array.h). Any constant argument
                             // is `int` sized.
-                            INT64 dimValue = gtDim->AsIntConCommon()->IntegralValue();
+                            INT64 dimValue = gtDim->AsIntCon()->IntegralValue();
                             assert((unsigned int)dimValue == dimValue);
                             unsigned dim = (unsigned int)dimValue;
                             if (dim < rank)
@@ -3808,7 +3808,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
 
                 if (op1->IsIntegralConst())
                 {
-                    float f32Cns = BitOperations::UInt32BitsToSingle((uint32_t)op1->AsIntConCommon()->IconValue());
+                    float f32Cns = BitOperations::UInt32BitsToSingle((uint32_t)op1->AsIntCon()->IconValue());
                     retNode      = gtNewDconNodeF(f32Cns);
                 }
                 else
@@ -3827,7 +3827,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 {
                     impPopStack();
 
-                    int64_t i64Cns = op1->AsIntConCommon()->LngValue();
+                    int64_t i64Cns = op1->AsIntCon()->LngValue();
                     retNode        = gtNewDconNodeD(*reinterpret_cast<double*>(&i64Cns));
                 }
 #if TARGET_64BIT
@@ -4156,14 +4156,14 @@ GenTree* Compiler::impSRCSUnsafeIntrinsic(NamedIntrinsic          intrinsic,
                 {
                     if (toType == TYP_DOUBLE)
                     {
-                        uint64_t u64Cns = static_cast<uint64_t>(op1->AsIntConCommon()->LngValue());
+                        uint64_t u64Cns = static_cast<uint64_t>(op1->AsIntCon()->LngValue());
                         return gtNewDconNodeD(BitOperations::UInt64BitsToDouble(u64Cns));
                     }
                     else
                     {
                         assert(toType == TYP_FLOAT);
 
-                        uint32_t u32Cns = static_cast<uint32_t>(op1->AsIntConCommon()->IconValue());
+                        uint32_t u32Cns = static_cast<uint32_t>(op1->AsIntCon()->IconValue());
                         return gtNewDconNodeF(BitOperations::UInt32BitsToSingle(u32Cns));
                     }
                 }
@@ -4606,12 +4606,12 @@ GenTree* Compiler::impPrimitiveNamedIntrinsic(NamedIntrinsic        intrinsic,
 
                 if (varTypeIsLong(baseType))
                 {
-                    uint64_t cns = static_cast<uint64_t>(op1->AsIntConCommon()->LngValue());
+                    uint64_t cns = static_cast<uint64_t>(op1->AsIntCon()->LngValue());
                     result       = gtNewLconNode(BitOperations::LeadingZeroCount(cns));
                 }
                 else
                 {
-                    uint32_t cns = static_cast<uint32_t>(op1->AsIntConCommon()->IconValue());
+                    uint32_t cns = static_cast<uint32_t>(op1->AsIntCon()->IconValue());
                     result       = gtNewIconNode(BitOperations::LeadingZeroCount(cns), baseType);
                 }
                 break;
@@ -4708,7 +4708,7 @@ GenTree* Compiler::impPrimitiveNamedIntrinsic(NamedIntrinsic        intrinsic,
 
                 if (varTypeIsLong(baseType))
                 {
-                    uint64_t cns = static_cast<uint64_t>(op1->AsIntConCommon()->LngValue());
+                    uint64_t cns = static_cast<uint64_t>(op1->AsIntCon()->LngValue());
 
                     if (varTypeIsUnsigned(JitType2PreciseVarType(baseJitType)) || (static_cast<int64_t>(cns) >= 0))
                     {
@@ -4717,7 +4717,7 @@ GenTree* Compiler::impPrimitiveNamedIntrinsic(NamedIntrinsic        intrinsic,
                 }
                 else
                 {
-                    uint32_t cns = static_cast<uint32_t>(op1->AsIntConCommon()->IconValue());
+                    uint32_t cns = static_cast<uint32_t>(op1->AsIntCon()->IconValue());
 
                     if (varTypeIsUnsigned(JitType2PreciseVarType(baseJitType)) || (static_cast<int32_t>(cns) >= 0))
                     {
@@ -4782,12 +4782,12 @@ GenTree* Compiler::impPrimitiveNamedIntrinsic(NamedIntrinsic        intrinsic,
 
                 if (varTypeIsLong(baseType))
                 {
-                    uint64_t cns = static_cast<uint64_t>(op1->AsIntConCommon()->LngValue());
+                    uint64_t cns = static_cast<uint64_t>(op1->AsIntCon()->LngValue());
                     result       = gtNewLconNode(BitOperations::PopCount(cns));
                 }
                 else
                 {
-                    uint32_t cns = static_cast<uint32_t>(op1->AsIntConCommon()->IconValue());
+                    uint32_t cns = static_cast<uint32_t>(op1->AsIntCon()->IconValue());
                     result       = gtNewIconNode(BitOperations::PopCount(cns), baseType);
                 }
                 break;
@@ -4842,7 +4842,7 @@ GenTree* Compiler::impPrimitiveNamedIntrinsic(NamedIntrinsic        intrinsic,
             impPopStack();
 
             GenTree* op1  = impPopStack().val;
-            uint32_t cns2 = static_cast<uint32_t>(op2->AsIntConCommon()->IconValue());
+            uint32_t cns2 = static_cast<uint32_t>(op2->AsIntCon()->IconValue());
 
             // Mask the offset to ensure deterministic xplat behavior for overshifting
             cns2 &= varTypeIsLong(baseType) ? 0x3F : 0x1F;
@@ -4857,18 +4857,18 @@ GenTree* Compiler::impPrimitiveNamedIntrinsic(NamedIntrinsic        intrinsic,
             {
                 if (varTypeIsLong(baseType))
                 {
-                    uint64_t cns1 = static_cast<uint64_t>(op1->AsIntConCommon()->LngValue());
+                    uint64_t cns1 = static_cast<uint64_t>(op1->AsIntCon()->LngValue());
                     result        = gtNewLconNode(BitOperations::RotateLeft(cns1, cns2));
                 }
                 else
                 {
-                    uint32_t cns1 = static_cast<uint32_t>(op1->AsIntConCommon()->IconValue());
+                    uint32_t cns1 = static_cast<uint32_t>(op1->AsIntCon()->IconValue());
                     result        = gtNewIconNode(BitOperations::RotateLeft(cns1, cns2), baseType);
                 }
                 break;
             }
 
-            op2->AsIntConCommon()->SetIconValue(cns2);
+            op2->AsIntCon()->SetIconValue(cns2);
             result = gtFoldExpr(gtNewOperNode(GT_ROL, baseType, op1, op2));
 
             break;
@@ -4891,7 +4891,7 @@ GenTree* Compiler::impPrimitiveNamedIntrinsic(NamedIntrinsic        intrinsic,
             impPopStack();
 
             GenTree* op1  = impPopStack().val;
-            uint32_t cns2 = static_cast<uint32_t>(op2->AsIntConCommon()->IconValue());
+            uint32_t cns2 = static_cast<uint32_t>(op2->AsIntCon()->IconValue());
 
             // Mask the offset to ensure deterministic xplat behavior for overshifting
             cns2 &= varTypeIsLong(baseType) ? 0x3F : 0x1F;
@@ -4906,18 +4906,18 @@ GenTree* Compiler::impPrimitiveNamedIntrinsic(NamedIntrinsic        intrinsic,
             {
                 if (varTypeIsLong(baseType))
                 {
-                    uint64_t cns1 = static_cast<uint64_t>(op1->AsIntConCommon()->LngValue());
+                    uint64_t cns1 = static_cast<uint64_t>(op1->AsIntCon()->LngValue());
                     result        = gtNewLconNode(BitOperations::RotateRight(cns1, cns2));
                 }
                 else
                 {
-                    uint32_t cns1 = static_cast<uint32_t>(op1->AsIntConCommon()->IconValue());
+                    uint32_t cns1 = static_cast<uint32_t>(op1->AsIntCon()->IconValue());
                     result        = gtNewIconNode(BitOperations::RotateRight(cns1, cns2), baseType);
                 }
                 break;
             }
 
-            op2->AsIntConCommon()->SetIconValue(cns2);
+            op2->AsIntCon()->SetIconValue(cns2);
             result = gtFoldExpr(gtNewOperNode(GT_ROR, baseType, op1, op2));
 
             break;
@@ -4937,12 +4937,12 @@ GenTree* Compiler::impPrimitiveNamedIntrinsic(NamedIntrinsic        intrinsic,
 
                 if (varTypeIsLong(baseType))
                 {
-                    uint64_t cns = static_cast<uint64_t>(op1->AsIntConCommon()->LngValue());
+                    uint64_t cns = static_cast<uint64_t>(op1->AsIntCon()->LngValue());
                     result       = gtNewLconNode(BitOperations::TrailingZeroCount(cns));
                 }
                 else
                 {
-                    uint32_t cns = static_cast<uint32_t>(op1->AsIntConCommon()->IconValue());
+                    uint32_t cns = static_cast<uint32_t>(op1->AsIntCon()->IconValue());
                     result       = gtNewIconNode(BitOperations::TrailingZeroCount(cns), baseType);
                 }
 

--- a/src/coreclr/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/jit/indirectcalltransformer.cpp
@@ -366,10 +366,10 @@ private:
             assert(checkIdx == 0);
 
             checkBlock                 = CreateAndInsertBasicBlock(BBJ_NONE, currBlock);
-            GenTree*   fatPointerMask  = new (compiler, GT_CNS_INT) GenTreeIntCon(TYP_I_IMPL, FAT_POINTER_MASK);
+            GenTree*   fatPointerMask  = compiler->gtNewIconNode(FAT_POINTER_MASK, TYP_I_IMPL);
             GenTree*   fptrAddressCopy = compiler->gtCloneExpr(fptrAddress);
             GenTree*   fatPointerAnd   = compiler->gtNewOperNode(GT_AND, TYP_I_IMPL, fptrAddressCopy, fatPointerMask);
-            GenTree*   zero            = new (compiler, GT_CNS_INT) GenTreeIntCon(TYP_I_IMPL, 0);
+            GenTree*   zero            = compiler->gtNewIconNode(0, TYP_I_IMPL);
             GenTree*   fatPointerCmp   = compiler->gtNewOperNode(GT_NE, TYP_INT, fatPointerAnd, zero);
             GenTree*   jmpTree         = compiler->gtNewOperNode(GT_JTRUE, TYP_VOID, fatPointerCmp);
             Statement* jmpStmt         = compiler->fgNewStmtFromTree(jmpTree, stmt->GetDebugInfo());
@@ -411,7 +411,7 @@ private:
         GenTree* GetFixedFptrAddress()
         {
             GenTree* fptrAddressCopy = compiler->gtCloneExpr(fptrAddress);
-            GenTree* fatPointerMask  = new (compiler, GT_CNS_INT) GenTreeIntCon(TYP_I_IMPL, FAT_POINTER_MASK);
+            GenTree* fatPointerMask  = compiler->gtNewIconNode(FAT_POINTER_MASK, TYP_I_IMPL);
             return compiler->gtNewOperNode(GT_SUB, pointerType, fptrAddressCopy, fatPointerMask);
         }
 
@@ -426,7 +426,7 @@ private:
         GenTree* GetHiddenArgument(GenTree* fixedFptrAddress)
         {
             GenTree* fixedFptrAddressCopy = compiler->gtCloneExpr(fixedFptrAddress);
-            GenTree* wordSize          = new (compiler, GT_CNS_INT) GenTreeIntCon(TYP_I_IMPL, genTypeSize(TYP_I_IMPL));
+            GenTree* wordSize             = compiler->gtNewIconNode(genTypeSize(TYP_I_IMPL), TYP_I_IMPL);
             GenTree* hiddenArgumentPtr = compiler->gtNewOperNode(GT_ADD, pointerType, fixedFptrAddressCopy, wordSize);
             return compiler->gtNewIndir(fixedFptrAddressCopy->TypeGet(), hiddenArgumentPtr);
         }

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -1992,7 +1992,6 @@ void Compiler::fgComputeLifeLIR(VARSET_TP& life, BasicBlock* block, VARSET_VALAR
             case GT_LABEL:
             case GT_FTN_ADDR:
             case GT_CNS_INT:
-            case GT_CNS_LNG:
             case GT_CNS_DBL:
             case GT_CNS_STR:
             case GT_CNS_VEC:

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -2751,7 +2751,7 @@ Compiler::fgWalkResult Compiler::optCanOptimizeByLoopCloning(GenTree* tree, Loop
                 // Update the loop context.
                 //
                 assert(relopOp2->IsIconHandle(GTF_ICON_CLASS_HDL));
-                CORINFO_CLASS_HANDLE clsHnd = (CORINFO_CLASS_HANDLE)relopOp2->AsIntConCommon()->IconValue();
+                CORINFO_CLASS_HANDLE clsHnd = (CORINFO_CLASS_HANDLE)relopOp2->AsIntCon()->IconValue();
 
                 assert(compCurBB->lastStmt() == info->stmt);
                 info->context->EnsureLoopOptInfo(info->loopNum)
@@ -2781,7 +2781,7 @@ Compiler::fgWalkResult Compiler::optCanOptimizeByLoopCloning(GenTree* tree, Loop
                     return WALK_CONTINUE;
                 }
 
-                offset    = indirAddr->gtGetOp2()->AsIntConCommon()->IconValue();
+                offset    = indirAddr->gtGetOp2()->AsIntCon()->IconValue();
                 indirAddr = indirAddr->gtGetOp1();
             }
 

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3832,7 +3832,7 @@ GenTree* Lowering::LowerJTrue(GenTreeOp* jtrue)
             newOper = GT_JTEST;
             cc      = cond->OperIs(GT_LT) ? GenCondition(GenCondition::NE) : GenCondition(GenCondition::EQ);
             // x < 0 => (x & signBit) != 0. Update the constant to be the sign bit.
-            relopOp2->AsIntConCommon()->SetIntegralValue(
+            relopOp2->AsIntCon()->SetIntegralValue(
                 (static_cast<INT64>(1) << (8 * genTypeSize(genActualType(relopOp1)) - 1)));
         }
         else if (cond->OperIs(GT_TEST_EQ, GT_TEST_NE) && isPow2(relopOp2->AsIntCon()->IconValue()))
@@ -6833,7 +6833,7 @@ bool Lowering::TryLowerConstIntDivOrMod(GenTree* node, GenTree** nextNode)
 #endif // !TARGET_64BIT
         }
 
-        divisor->AsIntConCommon()->SetIconValue(magic);
+        divisor->AsIntCon()->SetIconValue(magic);
 
         // Insert a new GT_MULHI node in front of the existing GT_DIV/GT_MOD node.
         // The existing node will later be transformed into a GT_ADD/GT_SUB that

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5150,7 +5150,7 @@ GenTree* Lowering::SetGCState(int state)
 
     GenTree* base = new (comp, GT_LCL_VAR) GenTreeLclVar(GT_LCL_VAR, TYP_I_IMPL, comp->info.compLvFrameListRoot);
 
-    GenTree* stateNode    = new (comp, GT_CNS_INT) GenTreeIntCon(TYP_BYTE, state);
+    GenTree* stateNode    = comp->gtNewIconNode(state);
     GenTree* addr         = new (comp, GT_LEA) GenTreeAddrMode(TYP_I_IMPL, base, nullptr, 1, pInfo->offsetOfGCState);
     GenTree* storeGcState = new (comp, GT_STOREIND) GenTreeStoreInd(TYP_BYTE, addr, stateNode);
     return storeGcState;

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -739,7 +739,7 @@ GenTree* Lowering::LowerArrLength(GenTreeArrCommon* node)
     GenTree* addr;
     noway_assert(arr->gtNext == node);
 
-    if ((arr->gtOper == GT_CNS_INT) && (arr->AsIntCon()->gtIconVal == 0))
+    if (arr->IsIntegralConst(0))
     {
         // If the array is NULL, then we should get a NULL reference
         // exception when computing its length.  We need to maintain
@@ -2911,7 +2911,7 @@ GenTree* Lowering::LowerTailCallViaJitHelper(GenTreeCall* call, GenTree* callTar
     argEntry = call->gtArgs.GetArgByIndex(numArgs - 2);
     assert(argEntry != nullptr);
     GenTree* arg1 = argEntry->GetEarlyNode()->AsPutArgStk()->gtGetOp1();
-    assert(arg1->gtOper == GT_CNS_INT);
+    assert(arg1->IsCnsIntOrI());
 
     ssize_t tailCallHelperFlags = 1 |                                  // always restore EDI,ESI,EBX
                                   (call->IsVirtualStub() ? 0x2 : 0x0); // Stub dispatch flag
@@ -2921,7 +2921,7 @@ GenTree* Lowering::LowerTailCallViaJitHelper(GenTreeCall* call, GenTree* callTar
     argEntry = call->gtArgs.GetArgByIndex(numArgs - 3);
     assert(argEntry != nullptr);
     GenTree* arg2 = argEntry->GetEarlyNode()->AsPutArgStk()->gtGetOp1();
-    assert(arg2->gtOper == GT_CNS_INT);
+    assert(arg2->IsCnsIntOrI());
 
     arg2->AsIntCon()->gtIconVal = nNewStkArgsWords;
 
@@ -2930,7 +2930,7 @@ GenTree* Lowering::LowerTailCallViaJitHelper(GenTreeCall* call, GenTree* callTar
     argEntry = call->gtArgs.GetArgByIndex(numArgs - 4);
     assert(argEntry != nullptr);
     GenTree* arg3 = argEntry->GetEarlyNode()->AsPutArgStk()->gtGetOp1();
-    assert(arg3->gtOper == GT_CNS_INT);
+    assert(arg3->IsCnsIntOrI());
 #endif // DEBUG
 
     // Transform this call node into a call to Jit tail call helper.
@@ -3311,7 +3311,7 @@ GenTree* Lowering::DecomposeLongCompare(GenTree* cmp)
         // then hiSrc1 would be 0.
         //
 
-        if (loSrc1->OperIs(GT_CNS_INT))
+        if (loSrc1->IsCnsIntOrI())
         {
             std::swap(loSrc1, loSrc2);
         }
@@ -3328,7 +3328,7 @@ GenTree* Lowering::DecomposeLongCompare(GenTree* cmp)
             ContainCheckBinary(loCmp->AsOp());
         }
 
-        if (hiSrc1->OperIs(GT_CNS_INT))
+        if (hiSrc1->IsCnsIntOrI())
         {
             std::swap(hiSrc1, hiSrc2);
         }
@@ -3380,7 +3380,7 @@ GenTree* Lowering::DecomposeLongCompare(GenTree* cmp)
         {
             bool mustSwap = true;
 
-            if (loSrc2->OperIs(GT_CNS_INT) && hiSrc2->OperIs(GT_CNS_INT))
+            if (loSrc2->IsCnsIntOrI() && hiSrc2->IsCnsIntOrI())
             {
                 uint32_t loValue  = static_cast<uint32_t>(loSrc2->AsIntCon()->IconValue());
                 uint32_t hiValue  = static_cast<uint32_t>(hiSrc2->AsIntCon()->IconValue());
@@ -4386,7 +4386,7 @@ void Lowering::LowerStoreLocCommon(GenTreeLclVarCommon* lclStore)
         {
             convertToStoreObj = true;
         }
-        else if (src->OperIs(GT_CNS_INT))
+        else if (src->IsCnsIntOrI())
         {
             assert(src->IsIntegralConst(0) && "expected an INIT_VAL for non-zero init.");
 

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2915,7 +2915,7 @@ GenTree* Lowering::LowerTailCallViaJitHelper(GenTreeCall* call, GenTree* callTar
 
     ssize_t tailCallHelperFlags = 1 |                                  // always restore EDI,ESI,EBX
                                   (call->IsVirtualStub() ? 0x2 : 0x0); // Stub dispatch flag
-    arg1->AsIntCon()->gtIconVal = tailCallHelperFlags;
+    arg1->AsIntCon()->SetIconValue(tailCallHelperFlags);
 
     // arg 2 == numberOfNewStackArgsWords
     argEntry = call->gtArgs.GetArgByIndex(numArgs - 3);
@@ -2923,7 +2923,7 @@ GenTree* Lowering::LowerTailCallViaJitHelper(GenTreeCall* call, GenTree* callTar
     GenTree* arg2 = argEntry->GetEarlyNode()->AsPutArgStk()->gtGetOp1();
     assert(arg2->IsCnsIntOrI());
 
-    arg2->AsIntCon()->gtIconVal = nNewStkArgsWords;
+    arg2->AsIntCon()->SetIconValue(nNewStkArgsWords);
 
 #ifdef DEBUG
     // arg 3 == numberOfOldStackArgsWords
@@ -8295,7 +8295,7 @@ void Lowering::LowerStoreIndirCoalescing(GenTreeStoreInd* ind)
         size_t val = (lowerCns | (upperCns << (genTypeSize(oldType) * BITS_IN_BYTE)));
         JITDUMP("Coalesced two stores into a single store with value %lld\n", (int64_t)val);
 
-        ind->Data()->AsIntCon()->gtIconVal = (ssize_t)val;
+        ind->Data()->AsIntCon()->SetIconValue(val);
         if (genTypeSize(oldType) == 1)
         {
             // A mark for future foldings that this IND doesn't need to be atomic.

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3832,8 +3832,7 @@ GenTree* Lowering::LowerJTrue(GenTreeOp* jtrue)
             newOper = GT_JTEST;
             cc      = cond->OperIs(GT_LT) ? GenCondition(GenCondition::NE) : GenCondition(GenCondition::EQ);
             // x < 0 => (x & signBit) != 0. Update the constant to be the sign bit.
-            relopOp2->AsIntCon()->SetIntegralValue(
-                (static_cast<INT64>(1) << (8 * genTypeSize(genActualType(relopOp1)) - 1)));
+            relopOp2->AsIntCon()->SetIntegralValueUnsigned(1ULL << (8 * genTypeSize(genActualType(relopOp1)) - 1));
         }
         else if (cond->OperIs(GT_TEST_EQ, GT_TEST_NE) && isPow2(relopOp2->AsIntCon()->IconValue()))
         {

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -65,7 +65,7 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode) const
 #endif
 
         // Make sure we have an actual immediate
-        if (!childNode->IsCnsIntOrI())
+        if (!childNode->IsIntegralConst())
             return false;
         if (childNode->AsIntCon()->ImmedValNeedsReloc(comp))
             return false;
@@ -250,7 +250,7 @@ bool Lowering::IsContainableUnaryOrBinaryOp(GenTree* parentNode, GenTree* childN
 
         GenTree* shiftAmountNode = childNode->gtGetOp2();
 
-        if (!shiftAmountNode->IsCnsIntOrI())
+        if (!shiftAmountNode->IsIntegralConst())
         {
             // Cannot contain if the childs op2 is not a constant
             return false;
@@ -397,7 +397,7 @@ void Lowering::LowerStoreLoc(GenTreeLclVarCommon* storeLoc)
     // On ARM, small stores can cost a bit more in terms of code size so we try to widen them. This is legal
     // as most small locals have 4-byte-wide stack homes, the common exception being (dependent) struct fields.
     //
-    if (storeLoc->OperIs(GT_STORE_LCL_VAR) && varTypeIsSmall(storeLoc) && storeLoc->Data()->IsCnsIntOrI())
+    if (storeLoc->OperIs(GT_STORE_LCL_VAR) && varTypeIsSmall(storeLoc) && storeLoc->Data()->IsIntegralConst())
     {
         LclVarDsc* varDsc = comp->lvaGetDesc(storeLoc);
         if (!varDsc->lvIsStructField && (varDsc->GetStackSlotHomeType() == TYP_INT))
@@ -571,7 +571,7 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
         }
 
         if (!blkNode->OperIs(GT_STORE_DYN_BLK) && (size <= comp->getUnrollThreshold(Compiler::UnrollKind::Memset)) &&
-            src->IsCnsIntOrI())
+            src->IsIntegralConst())
         {
             blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindUnroll;
 
@@ -688,7 +688,7 @@ void Lowering::ContainBlockStoreAddress(GenTreeBlk* blkNode, unsigned size, GenT
         return;
     }
 
-    if (!addr->OperIs(GT_ADD) || addr->gtOverflow() || !addr->AsOp()->gtGetOp2()->IsCnsIntOrI())
+    if (!addr->OperIs(GT_ADD) || addr->gtOverflow() || !addr->AsOp()->gtGetOp2()->IsIntegralConst())
     {
         return;
     }
@@ -811,7 +811,7 @@ void Lowering::LowerRotate(GenTree* tree)
         unsigned rotatedValueBitSize = genTypeSize(rotatedValue->gtType) * 8;
         GenTree* rotateLeftIndexNode = tree->AsOp()->gtOp2;
 
-        if (rotateLeftIndexNode->IsCnsIntOrI())
+        if (rotateLeftIndexNode->IsIntegralConst())
         {
             ssize_t rotateLeftIndex  = rotateLeftIndexNode->AsIntCon()->IconValue();
             ssize_t rotateRightIndex = rotatedValueBitSize - rotateLeftIndex;
@@ -1223,7 +1223,7 @@ bool Lowering::IsValidConstForMovImm(GenTreeHWIntrinsic* node)
         op1    = castOp;
     }
 
-    if (op1->IsCnsIntOrI())
+    if (op1->IsIntegralConst())
     {
         const ssize_t dataValue = op1->AsIntCon()->IconValue();
 
@@ -2149,7 +2149,7 @@ void Lowering::ContainCheckShiftRotate(GenTreeOp* node)
     }
 #endif // TARGET_ARM
 
-    if (shiftBy->IsCnsIntOrI())
+    if (shiftBy->IsIntegralConst())
     {
         MakeSrcContained(node, shiftBy);
     }

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -571,7 +571,7 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
         }
 
         if (!blkNode->OperIs(GT_STORE_DYN_BLK) && (size <= comp->getUnrollThreshold(Compiler::UnrollKind::Memset)) &&
-            src->OperIs(GT_CNS_INT))
+            src->IsCnsIntOrI())
         {
             blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindUnroll;
 
@@ -688,7 +688,7 @@ void Lowering::ContainBlockStoreAddress(GenTreeBlk* blkNode, unsigned size, GenT
         return;
     }
 
-    if (!addr->OperIs(GT_ADD) || addr->gtOverflow() || !addr->AsOp()->gtGetOp2()->OperIs(GT_CNS_INT))
+    if (!addr->OperIs(GT_ADD) || addr->gtOverflow() || !addr->AsOp()->gtGetOp2()->IsCnsIntOrI())
     {
         return;
     }

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -472,7 +472,7 @@ GenTree* Lowering::LowerMul(GenTreeOp* mul)
         else
         {
             assert(op2->IsIntegralConst());
-            assert(FitsIn<int32_t>(op2->AsIntConCommon()->IntegralValue()));
+            assert(FitsIn<int32_t>(op2->AsIntCon()->IntegralValue()));
 
             op2->ChangeType(TYP_INT);
         }
@@ -853,7 +853,7 @@ void Lowering::LowerModPow2(GenTree* node)
     const var_types type = mod->TypeGet();
     assert((type == TYP_INT) || (type == TYP_LONG));
 
-    ssize_t divisorCnsValue         = static_cast<ssize_t>(divisor->AsIntConCommon()->IntegralValue());
+    ssize_t divisorCnsValue         = static_cast<ssize_t>(divisor->AsIntCon()->IntegralValue());
     ssize_t divisorCnsValueMinusOne = divisorCnsValue - 1;
 
     BlockRange().Remove(divisor);

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -70,8 +70,8 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode) const
         if (childNode->AsIntCon()->ImmedValNeedsReloc(comp))
             return false;
 
-        // TODO-CrossBitness: we wouldn't need the cast below if GenTreeIntCon::gtIconVal had target_ssize_t type.
-        target_ssize_t immVal = (target_ssize_t)childNode->AsIntCon()->gtIconVal;
+        // TODO-CrossBitness: we wouldn't need the cast below if GenTreeIntCon::IconValue() had target_ssize_t type.
+        target_ssize_t immVal = (target_ssize_t)childNode->AsIntCon()->IconValue();
         emitAttr       attr   = emitActualTypeSize(childNode->TypeGet());
         emitAttr       size   = EA_SIZE(attr);
 #ifdef TARGET_ARM
@@ -813,9 +813,9 @@ void Lowering::LowerRotate(GenTree* tree)
 
         if (rotateLeftIndexNode->IsCnsIntOrI())
         {
-            ssize_t rotateLeftIndex                    = rotateLeftIndexNode->AsIntCon()->gtIconVal;
-            ssize_t rotateRightIndex                   = rotatedValueBitSize - rotateLeftIndex;
-            rotateLeftIndexNode->AsIntCon()->gtIconVal = rotateRightIndex;
+            ssize_t rotateLeftIndex  = rotateLeftIndexNode->AsIntCon()->IconValue();
+            ssize_t rotateRightIndex = rotatedValueBitSize - rotateLeftIndex;
+            rotateLeftIndexNode->AsIntCon()->SetIconValue(rotateRightIndex);
         }
         else
         {
@@ -1225,7 +1225,7 @@ bool Lowering::IsValidConstForMovImm(GenTreeHWIntrinsic* node)
 
     if (op1->IsCnsIntOrI())
     {
-        const ssize_t dataValue = op1->AsIntCon()->gtIconVal;
+        const ssize_t dataValue = op1->AsIntCon()->IconValue();
 
         if (comp->GetEmitter()->emitIns_valid_imm_for_movi(dataValue, emitActualTypeSize(node->GetSimdBaseType())))
         {
@@ -2479,7 +2479,7 @@ void Lowering::ContainCheckConditionalCompare(GenTreeCCMP* cmp)
 
     if (op2->IsCnsIntOrI() && !op2->AsIntCon()->ImmedValNeedsReloc(comp))
     {
-        target_ssize_t immVal = (target_ssize_t)op2->AsIntCon()->gtIconVal;
+        target_ssize_t immVal = (target_ssize_t)op2->AsIntCon()->IconValue();
 
         if (emitter::emitIns_valid_imm_for_ccmp(immVal))
         {
@@ -3051,7 +3051,7 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
                 {
                     MakeSrcContained(node, intrin.op2);
 
-                    if ((intrin.op2->AsIntCon()->gtIconVal == 0) && intrin.op3->IsCnsFltOrDbl())
+                    if ((intrin.op2->AsIntCon()->IconValue() == 0) && intrin.op3->IsCnsFltOrDbl())
                     {
                         assert(varTypeIsFloating(intrin.baseType));
 

--- a/src/coreclr/jit/lowerloongarch64.cpp
+++ b/src/coreclr/jit/lowerloongarch64.cpp
@@ -297,7 +297,7 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
         }
 
         if (!blkNode->OperIs(GT_STORE_DYN_BLK) && (size <= comp->getUnrollThreshold(Compiler::UnrollKind::Memset)) &&
-            src->OperIs(GT_CNS_INT))
+            src->IsCnsIntOrI())
         {
             blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindUnroll;
 
@@ -408,7 +408,7 @@ void Lowering::ContainBlockStoreAddress(GenTreeBlk* blkNode, unsigned size, GenT
         return;
     }
 
-    if (!addr->OperIs(GT_ADD) || addr->gtOverflow() || !addr->AsOp()->gtGetOp2()->OperIs(GT_CNS_INT))
+    if (!addr->OperIs(GT_ADD) || addr->gtOverflow() || !addr->AsOp()->gtGetOp2()->IsCnsIntOrI())
     {
         return;
     }

--- a/src/coreclr/jit/lowerloongarch64.cpp
+++ b/src/coreclr/jit/lowerloongarch64.cpp
@@ -59,8 +59,8 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode) const
         if (childNode->AsIntCon()->ImmedValNeedsReloc(comp))
             return false;
 
-        // TODO-CrossBitness: we wouldn't need the cast below if GenTreeIntCon::gtIconVal had target_ssize_t type.
-        target_ssize_t immVal = (target_ssize_t)childNode->AsIntCon()->gtIconVal;
+        // TODO-CrossBitness: we wouldn't need the cast below if GenTreeIntCon::IconValue() had target_ssize_t type.
+        target_ssize_t immVal = (target_ssize_t)childNode->AsIntCon()->IconValue();
 
         switch (parentNode->OperGet())
         {
@@ -554,9 +554,9 @@ void Lowering::LowerRotate(GenTree* tree)
 
         if (rotateLeftIndexNode->IsCnsIntOrI())
         {
-            ssize_t rotateLeftIndex                    = rotateLeftIndexNode->AsIntCon()->gtIconVal;
-            ssize_t rotateRightIndex                   = rotatedValueBitSize - rotateLeftIndex;
-            rotateLeftIndexNode->AsIntCon()->gtIconVal = rotateRightIndex;
+            ssize_t rotateLeftIndex  = rotateLeftIndexNode->AsIntCon()->IconValue();
+            ssize_t rotateRightIndex = rotatedValueBitSize - rotateLeftIndex;
+            rotateLeftIndexNode->AsIntCon()->SetIconValue(rotateRightIndex);
         }
         else
         {

--- a/src/coreclr/jit/lowerriscv64.cpp
+++ b/src/coreclr/jit/lowerriscv64.cpp
@@ -245,7 +245,7 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
             src = src->AsUnOp()->gtGetOp1();
         }
 
-        if (!blkNode->OperIs(GT_STORE_DYN_BLK) && (size <= INITBLK_UNROLL_LIMIT) && src->OperIs(GT_CNS_INT))
+        if (!blkNode->OperIs(GT_STORE_DYN_BLK) && (size <= INITBLK_UNROLL_LIMIT) && src->IsCnsIntOrI())
         {
             blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindUnroll;
 
@@ -354,7 +354,7 @@ void Lowering::ContainBlockStoreAddress(GenTreeBlk* blkNode, unsigned size, GenT
         return;
     }
 
-    if (!addr->OperIs(GT_ADD) || addr->gtOverflow() || !addr->AsOp()->gtGetOp2()->OperIs(GT_CNS_INT))
+    if (!addr->OperIs(GT_ADD) || addr->gtOverflow() || !addr->AsOp()->gtGetOp2()->IsCnsIntOrI())
     {
         return;
     }

--- a/src/coreclr/jit/lowerriscv64.cpp
+++ b/src/coreclr/jit/lowerriscv64.cpp
@@ -59,8 +59,8 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode) const
         if (childNode->AsIntCon()->ImmedValNeedsReloc(comp))
             return false;
 
-        // TODO-CrossBitness: we wouldn't need the cast below if GenTreeIntCon::gtIconVal had target_ssize_t type.
-        target_ssize_t immVal = (target_ssize_t)childNode->AsIntCon()->gtIconVal;
+        // TODO-CrossBitness: we wouldn't need the cast below if GenTreeIntCon::IconValue() had target_ssize_t type.
+        target_ssize_t immVal = (target_ssize_t)childNode->AsIntCon()->IconValue();
 
         switch (parentNode->OperGet())
         {

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -9707,7 +9707,7 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
                                 MakeSrcRegOptional(node, op3);
                             }
 
-                            uint8_t                 control  = static_cast<uint8_t>(op4->AsIntCon()->gtIconVal);
+                            uint8_t                 control  = static_cast<uint8_t>(op4->AsIntCon()->IconValue());
                             const TernaryLogicInfo& info     = TernaryLogicInfo::lookup(control);
                             TernaryLogicUseFlags    useFlags = info.GetAllUseFlags();
 

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -318,7 +318,7 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
 
         if (!blkNode->OperIs(GT_STORE_DYN_BLK) && (size <= comp->getUnrollThreshold(Compiler::UnrollKind::Memset)))
         {
-            if (!src->OperIs(GT_CNS_INT))
+            if (!src->IsCnsIntOrI())
             {
                 // TODO-CQ: We could unroll even when the initialization value is not a constant
                 // by inserting a MUL init, 0x01010101 instruction. We need to determine if the

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -540,11 +540,11 @@ inline bool leafInRange(GenTree* leaf, int lower, int upper)
     {
         return false;
     }
-    if (leaf->AsIntCon()->gtIconVal < lower)
+    if (leaf->AsIntCon()->IconValue() < lower)
     {
         return false;
     }
-    if (leaf->AsIntCon()->gtIconVal > upper)
+    if (leaf->AsIntCon()->IconValue() > upper)
     {
         return false;
     }
@@ -558,7 +558,7 @@ inline bool leafInRange(GenTree* leaf, int lower, int upper, int multiple)
     {
         return false;
     }
-    if (leaf->AsIntCon()->gtIconVal % multiple)
+    if (leaf->AsIntCon()->IconValue() % multiple)
     {
         return false;
     }

--- a/src/coreclr/jit/lsraarm.cpp
+++ b/src/coreclr/jit/lsraarm.cpp
@@ -53,7 +53,7 @@ int LinearScan::BuildLclHeap(GenTree* tree)
         assert(size->isContained());
         srcCount = 0;
 
-        size_t sizeVal = size->AsIntCon()->gtIconVal;
+        size_t sizeVal = size->AsIntCon()->IconValue();
         if (sizeVal == 0)
         {
             internalIntCount = 0;

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -1115,7 +1115,7 @@ int LinearScan::BuildNode(GenTree* tree)
                 assert(size->isContained());
                 srcCount = 0;
 
-                size_t sizeVal = size->AsIntCon()->gtIconVal;
+                size_t sizeVal = size->AsIntCon()->IconValue();
 
                 if (sizeVal != 0)
                 {

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -4348,14 +4348,14 @@ int LinearScan::BuildCmpOperands(GenTree* tree)
     // Example2: GT_EQ(int, op1 of type ubyte, op2 is GT_CNS_INT) - in this case codegen uses
     // ubyte as the result of the comparison and if the result needs to be materialized into a reg
     // simply zero extend it to TYP_INT size.
-    else if (varTypeIsByte(op1) && op2->IsCnsIntOrI())
+    else if (varTypeIsByte(op1) && op2->IsIntegralConst())
     {
         needByteRegs = true;
     }
     // Example3: GT_EQ(int, op1 is GT_CNS_INT, op2 of type ubyte) - in this case codegen uses
     // ubyte as the result of the comparison and if the result needs to be materialized into a reg
     // simply zero extend it to TYP_INT size.
-    else if (op1->IsCnsIntOrI() && varTypeIsByte(op2))
+    else if (op1->IsIntegralConst() && varTypeIsByte(op2))
     {
         needByteRegs = true;
     }

--- a/src/coreclr/jit/lsraloongarch64.cpp
+++ b/src/coreclr/jit/lsraloongarch64.cpp
@@ -436,7 +436,7 @@ int LinearScan::BuildNode(GenTree* tree)
                 assert(size->isContained());
                 srcCount = 0;
 
-                size_t sizeVal = size->AsIntCon()->gtIconVal;
+                size_t sizeVal = size->AsIntCon()->IconValue();
 
                 if (sizeVal != 0)
                 {

--- a/src/coreclr/jit/lsrariscv64.cpp
+++ b/src/coreclr/jit/lsrariscv64.cpp
@@ -470,7 +470,7 @@ int LinearScan::BuildNode(GenTree* tree)
                 assert(size->isContained());
                 srcCount = 0;
 
-                size_t sizeVal = size->AsIntCon()->gtIconVal;
+                size_t sizeVal = size->AsIntCon()->IconValue();
 
                 if (sizeVal != 0)
                 {

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -1811,7 +1811,7 @@ int LinearScan::BuildLclHeap(GenTree* tree)
     if (size->IsCnsIntOrI() && size->isContained())
     {
         srcCount       = 0;
-        size_t sizeVal = AlignUp((size_t)size->AsIntCon()->gtIconVal, STACK_ALIGN);
+        size_t sizeVal = AlignUp((size_t)size->AsIntCon()->IconValue(), STACK_ALIGN);
 
         // Explicitly zeroed LCLHEAP also needs a regCnt in case of x86 or large page
         if ((TARGET_POINTER_SIZE == 4) || (sizeVal >= compiler->eeGetPageSize()))

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -149,7 +149,6 @@ int LinearScan::BuildNode(GenTree* tree)
             break;
 
         case GT_CNS_INT:
-        case GT_CNS_LNG:
         case GT_CNS_DBL:
         case GT_CNS_VEC:
         {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11130,7 +11130,7 @@ GenTree* Compiler::fgOptimizeAddition(GenTreeOp* add)
     if (op2->IsIntegralConst(0) && (genActualType(add) == genActualType(op1)))
     {
         // Keep the offset nodes with annotations for value numbering purposes.
-        if (!op2->IsCnsIntOrI() || (op2->AsIntCon()->gtFieldSeq == nullptr))
+        if (op2->AsIntCon()->gtFieldSeq == nullptr)
         {
             DEBUG_DESTROY_NODE(op2);
             DEBUG_DESTROY_NODE(add);
@@ -11146,7 +11146,7 @@ GenTree* Compiler::fgOptimizeAddition(GenTreeOp* add)
     {
         // Reduce local addresses: "ADD(LCL_ADDR, OFFSET)" => "LCL_FLD_ADDR".
         //
-        if (op1->OperIs(GT_LCL_ADDR) && op2->IsCnsIntOrI())
+        if (op1->OperIs(GT_LCL_ADDR) && op2->IsIntegralConst())
         {
             GenTreeLclVarCommon* lclAddrNode = op1->AsLclVarCommon();
             GenTreeIntCon*       offsetNode  = op2->AsIntCon();

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -1341,7 +1341,7 @@ void CallArgs::SortArgs(Compiler* comp, GenTreeCall* call, CallArg** sortedArgs)
             assert(argx != nullptr);
             // put constants at the end of the table
             //
-            if (argx->gtOper == GT_CNS_INT)
+            if (argx->IsCnsIntOrI())
             {
                 noway_assert(curInx <= endTab);
 
@@ -1502,7 +1502,7 @@ void CallArgs::SortArgs(Compiler* comp, GenTreeCall* call, CallArg** sortedArgs)
 
                 // We should have already handled these kinds of args
                 assert((!argx->OperIs(GT_LCL_VAR, GT_LCL_FLD) || argx->TypeIs(TYP_STRUCT)) &&
-                       !argx->OperIs(GT_CNS_INT));
+                       !argx->IsCnsIntOrI());
 
                 // This arg should either have no persistent side effects or be the last one in our table
                 // assert(((argx->gtFlags & GTF_PERSISTENT_SIDE_EFFECTS) == 0) || (curInx == (argCount-1)));
@@ -4408,7 +4408,7 @@ GenTree* Compiler::fgMorphIndexAddr(GenTreeIndexAddr* indexAddr)
     // Widen 'index' on 64-bit targets
     if (index->TypeGet() != TYP_I_IMPL)
     {
-        if (index->OperGet() == GT_CNS_INT)
+        if (index->IsCnsIntOrI())
         {
             index->gtType = TYP_I_IMPL;
         }
@@ -7777,7 +7777,7 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
         GenTree* value = call->gtArgs.GetArgByIndex(2)->GetNode();
         if (value->IsIntegralConst(0))
         {
-            assert(value->OperGet() == GT_CNS_INT);
+            assert(value->IsCnsIntOrI());
 
             GenTree* arr   = call->gtArgs.GetArgByIndex(0)->GetNode();
             GenTree* index = call->gtArgs.GetArgByIndex(1)->GetNode();
@@ -8396,7 +8396,7 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac, bool* optA
             else
             {
                 GenTree* effOp1 = op1->gtEffectiveVal();
-                noway_assert((effOp1->gtOper == GT_CNS_INT) &&
+                noway_assert((effOp1->IsCnsIntOrI()) &&
                              (effOp1->IsIntegralConst(0) || effOp1->IsIntegralConst(1)));
             }
             break;
@@ -9258,7 +9258,7 @@ DONE_MORPHING_CHILDREN:
                     if (tree->OperIs(GT_GT, GT_LT, GT_LE, GT_GE))
                     {
                         tree = fgOptimizeRelationalComparisonWithFullRangeConst(tree->AsOp());
-                        if (tree->OperIs(GT_CNS_INT))
+                        if (tree->IsCnsIntOrI())
                         {
                             return tree;
                         }
@@ -11873,7 +11873,7 @@ GenTree* Compiler::fgMorphSmpOpOptional(GenTreeOp* tree, bool* optAssertionPropD
 
             /* Check for the case "(val + icon) * icon" */
 
-            if (op2->gtOper == GT_CNS_INT && op1->gtOper == GT_ADD)
+            if (op2->IsCnsIntOrI() && op1->gtOper == GT_ADD)
             {
                 GenTree* add = op1->AsOp()->gtOp2;
 
@@ -13132,7 +13132,7 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
             /* Yupee - we folded the conditional!
              * Remove the conditional statement */
 
-            noway_assert(cond->gtOper == GT_CNS_INT);
+            noway_assert(cond->IsCnsIntOrI());
             noway_assert((block->Next()->countOfInEdges() > 0) && (block->GetJumpDest()->countOfInEdges() > 0));
 
             if (condTree != cond)
@@ -13365,7 +13365,7 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
             // Yupee - we folded the conditional!
             // Remove the conditional statement
 
-            noway_assert(cond->gtOper == GT_CNS_INT);
+            noway_assert(cond->IsCnsIntOrI());
 
             if (condTree != cond)
             {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -600,7 +600,7 @@ GenTree* Compiler::fgMorphExpandCast(GenTreeCast* tree)
             // than 2^{31} for a cast to int.
             int maxWidth = (dstType == TYP_UINT) ? 32 : 31;
 
-            if ((andOp2->OperGet() == GT_CNS_NATIVELONG) && ((andOp2->AsIntCon()->LngValue() >> maxWidth) == 0))
+            if (andOp2->IsIntegralConst() && ((andOp2->AsIntCon()->LngValue() >> maxWidth) == 0))
             {
                 tree->ClearOverflow();
                 tree->SetAllEffectsFlags(oper);
@@ -8604,7 +8604,7 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac, bool* optA
             noway_assert(op2);
             if ((typ == TYP_LONG) && opts.OptimizationEnabled())
             {
-                if (op2->OperIs(GT_CNS_NATIVELONG) && op2->AsIntCon()->LngValue() >= 2 &&
+                if (op2->IsIntegralConst() && op2->AsIntCon()->LngValue() >= 2 &&
                     op2->AsIntCon()->LngValue() <= 0x3fffffff)
                 {
                     tree->AsOp()->gtOp1 = op1 = fgMorphTree(op1);
@@ -8617,7 +8617,7 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac, bool* optA
                     tree->gtFlags |= (op1->gtFlags & GTF_ALL_EFFECT);
 
                     // If op1 is a constant, then do constant folding of the division operator.
-                    if (op1->OperIs(GT_CNS_NATIVELONG))
+                    if (op1->IsIntegralConst())
                     {
                         tree = gtFoldExpr(tree);
                     }
@@ -10337,7 +10337,7 @@ SKIP:
 
         // Is the result of the mask effectively an INT?
         GenTreeOp* andOp = op1->AsOp();
-        if (!andOp->gtGetOp2()->OperIs(GT_CNS_NATIVELONG))
+        if (!andOp->gtGetOp2()->IsIntegralConst())
         {
             return cmp;
         }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -8395,8 +8395,7 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac, bool* optA
             else
             {
                 GenTree* effOp1 = op1->gtEffectiveVal();
-                noway_assert((effOp1->IsCnsIntOrI()) &&
-                             (effOp1->IsIntegralConst(0) || effOp1->IsIntegralConst(1)));
+                noway_assert(effOp1->IsCnsIntOrI() && (effOp1->IsIntegralConst(0) || effOp1->IsIntegralConst(1)));
             }
             break;
 
@@ -11272,8 +11271,8 @@ GenTree* Compiler::fgOptimizeMultiply(GenTreeOp* mul)
         // MUL(NEG(a), C) => MUL(a, NEG(C))
         if (opts.OptimizationEnabled() && op1->OperIs(GT_NEG) && !op2->IsIconHandle())
         {
-            mul->gtOp1                 = op1->AsUnOp()->gtGetOp1();
-            op2->AsIntCon()->gtIconVal = -op2->AsIntCon()->gtIconVal;
+            mul->gtOp1 = op1->AsUnOp()->gtGetOp1();
+            op2->AsIntCon()->SetIconValue(-op2->AsIntCon()->IconValue());
             fgUpdateConstTreeValueNumber(op2);
             DEBUG_DESTROY_NODE(op1);
 
@@ -11883,8 +11882,8 @@ GenTree* Compiler::fgMorphSmpOpOptional(GenTreeOp* tree, bool* optAssertionPropD
                         break;
                     }
 
-                    ssize_t imul = op2->AsIntCon()->gtIconVal;
-                    ssize_t iadd = add->AsIntCon()->gtIconVal;
+                    ssize_t imul = op2->AsIntCon()->IconValue();
+                    ssize_t iadd = add->AsIntCon()->IconValue();
 
                     /* Change '(val + iadd) * imul' -> '(val * imul) + (iadd * imul)' */
 
@@ -12443,7 +12442,7 @@ GenTree* Compiler::fgRecognizeAndMorphBitwiseRotation(GenTree* tree)
         {
             if (leftShiftIndex->gtGetOp2()->IsCnsIntOrI())
             {
-                leftShiftMask  = leftShiftIndex->gtGetOp2()->AsIntCon()->gtIconVal;
+                leftShiftMask  = leftShiftIndex->gtGetOp2()->AsIntCon()->IconValue();
                 leftShiftIndex = leftShiftIndex->gtGetOp1();
             }
             else
@@ -12456,7 +12455,7 @@ GenTree* Compiler::fgRecognizeAndMorphBitwiseRotation(GenTree* tree)
         {
             if (rightShiftIndex->gtGetOp2()->IsCnsIntOrI())
             {
-                rightShiftMask  = rightShiftIndex->gtGetOp2()->AsIntCon()->gtIconVal;
+                rightShiftMask  = rightShiftIndex->gtGetOp2()->AsIntCon()->IconValue();
                 rightShiftIndex = rightShiftIndex->gtGetOp1();
             }
             else
@@ -12496,7 +12495,7 @@ GenTree* Compiler::fgRecognizeAndMorphBitwiseRotation(GenTree* tree)
         {
             if (shiftIndexWithAdd->gtGetOp2()->IsCnsIntOrI())
             {
-                if (shiftIndexWithAdd->gtGetOp2()->AsIntCon()->gtIconVal == rotatedValueBitSize)
+                if (shiftIndexWithAdd->gtGetOp2()->AsIntCon()->IconValue() == rotatedValueBitSize)
                 {
                     if (shiftIndexWithAdd->gtGetOp1()->OperGet() == GT_NEG)
                     {
@@ -12529,7 +12528,8 @@ GenTree* Compiler::fgRecognizeAndMorphBitwiseRotation(GenTree* tree)
         }
         else if ((leftShiftIndex->IsCnsIntOrI() && rightShiftIndex->IsCnsIntOrI()))
         {
-            if (leftShiftIndex->AsIntCon()->gtIconVal + rightShiftIndex->AsIntCon()->gtIconVal == rotatedValueBitSize)
+            if (leftShiftIndex->AsIntCon()->IconValue() + rightShiftIndex->AsIntCon()->IconValue() ==
+                rotatedValueBitSize)
             {
                 // We found this pattern:
                 // (x << c1) | (x >>> c2)
@@ -13154,7 +13154,7 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
             BasicBlock* bTaken;
             BasicBlock* bNotTaken;
 
-            if (cond->AsIntCon()->gtIconVal != 0)
+            if (cond->AsIntCon()->IconValue() != 0)
             {
                 /* JTRUE 1 - transform the basic block into a BBJ_ALWAYS */
                 block->SetJumpKind(BBJ_ALWAYS);
@@ -13383,7 +13383,7 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
             // modify the flow graph
 
             // Find the actual jump target
-            size_t       switchVal = (size_t)cond->AsIntCon()->gtIconVal;
+            size_t       switchVal = (size_t)cond->AsIntCon()->IconValue();
             unsigned     jumpCnt   = block->GetJumpSwt()->bbsCount;
             BasicBlock** jumpTab   = block->GetJumpSwt()->bbsDstTab;
             bool         foundVal  = false;

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -1541,7 +1541,7 @@ GenTree* Compiler::fgMorphStoreDynBlock(GenTreeStoreDynBlk* tree)
 
     if (tree->gtDynamicSize->IsIntegralConst())
     {
-        int64_t size = tree->gtDynamicSize->AsIntConCommon()->IntegralValue();
+        int64_t size = tree->gtDynamicSize->AsIntCon()->IntegralValue();
 
         if ((size != 0) && FitsIn<int32_t>(size))
         {

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -379,7 +379,7 @@ void MorphInitBlockHelper::TryInitFieldByField()
 
     GenTree* initVal = m_src->OperIsInitVal() ? m_src->gtGetOp1() : m_src;
 
-    if (!initVal->OperIs(GT_CNS_INT))
+    if (!initVal->IsCnsIntOrI())
     {
         JITDUMP(" source is not constant.\n");
         return;

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -523,7 +523,7 @@ unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
         if (hashDsc->csdHashKey == key)
         {
             // Check for mismatched types on GT_CNS_INT nodes
-            if ((tree->OperGet() == GT_CNS_INT) && (tree->TypeGet() != hashDsc->csdTree->TypeGet()))
+            if ((tree->IsCnsIntOrI()) && (tree->TypeGet() != hashDsc->csdTree->TypeGet()))
             {
                 continue;
             }

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -480,7 +480,7 @@ unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
         // We don't share small offset constants when they require a reloc
         // Also, we don't share non-null const gc handles
         //
-        if (!tree->AsIntConCommon()->ImmedValNeedsReloc(this) && ((tree->IsIntegralConst(0)) || !varTypeIsGC(tree)))
+        if (!tree->AsIntCon()->ImmedValNeedsReloc(this) && ((tree->IsIntegralConst(0)) || !varTypeIsGC(tree)))
         {
             // Here we make constants that have the same upper bits use the same key
             //

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -3536,11 +3536,15 @@ bool Compiler::optIsCSEcandidate(GenTree* tree)
 
             return (tree->AsOp()->gtOp1->gtOper != GT_ARR_ELEM);
 
-        case GT_CNS_LNG:
-#ifndef TARGET_64BIT
-            return false; // Don't CSE 64-bit constants on 32-bit platforms
-#endif
         case GT_CNS_INT:
+#ifndef TARGET_64BIT
+            if (tree->TypeIs(TYP_LONG))
+            {
+                return false; // Don't CSE 64-bit constants on 32-bit platforms
+            }
+#endif
+            FALLTHROUGH;
+
         case GT_CNS_DBL:
         case GT_CNS_STR:
         case GT_CNS_VEC:

--- a/src/coreclr/jit/optimizebools.cpp
+++ b/src/coreclr/jit/optimizebools.cpp
@@ -1126,9 +1126,9 @@ void OptBoolsDsc::optOptimizeBoolsUpdateTrees()
     if (optReturnBlock)
     {
         // Update tree when m_b1 is BBJ_COND and m_b2 and m_b3 are GT_RETURN (BBJ_RETURN)
-        t1Comp->AsOp()->gtOp2->AsIntCon()->gtIconVal = 0;
-        m_testInfo1.testTree->gtOper                 = GT_RETURN;
-        m_testInfo1.testTree->gtType                 = m_testInfo2.testTree->gtType;
+        t1Comp->AsOp()->gtOp2->AsIntCon()->SetIconValue(0);
+        m_testInfo1.testTree->gtOper = GT_RETURN;
+        m_testInfo1.testTree->gtType = m_testInfo2.testTree->gtType;
 
         // Update the return count of flow graph
         assert(m_comp->fgReturnCount >= 2);
@@ -1336,9 +1336,9 @@ bool OptBoolsDsc::optOptimizeBoolsReturnBlock(BasicBlock* b3)
     genTreeOps foldOp;
     genTreeOps cmpOp;
 
-    ssize_t it1val = m_testInfo1.compTree->AsOp()->gtOp2->AsIntCon()->gtIconVal;
-    ssize_t it2val = m_testInfo2.compTree->AsOp()->gtOp2->AsIntCon()->gtIconVal;
-    ssize_t it3val = m_t3->AsOp()->gtOp1->AsIntCon()->gtIconVal;
+    ssize_t it1val = m_testInfo1.compTree->AsOp()->gtOp2->AsIntCon()->IconValue();
+    ssize_t it2val = m_testInfo2.compTree->AsOp()->gtOp2->AsIntCon()->IconValue();
+    ssize_t it3val = m_t3->AsOp()->gtOp1->AsIntCon()->IconValue();
 
     if (m_c1->gtOper == GT_LCL_VAR && m_c2->gtOper == GT_LCL_VAR &&
         m_c1->AsLclVarCommon()->GetLclNum() == m_c2->AsLclVarCommon()->GetLclNum())
@@ -1607,7 +1607,7 @@ GenTree* OptBoolsDsc::optIsBoolComp(OptTestInfo* pOptTest)
         return nullptr;
     }
 
-    ssize_t ival2 = opr2->AsIntCon()->gtIconVal;
+    ssize_t ival2 = opr2->AsIntCon()->IconValue();
 
     // Is the value a boolean?
     // We can either have a boolean expression (marked GTF_BOOLEAN) or a constant 0/1.
@@ -1629,7 +1629,7 @@ GenTree* OptBoolsDsc::optIsBoolComp(OptTestInfo* pOptTest)
         if (pOptTest->isBool)
         {
             m_comp->gtReverseCond(cond);
-            opr2->AsIntCon()->gtIconVal = 0;
+            opr2->AsIntCon()->SetIconValue(0);
         }
         else
         {

--- a/src/coreclr/jit/optimizebools.cpp
+++ b/src/coreclr/jit/optimizebools.cpp
@@ -1021,7 +1021,7 @@ Statement* OptBoolsDsc::optOptimizeBoolsChkBlkCond()
         }
 
         // The third block is Return with "CNS_INT int 0/1"
-        if (testTree3->AsOp()->gtOp1->gtOper != GT_CNS_INT)
+        if (!testTree3->AsOp()->gtOp1->IsCnsIntOrI())
         {
             return nullptr;
         }
@@ -1540,7 +1540,7 @@ void OptBoolsDsc::optOptimizeBoolsGcStress()
 
     // Comparand type is already checked, and we have const int, there is no harm
     // morphing it into a TYP_I_IMPL.
-    noway_assert(relop->AsOp()->gtOp2->gtOper == GT_CNS_INT);
+    noway_assert(relop->AsOp()->gtOp2->IsCnsIntOrI());
     relop->AsOp()->gtOp2->gtType = TYP_I_IMPL;
 
     // Recost/rethread the tree if necessary
@@ -1597,7 +1597,7 @@ GenTree* OptBoolsDsc::optIsBoolComp(OptTestInfo* pOptTest)
     GenTree* opr1 = cond->AsOp()->gtOp1;
     GenTree* opr2 = cond->AsOp()->gtOp2;
 
-    if (opr2->gtOper != GT_CNS_INT)
+    if (!opr2->IsCnsIntOrI())
     {
         return nullptr;
     }
@@ -1616,7 +1616,7 @@ GenTree* OptBoolsDsc::optIsBoolComp(OptTestInfo* pOptTest)
     {
         pOptTest->isBool = true;
     }
-    else if ((opr1->gtOper == GT_CNS_INT) && (opr1->IsIntegralConst(0) || opr1->IsIntegralConst(1)))
+    else if (opr1->IsCnsIntOrI() && (opr1->IsIntegralConst(0) || opr1->IsIntegralConst(1)))
     {
         pOptTest->isBool = true;
     }

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -5740,7 +5740,7 @@ bool Compiler::optNarrowTree(GenTree* tree, var_types srct, var_types dstt, Valu
             __int64 lmask;
 
             case GT_CNS_LNG:
-                lval  = tree->AsIntConCommon()->LngValue();
+                lval  = tree->AsIntCon()->LngValue();
                 lmask = 0;
 
                 switch (dstt)
@@ -9002,7 +9002,7 @@ ssize_t Compiler::optGetArrayRefScaleAndIndex(GenTree* mul, GenTree** pIndex DEB
     assert(mul->gtOper == GT_MUL || mul->gtOper == GT_LSH);
     assert(mul->AsOp()->gtOp2->IsCnsIntOrI());
 
-    ssize_t scale = mul->AsOp()->gtOp2->AsIntConCommon()->IconValue();
+    ssize_t scale = mul->AsOp()->gtOp2->AsIntCon()->IconValue();
 
     if (mul->gtOper == GT_LSH)
     {
@@ -9017,7 +9017,7 @@ ssize_t Compiler::optGetArrayRefScaleAndIndex(GenTree* mul, GenTree** pIndex DEB
         // When index->gtOper is GT_MUL and index->AsOp()->gtOp2->gtOper is GT_CNS_INT (i.e. * 5),
         //     we can bump up the scale from 4 to 5*4, and then change index to index->AsOp()->gtOp1.
         // Otherwise, we cannot optimize it. We will simply keep the original scale and index.
-        scale *= index->AsOp()->gtOp2->AsIntConCommon()->IconValue();
+        scale *= index->AsOp()->gtOp2->AsIntCon()->IconValue();
         index = index->AsOp()->gtOp1;
     }
 

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -5733,62 +5733,10 @@ bool Compiler::optNarrowTree(GenTree* tree, var_types srct, var_types dstt, Valu
         switch (oper)
         {
             /* Constants can usually be narrowed by changing their value */
-            CLANG_FORMAT_COMMENT_ANCHOR;
-
-#ifndef TARGET_64BIT
-            __int64 lval;
-            __int64 lmask;
-
-            case GT_CNS_LNG:
-                lval  = tree->AsIntCon()->LngValue();
-                lmask = 0;
-
-                switch (dstt)
-                {
-                    case TYP_BYTE:
-                        lmask = 0x0000007F;
-                        break;
-                    case TYP_UBYTE:
-                        lmask = 0x000000FF;
-                        break;
-                    case TYP_SHORT:
-                        lmask = 0x00007FFF;
-                        break;
-                    case TYP_USHORT:
-                        lmask = 0x0000FFFF;
-                        break;
-                    case TYP_INT:
-                        lmask = 0x7FFFFFFF;
-                        break;
-                    case TYP_UINT:
-                        lmask = 0xFFFFFFFF;
-                        break;
-
-                    default:
-                        return false;
-                }
-
-                if ((lval & lmask) != lval)
-                    return false;
-
-                if (doit)
-                {
-                    tree->BashToConst(static_cast<int32_t>(lval));
-                    if (vnStore != nullptr)
-                    {
-                        fgValueNumberTreeConst(tree);
-                    }
-                }
-
-                return true;
-#endif
-
             case GT_CNS_INT:
-
-                ssize_t ival;
-                ival = tree->AsIntCon()->IconValue();
-                ssize_t imask;
-                imask = 0;
+            {
+                int64_t value = tree->AsIntCon()->IntegralValue();
+                int64_t imask = 0;
 
                 switch (dstt)
                 {
@@ -5804,33 +5752,30 @@ bool Compiler::optNarrowTree(GenTree* tree, var_types srct, var_types dstt, Valu
                     case TYP_USHORT:
                         imask = 0x0000FFFF;
                         break;
-#ifdef TARGET_64BIT
                     case TYP_INT:
                         imask = 0x7FFFFFFF;
                         break;
                     case TYP_UINT:
                         imask = 0xFFFFFFFF;
                         break;
-#endif // TARGET_64BIT
                     default:
                         return false;
                 }
 
-                if ((ival & imask) != ival)
+                if ((value & imask) != value)
                 {
                     return false;
                 }
 
-#ifdef TARGET_64BIT
                 if (doit)
                 {
                     tree->gtType = TYP_INT;
-                    tree->AsIntCon()->SetIconValue((int)ival);
+                    tree->AsIntCon()->SetIconValue((int)value);
                     fgUpdateConstTreeValueNumber(tree);
                 }
-#endif // TARGET_64BIT
 
                 return true;
+            }
 
             /* Operands that are in memory can usually be narrowed
                simply by changing their gtType */

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -830,7 +830,7 @@ bool Compiler::optCheckIterInLoopTest(unsigned loopInd, GenTree* test, unsigned 
     iterOp->gtFlags |= GTF_VAR_ITERATOR;
 
     // Check what type of limit we have - constant, variable or arr-len.
-    if (limitOp->gtOper == GT_CNS_INT)
+    if (limitOp->IsCnsIntOrI())
     {
         optLoopTable[loopInd].lpFlags |= LPFLG_CONST_LIMIT;
         if ((limitOp->gtFlags & GTF_ICON_SIMD_COUNT) != 0)
@@ -922,7 +922,7 @@ unsigned Compiler::optIsLoopIncrTree(GenTree* incr)
 
         // Increment should be by a const int.
         // TODO-CQ: CLONE: allow variable increments.
-        if ((incrVal->gtOper != GT_CNS_INT) || (incrVal->TypeGet() != TYP_INT))
+        if (!incrVal->IsCnsIntOrI() || (incrVal->TypeGet() != TYP_INT))
         {
             return BAD_VAR_NUM;
         }
@@ -1029,7 +1029,7 @@ bool Compiler::optIsLoopTestEvalIntoTemp(Statement* testStmt, Statement** newTes
     GenTree* opr2 = relop->AsOp()->gtOp2;
 
     // Make sure we have jtrue (vtmp != 0)
-    if ((relop->OperGet() == GT_NE) && (opr1->OperGet() == GT_LCL_VAR) && (opr2->OperGet() == GT_CNS_INT) &&
+    if ((relop->OperGet() == GT_NE) && (opr1->OperGet() == GT_LCL_VAR) && (opr2->IsCnsIntOrI()) &&
         opr2->IsIntegralConst(0))
     {
         // Get the previous statement to get the def (rhs) of Vtmp to see
@@ -4266,7 +4266,7 @@ PhaseStatus Compiler::optUnrollLoops()
             !((incr->gtOper == GT_ADD) || (incr->gtOper == GT_SUB)) ||
             (incr->AsOp()->gtOp1->gtOper != GT_LCL_VAR) ||
             (incr->AsOp()->gtOp1->AsLclVarCommon()->GetLclNum() != lvar) ||
-            (incr->AsOp()->gtOp2->gtOper != GT_CNS_INT) ||
+            !incr->AsOp()->gtOp2->IsCnsIntOrI() ||
             (incr->AsOp()->gtOp2->AsIntCon()->gtIconVal != iterInc) ||
 
             (testStmt->GetRootNode()->gtOper != GT_JTRUE))
@@ -5879,7 +5879,7 @@ bool Compiler::optNarrowTree(GenTree* tree, var_types srct, var_types dstt, Valu
                 // If 'dstt' is unsigned and one of the operands can be narrowed into 'dsst',
                 // the result of the GT_AND will also fit into 'dstt' and can be narrowed.
                 // The same is true if one of the operands is an int const and can be narrowed into 'dsst'.
-                if (!gtIsActiveCSE_Candidate(op2) && ((op2->gtOper == GT_CNS_INT) || varTypeIsUnsigned(dstt)))
+                if (!gtIsActiveCSE_Candidate(op2) && ((op2->IsCnsIntOrI()) || varTypeIsUnsigned(dstt)))
                 {
                     if (optNarrowTree(op2, srct, dstt, NoVNPair, false))
                     {
@@ -5893,7 +5893,7 @@ bool Compiler::optNarrowTree(GenTree* tree, var_types srct, var_types dstt, Valu
                 }
 
                 if ((opToNarrow == nullptr) && !gtIsActiveCSE_Candidate(op1) &&
-                    ((op1->gtOper == GT_CNS_INT) || varTypeIsUnsigned(dstt)))
+                    ((op1->IsCnsIntOrI()) || varTypeIsUnsigned(dstt)))
                 {
                     if (optNarrowTree(op1, srct, dstt, NoVNPair, false))
                     {

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -760,7 +760,7 @@ bool Compiler::optPopulateInitInfo(unsigned loopInd, BasicBlock* initBlock, GenT
     }
 
     optLoopTable[loopInd].lpFlags |= LPFLG_CONST_INIT;
-    optLoopTable[loopInd].lpConstInit = (int)initValue->AsIntCon()->gtIconVal;
+    optLoopTable[loopInd].lpConstInit = (int)initValue->AsIntCon()->IconValue();
     optLoopTable[loopInd].lpInitBlock = initBlock;
 
     return true;
@@ -4261,13 +4261,13 @@ PhaseStatus Compiler::optUnrollLoops()
         if (!init->OperIs(GT_STORE_LCL_VAR) ||
             (init->AsLclVar()->GetLclNum() != lvar) ||
             !init->AsLclVar()->Data()->IsCnsIntOrI() ||
-            (init->AsLclVar()->Data()->AsIntCon()->gtIconVal != lbeg) ||
+            (init->AsLclVar()->Data()->AsIntCon()->IconValue() != lbeg) ||
 
             !((incr->gtOper == GT_ADD) || (incr->gtOper == GT_SUB)) ||
             (incr->AsOp()->gtOp1->gtOper != GT_LCL_VAR) ||
             (incr->AsOp()->gtOp1->AsLclVarCommon()->GetLclNum() != lvar) ||
             !incr->AsOp()->gtOp2->IsCnsIntOrI() ||
-            (incr->AsOp()->gtOp2->AsIntCon()->gtIconVal != iterInc) ||
+            (incr->AsOp()->gtOp2->AsIntCon()->IconValue() != iterInc) ||
 
             (testStmt->GetRootNode()->gtOper != GT_JTRUE))
         {
@@ -5786,7 +5786,7 @@ bool Compiler::optNarrowTree(GenTree* tree, var_types srct, var_types dstt, Valu
             case GT_CNS_INT:
 
                 ssize_t ival;
-                ival = tree->AsIntCon()->gtIconVal;
+                ival = tree->AsIntCon()->IconValue();
                 ssize_t imask;
                 imask = 0;
 
@@ -5824,12 +5824,9 @@ bool Compiler::optNarrowTree(GenTree* tree, var_types srct, var_types dstt, Valu
 #ifdef TARGET_64BIT
                 if (doit)
                 {
-                    tree->gtType                = TYP_INT;
-                    tree->AsIntCon()->gtIconVal = (int)ival;
-                    if (vnStore != nullptr)
-                    {
-                        fgValueNumberTreeConst(tree);
-                    }
+                    tree->gtType = TYP_INT;
+                    tree->AsIntCon()->SetIconValue((int)ival);
+                    fgUpdateConstTreeValueNumber(tree);
                 }
 #endif // TARGET_64BIT
 

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -434,7 +434,7 @@ bool RangeCheck::IsBinOpMonotonicallyIncreasing(GenTreeOp* binop)
             return IsMonotonicallyIncreasing(op1, true) && IsMonotonicallyIncreasing(op2, true);
 
         case GT_CNS_INT:
-            if (op2->AsIntConCommon()->IconValue() < 0)
+            if (op2->AsIntCon()->IconValue() < 0)
             {
                 JITDUMP("Not monotonically increasing because of encountered negative constant\n");
                 return false;

--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -157,8 +157,8 @@ void Rationalizer::RewriteSubLshDiv(GenTree** use)
         if (a->OperIs(GT_LCL_VAR) && cns->IsIntegralConstPow2() &&
             op1->AsLclVar()->GetLclNum() == a->AsLclVar()->GetLclNum())
         {
-            size_t shiftValue = shift->AsIntConCommon()->IntegralValue();
-            size_t cnsValue   = cns->AsIntConCommon()->IntegralValue();
+            size_t shiftValue = shift->AsIntCon()->IntegralValue();
+            size_t cnsValue   = cns->AsIntCon()->IntegralValue();
             if ((cnsValue >> shiftValue) == 1)
             {
                 node->ChangeOper(GT_MOD);

--- a/src/coreclr/jit/simd.cpp
+++ b/src/coreclr/jit/simd.cpp
@@ -613,7 +613,7 @@ bool Compiler::areArrayElementsContiguous(GenTree* op1, GenTree* op2)
 
     GenTree* op1IndexNode = op1IndexAddr->Index();
     GenTree* op2IndexNode = op2IndexAddr->Index();
-    if ((op1IndexNode->OperGet() == GT_CNS_INT && op2IndexNode->OperGet() == GT_CNS_INT) &&
+    if ((op1IndexNode->IsCnsIntOrI() && op2IndexNode->IsCnsIntOrI()) &&
         (op1IndexNode->AsIntCon()->gtIconVal + 1 == op2IndexNode->AsIntCon()->gtIconVal))
     {
         if (op1ArrayRef->OperIs(GT_IND) && op2ArrayRef->OperIs(GT_IND))

--- a/src/coreclr/jit/simd.cpp
+++ b/src/coreclr/jit/simd.cpp
@@ -614,7 +614,7 @@ bool Compiler::areArrayElementsContiguous(GenTree* op1, GenTree* op2)
     GenTree* op1IndexNode = op1IndexAddr->Index();
     GenTree* op2IndexNode = op2IndexAddr->Index();
     if ((op1IndexNode->IsCnsIntOrI() && op2IndexNode->IsCnsIntOrI()) &&
-        (op1IndexNode->AsIntCon()->gtIconVal + 1 == op2IndexNode->AsIntCon()->gtIconVal))
+        (op1IndexNode->AsIntCon()->IconValue() + 1 == op2IndexNode->AsIntCon()->IconValue()))
     {
         if (op1ArrayRef->OperIs(GT_IND) && op2ArrayRef->OperIs(GT_IND))
         {
@@ -718,7 +718,7 @@ GenTree* Compiler::CreateAddressNodeForSimdHWIntrinsicCreate(GenTree* tree, var_
     GenTree* index    = addr->AsIndexAddr()->Index();
     assert(index->IsCnsIntOrI());
 
-    unsigned indexVal = (unsigned)index->AsIntCon()->gtIconVal;
+    unsigned indexVal = (unsigned)index->AsIntCon()->IconValue();
     unsigned offset   = indexVal * genTypeSize(tree->TypeGet());
 
     // Generate the boundary check exception.

--- a/src/coreclr/jit/simdcodegenxarch.cpp
+++ b/src/coreclr/jit/simdcodegenxarch.cpp
@@ -71,7 +71,7 @@ void CodeGen::genStoreIndTypeSimd12(GenTreeStoreInd* treeNode)
     }
     else if (addr->IsCnsIntOrI() && addr->isContained())
     {
-        GenTreeIntConCommon* icon = addr->AsIntConCommon();
+        GenTreeIntCon* icon = addr->AsIntCon();
         assert(!icon->ImmedValNeedsReloc(compiler));
         icon->SetIconValue(icon->IconValue() + 8);
     }
@@ -152,7 +152,7 @@ void CodeGen::genLoadIndTypeSimd12(GenTreeIndir* treeNode)
     }
     else if (addr->IsCnsIntOrI() && addr->isContained())
     {
-        GenTreeIntConCommon* icon = addr->AsIntConCommon();
+        GenTreeIntCon* icon = addr->AsIntCon();
         assert(!icon->ImmedValNeedsReloc(compiler));
         icon->SetIconValue(icon->IconValue() + 8);
     }
@@ -188,7 +188,7 @@ void CodeGen::genLoadIndTypeSimd12(GenTreeIndir* treeNode)
         }
         else if (addr->IsCnsIntOrI() && addr->isContained())
         {
-            GenTreeIntConCommon* icon = addr->AsIntConCommon();
+            GenTreeIntCon* icon = addr->AsIntCon();
             icon->SetIconValue(icon->IconValue() - 8);
         }
         else

--- a/src/coreclr/jit/utils.h
+++ b/src/coreclr/jit/utils.h
@@ -1016,6 +1016,13 @@ bool FitsIn(var_types type, T value)
             return FitsIn<int64_t>(value);
         case TYP_ULONG:
             return FitsIn<uint64_t>(value);
+        case TYP_REF:
+        case TYP_BYREF:
+#ifdef TARGET_64BIT
+            return FitsIn<int64_t>(value);
+#else
+            return FitsIn<int32_t>(value);
+#endif
         default:
             unreached();
     }

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -10503,11 +10503,11 @@ void Compiler::fgValueNumberTreeConst(GenTree* tree)
             }
             else if ((typ == TYP_LONG) || (typ == TYP_ULONG))
             {
-                tree->gtVNPair.SetBoth(vnStore->VNForLongCon(INT64(tree->AsIntConCommon()->LngValue())));
+                tree->gtVNPair.SetBoth(vnStore->VNForLongCon(INT64(tree->AsIntCon()->LngValue())));
             }
             else
             {
-                tree->gtVNPair.SetBoth(vnStore->VNForIntCon(int(tree->AsIntConCommon()->IconValue())));
+                tree->gtVNPair.SetBoth(vnStore->VNForIntCon(int(tree->AsIntCon()->IconValue())));
             }
 
             if (tree->IsCnsIntOrI())
@@ -10580,7 +10580,7 @@ void Compiler::fgValueNumberTreeConst(GenTree* tree)
         }
 
         case TYP_REF:
-            if (tree->AsIntConCommon()->IconValue() == 0)
+            if (tree->AsIntCon()->IconValue() == 0)
             {
                 tree->gtVNPair.SetBoth(ValueNumStore::VNForNull());
             }
@@ -10588,14 +10588,14 @@ void Compiler::fgValueNumberTreeConst(GenTree* tree)
             {
                 assert(doesMethodHaveFrozenObjects());
                 tree->gtVNPair.SetBoth(
-                    vnStore->VNForHandle(ssize_t(tree->AsIntConCommon()->IconValue()), tree->GetIconHandleFlag()));
+                    vnStore->VNForHandle(ssize_t(tree->AsIntCon()->IconValue()), tree->GetIconHandleFlag()));
 
                 fgValueNumberRegisterConstFieldSeq(tree->AsIntCon());
             }
             break;
 
         case TYP_BYREF:
-            if (tree->AsIntConCommon()->IconValue() == 0)
+            if (tree->AsIntCon()->IconValue() == 0)
             {
                 tree->gtVNPair.SetBoth(ValueNumStore::VNForNull());
             }
@@ -10606,13 +10606,13 @@ void Compiler::fgValueNumberTreeConst(GenTree* tree)
                 if (tree->IsIconHandle())
                 {
                     tree->gtVNPair.SetBoth(
-                        vnStore->VNForHandle(ssize_t(tree->AsIntConCommon()->IconValue()), tree->GetIconHandleFlag()));
+                        vnStore->VNForHandle(ssize_t(tree->AsIntCon()->IconValue()), tree->GetIconHandleFlag()));
 
                     fgValueNumberRegisterConstFieldSeq(tree->AsIntCon());
                 }
                 else
                 {
-                    tree->gtVNPair.SetBoth(vnStore->VNForByrefCon((target_size_t)tree->AsIntConCommon()->IconValue()));
+                    tree->gtVNPair.SetBoth(vnStore->VNForByrefCon((target_size_t)tree->AsIntCon()->IconValue()));
                 }
             }
             break;

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -5480,7 +5480,7 @@ FieldSeq* ValueNumStore::FieldSeqVNToFieldSeq(ValueNum vn)
 
 ValueNum ValueNumStore::ExtendPtrVN(GenTree* opA, GenTree* opB)
 {
-    if (opB->OperGet() == GT_CNS_INT)
+    if (opB->IsCnsIntOrI())
     {
         return ExtendPtrVN(opA, opB->AsIntCon()->gtFieldSeq, opB->AsIntCon()->IconValue());
     }


### PR DESCRIPTION
`GT_CNS_LNG` is an oper used for integral constants on 32 bit targets. On 64 bit targets, `GT_CNS_INT` is used for all integral constants. This is a bit of a hindrance for 32 bit target CQ, as it forces the natural flow of code to not consider long constants, and in general it seems odd to have one of the fundamental IR concepts (integer constants) be target-specific.

This change deletes `GT_CNS_LNG`, in favor of representing all integer constants with `GT_CNS_INT`.