### PR TITLE
Reduce overhead of calling into SearchValues

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/AsciiByteSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/AsciiByteSearchValues.cs
@@ -9,7 +9,7 @@ namespace System.Buffers
 {
     internal sealed class AsciiByteSearchValues : SearchValues<byte>
     {
-        private readonly Vector128<byte> _bitmap;
+        private Vector256<byte> _bitmap;
         private readonly BitVector256 _lookup;
 
         public AsciiByteSearchValues(ReadOnlySpan<byte> values) =>
@@ -42,7 +42,7 @@ namespace System.Buffers
             where TNegator : struct, IndexOfAnyAsciiSearcher.INegator
         {
             return IndexOfAnyAsciiSearcher.IsVectorizationSupported && searchSpaceLength >= sizeof(ulong)
-                ? IndexOfAnyAsciiSearcher.IndexOfAnyVectorized<TNegator>(ref searchSpace, searchSpaceLength, _bitmap)
+                ? IndexOfAnyAsciiSearcher.IndexOfAnyVectorized<TNegator>(ref searchSpace, searchSpaceLength, ref _bitmap)
                 : IndexOfAnyScalar<TNegator>(ref searchSpace, searchSpaceLength);
         }
 
@@ -51,7 +51,7 @@ namespace System.Buffers
             where TNegator : struct, IndexOfAnyAsciiSearcher.INegator
         {
             return IndexOfAnyAsciiSearcher.IsVectorizationSupported && searchSpaceLength >= sizeof(ulong)
-                ? IndexOfAnyAsciiSearcher.LastIndexOfAnyVectorized<TNegator>(ref searchSpace, searchSpaceLength, _bitmap)
+                ? IndexOfAnyAsciiSearcher.LastIndexOfAnyVectorized<TNegator>(ref searchSpace, searchSpaceLength, ref _bitmap)
                 : LastIndexOfAnyScalar<TNegator>(ref searchSpace, searchSpaceLength);
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/AsciiCharSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/AsciiCharSearchValues.cs
@@ -10,10 +10,10 @@ namespace System.Buffers
     internal sealed class AsciiCharSearchValues<TOptimizations> : SearchValues<char>
         where TOptimizations : struct, IndexOfAnyAsciiSearcher.IOptimizations
     {
-        private readonly Vector128<byte> _bitmap;
+        private Vector256<byte> _bitmap;
         private readonly BitVector256 _lookup;
 
-        public AsciiCharSearchValues(Vector128<byte> bitmap, BitVector256 lookup)
+        public AsciiCharSearchValues(Vector256<byte> bitmap, BitVector256 lookup)
         {
             _bitmap = bitmap;
             _lookup = lookup;
@@ -46,7 +46,7 @@ namespace System.Buffers
             where TNegator : struct, IndexOfAnyAsciiSearcher.INegator
         {
             return IndexOfAnyAsciiSearcher.IsVectorizationSupported && searchSpaceLength >= Vector128<short>.Count
-                ? IndexOfAnyAsciiSearcher.IndexOfAnyVectorized<TNegator, TOptimizations>(ref Unsafe.As<char, short>(ref searchSpace), searchSpaceLength, _bitmap)
+                ? IndexOfAnyAsciiSearcher.IndexOfAnyVectorized<TNegator, TOptimizations>(ref Unsafe.As<char, short>(ref searchSpace), searchSpaceLength, ref _bitmap)
                 : IndexOfAnyScalar<TNegator>(ref searchSpace, searchSpaceLength);
         }
 
@@ -55,7 +55,7 @@ namespace System.Buffers
             where TNegator : struct, IndexOfAnyAsciiSearcher.INegator
         {
             return IndexOfAnyAsciiSearcher.IsVectorizationSupported && searchSpaceLength >= Vector128<short>.Count
-                ? IndexOfAnyAsciiSearcher.LastIndexOfAnyVectorized<TNegator, TOptimizations>(ref Unsafe.As<char, short>(ref searchSpace), searchSpaceLength, _bitmap)
+                ? IndexOfAnyAsciiSearcher.LastIndexOfAnyVectorized<TNegator, TOptimizations>(ref Unsafe.As<char, short>(ref searchSpace), searchSpaceLength, ref _bitmap)
                 : LastIndexOfAnyScalar<TNegator>(ref searchSpace, searchSpaceLength);
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/IndexOfAnyAsciiSearcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/IndexOfAnyAsciiSearcher.cs
@@ -19,7 +19,7 @@ namespace System.Buffers
     {
         internal static bool IsVectorizationSupported => Ssse3.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported;
 
-        internal static unsafe void ComputeBitmap256(ReadOnlySpan<byte> values, out Vector128<byte> bitmap0, out Vector128<byte> bitmap1, out BitVector256 lookup)
+        internal static unsafe void ComputeBitmap256(ReadOnlySpan<byte> values, out Vector256<byte> bitmap0, out Vector256<byte> bitmap1, out BitVector256 lookup)
         {
             // The exact format of these bitmaps differs from the other ComputeBitmap overloads as it's meant for the full [0, 255] range algorithm.
             // See http://0x80.pl/articles/simd-byte-lookup.html#universal-algorithm
@@ -47,12 +47,12 @@ namespace System.Buffers
                 }
             }
 
-            bitmap0 = bitmapSpace0;
-            bitmap1 = bitmapSpace1;
+            bitmap0 = Vector256.Create(bitmapSpace0, bitmapSpace0);
+            bitmap1 = Vector256.Create(bitmapSpace1, bitmapSpace1);
             lookup = lookupLocal;
         }
 
-        internal static unsafe void ComputeBitmap<T>(ReadOnlySpan<T> values, out Vector128<byte> bitmap, out BitVector256 lookup)
+        internal static unsafe void ComputeBitmap<T>(ReadOnlySpan<T> values, out Vector256<byte> bitmap, out BitVector256 lookup)
             where T : struct, IUnsignedNumber<T>
         {
             Debug.Assert(typeof(T) == typeof(byte) || typeof(T) == typeof(char));
@@ -79,7 +79,7 @@ namespace System.Buffers
                 bitmapLocal[(uint)lowNibble] |= (byte)(1 << highNibble);
             }
 
-            bitmap = bitmapSpace;
+            bitmap = Vector256.Create(bitmapSpace, bitmapSpace);
             lookup = lookupLocal;
         }
 
@@ -133,9 +133,11 @@ namespace System.Buffers
                 Vector128<byte> bitmap = default;
                 if (TryComputeBitmap(asciiValues, (byte*)&bitmap, out bool needleContainsZero))
                 {
+                    Vector256<byte> bitmap256 = Vector256.Create(bitmap, bitmap);
+
                     index = (Ssse3.IsSupported || PackedSimd.IsSupported) && needleContainsZero
-                        ? IndexOfAnyVectorized<TNegator, Ssse3AndWasmHandleZeroInNeedle>(ref searchSpace, searchSpaceLength, bitmap)
-                        : IndexOfAnyVectorized<TNegator, Default>(ref searchSpace, searchSpaceLength, bitmap);
+                        ? IndexOfAnyVectorized<TNegator, Ssse3AndWasmHandleZeroInNeedle>(ref searchSpace, searchSpaceLength, ref bitmap256)
+                        : IndexOfAnyVectorized<TNegator, Default>(ref searchSpace, searchSpaceLength, ref bitmap256);
                     return true;
                 }
             }
@@ -155,9 +157,11 @@ namespace System.Buffers
                 Vector128<byte> bitmap = default;
                 if (TryComputeBitmap(asciiValues, (byte*)&bitmap, out bool needleContainsZero))
                 {
+                    Vector256<byte> bitmap256 = Vector256.Create(bitmap, bitmap);
+
                     index = (Ssse3.IsSupported || PackedSimd.IsSupported) && needleContainsZero
-                        ? LastIndexOfAnyVectorized<TNegator, Ssse3AndWasmHandleZeroInNeedle>(ref searchSpace, searchSpaceLength, bitmap)
-                        : LastIndexOfAnyVectorized<TNegator, Default>(ref searchSpace, searchSpaceLength, bitmap);
+                        ? LastIndexOfAnyVectorized<TNegator, Ssse3AndWasmHandleZeroInNeedle>(ref searchSpace, searchSpaceLength, ref bitmap256)
+                        : LastIndexOfAnyVectorized<TNegator, Default>(ref searchSpace, searchSpaceLength, ref bitmap256);
                     return true;
                 }
             }
@@ -166,91 +170,91 @@ namespace System.Buffers
             return false;
         }
 
-        internal static int IndexOfAnyVectorized<TNegator, TOptimizations>(ref short searchSpace, int searchSpaceLength, Vector128<byte> bitmap)
+        internal static int IndexOfAnyVectorized<TNegator, TOptimizations>(ref short searchSpace, int searchSpaceLength, ref Vector256<byte> bitmapRef)
             where TNegator : struct, INegator
             where TOptimizations : struct, IOptimizations
         {
             ref short currentSearchSpace = ref searchSpace;
 
-            if (searchSpaceLength > 2 * Vector128<short>.Count)
+            if (Avx2.IsSupported && searchSpaceLength > 2 * Vector128<short>.Count)
             {
-                if (Avx2.IsSupported)
+                Vector256<byte> bitmap256 = bitmapRef;
+
+                if (searchSpaceLength > 2 * Vector256<short>.Count)
                 {
-                    Vector256<byte> bitmap256 = Vector256.Create(bitmap, bitmap);
+                    // Process the input in chunks of 32 characters (2 * Vector256<short>).
+                    // We're mainly interested in a single byte of each character, and the core lookup operates on a Vector256<byte>.
+                    // As packing two Vector256<short>s into a Vector256<byte> is cheap compared to the lookup, we can effectively double the throughput.
+                    // If the input length is a multiple of 32, don't consume the last 32 characters in this loop.
+                    // Let the fallback below handle it instead. This is why the condition is
+                    // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
+                    ref short twoVectorsAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - (2 * Vector256<short>.Count));
 
-                    if (searchSpaceLength > 2 * Vector256<short>.Count)
+                    do
                     {
-                        // Process the input in chunks of 32 characters (2 * Vector256<short>).
-                        // We're mainly interested in a single byte of each character, and the core lookup operates on a Vector256<byte>.
-                        // As packing two Vector256<short>s into a Vector256<byte> is cheap compared to the lookup, we can effectively double the throughput.
-                        // If the input length is a multiple of 32, don't consume the last 32 characters in this loop.
-                        // Let the fallback below handle it instead. This is why the condition is
-                        // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
-                        ref short twoVectorsAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - (2 * Vector256<short>.Count));
-
-                        do
-                        {
-                            Vector256<short> source0 = Vector256.LoadUnsafe(ref currentSearchSpace);
-                            Vector256<short> source1 = Vector256.LoadUnsafe(ref currentSearchSpace, (nuint)Vector256<short>.Count);
-
-                            Vector256<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source0, source1, bitmap256);
-                            if (result != Vector256<byte>.Zero)
-                            {
-                                return ComputeFirstIndex<short, TNegator>(ref searchSpace, ref currentSearchSpace, result);
-                            }
-
-                            currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, 2 * Vector256<short>.Count);
-                        }
-                        while (Unsafe.IsAddressLessThan(ref currentSearchSpace, ref twoVectorsAwayFromEnd));
-                    }
-
-                    // We have 1-32 characters remaining. Process the first and last vector in the search space.
-                    // They may overlap, but we'll handle that in the index calculation if we do get a match.
-                    Debug.Assert(searchSpaceLength >= Vector256<short>.Count, "We expect that the input is long enough for us to load a whole vector.");
-                    {
-                        ref short oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector256<short>.Count);
-
-                        ref short firstVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAwayFromEnd)
-                            ? ref oneVectorAwayFromEnd
-                            : ref currentSearchSpace;
-
-                        Vector256<short> source0 = Vector256.LoadUnsafe(ref firstVector);
-                        Vector256<short> source1 = Vector256.LoadUnsafe(ref oneVectorAwayFromEnd);
+                        Vector256<short> source0 = Vector256.LoadUnsafe(ref currentSearchSpace);
+                        Vector256<short> source1 = Vector256.LoadUnsafe(ref currentSearchSpace, (nuint)Vector256<short>.Count);
 
                         Vector256<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source0, source1, bitmap256);
                         if (result != Vector256<byte>.Zero)
                         {
-                            return ComputeFirstIndexOverlapped<short, TNegator>(ref searchSpace, ref firstVector, ref oneVectorAwayFromEnd, result);
-                        }
-                    }
-
-                    return -1;
-                }
-                else
-                {
-                    // Process the input in chunks of 16 characters (2 * Vector128<short>).
-                    // We're mainly interested in a single byte of each character, and the core lookup operates on a Vector128<byte>.
-                    // As packing two Vector128<short>s into a Vector128<byte> is cheap compared to the lookup, we can effectively double the throughput.
-                    // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
-                    // Let the fallback below handle it instead. This is why the condition is
-                    // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
-                    ref short twoVectorsAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - (2 * Vector128<short>.Count));
-
-                    do
-                    {
-                        Vector128<short> source0 = Vector128.LoadUnsafe(ref currentSearchSpace);
-                        Vector128<short> source1 = Vector128.LoadUnsafe(ref currentSearchSpace, (nuint)Vector128<short>.Count);
-
-                        Vector128<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source0, source1, bitmap);
-                        if (result != Vector128<byte>.Zero)
-                        {
                             return ComputeFirstIndex<short, TNegator>(ref searchSpace, ref currentSearchSpace, result);
                         }
 
-                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, 2 * Vector128<short>.Count);
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, 2 * Vector256<short>.Count);
                     }
                     while (Unsafe.IsAddressLessThan(ref currentSearchSpace, ref twoVectorsAwayFromEnd));
                 }
+
+                // We have 1-32 characters remaining. Process the first and last vector in the search space.
+                // They may overlap, but we'll handle that in the index calculation if we do get a match.
+                Debug.Assert(searchSpaceLength >= Vector256<short>.Count, "We expect that the input is long enough for us to load a whole vector.");
+                {
+                    ref short oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector256<short>.Count);
+
+                    ref short firstVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAwayFromEnd)
+                        ? ref oneVectorAwayFromEnd
+                        : ref currentSearchSpace;
+
+                    Vector256<short> source0 = Vector256.LoadUnsafe(ref firstVector);
+                    Vector256<short> source1 = Vector256.LoadUnsafe(ref oneVectorAwayFromEnd);
+
+                    Vector256<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source0, source1, bitmap256);
+                    if (result != Vector256<byte>.Zero)
+                    {
+                        return ComputeFirstIndexOverlapped<short, TNegator>(ref searchSpace, ref firstVector, ref oneVectorAwayFromEnd, result);
+                    }
+                }
+
+                return -1;
+            }
+
+            Vector128<byte> bitmap = bitmapRef._lower;
+
+            if (!Avx2.IsSupported && searchSpaceLength > 2 * Vector128<short>.Count)
+            {
+                // Process the input in chunks of 16 characters (2 * Vector128<short>).
+                // We're mainly interested in a single byte of each character, and the core lookup operates on a Vector128<byte>.
+                // As packing two Vector128<short>s into a Vector128<byte> is cheap compared to the lookup, we can effectively double the throughput.
+                // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
+                // Let the fallback below handle it instead. This is why the condition is
+                // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
+                ref short twoVectorsAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - (2 * Vector128<short>.Count));
+
+                do
+                {
+                    Vector128<short> source0 = Vector128.LoadUnsafe(ref currentSearchSpace);
+                    Vector128<short> source1 = Vector128.LoadUnsafe(ref currentSearchSpace, (nuint)Vector128<short>.Count);
+
+                    Vector128<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source0, source1, bitmap);
+                    if (result != Vector128<byte>.Zero)
+                    {
+                        return ComputeFirstIndex<short, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                    }
+
+                    currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, 2 * Vector128<short>.Count);
+                }
+                while (Unsafe.IsAddressLessThan(ref currentSearchSpace, ref twoVectorsAwayFromEnd));
             }
 
             // We have 1-16 characters remaining. Process the first and last vector in the search space.
@@ -276,91 +280,91 @@ namespace System.Buffers
             return -1;
         }
 
-        internal static int LastIndexOfAnyVectorized<TNegator, TOptimizations>(ref short searchSpace, int searchSpaceLength, Vector128<byte> bitmap)
+        internal static int LastIndexOfAnyVectorized<TNegator, TOptimizations>(ref short searchSpace, int searchSpaceLength, ref Vector256<byte> bitmapRef)
             where TNegator : struct, INegator
             where TOptimizations : struct, IOptimizations
         {
             ref short currentSearchSpace = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
 
-            if (searchSpaceLength > 2 * Vector128<short>.Count)
+            if (Avx2.IsSupported && searchSpaceLength > 2 * Vector128<short>.Count)
             {
-                if (Avx2.IsSupported)
+                Vector256<byte> bitmap256 = bitmapRef;
+
+                if (searchSpaceLength > 2 * Vector256<short>.Count)
                 {
-                    Vector256<byte> bitmap256 = Vector256.Create(bitmap, bitmap);
-
-                    if (searchSpaceLength > 2 * Vector256<short>.Count)
-                    {
-                        // Process the input in chunks of 32 characters (2 * Vector256<short>).
-                        // We're mainly interested in a single byte of each character, and the core lookup operates on a Vector256<byte>.
-                        // As packing two Vector256<short>s into a Vector256<byte> is cheap compared to the lookup, we can effectively double the throughput.
-                        // If the input length is a multiple of 32, don't consume the last 32 characters in this loop.
-                        // Let the fallback below handle it instead. This is why the condition is
-                        // ">" instead of ">=" above, and why "IsAddressGreaterThan" is used instead of "!IsAddressLessThan".
-                        ref short twoVectorsAfterStart = ref Unsafe.Add(ref searchSpace, 2 * Vector256<short>.Count);
-
-                        do
-                        {
-                            currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, 2 * Vector256<short>.Count);
-
-                            Vector256<short> source0 = Vector256.LoadUnsafe(ref currentSearchSpace);
-                            Vector256<short> source1 = Vector256.LoadUnsafe(ref currentSearchSpace, (nuint)Vector256<short>.Count);
-
-                            Vector256<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source0, source1, bitmap256);
-                            if (result != Vector256<byte>.Zero)
-                            {
-                                return ComputeLastIndex<short, TNegator>(ref searchSpace, ref currentSearchSpace, result);
-                            }
-                        }
-                        while (Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref twoVectorsAfterStart));
-                    }
-
-                    // We have 1-32 characters remaining. Process the first and last vector in the search space.
-                    // They may overlap, but we'll handle that in the index calculation if we do get a match.
-                    Debug.Assert(searchSpaceLength >= Vector256<short>.Count, "We expect that the input is long enough for us to load a whole vector.");
-                    {
-                        ref short oneVectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector256<short>.Count);
-
-                        ref short secondVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAfterStart)
-                            ? ref Unsafe.Subtract(ref currentSearchSpace, Vector256<short>.Count)
-                            : ref searchSpace;
-
-                        Vector256<short> source0 = Vector256.LoadUnsafe(ref searchSpace);
-                        Vector256<short> source1 = Vector256.LoadUnsafe(ref secondVector);
-
-                        Vector256<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source0, source1, bitmap256);
-                        if (result != Vector256<byte>.Zero)
-                        {
-                            return ComputeLastIndexOverlapped<short, TNegator>(ref searchSpace, ref secondVector, result);
-                        }
-                    }
-
-                    return -1;
-                }
-                else
-                {
-                    // Process the input in chunks of 16 characters (2 * Vector128<short>).
-                    // We're mainly interested in a single byte of each character, and the core lookup operates on a Vector128<byte>.
-                    // As packing two Vector128<short>s into a Vector128<byte> is cheap compared to the lookup, we can effectively double the throughput.
-                    // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
+                    // Process the input in chunks of 32 characters (2 * Vector256<short>).
+                    // We're mainly interested in a single byte of each character, and the core lookup operates on a Vector256<byte>.
+                    // As packing two Vector256<short>s into a Vector256<byte> is cheap compared to the lookup, we can effectively double the throughput.
+                    // If the input length is a multiple of 32, don't consume the last 32 characters in this loop.
                     // Let the fallback below handle it instead. This is why the condition is
                     // ">" instead of ">=" above, and why "IsAddressGreaterThan" is used instead of "!IsAddressLessThan".
-                    ref short twoVectorsAfterStart = ref Unsafe.Add(ref searchSpace, 2 * Vector128<short>.Count);
+                    ref short twoVectorsAfterStart = ref Unsafe.Add(ref searchSpace, 2 * Vector256<short>.Count);
 
                     do
                     {
-                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, 2 * Vector128<short>.Count);
+                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, 2 * Vector256<short>.Count);
 
-                        Vector128<short> source0 = Vector128.LoadUnsafe(ref currentSearchSpace);
-                        Vector128<short> source1 = Vector128.LoadUnsafe(ref currentSearchSpace, (nuint)Vector128<short>.Count);
+                        Vector256<short> source0 = Vector256.LoadUnsafe(ref currentSearchSpace);
+                        Vector256<short> source1 = Vector256.LoadUnsafe(ref currentSearchSpace, (nuint)Vector256<short>.Count);
 
-                        Vector128<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source0, source1, bitmap);
-                        if (result != Vector128<byte>.Zero)
+                        Vector256<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source0, source1, bitmap256);
+                        if (result != Vector256<byte>.Zero)
                         {
                             return ComputeLastIndex<short, TNegator>(ref searchSpace, ref currentSearchSpace, result);
                         }
                     }
                     while (Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref twoVectorsAfterStart));
                 }
+
+                // We have 1-32 characters remaining. Process the first and last vector in the search space.
+                // They may overlap, but we'll handle that in the index calculation if we do get a match.
+                Debug.Assert(searchSpaceLength >= Vector256<short>.Count, "We expect that the input is long enough for us to load a whole vector.");
+                {
+                    ref short oneVectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector256<short>.Count);
+
+                    ref short secondVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAfterStart)
+                        ? ref Unsafe.Subtract(ref currentSearchSpace, Vector256<short>.Count)
+                        : ref searchSpace;
+
+                    Vector256<short> source0 = Vector256.LoadUnsafe(ref searchSpace);
+                    Vector256<short> source1 = Vector256.LoadUnsafe(ref secondVector);
+
+                    Vector256<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source0, source1, bitmap256);
+                    if (result != Vector256<byte>.Zero)
+                    {
+                        return ComputeLastIndexOverlapped<short, TNegator>(ref searchSpace, ref secondVector, result);
+                    }
+                }
+
+                return -1;
+            }
+
+            Vector128<byte> bitmap = bitmapRef._lower;
+
+            if (!Avx2.IsSupported && searchSpaceLength > 2 * Vector128<short>.Count)
+            {
+                // Process the input in chunks of 16 characters (2 * Vector128<short>).
+                // We're mainly interested in a single byte of each character, and the core lookup operates on a Vector128<byte>.
+                // As packing two Vector128<short>s into a Vector128<byte> is cheap compared to the lookup, we can effectively double the throughput.
+                // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
+                // Let the fallback below handle it instead. This is why the condition is
+                // ">" instead of ">=" above, and why "IsAddressGreaterThan" is used instead of "!IsAddressLessThan".
+                ref short twoVectorsAfterStart = ref Unsafe.Add(ref searchSpace, 2 * Vector128<short>.Count);
+
+                do
+                {
+                    currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, 2 * Vector128<short>.Count);
+
+                    Vector128<short> source0 = Vector128.LoadUnsafe(ref currentSearchSpace);
+                    Vector128<short> source1 = Vector128.LoadUnsafe(ref currentSearchSpace, (nuint)Vector128<short>.Count);
+
+                    Vector128<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source0, source1, bitmap);
+                    if (result != Vector128<byte>.Zero)
+                    {
+                        return ComputeLastIndex<short, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                    }
+                }
+                while (Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref twoVectorsAfterStart));
             }
 
             // We have 1-16 characters remaining. Process the first and last vector in the search space.
@@ -386,85 +390,85 @@ namespace System.Buffers
             return -1;
         }
 
-        internal static int IndexOfAnyVectorized<TNegator>(ref byte searchSpace, int searchSpaceLength, Vector128<byte> bitmap)
+        internal static int IndexOfAnyVectorized<TNegator>(ref byte searchSpace, int searchSpaceLength, ref Vector256<byte> bitmapRef)
             where TNegator : struct, INegator
         {
             ref byte currentSearchSpace = ref searchSpace;
 
-            if (searchSpaceLength > Vector128<byte>.Count)
+            if (Avx2.IsSupported && searchSpaceLength > Vector128<byte>.Count)
             {
-                if (Avx2.IsSupported)
+                Vector256<byte> bitmap256 = bitmapRef;
+
+                if (searchSpaceLength > Vector256<byte>.Count)
                 {
-                    Vector256<byte> bitmap256 = Vector256.Create(bitmap, bitmap);
+                    // Process the input in chunks of 32 bytes.
+                    // If the input length is a multiple of 32, don't consume the last 32 characters in this loop.
+                    // Let the fallback below handle it instead. This is why the condition is
+                    // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
+                    ref byte vectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector256<byte>.Count);
 
-                    if (searchSpaceLength > Vector256<byte>.Count)
+                    do
                     {
-                        // Process the input in chunks of 32 bytes.
-                        // If the input length is a multiple of 32, don't consume the last 32 characters in this loop.
-                        // Let the fallback below handle it instead. This is why the condition is
-                        // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
-                        ref byte vectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector256<byte>.Count);
-
-                        do
-                        {
-                            Vector256<byte> source = Vector256.LoadUnsafe(ref currentSearchSpace);
-
-                            Vector256<byte> result = TNegator.NegateIfNeeded(IndexOfAnyLookupCore(source, bitmap256));
-                            if (result != Vector256<byte>.Zero)
-                            {
-                                return ComputeFirstIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
-                            }
-
-                            currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector256<byte>.Count);
-                        }
-                        while (Unsafe.IsAddressLessThan(ref currentSearchSpace, ref vectorAwayFromEnd));
-                    }
-
-                    // We have 1-32 bytes remaining. Process the first and last half vectors in the search space.
-                    // They may overlap, but we'll handle that in the index calculation if we do get a match.
-                    Debug.Assert(searchSpaceLength >= Vector128<byte>.Count, "We expect that the input is long enough for us to load a Vector128.");
-                    {
-                        ref byte halfVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector128<byte>.Count);
-
-                        ref byte firstVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref halfVectorAwayFromEnd)
-                            ? ref halfVectorAwayFromEnd
-                            : ref currentSearchSpace;
-
-                        Vector128<byte> source0 = Vector128.LoadUnsafe(ref firstVector);
-                        Vector128<byte> source1 = Vector128.LoadUnsafe(ref halfVectorAwayFromEnd);
-                        Vector256<byte> source = Vector256.Create(source0, source1);
+                        Vector256<byte> source = Vector256.LoadUnsafe(ref currentSearchSpace);
 
                         Vector256<byte> result = TNegator.NegateIfNeeded(IndexOfAnyLookupCore(source, bitmap256));
                         if (result != Vector256<byte>.Zero)
                         {
-                            return ComputeFirstIndexOverlapped<byte, TNegator>(ref searchSpace, ref firstVector, ref halfVectorAwayFromEnd, result);
-                        }
-                    }
-
-                    return -1;
-                }
-                else
-                {
-                    // Process the input in chunks of 16 bytes.
-                    // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
-                    // Let the fallback below handle it instead. This is why the condition is
-                    // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
-                    ref byte vectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector128<byte>.Count);
-
-                    do
-                    {
-                        Vector128<byte> source = Vector128.LoadUnsafe(ref currentSearchSpace);
-
-                        Vector128<byte> result = TNegator.NegateIfNeeded(IndexOfAnyLookupCore(source, bitmap));
-                        if (result != Vector128<byte>.Zero)
-                        {
                             return ComputeFirstIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
                         }
 
-                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector128<byte>.Count);
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector256<byte>.Count);
                     }
                     while (Unsafe.IsAddressLessThan(ref currentSearchSpace, ref vectorAwayFromEnd));
                 }
+
+                // We have 1-32 bytes remaining. Process the first and last half vectors in the search space.
+                // They may overlap, but we'll handle that in the index calculation if we do get a match.
+                Debug.Assert(searchSpaceLength >= Vector128<byte>.Count, "We expect that the input is long enough for us to load a Vector128.");
+                {
+                    ref byte halfVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector128<byte>.Count);
+
+                    ref byte firstVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref halfVectorAwayFromEnd)
+                        ? ref halfVectorAwayFromEnd
+                        : ref currentSearchSpace;
+
+                    Vector128<byte> source0 = Vector128.LoadUnsafe(ref firstVector);
+                    Vector128<byte> source1 = Vector128.LoadUnsafe(ref halfVectorAwayFromEnd);
+                    Vector256<byte> source = Vector256.Create(source0, source1);
+
+                    Vector256<byte> result = TNegator.NegateIfNeeded(IndexOfAnyLookupCore(source, bitmap256));
+                    if (result != Vector256<byte>.Zero)
+                    {
+                        return ComputeFirstIndexOverlapped<byte, TNegator>(ref searchSpace, ref firstVector, ref halfVectorAwayFromEnd, result);
+                    }
+                }
+
+                return -1;
+            }
+
+            Vector128<byte> bitmap = bitmapRef._lower;
+
+            if (!Avx2.IsSupported && searchSpaceLength > Vector128<byte>.Count)
+            {
+                // Process the input in chunks of 16 bytes.
+                // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
+                // Let the fallback below handle it instead. This is why the condition is
+                // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
+                ref byte vectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector128<byte>.Count);
+
+                do
+                {
+                    Vector128<byte> source = Vector128.LoadUnsafe(ref currentSearchSpace);
+
+                    Vector128<byte> result = TNegator.NegateIfNeeded(IndexOfAnyLookupCore(source, bitmap));
+                    if (result != Vector128<byte>.Zero)
+                    {
+                        return ComputeFirstIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                    }
+
+                    currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector128<byte>.Count);
+                }
+                while (Unsafe.IsAddressLessThan(ref currentSearchSpace, ref vectorAwayFromEnd));
             }
 
             // We have 1-16 bytes remaining. Process the first and last half vectors in the search space.
@@ -491,85 +495,85 @@ namespace System.Buffers
             return -1;
         }
 
-        internal static int LastIndexOfAnyVectorized<TNegator>(ref byte searchSpace, int searchSpaceLength, Vector128<byte> bitmap)
+        internal static int LastIndexOfAnyVectorized<TNegator>(ref byte searchSpace, int searchSpaceLength, ref Vector256<byte> bitmapRef)
             where TNegator : struct, INegator
         {
             ref byte currentSearchSpace = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
 
-            if (searchSpaceLength > Vector128<byte>.Count)
+            if (Avx2.IsSupported && searchSpaceLength > Vector128<byte>.Count)
             {
-                if (Avx2.IsSupported)
+                Vector256<byte> bitmap256 = bitmapRef;
+
+                if (searchSpaceLength > Vector256<byte>.Count)
                 {
-                    Vector256<byte> bitmap256 = Vector256.Create(bitmap, bitmap);
-
-                    if (searchSpaceLength > Vector256<byte>.Count)
-                    {
-                        // Process the input in chunks of 32 bytes.
-                        // If the input length is a multiple of 32, don't consume the last 32 characters in this loop.
-                        // Let the fallback below handle it instead. This is why the condition is
-                        // ">" instead of ">=" above, and why "IsAddressGreaterThan" is used instead of "!IsAddressLessThan".
-                        ref byte vectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector256<byte>.Count);
-
-                        do
-                        {
-                            currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector256<byte>.Count);
-
-                            Vector256<byte> source = Vector256.LoadUnsafe(ref currentSearchSpace);
-
-                            Vector256<byte> result = TNegator.NegateIfNeeded(IndexOfAnyLookupCore(source, bitmap256));
-                            if (result != Vector256<byte>.Zero)
-                            {
-                                return ComputeLastIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
-                            }
-                        }
-                        while (Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref vectorAfterStart));
-                    }
-
-                    // We have 1-32 bytes remaining. Process the first and last half vectors in the search space.
-                    // They may overlap, but we'll handle that in the index calculation if we do get a match.
-                    Debug.Assert(searchSpaceLength >= Vector128<byte>.Count, "We expect that the input is long enough for us to load a Vector128.");
-                    {
-                        ref byte halfVectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector128<byte>.Count);
-
-                        ref byte secondVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref halfVectorAfterStart)
-                            ? ref Unsafe.Subtract(ref currentSearchSpace, Vector128<byte>.Count)
-                            : ref searchSpace;
-
-                        Vector128<byte> source0 = Vector128.LoadUnsafe(ref searchSpace);
-                        Vector128<byte> source1 = Vector128.LoadUnsafe(ref secondVector);
-                        Vector256<byte> source = Vector256.Create(source0, source1);
-
-                        Vector256<byte> result = TNegator.NegateIfNeeded(IndexOfAnyLookupCore(source, bitmap256));
-                        if (result != Vector256<byte>.Zero)
-                        {
-                            return ComputeLastIndexOverlapped<byte, TNegator>(ref searchSpace, ref secondVector, result);
-                        }
-                    }
-
-                    return -1;
-                }
-                else
-                {
-                    // Process the input in chunks of 16 bytes.
-                    // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
+                    // Process the input in chunks of 32 bytes.
+                    // If the input length is a multiple of 32, don't consume the last 32 characters in this loop.
                     // Let the fallback below handle it instead. This is why the condition is
                     // ">" instead of ">=" above, and why "IsAddressGreaterThan" is used instead of "!IsAddressLessThan".
-                    ref byte vectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector128<byte>.Count);
+                    ref byte vectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector256<byte>.Count);
 
                     do
                     {
-                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector128<byte>.Count);
+                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector256<byte>.Count);
 
-                        Vector128<byte> source = Vector128.LoadUnsafe(ref currentSearchSpace);
+                        Vector256<byte> source = Vector256.LoadUnsafe(ref currentSearchSpace);
 
-                        Vector128<byte> result = TNegator.NegateIfNeeded(IndexOfAnyLookupCore(source, bitmap));
-                        if (result != Vector128<byte>.Zero)
+                        Vector256<byte> result = TNegator.NegateIfNeeded(IndexOfAnyLookupCore(source, bitmap256));
+                        if (result != Vector256<byte>.Zero)
                         {
                             return ComputeLastIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
                         }
                     }
                     while (Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref vectorAfterStart));
                 }
+
+                // We have 1-32 bytes remaining. Process the first and last half vectors in the search space.
+                // They may overlap, but we'll handle that in the index calculation if we do get a match.
+                Debug.Assert(searchSpaceLength >= Vector128<byte>.Count, "We expect that the input is long enough for us to load a Vector128.");
+                {
+                    ref byte halfVectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector128<byte>.Count);
+
+                    ref byte secondVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref halfVectorAfterStart)
+                        ? ref Unsafe.Subtract(ref currentSearchSpace, Vector128<byte>.Count)
+                        : ref searchSpace;
+
+                    Vector128<byte> source0 = Vector128.LoadUnsafe(ref searchSpace);
+                    Vector128<byte> source1 = Vector128.LoadUnsafe(ref secondVector);
+                    Vector256<byte> source = Vector256.Create(source0, source1);
+
+                    Vector256<byte> result = TNegator.NegateIfNeeded(IndexOfAnyLookupCore(source, bitmap256));
+                    if (result != Vector256<byte>.Zero)
+                    {
+                        return ComputeLastIndexOverlapped<byte, TNegator>(ref searchSpace, ref secondVector, result);
+                    }
+                }
+
+                return -1;
+            }
+
+            Vector128<byte> bitmap = bitmapRef._lower;
+
+            if (!Avx2.IsSupported && searchSpaceLength > Vector128<byte>.Count)
+            {
+                // Process the input in chunks of 16 bytes.
+                // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
+                // Let the fallback below handle it instead. This is why the condition is
+                // ">" instead of ">=" above, and why "IsAddressGreaterThan" is used instead of "!IsAddressLessThan".
+                ref byte vectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector128<byte>.Count);
+
+                do
+                {
+                    currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector128<byte>.Count);
+
+                    Vector128<byte> source = Vector128.LoadUnsafe(ref currentSearchSpace);
+
+                    Vector128<byte> result = TNegator.NegateIfNeeded(IndexOfAnyLookupCore(source, bitmap));
+                    if (result != Vector128<byte>.Zero)
+                    {
+                        return ComputeLastIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                    }
+                }
+                while (Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref vectorAfterStart));
             }
 
             // We have 1-16 bytes remaining. Process the first and last half vectors in the search space.
@@ -596,86 +600,87 @@ namespace System.Buffers
             return -1;
         }
 
-        internal static int IndexOfAnyVectorized<TNegator>(ref byte searchSpace, int searchSpaceLength, Vector128<byte> bitmap0, Vector128<byte> bitmap1)
+        internal static int IndexOfAnyVectorizedAnyByte<TNegator>(ref byte searchSpace, int searchSpaceLength, ref Vector512<byte> bitmapsRef)
             where TNegator : struct, INegator
         {
             ref byte currentSearchSpace = ref searchSpace;
 
-            if (searchSpaceLength > Vector128<byte>.Count)
+            if (Avx2.IsSupported && searchSpaceLength > Vector128<byte>.Count)
             {
-                if (Avx2.IsSupported)
+                Vector256<byte> bitmap256_0 = bitmapsRef._lower;
+                Vector256<byte> bitmap256_1 = bitmapsRef._upper;
+
+                if (searchSpaceLength > Vector256<byte>.Count)
                 {
-                    Vector256<byte> bitmap256_0 = Vector256.Create(bitmap0, bitmap0);
-                    Vector256<byte> bitmap256_1 = Vector256.Create(bitmap1, bitmap1);
+                    // Process the input in chunks of 32 bytes.
+                    // If the input length is a multiple of 32, don't consume the last 32 characters in this loop.
+                    // Let the fallback below handle it instead. This is why the condition is
+                    // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
+                    ref byte vectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector256<byte>.Count);
 
-                    if (searchSpaceLength > Vector256<byte>.Count)
+                    do
                     {
-                        // Process the input in chunks of 32 bytes.
-                        // If the input length is a multiple of 32, don't consume the last 32 characters in this loop.
-                        // Let the fallback below handle it instead. This is why the condition is
-                        // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
-                        ref byte vectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector256<byte>.Count);
-
-                        do
-                        {
-                            Vector256<byte> source = Vector256.LoadUnsafe(ref currentSearchSpace);
-
-                            Vector256<byte> result = IndexOfAnyLookup<TNegator>(source, bitmap256_0, bitmap256_1);
-                            if (result != Vector256<byte>.Zero)
-                            {
-                                return ComputeFirstIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
-                            }
-
-                            currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector256<byte>.Count);
-                        }
-                        while (Unsafe.IsAddressLessThan(ref currentSearchSpace, ref vectorAwayFromEnd));
-                    }
-
-                    // We have 1-32 bytes remaining. Process the first and last half vectors in the search space.
-                    // They may overlap, but we'll handle that in the index calculation if we do get a match.
-                    Debug.Assert(searchSpaceLength >= Vector128<byte>.Count, "We expect that the input is long enough for us to load a Vector128.");
-                    {
-                        ref byte halfVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector128<byte>.Count);
-
-                        ref byte firstVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref halfVectorAwayFromEnd)
-                            ? ref halfVectorAwayFromEnd
-                            : ref currentSearchSpace;
-
-                        Vector128<byte> source0 = Vector128.LoadUnsafe(ref firstVector);
-                        Vector128<byte> source1 = Vector128.LoadUnsafe(ref halfVectorAwayFromEnd);
-                        Vector256<byte> source = Vector256.Create(source0, source1);
+                        Vector256<byte> source = Vector256.LoadUnsafe(ref currentSearchSpace);
 
                         Vector256<byte> result = IndexOfAnyLookup<TNegator>(source, bitmap256_0, bitmap256_1);
                         if (result != Vector256<byte>.Zero)
                         {
-                            return ComputeFirstIndexOverlapped<byte, TNegator>(ref searchSpace, ref firstVector, ref halfVectorAwayFromEnd, result);
-                        }
-                    }
-
-                    return -1;
-                }
-                else
-                {
-                    // Process the input in chunks of 16 bytes.
-                    // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
-                    // Let the fallback below handle it instead. This is why the condition is
-                    // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
-                    ref byte vectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector128<byte>.Count);
-
-                    do
-                    {
-                        Vector128<byte> source = Vector128.LoadUnsafe(ref currentSearchSpace);
-
-                        Vector128<byte> result = IndexOfAnyLookup<TNegator>(source, bitmap0, bitmap1);
-                        if (result != Vector128<byte>.Zero)
-                        {
                             return ComputeFirstIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
                         }
 
-                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector128<byte>.Count);
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector256<byte>.Count);
                     }
                     while (Unsafe.IsAddressLessThan(ref currentSearchSpace, ref vectorAwayFromEnd));
                 }
+
+                // We have 1-32 bytes remaining. Process the first and last half vectors in the search space.
+                // They may overlap, but we'll handle that in the index calculation if we do get a match.
+                Debug.Assert(searchSpaceLength >= Vector128<byte>.Count, "We expect that the input is long enough for us to load a Vector128.");
+                {
+                    ref byte halfVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector128<byte>.Count);
+
+                    ref byte firstVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref halfVectorAwayFromEnd)
+                        ? ref halfVectorAwayFromEnd
+                        : ref currentSearchSpace;
+
+                    Vector128<byte> source0 = Vector128.LoadUnsafe(ref firstVector);
+                    Vector128<byte> source1 = Vector128.LoadUnsafe(ref halfVectorAwayFromEnd);
+                    Vector256<byte> source = Vector256.Create(source0, source1);
+
+                    Vector256<byte> result = IndexOfAnyLookup<TNegator>(source, bitmap256_0, bitmap256_1);
+                    if (result != Vector256<byte>.Zero)
+                    {
+                        return ComputeFirstIndexOverlapped<byte, TNegator>(ref searchSpace, ref firstVector, ref halfVectorAwayFromEnd, result);
+                    }
+                }
+
+                return -1;
+            }
+
+            Vector128<byte> bitmap0 = bitmapsRef._lower._lower;
+            Vector128<byte> bitmap1 = bitmapsRef._upper._lower;
+
+            if (!Avx2.IsSupported && searchSpaceLength > Vector128<byte>.Count)
+            {
+                // Process the input in chunks of 16 bytes.
+                // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
+                // Let the fallback below handle it instead. This is why the condition is
+                // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
+                ref byte vectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector128<byte>.Count);
+
+                do
+                {
+                    Vector128<byte> source = Vector128.LoadUnsafe(ref currentSearchSpace);
+
+                    Vector128<byte> result = IndexOfAnyLookup<TNegator>(source, bitmap0, bitmap1);
+                    if (result != Vector128<byte>.Zero)
+                    {
+                        return ComputeFirstIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                    }
+
+                    currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector128<byte>.Count);
+                }
+                while (Unsafe.IsAddressLessThan(ref currentSearchSpace, ref vectorAwayFromEnd));
             }
 
             // We have 1-16 bytes remaining. Process the first and last half vectors in the search space.
@@ -702,86 +707,87 @@ namespace System.Buffers
             return -1;
         }
 
-        internal static int LastIndexOfAnyVectorized<TNegator>(ref byte searchSpace, int searchSpaceLength, Vector128<byte> bitmap0, Vector128<byte> bitmap1)
+        internal static int LastIndexOfAnyVectorizedAnyByte<TNegator>(ref byte searchSpace, int searchSpaceLength, ref Vector512<byte> bitmapsRef)
             where TNegator : struct, INegator
         {
             ref byte currentSearchSpace = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
 
-            if (searchSpaceLength > Vector128<byte>.Count)
+            if (Avx2.IsSupported && searchSpaceLength > Vector128<byte>.Count)
             {
-                if (Avx2.IsSupported)
+                Vector256<byte> bitmap256_0 = bitmapsRef._lower;
+                Vector256<byte> bitmap256_1 = bitmapsRef._upper;
+
+                if (searchSpaceLength > Vector256<byte>.Count)
                 {
-                    Vector256<byte> bitmap256_0 = Vector256.Create(bitmap0, bitmap0);
-                    Vector256<byte> bitmap256_1 = Vector256.Create(bitmap1, bitmap1);
-
-                    if (searchSpaceLength > Vector256<byte>.Count)
-                    {
-                        // Process the input in chunks of 32 bytes.
-                        // If the input length is a multiple of 32, don't consume the last 32 characters in this loop.
-                        // Let the fallback below handle it instead. This is why the condition is
-                        // ">" instead of ">=" above, and why "IsAddressGreaterThan" is used instead of "!IsAddressLessThan".
-                        ref byte vectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector256<byte>.Count);
-
-                        do
-                        {
-                            currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector256<byte>.Count);
-
-                            Vector256<byte> source = Vector256.LoadUnsafe(ref currentSearchSpace);
-
-                            Vector256<byte> result = IndexOfAnyLookup<TNegator>(source, bitmap256_0, bitmap256_1);
-                            if (result != Vector256<byte>.Zero)
-                            {
-                                return ComputeLastIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
-                            }
-                        }
-                        while (Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref vectorAfterStart));
-                    }
-
-                    // We have 1-32 bytes remaining. Process the first and last half vectors in the search space.
-                    // They may overlap, but we'll handle that in the index calculation if we do get a match.
-                    Debug.Assert(searchSpaceLength >= Vector128<byte>.Count, "We expect that the input is long enough for us to load a Vector128.");
-                    {
-                        ref byte halfVectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector128<byte>.Count);
-
-                        ref byte secondVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref halfVectorAfterStart)
-                            ? ref Unsafe.Subtract(ref currentSearchSpace, Vector128<byte>.Count)
-                            : ref searchSpace;
-
-                        Vector128<byte> source0 = Vector128.LoadUnsafe(ref searchSpace);
-                        Vector128<byte> source1 = Vector128.LoadUnsafe(ref secondVector);
-                        Vector256<byte> source = Vector256.Create(source0, source1);
-
-                        Vector256<byte> result = IndexOfAnyLookup<TNegator>(source, bitmap256_0, bitmap256_1);
-                        if (result != Vector256<byte>.Zero)
-                        {
-                            return ComputeLastIndexOverlapped<byte, TNegator>(ref searchSpace, ref secondVector, result);
-                        }
-                    }
-
-                    return -1;
-                }
-                else
-                {
-                    // Process the input in chunks of 16 bytes.
-                    // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
+                    // Process the input in chunks of 32 bytes.
+                    // If the input length is a multiple of 32, don't consume the last 32 characters in this loop.
                     // Let the fallback below handle it instead. This is why the condition is
                     // ">" instead of ">=" above, and why "IsAddressGreaterThan" is used instead of "!IsAddressLessThan".
-                    ref byte vectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector128<byte>.Count);
+                    ref byte vectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector256<byte>.Count);
 
                     do
                     {
-                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector128<byte>.Count);
+                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector256<byte>.Count);
 
-                        Vector128<byte> source = Vector128.LoadUnsafe(ref currentSearchSpace);
+                        Vector256<byte> source = Vector256.LoadUnsafe(ref currentSearchSpace);
 
-                        Vector128<byte> result = IndexOfAnyLookup<TNegator>(source, bitmap0, bitmap1);
-                        if (result != Vector128<byte>.Zero)
+                        Vector256<byte> result = IndexOfAnyLookup<TNegator>(source, bitmap256_0, bitmap256_1);
+                        if (result != Vector256<byte>.Zero)
                         {
                             return ComputeLastIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
                         }
                     }
                     while (Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref vectorAfterStart));
                 }
+
+                // We have 1-32 bytes remaining. Process the first and last half vectors in the search space.
+                // They may overlap, but we'll handle that in the index calculation if we do get a match.
+                Debug.Assert(searchSpaceLength >= Vector128<byte>.Count, "We expect that the input is long enough for us to load a Vector128.");
+                {
+                    ref byte halfVectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector128<byte>.Count);
+
+                    ref byte secondVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref halfVectorAfterStart)
+                        ? ref Unsafe.Subtract(ref currentSearchSpace, Vector128<byte>.Count)
+                        : ref searchSpace;
+
+                    Vector128<byte> source0 = Vector128.LoadUnsafe(ref searchSpace);
+                    Vector128<byte> source1 = Vector128.LoadUnsafe(ref secondVector);
+                    Vector256<byte> source = Vector256.Create(source0, source1);
+
+                    Vector256<byte> result = IndexOfAnyLookup<TNegator>(source, bitmap256_0, bitmap256_1);
+                    if (result != Vector256<byte>.Zero)
+                    {
+                        return ComputeLastIndexOverlapped<byte, TNegator>(ref searchSpace, ref secondVector, result);
+                    }
+                }
+
+                return -1;
+            }
+
+            Vector128<byte> bitmap0 = bitmapsRef._lower._lower;
+            Vector128<byte> bitmap1 = bitmapsRef._upper._lower;
+
+            if (!Avx2.IsSupported && searchSpaceLength > Vector128<byte>.Count)
+            {
+                // Process the input in chunks of 16 bytes.
+                // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
+                // Let the fallback below handle it instead. This is why the condition is
+                // ">" instead of ">=" above, and why "IsAddressGreaterThan" is used instead of "!IsAddressLessThan".
+                ref byte vectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector128<byte>.Count);
+
+                do
+                {
+                    currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector128<byte>.Count);
+
+                    Vector128<byte> source = Vector128.LoadUnsafe(ref currentSearchSpace);
+
+                    Vector128<byte> result = IndexOfAnyLookup<TNegator>(source, bitmap0, bitmap1);
+                    if (result != Vector128<byte>.Zero)
+                    {
+                        return ComputeLastIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                    }
+                }
+                while (Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref vectorAfterStart));
             }
 
             // We have 1-16 bytes remaining. Process the first and last half vectors in the search space.

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.cs
@@ -112,7 +112,7 @@ namespace System.Buffers
             // IndexOfAnyAsciiSearcher for chars is slower than Any3CharSearchValues, but faster than Any4SearchValues
             if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && maxInclusive < 128)
             {
-                IndexOfAnyAsciiSearcher.ComputeBitmap(values, out Vector128<byte> bitmap, out BitVector256 lookup);
+                IndexOfAnyAsciiSearcher.ComputeBitmap(values, out Vector256<byte> bitmap, out BitVector256 lookup);
 
                 return (Ssse3.IsSupported || PackedSimd.IsSupported) && lookup.Contains(0)
                     ? new AsciiCharSearchValues<IndexOfAnyAsciiSearcher.Ssse3AndWasmHandleZeroInNeedle>(bitmap, lookup)


### PR DESCRIPTION
I recommend [looking at the diff without whitespace changes](https://github.com/dotnet/runtime/pull/86046/files?diff=unified&w=1).

The idea here is pretty simple - instead of passing the bitmaps to worker methods by value, we pass a ref and have the callee do the load. This simplifies both the call site and callee.

<details>
<summary>Ascii chars</summary>

|           Method | Toolchain | Length | MatchAtStart |      Mean |     Error | Ratio |
|----------------- |---------- |------- |------------- |----------:|----------:|------:|
|          CharAny |      main |      8 |        False |  3.874 ns | 0.0776 ns |  1.00 |
|          CharAny |        pr |      8 |        False |  2.382 ns | 0.0584 ns |  0.62 |
|                  |           |        |              |           |           |       |
|    CharAnyExcept |      main |      8 |        False |  2.526 ns | 0.0485 ns |  1.00 |
|    CharAnyExcept |        pr |      8 |        False |  2.786 ns | 0.0633 ns |  1.11 |
|                  |           |        |              |           |           |       |
|          CharAny |      main |      8 |         True |  3.895 ns | 0.0536 ns |  1.00 |
|          CharAny |        pr |      8 |         True |  2.985 ns | 0.0487 ns |  0.77 |
|                  |           |        |              |           |           |       |
|    CharAnyExcept |      main |      8 |         True |  3.194 ns | 0.0424 ns |  1.00 |
|    CharAnyExcept |        pr |      8 |         True |  3.312 ns | 0.0629 ns |  1.04 |
|                  |           |        |              |           |           |       |
|          CharAny |      main |     16 |        False |  3.901 ns | 0.0534 ns |  1.00 |
|          CharAny |        pr |     16 |        False |  2.447 ns | 0.0529 ns |  0.63 |
|                  |           |        |              |           |           |       |
|    CharAnyExcept |      main |     16 |        False |  2.555 ns | 0.0452 ns |  1.00 |
|    CharAnyExcept |        pr |     16 |        False |  2.620 ns | 0.0572 ns |  1.03 |
|                  |           |        |              |           |           |       |
|          CharAny |      main |     16 |         True |  4.152 ns | 0.1861 ns |  1.00 |
|          CharAny |        pr |     16 |         True |  3.105 ns | 0.0843 ns |  0.75 |
|                  |           |        |              |           |           |       |
|    CharAnyExcept |      main |     16 |         True |  3.219 ns | 0.0550 ns |  1.00 |
|    CharAnyExcept |        pr |     16 |         True |  3.236 ns | 0.0399 ns |  1.01 |
|                  |           |        |              |           |           |       |
|          CharAny |      main |     17 |        False |  4.096 ns | 0.0446 ns |  1.00 |
|          CharAny |        pr |     17 |        False |  2.753 ns | 0.1530 ns |  0.67 |
|                  |           |        |              |           |           |       |
|    CharAnyExcept |      main |     17 |        False |  3.671 ns | 0.0513 ns |  1.00 |
|    CharAnyExcept |        pr |     17 |        False |  3.104 ns | 0.0359 ns |  0.85 |
|                  |           |        |              |           |           |       |
|          CharAny |      main |     17 |         True |  5.536 ns | 0.0644 ns |  1.00 |
|          CharAny |        pr |     17 |         True |  3.549 ns | 0.0553 ns |  0.64 |
|                  |           |        |              |           |           |       |
|    CharAnyExcept |      main |     17 |         True |  3.927 ns | 0.0517 ns |  1.00 |
|    CharAnyExcept |        pr |     17 |         True |  3.764 ns | 0.0573 ns |  0.96 |
|                  |           |        |              |           |           |       |
|          CharAny |      main |     32 |        False |  4.075 ns | 0.0520 ns |  1.00 |
|          CharAny |        pr |     32 |        False |  2.434 ns | 0.0288 ns |  0.60 |
|                  |           |        |              |           |           |       |
|    CharAnyExcept |      main |     32 |        False |  3.694 ns | 0.0522 ns |  1.00 |
|    CharAnyExcept |        pr |     32 |        False |  2.966 ns | 0.0092 ns |  0.80 |
|                  |           |        |              |           |           |       |
|          CharAny |      main |     32 |         True |  5.368 ns | 0.0267 ns |  1.00 |
|          CharAny |        pr |     32 |         True |  3.360 ns | 0.0110 ns |  0.63 |
|                  |           |        |              |           |           |       |
|    CharAnyExcept |      main |     32 |         True |  3.784 ns | 0.0121 ns |  1.00 |
|    CharAnyExcept |        pr |     32 |         True |  3.566 ns | 0.0092 ns |  0.94 |
|                  |           |        |              |           |           |       |
|          CharAny |      main |     33 |        False |  5.504 ns | 0.0177 ns |  1.00 |
|          CharAny |        pr |     33 |        False |  3.781 ns | 0.3894 ns |  0.69 |
|                  |           |        |              |           |           |       |
|    CharAnyExcept |      main |     33 |        False |  4.241 ns | 0.0282 ns |  1.00 |
|    CharAnyExcept |        pr |     33 |        False |  3.607 ns | 0.0094 ns |  0.85 |
|                  |           |        |              |           |           |       |
|          CharAny |      main |     33 |         True |  4.775 ns | 0.0209 ns |  1.00 |
|          CharAny |        pr |     33 |         True |  3.023 ns | 0.0111 ns |  0.63 |
|                  |           |        |              |           |           |       |
|    CharAnyExcept |      main |     33 |         True |  3.988 ns | 0.0069 ns |  1.00 |
|    CharAnyExcept |        pr |     33 |         True |  2.678 ns | 0.0090 ns |  0.67 |
|                  |           |        |              |           |           |       |
|          CharAny |      main |   1000 |        False | 32.512 ns | 0.7871 ns |  1.00 |
|          CharAny |        pr |   1000 |        False | 33.715 ns | 0.1426 ns |  1.04 |
|                  |           |        |              |           |           |       |
|    CharAnyExcept |      main |   1000 |        False | 37.156 ns | 0.1488 ns |  1.00 |
|    CharAnyExcept |        pr |   1000 |        False | 36.509 ns | 0.2694 ns |  0.98 |
|                  |           |        |              |           |           |       |
|          CharAny |      main |   1000 |         True |  4.763 ns | 0.0100 ns |  1.00 |
|          CharAny |        pr |   1000 |         True |  3.033 ns | 0.0184 ns |  0.64 |
|                  |           |        |              |           |           |       |
|    CharAnyExcept |      main |   1000 |         True |  3.989 ns | 0.0097 ns |  1.00 |
|    CharAnyExcept |        pr |   1000 |         True |  2.914 ns | 0.1544 ns |  0.73 |

</details>

<details>
<summary>Ascii bytes</summary>

|           Method | Toolchain | Length | MatchAtStart |      Mean |     Error | Ratio |
|----------------- |---------- |------- |------------- |----------:|----------:|------:|
|          ByteAny |      main |      8 |        False |  3.658 ns | 0.0493 ns |  1.00 |
|          ByteAny |        pr |      8 |        False |  2.363 ns | 0.0344 ns |  0.65 |
|                  |           |        |              |           |           |       |
|    ByteAnyExcept |      main |      8 |        False |  2.882 ns | 0.0826 ns |  1.00 |
|    ByteAnyExcept |        pr |      8 |        False |  2.934 ns | 0.0523 ns |  1.02 |
|                  |           |        |              |           |           |       |
|          ByteAny |      main |      8 |         True |  4.621 ns | 0.0994 ns |  1.00 |
|          ByteAny |        pr |      8 |         True |  3.408 ns | 0.1378 ns |  0.74 |
|                  |           |        |              |           |           |       |
|    ByteAnyExcept |      main |      8 |         True |  3.381 ns | 0.0493 ns |  1.00 |
|    ByteAnyExcept |        pr |      8 |         True |  3.117 ns | 0.0641 ns |  0.92 |
|                  |           |        |              |           |           |       |
|          ByteAny |      main |     16 |        False |  3.691 ns | 0.0518 ns |  1.00 |
|          ByteAny |        pr |     16 |        False |  2.423 ns | 0.0581 ns |  0.66 |
|                  |           |        |              |           |           |       |
|    ByteAnyExcept |      main |     16 |        False |  2.769 ns | 0.0562 ns |  1.00 |
|    ByteAnyExcept |        pr |     16 |        False |  2.880 ns | 0.0363 ns |  1.04 |
|                  |           |        |              |           |           |       |
|          ByteAny |      main |     16 |         True |  4.518 ns | 0.2867 ns |  1.00 |
|          ByteAny |        pr |     16 |         True |  3.256 ns | 0.0565 ns |  0.73 |
|                  |           |        |              |           |           |       |
|    ByteAnyExcept |      main |     16 |         True |  3.397 ns | 0.0475 ns |  1.00 |
|    ByteAnyExcept |        pr |     16 |         True |  3.136 ns | 0.0546 ns |  0.92 |
|                  |           |        |              |           |           |       |
|          ByteAny |      main |     17 |        False |  3.741 ns | 0.0710 ns |  1.00 |
|          ByteAny |        pr |     17 |        False |  3.124 ns | 0.0432 ns |  0.84 |
|                  |           |        |              |           |           |       |
|    ByteAnyExcept |      main |     17 |        False |  3.130 ns | 0.0536 ns |  1.00 |
|    ByteAnyExcept |        pr |     17 |        False |  3.126 ns | 0.1198 ns |  1.00 |
|                  |           |        |              |           |           |       |
|          ByteAny |      main |     17 |         True |  5.326 ns | 0.1132 ns |  1.00 |
|          ByteAny |        pr |     17 |         True |  3.720 ns | 0.0843 ns |  0.70 |
|                  |           |        |              |           |           |       |
|    ByteAnyExcept |      main |     17 |         True |  3.491 ns | 0.0510 ns |  1.00 |
|    ByteAnyExcept |        pr |     17 |         True |  3.757 ns | 0.0458 ns |  1.08 |
|                  |           |        |              |           |           |       |
|          ByteAny |      main |     32 |        False |  3.731 ns | 0.0761 ns |  1.00 |
|          ByteAny |        pr |     32 |        False |  2.990 ns | 0.0076 ns |  0.80 |
|                  |           |        |              |           |           |       |
|    ByteAnyExcept |      main |     32 |        False |  3.111 ns | 0.0474 ns |  1.00 |
|    ByteAnyExcept |        pr |     32 |        False |  2.789 ns | 0.0119 ns |  0.90 |
|                  |           |        |              |           |           |       |
|          ByteAny |      main |     32 |         True |  4.691 ns | 0.0193 ns |  1.00 |
|          ByteAny |        pr |     32 |         True |  3.571 ns | 0.0215 ns |  0.76 |
|                  |           |        |              |           |           |       |
|    ByteAnyExcept |      main |     32 |         True |  3.330 ns | 0.0110 ns |  1.00 |
|    ByteAnyExcept |        pr |     32 |         True |  3.592 ns | 0.0159 ns |  1.08 |
|                  |           |        |              |           |           |       |
|          ByteAny |      main |     33 |        False |  4.261 ns | 0.0110 ns |  1.00 |
|          ByteAny |        pr |     33 |        False |  3.299 ns | 0.0268 ns |  0.77 |
|                  |           |        |              |           |           |       |
|    ByteAnyExcept |      main |     33 |        False |  3.775 ns | 0.0133 ns |  1.00 |
|    ByteAnyExcept |        pr |     33 |        False |  3.761 ns | 0.0887 ns |  1.00 |
|                  |           |        |              |           |           |       |
|          ByteAny |      main |     33 |         True |  3.117 ns | 0.0054 ns |  1.00 |
|          ByteAny |        pr |     33 |         True |  2.593 ns | 0.0092 ns |  0.83 |
|                  |           |        |              |           |           |       |
|    ByteAnyExcept |      main |     33 |         True |  3.087 ns | 0.0104 ns |  1.00 |
|    ByteAnyExcept |        pr |     33 |         True |  2.843 ns | 0.0157 ns |  0.92 |
|                  |           |        |              |           |           |       |
|          ByteAny |      main |   1000 |        False | 31.832 ns | 0.1279 ns |  1.00 |
|          ByteAny |        pr |   1000 |        False | 29.271 ns | 0.1388 ns |  0.92 |
|                  |           |        |              |           |           |       |
|    ByteAnyExcept |      main |   1000 |        False | 34.060 ns | 0.1269 ns |  1.00 |
|    ByteAnyExcept |        pr |   1000 |        False | 33.658 ns | 0.0880 ns |  0.99 |
|                  |           |        |              |           |           |       |
|          ByteAny |      main |   1000 |         True |  3.132 ns | 0.0133 ns |  1.00 |
|          ByteAny |        pr |   1000 |         True |  2.602 ns | 0.0148 ns |  0.83 |
|                  |           |        |              |           |           |       |
|    ByteAnyExcept |      main |   1000 |         True |  3.091 ns | 0.0115 ns |  1.00 |
|    ByteAnyExcept |        pr |   1000 |         True |  2.872 ns | 0.0269 ns |  0.93 |

</details>

<details>
<summary>Any bytes</summary>

|           Method | Toolchain | Length | MatchAtStart |      Mean |     Error | Ratio |
|----------------- |---------- |------- |------------- |----------:|----------:|------:|
|       ByteAny256 |      main |      8 |        False |  3.743 ns | 0.0655 ns |  1.00 |
|       ByteAny256 |        pr |      8 |        False |  3.446 ns | 0.0439 ns |  0.92 |
|                  |           |        |              |           |           |       |
| ByteAnyExcept256 |      main |      8 |        False |  3.568 ns | 0.0637 ns |  1.00 |
| ByteAnyExcept256 |        pr |      8 |        False |  3.115 ns | 0.0827 ns |  0.87 |
|                  |           |        |              |           |           |       |
|       ByteAny256 |      main |      8 |         True |  3.970 ns | 0.1732 ns |  1.00 |
|       ByteAny256 |        pr |      8 |         True |  3.899 ns | 0.0453 ns |  0.99 |
|                  |           |        |              |           |           |       |
| ByteAnyExcept256 |      main |      8 |         True |  3.778 ns | 0.0519 ns |  1.00 |
| ByteAnyExcept256 |        pr |      8 |         True |  3.793 ns | 0.0545 ns |  1.00 |
|                  |           |        |              |           |           |       |
|       ByteAny256 |      main |     16 |        False |  3.733 ns | 0.0431 ns |  1.00 |
|       ByteAny256 |        pr |     16 |        False |  3.449 ns | 0.0441 ns |  0.92 |
|                  |           |        |              |           |           |       |
| ByteAnyExcept256 |      main |     16 |        False |  3.544 ns | 0.0416 ns |  1.00 |
| ByteAnyExcept256 |        pr |     16 |        False |  3.228 ns | 0.1061 ns |  0.91 |
|                  |           |        |              |           |           |       |
|       ByteAny256 |      main |     16 |         True |  3.782 ns | 0.0628 ns |  1.00 |
|       ByteAny256 |        pr |     16 |         True |  3.917 ns | 0.0482 ns |  1.04 |
|                  |           |        |              |           |           |       |
| ByteAnyExcept256 |      main |     16 |         True |  3.759 ns | 0.0573 ns |  1.00 |
| ByteAnyExcept256 |        pr |     16 |         True |  3.747 ns | 0.0459 ns |  1.00 |
|                  |           |        |              |           |           |       |
|       ByteAny256 |      main |     17 |        False |  3.834 ns | 0.0462 ns |  1.00 |
|       ByteAny256 |        pr |     17 |        False |  3.403 ns | 0.0543 ns |  0.89 |
|                  |           |        |              |           |           |       |
| ByteAnyExcept256 |      main |     17 |        False |  4.030 ns | 0.0663 ns |  1.00 |
| ByteAnyExcept256 |        pr |     17 |        False |  3.908 ns | 0.0469 ns |  0.97 |
|                  |           |        |              |           |           |       |
|       ByteAny256 |      main |     17 |         True |  4.635 ns | 0.0738 ns |  1.00 |
|       ByteAny256 |        pr |     17 |         True |  4.234 ns | 0.0926 ns |  0.91 |
|                  |           |        |              |           |           |       |
| ByteAnyExcept256 |      main |     17 |         True |  4.318 ns | 0.0652 ns |  1.00 |
| ByteAnyExcept256 |        pr |     17 |         True |  4.833 ns | 0.0464 ns |  1.12 |
|                  |           |        |              |           |           |       |
|       ByteAny256 |      main |     32 |        False |  3.822 ns | 0.0640 ns |  1.00 |
|       ByteAny256 |        pr |     32 |        False |  3.232 ns | 0.0087 ns |  0.85 |
|                  |           |        |              |           |           |       |
| ByteAnyExcept256 |      main |     32 |        False |  3.993 ns | 0.0560 ns |  1.00 |
| ByteAnyExcept256 |        pr |     32 |        False |  3.763 ns | 0.0167 ns |  0.94 |
|                  |           |        |              |           |           |       |
|       ByteAny256 |      main |     32 |         True |  4.422 ns | 0.0089 ns |  1.00 |
|       ByteAny256 |        pr |     32 |         True |  3.922 ns | 0.0110 ns |  0.89 |
|                  |           |        |              |           |           |       |
| ByteAnyExcept256 |      main |     32 |         True |  4.084 ns | 0.0138 ns |  1.00 |
| ByteAnyExcept256 |        pr |     32 |         True |  4.667 ns | 0.0212 ns |  1.14 |
|                  |           |        |              |           |           |       |
|       ByteAny256 |      main |     33 |        False |  5.116 ns | 0.1425 ns |  1.00 |
|       ByteAny256 |        pr |     33 |        False |  4.365 ns | 0.0080 ns |  0.85 |
|                  |           |        |              |           |           |       |
| ByteAnyExcept256 |      main |     33 |        False |  5.238 ns | 0.0618 ns |  1.00 |
| ByteAnyExcept256 |        pr |     33 |        False |  4.946 ns | 0.0179 ns |  0.94 |
|                  |           |        |              |           |           |       |
|       ByteAny256 |      main |     33 |         True |  3.817 ns | 0.0207 ns |  1.00 |
|       ByteAny256 |        pr |     33 |         True |  3.473 ns | 0.0123 ns |  0.91 |
|                  |           |        |              |           |           |       |
| ByteAnyExcept256 |      main |     33 |         True |  3.784 ns | 0.0192 ns |  1.00 |
| ByteAnyExcept256 |        pr |     33 |         True |  3.627 ns | 0.0255 ns |  0.96 |
|                  |           |        |              |           |           |       |
|       ByteAny256 |      main |   1000 |        False | 45.522 ns | 0.1624 ns |  1.00 |
|       ByteAny256 |        pr |   1000 |        False | 44.646 ns | 0.1505 ns |  0.98 |
|                  |           |        |              |           |           |       |
| ByteAnyExcept256 |      main |   1000 |        False | 48.147 ns | 0.1320 ns |  1.00 |
| ByteAnyExcept256 |        pr |   1000 |        False | 48.476 ns | 0.1263 ns |  1.01 |
|                  |           |        |              |           |           |       |
|       ByteAny256 |      main |   1000 |         True |  3.800 ns | 0.0099 ns |  1.00 |
|       ByteAny256 |        pr |   1000 |         True |  3.474 ns | 0.0103 ns |  0.91 |
|                  |           |        |              |           |           |       |
| ByteAnyExcept256 |      main |   1000 |         True |  3.786 ns | 0.0254 ns |  1.00 |
| ByteAnyExcept256 |        pr |   1000 |         True |  3.618 ns | 0.0138 ns |  0.96 |

</details>

<details>
<summary>Regex</summary>

| Method | Toolchain |                              Pattern |  Options |     Mean |     Error | Ratio |
|------- |---------- |------------------------------------- |--------- |---------:|----------:|------:|
|  Count |      main | (?i)Sherlock\|(...)er\|John\|Baker [49] | Compiled | 2.015 ms | 0.0079 ms |  1.00 |
|  Count |        pr | (?i)Sherlock\|(...)er\|John\|Baker [49] | Compiled | 1.724 ms | 0.0038 ms |  0.86 |
|        |           |                                      |          |          |           |       |
|  Count |      main |                         [a-zA-Z]+ing | Compiled | 3.764 ms | 0.0408 ms |  1.00 |
|  Count |        pr |                         [a-zA-Z]+ing | Compiled | 3.541 ms | 0.0115 ms |  0.94 |

| Method | Toolchain |                         Pattern |  Options |     Mean |    Error | Ratio |
|------- |---------- |-------------------------------- |--------- |---------:|---------:|------:|
|  Count |      main | (?i)Tom\|Sawyer\|Huckleberry\|Finn | Compiled | 25.67 ms | 0.156 ms |  1.00 |
|  Count |        pr | (?i)Tom\|Sawyer\|Huckleberry\|Finn | Compiled | 22.56 ms | 0.123 ms |  0.88 |
|        |           |                                 |          |          |          |       |
|  Count |      main |                    [a-zA-Z]+ing | Compiled | 98.31 ms | 0.329 ms |  1.00 |
|  Count |        pr |                    [a-zA-Z]+ing | Compiled | 93.61 ms | 1.213 ms |  0.95 |

</details>

Between this and #84370, I think this closes #81105 and closes #80447.