### PR TITLE
SPMI: Export dynamic symbols in superpmi for unix builds

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi/CMakeLists.txt
+++ b/src/coreclr/tools/superpmi/superpmi/CMakeLists.txt
@@ -12,6 +12,11 @@ if(CLR_CMAKE_HOST_WIN32)
   set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded)
 endif(CLR_CMAKE_HOST_WIN32)
 
+if(CLR_CMAKE_HOST_UNIX)
+    # Make sure a public symbol is created for Instrumentor_GetInsCount
+    add_linker_flag(-Wl,--export-dynamic)
+endif(CLR_CMAKE_HOST_UNIX)
+
 include_directories(.)
 include_directories(../superpmi-shared)
 

--- a/src/coreclr/tools/superpmi/superpmi/CMakeLists.txt
+++ b/src/coreclr/tools/superpmi/superpmi/CMakeLists.txt
@@ -14,7 +14,11 @@ endif(CLR_CMAKE_HOST_WIN32)
 
 if(CLR_CMAKE_HOST_UNIX)
     # Make sure a public symbol is created for Instrumentor_GetInsCount
-    add_linker_flag(-Wl,--export-dynamic)
+    if(CLR_CMAKE_HOST_APPLE)
+        add_linker_flag(-Wl,-export_dynamic)
+    else()
+        add_linker_flag(-Wl,--export-dynamic)
+    endif(CLR_CMAKE_HOST_APPLE)
 endif(CLR_CMAKE_HOST_UNIX)
 
 include_directories(.)


### PR DESCRIPTION
This is necessary for Instrumentor_GetInsCount to get a public symbol that pin can find.