### PR TITLE
Update life of data node for simd12

### DIFF
--- a/src/coreclr/jit/simdcodegenxarch.cpp
+++ b/src/coreclr/jit/simdcodegenxarch.cpp
@@ -47,16 +47,15 @@ void CodeGen::genStoreIndTypeSimd12(GenTreeStoreInd* treeNode)
     GenTree* addr = treeNode->Addr();
     genConsumeAddress(addr);
 
+    GenTree*  data    = treeNode->Data();
+    regNumber dataReg = genConsumeReg(data);
+
     if (addr->isContained() && addr->OperIs(GT_LCL_ADDR))
     {
         genEmitStoreLclTypeSimd12(treeNode, addr->AsLclFld()->GetLclNum(), addr->AsLclFld()->GetLclOffs());
         genUpdateLife(treeNode);
-        genUpdateLife(treeNode->Data());
         return;
     }
-
-    GenTree*  data    = treeNode->Data();
-    regNumber dataReg = genConsumeReg(data);
 
     emitter* emit = GetEmitter();
 

--- a/src/coreclr/jit/simdcodegenxarch.cpp
+++ b/src/coreclr/jit/simdcodegenxarch.cpp
@@ -51,6 +51,7 @@ void CodeGen::genStoreIndTypeSimd12(GenTreeStoreInd* treeNode)
     {
         genEmitStoreLclTypeSimd12(treeNode, addr->AsLclFld()->GetLclNum(), addr->AsLclFld()->GetLclOffs());
         genUpdateLife(treeNode);
+        genUpdateLife(treeNode->Data());
         return;
     }
 


### PR DESCRIPTION
I see that for simd12 node, `[000174]` (addr node) is marked as contained, but when we generate code for it, we do not update the life of `[000030]`. Today, we do that only if `addr` is not contained.

```
N105 (  3,  2) [000030] ----------z                   t30 =    LCL_VAR   simd12<System.Numerics.Vector3> V01 arg0         u:1 mm5 (last use) REG mm5 $c0
N107 (  3,  3) [000174] -c---------                  t174 =    LCL_ADDR  byref  V16 tmp13        [+0] NA REG NA $200
                                                            /--*  t174   byref  
                                                            +--*  t30    simd12 
N109 ( 10,  8) [000195] nA--G------                         *  STOREIND  simd12 (copy) REG NA $VN.Void
```

Fixes: https://github.com/dotnet/runtime/issues/85899