### PR TITLE
Add necessary subset of wide char APIs to minipal

### DIFF
--- a/src/coreclr/classlibnative/bcltype/system.cpp
+++ b/src/coreclr/classlibnative/bcltype/system.cpp
@@ -236,7 +236,7 @@ void SystemNative::GenericFailFast(STRINGREF refMesgString, EXCEPTIONREF refExce
     else
     {
         pszMessage = W("There is not enough memory to print the supplied FailFast message.");
-        cchMessage = (DWORD)dn_wcslen(pszMessage);
+        cchMessage = (DWORD)strlen_u16(pszMessage);
     }
 
     if (cchMessage == 0) {

--- a/src/coreclr/classlibnative/bcltype/system.cpp
+++ b/src/coreclr/classlibnative/bcltype/system.cpp
@@ -236,7 +236,7 @@ void SystemNative::GenericFailFast(STRINGREF refMesgString, EXCEPTIONREF refExce
     else
     {
         pszMessage = W("There is not enough memory to print the supplied FailFast message.");
-        cchMessage = (DWORD)strlen_u16(pszMessage);
+        cchMessage = (DWORD)u16_strlen(pszMessage);
     }
 
     if (cchMessage == 0) {

--- a/src/coreclr/classlibnative/bcltype/system.cpp
+++ b/src/coreclr/classlibnative/bcltype/system.cpp
@@ -236,7 +236,7 @@ void SystemNative::GenericFailFast(STRINGREF refMesgString, EXCEPTIONREF refExce
     else
     {
         pszMessage = W("There is not enough memory to print the supplied FailFast message.");
-        cchMessage = (DWORD)wcslen(pszMessage);
+        cchMessage = (DWORD)dn_wcslen(pszMessage);
     }
 
     if (cchMessage == 0) {

--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -239,7 +239,7 @@ SplitFullName(_In_z_ PCWSTR fullName,
     // Split off parameters.
     //
 
-    paramsStart = dn_wcschr(fullName, W('('));
+    paramsStart = strchr_u16(fullName, W('('));
     if (paramsStart)
     {
         if (syntax != SPLIT_METHOD ||
@@ -258,7 +258,7 @@ SplitFullName(_In_z_ PCWSTR fullName,
     else
     {
         *params = NULL;
-        memberEnd = fullName + (dn_wcslen(fullName) - 1);
+        memberEnd = fullName + (strlen_u16(fullName) - 1);
     }
 
     if (syntax != SPLIT_TYPE)
@@ -5681,7 +5681,7 @@ static int FormatCLRStubName(
     // Compute the address as a string safely.
     WCHAR addrString[Max64BitHexString + 1];
     FormatInteger(addrString, ARRAY_SIZE(addrString), "%p", stubAddr);
-    size_t addStringLen = dn_wcslen(addrString);
+    size_t addStringLen = strlen_u16(addrString);
 
     // Compute maximum length, include the null terminator.
     size_t formatName_MaxLen = ARRAY_SIZE(formatName_Prefix) // Include trailing null
@@ -5692,7 +5692,7 @@ static int FormatCLRStubName(
     size_t stubManagedNameLen = 0;
     if (stubNameMaybe != NULL)
     {
-        stubManagedNameLen = dn_wcslen(stubNameMaybe);
+        stubManagedNameLen = strlen_u16(stubNameMaybe);
         formatName_MaxLen += ARRAY_SIZE(formatName_OpenBracket) - 1;
         formatName_MaxLen += ARRAY_SIZE(formatName_CloseBracket) - 1;
     }
@@ -6461,7 +6461,7 @@ ClrDataAccess::GetMetaDataFileInfoFromPEFile(PEAssembly *pPEAssembly,
     // It is possible that the module is in-memory. That is the wszFilePath here is empty.
     // We will try to use the module name instead in this case for hosting debugger
     // to find match.
-    if (dn_wcslen(wszFilePath) == 0)
+    if (strlen_u16(wszFilePath) == 0)
     {
         mdImage->GetModuleFileNameHintForDAC().DacGetUnicode(cchFilePath, wszFilePath, &uniPathChars);
         if (uniPathChars > cchFilePath)
@@ -7323,9 +7323,9 @@ STDAPI OutOfProcessExceptionEventCallback(_In_ PDWORD pContext,
         return hr;
     }
 
-    if ((pwszEventName == NULL) || (*pchSize <= dn_wcslen(gmb.wzEventTypeName)))
+    if ((pwszEventName == NULL) || (*pchSize <= strlen_u16(gmb.wzEventTypeName)))
     {
-        *pchSize = static_cast<DWORD>(dn_wcslen(gmb.wzEventTypeName)) + 1;
+        *pchSize = static_cast<DWORD>(strlen_u16(gmb.wzEventTypeName)) + 1;
         return HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
     }
 
@@ -7447,9 +7447,9 @@ STDAPI OutOfProcessExceptionEventSignatureCallback(_In_ PDWORD pContext,
     // Return pwszName as an emptry string to let WER use localized version of "Parameter n"
     *pwszName = W('\0');
 
-    if ((pwszValue == NULL) || (*pchValue <= dn_wcslen(pwszBucketValues[dwIndex])))
+    if ((pwszValue == NULL) || (*pchValue <= strlen_u16(pwszBucketValues[dwIndex])))
     {
-        *pchValue = static_cast<DWORD>(dn_wcslen(pwszBucketValues[dwIndex]))+ 1;
+        *pchValue = static_cast<DWORD>(strlen_u16(pwszBucketValues[dwIndex]))+ 1;
         return HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
     }
 

--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -239,7 +239,7 @@ SplitFullName(_In_z_ PCWSTR fullName,
     // Split off parameters.
     //
 
-    paramsStart = wcschr(fullName, W('('));
+    paramsStart = dn_wcschr(fullName, W('('));
     if (paramsStart)
     {
         if (syntax != SPLIT_METHOD ||
@@ -7620,7 +7620,7 @@ HRESULT DacHandleWalker::Next(unsigned int count,
 void DacHandleWalker::WalkHandles()
 {
     SUPPORTS_DAC;
-    
+
     if (mEnumerated)
         return;
 
@@ -7635,8 +7635,8 @@ void DacHandleWalker::WalkHandles()
 #endif // FEATURE_SVR_GC
 
     DacHandleWalkerParam param(&mList);
-    
-    
+
+
     for (dac_handle_table_map *map = g_gcDacGlobals->handle_table_map; SUCCEEDED(param.Result) && map; map = map->pNext)
     {
         for (int i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE && SUCCEEDED(param.Result); ++i)
@@ -7701,7 +7701,7 @@ HRESULT DacHandleWalker::GetCount(unsigned int *pCount)
         WalkHandles();
 
     *pCount = mList.GetCount();
-    
+
     SOSHelperLeave();
     return hr;
 }
@@ -7867,7 +7867,7 @@ void DacStackReferenceWalker::WalkStack()
 
     _ASSERTE(mList.GetCount() == 0);
     _ASSERTE(mThread);
-    
+
     class ProfilerFilterContextHolder
     {
         Thread* m_pThread;
@@ -7983,7 +7983,7 @@ void DacStackReferenceWalker::GCEnumCallback(LPVOID hCallback, OBJECTREF *pObjec
         if (SUCCEEDED(hr))
             obj = TO_TADDR(fixed_obj);
     }
-    
+
     // Report the object and where it was found.
     SOSStackRefData data = {0};
 
@@ -8028,7 +8028,7 @@ void DacStackReferenceWalker::GCReportCallback(PTR_PTR_Object ppObj, ScanContext
         if (SUCCEEDED(hr))
             obj = TO_CDADDR(fixed_addr);
     }
-    
+
     SOSStackRefData data = {0};
     data.HasRegisterInformation = false;
     data.Register = 0;
@@ -8048,7 +8048,7 @@ void DacStackReferenceWalker::GCReportCallback(PTR_PTR_Object ppObj, ScanContext
         data.SourceType = SOS_StackSourceIP;
         data.Source = TO_CDADDR(dsc->pc);
     }
-    
+
     dsc->pList->Add(data);
 }
 
@@ -8344,7 +8344,7 @@ HRESULT DacGCBookkeepingEnumerator::Init()
         mem.Size = card_table_info->size;
         mRegions.Add(mem);
     }
-    
+
     size_t card_table_info_size = g_gcDacGlobals->card_table_info_size;
     TADDR next = card_table_info->next_card_table;
 
@@ -8366,7 +8366,7 @@ HRESULT DacGCBookkeepingEnumerator::Init()
             mem.Size = ct->size;
             mRegions.Add(mem);
         }
-        
+
         next = ct->next_card_table;
         if (next == card_table_info->next_card_table)
             break;
@@ -8374,7 +8374,7 @@ HRESULT DacGCBookkeepingEnumerator::Init()
         if (--maxRegions <= 0)
             break;
     }
-    
+
     return S_OK;
 }
 
@@ -8405,7 +8405,7 @@ HRESULT DacHandleTableMemoryEnumerator::Init()
                     DPTR(dac_handle_table_segment) curr = pFirstSegment;
 
                     do
-                    {                        
+                    {
                         SOSMemoryRegion mem = {0};
                         mem.Start = curr.GetAddr();
                         mem.Size = HANDLE_SEGMENT_SIZE;
@@ -8484,7 +8484,7 @@ HRESULT DacFreeRegionEnumerator::Init()
             for (int i = 0; i < count_free_region_kinds; i++, regionList++)
                 AddFreeList(regionList, FreeRegionKind::FreeGlobalRegion);
     }
-    
+
 #if defined(FEATURE_SVR_GC)
     if (GCHeapUtilities::IsServerHeap())
     {
@@ -8504,7 +8504,7 @@ HRESULT DacFreeRegionEnumerator::Init()
             if (freeable_soh_segment_ptr != nullptr)
                 AddSegmentList(*freeable_soh_segment_ptr, FreeRegionKind::FreeSohSegment);
         }
-        
+
         if (g_gcDacGlobals->freeable_uoh_segment != nullptr)
         {
             DPTR(DPTR(dac_heap_segment)) freeable_uoh_segment_ptr(g_gcDacGlobals->freeable_uoh_segment);

--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -239,7 +239,7 @@ SplitFullName(_In_z_ PCWSTR fullName,
     // Split off parameters.
     //
 
-    paramsStart = strchr_u16(fullName, W('('));
+    paramsStart = u16_strchr(fullName, W('('));
     if (paramsStart)
     {
         if (syntax != SPLIT_METHOD ||
@@ -258,7 +258,7 @@ SplitFullName(_In_z_ PCWSTR fullName,
     else
     {
         *params = NULL;
-        memberEnd = fullName + (strlen_u16(fullName) - 1);
+        memberEnd = fullName + (u16_strlen(fullName) - 1);
     }
 
     if (syntax != SPLIT_TYPE)
@@ -5681,7 +5681,7 @@ static int FormatCLRStubName(
     // Compute the address as a string safely.
     WCHAR addrString[Max64BitHexString + 1];
     FormatInteger(addrString, ARRAY_SIZE(addrString), "%p", stubAddr);
-    size_t addStringLen = strlen_u16(addrString);
+    size_t addStringLen = u16_strlen(addrString);
 
     // Compute maximum length, include the null terminator.
     size_t formatName_MaxLen = ARRAY_SIZE(formatName_Prefix) // Include trailing null
@@ -5692,7 +5692,7 @@ static int FormatCLRStubName(
     size_t stubManagedNameLen = 0;
     if (stubNameMaybe != NULL)
     {
-        stubManagedNameLen = strlen_u16(stubNameMaybe);
+        stubManagedNameLen = u16_strlen(stubNameMaybe);
         formatName_MaxLen += ARRAY_SIZE(formatName_OpenBracket) - 1;
         formatName_MaxLen += ARRAY_SIZE(formatName_CloseBracket) - 1;
     }
@@ -6461,7 +6461,7 @@ ClrDataAccess::GetMetaDataFileInfoFromPEFile(PEAssembly *pPEAssembly,
     // It is possible that the module is in-memory. That is the wszFilePath here is empty.
     // We will try to use the module name instead in this case for hosting debugger
     // to find match.
-    if (strlen_u16(wszFilePath) == 0)
+    if (u16_strlen(wszFilePath) == 0)
     {
         mdImage->GetModuleFileNameHintForDAC().DacGetUnicode(cchFilePath, wszFilePath, &uniPathChars);
         if (uniPathChars > cchFilePath)
@@ -7323,9 +7323,9 @@ STDAPI OutOfProcessExceptionEventCallback(_In_ PDWORD pContext,
         return hr;
     }
 
-    if ((pwszEventName == NULL) || (*pchSize <= strlen_u16(gmb.wzEventTypeName)))
+    if ((pwszEventName == NULL) || (*pchSize <= u16_strlen(gmb.wzEventTypeName)))
     {
-        *pchSize = static_cast<DWORD>(strlen_u16(gmb.wzEventTypeName)) + 1;
+        *pchSize = static_cast<DWORD>(u16_strlen(gmb.wzEventTypeName)) + 1;
         return HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
     }
 
@@ -7447,9 +7447,9 @@ STDAPI OutOfProcessExceptionEventSignatureCallback(_In_ PDWORD pContext,
     // Return pwszName as an emptry string to let WER use localized version of "Parameter n"
     *pwszName = W('\0');
 
-    if ((pwszValue == NULL) || (*pchValue <= strlen_u16(pwszBucketValues[dwIndex])))
+    if ((pwszValue == NULL) || (*pchValue <= u16_strlen(pwszBucketValues[dwIndex])))
     {
-        *pchValue = static_cast<DWORD>(strlen_u16(pwszBucketValues[dwIndex]))+ 1;
+        *pchValue = static_cast<DWORD>(u16_strlen(pwszBucketValues[dwIndex]))+ 1;
         return HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
     }
 

--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -258,7 +258,7 @@ SplitFullName(_In_z_ PCWSTR fullName,
     else
     {
         *params = NULL;
-        memberEnd = fullName + (wcslen(fullName) - 1);
+        memberEnd = fullName + (dn_wcslen(fullName) - 1);
     }
 
     if (syntax != SPLIT_TYPE)
@@ -5681,7 +5681,7 @@ static int FormatCLRStubName(
     // Compute the address as a string safely.
     WCHAR addrString[Max64BitHexString + 1];
     FormatInteger(addrString, ARRAY_SIZE(addrString), "%p", stubAddr);
-    size_t addStringLen = wcslen(addrString);
+    size_t addStringLen = dn_wcslen(addrString);
 
     // Compute maximum length, include the null terminator.
     size_t formatName_MaxLen = ARRAY_SIZE(formatName_Prefix) // Include trailing null
@@ -5692,7 +5692,7 @@ static int FormatCLRStubName(
     size_t stubManagedNameLen = 0;
     if (stubNameMaybe != NULL)
     {
-        stubManagedNameLen = wcslen(stubNameMaybe);
+        stubManagedNameLen = dn_wcslen(stubNameMaybe);
         formatName_MaxLen += ARRAY_SIZE(formatName_OpenBracket) - 1;
         formatName_MaxLen += ARRAY_SIZE(formatName_CloseBracket) - 1;
     }
@@ -6461,7 +6461,7 @@ ClrDataAccess::GetMetaDataFileInfoFromPEFile(PEAssembly *pPEAssembly,
     // It is possible that the module is in-memory. That is the wszFilePath here is empty.
     // We will try to use the module name instead in this case for hosting debugger
     // to find match.
-    if (wcslen(wszFilePath) == 0)
+    if (dn_wcslen(wszFilePath) == 0)
     {
         mdImage->GetModuleFileNameHintForDAC().DacGetUnicode(cchFilePath, wszFilePath, &uniPathChars);
         if (uniPathChars > cchFilePath)
@@ -7323,9 +7323,9 @@ STDAPI OutOfProcessExceptionEventCallback(_In_ PDWORD pContext,
         return hr;
     }
 
-    if ((pwszEventName == NULL) || (*pchSize <= wcslen(gmb.wzEventTypeName)))
+    if ((pwszEventName == NULL) || (*pchSize <= dn_wcslen(gmb.wzEventTypeName)))
     {
-        *pchSize = static_cast<DWORD>(wcslen(gmb.wzEventTypeName)) + 1;
+        *pchSize = static_cast<DWORD>(dn_wcslen(gmb.wzEventTypeName)) + 1;
         return HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
     }
 
@@ -7447,9 +7447,9 @@ STDAPI OutOfProcessExceptionEventSignatureCallback(_In_ PDWORD pContext,
     // Return pwszName as an emptry string to let WER use localized version of "Parameter n"
     *pwszName = W('\0');
 
-    if ((pwszValue == NULL) || (*pchValue <= wcslen(pwszBucketValues[dwIndex])))
+    if ((pwszValue == NULL) || (*pchValue <= dn_wcslen(pwszBucketValues[dwIndex])))
     {
-        *pchValue = static_cast<DWORD>(wcslen(pwszBucketValues[dwIndex]))+ 1;
+        *pchValue = static_cast<DWORD>(dn_wcslen(pwszBucketValues[dwIndex]))+ 1;
         return HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
     }
 

--- a/src/coreclr/debug/daccess/inspect.cpp
+++ b/src/coreclr/debug/daccess/inspect.cpp
@@ -1047,7 +1047,7 @@ ClrDataValue::GetString(
 
             if (strLen)
             {
-                *strLen = static_cast<ULONG32>(strlen_u16(msgStr) + 1);
+                *strLen = static_cast<ULONG32>(u16_strlen(msgStr) + 1);
             }
             status = StringCchCopy(str, bufLen, msgStr) == S_OK ?
                 S_OK : S_FALSE;

--- a/src/coreclr/debug/daccess/inspect.cpp
+++ b/src/coreclr/debug/daccess/inspect.cpp
@@ -1047,7 +1047,7 @@ ClrDataValue::GetString(
 
             if (strLen)
             {
-                *strLen = static_cast<ULONG32>(wcslen(msgStr) + 1);
+                *strLen = static_cast<ULONG32>(dn_wcslen(msgStr) + 1);
             }
             status = StringCchCopy(str, bufLen, msgStr) == S_OK ?
                 S_OK : S_FALSE;

--- a/src/coreclr/debug/daccess/inspect.cpp
+++ b/src/coreclr/debug/daccess/inspect.cpp
@@ -1047,7 +1047,7 @@ ClrDataValue::GetString(
 
             if (strLen)
             {
-                *strLen = static_cast<ULONG32>(dn_wcslen(msgStr) + 1);
+                *strLen = static_cast<ULONG32>(strlen_u16(msgStr) + 1);
             }
             status = StringCchCopy(str, bufLen, msgStr) == S_OK ?
                 S_OK : S_FALSE;

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -584,7 +584,7 @@ ClrDataAccess::GetRegisterName(int regNum, unsigned int count, _Inout_updates_z_
     const WCHAR callerPrefix[] = W("caller.");
     // Include null terminator in prefixLen/regLen because wcscpy_s will fail otherwise
     unsigned int prefixLen = (unsigned int)ARRAY_SIZE(callerPrefix);
-    unsigned int regLen = (unsigned int)dn_wcslen(regs[regNum]) + 1;
+    unsigned int regLen = (unsigned int)strlen_u16(regs[regNum]) + 1;
     unsigned int needed = (callerFrame ? prefixLen - 1 : 0) + regLen;
     if (pNeeded)
         *pNeeded = needed;
@@ -1999,7 +1999,7 @@ ClrDataAccess::GetFrameName(CLRDATA_ADDRESS vtable, unsigned int count, _Inout_u
     else
     {
         // Turn from bytes to wide characters
-        unsigned int len = (unsigned int)dn_wcslen(pszName);
+        unsigned int len = (unsigned int)strlen_u16(pszName);
 
         if (frameName)
         {

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -584,7 +584,7 @@ ClrDataAccess::GetRegisterName(int regNum, unsigned int count, _Inout_updates_z_
     const WCHAR callerPrefix[] = W("caller.");
     // Include null terminator in prefixLen/regLen because wcscpy_s will fail otherwise
     unsigned int prefixLen = (unsigned int)ARRAY_SIZE(callerPrefix);
-    unsigned int regLen = (unsigned int)strlen_u16(regs[regNum]) + 1;
+    unsigned int regLen = (unsigned int)u16_strlen(regs[regNum]) + 1;
     unsigned int needed = (callerFrame ? prefixLen - 1 : 0) + regLen;
     if (pNeeded)
         *pNeeded = needed;
@@ -1999,7 +1999,7 @@ ClrDataAccess::GetFrameName(CLRDATA_ADDRESS vtable, unsigned int count, _Inout_u
     else
     {
         // Turn from bytes to wide characters
-        unsigned int len = (unsigned int)strlen_u16(pszName);
+        unsigned int len = (unsigned int)u16_strlen(pszName);
 
         if (frameName)
         {

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -584,7 +584,7 @@ ClrDataAccess::GetRegisterName(int regNum, unsigned int count, _Inout_updates_z_
     const WCHAR callerPrefix[] = W("caller.");
     // Include null terminator in prefixLen/regLen because wcscpy_s will fail otherwise
     unsigned int prefixLen = (unsigned int)ARRAY_SIZE(callerPrefix);
-    unsigned int regLen = (unsigned int)wcslen(regs[regNum]) + 1;
+    unsigned int regLen = (unsigned int)dn_wcslen(regs[regNum]) + 1;
     unsigned int needed = (callerFrame ? prefixLen - 1 : 0) + regLen;
     if (pNeeded)
         *pNeeded = needed;
@@ -1999,7 +1999,7 @@ ClrDataAccess::GetFrameName(CLRDATA_ADDRESS vtable, unsigned int count, _Inout_u
     else
     {
         // Turn from bytes to wide characters
-        unsigned int len = (unsigned int)wcslen(pszName);
+        unsigned int len = (unsigned int)dn_wcslen(pszName);
 
         if (frameName)
         {
@@ -3455,7 +3455,7 @@ static HRESULT TraverseLoaderHeapBlock(PTR_LoaderHeapBlock firstBlock, VISITHEAP
         pFunc(addr, size, bCurrentBlock);
 
         block = block->pNext;
-        
+
         // Ensure we only see the first block once and that we aren't looping
         // infinitely.
         if (block == firstBlock)
@@ -3472,7 +3472,7 @@ ClrDataAccess::TraverseLoaderHeap(CLRDATA_ADDRESS loaderHeapAddr, VISITHEAP pFun
         return E_INVALIDARG;
 
     SOSDacEnter();
-    
+
     hr = TraverseLoaderHeapBlock(PTR_LoaderHeap(TO_TADDR(loaderHeapAddr))->m_pFirstBlock, pFunc);
 
     SOSDacLeave();
@@ -3572,7 +3572,7 @@ HRESULT ClrDataAccess::GetDomainLoaderAllocator(CLRDATA_ADDRESS domainAddress, C
 // The ordering of these entries must match the order enumerated in GetLoaderAllocatorHeaps.
 // This array isn't fixed, we can reorder/add/remove entries as long as the corresponding
 // code in GetLoaderAllocatorHeaps is updated to match.
-static const char *LoaderAllocatorLoaderHeapNames[] = 
+static const char *LoaderAllocatorLoaderHeapNames[] =
 {
     "LowFrequencyHeap",
     "HighFrequencyHeap",
@@ -3614,7 +3614,7 @@ HRESULT ClrDataAccess::GetLoaderAllocatorHeaps(CLRDATA_ADDRESS loaderAllocatorAd
             pLoaderHeaps[i++] = HOST_CDADDR(pLoaderAllocator->GetExecutableHeap());
             pLoaderHeaps[i++] = HOST_CDADDR(pLoaderAllocator->GetFixupPrecodeHeap());
             pLoaderHeaps[i++] = HOST_CDADDR(pLoaderAllocator->GetNewStubPrecodeHeap());
-            
+
             VirtualCallStubManager *pVcsMgr = pLoaderAllocator->GetVirtualCallStubManager();
             if (pVcsMgr == nullptr)
             {
@@ -3626,7 +3626,7 @@ HRESULT ClrDataAccess::GetLoaderAllocatorHeaps(CLRDATA_ADDRESS loaderAllocatorAd
                 pLoaderHeaps[i++] = HOST_CDADDR(pVcsMgr->indcell_heap);
                 pLoaderHeaps[i++] = HOST_CDADDR(pVcsMgr->cache_entry_heap);
             }
-            
+
             // All of the above are "LoaderHeap" and not the ExplicitControl version.
             for (int j = 0; j < i; j++)
                 pKinds[j] = LoaderHeapKindNormal;
@@ -3641,7 +3641,7 @@ HRESULT
 ClrDataAccess::GetLoaderAllocatorHeapNames(int count, const char **ppNames, int *pNeeded)
 {
     SOSDacEnter();
-    
+
     const int loaderHeapCount = ARRAY_SIZE(LoaderAllocatorLoaderHeapNames);
     if (pNeeded)
         *pNeeded = loaderHeapCount;

--- a/src/coreclr/debug/daccess/task.cpp
+++ b/src/coreclr/debug/daccess/task.cpp
@@ -736,7 +736,7 @@ ClrDataAppDomain::GetName(
                     S_OK : S_FALSE;
                 if (nameLen)
                 {
-                    size_t cchName = dn_wcslen((PCWSTR)rawName) + 1;
+                    size_t cchName = strlen_u16((PCWSTR)rawName) + 1;
                     if (FitsIn<ULONG32>(cchName))
                     {
                         *nameLen = (ULONG32) cchName;
@@ -4771,7 +4771,7 @@ ClrDataExceptionState::GetString(
             status = StringCchCopy(str, bufLen, msgStr) == S_OK ? S_OK : S_FALSE;
             if (strLen != NULL)
             {
-                size_t cchName = dn_wcslen(msgStr) + 1;
+                size_t cchName = strlen_u16(msgStr) + 1;
                 if (FitsIn<ULONG32>(cchName))
                 {
                     *strLen = (ULONG32) cchName;

--- a/src/coreclr/debug/daccess/task.cpp
+++ b/src/coreclr/debug/daccess/task.cpp
@@ -736,7 +736,7 @@ ClrDataAppDomain::GetName(
                     S_OK : S_FALSE;
                 if (nameLen)
                 {
-                    size_t cchName = wcslen((PCWSTR)rawName) + 1;
+                    size_t cchName = dn_wcslen((PCWSTR)rawName) + 1;
                     if (FitsIn<ULONG32>(cchName))
                     {
                         *nameLen = (ULONG32) cchName;
@@ -4771,7 +4771,7 @@ ClrDataExceptionState::GetString(
             status = StringCchCopy(str, bufLen, msgStr) == S_OK ? S_OK : S_FALSE;
             if (strLen != NULL)
             {
-                size_t cchName = wcslen(msgStr) + 1;
+                size_t cchName = dn_wcslen(msgStr) + 1;
                 if (FitsIn<ULONG32>(cchName))
                 {
                     *strLen = (ULONG32) cchName;

--- a/src/coreclr/debug/daccess/task.cpp
+++ b/src/coreclr/debug/daccess/task.cpp
@@ -736,7 +736,7 @@ ClrDataAppDomain::GetName(
                     S_OK : S_FALSE;
                 if (nameLen)
                 {
-                    size_t cchName = strlen_u16((PCWSTR)rawName) + 1;
+                    size_t cchName = u16_strlen((PCWSTR)rawName) + 1;
                     if (FitsIn<ULONG32>(cchName))
                     {
                         *nameLen = (ULONG32) cchName;
@@ -4771,7 +4771,7 @@ ClrDataExceptionState::GetString(
             status = StringCchCopy(str, bufLen, msgStr) == S_OK ? S_OK : S_FALSE;
             if (strLen != NULL)
             {
-                size_t cchName = strlen_u16(msgStr) + 1;
+                size_t cchName = u16_strlen(msgStr) + 1;
                 if (FitsIn<ULONG32>(cchName))
                 {
                     *strLen = (ULONG32) cchName;

--- a/src/coreclr/debug/dbgutil/dbgutil.cpp
+++ b/src/coreclr/debug/dbgutil/dbgutil.cpp
@@ -329,7 +329,7 @@ HRESULT GetNextLevelResourceEntryRVAByName(ICorDebugDataTarget* pDataTarget,
     DWORD* pNextLevelRva)
 {
     HRESULT hr = S_OK;
-    DWORD nameLength = (DWORD)strlen_u16(pwzName);
+    DWORD nameLength = (DWORD)u16_strlen(pwzName);
     WCHAR entryName[50];
     assert(nameLength < 50);     // this implementation won't support matching a name longer
     // than 50 characters. We only look up the hard coded name

--- a/src/coreclr/debug/dbgutil/dbgutil.cpp
+++ b/src/coreclr/debug/dbgutil/dbgutil.cpp
@@ -16,6 +16,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <memory>
+#include <dn-u16.h>
 #include "corhlpr.h"
 
 #ifdef HOST_WINDOWS

--- a/src/coreclr/debug/dbgutil/dbgutil.cpp
+++ b/src/coreclr/debug/dbgutil/dbgutil.cpp
@@ -328,7 +328,7 @@ HRESULT GetNextLevelResourceEntryRVAByName(ICorDebugDataTarget* pDataTarget,
     DWORD* pNextLevelRva)
 {
     HRESULT hr = S_OK;
-    DWORD nameLength = (DWORD)wcslen(pwzName);
+    DWORD nameLength = (DWORD)dn_wcslen(pwzName);
     WCHAR entryName[50];
     assert(nameLength < 50);     // this implementation won't support matching a name longer
     // than 50 characters. We only look up the hard coded name

--- a/src/coreclr/debug/dbgutil/dbgutil.cpp
+++ b/src/coreclr/debug/dbgutil/dbgutil.cpp
@@ -329,7 +329,7 @@ HRESULT GetNextLevelResourceEntryRVAByName(ICorDebugDataTarget* pDataTarget,
     DWORD* pNextLevelRva)
 {
     HRESULT hr = S_OK;
-    DWORD nameLength = (DWORD)dn_wcslen(pwzName);
+    DWORD nameLength = (DWORD)strlen_u16(pwzName);
     WCHAR entryName[50];
     assert(nameLength < 50);     // this implementation won't support matching a name longer
     // than 50 characters. We only look up the hard coded name

--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -414,11 +414,11 @@ IMDInternalImport * CordbProcess::LookupMetaDataFromDebugger(
 
             WCHAR *mutableFilePath = (WCHAR *)filePath;
 
-            size_t pathLen = dn_wcslen(mutableFilePath);
+            size_t pathLen = strlen_u16(mutableFilePath);
 
             const WCHAR *nidll = W(".ni.dll");
             const WCHAR *niexe = W(".ni.exe");
-            const size_t dllLen = dn_wcslen(nidll);  // used for ni.exe as well
+            const size_t dllLen = strlen_u16(nidll);  // used for ni.exe as well
 
             if (pathLen > dllLen && _wcsicmp(mutableFilePath+pathLen-dllLen, nidll) == 0)
             {
@@ -9617,9 +9617,9 @@ void Ls_Rs_StringBuffer::CopyLSDataToRS(ICorDebugDataTarget * pTarget)
         ThrowHR(CORDBG_E_TARGET_INCONSISTENT);
     }
 
-    // Now we know it's safe to call dn_wcslen. The buffer is local, so we know the pages are there.
+    // Now we know it's safe to call strlen_u16. The buffer is local, so we know the pages are there.
     // And we know there's a null capping the max length of the string.
-    SIZE_T dwActualLenWithNull = dn_wcslen(pString) + 1;
+    SIZE_T dwActualLenWithNull = strlen_u16(pString) + 1;
     if (dwActualLenWithNull != dwExpectedLenWithNull)
     {
         ThrowHR(CORDBG_E_TARGET_INCONSISTENT);

--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -414,11 +414,11 @@ IMDInternalImport * CordbProcess::LookupMetaDataFromDebugger(
 
             WCHAR *mutableFilePath = (WCHAR *)filePath;
 
-            size_t pathLen = wcslen(mutableFilePath);
+            size_t pathLen = dn_wcslen(mutableFilePath);
 
             const WCHAR *nidll = W(".ni.dll");
             const WCHAR *niexe = W(".ni.exe");
-            const size_t dllLen = wcslen(nidll);  // used for ni.exe as well
+            const size_t dllLen = dn_wcslen(nidll);  // used for ni.exe as well
 
             if (pathLen > dllLen && _wcsicmp(mutableFilePath+pathLen-dllLen, nidll) == 0)
             {
@@ -9617,9 +9617,9 @@ void Ls_Rs_StringBuffer::CopyLSDataToRS(ICorDebugDataTarget * pTarget)
         ThrowHR(CORDBG_E_TARGET_INCONSISTENT);
     }
 
-    // Now we know it's safe to call wcslen. The buffer is local, so we know the pages are there.
+    // Now we know it's safe to call dn_wcslen. The buffer is local, so we know the pages are there.
     // And we know there's a null capping the max length of the string.
-    SIZE_T dwActualLenWithNull = wcslen(pString) + 1;
+    SIZE_T dwActualLenWithNull = dn_wcslen(pString) + 1;
     if (dwActualLenWithNull != dwExpectedLenWithNull)
     {
         ThrowHR(CORDBG_E_TARGET_INCONSISTENT);

--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -414,11 +414,11 @@ IMDInternalImport * CordbProcess::LookupMetaDataFromDebugger(
 
             WCHAR *mutableFilePath = (WCHAR *)filePath;
 
-            size_t pathLen = strlen_u16(mutableFilePath);
+            size_t pathLen = u16_strlen(mutableFilePath);
 
             const WCHAR *nidll = W(".ni.dll");
             const WCHAR *niexe = W(".ni.exe");
-            const size_t dllLen = strlen_u16(nidll);  // used for ni.exe as well
+            const size_t dllLen = u16_strlen(nidll);  // used for ni.exe as well
 
             if (pathLen > dllLen && _wcsicmp(mutableFilePath+pathLen-dllLen, nidll) == 0)
             {
@@ -9617,9 +9617,9 @@ void Ls_Rs_StringBuffer::CopyLSDataToRS(ICorDebugDataTarget * pTarget)
         ThrowHR(CORDBG_E_TARGET_INCONSISTENT);
     }
 
-    // Now we know it's safe to call strlen_u16. The buffer is local, so we know the pages are there.
+    // Now we know it's safe to call u16_strlen. The buffer is local, so we know the pages are there.
     // And we know there's a null capping the max length of the string.
-    SIZE_T dwActualLenWithNull = strlen_u16(pString) + 1;
+    SIZE_T dwActualLenWithNull = u16_strlen(pString) + 1;
     if (dwActualLenWithNull != dwExpectedLenWithNull)
     {
         ThrowHR(CORDBG_E_TARGET_INCONSISTENT);

--- a/src/coreclr/debug/di/publish.cpp
+++ b/src/coreclr/debug/di/publish.cpp
@@ -418,7 +418,7 @@ CorpubProcess::CorpubProcess(DWORD dwProcessId,
             if (ret > 0)
             {
                 // Recompute string length because we don't know if 'ret' is in bytes or char.
-                SIZE_T len = dn_wcslen(szName) + 1;
+                SIZE_T len = strlen_u16(szName) + 1;
                 m_szProcessName = new (nothrow) WCHAR[len];
                 if (m_szProcessName != NULL)
                 {
@@ -602,7 +602,7 @@ HRESULT AllocateAndReadRemoteString(
     if (SUCCEEDED(hr))
     {
         // Ensure that the string we just read is actually null terminated.
-        // We can't call dn_wcslen() on it yet, since that may AV on a non-null terminated string.
+        // We can't call strlen_u16() on it yet, since that may AV on a non-null terminated string.
         WCHAR * pString = *ppNewLocalBuffer;
 
         if (pString[ceSize - 1] == W('\0'))
@@ -612,7 +612,7 @@ HRESULT AllocateAndReadRemoteString(
         }
         pString[ceSize - 1] = W('\0');
 
-        SIZE_T ceTestLen = dn_wcslen(pString);
+        SIZE_T ceTestLen = strlen_u16(pString);
         if (ceTestLen == ceSize - 1)
         {
             // String was not previously null-terminated.

--- a/src/coreclr/debug/di/publish.cpp
+++ b/src/coreclr/debug/di/publish.cpp
@@ -418,7 +418,7 @@ CorpubProcess::CorpubProcess(DWORD dwProcessId,
             if (ret > 0)
             {
                 // Recompute string length because we don't know if 'ret' is in bytes or char.
-                SIZE_T len = wcslen(szName) + 1;
+                SIZE_T len = dn_wcslen(szName) + 1;
                 m_szProcessName = new (nothrow) WCHAR[len];
                 if (m_szProcessName != NULL)
                 {
@@ -602,7 +602,7 @@ HRESULT AllocateAndReadRemoteString(
     if (SUCCEEDED(hr))
     {
         // Ensure that the string we just read is actually null terminated.
-        // We can't call wcslen() on it yet, since that may AV on a non-null terminated string.
+        // We can't call dn_wcslen() on it yet, since that may AV on a non-null terminated string.
         WCHAR * pString = *ppNewLocalBuffer;
 
         if (pString[ceSize - 1] == W('\0'))
@@ -612,7 +612,7 @@ HRESULT AllocateAndReadRemoteString(
         }
         pString[ceSize - 1] = W('\0');
 
-        SIZE_T ceTestLen = wcslen(pString);
+        SIZE_T ceTestLen = dn_wcslen(pString);
         if (ceTestLen == ceSize - 1)
         {
             // String was not previously null-terminated.

--- a/src/coreclr/debug/di/publish.cpp
+++ b/src/coreclr/debug/di/publish.cpp
@@ -418,7 +418,7 @@ CorpubProcess::CorpubProcess(DWORD dwProcessId,
             if (ret > 0)
             {
                 // Recompute string length because we don't know if 'ret' is in bytes or char.
-                SIZE_T len = strlen_u16(szName) + 1;
+                SIZE_T len = u16_strlen(szName) + 1;
                 m_szProcessName = new (nothrow) WCHAR[len];
                 if (m_szProcessName != NULL)
                 {
@@ -602,7 +602,7 @@ HRESULT AllocateAndReadRemoteString(
     if (SUCCEEDED(hr))
     {
         // Ensure that the string we just read is actually null terminated.
-        // We can't call strlen_u16() on it yet, since that may AV on a non-null terminated string.
+        // We can't call u16_strlen() on it yet, since that may AV on a non-null terminated string.
         WCHAR * pString = *ppNewLocalBuffer;
 
         if (pString[ceSize - 1] == W('\0'))
@@ -612,7 +612,7 @@ HRESULT AllocateAndReadRemoteString(
         }
         pString[ceSize - 1] = W('\0');
 
-        SIZE_T ceTestLen = strlen_u16(pString);
+        SIZE_T ceTestLen = u16_strlen(pString);
         if (ceTestLen == ceSize - 1)
         {
             // String was not previously null-terminated.

--- a/src/coreclr/debug/di/rsmda.cpp
+++ b/src/coreclr/debug/di/rsmda.cpp
@@ -105,7 +105,7 @@ HRESULT CordbMDA::QueryInterface(REFIID riid, void **ppInterface)
 HRESULT CopyOutString(LPCWSTR pInputString, ULONG32 cchName, ULONG32 * pcchName, _Out_writes_to_opt_(cchName, *pcchName) WCHAR szName[])
 {
     _ASSERTE(pInputString != NULL);
-    ULONG32 len = (ULONG32) strlen_u16(pInputString) + 1;
+    ULONG32 len = (ULONG32) u16_strlen(pInputString) + 1;
 
     if (cchName == 0)
     {

--- a/src/coreclr/debug/di/rsmda.cpp
+++ b/src/coreclr/debug/di/rsmda.cpp
@@ -105,7 +105,7 @@ HRESULT CordbMDA::QueryInterface(REFIID riid, void **ppInterface)
 HRESULT CopyOutString(LPCWSTR pInputString, ULONG32 cchName, ULONG32 * pcchName, _Out_writes_to_opt_(cchName, *pcchName) WCHAR szName[])
 {
     _ASSERTE(pInputString != NULL);
-    ULONG32 len = (ULONG32) dn_wcslen(pInputString) + 1;
+    ULONG32 len = (ULONG32) strlen_u16(pInputString) + 1;
 
     if (cchName == 0)
     {

--- a/src/coreclr/debug/di/rsmda.cpp
+++ b/src/coreclr/debug/di/rsmda.cpp
@@ -105,7 +105,7 @@ HRESULT CordbMDA::QueryInterface(REFIID riid, void **ppInterface)
 HRESULT CopyOutString(LPCWSTR pInputString, ULONG32 cchName, ULONG32 * pcchName, _Out_writes_to_opt_(cchName, *pcchName) WCHAR szName[])
 {
     _ASSERTE(pInputString != NULL);
-    ULONG32 len = (ULONG32) wcslen(pInputString) + 1;
+    ULONG32 len = (ULONG32) dn_wcslen(pInputString) + 1;
 
     if (cchName == 0)
     {

--- a/src/coreclr/debug/di/rsthread.cpp
+++ b/src/coreclr/debug/di/rsthread.cpp
@@ -9975,7 +9975,7 @@ HRESULT CordbEval::NewString(LPCWSTR string)
 {
     PUBLIC_API_ENTRY(this);
     FAIL_IF_NEUTERED(this);
-    return NewStringWithLength(string, (UINT)dn_wcslen(string));
+    return NewStringWithLength(string, (UINT)strlen_u16(string));
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/coreclr/debug/di/rsthread.cpp
+++ b/src/coreclr/debug/di/rsthread.cpp
@@ -9975,7 +9975,7 @@ HRESULT CordbEval::NewString(LPCWSTR string)
 {
     PUBLIC_API_ENTRY(this);
     FAIL_IF_NEUTERED(this);
-    return NewStringWithLength(string, (UINT)strlen_u16(string));
+    return NewStringWithLength(string, (UINT)u16_strlen(string));
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/coreclr/debug/di/rsthread.cpp
+++ b/src/coreclr/debug/di/rsthread.cpp
@@ -9975,7 +9975,7 @@ HRESULT CordbEval::NewString(LPCWSTR string)
 {
     PUBLIC_API_ENTRY(this);
     FAIL_IF_NEUTERED(this);
-    return NewStringWithLength(string, (UINT)wcslen(string));
+    return NewStringWithLength(string, (UINT)dn_wcslen(string));
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/coreclr/debug/di/symbolinfo.cpp
+++ b/src/coreclr/debug/di/symbolinfo.cpp
@@ -258,7 +258,7 @@ STDMETHODIMP SymbolInfo::GetTypeDefProps (             // S_OK or error.
         *pdwTypeDefFlags=classInfo->flags;
 
 
-    SIZE_T cch=strlen_u16(classInfo->wszName)+1;
+    SIZE_T cch=u16_strlen(classInfo->wszName)+1;
     if (cch > UINT32_MAX)
         return E_UNEXPECTED;
     *pchTypeDef=(ULONG)cch;
@@ -309,7 +309,7 @@ STDMETHODIMP SymbolInfo::GetMethodProps (
 
 
     *pClass=m_LastMethod.cls;
-    SIZE_T cch=strlen_u16(m_LastMethod.wszName)+1;
+    SIZE_T cch=u16_strlen(m_LastMethod.wszName)+1;
     if(cch > UINT32_MAX)
         return E_UNEXPECTED;
     *pchMethod=(ULONG)cch;

--- a/src/coreclr/debug/di/symbolinfo.cpp
+++ b/src/coreclr/debug/di/symbolinfo.cpp
@@ -258,7 +258,7 @@ STDMETHODIMP SymbolInfo::GetTypeDefProps (             // S_OK or error.
         *pdwTypeDefFlags=classInfo->flags;
 
 
-    SIZE_T cch=wcslen(classInfo->wszName)+1;
+    SIZE_T cch=dn_wcslen(classInfo->wszName)+1;
     if (cch > UINT32_MAX)
         return E_UNEXPECTED;
     *pchTypeDef=(ULONG)cch;
@@ -309,7 +309,7 @@ STDMETHODIMP SymbolInfo::GetMethodProps (
 
 
     *pClass=m_LastMethod.cls;
-    SIZE_T cch=wcslen(m_LastMethod.wszName)+1;
+    SIZE_T cch=dn_wcslen(m_LastMethod.wszName)+1;
     if(cch > UINT32_MAX)
         return E_UNEXPECTED;
     *pchMethod=(ULONG)cch;

--- a/src/coreclr/debug/di/symbolinfo.cpp
+++ b/src/coreclr/debug/di/symbolinfo.cpp
@@ -258,7 +258,7 @@ STDMETHODIMP SymbolInfo::GetTypeDefProps (             // S_OK or error.
         *pdwTypeDefFlags=classInfo->flags;
 
 
-    SIZE_T cch=dn_wcslen(classInfo->wszName)+1;
+    SIZE_T cch=strlen_u16(classInfo->wszName)+1;
     if (cch > UINT32_MAX)
         return E_UNEXPECTED;
     *pchTypeDef=(ULONG)cch;
@@ -309,7 +309,7 @@ STDMETHODIMP SymbolInfo::GetMethodProps (
 
 
     *pClass=m_LastMethod.cls;
-    SIZE_T cch=dn_wcslen(m_LastMethod.wszName)+1;
+    SIZE_T cch=strlen_u16(m_LastMethod.wszName)+1;
     if(cch > UINT32_MAX)
         return E_UNEXPECTED;
     *pchMethod=(ULONG)cch;

--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -8379,8 +8379,8 @@ bool DebuggerUserBreakpoint::IsFrameInDebuggerNamespace(FrameInfo * pFrame)
         {
             MAKE_WIDEPTR_FROMUTF8(wszNamespace, szNamespace); // throw
             MAKE_WIDEPTR_FROMUTF8(wszClassName, szClassName);
-            if (wcscmp(wszClassName, W("Debugger")) == 0 &&
-                wcscmp(wszNamespace, W("System.Diagnostics")) == 0)
+            if (dn_wcscmp(wszClassName, W("Debugger")) == 0 &&
+                dn_wcscmp(wszNamespace, W("System.Diagnostics")) == 0)
             {
                 // This will continue stepping
                 return true;

--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -8379,8 +8379,8 @@ bool DebuggerUserBreakpoint::IsFrameInDebuggerNamespace(FrameInfo * pFrame)
         {
             MAKE_WIDEPTR_FROMUTF8(wszNamespace, szNamespace); // throw
             MAKE_WIDEPTR_FROMUTF8(wszClassName, szClassName);
-            if (strcmp_u16(wszClassName, W("Debugger")) == 0 &&
-                strcmp_u16(wszNamespace, W("System.Diagnostics")) == 0)
+            if (u16_strcmp(wszClassName, W("Debugger")) == 0 &&
+                u16_strcmp(wszNamespace, W("System.Diagnostics")) == 0)
             {
                 // This will continue stepping
                 return true;

--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -8379,8 +8379,8 @@ bool DebuggerUserBreakpoint::IsFrameInDebuggerNamespace(FrameInfo * pFrame)
         {
             MAKE_WIDEPTR_FROMUTF8(wszNamespace, szNamespace); // throw
             MAKE_WIDEPTR_FROMUTF8(wszClassName, szClassName);
-            if (dn_wcscmp(wszClassName, W("Debugger")) == 0 &&
-                dn_wcscmp(wszNamespace, W("System.Diagnostics")) == 0)
+            if (strcmp_u16(wszClassName, W("Debugger")) == 0 &&
+                strcmp_u16(wszNamespace, W("System.Diagnostics")) == 0)
             {
                 // This will continue stepping
                 return true;

--- a/src/coreclr/debug/inc/dbgappdomain.h
+++ b/src/coreclr/debug/inc/dbgappdomain.h
@@ -43,7 +43,7 @@ struct AppDomainInfo
         else
             m_szAppDomainName = W("<NoName>");
 
-        m_iNameLengthInBytes = (int) (dn_wcslen(m_szAppDomainName) + 1) * sizeof(WCHAR);
+        m_iNameLengthInBytes = (int) (strlen_u16(m_szAppDomainName) + 1) * sizeof(WCHAR);
     }
 #endif
 };

--- a/src/coreclr/debug/inc/dbgappdomain.h
+++ b/src/coreclr/debug/inc/dbgappdomain.h
@@ -43,7 +43,7 @@ struct AppDomainInfo
         else
             m_szAppDomainName = W("<NoName>");
 
-        m_iNameLengthInBytes = (int) (strlen_u16(m_szAppDomainName) + 1) * sizeof(WCHAR);
+        m_iNameLengthInBytes = (int) (u16_strlen(m_szAppDomainName) + 1) * sizeof(WCHAR);
     }
 #endif
 };

--- a/src/coreclr/debug/inc/dbgappdomain.h
+++ b/src/coreclr/debug/inc/dbgappdomain.h
@@ -43,7 +43,7 @@ struct AppDomainInfo
         else
             m_szAppDomainName = W("<NoName>");
 
-        m_iNameLengthInBytes = (int) (wcslen(m_szAppDomainName) + 1) * sizeof(WCHAR);
+        m_iNameLengthInBytes = (int) (dn_wcslen(m_szAppDomainName) + 1) * sizeof(WCHAR);
     }
 #endif
 };

--- a/src/coreclr/debug/inc/dbgipcevents.h
+++ b/src/coreclr/debug/inc/dbgipcevents.h
@@ -870,7 +870,7 @@ template <int nMaxLengthIncludingNull>
 class MSLAYOUT EmbeddedIPCString
 {
 public:
-    // Set, caller responsibility that wcslen(pData) < nMaxLengthIncludingNull
+    // Set, caller responsibility that dn_wcslen(pData) < nMaxLengthIncludingNull
     void SetString(const WCHAR * pData)
     {
         // If the string doesn't fit into the buffer, that's an issue (and so this is a real

--- a/src/coreclr/debug/inc/dbgipcevents.h
+++ b/src/coreclr/debug/inc/dbgipcevents.h
@@ -870,7 +870,7 @@ template <int nMaxLengthIncludingNull>
 class MSLAYOUT EmbeddedIPCString
 {
 public:
-    // Set, caller responsibility that strlen_u16(pData) < nMaxLengthIncludingNull
+    // Set, caller responsibility that u16_strlen(pData) < nMaxLengthIncludingNull
     void SetString(const WCHAR * pData)
     {
         // If the string doesn't fit into the buffer, that's an issue (and so this is a real

--- a/src/coreclr/debug/inc/dbgipcevents.h
+++ b/src/coreclr/debug/inc/dbgipcevents.h
@@ -870,7 +870,7 @@ template <int nMaxLengthIncludingNull>
 class MSLAYOUT EmbeddedIPCString
 {
 public:
-    // Set, caller responsibility that dn_wcslen(pData) < nMaxLengthIncludingNull
+    // Set, caller responsibility that strlen_u16(pData) < nMaxLengthIncludingNull
     void SetString(const WCHAR * pData)
     {
         // If the string doesn't fit into the buffer, that's an issue (and so this is a real

--- a/src/coreclr/debug/inc/ddmarshalutil.h
+++ b/src/coreclr/debug/inc/ddmarshalutil.h
@@ -90,7 +90,7 @@ public:
         if (!fIsNull)
         {
             _ASSERTE(pString != NULL);
-            DWORD len = (DWORD) dn_wcslen(pString);
+            DWORD len = (DWORD) strlen_u16(pString);
             DWORD cbCopy = (len + 1) * sizeof(WCHAR);
 
             EnsureSize(cbCopy);
@@ -179,7 +179,7 @@ public:
         else
         {
             const WCHAR * pString = (WCHAR*) &m_pBuffer[m_idx];
-            DWORD len = (DWORD) dn_wcslen(pString);
+            DWORD len = (DWORD) strlen_u16(pString);
             m_idx += (len + 1) * sizeof(WCHAR); // skip past null
             _ASSERTE(m_idx <= m_size);
             return pString;

--- a/src/coreclr/debug/inc/ddmarshalutil.h
+++ b/src/coreclr/debug/inc/ddmarshalutil.h
@@ -90,7 +90,7 @@ public:
         if (!fIsNull)
         {
             _ASSERTE(pString != NULL);
-            DWORD len = (DWORD) wcslen(pString);
+            DWORD len = (DWORD) dn_wcslen(pString);
             DWORD cbCopy = (len + 1) * sizeof(WCHAR);
 
             EnsureSize(cbCopy);
@@ -179,7 +179,7 @@ public:
         else
         {
             const WCHAR * pString = (WCHAR*) &m_pBuffer[m_idx];
-            DWORD len = (DWORD) wcslen(pString);
+            DWORD len = (DWORD) dn_wcslen(pString);
             m_idx += (len + 1) * sizeof(WCHAR); // skip past null
             _ASSERTE(m_idx <= m_size);
             return pString;

--- a/src/coreclr/debug/inc/ddmarshalutil.h
+++ b/src/coreclr/debug/inc/ddmarshalutil.h
@@ -90,7 +90,7 @@ public:
         if (!fIsNull)
         {
             _ASSERTE(pString != NULL);
-            DWORD len = (DWORD) strlen_u16(pString);
+            DWORD len = (DWORD) u16_strlen(pString);
             DWORD cbCopy = (len + 1) * sizeof(WCHAR);
 
             EnsureSize(cbCopy);
@@ -179,7 +179,7 @@ public:
         else
         {
             const WCHAR * pString = (WCHAR*) &m_pBuffer[m_idx];
-            DWORD len = (DWORD) strlen_u16(pString);
+            DWORD len = (DWORD) u16_strlen(pString);
             m_idx += (len + 1) * sizeof(WCHAR); // skip past null
             _ASSERTE(m_idx <= m_size);
             return pString;

--- a/src/coreclr/debug/shared/stringcopyholder.cpp
+++ b/src/coreclr/debug/shared/stringcopyholder.cpp
@@ -68,7 +68,7 @@ HRESULT StringCopyHolder::AssignCopy(const WCHAR * pStringSrc)
     }
     else
     {
-        SIZE_T cchLen = dn_wcslen(pStringSrc) + 1;
+        SIZE_T cchLen = strlen_u16(pStringSrc) + 1;
         m_szData = new (nothrow) WCHAR[cchLen];
         if (m_szData == NULL)
         {

--- a/src/coreclr/debug/shared/stringcopyholder.cpp
+++ b/src/coreclr/debug/shared/stringcopyholder.cpp
@@ -68,7 +68,7 @@ HRESULT StringCopyHolder::AssignCopy(const WCHAR * pStringSrc)
     }
     else
     {
-        SIZE_T cchLen = wcslen(pStringSrc) + 1;
+        SIZE_T cchLen = dn_wcslen(pStringSrc) + 1;
         m_szData = new (nothrow) WCHAR[cchLen];
         if (m_szData == NULL)
         {

--- a/src/coreclr/debug/shared/stringcopyholder.cpp
+++ b/src/coreclr/debug/shared/stringcopyholder.cpp
@@ -68,7 +68,7 @@ HRESULT StringCopyHolder::AssignCopy(const WCHAR * pStringSrc)
     }
     else
     {
-        SIZE_T cchLen = strlen_u16(pStringSrc) + 1;
+        SIZE_T cchLen = u16_strlen(pStringSrc) + 1;
         m_szData = new (nothrow) WCHAR[cchLen];
         if (m_szData == NULL)
         {

--- a/src/coreclr/dlls/mscordac/CMakeLists.txt
+++ b/src/coreclr/dlls/mscordac/CMakeLists.txt
@@ -166,6 +166,7 @@ if(CLR_CMAKE_HOST_WIN32)
         oleaut32.lib
         uuid.lib
         user32.lib
+        coreclrminipal
         ${STATIC_MT_CRT_LIB}
         ${STATIC_MT_VCRT_LIB}
     )

--- a/src/coreclr/dlls/mscordac/CMakeLists.txt
+++ b/src/coreclr/dlls/mscordac/CMakeLists.txt
@@ -175,6 +175,7 @@ else(CLR_CMAKE_HOST_WIN32)
         ${START_WHOLE_ARCHIVE} # force all PAL objects to be included so all exports are available
         coreclrpal
         palrt
+        coreclrminipal
         ${END_WHOLE_ARCHIVE}
     )
 endif(CLR_CMAKE_HOST_WIN32)

--- a/src/coreclr/dlls/mscordac/mscordac_unixexports.src
+++ b/src/coreclr/dlls/mscordac/mscordac_unixexports.src
@@ -55,6 +55,7 @@ nativeStringResourceTable_mscorrc
 #PAL_fprintf
 #PAL__wcstoui64
 #PAL_wcstoul
+#PAL_wcstod
 #PAL_VirtualReserveFromExecutableMemoryAllocatorWithinRange
 #PAL_VirtualUnwindOutOfProc
 #PAL_wcslen

--- a/src/coreclr/dlls/mscoree/exports.cpp
+++ b/src/coreclr/dlls/mscoree/exports.cpp
@@ -173,7 +173,7 @@ static void ConvertConfigPropertiesToUnicode(
         else if (strcmp(propertyKeys[propertyIndex], HOST_PROPERTY_HOSTPOLICY_EMBEDDED) == 0)
         {
             // The HOSTPOLICY_EMBEDDED property indicates if the executable has hostpolicy statically linked in
-            *hostPolicyEmbedded = (wcscmp(propertyValuesW[propertyIndex], W("true")) == 0);
+            *hostPolicyEmbedded = (dn_wcscmp(propertyValuesW[propertyIndex], W("true")) == 0);
         }
         else if (strcmp(propertyKeys[propertyIndex], HOST_PROPERTY_RUNTIME_CONTRACT) == 0)
         {

--- a/src/coreclr/dlls/mscoree/exports.cpp
+++ b/src/coreclr/dlls/mscoree/exports.cpp
@@ -159,7 +159,7 @@ static void ConvertConfigPropertiesToUnicode(
             // The function in HOST_RUNTIME_CONTRACT is given priority over this property,
             // so we only set the bundle probe if it has not already been set.
             if (*bundleProbe == nullptr)
-                *bundleProbe = (BundleProbeFn*)strtoui64_u16(propertyValuesW[propertyIndex], nullptr, 0);
+                *bundleProbe = (BundleProbeFn*)u16_strtoui64(propertyValuesW[propertyIndex], nullptr, 0);
         }
         else if (strcmp(propertyKeys[propertyIndex], HOST_PROPERTY_PINVOKE_OVERRIDE) == 0)
         {
@@ -168,17 +168,17 @@ static void ConvertConfigPropertiesToUnicode(
             // The function in HOST_RUNTIME_CONTRACT is given priority over this property,
             // so we only set the p/invoke override if it has not already been set.
             if (*pinvokeOverride == nullptr)
-                *pinvokeOverride = (PInvokeOverrideFn*)strtoui64_u16(propertyValuesW[propertyIndex], nullptr, 0);
+                *pinvokeOverride = (PInvokeOverrideFn*)u16_strtoui64(propertyValuesW[propertyIndex], nullptr, 0);
         }
         else if (strcmp(propertyKeys[propertyIndex], HOST_PROPERTY_HOSTPOLICY_EMBEDDED) == 0)
         {
             // The HOSTPOLICY_EMBEDDED property indicates if the executable has hostpolicy statically linked in
-            *hostPolicyEmbedded = (strcmp_u16(propertyValuesW[propertyIndex], W("true")) == 0);
+            *hostPolicyEmbedded = (u16_strcmp(propertyValuesW[propertyIndex], W("true")) == 0);
         }
         else if (strcmp(propertyKeys[propertyIndex], HOST_PROPERTY_RUNTIME_CONTRACT) == 0)
         {
             // Host contract is passed in as the value of HOST_RUNTIME_CONTRACT property (encoded as a string).
-            host_runtime_contract* hostContractLocal = (host_runtime_contract*)strtoui64_u16(propertyValuesW[propertyIndex], nullptr, 0);
+            host_runtime_contract* hostContractLocal = (host_runtime_contract*)u16_strtoui64(propertyValuesW[propertyIndex], nullptr, 0);
             *hostContract = hostContractLocal;
 
             // Functions in HOST_RUNTIME_CONTRACT have priority over the individual properties

--- a/src/coreclr/dlls/mscoree/exports.cpp
+++ b/src/coreclr/dlls/mscoree/exports.cpp
@@ -159,7 +159,7 @@ static void ConvertConfigPropertiesToUnicode(
             // The function in HOST_RUNTIME_CONTRACT is given priority over this property,
             // so we only set the bundle probe if it has not already been set.
             if (*bundleProbe == nullptr)
-                *bundleProbe = (BundleProbeFn*)_wcstoui64(propertyValuesW[propertyIndex], nullptr, 0);
+                *bundleProbe = (BundleProbeFn*)dn_wcstoui64(propertyValuesW[propertyIndex], nullptr, 0);
         }
         else if (strcmp(propertyKeys[propertyIndex], HOST_PROPERTY_PINVOKE_OVERRIDE) == 0)
         {
@@ -168,7 +168,7 @@ static void ConvertConfigPropertiesToUnicode(
             // The function in HOST_RUNTIME_CONTRACT is given priority over this property,
             // so we only set the p/invoke override if it has not already been set.
             if (*pinvokeOverride == nullptr)
-                *pinvokeOverride = (PInvokeOverrideFn*)_wcstoui64(propertyValuesW[propertyIndex], nullptr, 0);
+                *pinvokeOverride = (PInvokeOverrideFn*)dn_wcstoui64(propertyValuesW[propertyIndex], nullptr, 0);
         }
         else if (strcmp(propertyKeys[propertyIndex], HOST_PROPERTY_HOSTPOLICY_EMBEDDED) == 0)
         {
@@ -178,7 +178,7 @@ static void ConvertConfigPropertiesToUnicode(
         else if (strcmp(propertyKeys[propertyIndex], HOST_PROPERTY_RUNTIME_CONTRACT) == 0)
         {
             // Host contract is passed in as the value of HOST_RUNTIME_CONTRACT property (encoded as a string).
-            host_runtime_contract* hostContractLocal = (host_runtime_contract*)_wcstoui64(propertyValuesW[propertyIndex], nullptr, 0);
+            host_runtime_contract* hostContractLocal = (host_runtime_contract*)dn_wcstoui64(propertyValuesW[propertyIndex], nullptr, 0);
             *hostContract = hostContractLocal;
 
             // Functions in HOST_RUNTIME_CONTRACT have priority over the individual properties

--- a/src/coreclr/dlls/mscoree/exports.cpp
+++ b/src/coreclr/dlls/mscoree/exports.cpp
@@ -159,7 +159,7 @@ static void ConvertConfigPropertiesToUnicode(
             // The function in HOST_RUNTIME_CONTRACT is given priority over this property,
             // so we only set the bundle probe if it has not already been set.
             if (*bundleProbe == nullptr)
-                *bundleProbe = (BundleProbeFn*)dn_wcstoui64(propertyValuesW[propertyIndex], nullptr, 0);
+                *bundleProbe = (BundleProbeFn*)strtoui64_u16(propertyValuesW[propertyIndex], nullptr, 0);
         }
         else if (strcmp(propertyKeys[propertyIndex], HOST_PROPERTY_PINVOKE_OVERRIDE) == 0)
         {
@@ -168,17 +168,17 @@ static void ConvertConfigPropertiesToUnicode(
             // The function in HOST_RUNTIME_CONTRACT is given priority over this property,
             // so we only set the p/invoke override if it has not already been set.
             if (*pinvokeOverride == nullptr)
-                *pinvokeOverride = (PInvokeOverrideFn*)dn_wcstoui64(propertyValuesW[propertyIndex], nullptr, 0);
+                *pinvokeOverride = (PInvokeOverrideFn*)strtoui64_u16(propertyValuesW[propertyIndex], nullptr, 0);
         }
         else if (strcmp(propertyKeys[propertyIndex], HOST_PROPERTY_HOSTPOLICY_EMBEDDED) == 0)
         {
             // The HOSTPOLICY_EMBEDDED property indicates if the executable has hostpolicy statically linked in
-            *hostPolicyEmbedded = (dn_wcscmp(propertyValuesW[propertyIndex], W("true")) == 0);
+            *hostPolicyEmbedded = (strcmp_u16(propertyValuesW[propertyIndex], W("true")) == 0);
         }
         else if (strcmp(propertyKeys[propertyIndex], HOST_PROPERTY_RUNTIME_CONTRACT) == 0)
         {
             // Host contract is passed in as the value of HOST_RUNTIME_CONTRACT property (encoded as a string).
-            host_runtime_contract* hostContractLocal = (host_runtime_contract*)dn_wcstoui64(propertyValuesW[propertyIndex], nullptr, 0);
+            host_runtime_contract* hostContractLocal = (host_runtime_contract*)strtoui64_u16(propertyValuesW[propertyIndex], nullptr, 0);
             *hostContract = hostContractLocal;
 
             // Functions in HOST_RUNTIME_CONTRACT have priority over the individual properties

--- a/src/coreclr/dlls/mscorpe/ceefilegenwriter.cpp
+++ b/src/coreclr/dlls/mscorpe/ceefilegenwriter.cpp
@@ -490,7 +490,7 @@ HRESULT CeeFileGenWriter::setOutputFileName(_In_ LPWSTR fileName)
 {
     if (m_outputFileName)
         delete[] m_outputFileName;
-    size_t len = strlen_u16(fileName) + 1;
+    size_t len = u16_strlen(fileName) + 1;
     m_outputFileName = (LPWSTR)new (nothrow) WCHAR[len];
     TESTANDRETURN(m_outputFileName!=NULL, E_OUTOFMEMORY);
     wcscpy_s(m_outputFileName, len, fileName);
@@ -501,7 +501,7 @@ HRESULT CeeFileGenWriter::setResourceFileName(_In_ LPWSTR fileName)
 {
     if (m_resourceFileName)
         delete[] m_resourceFileName;
-    size_t len = strlen_u16(fileName) + 1;
+    size_t len = u16_strlen(fileName) + 1;
     m_resourceFileName = (LPWSTR)new (nothrow) WCHAR[len];
     TESTANDRETURN(m_resourceFileName!=NULL, E_OUTOFMEMORY);
     wcscpy_s(m_resourceFileName, len, fileName);

--- a/src/coreclr/dlls/mscorpe/ceefilegenwriter.cpp
+++ b/src/coreclr/dlls/mscorpe/ceefilegenwriter.cpp
@@ -490,7 +490,7 @@ HRESULT CeeFileGenWriter::setOutputFileName(_In_ LPWSTR fileName)
 {
     if (m_outputFileName)
         delete[] m_outputFileName;
-    size_t len = dn_wcslen(fileName) + 1;
+    size_t len = strlen_u16(fileName) + 1;
     m_outputFileName = (LPWSTR)new (nothrow) WCHAR[len];
     TESTANDRETURN(m_outputFileName!=NULL, E_OUTOFMEMORY);
     wcscpy_s(m_outputFileName, len, fileName);
@@ -501,7 +501,7 @@ HRESULT CeeFileGenWriter::setResourceFileName(_In_ LPWSTR fileName)
 {
     if (m_resourceFileName)
         delete[] m_resourceFileName;
-    size_t len = dn_wcslen(fileName) + 1;
+    size_t len = strlen_u16(fileName) + 1;
     m_resourceFileName = (LPWSTR)new (nothrow) WCHAR[len];
     TESTANDRETURN(m_resourceFileName!=NULL, E_OUTOFMEMORY);
     wcscpy_s(m_resourceFileName, len, fileName);

--- a/src/coreclr/dlls/mscorpe/ceefilegenwriter.cpp
+++ b/src/coreclr/dlls/mscorpe/ceefilegenwriter.cpp
@@ -490,7 +490,7 @@ HRESULT CeeFileGenWriter::setOutputFileName(_In_ LPWSTR fileName)
 {
     if (m_outputFileName)
         delete[] m_outputFileName;
-    size_t len = wcslen(fileName) + 1;
+    size_t len = dn_wcslen(fileName) + 1;
     m_outputFileName = (LPWSTR)new (nothrow) WCHAR[len];
     TESTANDRETURN(m_outputFileName!=NULL, E_OUTOFMEMORY);
     wcscpy_s(m_outputFileName, len, fileName);
@@ -501,7 +501,7 @@ HRESULT CeeFileGenWriter::setResourceFileName(_In_ LPWSTR fileName)
 {
     if (m_resourceFileName)
         delete[] m_resourceFileName;
-    size_t len = wcslen(fileName) + 1;
+    size_t len = dn_wcslen(fileName) + 1;
     m_resourceFileName = (LPWSTR)new (nothrow) WCHAR[len];
     TESTANDRETURN(m_resourceFileName!=NULL, E_OUTOFMEMORY);
     wcscpy_s(m_resourceFileName, len, fileName);

--- a/src/coreclr/gc/env/gcenv.base.h
+++ b/src/coreclr/gc/env/gcenv.base.h
@@ -121,10 +121,8 @@ inline HRESULT HRESULT_FROM_WIN32(unsigned long x)
 #endif
 
 #ifdef UNICODE
-#define _tcscpy wcscpy
 #define _tfopen _wfopen
 #else
-#define _tcscpy strcpy
 #define _tfopen fopen
 #endif
 

--- a/src/coreclr/gc/env/gcenv.base.h
+++ b/src/coreclr/gc/env/gcenv.base.h
@@ -121,11 +121,9 @@ inline HRESULT HRESULT_FROM_WIN32(unsigned long x)
 #endif
 
 #ifdef UNICODE
-#define _tcslen wcslen
 #define _tcscpy wcscpy
 #define _tfopen _wfopen
 #else
-#define _tcslen strlen
 #define _tcscpy strcpy
 #define _tfopen fopen
 #endif

--- a/src/coreclr/ilasm/CMakeLists.txt
+++ b/src/coreclr/ilasm/CMakeLists.txt
@@ -97,6 +97,7 @@ if(CLR_CMAKE_TARGET_WIN32)
         shlwapi.lib
         bcrypt.lib
         RuntimeObject.lib
+        coreclrminipal
     )
 else()
     list(APPEND ILASM_LINK_LIBRARIES

--- a/src/coreclr/ilasm/CMakeLists.txt
+++ b/src/coreclr/ilasm/CMakeLists.txt
@@ -103,6 +103,7 @@ else()
         coreclrpal
         mscorrc
         palrt
+        coreclrminipal
     )
 endif(CLR_CMAKE_TARGET_WIN32)
 

--- a/src/coreclr/ilasm/asmman.cpp
+++ b/src/coreclr/ilasm/asmman.cpp
@@ -28,10 +28,10 @@ BinStr* BinStrToUnicode(BinStr* pSource, bool Swap)
             {
                 memset(wz,0,L);
                 WszMultiByteToWideChar(g_uCodePage,0,pb,-1,wz,l);
-                tmp->remove(L-(DWORD)wcslen(wz)*sizeof(WCHAR));
+                tmp->remove(L-(DWORD)dn_wcslen(wz)*sizeof(WCHAR));
 #if BIGENDIAN
                 if (Swap)
-                    SwapStringLength(wz, (DWORD)wcslen(wz));
+                    SwapStringLength(wz, (DWORD)dn_wcslen(wz));
 #endif
                 delete pSource;
             }
@@ -994,8 +994,8 @@ HRESULT AsmMan::EmitManifest()
                         else
                         {
                             m_dwMResSizeTotal += m_dwMResSize[m_dwMResNum]+sizeof(DWORD);
-                            m_wzMResName[m_dwMResNum] = new WCHAR[wcslen(wzFileName)+1];
-                            wcscpy_s(m_wzMResName[m_dwMResNum],wcslen(wzFileName)+1,wzFileName);
+                            m_wzMResName[m_dwMResNum] = new WCHAR[dn_wcslen(wzFileName)+1];
+                            wcscpy_s(m_wzMResName[m_dwMResNum],dn_wcslen(wzFileName)+1,wzFileName);
                             m_fMResNew[m_dwMResNum] = TRUE;
                             m_dwMResNum++;
                         }

--- a/src/coreclr/ilasm/asmman.cpp
+++ b/src/coreclr/ilasm/asmman.cpp
@@ -28,10 +28,10 @@ BinStr* BinStrToUnicode(BinStr* pSource, bool Swap)
             {
                 memset(wz,0,L);
                 WszMultiByteToWideChar(g_uCodePage,0,pb,-1,wz,l);
-                tmp->remove(L-(DWORD)strlen_u16(wz)*sizeof(WCHAR));
+                tmp->remove(L-(DWORD)u16_strlen(wz)*sizeof(WCHAR));
 #if BIGENDIAN
                 if (Swap)
-                    SwapStringLength(wz, (DWORD)strlen_u16(wz));
+                    SwapStringLength(wz, (DWORD)u16_strlen(wz));
 #endif
                 delete pSource;
             }
@@ -961,9 +961,9 @@ HRESULT AsmMan::EmitManifest()
                 for(j=0; (hFile == INVALID_HANDLE_VALUE)&&(pwzInputFiles[j] != NULL); j++)
                 {
                     wcscpy_s(wzFileName,2048,pwzInputFiles[j]);
-                    pwz = (WCHAR*)strrchr_u16(wzFileName,DIRECTORY_SEPARATOR_CHAR_A);
+                    pwz = (WCHAR*)u16_strrchr(wzFileName,DIRECTORY_SEPARATOR_CHAR_A);
 #ifdef TARGET_WINDOWS
-                    if(pwz == NULL) pwz = (WCHAR*)strrchr_u16(wzFileName,':');
+                    if(pwz == NULL) pwz = (WCHAR*)u16_strrchr(wzFileName,':');
 #endif
                     if(pwz == NULL) pwz = &wzFileName[0];
                     else pwz++;
@@ -994,8 +994,8 @@ HRESULT AsmMan::EmitManifest()
                         else
                         {
                             m_dwMResSizeTotal += m_dwMResSize[m_dwMResNum]+sizeof(DWORD);
-                            m_wzMResName[m_dwMResNum] = new WCHAR[strlen_u16(wzFileName)+1];
-                            wcscpy_s(m_wzMResName[m_dwMResNum],strlen_u16(wzFileName)+1,wzFileName);
+                            m_wzMResName[m_dwMResNum] = new WCHAR[u16_strlen(wzFileName)+1];
+                            wcscpy_s(m_wzMResName[m_dwMResNum],u16_strlen(wzFileName)+1,wzFileName);
                             m_fMResNew[m_dwMResNum] = TRUE;
                             m_dwMResNum++;
                         }

--- a/src/coreclr/ilasm/asmman.cpp
+++ b/src/coreclr/ilasm/asmman.cpp
@@ -28,10 +28,10 @@ BinStr* BinStrToUnicode(BinStr* pSource, bool Swap)
             {
                 memset(wz,0,L);
                 WszMultiByteToWideChar(g_uCodePage,0,pb,-1,wz,l);
-                tmp->remove(L-(DWORD)dn_wcslen(wz)*sizeof(WCHAR));
+                tmp->remove(L-(DWORD)strlen_u16(wz)*sizeof(WCHAR));
 #if BIGENDIAN
                 if (Swap)
-                    SwapStringLength(wz, (DWORD)dn_wcslen(wz));
+                    SwapStringLength(wz, (DWORD)strlen_u16(wz));
 #endif
                 delete pSource;
             }
@@ -961,9 +961,9 @@ HRESULT AsmMan::EmitManifest()
                 for(j=0; (hFile == INVALID_HANDLE_VALUE)&&(pwzInputFiles[j] != NULL); j++)
                 {
                     wcscpy_s(wzFileName,2048,pwzInputFiles[j]);
-                    pwz = (WCHAR*)dn_wcsrchr(wzFileName,DIRECTORY_SEPARATOR_CHAR_A);
+                    pwz = (WCHAR*)strrchr_u16(wzFileName,DIRECTORY_SEPARATOR_CHAR_A);
 #ifdef TARGET_WINDOWS
-                    if(pwz == NULL) pwz = (WCHAR*)dn_wcsrchr(wzFileName,':');
+                    if(pwz == NULL) pwz = (WCHAR*)strrchr_u16(wzFileName,':');
 #endif
                     if(pwz == NULL) pwz = &wzFileName[0];
                     else pwz++;
@@ -994,8 +994,8 @@ HRESULT AsmMan::EmitManifest()
                         else
                         {
                             m_dwMResSizeTotal += m_dwMResSize[m_dwMResNum]+sizeof(DWORD);
-                            m_wzMResName[m_dwMResNum] = new WCHAR[dn_wcslen(wzFileName)+1];
-                            wcscpy_s(m_wzMResName[m_dwMResNum],dn_wcslen(wzFileName)+1,wzFileName);
+                            m_wzMResName[m_dwMResNum] = new WCHAR[strlen_u16(wzFileName)+1];
+                            wcscpy_s(m_wzMResName[m_dwMResNum],strlen_u16(wzFileName)+1,wzFileName);
                             m_fMResNew[m_dwMResNum] = TRUE;
                             m_dwMResNum++;
                         }

--- a/src/coreclr/ilasm/asmman.cpp
+++ b/src/coreclr/ilasm/asmman.cpp
@@ -961,9 +961,9 @@ HRESULT AsmMan::EmitManifest()
                 for(j=0; (hFile == INVALID_HANDLE_VALUE)&&(pwzInputFiles[j] != NULL); j++)
                 {
                     wcscpy_s(wzFileName,2048,pwzInputFiles[j]);
-                    pwz = wcsrchr(wzFileName,DIRECTORY_SEPARATOR_CHAR_A);
+                    pwz = dn_wcsrchr(wzFileName,DIRECTORY_SEPARATOR_CHAR_A);
 #ifdef TARGET_WINDOWS
-                    if(pwz == NULL) pwz = wcsrchr(wzFileName,':');
+                    if(pwz == NULL) pwz = dn_wcsrchr(wzFileName,':');
 #endif
                     if(pwz == NULL) pwz = &wzFileName[0];
                     else pwz++;

--- a/src/coreclr/ilasm/asmman.cpp
+++ b/src/coreclr/ilasm/asmman.cpp
@@ -961,9 +961,9 @@ HRESULT AsmMan::EmitManifest()
                 for(j=0; (hFile == INVALID_HANDLE_VALUE)&&(pwzInputFiles[j] != NULL); j++)
                 {
                     wcscpy_s(wzFileName,2048,pwzInputFiles[j]);
-                    pwz = dn_wcsrchr(wzFileName,DIRECTORY_SEPARATOR_CHAR_A);
+                    pwz = (WCHAR*)dn_wcsrchr(wzFileName,DIRECTORY_SEPARATOR_CHAR_A);
 #ifdef TARGET_WINDOWS
-                    if(pwz == NULL) pwz = dn_wcsrchr(wzFileName,':');
+                    if(pwz == NULL) pwz = (WCHAR*)dn_wcsrchr(wzFileName,':');
 #endif
                     if(pwz == NULL) pwz = &wzFileName[0];
                     else pwz++;

--- a/src/coreclr/ilasm/assem.cpp
+++ b/src/coreclr/ilasm/assem.cpp
@@ -665,7 +665,7 @@ BOOL Assembler::EmitMethod(Method *pMethod)
 
     if(IsMdPrivateScope(pMethod->m_Attr))
     {
-        WCHAR* p = (WCHAR*)dn_wcsstr(wzMemberName,W("$PST06"));
+        WCHAR* p = (WCHAR*)strstr_u16(wzMemberName,W("$PST06"));
         if(p) *p = W('\0');
     }
 
@@ -1106,7 +1106,7 @@ BOOL Assembler::EmitClass(Class *pClass)
 
     WszMultiByteToWideChar(g_uCodePage,0,szFullName,-1,wzFullName,dwUniBuf);
 
-    L = dn_wcslen(wzFullName);
+    L = strlen_u16(wzFullName);
     if((L==0)||(wzFullName[L-1]==L'.')) // Missing class name!
     {
         wcscat_s(wzFullName,dwUniBuf,W("$UNNAMED_TYPE$"));

--- a/src/coreclr/ilasm/assem.cpp
+++ b/src/coreclr/ilasm/assem.cpp
@@ -665,7 +665,7 @@ BOOL Assembler::EmitMethod(Method *pMethod)
 
     if(IsMdPrivateScope(pMethod->m_Attr))
     {
-        WCHAR* p = (WCHAR*)strstr_u16(wzMemberName,W("$PST06"));
+        WCHAR* p = (WCHAR*)u16_strstr(wzMemberName,W("$PST06"));
         if(p) *p = W('\0');
     }
 
@@ -1106,7 +1106,7 @@ BOOL Assembler::EmitClass(Class *pClass)
 
     WszMultiByteToWideChar(g_uCodePage,0,szFullName,-1,wzFullName,dwUniBuf);
 
-    L = strlen_u16(wzFullName);
+    L = u16_strlen(wzFullName);
     if((L==0)||(wzFullName[L-1]==L'.')) // Missing class name!
     {
         wcscat_s(wzFullName,dwUniBuf,W("$UNNAMED_TYPE$"));

--- a/src/coreclr/ilasm/assem.cpp
+++ b/src/coreclr/ilasm/assem.cpp
@@ -1106,7 +1106,7 @@ BOOL Assembler::EmitClass(Class *pClass)
 
     WszMultiByteToWideChar(g_uCodePage,0,szFullName,-1,wzFullName,dwUniBuf);
 
-    L = wcslen(wzFullName);
+    L = dn_wcslen(wzFullName);
     if((L==0)||(wzFullName[L-1]==L'.')) // Missing class name!
     {
         wcscat_s(wzFullName,dwUniBuf,W("$UNNAMED_TYPE$"));

--- a/src/coreclr/ilasm/assem.cpp
+++ b/src/coreclr/ilasm/assem.cpp
@@ -665,8 +665,8 @@ BOOL Assembler::EmitMethod(Method *pMethod)
 
     if(IsMdPrivateScope(pMethod->m_Attr))
     {
-        WCHAR* p = wcsstr(wzMemberName,W("$PST06"));
-        if(p) *p = 0;
+        WCHAR* p = (WCHAR*)dn_wcsstr(wzMemberName,W("$PST06"));
+        if(p) *p = W('\0');
     }
 
     if (FAILED(m_pEmitter->DefineMethod(ClassToken,       // parent class

--- a/src/coreclr/ilasm/assembler.cpp
+++ b/src/coreclr/ilasm/assembler.cpp
@@ -927,8 +927,8 @@ BOOL Assembler::EmitField(FieldDescriptor* pFD)
     WszMultiByteToWideChar(g_uCodePage,0,pFD->m_szName,-1,wzFieldName,dwUniBuf); //int)cFieldNameLength);
     if(IsFdPrivateScope(pFD->m_dwAttr))
     {
-        WCHAR* p = wcsstr(wzFieldName,W("$PST04"));
-        if(p) *p = 0;
+        WCHAR* p = (WCHAR*)dn_wcsstr(wzFieldName,W("$PST04"));
+        if(p) *p = W('\0');
     }
 
     if(pFD->m_pbsValue && pFD->m_pbsValue->length())

--- a/src/coreclr/ilasm/assembler.cpp
+++ b/src/coreclr/ilasm/assembler.cpp
@@ -927,7 +927,7 @@ BOOL Assembler::EmitField(FieldDescriptor* pFD)
     WszMultiByteToWideChar(g_uCodePage,0,pFD->m_szName,-1,wzFieldName,dwUniBuf); //int)cFieldNameLength);
     if(IsFdPrivateScope(pFD->m_dwAttr))
     {
-        WCHAR* p = (WCHAR*)dn_wcsstr(wzFieldName,W("$PST04"));
+        WCHAR* p = (WCHAR*)strstr_u16(wzFieldName,W("$PST04"));
         if(p) *p = W('\0');
     }
 

--- a/src/coreclr/ilasm/assembler.cpp
+++ b/src/coreclr/ilasm/assembler.cpp
@@ -927,7 +927,7 @@ BOOL Assembler::EmitField(FieldDescriptor* pFD)
     WszMultiByteToWideChar(g_uCodePage,0,pFD->m_szName,-1,wzFieldName,dwUniBuf); //int)cFieldNameLength);
     if(IsFdPrivateScope(pFD->m_dwAttr))
     {
-        WCHAR* p = (WCHAR*)strstr_u16(wzFieldName,W("$PST04"));
+        WCHAR* p = (WCHAR*)u16_strstr(wzFieldName,W("$PST04"));
         if(p) *p = W('\0');
     }
 

--- a/src/coreclr/ilasm/class.hpp
+++ b/src/coreclr/ilasm/class.hpp
@@ -83,7 +83,7 @@ public:
         int i,retval=-1;
         for(i=0; i < (int)m_NumTyPars; i++)
         {
-            if(!wcscmp(wz,m_TyPars[i].Name()))
+            if(!dn_wcscmp(wz,m_TyPars[i].Name()))
             {
                 retval = i;
                 break;

--- a/src/coreclr/ilasm/class.hpp
+++ b/src/coreclr/ilasm/class.hpp
@@ -83,7 +83,7 @@ public:
         int i,retval=-1;
         for(i=0; i < (int)m_NumTyPars; i++)
         {
-            if(!dn_wcscmp(wz,m_TyPars[i].Name()))
+            if(!strcmp_u16(wz,m_TyPars[i].Name()))
             {
                 retval = i;
                 break;

--- a/src/coreclr/ilasm/class.hpp
+++ b/src/coreclr/ilasm/class.hpp
@@ -83,7 +83,7 @@ public:
         int i,retval=-1;
         for(i=0; i < (int)m_NumTyPars; i++)
         {
-            if(!strcmp_u16(wz,m_TyPars[i].Name()))
+            if(!u16_strcmp(wz,m_TyPars[i].Name()))
             {
                 retval = i;
                 break;

--- a/src/coreclr/ilasm/grammar_after.cpp
+++ b/src/coreclr/ilasm/grammar_after.cpp
@@ -153,7 +153,7 @@ unsigned GetDoubleW(_In_ __nullterminated char* begNum, unsigned L, double** ppR
     memcpy(dbuff,begNum,L);
     dbuff[L] = 0;
     dbuff[L+1] = 0;
-    *ppRes = new double(strtod_u16((const WCHAR*)dbuff, (WCHAR**)&pdummy));
+    *ppRes = new double(u16_strtod((const WCHAR*)dbuff, (WCHAR**)&pdummy));
     return ((unsigned)(pdummy - dbuff));
 }
 /*--------------------------------------------------------------------------*/
@@ -978,9 +978,9 @@ Its_An_Id:
                             if(wzFile != NULL)
                             {
                                 if((parser->wzIncludePath != NULL)
-                                 &&(strchr_u16(wzFile,DIRECTORY_SEPARATOR_CHAR_A)==NULL)
+                                 &&(u16_strchr(wzFile,DIRECTORY_SEPARATOR_CHAR_A)==NULL)
 #ifdef TARGET_WINDOWS
-                                 &&(strchr_u16(wzFile,':')==NULL)
+                                 &&(u16_strchr(wzFile,':')==NULL)
 #endif
                                 )
                                 {

--- a/src/coreclr/ilasm/grammar_after.cpp
+++ b/src/coreclr/ilasm/grammar_after.cpp
@@ -153,7 +153,7 @@ unsigned GetDoubleW(_In_ __nullterminated char* begNum, unsigned L, double** ppR
     memcpy(dbuff,begNum,L);
     dbuff[L] = 0;
     dbuff[L+1] = 0;
-    *ppRes = new double(wcstod((const WCHAR*)dbuff, (WCHAR**)&pdummy));
+    *ppRes = new double(dn_wcstod((const WCHAR*)dbuff, (WCHAR**)&pdummy));
     return ((unsigned)(pdummy - dbuff));
 }
 /*--------------------------------------------------------------------------*/

--- a/src/coreclr/ilasm/grammar_after.cpp
+++ b/src/coreclr/ilasm/grammar_after.cpp
@@ -978,9 +978,9 @@ Its_An_Id:
                             if(wzFile != NULL)
                             {
                                 if((parser->wzIncludePath != NULL)
-                                 &&(wcschr(wzFile,DIRECTORY_SEPARATOR_CHAR_A)==NULL)
+                                 &&(dn_wcschr(wzFile,DIRECTORY_SEPARATOR_CHAR_A)==NULL)
 #ifdef TARGET_WINDOWS
-                                 &&(wcschr(wzFile,':')==NULL)
+                                 &&(dn_wcschr(wzFile,':')==NULL)
 #endif
                                 )
                                 {

--- a/src/coreclr/ilasm/grammar_after.cpp
+++ b/src/coreclr/ilasm/grammar_after.cpp
@@ -153,7 +153,7 @@ unsigned GetDoubleW(_In_ __nullterminated char* begNum, unsigned L, double** ppR
     memcpy(dbuff,begNum,L);
     dbuff[L] = 0;
     dbuff[L+1] = 0;
-    *ppRes = new double(dn_wcstod((const WCHAR*)dbuff, (WCHAR**)&pdummy));
+    *ppRes = new double(strtod_u16((const WCHAR*)dbuff, (WCHAR**)&pdummy));
     return ((unsigned)(pdummy - dbuff));
 }
 /*--------------------------------------------------------------------------*/
@@ -978,9 +978,9 @@ Its_An_Id:
                             if(wzFile != NULL)
                             {
                                 if((parser->wzIncludePath != NULL)
-                                 &&(dn_wcschr(wzFile,DIRECTORY_SEPARATOR_CHAR_A)==NULL)
+                                 &&(strchr_u16(wzFile,DIRECTORY_SEPARATOR_CHAR_A)==NULL)
 #ifdef TARGET_WINDOWS
-                                 &&(dn_wcschr(wzFile,':')==NULL)
+                                 &&(strchr_u16(wzFile,':')==NULL)
 #endif
                                 )
                                 {

--- a/src/coreclr/ilasm/main.cpp
+++ b/src/coreclr/ilasm/main.cpp
@@ -16,8 +16,8 @@
 
 WCHAR* EqualOrColon(_In_ __nullterminated WCHAR* szArg)
 {
-    WCHAR* pchE = dn_wcschr(szArg,W('='));
-    WCHAR* pchC = dn_wcschr(szArg,W(':'));
+    WCHAR* pchE = (WCHAR*)dn_wcschr(szArg,W('='));
+    WCHAR* pchC = (WCHAR*)dn_wcschr(szArg,W(':'));
     WCHAR* ret;
     if(pchE == NULL) ret = pchC;
     else if(pchC == NULL) ret = pchE;
@@ -632,7 +632,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
             if (pAsm->m_fGeneratePDB)
             {
                 wcscpy_s(wzPdbFilename, MAX_FILENAME_LENGTH, wzOutputFilename);
-                WCHAR* extPos = dn_wcsrchr(wzPdbFilename, W('.'));
+                WCHAR* extPos = (WCHAR*)dn_wcsrchr(wzPdbFilename, W('.'));
                 if (extPos != NULL)
                     *extPos = 0;
                 wcscat_s(wzPdbFilename, MAX_FILENAME_LENGTH, W(".pdb"));
@@ -834,7 +834,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
     if (exitval || !bGeneratePdb)
     {
         // PE file was not created, or no debug info required. Kill PDB if any
-        WCHAR* pc = dn_wcsrchr(wzOutputFilename,W('.'));
+        WCHAR* pc = (WCHAR*)dn_wcsrchr(wzOutputFilename,W('.'));
         if(pc==NULL)
         {
             pc = &wzOutputFilename[dn_wcslen(wzOutputFilename)];

--- a/src/coreclr/ilasm/main.cpp
+++ b/src/coreclr/ilasm/main.cpp
@@ -632,7 +632,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
             if (pAsm->m_fGeneratePDB)
             {
                 wcscpy_s(wzPdbFilename, MAX_FILENAME_LENGTH, wzOutputFilename);
-                WCHAR* extPos = wcsrchr(wzPdbFilename, W('.'));
+                WCHAR* extPos = dn_wcsrchr(wzPdbFilename, W('.'));
                 if (extPos != NULL)
                     *extPos = 0;
                 wcscat_s(wzPdbFilename, MAX_FILENAME_LENGTH, W(".pdb"));
@@ -834,7 +834,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
     if (exitval || !bGeneratePdb)
     {
         // PE file was not created, or no debug info required. Kill PDB if any
-        WCHAR* pc = wcsrchr(wzOutputFilename,W('.'));
+        WCHAR* pc = dn_wcsrchr(wzOutputFilename,W('.'));
         if(pc==NULL)
         {
             pc = &wzOutputFilename[wcslen(wzOutputFilename)];

--- a/src/coreclr/ilasm/main.cpp
+++ b/src/coreclr/ilasm/main.cpp
@@ -161,7 +161,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
 #pragma warning(push)
 #pragma warning(disable:26000) // "Suppress prefast warning about index overflow"
 #endif
-    if (! wcscmp(argv[1], W("/?")) || ! wcscmp(argv[1],W("-?")))
+    if (! dn_wcscmp(argv[1], W("/?")) || ! dn_wcscmp(argv[1],W("-?")))
 #ifdef _PREFAST_
 #pragma warning(pop)
 #endif

--- a/src/coreclr/ilasm/main.cpp
+++ b/src/coreclr/ilasm/main.cpp
@@ -16,8 +16,8 @@
 
 WCHAR* EqualOrColon(_In_ __nullterminated WCHAR* szArg)
 {
-    WCHAR* pchE = wcschr(szArg,W('='));
-    WCHAR* pchC = wcschr(szArg,W(':'));
+    WCHAR* pchE = dn_wcschr(szArg,W('='));
+    WCHAR* pchC = dn_wcschr(szArg,W(':'));
     WCHAR* ret;
     if(pchE == NULL) ret = pchC;
     else if(pchC == NULL) ret = pchE;

--- a/src/coreclr/ilasm/main.cpp
+++ b/src/coreclr/ilasm/main.cpp
@@ -16,8 +16,8 @@
 
 WCHAR* EqualOrColon(_In_ __nullterminated WCHAR* szArg)
 {
-    WCHAR* pchE = (WCHAR*)dn_wcschr(szArg,W('='));
-    WCHAR* pchC = (WCHAR*)dn_wcschr(szArg,W(':'));
+    WCHAR* pchE = (WCHAR*)strchr_u16(szArg,W('='));
+    WCHAR* pchC = (WCHAR*)strchr_u16(szArg,W(':'));
     WCHAR* ret;
     if(pchE == NULL) ret = pchC;
     else if(pchC == NULL) ret = pchE;
@@ -34,7 +34,7 @@ class NarrowForNumberParsing final
 public:
     NarrowForNumberParsing(const WCHAR* str)
     {
-        size_t len = dn_wcslen(str);
+        size_t len = strlen_u16(str);
         _buffer = (char*)malloc(len + 1);
         for (size_t i = 0; i < len; ++i)
             _buffer[i] = (char)str[i];
@@ -83,7 +83,7 @@ void MakeProperSourceFileName(_In_ __nullterminated WCHAR* wzOrigName,
                               _Out_writes_(MAX_FILENAME_LENGTH*3) char* szProperName)
 {
     wcscpy_s(wzProperName,MAX_FILENAME_LENGTH, wzOrigName);
-    size_t j = dn_wcslen(wzProperName);
+    size_t j = strlen_u16(wzProperName);
     do
     {
         j--;
@@ -161,7 +161,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
 #pragma warning(push)
 #pragma warning(disable:26000) // "Suppress prefast warning about index overflow"
 #endif
-    if (! dn_wcscmp(argv[1], W("/?")) || ! dn_wcscmp(argv[1],W("-?")))
+    if (! strcmp_u16(argv[1], W("/?")) || ! strcmp_u16(argv[1],W("-?")))
 #ifdef _PREFAST_
 #pragma warning(pop)
 #endif
@@ -267,7 +267,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                       if(pStr != NULL)
                       {
                           for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                          if(dn_wcslen(pStr)==0) goto InvalidOption; //if no suboption
+                          if(strlen_u16(pStr)==0) goto InvalidOption; //if no suboption
                           else
                           {
                               WCHAR wzSubOpt[8];
@@ -381,7 +381,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                             WCHAR *pStr = EqualOrColon(argv[i]);
                             if(pStr == NULL) goto ErrorExit;
                             for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                            if(dn_wcslen(pStr)==0) goto InvalidOption; //if no file name
+                            if(strlen_u16(pStr)==0) goto InvalidOption; //if no file name
                             pAsm->m_wzResourceFile = pStr;
                         }
                         else
@@ -392,7 +392,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                         WCHAR *pStr = EqualOrColon(argv[i]);
                         if(pStr == NULL) goto InvalidOption;
                         for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                        if(dn_wcslen(pStr)==0) goto InvalidOption; //if no file name
+                        if(strlen_u16(pStr)==0) goto InvalidOption; //if no file name
                         pAsm->m_wzKeySourceName = pStr;
                     }
                     else if (!_stricmp(szOpt, "INC"))
@@ -400,7 +400,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                         WCHAR *pStr = EqualOrColon(argv[i]);
                         if(pStr == NULL) goto InvalidOption;
                         for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                        if(dn_wcslen(pStr)==0) goto InvalidOption; //if no file name
+                        if(strlen_u16(pStr)==0) goto InvalidOption; //if no file name
                         wzIncludePath = pStr;
                     }
                     else if (!_stricmp(szOpt, "OUT"))
@@ -408,8 +408,8 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                         WCHAR *pStr = EqualOrColon(argv[i]);
                         if(pStr == NULL) goto InvalidOption;
                         for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                        if(dn_wcslen(pStr)==0) goto InvalidOption; //if no file name
-                        if(dn_wcslen(pStr) >= MAX_FILENAME_LENGTH)
+                        if(strlen_u16(pStr)==0) goto InvalidOption; //if no file name
+                        if(strlen_u16(pStr) >= MAX_FILENAME_LENGTH)
                         {
                             fprintf(stderr,"\nError: Output file name exceeds %d characters\n",MAX_FILENAME_LENGTH-1);
                             goto ErrorExit;
@@ -421,7 +421,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                         WCHAR *pStr = EqualOrColon(argv[i]);
                         if(pStr == NULL) goto InvalidOption;
                         for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                        if(dn_wcslen(pStr)==0) goto InvalidOption; //if no version string
+                        if(strlen_u16(pStr)==0) goto InvalidOption; //if no version string
                         pAsm->m_wzMetadataVersion = pStr;
                     }
                     else if (!_stricmp(szOpt, "MSV"))
@@ -429,7 +429,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                         WCHAR *pStr = EqualOrColon(argv[i]);
                         if(pStr == NULL) goto InvalidOption;
                         for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                        if(dn_wcslen(pStr)==0) goto InvalidOption; //if no version
+                        if(strlen_u16(pStr)==0) goto InvalidOption; //if no version
                         {
                             int major=-1,minor=-1;
                             NarrowForNumberParsing str{pStr};
@@ -456,7 +456,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                         WCHAR *pStr = EqualOrColon(argv[i]);
                         if(pStr == NULL) goto InvalidOption;
                         for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                        if(dn_wcslen(pStr)==0) goto InvalidOption; //if no version
+                        if(strlen_u16(pStr)==0) goto InvalidOption; //if no version
                         {
                             int major=-1,minor=-1;
                             NarrowForNumberParsing str{pStr};
@@ -537,7 +537,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                 }
                 else
                 {
-                    if(dn_wcslen(argv[i]) >= MAX_FILENAME_LENGTH)
+                    if(strlen_u16(argv[i]) >= MAX_FILENAME_LENGTH)
                     {
                         printf("\nError: Input file name exceeds %d characters\n",MAX_FILENAME_LENGTH-1);
                         goto ErrorExit;
@@ -616,7 +616,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
             if(wzOutputFilename[0] == 0)
             {
                 wcscpy_s(wzOutputFilename,MAX_FILENAME_LENGTH,pwzInputFiles[0]);
-                size_t j = dn_wcslen(wzOutputFilename);
+                size_t j = strlen_u16(wzOutputFilename);
                 do
                 {
                     j--;
@@ -632,7 +632,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
             if (pAsm->m_fGeneratePDB)
             {
                 wcscpy_s(wzPdbFilename, MAX_FILENAME_LENGTH, wzOutputFilename);
-                WCHAR* extPos = (WCHAR*)dn_wcsrchr(wzPdbFilename, W('.'));
+                WCHAR* extPos = (WCHAR*)strrchr_u16(wzPdbFilename, W('.'));
                 if (extPos != NULL)
                     *extPos = 0;
                 wcscat_s(wzPdbFilename, MAX_FILENAME_LENGTH, W(".pdb"));
@@ -774,7 +774,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                                     for(iFile = 0; iFile < NumDeltaFiles; iFile++)
                                     {
                                         wcscpy_s(wzNewOutputFilename,MAX_FILENAME_LENGTH+16,wzOutputFilename);
-                                        size_t len = dn_wcslen(wzNewOutputFilename);
+                                        size_t len = strlen_u16(wzNewOutputFilename);
                                         wzNewOutputFilename[len] = W('.');
                                         FormatInteger(&wzNewOutputFilename[len + 1], MaxSigned32BitDecString + 1, "%d", iFile+1);
                                         MakeProperSourceFileName(pwzDeltaFiles[iFile], uCodePage, wzInputFilename, szInputFilename);
@@ -834,10 +834,10 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
     if (exitval || !bGeneratePdb)
     {
         // PE file was not created, or no debug info required. Kill PDB if any
-        WCHAR* pc = (WCHAR*)dn_wcsrchr(wzOutputFilename,W('.'));
+        WCHAR* pc = (WCHAR*)strrchr_u16(wzOutputFilename,W('.'));
         if(pc==NULL)
         {
-            pc = &wzOutputFilename[dn_wcslen(wzOutputFilename)];
+            pc = &wzOutputFilename[strlen_u16(wzOutputFilename)];
             *pc = W('.');
         }
         wcscpy_s(pc+1,4,W("PDB"));

--- a/src/coreclr/ilasm/main.cpp
+++ b/src/coreclr/ilasm/main.cpp
@@ -16,8 +16,8 @@
 
 WCHAR* EqualOrColon(_In_ __nullterminated WCHAR* szArg)
 {
-    WCHAR* pchE = (WCHAR*)strchr_u16(szArg,W('='));
-    WCHAR* pchC = (WCHAR*)strchr_u16(szArg,W(':'));
+    WCHAR* pchE = (WCHAR*)u16_strchr(szArg,W('='));
+    WCHAR* pchC = (WCHAR*)u16_strchr(szArg,W(':'));
     WCHAR* ret;
     if(pchE == NULL) ret = pchC;
     else if(pchC == NULL) ret = pchE;
@@ -34,7 +34,7 @@ class NarrowForNumberParsing final
 public:
     NarrowForNumberParsing(const WCHAR* str)
     {
-        size_t len = strlen_u16(str);
+        size_t len = u16_strlen(str);
         _buffer = (char*)malloc(len + 1);
         for (size_t i = 0; i < len; ++i)
             _buffer[i] = (char)str[i];
@@ -83,7 +83,7 @@ void MakeProperSourceFileName(_In_ __nullterminated WCHAR* wzOrigName,
                               _Out_writes_(MAX_FILENAME_LENGTH*3) char* szProperName)
 {
     wcscpy_s(wzProperName,MAX_FILENAME_LENGTH, wzOrigName);
-    size_t j = strlen_u16(wzProperName);
+    size_t j = u16_strlen(wzProperName);
     do
     {
         j--;
@@ -161,7 +161,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
 #pragma warning(push)
 #pragma warning(disable:26000) // "Suppress prefast warning about index overflow"
 #endif
-    if (! strcmp_u16(argv[1], W("/?")) || ! strcmp_u16(argv[1],W("-?")))
+    if (! u16_strcmp(argv[1], W("/?")) || ! u16_strcmp(argv[1],W("-?")))
 #ifdef _PREFAST_
 #pragma warning(pop)
 #endif
@@ -267,7 +267,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                       if(pStr != NULL)
                       {
                           for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                          if(strlen_u16(pStr)==0) goto InvalidOption; //if no suboption
+                          if(u16_strlen(pStr)==0) goto InvalidOption; //if no suboption
                           else
                           {
                               WCHAR wzSubOpt[8];
@@ -381,7 +381,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                             WCHAR *pStr = EqualOrColon(argv[i]);
                             if(pStr == NULL) goto ErrorExit;
                             for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                            if(strlen_u16(pStr)==0) goto InvalidOption; //if no file name
+                            if(u16_strlen(pStr)==0) goto InvalidOption; //if no file name
                             pAsm->m_wzResourceFile = pStr;
                         }
                         else
@@ -392,7 +392,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                         WCHAR *pStr = EqualOrColon(argv[i]);
                         if(pStr == NULL) goto InvalidOption;
                         for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                        if(strlen_u16(pStr)==0) goto InvalidOption; //if no file name
+                        if(u16_strlen(pStr)==0) goto InvalidOption; //if no file name
                         pAsm->m_wzKeySourceName = pStr;
                     }
                     else if (!_stricmp(szOpt, "INC"))
@@ -400,7 +400,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                         WCHAR *pStr = EqualOrColon(argv[i]);
                         if(pStr == NULL) goto InvalidOption;
                         for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                        if(strlen_u16(pStr)==0) goto InvalidOption; //if no file name
+                        if(u16_strlen(pStr)==0) goto InvalidOption; //if no file name
                         wzIncludePath = pStr;
                     }
                     else if (!_stricmp(szOpt, "OUT"))
@@ -408,8 +408,8 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                         WCHAR *pStr = EqualOrColon(argv[i]);
                         if(pStr == NULL) goto InvalidOption;
                         for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                        if(strlen_u16(pStr)==0) goto InvalidOption; //if no file name
-                        if(strlen_u16(pStr) >= MAX_FILENAME_LENGTH)
+                        if(u16_strlen(pStr)==0) goto InvalidOption; //if no file name
+                        if(u16_strlen(pStr) >= MAX_FILENAME_LENGTH)
                         {
                             fprintf(stderr,"\nError: Output file name exceeds %d characters\n",MAX_FILENAME_LENGTH-1);
                             goto ErrorExit;
@@ -421,7 +421,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                         WCHAR *pStr = EqualOrColon(argv[i]);
                         if(pStr == NULL) goto InvalidOption;
                         for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                        if(strlen_u16(pStr)==0) goto InvalidOption; //if no version string
+                        if(u16_strlen(pStr)==0) goto InvalidOption; //if no version string
                         pAsm->m_wzMetadataVersion = pStr;
                     }
                     else if (!_stricmp(szOpt, "MSV"))
@@ -429,7 +429,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                         WCHAR *pStr = EqualOrColon(argv[i]);
                         if(pStr == NULL) goto InvalidOption;
                         for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                        if(strlen_u16(pStr)==0) goto InvalidOption; //if no version
+                        if(u16_strlen(pStr)==0) goto InvalidOption; //if no version
                         {
                             int major=-1,minor=-1;
                             NarrowForNumberParsing str{pStr};
@@ -456,7 +456,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                         WCHAR *pStr = EqualOrColon(argv[i]);
                         if(pStr == NULL) goto InvalidOption;
                         for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                        if(strlen_u16(pStr)==0) goto InvalidOption; //if no version
+                        if(u16_strlen(pStr)==0) goto InvalidOption; //if no version
                         {
                             int major=-1,minor=-1;
                             NarrowForNumberParsing str{pStr};
@@ -537,7 +537,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                 }
                 else
                 {
-                    if(strlen_u16(argv[i]) >= MAX_FILENAME_LENGTH)
+                    if(u16_strlen(argv[i]) >= MAX_FILENAME_LENGTH)
                     {
                         printf("\nError: Input file name exceeds %d characters\n",MAX_FILENAME_LENGTH-1);
                         goto ErrorExit;
@@ -616,7 +616,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
             if(wzOutputFilename[0] == 0)
             {
                 wcscpy_s(wzOutputFilename,MAX_FILENAME_LENGTH,pwzInputFiles[0]);
-                size_t j = strlen_u16(wzOutputFilename);
+                size_t j = u16_strlen(wzOutputFilename);
                 do
                 {
                     j--;
@@ -632,7 +632,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
             if (pAsm->m_fGeneratePDB)
             {
                 wcscpy_s(wzPdbFilename, MAX_FILENAME_LENGTH, wzOutputFilename);
-                WCHAR* extPos = (WCHAR*)strrchr_u16(wzPdbFilename, W('.'));
+                WCHAR* extPos = (WCHAR*)u16_strrchr(wzPdbFilename, W('.'));
                 if (extPos != NULL)
                     *extPos = 0;
                 wcscat_s(wzPdbFilename, MAX_FILENAME_LENGTH, W(".pdb"));
@@ -774,7 +774,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                                     for(iFile = 0; iFile < NumDeltaFiles; iFile++)
                                     {
                                         wcscpy_s(wzNewOutputFilename,MAX_FILENAME_LENGTH+16,wzOutputFilename);
-                                        size_t len = strlen_u16(wzNewOutputFilename);
+                                        size_t len = u16_strlen(wzNewOutputFilename);
                                         wzNewOutputFilename[len] = W('.');
                                         FormatInteger(&wzNewOutputFilename[len + 1], MaxSigned32BitDecString + 1, "%d", iFile+1);
                                         MakeProperSourceFileName(pwzDeltaFiles[iFile], uCodePage, wzInputFilename, szInputFilename);
@@ -834,10 +834,10 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
     if (exitval || !bGeneratePdb)
     {
         // PE file was not created, or no debug info required. Kill PDB if any
-        WCHAR* pc = (WCHAR*)strrchr_u16(wzOutputFilename,W('.'));
+        WCHAR* pc = (WCHAR*)u16_strrchr(wzOutputFilename,W('.'));
         if(pc==NULL)
         {
-            pc = &wzOutputFilename[strlen_u16(wzOutputFilename)];
+            pc = &wzOutputFilename[u16_strlen(wzOutputFilename)];
             *pc = W('.');
         }
         wcscpy_s(pc+1,4,W("PDB"));

--- a/src/coreclr/ilasm/main.cpp
+++ b/src/coreclr/ilasm/main.cpp
@@ -34,7 +34,7 @@ class NarrowForNumberParsing final
 public:
     NarrowForNumberParsing(const WCHAR* str)
     {
-        size_t len = wcslen(str);
+        size_t len = dn_wcslen(str);
         _buffer = (char*)malloc(len + 1);
         for (size_t i = 0; i < len; ++i)
             _buffer[i] = (char)str[i];
@@ -83,7 +83,7 @@ void MakeProperSourceFileName(_In_ __nullterminated WCHAR* wzOrigName,
                               _Out_writes_(MAX_FILENAME_LENGTH*3) char* szProperName)
 {
     wcscpy_s(wzProperName,MAX_FILENAME_LENGTH, wzOrigName);
-    size_t j = wcslen(wzProperName);
+    size_t j = dn_wcslen(wzProperName);
     do
     {
         j--;
@@ -267,7 +267,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                       if(pStr != NULL)
                       {
                           for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                          if(wcslen(pStr)==0) goto InvalidOption; //if no suboption
+                          if(dn_wcslen(pStr)==0) goto InvalidOption; //if no suboption
                           else
                           {
                               WCHAR wzSubOpt[8];
@@ -381,7 +381,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                             WCHAR *pStr = EqualOrColon(argv[i]);
                             if(pStr == NULL) goto ErrorExit;
                             for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                            if(wcslen(pStr)==0) goto InvalidOption; //if no file name
+                            if(dn_wcslen(pStr)==0) goto InvalidOption; //if no file name
                             pAsm->m_wzResourceFile = pStr;
                         }
                         else
@@ -392,7 +392,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                         WCHAR *pStr = EqualOrColon(argv[i]);
                         if(pStr == NULL) goto InvalidOption;
                         for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                        if(wcslen(pStr)==0) goto InvalidOption; //if no file name
+                        if(dn_wcslen(pStr)==0) goto InvalidOption; //if no file name
                         pAsm->m_wzKeySourceName = pStr;
                     }
                     else if (!_stricmp(szOpt, "INC"))
@@ -400,7 +400,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                         WCHAR *pStr = EqualOrColon(argv[i]);
                         if(pStr == NULL) goto InvalidOption;
                         for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                        if(wcslen(pStr)==0) goto InvalidOption; //if no file name
+                        if(dn_wcslen(pStr)==0) goto InvalidOption; //if no file name
                         wzIncludePath = pStr;
                     }
                     else if (!_stricmp(szOpt, "OUT"))
@@ -408,8 +408,8 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                         WCHAR *pStr = EqualOrColon(argv[i]);
                         if(pStr == NULL) goto InvalidOption;
                         for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                        if(wcslen(pStr)==0) goto InvalidOption; //if no file name
-                        if(wcslen(pStr) >= MAX_FILENAME_LENGTH)
+                        if(dn_wcslen(pStr)==0) goto InvalidOption; //if no file name
+                        if(dn_wcslen(pStr) >= MAX_FILENAME_LENGTH)
                         {
                             fprintf(stderr,"\nError: Output file name exceeds %d characters\n",MAX_FILENAME_LENGTH-1);
                             goto ErrorExit;
@@ -421,7 +421,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                         WCHAR *pStr = EqualOrColon(argv[i]);
                         if(pStr == NULL) goto InvalidOption;
                         for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                        if(wcslen(pStr)==0) goto InvalidOption; //if no version string
+                        if(dn_wcslen(pStr)==0) goto InvalidOption; //if no version string
                         pAsm->m_wzMetadataVersion = pStr;
                     }
                     else if (!_stricmp(szOpt, "MSV"))
@@ -429,7 +429,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                         WCHAR *pStr = EqualOrColon(argv[i]);
                         if(pStr == NULL) goto InvalidOption;
                         for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                        if(wcslen(pStr)==0) goto InvalidOption; //if no version
+                        if(dn_wcslen(pStr)==0) goto InvalidOption; //if no version
                         {
                             int major=-1,minor=-1;
                             NarrowForNumberParsing str{pStr};
@@ -456,7 +456,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                         WCHAR *pStr = EqualOrColon(argv[i]);
                         if(pStr == NULL) goto InvalidOption;
                         for(pStr++; *pStr == W(' '); pStr++); //skip the blanks
-                        if(wcslen(pStr)==0) goto InvalidOption; //if no version
+                        if(dn_wcslen(pStr)==0) goto InvalidOption; //if no version
                         {
                             int major=-1,minor=-1;
                             NarrowForNumberParsing str{pStr};
@@ -537,7 +537,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                 }
                 else
                 {
-                    if(wcslen(argv[i]) >= MAX_FILENAME_LENGTH)
+                    if(dn_wcslen(argv[i]) >= MAX_FILENAME_LENGTH)
                     {
                         printf("\nError: Input file name exceeds %d characters\n",MAX_FILENAME_LENGTH-1);
                         goto ErrorExit;
@@ -616,7 +616,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
             if(wzOutputFilename[0] == 0)
             {
                 wcscpy_s(wzOutputFilename,MAX_FILENAME_LENGTH,pwzInputFiles[0]);
-                size_t j = wcslen(wzOutputFilename);
+                size_t j = dn_wcslen(wzOutputFilename);
                 do
                 {
                     j--;
@@ -774,7 +774,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
                                     for(iFile = 0; iFile < NumDeltaFiles; iFile++)
                                     {
                                         wcscpy_s(wzNewOutputFilename,MAX_FILENAME_LENGTH+16,wzOutputFilename);
-                                        size_t len = wcslen(wzNewOutputFilename);
+                                        size_t len = dn_wcslen(wzNewOutputFilename);
                                         wzNewOutputFilename[len] = W('.');
                                         FormatInteger(&wzNewOutputFilename[len + 1], MaxSigned32BitDecString + 1, "%d", iFile+1);
                                         MakeProperSourceFileName(pwzDeltaFiles[iFile], uCodePage, wzInputFilename, szInputFilename);
@@ -837,7 +837,7 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
         WCHAR* pc = dn_wcsrchr(wzOutputFilename,W('.'));
         if(pc==NULL)
         {
-            pc = &wzOutputFilename[wcslen(wzOutputFilename)];
+            pc = &wzOutputFilename[dn_wcslen(wzOutputFilename)];
             *pc = W('.');
         }
         wcscpy_s(pc+1,4,W("PDB"));

--- a/src/coreclr/ilasm/method.hpp
+++ b/src/coreclr/ilasm/method.hpp
@@ -359,7 +359,7 @@ public:
         int i,retval=-1;
         for(i=0; i < (int)m_NumTyPars; i++)
         {
-            if(!dn_wcscmp(wz,m_TyPars[i].Name()))
+            if(!strcmp_u16(wz,m_TyPars[i].Name()))
             {
                 retval = i;
             }

--- a/src/coreclr/ilasm/method.hpp
+++ b/src/coreclr/ilasm/method.hpp
@@ -359,7 +359,7 @@ public:
         int i,retval=-1;
         for(i=0; i < (int)m_NumTyPars; i++)
         {
-            if(!strcmp_u16(wz,m_TyPars[i].Name()))
+            if(!u16_strcmp(wz,m_TyPars[i].Name()))
             {
                 retval = i;
             }

--- a/src/coreclr/ilasm/method.hpp
+++ b/src/coreclr/ilasm/method.hpp
@@ -359,7 +359,7 @@ public:
         int i,retval=-1;
         for(i=0; i < (int)m_NumTyPars; i++)
         {
-            if(!wcscmp(wz,m_TyPars[i].Name()))
+            if(!dn_wcscmp(wz,m_TyPars[i].Name()))
             {
                 retval = i;
             }

--- a/src/coreclr/ilasm/writer.cpp
+++ b/src/coreclr/ilasm/writer.cpp
@@ -766,8 +766,8 @@ HRESULT Assembler::ResolveLocalMemberRefs()
 
                             if(IsMdPrivateScope(pListMD->m_Attr))
                             {
-                                WCHAR* p = wcsstr(wzUniBuf,W("$PST06"));
-                                if(p) *p = 0;
+                                WCHAR* p = (WCHAR*)dn_wcsstr(wzUniBuf,W("$PST06"));
+                                if(p) *p = W('\0');
                             }
 
                             m_pEmitter->DefineMemberRef(tkMemberDef, wzUniBuf,

--- a/src/coreclr/ilasm/writer.cpp
+++ b/src/coreclr/ilasm/writer.cpp
@@ -1100,9 +1100,9 @@ HRESULT Assembler::CreatePEFile(_In_ __nullterminated WCHAR *pwzOutputFilename)
     else
     {
         WCHAR* pwc;
-        if ((pwc = wcsrchr(m_wzOutputFileName, DIRECTORY_SEPARATOR_CHAR_A)) != NULL) pwc++;
+        if ((pwc = dn_wcsrchr(m_wzOutputFileName, DIRECTORY_SEPARATOR_CHAR_A)) != NULL) pwc++;
 #ifdef TARGET_WINDOWS
-        else if ((pwc = wcsrchr(m_wzOutputFileName, ':')) != NULL) pwc++;
+        else if ((pwc = dn_wcsrchr(m_wzOutputFileName, ':')) != NULL) pwc++;
 #endif
         else pwc = m_wzOutputFileName;
 

--- a/src/coreclr/ilasm/writer.cpp
+++ b/src/coreclr/ilasm/writer.cpp
@@ -1100,9 +1100,9 @@ HRESULT Assembler::CreatePEFile(_In_ __nullterminated WCHAR *pwzOutputFilename)
     else
     {
         WCHAR* pwc;
-        if ((pwc = dn_wcsrchr(m_wzOutputFileName, DIRECTORY_SEPARATOR_CHAR_A)) != NULL) pwc++;
+        if ((pwc = (WCHAR*)dn_wcsrchr(m_wzOutputFileName, DIRECTORY_SEPARATOR_CHAR_A)) != NULL) pwc++;
 #ifdef TARGET_WINDOWS
-        else if ((pwc = dn_wcsrchr(m_wzOutputFileName, ':')) != NULL) pwc++;
+        else if ((pwc = (WCHAR*)dn_wcsrchr(m_wzOutputFileName, ':')) != NULL) pwc++;
 #endif
         else pwc = m_wzOutputFileName;
 

--- a/src/coreclr/ilasm/writer.cpp
+++ b/src/coreclr/ilasm/writer.cpp
@@ -328,9 +328,9 @@ HRESULT Assembler::CreateExportDirectory()
     unsigned                i, L, ordBase = 0xFFFFFFFF, Ldllname;
     // get the DLL name from output file name
     char*                   pszDllName;
-    Ldllname = (unsigned)strlen_u16(m_wzOutputFileName)*3+3;
+    Ldllname = (unsigned)u16_strlen(m_wzOutputFileName)*3+3;
     NewArrayHolder<char>    szOutputFileName(new char[Ldllname]);
-    memset(szOutputFileName,0,strlen_u16(m_wzOutputFileName)*3+3);
+    memset(szOutputFileName,0,u16_strlen(m_wzOutputFileName)*3+3);
     WszWideCharToMultiByte(CP_ACP,0,m_wzOutputFileName,-1,szOutputFileName,Ldllname,NULL,NULL);
     pszDllName = strrchr(szOutputFileName,DIRECTORY_SEPARATOR_CHAR_A);
 #ifdef TARGET_WINDOWS
@@ -766,7 +766,7 @@ HRESULT Assembler::ResolveLocalMemberRefs()
 
                             if(IsMdPrivateScope(pListMD->m_Attr))
                             {
-                                WCHAR* p = (WCHAR*)strstr_u16(wzUniBuf,W("$PST06"));
+                                WCHAR* p = (WCHAR*)u16_strstr(wzUniBuf,W("$PST06"));
                                 if(p) *p = W('\0');
                             }
 
@@ -1100,9 +1100,9 @@ HRESULT Assembler::CreatePEFile(_In_ __nullterminated WCHAR *pwzOutputFilename)
     else
     {
         WCHAR* pwc;
-        if ((pwc = (WCHAR*)strrchr_u16(m_wzOutputFileName, DIRECTORY_SEPARATOR_CHAR_A)) != NULL) pwc++;
+        if ((pwc = (WCHAR*)u16_strrchr(m_wzOutputFileName, DIRECTORY_SEPARATOR_CHAR_A)) != NULL) pwc++;
 #ifdef TARGET_WINDOWS
-        else if ((pwc = (WCHAR*)strrchr_u16(m_wzOutputFileName, ':')) != NULL) pwc++;
+        else if ((pwc = (WCHAR*)u16_strrchr(m_wzOutputFileName, ':')) != NULL) pwc++;
 #endif
         else pwc = m_wzOutputFileName;
 

--- a/src/coreclr/ilasm/writer.cpp
+++ b/src/coreclr/ilasm/writer.cpp
@@ -328,9 +328,9 @@ HRESULT Assembler::CreateExportDirectory()
     unsigned                i, L, ordBase = 0xFFFFFFFF, Ldllname;
     // get the DLL name from output file name
     char*                   pszDllName;
-    Ldllname = (unsigned)wcslen(m_wzOutputFileName)*3+3;
+    Ldllname = (unsigned)dn_wcslen(m_wzOutputFileName)*3+3;
     NewArrayHolder<char>    szOutputFileName(new char[Ldllname]);
-    memset(szOutputFileName,0,wcslen(m_wzOutputFileName)*3+3);
+    memset(szOutputFileName,0,dn_wcslen(m_wzOutputFileName)*3+3);
     WszWideCharToMultiByte(CP_ACP,0,m_wzOutputFileName,-1,szOutputFileName,Ldllname,NULL,NULL);
     pszDllName = strrchr(szOutputFileName,DIRECTORY_SEPARATOR_CHAR_A);
 #ifdef TARGET_WINDOWS

--- a/src/coreclr/ilasm/writer.cpp
+++ b/src/coreclr/ilasm/writer.cpp
@@ -328,9 +328,9 @@ HRESULT Assembler::CreateExportDirectory()
     unsigned                i, L, ordBase = 0xFFFFFFFF, Ldllname;
     // get the DLL name from output file name
     char*                   pszDllName;
-    Ldllname = (unsigned)dn_wcslen(m_wzOutputFileName)*3+3;
+    Ldllname = (unsigned)strlen_u16(m_wzOutputFileName)*3+3;
     NewArrayHolder<char>    szOutputFileName(new char[Ldllname]);
-    memset(szOutputFileName,0,dn_wcslen(m_wzOutputFileName)*3+3);
+    memset(szOutputFileName,0,strlen_u16(m_wzOutputFileName)*3+3);
     WszWideCharToMultiByte(CP_ACP,0,m_wzOutputFileName,-1,szOutputFileName,Ldllname,NULL,NULL);
     pszDllName = strrchr(szOutputFileName,DIRECTORY_SEPARATOR_CHAR_A);
 #ifdef TARGET_WINDOWS
@@ -766,7 +766,7 @@ HRESULT Assembler::ResolveLocalMemberRefs()
 
                             if(IsMdPrivateScope(pListMD->m_Attr))
                             {
-                                WCHAR* p = (WCHAR*)dn_wcsstr(wzUniBuf,W("$PST06"));
+                                WCHAR* p = (WCHAR*)strstr_u16(wzUniBuf,W("$PST06"));
                                 if(p) *p = W('\0');
                             }
 
@@ -1100,9 +1100,9 @@ HRESULT Assembler::CreatePEFile(_In_ __nullterminated WCHAR *pwzOutputFilename)
     else
     {
         WCHAR* pwc;
-        if ((pwc = (WCHAR*)dn_wcsrchr(m_wzOutputFileName, DIRECTORY_SEPARATOR_CHAR_A)) != NULL) pwc++;
+        if ((pwc = (WCHAR*)strrchr_u16(m_wzOutputFileName, DIRECTORY_SEPARATOR_CHAR_A)) != NULL) pwc++;
 #ifdef TARGET_WINDOWS
-        else if ((pwc = (WCHAR*)dn_wcsrchr(m_wzOutputFileName, ':')) != NULL) pwc++;
+        else if ((pwc = (WCHAR*)strrchr_u16(m_wzOutputFileName, ':')) != NULL) pwc++;
 #endif
         else pwc = m_wzOutputFileName;
 

--- a/src/coreclr/ildasm/dasm.cpp
+++ b/src/coreclr/ildasm/dasm.cpp
@@ -3059,7 +3059,7 @@ char *DumpGenericPars(_Inout_updates_(SZSTRING_SIZE) char* szString, mdToken tok
       for (i = 1; NumTyPars != 0; i++)
       {
         g_pPubImport->GetGenericParamProps(tkTyPar, &ulSequence, &attr, &tkOwner, NULL, wzArgName, UNIBUF_SIZE/2, &chName);
-        //if(strlen_u16(wzArgName) >= MAX_CLASSNAME_LENGTH)
+        //if(u16_strlen(wzArgName) >= MAX_CLASSNAME_LENGTH)
         //    wzArgName[MAX_CLASSNAME_LENGTH-1] = 0;
         hEnumTyParConstr = NULL;
         if (FAILED(g_pPubImport->EnumGenericParamConstraints(&hEnumTyParConstr, tkTyPar, tkConstr, 2048, &NumConstrs)))
@@ -3114,7 +3114,7 @@ char *DumpGenericPars(_Inout_updates_(SZSTRING_SIZE) char* szString, mdToken tok
         }
         // re-get name, wzUniBuf may not contain it any more
         g_pPubImport->GetGenericParamProps(tkTyPar, NULL, &attr, NULL, NULL, wzArgName, UNIBUF_SIZE/2, &chName);
-        //if(strlen_u16(wzArgName) >= MAX_CLASSNAME_LENGTH)
+        //if(u16_strlen(wzArgName) >= MAX_CLASSNAME_LENGTH)
         //    wzArgName[MAX_CLASSNAME_LENGTH-1] = 0;
         if (chName)
         {
@@ -3184,7 +3184,7 @@ void DumpGenericParsCA(mdToken tok, void* GUICookie/*=NULL*/)
                 if(SUCCEEDED(g_pPubImport->GetGenericParamProps(tkTyPar, NULL, &attr, NULL, NULL, wzArgName, UNIBUF_SIZE/2, &chName))
                         &&(chName > 0))
                 {
-                    //if(strlen_u16(wzArgName) >= MAX_CLASSNAME_LENGTH)
+                    //if(u16_strlen(wzArgName) >= MAX_CLASSNAME_LENGTH)
                     //    wzArgName[MAX_CLASSNAME_LENGTH-1] = 0;
                     char* sz = (char*)(&wzUniBuf[UNIBUF_SIZE/2]);
                     WszWideCharToMultiByte(CP_UTF8,0,wzArgName,-1,sz,UNIBUF_SIZE,NULL,NULL);
@@ -6965,7 +6965,7 @@ void DumpMI(_In_ __nullterminated const char *str)
 
 void DumpMetaInfo(_In_ __nullterminated const WCHAR* pwzFileName, _In_opt_z_ const char* pszObjFileName, void* GUICookie)
 {
-    const WCHAR* pch = strrchr_u16(pwzFileName,L'.');
+    const WCHAR* pch = u16_strrchr(pwzFileName,L'.');
 
     DumpMI((char*)GUICookie); // initialize the print function for DumpMetaInfo
 
@@ -7775,8 +7775,8 @@ ReportAndExit:
             WCHAR wzResFileName[2048], *pwc;
             memset(wzResFileName,0,sizeof(wzResFileName));
             WszMultiByteToWideChar(CP_UTF8,0,g_szOutputFile,-1,wzResFileName,2048);
-            pwc = (WCHAR*)strrchr_u16(wzResFileName,L'.');
-            if(pwc == NULL) pwc = &wzResFileName[strlen_u16(wzResFileName)];
+            pwc = (WCHAR*)u16_strrchr(wzResFileName,L'.');
+            if(pwc == NULL) pwc = &wzResFileName[u16_strlen(wzResFileName)];
             wcscpy_s(pwc, 2048 - (pwc - wzResFileName), L".res");
             DWORD ret = DumpResourceToFile(wzResFileName);
             switch(ret)

--- a/src/coreclr/ildasm/dasm.cpp
+++ b/src/coreclr/ildasm/dasm.cpp
@@ -7775,7 +7775,7 @@ ReportAndExit:
             WCHAR wzResFileName[2048], *pwc;
             memset(wzResFileName,0,sizeof(wzResFileName));
             WszMultiByteToWideChar(CP_UTF8,0,g_szOutputFile,-1,wzResFileName,2048);
-            pwc = dn_wcsrchr(wzResFileName,L'.');
+            pwc = (WCHAR*)dn_wcsrchr(wzResFileName,L'.');
             if(pwc == NULL) pwc = &wzResFileName[dn_wcslen(wzResFileName)];
             wcscpy_s(pwc, 2048 - (pwc - wzResFileName), L".res");
             DWORD ret = DumpResourceToFile(wzResFileName);

--- a/src/coreclr/ildasm/dasm.cpp
+++ b/src/coreclr/ildasm/dasm.cpp
@@ -6965,7 +6965,7 @@ void DumpMI(_In_ __nullterminated const char *str)
 
 void DumpMetaInfo(_In_ __nullterminated const WCHAR* pwzFileName, _In_opt_z_ const char* pszObjFileName, void* GUICookie)
 {
-    const WCHAR* pch = wcsrchr(pwzFileName,L'.');
+    const WCHAR* pch = dn_wcsrchr(pwzFileName,L'.');
 
     DumpMI((char*)GUICookie); // initialize the print function for DumpMetaInfo
 
@@ -7775,7 +7775,7 @@ ReportAndExit:
             WCHAR wzResFileName[2048], *pwc;
             memset(wzResFileName,0,sizeof(wzResFileName));
             WszMultiByteToWideChar(CP_UTF8,0,g_szOutputFile,-1,wzResFileName,2048);
-            pwc = wcsrchr(wzResFileName,L'.');
+            pwc = dn_wcsrchr(wzResFileName,L'.');
             if(pwc == NULL) pwc = &wzResFileName[wcslen(wzResFileName)];
             wcscpy_s(pwc, 2048 - (pwc - wzResFileName), L".res");
             DWORD ret = DumpResourceToFile(wzResFileName);

--- a/src/coreclr/ildasm/dasm.cpp
+++ b/src/coreclr/ildasm/dasm.cpp
@@ -3059,7 +3059,7 @@ char *DumpGenericPars(_Inout_updates_(SZSTRING_SIZE) char* szString, mdToken tok
       for (i = 1; NumTyPars != 0; i++)
       {
         g_pPubImport->GetGenericParamProps(tkTyPar, &ulSequence, &attr, &tkOwner, NULL, wzArgName, UNIBUF_SIZE/2, &chName);
-        //if(dn_wcslen(wzArgName) >= MAX_CLASSNAME_LENGTH)
+        //if(strlen_u16(wzArgName) >= MAX_CLASSNAME_LENGTH)
         //    wzArgName[MAX_CLASSNAME_LENGTH-1] = 0;
         hEnumTyParConstr = NULL;
         if (FAILED(g_pPubImport->EnumGenericParamConstraints(&hEnumTyParConstr, tkTyPar, tkConstr, 2048, &NumConstrs)))
@@ -3114,7 +3114,7 @@ char *DumpGenericPars(_Inout_updates_(SZSTRING_SIZE) char* szString, mdToken tok
         }
         // re-get name, wzUniBuf may not contain it any more
         g_pPubImport->GetGenericParamProps(tkTyPar, NULL, &attr, NULL, NULL, wzArgName, UNIBUF_SIZE/2, &chName);
-        //if(dn_wcslen(wzArgName) >= MAX_CLASSNAME_LENGTH)
+        //if(strlen_u16(wzArgName) >= MAX_CLASSNAME_LENGTH)
         //    wzArgName[MAX_CLASSNAME_LENGTH-1] = 0;
         if (chName)
         {
@@ -3184,7 +3184,7 @@ void DumpGenericParsCA(mdToken tok, void* GUICookie/*=NULL*/)
                 if(SUCCEEDED(g_pPubImport->GetGenericParamProps(tkTyPar, NULL, &attr, NULL, NULL, wzArgName, UNIBUF_SIZE/2, &chName))
                         &&(chName > 0))
                 {
-                    //if(dn_wcslen(wzArgName) >= MAX_CLASSNAME_LENGTH)
+                    //if(strlen_u16(wzArgName) >= MAX_CLASSNAME_LENGTH)
                     //    wzArgName[MAX_CLASSNAME_LENGTH-1] = 0;
                     char* sz = (char*)(&wzUniBuf[UNIBUF_SIZE/2]);
                     WszWideCharToMultiByte(CP_UTF8,0,wzArgName,-1,sz,UNIBUF_SIZE,NULL,NULL);
@@ -6965,7 +6965,7 @@ void DumpMI(_In_ __nullterminated const char *str)
 
 void DumpMetaInfo(_In_ __nullterminated const WCHAR* pwzFileName, _In_opt_z_ const char* pszObjFileName, void* GUICookie)
 {
-    const WCHAR* pch = dn_wcsrchr(pwzFileName,L'.');
+    const WCHAR* pch = strrchr_u16(pwzFileName,L'.');
 
     DumpMI((char*)GUICookie); // initialize the print function for DumpMetaInfo
 
@@ -7775,8 +7775,8 @@ ReportAndExit:
             WCHAR wzResFileName[2048], *pwc;
             memset(wzResFileName,0,sizeof(wzResFileName));
             WszMultiByteToWideChar(CP_UTF8,0,g_szOutputFile,-1,wzResFileName,2048);
-            pwc = (WCHAR*)dn_wcsrchr(wzResFileName,L'.');
-            if(pwc == NULL) pwc = &wzResFileName[dn_wcslen(wzResFileName)];
+            pwc = (WCHAR*)strrchr_u16(wzResFileName,L'.');
+            if(pwc == NULL) pwc = &wzResFileName[strlen_u16(wzResFileName)];
             wcscpy_s(pwc, 2048 - (pwc - wzResFileName), L".res");
             DWORD ret = DumpResourceToFile(wzResFileName);
             switch(ret)

--- a/src/coreclr/ildasm/dasm.cpp
+++ b/src/coreclr/ildasm/dasm.cpp
@@ -3059,7 +3059,7 @@ char *DumpGenericPars(_Inout_updates_(SZSTRING_SIZE) char* szString, mdToken tok
       for (i = 1; NumTyPars != 0; i++)
       {
         g_pPubImport->GetGenericParamProps(tkTyPar, &ulSequence, &attr, &tkOwner, NULL, wzArgName, UNIBUF_SIZE/2, &chName);
-        //if(wcslen(wzArgName) >= MAX_CLASSNAME_LENGTH)
+        //if(dn_wcslen(wzArgName) >= MAX_CLASSNAME_LENGTH)
         //    wzArgName[MAX_CLASSNAME_LENGTH-1] = 0;
         hEnumTyParConstr = NULL;
         if (FAILED(g_pPubImport->EnumGenericParamConstraints(&hEnumTyParConstr, tkTyPar, tkConstr, 2048, &NumConstrs)))
@@ -3114,7 +3114,7 @@ char *DumpGenericPars(_Inout_updates_(SZSTRING_SIZE) char* szString, mdToken tok
         }
         // re-get name, wzUniBuf may not contain it any more
         g_pPubImport->GetGenericParamProps(tkTyPar, NULL, &attr, NULL, NULL, wzArgName, UNIBUF_SIZE/2, &chName);
-        //if(wcslen(wzArgName) >= MAX_CLASSNAME_LENGTH)
+        //if(dn_wcslen(wzArgName) >= MAX_CLASSNAME_LENGTH)
         //    wzArgName[MAX_CLASSNAME_LENGTH-1] = 0;
         if (chName)
         {
@@ -3184,7 +3184,7 @@ void DumpGenericParsCA(mdToken tok, void* GUICookie/*=NULL*/)
                 if(SUCCEEDED(g_pPubImport->GetGenericParamProps(tkTyPar, NULL, &attr, NULL, NULL, wzArgName, UNIBUF_SIZE/2, &chName))
                         &&(chName > 0))
                 {
-                    //if(wcslen(wzArgName) >= MAX_CLASSNAME_LENGTH)
+                    //if(dn_wcslen(wzArgName) >= MAX_CLASSNAME_LENGTH)
                     //    wzArgName[MAX_CLASSNAME_LENGTH-1] = 0;
                     char* sz = (char*)(&wzUniBuf[UNIBUF_SIZE/2]);
                     WszWideCharToMultiByte(CP_UTF8,0,wzArgName,-1,sz,UNIBUF_SIZE,NULL,NULL);
@@ -7776,7 +7776,7 @@ ReportAndExit:
             memset(wzResFileName,0,sizeof(wzResFileName));
             WszMultiByteToWideChar(CP_UTF8,0,g_szOutputFile,-1,wzResFileName,2048);
             pwc = dn_wcsrchr(wzResFileName,L'.');
-            if(pwc == NULL) pwc = &wzResFileName[wcslen(wzResFileName)];
+            if(pwc == NULL) pwc = &wzResFileName[dn_wcslen(wzResFileName)];
             wcscpy_s(pwc, 2048 - (pwc - wzResFileName), L".res");
             DWORD ret = DumpResourceToFile(wzResFileName);
             switch(ret)

--- a/src/coreclr/ildasm/dis.cpp
+++ b/src/coreclr/ildasm/dis.cpp
@@ -143,7 +143,7 @@ static void UnicodeToFile(_In_ __nullterminated const WCHAR* wz, FILE* pF)
 {
     unsigned endofline = 0x000A000D;
     int L;
-    if((L=(int)wcslen(wz))) fwrite(wz,L*sizeof(WCHAR),1,pF);
+    if((L=(int)dn_wcslen(wz))) fwrite(wz,L*sizeof(WCHAR),1,pF);
     fwrite(&endofline,4,1,pF);
 }
 static void ToGUIOrFile(_In_ __nullterminated const char* sz, void* GUICookie)

--- a/src/coreclr/ildasm/dis.cpp
+++ b/src/coreclr/ildasm/dis.cpp
@@ -143,7 +143,7 @@ static void UnicodeToFile(_In_ __nullterminated const WCHAR* wz, FILE* pF)
 {
     unsigned endofline = 0x000A000D;
     int L;
-    if((L=(int)strlen_u16(wz))) fwrite(wz,L*sizeof(WCHAR),1,pF);
+    if((L=(int)u16_strlen(wz))) fwrite(wz,L*sizeof(WCHAR),1,pF);
     fwrite(&endofline,4,1,pF);
 }
 static void ToGUIOrFile(_In_ __nullterminated const char* sz, void* GUICookie)
@@ -1103,7 +1103,7 @@ BOOL Disassemble(IMDInternalImport *pImport, BYTE *ILHeader, void *GUICookie, md
                 {
                     WCHAR wzFileName[2048];
                     SourceLinesHelper(GUICookie, pLCD, wzFileName, 2048);
-                    bIsNewFile = (strcmp_u16(wzFileName,wzWasFileName)!=0);
+                    bIsNewFile = (u16_strcmp(wzFileName,wzWasFileName)!=0);
                     if(bIsNewFile||(pLCD->Line < ulWasLine))
                     {
                         wcscpy_s(wzWasFileName,2048,wzFileName);

--- a/src/coreclr/ildasm/dis.cpp
+++ b/src/coreclr/ildasm/dis.cpp
@@ -143,7 +143,7 @@ static void UnicodeToFile(_In_ __nullterminated const WCHAR* wz, FILE* pF)
 {
     unsigned endofline = 0x000A000D;
     int L;
-    if((L=(int)dn_wcslen(wz))) fwrite(wz,L*sizeof(WCHAR),1,pF);
+    if((L=(int)strlen_u16(wz))) fwrite(wz,L*sizeof(WCHAR),1,pF);
     fwrite(&endofline,4,1,pF);
 }
 static void ToGUIOrFile(_In_ __nullterminated const char* sz, void* GUICookie)
@@ -1103,7 +1103,7 @@ BOOL Disassemble(IMDInternalImport *pImport, BYTE *ILHeader, void *GUICookie, md
                 {
                     WCHAR wzFileName[2048];
                     SourceLinesHelper(GUICookie, pLCD, wzFileName, 2048);
-                    bIsNewFile = (dn_wcscmp(wzFileName,wzWasFileName)!=0);
+                    bIsNewFile = (strcmp_u16(wzFileName,wzWasFileName)!=0);
                     if(bIsNewFile||(pLCD->Line < ulWasLine))
                     {
                         wcscpy_s(wzWasFileName,2048,wzFileName);

--- a/src/coreclr/ildasm/dis.cpp
+++ b/src/coreclr/ildasm/dis.cpp
@@ -1103,7 +1103,7 @@ BOOL Disassemble(IMDInternalImport *pImport, BYTE *ILHeader, void *GUICookie, md
                 {
                     WCHAR wzFileName[2048];
                     SourceLinesHelper(GUICookie, pLCD, wzFileName, 2048);
-                    bIsNewFile = (wcscmp(wzFileName,wzWasFileName)!=0);
+                    bIsNewFile = (dn_wcscmp(wzFileName,wzWasFileName)!=0);
                     if(bIsNewFile||(pLCD->Line < ulWasLine))
                     {
                         wcscpy_s(wzWasFileName,2048,wzFileName);

--- a/src/coreclr/ildasm/dman.cpp
+++ b/src/coreclr/ildasm/dman.cpp
@@ -125,7 +125,7 @@ void DumpScope(void* GUICookie)
     if(SUCCEEDED(g_pPubImport->GetScopeProps( scopeName, 1024, NULL, &mvid))&& scopeName[0])
     {
         {
-            UINT32 L = (UINT32)wcslen(scopeName)*3+3;
+            UINT32 L = (UINT32)dn_wcslen(scopeName)*3+3;
             char* sz = new char[L];
             memset(sz,0,L);
             WszWideCharToMultiByte(CP_UTF8,0,scopeName,-1,sz,L,NULL,NULL);
@@ -423,7 +423,7 @@ void DumpComTypeFQN(
         }
     }
 
-    UINT32 L = (UINT32)wcslen(pCTD->wzName)*3+3;
+    UINT32 L = (UINT32)dn_wcslen(pCTD->wzName)*3+3;
     char* sz = new char[L];
     memset(sz,0,L);
     WszWideCharToMultiByte(CP_UTF8,0,pCTD->wzName,-1,sz,L,NULL,NULL);
@@ -446,7 +446,7 @@ void DumpImplementation(mdToken tkImplementation,
             if(i < nFiles)
             {
                 {
-                    UINT32 L = (UINT32)wcslen(rFile[i].name)*3+3;
+                    UINT32 L = (UINT32)dn_wcslen(rFile[i].name)*3+3;
                     char* sz = new char[L];
                     memset(sz,0,L);
                     WszWideCharToMultiByte(CP_UTF8,0,rFile[i].name,-1,sz,L,NULL,NULL);
@@ -466,7 +466,7 @@ void DumpImplementation(mdToken tkImplementation,
             if(i < nAsmRefs)
             {
                 {
-                    UINT32 L = (UINT32)wcslen(rAsmRef[i].name)*3+3;
+                    UINT32 L = (UINT32)dn_wcslen(rAsmRef[i].name)*3+3;
                     char* sz = new char[L];
                     memset(sz,0,L);
                     WszWideCharToMultiByte(CP_UTF8,0,rAsmRef[i].name,-1,sz,L,NULL,NULL);
@@ -512,7 +512,7 @@ void DumpComType(LocalComTypeDescr* pCTD,
 
     char* pc=&szString[strlen(szString)];
     {
-        UINT32 L = (UINT32)wcslen(pCTD->wzName)*3+3;
+        UINT32 L = (UINT32)dn_wcslen(pCTD->wzName)*3+3;
         char* sz = new char[L];
         memset(sz,0,L);
         WszWideCharToMultiByte(CP_UTF8,0,pCTD->wzName,-1,sz,L,NULL,NULL);
@@ -628,7 +628,7 @@ static BOOL ConvertToLegalFileNameInPlace(__inout LPWSTR wzName)
 
     for (size_t i = 0; i < (sizeof(rwzReserved) / sizeof(WCHAR *)); i++)
     {
-        _ASSERTE(wcslen(rwzReserved[i]) == 3);
+        _ASSERTE(dn_wcslen(rwzReserved[i]) == 3);
         if (_wcsnicmp(wzName, rwzReserved[i], 3) == 0)
         {
             LPWSTR pwc = wzName + 3;
@@ -801,7 +801,7 @@ void DumpManifestResources(void* GUICookie)
 
 #define NAME_ARRAY_ADD(index, str)                                                    \
             {                                                                         \
-                size_t __dwBufLen = wcslen(str) + 1;                                  \
+                size_t __dwBufLen = dn_wcslen(str) + 1;                                  \
                                                                                       \
                 qbNameArray[index].Init();                                            \
                 WCHAR *__wpc = (WCHAR *)qbNameArray[index].AllocNoThrow(__dwBufLen);  \
@@ -813,7 +813,7 @@ void DumpManifestResources(void* GUICookie)
 
             // add the Win32 resource file name to avoid conflict between the native and a managed resource file
             WCHAR *pwc = dn_wcsrchr(wzName, L'.');
-            if (pwc == NULL) pwc = &wzName[wcslen(wzName)];
+            if (pwc == NULL) pwc = &wzName[dn_wcslen(wzName)];
             wcscpy_s(pwc, 2048 - (pwc - wzFileName), W(".res"));
 
             NAME_ARRAY_ADD(1, wzName);
@@ -845,7 +845,7 @@ void DumpManifestResources(void* GUICookie)
                     BOOL fAlias = ConvertToLegalFileNameInPlace(wzName);
 
                     // check for duplicate file name
-                    WCHAR *wpc = wzName + wcslen(wzName);
+                    WCHAR *wpc = wzName + dn_wcslen(wzName);
                     for (int iIndex = 1;; iIndex++)
                     {
                         BOOL fConflict = FALSE;

--- a/src/coreclr/ildasm/dman.cpp
+++ b/src/coreclr/ildasm/dman.cpp
@@ -360,7 +360,7 @@ void DumpAssemblyRefs(void* GUICookie)
                         // check for name duplication and introduce alias if needed
                         for(ixx = 0; ixx < ix; ixx++)
                         {
-                            if(!wcscmp(rAsmRef[ixx].name,rAsmRef[ix].name)) break;
+                            if(!dn_wcscmp(rAsmRef[ixx].name,rAsmRef[ix].name)) break;
                         }
                         if(ixx < ix)
                         {

--- a/src/coreclr/ildasm/dman.cpp
+++ b/src/coreclr/ildasm/dman.cpp
@@ -125,7 +125,7 @@ void DumpScope(void* GUICookie)
     if(SUCCEEDED(g_pPubImport->GetScopeProps( scopeName, 1024, NULL, &mvid))&& scopeName[0])
     {
         {
-            UINT32 L = (UINT32)dn_wcslen(scopeName)*3+3;
+            UINT32 L = (UINT32)strlen_u16(scopeName)*3+3;
             char* sz = new char[L];
             memset(sz,0,L);
             WszWideCharToMultiByte(CP_UTF8,0,scopeName,-1,sz,L,NULL,NULL);
@@ -360,7 +360,7 @@ void DumpAssemblyRefs(void* GUICookie)
                         // check for name duplication and introduce alias if needed
                         for(ixx = 0; ixx < ix; ixx++)
                         {
-                            if(!dn_wcscmp(rAsmRef[ixx].name,rAsmRef[ix].name)) break;
+                            if(!strcmp_u16(rAsmRef[ixx].name,rAsmRef[ix].name)) break;
                         }
                         if(ixx < ix)
                         {
@@ -423,7 +423,7 @@ void DumpComTypeFQN(
         }
     }
 
-    UINT32 L = (UINT32)dn_wcslen(pCTD->wzName)*3+3;
+    UINT32 L = (UINT32)strlen_u16(pCTD->wzName)*3+3;
     char* sz = new char[L];
     memset(sz,0,L);
     WszWideCharToMultiByte(CP_UTF8,0,pCTD->wzName,-1,sz,L,NULL,NULL);
@@ -446,7 +446,7 @@ void DumpImplementation(mdToken tkImplementation,
             if(i < nFiles)
             {
                 {
-                    UINT32 L = (UINT32)dn_wcslen(rFile[i].name)*3+3;
+                    UINT32 L = (UINT32)strlen_u16(rFile[i].name)*3+3;
                     char* sz = new char[L];
                     memset(sz,0,L);
                     WszWideCharToMultiByte(CP_UTF8,0,rFile[i].name,-1,sz,L,NULL,NULL);
@@ -466,7 +466,7 @@ void DumpImplementation(mdToken tkImplementation,
             if(i < nAsmRefs)
             {
                 {
-                    UINT32 L = (UINT32)dn_wcslen(rAsmRef[i].name)*3+3;
+                    UINT32 L = (UINT32)strlen_u16(rAsmRef[i].name)*3+3;
                     char* sz = new char[L];
                     memset(sz,0,L);
                     WszWideCharToMultiByte(CP_UTF8,0,rAsmRef[i].name,-1,sz,L,NULL,NULL);
@@ -512,7 +512,7 @@ void DumpComType(LocalComTypeDescr* pCTD,
 
     char* pc=&szString[strlen(szString)];
     {
-        UINT32 L = (UINT32)dn_wcslen(pCTD->wzName)*3+3;
+        UINT32 L = (UINT32)strlen_u16(pCTD->wzName)*3+3;
         char* sz = new char[L];
         memset(sz,0,L);
         WszWideCharToMultiByte(CP_UTF8,0,pCTD->wzName,-1,sz,L,NULL,NULL);
@@ -628,7 +628,7 @@ static BOOL ConvertToLegalFileNameInPlace(__inout LPWSTR wzName)
 
     for (size_t i = 0; i < (sizeof(rwzReserved) / sizeof(WCHAR *)); i++)
     {
-        _ASSERTE(dn_wcslen(rwzReserved[i]) == 3);
+        _ASSERTE(strlen_u16(rwzReserved[i]) == 3);
         if (_wcsnicmp(wzName, rwzReserved[i], 3) == 0)
         {
             LPWSTR pwc = wzName + 3;
@@ -782,9 +782,9 @@ void DumpManifestResources(void* GUICookie)
             static WCHAR wzFileName[2048];
 
             WszMultiByteToWideChar(CP_UTF8,0,g_szOutputFile,-1,wzFileName,2048);
-            wzName = (WCHAR*)dn_wcsrchr(wzFileName,DIRECTORY_SEPARATOR_CHAR_W);
+            wzName = (WCHAR*)strrchr_u16(wzFileName,DIRECTORY_SEPARATOR_CHAR_W);
 #ifdef HOST_WINDOWS
-            if(wzName == NULL) wzName = (WCHAR*)dn_wcsrchr(wzFileName,':');
+            if(wzName == NULL) wzName = (WCHAR*)strrchr_u16(wzFileName,':');
 #endif
             if (wzName == NULL) wzName = wzFileName;
             else wzName++;
@@ -801,7 +801,7 @@ void DumpManifestResources(void* GUICookie)
 
 #define NAME_ARRAY_ADD(index, str)                                                    \
             {                                                                         \
-                size_t __dwBufLen = dn_wcslen(str) + 1;                                  \
+                size_t __dwBufLen = strlen_u16(str) + 1;                                  \
                                                                                       \
                 qbNameArray[index].Init();                                            \
                 WCHAR *__wpc = (WCHAR *)qbNameArray[index].AllocNoThrow(__dwBufLen);  \
@@ -812,8 +812,8 @@ void DumpManifestResources(void* GUICookie)
             NAME_ARRAY_ADD(0, wzName);
 
             // add the Win32 resource file name to avoid conflict between the native and a managed resource file
-            WCHAR *pwc = (WCHAR*)dn_wcsrchr(wzName, L'.');
-            if (pwc == NULL) pwc = &wzName[dn_wcslen(wzName)];
+            WCHAR *pwc = (WCHAR*)strrchr_u16(wzName, L'.');
+            if (pwc == NULL) pwc = &wzName[strlen_u16(wzName)];
             wcscpy_s(pwc, 2048 - (pwc - wzFileName), W(".res"));
 
             NAME_ARRAY_ADD(1, wzName);
@@ -845,7 +845,7 @@ void DumpManifestResources(void* GUICookie)
                     BOOL fAlias = ConvertToLegalFileNameInPlace(wzName);
 
                     // check for duplicate file name
-                    WCHAR *wpc = wzName + dn_wcslen(wzName);
+                    WCHAR *wpc = wzName + strlen_u16(wzName);
                     for (int iIndex = 1;; iIndex++)
                     {
                         BOOL fConflict = FALSE;

--- a/src/coreclr/ildasm/dman.cpp
+++ b/src/coreclr/ildasm/dman.cpp
@@ -782,9 +782,9 @@ void DumpManifestResources(void* GUICookie)
             static WCHAR wzFileName[2048];
 
             WszMultiByteToWideChar(CP_UTF8,0,g_szOutputFile,-1,wzFileName,2048);
-            wzName = wcsrchr(wzFileName,DIRECTORY_SEPARATOR_CHAR_W);
+            wzName = dn_wcsrchr(wzFileName,DIRECTORY_SEPARATOR_CHAR_W);
 #ifdef HOST_WINDOWS
-            if(wzName == NULL) wzName = wcsrchr(wzFileName,':');
+            if(wzName == NULL) wzName = dn_wcsrchr(wzFileName,':');
 #endif
             if (wzName == NULL) wzName = wzFileName;
             else wzName++;
@@ -812,7 +812,7 @@ void DumpManifestResources(void* GUICookie)
             NAME_ARRAY_ADD(0, wzName);
 
             // add the Win32 resource file name to avoid conflict between the native and a managed resource file
-            WCHAR *pwc = wcsrchr(wzName, L'.');
+            WCHAR *pwc = dn_wcsrchr(wzName, L'.');
             if (pwc == NULL) pwc = &wzName[wcslen(wzName)];
             wcscpy_s(pwc, 2048 - (pwc - wzFileName), W(".res"));
 

--- a/src/coreclr/ildasm/dman.cpp
+++ b/src/coreclr/ildasm/dman.cpp
@@ -782,9 +782,9 @@ void DumpManifestResources(void* GUICookie)
             static WCHAR wzFileName[2048];
 
             WszMultiByteToWideChar(CP_UTF8,0,g_szOutputFile,-1,wzFileName,2048);
-            wzName = dn_wcsrchr(wzFileName,DIRECTORY_SEPARATOR_CHAR_W);
+            wzName = (WCHAR*)dn_wcsrchr(wzFileName,DIRECTORY_SEPARATOR_CHAR_W);
 #ifdef HOST_WINDOWS
-            if(wzName == NULL) wzName = dn_wcsrchr(wzFileName,':');
+            if(wzName == NULL) wzName = (WCHAR*)dn_wcsrchr(wzFileName,':');
 #endif
             if (wzName == NULL) wzName = wzFileName;
             else wzName++;
@@ -812,7 +812,7 @@ void DumpManifestResources(void* GUICookie)
             NAME_ARRAY_ADD(0, wzName);
 
             // add the Win32 resource file name to avoid conflict between the native and a managed resource file
-            WCHAR *pwc = dn_wcsrchr(wzName, L'.');
+            WCHAR *pwc = (WCHAR*)dn_wcsrchr(wzName, L'.');
             if (pwc == NULL) pwc = &wzName[dn_wcslen(wzName)];
             wcscpy_s(pwc, 2048 - (pwc - wzFileName), W(".res"));
 

--- a/src/coreclr/ildasm/dman.cpp
+++ b/src/coreclr/ildasm/dman.cpp
@@ -125,7 +125,7 @@ void DumpScope(void* GUICookie)
     if(SUCCEEDED(g_pPubImport->GetScopeProps( scopeName, 1024, NULL, &mvid))&& scopeName[0])
     {
         {
-            UINT32 L = (UINT32)strlen_u16(scopeName)*3+3;
+            UINT32 L = (UINT32)u16_strlen(scopeName)*3+3;
             char* sz = new char[L];
             memset(sz,0,L);
             WszWideCharToMultiByte(CP_UTF8,0,scopeName,-1,sz,L,NULL,NULL);
@@ -360,7 +360,7 @@ void DumpAssemblyRefs(void* GUICookie)
                         // check for name duplication and introduce alias if needed
                         for(ixx = 0; ixx < ix; ixx++)
                         {
-                            if(!strcmp_u16(rAsmRef[ixx].name,rAsmRef[ix].name)) break;
+                            if(!u16_strcmp(rAsmRef[ixx].name,rAsmRef[ix].name)) break;
                         }
                         if(ixx < ix)
                         {
@@ -423,7 +423,7 @@ void DumpComTypeFQN(
         }
     }
 
-    UINT32 L = (UINT32)strlen_u16(pCTD->wzName)*3+3;
+    UINT32 L = (UINT32)u16_strlen(pCTD->wzName)*3+3;
     char* sz = new char[L];
     memset(sz,0,L);
     WszWideCharToMultiByte(CP_UTF8,0,pCTD->wzName,-1,sz,L,NULL,NULL);
@@ -446,7 +446,7 @@ void DumpImplementation(mdToken tkImplementation,
             if(i < nFiles)
             {
                 {
-                    UINT32 L = (UINT32)strlen_u16(rFile[i].name)*3+3;
+                    UINT32 L = (UINT32)u16_strlen(rFile[i].name)*3+3;
                     char* sz = new char[L];
                     memset(sz,0,L);
                     WszWideCharToMultiByte(CP_UTF8,0,rFile[i].name,-1,sz,L,NULL,NULL);
@@ -466,7 +466,7 @@ void DumpImplementation(mdToken tkImplementation,
             if(i < nAsmRefs)
             {
                 {
-                    UINT32 L = (UINT32)strlen_u16(rAsmRef[i].name)*3+3;
+                    UINT32 L = (UINT32)u16_strlen(rAsmRef[i].name)*3+3;
                     char* sz = new char[L];
                     memset(sz,0,L);
                     WszWideCharToMultiByte(CP_UTF8,0,rAsmRef[i].name,-1,sz,L,NULL,NULL);
@@ -512,7 +512,7 @@ void DumpComType(LocalComTypeDescr* pCTD,
 
     char* pc=&szString[strlen(szString)];
     {
-        UINT32 L = (UINT32)strlen_u16(pCTD->wzName)*3+3;
+        UINT32 L = (UINT32)u16_strlen(pCTD->wzName)*3+3;
         char* sz = new char[L];
         memset(sz,0,L);
         WszWideCharToMultiByte(CP_UTF8,0,pCTD->wzName,-1,sz,L,NULL,NULL);
@@ -628,7 +628,7 @@ static BOOL ConvertToLegalFileNameInPlace(__inout LPWSTR wzName)
 
     for (size_t i = 0; i < (sizeof(rwzReserved) / sizeof(WCHAR *)); i++)
     {
-        _ASSERTE(strlen_u16(rwzReserved[i]) == 3);
+        _ASSERTE(u16_strlen(rwzReserved[i]) == 3);
         if (_wcsnicmp(wzName, rwzReserved[i], 3) == 0)
         {
             LPWSTR pwc = wzName + 3;
@@ -782,9 +782,9 @@ void DumpManifestResources(void* GUICookie)
             static WCHAR wzFileName[2048];
 
             WszMultiByteToWideChar(CP_UTF8,0,g_szOutputFile,-1,wzFileName,2048);
-            wzName = (WCHAR*)strrchr_u16(wzFileName,DIRECTORY_SEPARATOR_CHAR_W);
+            wzName = (WCHAR*)u16_strrchr(wzFileName,DIRECTORY_SEPARATOR_CHAR_W);
 #ifdef HOST_WINDOWS
-            if(wzName == NULL) wzName = (WCHAR*)strrchr_u16(wzFileName,':');
+            if(wzName == NULL) wzName = (WCHAR*)u16_strrchr(wzFileName,':');
 #endif
             if (wzName == NULL) wzName = wzFileName;
             else wzName++;
@@ -801,7 +801,7 @@ void DumpManifestResources(void* GUICookie)
 
 #define NAME_ARRAY_ADD(index, str)                                                    \
             {                                                                         \
-                size_t __dwBufLen = strlen_u16(str) + 1;                                  \
+                size_t __dwBufLen = u16_strlen(str) + 1;                                  \
                                                                                       \
                 qbNameArray[index].Init();                                            \
                 WCHAR *__wpc = (WCHAR *)qbNameArray[index].AllocNoThrow(__dwBufLen);  \
@@ -812,8 +812,8 @@ void DumpManifestResources(void* GUICookie)
             NAME_ARRAY_ADD(0, wzName);
 
             // add the Win32 resource file name to avoid conflict between the native and a managed resource file
-            WCHAR *pwc = (WCHAR*)strrchr_u16(wzName, L'.');
-            if (pwc == NULL) pwc = &wzName[strlen_u16(wzName)];
+            WCHAR *pwc = (WCHAR*)u16_strrchr(wzName, L'.');
+            if (pwc == NULL) pwc = &wzName[u16_strlen(wzName)];
             wcscpy_s(pwc, 2048 - (pwc - wzFileName), W(".res"));
 
             NAME_ARRAY_ADD(1, wzName);
@@ -845,7 +845,7 @@ void DumpManifestResources(void* GUICookie)
                     BOOL fAlias = ConvertToLegalFileNameInPlace(wzName);
 
                     // check for duplicate file name
-                    WCHAR *wpc = wzName + strlen_u16(wzName);
+                    WCHAR *wpc = wzName + u16_strlen(wzName);
                     for (int iIndex = 1;; iIndex++)
                     {
                         BOOL fConflict = FALSE;

--- a/src/coreclr/ildasm/dres.cpp
+++ b/src/coreclr/ildasm/dres.cpp
@@ -104,8 +104,8 @@ struct ResourceNode
         {
             //fwrite(&(g_prResNodePtr[i]->ResHdr),g_prResNodePtr[i]->ResHdr.dwHeaderSize,1,pF);
             ResHdr.dwHeaderSize = sizeof(ResourceHeader);
-            if(wzType) ResHdr.dwHeaderSize += (DWORD)((wcslen(wzType) + 1)*sizeof(WCHAR) - sizeof(DWORD));
-            if(wzName) ResHdr.dwHeaderSize += (DWORD)((wcslen(wzName) + 1)*sizeof(WCHAR) - sizeof(DWORD));
+            if(wzType) ResHdr.dwHeaderSize += (DWORD)((dn_wcslen(wzType) + 1)*sizeof(WCHAR) - sizeof(DWORD));
+            if(wzName) ResHdr.dwHeaderSize += (DWORD)((dn_wcslen(wzName) + 1)*sizeof(WCHAR) - sizeof(DWORD));
 
             //---- Constant part of the header: DWORD,DWORD
             fwrite(&ResHdr.dwDataSize, sizeof(DWORD),1,pF);
@@ -113,15 +113,15 @@ struct ResourceNode
             //--- Variable part of header: type and name
             if(wzType)
             {
-                fwrite(wzType,(wcslen(wzType) + 1)*sizeof(WCHAR), 1, pF);
-                dwFiller += (DWORD)wcslen(wzType) + 1;
+                fwrite(wzType,(dn_wcslen(wzType) + 1)*sizeof(WCHAR), 1, pF);
+                dwFiller += (DWORD)dn_wcslen(wzType) + 1;
             }
             else
                 fwrite(&ResHdr.dwTypeID,sizeof(DWORD),1,pF);
             if(wzName)
             {
-                fwrite(wzName,(wcslen(wzName) + 1)*sizeof(WCHAR), 1, pF);
-                dwFiller += (DWORD)wcslen(wzName) + 1;
+                fwrite(wzName,(dn_wcslen(wzName) + 1)*sizeof(WCHAR), 1, pF);
+                dwFiller += (DWORD)dn_wcslen(wzName) + 1;
             }
             else
                 fwrite(&ResHdr.dwNameID,sizeof(DWORD),1,pF);

--- a/src/coreclr/ildasm/dres.cpp
+++ b/src/coreclr/ildasm/dres.cpp
@@ -104,8 +104,8 @@ struct ResourceNode
         {
             //fwrite(&(g_prResNodePtr[i]->ResHdr),g_prResNodePtr[i]->ResHdr.dwHeaderSize,1,pF);
             ResHdr.dwHeaderSize = sizeof(ResourceHeader);
-            if(wzType) ResHdr.dwHeaderSize += (DWORD)((dn_wcslen(wzType) + 1)*sizeof(WCHAR) - sizeof(DWORD));
-            if(wzName) ResHdr.dwHeaderSize += (DWORD)((dn_wcslen(wzName) + 1)*sizeof(WCHAR) - sizeof(DWORD));
+            if(wzType) ResHdr.dwHeaderSize += (DWORD)((strlen_u16(wzType) + 1)*sizeof(WCHAR) - sizeof(DWORD));
+            if(wzName) ResHdr.dwHeaderSize += (DWORD)((strlen_u16(wzName) + 1)*sizeof(WCHAR) - sizeof(DWORD));
 
             //---- Constant part of the header: DWORD,DWORD
             fwrite(&ResHdr.dwDataSize, sizeof(DWORD),1,pF);
@@ -113,15 +113,15 @@ struct ResourceNode
             //--- Variable part of header: type and name
             if(wzType)
             {
-                fwrite(wzType,(dn_wcslen(wzType) + 1)*sizeof(WCHAR), 1, pF);
-                dwFiller += (DWORD)dn_wcslen(wzType) + 1;
+                fwrite(wzType,(strlen_u16(wzType) + 1)*sizeof(WCHAR), 1, pF);
+                dwFiller += (DWORD)strlen_u16(wzType) + 1;
             }
             else
                 fwrite(&ResHdr.dwTypeID,sizeof(DWORD),1,pF);
             if(wzName)
             {
-                fwrite(wzName,(dn_wcslen(wzName) + 1)*sizeof(WCHAR), 1, pF);
-                dwFiller += (DWORD)dn_wcslen(wzName) + 1;
+                fwrite(wzName,(strlen_u16(wzName) + 1)*sizeof(WCHAR), 1, pF);
+                dwFiller += (DWORD)strlen_u16(wzName) + 1;
             }
             else
                 fwrite(&ResHdr.dwNameID,sizeof(DWORD),1,pF);

--- a/src/coreclr/ildasm/dres.cpp
+++ b/src/coreclr/ildasm/dres.cpp
@@ -104,8 +104,8 @@ struct ResourceNode
         {
             //fwrite(&(g_prResNodePtr[i]->ResHdr),g_prResNodePtr[i]->ResHdr.dwHeaderSize,1,pF);
             ResHdr.dwHeaderSize = sizeof(ResourceHeader);
-            if(wzType) ResHdr.dwHeaderSize += (DWORD)((strlen_u16(wzType) + 1)*sizeof(WCHAR) - sizeof(DWORD));
-            if(wzName) ResHdr.dwHeaderSize += (DWORD)((strlen_u16(wzName) + 1)*sizeof(WCHAR) - sizeof(DWORD));
+            if(wzType) ResHdr.dwHeaderSize += (DWORD)((u16_strlen(wzType) + 1)*sizeof(WCHAR) - sizeof(DWORD));
+            if(wzName) ResHdr.dwHeaderSize += (DWORD)((u16_strlen(wzName) + 1)*sizeof(WCHAR) - sizeof(DWORD));
 
             //---- Constant part of the header: DWORD,DWORD
             fwrite(&ResHdr.dwDataSize, sizeof(DWORD),1,pF);
@@ -113,15 +113,15 @@ struct ResourceNode
             //--- Variable part of header: type and name
             if(wzType)
             {
-                fwrite(wzType,(strlen_u16(wzType) + 1)*sizeof(WCHAR), 1, pF);
-                dwFiller += (DWORD)strlen_u16(wzType) + 1;
+                fwrite(wzType,(u16_strlen(wzType) + 1)*sizeof(WCHAR), 1, pF);
+                dwFiller += (DWORD)u16_strlen(wzType) + 1;
             }
             else
                 fwrite(&ResHdr.dwTypeID,sizeof(DWORD),1,pF);
             if(wzName)
             {
-                fwrite(wzName,(strlen_u16(wzName) + 1)*sizeof(WCHAR), 1, pF);
-                dwFiller += (DWORD)strlen_u16(wzName) + 1;
+                fwrite(wzName,(u16_strlen(wzName) + 1)*sizeof(WCHAR), 1, pF);
+                dwFiller += (DWORD)u16_strlen(wzName) + 1;
             }
             else
                 fwrite(&ResHdr.dwNameID,sizeof(DWORD),1,pF);

--- a/src/coreclr/ildasm/exe/CMakeLists.txt
+++ b/src/coreclr/ildasm/exe/CMakeLists.txt
@@ -94,6 +94,7 @@ else()
         coreclrpal
         mscorrc
         palrt
+        coreclrminipal
     )
 endif(CLR_CMAKE_HOST_WIN32)
 

--- a/src/coreclr/ildasm/exe/CMakeLists.txt
+++ b/src/coreclr/ildasm/exe/CMakeLists.txt
@@ -88,6 +88,7 @@ if(CLR_CMAKE_HOST_WIN32)
         shlwapi.lib
         bcrypt.lib
         RuntimeObject.lib
+        coreclrminipal
     )
 else()
     list(APPEND ILDASM_LINK_LIBRARIES

--- a/src/coreclr/inc/configuration.h
+++ b/src/coreclr/inc/configuration.h
@@ -21,12 +21,12 @@ public:
 
     // Returns (in priority order):
     //    - The value of the ConfigDWORDInfo if it's set
-    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a dn_wcstoul).
+    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a strtoul_u16).
     //    - The default set in the ConfigDWORDInfo
     static DWORD GetKnobDWORDValue(LPCWSTR name, const CLRConfig::ConfigDWORDInfo& dwordInfo);
 
     // Returns (in priority order):
-    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a dn_wcstoul)
+    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a strtoul_u16)
     //    - The default value passed in
     static DWORD GetKnobDWORDValue(LPCWSTR name, DWORD defaultValue);
 
@@ -34,7 +34,7 @@ public:
     // in the traditional way separately if you need to.
     //
     // Returns (in priority order):
-    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a dn_wcstoui64)
+    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a strtoui64_u16)
     //    - The default value passed in
     static ULONGLONG GetKnobULONGLONGValue(LPCWSTR name, ULONGLONG defaultValue);
 
@@ -51,18 +51,18 @@ public:
 
     // Returns (in priority order):
     //    - The value of the ConfigDWORDInfo if it's set (0 is false, anything else is true)
-    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a dn_wcscmp with "true").
+    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a strcmp_u16 with "true").
     //    - The default set in the ConfigDWORDInfo (0 is false, anything else is true)
     static bool GetKnobBooleanValue(LPCWSTR name, const CLRConfig::ConfigDWORDInfo& dwordInfo);
 
     // Returns (in priority order):
     //    - The value of the ConfigDWORDInfo if it's set (0 is false, anything else is true)
-    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a dn_wcscmp with "true").
+    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a strcmp_u16 with "true").
     //    - The default value passed in
     static bool GetKnobBooleanValue(LPCWSTR name, const CLRConfig::ConfigDWORDInfo& dwordInfo, bool defaultValue);
 
     // Returns (in priority order):
-    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a dn_wcscmp with "true").
+    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a strcmp_u16 with "true").
     //    - The default value passed in
     static bool GetKnobBooleanValue(LPCWSTR name, bool defaultValue);
 };

--- a/src/coreclr/inc/configuration.h
+++ b/src/coreclr/inc/configuration.h
@@ -21,12 +21,12 @@ public:
 
     // Returns (in priority order):
     //    - The value of the ConfigDWORDInfo if it's set
-    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a strtoul_u16).
+    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a u16_strtoul).
     //    - The default set in the ConfigDWORDInfo
     static DWORD GetKnobDWORDValue(LPCWSTR name, const CLRConfig::ConfigDWORDInfo& dwordInfo);
 
     // Returns (in priority order):
-    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a strtoul_u16)
+    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a u16_strtoul)
     //    - The default value passed in
     static DWORD GetKnobDWORDValue(LPCWSTR name, DWORD defaultValue);
 
@@ -34,7 +34,7 @@ public:
     // in the traditional way separately if you need to.
     //
     // Returns (in priority order):
-    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a strtoui64_u16)
+    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a u16_strtoui64)
     //    - The default value passed in
     static ULONGLONG GetKnobULONGLONGValue(LPCWSTR name, ULONGLONG defaultValue);
 
@@ -51,18 +51,18 @@ public:
 
     // Returns (in priority order):
     //    - The value of the ConfigDWORDInfo if it's set (0 is false, anything else is true)
-    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a strcmp_u16 with "true").
+    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a u16_strcmp with "true").
     //    - The default set in the ConfigDWORDInfo (0 is false, anything else is true)
     static bool GetKnobBooleanValue(LPCWSTR name, const CLRConfig::ConfigDWORDInfo& dwordInfo);
 
     // Returns (in priority order):
     //    - The value of the ConfigDWORDInfo if it's set (0 is false, anything else is true)
-    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a strcmp_u16 with "true").
+    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a u16_strcmp with "true").
     //    - The default value passed in
     static bool GetKnobBooleanValue(LPCWSTR name, const CLRConfig::ConfigDWORDInfo& dwordInfo, bool defaultValue);
 
     // Returns (in priority order):
-    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a strcmp_u16 with "true").
+    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a u16_strcmp with "true").
     //    - The default value passed in
     static bool GetKnobBooleanValue(LPCWSTR name, bool defaultValue);
 };

--- a/src/coreclr/inc/configuration.h
+++ b/src/coreclr/inc/configuration.h
@@ -51,18 +51,18 @@ public:
 
     // Returns (in priority order):
     //    - The value of the ConfigDWORDInfo if it's set (0 is false, anything else is true)
-    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a wcscmp with "true").
+    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a dn_wcscmp with "true").
     //    - The default set in the ConfigDWORDInfo (0 is false, anything else is true)
     static bool GetKnobBooleanValue(LPCWSTR name, const CLRConfig::ConfigDWORDInfo& dwordInfo);
 
     // Returns (in priority order):
     //    - The value of the ConfigDWORDInfo if it's set (0 is false, anything else is true)
-    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a wcscmp with "true").
+    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a dn_wcscmp with "true").
     //    - The default value passed in
     static bool GetKnobBooleanValue(LPCWSTR name, const CLRConfig::ConfigDWORDInfo& dwordInfo, bool defaultValue);
 
     // Returns (in priority order):
-    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a wcscmp with "true").
+    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a dn_wcscmp with "true").
     //    - The default value passed in
     static bool GetKnobBooleanValue(LPCWSTR name, bool defaultValue);
 };

--- a/src/coreclr/inc/configuration.h
+++ b/src/coreclr/inc/configuration.h
@@ -21,12 +21,12 @@ public:
 
     // Returns (in priority order):
     //    - The value of the ConfigDWORDInfo if it's set
-    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a wcstoul).
+    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a dn_wcstoul).
     //    - The default set in the ConfigDWORDInfo
     static DWORD GetKnobDWORDValue(LPCWSTR name, const CLRConfig::ConfigDWORDInfo& dwordInfo);
 
     // Returns (in priority order):
-    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a wcstoul)
+    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a dn_wcstoul)
     //    - The default value passed in
     static DWORD GetKnobDWORDValue(LPCWSTR name, DWORD defaultValue);
 
@@ -34,7 +34,7 @@ public:
     // in the traditional way separately if you need to.
     //
     // Returns (in priority order):
-    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a _wcstoui64)
+    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a dn_wcstoui64)
     //    - The default value passed in
     static ULONGLONG GetKnobULONGLONGValue(LPCWSTR name, ULONGLONG defaultValue);
 

--- a/src/coreclr/inc/corhdr.h
+++ b/src/coreclr/inc/corhdr.h
@@ -439,9 +439,9 @@ typedef enum CorMethodAttr
 
 #define IsMdRTSpecialName(x)                ((x) & mdRTSpecialName)
 #define IsMdInstanceInitializer(x, str)     (((x) & mdRTSpecialName) && !strcmp((str), COR_CTOR_METHOD_NAME))
-#define IsMdInstanceInitializerW(x, str)    (((x) & mdRTSpecialName) && !wcscmp((str), COR_CTOR_METHOD_NAME_W))
+#define IsMdInstanceInitializerW(x, str)    (((x) & mdRTSpecialName) && !dn_wcscmp((str), COR_CTOR_METHOD_NAME_W))
 #define IsMdClassConstructor(x, str)        (((x) & mdRTSpecialName) && !strcmp((str), COR_CCTOR_METHOD_NAME))
-#define IsMdClassConstructorW(x, str)       (((x) & mdRTSpecialName) && !wcscmp((str), COR_CCTOR_METHOD_NAME_W))
+#define IsMdClassConstructorW(x, str)       (((x) & mdRTSpecialName) && !dn_wcscmp((str), COR_CCTOR_METHOD_NAME_W))
 #define IsMdHasSecurity(x)                  ((x) & mdHasSecurity)
 #define IsMdRequireSecObject(x)             ((x) & mdRequireSecObject)
 

--- a/src/coreclr/inc/corhdr.h
+++ b/src/coreclr/inc/corhdr.h
@@ -439,9 +439,9 @@ typedef enum CorMethodAttr
 
 #define IsMdRTSpecialName(x)                ((x) & mdRTSpecialName)
 #define IsMdInstanceInitializer(x, str)     (((x) & mdRTSpecialName) && !strcmp((str), COR_CTOR_METHOD_NAME))
-#define IsMdInstanceInitializerW(x, str)    (((x) & mdRTSpecialName) && !dn_wcscmp((str), COR_CTOR_METHOD_NAME_W))
+#define IsMdInstanceInitializerW(x, str)    (((x) & mdRTSpecialName) && !strcmp_u16((str), COR_CTOR_METHOD_NAME_W))
 #define IsMdClassConstructor(x, str)        (((x) & mdRTSpecialName) && !strcmp((str), COR_CCTOR_METHOD_NAME))
-#define IsMdClassConstructorW(x, str)       (((x) & mdRTSpecialName) && !dn_wcscmp((str), COR_CCTOR_METHOD_NAME_W))
+#define IsMdClassConstructorW(x, str)       (((x) & mdRTSpecialName) && !strcmp_u16((str), COR_CCTOR_METHOD_NAME_W))
 #define IsMdHasSecurity(x)                  ((x) & mdHasSecurity)
 #define IsMdRequireSecObject(x)             ((x) & mdRequireSecObject)
 

--- a/src/coreclr/inc/corhdr.h
+++ b/src/coreclr/inc/corhdr.h
@@ -439,9 +439,9 @@ typedef enum CorMethodAttr
 
 #define IsMdRTSpecialName(x)                ((x) & mdRTSpecialName)
 #define IsMdInstanceInitializer(x, str)     (((x) & mdRTSpecialName) && !strcmp((str), COR_CTOR_METHOD_NAME))
-#define IsMdInstanceInitializerW(x, str)    (((x) & mdRTSpecialName) && !strcmp_u16((str), COR_CTOR_METHOD_NAME_W))
+#define IsMdInstanceInitializerW(x, str)    (((x) & mdRTSpecialName) && !u16_strcmp((str), COR_CTOR_METHOD_NAME_W))
 #define IsMdClassConstructor(x, str)        (((x) & mdRTSpecialName) && !strcmp((str), COR_CCTOR_METHOD_NAME))
-#define IsMdClassConstructorW(x, str)       (((x) & mdRTSpecialName) && !strcmp_u16((str), COR_CCTOR_METHOD_NAME_W))
+#define IsMdClassConstructorW(x, str)       (((x) & mdRTSpecialName) && !u16_strcmp((str), COR_CCTOR_METHOD_NAME_W))
 #define IsMdHasSecurity(x)                  ((x) & mdHasSecurity)
 #define IsMdRequireSecObject(x)             ((x) & mdRequireSecObject)
 

--- a/src/coreclr/inc/eventtracebase.h
+++ b/src/coreclr/inc/eventtracebase.h
@@ -343,7 +343,7 @@ private:
     ComponentSpan GetNextComponentString(LPCWSTR start) const
     {
         const WCHAR ComponentDelimiter = W(':');
-        const WCHAR * end = wcschr(start, ComponentDelimiter);
+        const WCHAR * end = dn_wcschr(start, ComponentDelimiter);
         if (end == nullptr)
         {
             end = start + wcslen(start);
@@ -359,7 +359,7 @@ private:
         {
             auto const length = component.End - component.Start;
             providerName = new WCHAR[length + 1];
-            wcsncpy(providerName, component.Start, length);
+            dn_wcsncpy(providerName, component.Start, length);
             providerName[length] = '\0';
         }
         return providerName;
@@ -392,7 +392,7 @@ private:
         {
             auto const length = component.End - component.Start;
             argument = new WCHAR[length + 1];
-            wcsncpy(argument, component.Start, length);
+            dn_wcsncpy(argument, component.Start, length);
             argument[length] = '\0';
         }
         return argument;
@@ -534,7 +534,7 @@ public:
         while (configToParse != nullptr)
         {
             const WCHAR comma = W(',');
-            auto end = wcschr(configToParse, comma);
+            auto end = dn_wcschr(configToParse, comma);
             configuration.Parse(configToParse);
             XplatEventLoggerController::UpdateProviderContext(configuration);
             if (end == nullptr)

--- a/src/coreclr/inc/eventtracebase.h
+++ b/src/coreclr/inc/eventtracebase.h
@@ -343,10 +343,10 @@ private:
     ComponentSpan GetNextComponentString(LPCWSTR start) const
     {
         const WCHAR ComponentDelimiter = W(':');
-        const WCHAR * end = strchr_u16(start, ComponentDelimiter);
+        const WCHAR * end = u16_strchr(start, ComponentDelimiter);
         if (end == nullptr)
         {
-            end = start + strlen_u16(start);
+            end = start + u16_strlen(start);
         }
 
         return ComponentSpan(start, end);
@@ -359,7 +359,7 @@ private:
         {
             auto const length = component.End - component.Start;
             providerName = new WCHAR[length + 1];
-            strncpy_u16(providerName, length + 1, component.Start, length);
+            u16_strncpy_s(providerName, length + 1, component.Start, length);
             providerName[length] = '\0';
         }
         return providerName;
@@ -370,7 +370,7 @@ private:
         auto enabledKeywordsMask = (uint64_t)(-1);
         if ((component.End - component.Start) != 0)
         {
-            enabledKeywordsMask = strtoui64_u16(component.Start, nullptr, 16);
+            enabledKeywordsMask = u16_strtoui64(component.Start, nullptr, 16);
         }
         return enabledKeywordsMask;
     }
@@ -392,7 +392,7 @@ private:
         {
             auto const length = component.End - component.Start;
             argument = new WCHAR[length + 1];
-            strncpy_u16(argument, length + 1, component.Start, length);
+            u16_strncpy_s(argument, length + 1, component.Start, length);
             argument[length] = '\0';
         }
         return argument;
@@ -457,7 +457,7 @@ private:
 #ifdef FEATURE_EVENT_TRACE
     static LTTNG_TRACE_CONTEXT * const GetProvider(LPCWSTR providerName)
     {
-        auto length = strlen_u16(providerName);
+        auto length = u16_strlen(providerName);
         for (auto provider : ALL_LTTNG_PROVIDERS_CONTEXT)
         {
             if (_wcsicmp(provider->Name, providerName) == 0)
@@ -534,7 +534,7 @@ public:
         while (configToParse != nullptr)
         {
             const WCHAR comma = W(',');
-            auto end = (LPWSTR)strchr_u16(configToParse, comma);
+            auto end = (LPWSTR)u16_strchr(configToParse, comma);
             configuration.Parse(configToParse);
             XplatEventLoggerController::UpdateProviderContext(configuration);
             if (end == nullptr)

--- a/src/coreclr/inc/eventtracebase.h
+++ b/src/coreclr/inc/eventtracebase.h
@@ -534,7 +534,7 @@ public:
         while (configToParse != nullptr)
         {
             const WCHAR comma = W(',');
-            auto end = dn_wcschr(configToParse, comma);
+            auto end = (LPWSTR)dn_wcschr(configToParse, comma);
             configuration.Parse(configToParse);
             XplatEventLoggerController::UpdateProviderContext(configuration);
             if (end == nullptr)

--- a/src/coreclr/inc/eventtracebase.h
+++ b/src/coreclr/inc/eventtracebase.h
@@ -370,7 +370,7 @@ private:
         auto enabledKeywordsMask = (uint64_t)(-1);
         if ((component.End - component.Start) != 0)
         {
-            enabledKeywordsMask = _wcstoui64(component.Start, nullptr, 16);
+            enabledKeywordsMask = dn_wcstoui64(component.Start, nullptr, 16);
         }
         return enabledKeywordsMask;
     }

--- a/src/coreclr/inc/eventtracebase.h
+++ b/src/coreclr/inc/eventtracebase.h
@@ -343,10 +343,10 @@ private:
     ComponentSpan GetNextComponentString(LPCWSTR start) const
     {
         const WCHAR ComponentDelimiter = W(':');
-        const WCHAR * end = dn_wcschr(start, ComponentDelimiter);
+        const WCHAR * end = strchr_u16(start, ComponentDelimiter);
         if (end == nullptr)
         {
-            end = start + dn_wcslen(start);
+            end = start + strlen_u16(start);
         }
 
         return ComponentSpan(start, end);
@@ -359,7 +359,7 @@ private:
         {
             auto const length = component.End - component.Start;
             providerName = new WCHAR[length + 1];
-            dn_wcsncpy(providerName, length + 1, component.Start, length);
+            strncpy_u16(providerName, length + 1, component.Start, length);
             providerName[length] = '\0';
         }
         return providerName;
@@ -370,7 +370,7 @@ private:
         auto enabledKeywordsMask = (uint64_t)(-1);
         if ((component.End - component.Start) != 0)
         {
-            enabledKeywordsMask = dn_wcstoui64(component.Start, nullptr, 16);
+            enabledKeywordsMask = strtoui64_u16(component.Start, nullptr, 16);
         }
         return enabledKeywordsMask;
     }
@@ -392,7 +392,7 @@ private:
         {
             auto const length = component.End - component.Start;
             argument = new WCHAR[length + 1];
-            dn_wcsncpy(argument, length + 1, component.Start, length);
+            strncpy_u16(argument, length + 1, component.Start, length);
             argument[length] = '\0';
         }
         return argument;
@@ -457,7 +457,7 @@ private:
 #ifdef FEATURE_EVENT_TRACE
     static LTTNG_TRACE_CONTEXT * const GetProvider(LPCWSTR providerName)
     {
-        auto length = dn_wcslen(providerName);
+        auto length = strlen_u16(providerName);
         for (auto provider : ALL_LTTNG_PROVIDERS_CONTEXT)
         {
             if (_wcsicmp(provider->Name, providerName) == 0)
@@ -534,7 +534,7 @@ public:
         while (configToParse != nullptr)
         {
             const WCHAR comma = W(',');
-            auto end = (LPWSTR)dn_wcschr(configToParse, comma);
+            auto end = (LPWSTR)strchr_u16(configToParse, comma);
             configuration.Parse(configToParse);
             XplatEventLoggerController::UpdateProviderContext(configuration);
             if (end == nullptr)

--- a/src/coreclr/inc/eventtracebase.h
+++ b/src/coreclr/inc/eventtracebase.h
@@ -346,7 +346,7 @@ private:
         const WCHAR * end = dn_wcschr(start, ComponentDelimiter);
         if (end == nullptr)
         {
-            end = start + wcslen(start);
+            end = start + dn_wcslen(start);
         }
 
         return ComponentSpan(start, end);
@@ -457,7 +457,7 @@ private:
 #ifdef FEATURE_EVENT_TRACE
     static LTTNG_TRACE_CONTEXT * const GetProvider(LPCWSTR providerName)
     {
-        auto length = wcslen(providerName);
+        auto length = dn_wcslen(providerName);
         for (auto provider : ALL_LTTNG_PROVIDERS_CONTEXT)
         {
             if (_wcsicmp(provider->Name, providerName) == 0)

--- a/src/coreclr/inc/eventtracebase.h
+++ b/src/coreclr/inc/eventtracebase.h
@@ -359,7 +359,7 @@ private:
         {
             auto const length = component.End - component.Start;
             providerName = new WCHAR[length + 1];
-            dn_wcsncpy(providerName, component.Start, length);
+            dn_wcsncpy(providerName, length + 1, component.Start, length);
             providerName[length] = '\0';
         }
         return providerName;
@@ -392,7 +392,7 @@ private:
         {
             auto const length = component.End - component.Start;
             argument = new WCHAR[length + 1];
-            dn_wcsncpy(argument, component.Start, length);
+            dn_wcsncpy(argument, length + 1, component.Start, length);
             argument[length] = '\0';
         }
         return argument;

--- a/src/coreclr/inc/executableallocator.h
+++ b/src/coreclr/inc/executableallocator.h
@@ -11,7 +11,7 @@
 #include "utilcode.h"
 #include "ex.h"
 
-#include "minipal.h"
+#include <minipal.h>
 
 #ifndef DACCESS_COMPILE
 
@@ -350,10 +350,10 @@ public:
 #undef ExecutableWriterHolder
 #ifdef HOST_UNIX
 #define ExecutableWriterHolder ExecutableAllocator::LogUsage(__FILE__, __LINE__, __PRETTY_FUNCTION__); ExecutableWriterHolderNoLog
-#define AssignExecutableWriterHolder(addressRX, size) AssignExecutableWriterHolder(addressRX, size); ExecutableAllocator::LogUsage(__FILE__, __LINE__, __PRETTY_FUNCTION__); 
+#define AssignExecutableWriterHolder(addressRX, size) AssignExecutableWriterHolder(addressRX, size); ExecutableAllocator::LogUsage(__FILE__, __LINE__, __PRETTY_FUNCTION__);
 #else
 #define ExecutableWriterHolder ExecutableAllocator::LogUsage(__FILE__, __LINE__, __FUNCTION__); ExecutableWriterHolderNoLog
-#define AssignExecutableWriterHolder(addressRX, size) AssignExecutableWriterHolder(addressRX, size); ExecutableAllocator::LogUsage(__FILE__, __LINE__, __FUNCTION__); 
+#define AssignExecutableWriterHolder(addressRX, size) AssignExecutableWriterHolder(addressRX, size); ExecutableAllocator::LogUsage(__FILE__, __LINE__, __FUNCTION__);
 #endif
 #else
 #define ExecutableWriterHolder ExecutableWriterHolderNoLog

--- a/src/coreclr/inc/outstring.h
+++ b/src/coreclr/inc/outstring.h
@@ -73,7 +73,7 @@ public:
     }
 
     OutString& operator<<(const WCHAR* str) {
-        size_t len = strlen_u16(str);
+        size_t len = u16_strlen(str);
         if (cur+len > end)
             Realloc(len);
         while(str != 0)

--- a/src/coreclr/inc/outstring.h
+++ b/src/coreclr/inc/outstring.h
@@ -73,7 +73,7 @@ public:
     }
 
     OutString& operator<<(const WCHAR* str) {
-        size_t len = wcslen(str);
+        size_t len = dn_wcslen(str);
         if (cur+len > end)
             Realloc(len);
         while(str != 0)

--- a/src/coreclr/inc/outstring.h
+++ b/src/coreclr/inc/outstring.h
@@ -73,7 +73,7 @@ public:
     }
 
     OutString& operator<<(const WCHAR* str) {
-        size_t len = dn_wcslen(str);
+        size_t len = strlen_u16(str);
         if (cur+len > end)
             Realloc(len);
         while(str != 0)

--- a/src/coreclr/inc/shash.h
+++ b/src/coreclr/inc/shash.h
@@ -692,7 +692,7 @@ private:
 
     static size_t _strcmp(WCHAR const *left, WCHAR const *right)
     {
-        return ::wcscmp(left, right);
+        return ::dn_wcscmp(left, right);
     }
 
     static size_t _hash(CHAR const *str)

--- a/src/coreclr/inc/shash.h
+++ b/src/coreclr/inc/shash.h
@@ -692,7 +692,7 @@ private:
 
     static size_t _strcmp(WCHAR const *left, WCHAR const *right)
     {
-        return ::dn_wcscmp(left, right);
+        return ::strcmp_u16(left, right);
     }
 
     static size_t _hash(CHAR const *str)

--- a/src/coreclr/inc/shash.h
+++ b/src/coreclr/inc/shash.h
@@ -692,7 +692,7 @@ private:
 
     static size_t _strcmp(WCHAR const *left, WCHAR const *right)
     {
-        return ::strcmp_u16(left, right);
+        return ::u16_strcmp(left, right);
     }
 
     static size_t _hash(CHAR const *str)

--- a/src/coreclr/inc/sstring.h
+++ b/src/coreclr/inc/sstring.h
@@ -619,11 +619,11 @@ public:
 #endif  // CHECK_INVARIANTS
 
     // Helpers for CRT function equivalance.
-    static int __cdecl _stricmp(const CHAR *buffer1, const CHAR *buffer2);
-    static int __cdecl _strnicmp(const CHAR *buffer1, const CHAR *buffer2, COUNT_T count);
+    static int _stricmp(const CHAR *buffer1, const CHAR *buffer2);
+    static int _strnicmp(const CHAR *buffer1, const CHAR *buffer2, COUNT_T count);
 
-    static int __cdecl _wcsicmp(const WCHAR *buffer1, const WCHAR *buffer2);
-    static int __cdecl _wcsnicmp(const WCHAR *buffer1, const WCHAR *buffer2, COUNT_T count);
+    static int _wcsicmp(const WCHAR *buffer1, const WCHAR *buffer2);
+    static int _wcsnicmp(const WCHAR *buffer1, const WCHAR *buffer2, COUNT_T count);
 
     // C++ convenience overloads
     static int _tstricmp(const CHAR *buffer1, const CHAR *buffer2);

--- a/src/coreclr/inc/sstring.inl
+++ b/src/coreclr/inc/sstring.inl
@@ -380,7 +380,7 @@ inline SString::SString(tagUTF8Literal dummytag, const UTF8 *literal)
 }
 
 inline SString::SString(tagLiteral dummytag, const WCHAR *literal)
-  : SBuffer(Immutable, (const BYTE *) literal, (COUNT_T) (wcslen(literal)+1)*sizeof(WCHAR))
+  : SBuffer(Immutable, (const BYTE *) literal, (COUNT_T) (dn_wcslen(literal)+1)*sizeof(WCHAR))
 {
     SS_CONTRACT_VOID
     {

--- a/src/coreclr/inc/sstring.inl
+++ b/src/coreclr/inc/sstring.inl
@@ -380,7 +380,7 @@ inline SString::SString(tagUTF8Literal dummytag, const UTF8 *literal)
 }
 
 inline SString::SString(tagLiteral dummytag, const WCHAR *literal)
-  : SBuffer(Immutable, (const BYTE *) literal, (COUNT_T) (dn_wcslen(literal)+1)*sizeof(WCHAR))
+  : SBuffer(Immutable, (const BYTE *) literal, (COUNT_T) (strlen_u16(literal)+1)*sizeof(WCHAR))
 {
     SS_CONTRACT_VOID
     {

--- a/src/coreclr/inc/sstring.inl
+++ b/src/coreclr/inc/sstring.inl
@@ -784,7 +784,7 @@ inline void SString::AppendUTF8(const CHAR c)
 
 // Helpers for CRT function equivalance.
 /* static */
-inline int __cdecl SString::_stricmp(const CHAR *buffer1, const CHAR *buffer2) {
+inline int SString::_stricmp(const CHAR *buffer1, const CHAR *buffer2) {
     WRAPPER_NO_CONTRACT;
     int returnValue = CaseCompareHelperA(buffer1, buffer2, 0, TRUE, FALSE);
 #ifdef VERIFY_CRT_EQUIVALNCE
@@ -795,7 +795,7 @@ inline int __cdecl SString::_stricmp(const CHAR *buffer1, const CHAR *buffer2) {
 }
 
 /* static */
-inline int __cdecl SString::_strnicmp(const CHAR *buffer1, const CHAR *buffer2, COUNT_T count) {
+inline int SString::_strnicmp(const CHAR *buffer1, const CHAR *buffer2, COUNT_T count) {
     WRAPPER_NO_CONTRACT;
     int returnValue = CaseCompareHelperA(buffer1, buffer2, count, TRUE, TRUE);
 #ifdef VERIFY_CRT_EQUIVALNCE
@@ -805,7 +805,7 @@ inline int __cdecl SString::_strnicmp(const CHAR *buffer1, const CHAR *buffer2, 
 }
 
 /* static */
-inline int __cdecl SString::_wcsicmp(const WCHAR *buffer1, const WCHAR *buffer2) {
+inline int SString::_wcsicmp(const WCHAR *buffer1, const WCHAR *buffer2) {
     WRAPPER_NO_CONTRACT;
     int returnValue = CaseCompareHelper(buffer1, buffer2, 0, TRUE, FALSE);
 #ifdef VERIFY_CRT_EQUIVALNCE
@@ -816,7 +816,7 @@ inline int __cdecl SString::_wcsicmp(const WCHAR *buffer1, const WCHAR *buffer2)
 }
 
 /* static */
-inline int __cdecl SString::_wcsnicmp(const WCHAR *buffer1, const WCHAR *buffer2, COUNT_T count) {
+inline int SString::_wcsnicmp(const WCHAR *buffer1, const WCHAR *buffer2, COUNT_T count) {
     WRAPPER_NO_CONTRACT;
     int returnValue = CaseCompareHelper(buffer1, buffer2, count, TRUE, TRUE);
 #ifdef VERIFY_CRT_EQUIVALNCE

--- a/src/coreclr/inc/sstring.inl
+++ b/src/coreclr/inc/sstring.inl
@@ -380,7 +380,7 @@ inline SString::SString(tagUTF8Literal dummytag, const UTF8 *literal)
 }
 
 inline SString::SString(tagLiteral dummytag, const WCHAR *literal)
-  : SBuffer(Immutable, (const BYTE *) literal, (COUNT_T) (strlen_u16(literal)+1)*sizeof(WCHAR))
+  : SBuffer(Immutable, (const BYTE *) literal, (COUNT_T) (u16_strlen(literal)+1)*sizeof(WCHAR))
 {
     SS_CONTRACT_VOID
     {

--- a/src/coreclr/inc/utilcode.h
+++ b/src/coreclr/inc/utilcode.h
@@ -217,7 +217,7 @@ typedef LPSTR   LPUTF8;
 // most development in the EE, especially anything like metadata or class
 // names.  See the BESTFIT version if you're printing out info to the console.
 #define MAKE_MULTIBYTE_FROMWIDE(ptrname, widestr, codepage) \
-    int __l##ptrname = (int)strlen_u16(widestr);        \
+    int __l##ptrname = (int)u16_strlen(widestr);        \
     if (__l##ptrname > MAKE_MAX_LENGTH)         \
         MAKE_TOOLONGACTION;                     \
     __l##ptrname = (int)((__l##ptrname + 1) * 2 * sizeof(char)); \
@@ -235,7 +235,7 @@ typedef LPSTR   LPUTF8;
 // representable.  This is reasonable for writing to the console, but
 // shouldn't be used for most string conversions.
 #define MAKE_MULTIBYTE_FROMWIDE_BESTFIT(ptrname, widestr, codepage) \
-    int __l##ptrname = (int)strlen_u16(widestr);        \
+    int __l##ptrname = (int)u16_strlen(widestr);        \
     if (__l##ptrname > MAKE_MAX_LENGTH)         \
         MAKE_TOOLONGACTION;                     \
     __l##ptrname = (int)((__l##ptrname + 1) * 2 * sizeof(char)); \
@@ -285,7 +285,7 @@ typedef LPSTR   LPUTF8;
 
 #define MAKE_UTF8PTR_FROMWIDE_NOTHROW(ptrname, widestr) \
     CQuickBytes __qb##ptrname; \
-    int __l##ptrname = (int)strlen_u16(widestr); \
+    int __l##ptrname = (int)u16_strlen(widestr); \
     LPUTF8 ptrname = 0; \
     if (__l##ptrname <= MAKE_MAX_LENGTH) { \
         __l##ptrname = (int)((__l##ptrname + 1) * 2 * sizeof(char)); \
@@ -437,7 +437,7 @@ LPWSTR DuplicateString(
 
     if (wszString != NULL)
     {
-        return DuplicateString(wszString, strlen_u16(wszString));
+        return DuplicateString(wszString, u16_strlen(wszString));
     }
     else
     {
@@ -627,7 +627,7 @@ public:
         if (id == UICULTUREID_DONTCARE)
             return FALSE;
 
-        return strcmp_u16(id, m_LangId) == 0;
+        return u16_strcmp(id, m_LangId) == 0;
     }
 
     HRESOURCEDLL GetLibraryHandle()
@@ -2381,7 +2381,7 @@ inline ULONG HashStringN(LPCWSTR szStr, SIZE_T cchStr)
     ULONG *ptr = (ULONG *)szStr;
 
     // we assume that szStr is null-terminated
-    _ASSERTE(cchStr <= strlen_u16(szStr));
+    _ASSERTE(cchStr <= u16_strlen(szStr));
     SIZE_T cDwordCount = (cchStr + 1) / 2;
 
     for (SIZE_T i = 0; i < cDwordCount; i++)

--- a/src/coreclr/inc/utilcode.h
+++ b/src/coreclr/inc/utilcode.h
@@ -37,7 +37,8 @@
 
 #include "contract.h"
 
-#include<minipal/utils.h>
+#include <minipal/utils.h>
+#include <dn-u16.h>
 
 #include "clrnt.h"
 

--- a/src/coreclr/inc/utilcode.h
+++ b/src/coreclr/inc/utilcode.h
@@ -217,7 +217,7 @@ typedef LPSTR   LPUTF8;
 // most development in the EE, especially anything like metadata or class
 // names.  See the BESTFIT version if you're printing out info to the console.
 #define MAKE_MULTIBYTE_FROMWIDE(ptrname, widestr, codepage) \
-    int __l##ptrname = (int)dn_wcslen(widestr);        \
+    int __l##ptrname = (int)strlen_u16(widestr);        \
     if (__l##ptrname > MAKE_MAX_LENGTH)         \
         MAKE_TOOLONGACTION;                     \
     __l##ptrname = (int)((__l##ptrname + 1) * 2 * sizeof(char)); \
@@ -235,7 +235,7 @@ typedef LPSTR   LPUTF8;
 // representable.  This is reasonable for writing to the console, but
 // shouldn't be used for most string conversions.
 #define MAKE_MULTIBYTE_FROMWIDE_BESTFIT(ptrname, widestr, codepage) \
-    int __l##ptrname = (int)dn_wcslen(widestr);        \
+    int __l##ptrname = (int)strlen_u16(widestr);        \
     if (__l##ptrname > MAKE_MAX_LENGTH)         \
         MAKE_TOOLONGACTION;                     \
     __l##ptrname = (int)((__l##ptrname + 1) * 2 * sizeof(char)); \
@@ -285,7 +285,7 @@ typedef LPSTR   LPUTF8;
 
 #define MAKE_UTF8PTR_FROMWIDE_NOTHROW(ptrname, widestr) \
     CQuickBytes __qb##ptrname; \
-    int __l##ptrname = (int)dn_wcslen(widestr); \
+    int __l##ptrname = (int)strlen_u16(widestr); \
     LPUTF8 ptrname = 0; \
     if (__l##ptrname <= MAKE_MAX_LENGTH) { \
         __l##ptrname = (int)((__l##ptrname + 1) * 2 * sizeof(char)); \
@@ -437,7 +437,7 @@ LPWSTR DuplicateString(
 
     if (wszString != NULL)
     {
-        return DuplicateString(wszString, dn_wcslen(wszString));
+        return DuplicateString(wszString, strlen_u16(wszString));
     }
     else
     {
@@ -627,7 +627,7 @@ public:
         if (id == UICULTUREID_DONTCARE)
             return FALSE;
 
-        return dn_wcscmp(id, m_LangId) == 0;
+        return strcmp_u16(id, m_LangId) == 0;
     }
 
     HRESOURCEDLL GetLibraryHandle()
@@ -2381,7 +2381,7 @@ inline ULONG HashStringN(LPCWSTR szStr, SIZE_T cchStr)
     ULONG *ptr = (ULONG *)szStr;
 
     // we assume that szStr is null-terminated
-    _ASSERTE(cchStr <= dn_wcslen(szStr));
+    _ASSERTE(cchStr <= strlen_u16(szStr));
     SIZE_T cDwordCount = (cchStr + 1) / 2;
 
     for (SIZE_T i = 0; i < cDwordCount; i++)

--- a/src/coreclr/inc/utilcode.h
+++ b/src/coreclr/inc/utilcode.h
@@ -627,7 +627,7 @@ public:
         if (id == UICULTUREID_DONTCARE)
             return FALSE;
 
-        return wcscmp(id, m_LangId) == 0;
+        return dn_wcscmp(id, m_LangId) == 0;
     }
 
     HRESOURCEDLL GetLibraryHandle()

--- a/src/coreclr/inc/utilcode.h
+++ b/src/coreclr/inc/utilcode.h
@@ -217,7 +217,7 @@ typedef LPSTR   LPUTF8;
 // most development in the EE, especially anything like metadata or class
 // names.  See the BESTFIT version if you're printing out info to the console.
 #define MAKE_MULTIBYTE_FROMWIDE(ptrname, widestr, codepage) \
-    int __l##ptrname = (int)wcslen(widestr);        \
+    int __l##ptrname = (int)dn_wcslen(widestr);        \
     if (__l##ptrname > MAKE_MAX_LENGTH)         \
         MAKE_TOOLONGACTION;                     \
     __l##ptrname = (int)((__l##ptrname + 1) * 2 * sizeof(char)); \
@@ -235,7 +235,7 @@ typedef LPSTR   LPUTF8;
 // representable.  This is reasonable for writing to the console, but
 // shouldn't be used for most string conversions.
 #define MAKE_MULTIBYTE_FROMWIDE_BESTFIT(ptrname, widestr, codepage) \
-    int __l##ptrname = (int)wcslen(widestr);        \
+    int __l##ptrname = (int)dn_wcslen(widestr);        \
     if (__l##ptrname > MAKE_MAX_LENGTH)         \
         MAKE_TOOLONGACTION;                     \
     __l##ptrname = (int)((__l##ptrname + 1) * 2 * sizeof(char)); \
@@ -285,7 +285,7 @@ typedef LPSTR   LPUTF8;
 
 #define MAKE_UTF8PTR_FROMWIDE_NOTHROW(ptrname, widestr) \
     CQuickBytes __qb##ptrname; \
-    int __l##ptrname = (int)wcslen(widestr); \
+    int __l##ptrname = (int)dn_wcslen(widestr); \
     LPUTF8 ptrname = 0; \
     if (__l##ptrname <= MAKE_MAX_LENGTH) { \
         __l##ptrname = (int)((__l##ptrname + 1) * 2 * sizeof(char)); \
@@ -437,7 +437,7 @@ LPWSTR DuplicateString(
 
     if (wszString != NULL)
     {
-        return DuplicateString(wszString, wcslen(wszString));
+        return DuplicateString(wszString, dn_wcslen(wszString));
     }
     else
     {
@@ -2381,7 +2381,7 @@ inline ULONG HashStringN(LPCWSTR szStr, SIZE_T cchStr)
     ULONG *ptr = (ULONG *)szStr;
 
     // we assume that szStr is null-terminated
-    _ASSERTE(cchStr <= wcslen(szStr));
+    _ASSERTE(cchStr <= dn_wcslen(szStr));
     SIZE_T cDwordCount = (cchStr + 1) / 2;
 
     for (SIZE_T i = 0; i < cDwordCount; i++)

--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -550,6 +550,7 @@ else()
        bcrypt.lib
        crypt32.lib
        RuntimeObject.lib
+       coreclrminipal
     )
 endif(CLR_CMAKE_HOST_UNIX)
 

--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -533,6 +533,7 @@ if(CLR_CMAKE_HOST_UNIX)
     list(APPEND JIT_LINK_LIBRARIES
        mscorrc
        coreclrpal
+       coreclrminipal
     )
 else()
     list(APPEND JIT_LINK_LIBRARIES

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -3533,7 +3533,7 @@ bool Compiler::compStressCompileHelper(compStressArea stressArea, unsigned weigh
     // Does user explicitly prevent using this STRESS_MODE through the command line?
     const WCHAR* strStressModeNamesNot = JitConfig.JitStressModeNamesNot();
     if ((strStressModeNamesNot != nullptr) &&
-        (strstr_u16(strStressModeNamesNot, s_compStressModeNamesW[stressArea]) != nullptr))
+        (u16_strstr(strStressModeNamesNot, s_compStressModeNamesW[stressArea]) != nullptr))
     {
         return false;
     }
@@ -3542,7 +3542,7 @@ bool Compiler::compStressCompileHelper(compStressArea stressArea, unsigned weigh
     const WCHAR* strStressModeNames = JitConfig.JitStressModeNames();
     if (strStressModeNames != nullptr)
     {
-        if (strstr_u16(strStressModeNames, s_compStressModeNamesW[stressArea]) != nullptr)
+        if (u16_strstr(strStressModeNames, s_compStressModeNamesW[stressArea]) != nullptr)
         {
             return true;
         }

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -3533,7 +3533,7 @@ bool Compiler::compStressCompileHelper(compStressArea stressArea, unsigned weigh
     // Does user explicitly prevent using this STRESS_MODE through the command line?
     const WCHAR* strStressModeNamesNot = JitConfig.JitStressModeNamesNot();
     if ((strStressModeNamesNot != nullptr) &&
-        (dn_wcsstr(strStressModeNamesNot, s_compStressModeNamesW[stressArea]) != nullptr))
+        (strstr_u16(strStressModeNamesNot, s_compStressModeNamesW[stressArea]) != nullptr))
     {
         return false;
     }
@@ -3542,7 +3542,7 @@ bool Compiler::compStressCompileHelper(compStressArea stressArea, unsigned weigh
     const WCHAR* strStressModeNames = JitConfig.JitStressModeNames();
     if (strStressModeNames != nullptr)
     {
-        if (dn_wcsstr(strStressModeNames, s_compStressModeNamesW[stressArea]) != nullptr)
+        if (strstr_u16(strStressModeNames, s_compStressModeNamesW[stressArea]) != nullptr)
         {
             return true;
         }

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -3533,7 +3533,7 @@ bool Compiler::compStressCompileHelper(compStressArea stressArea, unsigned weigh
     // Does user explicitly prevent using this STRESS_MODE through the command line?
     const WCHAR* strStressModeNamesNot = JitConfig.JitStressModeNamesNot();
     if ((strStressModeNamesNot != nullptr) &&
-        (wcsstr(strStressModeNamesNot, s_compStressModeNamesW[stressArea]) != nullptr))
+        (dn_wcsstr(strStressModeNamesNot, s_compStressModeNamesW[stressArea]) != nullptr))
     {
         return false;
     }
@@ -3542,7 +3542,7 @@ bool Compiler::compStressCompileHelper(compStressArea stressArea, unsigned weigh
     const WCHAR* strStressModeNames = JitConfig.JitStressModeNames();
     if (strStressModeNames != nullptr)
     {
-        if (wcsstr(strStressModeNames, s_compStressModeNamesW[stressArea]) != nullptr)
+        if (dn_wcsstr(strStressModeNames, s_compStressModeNamesW[stressArea]) != nullptr)
         {
             return true;
         }

--- a/src/coreclr/jit/disasm.cpp
+++ b/src/coreclr/jit/disasm.cpp
@@ -1218,7 +1218,7 @@ size_t CbDisassembleWithBytes(DIS* pdis, DIS::ADDR addr, const BYTE* pb, size_t 
 
             else
             {
-                pwzNext = dn_wcsrchr(pwzBytes, W(' '));
+                pwzNext = (WCHAR*)dn_wcsrchr(pwzBytes, W(' '));
                 assert(pwzNext);
 
                 pwzBytes[cchBytesMax] = ch;

--- a/src/coreclr/jit/disasm.cpp
+++ b/src/coreclr/jit/disasm.cpp
@@ -1199,7 +1199,7 @@ size_t CbDisassembleWithBytes(DIS* pdis, DIS::ADDR addr, const BYTE* pb, size_t 
     {
         bool fFirst = (pwzBytes == wzBytes);
 
-        cchBytes = wcslen(pwzBytes);
+        cchBytes = dn_wcslen(pwzBytes);
 
         if (cchBytes <= cchBytesMax)
         {

--- a/src/coreclr/jit/disasm.cpp
+++ b/src/coreclr/jit/disasm.cpp
@@ -1199,7 +1199,7 @@ size_t CbDisassembleWithBytes(DIS* pdis, DIS::ADDR addr, const BYTE* pb, size_t 
     {
         bool fFirst = (pwzBytes == wzBytes);
 
-        cchBytes = strlen_u16(pwzBytes);
+        cchBytes = u16_strlen(pwzBytes);
 
         if (cchBytes <= cchBytesMax)
         {
@@ -1218,7 +1218,7 @@ size_t CbDisassembleWithBytes(DIS* pdis, DIS::ADDR addr, const BYTE* pb, size_t 
 
             else
             {
-                pwzNext = (WCHAR*)strrchr_u16(pwzBytes, W(' '));
+                pwzNext = (WCHAR*)u16_strrchr(pwzBytes, W(' '));
                 assert(pwzNext);
 
                 pwzBytes[cchBytesMax] = ch;

--- a/src/coreclr/jit/disasm.cpp
+++ b/src/coreclr/jit/disasm.cpp
@@ -1218,7 +1218,7 @@ size_t CbDisassembleWithBytes(DIS* pdis, DIS::ADDR addr, const BYTE* pb, size_t 
 
             else
             {
-                pwzNext = wcsrchr(pwzBytes, W(' '));
+                pwzNext = dn_wcsrchr(pwzBytes, W(' '));
                 assert(pwzNext);
 
                 pwzBytes[cchBytesMax] = ch;

--- a/src/coreclr/jit/disasm.cpp
+++ b/src/coreclr/jit/disasm.cpp
@@ -1199,7 +1199,7 @@ size_t CbDisassembleWithBytes(DIS* pdis, DIS::ADDR addr, const BYTE* pb, size_t 
     {
         bool fFirst = (pwzBytes == wzBytes);
 
-        cchBytes = dn_wcslen(pwzBytes);
+        cchBytes = strlen_u16(pwzBytes);
 
         if (cchBytes <= cchBytesMax)
         {
@@ -1218,7 +1218,7 @@ size_t CbDisassembleWithBytes(DIS* pdis, DIS::ADDR addr, const BYTE* pb, size_t 
 
             else
             {
-                pwzNext = (WCHAR*)dn_wcsrchr(pwzBytes, W(' '));
+                pwzNext = (WCHAR*)strrchr_u16(pwzBytes, W(' '));
                 assert(pwzNext);
 
                 pwzBytes[cchBytesMax] = ch;

--- a/src/coreclr/md/ceefilegen/ceesectionstring.cpp
+++ b/src/coreclr/md/ceefilegen/ceesectionstring.cpp
@@ -70,7 +70,7 @@ StringTableEntry *CeeSectionString::findStringInsert(
         cur = cur->m_next;
     }
     while (cur && cur->m_hashId == hashId) {
-        if (wcscmp(target, (LPWSTR)(computePointer(cur->m_offset))) == 0)
+        if (dn_wcscmp(target, (LPWSTR)(computePointer(cur->m_offset))) == 0)
             return cur;
         prev = cur;
         cur = cur->m_next;

--- a/src/coreclr/md/ceefilegen/ceesectionstring.cpp
+++ b/src/coreclr/md/ceefilegen/ceesectionstring.cpp
@@ -42,7 +42,7 @@ StringTableEntry* CeeSectionString::createEntry(_In_z_ LPWSTR target, ULONG hash
     entry->m_next = NULL;
     entry->m_hashId = hashId;
     entry->m_offset = dataLen();
-    size_t len = (wcslen(target)+1) * sizeof(WCHAR);
+    size_t len = (dn_wcslen(target)+1) * sizeof(WCHAR);
     if (len > UINT32_MAX) {
         delete entry;
         return NULL;

--- a/src/coreclr/md/ceefilegen/ceesectionstring.cpp
+++ b/src/coreclr/md/ceefilegen/ceesectionstring.cpp
@@ -42,7 +42,7 @@ StringTableEntry* CeeSectionString::createEntry(_In_z_ LPWSTR target, ULONG hash
     entry->m_next = NULL;
     entry->m_hashId = hashId;
     entry->m_offset = dataLen();
-    size_t len = (strlen_u16(target)+1) * sizeof(WCHAR);
+    size_t len = (u16_strlen(target)+1) * sizeof(WCHAR);
     if (len > UINT32_MAX) {
         delete entry;
         return NULL;
@@ -70,7 +70,7 @@ StringTableEntry *CeeSectionString::findStringInsert(
         cur = cur->m_next;
     }
     while (cur && cur->m_hashId == hashId) {
-        if (strcmp_u16(target, (LPWSTR)(computePointer(cur->m_offset))) == 0)
+        if (u16_strcmp(target, (LPWSTR)(computePointer(cur->m_offset))) == 0)
             return cur;
         prev = cur;
         cur = cur->m_next;

--- a/src/coreclr/md/ceefilegen/ceesectionstring.cpp
+++ b/src/coreclr/md/ceefilegen/ceesectionstring.cpp
@@ -42,7 +42,7 @@ StringTableEntry* CeeSectionString::createEntry(_In_z_ LPWSTR target, ULONG hash
     entry->m_next = NULL;
     entry->m_hashId = hashId;
     entry->m_offset = dataLen();
-    size_t len = (dn_wcslen(target)+1) * sizeof(WCHAR);
+    size_t len = (strlen_u16(target)+1) * sizeof(WCHAR);
     if (len > UINT32_MAX) {
         delete entry;
         return NULL;
@@ -70,7 +70,7 @@ StringTableEntry *CeeSectionString::findStringInsert(
         cur = cur->m_next;
     }
     while (cur && cur->m_hashId == hashId) {
-        if (dn_wcscmp(target, (LPWSTR)(computePointer(cur->m_offset))) == 0)
+        if (strcmp_u16(target, (LPWSTR)(computePointer(cur->m_offset))) == 0)
             return cur;
         prev = cur;
         cur = cur->m_next;

--- a/src/coreclr/md/compiler/assemblymd.cpp
+++ b/src/coreclr/md/compiler/assemblymd.cpp
@@ -214,7 +214,7 @@ STDMETHODIMP RegMeta::GetExportedTypeProps(   // S_OK or error.
             if (bTruncation || !szName)
                 *pchName = ns::GetFullLength(wzTypeNamespace, wzTypeName);
             else
-                *pchName = (ULONG)(wcslen(szName) + 1);
+                *pchName = (ULONG)(dn_wcslen(szName) + 1);
         }
     }
     if (ptkImplementation)

--- a/src/coreclr/md/compiler/assemblymd.cpp
+++ b/src/coreclr/md/compiler/assemblymd.cpp
@@ -214,7 +214,7 @@ STDMETHODIMP RegMeta::GetExportedTypeProps(   // S_OK or error.
             if (bTruncation || !szName)
                 *pchName = ns::GetFullLength(wzTypeNamespace, wzTypeName);
             else
-                *pchName = (ULONG)(dn_wcslen(szName) + 1);
+                *pchName = (ULONG)(strlen_u16(szName) + 1);
         }
     }
     if (ptkImplementation)

--- a/src/coreclr/md/compiler/assemblymd.cpp
+++ b/src/coreclr/md/compiler/assemblymd.cpp
@@ -214,7 +214,7 @@ STDMETHODIMP RegMeta::GetExportedTypeProps(   // S_OK or error.
             if (bTruncation || !szName)
                 *pchName = ns::GetFullLength(wzTypeNamespace, wzTypeName);
             else
-                *pchName = (ULONG)(strlen_u16(szName) + 1);
+                *pchName = (ULONG)(u16_strlen(szName) + 1);
         }
     }
     if (ptkImplementation)

--- a/src/coreclr/md/compiler/emit.cpp
+++ b/src/coreclr/md/compiler/emit.cpp
@@ -112,9 +112,9 @@ STDMETHODIMP RegMeta::DefineMethod(           // S_OK or error.
     // #define COR_CTOR_METHOD_NAME_W      L".ctor"
     // #define COR_CCTOR_METHOD_NAME_W     L".cctor"
 
-    if (!dn_wcscmp(szName, W(".ctor")) || // COR_CTOR_METHOD_NAME_W
-        !dn_wcscmp(szName, W(".cctor")) || // COR_CCTOR_METHOD_NAME_W
-        !dn_wcscmp(szName, W("_VtblGap")) )
+    if (!strcmp_u16(szName, W(".ctor")) || // COR_CTOR_METHOD_NAME_W
+        !strcmp_u16(szName, W(".cctor")) || // COR_CCTOR_METHOD_NAME_W
+        !strcmp_u16(szName, W("_VtblGap")) )
     {
         dwMethodFlags |= mdRTSpecialName | mdSpecialName;
     }
@@ -2608,7 +2608,7 @@ HRESULT RegMeta::DefineField(           // S_OK or error.
     // macro in the code below to work around this issue.
     // #define COR_ENUM_FIELD_NAME_W       L"value__"
 
-    if (!dn_wcscmp(szName, W("value__")))
+    if (!strcmp_u16(szName, W("value__")))
     {
         dwFieldFlags |= fdRTSpecialName | fdSpecialName;
     }

--- a/src/coreclr/md/compiler/emit.cpp
+++ b/src/coreclr/md/compiler/emit.cpp
@@ -112,9 +112,9 @@ STDMETHODIMP RegMeta::DefineMethod(           // S_OK or error.
     // #define COR_CTOR_METHOD_NAME_W      L".ctor"
     // #define COR_CCTOR_METHOD_NAME_W     L".cctor"
 
-    if (!wcscmp(szName, W(".ctor")) || // COR_CTOR_METHOD_NAME_W
-        !wcscmp(szName, W(".cctor")) || // COR_CCTOR_METHOD_NAME_W
-        !wcsncmp(szName, W("_VtblGap"), 8) )
+    if (!dn_wcscmp(szName, W(".ctor")) || // COR_CTOR_METHOD_NAME_W
+        !dn_wcscmp(szName, W(".cctor")) || // COR_CCTOR_METHOD_NAME_W
+        !dn_wcscmp(szName, W("_VtblGap")) )
     {
         dwMethodFlags |= mdRTSpecialName | mdSpecialName;
     }
@@ -2608,7 +2608,7 @@ HRESULT RegMeta::DefineField(           // S_OK or error.
     // macro in the code below to work around this issue.
     // #define COR_ENUM_FIELD_NAME_W       L"value__"
 
-    if (!wcscmp(szName, W("value__")))
+    if (!dn_wcscmp(szName, W("value__")))
     {
         dwFieldFlags |= fdRTSpecialName | fdSpecialName;
     }

--- a/src/coreclr/md/compiler/emit.cpp
+++ b/src/coreclr/md/compiler/emit.cpp
@@ -112,9 +112,9 @@ STDMETHODIMP RegMeta::DefineMethod(           // S_OK or error.
     // #define COR_CTOR_METHOD_NAME_W      L".ctor"
     // #define COR_CCTOR_METHOD_NAME_W     L".cctor"
 
-    if (!strcmp_u16(szName, W(".ctor")) || // COR_CTOR_METHOD_NAME_W
-        !strcmp_u16(szName, W(".cctor")) || // COR_CCTOR_METHOD_NAME_W
-        !strcmp_u16(szName, W("_VtblGap")) )
+    if (!u16_strcmp(szName, W(".ctor")) || // COR_CTOR_METHOD_NAME_W
+        !u16_strcmp(szName, W(".cctor")) || // COR_CCTOR_METHOD_NAME_W
+        !u16_strcmp(szName, W("_VtblGap")) )
     {
         dwMethodFlags |= mdRTSpecialName | mdSpecialName;
     }
@@ -2608,7 +2608,7 @@ HRESULT RegMeta::DefineField(           // S_OK or error.
     // macro in the code below to work around this issue.
     // #define COR_ENUM_FIELD_NAME_W       L"value__"
 
-    if (!strcmp_u16(szName, W("value__")))
+    if (!u16_strcmp(szName, W("value__")))
     {
         dwFieldFlags |= fdRTSpecialName | fdSpecialName;
     }

--- a/src/coreclr/md/compiler/mdutil.cpp
+++ b/src/coreclr/md/compiler/mdutil.cpp
@@ -266,7 +266,7 @@ HRESULT LOADEDMODULES::FindCachedReadOnlyEntry(
                 // If the name matches...
                 LPCWSTR pszName = pRegMeta->GetNameOfDBFile();
     #ifdef FEATURE_CASE_SENSITIVE_FILESYSTEM
-                if (wcscmp(szName, pszName) == 0)
+                if (dn_wcscmp(szName, pszName) == 0)
     #else
                 if (SString::_wcsicmp(szName, pszName) == 0)
     #endif
@@ -300,7 +300,7 @@ HRESULT LOADEDMODULES::FindCachedReadOnlyEntry(
                 // If the name matches...
                 LPCWSTR pszName = pRegMeta->GetNameOfDBFile();
     #ifdef FEATURE_CASE_SENSITIVE_FILESYSTEM
-                if (wcscmp(szName, pszName) == 0)
+                if (dn_wcscmp(szName, pszName) == 0)
     #else
                 if (SString::_wcsicmp(szName, pszName) == 0)
     #endif

--- a/src/coreclr/md/compiler/mdutil.cpp
+++ b/src/coreclr/md/compiler/mdutil.cpp
@@ -444,7 +444,7 @@ ErrExit:
 //
 // Determine the blob size base of the ELEMENT_TYPE_* associated with the blob.
 // This cannot be a table lookup because ELEMENT_TYPE_STRING is an unicode string.
-// The size of the blob is determined by calling wcsstr of the string + 1.
+// The size of the blob is determined by calling dn_wcsstr of the string + 1.
 //
 //*******************************************************************************
 ULONG _GetSizeOfConstantBlob(

--- a/src/coreclr/md/compiler/mdutil.cpp
+++ b/src/coreclr/md/compiler/mdutil.cpp
@@ -266,7 +266,7 @@ HRESULT LOADEDMODULES::FindCachedReadOnlyEntry(
                 // If the name matches...
                 LPCWSTR pszName = pRegMeta->GetNameOfDBFile();
     #ifdef FEATURE_CASE_SENSITIVE_FILESYSTEM
-                if (dn_wcscmp(szName, pszName) == 0)
+                if (strcmp_u16(szName, pszName) == 0)
     #else
                 if (SString::_wcsicmp(szName, pszName) == 0)
     #endif
@@ -300,7 +300,7 @@ HRESULT LOADEDMODULES::FindCachedReadOnlyEntry(
                 // If the name matches...
                 LPCWSTR pszName = pRegMeta->GetNameOfDBFile();
     #ifdef FEATURE_CASE_SENSITIVE_FILESYSTEM
-                if (dn_wcscmp(szName, pszName) == 0)
+                if (strcmp_u16(szName, pszName) == 0)
     #else
                 if (SString::_wcsicmp(szName, pszName) == 0)
     #endif
@@ -444,7 +444,7 @@ ErrExit:
 //
 // Determine the blob size base of the ELEMENT_TYPE_* associated with the blob.
 // This cannot be a table lookup because ELEMENT_TYPE_STRING is an unicode string.
-// The size of the blob is determined by calling dn_wcsstr of the string + 1.
+// The size of the blob is determined by calling strstr_u16 of the string + 1.
 //
 //*******************************************************************************
 ULONG _GetSizeOfConstantBlob(
@@ -488,7 +488,7 @@ ULONG _GetSizeOfConstantBlob(
         if (cchString != (ULONG) -1)
             ulSize = cchString * sizeof(WCHAR);
         else
-            ulSize = (ULONG)(sizeof(WCHAR) * dn_wcslen((LPWSTR)pValue));
+            ulSize = (ULONG)(sizeof(WCHAR) * strlen_u16((LPWSTR)pValue));
         break;
 
     case ELEMENT_TYPE_CLASS:

--- a/src/coreclr/md/compiler/mdutil.cpp
+++ b/src/coreclr/md/compiler/mdutil.cpp
@@ -266,7 +266,7 @@ HRESULT LOADEDMODULES::FindCachedReadOnlyEntry(
                 // If the name matches...
                 LPCWSTR pszName = pRegMeta->GetNameOfDBFile();
     #ifdef FEATURE_CASE_SENSITIVE_FILESYSTEM
-                if (strcmp_u16(szName, pszName) == 0)
+                if (u16_strcmp(szName, pszName) == 0)
     #else
                 if (SString::_wcsicmp(szName, pszName) == 0)
     #endif
@@ -300,7 +300,7 @@ HRESULT LOADEDMODULES::FindCachedReadOnlyEntry(
                 // If the name matches...
                 LPCWSTR pszName = pRegMeta->GetNameOfDBFile();
     #ifdef FEATURE_CASE_SENSITIVE_FILESYSTEM
-                if (strcmp_u16(szName, pszName) == 0)
+                if (u16_strcmp(szName, pszName) == 0)
     #else
                 if (SString::_wcsicmp(szName, pszName) == 0)
     #endif
@@ -444,7 +444,7 @@ ErrExit:
 //
 // Determine the blob size base of the ELEMENT_TYPE_* associated with the blob.
 // This cannot be a table lookup because ELEMENT_TYPE_STRING is an unicode string.
-// The size of the blob is determined by calling strstr_u16 of the string + 1.
+// The size of the blob is determined by calling u16_strstr of the string + 1.
 //
 //*******************************************************************************
 ULONG _GetSizeOfConstantBlob(
@@ -488,7 +488,7 @@ ULONG _GetSizeOfConstantBlob(
         if (cchString != (ULONG) -1)
             ulSize = cchString * sizeof(WCHAR);
         else
-            ulSize = (ULONG)(sizeof(WCHAR) * strlen_u16((LPWSTR)pValue));
+            ulSize = (ULONG)(sizeof(WCHAR) * u16_strlen((LPWSTR)pValue));
         break;
 
     case ELEMENT_TYPE_CLASS:

--- a/src/coreclr/md/compiler/mdutil.cpp
+++ b/src/coreclr/md/compiler/mdutil.cpp
@@ -488,7 +488,7 @@ ULONG _GetSizeOfConstantBlob(
         if (cchString != (ULONG) -1)
             ulSize = cchString * sizeof(WCHAR);
         else
-            ulSize = (ULONG)(sizeof(WCHAR) * wcslen((LPWSTR)pValue));
+            ulSize = (ULONG)(sizeof(WCHAR) * dn_wcslen((LPWSTR)pValue));
         break;
 
     case ELEMENT_TYPE_CLASS:

--- a/src/coreclr/md/compiler/regmeta.h
+++ b/src/coreclr/md/compiler/regmeta.h
@@ -40,7 +40,7 @@ struct CORDBG_SYMBOL_URL
 
     ULONG Size() const
     {
-        return (ULONG)(sizeof(GUID) + ((wcslen(rcName) + 1) * 2));
+        return (ULONG)(sizeof(GUID) + ((dn_wcslen(rcName) + 1) * 2));
     }
 
 #ifdef _PREFAST_

--- a/src/coreclr/md/compiler/regmeta.h
+++ b/src/coreclr/md/compiler/regmeta.h
@@ -40,7 +40,7 @@ struct CORDBG_SYMBOL_URL
 
     ULONG Size() const
     {
-        return (ULONG)(sizeof(GUID) + ((dn_wcslen(rcName) + 1) * 2));
+        return (ULONG)(sizeof(GUID) + ((strlen_u16(rcName) + 1) * 2));
     }
 
 #ifdef _PREFAST_

--- a/src/coreclr/md/compiler/regmeta.h
+++ b/src/coreclr/md/compiler/regmeta.h
@@ -40,7 +40,7 @@ struct CORDBG_SYMBOL_URL
 
     ULONG Size() const
     {
-        return (ULONG)(sizeof(GUID) + ((strlen_u16(rcName) + 1) * 2));
+        return (ULONG)(sizeof(GUID) + ((u16_strlen(rcName) + 1) * 2));
     }
 
 #ifdef _PREFAST_

--- a/src/coreclr/md/compiler/regmeta_import.cpp
+++ b/src/coreclr/md/compiler/regmeta_import.cpp
@@ -765,7 +765,7 @@ RegMeta::GetTypeDefProps(
             }
             else
             {
-                *pchTypeDef = (ULONG)(dn_wcslen(szTypeDef) + 1);
+                *pchTypeDef = (ULONG)(strlen_u16(szTypeDef) + 1);
             }
         }
     }
@@ -900,7 +900,7 @@ RegMeta::GetTypeRefProps(
             }
             else
             {
-                *pchTypeRef = (ULONG)(dn_wcslen(szTypeRef) + 1);
+                *pchTypeRef = (ULONG)(strlen_u16(szTypeRef) + 1);
             }
         }
     }

--- a/src/coreclr/md/compiler/regmeta_import.cpp
+++ b/src/coreclr/md/compiler/regmeta_import.cpp
@@ -765,7 +765,7 @@ RegMeta::GetTypeDefProps(
             }
             else
             {
-                *pchTypeDef = (ULONG)(strlen_u16(szTypeDef) + 1);
+                *pchTypeDef = (ULONG)(u16_strlen(szTypeDef) + 1);
             }
         }
     }
@@ -900,7 +900,7 @@ RegMeta::GetTypeRefProps(
             }
             else
             {
-                *pchTypeRef = (ULONG)(strlen_u16(szTypeRef) + 1);
+                *pchTypeRef = (ULONG)(u16_strlen(szTypeRef) + 1);
             }
         }
     }

--- a/src/coreclr/md/compiler/regmeta_import.cpp
+++ b/src/coreclr/md/compiler/regmeta_import.cpp
@@ -765,7 +765,7 @@ RegMeta::GetTypeDefProps(
             }
             else
             {
-                *pchTypeDef = (ULONG)(wcslen(szTypeDef) + 1);
+                *pchTypeDef = (ULONG)(dn_wcslen(szTypeDef) + 1);
             }
         }
     }
@@ -900,7 +900,7 @@ RegMeta::GetTypeRefProps(
             }
             else
             {
-                *pchTypeRef = (ULONG)(wcslen(szTypeRef) + 1);
+                *pchTypeRef = (ULONG)(dn_wcslen(szTypeRef) + 1);
             }
         }
     }

--- a/src/coreclr/md/enc/liteweightstgdbrw.cpp
+++ b/src/coreclr/md/enc/liteweightstgdbrw.cpp
@@ -618,7 +618,7 @@ CLiteWeightStgdbRW::GetPoolSaveSize(
 
 #ifdef FEATURE_METADATA_EMIT_PORTABLE_PDB
     // Treat PDB stream differently since we are not using StgPools
-    if (dn_wcscmp(PDB_STREAM, szHeap) == 0)
+    if (strcmp_u16(PDB_STREAM, szHeap) == 0)
     {
         if (m_pPdbHeap && !m_pPdbHeap->IsEmpty())
         {
@@ -855,7 +855,7 @@ HRESULT CLiteWeightStgdbRW::SavePool(   // Return code.
 
 #ifdef FEATURE_METADATA_EMIT_PORTABLE_PDB
     // Treat PDB stream differently since we are not using StgPools
-    if (dn_wcscmp(PDB_STREAM, szName) == 0)
+    if (strcmp_u16(PDB_STREAM, szName) == 0)
     {
         if (m_pPdbHeap && !m_pPdbHeap->IsEmpty())
         {
@@ -1167,7 +1167,7 @@ CLiteWeightStgdbRW::SetFileName(
 
     // Size of the file name incl. null terminator
     size_t cchFileName;
-    cchFileName = dn_wcslen(wszFileName) + 1;
+    cchFileName = strlen_u16(wszFileName) + 1;
 
     // Allocate and copy the file name
     m_wszFileName = new (nothrow) WCHAR[cchFileName];

--- a/src/coreclr/md/enc/liteweightstgdbrw.cpp
+++ b/src/coreclr/md/enc/liteweightstgdbrw.cpp
@@ -618,7 +618,7 @@ CLiteWeightStgdbRW::GetPoolSaveSize(
 
 #ifdef FEATURE_METADATA_EMIT_PORTABLE_PDB
     // Treat PDB stream differently since we are not using StgPools
-    if (strcmp_u16(PDB_STREAM, szHeap) == 0)
+    if (u16_strcmp(PDB_STREAM, szHeap) == 0)
     {
         if (m_pPdbHeap && !m_pPdbHeap->IsEmpty())
         {
@@ -855,7 +855,7 @@ HRESULT CLiteWeightStgdbRW::SavePool(   // Return code.
 
 #ifdef FEATURE_METADATA_EMIT_PORTABLE_PDB
     // Treat PDB stream differently since we are not using StgPools
-    if (strcmp_u16(PDB_STREAM, szName) == 0)
+    if (u16_strcmp(PDB_STREAM, szName) == 0)
     {
         if (m_pPdbHeap && !m_pPdbHeap->IsEmpty())
         {
@@ -1167,7 +1167,7 @@ CLiteWeightStgdbRW::SetFileName(
 
     // Size of the file name incl. null terminator
     size_t cchFileName;
-    cchFileName = strlen_u16(wszFileName) + 1;
+    cchFileName = u16_strlen(wszFileName) + 1;
 
     // Allocate and copy the file name
     m_wszFileName = new (nothrow) WCHAR[cchFileName];

--- a/src/coreclr/md/enc/liteweightstgdbrw.cpp
+++ b/src/coreclr/md/enc/liteweightstgdbrw.cpp
@@ -1167,7 +1167,7 @@ CLiteWeightStgdbRW::SetFileName(
 
     // Size of the file name incl. null terminator
     size_t cchFileName;
-    cchFileName = wcslen(wszFileName) + 1;
+    cchFileName = dn_wcslen(wszFileName) + 1;
 
     // Allocate and copy the file name
     m_wszFileName = new (nothrow) WCHAR[cchFileName];

--- a/src/coreclr/md/enc/liteweightstgdbrw.cpp
+++ b/src/coreclr/md/enc/liteweightstgdbrw.cpp
@@ -618,7 +618,7 @@ CLiteWeightStgdbRW::GetPoolSaveSize(
 
 #ifdef FEATURE_METADATA_EMIT_PORTABLE_PDB
     // Treat PDB stream differently since we are not using StgPools
-    if (wcscmp(PDB_STREAM, szHeap) == 0)
+    if (dn_wcscmp(PDB_STREAM, szHeap) == 0)
     {
         if (m_pPdbHeap && !m_pPdbHeap->IsEmpty())
         {
@@ -855,7 +855,7 @@ HRESULT CLiteWeightStgdbRW::SavePool(   // Return code.
 
 #ifdef FEATURE_METADATA_EMIT_PORTABLE_PDB
     // Treat PDB stream differently since we are not using StgPools
-    if (wcscmp(PDB_STREAM, szName) == 0)
+    if (dn_wcscmp(PDB_STREAM, szName) == 0)
     {
         if (m_pPdbHeap && !m_pPdbHeap->IsEmpty())
         {

--- a/src/coreclr/md/enc/rwutil.cpp
+++ b/src/coreclr/md/enc/rwutil.cpp
@@ -24,7 +24,7 @@ Unicode2UTF(
     LPUTF8  szDst,  // Buffer for the output UTF8 string.
     int     cbDst)  // Size of the buffer for UTF8 string.
 {
-    int cchSrc = (int)strlen_u16(wszSrc);
+    int cchSrc = (int)u16_strlen(wszSrc);
     int cchRet;
 
     cchRet = WszWideCharToMultiByte(

--- a/src/coreclr/md/enc/rwutil.cpp
+++ b/src/coreclr/md/enc/rwutil.cpp
@@ -24,7 +24,7 @@ Unicode2UTF(
     LPUTF8  szDst,  // Buffer for the output UTF8 string.
     int     cbDst)  // Size of the buffer for UTF8 string.
 {
-    int cchSrc = (int)dn_wcslen(wszSrc);
+    int cchSrc = (int)strlen_u16(wszSrc);
     int cchRet;
 
     cchRet = WszWideCharToMultiByte(

--- a/src/coreclr/md/enc/rwutil.cpp
+++ b/src/coreclr/md/enc/rwutil.cpp
@@ -24,7 +24,7 @@ Unicode2UTF(
     LPUTF8  szDst,  // Buffer for the output UTF8 string.
     int     cbDst)  // Size of the buffer for UTF8 string.
 {
-    int cchSrc = (int)wcslen(wszSrc);
+    int cchSrc = (int)dn_wcslen(wszSrc);
     int cchRet;
 
     cchRet = WszWideCharToMultiByte(

--- a/src/coreclr/md/inc/rwutil.h
+++ b/src/coreclr/md/inc/rwutil.h
@@ -21,7 +21,7 @@ class UTSemReadWrite;
         }                                                   \
         else                                                \
         {                                                   \
-            int cbBuffer = ((int)dn_wcslen(wszInput) * 3) + 1; \
+            int cbBuffer = ((int)strlen_u16(wszInput) * 3) + 1; \
             (szOutput) = (char *)_alloca(cbBuffer);         \
             Unicode2UTF((wszInput), (szOutput), cbBuffer);  \
         }                                                   \

--- a/src/coreclr/md/inc/rwutil.h
+++ b/src/coreclr/md/inc/rwutil.h
@@ -21,7 +21,7 @@ class UTSemReadWrite;
         }                                                   \
         else                                                \
         {                                                   \
-            int cbBuffer = ((int)wcslen(wszInput) * 3) + 1; \
+            int cbBuffer = ((int)dn_wcslen(wszInput) * 3) + 1; \
             (szOutput) = (char *)_alloca(cbBuffer);         \
             Unicode2UTF((wszInput), (szOutput), cbBuffer);  \
         }                                                   \

--- a/src/coreclr/md/inc/rwutil.h
+++ b/src/coreclr/md/inc/rwutil.h
@@ -21,7 +21,7 @@ class UTSemReadWrite;
         }                                                   \
         else                                                \
         {                                                   \
-            int cbBuffer = ((int)strlen_u16(wszInput) * 3) + 1; \
+            int cbBuffer = ((int)u16_strlen(wszInput) * 3) + 1; \
             (szOutput) = (char *)_alloca(cbBuffer);         \
             Unicode2UTF((wszInput), (szOutput), cbBuffer);  \
         }                                                   \

--- a/src/coreclr/minipal/Unix/CMakeLists.txt
+++ b/src/coreclr/minipal/Unix/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(coreclrminipal
     STATIC
     doublemapping.cpp
+    dn-u16.cpp
 )

--- a/src/coreclr/minipal/Unix/dn-u16.cpp
+++ b/src/coreclr/minipal/Unix/dn-u16.cpp
@@ -1,0 +1,189 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+typedef char16_t WCHAR;
+
+#include <dn-u16.h>
+#include <string.h>
+
+size_t dn_wcslen(const WCHAR* str)
+{
+    if (str == NULL)
+        return 0;
+
+    size_t nChar = 0;
+    while (*str++)
+        nChar++;
+
+    return nChar;
+}
+
+int dn_wcscmp(const WCHAR* str1, const WCHAR* str2)
+{
+    return dn_wcsncmp(str1, str2, 0x7fffffff);
+}
+
+int dn_wcsncmp(const WCHAR* str1, const WCHAR* str2, size_t count)
+{
+    int diff = 0;
+    for (size_t i = 0; i < count; i++)
+    {
+        diff = str1[i] - str2[i];
+        if (diff != 0)
+            break;
+
+        // stop if we reach the end of the string
+        if(str1[i] == (WCHAR)'\0')
+            break;
+    }
+    return diff;
+}
+
+WCHAR* dn_wcscat(WCHAR* dst, const WCHAR* src)
+{
+    if (dst == NULL || src == NULL)
+    {
+        return NULL;
+    }
+
+    WCHAR* start = dst;
+
+    // find end of source string
+    while (*dst)
+    {
+        dst++;
+    }
+
+    // concatenate new string
+    size_t srcLength = dn_wcslen(src);
+    size_t loopCount = 0;
+    while (*src && loopCount < srcLength)
+    {
+        *dst++ = *src++;
+        loopCount++;
+    }
+
+    // add terminating null
+    *dst = (WCHAR)'\0';
+    return start;
+}
+
+WCHAR* dn_wcscpy(WCHAR* dst, const WCHAR* src)
+{
+    if (dst == NULL || src == NULL)
+    {
+        return NULL;
+    }
+
+    WCHAR* start = dst;
+
+    // copy source string to destination string
+    while (*src)
+    {
+        *dst++ = *src++;
+    }
+
+    // add terminating null
+    *dst = (WCHAR)'\0';
+    return start;
+}
+
+WCHAR* dn_wcsncpy(WCHAR* dst, const WCHAR* src, size_t count)
+{
+    size_t length = sizeof(WCHAR) * count;
+
+    memset(dst, 0, length);
+    size_t srcLength = dn_wcslen(src);
+    length = (count < srcLength) ? count : srcLength;
+    memcpy(dst, src, length * sizeof(WCHAR));
+    return dst;
+}
+
+const WCHAR* dn_wcsstr(const WCHAR *str, const WCHAR *strCharSet)
+{
+    if (str == NULL || strCharSet == NULL)
+    {
+        return NULL;
+    }
+
+    // No characters to examine
+    if (dn_wcslen(strCharSet) == 0)
+        return str;
+
+    const WCHAR* ret = NULL;
+    int i;
+    while (*str != (WCHAR)'\0')
+    {
+        i = 0;
+        while (true)
+        {
+            if (*(strCharSet + i) == (WCHAR)'\0')
+            {
+                ret = str;
+                goto LEAVE;
+            }
+            else if (*(str + i) == (WCHAR)'\0')
+            {
+                ret = NULL;
+                goto LEAVE;
+            }
+            else if (*(str + i) != *(strCharSet + i))
+            {
+                break;
+            }
+            i++;
+        }
+        str++;
+    }
+ LEAVE:
+    return ret;
+}
+
+WCHAR* dn_wcschr(const WCHAR* str, WCHAR ch)
+{
+    while (*str)
+    {
+        if (*str == ch)
+            return (WCHAR*)str;
+        str++;
+    }
+
+    // Check if the comparand was \000
+    if (*str == ch)
+        return (WCHAR*)str;
+
+    return NULL;
+}
+
+WCHAR* dn_wcsrchr(const WCHAR* str, WCHAR ch)
+{
+    WCHAR* last = NULL;
+    while (*str)
+    {
+        if (*str == ch)
+            last = (WCHAR*)str;
+        str++;
+    }
+
+    return last;
+}
+
+// Forward declare PAL function
+extern "C" uint32_t PAL_wcstoul(const WCHAR* nptr, WCHAR** endptr, int base);
+extern "C" uint64_t PAL__wcstoui64(const WCHAR* nptr, WCHAR** endptr, int base);
+extern "C" double PAL_wcstod(const WCHAR* nptr, WCHAR** endptr);
+
+uint32_t dn_wcstoul(const WCHAR* nptr, WCHAR** endptr, int base)
+{
+    return PAL_wcstoul(nptr, endptr, base);
+}
+
+uint64_t dn_wcstoui64(const WCHAR* nptr, WCHAR** endptr, int base)
+{
+    return PAL__wcstoui64(nptr, endptr, base);
+}
+
+double dn_wcstod(const WCHAR* nptr, WCHAR** endptr)
+{
+    return PAL_wcstod(nptr, endptr);
+}

--- a/src/coreclr/minipal/Unix/dn-u16.cpp
+++ b/src/coreclr/minipal/Unix/dn-u16.cpp
@@ -8,7 +8,7 @@ typedef char16_t WCHAR;
 
 size_t dn_wcslen(const WCHAR* str)
 {
-    if (str == NULL)
+    if (str == nullptr)
         return 0;
 
     size_t nChar = 0;
@@ -39,19 +39,22 @@ int dn_wcsncmp(const WCHAR* str1, const WCHAR* str2, size_t count)
     return diff;
 }
 
-WCHAR* dn_wcscat(WCHAR* dst, const WCHAR* src)
+WCHAR* dn_wcscat(WCHAR* dst, size_t dstLen, const WCHAR* src)
 {
-    if (dst == NULL || src == NULL)
+    if (dst == nullptr || src == nullptr)
     {
-        return NULL;
+        return nullptr;
     }
 
     WCHAR* start = dst;
+    WCHAR* end = dst + dstLen;
 
     // find end of source string
     while (*dst)
     {
         dst++;
+        if (dst >= end)
+            return nullptr;
     }
 
     // concatenate new string
@@ -60,6 +63,8 @@ WCHAR* dn_wcscat(WCHAR* dst, const WCHAR* src)
     while (*src && loopCount < srcLength)
     {
         *dst++ = *src++;
+        if (dst >= end)
+            return nullptr;
         loopCount++;
     }
 
@@ -68,19 +73,22 @@ WCHAR* dn_wcscat(WCHAR* dst, const WCHAR* src)
     return start;
 }
 
-WCHAR* dn_wcscpy(WCHAR* dst, const WCHAR* src)
+WCHAR* dn_wcscpy(WCHAR* dst, size_t dstLen, const WCHAR* src)
 {
-    if (dst == NULL || src == NULL)
+    if (dst == nullptr || src == nullptr)
     {
-        return NULL;
+        return nullptr;
     }
 
     WCHAR* start = dst;
+    WCHAR* end = dst + dstLen;
 
     // copy source string to destination string
     while (*src)
     {
         *dst++ = *src++;
+        if (dst >= end)
+            return nullptr;
     }
 
     // add terminating null
@@ -88,29 +96,31 @@ WCHAR* dn_wcscpy(WCHAR* dst, const WCHAR* src)
     return start;
 }
 
-WCHAR* dn_wcsncpy(WCHAR* dst, const WCHAR* src, size_t count)
+WCHAR* dn_wcsncpy(WCHAR* dst, size_t dstLen, const WCHAR* src, size_t count)
 {
-    size_t length = sizeof(WCHAR) * count;
+    ::memset(dst, 0, dstLen * sizeof(WCHAR));
 
-    memset(dst, 0, length);
     size_t srcLength = dn_wcslen(src);
-    length = (count < srcLength) ? count : srcLength;
-    memcpy(dst, src, length * sizeof(WCHAR));
+    size_t length = (count < srcLength) ? count : srcLength;
+    if (length > dstLen)
+        return nullptr;
+
+    ::memcpy(dst, src, length * sizeof(WCHAR));
     return dst;
 }
 
 const WCHAR* dn_wcsstr(const WCHAR *str, const WCHAR *strCharSet)
 {
-    if (str == NULL || strCharSet == NULL)
+    if (str == nullptr || strCharSet == nullptr)
     {
-        return NULL;
+        return nullptr;
     }
 
     // No characters to examine
     if (dn_wcslen(strCharSet) == 0)
         return str;
 
-    const WCHAR* ret = NULL;
+    const WCHAR* ret = nullptr;
     int i;
     while (*str != (WCHAR)'\0')
     {
@@ -124,7 +134,7 @@ const WCHAR* dn_wcsstr(const WCHAR *str, const WCHAR *strCharSet)
             }
             else if (*(str + i) == (WCHAR)'\0')
             {
-                ret = NULL;
+                ret = nullptr;
                 goto LEAVE;
             }
             else if (*(str + i) != *(strCharSet + i))
@@ -139,29 +149,29 @@ const WCHAR* dn_wcsstr(const WCHAR *str, const WCHAR *strCharSet)
     return ret;
 }
 
-WCHAR* dn_wcschr(const WCHAR* str, WCHAR ch)
+const WCHAR* dn_wcschr(const WCHAR* str, WCHAR ch)
 {
     while (*str)
     {
         if (*str == ch)
-            return (WCHAR*)str;
+            return str;
         str++;
     }
 
     // Check if the comparand was \000
     if (*str == ch)
-        return (WCHAR*)str;
+        return str;
 
-    return NULL;
+    return nullptr;
 }
 
-WCHAR* dn_wcsrchr(const WCHAR* str, WCHAR ch)
+const WCHAR* dn_wcsrchr(const WCHAR* str, WCHAR ch)
 {
-    WCHAR* last = NULL;
+    const WCHAR* last = nullptr;
     while (*str)
     {
         if (*str == ch)
-            last = (WCHAR*)str;
+            last = str;
         str++;
     }
 

--- a/src/coreclr/minipal/Unix/dn-u16.cpp
+++ b/src/coreclr/minipal/Unix/dn-u16.cpp
@@ -6,7 +6,7 @@ typedef char16_t WCHAR;
 #include <dn-u16.h>
 #include <string.h>
 
-size_t strlen_u16(const WCHAR* str)
+size_t u16_strlen(const WCHAR* str)
 {
     size_t nChar = 0;
     while (*str++)
@@ -14,12 +14,12 @@ size_t strlen_u16(const WCHAR* str)
     return nChar;
 }
 
-int strcmp_u16(const WCHAR* str1, const WCHAR* str2)
+int u16_strcmp(const WCHAR* str1, const WCHAR* str2)
 {
-    return strncmp_u16(str1, str2, 0x7fffffff);
+    return u16_strncmp(str1, str2, 0x7fffffff);
 }
 
-int strncmp_u16(const WCHAR* str1, const WCHAR* str2, size_t count)
+int u16_strncmp(const WCHAR* str1, const WCHAR* str2, size_t count)
 {
     int diff = 0;
     for (size_t i = 0; i < count; i++)
@@ -35,7 +35,7 @@ int strncmp_u16(const WCHAR* str1, const WCHAR* str2, size_t count)
     return diff;
 }
 
-WCHAR* strcat_u16(WCHAR* dst, size_t dstLen, const WCHAR* src)
+WCHAR* u16_strcat_s(WCHAR* dst, size_t dstLen, const WCHAR* src)
 {
     if (dst == nullptr || src == nullptr)
     {
@@ -54,7 +54,7 @@ WCHAR* strcat_u16(WCHAR* dst, size_t dstLen, const WCHAR* src)
     }
 
     // concatenate new string
-    size_t srcLength = strlen_u16(src);
+    size_t srcLength = u16_strlen(src);
     size_t loopCount = 0;
     while (*src && loopCount < srcLength)
     {
@@ -69,7 +69,7 @@ WCHAR* strcat_u16(WCHAR* dst, size_t dstLen, const WCHAR* src)
     return start;
 }
 
-WCHAR* strcpy_u16(WCHAR* dst, size_t dstLen, const WCHAR* src)
+WCHAR* u16_strcpy_s(WCHAR* dst, size_t dstLen, const WCHAR* src)
 {
     if (dst == nullptr || src == nullptr)
     {
@@ -92,11 +92,11 @@ WCHAR* strcpy_u16(WCHAR* dst, size_t dstLen, const WCHAR* src)
     return start;
 }
 
-WCHAR* strncpy_u16(WCHAR* dst, size_t dstLen, const WCHAR* src, size_t count)
+WCHAR* u16_strncpy_s(WCHAR* dst, size_t dstLen, const WCHAR* src, size_t count)
 {
     ::memset(dst, 0, dstLen * sizeof(WCHAR));
 
-    size_t srcLength = strlen_u16(src);
+    size_t srcLength = u16_strlen(src);
     size_t length = (count < srcLength) ? count : srcLength;
     if (length > dstLen)
         return nullptr;
@@ -105,7 +105,7 @@ WCHAR* strncpy_u16(WCHAR* dst, size_t dstLen, const WCHAR* src, size_t count)
     return dst;
 }
 
-const WCHAR* strstr_u16(const WCHAR *str, const WCHAR *strCharSet)
+const WCHAR* u16_strstr(const WCHAR *str, const WCHAR *strCharSet)
 {
     if (str == nullptr || strCharSet == nullptr)
     {
@@ -113,7 +113,7 @@ const WCHAR* strstr_u16(const WCHAR *str, const WCHAR *strCharSet)
     }
 
     // No characters to examine
-    if (strlen_u16(strCharSet) == 0)
+    if (u16_strlen(strCharSet) == 0)
         return str;
 
     const WCHAR* ret = nullptr;
@@ -145,7 +145,7 @@ const WCHAR* strstr_u16(const WCHAR *str, const WCHAR *strCharSet)
     return ret;
 }
 
-const WCHAR* strchr_u16(const WCHAR* str, WCHAR ch)
+const WCHAR* u16_strchr(const WCHAR* str, WCHAR ch)
 {
     while (*str)
     {
@@ -161,7 +161,7 @@ const WCHAR* strchr_u16(const WCHAR* str, WCHAR ch)
     return nullptr;
 }
 
-const WCHAR* strrchr_u16(const WCHAR* str, WCHAR ch)
+const WCHAR* u16_strrchr(const WCHAR* str, WCHAR ch)
 {
     const WCHAR* last = nullptr;
     while (*str)
@@ -179,17 +179,17 @@ extern "C" uint32_t PAL_wcstoul(const WCHAR* nptr, WCHAR** endptr, int base);
 extern "C" uint64_t PAL__wcstoui64(const WCHAR* nptr, WCHAR** endptr, int base);
 extern "C" double PAL_wcstod(const WCHAR* nptr, WCHAR** endptr);
 
-uint32_t strtoul_u16(const WCHAR* nptr, WCHAR** endptr, int base)
+uint32_t u16_strtoul(const WCHAR* nptr, WCHAR** endptr, int base)
 {
     return PAL_wcstoul(nptr, endptr, base);
 }
 
-uint64_t strtoui64_u16(const WCHAR* nptr, WCHAR** endptr, int base)
+uint64_t u16_strtoui64(const WCHAR* nptr, WCHAR** endptr, int base)
 {
     return PAL__wcstoui64(nptr, endptr, base);
 }
 
-double strtod_u16(const WCHAR* nptr, WCHAR** endptr)
+double u16_strtod(const WCHAR* nptr, WCHAR** endptr)
 {
     return PAL_wcstod(nptr, endptr);
 }

--- a/src/coreclr/minipal/Unix/dn-u16.cpp
+++ b/src/coreclr/minipal/Unix/dn-u16.cpp
@@ -6,7 +6,7 @@ typedef char16_t WCHAR;
 #include <dn-u16.h>
 #include <string.h>
 
-size_t dn_wcslen(const WCHAR* str)
+size_t strlen_u16(const WCHAR* str)
 {
     if (str == nullptr)
         return 0;
@@ -18,12 +18,12 @@ size_t dn_wcslen(const WCHAR* str)
     return nChar;
 }
 
-int dn_wcscmp(const WCHAR* str1, const WCHAR* str2)
+int strcmp_u16(const WCHAR* str1, const WCHAR* str2)
 {
-    return dn_wcsncmp(str1, str2, 0x7fffffff);
+    return strncmp_u16(str1, str2, 0x7fffffff);
 }
 
-int dn_wcsncmp(const WCHAR* str1, const WCHAR* str2, size_t count)
+int strncmp_u16(const WCHAR* str1, const WCHAR* str2, size_t count)
 {
     int diff = 0;
     for (size_t i = 0; i < count; i++)
@@ -39,7 +39,7 @@ int dn_wcsncmp(const WCHAR* str1, const WCHAR* str2, size_t count)
     return diff;
 }
 
-WCHAR* dn_wcscat(WCHAR* dst, size_t dstLen, const WCHAR* src)
+WCHAR* strcat_u16(WCHAR* dst, size_t dstLen, const WCHAR* src)
 {
     if (dst == nullptr || src == nullptr)
     {
@@ -58,7 +58,7 @@ WCHAR* dn_wcscat(WCHAR* dst, size_t dstLen, const WCHAR* src)
     }
 
     // concatenate new string
-    size_t srcLength = dn_wcslen(src);
+    size_t srcLength = strlen_u16(src);
     size_t loopCount = 0;
     while (*src && loopCount < srcLength)
     {
@@ -73,7 +73,7 @@ WCHAR* dn_wcscat(WCHAR* dst, size_t dstLen, const WCHAR* src)
     return start;
 }
 
-WCHAR* dn_wcscpy(WCHAR* dst, size_t dstLen, const WCHAR* src)
+WCHAR* strcpy_u16(WCHAR* dst, size_t dstLen, const WCHAR* src)
 {
     if (dst == nullptr || src == nullptr)
     {
@@ -96,11 +96,11 @@ WCHAR* dn_wcscpy(WCHAR* dst, size_t dstLen, const WCHAR* src)
     return start;
 }
 
-WCHAR* dn_wcsncpy(WCHAR* dst, size_t dstLen, const WCHAR* src, size_t count)
+WCHAR* strncpy_u16(WCHAR* dst, size_t dstLen, const WCHAR* src, size_t count)
 {
     ::memset(dst, 0, dstLen * sizeof(WCHAR));
 
-    size_t srcLength = dn_wcslen(src);
+    size_t srcLength = strlen_u16(src);
     size_t length = (count < srcLength) ? count : srcLength;
     if (length > dstLen)
         return nullptr;
@@ -109,7 +109,7 @@ WCHAR* dn_wcsncpy(WCHAR* dst, size_t dstLen, const WCHAR* src, size_t count)
     return dst;
 }
 
-const WCHAR* dn_wcsstr(const WCHAR *str, const WCHAR *strCharSet)
+const WCHAR* strstr_u16(const WCHAR *str, const WCHAR *strCharSet)
 {
     if (str == nullptr || strCharSet == nullptr)
     {
@@ -117,7 +117,7 @@ const WCHAR* dn_wcsstr(const WCHAR *str, const WCHAR *strCharSet)
     }
 
     // No characters to examine
-    if (dn_wcslen(strCharSet) == 0)
+    if (strlen_u16(strCharSet) == 0)
         return str;
 
     const WCHAR* ret = nullptr;
@@ -149,7 +149,7 @@ const WCHAR* dn_wcsstr(const WCHAR *str, const WCHAR *strCharSet)
     return ret;
 }
 
-const WCHAR* dn_wcschr(const WCHAR* str, WCHAR ch)
+const WCHAR* strchr_u16(const WCHAR* str, WCHAR ch)
 {
     while (*str)
     {
@@ -165,7 +165,7 @@ const WCHAR* dn_wcschr(const WCHAR* str, WCHAR ch)
     return nullptr;
 }
 
-const WCHAR* dn_wcsrchr(const WCHAR* str, WCHAR ch)
+const WCHAR* strrchr_u16(const WCHAR* str, WCHAR ch)
 {
     const WCHAR* last = nullptr;
     while (*str)
@@ -183,17 +183,17 @@ extern "C" uint32_t PAL_wcstoul(const WCHAR* nptr, WCHAR** endptr, int base);
 extern "C" uint64_t PAL__wcstoui64(const WCHAR* nptr, WCHAR** endptr, int base);
 extern "C" double PAL_wcstod(const WCHAR* nptr, WCHAR** endptr);
 
-uint32_t dn_wcstoul(const WCHAR* nptr, WCHAR** endptr, int base)
+uint32_t strtoul_u16(const WCHAR* nptr, WCHAR** endptr, int base)
 {
     return PAL_wcstoul(nptr, endptr, base);
 }
 
-uint64_t dn_wcstoui64(const WCHAR* nptr, WCHAR** endptr, int base)
+uint64_t strtoui64_u16(const WCHAR* nptr, WCHAR** endptr, int base)
 {
     return PAL__wcstoui64(nptr, endptr, base);
 }
 
-double dn_wcstod(const WCHAR* nptr, WCHAR** endptr)
+double strtod_u16(const WCHAR* nptr, WCHAR** endptr)
 {
     return PAL_wcstod(nptr, endptr);
 }

--- a/src/coreclr/minipal/Unix/dn-u16.cpp
+++ b/src/coreclr/minipal/Unix/dn-u16.cpp
@@ -8,13 +8,9 @@ typedef char16_t WCHAR;
 
 size_t strlen_u16(const WCHAR* str)
 {
-    if (str == nullptr)
-        return 0;
-
     size_t nChar = 0;
     while (*str++)
         nChar++;
-
     return nChar;
 }
 

--- a/src/coreclr/minipal/Windows/CMakeLists.txt
+++ b/src/coreclr/minipal/Windows/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(coreclrminipal
     STATIC
     doublemapping.cpp
+    dn-u16.cpp
 )

--- a/src/coreclr/minipal/Windows/dn-u16.cpp
+++ b/src/coreclr/minipal/Windows/dn-u16.cpp
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <dn-u16.h>
+#include <wchar.h>
+
+size_t dn_wcslen(const WCHAR* str)
+{
+    if (str == NULL)
+        return 0;
+    return ::wcslen(str);
+}
+
+int dn_wcscmp(const WCHAR* str1, const WCHAR* str2)
+{
+    return ::wcscmp(str1, str2);
+}
+
+int dn_wcsncmp(const WCHAR* str1, const WCHAR* str2, size_t count)
+{
+    return ::wcsncmp(str1, str2, count);
+}
+
+WCHAR* dn_wcscpy(WCHAR* dst, const WCHAR* src)
+{
+    return ::wcscpy(dst, src);
+}
+
+WCHAR* dn_wcscat(WCHAR* dst, const WCHAR* src)
+{
+    return ::wcscat(dst, src);
+}
+
+WCHAR* dn_wcsncpy(WCHAR* dst, const WCHAR* src, size_t count)
+{
+    return ::wcsncpy(dst, src, count);
+}
+
+const WCHAR* dn_wcsstr(const WCHAR *str, const WCHAR *strCharSet)
+{
+    return ::wcsstr(str, strCharSet);
+}
+
+WCHAR* dn_wcschr(const WCHAR* str, WCHAR ch)
+{
+    return ::wcschr(str, ch);
+}
+
+WCHAR* dn_wcsrchr(const WCHAR* str, WCHAR ch)
+{
+    return ::wcsrchr(str, ch);
+}
+
+ULONG dn_wcstoul(const WCHAR* nptr, WCHAR** endptr, int base)
+{
+    return ::wcstoul(nptr, endptr, base);
+}
+
+uint64_t dn_wcstoui64(const WCHAR* nptr, WCHAR** endptr, int base)
+{
+    return ::_wcstoui64(nptr, endptr, base);
+}
+
+double dn_wcstod(const WCHAR* nptr, WCHAR** endptr)
+{
+    return ::wcstod(nptr, endptr);
+}

--- a/src/coreclr/minipal/Windows/dn-u16.cpp
+++ b/src/coreclr/minipal/Windows/dn-u16.cpp
@@ -8,8 +8,6 @@
 
 size_t strlen_u16(const WCHAR* str)
 {
-    if (str == NULL)
-        return 0;
     return ::wcslen(str);
 }
 

--- a/src/coreclr/minipal/Windows/dn-u16.cpp
+++ b/src/coreclr/minipal/Windows/dn-u16.cpp
@@ -1,8 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#include <dn-u16.h>
+#include <Windows.h>
 #include <wchar.h>
+
+#include <dn-u16.h>
 
 size_t dn_wcslen(const WCHAR* str)
 {
@@ -21,19 +23,25 @@ int dn_wcsncmp(const WCHAR* str1, const WCHAR* str2, size_t count)
     return ::wcsncmp(str1, str2, count);
 }
 
-WCHAR* dn_wcscpy(WCHAR* dst, const WCHAR* src)
+WCHAR* dn_wcscpy(WCHAR* dst, size_t dstLen, const WCHAR* src)
 {
-    return ::wcscpy(dst, src);
+    if (0 != ::wcscpy_s(dst, dstLen, src))
+        return nullptr;
+    return dst;
 }
 
-WCHAR* dn_wcscat(WCHAR* dst, const WCHAR* src)
+WCHAR* dn_wcscat(WCHAR* dst, size_t dstLen, const WCHAR* src)
 {
-    return ::wcscat(dst, src);
+    if (0 != ::wcscat_s(dst, dstLen, src))
+        return nullptr;
+    return dst;
 }
 
-WCHAR* dn_wcsncpy(WCHAR* dst, const WCHAR* src, size_t count)
+WCHAR* dn_wcsncpy(WCHAR* dst, size_t dstLen, const WCHAR* src, size_t count)
 {
-    return ::wcsncpy(dst, src, count);
+    if (0 != ::wcsncpy_s(dst, dstLen, src, count))
+        return nullptr;
+    return dst;
 }
 
 const WCHAR* dn_wcsstr(const WCHAR *str, const WCHAR *strCharSet)
@@ -41,17 +49,17 @@ const WCHAR* dn_wcsstr(const WCHAR *str, const WCHAR *strCharSet)
     return ::wcsstr(str, strCharSet);
 }
 
-WCHAR* dn_wcschr(const WCHAR* str, WCHAR ch)
+const WCHAR* dn_wcschr(const WCHAR* str, WCHAR ch)
 {
     return ::wcschr(str, ch);
 }
 
-WCHAR* dn_wcsrchr(const WCHAR* str, WCHAR ch)
+const WCHAR* dn_wcsrchr(const WCHAR* str, WCHAR ch)
 {
     return ::wcsrchr(str, ch);
 }
 
-ULONG dn_wcstoul(const WCHAR* nptr, WCHAR** endptr, int base)
+uint32_t dn_wcstoul(const WCHAR* nptr, WCHAR** endptr, int base)
 {
     return ::wcstoul(nptr, endptr, base);
 }

--- a/src/coreclr/minipal/Windows/dn-u16.cpp
+++ b/src/coreclr/minipal/Windows/dn-u16.cpp
@@ -6,68 +6,68 @@
 
 #include <dn-u16.h>
 
-size_t strlen_u16(const WCHAR* str)
+size_t u16_strlen(const WCHAR* str)
 {
     return ::wcslen(str);
 }
 
-int strcmp_u16(const WCHAR* str1, const WCHAR* str2)
+int u16_strcmp(const WCHAR* str1, const WCHAR* str2)
 {
     return ::wcscmp(str1, str2);
 }
 
-int strncmp_u16(const WCHAR* str1, const WCHAR* str2, size_t count)
+int u16_strncmp(const WCHAR* str1, const WCHAR* str2, size_t count)
 {
     return ::wcsncmp(str1, str2, count);
 }
 
-WCHAR* strcpy_u16(WCHAR* dst, size_t dstLen, const WCHAR* src)
+WCHAR* u16_strcpy_s(WCHAR* dst, size_t dstLen, const WCHAR* src)
 {
     if (0 != ::wcscpy_s(dst, dstLen, src))
         return nullptr;
     return dst;
 }
 
-WCHAR* strcat_u16(WCHAR* dst, size_t dstLen, const WCHAR* src)
+WCHAR* u16_strcat_s(WCHAR* dst, size_t dstLen, const WCHAR* src)
 {
     if (0 != ::wcscat_s(dst, dstLen, src))
         return nullptr;
     return dst;
 }
 
-WCHAR* strncpy_u16(WCHAR* dst, size_t dstLen, const WCHAR* src, size_t count)
+WCHAR* u16_strncpy_s(WCHAR* dst, size_t dstLen, const WCHAR* src, size_t count)
 {
     if (0 != ::wcsncpy_s(dst, dstLen, src, count))
         return nullptr;
     return dst;
 }
 
-const WCHAR* strstr_u16(const WCHAR *str, const WCHAR *strCharSet)
+const WCHAR* u16_strstr(const WCHAR *str, const WCHAR *strCharSet)
 {
     return ::wcsstr(str, strCharSet);
 }
 
-const WCHAR* strchr_u16(const WCHAR* str, WCHAR ch)
+const WCHAR* u16_strchr(const WCHAR* str, WCHAR ch)
 {
     return ::wcschr(str, ch);
 }
 
-const WCHAR* strrchr_u16(const WCHAR* str, WCHAR ch)
+const WCHAR* u16_strrchr(const WCHAR* str, WCHAR ch)
 {
     return ::wcsrchr(str, ch);
 }
 
-uint32_t strtoul_u16(const WCHAR* nptr, WCHAR** endptr, int base)
+uint32_t u16_strtoul(const WCHAR* nptr, WCHAR** endptr, int base)
 {
     return ::wcstoul(nptr, endptr, base);
 }
 
-uint64_t strtoui64_u16(const WCHAR* nptr, WCHAR** endptr, int base)
+uint64_t u16_strtoui64(const WCHAR* nptr, WCHAR** endptr, int base)
 {
     return ::_wcstoui64(nptr, endptr, base);
 }
 
-double strtod_u16(const WCHAR* nptr, WCHAR** endptr)
+double u16_strtod(const WCHAR* nptr, WCHAR** endptr)
 {
     return ::wcstod(nptr, endptr);
 }

--- a/src/coreclr/minipal/Windows/dn-u16.cpp
+++ b/src/coreclr/minipal/Windows/dn-u16.cpp
@@ -6,70 +6,70 @@
 
 #include <dn-u16.h>
 
-size_t dn_wcslen(const WCHAR* str)
+size_t strlen_u16(const WCHAR* str)
 {
     if (str == NULL)
         return 0;
     return ::wcslen(str);
 }
 
-int dn_wcscmp(const WCHAR* str1, const WCHAR* str2)
+int strcmp_u16(const WCHAR* str1, const WCHAR* str2)
 {
     return ::wcscmp(str1, str2);
 }
 
-int dn_wcsncmp(const WCHAR* str1, const WCHAR* str2, size_t count)
+int strncmp_u16(const WCHAR* str1, const WCHAR* str2, size_t count)
 {
     return ::wcsncmp(str1, str2, count);
 }
 
-WCHAR* dn_wcscpy(WCHAR* dst, size_t dstLen, const WCHAR* src)
+WCHAR* strcpy_u16(WCHAR* dst, size_t dstLen, const WCHAR* src)
 {
     if (0 != ::wcscpy_s(dst, dstLen, src))
         return nullptr;
     return dst;
 }
 
-WCHAR* dn_wcscat(WCHAR* dst, size_t dstLen, const WCHAR* src)
+WCHAR* strcat_u16(WCHAR* dst, size_t dstLen, const WCHAR* src)
 {
     if (0 != ::wcscat_s(dst, dstLen, src))
         return nullptr;
     return dst;
 }
 
-WCHAR* dn_wcsncpy(WCHAR* dst, size_t dstLen, const WCHAR* src, size_t count)
+WCHAR* strncpy_u16(WCHAR* dst, size_t dstLen, const WCHAR* src, size_t count)
 {
     if (0 != ::wcsncpy_s(dst, dstLen, src, count))
         return nullptr;
     return dst;
 }
 
-const WCHAR* dn_wcsstr(const WCHAR *str, const WCHAR *strCharSet)
+const WCHAR* strstr_u16(const WCHAR *str, const WCHAR *strCharSet)
 {
     return ::wcsstr(str, strCharSet);
 }
 
-const WCHAR* dn_wcschr(const WCHAR* str, WCHAR ch)
+const WCHAR* strchr_u16(const WCHAR* str, WCHAR ch)
 {
     return ::wcschr(str, ch);
 }
 
-const WCHAR* dn_wcsrchr(const WCHAR* str, WCHAR ch)
+const WCHAR* strrchr_u16(const WCHAR* str, WCHAR ch)
 {
     return ::wcsrchr(str, ch);
 }
 
-uint32_t dn_wcstoul(const WCHAR* nptr, WCHAR** endptr, int base)
+uint32_t strtoul_u16(const WCHAR* nptr, WCHAR** endptr, int base)
 {
     return ::wcstoul(nptr, endptr, base);
 }
 
-uint64_t dn_wcstoui64(const WCHAR* nptr, WCHAR** endptr, int base)
+uint64_t strtoui64_u16(const WCHAR* nptr, WCHAR** endptr, int base)
 {
     return ::_wcstoui64(nptr, endptr, base);
 }
 
-double dn_wcstod(const WCHAR* nptr, WCHAR** endptr)
+double strtod_u16(const WCHAR* nptr, WCHAR** endptr)
 {
     return ::wcstod(nptr, endptr);
 }

--- a/src/coreclr/minipal/dn-u16.h
+++ b/src/coreclr/minipal/dn-u16.h
@@ -1,7 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#include <stdlib.h>
+#include <stddef.h>
+#include <stdint.h>
 
 //
 // Wide character (UTF-16) abstraction layer.
@@ -10,12 +11,12 @@
 size_t dn_wcslen(const WCHAR* str);
 int dn_wcscmp(const WCHAR* str1, const WCHAR* str2);
 int dn_wcsncmp(const WCHAR* str1, const WCHAR* str2, size_t count);
-WCHAR* dn_wcscat(WCHAR* dst, const WCHAR* src);
-WCHAR* dn_wcscpy(WCHAR* dst, const WCHAR* src);
-WCHAR* dn_wcsncpy(WCHAR* dst, const WCHAR* src, size_t count);
+WCHAR* dn_wcscat(WCHAR* dst, size_t dstLen, const WCHAR* src);
+WCHAR* dn_wcscpy(WCHAR* dst, size_t dstLen, const WCHAR* src);
+WCHAR* dn_wcsncpy(WCHAR* dst, size_t dstLen, const WCHAR* src, size_t count);
 const WCHAR* dn_wcsstr(const WCHAR *str, const WCHAR *strCharSet);
-WCHAR* dn_wcschr(const WCHAR* str, WCHAR ch);
-WCHAR* dn_wcsrchr(const WCHAR* str, WCHAR ch);
+const WCHAR* dn_wcschr(const WCHAR* str, WCHAR ch);
+const WCHAR* dn_wcsrchr(const WCHAR* str, WCHAR ch);
 uint32_t dn_wcstoul(const WCHAR* nptr, WCHAR** endptr, int base);
 uint64_t dn_wcstoui64(const WCHAR* nptr, WCHAR** endptr, int base);
 double dn_wcstod(const WCHAR* nptr, WCHAR** endptr);

--- a/src/coreclr/minipal/dn-u16.h
+++ b/src/coreclr/minipal/dn-u16.h
@@ -8,15 +8,15 @@
 // Wide character (UTF-16) abstraction layer.
 //
 
-size_t dn_wcslen(const WCHAR* str);
-int dn_wcscmp(const WCHAR* str1, const WCHAR* str2);
-int dn_wcsncmp(const WCHAR* str1, const WCHAR* str2, size_t count);
-WCHAR* dn_wcscat(WCHAR* dst, size_t dstLen, const WCHAR* src);
-WCHAR* dn_wcscpy(WCHAR* dst, size_t dstLen, const WCHAR* src);
-WCHAR* dn_wcsncpy(WCHAR* dst, size_t dstLen, const WCHAR* src, size_t count);
-const WCHAR* dn_wcsstr(const WCHAR *str, const WCHAR *strCharSet);
-const WCHAR* dn_wcschr(const WCHAR* str, WCHAR ch);
-const WCHAR* dn_wcsrchr(const WCHAR* str, WCHAR ch);
-uint32_t dn_wcstoul(const WCHAR* nptr, WCHAR** endptr, int base);
-uint64_t dn_wcstoui64(const WCHAR* nptr, WCHAR** endptr, int base);
-double dn_wcstod(const WCHAR* nptr, WCHAR** endptr);
+size_t strlen_u16(const WCHAR* str);
+int strcmp_u16(const WCHAR* str1, const WCHAR* str2);
+int strncmp_u16(const WCHAR* str1, const WCHAR* str2, size_t count);
+WCHAR* strcat_u16(WCHAR* dst, size_t dstLen, const WCHAR* src);
+WCHAR* strcpy_u16(WCHAR* dst, size_t dstLen, const WCHAR* src);
+WCHAR* strncpy_u16(WCHAR* dst, size_t dstLen, const WCHAR* src, size_t count);
+const WCHAR* strstr_u16(const WCHAR* str, const WCHAR* strCharSet);
+const WCHAR* strchr_u16(const WCHAR* str, WCHAR ch);
+const WCHAR* strrchr_u16(const WCHAR* str, WCHAR ch);
+uint32_t strtoul_u16(const WCHAR* nptr, WCHAR** endptr, int base);
+uint64_t strtoui64_u16(const WCHAR* nptr, WCHAR** endptr, int base);
+double strtod_u16(const WCHAR* nptr, WCHAR** endptr);

--- a/src/coreclr/minipal/dn-u16.h
+++ b/src/coreclr/minipal/dn-u16.h
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <stdlib.h>
+
+//
+// Wide character (UTF-16) abstraction layer.
+//
+
+size_t dn_wcslen(const WCHAR* str);
+int dn_wcscmp(const WCHAR* str1, const WCHAR* str2);
+int dn_wcsncmp(const WCHAR* str1, const WCHAR* str2, size_t count);
+WCHAR* dn_wcscat(WCHAR* dst, const WCHAR* src);
+WCHAR* dn_wcscpy(WCHAR* dst, const WCHAR* src);
+WCHAR* dn_wcsncpy(WCHAR* dst, const WCHAR* src, size_t count);
+const WCHAR* dn_wcsstr(const WCHAR *str, const WCHAR *strCharSet);
+WCHAR* dn_wcschr(const WCHAR* str, WCHAR ch);
+WCHAR* dn_wcsrchr(const WCHAR* str, WCHAR ch);
+uint32_t dn_wcstoul(const WCHAR* nptr, WCHAR** endptr, int base);
+uint64_t dn_wcstoui64(const WCHAR* nptr, WCHAR** endptr, int base);
+double dn_wcstod(const WCHAR* nptr, WCHAR** endptr);

--- a/src/coreclr/minipal/dn-u16.h
+++ b/src/coreclr/minipal/dn-u16.h
@@ -8,15 +8,15 @@
 // Wide character (UTF-16) abstraction layer.
 //
 
-size_t strlen_u16(const WCHAR* str);
-int strcmp_u16(const WCHAR* str1, const WCHAR* str2);
-int strncmp_u16(const WCHAR* str1, const WCHAR* str2, size_t count);
-WCHAR* strcat_u16(WCHAR* dst, size_t dstLen, const WCHAR* src);
-WCHAR* strcpy_u16(WCHAR* dst, size_t dstLen, const WCHAR* src);
-WCHAR* strncpy_u16(WCHAR* dst, size_t dstLen, const WCHAR* src, size_t count);
-const WCHAR* strstr_u16(const WCHAR* str, const WCHAR* strCharSet);
-const WCHAR* strchr_u16(const WCHAR* str, WCHAR ch);
-const WCHAR* strrchr_u16(const WCHAR* str, WCHAR ch);
-uint32_t strtoul_u16(const WCHAR* nptr, WCHAR** endptr, int base);
-uint64_t strtoui64_u16(const WCHAR* nptr, WCHAR** endptr, int base);
-double strtod_u16(const WCHAR* nptr, WCHAR** endptr);
+size_t u16_strlen(const WCHAR* str);
+int u16_strcmp(const WCHAR* str1, const WCHAR* str2);
+int u16_strncmp(const WCHAR* str1, const WCHAR* str2, size_t count);
+WCHAR* u16_strcat_s(WCHAR* dst, size_t dstLen, const WCHAR* src);
+WCHAR* u16_strcpy_s(WCHAR* dst, size_t dstLen, const WCHAR* src);
+WCHAR* u16_strncpy_s(WCHAR* dst, size_t dstLen, const WCHAR* src, size_t count);
+const WCHAR* u16_strstr(const WCHAR* str, const WCHAR* strCharSet);
+const WCHAR* u16_strchr(const WCHAR* str, WCHAR ch);
+const WCHAR* u16_strrchr(const WCHAR* str, WCHAR ch);
+uint32_t u16_strtoul(const WCHAR* nptr, WCHAR** endptr, int base);
+uint64_t u16_strtoui64(const WCHAR* nptr, WCHAR** endptr, int base);
+double u16_strtod(const WCHAR* nptr, WCHAR** endptr);

--- a/src/coreclr/nativeaot/Runtime/eventpipe/disableddotnetruntime.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/disableddotnetruntime.cpp
@@ -12,10 +12,6 @@ This file is generated using the logic from <root>/src/scripts/genEventPipe.py
 #include "eventpipeadapter.h"
 #include "gcheaputilities.h"
 
-#if defined(TARGET_UNIX)
-#define wcslen PAL_wcslen
-#endif
-
 #ifndef ERROR_WRITE_FAULT
 #define ERROR_WRITE_FAULT 29L
 #endif
@@ -39,8 +35,8 @@ ULONG EventPipeWriteEventExceptionThrown_V1(
     const GUID * ActivityId,
     const GUID * RelatedActivityId
 )
-{ 
-    return 0; 
+{
+    return 0;
 }
 
 ULONG EventPipeWriteEventGCAllocationTick_V1(

--- a/src/coreclr/nativeaot/Runtime/eventpipe/dotnetruntime.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/dotnetruntime.cpp
@@ -9,10 +9,6 @@
 #include "eventpipeadapter.h"
 #include "gcheaputilities.h"
 
-#if defined(TARGET_UNIX)
-#define wcslen PAL_wcslen
-#endif
-
 #ifndef _INC_WINDOWS
     typedef void* LPVOID;
     typedef uint32_t UINT;
@@ -1893,7 +1889,7 @@ void EventPipeEtwCallbackDotNETRuntime(
 
 DOTNET_TRACE_CONTEXT MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_DOTNET_Context;
 
-// @TODO 
+// @TODO
 int const EVENT_CONTROL_CODE_ENABLE_PROVIDER=1;
 int const EVENT_CONTROL_CODE_DISABLE_PROVIDER=0;
 

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -4045,18 +4045,6 @@ PAL_GetCurrentThreadAffinitySet(SIZE_T size, UINT_PTR* data);
    defines */
 #ifndef PAL_STDCPP_COMPAT
 #define exit          PAL_exit
-#define wcstod        PAL_wcstod
-#define wcstoul       PAL_wcstoul
-#define wcscat        PAL_wcscat
-#define wcscpy        PAL_wcscpy
-#define wcslen        PAL_wcslen
-#define wcsncmp       PAL_wcsncmp
-#define wcschr        PAL_wcschr
-#define wcsrchr       PAL_wcsrchr
-#define wcsstr        PAL_wcsstr
-#define wcspbrk       PAL_wcspbrk
-#define wcscmp        PAL_wcscmp
-#define wcsncpy       PAL_wcsncpy
 #define realloc       PAL_realloc
 #define fopen         PAL_fopen
 #define strtok        PAL_strtok
@@ -4105,10 +4093,8 @@ PAL_GetCurrentThreadAffinitySet(SIZE_T size, UINT_PTR* data);
 #define _open         PAL__open
 #define _pread        PAL__pread
 #define _close        PAL__close
-#define _wcstoui64    PAL__wcstoui64
 #define _flushall     PAL__flushall
 #define strnlen       PAL_strnlen
-#define wcsnlen       PAL_wcsnlen
 
 #ifdef HOST_AMD64
 #define _mm_getcsr    PAL__mm_getcsr
@@ -4217,10 +4203,10 @@ PALIMPORT DLLEXPORT const WCHAR * __cdecl PAL_wcsrchr(const WCHAR *, WCHAR);
 PALIMPORT WCHAR _WConst_return * __cdecl PAL_wcspbrk(const WCHAR *, const WCHAR *);
 PALIMPORT DLLEXPORT WCHAR _WConst_return * __cdecl PAL_wcsstr(const WCHAR *, const WCHAR *);
 PALIMPORT DLLEXPORT ULONG __cdecl PAL_wcstoul(const WCHAR *, WCHAR **, int);
-PALIMPORT double __cdecl PAL_wcstod(const WCHAR *, WCHAR **);
+PALIMPORT DLLEXPORT ULONGLONG __cdecl PAL__wcstoui64(const WCHAR *, WCHAR **, int);
+PALIMPORT DLLEXPORT double __cdecl PAL_wcstod(const WCHAR *, WCHAR **);
 
 PALIMPORT errno_t __cdecl _wcslwr_s(WCHAR *, size_t sz);
-PALIMPORT DLLEXPORT ULONGLONG _wcstoui64(const WCHAR *, WCHAR **, int);
 PALIMPORT DLLEXPORT errno_t __cdecl _i64tow_s(long long, WCHAR *, size_t, int);
 PALIMPORT int __cdecl _wtoi(const WCHAR *);
 

--- a/src/coreclr/pal/src/eventprovider/lttngprovider/eventproviderhelpers.cpp
+++ b/src/coreclr/pal/src/eventprovider/lttngprovider/eventproviderhelpers.cpp
@@ -9,8 +9,6 @@
 #include <new>
 #include <memory.h>
 
-#define wcslen PAL_wcslen
-
 bool ResizeBuffer(char *&buffer, size_t& size, size_t currLen, size_t newSize, bool &fixedBuffer)
 {
     newSize = (size_t)(newSize * 1.5);
@@ -55,7 +53,7 @@ bool WriteToBuffer(const BYTE *src, size_t len, char *&buffer, size_t& offset, s
 bool WriteToBuffer(PCWSTR str, char *&buffer, size_t& offset, size_t& size, bool &fixedBuffer)
 {
     if(!str) return true;
-    size_t byteCount = (wcslen(str) + 1) * sizeof(*str);
+    size_t byteCount = (PAL_wcslen(str) + 1) * sizeof(*str);
 
     if (offset + byteCount > size)
     {

--- a/src/coreclr/pal/src/include/pal/palinternal.h
+++ b/src/coreclr/pal/src/include/pal/palinternal.h
@@ -505,19 +505,6 @@ function_name() to call the system's implementation
 
 #undef fprintf
 #undef vfprintf
-#undef wcstod
-#undef wcstoul
-#undef _wcstoui64
-#undef wcscat
-#undef wcscpy
-#undef wcslen
-#undef wcsncmp
-#undef wcschr
-#undef wcsrchr
-#undef wcspbrk
-#undef wcsstr
-#undef wcscmp
-#undef wcsncpy
 #undef iswupper
 #undef iswspace
 #undef towlower

--- a/src/coreclr/pal/tests/palsuite/common/palsuite.h
+++ b/src/coreclr/pal/tests/palsuite/common/palsuite.h
@@ -229,4 +229,17 @@ BOOL
 DeleteFileW(
         IN LPCWSTR lpFileName);
 
+#define wcstod        PAL_wcstod
+#define wcstoul       PAL_wcstoul
+#define wcscat        PAL_wcscat
+#define wcscpy        PAL_wcscpy
+#define wcslen        PAL_wcslen
+#define wcsncmp       PAL_wcsncmp
+#define wcschr        PAL_wcschr
+#define wcsrchr        PAL_wcsrchr
+#define wcspbrk       PAL_wcspbrk
+#define wcsstr        PAL_wcsstr
+#define wcscmp        PAL_wcscmp
+#define wcsncpy       PAL_wcsncpy
+
 #endif

--- a/src/coreclr/scripts/genEventPipe.py
+++ b/src/coreclr/scripts/genEventPipe.py
@@ -510,7 +510,7 @@ bool WriteToBuffer(const BYTE *src, size_t len, BYTE *&buffer, size_t& offset, s
 bool WriteToBuffer(PCWSTR str, BYTE *&buffer, size_t& offset, size_t& size, bool &fixedBuffer)
 {
     if (!str) return true;
-    size_t byteCount = (strlen_u16(str) + 1) * sizeof(*str);
+    size_t byteCount = (u16_strlen(str) + 1) * sizeof(*str);
 
     if (offset + byteCount > size)
     {

--- a/src/coreclr/scripts/genEventPipe.py
+++ b/src/coreclr/scripts/genEventPipe.py
@@ -510,7 +510,7 @@ bool WriteToBuffer(const BYTE *src, size_t len, BYTE *&buffer, size_t& offset, s
 bool WriteToBuffer(PCWSTR str, BYTE *&buffer, size_t& offset, size_t& size, bool &fixedBuffer)
 {
     if (!str) return true;
-    size_t byteCount = (dn_wcslen(str) + 1) * sizeof(*str);
+    size_t byteCount = (strlen_u16(str) + 1) * sizeof(*str);
 
     if (offset + byteCount > size)
     {

--- a/src/coreclr/scripts/genEventPipe.py
+++ b/src/coreclr/scripts/genEventPipe.py
@@ -510,7 +510,7 @@ bool WriteToBuffer(const BYTE *src, size_t len, BYTE *&buffer, size_t& offset, s
 bool WriteToBuffer(PCWSTR str, BYTE *&buffer, size_t& offset, size_t& size, bool &fixedBuffer)
 {
     if (!str) return true;
-    size_t byteCount = (wcslen(str) + 1) * sizeof(*str);
+    size_t byteCount = (dn_wcslen(str) + 1) * sizeof(*str);
 
     if (offset + byteCount > size)
     {
@@ -757,10 +757,6 @@ def generateEventPipeHelperFile(etwmanifest, eventpipe_directory, target_cpp, ru
 def getCoreCLREventPipeImplFilePrefix():
     return """#include <common.h>
 #include "eventpipeadapter.h"
-
-#if defined(TARGET_UNIX)
-#define wcslen PAL_wcslen
-#endif
 
 bool ResizeBuffer(BYTE *&buffer, size_t& size, size_t currLen, size_t newSize, bool &fixedBuffer);
 bool WriteToBuffer(PCWSTR str, BYTE *&buffer, size_t& offset, size_t& size, bool &fixedBuffer);

--- a/src/coreclr/scripts/genLttngProvider.py
+++ b/src/coreclr/scripts/genLttngProvider.py
@@ -315,7 +315,7 @@ def generateMethodBody(template, providerName, eventName, runtimeFlavor):
             result.append("    INT " + paramname + "_path_size = -1;\n")
             result.append("    PathCharString " + paramname + "_PS;\n")
             result.append("    INT " + paramname + "_full_name_path_size")
-            result.append(" = (dn_wcslen(" + paramname + ") + 1)*sizeof(WCHAR);\n")
+            result.append(" = (lttng_strlen16(" + paramname + ") + 1)*sizeof(WCHAR);\n")
             result.append("    CHAR* " + paramname + "_full_name = ")
             result.append(paramname + "_PS.OpenStringBuffer(" + paramname + "_full_name_path_size );\n")
             result.append("    if (" + paramname + "_full_name == NULL )")
@@ -429,6 +429,19 @@ def generateMethodBody(template, providerName, eventName, runtimeFlavor):
 
 def generateLttngTpProvider(providerName, eventNodes, allTemplates, runtimeFlavor):
     lTTngImpl = []
+
+    lTTngImpl.append("""// Local implementation of WCHAR (UTF-16) string length
+static size_t lttng_strlen16(const WCHAR* string)
+{
+    if (string == NULL)
+        return 0;
+    size_t nChar = 0;
+    while (*string++)
+        nChar++;
+    return nChar;
+}
+""")
+
     for eventNode in eventNodes:
         eventName    = eventNode.getAttribute('symbol')
         templateName = eventNode.getAttribute('template')

--- a/src/coreclr/scripts/genLttngProvider.py
+++ b/src/coreclr/scripts/genLttngProvider.py
@@ -433,8 +433,6 @@ def generateLttngTpProvider(providerName, eventNodes, allTemplates, runtimeFlavo
     lTTngImpl.append("""// Local implementation of WCHAR (UTF-16) string length
 static size_t lttng_strlen16(const WCHAR* string)
 {
-    if (string == NULL)
-        return 0;
     size_t nChar = 0;
     while (*string++)
         nChar++;

--- a/src/coreclr/scripts/genLttngProvider.py
+++ b/src/coreclr/scripts/genLttngProvider.py
@@ -315,7 +315,7 @@ def generateMethodBody(template, providerName, eventName, runtimeFlavor):
             result.append("    INT " + paramname + "_path_size = -1;\n")
             result.append("    PathCharString " + paramname + "_PS;\n")
             result.append("    INT " + paramname + "_full_name_path_size")
-            result.append(" = (wcslen(" + paramname + ") + 1)*sizeof(WCHAR);\n")
+            result.append(" = (dn_wcslen(" + paramname + ") + 1)*sizeof(WCHAR);\n")
             result.append("    CHAR* " + paramname + "_full_name = ")
             result.append(paramname + "_PS.OpenStringBuffer(" + paramname + "_full_name_path_size );\n")
             result.append("    if (" + paramname + "_full_name == NULL )")
@@ -582,8 +582,6 @@ extern "C" bool XplatEventLoggerIsEnabled();
 #define tracepoint_enabled(provider, name) XplatEventLoggerIsEnabled()
 #define do_tracepoint tracepoint
 #endif
-
-#define wcslen PAL_wcslen
 
 bool ResizeBuffer(char *&buffer, size_t& size, size_t currLen, size_t newSize, bool &fixedBuffer);
 bool WriteToBuffer(PCWSTR str, char *&buffer, size_t& offset, size_t& size, bool &fixedBuffer);

--- a/src/coreclr/tools/metainfo/mdinfo.cpp
+++ b/src/coreclr/tools/metainfo/mdinfo.cpp
@@ -905,9 +905,9 @@ void MDInfo::DisplayMethodInfo(mdMethodDef inMethod, DWORD *pflags)
     if (!*szTempBuf)
         strcpy_s(szTempBuf, STRING_BUFFER_LEN, "[none]");
 
-    bool result = (((flags) & mdRTSpecialName) && !wcscmp((memberName), W(".ctor")));
+    bool result = (((flags) & mdRTSpecialName) && !dn_wcscmp((memberName), W(".ctor")));
     if (result) strcat_s(szTempBuf, STRING_BUFFER_LEN, "[.ctor] ");
-    result = (((flags) & mdRTSpecialName) && !wcscmp((memberName), W(".cctor")));
+    result = (((flags) & mdRTSpecialName) && !dn_wcscmp((memberName), W(".cctor")));
     if (result) strcat_s(szTempBuf,STRING_BUFFER_LEN, "[.cctor] ");
     // "Reserved" flags
     ISFLAG(Md, HasSecurity);
@@ -1964,7 +1964,7 @@ void MDInfo::DisplayCustomAttributeInfo(mdCustomAttribute inValue, const char *p
     }
 
     // Keep track of coff overhead.
-    if (!wcscmp(W("__DecoratedName"), rcName))
+    if (!dn_wcscmp(W("__DecoratedName"), rcName))
     {
         bCoffSymbol = true;
         g_cbCoffNames += cbValue + 6;

--- a/src/coreclr/tools/metainfo/mdinfo.cpp
+++ b/src/coreclr/tools/metainfo/mdinfo.cpp
@@ -905,9 +905,9 @@ void MDInfo::DisplayMethodInfo(mdMethodDef inMethod, DWORD *pflags)
     if (!*szTempBuf)
         strcpy_s(szTempBuf, STRING_BUFFER_LEN, "[none]");
 
-    bool result = (((flags) & mdRTSpecialName) && !dn_wcscmp((memberName), W(".ctor")));
+    bool result = (((flags) & mdRTSpecialName) && !strcmp_u16((memberName), W(".ctor")));
     if (result) strcat_s(szTempBuf, STRING_BUFFER_LEN, "[.ctor] ");
-    result = (((flags) & mdRTSpecialName) && !dn_wcscmp((memberName), W(".cctor")));
+    result = (((flags) & mdRTSpecialName) && !strcmp_u16((memberName), W(".cctor")));
     if (result) strcat_s(szTempBuf,STRING_BUFFER_LEN, "[.cctor] ");
     // "Reserved" flags
     ISFLAG(Md, HasSecurity);
@@ -1964,7 +1964,7 @@ void MDInfo::DisplayCustomAttributeInfo(mdCustomAttribute inValue, const char *p
     }
 
     // Keep track of coff overhead.
-    if (!dn_wcscmp(W("__DecoratedName"), rcName))
+    if (!strcmp_u16(W("__DecoratedName"), rcName))
     {
         bCoffSymbol = true;
         g_cbCoffNames += cbValue + 6;

--- a/src/coreclr/tools/metainfo/mdinfo.cpp
+++ b/src/coreclr/tools/metainfo/mdinfo.cpp
@@ -905,9 +905,9 @@ void MDInfo::DisplayMethodInfo(mdMethodDef inMethod, DWORD *pflags)
     if (!*szTempBuf)
         strcpy_s(szTempBuf, STRING_BUFFER_LEN, "[none]");
 
-    bool result = (((flags) & mdRTSpecialName) && !strcmp_u16((memberName), W(".ctor")));
+    bool result = (((flags) & mdRTSpecialName) && !u16_strcmp((memberName), W(".ctor")));
     if (result) strcat_s(szTempBuf, STRING_BUFFER_LEN, "[.ctor] ");
-    result = (((flags) & mdRTSpecialName) && !strcmp_u16((memberName), W(".cctor")));
+    result = (((flags) & mdRTSpecialName) && !u16_strcmp((memberName), W(".cctor")));
     if (result) strcat_s(szTempBuf,STRING_BUFFER_LEN, "[.cctor] ");
     // "Reserved" flags
     ISFLAG(Md, HasSecurity);
@@ -1964,7 +1964,7 @@ void MDInfo::DisplayCustomAttributeInfo(mdCustomAttribute inValue, const char *p
     }
 
     // Keep track of coff overhead.
-    if (!strcmp_u16(W("__DecoratedName"), rcName))
+    if (!u16_strcmp(W("__DecoratedName"), rcName))
     {
         bCoffSymbol = true;
         g_cbCoffNames += cbValue + 6;

--- a/src/coreclr/tools/metainfo/mdobj.cpp
+++ b/src/coreclr/tools/metainfo/mdobj.cpp
@@ -255,7 +255,7 @@ void DisplayFile(_In_z_ WCHAR* szFile, BOOL isFile, ULONG DumpFilter, _In_opt_z_
 
     // We need to make sure this file isn't too long. Checking _MAX_PATH is probably safe, but since we have a much
     // larger buffer, we might as well use it all.
-    if (wcslen(szFile) > 1000)
+    if (dn_wcslen(szFile) > 1000)
         return;
 
 

--- a/src/coreclr/tools/metainfo/mdobj.cpp
+++ b/src/coreclr/tools/metainfo/mdobj.cpp
@@ -273,8 +273,8 @@ void DisplayFile(_In_z_ WCHAR* szFile, BOOL isFile, ULONG DumpFilter, _In_opt_z_
     // print bar that separates different files
     pDisplayString("////////////////////////////////////////////////////////////////\n");
 
-    WCHAR *pExt = wcsrchr(szFile, W('.'));
-    WCHAR *pFname = wcsrchr(szFile, DIRECTORY_SEPARATOR_CHAR_W);
+    WCHAR *pExt = dn_wcsrchr(szFile, W('.'));
+    WCHAR *pFname = dn_wcsrchr(szFile, DIRECTORY_SEPARATOR_CHAR_W);
     if (pFname == NULL)
     {
         pFname = szFile;

--- a/src/coreclr/tools/metainfo/mdobj.cpp
+++ b/src/coreclr/tools/metainfo/mdobj.cpp
@@ -273,8 +273,8 @@ void DisplayFile(_In_z_ WCHAR* szFile, BOOL isFile, ULONG DumpFilter, _In_opt_z_
     // print bar that separates different files
     pDisplayString("////////////////////////////////////////////////////////////////\n");
 
-    WCHAR *pExt = dn_wcsrchr(szFile, W('.'));
-    WCHAR *pFname = dn_wcsrchr(szFile, DIRECTORY_SEPARATOR_CHAR_W);
+    WCHAR *pExt = (WCHAR*)dn_wcsrchr(szFile, W('.'));
+    WCHAR *pFname = (WCHAR*)dn_wcsrchr(szFile, DIRECTORY_SEPARATOR_CHAR_W);
     if (pFname == NULL)
     {
         pFname = szFile;

--- a/src/coreclr/tools/metainfo/mdobj.cpp
+++ b/src/coreclr/tools/metainfo/mdobj.cpp
@@ -255,7 +255,7 @@ void DisplayFile(_In_z_ WCHAR* szFile, BOOL isFile, ULONG DumpFilter, _In_opt_z_
 
     // We need to make sure this file isn't too long. Checking _MAX_PATH is probably safe, but since we have a much
     // larger buffer, we might as well use it all.
-    if (strlen_u16(szFile) > 1000)
+    if (u16_strlen(szFile) > 1000)
         return;
 
 
@@ -273,8 +273,8 @@ void DisplayFile(_In_z_ WCHAR* szFile, BOOL isFile, ULONG DumpFilter, _In_opt_z_
     // print bar that separates different files
     pDisplayString("////////////////////////////////////////////////////////////////\n");
 
-    WCHAR *pExt = (WCHAR*)strrchr_u16(szFile, W('.'));
-    WCHAR *pFname = (WCHAR*)strrchr_u16(szFile, DIRECTORY_SEPARATOR_CHAR_W);
+    WCHAR *pExt = (WCHAR*)u16_strrchr(szFile, W('.'));
+    WCHAR *pFname = (WCHAR*)u16_strrchr(szFile, DIRECTORY_SEPARATOR_CHAR_W);
     if (pFname == NULL)
     {
         pFname = szFile;

--- a/src/coreclr/tools/metainfo/mdobj.cpp
+++ b/src/coreclr/tools/metainfo/mdobj.cpp
@@ -255,7 +255,7 @@ void DisplayFile(_In_z_ WCHAR* szFile, BOOL isFile, ULONG DumpFilter, _In_opt_z_
 
     // We need to make sure this file isn't too long. Checking _MAX_PATH is probably safe, but since we have a much
     // larger buffer, we might as well use it all.
-    if (dn_wcslen(szFile) > 1000)
+    if (strlen_u16(szFile) > 1000)
         return;
 
 
@@ -273,8 +273,8 @@ void DisplayFile(_In_z_ WCHAR* szFile, BOOL isFile, ULONG DumpFilter, _In_opt_z_
     // print bar that separates different files
     pDisplayString("////////////////////////////////////////////////////////////////\n");
 
-    WCHAR *pExt = (WCHAR*)dn_wcsrchr(szFile, W('.'));
-    WCHAR *pFname = (WCHAR*)dn_wcsrchr(szFile, DIRECTORY_SEPARATOR_CHAR_W);
+    WCHAR *pExt = (WCHAR*)strrchr_u16(szFile, W('.'));
+    WCHAR *pFname = (WCHAR*)strrchr_u16(szFile, DIRECTORY_SEPARATOR_CHAR_W);
     if (pFname == NULL)
     {
         pFname = szFile;

--- a/src/coreclr/tools/superpmi/mcs/CMakeLists.txt
+++ b/src/coreclr/tools/superpmi/mcs/CMakeLists.txt
@@ -59,6 +59,7 @@ if(CLR_CMAKE_HOST_UNIX)
         mscorrc
         coreclrpal
         palrt
+        coreclrminipal
     )
 else()
     target_link_libraries(mcs

--- a/src/coreclr/tools/superpmi/mcs/CMakeLists.txt
+++ b/src/coreclr/tools/superpmi/mcs/CMakeLists.txt
@@ -65,6 +65,7 @@ else()
     target_link_libraries(mcs
         PRIVATE
         advapi32.lib
+        coreclrminipal
         ${STATIC_MT_CRT_LIB}
         ${STATIC_MT_CPP_LIB}
     )

--- a/src/coreclr/tools/superpmi/mcs/verbmerge.cpp
+++ b/src/coreclr/tools/superpmi/mcs/verbmerge.cpp
@@ -20,13 +20,13 @@ RemoveDup verbMerge::m_removeDups;
 // static
 LPWSTR verbMerge::MergePathStrings(LPCWSTR dir, LPCWSTR file)
 {
-    size_t dirlen  = strlen_u16(dir);
-    size_t filelen = strlen_u16(file);
+    size_t dirlen  = u16_strlen(dir);
+    size_t filelen = u16_strlen(file);
     size_t newlen  = dirlen + 1 /* slash */ + filelen + 1 /* null */;
     LPWSTR newpath = new WCHAR[newlen];
-    strcpy_u16(newpath, newlen, dir);
-    strcat_u16(newpath, newlen, DIRECTORY_SEPARATOR_STR_W);
-    strcat_u16(newpath, newlen, file);
+    u16_strcpy_s(newpath, newlen, dir);
+    u16_strcat_s(newpath, newlen, DIRECTORY_SEPARATOR_STR_W);
+    u16_strcat_s(newpath, newlen, file);
     return newpath;
 }
 
@@ -163,9 +163,9 @@ bool verbMerge::DirectoryFilterDirectories(WIN32_FIND_DATAW* findData)
         if ((findData->dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) != 0)
             return false;
 
-        if (strcmp_u16(findData->cFileName, W(".")) == 0)
+        if (u16_strcmp(findData->cFileName, W(".")) == 0)
             return false;
-        if (strcmp_u16(findData->cFileName, W("..")) == 0)
+        if (u16_strcmp(findData->cFileName, W("..")) == 0)
             return false;
 
         return true;
@@ -193,7 +193,7 @@ int __cdecl verbMerge::WIN32_FIND_DATAW_qsort_helper(const void* p1, const void*
 {
     const WIN32_FIND_DATAW* file1 = (WIN32_FIND_DATAW*)p1;
     const WIN32_FIND_DATAW* file2 = (WIN32_FIND_DATAW*)p2;
-    return strcmp_u16(file1->cFileName, file2->cFileName);
+    return u16_strcmp(file1->cFileName, file2->cFileName);
 }
 
 // Enumerate a directory for the files specified by "searchPattern". For each element in the directory,
@@ -352,29 +352,29 @@ int verbMerge::AppendAllInDir(HANDLE              hFileOut,
         const _WIN32_FIND_DATAW& findData     = fileArray[i];
         LPWSTR                   fileFullPath = MergePathStrings(dir, findData.cFileName);
 #ifdef TARGET_WINDOWS
-        if (strlen_u16(fileFullPath) > MAX_PATH) // This path is too long, use \\?\ to access it.
+        if (u16_strlen(fileFullPath) > MAX_PATH) // This path is too long, use \\?\ to access it.
         {
-            if (strcmp_u16(dir, W(".")) == 0)
+            if (u16_strcmp(dir, W(".")) == 0)
             {
                 LogError("can't access the relative path with UNC");
                 goto CLEAN_UP;
             }
-            size_t newBufferLen = strlen_u16(fileFullPath) + 30;
+            size_t newBufferLen = u16_strlen(fileFullPath) + 30;
             LPWSTR newBuffer = new WCHAR[newBufferLen];
-            strcpy_u16(newBuffer, newBufferLen, W("\\\\?\\"));
+            u16_strcpy_s(newBuffer, newBufferLen, W("\\\\?\\"));
             if (*fileFullPath == '\\') // It is UNC path, use \\?\UNC\serverName to access it.
             {
                 LPWSTR serverName = fileFullPath;
-                strcat_u16(newBuffer, newBufferLen, W("UNC\\"));
+                u16_strcat_s(newBuffer, newBufferLen, W("UNC\\"));
                 while (*serverName == '\\')
                 {
                     serverName++;
                 }
-                strcat_u16(newBuffer, newBufferLen, serverName);
+                u16_strcat_s(newBuffer, newBufferLen, serverName);
             }
             else
             {
-                strcat_u16(newBuffer, newBufferLen, fileFullPath);
+                u16_strcat_s(newBuffer, newBufferLen, fileFullPath);
             }
             delete[] fileFullPath;
 
@@ -502,13 +502,13 @@ int verbMerge::DoWork(const char* nameOfOutputFile, const char* pattern, bool re
     LPCWSTR        dir    = nullptr;
     LPCWSTR        file   = nullptr;
 
-    LPWSTR lastSlash = (WCHAR*)strrchr_u16(patternAsWchar, DIRECTORY_SEPARATOR_CHAR_A);
+    LPWSTR lastSlash = (WCHAR*)u16_strrchr(patternAsWchar, DIRECTORY_SEPARATOR_CHAR_A);
     if (lastSlash == NULL)
     {
         // The user may have passed a relative path without a slash, or the current directory.
         // If there is a wildcard, we use it as the file pattern. If there isn't, we assume it's a relative directory
         // name and use it as a directory, with "*" as the file pattern.
-        LPCWSTR wildcard = strchr_u16(patternAsWchar, '*');
+        LPCWSTR wildcard = u16_strchr(patternAsWchar, '*');
         if (wildcard == NULL)
         {
             file = W("*");
@@ -523,7 +523,7 @@ int verbMerge::DoWork(const char* nameOfOutputFile, const char* pattern, bool re
     else
     {
         dir              = patternAsWchar;
-        LPCWSTR wildcard = strchr_u16(lastSlash, '*');
+        LPCWSTR wildcard = u16_strchr(lastSlash, '*');
         if (wildcard == NULL)
         {
             file = W("*");

--- a/src/coreclr/tools/superpmi/mcs/verbmerge.cpp
+++ b/src/coreclr/tools/superpmi/mcs/verbmerge.cpp
@@ -501,7 +501,7 @@ int verbMerge::DoWork(const char* nameOfOutputFile, const char* pattern, bool re
     LPCWSTR        dir    = nullptr;
     LPCWSTR        file   = nullptr;
 
-    LPWSTR lastSlash = wcsrchr(patternAsWchar, DIRECTORY_SEPARATOR_CHAR_A);
+    LPWSTR lastSlash = dn_wcsrchr(patternAsWchar, DIRECTORY_SEPARATOR_CHAR_A);
     if (lastSlash == NULL)
     {
         // The user may have passed a relative path without a slash, or the current directory.

--- a/src/coreclr/tools/superpmi/mcs/verbmerge.cpp
+++ b/src/coreclr/tools/superpmi/mcs/verbmerge.cpp
@@ -20,8 +20,8 @@ RemoveDup verbMerge::m_removeDups;
 // static
 LPWSTR verbMerge::MergePathStrings(LPCWSTR dir, LPCWSTR file)
 {
-    size_t dirlen  = wcslen(dir);
-    size_t filelen = wcslen(file);
+    size_t dirlen  = dn_wcslen(dir);
+    size_t filelen = dn_wcslen(file);
     size_t newlen  = dirlen + 1 /* slash */ + filelen + 1 /* null */;
     LPWSTR newpath = new WCHAR[newlen];
     wcscpy(newpath, dir);
@@ -352,14 +352,14 @@ int verbMerge::AppendAllInDir(HANDLE              hFileOut,
         const _WIN32_FIND_DATAW& findData     = fileArray[i];
         LPWSTR                   fileFullPath = MergePathStrings(dir, findData.cFileName);
 #ifdef TARGET_WINDOWS
-        if (wcslen(fileFullPath) > MAX_PATH) // This path is too long, use \\?\ to access it.
+        if (dn_wcslen(fileFullPath) > MAX_PATH) // This path is too long, use \\?\ to access it.
         {
             if (dn_wcscmp(dir, W(".")) == 0)
             {
                 LogError("can't access the relative path with UNC");
                 goto CLEAN_UP;
             }
-            LPWSTR newBuffer = new WCHAR[wcslen(fileFullPath) + 30];
+            LPWSTR newBuffer = new WCHAR[dn_wcslen(fileFullPath) + 30];
             wcscpy(newBuffer, W("\\\\?\\"));
             if (*fileFullPath == '\\') // It is UNC path, use \\?\UNC\serverName to access it.
             {

--- a/src/coreclr/tools/superpmi/mcs/verbmerge.cpp
+++ b/src/coreclr/tools/superpmi/mcs/verbmerge.cpp
@@ -24,7 +24,7 @@ LPWSTR verbMerge::MergePathStrings(LPCWSTR dir, LPCWSTR file)
     size_t filelen = dn_wcslen(file);
     size_t newlen  = dirlen + 1 /* slash */ + filelen + 1 /* null */;
     LPWSTR newpath = new WCHAR[newlen];
-    wcscpy(newpath, dir);
+    dn_wcscpy(newpath, dir);
     wcscat(newpath, DIRECTORY_SEPARATOR_STR_W);
     wcscat(newpath, file);
     return newpath;
@@ -360,7 +360,7 @@ int verbMerge::AppendAllInDir(HANDLE              hFileOut,
                 goto CLEAN_UP;
             }
             LPWSTR newBuffer = new WCHAR[dn_wcslen(fileFullPath) + 30];
-            wcscpy(newBuffer, W("\\\\?\\"));
+            dn_wcscpy(newBuffer, W("\\\\?\\"));
             if (*fileFullPath == '\\') // It is UNC path, use \\?\UNC\serverName to access it.
             {
                 LPWSTR serverName = fileFullPath;

--- a/src/coreclr/tools/superpmi/mcs/verbmerge.cpp
+++ b/src/coreclr/tools/superpmi/mcs/verbmerge.cpp
@@ -507,7 +507,7 @@ int verbMerge::DoWork(const char* nameOfOutputFile, const char* pattern, bool re
         // The user may have passed a relative path without a slash, or the current directory.
         // If there is a wildcard, we use it as the file pattern. If there isn't, we assume it's a relative directory
         // name and use it as a directory, with "*" as the file pattern.
-        LPCWSTR wildcard = wcschr(patternAsWchar, '*');
+        LPCWSTR wildcard = dn_wcschr(patternAsWchar, '*');
         if (wildcard == NULL)
         {
             file = W("*");
@@ -522,7 +522,7 @@ int verbMerge::DoWork(const char* nameOfOutputFile, const char* pattern, bool re
     else
     {
         dir              = patternAsWchar;
-        LPCWSTR wildcard = wcschr(lastSlash, '*');
+        LPCWSTR wildcard = dn_wcschr(lastSlash, '*');
         if (wildcard == NULL)
         {
             file = W("*");

--- a/src/coreclr/tools/superpmi/mcs/verbmerge.cpp
+++ b/src/coreclr/tools/superpmi/mcs/verbmerge.cpp
@@ -24,9 +24,9 @@ LPWSTR verbMerge::MergePathStrings(LPCWSTR dir, LPCWSTR file)
     size_t filelen = dn_wcslen(file);
     size_t newlen  = dirlen + 1 /* slash */ + filelen + 1 /* null */;
     LPWSTR newpath = new WCHAR[newlen];
-    dn_wcscpy(newpath, dir);
-    dn_wcscat(newpath, DIRECTORY_SEPARATOR_STR_W);
-    dn_wcscat(newpath, file);
+    dn_wcscpy(newpath, newlen, dir);
+    dn_wcscat(newpath, newlen, DIRECTORY_SEPARATOR_STR_W);
+    dn_wcscat(newpath, newlen, file);
     return newpath;
 }
 
@@ -359,21 +359,22 @@ int verbMerge::AppendAllInDir(HANDLE              hFileOut,
                 LogError("can't access the relative path with UNC");
                 goto CLEAN_UP;
             }
-            LPWSTR newBuffer = new WCHAR[dn_wcslen(fileFullPath) + 30];
-            dn_wcscpy(newBuffer, W("\\\\?\\"));
+            size_t newBufferLen = dn_wcslen(fileFullPath) + 30;
+            LPWSTR newBuffer = new WCHAR[newBufferLen];
+            dn_wcscpy(newBuffer, newBufferLen, W("\\\\?\\"));
             if (*fileFullPath == '\\') // It is UNC path, use \\?\UNC\serverName to access it.
             {
                 LPWSTR serverName = fileFullPath;
-                dn_wcscat(newBuffer, W("UNC\\"));
+                dn_wcscat(newBuffer, newBufferLen, W("UNC\\"));
                 while (*serverName == '\\')
                 {
                     serverName++;
                 }
-                dn_wcscat(newBuffer, serverName);
+                dn_wcscat(newBuffer, newBufferLen, serverName);
             }
             else
             {
-                dn_wcscat(newBuffer, fileFullPath);
+                dn_wcscat(newBuffer, newBufferLen, fileFullPath);
             }
             delete[] fileFullPath;
 
@@ -501,7 +502,7 @@ int verbMerge::DoWork(const char* nameOfOutputFile, const char* pattern, bool re
     LPCWSTR        dir    = nullptr;
     LPCWSTR        file   = nullptr;
 
-    LPWSTR lastSlash = dn_wcsrchr(patternAsWchar, DIRECTORY_SEPARATOR_CHAR_A);
+    LPWSTR lastSlash = (WCHAR*)dn_wcsrchr(patternAsWchar, DIRECTORY_SEPARATOR_CHAR_A);
     if (lastSlash == NULL)
     {
         // The user may have passed a relative path without a slash, or the current directory.

--- a/src/coreclr/tools/superpmi/mcs/verbmerge.cpp
+++ b/src/coreclr/tools/superpmi/mcs/verbmerge.cpp
@@ -163,9 +163,9 @@ bool verbMerge::DirectoryFilterDirectories(WIN32_FIND_DATAW* findData)
         if ((findData->dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) != 0)
             return false;
 
-        if (wcscmp(findData->cFileName, W(".")) == 0)
+        if (dn_wcscmp(findData->cFileName, W(".")) == 0)
             return false;
-        if (wcscmp(findData->cFileName, W("..")) == 0)
+        if (dn_wcscmp(findData->cFileName, W("..")) == 0)
             return false;
 
         return true;
@@ -193,7 +193,7 @@ int __cdecl verbMerge::WIN32_FIND_DATAW_qsort_helper(const void* p1, const void*
 {
     const WIN32_FIND_DATAW* file1 = (WIN32_FIND_DATAW*)p1;
     const WIN32_FIND_DATAW* file2 = (WIN32_FIND_DATAW*)p2;
-    return wcscmp(file1->cFileName, file2->cFileName);
+    return dn_wcscmp(file1->cFileName, file2->cFileName);
 }
 
 // Enumerate a directory for the files specified by "searchPattern". For each element in the directory,
@@ -354,7 +354,7 @@ int verbMerge::AppendAllInDir(HANDLE              hFileOut,
 #ifdef TARGET_WINDOWS
         if (wcslen(fileFullPath) > MAX_PATH) // This path is too long, use \\?\ to access it.
         {
-            if (wcscmp(dir, W(".")) == 0)
+            if (dn_wcscmp(dir, W(".")) == 0)
             {
                 LogError("can't access the relative path with UNC");
                 goto CLEAN_UP;

--- a/src/coreclr/tools/superpmi/mcs/verbmerge.cpp
+++ b/src/coreclr/tools/superpmi/mcs/verbmerge.cpp
@@ -20,13 +20,13 @@ RemoveDup verbMerge::m_removeDups;
 // static
 LPWSTR verbMerge::MergePathStrings(LPCWSTR dir, LPCWSTR file)
 {
-    size_t dirlen  = dn_wcslen(dir);
-    size_t filelen = dn_wcslen(file);
+    size_t dirlen  = strlen_u16(dir);
+    size_t filelen = strlen_u16(file);
     size_t newlen  = dirlen + 1 /* slash */ + filelen + 1 /* null */;
     LPWSTR newpath = new WCHAR[newlen];
-    dn_wcscpy(newpath, newlen, dir);
-    dn_wcscat(newpath, newlen, DIRECTORY_SEPARATOR_STR_W);
-    dn_wcscat(newpath, newlen, file);
+    strcpy_u16(newpath, newlen, dir);
+    strcat_u16(newpath, newlen, DIRECTORY_SEPARATOR_STR_W);
+    strcat_u16(newpath, newlen, file);
     return newpath;
 }
 
@@ -163,9 +163,9 @@ bool verbMerge::DirectoryFilterDirectories(WIN32_FIND_DATAW* findData)
         if ((findData->dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) != 0)
             return false;
 
-        if (dn_wcscmp(findData->cFileName, W(".")) == 0)
+        if (strcmp_u16(findData->cFileName, W(".")) == 0)
             return false;
-        if (dn_wcscmp(findData->cFileName, W("..")) == 0)
+        if (strcmp_u16(findData->cFileName, W("..")) == 0)
             return false;
 
         return true;
@@ -193,7 +193,7 @@ int __cdecl verbMerge::WIN32_FIND_DATAW_qsort_helper(const void* p1, const void*
 {
     const WIN32_FIND_DATAW* file1 = (WIN32_FIND_DATAW*)p1;
     const WIN32_FIND_DATAW* file2 = (WIN32_FIND_DATAW*)p2;
-    return dn_wcscmp(file1->cFileName, file2->cFileName);
+    return strcmp_u16(file1->cFileName, file2->cFileName);
 }
 
 // Enumerate a directory for the files specified by "searchPattern". For each element in the directory,
@@ -352,29 +352,29 @@ int verbMerge::AppendAllInDir(HANDLE              hFileOut,
         const _WIN32_FIND_DATAW& findData     = fileArray[i];
         LPWSTR                   fileFullPath = MergePathStrings(dir, findData.cFileName);
 #ifdef TARGET_WINDOWS
-        if (dn_wcslen(fileFullPath) > MAX_PATH) // This path is too long, use \\?\ to access it.
+        if (strlen_u16(fileFullPath) > MAX_PATH) // This path is too long, use \\?\ to access it.
         {
-            if (dn_wcscmp(dir, W(".")) == 0)
+            if (strcmp_u16(dir, W(".")) == 0)
             {
                 LogError("can't access the relative path with UNC");
                 goto CLEAN_UP;
             }
-            size_t newBufferLen = dn_wcslen(fileFullPath) + 30;
+            size_t newBufferLen = strlen_u16(fileFullPath) + 30;
             LPWSTR newBuffer = new WCHAR[newBufferLen];
-            dn_wcscpy(newBuffer, newBufferLen, W("\\\\?\\"));
+            strcpy_u16(newBuffer, newBufferLen, W("\\\\?\\"));
             if (*fileFullPath == '\\') // It is UNC path, use \\?\UNC\serverName to access it.
             {
                 LPWSTR serverName = fileFullPath;
-                dn_wcscat(newBuffer, newBufferLen, W("UNC\\"));
+                strcat_u16(newBuffer, newBufferLen, W("UNC\\"));
                 while (*serverName == '\\')
                 {
                     serverName++;
                 }
-                dn_wcscat(newBuffer, newBufferLen, serverName);
+                strcat_u16(newBuffer, newBufferLen, serverName);
             }
             else
             {
-                dn_wcscat(newBuffer, newBufferLen, fileFullPath);
+                strcat_u16(newBuffer, newBufferLen, fileFullPath);
             }
             delete[] fileFullPath;
 
@@ -502,13 +502,13 @@ int verbMerge::DoWork(const char* nameOfOutputFile, const char* pattern, bool re
     LPCWSTR        dir    = nullptr;
     LPCWSTR        file   = nullptr;
 
-    LPWSTR lastSlash = (WCHAR*)dn_wcsrchr(patternAsWchar, DIRECTORY_SEPARATOR_CHAR_A);
+    LPWSTR lastSlash = (WCHAR*)strrchr_u16(patternAsWchar, DIRECTORY_SEPARATOR_CHAR_A);
     if (lastSlash == NULL)
     {
         // The user may have passed a relative path without a slash, or the current directory.
         // If there is a wildcard, we use it as the file pattern. If there isn't, we assume it's a relative directory
         // name and use it as a directory, with "*" as the file pattern.
-        LPCWSTR wildcard = dn_wcschr(patternAsWchar, '*');
+        LPCWSTR wildcard = strchr_u16(patternAsWchar, '*');
         if (wildcard == NULL)
         {
             file = W("*");
@@ -523,7 +523,7 @@ int verbMerge::DoWork(const char* nameOfOutputFile, const char* pattern, bool re
     else
     {
         dir              = patternAsWchar;
-        LPCWSTR wildcard = dn_wcschr(lastSlash, '*');
+        LPCWSTR wildcard = strchr_u16(lastSlash, '*');
         if (wildcard == NULL)
         {
             file = W("*");

--- a/src/coreclr/tools/superpmi/mcs/verbmerge.cpp
+++ b/src/coreclr/tools/superpmi/mcs/verbmerge.cpp
@@ -25,8 +25,8 @@ LPWSTR verbMerge::MergePathStrings(LPCWSTR dir, LPCWSTR file)
     size_t newlen  = dirlen + 1 /* slash */ + filelen + 1 /* null */;
     LPWSTR newpath = new WCHAR[newlen];
     dn_wcscpy(newpath, dir);
-    wcscat(newpath, DIRECTORY_SEPARATOR_STR_W);
-    wcscat(newpath, file);
+    dn_wcscat(newpath, DIRECTORY_SEPARATOR_STR_W);
+    dn_wcscat(newpath, file);
     return newpath;
 }
 
@@ -364,16 +364,16 @@ int verbMerge::AppendAllInDir(HANDLE              hFileOut,
             if (*fileFullPath == '\\') // It is UNC path, use \\?\UNC\serverName to access it.
             {
                 LPWSTR serverName = fileFullPath;
-                wcscat(newBuffer, W("UNC\\"));
+                dn_wcscat(newBuffer, W("UNC\\"));
                 while (*serverName == '\\')
                 {
                     serverName++;
                 }
-                wcscat(newBuffer, serverName);
+                dn_wcscat(newBuffer, serverName);
             }
             else
             {
-                wcscat(newBuffer, fileFullPath);
+                dn_wcscat(newBuffer, fileFullPath);
             }
             delete[] fileFullPath;
 

--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
@@ -1308,7 +1308,7 @@ void MethodContext::recGetJitTimeLogFilename(LPCWSTR tempFileName)
     DWORD name_index = -1;
     if (tempFileName != nullptr)
     {
-        name_index = GetJitTimeLogFilename->AddBuffer((unsigned char*)tempFileName, (DWORD)wcslen(tempFileName) + 2);
+        name_index = GetJitTimeLogFilename->AddBuffer((unsigned char*)tempFileName, (DWORD)dn_wcslen(tempFileName) + 2);
     }
     GetJitTimeLogFilename->Add(0, name_index);
     DEBUG_REC(dmpGetJitTimeLogFilename(0, name_index));
@@ -7089,7 +7089,7 @@ void MethodContext::recGetIntConfigValue(const WCHAR* name, int defaultValue, in
     ZeroMemory(&key, sizeof(key)); // Zero key including any struct padding
 
     DWORD index =
-        (DWORD)GetIntConfigValue->AddBuffer((unsigned char*)name, sizeof(WCHAR) * ((unsigned int)wcslen(name) + 1));
+        (DWORD)GetIntConfigValue->AddBuffer((unsigned char*)name, sizeof(WCHAR) * ((unsigned int)dn_wcslen(name) + 1));
 
     key.nameIndex    = index;
     key.defaultValue = defaultValue;
@@ -7119,7 +7119,7 @@ int MethodContext::repGetIntConfigValue(const WCHAR* name, int defaultValue)
     Agnostic_ConfigIntInfo key;
     ZeroMemory(&key, sizeof(key)); // Zero key including any struct padding
 
-    size_t nameLenInBytes = sizeof(WCHAR) * (wcslen(name) + 1);
+    size_t nameLenInBytes = sizeof(WCHAR) * (dn_wcslen(name) + 1);
     int    nameIndex      = GetIntConfigValue->Contains((unsigned char*)name, (unsigned int)nameLenInBytes);
     if (nameIndex == -1) // config name not in map
         return defaultValue;
@@ -7141,12 +7141,12 @@ void MethodContext::recGetStringConfigValue(const WCHAR* name, const WCHAR* resu
     AssertCodeMsg(name != nullptr, EXCEPTIONCODE_MC, "Name can not be nullptr");
 
     DWORD nameIndex = (DWORD)GetStringConfigValue->AddBuffer((unsigned char*)name,
-                                                             sizeof(WCHAR) * ((unsigned int)wcslen(name) + 1));
+                                                             sizeof(WCHAR) * ((unsigned int)dn_wcslen(name) + 1));
 
     DWORD resultIndex = (DWORD)-1;
     if (result != nullptr)
         resultIndex = (DWORD)GetStringConfigValue->AddBuffer((unsigned char*)result,
-                                                             sizeof(WCHAR) * ((unsigned int)wcslen(result) + 1));
+                                                             sizeof(WCHAR) * ((unsigned int)dn_wcslen(result) + 1));
 
     GetStringConfigValue->Add(nameIndex, resultIndex);
     DEBUG_REC(dmpGetStringConfigValue(nameIndex, resultIndex));
@@ -7170,7 +7170,7 @@ const WCHAR* MethodContext::repGetStringConfigValue(const WCHAR* name)
 
     AssertCodeMsg(name != nullptr, EXCEPTIONCODE_MC, "Name can not be nullptr");
 
-    size_t nameLenInBytes = sizeof(WCHAR) * (wcslen(name) + 1);
+    size_t nameLenInBytes = sizeof(WCHAR) * (dn_wcslen(name) + 1);
     int    nameIndex      = GetStringConfigValue->Contains((unsigned char*)name, (unsigned int)nameLenInBytes);
     if (nameIndex == -1) // config name not in map
         return nullptr;

--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
@@ -1308,7 +1308,7 @@ void MethodContext::recGetJitTimeLogFilename(LPCWSTR tempFileName)
     DWORD name_index = -1;
     if (tempFileName != nullptr)
     {
-        name_index = GetJitTimeLogFilename->AddBuffer((unsigned char*)tempFileName, (DWORD)dn_wcslen(tempFileName) + 2);
+        name_index = GetJitTimeLogFilename->AddBuffer((unsigned char*)tempFileName, (DWORD)strlen_u16(tempFileName) + 2);
     }
     GetJitTimeLogFilename->Add(0, name_index);
     DEBUG_REC(dmpGetJitTimeLogFilename(0, name_index));
@@ -7089,7 +7089,7 @@ void MethodContext::recGetIntConfigValue(const WCHAR* name, int defaultValue, in
     ZeroMemory(&key, sizeof(key)); // Zero key including any struct padding
 
     DWORD index =
-        (DWORD)GetIntConfigValue->AddBuffer((unsigned char*)name, sizeof(WCHAR) * ((unsigned int)dn_wcslen(name) + 1));
+        (DWORD)GetIntConfigValue->AddBuffer((unsigned char*)name, sizeof(WCHAR) * ((unsigned int)strlen_u16(name) + 1));
 
     key.nameIndex    = index;
     key.defaultValue = defaultValue;
@@ -7119,7 +7119,7 @@ int MethodContext::repGetIntConfigValue(const WCHAR* name, int defaultValue)
     Agnostic_ConfigIntInfo key;
     ZeroMemory(&key, sizeof(key)); // Zero key including any struct padding
 
-    size_t nameLenInBytes = sizeof(WCHAR) * (dn_wcslen(name) + 1);
+    size_t nameLenInBytes = sizeof(WCHAR) * (strlen_u16(name) + 1);
     int    nameIndex      = GetIntConfigValue->Contains((unsigned char*)name, (unsigned int)nameLenInBytes);
     if (nameIndex == -1) // config name not in map
         return defaultValue;
@@ -7141,12 +7141,12 @@ void MethodContext::recGetStringConfigValue(const WCHAR* name, const WCHAR* resu
     AssertCodeMsg(name != nullptr, EXCEPTIONCODE_MC, "Name can not be nullptr");
 
     DWORD nameIndex = (DWORD)GetStringConfigValue->AddBuffer((unsigned char*)name,
-                                                             sizeof(WCHAR) * ((unsigned int)dn_wcslen(name) + 1));
+                                                             sizeof(WCHAR) * ((unsigned int)strlen_u16(name) + 1));
 
     DWORD resultIndex = (DWORD)-1;
     if (result != nullptr)
         resultIndex = (DWORD)GetStringConfigValue->AddBuffer((unsigned char*)result,
-                                                             sizeof(WCHAR) * ((unsigned int)dn_wcslen(result) + 1));
+                                                             sizeof(WCHAR) * ((unsigned int)strlen_u16(result) + 1));
 
     GetStringConfigValue->Add(nameIndex, resultIndex);
     DEBUG_REC(dmpGetStringConfigValue(nameIndex, resultIndex));
@@ -7170,7 +7170,7 @@ const WCHAR* MethodContext::repGetStringConfigValue(const WCHAR* name)
 
     AssertCodeMsg(name != nullptr, EXCEPTIONCODE_MC, "Name can not be nullptr");
 
-    size_t nameLenInBytes = sizeof(WCHAR) * (dn_wcslen(name) + 1);
+    size_t nameLenInBytes = sizeof(WCHAR) * (strlen_u16(name) + 1);
     int    nameIndex      = GetStringConfigValue->Contains((unsigned char*)name, (unsigned int)nameLenInBytes);
     if (nameIndex == -1) // config name not in map
         return nullptr;
@@ -7555,11 +7555,11 @@ void SetDebugDumpVariables()
         g_debugRepStr = GetEnvironmentVariableWithDefaultW(W("SuperPMIShimDebugRep"), W("0"));
     }
 
-    if (0 == dn_wcscmp(g_debugRecStr, W("1")))
+    if (0 == strcmp_u16(g_debugRecStr, W("1")))
     {
         g_debugRec = true;
     }
-    if (0 == dn_wcscmp(g_debugRepStr, W("1")))
+    if (0 == strcmp_u16(g_debugRepStr, W("1")))
     {
         g_debugRep = true;
     }

--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
@@ -7555,11 +7555,11 @@ void SetDebugDumpVariables()
         g_debugRepStr = GetEnvironmentVariableWithDefaultW(W("SuperPMIShimDebugRep"), W("0"));
     }
 
-    if (0 == wcscmp(g_debugRecStr, W("1")))
+    if (0 == dn_wcscmp(g_debugRecStr, W("1")))
     {
         g_debugRec = true;
     }
-    if (0 == wcscmp(g_debugRepStr, W("1")))
+    if (0 == dn_wcscmp(g_debugRepStr, W("1")))
     {
         g_debugRep = true;
     }

--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
@@ -1308,7 +1308,7 @@ void MethodContext::recGetJitTimeLogFilename(LPCWSTR tempFileName)
     DWORD name_index = -1;
     if (tempFileName != nullptr)
     {
-        name_index = GetJitTimeLogFilename->AddBuffer((unsigned char*)tempFileName, (DWORD)strlen_u16(tempFileName) + 2);
+        name_index = GetJitTimeLogFilename->AddBuffer((unsigned char*)tempFileName, (DWORD)u16_strlen(tempFileName) + 2);
     }
     GetJitTimeLogFilename->Add(0, name_index);
     DEBUG_REC(dmpGetJitTimeLogFilename(0, name_index));
@@ -7089,7 +7089,7 @@ void MethodContext::recGetIntConfigValue(const WCHAR* name, int defaultValue, in
     ZeroMemory(&key, sizeof(key)); // Zero key including any struct padding
 
     DWORD index =
-        (DWORD)GetIntConfigValue->AddBuffer((unsigned char*)name, sizeof(WCHAR) * ((unsigned int)strlen_u16(name) + 1));
+        (DWORD)GetIntConfigValue->AddBuffer((unsigned char*)name, sizeof(WCHAR) * ((unsigned int)u16_strlen(name) + 1));
 
     key.nameIndex    = index;
     key.defaultValue = defaultValue;
@@ -7119,7 +7119,7 @@ int MethodContext::repGetIntConfigValue(const WCHAR* name, int defaultValue)
     Agnostic_ConfigIntInfo key;
     ZeroMemory(&key, sizeof(key)); // Zero key including any struct padding
 
-    size_t nameLenInBytes = sizeof(WCHAR) * (strlen_u16(name) + 1);
+    size_t nameLenInBytes = sizeof(WCHAR) * (u16_strlen(name) + 1);
     int    nameIndex      = GetIntConfigValue->Contains((unsigned char*)name, (unsigned int)nameLenInBytes);
     if (nameIndex == -1) // config name not in map
         return defaultValue;
@@ -7141,12 +7141,12 @@ void MethodContext::recGetStringConfigValue(const WCHAR* name, const WCHAR* resu
     AssertCodeMsg(name != nullptr, EXCEPTIONCODE_MC, "Name can not be nullptr");
 
     DWORD nameIndex = (DWORD)GetStringConfigValue->AddBuffer((unsigned char*)name,
-                                                             sizeof(WCHAR) * ((unsigned int)strlen_u16(name) + 1));
+                                                             sizeof(WCHAR) * ((unsigned int)u16_strlen(name) + 1));
 
     DWORD resultIndex = (DWORD)-1;
     if (result != nullptr)
         resultIndex = (DWORD)GetStringConfigValue->AddBuffer((unsigned char*)result,
-                                                             sizeof(WCHAR) * ((unsigned int)strlen_u16(result) + 1));
+                                                             sizeof(WCHAR) * ((unsigned int)u16_strlen(result) + 1));
 
     GetStringConfigValue->Add(nameIndex, resultIndex);
     DEBUG_REC(dmpGetStringConfigValue(nameIndex, resultIndex));
@@ -7170,7 +7170,7 @@ const WCHAR* MethodContext::repGetStringConfigValue(const WCHAR* name)
 
     AssertCodeMsg(name != nullptr, EXCEPTIONCODE_MC, "Name can not be nullptr");
 
-    size_t nameLenInBytes = sizeof(WCHAR) * (strlen_u16(name) + 1);
+    size_t nameLenInBytes = sizeof(WCHAR) * (u16_strlen(name) + 1);
     int    nameIndex      = GetStringConfigValue->Contains((unsigned char*)name, (unsigned int)nameLenInBytes);
     if (nameIndex == -1) // config name not in map
         return nullptr;
@@ -7555,11 +7555,11 @@ void SetDebugDumpVariables()
         g_debugRepStr = GetEnvironmentVariableWithDefaultW(W("SuperPMIShimDebugRep"), W("0"));
     }
 
-    if (0 == strcmp_u16(g_debugRecStr, W("1")))
+    if (0 == u16_strcmp(g_debugRecStr, W("1")))
     {
         g_debugRec = true;
     }
-    if (0 == strcmp_u16(g_debugRepStr, W("1")))
+    if (0 == u16_strcmp(g_debugRepStr, W("1")))
     {
         g_debugRep = true;
     }

--- a/src/coreclr/tools/superpmi/superpmi-shared/spmiutil.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/spmiutil.cpp
@@ -152,15 +152,11 @@ void ReplaceIllegalCharacters(WCHAR* fileName)
 {
     WCHAR* quote = nullptr;
 
-    // If there are any quotes in the file name convert them to spaces.
-    while ((quote = wcsstr(fileName, W("\""))) != nullptr)
-    {
-        *quote = W(' ');
-    }
-
-    // Convert non-ASCII to ASCII for simplicity and remove any
-    // illegal or annoying characters from the file name by
+    // Perform the following transforms:
+    //  - Convert non-ASCII to ASCII for simplicity
+    //  - Remove any illegal or annoying characters from the file name by
     // converting them to underscores.
+    //  - Replace any quotes in the file name with spaces.
     for (quote = fileName; *quote != '\0'; quote++)
     {
         WCHAR ch = *quote;
@@ -173,10 +169,13 @@ void ReplaceIllegalCharacters(WCHAR* fileName)
             switch (ch)
             {
                 case W('('): case W(')'): case W('='): case W('<'):
-                case W('>'): case W(':'): case W('"'): case W('/'):
-                case W('\\'): case W('|'): case W('?'): case W('!'):
-                case W('*'): case W('.'): case W(','):
+                case W('>'): case W(':'): case W('/'): case W('\\'):
+                case W('|'): case W('?'): case W('!'): case W('*'):
+                case W('.'): case W(','):
                     *quote = W('_');
+                    break;
+                case W('"'):
+                    *quote = W(' ');
                     break;
                 default:
                     break;

--- a/src/coreclr/tools/superpmi/superpmi-shared/spmiutil.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/spmiutil.cpp
@@ -158,7 +158,9 @@ void ReplaceIllegalCharacters(WCHAR* fileName)
         *quote = W(' ');
     }
 
-    // Convert non-ASCII to ASCII for simplicity.
+    // Convert non-ASCII to ASCII for simplicity and remove any
+    // illegal or annoying characters from the file name by
+    // converting them to underscores.
     for (quote = fileName; *quote != '\0'; quote++)
     {
         WCHAR ch = *quote;
@@ -166,12 +168,20 @@ void ReplaceIllegalCharacters(WCHAR* fileName)
         {
             *quote = W('_');
         }
-    }
-
-    // Remove any illegal or annoying characters from the file name by converting them to underscores.
-    while ((quote = wcspbrk(fileName, W("()=<>:\"/\\|?! *.,"))) != nullptr)
-    {
-        *quote = W('_');
+        else
+        {
+            switch (ch)
+            {
+                case W('('): case W(')'): case W('='): case W('<'):
+                case W('>'): case W(':'): case W('"'): case W('/'):
+                case W('\\'): case W('|'): case W('?'): case W('!'):
+                case W('*'): case W('.'): case W(','):
+                    *quote = W('_');
+                    break;
+                default:
+                    break;
+            }
+        }
     }
 }
 

--- a/src/coreclr/tools/superpmi/superpmi-shared/spmiutil.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/spmiutil.cpp
@@ -87,7 +87,7 @@ WCHAR* GetEnvironmentVariableWithDefaultW(const WCHAR* envVarName, const WCHAR* 
     {
         if (defaultValue != nullptr)
         {
-            dwRetVal  = (DWORD)dn_wcslen(defaultValue) + 1; // add one for null terminator
+            dwRetVal  = (DWORD)strlen_u16(defaultValue) + 1; // add one for null terminator
             retString = new WCHAR[dwRetVal];
             memcpy_s(retString, dwRetVal * sizeof(WCHAR), defaultValue, dwRetVal * sizeof(WCHAR));
         }
@@ -187,8 +187,8 @@ void ReplaceIllegalCharacters(WCHAR* fileName)
 // All lengths in this function exclude the terminal NULL.
 WCHAR* GetResultFileName(const WCHAR* folderPath, const WCHAR* fileName, const WCHAR* extension)
 {
-    const size_t extensionLength    = dn_wcslen(extension);
-    const size_t fileNameLength     = dn_wcslen(fileName);
+    const size_t extensionLength    = strlen_u16(extension);
+    const size_t fileNameLength     = strlen_u16(fileName);
     const size_t randomStringLength = 8;
     const size_t maxPathLength      = MAX_PATH - 50;
 

--- a/src/coreclr/tools/superpmi/superpmi-shared/spmiutil.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/spmiutil.cpp
@@ -87,7 +87,7 @@ WCHAR* GetEnvironmentVariableWithDefaultW(const WCHAR* envVarName, const WCHAR* 
     {
         if (defaultValue != nullptr)
         {
-            dwRetVal  = (DWORD)strlen_u16(defaultValue) + 1; // add one for null terminator
+            dwRetVal  = (DWORD)u16_strlen(defaultValue) + 1; // add one for null terminator
             retString = new WCHAR[dwRetVal];
             memcpy_s(retString, dwRetVal * sizeof(WCHAR), defaultValue, dwRetVal * sizeof(WCHAR));
         }
@@ -187,8 +187,8 @@ void ReplaceIllegalCharacters(WCHAR* fileName)
 // All lengths in this function exclude the terminal NULL.
 WCHAR* GetResultFileName(const WCHAR* folderPath, const WCHAR* fileName, const WCHAR* extension)
 {
-    const size_t extensionLength    = strlen_u16(extension);
-    const size_t fileNameLength     = strlen_u16(fileName);
+    const size_t extensionLength    = u16_strlen(extension);
+    const size_t fileNameLength     = u16_strlen(fileName);
     const size_t randomStringLength = 8;
     const size_t maxPathLength      = MAX_PATH - 50;
 

--- a/src/coreclr/tools/superpmi/superpmi-shared/spmiutil.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/spmiutil.cpp
@@ -87,7 +87,7 @@ WCHAR* GetEnvironmentVariableWithDefaultW(const WCHAR* envVarName, const WCHAR* 
     {
         if (defaultValue != nullptr)
         {
-            dwRetVal  = (DWORD)wcslen(defaultValue) + 1; // add one for null terminator
+            dwRetVal  = (DWORD)dn_wcslen(defaultValue) + 1; // add one for null terminator
             retString = new WCHAR[dwRetVal];
             memcpy_s(retString, dwRetVal * sizeof(WCHAR), defaultValue, dwRetVal * sizeof(WCHAR));
         }
@@ -178,8 +178,8 @@ void ReplaceIllegalCharacters(WCHAR* fileName)
 // All lengths in this function exclude the terminal NULL.
 WCHAR* GetResultFileName(const WCHAR* folderPath, const WCHAR* fileName, const WCHAR* extension)
 {
-    const size_t extensionLength    = wcslen(extension);
-    const size_t fileNameLength     = wcslen(fileName);
+    const size_t extensionLength    = dn_wcslen(extension);
+    const size_t fileNameLength     = dn_wcslen(fileName);
     const size_t randomStringLength = 8;
     const size_t maxPathLength      = MAX_PATH - 50;
 

--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/CMakeLists.txt
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/CMakeLists.txt
@@ -74,6 +74,7 @@ if(CLR_CMAKE_HOST_UNIX)
         mscorrc
         coreclrpal
         palrt
+        coreclrminipal
     )
 else()
     target_link_libraries(superpmi-shim-collector

--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/CMakeLists.txt
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/CMakeLists.txt
@@ -80,6 +80,7 @@ else()
     target_link_libraries(superpmi-shim-collector
         PRIVATE
         advapi32.lib
+        coreclrminipal
         ${STATIC_MT_CRT_LIB}
         ${STATIC_MT_CPP_LIB}
     )

--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/jithost.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/jithost.cpp
@@ -119,7 +119,7 @@ int JitHost::getIntConfigValue(const WCHAR* key, int defaultValue)
     // even record that it was called (since it would get recorded into the
     // global state). (See the superpmi.exe tool implementation of JitHost::getIntConfigValue()
     // for the special-case implementation of this.)
-    if (strcmp_u16(key, W("SuperPMIMethodContextNumber")) == 0)
+    if (u16_strcmp(key, W("SuperPMIMethodContextNumber")) == 0)
     {
         return defaultValue;
     }

--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/jithost.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/jithost.cpp
@@ -119,7 +119,7 @@ int JitHost::getIntConfigValue(const WCHAR* key, int defaultValue)
     // even record that it was called (since it would get recorded into the
     // global state). (See the superpmi.exe tool implementation of JitHost::getIntConfigValue()
     // for the special-case implementation of this.)
-    if (dn_wcscmp(key, W("SuperPMIMethodContextNumber")) == 0)
+    if (strcmp_u16(key, W("SuperPMIMethodContextNumber")) == 0)
     {
         return defaultValue;
     }

--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/jithost.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/jithost.cpp
@@ -119,7 +119,7 @@ int JitHost::getIntConfigValue(const WCHAR* key, int defaultValue)
     // even record that it was called (since it would get recorded into the
     // global state). (See the superpmi.exe tool implementation of JitHost::getIntConfigValue()
     // for the special-case implementation of this.)
-    if (wcscmp(key, W("SuperPMIMethodContextNumber")) == 0)
+    if (dn_wcscmp(key, W("SuperPMIMethodContextNumber")) == 0)
     {
         return defaultValue;
     }

--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/superpmi-shim-collector.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/superpmi-shim-collector.cpp
@@ -37,7 +37,7 @@ void SetDefaultPaths()
 
     if (g_DefaultRealJitPath == nullptr)
     {
-        size_t len           = dn_wcslen(g_HomeDirectory) + 1 + dn_wcslen(DEFAULT_REAL_JIT_NAME_W) + 1;
+        size_t len           = strlen_u16(g_HomeDirectory) + 1 + strlen_u16(DEFAULT_REAL_JIT_NAME_W) + 1;
         g_DefaultRealJitPath = new WCHAR[len];
         wcscpy_s(g_DefaultRealJitPath, len, g_HomeDirectory);
         wcscat_s(g_DefaultRealJitPath, len, DIRECTORY_SEPARATOR_STR_W);

--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/superpmi-shim-collector.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/superpmi-shim-collector.cpp
@@ -37,7 +37,7 @@ void SetDefaultPaths()
 
     if (g_DefaultRealJitPath == nullptr)
     {
-        size_t len           = strlen_u16(g_HomeDirectory) + 1 + strlen_u16(DEFAULT_REAL_JIT_NAME_W) + 1;
+        size_t len           = u16_strlen(g_HomeDirectory) + 1 + u16_strlen(DEFAULT_REAL_JIT_NAME_W) + 1;
         g_DefaultRealJitPath = new WCHAR[len];
         wcscpy_s(g_DefaultRealJitPath, len, g_HomeDirectory);
         wcscat_s(g_DefaultRealJitPath, len, DIRECTORY_SEPARATOR_STR_W);

--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/superpmi-shim-collector.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/superpmi-shim-collector.cpp
@@ -37,7 +37,7 @@ void SetDefaultPaths()
 
     if (g_DefaultRealJitPath == nullptr)
     {
-        size_t len           = wcslen(g_HomeDirectory) + 1 + wcslen(DEFAULT_REAL_JIT_NAME_W) + 1;
+        size_t len           = dn_wcslen(g_HomeDirectory) + 1 + dn_wcslen(DEFAULT_REAL_JIT_NAME_W) + 1;
         g_DefaultRealJitPath = new WCHAR[len];
         wcscpy_s(g_DefaultRealJitPath, len, g_HomeDirectory);
         wcscat_s(g_DefaultRealJitPath, len, DIRECTORY_SEPARATOR_STR_W);

--- a/src/coreclr/tools/superpmi/superpmi-shim-counter/CMakeLists.txt
+++ b/src/coreclr/tools/superpmi/superpmi-shim-counter/CMakeLists.txt
@@ -55,6 +55,7 @@ if(CLR_CMAKE_HOST_UNIX)
         mscorrc
         coreclrpal
         palrt
+        coreclrminipal
     )
 else()
     target_link_libraries(superpmi-shim-counter

--- a/src/coreclr/tools/superpmi/superpmi-shim-counter/CMakeLists.txt
+++ b/src/coreclr/tools/superpmi/superpmi-shim-counter/CMakeLists.txt
@@ -61,6 +61,7 @@ else()
     target_link_libraries(superpmi-shim-counter
         PRIVATE
         advapi32.lib
+        coreclrminipal
         ${STATIC_MT_CRT_LIB}
         ${STATIC_MT_CPP_LIB}
     )

--- a/src/coreclr/tools/superpmi/superpmi-shim-counter/superpmi-shim-counter.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-counter/superpmi-shim-counter.cpp
@@ -31,7 +31,7 @@ void SetDefaultPaths()
 
     if (g_DefaultRealJitPath == nullptr)
     {
-        size_t len           = strlen_u16(g_HomeDirectory) + 1 + strlen_u16(DEFAULT_REAL_JIT_NAME_W) + 1;
+        size_t len           = u16_strlen(g_HomeDirectory) + 1 + u16_strlen(DEFAULT_REAL_JIT_NAME_W) + 1;
         g_DefaultRealJitPath = new WCHAR[len];
         wcscpy_s(g_DefaultRealJitPath, len, g_HomeDirectory);
         wcscat_s(g_DefaultRealJitPath, len, DIRECTORY_SEPARATOR_STR_W);

--- a/src/coreclr/tools/superpmi/superpmi-shim-counter/superpmi-shim-counter.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-counter/superpmi-shim-counter.cpp
@@ -31,7 +31,7 @@ void SetDefaultPaths()
 
     if (g_DefaultRealJitPath == nullptr)
     {
-        size_t len           = wcslen(g_HomeDirectory) + 1 + wcslen(DEFAULT_REAL_JIT_NAME_W) + 1;
+        size_t len           = dn_wcslen(g_HomeDirectory) + 1 + dn_wcslen(DEFAULT_REAL_JIT_NAME_W) + 1;
         g_DefaultRealJitPath = new WCHAR[len];
         wcscpy_s(g_DefaultRealJitPath, len, g_HomeDirectory);
         wcscat_s(g_DefaultRealJitPath, len, DIRECTORY_SEPARATOR_STR_W);

--- a/src/coreclr/tools/superpmi/superpmi-shim-counter/superpmi-shim-counter.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-counter/superpmi-shim-counter.cpp
@@ -31,7 +31,7 @@ void SetDefaultPaths()
 
     if (g_DefaultRealJitPath == nullptr)
     {
-        size_t len           = dn_wcslen(g_HomeDirectory) + 1 + dn_wcslen(DEFAULT_REAL_JIT_NAME_W) + 1;
+        size_t len           = strlen_u16(g_HomeDirectory) + 1 + strlen_u16(DEFAULT_REAL_JIT_NAME_W) + 1;
         g_DefaultRealJitPath = new WCHAR[len];
         wcscpy_s(g_DefaultRealJitPath, len, g_HomeDirectory);
         wcscat_s(g_DefaultRealJitPath, len, DIRECTORY_SEPARATOR_STR_W);

--- a/src/coreclr/tools/superpmi/superpmi-shim-simple/CMakeLists.txt
+++ b/src/coreclr/tools/superpmi/superpmi-shim-simple/CMakeLists.txt
@@ -60,6 +60,7 @@ else()
     target_link_libraries(superpmi-shim-simple
         PRIVATE
         advapi32.lib
+        coreclrminipal
         ${STATIC_MT_CRT_LIB}
         ${STATIC_MT_CPP_LIB}
     )

--- a/src/coreclr/tools/superpmi/superpmi-shim-simple/CMakeLists.txt
+++ b/src/coreclr/tools/superpmi/superpmi-shim-simple/CMakeLists.txt
@@ -54,6 +54,7 @@ if(CLR_CMAKE_HOST_UNIX)
         mscorrc
         coreclrpal
         palrt
+        coreclrminipal
     )
 else()
     target_link_libraries(superpmi-shim-simple

--- a/src/coreclr/tools/superpmi/superpmi-shim-simple/superpmi-shim-simple.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-simple/superpmi-shim-simple.cpp
@@ -29,7 +29,7 @@ void SetDefaultPaths()
 
     if (g_DefaultRealJitPath == nullptr)
     {
-        size_t len           = wcslen(g_HomeDirectory) + 1 + wcslen(DEFAULT_REAL_JIT_NAME_W) + 1;
+        size_t len           = dn_wcslen(g_HomeDirectory) + 1 + dn_wcslen(DEFAULT_REAL_JIT_NAME_W) + 1;
         g_DefaultRealJitPath = new WCHAR[len];
         wcscpy_s(g_DefaultRealJitPath, len, g_HomeDirectory);
         wcscat_s(g_DefaultRealJitPath, len, DIRECTORY_SEPARATOR_STR_W);

--- a/src/coreclr/tools/superpmi/superpmi-shim-simple/superpmi-shim-simple.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-simple/superpmi-shim-simple.cpp
@@ -29,7 +29,7 @@ void SetDefaultPaths()
 
     if (g_DefaultRealJitPath == nullptr)
     {
-        size_t len           = dn_wcslen(g_HomeDirectory) + 1 + dn_wcslen(DEFAULT_REAL_JIT_NAME_W) + 1;
+        size_t len           = strlen_u16(g_HomeDirectory) + 1 + strlen_u16(DEFAULT_REAL_JIT_NAME_W) + 1;
         g_DefaultRealJitPath = new WCHAR[len];
         wcscpy_s(g_DefaultRealJitPath, len, g_HomeDirectory);
         wcscat_s(g_DefaultRealJitPath, len, DIRECTORY_SEPARATOR_STR_W);

--- a/src/coreclr/tools/superpmi/superpmi-shim-simple/superpmi-shim-simple.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-simple/superpmi-shim-simple.cpp
@@ -29,7 +29,7 @@ void SetDefaultPaths()
 
     if (g_DefaultRealJitPath == nullptr)
     {
-        size_t len           = strlen_u16(g_HomeDirectory) + 1 + strlen_u16(DEFAULT_REAL_JIT_NAME_W) + 1;
+        size_t len           = u16_strlen(g_HomeDirectory) + 1 + u16_strlen(DEFAULT_REAL_JIT_NAME_W) + 1;
         g_DefaultRealJitPath = new WCHAR[len];
         wcscpy_s(g_DefaultRealJitPath, len, g_HomeDirectory);
         wcscat_s(g_DefaultRealJitPath, len, DIRECTORY_SEPARATOR_STR_W);

--- a/src/coreclr/tools/superpmi/superpmi/CMakeLists.txt
+++ b/src/coreclr/tools/superpmi/superpmi/CMakeLists.txt
@@ -65,6 +65,7 @@ if(CLR_CMAKE_HOST_UNIX)
         mscorrc
         coreclrpal
         palrt
+        coreclrminipal
     )
 else()
     target_link_libraries(superpmi

--- a/src/coreclr/tools/superpmi/superpmi/CMakeLists.txt
+++ b/src/coreclr/tools/superpmi/superpmi/CMakeLists.txt
@@ -72,6 +72,7 @@ else()
         PRIVATE
         version.lib
         advapi32.lib
+        coreclrminipal
         ${STATIC_MT_CRT_LIB}
         ${STATIC_MT_CPP_LIB}
     )

--- a/src/coreclr/tools/superpmi/superpmi/commandline.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/commandline.cpp
@@ -732,9 +732,9 @@ bool CommandLine::AddJitOption(int&  currArgument,
     }
 
     DWORD keyIndex =
-        (DWORD)targetjitOptions->AddBuffer((unsigned char*)key, sizeof(WCHAR) * ((unsigned int)strlen_u16(key) + 1));
+        (DWORD)targetjitOptions->AddBuffer((unsigned char*)key, sizeof(WCHAR) * ((unsigned int)u16_strlen(key) + 1));
     DWORD valueIndex =
-        (DWORD)targetjitOptions->AddBuffer((unsigned char*)value, sizeof(WCHAR) * ((unsigned int)strlen_u16(value) + 1));
+        (DWORD)targetjitOptions->AddBuffer((unsigned char*)value, sizeof(WCHAR) * ((unsigned int)u16_strlen(value) + 1));
     targetjitOptions->Add(keyIndex, valueIndex);
 
     delete[] key;

--- a/src/coreclr/tools/superpmi/superpmi/commandline.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/commandline.cpp
@@ -732,9 +732,9 @@ bool CommandLine::AddJitOption(int&  currArgument,
     }
 
     DWORD keyIndex =
-        (DWORD)targetjitOptions->AddBuffer((unsigned char*)key, sizeof(WCHAR) * ((unsigned int)dn_wcslen(key) + 1));
+        (DWORD)targetjitOptions->AddBuffer((unsigned char*)key, sizeof(WCHAR) * ((unsigned int)strlen_u16(key) + 1));
     DWORD valueIndex =
-        (DWORD)targetjitOptions->AddBuffer((unsigned char*)value, sizeof(WCHAR) * ((unsigned int)dn_wcslen(value) + 1));
+        (DWORD)targetjitOptions->AddBuffer((unsigned char*)value, sizeof(WCHAR) * ((unsigned int)strlen_u16(value) + 1));
     targetjitOptions->Add(keyIndex, valueIndex);
 
     delete[] key;

--- a/src/coreclr/tools/superpmi/superpmi/commandline.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/commandline.cpp
@@ -732,9 +732,9 @@ bool CommandLine::AddJitOption(int&  currArgument,
     }
 
     DWORD keyIndex =
-        (DWORD)targetjitOptions->AddBuffer((unsigned char*)key, sizeof(WCHAR) * ((unsigned int)wcslen(key) + 1));
+        (DWORD)targetjitOptions->AddBuffer((unsigned char*)key, sizeof(WCHAR) * ((unsigned int)dn_wcslen(key) + 1));
     DWORD valueIndex =
-        (DWORD)targetjitOptions->AddBuffer((unsigned char*)value, sizeof(WCHAR) * ((unsigned int)wcslen(value) + 1));
+        (DWORD)targetjitOptions->AddBuffer((unsigned char*)value, sizeof(WCHAR) * ((unsigned int)dn_wcslen(value) + 1));
     targetjitOptions->Add(keyIndex, valueIndex);
 
     delete[] key;

--- a/src/coreclr/tools/superpmi/superpmi/jitdebugger.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jitdebugger.cpp
@@ -160,9 +160,9 @@ HRESULT GetCurrentModuleFileName(_Out_writes_(*pcchBuffer) LPWSTR pBuffer, __ino
     // If no backslash, use the whole name; if there is a backslash, skip it.
     appName = appName ? appName + 1 : appPath;
 
-    if (*pcchBuffer < wcslen(appName))
+    if (*pcchBuffer < dn_wcslen(appName))
     {
-        *pcchBuffer = static_cast<DWORD>(wcslen(appName)) + 1;
+        *pcchBuffer = static_cast<DWORD>(dn_wcslen(appName)) + 1;
         return HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
     }
 

--- a/src/coreclr/tools/superpmi/superpmi/jitdebugger.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jitdebugger.cpp
@@ -155,7 +155,7 @@ HRESULT GetCurrentModuleFileName(_Out_writes_(*pcchBuffer) LPWSTR pBuffer, __ino
     }
 
     // Pick off the part after the path.
-    WCHAR* appName = dn_wcsrchr(appPath, DIRECTORY_SEPARATOR_CHAR_W);
+    WCHAR* appName = (WCHAR*)dn_wcsrchr(appPath, DIRECTORY_SEPARATOR_CHAR_W);
 
     // If no backslash, use the whole name; if there is a backslash, skip it.
     appName = appName ? appName + 1 : appPath;

--- a/src/coreclr/tools/superpmi/superpmi/jitdebugger.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jitdebugger.cpp
@@ -155,7 +155,7 @@ HRESULT GetCurrentModuleFileName(_Out_writes_(*pcchBuffer) LPWSTR pBuffer, __ino
     }
 
     // Pick off the part after the path.
-    WCHAR* appName = wcsrchr(appPath, DIRECTORY_SEPARATOR_CHAR_W);
+    WCHAR* appName = dn_wcsrchr(appPath, DIRECTORY_SEPARATOR_CHAR_W);
 
     // If no backslash, use the whole name; if there is a backslash, skip it.
     appName = appName ? appName + 1 : appPath;

--- a/src/coreclr/tools/superpmi/superpmi/jitdebugger.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jitdebugger.cpp
@@ -155,14 +155,14 @@ HRESULT GetCurrentModuleFileName(_Out_writes_(*pcchBuffer) LPWSTR pBuffer, __ino
     }
 
     // Pick off the part after the path.
-    WCHAR* appName = (WCHAR*)dn_wcsrchr(appPath, DIRECTORY_SEPARATOR_CHAR_W);
+    WCHAR* appName = (WCHAR*)strrchr_u16(appPath, DIRECTORY_SEPARATOR_CHAR_W);
 
     // If no backslash, use the whole name; if there is a backslash, skip it.
     appName = appName ? appName + 1 : appPath;
 
-    if (*pcchBuffer < dn_wcslen(appName))
+    if (*pcchBuffer < strlen_u16(appName))
     {
-        *pcchBuffer = static_cast<DWORD>(dn_wcslen(appName)) + 1;
+        *pcchBuffer = static_cast<DWORD>(strlen_u16(appName)) + 1;
         return HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
     }
 

--- a/src/coreclr/tools/superpmi/superpmi/jitdebugger.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jitdebugger.cpp
@@ -155,14 +155,14 @@ HRESULT GetCurrentModuleFileName(_Out_writes_(*pcchBuffer) LPWSTR pBuffer, __ino
     }
 
     // Pick off the part after the path.
-    WCHAR* appName = (WCHAR*)strrchr_u16(appPath, DIRECTORY_SEPARATOR_CHAR_W);
+    WCHAR* appName = (WCHAR*)u16_strrchr(appPath, DIRECTORY_SEPARATOR_CHAR_W);
 
     // If no backslash, use the whole name; if there is a backslash, skip it.
     appName = appName ? appName + 1 : appPath;
 
-    if (*pcchBuffer < strlen_u16(appName))
+    if (*pcchBuffer < u16_strlen(appName))
     {
-        *pcchBuffer = static_cast<DWORD>(strlen_u16(appName)) + 1;
+        *pcchBuffer = static_cast<DWORD>(u16_strlen(appName)) + 1;
         return HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
     }
 

--- a/src/coreclr/tools/superpmi/superpmi/jithost.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jithost.cpp
@@ -77,7 +77,7 @@ bool JitHost::convertStringValueToInt(const WCHAR* key, const WCHAR* stringValue
     }
 
     WCHAR*      endPtr;
-    unsigned long longResult = wcstoul(stringValue, &endPtr, 16);
+    unsigned long longResult = dn_wcstoul(stringValue, &endPtr, 16);
     bool          succeeded  = (errno != ERANGE) && (endPtr != stringValue) && (longResult <= INT_MAX);
     if (!succeeded)
     {

--- a/src/coreclr/tools/superpmi/superpmi/jithost.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jithost.cpp
@@ -12,7 +12,7 @@
 WCHAR* GetPrefixedEnvironmentVariable(const WCHAR* prefix, size_t prefixLen, const WCHAR* key, JitInstance& jitInstance)
 {
     // Prepend prefix to the provided key
-    size_t   keyLen       = strlen_u16(key);
+    size_t   keyLen       = u16_strlen(key);
     size_t   keyBufferLen = keyLen + prefixLen + 1;
     WCHAR* keyBuffer =
         reinterpret_cast<WCHAR*>(jitInstance.allocateArray(sizeof(WCHAR) * keyBufferLen));
@@ -77,7 +77,7 @@ bool JitHost::convertStringValueToInt(const WCHAR* key, const WCHAR* stringValue
     }
 
     WCHAR*      endPtr;
-    unsigned long longResult = strtoul_u16(stringValue, &endPtr, 16);
+    unsigned long longResult = u16_strtoul(stringValue, &endPtr, 16);
     bool          succeeded  = (errno != ERANGE) && (endPtr != stringValue) && (longResult <= INT_MAX);
     if (!succeeded)
     {
@@ -117,7 +117,7 @@ int JitHost::getIntConfigValue(const WCHAR* key, int defaultValue)
     if (!valueFound)
     {
         // Look for special case keys.
-        if (strcmp_u16(key, W("SuperPMIMethodContextNumber")) == 0)
+        if (u16_strcmp(key, W("SuperPMIMethodContextNumber")) == 0)
         {
             result     = jitInstance.mc->index;
             valueFound = true;
@@ -178,7 +178,7 @@ const WCHAR* JitHost::getStringConfigValue(const WCHAR* key)
     if (result != nullptr && needToDup)
     {
         // Now we need to dup it, so you can call freeStringConfigValue() on what we return.
-        size_t   resultLenInChars = strlen_u16(result) + 1;
+        size_t   resultLenInChars = u16_strlen(result) + 1;
         WCHAR* dupResult = (WCHAR*)jitInstance.allocateLongLivedArray(sizeof(WCHAR) * resultLenInChars);
         wcscpy_s(dupResult, resultLenInChars, result);
         result = dupResult;

--- a/src/coreclr/tools/superpmi/superpmi/jithost.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jithost.cpp
@@ -12,7 +12,7 @@
 WCHAR* GetPrefixedEnvironmentVariable(const WCHAR* prefix, size_t prefixLen, const WCHAR* key, JitInstance& jitInstance)
 {
     // Prepend prefix to the provided key
-    size_t   keyLen       = wcslen(key);
+    size_t   keyLen       = dn_wcslen(key);
     size_t   keyBufferLen = keyLen + prefixLen + 1;
     WCHAR* keyBuffer =
         reinterpret_cast<WCHAR*>(jitInstance.allocateArray(sizeof(WCHAR) * keyBufferLen));
@@ -178,7 +178,7 @@ const WCHAR* JitHost::getStringConfigValue(const WCHAR* key)
     if (result != nullptr && needToDup)
     {
         // Now we need to dup it, so you can call freeStringConfigValue() on what we return.
-        size_t   resultLenInChars = wcslen(result) + 1;
+        size_t   resultLenInChars = dn_wcslen(result) + 1;
         WCHAR* dupResult = (WCHAR*)jitInstance.allocateLongLivedArray(sizeof(WCHAR) * resultLenInChars);
         wcscpy_s(dupResult, resultLenInChars, result);
         result = dupResult;

--- a/src/coreclr/tools/superpmi/superpmi/jithost.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jithost.cpp
@@ -12,7 +12,7 @@
 WCHAR* GetPrefixedEnvironmentVariable(const WCHAR* prefix, size_t prefixLen, const WCHAR* key, JitInstance& jitInstance)
 {
     // Prepend prefix to the provided key
-    size_t   keyLen       = dn_wcslen(key);
+    size_t   keyLen       = strlen_u16(key);
     size_t   keyBufferLen = keyLen + prefixLen + 1;
     WCHAR* keyBuffer =
         reinterpret_cast<WCHAR*>(jitInstance.allocateArray(sizeof(WCHAR) * keyBufferLen));
@@ -77,7 +77,7 @@ bool JitHost::convertStringValueToInt(const WCHAR* key, const WCHAR* stringValue
     }
 
     WCHAR*      endPtr;
-    unsigned long longResult = dn_wcstoul(stringValue, &endPtr, 16);
+    unsigned long longResult = strtoul_u16(stringValue, &endPtr, 16);
     bool          succeeded  = (errno != ERANGE) && (endPtr != stringValue) && (longResult <= INT_MAX);
     if (!succeeded)
     {
@@ -117,7 +117,7 @@ int JitHost::getIntConfigValue(const WCHAR* key, int defaultValue)
     if (!valueFound)
     {
         // Look for special case keys.
-        if (dn_wcscmp(key, W("SuperPMIMethodContextNumber")) == 0)
+        if (strcmp_u16(key, W("SuperPMIMethodContextNumber")) == 0)
         {
             result     = jitInstance.mc->index;
             valueFound = true;
@@ -178,7 +178,7 @@ const WCHAR* JitHost::getStringConfigValue(const WCHAR* key)
     if (result != nullptr && needToDup)
     {
         // Now we need to dup it, so you can call freeStringConfigValue() on what we return.
-        size_t   resultLenInChars = dn_wcslen(result) + 1;
+        size_t   resultLenInChars = strlen_u16(result) + 1;
         WCHAR* dupResult = (WCHAR*)jitInstance.allocateLongLivedArray(sizeof(WCHAR) * resultLenInChars);
         wcscpy_s(dupResult, resultLenInChars, result);
         result = dupResult;

--- a/src/coreclr/tools/superpmi/superpmi/jithost.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jithost.cpp
@@ -117,7 +117,7 @@ int JitHost::getIntConfigValue(const WCHAR* key, int defaultValue)
     if (!valueFound)
     {
         // Look for special case keys.
-        if (wcscmp(key, W("SuperPMIMethodContextNumber")) == 0)
+        if (dn_wcscmp(key, W("SuperPMIMethodContextNumber")) == 0)
         {
             result     = jitInstance.mc->index;
             valueFound = true;

--- a/src/coreclr/tools/superpmi/superpmi/jitinstance.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jitinstance.cpp
@@ -35,7 +35,7 @@ JitInstance* JitInstance::InitJit(char*                         nameOfJit,
     const WCHAR* altJitFlag = jit->getForceOption(W("AltJit"));
     if (altJitFlag != nullptr)
     {
-        if (dn_wcscmp(altJitFlag, W("")) == 0)
+        if (strcmp_u16(altJitFlag, W("")) == 0)
         {
             jit->forceClearAltJitFlag = true;
         }
@@ -47,7 +47,7 @@ JitInstance* JitInstance::InitJit(char*                         nameOfJit,
     const WCHAR* altJitNgenFlag = jit->getForceOption(W("AltJitNgen"));
     if (altJitNgenFlag != nullptr)
     {
-        if (dn_wcscmp(altJitNgenFlag, W("")) == 0)
+        if (strcmp_u16(altJitNgenFlag, W("")) == 0)
         {
             jit->forceClearAltJitFlag = true;
         }
@@ -532,7 +532,7 @@ const WCHAR* JitInstance::getOption(const WCHAR* key, LightWeightMap<DWORD, DWOR
         return nullptr;
     }
 
-    size_t keyLenInBytes = sizeof(WCHAR) * (dn_wcslen(key) + 1);
+    size_t keyLenInBytes = sizeof(WCHAR) * (strlen_u16(key) + 1);
     int    keyIndex      = options->Contains((unsigned char*)key, (unsigned int)keyLenInBytes);
     if (keyIndex == -1)
     {

--- a/src/coreclr/tools/superpmi/superpmi/jitinstance.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jitinstance.cpp
@@ -35,7 +35,7 @@ JitInstance* JitInstance::InitJit(char*                         nameOfJit,
     const WCHAR* altJitFlag = jit->getForceOption(W("AltJit"));
     if (altJitFlag != nullptr)
     {
-        if (strcmp_u16(altJitFlag, W("")) == 0)
+        if (u16_strcmp(altJitFlag, W("")) == 0)
         {
             jit->forceClearAltJitFlag = true;
         }
@@ -47,7 +47,7 @@ JitInstance* JitInstance::InitJit(char*                         nameOfJit,
     const WCHAR* altJitNgenFlag = jit->getForceOption(W("AltJitNgen"));
     if (altJitNgenFlag != nullptr)
     {
-        if (strcmp_u16(altJitNgenFlag, W("")) == 0)
+        if (u16_strcmp(altJitNgenFlag, W("")) == 0)
         {
             jit->forceClearAltJitFlag = true;
         }
@@ -532,7 +532,7 @@ const WCHAR* JitInstance::getOption(const WCHAR* key, LightWeightMap<DWORD, DWOR
         return nullptr;
     }
 
-    size_t keyLenInBytes = sizeof(WCHAR) * (strlen_u16(key) + 1);
+    size_t keyLenInBytes = sizeof(WCHAR) * (u16_strlen(key) + 1);
     int    keyIndex      = options->Contains((unsigned char*)key, (unsigned int)keyLenInBytes);
     if (keyIndex == -1)
     {

--- a/src/coreclr/tools/superpmi/superpmi/jitinstance.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jitinstance.cpp
@@ -35,7 +35,7 @@ JitInstance* JitInstance::InitJit(char*                         nameOfJit,
     const WCHAR* altJitFlag = jit->getForceOption(W("AltJit"));
     if (altJitFlag != nullptr)
     {
-        if (wcscmp(altJitFlag, W("")) == 0)
+        if (dn_wcscmp(altJitFlag, W("")) == 0)
         {
             jit->forceClearAltJitFlag = true;
         }
@@ -47,7 +47,7 @@ JitInstance* JitInstance::InitJit(char*                         nameOfJit,
     const WCHAR* altJitNgenFlag = jit->getForceOption(W("AltJitNgen"));
     if (altJitNgenFlag != nullptr)
     {
-        if (wcscmp(altJitNgenFlag, W("")) == 0)
+        if (dn_wcscmp(altJitNgenFlag, W("")) == 0)
         {
             jit->forceClearAltJitFlag = true;
         }

--- a/src/coreclr/tools/superpmi/superpmi/jitinstance.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jitinstance.cpp
@@ -532,7 +532,7 @@ const WCHAR* JitInstance::getOption(const WCHAR* key, LightWeightMap<DWORD, DWOR
         return nullptr;
     }
 
-    size_t keyLenInBytes = sizeof(WCHAR) * (wcslen(key) + 1);
+    size_t keyLenInBytes = sizeof(WCHAR) * (dn_wcslen(key) + 1);
     int    keyIndex      = options->Contains((unsigned char*)key, (unsigned int)keyLenInBytes);
     if (keyIndex == -1)
     {

--- a/src/coreclr/tools/superpmi/superpmi/neardiffer.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/neardiffer.cpp
@@ -81,7 +81,7 @@ bool NearDiffer::InitAsmDiff()
             return false;
         }
 
-        WCHAR* ptr = (WCHAR*)dn_wcsrchr(coreCLRLoadedPath, '/');
+        WCHAR* ptr = (WCHAR*)strrchr_u16(coreCLRLoadedPath, '/');
 
         // Move past the / character.
         ptr = ptr + 1;
@@ -736,9 +736,9 @@ bool NearDiffer::compareCodeSection(MethodContext* mc,
         disasm_1->CchFormatInstr(instrMnemonic_1, 64);
         WCHAR instrMnemonic_2[64]; // I never know how much to allocate...
         disasm_2->CchFormatInstr(instrMnemonic_2, 64);
-        if (dn_wcscmp(instrMnemonic_1, L"ret") == 0)
+        if (strcmp_u16(instrMnemonic_1, L"ret") == 0)
             haveSeenRet = true;
-        if (dn_wcscmp(instrMnemonic_1, L"rep ret") == 0)
+        if (strcmp_u16(instrMnemonic_1, L"rep ret") == 0)
             haveSeenRet = true;
 
         // First, check to see if these instructions are actually identical.

--- a/src/coreclr/tools/superpmi/superpmi/neardiffer.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/neardiffer.cpp
@@ -81,7 +81,7 @@ bool NearDiffer::InitAsmDiff()
             return false;
         }
 
-        WCHAR* ptr = dn_wcsrchr(coreCLRLoadedPath, '/');
+        WCHAR* ptr = (WCHAR*)dn_wcsrchr(coreCLRLoadedPath, '/');
 
         // Move past the / character.
         ptr = ptr + 1;

--- a/src/coreclr/tools/superpmi/superpmi/neardiffer.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/neardiffer.cpp
@@ -736,9 +736,9 @@ bool NearDiffer::compareCodeSection(MethodContext* mc,
         disasm_1->CchFormatInstr(instrMnemonic_1, 64);
         WCHAR instrMnemonic_2[64]; // I never know how much to allocate...
         disasm_2->CchFormatInstr(instrMnemonic_2, 64);
-        if (wcscmp(instrMnemonic_1, L"ret") == 0)
+        if (dn_wcscmp(instrMnemonic_1, L"ret") == 0)
             haveSeenRet = true;
-        if (wcscmp(instrMnemonic_1, L"rep ret") == 0)
+        if (dn_wcscmp(instrMnemonic_1, L"rep ret") == 0)
             haveSeenRet = true;
 
         // First, check to see if these instructions are actually identical.

--- a/src/coreclr/tools/superpmi/superpmi/neardiffer.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/neardiffer.cpp
@@ -81,7 +81,7 @@ bool NearDiffer::InitAsmDiff()
             return false;
         }
 
-        WCHAR* ptr = (WCHAR*)strrchr_u16(coreCLRLoadedPath, '/');
+        WCHAR* ptr = (WCHAR*)u16_strrchr(coreCLRLoadedPath, '/');
 
         // Move past the / character.
         ptr = ptr + 1;
@@ -736,9 +736,9 @@ bool NearDiffer::compareCodeSection(MethodContext* mc,
         disasm_1->CchFormatInstr(instrMnemonic_1, 64);
         WCHAR instrMnemonic_2[64]; // I never know how much to allocate...
         disasm_2->CchFormatInstr(instrMnemonic_2, 64);
-        if (strcmp_u16(instrMnemonic_1, L"ret") == 0)
+        if (u16_strcmp(instrMnemonic_1, L"ret") == 0)
             haveSeenRet = true;
-        if (strcmp_u16(instrMnemonic_1, L"rep ret") == 0)
+        if (u16_strcmp(instrMnemonic_1, L"rep ret") == 0)
             haveSeenRet = true;
 
         // First, check to see if these instructions are actually identical.

--- a/src/coreclr/tools/superpmi/superpmi/neardiffer.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/neardiffer.cpp
@@ -81,7 +81,7 @@ bool NearDiffer::InitAsmDiff()
             return false;
         }
 
-        WCHAR* ptr = ::wcsrchr(coreCLRLoadedPath, '/');
+        WCHAR* ptr = dn_wcsrchr(coreCLRLoadedPath, '/');
 
         // Move past the / character.
         ptr = ptr + 1;
@@ -452,7 +452,7 @@ bool NearDiffer::compareOffsets(
     //
     // Since the mov/movk sequence is specific to the replay address constant, we don't assume the baseline
     // and diff have the same number of instructions (e.g., it's possible to skip a `movk` if it is zero).
-    // 
+    //
     // Some version of this logic might apply to ARM as well.
     //
     if (targetArch == SPMI_TARGET_ARCHITECTURE_ARM64)

--- a/src/coreclr/utilcode/CMakeLists.txt
+++ b/src/coreclr/utilcode/CMakeLists.txt
@@ -91,8 +91,10 @@ add_library(utilcode INTERFACE)
 target_sources(utilcode INTERFACE $<TARGET_OBJECTS:utilcode_obj>)
 add_library_clr(utilcodestaticnohost STATIC ${UTILCODE_STATICNOHOST_SOURCES})
 
+target_link_libraries(utilcodestaticnohost PUBLIC coreclrminipal)
+
 if(CLR_CMAKE_HOST_UNIX)
-  target_link_libraries(utilcodestaticnohost PUBLIC nativeresourcestring coreclrminipal)
+  target_link_libraries(utilcodestaticnohost PUBLIC nativeresourcestring)
   target_link_libraries(utilcode_dac PUBLIC nativeresourcestring)
   target_link_libraries(utilcode INTERFACE nativeresourcestring)
   add_dependencies(utilcode_dac coreclrpal)

--- a/src/coreclr/utilcode/CMakeLists.txt
+++ b/src/coreclr/utilcode/CMakeLists.txt
@@ -92,7 +92,7 @@ target_sources(utilcode INTERFACE $<TARGET_OBJECTS:utilcode_obj>)
 add_library_clr(utilcodestaticnohost STATIC ${UTILCODE_STATICNOHOST_SOURCES})
 
 if(CLR_CMAKE_HOST_UNIX)
-  target_link_libraries(utilcodestaticnohost PUBLIC nativeresourcestring)
+  target_link_libraries(utilcodestaticnohost PUBLIC nativeresourcestring coreclrminipal)
   target_link_libraries(utilcode_dac PUBLIC nativeresourcestring)
   target_link_libraries(utilcode INTERFACE nativeresourcestring)
   add_dependencies(utilcode_dac coreclrpal)

--- a/src/coreclr/utilcode/ccomprc.cpp
+++ b/src/coreclr/utilcode/ccomprc.cpp
@@ -136,7 +136,7 @@ HRESULT CCompRC::Init(LPCWSTR pResourceFile)
         {
             NewArrayHolder<WCHAR> pwszResourceFile(NULL);
 
-            DWORD lgth = (DWORD) dn_wcslen(pResourceFile) + 1;
+            DWORD lgth = (DWORD) strlen_u16(pResourceFile) + 1;
             pwszResourceFile = new(nothrow) WCHAR[lgth];
             if (pwszResourceFile)
             {

--- a/src/coreclr/utilcode/ccomprc.cpp
+++ b/src/coreclr/utilcode/ccomprc.cpp
@@ -136,7 +136,7 @@ HRESULT CCompRC::Init(LPCWSTR pResourceFile)
         {
             NewArrayHolder<WCHAR> pwszResourceFile(NULL);
 
-            DWORD lgth = (DWORD) strlen_u16(pResourceFile) + 1;
+            DWORD lgth = (DWORD) u16_strlen(pResourceFile) + 1;
             pwszResourceFile = new(nothrow) WCHAR[lgth];
             if (pwszResourceFile)
             {

--- a/src/coreclr/utilcode/ccomprc.cpp
+++ b/src/coreclr/utilcode/ccomprc.cpp
@@ -136,7 +136,7 @@ HRESULT CCompRC::Init(LPCWSTR pResourceFile)
         {
             NewArrayHolder<WCHAR> pwszResourceFile(NULL);
 
-            DWORD lgth = (DWORD) wcslen(pResourceFile) + 1;
+            DWORD lgth = (DWORD) dn_wcslen(pResourceFile) + 1;
             pwszResourceFile = new(nothrow) WCHAR[lgth];
             if (pwszResourceFile)
             {

--- a/src/coreclr/utilcode/clrconfig.cpp
+++ b/src/coreclr/utilcode/clrconfig.cpp
@@ -143,7 +143,7 @@ namespace
 
         WCHAR buff[64];
         const WCHAR* fallbackPrefix = NULL;
-        const size_t namelen = wcslen(name);
+        const size_t namelen = dn_wcslen(name);
 
         bool noPrefix = CheckLookupOption(options, LookupOptions::DontPrependPrefix);
         if (noPrefix)
@@ -324,7 +324,7 @@ namespace
         *pwszTrimmed = NULL;
 
         // Get pointers into internal string that show where to do the trimming.
-        size_t cchOrig = wcslen(wszOrig);
+        size_t cchOrig = dn_wcslen(wszOrig);
         if (!FitsIn<DWORD>(cchOrig))
             return COR_E_OVERFLOW;
         DWORD cchAfterTrim = (DWORD) cchOrig;

--- a/src/coreclr/utilcode/clrconfig.cpp
+++ b/src/coreclr/utilcode/clrconfig.cpp
@@ -143,7 +143,7 @@ namespace
 
         WCHAR buff[64];
         const WCHAR* fallbackPrefix = NULL;
-        const size_t namelen = dn_wcslen(name);
+        const size_t namelen = strlen_u16(name);
 
         bool noPrefix = CheckLookupOption(options, LookupOptions::DontPrependPrefix);
         if (noPrefix)
@@ -249,7 +249,7 @@ namespace
         {
             errno = 0;
             LPWSTR endPtr;
-            DWORD configMaybe = dn_wcstoul(val, &endPtr, radix);
+            DWORD configMaybe = strtoul_u16(val, &endPtr, radix);
             BOOL fSuccess = ((errno != ERANGE) && (endPtr != val));
             if (fSuccess)
             {
@@ -324,7 +324,7 @@ namespace
         *pwszTrimmed = NULL;
 
         // Get pointers into internal string that show where to do the trimming.
-        size_t cchOrig = dn_wcslen(wszOrig);
+        size_t cchOrig = strlen_u16(wszOrig);
         if (!FitsIn<DWORD>(cchOrig))
             return COR_E_OVERFLOW;
         DWORD cchAfterTrim = (DWORD) cchOrig;

--- a/src/coreclr/utilcode/clrconfig.cpp
+++ b/src/coreclr/utilcode/clrconfig.cpp
@@ -143,7 +143,7 @@ namespace
 
         WCHAR buff[64];
         const WCHAR* fallbackPrefix = NULL;
-        const size_t namelen = strlen_u16(name);
+        const size_t namelen = u16_strlen(name);
 
         bool noPrefix = CheckLookupOption(options, LookupOptions::DontPrependPrefix);
         if (noPrefix)
@@ -249,7 +249,7 @@ namespace
         {
             errno = 0;
             LPWSTR endPtr;
-            DWORD configMaybe = strtoul_u16(val, &endPtr, radix);
+            DWORD configMaybe = u16_strtoul(val, &endPtr, radix);
             BOOL fSuccess = ((errno != ERANGE) && (endPtr != val));
             if (fSuccess)
             {
@@ -324,7 +324,7 @@ namespace
         *pwszTrimmed = NULL;
 
         // Get pointers into internal string that show where to do the trimming.
-        size_t cchOrig = strlen_u16(wszOrig);
+        size_t cchOrig = u16_strlen(wszOrig);
         if (!FitsIn<DWORD>(cchOrig))
             return COR_E_OVERFLOW;
         DWORD cchAfterTrim = (DWORD) cchOrig;

--- a/src/coreclr/utilcode/clrconfig.cpp
+++ b/src/coreclr/utilcode/clrconfig.cpp
@@ -249,7 +249,7 @@ namespace
         {
             errno = 0;
             LPWSTR endPtr;
-            DWORD configMaybe = wcstoul(val, &endPtr, radix);
+            DWORD configMaybe = dn_wcstoul(val, &endPtr, radix);
             BOOL fSuccess = ((errno != ERANGE) && (endPtr != val));
             if (fSuccess)
             {

--- a/src/coreclr/utilcode/configuration.cpp
+++ b/src/coreclr/utilcode/configuration.cpp
@@ -40,7 +40,7 @@ static LPCWSTR GetConfigurationValue(LPCWSTR name)
     for (int i = 0; i < numberOfKnobs; ++i)
     {
         _ASSERT(knobNames[i] != nullptr);
-        if (wcscmp(name, knobNames[i]) == 0)
+        if (dn_wcscmp(name, knobNames[i]) == 0)
         {
             return knobValues[i];
         }
@@ -117,7 +117,7 @@ bool Configuration::GetKnobBooleanValue(LPCWSTR name, const CLRConfig::ConfigDWO
     LPCWSTR knobValue = GetConfigurationValue(name);
     if (knobValue != nullptr)
     {
-        return (wcscmp(knobValue, W("true")) == 0);
+        return (dn_wcscmp(knobValue, W("true")) == 0);
     }
 
     return (legacyValue != 0);
@@ -140,7 +140,7 @@ bool Configuration::GetKnobBooleanValue(LPCWSTR name, bool defaultValue)
     LPCWSTR knobValue = GetConfigurationValue(name);
     if (knobValue != nullptr)
     {
-        return (wcscmp(knobValue, W("true")) == 0);
+        return (dn_wcscmp(knobValue, W("true")) == 0);
     }
 
     return defaultValue;

--- a/src/coreclr/utilcode/configuration.cpp
+++ b/src/coreclr/utilcode/configuration.cpp
@@ -61,7 +61,7 @@ DWORD Configuration::GetKnobDWORDValue(LPCWSTR name, const CLRConfig::ConfigDWOR
     LPCWSTR knobValue = GetConfigurationValue(name);
     if (knobValue != nullptr)
     {
-        return wcstoul(knobValue, nullptr, 0);
+        return dn_wcstoul(knobValue, nullptr, 0);
     }
 
     return legacyValue;
@@ -72,7 +72,7 @@ DWORD Configuration::GetKnobDWORDValue(LPCWSTR name, DWORD defaultValue)
     LPCWSTR knobValue = GetConfigurationValue(name);
     if (knobValue != nullptr)
     {
-        return wcstoul(knobValue, nullptr, 0);
+        return dn_wcstoul(knobValue, nullptr, 0);
     }
 
     return defaultValue;
@@ -83,7 +83,7 @@ ULONGLONG Configuration::GetKnobULONGLONGValue(LPCWSTR name, ULONGLONG defaultVa
     LPCWSTR knobValue = GetConfigurationValue(name);
     if (knobValue != nullptr)
     {
-        return _wcstoui64(knobValue, nullptr, 0);
+        return dn_wcstoui64(knobValue, nullptr, 0);
     }
 
     return defaultValue;

--- a/src/coreclr/utilcode/configuration.cpp
+++ b/src/coreclr/utilcode/configuration.cpp
@@ -40,7 +40,7 @@ static LPCWSTR GetConfigurationValue(LPCWSTR name)
     for (int i = 0; i < numberOfKnobs; ++i)
     {
         _ASSERT(knobNames[i] != nullptr);
-        if (dn_wcscmp(name, knobNames[i]) == 0)
+        if (strcmp_u16(name, knobNames[i]) == 0)
         {
             return knobValues[i];
         }
@@ -61,7 +61,7 @@ DWORD Configuration::GetKnobDWORDValue(LPCWSTR name, const CLRConfig::ConfigDWOR
     LPCWSTR knobValue = GetConfigurationValue(name);
     if (knobValue != nullptr)
     {
-        return dn_wcstoul(knobValue, nullptr, 0);
+        return strtoul_u16(knobValue, nullptr, 0);
     }
 
     return legacyValue;
@@ -72,7 +72,7 @@ DWORD Configuration::GetKnobDWORDValue(LPCWSTR name, DWORD defaultValue)
     LPCWSTR knobValue = GetConfigurationValue(name);
     if (knobValue != nullptr)
     {
-        return dn_wcstoul(knobValue, nullptr, 0);
+        return strtoul_u16(knobValue, nullptr, 0);
     }
 
     return defaultValue;
@@ -83,7 +83,7 @@ ULONGLONG Configuration::GetKnobULONGLONGValue(LPCWSTR name, ULONGLONG defaultVa
     LPCWSTR knobValue = GetConfigurationValue(name);
     if (knobValue != nullptr)
     {
-        return dn_wcstoui64(knobValue, nullptr, 0);
+        return strtoui64_u16(knobValue, nullptr, 0);
     }
 
     return defaultValue;
@@ -117,7 +117,7 @@ bool Configuration::GetKnobBooleanValue(LPCWSTR name, const CLRConfig::ConfigDWO
     LPCWSTR knobValue = GetConfigurationValue(name);
     if (knobValue != nullptr)
     {
-        return (dn_wcscmp(knobValue, W("true")) == 0);
+        return (strcmp_u16(knobValue, W("true")) == 0);
     }
 
     return (legacyValue != 0);
@@ -140,7 +140,7 @@ bool Configuration::GetKnobBooleanValue(LPCWSTR name, bool defaultValue)
     LPCWSTR knobValue = GetConfigurationValue(name);
     if (knobValue != nullptr)
     {
-        return (dn_wcscmp(knobValue, W("true")) == 0);
+        return (strcmp_u16(knobValue, W("true")) == 0);
     }
 
     return defaultValue;

--- a/src/coreclr/utilcode/configuration.cpp
+++ b/src/coreclr/utilcode/configuration.cpp
@@ -40,7 +40,7 @@ static LPCWSTR GetConfigurationValue(LPCWSTR name)
     for (int i = 0; i < numberOfKnobs; ++i)
     {
         _ASSERT(knobNames[i] != nullptr);
-        if (strcmp_u16(name, knobNames[i]) == 0)
+        if (u16_strcmp(name, knobNames[i]) == 0)
         {
             return knobValues[i];
         }
@@ -61,7 +61,7 @@ DWORD Configuration::GetKnobDWORDValue(LPCWSTR name, const CLRConfig::ConfigDWOR
     LPCWSTR knobValue = GetConfigurationValue(name);
     if (knobValue != nullptr)
     {
-        return strtoul_u16(knobValue, nullptr, 0);
+        return u16_strtoul(knobValue, nullptr, 0);
     }
 
     return legacyValue;
@@ -72,7 +72,7 @@ DWORD Configuration::GetKnobDWORDValue(LPCWSTR name, DWORD defaultValue)
     LPCWSTR knobValue = GetConfigurationValue(name);
     if (knobValue != nullptr)
     {
-        return strtoul_u16(knobValue, nullptr, 0);
+        return u16_strtoul(knobValue, nullptr, 0);
     }
 
     return defaultValue;
@@ -83,7 +83,7 @@ ULONGLONG Configuration::GetKnobULONGLONGValue(LPCWSTR name, ULONGLONG defaultVa
     LPCWSTR knobValue = GetConfigurationValue(name);
     if (knobValue != nullptr)
     {
-        return strtoui64_u16(knobValue, nullptr, 0);
+        return u16_strtoui64(knobValue, nullptr, 0);
     }
 
     return defaultValue;
@@ -117,7 +117,7 @@ bool Configuration::GetKnobBooleanValue(LPCWSTR name, const CLRConfig::ConfigDWO
     LPCWSTR knobValue = GetConfigurationValue(name);
     if (knobValue != nullptr)
     {
-        return (strcmp_u16(knobValue, W("true")) == 0);
+        return (u16_strcmp(knobValue, W("true")) == 0);
     }
 
     return (legacyValue != 0);
@@ -140,7 +140,7 @@ bool Configuration::GetKnobBooleanValue(LPCWSTR name, bool defaultValue)
     LPCWSTR knobValue = GetConfigurationValue(name);
     if (knobValue != nullptr)
     {
-        return (strcmp_u16(knobValue, W("true")) == 0);
+        return (u16_strcmp(knobValue, W("true")) == 0);
     }
 
     return defaultValue;

--- a/src/coreclr/utilcode/dacutil.cpp
+++ b/src/coreclr/utilcode/dacutil.cpp
@@ -106,7 +106,7 @@ LiveProcDataTarget::GetImageBase(
     // about right now is the base of mscorwks.
     //
 
-    if (wcscmp(name, MAIN_CLR_DLL_NAME_W))
+    if (dn_wcscmp(name, MAIN_CLR_DLL_NAME_W))
     {
         return E_NOINTERFACE;
     }

--- a/src/coreclr/utilcode/dacutil.cpp
+++ b/src/coreclr/utilcode/dacutil.cpp
@@ -106,7 +106,7 @@ LiveProcDataTarget::GetImageBase(
     // about right now is the base of mscorwks.
     //
 
-    if (strcmp_u16(name, MAIN_CLR_DLL_NAME_W))
+    if (u16_strcmp(name, MAIN_CLR_DLL_NAME_W))
     {
         return E_NOINTERFACE;
     }

--- a/src/coreclr/utilcode/dacutil.cpp
+++ b/src/coreclr/utilcode/dacutil.cpp
@@ -106,7 +106,7 @@ LiveProcDataTarget::GetImageBase(
     // about right now is the base of mscorwks.
     //
 
-    if (dn_wcscmp(name, MAIN_CLR_DLL_NAME_W))
+    if (strcmp_u16(name, MAIN_CLR_DLL_NAME_W))
     {
         return E_NOINTERFACE;
     }

--- a/src/coreclr/utilcode/guidfromname.cpp
+++ b/src/coreclr/utilcode/guidfromname.cpp
@@ -206,5 +206,5 @@ void CorGuidFromNameW
         pGuidResult,
         COMPLUS_RUNTIME_GUID,
         wzName,
-        (DWORD)((cchName == (SIZE_T) -1 ? (dn_wcslen(wzName)+1) : cchName) * sizeof(WCHAR)));
+        (DWORD)((cchName == (SIZE_T) -1 ? (strlen_u16(wzName)+1) : cchName) * sizeof(WCHAR)));
 }

--- a/src/coreclr/utilcode/guidfromname.cpp
+++ b/src/coreclr/utilcode/guidfromname.cpp
@@ -206,5 +206,5 @@ void CorGuidFromNameW
         pGuidResult,
         COMPLUS_RUNTIME_GUID,
         wzName,
-        (DWORD)((cchName == (SIZE_T) -1 ? (wcslen(wzName)+1) : cchName) * sizeof(WCHAR)));
+        (DWORD)((cchName == (SIZE_T) -1 ? (dn_wcslen(wzName)+1) : cchName) * sizeof(WCHAR)));
 }

--- a/src/coreclr/utilcode/guidfromname.cpp
+++ b/src/coreclr/utilcode/guidfromname.cpp
@@ -206,5 +206,5 @@ void CorGuidFromNameW
         pGuidResult,
         COMPLUS_RUNTIME_GUID,
         wzName,
-        (DWORD)((cchName == (SIZE_T) -1 ? (strlen_u16(wzName)+1) : cchName) * sizeof(WCHAR)));
+        (DWORD)((cchName == (SIZE_T) -1 ? (u16_strlen(wzName)+1) : cchName) * sizeof(WCHAR)));
 }

--- a/src/coreclr/utilcode/log.cpp
+++ b/src/coreclr/utilcode/log.cpp
@@ -66,7 +66,7 @@ VOID InitLogging()
     LPWSTR fileName = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_LogFile);
     if (fileName != 0)
     {
-        if (SUCCEEDED(szLogFileName.ReSizeNoThrow(dn_wcslen(fileName) + 32)))
+        if (SUCCEEDED(szLogFileName.ReSizeNoThrow(strlen_u16(fileName) + 32)))
         {
             wcscpy_s(szLogFileName.Ptr(), szLogFileName.Size(), fileName);
         }
@@ -98,9 +98,9 @@ VOID InitLogging()
             NULL);
 
             // Some other logging may be going on, try again with another file name
-        if (LogFileHandle == INVALID_HANDLE_VALUE && dn_wcslen(szLogFileName.Ptr()) + 3 <= szLogFileName.Size())
+        if (LogFileHandle == INVALID_HANDLE_VALUE && strlen_u16(szLogFileName.Ptr()) + 3 <= szLogFileName.Size())
         {
-            WCHAR* ptr = szLogFileName.Ptr() + dn_wcslen(szLogFileName.Ptr()) + 1;
+            WCHAR* ptr = szLogFileName.Ptr() + strlen_u16(szLogFileName.Ptr()) + 1;
             ptr[-1] = W('.');
             ptr[0] = W('0');
             ptr[1] = 0;

--- a/src/coreclr/utilcode/log.cpp
+++ b/src/coreclr/utilcode/log.cpp
@@ -66,7 +66,7 @@ VOID InitLogging()
     LPWSTR fileName = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_LogFile);
     if (fileName != 0)
     {
-        if (SUCCEEDED(szLogFileName.ReSizeNoThrow(wcslen(fileName) + 32)))
+        if (SUCCEEDED(szLogFileName.ReSizeNoThrow(dn_wcslen(fileName) + 32)))
         {
             wcscpy_s(szLogFileName.Ptr(), szLogFileName.Size(), fileName);
         }
@@ -98,9 +98,9 @@ VOID InitLogging()
             NULL);
 
             // Some other logging may be going on, try again with another file name
-        if (LogFileHandle == INVALID_HANDLE_VALUE && wcslen(szLogFileName.Ptr()) + 3 <= szLogFileName.Size())
+        if (LogFileHandle == INVALID_HANDLE_VALUE && dn_wcslen(szLogFileName.Ptr()) + 3 <= szLogFileName.Size())
         {
-            WCHAR* ptr = szLogFileName.Ptr() + wcslen(szLogFileName.Ptr()) + 1;
+            WCHAR* ptr = szLogFileName.Ptr() + dn_wcslen(szLogFileName.Ptr()) + 1;
             ptr[-1] = W('.');
             ptr[0] = W('0');
             ptr[1] = 0;

--- a/src/coreclr/utilcode/log.cpp
+++ b/src/coreclr/utilcode/log.cpp
@@ -66,7 +66,7 @@ VOID InitLogging()
     LPWSTR fileName = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_LogFile);
     if (fileName != 0)
     {
-        if (SUCCEEDED(szLogFileName.ReSizeNoThrow(strlen_u16(fileName) + 32)))
+        if (SUCCEEDED(szLogFileName.ReSizeNoThrow(u16_strlen(fileName) + 32)))
         {
             wcscpy_s(szLogFileName.Ptr(), szLogFileName.Size(), fileName);
         }
@@ -98,9 +98,9 @@ VOID InitLogging()
             NULL);
 
             // Some other logging may be going on, try again with another file name
-        if (LogFileHandle == INVALID_HANDLE_VALUE && strlen_u16(szLogFileName.Ptr()) + 3 <= szLogFileName.Size())
+        if (LogFileHandle == INVALID_HANDLE_VALUE && u16_strlen(szLogFileName.Ptr()) + 3 <= szLogFileName.Size())
         {
-            WCHAR* ptr = szLogFileName.Ptr() + strlen_u16(szLogFileName.Ptr()) + 1;
+            WCHAR* ptr = szLogFileName.Ptr() + u16_strlen(szLogFileName.Ptr()) + 1;
             ptr[-1] = W('.');
             ptr[0] = W('0');
             ptr[1] = 0;

--- a/src/coreclr/utilcode/longfilepathwrappers.cpp
+++ b/src/coreclr/utilcode/longfilepathwrappers.cpp
@@ -571,7 +571,7 @@ HRESULT LongFile::NormalizePath(SString & path)
         //In this case if path is \\server the extended syntax should be like  \\?\UNC\server
         //The below logic populates the path from prefixLen offset from the start. This ensures that first 2 characters are overwritten
         //
-        prefixLen = prefix.GetCount() - (COUNT_T)dn_wcslen(UNCPATHPREFIX);
+        prefixLen = prefix.GetCount() - (COUNT_T)strlen_u16(UNCPATHPREFIX);
         _ASSERTE(prefixLen > 0 );
     }
 
@@ -615,10 +615,10 @@ HRESULT LongFile::NormalizePath(SString & path)
 	SString fullpath(SString::Literal,buffer + prefixLen);
 
     //Check if the resolved path is a UNC. By default we assume relative path to resolve to disk
-    if (fullpath.BeginsWith(SL(UNCPathPrefix)) && prefixLen != prefix.GetCount() - (COUNT_T)dn_wcslen(UNCPATHPREFIX))
+    if (fullpath.BeginsWith(SL(UNCPathPrefix)) && prefixLen != prefix.GetCount() - (COUNT_T)strlen_u16(UNCPATHPREFIX))
     {
         //Remove the leading '\\' from the UNC path to be replaced with UNCExtendedPathPrefix
-        fullpath.Replace(fullpath.Begin(), (COUNT_T)dn_wcslen(UNCPATHPREFIX), UNCExtendedPathPrefix);
+        fullpath.Replace(fullpath.Begin(), (COUNT_T)strlen_u16(UNCPATHPREFIX), UNCExtendedPathPrefix);
         path.CloseBuffer();
         path.Set(fullpath);
     }

--- a/src/coreclr/utilcode/longfilepathwrappers.cpp
+++ b/src/coreclr/utilcode/longfilepathwrappers.cpp
@@ -571,7 +571,7 @@ HRESULT LongFile::NormalizePath(SString & path)
         //In this case if path is \\server the extended syntax should be like  \\?\UNC\server
         //The below logic populates the path from prefixLen offset from the start. This ensures that first 2 characters are overwritten
         //
-        prefixLen = prefix.GetCount() - (COUNT_T)strlen_u16(UNCPATHPREFIX);
+        prefixLen = prefix.GetCount() - (COUNT_T)u16_strlen(UNCPATHPREFIX);
         _ASSERTE(prefixLen > 0 );
     }
 
@@ -615,10 +615,10 @@ HRESULT LongFile::NormalizePath(SString & path)
 	SString fullpath(SString::Literal,buffer + prefixLen);
 
     //Check if the resolved path is a UNC. By default we assume relative path to resolve to disk
-    if (fullpath.BeginsWith(SL(UNCPathPrefix)) && prefixLen != prefix.GetCount() - (COUNT_T)strlen_u16(UNCPATHPREFIX))
+    if (fullpath.BeginsWith(SL(UNCPathPrefix)) && prefixLen != prefix.GetCount() - (COUNT_T)u16_strlen(UNCPATHPREFIX))
     {
         //Remove the leading '\\' from the UNC path to be replaced with UNCExtendedPathPrefix
-        fullpath.Replace(fullpath.Begin(), (COUNT_T)strlen_u16(UNCPATHPREFIX), UNCExtendedPathPrefix);
+        fullpath.Replace(fullpath.Begin(), (COUNT_T)u16_strlen(UNCPATHPREFIX), UNCExtendedPathPrefix);
         path.CloseBuffer();
         path.Set(fullpath);
     }

--- a/src/coreclr/utilcode/longfilepathwrappers.cpp
+++ b/src/coreclr/utilcode/longfilepathwrappers.cpp
@@ -571,7 +571,7 @@ HRESULT LongFile::NormalizePath(SString & path)
         //In this case if path is \\server the extended syntax should be like  \\?\UNC\server
         //The below logic populates the path from prefixLen offset from the start. This ensures that first 2 characters are overwritten
         //
-        prefixLen = prefix.GetCount() - (COUNT_T)wcslen(UNCPATHPREFIX);
+        prefixLen = prefix.GetCount() - (COUNT_T)dn_wcslen(UNCPATHPREFIX);
         _ASSERTE(prefixLen > 0 );
     }
 
@@ -615,10 +615,10 @@ HRESULT LongFile::NormalizePath(SString & path)
 	SString fullpath(SString::Literal,buffer + prefixLen);
 
     //Check if the resolved path is a UNC. By default we assume relative path to resolve to disk
-    if (fullpath.BeginsWith(SL(UNCPathPrefix)) && prefixLen != prefix.GetCount() - (COUNT_T)wcslen(UNCPATHPREFIX))
+    if (fullpath.BeginsWith(SL(UNCPathPrefix)) && prefixLen != prefix.GetCount() - (COUNT_T)dn_wcslen(UNCPATHPREFIX))
     {
         //Remove the leading '\\' from the UNC path to be replaced with UNCExtendedPathPrefix
-        fullpath.Replace(fullpath.Begin(), (COUNT_T)wcslen(UNCPATHPREFIX), UNCExtendedPathPrefix);
+        fullpath.Replace(fullpath.Begin(), (COUNT_T)dn_wcslen(UNCPATHPREFIX), UNCExtendedPathPrefix);
         path.CloseBuffer();
         path.Set(fullpath);
     }

--- a/src/coreclr/utilcode/namespaceutil.cpp
+++ b/src/coreclr/utilcode/namespaceutil.cpp
@@ -36,9 +36,9 @@ int ns::GetFullLength(                  // Number of chars in full name.
 
     int iLen = 1;                       // Null terminator.
     if (szNameSpace)
-        iLen += (int)strlen_u16(szNameSpace);
+        iLen += (int)u16_strlen(szNameSpace);
     if (szName)
-        iLen += (int)strlen_u16(szName);
+        iLen += (int)u16_strlen(szName);
     if (szNameSpace && *szNameSpace && szName && *szName)
         ++iLen;
     return iLen;
@@ -81,7 +81,7 @@ WCHAR *ns::FindSep(                     // Pointer to separator or null.
     STATIC_CONTRACT_FORBID_FAULT;
 
     _ASSERTE(szPath);
-    WCHAR *ptr = (WCHAR*)strrchr_u16(szPath, NAMESPACE_SEPARATOR_WCHAR);
+    WCHAR *ptr = (WCHAR*)u16_strrchr(szPath, NAMESPACE_SEPARATOR_WCHAR);
     if((ptr == NULL) || (ptr == szPath)) return NULL;
     if(*(ptr - 1) == NAMESPACE_SEPARATOR_WCHAR) // here ptr is at least szPath+1
         --ptr;
@@ -229,7 +229,7 @@ int ns::SplitPath(                      // true ok, false trunction.
             ++ptr;
         else
             ptr = szPath;
-        iLen = (int)strlen_u16(ptr);
+        iLen = (int)u16_strlen(ptr);
         iCopyMax = min(iCopyMax, iLen);
         wcsncpy_s(szName, cchName, ptr, iCopyMax);
         szName[iCopyMax] = 0;
@@ -473,9 +473,9 @@ int ns::MakePath(                       // true ok, false out of memory
 
     int iLen = 2;
     if (szNameSpace)
-        iLen += (int)strlen_u16(szNameSpace);
+        iLen += (int)u16_strlen(szNameSpace);
     if (szName)
-        iLen += (int)strlen_u16(szName);
+        iLen += (int)u16_strlen(szName);
     WCHAR *szOut = (WCHAR *) qb.AllocNoThrow(iLen * sizeof(WCHAR));
     if (!szOut)
         return false;
@@ -586,9 +586,9 @@ bool ns::MakeAssemblyQualifiedName(                                        // tr
     int iTypeName = 0;
     int iAssemblyName = 0;
     if (szTypeName)
-        iTypeName = (int)strlen_u16(szTypeName);
+        iTypeName = (int)u16_strlen(szTypeName);
     if (szAssemblyName)
-        iAssemblyName = (int)strlen_u16(szAssemblyName);
+        iAssemblyName = (int)u16_strlen(szAssemblyName);
 
     int iLen = ASSEMBLY_SEPARATOR_LEN + iTypeName + iAssemblyName + 1; // Space for null terminator
     WCHAR *szOut = (WCHAR *) qb.AllocNoThrow(iLen * sizeof(WCHAR));

--- a/src/coreclr/utilcode/namespaceutil.cpp
+++ b/src/coreclr/utilcode/namespaceutil.cpp
@@ -81,7 +81,7 @@ WCHAR *ns::FindSep(                     // Pointer to separator or null.
     STATIC_CONTRACT_FORBID_FAULT;
 
     _ASSERTE(szPath);
-    WCHAR *ptr = (WCHAR*)wcsrchr(szPath, NAMESPACE_SEPARATOR_WCHAR);
+    WCHAR *ptr = (WCHAR*)dn_wcsrchr(szPath, NAMESPACE_SEPARATOR_WCHAR);
     if((ptr == NULL) || (ptr == szPath)) return NULL;
     if(*(ptr - 1) == NAMESPACE_SEPARATOR_WCHAR) // here ptr is at least szPath+1
         --ptr;

--- a/src/coreclr/utilcode/namespaceutil.cpp
+++ b/src/coreclr/utilcode/namespaceutil.cpp
@@ -36,9 +36,9 @@ int ns::GetFullLength(                  // Number of chars in full name.
 
     int iLen = 1;                       // Null terminator.
     if (szNameSpace)
-        iLen += (int)wcslen(szNameSpace);
+        iLen += (int)dn_wcslen(szNameSpace);
     if (szName)
-        iLen += (int)wcslen(szName);
+        iLen += (int)dn_wcslen(szName);
     if (szNameSpace && *szNameSpace && szName && *szName)
         ++iLen;
     return iLen;
@@ -229,7 +229,7 @@ int ns::SplitPath(                      // true ok, false trunction.
             ++ptr;
         else
             ptr = szPath;
-        iLen = (int)wcslen(ptr);
+        iLen = (int)dn_wcslen(ptr);
         iCopyMax = min(iCopyMax, iLen);
         wcsncpy_s(szName, cchName, ptr, iCopyMax);
         szName[iCopyMax] = 0;
@@ -473,9 +473,9 @@ int ns::MakePath(                       // true ok, false out of memory
 
     int iLen = 2;
     if (szNameSpace)
-        iLen += (int)wcslen(szNameSpace);
+        iLen += (int)dn_wcslen(szNameSpace);
     if (szName)
-        iLen += (int)wcslen(szName);
+        iLen += (int)dn_wcslen(szName);
     WCHAR *szOut = (WCHAR *) qb.AllocNoThrow(iLen * sizeof(WCHAR));
     if (!szOut)
         return false;
@@ -586,9 +586,9 @@ bool ns::MakeAssemblyQualifiedName(                                        // tr
     int iTypeName = 0;
     int iAssemblyName = 0;
     if (szTypeName)
-        iTypeName = (int)wcslen(szTypeName);
+        iTypeName = (int)dn_wcslen(szTypeName);
     if (szAssemblyName)
-        iAssemblyName = (int)wcslen(szAssemblyName);
+        iAssemblyName = (int)dn_wcslen(szAssemblyName);
 
     int iLen = ASSEMBLY_SEPARATOR_LEN + iTypeName + iAssemblyName + 1; // Space for null terminator
     WCHAR *szOut = (WCHAR *) qb.AllocNoThrow(iLen * sizeof(WCHAR));

--- a/src/coreclr/utilcode/namespaceutil.cpp
+++ b/src/coreclr/utilcode/namespaceutil.cpp
@@ -36,9 +36,9 @@ int ns::GetFullLength(                  // Number of chars in full name.
 
     int iLen = 1;                       // Null terminator.
     if (szNameSpace)
-        iLen += (int)dn_wcslen(szNameSpace);
+        iLen += (int)strlen_u16(szNameSpace);
     if (szName)
-        iLen += (int)dn_wcslen(szName);
+        iLen += (int)strlen_u16(szName);
     if (szNameSpace && *szNameSpace && szName && *szName)
         ++iLen;
     return iLen;
@@ -81,7 +81,7 @@ WCHAR *ns::FindSep(                     // Pointer to separator or null.
     STATIC_CONTRACT_FORBID_FAULT;
 
     _ASSERTE(szPath);
-    WCHAR *ptr = (WCHAR*)dn_wcsrchr(szPath, NAMESPACE_SEPARATOR_WCHAR);
+    WCHAR *ptr = (WCHAR*)strrchr_u16(szPath, NAMESPACE_SEPARATOR_WCHAR);
     if((ptr == NULL) || (ptr == szPath)) return NULL;
     if(*(ptr - 1) == NAMESPACE_SEPARATOR_WCHAR) // here ptr is at least szPath+1
         --ptr;
@@ -229,7 +229,7 @@ int ns::SplitPath(                      // true ok, false trunction.
             ++ptr;
         else
             ptr = szPath;
-        iLen = (int)dn_wcslen(ptr);
+        iLen = (int)strlen_u16(ptr);
         iCopyMax = min(iCopyMax, iLen);
         wcsncpy_s(szName, cchName, ptr, iCopyMax);
         szName[iCopyMax] = 0;
@@ -473,9 +473,9 @@ int ns::MakePath(                       // true ok, false out of memory
 
     int iLen = 2;
     if (szNameSpace)
-        iLen += (int)dn_wcslen(szNameSpace);
+        iLen += (int)strlen_u16(szNameSpace);
     if (szName)
-        iLen += (int)dn_wcslen(szName);
+        iLen += (int)strlen_u16(szName);
     WCHAR *szOut = (WCHAR *) qb.AllocNoThrow(iLen * sizeof(WCHAR));
     if (!szOut)
         return false;
@@ -586,9 +586,9 @@ bool ns::MakeAssemblyQualifiedName(                                        // tr
     int iTypeName = 0;
     int iAssemblyName = 0;
     if (szTypeName)
-        iTypeName = (int)dn_wcslen(szTypeName);
+        iTypeName = (int)strlen_u16(szTypeName);
     if (szAssemblyName)
-        iAssemblyName = (int)dn_wcslen(szAssemblyName);
+        iAssemblyName = (int)strlen_u16(szAssemblyName);
 
     int iLen = ASSEMBLY_SEPARATOR_LEN + iTypeName + iAssemblyName + 1; // Space for null terminator
     WCHAR *szOut = (WCHAR *) qb.AllocNoThrow(iLen * sizeof(WCHAR));

--- a/src/coreclr/utilcode/pedecoder.cpp
+++ b/src/coreclr/utilcode/pedecoder.cpp
@@ -1758,7 +1758,7 @@ DWORD ReadResourceDirectory(const PEDecoder *pDecoder, DWORD rvaOfResourceSectio
                 return 0;
 
             size_t entryNameLen = *(WORD*)pDecoder->GetRvaData(entryNameRva);
-            if (dn_wcslen(name) != entryNameLen)
+            if (strlen_u16(name) != entryNameLen)
                 continue;
 
             if (!pDecoder->CheckRva(entryNameRva, (COUNT_T)(sizeof(WORD) * (1 + entryNameLen))))
@@ -1926,7 +1926,7 @@ bool DoesResourceNameMatch(LPCWSTR nameA, LPCWSTR nameB)
         if (IS_INTRESOURCE(nameB))
             return false;
         else
-            foundEntry = !dn_wcscmp(nameB, nameA);
+            foundEntry = !strcmp_u16(nameB, nameA);
     }
 
     return foundEntry;

--- a/src/coreclr/utilcode/pedecoder.cpp
+++ b/src/coreclr/utilcode/pedecoder.cpp
@@ -1926,7 +1926,7 @@ bool DoesResourceNameMatch(LPCWSTR nameA, LPCWSTR nameB)
         if (IS_INTRESOURCE(nameB))
             return false;
         else
-            foundEntry = !wcscmp(nameB, nameA);
+            foundEntry = !dn_wcscmp(nameB, nameA);
     }
 
     return foundEntry;

--- a/src/coreclr/utilcode/pedecoder.cpp
+++ b/src/coreclr/utilcode/pedecoder.cpp
@@ -1758,7 +1758,7 @@ DWORD ReadResourceDirectory(const PEDecoder *pDecoder, DWORD rvaOfResourceSectio
                 return 0;
 
             size_t entryNameLen = *(WORD*)pDecoder->GetRvaData(entryNameRva);
-            if (wcslen(name) != entryNameLen)
+            if (dn_wcslen(name) != entryNameLen)
                 continue;
 
             if (!pDecoder->CheckRva(entryNameRva, (COUNT_T)(sizeof(WORD) * (1 + entryNameLen))))

--- a/src/coreclr/utilcode/pedecoder.cpp
+++ b/src/coreclr/utilcode/pedecoder.cpp
@@ -1758,7 +1758,7 @@ DWORD ReadResourceDirectory(const PEDecoder *pDecoder, DWORD rvaOfResourceSectio
                 return 0;
 
             size_t entryNameLen = *(WORD*)pDecoder->GetRvaData(entryNameRva);
-            if (strlen_u16(name) != entryNameLen)
+            if (u16_strlen(name) != entryNameLen)
                 continue;
 
             if (!pDecoder->CheckRva(entryNameRva, (COUNT_T)(sizeof(WORD) * (1 + entryNameLen))))
@@ -1926,7 +1926,7 @@ bool DoesResourceNameMatch(LPCWSTR nameA, LPCWSTR nameB)
         if (IS_INTRESOURCE(nameB))
             return false;
         else
-            foundEntry = !strcmp_u16(nameB, nameA);
+            foundEntry = !u16_strcmp(nameB, nameA);
     }
 
     return foundEntry;

--- a/src/coreclr/utilcode/posterror.cpp
+++ b/src/coreclr/utilcode/posterror.cpp
@@ -149,7 +149,7 @@ static HRESULT FormatRuntimeErrorVA(
             hr = S_OK;
 
             // System messages contain a trailing \r\n, which we don't want normally.
-            size_t iLen = wcslen(rcMsg);
+            size_t iLen = dn_wcslen(rcMsg);
             if (iLen > 3 && rcMsg[iLen - 2] == '\r' && rcMsg[iLen - 1] == '\n')
                 rcMsg[iLen - 2] = '\0';
         }

--- a/src/coreclr/utilcode/posterror.cpp
+++ b/src/coreclr/utilcode/posterror.cpp
@@ -149,7 +149,7 @@ static HRESULT FormatRuntimeErrorVA(
             hr = S_OK;
 
             // System messages contain a trailing \r\n, which we don't want normally.
-            size_t iLen = dn_wcslen(rcMsg);
+            size_t iLen = strlen_u16(rcMsg);
             if (iLen > 3 && rcMsg[iLen - 2] == '\r' && rcMsg[iLen - 1] == '\n')
                 rcMsg[iLen - 2] = '\0';
         }

--- a/src/coreclr/utilcode/posterror.cpp
+++ b/src/coreclr/utilcode/posterror.cpp
@@ -149,7 +149,7 @@ static HRESULT FormatRuntimeErrorVA(
             hr = S_OK;
 
             // System messages contain a trailing \r\n, which we don't want normally.
-            size_t iLen = strlen_u16(rcMsg);
+            size_t iLen = u16_strlen(rcMsg);
             if (iLen > 3 && rcMsg[iLen - 2] == '\r' && rcMsg[iLen - 1] == '\n')
                 rcMsg[iLen - 2] = '\0';
         }

--- a/src/coreclr/utilcode/prettyprintsig.cpp
+++ b/src/coreclr/utilcode/prettyprintsig.cpp
@@ -65,7 +65,7 @@ static HRESULT appendStrW(CQuickBytes *out, const WCHAR* str)
     }
     CONTRACTL_END
 
-    SIZE_T len = dn_wcslen(str) * sizeof(WCHAR);
+    SIZE_T len = strlen_u16(str) * sizeof(WCHAR);
     SIZE_T oldSize = out->Size();
     if (FAILED(out->ReSizeNoThrow(oldSize + len)))
         return E_OUTOFMEMORY;

--- a/src/coreclr/utilcode/prettyprintsig.cpp
+++ b/src/coreclr/utilcode/prettyprintsig.cpp
@@ -65,7 +65,7 @@ static HRESULT appendStrW(CQuickBytes *out, const WCHAR* str)
     }
     CONTRACTL_END
 
-    SIZE_T len = wcslen(str) * sizeof(WCHAR);
+    SIZE_T len = dn_wcslen(str) * sizeof(WCHAR);
     SIZE_T oldSize = out->Size();
     if (FAILED(out->ReSizeNoThrow(oldSize + len)))
         return E_OUTOFMEMORY;

--- a/src/coreclr/utilcode/prettyprintsig.cpp
+++ b/src/coreclr/utilcode/prettyprintsig.cpp
@@ -65,7 +65,7 @@ static HRESULT appendStrW(CQuickBytes *out, const WCHAR* str)
     }
     CONTRACTL_END
 
-    SIZE_T len = strlen_u16(str) * sizeof(WCHAR);
+    SIZE_T len = u16_strlen(str) * sizeof(WCHAR);
     SIZE_T oldSize = out->Size();
     if (FAILED(out->ReSizeNoThrow(oldSize + len)))
         return E_OUTOFMEMORY;

--- a/src/coreclr/utilcode/splitpath.cpp
+++ b/src/coreclr/utilcode/splitpath.cpp
@@ -86,7 +86,7 @@ void    SplitPathInterior(
 
     /* extract drive letter and :, if any */
 
-    if ((wcslen(wszPath) > (_MAX_DRIVE - 2)) && (*(wszPath + _MAX_DRIVE - 2) == _T(':'))) {
+    if ((dn_wcslen(wszPath) > (_MAX_DRIVE - 2)) && (*(wszPath + _MAX_DRIVE - 2) == _T(':'))) {
         if (pwszDrive && pcchDrive) {
             *pwszDrive = wszPath;
             *pcchDrive = _MAX_DRIVE - 1;

--- a/src/coreclr/utilcode/splitpath.cpp
+++ b/src/coreclr/utilcode/splitpath.cpp
@@ -86,7 +86,7 @@ void    SplitPathInterior(
 
     /* extract drive letter and :, if any */
 
-    if ((dn_wcslen(wszPath) > (_MAX_DRIVE - 2)) && (*(wszPath + _MAX_DRIVE - 2) == _T(':'))) {
+    if ((strlen_u16(wszPath) > (_MAX_DRIVE - 2)) && (*(wszPath + _MAX_DRIVE - 2) == _T(':'))) {
         if (pwszDrive && pcchDrive) {
             *pwszDrive = wszPath;
             *pcchDrive = _MAX_DRIVE - 1;

--- a/src/coreclr/utilcode/splitpath.cpp
+++ b/src/coreclr/utilcode/splitpath.cpp
@@ -86,7 +86,7 @@ void    SplitPathInterior(
 
     /* extract drive letter and :, if any */
 
-    if ((strlen_u16(wszPath) > (_MAX_DRIVE - 2)) && (*(wszPath + _MAX_DRIVE - 2) == _T(':'))) {
+    if ((u16_strlen(wszPath) > (_MAX_DRIVE - 2)) && (*(wszPath + _MAX_DRIVE - 2) == _T(':'))) {
         if (pwszDrive && pcchDrive) {
             *pwszDrive = wszPath;
             *pcchDrive = _MAX_DRIVE - 1;

--- a/src/coreclr/utilcode/sstring.cpp
+++ b/src/coreclr/utilcode/sstring.cpp
@@ -244,7 +244,7 @@ void SString::Set(const WCHAR *string)
         Clear();
     else
     {
-        Resize((COUNT_T) dn_wcslen(string), REPRESENTATION_UNICODE);
+        Resize((COUNT_T) strlen_u16(string), REPRESENTATION_UNICODE);
         wcscpy_s(GetRawUnicode(), GetBufferSizeInCharIncludeNullChar(), string);
     }
 
@@ -985,7 +985,7 @@ BOOL SString::Find(CIterator &i, const SString &s) const
             const WCHAR *end = GetUnicode() + GetRawCount() - count;
             while (start <= end)
             {
-                if (dn_wcsncmp(start, source.GetRawUnicode(), count) == 0)
+                if (strncmp_u16(start, source.GetRawUnicode(), count) == 0)
                 {
                     i.Resync(this, (BYTE*) start);
                     RETURN TRUE;
@@ -1124,7 +1124,7 @@ BOOL SString::FindBack(CIterator &i, const SString &s) const
 
             while (start >= end)
             {
-                if (dn_wcsncmp(start, source.GetRawUnicode(), count) == 0)
+                if (strncmp_u16(start, source.GetRawUnicode(), count) == 0)
                 {
                     i.Resync(this, (BYTE*) start);
                     RETURN TRUE;
@@ -1334,7 +1334,7 @@ int SString::Compare(const SString &s) const
     switch (GetRepresentation())
     {
     case REPRESENTATION_UNICODE:
-        result = dn_wcsncmp(GetRawUnicode(), source.GetRawUnicode(), smaller);
+        result = strncmp_u16(GetRawUnicode(), source.GetRawUnicode(), smaller);
         break;
 
     case REPRESENTATION_ASCII:
@@ -1448,7 +1448,7 @@ BOOL SString::Equals(const SString &s) const
     switch (GetRepresentation())
     {
     case REPRESENTATION_UNICODE:
-        RETURN (dn_wcsncmp(GetRawUnicode(), source.GetRawUnicode(), count) == 0);
+        RETURN (strncmp_u16(GetRawUnicode(), source.GetRawUnicode(), count) == 0);
 
     case REPRESENTATION_ASCII:
         RETURN (strncmp(GetRawASCII(), source.GetRawASCII(), count) == 0);
@@ -1536,7 +1536,7 @@ BOOL SString::Match(const CIterator &i, const SString &s) const
     switch (GetRepresentation())
     {
     case REPRESENTATION_UNICODE:
-        RETURN (dn_wcsncmp(i.GetUnicode(), source.GetRawUnicode(), count) == 0);
+        RETURN (strncmp_u16(i.GetUnicode(), source.GetRawUnicode(), count) == 0);
 
     case REPRESENTATION_ASCII:
         RETURN (strncmp(i.GetASCII(), source.GetRawASCII(), count) == 0);

--- a/src/coreclr/utilcode/sstring.cpp
+++ b/src/coreclr/utilcode/sstring.cpp
@@ -244,7 +244,7 @@ void SString::Set(const WCHAR *string)
         Clear();
     else
     {
-        Resize((COUNT_T) wcslen(string), REPRESENTATION_UNICODE);
+        Resize((COUNT_T) dn_wcslen(string), REPRESENTATION_UNICODE);
         wcscpy_s(GetRawUnicode(), GetBufferSizeInCharIncludeNullChar(), string);
     }
 

--- a/src/coreclr/utilcode/sstring.cpp
+++ b/src/coreclr/utilcode/sstring.cpp
@@ -244,7 +244,7 @@ void SString::Set(const WCHAR *string)
         Clear();
     else
     {
-        Resize((COUNT_T) strlen_u16(string), REPRESENTATION_UNICODE);
+        Resize((COUNT_T) u16_strlen(string), REPRESENTATION_UNICODE);
         wcscpy_s(GetRawUnicode(), GetBufferSizeInCharIncludeNullChar(), string);
     }
 
@@ -985,7 +985,7 @@ BOOL SString::Find(CIterator &i, const SString &s) const
             const WCHAR *end = GetUnicode() + GetRawCount() - count;
             while (start <= end)
             {
-                if (strncmp_u16(start, source.GetRawUnicode(), count) == 0)
+                if (u16_strncmp(start, source.GetRawUnicode(), count) == 0)
                 {
                     i.Resync(this, (BYTE*) start);
                     RETURN TRUE;
@@ -1124,7 +1124,7 @@ BOOL SString::FindBack(CIterator &i, const SString &s) const
 
             while (start >= end)
             {
-                if (strncmp_u16(start, source.GetRawUnicode(), count) == 0)
+                if (u16_strncmp(start, source.GetRawUnicode(), count) == 0)
                 {
                     i.Resync(this, (BYTE*) start);
                     RETURN TRUE;
@@ -1334,7 +1334,7 @@ int SString::Compare(const SString &s) const
     switch (GetRepresentation())
     {
     case REPRESENTATION_UNICODE:
-        result = strncmp_u16(GetRawUnicode(), source.GetRawUnicode(), smaller);
+        result = u16_strncmp(GetRawUnicode(), source.GetRawUnicode(), smaller);
         break;
 
     case REPRESENTATION_ASCII:
@@ -1448,7 +1448,7 @@ BOOL SString::Equals(const SString &s) const
     switch (GetRepresentation())
     {
     case REPRESENTATION_UNICODE:
-        RETURN (strncmp_u16(GetRawUnicode(), source.GetRawUnicode(), count) == 0);
+        RETURN (u16_strncmp(GetRawUnicode(), source.GetRawUnicode(), count) == 0);
 
     case REPRESENTATION_ASCII:
         RETURN (strncmp(GetRawASCII(), source.GetRawASCII(), count) == 0);
@@ -1536,7 +1536,7 @@ BOOL SString::Match(const CIterator &i, const SString &s) const
     switch (GetRepresentation())
     {
     case REPRESENTATION_UNICODE:
-        RETURN (strncmp_u16(i.GetUnicode(), source.GetRawUnicode(), count) == 0);
+        RETURN (u16_strncmp(i.GetUnicode(), source.GetRawUnicode(), count) == 0);
 
     case REPRESENTATION_ASCII:
         RETURN (strncmp(i.GetASCII(), source.GetRawASCII(), count) == 0);

--- a/src/coreclr/utilcode/sstring.cpp
+++ b/src/coreclr/utilcode/sstring.cpp
@@ -985,7 +985,7 @@ BOOL SString::Find(CIterator &i, const SString &s) const
             const WCHAR *end = GetUnicode() + GetRawCount() - count;
             while (start <= end)
             {
-                if (wcsncmp(start, source.GetRawUnicode(), count) == 0)
+                if (dn_wcsncmp(start, source.GetRawUnicode(), count) == 0)
                 {
                     i.Resync(this, (BYTE*) start);
                     RETURN TRUE;
@@ -1124,7 +1124,7 @@ BOOL SString::FindBack(CIterator &i, const SString &s) const
 
             while (start >= end)
             {
-                if (wcsncmp(start, source.GetRawUnicode(), count) == 0)
+                if (dn_wcsncmp(start, source.GetRawUnicode(), count) == 0)
                 {
                     i.Resync(this, (BYTE*) start);
                     RETURN TRUE;
@@ -1334,7 +1334,7 @@ int SString::Compare(const SString &s) const
     switch (GetRepresentation())
     {
     case REPRESENTATION_UNICODE:
-        result = wcsncmp(GetRawUnicode(), source.GetRawUnicode(), smaller);
+        result = dn_wcsncmp(GetRawUnicode(), source.GetRawUnicode(), smaller);
         break;
 
     case REPRESENTATION_ASCII:
@@ -1448,7 +1448,7 @@ BOOL SString::Equals(const SString &s) const
     switch (GetRepresentation())
     {
     case REPRESENTATION_UNICODE:
-        RETURN (wcsncmp(GetRawUnicode(), source.GetRawUnicode(), count) == 0);
+        RETURN (dn_wcsncmp(GetRawUnicode(), source.GetRawUnicode(), count) == 0);
 
     case REPRESENTATION_ASCII:
         RETURN (strncmp(GetRawASCII(), source.GetRawASCII(), count) == 0);
@@ -1536,7 +1536,7 @@ BOOL SString::Match(const CIterator &i, const SString &s) const
     switch (GetRepresentation())
     {
     case REPRESENTATION_UNICODE:
-        RETURN (wcsncmp(i.GetUnicode(), source.GetRawUnicode(), count) == 0);
+        RETURN (dn_wcsncmp(i.GetUnicode(), source.GetRawUnicode(), count) == 0);
 
     case REPRESENTATION_ASCII:
         RETURN (strncmp(i.GetASCII(), source.GetRawASCII(), count) == 0);

--- a/src/coreclr/utilcode/sstring_com.cpp
+++ b/src/coreclr/utilcode/sstring_com.cpp
@@ -83,7 +83,7 @@ HRESULT SString::LoadResourceAndReturnHR(CCompRC* pResourceDLL, CCompRC::Resourc
 
             if (SUCCEEDED(hr))
             {
-                Truncate(Begin() + (COUNT_T) dn_wcslen(GetRawUnicode()));
+                Truncate(Begin() + (COUNT_T) strlen_u16(GetRawUnicode()));
             }
 
             Normalize();

--- a/src/coreclr/utilcode/sstring_com.cpp
+++ b/src/coreclr/utilcode/sstring_com.cpp
@@ -83,7 +83,7 @@ HRESULT SString::LoadResourceAndReturnHR(CCompRC* pResourceDLL, CCompRC::Resourc
 
             if (SUCCEEDED(hr))
             {
-                Truncate(Begin() + (COUNT_T) strlen_u16(GetRawUnicode()));
+                Truncate(Begin() + (COUNT_T) u16_strlen(GetRawUnicode()));
             }
 
             Normalize();

--- a/src/coreclr/utilcode/sstring_com.cpp
+++ b/src/coreclr/utilcode/sstring_com.cpp
@@ -83,7 +83,7 @@ HRESULT SString::LoadResourceAndReturnHR(CCompRC* pResourceDLL, CCompRC::Resourc
 
             if (SUCCEEDED(hr))
             {
-                Truncate(Begin() + (COUNT_T) wcslen(GetRawUnicode()));
+                Truncate(Begin() + (COUNT_T) dn_wcslen(GetRawUnicode()));
             }
 
             Normalize();

--- a/src/coreclr/utilcode/stdafx.h
+++ b/src/coreclr/utilcode/stdafx.h
@@ -11,6 +11,7 @@
 
 #include <switches.h>
 #include <crtwrap.h>
+#include <dn-u16.h>
 
 #define IN_WINFIX_CPP
 

--- a/src/coreclr/utilcode/stresslog.cpp
+++ b/src/coreclr/utilcode/stresslog.cpp
@@ -149,7 +149,7 @@ void ReplacePid(LPCWSTR original, LPWSTR replaced, size_t replacedLength)
     // replace it by the PID of our process
     // only the first occurrence will be replaced
     const WCHAR* pidLit =  W("{pid}");
-    const WCHAR* pidPtr = strstr_u16(original, pidLit);
+    const WCHAR* pidPtr = u16_strstr(original, pidLit);
     if (pidPtr != nullptr)
     {
         // copy the file name up to the "{pid}" occurrence
@@ -163,11 +163,11 @@ void ReplacePid(LPCWSTR original, LPWSTR replaced, size_t replacedLength)
         wcscat_s(replaced, replacedLength, pidStr);
 
         // append the rest of the filename
-        wcscat_s(replaced, replacedLength, original + pidInx + strlen_u16(pidLit));
+        wcscat_s(replaced, replacedLength, original + pidInx + u16_strlen(pidLit));
     }
     else
     {
-        size_t originalLength = strlen_u16(original);
+        size_t originalLength = u16_strlen(original);
         wcsncpy_s(replaced, replacedLength, original, originalLength);
     }
 }

--- a/src/coreclr/utilcode/stresslog.cpp
+++ b/src/coreclr/utilcode/stresslog.cpp
@@ -163,11 +163,11 @@ void ReplacePid(LPCWSTR original, LPWSTR replaced, size_t replacedLength)
         wcscat_s(replaced, replacedLength, pidStr);
 
         // append the rest of the filename
-        wcscat_s(replaced, replacedLength, original + pidInx + wcslen(pidLit));
+        wcscat_s(replaced, replacedLength, original + pidInx + dn_wcslen(pidLit));
     }
     else
     {
-        size_t originalLength = wcslen(original);
+        size_t originalLength = dn_wcslen(original);
         wcsncpy_s(replaced, replacedLength, original, originalLength);
     }
 }

--- a/src/coreclr/utilcode/stresslog.cpp
+++ b/src/coreclr/utilcode/stresslog.cpp
@@ -149,7 +149,7 @@ void ReplacePid(LPCWSTR original, LPWSTR replaced, size_t replacedLength)
     // replace it by the PID of our process
     // only the first occurrence will be replaced
     const WCHAR* pidLit =  W("{pid}");
-    const WCHAR* pidPtr = wcsstr(original, pidLit);
+    const WCHAR* pidPtr = dn_wcsstr(original, pidLit);
     if (pidPtr != nullptr)
     {
         // copy the file name up to the "{pid}" occurrence

--- a/src/coreclr/utilcode/stresslog.cpp
+++ b/src/coreclr/utilcode/stresslog.cpp
@@ -149,7 +149,7 @@ void ReplacePid(LPCWSTR original, LPWSTR replaced, size_t replacedLength)
     // replace it by the PID of our process
     // only the first occurrence will be replaced
     const WCHAR* pidLit =  W("{pid}");
-    const WCHAR* pidPtr = dn_wcsstr(original, pidLit);
+    const WCHAR* pidPtr = strstr_u16(original, pidLit);
     if (pidPtr != nullptr)
     {
         // copy the file name up to the "{pid}" occurrence
@@ -163,11 +163,11 @@ void ReplacePid(LPCWSTR original, LPWSTR replaced, size_t replacedLength)
         wcscat_s(replaced, replacedLength, pidStr);
 
         // append the rest of the filename
-        wcscat_s(replaced, replacedLength, original + pidInx + dn_wcslen(pidLit));
+        wcscat_s(replaced, replacedLength, original + pidInx + strlen_u16(pidLit));
     }
     else
     {
-        size_t originalLength = dn_wcslen(original);
+        size_t originalLength = strlen_u16(original);
         wcsncpy_s(replaced, replacedLength, original, originalLength);
     }
 }

--- a/src/coreclr/utilcode/util.cpp
+++ b/src/coreclr/utilcode/util.cpp
@@ -2765,7 +2765,17 @@ namespace Reg
                 // be done using REG_MULTI_SZ - however this was tolerated in the
                 // past and so it would be a breaking change to stop doing so.
                 _ASSERTE(dn_wcslen(wszValueBuf) <= (size / sizeof(WCHAR)) - 1);
-                ssValue.CloseBuffer((COUNT_T)wcsnlen(wszValueBuf, (size_t)size));
+
+                // Compute the length of the string taking into account the there
+                // could be a double NULL we are trying to detect.
+                size_t n = 0;
+                while (n < (size_t)size && *wcs)
+                {
+                    n++;
+                    wcs++;
+                }
+
+                ssValue.CloseBuffer((COUNT_T)wcsnlen(wszValueBuf, n));
             }
             else
             {

--- a/src/coreclr/utilcode/util.cpp
+++ b/src/coreclr/utilcode/util.cpp
@@ -182,7 +182,7 @@ namespace
         if (phmodDll != nullptr)
             *phmodDll = nullptr;
 
-        bool fIsDllPathPrefix = (wszDllPath != nullptr) && (dn_wcslen(wszDllPath) > 0) && (wszDllPath[dn_wcslen(wszDllPath) - 1] == W('\\'));
+        bool fIsDllPathPrefix = (wszDllPath != nullptr) && (strlen_u16(wszDllPath) > 0) && (wszDllPath[strlen_u16(wszDllPath) - 1] == W('\\'));
 
         // - An empty string will be treated as NULL.
         // - A string ending will a backslash will be treated as a prefix for where to look for the DLL
@@ -2764,7 +2764,7 @@ namespace Reg
                 // terminating NULL is not a legitimate scenario for REG_SZ - this must
                 // be done using REG_MULTI_SZ - however this was tolerated in the
                 // past and so it would be a breaking change to stop doing so.
-                _ASSERTE(dn_wcslen(wszValueBuf) <= (size / sizeof(WCHAR)) - 1);
+                _ASSERTE(strlen_u16(wszValueBuf) <= (size / sizeof(WCHAR)) - 1);
                 ssValue.CloseBuffer((COUNT_T)wcsnlen(wszValueBuf, (size_t)size));
             }
             else

--- a/src/coreclr/utilcode/util.cpp
+++ b/src/coreclr/utilcode/util.cpp
@@ -182,7 +182,7 @@ namespace
         if (phmodDll != nullptr)
             *phmodDll = nullptr;
 
-        bool fIsDllPathPrefix = (wszDllPath != nullptr) && (wcslen(wszDllPath) > 0) && (wszDllPath[wcslen(wszDllPath) - 1] == W('\\'));
+        bool fIsDllPathPrefix = (wszDllPath != nullptr) && (dn_wcslen(wszDllPath) > 0) && (wszDllPath[dn_wcslen(wszDllPath) - 1] == W('\\'));
 
         // - An empty string will be treated as NULL.
         // - A string ending will a backslash will be treated as a prefix for where to look for the DLL
@@ -2764,7 +2764,7 @@ namespace Reg
                 // terminating NULL is not a legitimate scenario for REG_SZ - this must
                 // be done using REG_MULTI_SZ - however this was tolerated in the
                 // past and so it would be a breaking change to stop doing so.
-                _ASSERTE(wcslen(wszValueBuf) <= (size / sizeof(WCHAR)) - 1);
+                _ASSERTE(dn_wcslen(wszValueBuf) <= (size / sizeof(WCHAR)) - 1);
                 ssValue.CloseBuffer((COUNT_T)wcsnlen(wszValueBuf, (size_t)size));
             }
             else

--- a/src/coreclr/utilcode/util.cpp
+++ b/src/coreclr/utilcode/util.cpp
@@ -182,7 +182,7 @@ namespace
         if (phmodDll != nullptr)
             *phmodDll = nullptr;
 
-        bool fIsDllPathPrefix = (wszDllPath != nullptr) && (strlen_u16(wszDllPath) > 0) && (wszDllPath[strlen_u16(wszDllPath) - 1] == W('\\'));
+        bool fIsDllPathPrefix = (wszDllPath != nullptr) && (u16_strlen(wszDllPath) > 0) && (wszDllPath[u16_strlen(wszDllPath) - 1] == W('\\'));
 
         // - An empty string will be treated as NULL.
         // - A string ending will a backslash will be treated as a prefix for where to look for the DLL
@@ -2764,7 +2764,7 @@ namespace Reg
                 // terminating NULL is not a legitimate scenario for REG_SZ - this must
                 // be done using REG_MULTI_SZ - however this was tolerated in the
                 // past and so it would be a breaking change to stop doing so.
-                _ASSERTE(strlen_u16(wszValueBuf) <= (size / sizeof(WCHAR)) - 1);
+                _ASSERTE(u16_strlen(wszValueBuf) <= (size / sizeof(WCHAR)) - 1);
                 ssValue.CloseBuffer((COUNT_T)wcsnlen(wszValueBuf, (size_t)size));
             }
             else

--- a/src/coreclr/utilcode/util.cpp
+++ b/src/coreclr/utilcode/util.cpp
@@ -2765,17 +2765,7 @@ namespace Reg
                 // be done using REG_MULTI_SZ - however this was tolerated in the
                 // past and so it would be a breaking change to stop doing so.
                 _ASSERTE(dn_wcslen(wszValueBuf) <= (size / sizeof(WCHAR)) - 1);
-
-                // Compute the length of the string taking into account the there
-                // could be a double NULL we are trying to detect.
-                size_t n = 0;
-                while (n < (size_t)size && *wcs)
-                {
-                    n++;
-                    wcs++;
-                }
-
-                ssValue.CloseBuffer((COUNT_T)wcsnlen(wszValueBuf, n));
+                ssValue.CloseBuffer((COUNT_T)wcsnlen(wszValueBuf, (size_t)size));
             }
             else
             {

--- a/src/coreclr/utilcode/util_nodependencies.cpp
+++ b/src/coreclr/utilcode/util_nodependencies.cpp
@@ -621,7 +621,7 @@ LPCWSTRToGuid(
     // covering the 128-bit GUID. The string includes enclosing braces, which are an OLE convention.
 
     // Verify the surrounding syntax.
-    if (wcslen(szGuid) != 38 || szGuid[0] != '{' || szGuid[9] != '-' ||
+    if (dn_wcslen(szGuid) != 38 || szGuid[0] != '{' || szGuid[9] != '-' ||
         szGuid[14] != '-' || szGuid[19] != '-' || szGuid[24] != '-' || szGuid[37] != '}')
     {
         return FALSE;

--- a/src/coreclr/utilcode/util_nodependencies.cpp
+++ b/src/coreclr/utilcode/util_nodependencies.cpp
@@ -621,7 +621,7 @@ LPCWSTRToGuid(
     // covering the 128-bit GUID. The string includes enclosing braces, which are an OLE convention.
 
     // Verify the surrounding syntax.
-    if (strlen_u16(szGuid) != 38 || szGuid[0] != '{' || szGuid[9] != '-' ||
+    if (u16_strlen(szGuid) != 38 || szGuid[0] != '{' || szGuid[9] != '-' ||
         szGuid[14] != '-' || szGuid[19] != '-' || szGuid[24] != '-' || szGuid[37] != '}')
     {
         return FALSE;

--- a/src/coreclr/utilcode/util_nodependencies.cpp
+++ b/src/coreclr/utilcode/util_nodependencies.cpp
@@ -621,7 +621,7 @@ LPCWSTRToGuid(
     // covering the 128-bit GUID. The string includes enclosing braces, which are an OLE convention.
 
     // Verify the surrounding syntax.
-    if (dn_wcslen(szGuid) != 38 || szGuid[0] != '{' || szGuid[9] != '-' ||
+    if (strlen_u16(szGuid) != 38 || szGuid[0] != '{' || szGuid[9] != '-' ||
         szGuid[14] != '-' || szGuid[19] != '-' || szGuid[24] != '-' || szGuid[37] != '}')
     {
         return FALSE;

--- a/src/coreclr/utilcode/winfix.cpp
+++ b/src/coreclr/utilcode/winfix.cpp
@@ -151,7 +151,7 @@ WszCreateProcess(
     BOOL fResult;
     DWORD err;
     {
-        size_t commandLineLength = wcslen(lpCommandLine) + 1;
+        size_t commandLineLength = dn_wcslen(lpCommandLine) + 1;
         NewArrayHolder<WCHAR> nonConstCommandLine(new (nothrow) WCHAR[commandLineLength]);
         if (nonConstCommandLine == NULL)
         {

--- a/src/coreclr/utilcode/winfix.cpp
+++ b/src/coreclr/utilcode/winfix.cpp
@@ -151,7 +151,7 @@ WszCreateProcess(
     BOOL fResult;
     DWORD err;
     {
-        size_t commandLineLength = strlen_u16(lpCommandLine) + 1;
+        size_t commandLineLength = u16_strlen(lpCommandLine) + 1;
         NewArrayHolder<WCHAR> nonConstCommandLine(new (nothrow) WCHAR[commandLineLength]);
         if (nonConstCommandLine == NULL)
         {

--- a/src/coreclr/utilcode/winfix.cpp
+++ b/src/coreclr/utilcode/winfix.cpp
@@ -151,7 +151,7 @@ WszCreateProcess(
     BOOL fResult;
     DWORD err;
     {
-        size_t commandLineLength = dn_wcslen(lpCommandLine) + 1;
+        size_t commandLineLength = strlen_u16(lpCommandLine) + 1;
         NewArrayHolder<WCHAR> nonConstCommandLine(new (nothrow) WCHAR[commandLineLength]);
         if (nonConstCommandLine == NULL)
         {

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -3359,7 +3359,7 @@ void AppDomain::AddUnmanagedImageToCache(LPCWSTR libraryName, NATIVE_LIBRARY_HAN
         return;
     }
 
-    size_t len = (dn_wcslen(libraryName) + 1) * sizeof(WCHAR);
+    size_t len = (strlen_u16(libraryName) + 1) * sizeof(WCHAR);
     AllocMemHolder<WCHAR> copiedName(GetLowFrequencyHeap()->AllocMem(S_SIZE_T(len)));
     memcpy(copiedName, libraryName, len);
 

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -3359,7 +3359,7 @@ void AppDomain::AddUnmanagedImageToCache(LPCWSTR libraryName, NATIVE_LIBRARY_HAN
         return;
     }
 
-    size_t len = (strlen_u16(libraryName) + 1) * sizeof(WCHAR);
+    size_t len = (u16_strlen(libraryName) + 1) * sizeof(WCHAR);
     AllocMemHolder<WCHAR> copiedName(GetLowFrequencyHeap()->AllocMem(S_SIZE_T(len)));
     memcpy(copiedName, libraryName, len);
 

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -3359,7 +3359,7 @@ void AppDomain::AddUnmanagedImageToCache(LPCWSTR libraryName, NATIVE_LIBRARY_HAN
         return;
     }
 
-    size_t len = (wcslen(libraryName) + 1) * sizeof(WCHAR);
+    size_t len = (dn_wcslen(libraryName) + 1) * sizeof(WCHAR);
     AllocMemHolder<WCHAR> copiedName(GetLowFrequencyHeap()->AllocMem(S_SIZE_T(len)));
     memcpy(copiedName, libraryName, len);
 

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -2278,7 +2278,7 @@ private:
         using key_t = LPCWSTR;
         static const key_t GetKey(_In_ const element_t& e) { return e.Name; }
         static count_t Hash(_In_ key_t key) { return HashString(key); }
-        static bool Equals(_In_ key_t lhs, _In_ key_t rhs) { return strcmp_u16(lhs, rhs) == 0; }
+        static bool Equals(_In_ key_t lhs, _In_ key_t rhs) { return u16_strcmp(lhs, rhs) == 0; }
         static bool IsNull(_In_ const element_t& e) { return e.Handle == NULL; }
         static const element_t Null() { return UnmanagedImageCacheEntry(); }
     };

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -2278,7 +2278,7 @@ private:
         using key_t = LPCWSTR;
         static const key_t GetKey(_In_ const element_t& e) { return e.Name; }
         static count_t Hash(_In_ key_t key) { return HashString(key); }
-        static bool Equals(_In_ key_t lhs, _In_ key_t rhs) { return wcscmp(lhs, rhs) == 0; }
+        static bool Equals(_In_ key_t lhs, _In_ key_t rhs) { return dn_wcscmp(lhs, rhs) == 0; }
         static bool IsNull(_In_ const element_t& e) { return e.Handle == NULL; }
         static const element_t Null() { return UnmanagedImageCacheEntry(); }
     };

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -2278,7 +2278,7 @@ private:
         using key_t = LPCWSTR;
         static const key_t GetKey(_In_ const element_t& e) { return e.Name; }
         static count_t Hash(_In_ key_t key) { return HashString(key); }
-        static bool Equals(_In_ key_t lhs, _In_ key_t rhs) { return dn_wcscmp(lhs, rhs) == 0; }
+        static bool Equals(_In_ key_t lhs, _In_ key_t rhs) { return strcmp_u16(lhs, rhs) == 0; }
         static bool IsNull(_In_ const element_t& e) { return e.Handle == NULL; }
         static const element_t Null() { return UnmanagedImageCacheEntry(); }
     };

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -397,9 +397,9 @@ Assembly *Assembly::CreateDynamic(AssemblyBinder* pBinder, NativeAssemblyNamePar
         COMPlusThrow(kArgumentException, W("ArgumentNull_AssemblyNameName"));
 
     if (COMCharacter::nativeIsWhiteSpace(pAssemblyNameParts->_pName[0])
-        || dn_wcschr(pAssemblyNameParts->_pName, '\\') != NULL
-        || dn_wcschr(pAssemblyNameParts->_pName, ':') != NULL
-        || dn_wcschr(pAssemblyNameParts->_pName, '/') != NULL)
+        || strchr_u16(pAssemblyNameParts->_pName, '\\') != NULL
+        || strchr_u16(pAssemblyNameParts->_pName, ':') != NULL
+        || strchr_u16(pAssemblyNameParts->_pName, '/') != NULL)
     {
         COMPlusThrow(kArgumentException, W("InvalidAssemblyName"));
     }
@@ -1725,7 +1725,7 @@ BOOL Assembly::IsInstrumentedHelper()
     do
     {
         _ASSERTE(pCur[0] != W('\0'));
-        const WCHAR * pNextSpace = dn_wcschr(pCur, W(' '));
+        const WCHAR * pNextSpace = strchr_u16(pCur, W(' '));
         _ASSERTE(pNextSpace == NULL || pNextSpace[0] == W(' '));
 
         if (pCur != pNextSpace)

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -397,9 +397,9 @@ Assembly *Assembly::CreateDynamic(AssemblyBinder* pBinder, NativeAssemblyNamePar
         COMPlusThrow(kArgumentException, W("ArgumentNull_AssemblyNameName"));
 
     if (COMCharacter::nativeIsWhiteSpace(pAssemblyNameParts->_pName[0])
-        || wcschr(pAssemblyNameParts->_pName, '\\') != NULL
-        || wcschr(pAssemblyNameParts->_pName, ':') != NULL
-        || wcschr(pAssemblyNameParts->_pName, '/') != NULL)
+        || dn_wcschr(pAssemblyNameParts->_pName, '\\') != NULL
+        || dn_wcschr(pAssemblyNameParts->_pName, ':') != NULL
+        || dn_wcschr(pAssemblyNameParts->_pName, '/') != NULL)
     {
         COMPlusThrow(kArgumentException, W("InvalidAssemblyName"));
     }
@@ -1725,7 +1725,7 @@ BOOL Assembly::IsInstrumentedHelper()
     do
     {
         _ASSERTE(pCur[0] != W('\0'));
-        const WCHAR * pNextSpace = wcschr(pCur, W(' '));
+        const WCHAR * pNextSpace = dn_wcschr(pCur, W(' '));
         _ASSERTE(pNextSpace == NULL || pNextSpace[0] == W(' '));
 
         if (pCur != pNextSpace)

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -397,9 +397,9 @@ Assembly *Assembly::CreateDynamic(AssemblyBinder* pBinder, NativeAssemblyNamePar
         COMPlusThrow(kArgumentException, W("ArgumentNull_AssemblyNameName"));
 
     if (COMCharacter::nativeIsWhiteSpace(pAssemblyNameParts->_pName[0])
-        || strchr_u16(pAssemblyNameParts->_pName, '\\') != NULL
-        || strchr_u16(pAssemblyNameParts->_pName, ':') != NULL
-        || strchr_u16(pAssemblyNameParts->_pName, '/') != NULL)
+        || u16_strchr(pAssemblyNameParts->_pName, '\\') != NULL
+        || u16_strchr(pAssemblyNameParts->_pName, ':') != NULL
+        || u16_strchr(pAssemblyNameParts->_pName, '/') != NULL)
     {
         COMPlusThrow(kArgumentException, W("InvalidAssemblyName"));
     }
@@ -1725,7 +1725,7 @@ BOOL Assembly::IsInstrumentedHelper()
     do
     {
         _ASSERTE(pCur[0] != W('\0'));
-        const WCHAR * pNextSpace = strchr_u16(pCur, W(' '));
+        const WCHAR * pNextSpace = u16_strchr(pCur, W(' '));
         _ASSERTE(pNextSpace == NULL || pNextSpace[0] == W(' '));
 
         if (pCur != pNextSpace)

--- a/src/coreclr/vm/autotrace.cpp
+++ b/src/coreclr/vm/autotrace.cpp
@@ -50,7 +50,7 @@ void auto_trace_init()
 
         // Copy in the command - %s
         wcscpy_s(command, bufferLen, commandTextValue);
-        written += strlen_u16(commandTextValue);
+        written += u16_strlen(commandTextValue);
 
         // Append " -p "
         wcscat_s(command, bufferLen - written, flagFormat);

--- a/src/coreclr/vm/autotrace.cpp
+++ b/src/coreclr/vm/autotrace.cpp
@@ -50,7 +50,7 @@ void auto_trace_init()
 
         // Copy in the command - %s
         wcscpy_s(command, bufferLen, commandTextValue);
-        written += wcslen(commandTextValue);
+        written += dn_wcslen(commandTextValue);
 
         // Append " -p "
         wcscat_s(command, bufferLen - written, flagFormat);

--- a/src/coreclr/vm/autotrace.cpp
+++ b/src/coreclr/vm/autotrace.cpp
@@ -50,7 +50,7 @@ void auto_trace_init()
 
         // Copy in the command - %s
         wcscpy_s(command, bufferLen, commandTextValue);
-        written += dn_wcslen(commandTextValue);
+        written += strlen_u16(commandTextValue);
 
         // Append " -p "
         wcscat_s(command, bufferLen - written, flagFormat);

--- a/src/coreclr/vm/bundle.cpp
+++ b/src/coreclr/vm/bundle.cpp
@@ -67,7 +67,7 @@ BundleFileLocation Bundle::Probe(const SString& path, bool pathIsBundleRelative)
     if (!pathIsBundleRelative)
     {
 #ifdef TARGET_UNIX
-        if (strncmp_u16(m_basePath, path, m_basePath.GetCount()) == 0)
+        if (u16_strncmp(m_basePath, path, m_basePath.GetCount()) == 0)
 #else
         if (_wcsnicmp(m_basePath, path, m_basePath.GetCount()) == 0)
 #endif // TARGET_UNIX

--- a/src/coreclr/vm/bundle.cpp
+++ b/src/coreclr/vm/bundle.cpp
@@ -67,7 +67,7 @@ BundleFileLocation Bundle::Probe(const SString& path, bool pathIsBundleRelative)
     if (!pathIsBundleRelative)
     {
 #ifdef TARGET_UNIX
-        if (dn_wcsncmp(m_basePath, path, m_basePath.GetCount()) == 0)
+        if (strncmp_u16(m_basePath, path, m_basePath.GetCount()) == 0)
 #else
         if (_wcsnicmp(m_basePath, path, m_basePath.GetCount()) == 0)
 #endif // TARGET_UNIX

--- a/src/coreclr/vm/bundle.cpp
+++ b/src/coreclr/vm/bundle.cpp
@@ -55,7 +55,7 @@ BundleFileLocation Bundle::Probe(const SString& path, bool pathIsBundleRelative)
 
     BundleFileLocation loc;
 
-    // Skip over m_base_path, if any. For example: 
+    // Skip over m_base_path, if any. For example:
     //    Bundle.Probe("lib.dll") => m_probe("lib.dll")
     //    Bundle.Probe("path/to/exe/lib.dll") => m_probe("lib.dll")
     //    Bundle.Probe("path/to/exe/and/some/more/lib.dll") => m_probe("and/some/more/lib.dll")
@@ -67,7 +67,7 @@ BundleFileLocation Bundle::Probe(const SString& path, bool pathIsBundleRelative)
     if (!pathIsBundleRelative)
     {
 #ifdef TARGET_UNIX
-        if (wcsncmp(m_basePath, path, m_basePath.GetCount()) == 0)
+        if (dn_wcsncmp(m_basePath, path, m_basePath.GetCount()) == 0)
 #else
         if (_wcsnicmp(m_basePath, path, m_basePath.GetCount()) == 0)
 #endif // TARGET_UNIX

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -4419,7 +4419,7 @@ void Append_Next_Item(LPWSTR* ppCursor, SIZE_T* pRemainingLen, LPCWSTR pItem, bo
     SIZE_T remainingLen = *pRemainingLen;
 
     // Calculate the length of pItem
-    SIZE_T itemLen = dn_wcslen(pItem);
+    SIZE_T itemLen = strlen_u16(pItem);
 
     // Append pItem at pCursor
     wcscpy_s(pCursor, remainingLen, pItem);
@@ -4459,14 +4459,14 @@ void SaveManagedCommandLine(LPCWSTR pwzAssemblyPath, int argc, LPCWSTR *argv)
 #else
     // On UNIX, the PAL doesn't have the command line arguments, so we must build the command line.
     // osCommandLine contains the full path to the executable.
-    SIZE_T  commandLineLen = (dn_wcslen(osCommandLine) + 1);
+    SIZE_T  commandLineLen = (strlen_u16(osCommandLine) + 1);
 
     // We will append pwzAssemblyPath to the 'corerun' osCommandLine
-    commandLineLen += (dn_wcslen(pwzAssemblyPath) + 1);
+    commandLineLen += (strlen_u16(pwzAssemblyPath) + 1);
 
     for (int i = 0; i < argc; i++)
     {
-        commandLineLen += (dn_wcslen(argv[i]) + 1);
+        commandLineLen += (strlen_u16(argv[i]) + 1);
     }
     commandLineLen++;  // Add 1 for the null-termination
 

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -4419,7 +4419,7 @@ void Append_Next_Item(LPWSTR* ppCursor, SIZE_T* pRemainingLen, LPCWSTR pItem, bo
     SIZE_T remainingLen = *pRemainingLen;
 
     // Calculate the length of pItem
-    SIZE_T itemLen = strlen_u16(pItem);
+    SIZE_T itemLen = u16_strlen(pItem);
 
     // Append pItem at pCursor
     wcscpy_s(pCursor, remainingLen, pItem);
@@ -4459,14 +4459,14 @@ void SaveManagedCommandLine(LPCWSTR pwzAssemblyPath, int argc, LPCWSTR *argv)
 #else
     // On UNIX, the PAL doesn't have the command line arguments, so we must build the command line.
     // osCommandLine contains the full path to the executable.
-    SIZE_T  commandLineLen = (strlen_u16(osCommandLine) + 1);
+    SIZE_T  commandLineLen = (u16_strlen(osCommandLine) + 1);
 
     // We will append pwzAssemblyPath to the 'corerun' osCommandLine
-    commandLineLen += (strlen_u16(pwzAssemblyPath) + 1);
+    commandLineLen += (u16_strlen(pwzAssemblyPath) + 1);
 
     for (int i = 0; i < argc; i++)
     {
-        commandLineLen += (strlen_u16(argv[i]) + 1);
+        commandLineLen += (u16_strlen(argv[i]) + 1);
     }
     commandLineLen++;  // Add 1 for the null-termination
 

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -4419,7 +4419,7 @@ void Append_Next_Item(LPWSTR* ppCursor, SIZE_T* pRemainingLen, LPCWSTR pItem, bo
     SIZE_T remainingLen = *pRemainingLen;
 
     // Calculate the length of pItem
-    SIZE_T itemLen = wcslen(pItem);
+    SIZE_T itemLen = dn_wcslen(pItem);
 
     // Append pItem at pCursor
     wcscpy_s(pCursor, remainingLen, pItem);
@@ -4459,14 +4459,14 @@ void SaveManagedCommandLine(LPCWSTR pwzAssemblyPath, int argc, LPCWSTR *argv)
 #else
     // On UNIX, the PAL doesn't have the command line arguments, so we must build the command line.
     // osCommandLine contains the full path to the executable.
-    SIZE_T  commandLineLen = (wcslen(osCommandLine) + 1);
+    SIZE_T  commandLineLen = (dn_wcslen(osCommandLine) + 1);
 
     // We will append pwzAssemblyPath to the 'corerun' osCommandLine
-    commandLineLen += (wcslen(pwzAssemblyPath) + 1);
+    commandLineLen += (dn_wcslen(pwzAssemblyPath) + 1);
 
     for (int i = 0; i < argc; i++)
     {
-        commandLineLen += (wcslen(argv[i]) + 1);
+        commandLineLen += (dn_wcslen(argv[i]) + 1);
     }
     commandLineLen++;  // Add 1 for the null-termination
 

--- a/src/coreclr/vm/commodule.cpp
+++ b/src/coreclr/vm/commodule.cpp
@@ -618,7 +618,7 @@ static void ReplaceNiExtension(SString& fileName, PCWSTR pwzOldSuffix, PCWSTR pw
 
     if (fileName.EndsWithCaseInsensitive(pwzOldSuffix))
     {
-        COUNT_T oldSuffixLen = (COUNT_T)wcslen(pwzOldSuffix);
+        COUNT_T oldSuffixLen = (COUNT_T)dn_wcslen(pwzOldSuffix);
         fileName.Replace(fileName.End() - oldSuffixLen, oldSuffixLen, pwzNewSuffix);
     }
 }

--- a/src/coreclr/vm/commodule.cpp
+++ b/src/coreclr/vm/commodule.cpp
@@ -618,7 +618,7 @@ static void ReplaceNiExtension(SString& fileName, PCWSTR pwzOldSuffix, PCWSTR pw
 
     if (fileName.EndsWithCaseInsensitive(pwzOldSuffix))
     {
-        COUNT_T oldSuffixLen = (COUNT_T)dn_wcslen(pwzOldSuffix);
+        COUNT_T oldSuffixLen = (COUNT_T)strlen_u16(pwzOldSuffix);
         fileName.Replace(fileName.End() - oldSuffixLen, oldSuffixLen, pwzNewSuffix);
     }
 }

--- a/src/coreclr/vm/commodule.cpp
+++ b/src/coreclr/vm/commodule.cpp
@@ -618,7 +618,7 @@ static void ReplaceNiExtension(SString& fileName, PCWSTR pwzOldSuffix, PCWSTR pw
 
     if (fileName.EndsWithCaseInsensitive(pwzOldSuffix))
     {
-        COUNT_T oldSuffixLen = (COUNT_T)strlen_u16(pwzOldSuffix);
+        COUNT_T oldSuffixLen = (COUNT_T)u16_strlen(pwzOldSuffix);
         fileName.Replace(fileName.End() - oldSuffixLen, oldSuffixLen, pwzNewSuffix);
     }
 }

--- a/src/coreclr/vm/commtmemberinfomap.cpp
+++ b/src/coreclr/vm/commtmemberinfomap.cpp
@@ -332,7 +332,7 @@ void ComMTMemberInfoMap::SetupPropsForIClassX(size_t sizeOfPtr)
 
             IfFailThrow(pField->GetMDImport()->GetNameOfFieldDef(pField->GetMemberDef(), &pszName));
             IfFailThrow(Utf2Quick(pszName, rName));
-            ULONG cchpName = ((int)wcslen(rName.Ptr())) + 1;
+            ULONG cchpName = ((int)dn_wcslen(rName.Ptr())) + 1;
             m_MethodProps[i].pName = reinterpret_cast<WCHAR*>(m_sNames.Alloc(cchpName * sizeof(WCHAR)));
 
             m_MethodProps[i].pMeth = (MethodDesc*)pFieldMeth;
@@ -451,12 +451,12 @@ UnLink:
             WCHAR *pNewName;
             //string length + "get" + null terminator.
             //XXX Fri 11/19/2004 Why is this + 4 rather than +3?
-            ULONG cchpNewName = ((int)wcslen(m_MethodProps[ixGet].pName)) + 4 + 1;
+            ULONG cchpNewName = ((int)dn_wcslen(m_MethodProps[ixGet].pName)) + 4 + 1;
             pNewName = reinterpret_cast<WCHAR*>(m_sNames.Alloc(cchpNewName * sizeof(WCHAR)));
             wcscpy_s(pNewName, cchpNewName, W("get"));
             wcscat_s(pNewName, cchpNewName, m_MethodProps[ixGet].pName);
             m_MethodProps[ixGet].pName = pNewName;
-            pNewName = reinterpret_cast<WCHAR*>(m_sNames.Alloc((int)((4+wcslen(m_MethodProps[ixSet].pName))*sizeof(WCHAR)+2)));
+            pNewName = reinterpret_cast<WCHAR*>(m_sNames.Alloc((int)((4+dn_wcslen(m_MethodProps[ixSet].pName))*sizeof(WCHAR)+2)));
             wcscpy_s(pNewName, cchpNewName, W("set"));
             wcscat_s(pNewName, cchpNewName, m_MethodProps[ixSet].pName);
             m_MethodProps[ixSet].pName = pNewName;
@@ -775,7 +775,7 @@ void ComMTMemberInfoMap::GetMethodPropsForMeth(
             }
         }
 
-        ULONG len = ((int)wcslen(pName)) + 1;
+        ULONG len = ((int)dn_wcslen(pName)) + 1;
         rProps[ix].pName = reinterpret_cast<WCHAR*>(sNames.Alloc(len * sizeof(WCHAR)));
         if (rProps[ix].pName == NULL)
         {
@@ -896,7 +896,7 @@ void ComMTMemberInfoMap::EliminateDuplicateNames(
             if (bDup)
             {
                 // Duplicate.
-                DWORD cchName = (DWORD) wcslen(rProps[iCur].pName);
+                DWORD cchName = (DWORD) dn_wcslen(rProps[iCur].pName);
                 if (cchName > MAX_CLASSNAME_LENGTH-cchDuplicateDecoration)
                     cchName = MAX_CLASSNAME_LENGTH-cchDuplicateDecoration;
 
@@ -925,7 +925,7 @@ void ComMTMemberInfoMap::EliminateDuplicateNames(
                 }
 
                 // Remember the new name.
-                ULONG len = ((int)wcslen(rcName)) + 1;
+                ULONG len = ((int)dn_wcslen(rcName)) + 1;
                 rProps[iCur].pName = reinterpret_cast<WCHAR*>(sNames.Alloc(len * sizeof(WCHAR)));
                 if (rProps[iCur].pName == NULL)
                 {
@@ -989,7 +989,7 @@ void ComMTMemberInfoMap::EliminateDuplicateNames(
             iCur = piTable[i];
 
             // Copy name into local buffer
-            DWORD cchName = (DWORD) wcslen(rProps[iCur].pName);
+            DWORD cchName = (DWORD) dn_wcslen(rProps[iCur].pName);
             if (cchName > MAX_CLASSNAME_LENGTH-cchDuplicateDecoration)
                 cchName = MAX_CLASSNAME_LENGTH-cchDuplicateDecoration;
 
@@ -1007,7 +1007,7 @@ void ComMTMemberInfoMap::EliminateDuplicateNames(
             } while (htNames.Find(rcName) != NULL);
 
             // Now rcName has an acceptable (unique) name.  Remember the new name.
-            ULONG len = ((int)wcslen(rcName)) + 1;
+            ULONG len = ((int)dn_wcslen(rcName)) + 1;
             rProps[iCur].pName = reinterpret_cast<WCHAR*>(sNames.Alloc(len * sizeof(WCHAR)));
             if (rProps[iCur].pName == NULL)
             {

--- a/src/coreclr/vm/commtmemberinfomap.cpp
+++ b/src/coreclr/vm/commtmemberinfomap.cpp
@@ -332,7 +332,7 @@ void ComMTMemberInfoMap::SetupPropsForIClassX(size_t sizeOfPtr)
 
             IfFailThrow(pField->GetMDImport()->GetNameOfFieldDef(pField->GetMemberDef(), &pszName));
             IfFailThrow(Utf2Quick(pszName, rName));
-            ULONG cchpName = ((int)dn_wcslen(rName.Ptr())) + 1;
+            ULONG cchpName = ((int)strlen_u16(rName.Ptr())) + 1;
             m_MethodProps[i].pName = reinterpret_cast<WCHAR*>(m_sNames.Alloc(cchpName * sizeof(WCHAR)));
 
             m_MethodProps[i].pMeth = (MethodDesc*)pFieldMeth;
@@ -451,12 +451,12 @@ UnLink:
             WCHAR *pNewName;
             //string length + "get" + null terminator.
             //XXX Fri 11/19/2004 Why is this + 4 rather than +3?
-            ULONG cchpNewName = ((int)dn_wcslen(m_MethodProps[ixGet].pName)) + 4 + 1;
+            ULONG cchpNewName = ((int)strlen_u16(m_MethodProps[ixGet].pName)) + 4 + 1;
             pNewName = reinterpret_cast<WCHAR*>(m_sNames.Alloc(cchpNewName * sizeof(WCHAR)));
             wcscpy_s(pNewName, cchpNewName, W("get"));
             wcscat_s(pNewName, cchpNewName, m_MethodProps[ixGet].pName);
             m_MethodProps[ixGet].pName = pNewName;
-            pNewName = reinterpret_cast<WCHAR*>(m_sNames.Alloc((int)((4+dn_wcslen(m_MethodProps[ixSet].pName))*sizeof(WCHAR)+2)));
+            pNewName = reinterpret_cast<WCHAR*>(m_sNames.Alloc((int)((4+strlen_u16(m_MethodProps[ixSet].pName))*sizeof(WCHAR)+2)));
             wcscpy_s(pNewName, cchpNewName, W("set"));
             wcscat_s(pNewName, cchpNewName, m_MethodProps[ixSet].pName);
             m_MethodProps[ixSet].pName = pNewName;
@@ -775,7 +775,7 @@ void ComMTMemberInfoMap::GetMethodPropsForMeth(
             }
         }
 
-        ULONG len = ((int)dn_wcslen(pName)) + 1;
+        ULONG len = ((int)strlen_u16(pName)) + 1;
         rProps[ix].pName = reinterpret_cast<WCHAR*>(sNames.Alloc(len * sizeof(WCHAR)));
         if (rProps[ix].pName == NULL)
         {
@@ -896,7 +896,7 @@ void ComMTMemberInfoMap::EliminateDuplicateNames(
             if (bDup)
             {
                 // Duplicate.
-                DWORD cchName = (DWORD) dn_wcslen(rProps[iCur].pName);
+                DWORD cchName = (DWORD) strlen_u16(rProps[iCur].pName);
                 if (cchName > MAX_CLASSNAME_LENGTH-cchDuplicateDecoration)
                     cchName = MAX_CLASSNAME_LENGTH-cchDuplicateDecoration;
 
@@ -925,7 +925,7 @@ void ComMTMemberInfoMap::EliminateDuplicateNames(
                 }
 
                 // Remember the new name.
-                ULONG len = ((int)dn_wcslen(rcName)) + 1;
+                ULONG len = ((int)strlen_u16(rcName)) + 1;
                 rProps[iCur].pName = reinterpret_cast<WCHAR*>(sNames.Alloc(len * sizeof(WCHAR)));
                 if (rProps[iCur].pName == NULL)
                 {
@@ -989,7 +989,7 @@ void ComMTMemberInfoMap::EliminateDuplicateNames(
             iCur = piTable[i];
 
             // Copy name into local buffer
-            DWORD cchName = (DWORD) dn_wcslen(rProps[iCur].pName);
+            DWORD cchName = (DWORD) strlen_u16(rProps[iCur].pName);
             if (cchName > MAX_CLASSNAME_LENGTH-cchDuplicateDecoration)
                 cchName = MAX_CLASSNAME_LENGTH-cchDuplicateDecoration;
 
@@ -1007,7 +1007,7 @@ void ComMTMemberInfoMap::EliminateDuplicateNames(
             } while (htNames.Find(rcName) != NULL);
 
             // Now rcName has an acceptable (unique) name.  Remember the new name.
-            ULONG len = ((int)dn_wcslen(rcName)) + 1;
+            ULONG len = ((int)strlen_u16(rcName)) + 1;
             rProps[iCur].pName = reinterpret_cast<WCHAR*>(sNames.Alloc(len * sizeof(WCHAR)));
             if (rProps[iCur].pName == NULL)
             {

--- a/src/coreclr/vm/commtmemberinfomap.cpp
+++ b/src/coreclr/vm/commtmemberinfomap.cpp
@@ -332,7 +332,7 @@ void ComMTMemberInfoMap::SetupPropsForIClassX(size_t sizeOfPtr)
 
             IfFailThrow(pField->GetMDImport()->GetNameOfFieldDef(pField->GetMemberDef(), &pszName));
             IfFailThrow(Utf2Quick(pszName, rName));
-            ULONG cchpName = ((int)strlen_u16(rName.Ptr())) + 1;
+            ULONG cchpName = ((int)u16_strlen(rName.Ptr())) + 1;
             m_MethodProps[i].pName = reinterpret_cast<WCHAR*>(m_sNames.Alloc(cchpName * sizeof(WCHAR)));
 
             m_MethodProps[i].pMeth = (MethodDesc*)pFieldMeth;
@@ -451,12 +451,12 @@ UnLink:
             WCHAR *pNewName;
             //string length + "get" + null terminator.
             //XXX Fri 11/19/2004 Why is this + 4 rather than +3?
-            ULONG cchpNewName = ((int)strlen_u16(m_MethodProps[ixGet].pName)) + 4 + 1;
+            ULONG cchpNewName = ((int)u16_strlen(m_MethodProps[ixGet].pName)) + 4 + 1;
             pNewName = reinterpret_cast<WCHAR*>(m_sNames.Alloc(cchpNewName * sizeof(WCHAR)));
             wcscpy_s(pNewName, cchpNewName, W("get"));
             wcscat_s(pNewName, cchpNewName, m_MethodProps[ixGet].pName);
             m_MethodProps[ixGet].pName = pNewName;
-            pNewName = reinterpret_cast<WCHAR*>(m_sNames.Alloc((int)((4+strlen_u16(m_MethodProps[ixSet].pName))*sizeof(WCHAR)+2)));
+            pNewName = reinterpret_cast<WCHAR*>(m_sNames.Alloc((int)((4+u16_strlen(m_MethodProps[ixSet].pName))*sizeof(WCHAR)+2)));
             wcscpy_s(pNewName, cchpNewName, W("set"));
             wcscat_s(pNewName, cchpNewName, m_MethodProps[ixSet].pName);
             m_MethodProps[ixSet].pName = pNewName;
@@ -775,7 +775,7 @@ void ComMTMemberInfoMap::GetMethodPropsForMeth(
             }
         }
 
-        ULONG len = ((int)strlen_u16(pName)) + 1;
+        ULONG len = ((int)u16_strlen(pName)) + 1;
         rProps[ix].pName = reinterpret_cast<WCHAR*>(sNames.Alloc(len * sizeof(WCHAR)));
         if (rProps[ix].pName == NULL)
         {
@@ -896,7 +896,7 @@ void ComMTMemberInfoMap::EliminateDuplicateNames(
             if (bDup)
             {
                 // Duplicate.
-                DWORD cchName = (DWORD) strlen_u16(rProps[iCur].pName);
+                DWORD cchName = (DWORD) u16_strlen(rProps[iCur].pName);
                 if (cchName > MAX_CLASSNAME_LENGTH-cchDuplicateDecoration)
                     cchName = MAX_CLASSNAME_LENGTH-cchDuplicateDecoration;
 
@@ -925,7 +925,7 @@ void ComMTMemberInfoMap::EliminateDuplicateNames(
                 }
 
                 // Remember the new name.
-                ULONG len = ((int)strlen_u16(rcName)) + 1;
+                ULONG len = ((int)u16_strlen(rcName)) + 1;
                 rProps[iCur].pName = reinterpret_cast<WCHAR*>(sNames.Alloc(len * sizeof(WCHAR)));
                 if (rProps[iCur].pName == NULL)
                 {
@@ -989,7 +989,7 @@ void ComMTMemberInfoMap::EliminateDuplicateNames(
             iCur = piTable[i];
 
             // Copy name into local buffer
-            DWORD cchName = (DWORD) strlen_u16(rProps[iCur].pName);
+            DWORD cchName = (DWORD) u16_strlen(rProps[iCur].pName);
             if (cchName > MAX_CLASSNAME_LENGTH-cchDuplicateDecoration)
                 cchName = MAX_CLASSNAME_LENGTH-cchDuplicateDecoration;
 
@@ -1007,7 +1007,7 @@ void ComMTMemberInfoMap::EliminateDuplicateNames(
             } while (htNames.Find(rcName) != NULL);
 
             // Now rcName has an acceptable (unique) name.  Remember the new name.
-            ULONG len = ((int)strlen_u16(rcName)) + 1;
+            ULONG len = ((int)u16_strlen(rcName)) + 1;
             rProps[iCur].pName = reinterpret_cast<WCHAR*>(sNames.Alloc(len * sizeof(WCHAR)));
             if (rProps[iCur].pName == NULL)
             {

--- a/src/coreclr/vm/comreflectioncache.hpp
+++ b/src/coreclr/vm/comreflectioncache.hpp
@@ -223,7 +223,7 @@ struct DispIDCacheElement
     {
         LIMITED_METHOD_CONTRACT;
         return (pMT == var.pMT && strNameLength == var.strNameLength
-                && lcid == var.lcid && dn_wcscmp (strName, var.strName) == 0);
+                && lcid == var.lcid && strcmp_u16 (strName, var.strName) == 0);
     }
 
     DispIDCacheElement& operator= (const DispIDCacheElement& var)

--- a/src/coreclr/vm/comreflectioncache.hpp
+++ b/src/coreclr/vm/comreflectioncache.hpp
@@ -223,7 +223,7 @@ struct DispIDCacheElement
     {
         LIMITED_METHOD_CONTRACT;
         return (pMT == var.pMT && strNameLength == var.strNameLength
-                && lcid == var.lcid && strcmp_u16 (strName, var.strName) == 0);
+                && lcid == var.lcid && u16_strcmp (strName, var.strName) == 0);
     }
 
     DispIDCacheElement& operator= (const DispIDCacheElement& var)

--- a/src/coreclr/vm/comreflectioncache.hpp
+++ b/src/coreclr/vm/comreflectioncache.hpp
@@ -223,7 +223,7 @@ struct DispIDCacheElement
     {
         LIMITED_METHOD_CONTRACT;
         return (pMT == var.pMT && strNameLength == var.strNameLength
-                && lcid == var.lcid && wcscmp (strName, var.strName) == 0);
+                && lcid == var.lcid && dn_wcscmp (strName, var.strName) == 0);
     }
 
     DispIDCacheElement& operator= (const DispIDCacheElement& var)

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -846,7 +846,7 @@ DEFINE_METHOD(STRING,               CTORF_SBYTEPTR,         Ctor,               
 DEFINE_METHOD(STRING,               CTORF_SBYTEPTR_START_LEN, Ctor,                     SM_PtrSByt_Int_Int_RetStr)
 DEFINE_METHOD(STRING,               CTORF_SBYTEPTR_START_LEN_ENCODING, Ctor,            SM_PtrSByt_Int_Int_Encoding_RetStr)
 DEFINE_METHOD(STRING,               INTERNAL_COPY,          InternalCopy,               SM_Str_IntPtr_Int_RetVoid)
-DEFINE_METHOD(STRING,               WCSLEN,                 wcslen,                     SM_PtrChar_RetInt)
+DEFINE_METHOD(STRING,               WCSLEN,                 dn_wcslen,                     SM_PtrChar_RetInt)
 DEFINE_METHOD(STRING,               STRLEN,                 strlen,                     SM_PtrByte_RetInt)
 DEFINE_PROPERTY(STRING,             LENGTH,                 Length,                     Int)
 

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -846,7 +846,7 @@ DEFINE_METHOD(STRING,               CTORF_SBYTEPTR,         Ctor,               
 DEFINE_METHOD(STRING,               CTORF_SBYTEPTR_START_LEN, Ctor,                     SM_PtrSByt_Int_Int_RetStr)
 DEFINE_METHOD(STRING,               CTORF_SBYTEPTR_START_LEN_ENCODING, Ctor,            SM_PtrSByt_Int_Int_Encoding_RetStr)
 DEFINE_METHOD(STRING,               INTERNAL_COPY,          InternalCopy,               SM_Str_IntPtr_Int_RetVoid)
-DEFINE_METHOD(STRING,               WCSLEN,                 dn_wcslen,                     SM_PtrChar_RetInt)
+DEFINE_METHOD(STRING,               WCSLEN,                 wcslen,                     SM_PtrChar_RetInt)
 DEFINE_METHOD(STRING,               STRLEN,                 strlen,                     SM_PtrByte_RetInt)
 DEFINE_PROPERTY(STRING,             LENGTH,                 Length,                     Int)
 

--- a/src/coreclr/vm/corhost.cpp
+++ b/src/coreclr/vm/corhost.cpp
@@ -582,33 +582,33 @@ HRESULT CorHost2::CreateAppDomainWithManager(
 
     for (int i = 0; i < nProperties; i++)
     {
-        if (strcmp_u16(pPropertyNames[i], _T(HOST_PROPERTY_NATIVE_DLL_SEARCH_DIRECTORIES)) == 0)
+        if (u16_strcmp(pPropertyNames[i], _T(HOST_PROPERTY_NATIVE_DLL_SEARCH_DIRECTORIES)) == 0)
         {
             pwzNativeDllSearchDirectories = pPropertyValues[i];
         }
         else
-        if (strcmp_u16(pPropertyNames[i], _T(HOST_PROPERTY_TRUSTED_PLATFORM_ASSEMBLIES)) == 0)
+        if (u16_strcmp(pPropertyNames[i], _T(HOST_PROPERTY_TRUSTED_PLATFORM_ASSEMBLIES)) == 0)
         {
             pwzTrustedPlatformAssemblies = pPropertyValues[i];
         }
         else
-        if (strcmp_u16(pPropertyNames[i], _T(HOST_PROPERTY_PLATFORM_RESOURCE_ROOTS)) == 0)
+        if (u16_strcmp(pPropertyNames[i], _T(HOST_PROPERTY_PLATFORM_RESOURCE_ROOTS)) == 0)
         {
             pwzPlatformResourceRoots = pPropertyValues[i];
         }
         else
-        if (strcmp_u16(pPropertyNames[i], _T(HOST_PROPERTY_APP_PATHS)) == 0)
+        if (u16_strcmp(pPropertyNames[i], _T(HOST_PROPERTY_APP_PATHS)) == 0)
         {
             pwzAppPaths = pPropertyValues[i];
         }
         else
-        if (strcmp_u16(pPropertyNames[i], W("DEFAULT_STACK_SIZE")) == 0)
+        if (u16_strcmp(pPropertyNames[i], W("DEFAULT_STACK_SIZE")) == 0)
         {
             extern void ParseDefaultStackSize(LPCWSTR value);
             ParseDefaultStackSize(pPropertyValues[i]);
         }
         else
-        if (strcmp_u16(pPropertyNames[i], W("USE_ENTRYPOINT_FILTER")) == 0)
+        if (u16_strcmp(pPropertyNames[i], W("USE_ENTRYPOINT_FILTER")) == 0)
         {
             extern void ParseUseEntryPointFilter(LPCWSTR value);
             ParseUseEntryPointFilter(pPropertyValues[i]);

--- a/src/coreclr/vm/corhost.cpp
+++ b/src/coreclr/vm/corhost.cpp
@@ -582,33 +582,33 @@ HRESULT CorHost2::CreateAppDomainWithManager(
 
     for (int i = 0; i < nProperties; i++)
     {
-        if (wcscmp(pPropertyNames[i], _T(HOST_PROPERTY_NATIVE_DLL_SEARCH_DIRECTORIES)) == 0)
+        if (dn_wcscmp(pPropertyNames[i], _T(HOST_PROPERTY_NATIVE_DLL_SEARCH_DIRECTORIES)) == 0)
         {
             pwzNativeDllSearchDirectories = pPropertyValues[i];
         }
         else
-        if (wcscmp(pPropertyNames[i], _T(HOST_PROPERTY_TRUSTED_PLATFORM_ASSEMBLIES)) == 0)
+        if (dn_wcscmp(pPropertyNames[i], _T(HOST_PROPERTY_TRUSTED_PLATFORM_ASSEMBLIES)) == 0)
         {
             pwzTrustedPlatformAssemblies = pPropertyValues[i];
         }
         else
-        if (wcscmp(pPropertyNames[i], _T(HOST_PROPERTY_PLATFORM_RESOURCE_ROOTS)) == 0)
+        if (dn_wcscmp(pPropertyNames[i], _T(HOST_PROPERTY_PLATFORM_RESOURCE_ROOTS)) == 0)
         {
             pwzPlatformResourceRoots = pPropertyValues[i];
         }
         else
-        if (wcscmp(pPropertyNames[i], _T(HOST_PROPERTY_APP_PATHS)) == 0)
+        if (dn_wcscmp(pPropertyNames[i], _T(HOST_PROPERTY_APP_PATHS)) == 0)
         {
             pwzAppPaths = pPropertyValues[i];
         }
         else
-        if (wcscmp(pPropertyNames[i], W("DEFAULT_STACK_SIZE")) == 0)
+        if (dn_wcscmp(pPropertyNames[i], W("DEFAULT_STACK_SIZE")) == 0)
         {
             extern void ParseDefaultStackSize(LPCWSTR value);
             ParseDefaultStackSize(pPropertyValues[i]);
         }
         else
-        if (wcscmp(pPropertyNames[i], W("USE_ENTRYPOINT_FILTER")) == 0)
+        if (dn_wcscmp(pPropertyNames[i], W("USE_ENTRYPOINT_FILTER")) == 0)
         {
             extern void ParseUseEntryPointFilter(LPCWSTR value);
             ParseUseEntryPointFilter(pPropertyValues[i]);

--- a/src/coreclr/vm/corhost.cpp
+++ b/src/coreclr/vm/corhost.cpp
@@ -582,33 +582,33 @@ HRESULT CorHost2::CreateAppDomainWithManager(
 
     for (int i = 0; i < nProperties; i++)
     {
-        if (dn_wcscmp(pPropertyNames[i], _T(HOST_PROPERTY_NATIVE_DLL_SEARCH_DIRECTORIES)) == 0)
+        if (strcmp_u16(pPropertyNames[i], _T(HOST_PROPERTY_NATIVE_DLL_SEARCH_DIRECTORIES)) == 0)
         {
             pwzNativeDllSearchDirectories = pPropertyValues[i];
         }
         else
-        if (dn_wcscmp(pPropertyNames[i], _T(HOST_PROPERTY_TRUSTED_PLATFORM_ASSEMBLIES)) == 0)
+        if (strcmp_u16(pPropertyNames[i], _T(HOST_PROPERTY_TRUSTED_PLATFORM_ASSEMBLIES)) == 0)
         {
             pwzTrustedPlatformAssemblies = pPropertyValues[i];
         }
         else
-        if (dn_wcscmp(pPropertyNames[i], _T(HOST_PROPERTY_PLATFORM_RESOURCE_ROOTS)) == 0)
+        if (strcmp_u16(pPropertyNames[i], _T(HOST_PROPERTY_PLATFORM_RESOURCE_ROOTS)) == 0)
         {
             pwzPlatformResourceRoots = pPropertyValues[i];
         }
         else
-        if (dn_wcscmp(pPropertyNames[i], _T(HOST_PROPERTY_APP_PATHS)) == 0)
+        if (strcmp_u16(pPropertyNames[i], _T(HOST_PROPERTY_APP_PATHS)) == 0)
         {
             pwzAppPaths = pPropertyValues[i];
         }
         else
-        if (dn_wcscmp(pPropertyNames[i], W("DEFAULT_STACK_SIZE")) == 0)
+        if (strcmp_u16(pPropertyNames[i], W("DEFAULT_STACK_SIZE")) == 0)
         {
             extern void ParseDefaultStackSize(LPCWSTR value);
             ParseDefaultStackSize(pPropertyValues[i]);
         }
         else
-        if (dn_wcscmp(pPropertyNames[i], W("USE_ENTRYPOINT_FILTER")) == 0)
+        if (strcmp_u16(pPropertyNames[i], W("USE_ENTRYPOINT_FILTER")) == 0)
         {
             extern void ParseUseEntryPointFilter(LPCWSTR value);
             ParseUseEntryPointFilter(pPropertyValues[i]);

--- a/src/coreclr/vm/debugdebugger.cpp
+++ b/src/coreclr/vm/debugdebugger.cpp
@@ -268,7 +268,7 @@ extern "C" void QCALLTYPE DebugDebugger_Log(INT32 Level, PCWSTR pwzModule, PCWST
             if (pwzModule != NULL)
             {
                 // truncate if necessary
-                COUNT_T iLen = (COUNT_T) dn_wcslen(pwzModule);
+                COUNT_T iLen = (COUNT_T) strlen_u16(pwzModule);
                 if (iLen > MAX_LOG_SWITCH_NAME_LEN)
                 {
                     iLen = MAX_LOG_SWITCH_NAME_LEN;
@@ -279,7 +279,7 @@ extern "C" void QCALLTYPE DebugDebugger_Log(INT32 Level, PCWSTR pwzModule, PCWST
             SString message;
             if (pwzMessage != NULL)
             {
-                message.Set(pwzMessage, (COUNT_T) dn_wcslen(pwzMessage));
+                message.Set(pwzMessage, (COUNT_T) strlen_u16(pwzMessage));
             }
 
             g_pDebugInterface->SendLogMessage (Level, &switchName, &message);

--- a/src/coreclr/vm/debugdebugger.cpp
+++ b/src/coreclr/vm/debugdebugger.cpp
@@ -268,7 +268,7 @@ extern "C" void QCALLTYPE DebugDebugger_Log(INT32 Level, PCWSTR pwzModule, PCWST
             if (pwzModule != NULL)
             {
                 // truncate if necessary
-                COUNT_T iLen = (COUNT_T) wcslen(pwzModule);
+                COUNT_T iLen = (COUNT_T) dn_wcslen(pwzModule);
                 if (iLen > MAX_LOG_SWITCH_NAME_LEN)
                 {
                     iLen = MAX_LOG_SWITCH_NAME_LEN;
@@ -279,7 +279,7 @@ extern "C" void QCALLTYPE DebugDebugger_Log(INT32 Level, PCWSTR pwzModule, PCWST
             SString message;
             if (pwzMessage != NULL)
             {
-                message.Set(pwzMessage, (COUNT_T) wcslen(pwzMessage));
+                message.Set(pwzMessage, (COUNT_T) dn_wcslen(pwzMessage));
             }
 
             g_pDebugInterface->SendLogMessage (Level, &switchName, &message);

--- a/src/coreclr/vm/debugdebugger.cpp
+++ b/src/coreclr/vm/debugdebugger.cpp
@@ -268,7 +268,7 @@ extern "C" void QCALLTYPE DebugDebugger_Log(INT32 Level, PCWSTR pwzModule, PCWST
             if (pwzModule != NULL)
             {
                 // truncate if necessary
-                COUNT_T iLen = (COUNT_T) strlen_u16(pwzModule);
+                COUNT_T iLen = (COUNT_T) u16_strlen(pwzModule);
                 if (iLen > MAX_LOG_SWITCH_NAME_LEN)
                 {
                     iLen = MAX_LOG_SWITCH_NAME_LEN;
@@ -279,7 +279,7 @@ extern "C" void QCALLTYPE DebugDebugger_Log(INT32 Level, PCWSTR pwzModule, PCWST
             SString message;
             if (pwzMessage != NULL)
             {
-                message.Set(pwzMessage, (COUNT_T) strlen_u16(pwzMessage));
+                message.Set(pwzMessage, (COUNT_T) u16_strlen(pwzMessage));
             }
 
             g_pDebugInterface->SendLogMessage (Level, &switchName, &message);

--- a/src/coreclr/vm/dispatchinfo.cpp
+++ b/src/coreclr/vm/dispatchinfo.cpp
@@ -225,7 +225,7 @@ HRESULT DispatchMemberInfo::GetIDsOfParameters(_In_reads_(NumNames) WCHAR **astr
         aDispIds[cNames] = DISPID_UNKNOWN;
 
     // Retrieve the appropriate string comparation function.
-    UnicodeStringCompareFuncPtr StrCompFunc = bCaseSensitive ? dn_wcscmp : SString::_wcsicmp;
+    UnicodeStringCompareFuncPtr StrCompFunc = bCaseSensitive ? strcmp_u16 : SString::_wcsicmp;
 
     GCPROTECT_BEGIN(ParamArray)
     {
@@ -525,7 +525,7 @@ LPWSTR DispatchMemberInfo::GetMemberName(OBJECTREF MemberInfoObj, ComMTMemberInf
         // If we managed to get the member's properties then extract the name.
         if (pMemberProps)
         {
-            int MemberNameLen = (INT)dn_wcslen(pMemberProps->pName);
+            int MemberNameLen = (INT)strlen_u16(pMemberProps->pName);
             strMemberName = new WCHAR[MemberNameLen + 1];
 
             memcpy(strMemberName, pMemberProps->pName, (MemberNameLen + 1) * sizeof(WCHAR));

--- a/src/coreclr/vm/dispatchinfo.cpp
+++ b/src/coreclr/vm/dispatchinfo.cpp
@@ -225,7 +225,7 @@ HRESULT DispatchMemberInfo::GetIDsOfParameters(_In_reads_(NumNames) WCHAR **astr
         aDispIds[cNames] = DISPID_UNKNOWN;
 
     // Retrieve the appropriate string comparation function.
-    UnicodeStringCompareFuncPtr StrCompFunc = bCaseSensitive ? strcmp_u16 : SString::_wcsicmp;
+    UnicodeStringCompareFuncPtr StrCompFunc = bCaseSensitive ? u16_strcmp : SString::_wcsicmp;
 
     GCPROTECT_BEGIN(ParamArray)
     {
@@ -525,7 +525,7 @@ LPWSTR DispatchMemberInfo::GetMemberName(OBJECTREF MemberInfoObj, ComMTMemberInf
         // If we managed to get the member's properties then extract the name.
         if (pMemberProps)
         {
-            int MemberNameLen = (INT)strlen_u16(pMemberProps->pName);
+            int MemberNameLen = (INT)u16_strlen(pMemberProps->pName);
             strMemberName = new WCHAR[MemberNameLen + 1];
 
             memcpy(strMemberName, pMemberProps->pName, (MemberNameLen + 1) * sizeof(WCHAR));

--- a/src/coreclr/vm/dispatchinfo.cpp
+++ b/src/coreclr/vm/dispatchinfo.cpp
@@ -61,7 +61,7 @@ inline UPTR DispID2HashKey(DISPID DispID)
 }
 
 // Typedef for string comparison functions.
-typedef int (__cdecl *UnicodeStringCompareFuncPtr)(const WCHAR *, const WCHAR *);
+typedef int (*UnicodeStringCompareFuncPtr)(const WCHAR *, const WCHAR *);
 
 //--------------------------------------------------------------------------------
 // The DispatchMemberInfo class implementation.

--- a/src/coreclr/vm/dispatchinfo.cpp
+++ b/src/coreclr/vm/dispatchinfo.cpp
@@ -525,7 +525,7 @@ LPWSTR DispatchMemberInfo::GetMemberName(OBJECTREF MemberInfoObj, ComMTMemberInf
         // If we managed to get the member's properties then extract the name.
         if (pMemberProps)
         {
-            int MemberNameLen = (INT)wcslen(pMemberProps->pName);
+            int MemberNameLen = (INT)dn_wcslen(pMemberProps->pName);
             strMemberName = new WCHAR[MemberNameLen + 1];
 
             memcpy(strMemberName, pMemberProps->pName, (MemberNameLen + 1) * sizeof(WCHAR));

--- a/src/coreclr/vm/dispatchinfo.cpp
+++ b/src/coreclr/vm/dispatchinfo.cpp
@@ -225,7 +225,7 @@ HRESULT DispatchMemberInfo::GetIDsOfParameters(_In_reads_(NumNames) WCHAR **astr
         aDispIds[cNames] = DISPID_UNKNOWN;
 
     // Retrieve the appropriate string comparation function.
-    UnicodeStringCompareFuncPtr StrCompFunc = bCaseSensitive ? wcscmp : SString::_wcsicmp;
+    UnicodeStringCompareFuncPtr StrCompFunc = bCaseSensitive ? dn_wcscmp : SString::_wcsicmp;
 
     GCPROTECT_BEGIN(ParamArray)
     {

--- a/src/coreclr/vm/dwbucketmanager.hpp
+++ b/src/coreclr/vm/dwbucketmanager.hpp
@@ -64,7 +64,7 @@ DWORD GetCountBucketParamsForEvent(LPCWSTR wzEventName)
     DWORD countParams = kInvalidParamsCount;
     for (int index = 0; index < EndOfWerBucketTypes; ++index)
     {
-        if (dn_wcscmp(wzEventName, g_WerEventTraits[index].EventNameW) == 0)
+        if (strcmp_u16(wzEventName, g_WerEventTraits[index].EventNameW) == 0)
         {
             _ASSERTE(index == g_WerEventTraits[index].BucketType);
             countParams = g_WerEventTraits[index].CountParams;
@@ -454,7 +454,7 @@ void BaseBucketParamsManager::GetAppName(_Out_writes_(maxLength) WCHAR* targetPa
     if (GetCurrentModuleFileName(appPath) == S_OK)
     {
         // Get just the module name; remove the path
-        const WCHAR* appName = dn_wcsrchr(appPath, DIRECTORY_SEPARATOR_CHAR_W);
+        const WCHAR* appName = strrchr_u16(appPath, DIRECTORY_SEPARATOR_CHAR_W);
         appName = appName ? appName + 1 : appPath;
 
         CopyStringToBucket(targetParam, maxLength, appName);
@@ -1087,7 +1087,7 @@ int BaseBucketParamsManager::CopyStringToBucket(_Out_writes_(targetMaxLength) LP
         0
     };
 
-    int srcLen = static_cast<int>(dn_wcslen(pSource));
+    int srcLen = static_cast<int>(strlen_u16(pSource));
 
     // If the source contains unicode characters, they'll be encoded at 4 chars per char.
     int targLen = ContainsUnicodeChars(pSource) ? targetMaxLength / 4 : targetMaxLength;
@@ -1098,7 +1098,7 @@ int BaseBucketParamsManager::CopyStringToBucket(_Out_writes_(targetMaxLength) LP
         for (int i = 0; truncations[i]; ++i)
         {
             // how long is this suffix?
-            int slen = static_cast<int>(dn_wcslen(truncations[i]));
+            int slen = static_cast<int>(strlen_u16(truncations[i]));
 
             // Could the string have this suffix?
             if (slen < srcLen)
@@ -1129,7 +1129,7 @@ int BaseBucketParamsManager::CopyStringToBucket(_Out_writes_(targetMaxLength) LP
 
     // String didn't fit, so hash it.
     SHA1Hash hash;
-    hash.AddData(reinterpret_cast<BYTE*>(const_cast<LPWSTR>(pSource)), (static_cast<int>(dn_wcslen(pSource))) * sizeof(WCHAR));
+    hash.AddData(reinterpret_cast<BYTE*>(const_cast<LPWSTR>(pSource)), (static_cast<int>(strlen_u16(pSource))) * sizeof(WCHAR));
 
     // Encode in base32.  The hash is a fixed size; we'll accept up to maxLen characters of the encoding.
     BytesToBase32 b32(hash.GetHash(), SHA1_HASH_SIZE);

--- a/src/coreclr/vm/dwbucketmanager.hpp
+++ b/src/coreclr/vm/dwbucketmanager.hpp
@@ -454,7 +454,7 @@ void BaseBucketParamsManager::GetAppName(_Out_writes_(maxLength) WCHAR* targetPa
     if (GetCurrentModuleFileName(appPath) == S_OK)
     {
         // Get just the module name; remove the path
-        const WCHAR* appName = wcsrchr(appPath, DIRECTORY_SEPARATOR_CHAR_W);
+        const WCHAR* appName = dn_wcsrchr(appPath, DIRECTORY_SEPARATOR_CHAR_W);
         appName = appName ? appName + 1 : appPath;
 
         CopyStringToBucket(targetParam, maxLength, appName);

--- a/src/coreclr/vm/dwbucketmanager.hpp
+++ b/src/coreclr/vm/dwbucketmanager.hpp
@@ -1087,7 +1087,7 @@ int BaseBucketParamsManager::CopyStringToBucket(_Out_writes_(targetMaxLength) LP
         0
     };
 
-    int srcLen = static_cast<int>(wcslen(pSource));
+    int srcLen = static_cast<int>(dn_wcslen(pSource));
 
     // If the source contains unicode characters, they'll be encoded at 4 chars per char.
     int targLen = ContainsUnicodeChars(pSource) ? targetMaxLength / 4 : targetMaxLength;
@@ -1098,7 +1098,7 @@ int BaseBucketParamsManager::CopyStringToBucket(_Out_writes_(targetMaxLength) LP
         for (int i = 0; truncations[i]; ++i)
         {
             // how long is this suffix?
-            int slen = static_cast<int>(wcslen(truncations[i]));
+            int slen = static_cast<int>(dn_wcslen(truncations[i]));
 
             // Could the string have this suffix?
             if (slen < srcLen)
@@ -1129,7 +1129,7 @@ int BaseBucketParamsManager::CopyStringToBucket(_Out_writes_(targetMaxLength) LP
 
     // String didn't fit, so hash it.
     SHA1Hash hash;
-    hash.AddData(reinterpret_cast<BYTE*>(const_cast<LPWSTR>(pSource)), (static_cast<int>(wcslen(pSource))) * sizeof(WCHAR));
+    hash.AddData(reinterpret_cast<BYTE*>(const_cast<LPWSTR>(pSource)), (static_cast<int>(dn_wcslen(pSource))) * sizeof(WCHAR));
 
     // Encode in base32.  The hash is a fixed size; we'll accept up to maxLen characters of the encoding.
     BytesToBase32 b32(hash.GetHash(), SHA1_HASH_SIZE);

--- a/src/coreclr/vm/dwbucketmanager.hpp
+++ b/src/coreclr/vm/dwbucketmanager.hpp
@@ -64,7 +64,7 @@ DWORD GetCountBucketParamsForEvent(LPCWSTR wzEventName)
     DWORD countParams = kInvalidParamsCount;
     for (int index = 0; index < EndOfWerBucketTypes; ++index)
     {
-        if (strcmp_u16(wzEventName, g_WerEventTraits[index].EventNameW) == 0)
+        if (u16_strcmp(wzEventName, g_WerEventTraits[index].EventNameW) == 0)
         {
             _ASSERTE(index == g_WerEventTraits[index].BucketType);
             countParams = g_WerEventTraits[index].CountParams;
@@ -454,7 +454,7 @@ void BaseBucketParamsManager::GetAppName(_Out_writes_(maxLength) WCHAR* targetPa
     if (GetCurrentModuleFileName(appPath) == S_OK)
     {
         // Get just the module name; remove the path
-        const WCHAR* appName = strrchr_u16(appPath, DIRECTORY_SEPARATOR_CHAR_W);
+        const WCHAR* appName = u16_strrchr(appPath, DIRECTORY_SEPARATOR_CHAR_W);
         appName = appName ? appName + 1 : appPath;
 
         CopyStringToBucket(targetParam, maxLength, appName);
@@ -1087,7 +1087,7 @@ int BaseBucketParamsManager::CopyStringToBucket(_Out_writes_(targetMaxLength) LP
         0
     };
 
-    int srcLen = static_cast<int>(strlen_u16(pSource));
+    int srcLen = static_cast<int>(u16_strlen(pSource));
 
     // If the source contains unicode characters, they'll be encoded at 4 chars per char.
     int targLen = ContainsUnicodeChars(pSource) ? targetMaxLength / 4 : targetMaxLength;
@@ -1098,7 +1098,7 @@ int BaseBucketParamsManager::CopyStringToBucket(_Out_writes_(targetMaxLength) LP
         for (int i = 0; truncations[i]; ++i)
         {
             // how long is this suffix?
-            int slen = static_cast<int>(strlen_u16(truncations[i]));
+            int slen = static_cast<int>(u16_strlen(truncations[i]));
 
             // Could the string have this suffix?
             if (slen < srcLen)
@@ -1129,7 +1129,7 @@ int BaseBucketParamsManager::CopyStringToBucket(_Out_writes_(targetMaxLength) LP
 
     // String didn't fit, so hash it.
     SHA1Hash hash;
-    hash.AddData(reinterpret_cast<BYTE*>(const_cast<LPWSTR>(pSource)), (static_cast<int>(strlen_u16(pSource))) * sizeof(WCHAR));
+    hash.AddData(reinterpret_cast<BYTE*>(const_cast<LPWSTR>(pSource)), (static_cast<int>(u16_strlen(pSource))) * sizeof(WCHAR));
 
     // Encode in base32.  The hash is a fixed size; we'll accept up to maxLen characters of the encoding.
     BytesToBase32 b32(hash.GetHash(), SHA1_HASH_SIZE);

--- a/src/coreclr/vm/dwbucketmanager.hpp
+++ b/src/coreclr/vm/dwbucketmanager.hpp
@@ -64,7 +64,7 @@ DWORD GetCountBucketParamsForEvent(LPCWSTR wzEventName)
     DWORD countParams = kInvalidParamsCount;
     for (int index = 0; index < EndOfWerBucketTypes; ++index)
     {
-        if (wcscmp(wzEventName, g_WerEventTraits[index].EventNameW) == 0)
+        if (dn_wcscmp(wzEventName, g_WerEventTraits[index].EventNameW) == 0)
         {
             _ASSERTE(index == g_WerEventTraits[index].BucketType);
             countParams = g_WerEventTraits[index].CountParams;

--- a/src/coreclr/vm/dwreport.cpp
+++ b/src/coreclr/vm/dwreport.cpp
@@ -269,7 +269,7 @@ int DwGetAppDescription(                // Number of characters written.
     }
 
     // If the description is a single space, ignore it.
-    if (strcmp_u16(fileDescription, W(" ")) == 0)
+    if (u16_strcmp(fileDescription, W(" ")) == 0)
     {
         return 0;
     }
@@ -401,7 +401,7 @@ int DwGetAssemblyVersion(               // Number of characters written.
     }
 
     // If the assembly version is a single space, ignore it.
-    if (strcmp_u16(assemblyVersion, W(" ")) == 0)
+    if (u16_strcmp(assemblyVersion, W(" ")) == 0)
     {
         return 0;
     }

--- a/src/coreclr/vm/dwreport.cpp
+++ b/src/coreclr/vm/dwreport.cpp
@@ -269,7 +269,7 @@ int DwGetAppDescription(                // Number of characters written.
     }
 
     // If the description is a single space, ignore it.
-    if (dn_wcscmp(fileDescription, W(" ")) == 0)
+    if (strcmp_u16(fileDescription, W(" ")) == 0)
     {
         return 0;
     }
@@ -401,7 +401,7 @@ int DwGetAssemblyVersion(               // Number of characters written.
     }
 
     // If the assembly version is a single space, ignore it.
-    if (dn_wcscmp(assemblyVersion, W(" ")) == 0)
+    if (strcmp_u16(assemblyVersion, W(" ")) == 0)
     {
         return 0;
     }

--- a/src/coreclr/vm/dwreport.cpp
+++ b/src/coreclr/vm/dwreport.cpp
@@ -269,7 +269,7 @@ int DwGetAppDescription(                // Number of characters written.
     }
 
     // If the description is a single space, ignore it.
-    if (wcscmp(fileDescription, W(" ")) == 0)
+    if (dn_wcscmp(fileDescription, W(" ")) == 0)
     {
         return 0;
     }
@@ -401,7 +401,7 @@ int DwGetAssemblyVersion(               // Number of characters written.
     }
 
     // If the assembly version is a single space, ignore it.
-    if (wcscmp(assemblyVersion, W(" ")) == 0)
+    if (dn_wcscmp(assemblyVersion, W(" ")) == 0)
     {
         return 0;
     }

--- a/src/coreclr/vm/eeconfig.cpp
+++ b/src/coreclr/vm/eeconfig.cpp
@@ -629,7 +629,7 @@ HRESULT EEConfig::sync()
         if( str )
         {
             errno = 0;
-            iStartupDelayMS = wcstoul(str, &end, 10);
+            iStartupDelayMS = dn_wcstoul(str, &end, 10);
             if (errno == ERANGE || end == str)
                 iStartupDelayMS = 0;
         }

--- a/src/coreclr/vm/eeconfig.cpp
+++ b/src/coreclr/vm/eeconfig.cpp
@@ -388,7 +388,7 @@ HRESULT EEConfig::sync()
                 if (WszGetModuleFileName(NULL, wszFileName) != 0)
                 {
                     // just keep the name
-                    LPCWSTR pwszName = strrchr_u16(wszFileName, DIRECTORY_SEPARATOR_CHAR_W);
+                    LPCWSTR pwszName = u16_strrchr(wszFileName, DIRECTORY_SEPARATOR_CHAR_W);
                     pwszName = (pwszName == NULL) ? wszFileName.GetUnicode() : (pwszName + 1);
 
                     if (SString::_wcsicmp(pwszName,pszGCStressExe) == 0)
@@ -629,7 +629,7 @@ HRESULT EEConfig::sync()
         if( str )
         {
             errno = 0;
-            iStartupDelayMS = strtoul_u16(str, &end, 10);
+            iStartupDelayMS = u16_strtoul(str, &end, 10);
             if (errno == ERANGE || end == str)
                 iStartupDelayMS = 0;
         }

--- a/src/coreclr/vm/eeconfig.cpp
+++ b/src/coreclr/vm/eeconfig.cpp
@@ -388,7 +388,7 @@ HRESULT EEConfig::sync()
                 if (WszGetModuleFileName(NULL, wszFileName) != 0)
                 {
                     // just keep the name
-                    LPCWSTR pwszName = wcsrchr(wszFileName, DIRECTORY_SEPARATOR_CHAR_W);
+                    LPCWSTR pwszName = dn_wcsrchr(wszFileName, DIRECTORY_SEPARATOR_CHAR_W);
                     pwszName = (pwszName == NULL) ? wszFileName.GetUnicode() : (pwszName + 1);
 
                     if (SString::_wcsicmp(pwszName,pszGCStressExe) == 0)

--- a/src/coreclr/vm/eeconfig.cpp
+++ b/src/coreclr/vm/eeconfig.cpp
@@ -388,7 +388,7 @@ HRESULT EEConfig::sync()
                 if (WszGetModuleFileName(NULL, wszFileName) != 0)
                 {
                     // just keep the name
-                    LPCWSTR pwszName = dn_wcsrchr(wszFileName, DIRECTORY_SEPARATOR_CHAR_W);
+                    LPCWSTR pwszName = strrchr_u16(wszFileName, DIRECTORY_SEPARATOR_CHAR_W);
                     pwszName = (pwszName == NULL) ? wszFileName.GetUnicode() : (pwszName + 1);
 
                     if (SString::_wcsicmp(pwszName,pszGCStressExe) == 0)
@@ -629,7 +629,7 @@ HRESULT EEConfig::sync()
         if( str )
         {
             errno = 0;
-            iStartupDelayMS = dn_wcstoul(str, &end, 10);
+            iStartupDelayMS = strtoul_u16(str, &end, 10);
             if (errno == ERANGE || end == str)
                 iStartupDelayMS = 0;
         }

--- a/src/coreclr/vm/eehash.cpp
+++ b/src/coreclr/vm/eehash.cpp
@@ -362,7 +362,7 @@ EEHashEntry_t *EEClassFactoryInfoHashTableHelper::AllocateEntry(ClassFactoryInfo
     _ASSERTE(bDeepCopy && "Non deep copy is not supported by the EEComCompInfoHashTableHelper");
 
     if (pKey->m_strServerName)
-        cbStringLen = (S_SIZE_T(wcslen(pKey->m_strServerName)) + S_SIZE_T(1)) * S_SIZE_T(sizeof(WCHAR));
+        cbStringLen = (S_SIZE_T(dn_wcslen(pKey->m_strServerName)) + S_SIZE_T(1)) * S_SIZE_T(sizeof(WCHAR));
 
     S_SIZE_T cbEntry = S_SIZE_T(SIZEOF_EEHASH_ENTRY + sizeof(ClassFactoryInfo)) + cbStringLen;
 

--- a/src/coreclr/vm/eehash.cpp
+++ b/src/coreclr/vm/eehash.cpp
@@ -405,7 +405,7 @@ BOOL EEClassFactoryInfoHashTableHelper::CompareKeys(EEHashEntry_t *pEntry, Class
         return FALSE;
 
     // Finally do a string comparison of the server names.
-    return wcscmp(((ClassFactoryInfo*)pEntry->Key)->m_strServerName, pKey->m_strServerName) == 0;
+    return dn_wcscmp(((ClassFactoryInfo*)pEntry->Key)->m_strServerName, pKey->m_strServerName) == 0;
 }
 
 DWORD EEClassFactoryInfoHashTableHelper::Hash(ClassFactoryInfo *pKey)

--- a/src/coreclr/vm/eehash.cpp
+++ b/src/coreclr/vm/eehash.cpp
@@ -362,7 +362,7 @@ EEHashEntry_t *EEClassFactoryInfoHashTableHelper::AllocateEntry(ClassFactoryInfo
     _ASSERTE(bDeepCopy && "Non deep copy is not supported by the EEComCompInfoHashTableHelper");
 
     if (pKey->m_strServerName)
-        cbStringLen = (S_SIZE_T(strlen_u16(pKey->m_strServerName)) + S_SIZE_T(1)) * S_SIZE_T(sizeof(WCHAR));
+        cbStringLen = (S_SIZE_T(u16_strlen(pKey->m_strServerName)) + S_SIZE_T(1)) * S_SIZE_T(sizeof(WCHAR));
 
     S_SIZE_T cbEntry = S_SIZE_T(SIZEOF_EEHASH_ENTRY + sizeof(ClassFactoryInfo)) + cbStringLen;
 
@@ -405,7 +405,7 @@ BOOL EEClassFactoryInfoHashTableHelper::CompareKeys(EEHashEntry_t *pEntry, Class
         return FALSE;
 
     // Finally do a string comparison of the server names.
-    return strcmp_u16(((ClassFactoryInfo*)pEntry->Key)->m_strServerName, pKey->m_strServerName) == 0;
+    return u16_strcmp(((ClassFactoryInfo*)pEntry->Key)->m_strServerName, pKey->m_strServerName) == 0;
 }
 
 DWORD EEClassFactoryInfoHashTableHelper::Hash(ClassFactoryInfo *pKey)

--- a/src/coreclr/vm/eehash.cpp
+++ b/src/coreclr/vm/eehash.cpp
@@ -362,7 +362,7 @@ EEHashEntry_t *EEClassFactoryInfoHashTableHelper::AllocateEntry(ClassFactoryInfo
     _ASSERTE(bDeepCopy && "Non deep copy is not supported by the EEComCompInfoHashTableHelper");
 
     if (pKey->m_strServerName)
-        cbStringLen = (S_SIZE_T(dn_wcslen(pKey->m_strServerName)) + S_SIZE_T(1)) * S_SIZE_T(sizeof(WCHAR));
+        cbStringLen = (S_SIZE_T(strlen_u16(pKey->m_strServerName)) + S_SIZE_T(1)) * S_SIZE_T(sizeof(WCHAR));
 
     S_SIZE_T cbEntry = S_SIZE_T(SIZEOF_EEHASH_ENTRY + sizeof(ClassFactoryInfo)) + cbStringLen;
 
@@ -405,7 +405,7 @@ BOOL EEClassFactoryInfoHashTableHelper::CompareKeys(EEHashEntry_t *pEntry, Class
         return FALSE;
 
     // Finally do a string comparison of the server names.
-    return dn_wcscmp(((ClassFactoryInfo*)pEntry->Key)->m_strServerName, pKey->m_strServerName) == 0;
+    return strcmp_u16(((ClassFactoryInfo*)pEntry->Key)->m_strServerName, pKey->m_strServerName) == 0;
 }
 
 DWORD EEClassFactoryInfoHashTableHelper::Hash(ClassFactoryInfo *pKey)

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -1498,7 +1498,7 @@ ep_rt_utf16_string_len (const ep_char16_t *str)
 	STATIC_CONTRACT_NOTHROW;
 	EP_ASSERT (str != NULL);
 
-	return dn_wcslen (reinterpret_cast<LPCWSTR>(str));
+	return strlen_u16 (reinterpret_cast<LPCWSTR>(str));
 }
 
 static

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -1498,7 +1498,7 @@ ep_rt_utf16_string_len (const ep_char16_t *str)
 	STATIC_CONTRACT_NOTHROW;
 	EP_ASSERT (str != NULL);
 
-	return wcslen (reinterpret_cast<LPCWSTR>(str));
+	return dn_wcslen (reinterpret_cast<LPCWSTR>(str));
 }
 
 static

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -1498,7 +1498,7 @@ ep_rt_utf16_string_len (const ep_char16_t *str)
 	STATIC_CONTRACT_NOTHROW;
 	EP_ASSERT (str != NULL);
 
-	return strlen_u16 (reinterpret_cast<LPCWSTR>(str));
+	return u16_strlen (reinterpret_cast<LPCWSTR>(str));
 }
 
 static

--- a/src/coreclr/vm/eventreporter.cpp
+++ b/src/coreclr/vm/eventreporter.cpp
@@ -63,7 +63,7 @@ EventReporter::EventReporter(EventReporterType type)
     if (ret != 0)
     {
         // If app name has a '\', consider the part after that; otherwise consider whole name.
-        LPCWSTR appName =  wcsrchr(appPath, W('\\'));
+        LPCWSTR appName =  dn_wcsrchr(appPath, W('\\'));
         appName = appName ? appName+1 : (LPCWSTR)appPath;
         m_Description.Append(appName);
         m_Description.Append(W("\n"));

--- a/src/coreclr/vm/eventreporter.cpp
+++ b/src/coreclr/vm/eventreporter.cpp
@@ -63,7 +63,7 @@ EventReporter::EventReporter(EventReporterType type)
     if (ret != 0)
     {
         // If app name has a '\', consider the part after that; otherwise consider whole name.
-        LPCWSTR appName =  strrchr_u16(appPath, W('\\'));
+        LPCWSTR appName =  u16_strrchr(appPath, W('\\'));
         appName = appName ? appName+1 : (LPCWSTR)appPath;
         m_Description.Append(appName);
         m_Description.Append(W("\n"));

--- a/src/coreclr/vm/eventreporter.cpp
+++ b/src/coreclr/vm/eventreporter.cpp
@@ -63,7 +63,7 @@ EventReporter::EventReporter(EventReporterType type)
     if (ret != 0)
     {
         // If app name has a '\', consider the part after that; otherwise consider whole name.
-        LPCWSTR appName =  dn_wcsrchr(appPath, W('\\'));
+        LPCWSTR appName =  strrchr_u16(appPath, W('\\'));
         appName = appName ? appName+1 : (LPCWSTR)appPath;
         m_Description.Append(appName);
         m_Description.Append(W("\n"));

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -6376,7 +6376,7 @@ VOID ETW::LoaderLog::SendModuleEvent(Module *pModule, DWORD dwEventOptions, BOOL
     }
 
     // if we do not have a module path yet, we put the module name
-    if(bIsDynamicAssembly || ModuleILPath==NULL || wcslen(ModuleILPath) <= 2)
+    if(bIsDynamicAssembly || ModuleILPath==NULL || dn_wcslen(ModuleILPath) <= 2)
     {
         moduleName.SetUTF8(pModule->GetSimpleName());
         ModuleILPath = (PWCHAR)moduleName.GetUnicode();

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -2848,7 +2848,7 @@ void ETW::TypeSystemLog::PostRegistrationInit()
             return;
         }
         LPWSTR endPtr;
-        DWORD dwCustomObjectAllocationEventsPerTypePerSec = strtoul_u16(
+        DWORD dwCustomObjectAllocationEventsPerTypePerSec = u16_strtoul(
             wszCustomObjectAllocationEventsPerTypePerSec,
             &endPtr,
             10          // Base 10 conversion
@@ -6376,7 +6376,7 @@ VOID ETW::LoaderLog::SendModuleEvent(Module *pModule, DWORD dwEventOptions, BOOL
     }
 
     // if we do not have a module path yet, we put the module name
-    if(bIsDynamicAssembly || ModuleILPath==NULL || strlen_u16(ModuleILPath) <= 2)
+    if(bIsDynamicAssembly || ModuleILPath==NULL || u16_strlen(ModuleILPath) <= 2)
     {
         moduleName.SetUTF8(pModule->GetSimpleName());
         ModuleILPath = (PWCHAR)moduleName.GetUnicode();

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -2848,7 +2848,7 @@ void ETW::TypeSystemLog::PostRegistrationInit()
             return;
         }
         LPWSTR endPtr;
-        DWORD dwCustomObjectAllocationEventsPerTypePerSec = dn_wcstoul(
+        DWORD dwCustomObjectAllocationEventsPerTypePerSec = strtoul_u16(
             wszCustomObjectAllocationEventsPerTypePerSec,
             &endPtr,
             10          // Base 10 conversion
@@ -6376,7 +6376,7 @@ VOID ETW::LoaderLog::SendModuleEvent(Module *pModule, DWORD dwEventOptions, BOOL
     }
 
     // if we do not have a module path yet, we put the module name
-    if(bIsDynamicAssembly || ModuleILPath==NULL || dn_wcslen(ModuleILPath) <= 2)
+    if(bIsDynamicAssembly || ModuleILPath==NULL || strlen_u16(ModuleILPath) <= 2)
     {
         moduleName.SetUTF8(pModule->GetSimpleName());
         ModuleILPath = (PWCHAR)moduleName.GetUnicode();

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -2848,7 +2848,7 @@ void ETW::TypeSystemLog::PostRegistrationInit()
             return;
         }
         LPWSTR endPtr;
-        DWORD dwCustomObjectAllocationEventsPerTypePerSec = wcstoul(
+        DWORD dwCustomObjectAllocationEventsPerTypePerSec = dn_wcstoul(
             wszCustomObjectAllocationEventsPerTypePerSec,
             &endPtr,
             10          // Base 10 conversion

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -1223,7 +1223,7 @@ bool GCToEEInterface::GetIntConfigValue(const char* privateKey, const char* publ
         WCHAR *end;
         uint64_t result;
         errno = 0;
-        result = strtoui64_u16(out, &end, 16);
+        result = u16_strtoui64(out, &end, 16);
         // errno is ERANGE if the number is out of range, and end is set to pvalue if
         // no valid conversion exists.
         if (errno == ERANGE || end == out)

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -1223,7 +1223,7 @@ bool GCToEEInterface::GetIntConfigValue(const char* privateKey, const char* publ
         WCHAR *end;
         uint64_t result;
         errno = 0;
-        result = dn_wcstoui64(out, &end, 16);
+        result = strtoui64_u16(out, &end, 16);
         // errno is ERANGE if the number is out of range, and end is set to pvalue if
         // no valid conversion exists.
         if (errno == ERANGE || end == out)

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -1223,7 +1223,7 @@ bool GCToEEInterface::GetIntConfigValue(const char* privateKey, const char* publ
         WCHAR *end;
         uint64_t result;
         errno = 0;
-        result = _wcstoui64(out, &end, 16);
+        result = dn_wcstoui64(out, &end, 16);
         // errno is ERANGE if the number is out of range, and end is set to pvalue if
         // no valid conversion exists.
         if (errno == ERANGE || end == out)
@@ -1707,7 +1707,7 @@ void GCToEEInterface::UpdateGCEventStatus(int currentPublicLevel, int currentPub
     BOOL prv_gcprv_informational = EventXplatEnabledBGCBegin() || EventPipeEventEnabledBGCBegin();
     BOOL prv_gcprv_verbose = EventXplatEnabledPinPlugAtGCTime() || EventPipeEventEnabledPinPlugAtGCTime();
 
-    int publicProviderLevel = keyword_gc_verbose ? GCEventLevel_Verbose : 
+    int publicProviderLevel = keyword_gc_verbose ? GCEventLevel_Verbose :
                                  ((keyword_gc_informational || keyword_gc_heapsurvival_and_movement_informational) ? GCEventLevel_Information : GCEventLevel_None);
     int publicProviderKeywords = (keyword_gc_informational ? GCEventKeyword_GC : GCEventKeyword_None) |
                                  (keyword_gchandle_informational ? GCEventKeyword_GCHandle : GCEventKeyword_None) |

--- a/src/coreclr/vm/gcenv.h
+++ b/src/coreclr/vm/gcenv.h
@@ -62,7 +62,6 @@ namespace ETW
 };
 
 #ifdef TARGET_UNIX
-#define _tcslen wcslen
 #define _tcscpy wcscpy
 #define _tfopen _wfopen
 #endif

--- a/src/coreclr/vm/gcenv.h
+++ b/src/coreclr/vm/gcenv.h
@@ -62,7 +62,6 @@ namespace ETW
 };
 
 #ifdef TARGET_UNIX
-#define _tcscpy wcscpy
 #define _tfopen _wfopen
 #endif
 

--- a/src/coreclr/vm/gdbjit.cpp
+++ b/src/coreclr/vm/gdbjit.cpp
@@ -1846,8 +1846,8 @@ static inline bool isListedModule(const WCHAR *wszModuleFile)
     }
     if (isUserDebug == FALSE)
     {
-        dn_wcsncpy(wszModuleName, tmp, wcslen(tmp));
-        wszModuleName[wcslen(tmp)] = W('\0');
+        dn_wcsncpy(wszModuleName, tmp, dn_wcslen(tmp));
+        wszModuleName[dn_wcslen(tmp)] = W('\0');
         if (dn_wcscmp(wszModuleName, wszModuleFile) == 0)
         {
             isUserDebug = TRUE;

--- a/src/coreclr/vm/gdbjit.cpp
+++ b/src/coreclr/vm/gdbjit.cpp
@@ -1828,27 +1828,27 @@ static inline bool isListedModule(const WCHAR *wszModuleFile)
     BOOL isUserDebug = FALSE;
 
     NewArrayHolder<WCHAR> wszModuleName = new WCHAR[g_cBytesNeeded];
-    LPWSTR pComma = (LPWSTR)dn_wcschr(g_wszModuleNames, W(','));
+    LPWSTR pComma = (LPWSTR)strchr_u16(g_wszModuleNames, W(','));
     LPWSTR tmp = g_wszModuleNames;
 
     while (pComma != NULL)
     {
-        dn_wcsncpy(wszModuleName, g_cBytesNeeded, tmp, pComma - tmp);
+        strncpy_u16(wszModuleName, g_cBytesNeeded, tmp, pComma - tmp);
         wszModuleName[pComma - tmp] = W('\0');
 
-        if (dn_wcscmp(wszModuleName, wszModuleFile) == 0)
+        if (strcmp_u16(wszModuleName, wszModuleFile) == 0)
         {
             isUserDebug = TRUE;
             break;
         }
         tmp = pComma + 1;
-        pComma = (LPWSTR)dn_wcschr(tmp, W(','));
+        pComma = (LPWSTR)strchr_u16(tmp, W(','));
     }
     if (isUserDebug == FALSE)
     {
-        dn_wcsncpy(wszModuleName, g_cBytesNeeded, tmp, dn_wcslen(tmp));
-        wszModuleName[dn_wcslen(tmp)] = W('\0');
-        if (dn_wcscmp(wszModuleName, wszModuleFile) == 0)
+        strncpy_u16(wszModuleName, g_cBytesNeeded, tmp, strlen_u16(tmp));
+        wszModuleName[strlen_u16(tmp)] = W('\0');
+        if (strcmp_u16(wszModuleName, wszModuleFile) == 0)
         {
             isUserDebug = TRUE;
         }
@@ -2562,15 +2562,15 @@ void NotifyGdb::OnMethodPrepared(MethodDesc* methodDescPtr)
 #endif
 
     // remove '.ni.dll' or '.ni.exe' suffix from wszModuleFile
-    LPWSTR pNIExt = const_cast<LPWSTR>(dn_wcsstr(wszModuleFile, W(".ni.exe"))); // where '.ni.exe' start at
+    LPWSTR pNIExt = const_cast<LPWSTR>(strstr_u16(wszModuleFile, W(".ni.exe"))); // where '.ni.exe' start at
     if (!pNIExt)
     {
-      pNIExt = const_cast<LPWSTR>(dn_wcsstr(wszModuleFile, W(".ni.dll"))); // where '.ni.dll' start at
+      pNIExt = const_cast<LPWSTR>(strstr_u16(wszModuleFile, W(".ni.dll"))); // where '.ni.dll' start at
     }
 
     if (pNIExt)
     {
-      dn_wcscpy(pNIExt, dn_wcslen(pNIExt) + 1, W(".dll"));
+      strcpy_u16(pNIExt, strlen_u16(pNIExt) + 1, W(".dll"));
     }
 
     if (isListedModule(wszModuleFile))

--- a/src/coreclr/vm/gdbjit.cpp
+++ b/src/coreclr/vm/gdbjit.cpp
@@ -1828,7 +1828,7 @@ static inline bool isListedModule(const WCHAR *wszModuleFile)
     BOOL isUserDebug = FALSE;
 
     NewArrayHolder<WCHAR> wszModuleName = new WCHAR[g_cBytesNeeded];
-    LPWSTR pComma = wcsstr(g_wszModuleNames, W(","));
+    LPWSTR pComma = dn_wcschr(g_wszModuleNames, W(','));
     LPWSTR tmp = g_wszModuleNames;
 
     while (pComma != NULL)
@@ -1842,7 +1842,7 @@ static inline bool isListedModule(const WCHAR *wszModuleFile)
             break;
         }
         tmp = pComma + 1;
-        pComma = wcsstr(tmp, W(","));
+        pComma = dn_wcschr(tmp, W(','));
     }
     if (isUserDebug == FALSE)
     {
@@ -2562,10 +2562,10 @@ void NotifyGdb::OnMethodPrepared(MethodDesc* methodDescPtr)
 #endif
 
     // remove '.ni.dll' or '.ni.exe' suffix from wszModuleFile
-    LPWSTR pNIExt = const_cast<LPWSTR>(wcsstr(wszModuleFile, W(".ni.exe"))); // where '.ni.exe' start at
+    LPWSTR pNIExt = const_cast<LPWSTR>(dn_wcsstr(wszModuleFile, W(".ni.exe"))); // where '.ni.exe' start at
     if (!pNIExt)
     {
-      pNIExt = const_cast<LPWSTR>(wcsstr(wszModuleFile, W(".ni.dll"))); // where '.ni.dll' start at
+      pNIExt = const_cast<LPWSTR>(dn_wcsstr(wszModuleFile, W(".ni.dll"))); // where '.ni.dll' start at
     }
 
     if (pNIExt)

--- a/src/coreclr/vm/gdbjit.cpp
+++ b/src/coreclr/vm/gdbjit.cpp
@@ -1836,7 +1836,7 @@ static inline bool isListedModule(const WCHAR *wszModuleFile)
         dn_wcsncpy(wszModuleName, tmp, pComma - tmp);
         wszModuleName[pComma - tmp] = W('\0');
 
-        if (wcscmp(wszModuleName, wszModuleFile) == 0)
+        if (dn_wcscmp(wszModuleName, wszModuleFile) == 0)
         {
             isUserDebug = TRUE;
             break;
@@ -1848,7 +1848,7 @@ static inline bool isListedModule(const WCHAR *wszModuleFile)
     {
         dn_wcsncpy(wszModuleName, tmp, wcslen(tmp));
         wszModuleName[wcslen(tmp)] = W('\0');
-        if (wcscmp(wszModuleName, wszModuleFile) == 0)
+        if (dn_wcscmp(wszModuleName, wszModuleFile) == 0)
         {
             isUserDebug = TRUE;
         }

--- a/src/coreclr/vm/gdbjit.cpp
+++ b/src/coreclr/vm/gdbjit.cpp
@@ -1828,12 +1828,12 @@ static inline bool isListedModule(const WCHAR *wszModuleFile)
     BOOL isUserDebug = FALSE;
 
     NewArrayHolder<WCHAR> wszModuleName = new WCHAR[g_cBytesNeeded];
-    LPWSTR pComma = dn_wcschr(g_wszModuleNames, W(','));
+    LPWSTR pComma = (LPWSTR)dn_wcschr(g_wszModuleNames, W(','));
     LPWSTR tmp = g_wszModuleNames;
 
     while (pComma != NULL)
     {
-        dn_wcsncpy(wszModuleName, tmp, pComma - tmp);
+        dn_wcsncpy(wszModuleName, g_cBytesNeeded, tmp, pComma - tmp);
         wszModuleName[pComma - tmp] = W('\0');
 
         if (dn_wcscmp(wszModuleName, wszModuleFile) == 0)
@@ -1842,11 +1842,11 @@ static inline bool isListedModule(const WCHAR *wszModuleFile)
             break;
         }
         tmp = pComma + 1;
-        pComma = dn_wcschr(tmp, W(','));
+        pComma = (LPWSTR)dn_wcschr(tmp, W(','));
     }
     if (isUserDebug == FALSE)
     {
-        dn_wcsncpy(wszModuleName, tmp, dn_wcslen(tmp));
+        dn_wcsncpy(wszModuleName, g_cBytesNeeded, tmp, dn_wcslen(tmp));
         wszModuleName[dn_wcslen(tmp)] = W('\0');
         if (dn_wcscmp(wszModuleName, wszModuleFile) == 0)
         {
@@ -2570,7 +2570,7 @@ void NotifyGdb::OnMethodPrepared(MethodDesc* methodDescPtr)
 
     if (pNIExt)
     {
-      dn_wcscpy(pNIExt, W(".dll"));
+      dn_wcscpy(pNIExt, dn_wcslen(pNIExt) + 1, W(".dll"));
     }
 
     if (isListedModule(wszModuleFile))

--- a/src/coreclr/vm/gdbjit.cpp
+++ b/src/coreclr/vm/gdbjit.cpp
@@ -1833,7 +1833,7 @@ static inline bool isListedModule(const WCHAR *wszModuleFile)
 
     while (pComma != NULL)
     {
-        wcsncpy(wszModuleName, tmp, pComma - tmp);
+        dn_wcsncpy(wszModuleName, tmp, pComma - tmp);
         wszModuleName[pComma - tmp] = W('\0');
 
         if (wcscmp(wszModuleName, wszModuleFile) == 0)
@@ -1846,7 +1846,7 @@ static inline bool isListedModule(const WCHAR *wszModuleFile)
     }
     if (isUserDebug == FALSE)
     {
-        wcsncpy(wszModuleName, tmp, wcslen(tmp));
+        dn_wcsncpy(wszModuleName, tmp, wcslen(tmp));
         wszModuleName[wcslen(tmp)] = W('\0');
         if (wcscmp(wszModuleName, wszModuleFile) == 0)
         {

--- a/src/coreclr/vm/gdbjit.cpp
+++ b/src/coreclr/vm/gdbjit.cpp
@@ -2570,7 +2570,7 @@ void NotifyGdb::OnMethodPrepared(MethodDesc* methodDescPtr)
 
     if (pNIExt)
     {
-      wcscpy(pNIExt, W(".dll"));
+      dn_wcscpy(pNIExt, W(".dll"));
     }
 
     if (isListedModule(wszModuleFile))

--- a/src/coreclr/vm/gdbjit.cpp
+++ b/src/coreclr/vm/gdbjit.cpp
@@ -1828,27 +1828,27 @@ static inline bool isListedModule(const WCHAR *wszModuleFile)
     BOOL isUserDebug = FALSE;
 
     NewArrayHolder<WCHAR> wszModuleName = new WCHAR[g_cBytesNeeded];
-    LPWSTR pComma = (LPWSTR)strchr_u16(g_wszModuleNames, W(','));
+    LPWSTR pComma = (LPWSTR)u16_strchr(g_wszModuleNames, W(','));
     LPWSTR tmp = g_wszModuleNames;
 
     while (pComma != NULL)
     {
-        strncpy_u16(wszModuleName, g_cBytesNeeded, tmp, pComma - tmp);
+        u16_strncpy_s(wszModuleName, g_cBytesNeeded, tmp, pComma - tmp);
         wszModuleName[pComma - tmp] = W('\0');
 
-        if (strcmp_u16(wszModuleName, wszModuleFile) == 0)
+        if (u16_strcmp(wszModuleName, wszModuleFile) == 0)
         {
             isUserDebug = TRUE;
             break;
         }
         tmp = pComma + 1;
-        pComma = (LPWSTR)strchr_u16(tmp, W(','));
+        pComma = (LPWSTR)u16_strchr(tmp, W(','));
     }
     if (isUserDebug == FALSE)
     {
-        strncpy_u16(wszModuleName, g_cBytesNeeded, tmp, strlen_u16(tmp));
-        wszModuleName[strlen_u16(tmp)] = W('\0');
-        if (strcmp_u16(wszModuleName, wszModuleFile) == 0)
+        u16_strncpy_s(wszModuleName, g_cBytesNeeded, tmp, u16_strlen(tmp));
+        wszModuleName[u16_strlen(tmp)] = W('\0');
+        if (u16_strcmp(wszModuleName, wszModuleFile) == 0)
         {
             isUserDebug = TRUE;
         }
@@ -2562,15 +2562,15 @@ void NotifyGdb::OnMethodPrepared(MethodDesc* methodDescPtr)
 #endif
 
     // remove '.ni.dll' or '.ni.exe' suffix from wszModuleFile
-    LPWSTR pNIExt = const_cast<LPWSTR>(strstr_u16(wszModuleFile, W(".ni.exe"))); // where '.ni.exe' start at
+    LPWSTR pNIExt = const_cast<LPWSTR>(u16_strstr(wszModuleFile, W(".ni.exe"))); // where '.ni.exe' start at
     if (!pNIExt)
     {
-      pNIExt = const_cast<LPWSTR>(strstr_u16(wszModuleFile, W(".ni.dll"))); // where '.ni.dll' start at
+      pNIExt = const_cast<LPWSTR>(u16_strstr(wszModuleFile, W(".ni.dll"))); // where '.ni.dll' start at
     }
 
     if (pNIExt)
     {
-      strcpy_u16(pNIExt, strlen_u16(pNIExt) + 1, W(".dll"));
+      u16_strcpy_s(pNIExt, u16_strlen(pNIExt) + 1, W(".dll"));
     }
 
     if (isListedModule(wszModuleFile))

--- a/src/coreclr/vm/genanalysis.cpp
+++ b/src/coreclr/vm/genanalysis.cpp
@@ -28,7 +28,7 @@ bool gcGenAnalysisDump = false;
         {
             // Get the managed command line.
             LPCWSTR pCmdLine = GetCommandLineForDiagnostics();
-            match = strncmp_u16(pCmdLine, gcGenAnalysisCmd, strlen_u16(gcGenAnalysisCmd)) == 0;
+            match = u16_strncmp(pCmdLine, gcGenAnalysisCmd, u16_strlen(gcGenAnalysisCmd)) == 0;
         }
         if (match && !CLRConfig::IsConfigOptionSpecified(W("GCGenAnalysisGen")))
         {

--- a/src/coreclr/vm/genanalysis.cpp
+++ b/src/coreclr/vm/genanalysis.cpp
@@ -28,7 +28,7 @@ bool gcGenAnalysisDump = false;
         {
             // Get the managed command line.
             LPCWSTR pCmdLine = GetCommandLineForDiagnostics();
-            match = wcsncmp(pCmdLine, gcGenAnalysisCmd, wcslen(gcGenAnalysisCmd)) == 0;
+            match = dn_wcsncmp(pCmdLine, gcGenAnalysisCmd, wcslen(gcGenAnalysisCmd)) == 0;
         }
         if (match && !CLRConfig::IsConfigOptionSpecified(W("GCGenAnalysisGen")))
         {

--- a/src/coreclr/vm/genanalysis.cpp
+++ b/src/coreclr/vm/genanalysis.cpp
@@ -28,7 +28,7 @@ bool gcGenAnalysisDump = false;
         {
             // Get the managed command line.
             LPCWSTR pCmdLine = GetCommandLineForDiagnostics();
-            match = dn_wcsncmp(pCmdLine, gcGenAnalysisCmd, wcslen(gcGenAnalysisCmd)) == 0;
+            match = dn_wcsncmp(pCmdLine, gcGenAnalysisCmd, dn_wcslen(gcGenAnalysisCmd)) == 0;
         }
         if (match && !CLRConfig::IsConfigOptionSpecified(W("GCGenAnalysisGen")))
         {

--- a/src/coreclr/vm/genanalysis.cpp
+++ b/src/coreclr/vm/genanalysis.cpp
@@ -28,7 +28,7 @@ bool gcGenAnalysisDump = false;
         {
             // Get the managed command line.
             LPCWSTR pCmdLine = GetCommandLineForDiagnostics();
-            match = dn_wcsncmp(pCmdLine, gcGenAnalysisCmd, dn_wcslen(gcGenAnalysisCmd)) == 0;
+            match = strncmp_u16(pCmdLine, gcGenAnalysisCmd, strlen_u16(gcGenAnalysisCmd)) == 0;
         }
         if (match && !CLRConfig::IsConfigOptionSpecified(W("GCGenAnalysisGen")))
         {

--- a/src/coreclr/vm/ilmarshalers.cpp
+++ b/src/coreclr/vm/ilmarshalers.cpp
@@ -816,7 +816,7 @@ void ILWSTRBufferMarshaler::EmitConvertSpaceNativeToCLR(ILCodeStream* pslILEmit)
     if (IsIn(m_dwMarshalFlags) || IsCLRToNative(m_dwMarshalFlags))
     {
         EmitLoadNativeValue(pslILEmit);
-        // static int System.String.strlen_u16(char *ptr)
+        // static int System.String.u16_strlen(char *ptr)
         pslILEmit->EmitCALL(METHOD__STRING__WCSLEN, 1, 1);
     }
     else
@@ -845,7 +845,7 @@ void ILWSTRBufferMarshaler::EmitConvertContentsNativeToCLR(ILCodeStream* pslILEm
     EmitLoadNativeValue(pslILEmit);
 
     pslILEmit->EmitDUP();
-    // static int System.String.strlen_u16(char *ptr)
+    // static int System.String.u16_strlen(char *ptr)
     pslILEmit->EmitCALL(METHOD__STRING__WCSLEN, 1, 1);
 
     // void System.Text.StringBuilder.ReplaceBuffer(char* newBuffer, int newLength);

--- a/src/coreclr/vm/ilmarshalers.cpp
+++ b/src/coreclr/vm/ilmarshalers.cpp
@@ -816,7 +816,7 @@ void ILWSTRBufferMarshaler::EmitConvertSpaceNativeToCLR(ILCodeStream* pslILEmit)
     if (IsIn(m_dwMarshalFlags) || IsCLRToNative(m_dwMarshalFlags))
     {
         EmitLoadNativeValue(pslILEmit);
-        // static int System.String.dn_wcslen(char *ptr)
+        // static int System.String.strlen_u16(char *ptr)
         pslILEmit->EmitCALL(METHOD__STRING__WCSLEN, 1, 1);
     }
     else
@@ -845,7 +845,7 @@ void ILWSTRBufferMarshaler::EmitConvertContentsNativeToCLR(ILCodeStream* pslILEm
     EmitLoadNativeValue(pslILEmit);
 
     pslILEmit->EmitDUP();
-    // static int System.String.dn_wcslen(char *ptr)
+    // static int System.String.strlen_u16(char *ptr)
     pslILEmit->EmitCALL(METHOD__STRING__WCSLEN, 1, 1);
 
     // void System.Text.StringBuilder.ReplaceBuffer(char* newBuffer, int newLength);

--- a/src/coreclr/vm/ilmarshalers.cpp
+++ b/src/coreclr/vm/ilmarshalers.cpp
@@ -816,7 +816,7 @@ void ILWSTRBufferMarshaler::EmitConvertSpaceNativeToCLR(ILCodeStream* pslILEmit)
     if (IsIn(m_dwMarshalFlags) || IsCLRToNative(m_dwMarshalFlags))
     {
         EmitLoadNativeValue(pslILEmit);
-        // static int System.String.wcslen(char *ptr)
+        // static int System.String.dn_wcslen(char *ptr)
         pslILEmit->EmitCALL(METHOD__STRING__WCSLEN, 1, 1);
     }
     else
@@ -845,7 +845,7 @@ void ILWSTRBufferMarshaler::EmitConvertContentsNativeToCLR(ILCodeStream* pslILEm
     EmitLoadNativeValue(pslILEmit);
 
     pslILEmit->EmitDUP();
-    // static int System.String.wcslen(char *ptr)
+    // static int System.String.dn_wcslen(char *ptr)
     pslILEmit->EmitCALL(METHOD__STRING__WCSLEN, 1, 1);
 
     // void System.Text.StringBuilder.ReplaceBuffer(char* newBuffer, int newLength);

--- a/src/coreclr/vm/interoputil.cpp
+++ b/src/coreclr/vm/interoputil.cpp
@@ -539,7 +539,7 @@ SIZE_T GetStringizedItfDef(TypeHandle InterfaceType, CQuickArray<BYTE> &rDef)
     DefineFullyQualifiedNameForClassW();
     szName = GetFullyQualifiedNameForClassNestedAwareW(pIntfMT);
 
-    cchName = (ULONG)strlen_u16(szName);
+    cchName = (ULONG)u16_strlen(szName);
 
     // Start with the interface name.
     cbCur = cchName * sizeof(WCHAR);
@@ -2318,7 +2318,7 @@ ULONG GetStringizedClassItfDef(TypeHandle InterfaceType, CQuickArray<BYTE> &rDef
     // Get the name of the class.
     DefineFullyQualifiedNameForClassW();
     szName = GetFullyQualifiedNameForClassNestedAwareW(pIntfMT);
-    cchName = (ULONG)strlen_u16(szName);
+    cchName = (ULONG)u16_strlen(szName);
 
     // Start with the interface name.
     cbCur = cchName * sizeof(WCHAR);
@@ -2753,12 +2753,12 @@ DISPID ExtractStandardDispId(_In_z_ LPWSTR strStdDispIdMemberName)
     CONTRACTL_END;
 
     // Find the first character after the = in the standard DISPID member name.
-    LPWSTR strDispId = (LPWSTR)strchr_u16(&strStdDispIdMemberName[STANDARD_DISPID_PREFIX_LENGTH], W('=')) + 1;
+    LPWSTR strDispId = (LPWSTR)u16_strchr(&strStdDispIdMemberName[STANDARD_DISPID_PREFIX_LENGTH], W('=')) + 1;
     if (!strDispId)
         COMPlusThrow(kArgumentException, IDS_EE_INVALID_STD_DISPID_NAME);
 
     // Validate that the last character of the standard member name is a ].
-    LPWSTR strClosingBracket = (LPWSTR)strchr_u16(strDispId, W(']'));
+    LPWSTR strClosingBracket = (LPWSTR)u16_strchr(strDispId, W(']'));
     if (!strClosingBracket || (strClosingBracket[1] != 0))
         COMPlusThrow(kArgumentException, IDS_EE_INVALID_STD_DISPID_NAME);
 
@@ -3578,7 +3578,7 @@ static void GetComClassHelper(
         NewArrayHolder<WCHAR> wszRefServer = NULL;
         if (pClassFactInfo->m_strServerName)
         {
-            size_t len = strlen_u16(pClassFactInfo->m_strServerName)+1;
+            size_t len = u16_strlen(pClassFactInfo->m_strServerName)+1;
             wszRefServer = new WCHAR[len];
             wcscpy_s(wszRefServer, len, pClassFactInfo->m_strServerName);
         }

--- a/src/coreclr/vm/interoputil.cpp
+++ b/src/coreclr/vm/interoputil.cpp
@@ -539,7 +539,7 @@ SIZE_T GetStringizedItfDef(TypeHandle InterfaceType, CQuickArray<BYTE> &rDef)
     DefineFullyQualifiedNameForClassW();
     szName = GetFullyQualifiedNameForClassNestedAwareW(pIntfMT);
 
-    cchName = (ULONG)wcslen(szName);
+    cchName = (ULONG)dn_wcslen(szName);
 
     // Start with the interface name.
     cbCur = cchName * sizeof(WCHAR);
@@ -2318,7 +2318,7 @@ ULONG GetStringizedClassItfDef(TypeHandle InterfaceType, CQuickArray<BYTE> &rDef
     // Get the name of the class.
     DefineFullyQualifiedNameForClassW();
     szName = GetFullyQualifiedNameForClassNestedAwareW(pIntfMT);
-    cchName = (ULONG)wcslen(szName);
+    cchName = (ULONG)dn_wcslen(szName);
 
     // Start with the interface name.
     cbCur = cchName * sizeof(WCHAR);
@@ -3578,7 +3578,7 @@ static void GetComClassHelper(
         NewArrayHolder<WCHAR> wszRefServer = NULL;
         if (pClassFactInfo->m_strServerName)
         {
-            size_t len = wcslen(pClassFactInfo->m_strServerName)+1;
+            size_t len = dn_wcslen(pClassFactInfo->m_strServerName)+1;
             wszRefServer = new WCHAR[len];
             wcscpy_s(wszRefServer, len, pClassFactInfo->m_strServerName);
         }

--- a/src/coreclr/vm/interoputil.cpp
+++ b/src/coreclr/vm/interoputil.cpp
@@ -2753,12 +2753,12 @@ DISPID ExtractStandardDispId(_In_z_ LPWSTR strStdDispIdMemberName)
     CONTRACTL_END;
 
     // Find the first character after the = in the standard DISPID member name.
-    LPWSTR strDispId = dn_wcschr(&strStdDispIdMemberName[STANDARD_DISPID_PREFIX_LENGTH], W('=')) + 1;
+    LPWSTR strDispId = (LPWSTR)dn_wcschr(&strStdDispIdMemberName[STANDARD_DISPID_PREFIX_LENGTH], W('=')) + 1;
     if (!strDispId)
         COMPlusThrow(kArgumentException, IDS_EE_INVALID_STD_DISPID_NAME);
 
     // Validate that the last character of the standard member name is a ].
-    LPWSTR strClosingBracket = dn_wcschr(strDispId, W(']'));
+    LPWSTR strClosingBracket = (LPWSTR)dn_wcschr(strDispId, W(']'));
     if (!strClosingBracket || (strClosingBracket[1] != 0))
         COMPlusThrow(kArgumentException, IDS_EE_INVALID_STD_DISPID_NAME);
 

--- a/src/coreclr/vm/interoputil.cpp
+++ b/src/coreclr/vm/interoputil.cpp
@@ -2753,12 +2753,12 @@ DISPID ExtractStandardDispId(_In_z_ LPWSTR strStdDispIdMemberName)
     CONTRACTL_END;
 
     // Find the first character after the = in the standard DISPID member name.
-    LPWSTR strDispId = wcsstr(&strStdDispIdMemberName[STANDARD_DISPID_PREFIX_LENGTH], W("=")) + 1;
+    LPWSTR strDispId = dn_wcschr(&strStdDispIdMemberName[STANDARD_DISPID_PREFIX_LENGTH], W('=')) + 1;
     if (!strDispId)
         COMPlusThrow(kArgumentException, IDS_EE_INVALID_STD_DISPID_NAME);
 
     // Validate that the last character of the standard member name is a ].
-    LPWSTR strClosingBracket = wcsstr(strDispId, W("]"));
+    LPWSTR strClosingBracket = dn_wcschr(strDispId, W(']'));
     if (!strClosingBracket || (strClosingBracket[1] != 0))
         COMPlusThrow(kArgumentException, IDS_EE_INVALID_STD_DISPID_NAME);
 

--- a/src/coreclr/vm/interoputil.cpp
+++ b/src/coreclr/vm/interoputil.cpp
@@ -539,7 +539,7 @@ SIZE_T GetStringizedItfDef(TypeHandle InterfaceType, CQuickArray<BYTE> &rDef)
     DefineFullyQualifiedNameForClassW();
     szName = GetFullyQualifiedNameForClassNestedAwareW(pIntfMT);
 
-    cchName = (ULONG)dn_wcslen(szName);
+    cchName = (ULONG)strlen_u16(szName);
 
     // Start with the interface name.
     cbCur = cchName * sizeof(WCHAR);
@@ -2318,7 +2318,7 @@ ULONG GetStringizedClassItfDef(TypeHandle InterfaceType, CQuickArray<BYTE> &rDef
     // Get the name of the class.
     DefineFullyQualifiedNameForClassW();
     szName = GetFullyQualifiedNameForClassNestedAwareW(pIntfMT);
-    cchName = (ULONG)dn_wcslen(szName);
+    cchName = (ULONG)strlen_u16(szName);
 
     // Start with the interface name.
     cbCur = cchName * sizeof(WCHAR);
@@ -2753,12 +2753,12 @@ DISPID ExtractStandardDispId(_In_z_ LPWSTR strStdDispIdMemberName)
     CONTRACTL_END;
 
     // Find the first character after the = in the standard DISPID member name.
-    LPWSTR strDispId = (LPWSTR)dn_wcschr(&strStdDispIdMemberName[STANDARD_DISPID_PREFIX_LENGTH], W('=')) + 1;
+    LPWSTR strDispId = (LPWSTR)strchr_u16(&strStdDispIdMemberName[STANDARD_DISPID_PREFIX_LENGTH], W('=')) + 1;
     if (!strDispId)
         COMPlusThrow(kArgumentException, IDS_EE_INVALID_STD_DISPID_NAME);
 
     // Validate that the last character of the standard member name is a ].
-    LPWSTR strClosingBracket = (LPWSTR)dn_wcschr(strDispId, W(']'));
+    LPWSTR strClosingBracket = (LPWSTR)strchr_u16(strDispId, W(']'));
     if (!strClosingBracket || (strClosingBracket[1] != 0))
         COMPlusThrow(kArgumentException, IDS_EE_INVALID_STD_DISPID_NAME);
 
@@ -3578,7 +3578,7 @@ static void GetComClassHelper(
         NewArrayHolder<WCHAR> wszRefServer = NULL;
         if (pClassFactInfo->m_strServerName)
         {
-            size_t len = dn_wcslen(pClassFactInfo->m_strServerName)+1;
+            size_t len = strlen_u16(pClassFactInfo->m_strServerName)+1;
             wszRefServer = new WCHAR[len];
             wcscpy_s(wszRefServer, len, pClassFactInfo->m_strServerName);
         }

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -7103,7 +7103,7 @@ void MethodTable::GetGuid(GUID *pGuid, BOOL bGenerateIfNotFound, BOOL bClassic /
             szName = GetFullyQualifiedNameForClassNestedAwareW(this);
             if (szName == NULL)
                 return;
-            cchName = dn_wcslen(szName);
+            cchName = strlen_u16(szName);
 
             // Enlarge buffer for class name.
             cbCur = cchName * sizeof(WCHAR);

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -7103,7 +7103,7 @@ void MethodTable::GetGuid(GUID *pGuid, BOOL bGenerateIfNotFound, BOOL bClassic /
             szName = GetFullyQualifiedNameForClassNestedAwareW(this);
             if (szName == NULL)
                 return;
-            cchName = wcslen(szName);
+            cchName = dn_wcslen(szName);
 
             // Enlarge buffer for class name.
             cbCur = cchName * sizeof(WCHAR);

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -7103,7 +7103,7 @@ void MethodTable::GetGuid(GUID *pGuid, BOOL bGenerateIfNotFound, BOOL bClassic /
             szName = GetFullyQualifiedNameForClassNestedAwareW(this);
             if (szName == NULL)
                 return;
-            cchName = strlen_u16(szName);
+            cchName = u16_strlen(szName);
 
             // Enlarge buffer for class name.
             cbCur = cchName * sizeof(WCHAR);

--- a/src/coreclr/vm/multicorejit.cpp
+++ b/src/coreclr/vm/multicorejit.cpp
@@ -946,7 +946,7 @@ HRESULT MulticoreJitRecorder::StartProfile(const WCHAR * pRoot, const WCHAR * pF
     MulticoreJitTrace(("StartProfile('%s', '%s', %d)", pRootUtf8, pFileUtf8, suffix));
 #endif // MULTICOREJIT_LOGGING
 
-    size_t lenFile = dn_wcslen(pFile);
+    size_t lenFile = strlen_u16(pFile);
 
     // Options (only AutoStartProfile using environment variable, for testing)
     // ([d|D]main-thread-delay)

--- a/src/coreclr/vm/multicorejit.cpp
+++ b/src/coreclr/vm/multicorejit.cpp
@@ -946,7 +946,7 @@ HRESULT MulticoreJitRecorder::StartProfile(const WCHAR * pRoot, const WCHAR * pF
     MulticoreJitTrace(("StartProfile('%s', '%s', %d)", pRootUtf8, pFileUtf8, suffix));
 #endif // MULTICOREJIT_LOGGING
 
-    size_t lenFile = strlen_u16(pFile);
+    size_t lenFile = u16_strlen(pFile);
 
     // Options (only AutoStartProfile using environment variable, for testing)
     // ([d|D]main-thread-delay)

--- a/src/coreclr/vm/multicorejit.cpp
+++ b/src/coreclr/vm/multicorejit.cpp
@@ -946,7 +946,7 @@ HRESULT MulticoreJitRecorder::StartProfile(const WCHAR * pRoot, const WCHAR * pF
     MulticoreJitTrace(("StartProfile('%s', '%s', %d)", pRootUtf8, pFileUtf8, suffix));
 #endif // MULTICOREJIT_LOGGING
 
-    size_t lenFile = wcslen(pFile);
+    size_t lenFile = dn_wcslen(pFile);
 
     // Options (only AutoStartProfile using environment variable, for testing)
     // ([d|D]main-thread-delay)

--- a/src/coreclr/vm/nativelibrary.cpp
+++ b/src/coreclr/vm/nativelibrary.cpp
@@ -642,12 +642,12 @@ namespace
         if (g_hostpolicy_embedded)
         {
 #ifdef TARGET_WINDOWS
-            if (strcmp_u16(wszLibName, W("hostpolicy.dll")) == 0)
+            if (u16_strcmp(wszLibName, W("hostpolicy.dll")) == 0)
             {
                 return WszGetModuleHandle(NULL);
             }
 #else
-            if (strcmp_u16(wszLibName, W("libhostpolicy")) == 0)
+            if (u16_strcmp(wszLibName, W("libhostpolicy")) == 0)
             {
                 return PAL_LoadLibraryDirect(NULL);
             }

--- a/src/coreclr/vm/nativelibrary.cpp
+++ b/src/coreclr/vm/nativelibrary.cpp
@@ -642,12 +642,12 @@ namespace
         if (g_hostpolicy_embedded)
         {
 #ifdef TARGET_WINDOWS
-            if (dn_wcscmp(wszLibName, W("hostpolicy.dll")) == 0)
+            if (strcmp_u16(wszLibName, W("hostpolicy.dll")) == 0)
             {
                 return WszGetModuleHandle(NULL);
             }
 #else
-            if (dn_wcscmp(wszLibName, W("libhostpolicy")) == 0)
+            if (strcmp_u16(wszLibName, W("libhostpolicy")) == 0)
             {
                 return PAL_LoadLibraryDirect(NULL);
             }

--- a/src/coreclr/vm/nativelibrary.cpp
+++ b/src/coreclr/vm/nativelibrary.cpp
@@ -642,12 +642,12 @@ namespace
         if (g_hostpolicy_embedded)
         {
 #ifdef TARGET_WINDOWS
-            if (wcscmp(wszLibName, W("hostpolicy.dll")) == 0)
+            if (dn_wcscmp(wszLibName, W("hostpolicy.dll")) == 0)
             {
                 return WszGetModuleHandle(NULL);
             }
 #else
-            if (wcscmp(wszLibName, W("libhostpolicy")) == 0)
+            if (dn_wcscmp(wszLibName, W("libhostpolicy")) == 0)
             {
                 return PAL_LoadLibraryDirect(NULL);
             }

--- a/src/coreclr/vm/object.cpp
+++ b/src/coreclr/vm/object.cpp
@@ -694,7 +694,7 @@ STRINGREF StringObject::NewString(const WCHAR *pwsz)
     else
     {
 
-        DWORD nch = (DWORD)strlen_u16(pwsz);
+        DWORD nch = (DWORD)u16_strlen(pwsz);
         if (nch==0) {
             return GetEmptyString();
         }

--- a/src/coreclr/vm/object.cpp
+++ b/src/coreclr/vm/object.cpp
@@ -694,7 +694,7 @@ STRINGREF StringObject::NewString(const WCHAR *pwsz)
     else
     {
 
-        DWORD nch = (DWORD)wcslen(pwsz);
+        DWORD nch = (DWORD)dn_wcslen(pwsz);
         if (nch==0) {
             return GetEmptyString();
         }

--- a/src/coreclr/vm/object.cpp
+++ b/src/coreclr/vm/object.cpp
@@ -694,7 +694,7 @@ STRINGREF StringObject::NewString(const WCHAR *pwsz)
     else
     {
 
-        DWORD nch = (DWORD)dn_wcslen(pwsz);
+        DWORD nch = (DWORD)strlen_u16(pwsz);
         if (nch==0) {
             return GetEmptyString();
         }

--- a/src/coreclr/vm/object.h
+++ b/src/coreclr/vm/object.h
@@ -1284,7 +1284,7 @@ __inline bool IsCultureEnglishOrInvariant(LPCWSTR localeName)
     LIMITED_METHOD_CONTRACT;
     if (localeName != NULL &&
         (localeName[0] == W('\0') ||
-         dn_wcscmp(localeName, W("en-US")) == 0))
+         strcmp_u16(localeName, W("en-US")) == 0))
     {
         return true;
     }

--- a/src/coreclr/vm/object.h
+++ b/src/coreclr/vm/object.h
@@ -1284,7 +1284,7 @@ __inline bool IsCultureEnglishOrInvariant(LPCWSTR localeName)
     LIMITED_METHOD_CONTRACT;
     if (localeName != NULL &&
         (localeName[0] == W('\0') ||
-         wcscmp(localeName, W("en-US")) == 0))
+         dn_wcscmp(localeName, W("en-US")) == 0))
     {
         return true;
     }

--- a/src/coreclr/vm/object.h
+++ b/src/coreclr/vm/object.h
@@ -1284,7 +1284,7 @@ __inline bool IsCultureEnglishOrInvariant(LPCWSTR localeName)
     LIMITED_METHOD_CONTRACT;
     if (localeName != NULL &&
         (localeName[0] == W('\0') ||
-         strcmp_u16(localeName, W("en-US")) == 0))
+         u16_strcmp(localeName, W("en-US")) == 0))
     {
         return true;
     }

--- a/src/coreclr/vm/peimage.inl
+++ b/src/coreclr/vm/peimage.inl
@@ -313,7 +313,7 @@ inline PTR_PEImage PEImage::FindByPath(LPCWSTR pPath, BOOL isInBundle /* = TRUE 
 #ifdef FEATURE_CASE_SENSITIVE_FILESYSTEM
     DWORD dwHash=path.Hash();
 #else
-    DWORD dwHash = CaseHashHelper(pPath, (COUNT_T) strlen_u16(pPath));
+    DWORD dwHash = CaseHashHelper(pPath, (COUNT_T) u16_strlen(pPath));
 #endif
     return (PEImage *) s_Images->LookupValue(dwHash, &locator);
 }

--- a/src/coreclr/vm/peimage.inl
+++ b/src/coreclr/vm/peimage.inl
@@ -313,7 +313,7 @@ inline PTR_PEImage PEImage::FindByPath(LPCWSTR pPath, BOOL isInBundle /* = TRUE 
 #ifdef FEATURE_CASE_SENSITIVE_FILESYSTEM
     DWORD dwHash=path.Hash();
 #else
-    DWORD dwHash = CaseHashHelper(pPath, (COUNT_T) dn_wcslen(pPath));
+    DWORD dwHash = CaseHashHelper(pPath, (COUNT_T) strlen_u16(pPath));
 #endif
     return (PEImage *) s_Images->LookupValue(dwHash, &locator);
 }

--- a/src/coreclr/vm/peimage.inl
+++ b/src/coreclr/vm/peimage.inl
@@ -313,7 +313,7 @@ inline PTR_PEImage PEImage::FindByPath(LPCWSTR pPath, BOOL isInBundle /* = TRUE 
 #ifdef FEATURE_CASE_SENSITIVE_FILESYSTEM
     DWORD dwHash=path.Hash();
 #else
-    DWORD dwHash = CaseHashHelper(pPath, (COUNT_T) wcslen(pPath));
+    DWORD dwHash = CaseHashHelper(pPath, (COUNT_T) dn_wcslen(pPath));
 #endif
     return (PEImage *) s_Images->LookupValue(dwHash, &locator);
 }

--- a/src/coreclr/vm/profilinghelper.cpp
+++ b/src/coreclr/vm/profilinghelper.cpp
@@ -673,7 +673,7 @@ HRESULT ProfilingAPIUtility::AttemptLoadProfilerForStartup()
         return S_FALSE;
     }
 
-    if ((wszProfilerDLL != NULL) && (strlen_u16(wszProfilerDLL) >= MAX_LONGPATH))
+    if ((wszProfilerDLL != NULL) && (u16_strlen(wszProfilerDLL) >= MAX_LONGPATH))
     {
         LOG((LF_CORPROF, LL_INFO10, "**PROF: Profiling flag set, but CORECLR_PROFILER_PATH was not set properly.\n"));
 

--- a/src/coreclr/vm/profilinghelper.cpp
+++ b/src/coreclr/vm/profilinghelper.cpp
@@ -673,7 +673,7 @@ HRESULT ProfilingAPIUtility::AttemptLoadProfilerForStartup()
         return S_FALSE;
     }
 
-    if ((wszProfilerDLL != NULL) && (wcslen(wszProfilerDLL) >= MAX_LONGPATH))
+    if ((wszProfilerDLL != NULL) && (dn_wcslen(wszProfilerDLL) >= MAX_LONGPATH))
     {
         LOG((LF_CORPROF, LL_INFO10, "**PROF: Profiling flag set, but CORECLR_PROFILER_PATH was not set properly.\n"));
 

--- a/src/coreclr/vm/profilinghelper.cpp
+++ b/src/coreclr/vm/profilinghelper.cpp
@@ -673,7 +673,7 @@ HRESULT ProfilingAPIUtility::AttemptLoadProfilerForStartup()
         return S_FALSE;
     }
 
-    if ((wszProfilerDLL != NULL) && (dn_wcslen(wszProfilerDLL) >= MAX_LONGPATH))
+    if ((wszProfilerDLL != NULL) && (strlen_u16(wszProfilerDLL) >= MAX_LONGPATH))
     {
         LOG((LF_CORPROF, LL_INFO10, "**PROF: Profiling flag set, but CORECLR_PROFILER_PATH was not set properly.\n"));
 

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -4126,7 +4126,7 @@ HRESULT ProfToEEInterfaceImpl::GetModuleInfo2(ModuleID     moduleId,
             wszFileName = strScopeName.GetUnicode();
         }
 
-        ULONG trueLen = (ULONG)(strlen_u16(wszFileName) + 1);
+        ULONG trueLen = (ULONG)(u16_strlen(wszFileName) + 1);
 
         // Return name of module as required.
         if (wszName && cchName > 0)
@@ -5611,7 +5611,7 @@ HRESULT ProfToEEInterfaceImpl::GetAppDomainInfo(AppDomainID appDomainId,
     if (szFriendlyName != NULL)
     {
         // Get the module file name
-        ULONG trueLen = (ULONG)(strlen_u16(szFriendlyName) + 1);
+        ULONG trueLen = (ULONG)(u16_strlen(szFriendlyName) + 1);
 
         // Return name of module as required.
         if (szName && cchName > 0)
@@ -6488,7 +6488,7 @@ HRESULT ProfToEEInterfaceImpl::GetDynamicFunctionInfo(FunctionID functionId,
         ss.Normalize();
         LPCWSTR methodName = ss.GetUnicode();
 
-        ULONG trueLen = (ULONG)(strlen_u16(methodName) + 1);
+        ULONG trueLen = (ULONG)(u16_strlen(methodName) + 1);
 
         // Return name of method as required.
         if (wszName && cchName > 0)
@@ -9686,7 +9686,7 @@ HRESULT ProfToEEInterfaceImpl::GetRuntimeInformation(USHORT * pClrInstanceId,
         PCWSTR pczVersionString = CLR_PRODUCT_VERSION_L;
 
         // Get the module file name
-        ULONG trueLen = (ULONG)(strlen_u16(pczVersionString) + 1);
+        ULONG trueLen = (ULONG)(u16_strlen(pczVersionString) + 1);
 
         // Return name of module as required.
         if (szVersionString && cchVersionString > 0)

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -4126,7 +4126,7 @@ HRESULT ProfToEEInterfaceImpl::GetModuleInfo2(ModuleID     moduleId,
             wszFileName = strScopeName.GetUnicode();
         }
 
-        ULONG trueLen = (ULONG)(dn_wcslen(wszFileName) + 1);
+        ULONG trueLen = (ULONG)(strlen_u16(wszFileName) + 1);
 
         // Return name of module as required.
         if (wszName && cchName > 0)
@@ -5611,7 +5611,7 @@ HRESULT ProfToEEInterfaceImpl::GetAppDomainInfo(AppDomainID appDomainId,
     if (szFriendlyName != NULL)
     {
         // Get the module file name
-        ULONG trueLen = (ULONG)(dn_wcslen(szFriendlyName) + 1);
+        ULONG trueLen = (ULONG)(strlen_u16(szFriendlyName) + 1);
 
         // Return name of module as required.
         if (szName && cchName > 0)
@@ -6488,7 +6488,7 @@ HRESULT ProfToEEInterfaceImpl::GetDynamicFunctionInfo(FunctionID functionId,
         ss.Normalize();
         LPCWSTR methodName = ss.GetUnicode();
 
-        ULONG trueLen = (ULONG)(dn_wcslen(methodName) + 1);
+        ULONG trueLen = (ULONG)(strlen_u16(methodName) + 1);
 
         // Return name of method as required.
         if (wszName && cchName > 0)
@@ -9686,7 +9686,7 @@ HRESULT ProfToEEInterfaceImpl::GetRuntimeInformation(USHORT * pClrInstanceId,
         PCWSTR pczVersionString = CLR_PRODUCT_VERSION_L;
 
         // Get the module file name
-        ULONG trueLen = (ULONG)(dn_wcslen(pczVersionString) + 1);
+        ULONG trueLen = (ULONG)(strlen_u16(pczVersionString) + 1);
 
         // Return name of module as required.
         if (szVersionString && cchVersionString > 0)

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -4126,7 +4126,7 @@ HRESULT ProfToEEInterfaceImpl::GetModuleInfo2(ModuleID     moduleId,
             wszFileName = strScopeName.GetUnicode();
         }
 
-        ULONG trueLen = (ULONG)(wcslen(wszFileName) + 1);
+        ULONG trueLen = (ULONG)(dn_wcslen(wszFileName) + 1);
 
         // Return name of module as required.
         if (wszName && cchName > 0)
@@ -5611,7 +5611,7 @@ HRESULT ProfToEEInterfaceImpl::GetAppDomainInfo(AppDomainID appDomainId,
     if (szFriendlyName != NULL)
     {
         // Get the module file name
-        ULONG trueLen = (ULONG)(wcslen(szFriendlyName) + 1);
+        ULONG trueLen = (ULONG)(dn_wcslen(szFriendlyName) + 1);
 
         // Return name of module as required.
         if (szName && cchName > 0)
@@ -6488,7 +6488,7 @@ HRESULT ProfToEEInterfaceImpl::GetDynamicFunctionInfo(FunctionID functionId,
         ss.Normalize();
         LPCWSTR methodName = ss.GetUnicode();
 
-        ULONG trueLen = (ULONG)(wcslen(methodName) + 1);
+        ULONG trueLen = (ULONG)(dn_wcslen(methodName) + 1);
 
         // Return name of method as required.
         if (wszName && cchName > 0)
@@ -9686,7 +9686,7 @@ HRESULT ProfToEEInterfaceImpl::GetRuntimeInformation(USHORT * pClrInstanceId,
         PCWSTR pczVersionString = CLR_PRODUCT_VERSION_L;
 
         // Get the module file name
-        ULONG trueLen = (ULONG)(wcslen(pczVersionString) + 1);
+        ULONG trueLen = (ULONG)(dn_wcslen(pczVersionString) + 1);
 
         // Return name of module as required.
         if (szVersionString && cchVersionString > 0)

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -2165,7 +2165,7 @@ void ParseDefaultStackSize(LPCWSTR valueStr)
     {
         LPWSTR end;
         errno = 0;
-        unsigned long value = strtoul_u16(valueStr, &end, 16); // Base 16 without a prefix
+        unsigned long value = u16_strtoul(valueStr, &end, 16); // Base 16 without a prefix
 
         if ((errno == ERANGE)     // Parsed value doesn't fit in an unsigned long
             || (valueStr == end)  // No characters parsed

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -2165,7 +2165,7 @@ void ParseDefaultStackSize(LPCWSTR valueStr)
     {
         LPWSTR end;
         errno = 0;
-        unsigned long value = dn_wcstoul(valueStr, &end, 16); // Base 16 without a prefix
+        unsigned long value = strtoul_u16(valueStr, &end, 16); // Base 16 without a prefix
 
         if ((errno == ERANGE)     // Parsed value doesn't fit in an unsigned long
             || (valueStr == end)  // No characters parsed

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -2165,7 +2165,7 @@ void ParseDefaultStackSize(LPCWSTR valueStr)
     {
         LPWSTR end;
         errno = 0;
-        unsigned long value = wcstoul(valueStr, &end, 16); // Base 16 without a prefix
+        unsigned long value = dn_wcstoul(valueStr, &end, 16); // Base 16 without a prefix
 
         if ((errno == ERANGE)     // Parsed value doesn't fit in an unsigned long
             || (valueStr == end)  // No characters parsed


### PR DESCRIPTION
Create the narrow subset of `WCHAR` (wide character) APIs that coreclr needs and abstract over them on all platforms.

~~This was developed on macOS and has not been built on any other platform.~~

Removing PAL tests at present is ill-advised since there are Win32 emulated APIs that rely on the PAL versions of the functions. The goal here though is the PAL implementation of most of the wide character APIs is no longer used directly by coreclr.