### PR TITLE
[mono] Avoid an assert if the class name table is too large.

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -11646,11 +11646,15 @@ emit_class_name_table (MonoAotCompile *acfg)
 	name_p = name_buf = (guint8 *)g_malloc0 (name_buf_size);
 #endif
 
+	guint table_len = table->len;
+	if (table_size > 65000 || table->len > 65000) {
+		table_size = 0;
+		table_len = 0;
+	}
+
 	/* FIXME: Optimize memory usage */
-	g_assert (table_size < 65000);
 	encode_int16 (GINT_TO_UINT16 (table_size), p, &p);
-	g_assert (table->len < 65000);
-	for (guint i = 0; i < table->len; ++i) {
+	for (guint i = 0; i < table_len; ++i) {
 		entry = (ClassNameTableEntry *)g_ptr_array_index (table, i);
 		if (entry == NULL) {
 			encode_int16 (0, p, &p);

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -2639,6 +2639,9 @@ mono_aot_get_class_from_name (MonoImage *image, const char *name_space, const ch
 	table_size = amodule->class_name_table [0];
 	table = amodule->class_name_table + 1;
 
+	if (table_size == 0)
+		return FALSE;
+
 	if (name_space [0] == '\0')
 		full_name = g_strdup_printf ("%s", name);
 	else {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/85917.