### PR TITLE
[NativeAOT] Another attempt to prevent stripping exported symbols from executables when explicitly specified

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -335,7 +335,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <PropertyGroup>
       <_IgnoreLinkerWarnings>false</_IgnoreLinkerWarnings>
       <_IgnoreLinkerWarnings Condition="'$(_IsApplePlatform)' == 'true'">true</_IgnoreLinkerWarnings>
-      <StripFlag Condition="'$(_IsApplePlatform)' == 'true' and '$(NativeLib)' == 'Shared'">-x</StripFlag> <!-- keep global symbols in dylib -->
+      <_StripFlag Condition="'$(_IsApplePlatform)' == 'true' and ('$(NativeLib)' == 'Shared' or '$(IlcExportUnmanagedEntrypoints)' == 'true')">-x</_StripFlag> <!-- keep global symbols in dylib (or if it is explicitly specified) -->
     </PropertyGroup>
 
     <!-- write linker script for lld (13+) to retain the __modules section -->
@@ -362,7 +362,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <Exec Condition="'$(StripSymbols)' == 'true' and '$(_IsApplePlatform)' == 'true' and '$(NativeLib)' != 'Static'"
       Command="
         dsymutil $(DsymUtilOptions) &quot;$(NativeBinary)&quot; &amp;&amp;
-        strip -no_code_signature_warning $(StripFlag) &quot;$(NativeBinary)&quot;" />
+        strip -no_code_signature_warning $(_StripFlag) &quot;$(NativeBinary)&quot;" />
   </Target>
 
   <Target Name="CreateLib"

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -335,7 +335,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <PropertyGroup>
       <_IgnoreLinkerWarnings>false</_IgnoreLinkerWarnings>
       <_IgnoreLinkerWarnings Condition="'$(_IsApplePlatform)' == 'true'">true</_IgnoreLinkerWarnings>
-      <_StripFlag Condition="'$(_IsApplePlatform)' == 'true' and ('$(NativeLib)' == 'Shared' or '$(IlcExportUnmanagedEntrypoints)' == 'true')">-x</_StripFlag> <!-- keep global symbols in dylib (or if it is explicitly specified) -->
+      <_StripFlag Condition="'$(_IsApplePlatform)' == 'true' and '$(IlcExportUnmanagedEntrypoints)' == 'true'">-x</_StripFlag> <!-- keep only global symbols -->
     </PropertyGroup>
 
     <!-- write linker script for lld (13+) to retain the __modules section -->

--- a/src/tests/nativeaot/GenerateUnmanagedEntryPoints/GenerateUnmanagedEntryPoints.csproj
+++ b/src/tests/nativeaot/GenerateUnmanagedEntryPoints/GenerateUnmanagedEntryPoints.csproj
@@ -4,9 +4,6 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IlcExportUnmanagedEntrypoints>true</IlcExportUnmanagedEntrypoints>
-    
-    <!-- Stripping symbols causes problems for running the test on macOS -->
-    <StripSymbols>false</StripSymbols>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR fixes a regression caused by https://github.com/dotnet/runtime/pull/85293 which was reverted by https://github.com/dotnet/runtime/pull/85601

## Problem

The issue with the initial approach is that we used the following `strip` command to keep only the symbols exported by the compiler:
```
strip -i -s <symbols_to_keep.exports> <binary>
```

However, executing this command produces a warning:
```
/Applications/Xcode_13.2.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strip : warning : removing global symbols from a final linked no longer supported.  Use -exported_symbols_list at link time when building: /Users/runner/work/1/s/artifacts/tests/coreclr/osx.x64.Release/nativeaot/GenerateUnmanagedEntryPoints/GenerateUnmanagedEntryPoints/native/GenerateUnmanagedEntryPoints [/Users/runner/work/1/s/src/tests/nativeaot/GenerateUnmanagedEntryPoints/GenerateUnmanagedEntryPoints.csproj] [/Users/runner/work/1/s/src/tests/build.proj]
```

This can be observed in the `runtime` CI lane: https://dev.azure.com/dnceng-public/public/_build/results?buildId=258886&view=logs&j=66dceaa3-58e2-55af-b0bc-5748606ebc0e&t=2c1c2642-0b2e-5086-de47-1b8a1c2ab601&l=637

On the other hand, the job `osx-x64 Release NativeAOT_Libs`  in the `runtime-extra-platforms` CI lane, treats warnings as errors, which results with a build failure when stripping is attempted: https://dev.azure.com/dnceng-public/public/_build/results?buildId=257857&view=logs&j=1b7517dc-3493-5614-db19-9039ca700e8e&t=30be22c2-1ac3-5d1e-cae6-35f9adc3d580&l=6564

## Solution

To achieve the desired behaviour, it is needed to:
1. Export only the desired symbols during native linking, as suggested by the warning message (which we already do) https://github.com/dotnet/runtime/blob/d8cf33b2873d7472f46242b62639e8d92293bbdf/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets#L315
2. Strip local symbols from the binary:
```
strip -x <binary>
``` 

---
Fixes: https://github.com/dotnet/runtime/issues/85600