### PR TITLE
Fix ReadOnlySpanGetReferenceAndReadInteger on BigEndian

### DIFF
--- a/src/libraries/System.Memory/tests/MemoryMarshal/GetReference.cs
+++ b/src/libraries/System.Memory/tests/MemoryMarshal/GetReference.cs
@@ -104,11 +104,15 @@ namespace System.SpanTests
         [Fact]
         public static void ReadOnlySpanGetReferenceAndReadInteger()
         {
-            Assert.Equal(6619240, 
+            Assert.Equal(BitConverter.IsLittleEndian ?
+                    0x65_00_68 :
+                    0x68_00_65,
                 Unsafe.As<byte, int>(ref Unsafe.Add(ref Unsafe.As<char, byte>(
-                ref MemoryMarshal.GetReference("hello world 1".AsSpan())), 0)));
+                    ref MemoryMarshal.GetReference("hello world 1".AsSpan())), 0)));
 
-            Assert.Equal(7998511687277765888,
+            Assert.Equal(BitConverter.IsLittleEndian ?
+                    0x6F_00_6C_00_6C_00_65_00 :
+                    0x00_65_00_6C_00_6C_00_6F,
                 Unsafe.As<byte, long>(ref Unsafe.Add(ref Unsafe.As<char, byte>(
                     ref MemoryMarshal.GetReference("hello world 2".AsSpan())), 1)));
         }

--- a/src/libraries/System.Memory/tests/MemoryMarshal/GetReference.cs
+++ b/src/libraries/System.Memory/tests/MemoryMarshal/GetReference.cs
@@ -105,14 +105,14 @@ namespace System.SpanTests
         public static void ReadOnlySpanGetReferenceAndReadInteger()
         {
             Assert.Equal(BitConverter.IsLittleEndian ?
-                    0x65_00_68 :
-                    0x68_00_65,
+                0x65_00_68 :
+                0x68_00_65,
                 Unsafe.As<byte, int>(ref Unsafe.Add(ref Unsafe.As<char, byte>(
                     ref MemoryMarshal.GetReference("hello world 1".AsSpan())), 0)));
 
             Assert.Equal(BitConverter.IsLittleEndian ?
-                    0x6F_00_6C_00_6C_00_65_00 :
-                    0x00_65_00_6C_00_6C_00_6F,
+                0x6F_00_6C_00_6C_00_65_00 :
+                0x00_65_00_6C_00_6C_00_6F,
                 Unsafe.As<byte, long>(ref Unsafe.Add(ref Unsafe.As<char, byte>(
                     ref MemoryMarshal.GetReference("hello world 2".AsSpan())), 1)));
         }


### PR DESCRIPTION
Addresses https://github.com/dotnet/runtime/pull/85127#issuecomment-1539725056