### PR TITLE
Speed up typeof

### DIFF
--- a/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
+++ b/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
@@ -65,7 +65,6 @@ enum EETypeElementType : uint8_t
 // GetFieldOffset() APIs.
 enum EETypeField
 {
-    ETF_InterfaceMap,
     ETF_TypeManagerIndirection,
     ETF_WritableData,
     ETF_Finalizer,

--- a/src/coreclr/nativeaot/Runtime/inc/MethodTable.inl
+++ b/src/coreclr/nativeaot/Runtime/inc/MethodTable.inl
@@ -106,12 +106,7 @@ __forceinline uint32_t MethodTable::GetFieldOffset(EETypeField eField)
     // First part of MethodTable consists of the fixed portion followed by the vtable.
     uint32_t cbOffset = offsetof(MethodTable, m_VTable) + (sizeof(UIntTarget) * m_usNumVtableSlots);
 
-    // Then we have the interface map.
-    if (eField == ETF_InterfaceMap)
-    {
-        ASSERT(GetNumInterfaces() > 0);
-        return cbOffset;
-    }
+    // Followed by interface list
     cbOffset += sizeof(MethodTable*) * GetNumInterfaces();
 
     const uint32_t relativeOrFullPointerOffset =

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/LdTokenHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/LdTokenHelpers.cs
@@ -31,9 +31,9 @@ namespace Internal.Runtime.CompilerHelpers
             return returnValue;
         }
 
-        private static Type GetRuntimeType(IntPtr pEEType)
+        private static unsafe Type GetRuntimeType(MethodTable* pMT)
         {
-            return Type.GetTypeFromEETypePtr(new EETypePtr(pEEType));
+            return Type.GetTypeFromMethodTable(pMT);
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/SynchronizedMethodHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/SynchronizedMethodHelpers.cs
@@ -44,10 +44,10 @@ namespace Internal.Runtime.CompilerHelpers
             lockTaken = false;
         }
 
-        private static void MonitorEnterStatic(IntPtr pEEType, ref bool lockTaken)
+        private static unsafe void MonitorEnterStatic(MethodTable* pMT, ref bool lockTaken)
         {
             // Inlined Monitor.Enter with a few tweaks
-            object obj = GetStaticLockObject(pEEType);
+            object obj = GetStaticLockObject(pMT);
             int resultOrIndex = ObjectHeader.Acquire(obj);
             if (resultOrIndex < 0)
             {
@@ -68,20 +68,20 @@ namespace Internal.Runtime.CompilerHelpers
             Monitor.TryAcquireContended(lck, obj, Timeout.Infinite);
             lockTaken = true;
         }
-        private static void MonitorExitStatic(IntPtr pEEType, ref bool lockTaken)
+        private static unsafe void MonitorExitStatic(MethodTable* pMT, ref bool lockTaken)
         {
             // Inlined Monitor.Exit with a few tweaks
             if (!lockTaken)
                 return;
 
-            object obj = GetStaticLockObject(pEEType);
+            object obj = GetStaticLockObject(pMT);
             ObjectHeader.Release(obj);
             lockTaken = false;
         }
 
-        private static Type GetStaticLockObject(IntPtr pEEType)
+        private static unsafe Type GetStaticLockObject(MethodTable* pMT)
         {
-            return Type.GetTypeFromEETypePtr(new EETypePtr(pEEType));
+            return Type.GetTypeFromMethodTable(pMT);
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Object.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Object.NativeAot.cs
@@ -22,7 +22,7 @@ namespace System
         [Intrinsic]
         public Type GetType()
         {
-            return Type.GetTypeFromEETypePtr(this.GetEETypePtr());
+            return Type.GetTypeFromMethodTable(m_pEEType);
         }
 
         [Intrinsic]

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/DynamicInvokeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/DynamicInvokeInfo.cs
@@ -324,7 +324,7 @@ namespace System.Reflection
             return ref ret;
         }
 
-        private object? GetCoercedDefaultValue(int index, in ArgumentInfo argumentInfo)
+        private unsafe object? GetCoercedDefaultValue(int index, in ArgumentInfo argumentInfo)
         {
             object? defaultValue = Method.GetParametersNoCopy()[index].DefaultValue;
             if (defaultValue == DBNull.Value)
@@ -337,7 +337,7 @@ namespace System.Reflection
                 EETypePtr nullableType = argumentInfo.Type.NullableType;
                 if (nullableType.IsEnum)
                 {
-                    defaultValue = Enum.ToObject(Type.GetTypeFromEETypePtr(nullableType), defaultValue);
+                    defaultValue = Enum.ToObject(Type.GetTypeFromMethodTable(nullableType.ToPointer()), defaultValue);
                 }
             }
 
@@ -444,7 +444,7 @@ namespace System.Reflection
                 {
                     if ((transform & Transform.Pointer) != 0)
                     {
-                        Type type = Type.GetTypeFromEETypePtr(argumentInfo.Type);
+                        Type type = Type.GetTypeFromMethodTable(argumentInfo.Type.ToPointer());
                         Debug.Assert(type.IsPointer);
                         obj = Pointer.Box((void*)Unsafe.As<byte, IntPtr>(ref obj.GetRawData()), type);
                     }
@@ -476,7 +476,7 @@ namespace System.Reflection
             object obj;
             if ((_returnTransform & Transform.Pointer) != 0)
             {
-                Type type = Type.GetTypeFromEETypePtr(_returnType);
+                Type type = Type.GetTypeFromMethodTable(_returnType.ToPointer());
                 Debug.Assert(type.IsPointer);
                 obj = Pointer.Box((void*)Unsafe.As<byte, IntPtr>(ref byref), type);
             }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
@@ -360,7 +360,7 @@ namespace System.Runtime.CompilerServices
             if (mt->IsNullable)
             {
                 mt = mt->NullableType;
-                return GetUninitializedObject(Type.GetTypeFromEETypePtr(new EETypePtr(mt)));
+                return GetUninitializedObject(Type.GetTypeFromMethodTable(mt));
             }
 
             // Triggering the .cctor here is slightly different than desktop/CoreCLR, which

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Type.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Type.NativeAot.cs
@@ -10,6 +10,7 @@ using System.Threading;
 
 using Internal.Reflection.Augments;
 using Internal.Reflection.Core.NonPortable;
+using Internal.Runtime;
 using Internal.Runtime.Augments;
 using Internal.Runtime.CompilerServices;
 
@@ -20,38 +21,39 @@ namespace System
         public bool IsInterface => (GetAttributeFlagsImpl() & TypeAttributes.ClassSemanticsMask) == TypeAttributes.Interface;
 
         [Intrinsic]
-        public static Type? GetTypeFromHandle(RuntimeTypeHandle handle) => handle.IsNull ? null : GetTypeFromEETypePtr(handle.ToEETypePtr());
+        public static unsafe Type? GetTypeFromHandle(RuntimeTypeHandle handle) => handle.IsNull ? null : GetTypeFromMethodTable(handle.ToMethodTable());
 
-        internal static Type GetTypeFromEETypePtr(EETypePtr eeType)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static unsafe Type GetTypeFromMethodTable(MethodTable* pMT)
         {
-            // If we support the writable data section on EETypes, the runtime type associated with the MethodTable
+            // If we support the writable data section on MethodTables, the runtime type associated with the MethodTable
             // is cached there. If writable data is not supported, we need to do a lookup in the runtime type
             // unifier's hash table.
-            if (Internal.Runtime.MethodTable.SupportsWritableData)
+            if (MethodTable.SupportsWritableData)
             {
-                ref GCHandle handle = ref eeType.GetWritableData<GCHandle>();
+                ref GCHandle handle = ref Unsafe.AsRef<GCHandle>(pMT->WritableData);
                 if (handle.IsAllocated)
                 {
                     return Unsafe.As<Type>(handle.Target);
                 }
                 else
                 {
-                    return GetTypeFromEETypePtrSlow(eeType, ref handle);
+                    return GetTypeFromMethodTableSlow(pMT, ref handle);
                 }
             }
             else
             {
-                return RuntimeTypeUnifier.GetRuntimeTypeForEEType(eeType);
+                return RuntimeTypeUnifier.GetRuntimeTypeForEEType(new EETypePtr(pMT));
             }
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static Type GetTypeFromEETypePtrSlow(EETypePtr eeType, ref GCHandle handle)
+        private static unsafe Type GetTypeFromMethodTableSlow(MethodTable* pMT, ref GCHandle handle)
         {
             // Note: this is bypassing the "fast" unifier cache (based on a simple IntPtr
             // identity of MethodTable pointers). There is another unifier behind that cache
             // that ensures this code is race-free.
-            Type result = RuntimeTypeUnifier.GetRuntimeTypeBypassCache(eeType);
+            Type result = RuntimeTypeUnifier.GetRuntimeTypeBypassCache(new EETypePtr(pMT));
             GCHandle tempHandle = GCHandle.Alloc(result);
 
             // We don't want to leak a handle if there's a race

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -324,7 +324,7 @@ namespace Internal.Runtime.TypeLoader
                 {
                     writableDataPtr = MemoryHelpers.AllocateMemory(WritableData.GetSize(IntPtr.Size));
                     MemoryHelpers.Memset(writableDataPtr, WritableData.GetSize(IntPtr.Size), 0);
-                    pEEType->WritableData = writableDataPtr;
+                    pEEType->WritableData = (void*)writableDataPtr;
                 }
 
                 pEEType->DynamicTemplateType = pTemplateEEType;

--- a/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
@@ -177,7 +177,6 @@ namespace Internal.Runtime
 
     internal enum EETypeField
     {
-        ETF_InterfaceMap,
         ETF_TypeManagerIndirection,
         ETF_WritableData,
         ETF_DispatchMap,

--- a/src/libraries/System.Private.CoreLib/src/System/Nullable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Nullable.cs
@@ -103,21 +103,6 @@ namespace System
         {
             ArgumentNullException.ThrowIfNull(nullableType);
 
-#if NATIVEAOT
-            // This is necessary to handle types without reflection metadata
-            if (nullableType.TryGetEEType(out EETypePtr nullableEEType))
-            {
-                if (nullableEEType.IsGeneric)
-                {
-                    if (nullableEEType.IsNullable)
-                    {
-                        return Type.GetTypeFromEETypePtr(nullableEEType.NullableType);
-                    }
-                }
-                return null;
-            }
-#endif
-
             if (nullableType.IsGenericType && !nullableType.IsGenericTypeDefinition)
             {
                 // Instantiated generic type only


### PR DESCRIPTION
Saw it in BasicMinimalApi profiles. The ultimate fix is to make `RuntimeType` a frozen object, but this will do for now.

Also made a bit of progress in eradicating `EETypePtr` while I'm touching this.

Cc @dotnet/ilc-contrib 