### PR TITLE
Ensure DecomposeRotate correctly orders parameters.

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -4842,11 +4842,24 @@ void CodeGen::genCodeForShiftLong(GenTree* tree)
 
     unsigned int count = (unsigned int)shiftBy->AsIntConCommon()->IconValue();
 
-    regNumber tgtReg = tree->GetRegNum();
-    assert(regLo != tgtReg);
+    if (oper == GT_LSH_HI)
+    {
+        regNumber tgtReg = tree->GetRegNum();
+        assert(regLo != tgtReg);
 
-    inst_Mov(targetType, tgtReg, regHi, /* canSkip */ true);
-    inst_RV_RV_IV(ins, emitTypeSize(targetType), tgtReg, regLo, count);
+        inst_Mov(targetType, tgtReg, regHi, /* canSkip */ true);
+        inst_RV_RV_IV(ins, emitTypeSize(targetType), tree->GetRegNum(), regLo, count);
+    }
+    else
+    {
+        assert(oper == GT_RSH_LO);
+
+        regNumber tgtReg = tree->GetRegNum();
+        assert(regHi != tgtReg);
+
+        inst_Mov(targetType, tgtReg, regLo, /* canSkip */ true);
+        inst_RV_RV_IV(ins, emitTypeSize(targetType), tree->GetRegNum(), regHi, count);
+    }
 
     genProduceReg(tree);
 }

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -4842,19 +4842,11 @@ void CodeGen::genCodeForShiftLong(GenTree* tree)
 
     unsigned int count = (unsigned int)shiftBy->AsIntConCommon()->IconValue();
 
-    regNumber regResult = (oper == GT_LSH_HI) ? regHi : regLo;
+    regNumber tgtReg = tree->GetRegNum();
+    assert(regLo != tgtReg);
 
-    inst_Mov(targetType, tree->GetRegNum(), regResult, /* canSkip */ true);
-
-    if (oper == GT_LSH_HI)
-    {
-        inst_RV_RV_IV(ins, emitTypeSize(targetType), tree->GetRegNum(), regLo, count);
-    }
-    else
-    {
-        assert(oper == GT_RSH_LO);
-        inst_RV_RV_IV(ins, emitTypeSize(targetType), tree->GetRegNum(), regHi, count);
-    }
+    inst_Mov(targetType, tgtReg, regHi, /* canSkip */ true);
+    inst_RV_RV_IV(ins, emitTypeSize(targetType), tgtReg, regLo, count);
 
     genProduceReg(tree);
 }

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -1461,8 +1461,8 @@ GenTree* DecomposeLongs::DecomposeRotate(LIR::Use& use)
             hiOp1 = gtLong->gtGetOp1();
             loOp1 = gtLong->gtGetOp2();
 
-            hiOp1 = RepresentOpAsLocalVar(hiOp1, gtLong, &gtLong->AsOp()->gtOp1);
             loOp1 = RepresentOpAsLocalVar(loOp1, gtLong, &gtLong->AsOp()->gtOp2);
+            hiOp1 = RepresentOpAsLocalVar(hiOp1, gtLong, &gtLong->AsOp()->gtOp1);
 
             count -= 32;
         }
@@ -1475,6 +1475,11 @@ GenTree* DecomposeLongs::DecomposeRotate(LIR::Use& use)
             hiOp1 = RepresentOpAsLocalVar(hiOp1, gtLong, &gtLong->AsOp()->gtOp2);
         }
 
+        if (oper == GT_RSH_LO)
+        {
+            // lsra/codegen expects these operands in the opposite order
+            std::swap(loOp1, hiOp1);
+        }
         Range().Remove(gtLong);
 
         unsigned loOp1LclNum = loOp1->AsLclVarCommon()->GetLclNum();

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -1399,12 +1399,12 @@ GenTree* DecomposeLongs::DecomposeRotate(LIR::Use& use)
     // For longs, we need to change rols into two GT_LSH_HIs and rors into two GT_RSH_LOs
     // so we will get:
     //
-    // shld lo, hi, rotateAmount
+    // shld lo, hiCopy, rotateAmount
     // shld hi, loCopy, rotateAmount
     //
     // or:
     //
-    // shrd lo, hi, rotateAmount
+    // shrd lo, hiCopy, rotateAmount
     // shrd hi, loCopy, rotateAmount
 
     if (oper == GT_ROL)
@@ -1461,8 +1461,8 @@ GenTree* DecomposeLongs::DecomposeRotate(LIR::Use& use)
             hiOp1 = gtLong->gtGetOp1();
             loOp1 = gtLong->gtGetOp2();
 
-            loOp1 = RepresentOpAsLocalVar(loOp1, gtLong, &gtLong->AsOp()->gtOp2);
             hiOp1 = RepresentOpAsLocalVar(hiOp1, gtLong, &gtLong->AsOp()->gtOp1);
+            loOp1 = RepresentOpAsLocalVar(loOp1, gtLong, &gtLong->AsOp()->gtOp2);
 
             count -= 32;
         }

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -1105,7 +1105,14 @@ int LinearScan::BuildShiftRotate(GenTree* tree)
 
         if (!tree->isContained())
         {
-            setDelayFree(sourceLoUse);
+            if (tree->OperGet() == GT_LSH_HI)
+            {
+                setDelayFree(sourceLoUse);
+            }
+            else
+            {
+                setDelayFree(sourceHiUse);
+            }
         }
     }
     else

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -1105,14 +1105,7 @@ int LinearScan::BuildShiftRotate(GenTree* tree)
 
         if (!tree->isContained())
         {
-            if (tree->OperGet() == GT_LSH_HI)
-            {
-                setDelayFree(sourceLoUse);
-            }
-            else
-            {
-                setDelayFree(sourceHiUse);
-            }
+            setDelayFree(sourceLoUse);
         }
     }
     else

--- a/src/tests/JIT/Regression/JitBlue/Runtime_86027/Runtime_86207.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_86027/Runtime_86207.cs
@@ -8,7 +8,7 @@ using Xunit;
 public class Runtime_86027
 {
     [Fact]
-    public static int TestRotateLeft()
+    public static int TestRotateLeft1()
     {
         long[] firstOp = new long[] { 7822136809956075968, 1 };
 
@@ -21,11 +21,63 @@ public class Runtime_86027
     }
 
     [Fact]
-    public static int TestRotateRight()
+    public static int TestRotateLeft32()
+    {
+        long[] firstOp = new long[] { 7822136809956075968, 1 };
+
+        if (long.RotateLeft(firstOp[0], 32) != 3886722753596608508)
+        {
+            return 0;
+        }
+
+        return 100;
+    }
+
+    [Fact]
+    public static int TestRotateLeft33()
+    {
+        long[] firstOp = new long[] { 7822136809956075968, 1 };
+
+        if (long.RotateLeft(firstOp[0], 33) != 7773445507193217016)
+        {
+            return 0;
+        }
+
+        return 100;
+    }
+
+    [Fact]
+    public static int TestRotateRight1()
     {
         long[] firstOp = new long[] { 7822136809956075968, 1 };
 
         if (long.RotateRight(firstOp[0], 1) != 3911068404978037984)
+        {
+            return 0;
+        }
+
+        return 100;
+    }
+
+    [Fact]
+    public static int TestRotateRight32()
+    {
+        long[] firstOp = new long[] { 7822136809956075968, 1 };
+
+        if (long.RotateRight(firstOp[0], 32) != 3886722753596608508)
+        {
+            return 0;
+        }
+
+        return 100;
+    }
+
+    [Fact]
+    public static int TestRotateRight33()
+    {
+        long[] firstOp = new long[] { 7822136809956075968, 1 };
+
+        if (long.RotateRight(firstOp[0], 33) != 1943361376798304254)
         {
             return 0;
         }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_86027/Runtime_86207.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_86027/Runtime_86207.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_86027
+{
+    [Fact]
+    public static int TestRotateLeft()
+    {
+        long[] firstOp = new long[] { 7822136809956075968, 1 };
+
+        if (long.RotateLeft(firstOp[0], 1) != -2802470453797399680)
+        {
+            return 0;
+        }
+
+        return 100;
+    }
+
+    [Fact]
+    public static int TestRotateRight()
+    {
+        long[] firstOp = new long[] { 7822136809956075968, 1 };
+
+        if (long.RotateRight(firstOp[0], 1) != 3911068404978037984)
+        {
+            return 0;
+        }
+
+        return 100;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_86027/Runtime_86207.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_86027/Runtime_86207.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <DebugType>None</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This resolves #86027 

`LSH_HI` emits itself as the following, which operates as `(tgt << amt) | (upper >>> (32 - amt))`
```
mov tgt, upper
shld tgt, lower, amt
```

`RSH_LO` emits itself as the following, which operates as `(tgt >>> amt) | (upper << (32 - amt))`
```
mov tgt, lower
shrd tgt, upper, amt
```

LSRA and CodeGen were incorrectly swapping the operands for `GT_RSH_LO` which hasn't been caught because the `morph` logic almost exclusively generates `GT_ROL`. That is, `RotateRight(x, 1)` was generating a `GT_ROL(x, 63)` node, which means the `GT_ROR` path was effectively unused.

This was changed in .NET 8 when support for recognizing these as intrinsic on import was added and so `RotateRight` was imported directly as `GT_ROR`