### PR TITLE
Stop special casing reflected-on internals

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/CompatibilitySuppressions.xml
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/CompatibilitySuppressions.xml
@@ -806,10 +806,6 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:System.Diagnostics.Tracing.PropertyValue</Target>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:System.MDArray</Target>
   </Suppression>
   <Suppression>
@@ -871,10 +867,6 @@
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:System.Reflection.RuntimeAssemblyName</Target>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:System.Resources.RuntimeResourceSet</Target>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/PropertyValue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/PropertyValue.cs
@@ -13,13 +13,7 @@ namespace System.Diagnostics.Tracing
     ///
     /// To get the value of a property quickly, use a delegate produced by <see cref="PropertyValue.GetPropertyGetter(PropertyInfo)"/>.
     /// </summary>
-#if NATIVEAOT
-    [CLSCompliant(false)]
-    public // On NativeAOT, this must be public to prevent it from getting reflection blocked.
-#else
-    internal
-#endif
-    readonly unsafe struct PropertyValue
+    internal readonly unsafe struct PropertyValue
     {
         /// <summary>
         /// Union of well-known value types, to avoid boxing those types.
@@ -202,12 +196,7 @@ namespace System.Diagnostics.Tracing
             return helper.GetPropertyGetter(property);
         }
 
-#if NATIVEAOT
-        public // On NativeAOT, this must be public to prevent it from getting reflection blocked.
-#else
-        private
-#endif
-        abstract class TypeHelper
+        private abstract class TypeHelper
         {
             public abstract Func<PropertyValue, PropertyValue> GetPropertyGetter(PropertyInfo property);
 
@@ -219,12 +208,7 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-#if NATIVEAOT
-        public // On NativeAOT, this must be public to prevent it from getting reflection blocked.
-#else
-        private
-#endif
-        sealed class ReferenceTypeHelper<TContainer> : TypeHelper where TContainer : class
+        private sealed class ReferenceTypeHelper<TContainer> : TypeHelper where TContainer : class
         {
             private static Func<TContainer, TProperty> GetGetMethod<TProperty>(PropertyInfo property) where TProperty : struct =>
                 property.GetMethod!.CreateDelegate<Func<TContainer, TProperty>>();

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/RuntimeResourceSet.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/RuntimeResourceSet.cs
@@ -154,12 +154,7 @@ namespace System.Resources
     // into smaller chunks, each of size sqrt(n), would be substantially better for
     // resource files containing thousands of resources.
     //
-#if NATIVEAOT
-    public  // On NativeAOT, this must be public to prevent it from getting reflection blocked.
-#else
-    internal
-#endif
-    sealed class RuntimeResourceSet : ResourceSet, IEnumerable
+    internal sealed class RuntimeResourceSet : ResourceSet, IEnumerable
     {
         // Cache for resources.  Key is the resource name, which can be cached
         // for arbitrarily long times, since the object is usually a string

--- a/src/libraries/System.Private.CoreLib/src/System/SR.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SR.cs
@@ -15,7 +15,9 @@ namespace System
         private static readonly object _lock = new object();
         private static List<string>? _currentlyLoading;
         private static int _infinitelyRecursingCount;
+#if SYSTEM_PRIVATE_CORELIB
         private static bool _resourceManagerInited;
+#endif
 
         private static string InternalGetResourceString(string key)
         {
@@ -72,6 +74,7 @@ namespace System
 
                 _currentlyLoading ??= new List<string>();
 
+#if SYSTEM_PRIVATE_CORELIB
                 // Call class constructors preemptively, so that we cannot get into an infinite
                 // loop constructing a TypeInitializationException.  If this were omitted,
                 // we could get the Infinite recursion assert above by failing type initialization
@@ -84,6 +87,7 @@ namespace System
                     RuntimeHelpers.RunClassConstructor(typeof(BinaryReader).TypeHandle);
                     _resourceManagerInited = true;
                 }
+#endif
 
                 _currentlyLoading.Add(key); // Push
 


### PR DESCRIPTION
Concept of reflection blocked internals was deleted in #85810. This is no longer needed.

Cc @dotnet/ilc-contrib 