### PR TITLE
Revert "let user know working directory will be used as content root path by default (#82445)

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/ConsoleLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/ConsoleLifetime.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.IO;
 using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
@@ -80,13 +79,6 @@ namespace Microsoft.Extensions.Hosting.Internal
             Logger.LogInformation("Application started. Press Ctrl+C to shut down.");
             Logger.LogInformation("Hosting environment: {EnvName}", Environment.EnvironmentName);
             Logger.LogInformation("Content root path: {ContentRoot}", Environment.ContentRootPath);
-            string contentRootFullPath = Path.GetFullPath(Environment.ContentRootPath);
-
-            if (contentRootFullPath.Equals(System.Environment.CurrentDirectory, StringComparison.Ordinal)
-                || contentRootFullPath.Equals(AppContext.BaseDirectory, StringComparison.Ordinal))
-            {
-                Logger.LogInformation("Current working directory is /. If Content root path is not set explicitly, then working directory is used by default.");
-            }
         }
 
         private void OnApplicationStopping()


### PR DESCRIPTION
This reverts commit c958573654937f9582b6a23522b2ad16cd7dbf96.

Fixes https://github.com/dotnet/runtime/issues/85809

https://github.com/dotnet/runtime/issues/78789 will be re-opened.
