### PR TITLE
[release/7.0] Fix HTTP/3 and HTTTP/2 header decoder buffer allocation

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http2/Hpack/HPackDecoder.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http2/Hpack/HPackDecoder.cs
@@ -187,12 +187,11 @@ namespace System.Net.Http.HPack
             // will no longer be valid.
             if (_headerNameRange != null)
             {
-                EnsureStringCapacity(ref _headerNameOctets);
+                EnsureStringCapacity(ref _headerNameOctets, _headerNameLength);
                 _headerName = _headerNameOctets;
 
                 ReadOnlySpan<byte> headerBytes = data.Slice(_headerNameRange.GetValueOrDefault().start, _headerNameRange.GetValueOrDefault().length);
                 headerBytes.CopyTo(_headerName);
-                _headerNameLength = headerBytes.Length;
                 _headerNameRange = null;
             }
         }
@@ -427,6 +426,7 @@ namespace System.Net.Http.HPack
             {
                 // Fast path. Store the range rather than copying.
                 _headerNameRange = (start: currentIndex, count);
+                _headerNameLength = _stringLength;
                 currentIndex += count;
 
                 _state = State.HeaderValueLength;
@@ -621,11 +621,12 @@ namespace System.Net.Http.HPack
             _state = nextState;
         }
 
-        private void EnsureStringCapacity(ref byte[] dst)
+        private void EnsureStringCapacity(ref byte[] dst, int stringLength = -1)
         {
-            if (dst.Length < _stringLength)
+            stringLength = stringLength >= 0 ? stringLength : _stringLength;
+            if (dst.Length < stringLength)
             {
-                dst = new byte[Math.Max(_stringLength, dst.Length * 2)];
+                dst = new byte[Math.Max(stringLength, dst.Length * 2)];
             }
         }
 

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/QPack/QPackDecoder.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/QPack/QPackDecoder.cs
@@ -243,12 +243,11 @@ namespace System.Net.Http.QPack
             // will no longer be valid.
             if (_headerNameRange != null)
             {
-                EnsureStringCapacity(ref _headerNameOctets, _stringLength, existingLength: 0);
+                EnsureStringCapacity(ref _headerNameOctets, _headerNameLength, existingLength: 0);
                 _headerName = _headerNameOctets;
 
                 ReadOnlySpan<byte> headerBytes = data.Slice(_headerNameRange.GetValueOrDefault().start, _headerNameRange.GetValueOrDefault().length);
                 headerBytes.CopyTo(_headerName);
-                _headerNameLength = headerBytes.Length;
                 _headerNameRange = null;
             }
         }
@@ -294,6 +293,7 @@ namespace System.Net.Http.QPack
             {
                 // Fast path. Store the range rather than copying.
                 _headerNameRange = (start: currentIndex, count);
+                _headerNameLength = _stringLength;
                 currentIndex += count;
 
                 _state = State.HeaderValueLength;

--- a/src/libraries/Common/tests/Tests/System/Net/aspnetcore/Http2/HPackDecoderTest.cs
+++ b/src/libraries/Common/tests/Tests/System/Net/aspnetcore/Http2/HPackDecoderTest.cs
@@ -46,7 +46,12 @@ namespace System.Net.Http.Unit.Tests.HPack
 
         private const string _headerNameString = "new-header";
 
+        // On purpose longer than 4096 (DefaultStringOctetsSize from HPackDecoder) to trigger https://github.com/dotnet/runtime/issues/78516
+        private static readonly string _literalHeaderNameString = string.Concat(Enumerable.Range(0, 4100).Select(c => (char)('a' + (c % 26))));
+
         private static readonly byte[] _headerNameBytes = Encoding.ASCII.GetBytes(_headerNameString);
+
+        private static readonly byte[] _literalHeaderNameBytes = Encoding.ASCII.GetBytes(_literalHeaderNameString);
 
         // n     e     w       -      h     e     a     d     e     r      *
         // 10101000 10111110 00010110 10011100 10100011 10010000 10110110 01111111
@@ -62,6 +67,12 @@ namespace System.Net.Http.Unit.Tests.HPack
 
         private static readonly byte[] _headerName = new byte[] { (byte)_headerNameBytes.Length }
             .Concat(_headerNameBytes)
+            .ToArray();
+
+        // size = 4096 ==> 0x7f, 0x81, 0x1f (7+) prefixed integer
+        // size = 4100 ==> 0x7f, 0x85, 0x1f (7+) prefixed integer
+        private static readonly byte[] _literalHeaderName = new byte[] { 0x7f, 0x85, 0x1f } // 4100
+            .Concat(_literalHeaderNameBytes)
             .ToArray();
 
         private static readonly byte[] _headerNameHuffman = new byte[] { (byte)(0x80 | _headerNameHuffmanBytes.Length) }
@@ -390,6 +401,101 @@ namespace System.Net.Http.Unit.Tests.HPack
             HPackDecodingException exception = Assert.Throws<HPackDecodingException>(() => _decoder.Decode(new byte[] { 0x1f, 0x2f }, endHeaders: true, handler: _handler));
             Assert.Equal(SR.Format(SR.net_http_hpack_invalid_index, 62), exception.Message);
             Assert.Empty(_handler.DecodedHeaders);
+        }
+
+        [Fact]
+        public void DecodesLiteralHeaderFieldNeverIndexed_NewName_SingleBuffer()
+        {
+            byte[] encoded = _literalHeaderFieldWithoutIndexingNewName
+                .Concat(_literalHeaderName)
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(encoded, endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
+        }
+
+        [Fact]
+        public void DecodesLiteralHeaderFieldNeverIndexed_NewName_NameLengthBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalHeaderFieldWithoutIndexingNewName
+                .Concat(_literalHeaderName)
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(encoded[..1], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[1..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
+        }
+
+        [Fact]
+        public void DecodesLiteralHeaderFieldNeverIndexed_NewName_NameBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalHeaderFieldWithoutIndexingNewName
+                .Concat(_literalHeaderName)
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(encoded[..(_literalHeaderNameString.Length / 2)], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[(_literalHeaderNameString.Length / 2)..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
+        }
+
+        [Fact]
+        public void DecodesLiteralHeaderFieldNeverIndexed_NewName_NameAndValueBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalHeaderFieldWithoutIndexingNewName
+                .Concat(_literalHeaderName)
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(encoded[..^_headerValue.Length], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[^_headerValue.Length..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
+        }
+
+        [Fact]
+        public void DecodesLiteralHeaderFieldNeverIndexed_NewName_ValueLengthBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalHeaderFieldWithoutIndexingNewName
+                .Concat(_literalHeaderName)
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(encoded[..^(_headerValue.Length - 1)], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[^(_headerValue.Length - 1)..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
+        }
+
+        [Fact]
+        public void DecodesLiteralHeaderFieldNeverIndexed_NewName_ValueBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalHeaderFieldWithoutIndexingNewName
+                .Concat(_literalHeaderName)
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(encoded[..^(_headerValueString.Length / 2)], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[^(_headerValueString.Length / 2)..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
         }
 
         [Fact]

--- a/src/libraries/Common/tests/Tests/System/Net/aspnetcore/Http3/QPackDecoderTest.cs
+++ b/src/libraries/Common/tests/Tests/System/Net/aspnetcore/Http3/QPackDecoderTest.cs
@@ -25,11 +25,11 @@ namespace System.Net.Http.Unit.Tests.QPack
         // 4.5.4 - Literal Header Field With Name Reference - Static Table - Index 44 (content-type)
         private static readonly byte[] _literalHeaderFieldWithNameReferenceStatic = new byte[] { 0x5f, 0x1d };
 
-        // 4.5.6 - Literal Field Line With Literal Name - (translate)
-        private static readonly byte[] _literalFieldLineWithLiteralName = new byte[] { 0x37, 0x02, 0x74, 0x72, 0x61, 0x6e, 0x73, 0x6c, 0x61, 0x74, 0x65 };
+        // 4.5.6 - Literal Field Line With Literal Name - (literal-header-field)
+        private static readonly byte[] _literalFieldLineWithLiteralName = new byte[] { 0x37, 0x0d, 0x6c, 0x69, 0x74, 0x65, 0x72, 0x61, 0x6c, 0x2d, 0x68, 0x65, 0x61, 0x64, 0x65, 0x72, 0x2d, 0x66, 0x69, 0x65, 0x6c, 0x64 };
 
         private const string _contentTypeString = "content-type";
-        private const string _translateString = "translate";
+        private const string _literalHeaderFieldString = "literal-header-field";
 
         // n     e     w       -      h     e     a     d     e     r      *
         // 10101000 10111110 00010110 10011100 10100011 10010000 10110110 01111111
@@ -97,7 +97,7 @@ namespace System.Net.Http.Unit.Tests.QPack
                 .Concat(_headerValue)
                 .ToArray();
 
-            TestDecodeWithoutIndexing(encoded, _translateString, _headerValueString);
+            TestDecodeWithoutIndexing(encoded, _literalHeaderFieldString, _headerValueString);
         }
 
         [Fact]
@@ -140,7 +140,7 @@ namespace System.Net.Http.Unit.Tests.QPack
                 .Concat(_headerValueHuffman)
                 .ToArray();
 
-            TestDecodeWithoutIndexing(encoded, _translateString, _headerValueString);
+            TestDecodeWithoutIndexing(encoded, _literalHeaderFieldString, _headerValueString);
         }
 
         [Fact]
@@ -171,6 +171,101 @@ namespace System.Net.Http.Unit.Tests.QPack
                 new KeyValuePair<string, string>(":path", new string('A', 8192 / 2)),
                 new KeyValuePair<string, string>(":scheme", "http")
             });
+        }
+
+        [Fact]
+        public void LiteralFieldWithoutNameReference_SingleBuffer()
+        {
+            byte[] encoded = _literalFieldLineWithLiteralName
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(new byte[] { 0x00, 0x00 }, endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded, endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderFieldString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderFieldString]);
+        }
+
+        [Fact]
+        public void LiteralFieldWithoutNameReference_NameLengthBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalFieldLineWithLiteralName
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(new byte[] { 0x00, 0x00 }, endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[..1], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[1..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderFieldString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderFieldString]);
+        }
+
+        [Fact]
+        public void LiteralFieldWithoutNameReference_NameBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalFieldLineWithLiteralName
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(new byte[] { 0x00, 0x00 }, endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[..(_literalHeaderFieldString.Length / 2)], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[(_literalHeaderFieldString.Length / 2)..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderFieldString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderFieldString]);
+        }
+
+        [Fact]
+        public void LiteralFieldWithoutNameReference_NameAndValueBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalFieldLineWithLiteralName
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(new byte[] { 0x00, 0x00 }, endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[..^_headerValue.Length], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[^_headerValue.Length..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderFieldString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderFieldString]);
+        }
+
+        [Fact]
+        public void LiteralFieldWithoutNameReference_ValueLengthBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalFieldLineWithLiteralName
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(new byte[] { 0x00, 0x00 }, endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[..^(_headerValue.Length - 1)], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[^(_headerValue.Length - 1)..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderFieldString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderFieldString]);
+        }
+
+        [Fact]
+        public void LiteralFieldWithoutNameReference_ValueBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalFieldLineWithLiteralName
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(new byte[] { 0x00, 0x00 }, endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[..^(_headerValueString.Length / 2)], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[^(_headerValueString.Length / 2)..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderFieldString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderFieldString]);
         }
 
         public static readonly TheoryData<byte[]> _incompleteHeaderBlockData = new TheoryData<byte[]>

--- a/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -322,6 +322,8 @@
              Link="HPack\HPackIntegerTest.cs" />
     <Compile Include="$(CommonPath)..\tests\Tests\System\Net\aspnetcore\Http2\HuffmanDecodingTests.cs"
              Link="HPack\HuffmanDecodingTests.cs" />
+    <Compile Include="$(CommonPath)..\tests\Tests\System\Net\aspnetcore\Http3\QPackDecoderTest.cs"
+             Link="QPack\QPackDecoderTest.cs" />
     <Compile Include="HttpContentTest.cs" />
     <Compile Include="HttpRuleParserTest.cs" />
     <Compile Include="MockContent.cs" />
@@ -393,8 +395,12 @@
              Link="Common\System\Net\Http\aspnetcore\Http3\QPack\HeaderField.cs" />
     <Compile Include="$(CommonPath)System\Net\Http\aspnetcore\Http3\QPack\QPackEncoder.cs"
              Link="Common\System\Net\Http\aspnetcore\Http3\QPack\QPackEncoder.cs" />
+    <Compile Include="$(CommonPath)System\Net\Http\aspnetcore\Http3\QPack\QPackDecoder.cs"
+             Link="Common\System\Net\Http\aspnetcore\Http3\QPack\QPackDecoder.cs" />
     <Compile Include="$(CommonPath)System\Net\Http\aspnetcore\Http3\QPack\QPackEncodingException.cs"
              Link="Common\System\Net\Http\aspnetcore\Http3\QPack\QPackEncodingException.cs" />
+    <Compile Include="$(CommonPath)System\Net\Http\aspnetcore\Http3\QPack\QPackDecodingException.cs"
+             Link="Common\System\Net\Http\aspnetcore\Http3\QPack\QPackDecodingException.cs" />
     <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs"
              Link="Common\System\Text\ValueStringBuilder.cs" />
     <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.AppendSpanFormattable.cs"


### PR DESCRIPTION
Fixes #78516

Backports #78862

## Customer impact

Reliability problem in HTTP/2 and HTTP/3, where some requests/responses with large headers that should be accepted might end up throwing exception.
- In HPack cases (HTTP/2 scenarios), the issue is much less likely to be hit as it requires 4KB of headers.
- In QPack (HTTP/3), the header size required to hit this is much smaller and that's where this was caught by the original issue reporter.

This is a shared code with Kestrel so this affects server side as well - expect follow up PR in ASP.NET.

## Testing

Added tests for the root cause and similar scenarios, increasing test coverage. All of those are ran in CI.

## Risk

Low, as this affects only QPack (H/3 is still not as wide-spread as other HTTP versions) and HPack in (rare) case of 4KB+ sized headers data buffers.