### PR TITLE
[PERF] Add arm64 dynamic pgo runs

### DIFF
--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -271,6 +271,22 @@ jobs:
       buildConfig: release
       runtimeFlavor: coreclr
       platforms:
+      - linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        pgoRunType: --dynamicpgo
+
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
       - windows_x64
       jobParameters:
         testGroup: perf

--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -31,223 +31,223 @@ jobs:
       platforms:
       - linux_x64
       - windows_x64
-      - windows_x86
-      - linux_musl_x64
+      # - windows_x86
+      # - linux_musl_x64
       jobParameters:
         testGroup: perf
 
-  # build mono for AOT
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - linux_x64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: AOT
-        isOfficialBuild: false
-        extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: AOT Mono Artifacts
-          artifactName: LinuxMonoAOTx64
-          archiveExtension: '.tar.gz'
-          archiveType: tar
-          tarCompression: gz
+  # # build mono for AOT
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - linux_x64
+  #     jobParameters:
+  #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #       nameSuffix: AOT
+  #       isOfficialBuild: false
+  #       extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+  #       extraStepsParameters:
+  #         rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #         includeRootFolder: true
+  #         displayName: AOT Mono Artifacts
+  #         artifactName: LinuxMonoAOTx64
+  #         archiveExtension: '.tar.gz'
+  #         archiveType: tar
+  #         tarCompression: gz
 
-  # build mono Android scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - android_arm64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: AndroidMono
-        isOfficialBuild: false
-        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: Android Mono Artifacts
-          artifactName: AndroidMonoarm64
-          archiveExtension: '.tar.gz'
-          archiveType: tar
-          tarCompression: gz
+  # # build mono Android scenarios
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - android_arm64
+  #     jobParameters:
+  #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #       nameSuffix: AndroidMono
+  #       isOfficialBuild: false
+  #       extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+  #       extraStepsParameters:
+  #         rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #         includeRootFolder: true
+  #         displayName: Android Mono Artifacts
+  #         artifactName: AndroidMonoarm64
+  #         archiveExtension: '.tar.gz'
+  #         archiveType: tar
+  #         tarCompression: gz
 
-  # build mono iOS scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - ios_arm64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: iOSMono
-        isOfficialBuild: false
-        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: iOS Mono Artifacts
-          artifactName: iOSMonoarm64
-          archiveExtension: '.tar.gz'
-          archiveType: tar
-          tarCompression: gz
+  # # build mono iOS scenarios
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - ios_arm64
+  #     jobParameters:
+  #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #       nameSuffix: iOSMono
+  #       isOfficialBuild: false
+  #       extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+  #       extraStepsParameters:
+  #         rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #         includeRootFolder: true
+  #         displayName: iOS Mono Artifacts
+  #         artifactName: iOSMonoarm64
+  #         archiveExtension: '.tar.gz'
+  #         archiveType: tar
+  #         tarCompression: gz
 
-  # build mono
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-      runtimeFlavor: mono
-      buildConfig: release
-      platforms:
-      - linux_x64
+  # # build mono
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+  #     runtimeFlavor: mono
+  #     buildConfig: release
+  #     platforms:
+  #     - linux_x64
 
-  # run android scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - windows_x64
-      jobParameters:
-        testGroup: perf
-        runtimeType: AndroidMono
-        projectFile: android_scenarios.proj
-        runKind: android_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfpixel4a'
+  # # run android scenarios
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #       - windows_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       runtimeType: AndroidMono
+  #       projectFile: android_scenarios.proj
+  #       runKind: android_scenarios
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #       logicalmachine: 'perfpixel4a'
 
-  # run mono iOS scenarios scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - osx_x64
-      jobParameters:
-        testGroup: perf
-        runtimeType: iOSMono
-        projectFile: ios_scenarios.proj
-        runKind: ios_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfiphone12mini'
-        iOSLlvmBuild: False
+  # # run mono iOS scenarios scenarios
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #       - osx_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       runtimeType: iOSMono
+  #       projectFile: ios_scenarios.proj
+  #       runKind: ios_scenarios
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #       logicalmachine: 'perfiphone12mini'
+  #       iOSLlvmBuild: False
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - osx_x64
-      jobParameters:
-        testGroup: perf
-        runtimeType: iOSMono
-        projectFile: ios_scenarios.proj
-        runKind: ios_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfiphone12mini'
-        iOSLlvmBuild: True
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #       - osx_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       runtimeType: iOSMono
+  #       projectFile: ios_scenarios.proj
+  #       runKind: ios_scenarios
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #       logicalmachine: 'perfiphone12mini'
+  #       iOSLlvmBuild: True
 
-  # run mono microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  # # run mono microbenchmarks perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - linux_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       runtimeType: mono
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro_mono
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
 
-  # run mono interpreter perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        codeGenType: 'Interpreter'
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  # # run mono interpreter perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - linux_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       runtimeType: mono
+  #       codeGenType: 'Interpreter'
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro_mono
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
 
-  # run mono aot microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildConfig: release
-      runtimeFlavor: aot
-      platforms:
-      - linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        codeGenType: 'AOT'
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  # # run mono aot microbenchmarks perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+  #     buildConfig: release
+  #     runtimeFlavor: aot
+  #     platforms:
+  #     - linux_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       runtimeType: mono
+  #       codeGenType: 'AOT'
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro_mono
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
 
-  # run coreclr perftiger microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - linux_x64
-      - windows_x64
-      - windows_x86
-      - linux_musl_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  # # run coreclr perftiger microbenchmarks perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - linux_x64
+  #     - windows_x64
+  #     - windows_x86
+  #     - linux_musl_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
 
-  # run coreclr perftiger microbenchmarks pgo perf jobs
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: -NoPgo
+  # # run coreclr perftiger microbenchmarks pgo perf jobs
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - windows_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
+  #       pgoRunType: -NoPgo
 
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
@@ -281,95 +281,95 @@ jobs:
         logicalmachine: 'perftiger'
         pgoRunType: --dynamicpgo
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: -FullPgo
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - windows_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
+  #       pgoRunType: -FullPgo
 
-  # run coreclr perfowl microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - linux_x64
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perfowl'
+  # # run coreclr perfowl microbenchmarks perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - linux_x64
+  #     - windows_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perfowl'
 
-  # run coreclr crossgen perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - linux_x64
-      - windows_x64
-      - windows_x86
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: crossgen_perf.proj
-        runKind: crossgen_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perftiger'
+  # # run coreclr crossgen perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - linux_x64
+  #     - windows_x64
+  #     - windows_x86
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: crossgen_perf.proj
+  #       runKind: crossgen_scenarios
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #       logicalmachine: 'perftiger'
 
-  # build mono runtime packs
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - android_arm64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: Mono_Packs
-        isOfficialBuild: false
-        extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-        extraStepsParameters:
-          name: MonoRuntimePacks
+  # # build mono runtime packs
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - android_arm64
+  #     jobParameters:
+  #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #       nameSuffix: Mono_Packs
+  #       isOfficialBuild: false
+  #       extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+  #       extraStepsParameters:
+  #         name: MonoRuntimePacks
 
-  # build PerfBDN app
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - ios_arm64
-      jobParameters:
-        dependsOn:
-         - Build_android_arm64_release_Mono_Packs
-        buildArgs: -s mono -c $(_BuildConfig)
-        nameSuffix: PerfBDNApp
-        isOfficialBuild: false
-        pool:
-          vmImage: 'macos-12'
-        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-bdn-app.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: Android BDN App Artifacts
-          artifactName: PerfBDNAppArm
-          archiveExtension: '.tar.gz'
-          archiveType: tar
-          tarCompression: gz
+  # # build PerfBDN app
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - ios_arm64
+  #     jobParameters:
+  #       dependsOn:
+  #        - Build_android_arm64_release_Mono_Packs
+  #       buildArgs: -s mono -c $(_BuildConfig)
+  #       nameSuffix: PerfBDNApp
+  #       isOfficialBuild: false
+  #       pool:
+  #         vmImage: 'macos-12'
+  #       extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-bdn-app.yml
+  #       extraStepsParameters:
+  #         rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #         includeRootFolder: true
+  #         displayName: Android BDN App Artifacts
+  #         artifactName: PerfBDNAppArm
+  #         archiveExtension: '.tar.gz'
+  #         archiveType: tar
+  #         tarCompression: gz

--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -31,223 +31,223 @@ jobs:
       platforms:
       - linux_x64
       - windows_x64
-      # - windows_x86
-      # - linux_musl_x64
+      - windows_x86
+      - linux_musl_x64
       jobParameters:
         testGroup: perf
 
-  # # build mono for AOT
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #     - linux_x64
-  #     jobParameters:
-  #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #       nameSuffix: AOT
-  #       isOfficialBuild: false
-  #       extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-  #       extraStepsParameters:
-  #         rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-  #         includeRootFolder: true
-  #         displayName: AOT Mono Artifacts
-  #         artifactName: LinuxMonoAOTx64
-  #         archiveExtension: '.tar.gz'
-  #         archiveType: tar
-  #         tarCompression: gz
+  # build mono for AOT
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - linux_x64
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: AOT
+        isOfficialBuild: false
+        extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+        extraStepsParameters:
+          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+          includeRootFolder: true
+          displayName: AOT Mono Artifacts
+          artifactName: LinuxMonoAOTx64
+          archiveExtension: '.tar.gz'
+          archiveType: tar
+          tarCompression: gz
 
-  # # build mono Android scenarios
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #     - android_arm64
-  #     jobParameters:
-  #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #       nameSuffix: AndroidMono
-  #       isOfficialBuild: false
-  #       extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-  #       extraStepsParameters:
-  #         rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-  #         includeRootFolder: true
-  #         displayName: Android Mono Artifacts
-  #         artifactName: AndroidMonoarm64
-  #         archiveExtension: '.tar.gz'
-  #         archiveType: tar
-  #         tarCompression: gz
+  # build mono Android scenarios
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - android_arm64
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: AndroidMono
+        isOfficialBuild: false
+        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+        extraStepsParameters:
+          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+          includeRootFolder: true
+          displayName: Android Mono Artifacts
+          artifactName: AndroidMonoarm64
+          archiveExtension: '.tar.gz'
+          archiveType: tar
+          tarCompression: gz
 
-  # # build mono iOS scenarios
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #     - ios_arm64
-  #     jobParameters:
-  #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #       nameSuffix: iOSMono
-  #       isOfficialBuild: false
-  #       extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-  #       extraStepsParameters:
-  #         rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-  #         includeRootFolder: true
-  #         displayName: iOS Mono Artifacts
-  #         artifactName: iOSMonoarm64
-  #         archiveExtension: '.tar.gz'
-  #         archiveType: tar
-  #         tarCompression: gz
+  # build mono iOS scenarios
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - ios_arm64
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: iOSMono
+        isOfficialBuild: false
+        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+        extraStepsParameters:
+          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+          includeRootFolder: true
+          displayName: iOS Mono Artifacts
+          artifactName: iOSMonoarm64
+          archiveExtension: '.tar.gz'
+          archiveType: tar
+          tarCompression: gz
 
-  # # build mono
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-  #     runtimeFlavor: mono
-  #     buildConfig: release
-  #     platforms:
-  #     - linux_x64
+  # build mono
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+      runtimeFlavor: mono
+      buildConfig: release
+      platforms:
+      - linux_x64
 
-  # # run android scenarios
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #       - windows_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       runtimeType: AndroidMono
-  #       projectFile: android_scenarios.proj
-  #       runKind: android_scenarios
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-  #       logicalmachine: 'perfpixel4a'
+  # run android scenarios
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+        - windows_x64
+      jobParameters:
+        testGroup: perf
+        runtimeType: AndroidMono
+        projectFile: android_scenarios.proj
+        runKind: android_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        logicalmachine: 'perfpixel4a'
 
-  # # run mono iOS scenarios scenarios
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #       - osx_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       runtimeType: iOSMono
-  #       projectFile: ios_scenarios.proj
-  #       runKind: ios_scenarios
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-  #       logicalmachine: 'perfiphone12mini'
-  #       iOSLlvmBuild: False
+  # run mono iOS scenarios scenarios
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+        - osx_x64
+      jobParameters:
+        testGroup: perf
+        runtimeType: iOSMono
+        projectFile: ios_scenarios.proj
+        runKind: ios_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        logicalmachine: 'perfiphone12mini'
+        iOSLlvmBuild: False
 
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #       - osx_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       runtimeType: iOSMono
-  #       projectFile: ios_scenarios.proj
-  #       runKind: ios_scenarios
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-  #       logicalmachine: 'perfiphone12mini'
-  #       iOSLlvmBuild: True
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+        - osx_x64
+      jobParameters:
+        testGroup: perf
+        runtimeType: iOSMono
+        projectFile: ios_scenarios.proj
+        runKind: ios_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        logicalmachine: 'perfiphone12mini'
+        iOSLlvmBuild: True
 
-  # # run mono microbenchmarks perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #     - linux_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       runtimeType: mono
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro_mono
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
+  # run mono microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        projectFile: microbenchmarks.proj
+        runKind: micro_mono
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  # # run mono interpreter perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #     - linux_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       runtimeType: mono
-  #       codeGenType: 'Interpreter'
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro_mono
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
+  # run mono interpreter perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        codeGenType: 'Interpreter'
+        projectFile: microbenchmarks.proj
+        runKind: micro_mono
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  # # run mono aot microbenchmarks perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-  #     buildConfig: release
-  #     runtimeFlavor: aot
-  #     platforms:
-  #     - linux_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       runtimeType: mono
-  #       codeGenType: 'AOT'
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro_mono
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
+  # run mono aot microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+      buildConfig: release
+      runtimeFlavor: aot
+      platforms:
+      - linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        codeGenType: 'AOT'
+        projectFile: microbenchmarks.proj
+        runKind: micro_mono
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  # # run coreclr perftiger microbenchmarks perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - linux_x64
-  #     - windows_x64
-  #     - windows_x86
-  #     - linux_musl_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
+  # run coreclr perftiger microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - linux_x64
+      - windows_x64
+      - windows_x86
+      - linux_musl_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  # # run coreclr perftiger microbenchmarks pgo perf jobs
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - windows_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
-  #       pgoRunType: -NoPgo
+  # run coreclr perftiger microbenchmarks pgo perf jobs
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        pgoRunType: -NoPgo
 
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
@@ -281,95 +281,95 @@ jobs:
         logicalmachine: 'perftiger'
         pgoRunType: --dynamicpgo
 
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - windows_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
-  #       pgoRunType: -FullPgo
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        pgoRunType: -FullPgo
 
-  # # run coreclr perfowl microbenchmarks perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - linux_x64
-  #     - windows_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perfowl'
+  # run coreclr perfowl microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - linux_x64
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perfowl'
 
-  # # run coreclr crossgen perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - linux_x64
-  #     - windows_x64
-  #     - windows_x86
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       projectFile: crossgen_perf.proj
-  #       runKind: crossgen_scenarios
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-  #       logicalmachine: 'perftiger'
+  # run coreclr crossgen perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - linux_x64
+      - windows_x64
+      - windows_x86
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: crossgen_perf.proj
+        runKind: crossgen_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        logicalmachine: 'perftiger'
 
-  # # build mono runtime packs
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #     - android_arm64
-  #     jobParameters:
-  #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #       nameSuffix: Mono_Packs
-  #       isOfficialBuild: false
-  #       extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-  #       extraStepsParameters:
-  #         name: MonoRuntimePacks
+  # build mono runtime packs
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - android_arm64
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: Mono_Packs
+        isOfficialBuild: false
+        extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+        extraStepsParameters:
+          name: MonoRuntimePacks
 
-  # # build PerfBDN app
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #     - ios_arm64
-  #     jobParameters:
-  #       dependsOn:
-  #        - Build_android_arm64_release_Mono_Packs
-  #       buildArgs: -s mono -c $(_BuildConfig)
-  #       nameSuffix: PerfBDNApp
-  #       isOfficialBuild: false
-  #       pool:
-  #         vmImage: 'macos-12'
-  #       extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-bdn-app.yml
-  #       extraStepsParameters:
-  #         rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-  #         includeRootFolder: true
-  #         displayName: Android BDN App Artifacts
-  #         artifactName: PerfBDNAppArm
-  #         archiveExtension: '.tar.gz'
-  #         archiveType: tar
-  #         tarCompression: gz
+  # build PerfBDN app
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - ios_arm64
+      jobParameters:
+        dependsOn:
+         - Build_android_arm64_release_Mono_Packs
+        buildArgs: -s mono -c $(_BuildConfig)
+        nameSuffix: PerfBDNApp
+        isOfficialBuild: false
+        pool:
+          vmImage: 'macos-12'
+        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-bdn-app.yml
+        extraStepsParameters:
+          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+          includeRootFolder: true
+          displayName: Android BDN App Artifacts
+          artifactName: PerfBDNAppArm
+          archiveExtension: '.tar.gz'
+          archiveType: tar
+          tarCompression: gz

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -205,7 +205,7 @@ extends:
               runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
               logicalmachine: 'perfampere'
               timeoutInMinutes: 500 
-              pgoRunType: -DynamicPgo
+              pgoRunType: --dynamicpgo
 
       # # run coreclr Windows arm64 microbenchmarks perf job
       #   - template: /eng/pipelines/common/platform-matrix.yml

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -103,91 +103,91 @@ extends:
             jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
             buildConfig: release
             platforms:
-            - linux_x64
-            - windows_x64
+            # - linux_x64
+            # - windows_x64
             - linux_arm64
             - windows_arm64
             jobParameters:
               testGroup: perf
 
-        # build mono on wasm
-        - template: /eng/pipelines/common/platform-matrix.yml
-          parameters:
-            jobTemplate: /eng/pipelines/common/global-build-job.yml
-            buildConfig: release
-            runtimeFlavor: mono
-            platforms:
-            - browser_wasm
-            jobParameters:
-              buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-              nameSuffix: wasm
-              isOfficialBuild: false
-              extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-              extraStepsParameters:
-                rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-                includeRootFolder: true
-                displayName: Browser Wasm Artifacts
-                artifactName: BrowserWasm
-                archiveType: zip
-                archiveExtension: .zip
+      #   # build mono on wasm
+      #   - template: /eng/pipelines/common/platform-matrix.yml
+      #     parameters:
+      #       jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #       buildConfig: release
+      #       runtimeFlavor: mono
+      #       platforms:
+      #       - browser_wasm
+      #       jobParameters:
+      #         buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+      #         nameSuffix: wasm
+      #         isOfficialBuild: false
+      #         extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+      #         extraStepsParameters:
+      #           rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+      #           includeRootFolder: true
+      #           displayName: Browser Wasm Artifacts
+      #           artifactName: BrowserWasm
+      #           archiveType: zip
+      #           archiveExtension: .zip
 
-        - template: /eng/pipelines/common/platform-matrix.yml
-          parameters:
-            jobTemplate: /eng/pipelines/common/global-build-job.yml
-            buildConfig: release
-            runtimeFlavor: mono
-            runtimeVariant: 'llvmaot'
-            platforms:
-            - linux_arm64
-            jobParameters:
-              buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
-              nameSuffix: AOT
-              isOfficialBuild: false
-              extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-              extraStepsParameters:
-                rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-                includeRootFolder: true
-                displayName: AOT Mono Artifacts
-                artifactName: LinuxMonoAOTarm64
-                archiveExtension: '.tar.gz'
-                archiveType: tar
-                tarCompression: gz
+      #   - template: /eng/pipelines/common/platform-matrix.yml
+      #     parameters:
+      #       jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #       buildConfig: release
+      #       runtimeFlavor: mono
+      #       runtimeVariant: 'llvmaot'
+      #       platforms:
+      #       - linux_arm64
+      #       jobParameters:
+      #         buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
+      #         nameSuffix: AOT
+      #         isOfficialBuild: false
+      #         extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+      #         extraStepsParameters:
+      #           rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+      #           includeRootFolder: true
+      #           displayName: AOT Mono Artifacts
+      #           artifactName: LinuxMonoAOTarm64
+      #           archiveExtension: '.tar.gz'
+      #           archiveType: tar
+      #           tarCompression: gz
 
-        # run mono aot microbenchmarks perf job
-        - template: /eng/pipelines/common/platform-matrix.yml
-          parameters:
-            jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-            buildConfig: release
-            runtimeFlavor: aot
-            platforms:
-            - linux_arm64
-            jobParameters:
-              testGroup: perf
-              liveLibrariesBuildConfig: Release
-              runtimeType: mono
-              codeGenType: 'AOT'
-              projectFile: microbenchmarks.proj
-              runKind: micro_mono
-              runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-              logicalmachine: 'perfampere'
-              timeoutInMinutes: 500 
+      #   # run mono aot microbenchmarks perf job
+      #   - template: /eng/pipelines/common/platform-matrix.yml
+      #     parameters:
+      #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+      #       buildConfig: release
+      #       runtimeFlavor: aot
+      #       platforms:
+      #       - linux_arm64
+      #       jobParameters:
+      #         testGroup: perf
+      #         liveLibrariesBuildConfig: Release
+      #         runtimeType: mono
+      #         codeGenType: 'AOT'
+      #         projectFile: microbenchmarks.proj
+      #         runKind: micro_mono
+      #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+      #         logicalmachine: 'perfampere'
+      #         timeoutInMinutes: 500 
 
-      # run coreclr Linux arm64 ampere microbenchmarks perf job
-        - template: /eng/pipelines/common/platform-matrix.yml
-          parameters:
-            jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-            buildConfig: release
-            runtimeFlavor: coreclr
-            platforms:
-            - linux_arm64
-            jobParameters:
-              testGroup: perf
-              liveLibrariesBuildConfig: Release
-              projectFile: microbenchmarks.proj
-              runKind: micro
-              runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-              logicalmachine: 'perfampere'
-              timeoutInMinutes: 500 
+      # # run coreclr Linux arm64 ampere microbenchmarks perf job
+      #   - template: /eng/pipelines/common/platform-matrix.yml
+      #     parameters:
+      #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      #       buildConfig: release
+      #       runtimeFlavor: coreclr
+      #       platforms:
+      #       - linux_arm64
+      #       jobParameters:
+      #         testGroup: perf
+      #         liveLibrariesBuildConfig: Release
+      #         projectFile: microbenchmarks.proj
+      #         runKind: micro
+      #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+      #         logicalmachine: 'perfampere'
+      #         timeoutInMinutes: 500 
 
       # run coreclr Linux arm64 ampere microbenchmarks perf job
         - template: /eng/pipelines/common/platform-matrix.yml
@@ -207,37 +207,37 @@ extends:
               timeoutInMinutes: 500 
               pgoRunType: -DynamicPgo
 
-      # run coreclr Windows arm64 microbenchmarks perf job
-        - template: /eng/pipelines/common/platform-matrix.yml
-          parameters:
-            jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-            buildConfig: release
-            runtimeFlavor: coreclr
-            platforms:
-            - windows_arm64
-            jobParameters:
-              testGroup: perf
-              liveLibrariesBuildConfig: Release
-              projectFile: microbenchmarks.proj
-              runKind: micro
-              runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-              logicalmachine: 'perfsurf' 
+      # # run coreclr Windows arm64 microbenchmarks perf job
+      #   - template: /eng/pipelines/common/platform-matrix.yml
+      #     parameters:
+      #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      #       buildConfig: release
+      #       runtimeFlavor: coreclr
+      #       platforms:
+      #       - windows_arm64
+      #       jobParameters:
+      #         testGroup: perf
+      #         liveLibrariesBuildConfig: Release
+      #         projectFile: microbenchmarks.proj
+      #         runKind: micro
+      #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+      #         logicalmachine: 'perfsurf' 
 
-      # run coreclr Windows arm64 ampere microbenchmarks perf job
-        - template: /eng/pipelines/common/platform-matrix.yml
-          parameters:
-            jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-            buildConfig: release
-            runtimeFlavor: coreclr
-            platforms:
-            - windows_arm64
-            jobParameters:
-              testGroup: perf
-              liveLibrariesBuildConfig: Release
-              projectFile: microbenchmarks.proj
-              runKind: micro
-              runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-              logicalmachine: 'perfampere'
+      # # run coreclr Windows arm64 ampere microbenchmarks perf job
+      #   - template: /eng/pipelines/common/platform-matrix.yml
+      #     parameters:
+      #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      #       buildConfig: release
+      #       runtimeFlavor: coreclr
+      #       platforms:
+      #       - windows_arm64
+      #       jobParameters:
+      #         testGroup: perf
+      #         liveLibrariesBuildConfig: Release
+      #         projectFile: microbenchmarks.proj
+      #         runKind: micro
+      #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+      #         logicalmachine: 'perfampere'
 
       # run coreclr Windows arm64 ampere dynamic Pgo microbenchmarks perf job
         - template: /eng/pipelines/common/platform-matrix.yml
@@ -256,23 +256,23 @@ extends:
               logicalmachine: 'perfampere'
               pgoRunType: -DynamicPgo
 
-        # run coreclr cloudvm microbenchmarks perf job
-        # this run is added temporarily for measuring AVX-512 performance
-        - template: /eng/pipelines/common/platform-matrix.yml
-          parameters:
-            jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-            buildConfig: release
-            runtimeFlavor: coreclr
-            platforms:
-            - linux_x64
-            - windows_x64
-            jobParameters:
-              testGroup: perf
-              liveLibrariesBuildConfig: Release
-              projectFile: microbenchmarks.proj
-              runKind: micro
-              runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-              logicalmachine: 'cloudvm'
+        # # run coreclr cloudvm microbenchmarks perf job
+        # # this run is added temporarily for measuring AVX-512 performance
+        # - template: /eng/pipelines/common/platform-matrix.yml
+        #   parameters:
+        #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+        #     buildConfig: release
+        #     runtimeFlavor: coreclr
+        #     platforms:
+        #     - linux_x64
+        #     - windows_x64
+        #     jobParameters:
+        #       testGroup: perf
+        #       liveLibrariesBuildConfig: Release
+        #       projectFile: microbenchmarks.proj
+        #       runKind: micro
+        #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        #       logicalmachine: 'cloudvm'
 
       # Uncomment once we fix https://github.com/dotnet/performance/issues/1950
       # # run coreclr linux crossgen perf job

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -189,6 +189,24 @@ extends:
               logicalmachine: 'perfampere'
               timeoutInMinutes: 500 
 
+      # run coreclr Linux arm64 ampere microbenchmarks perf job
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+            buildConfig: release
+            runtimeFlavor: coreclr
+            platforms:
+            - linux_arm64
+            jobParameters:
+              testGroup: perf
+              liveLibrariesBuildConfig: Release
+              projectFile: microbenchmarks.proj
+              runKind: micro
+              runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+              logicalmachine: 'perfampere'
+              timeoutInMinutes: 500 
+              pgoRunType: -DynamicPgo
+
       # run coreclr Windows arm64 microbenchmarks perf job
         - template: /eng/pipelines/common/platform-matrix.yml
           parameters:
@@ -220,7 +238,24 @@ extends:
               runKind: micro
               runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
               logicalmachine: 'perfampere'
-        
+
+      # run coreclr Windows arm64 ampere dynamic Pgo microbenchmarks perf job
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+            buildConfig: release
+            runtimeFlavor: coreclr
+            platforms:
+            - windows_arm64
+            jobParameters:
+              testGroup: perf
+              liveLibrariesBuildConfig: Release
+              projectFile: microbenchmarks.proj
+              runKind: micro
+              runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+              logicalmachine: 'perfampere'
+              pgoRunType: -DynamicPgo
+
         # run coreclr cloudvm microbenchmarks perf job
         # this run is added temporarily for measuring AVX-512 performance
         - template: /eng/pipelines/common/platform-matrix.yml

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -103,91 +103,91 @@ extends:
             jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
             buildConfig: release
             platforms:
-            # - linux_x64
-            # - windows_x64
+            - linux_x64
+            - windows_x64
             - linux_arm64
             - windows_arm64
             jobParameters:
               testGroup: perf
 
-      #   # build mono on wasm
-      #   - template: /eng/pipelines/common/platform-matrix.yml
-      #     parameters:
-      #       jobTemplate: /eng/pipelines/common/global-build-job.yml
-      #       buildConfig: release
-      #       runtimeFlavor: mono
-      #       platforms:
-      #       - browser_wasm
-      #       jobParameters:
-      #         buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-      #         nameSuffix: wasm
-      #         isOfficialBuild: false
-      #         extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-      #         extraStepsParameters:
-      #           rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-      #           includeRootFolder: true
-      #           displayName: Browser Wasm Artifacts
-      #           artifactName: BrowserWasm
-      #           archiveType: zip
-      #           archiveExtension: .zip
+        # build mono on wasm
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/common/global-build-job.yml
+            buildConfig: release
+            runtimeFlavor: mono
+            platforms:
+            - browser_wasm
+            jobParameters:
+              buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+              nameSuffix: wasm
+              isOfficialBuild: false
+              extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+              extraStepsParameters:
+                rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+                includeRootFolder: true
+                displayName: Browser Wasm Artifacts
+                artifactName: BrowserWasm
+                archiveType: zip
+                archiveExtension: .zip
 
-      #   - template: /eng/pipelines/common/platform-matrix.yml
-      #     parameters:
-      #       jobTemplate: /eng/pipelines/common/global-build-job.yml
-      #       buildConfig: release
-      #       runtimeFlavor: mono
-      #       runtimeVariant: 'llvmaot'
-      #       platforms:
-      #       - linux_arm64
-      #       jobParameters:
-      #         buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
-      #         nameSuffix: AOT
-      #         isOfficialBuild: false
-      #         extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-      #         extraStepsParameters:
-      #           rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-      #           includeRootFolder: true
-      #           displayName: AOT Mono Artifacts
-      #           artifactName: LinuxMonoAOTarm64
-      #           archiveExtension: '.tar.gz'
-      #           archiveType: tar
-      #           tarCompression: gz
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/common/global-build-job.yml
+            buildConfig: release
+            runtimeFlavor: mono
+            runtimeVariant: 'llvmaot'
+            platforms:
+            - linux_arm64
+            jobParameters:
+              buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
+              nameSuffix: AOT
+              isOfficialBuild: false
+              extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+              extraStepsParameters:
+                rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+                includeRootFolder: true
+                displayName: AOT Mono Artifacts
+                artifactName: LinuxMonoAOTarm64
+                archiveExtension: '.tar.gz'
+                archiveType: tar
+                tarCompression: gz
 
-      #   # run mono aot microbenchmarks perf job
-      #   - template: /eng/pipelines/common/platform-matrix.yml
-      #     parameters:
-      #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-      #       buildConfig: release
-      #       runtimeFlavor: aot
-      #       platforms:
-      #       - linux_arm64
-      #       jobParameters:
-      #         testGroup: perf
-      #         liveLibrariesBuildConfig: Release
-      #         runtimeType: mono
-      #         codeGenType: 'AOT'
-      #         projectFile: microbenchmarks.proj
-      #         runKind: micro_mono
-      #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-      #         logicalmachine: 'perfampere'
-      #         timeoutInMinutes: 500 
+        # run mono aot microbenchmarks perf job
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+            buildConfig: release
+            runtimeFlavor: aot
+            platforms:
+            - linux_arm64
+            jobParameters:
+              testGroup: perf
+              liveLibrariesBuildConfig: Release
+              runtimeType: mono
+              codeGenType: 'AOT'
+              projectFile: microbenchmarks.proj
+              runKind: micro_mono
+              runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+              logicalmachine: 'perfampere'
+              timeoutInMinutes: 500 
 
-      # # run coreclr Linux arm64 ampere microbenchmarks perf job
-      #   - template: /eng/pipelines/common/platform-matrix.yml
-      #     parameters:
-      #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      #       buildConfig: release
-      #       runtimeFlavor: coreclr
-      #       platforms:
-      #       - linux_arm64
-      #       jobParameters:
-      #         testGroup: perf
-      #         liveLibrariesBuildConfig: Release
-      #         projectFile: microbenchmarks.proj
-      #         runKind: micro
-      #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-      #         logicalmachine: 'perfampere'
-      #         timeoutInMinutes: 500 
+      # run coreclr Linux arm64 ampere microbenchmarks perf job
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+            buildConfig: release
+            runtimeFlavor: coreclr
+            platforms:
+            - linux_arm64
+            jobParameters:
+              testGroup: perf
+              liveLibrariesBuildConfig: Release
+              projectFile: microbenchmarks.proj
+              runKind: micro
+              runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+              logicalmachine: 'perfampere'
+              timeoutInMinutes: 500 
 
       # run coreclr Linux arm64 ampere microbenchmarks perf job
         - template: /eng/pipelines/common/platform-matrix.yml
@@ -207,37 +207,37 @@ extends:
               timeoutInMinutes: 500 
               pgoRunType: --dynamicpgo
 
-      # # run coreclr Windows arm64 microbenchmarks perf job
-      #   - template: /eng/pipelines/common/platform-matrix.yml
-      #     parameters:
-      #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      #       buildConfig: release
-      #       runtimeFlavor: coreclr
-      #       platforms:
-      #       - windows_arm64
-      #       jobParameters:
-      #         testGroup: perf
-      #         liveLibrariesBuildConfig: Release
-      #         projectFile: microbenchmarks.proj
-      #         runKind: micro
-      #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-      #         logicalmachine: 'perfsurf' 
+      # run coreclr Windows arm64 microbenchmarks perf job
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+            buildConfig: release
+            runtimeFlavor: coreclr
+            platforms:
+            - windows_arm64
+            jobParameters:
+              testGroup: perf
+              liveLibrariesBuildConfig: Release
+              projectFile: microbenchmarks.proj
+              runKind: micro
+              runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+              logicalmachine: 'perfsurf' 
 
-      # # run coreclr Windows arm64 ampere microbenchmarks perf job
-      #   - template: /eng/pipelines/common/platform-matrix.yml
-      #     parameters:
-      #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      #       buildConfig: release
-      #       runtimeFlavor: coreclr
-      #       platforms:
-      #       - windows_arm64
-      #       jobParameters:
-      #         testGroup: perf
-      #         liveLibrariesBuildConfig: Release
-      #         projectFile: microbenchmarks.proj
-      #         runKind: micro
-      #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-      #         logicalmachine: 'perfampere'
+      # run coreclr Windows arm64 ampere microbenchmarks perf job
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+            buildConfig: release
+            runtimeFlavor: coreclr
+            platforms:
+            - windows_arm64
+            jobParameters:
+              testGroup: perf
+              liveLibrariesBuildConfig: Release
+              projectFile: microbenchmarks.proj
+              runKind: micro
+              runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+              logicalmachine: 'perfampere'
 
       # run coreclr Windows arm64 ampere dynamic Pgo microbenchmarks perf job
         - template: /eng/pipelines/common/platform-matrix.yml
@@ -256,23 +256,23 @@ extends:
               logicalmachine: 'perfampere'
               pgoRunType: -DynamicPgo
 
-        # # run coreclr cloudvm microbenchmarks perf job
-        # # this run is added temporarily for measuring AVX-512 performance
-        # - template: /eng/pipelines/common/platform-matrix.yml
-        #   parameters:
-        #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-        #     buildConfig: release
-        #     runtimeFlavor: coreclr
-        #     platforms:
-        #     - linux_x64
-        #     - windows_x64
-        #     jobParameters:
-        #       testGroup: perf
-        #       liveLibrariesBuildConfig: Release
-        #       projectFile: microbenchmarks.proj
-        #       runKind: micro
-        #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        #       logicalmachine: 'cloudvm'
+        # run coreclr cloudvm microbenchmarks perf job
+        # this run is added temporarily for measuring AVX-512 performance
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+            buildConfig: release
+            runtimeFlavor: coreclr
+            platforms:
+            - linux_x64
+            - windows_x64
+            jobParameters:
+              testGroup: perf
+              liveLibrariesBuildConfig: Release
+              projectFile: microbenchmarks.proj
+              runKind: micro
+              runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+              logicalmachine: 'cloudvm'
 
       # Uncomment once we fix https://github.com/dotnet/performance/issues/1950
       # # run coreclr linux crossgen perf job

--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -157,7 +157,7 @@ jobs:
       displayName: Performance Setup (Windows)
       condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'))
       continueOnError: ${{ parameters.continueOnError }}
-    - script: $(Build.SourcesDirectory)/eng/testing/performance/performance-setup.sh $(IsInternal)$(Interpreter) --framework $(_Framework) --kind ${{ parameters.runKind }} --logicalmachine ${{ parameters.logicalMachine }} --uselocalcommittime ${{ parameters.extraSetupParameters }}
+    - script: $(Build.SourcesDirectory)/eng/testing/performance/performance-setup.sh $(IsInternal)$(Interpreter) --framework $(_Framework) --kind ${{ parameters.runKind }} --logicalmachine ${{ parameters.logicalMachine }} ${{ parameters.pgoRunType }} --uselocalcommittime ${{ parameters.extraSetupParameters }}
       displayName: Performance Setup (Unix)
       condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
       continueOnError: ${{ parameters.continueOnError }}

--- a/eng/testing/performance/performance-setup.sh
+++ b/eng/testing/performance/performance-setup.sh
@@ -139,6 +139,18 @@ while (($# > 0)); do
       wasmaot=true
       shift 1
       ;;
+    --nopgo)
+      nopgo=true
+      shift 1
+      ;;
+    --dynamicpgo)
+      dynamicpgo=true
+      shift 1
+      ;;
+    --fullpgo)
+      fullpgo=true
+      shift 1
+      ;;
     --compare)
       compare=true
       shift 1
@@ -213,6 +225,9 @@ while (($# > 0)); do
       echo "  --iosllvmbuild                 Set LLVM for iOS Mono/Maui runs"
       echo "  --mauiversion                  Set the maui version for Mono/Maui runs"
       echo "  --uselocalcommittime           Pass local runtime commit time to the setup script"
+      echo "  --nopgo                        Set for No PGO runs"
+      echo "  --dynamicpgo                   Set for dynamic PGO runs"
+      echo "  --fullpgo                      Set for Full PGO runs"
       echo ""
       exit 1
       ;;
@@ -318,6 +333,17 @@ if [[ "$iosmono" == "true" ]]; then
     extra_benchmark_dotnet_arguments="$extra_benchmark_dotnet_arguments"
 fi
 
+if [[ "$nopgo" == "true" ]]; then
+    configurations="$configurations PGOType=nopgo"
+fi
+if [[ "$dynamicpgo" == "true" ]]; then
+    configurations="$configurations PGOType=dynamicpgo"
+fi
+if [[ "$fullpgo" == "true" ]]; then
+    configurations="$configurations PGOType=fullpgo"
+    extra_benchmark_dotnet_arguments="$extra_benchmark_dotnet_arguments --category-exclusion-filter NoAOT"
+fi
+
 cleaned_branch_name="main"
 if [[ $branch == *"refs/heads/release"* ]]; then
     cleaned_branch_name=${branch/refs\/heads\//}
@@ -378,6 +404,16 @@ fi
 
 if [[ -n "$dotnet_versions" ]]; then
     setup_arguments="$setup_arguments --dotnet-versions $dotnet_versions"
+fi
+
+if [[ "$nopgo" == "true" ]]; then
+    setup_arguments="$setup_arguments --no-pgo"
+fi
+if [[ "$dynamicpgo" == "true" ]]; then
+    setup_arguments="$setup_arguments --dynamic-pgo"
+fi
+if [[ "$fullpgo" == "true" ]]; then
+    setup_arguments="$setup_arguments --full-pgo"
 fi
 
 if [[ "$monoaot" == "true" ]]; then


### PR DESCRIPTION
This adds dynamic PGO arm64 runs to our regularly scheduled runs. It seems that everything should be properly configured just by setting the pgoRunType to DynamicPgo which then sets COMPlus_TieredPGO=1.

This is essentially a PR to get Linux PGO scenarios on par with the Windows ones from: https://github.com/dotnet/runtime/commit/6c31866e2c7fdfa93867ee04dcc75f531a710816