### PR TITLE
Add integration tests for PreserveSig and use the MemberFunction calling convention by default in the ComInterfaceGenerator

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
@@ -497,7 +497,10 @@ namespace Microsoft.Interop
 
             var methodSyntaxTemplate = new ContainingSyntax(syntax.Modifiers.StripAccessibilityModifiers().StripTriviaFromTokens(), SyntaxKind.MethodDeclaration, syntax.Identifier, syntax.TypeParameterList);
 
-            ImmutableArray<FunctionPointerUnmanagedCallingConventionSyntax> callConv = VtableIndexStubGenerator.GenerateCallConvSyntaxFromAttributes(suppressGCTransitionAttribute, unmanagedCallConvAttribute);
+            ImmutableArray<FunctionPointerUnmanagedCallingConventionSyntax> callConv = VirtualMethodPointerStubGenerator.GenerateCallConvSyntaxFromAttributes(
+                suppressGCTransitionAttribute,
+                unmanagedCallConvAttribute,
+                ImmutableArray.Create(FunctionPointerUnmanagedCallingConvention(Identifier("MemberFunction"))));
 
             var typeKeyOwner = ManagedTypeInfo.CreateTypeInfoForTypeSymbol(symbol.ContainingType);
 

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VirtualMethodPointerStubGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VirtualMethodPointerStubGenerator.cs
@@ -196,5 +196,41 @@ namespace Microsoft.Interop
                     FunctionPointerParameterList(SeparatedList(functionPointerParameters)));
             return functionPointerType;
         }
+
+        public static ImmutableArray<FunctionPointerUnmanagedCallingConventionSyntax> GenerateCallConvSyntaxFromAttributes(AttributeData? suppressGCTransitionAttribute, AttributeData? unmanagedCallConvAttribute, ImmutableArray<FunctionPointerUnmanagedCallingConventionSyntax> defaultCallingConventions)
+        {
+            const string CallConvsField = "CallConvs";
+            ImmutableArray<FunctionPointerUnmanagedCallingConventionSyntax>.Builder callingConventions = ImmutableArray.CreateBuilder<FunctionPointerUnmanagedCallingConventionSyntax>();
+
+            // We'll always support adding SuppressGCTransition to other calling convention options.
+            if (suppressGCTransitionAttribute is not null)
+            {
+                callingConventions.Add(FunctionPointerUnmanagedCallingConvention(Identifier("SuppressGCTransition")));
+            }
+
+            // UnmanagedCallConvAttribute overrides the default calling convention rules.
+            if (unmanagedCallConvAttribute is not null)
+            {
+                foreach (KeyValuePair<string, TypedConstant> arg in unmanagedCallConvAttribute.NamedArguments)
+                {
+                    if (arg.Key == CallConvsField)
+                    {
+                        foreach (TypedConstant callConv in arg.Value.Values)
+                        {
+                            ITypeSymbol callConvSymbol = (ITypeSymbol)callConv.Value!;
+                            if (callConvSymbol.Name.StartsWith("CallConv", StringComparison.Ordinal))
+                            {
+                                callingConventions.Add(FunctionPointerUnmanagedCallingConvention(Identifier(callConvSymbol.Name.Substring("CallConv".Length))));
+                            }
+                        }
+                    }
+                }
+            }
+            else
+            {
+                callingConventions.AddRange(defaultCallingConventions);
+            }
+            return callingConventions.ToImmutable();
+        }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/PreserveSigTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/PreserveSigTests.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using SharedTypes.ComInterfaces;
+using Xunit;
+
+namespace ComInterfaceGenerator.Tests
+{
+    public unsafe partial class PreserveSigTests
+    {
+        [LibraryImport(NativeExportsNE.NativeExportsNE_Binary, EntryPoint = "create_point_provider")]
+        public static partial void* NewNativeObject();
+
+        [Fact]
+        public unsafe void CallRcwFromGeneratedComInterface()
+        {
+            var ptr = NewNativeObject(); // new_native_object
+            var cw = new StrategyBasedComWrappers();
+            var obj = (IPointProvider)cw.GetOrCreateObjectForComInstance((nint)ptr, CreateObjectFlags.None);
+
+            var expected = new Point(42, 63);
+
+            obj.SetPoint(expected);
+
+            Assert.Equal(expected, obj.GetPoint());
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/TargetSignatureTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/TargetSignatureTests.cs
@@ -229,17 +229,17 @@ namespace ComInterfaceGenerator.Unit.Tests
         public async Task ComInterfaceMethodFunctionPointerReturnsInt()
         {
             string source = $$"""
-        using System.Runtime.CompilerServices;
-        using System.Runtime.InteropServices;
-        using System.Runtime.InteropServices.Marshalling;
+                using System.Runtime.CompilerServices;
+                using System.Runtime.InteropServices;
+                using System.Runtime.InteropServices.Marshalling;
 
-        [GeneratedComInterface]
-        [Guid("0A617667-4961-4F90-B74F-6DC368E98179")]
-        partial interface IComInterface
-        {
-            void Method();
-        }
-        """;
+                [GeneratedComInterface]
+                [Guid("0A617667-4961-4F90-B74F-6DC368E98179")]
+                partial interface IComInterface
+                {
+                    void Method();
+                }
+                """;
 
             await VerifyComInterfaceGeneratorAsync(source, "IComInterface", "Method", (newComp, signature) =>
             {

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/TargetSignatureTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/TargetSignatureTests.cs
@@ -179,7 +179,7 @@ namespace ComInterfaceGenerator.Unit.Tests
         }
 
         [Fact]
-        public async Task ComInterfaceMethodFunctionPointerReturnsInt()
+        public async Task ComInterfaceMethodHasMemberFunctionCallingConventionByDefault()
         {
             string source = $$"""
                 using System.Runtime.CompilerServices;
@@ -193,6 +193,53 @@ namespace ComInterfaceGenerator.Unit.Tests
                     void Method();
                 }
                 """;
+
+            await VerifyComInterfaceGeneratorAsync(source, "IComInterface", "Method", (newComp, signature) =>
+            {
+                Assert.Equal(SignatureCallingConvention.Unmanaged, signature.CallingConvention);
+                Assert.Equal(newComp.GetTypeByMetadataName("System.Runtime.CompilerServices.CallConvMemberFunction"), Assert.Single(signature.UnmanagedCallingConventionTypes), SymbolEqualityComparer.Default);
+            });
+        }
+
+        [Fact]
+        public async Task ComInterfacePreserveSigMethodHasMemberFunctionCallingConventionByDefault()
+        {
+            string source = $$"""
+                using System.Runtime.CompilerServices;
+                using System.Runtime.InteropServices;
+                using System.Runtime.InteropServices.Marshalling;
+
+                [GeneratedComInterface]
+                [Guid("0A617667-4961-4F90-B74F-6DC368E98179")]
+                partial interface IComInterface
+                {
+                    [PreserveSig]
+                    int Method();
+                }
+                """;
+
+            await VerifyComInterfaceGeneratorAsync(source, "IComInterface", "Method", (newComp, signature) =>
+            {
+                Assert.Equal(SignatureCallingConvention.Unmanaged, signature.CallingConvention);
+                Assert.Equal(newComp.GetTypeByMetadataName("System.Runtime.CompilerServices.CallConvMemberFunction"), Assert.Single(signature.UnmanagedCallingConventionTypes), SymbolEqualityComparer.Default);
+            });
+        }
+
+        [Fact]
+        public async Task ComInterfaceMethodFunctionPointerReturnsInt()
+        {
+            string source = $$"""
+        using System.Runtime.CompilerServices;
+        using System.Runtime.InteropServices;
+        using System.Runtime.InteropServices.Marshalling;
+
+        [GeneratedComInterface]
+        [Guid("0A617667-4961-4F90-B74F-6DC368E98179")]
+        partial interface IComInterface
+        {
+            void Method();
+        }
+        """;
 
             await VerifyComInterfaceGeneratorAsync(source, "IComInterface", "Method", (newComp, signature) =>
             {

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/ComInterfaceGenerator/GetPoint.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/ComInterfaceGenerator/GetPoint.cs
@@ -1,0 +1,111 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using SharedTypes.ComInterfaces;
+using static System.Runtime.InteropServices.ComWrappers;
+
+namespace NativeExports.ComInterfaceGenerator
+{
+    internal unsafe class GetPoint
+    {
+        [UnmanagedCallersOnly(EntryPoint = "create_point_provider")]
+        public static void* CreatePointProvider()
+        {
+            MyComWrapper cw = new();
+            var myObject = new ImplementingObject();
+            nint ptr = cw.GetOrCreateComInterfaceForObject(myObject, CreateComInterfaceFlags.None);
+
+            return (void*)ptr;
+        }
+
+        private sealed class MyComWrapper : ComWrappers
+        {
+            protected override ComInterfaceEntry* ComputeVtables(object obj, CreateComInterfaceFlags flags, out int count)
+            {
+                if (obj is ImplementingObject)
+                {
+                    ComInterfaceEntry* comInterfaceEntry = (ComInterfaceEntry*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(ImplementingObject), sizeof(ComInterfaceEntry));
+                    comInterfaceEntry->IID = typeof(IPointProvider).GUID;
+                    comInterfaceEntry->Vtable = (nint)ImplementingObject.ABI.VTable;
+                    count = 1;
+                    return comInterfaceEntry;
+                }
+                count = 0;
+                return null;
+            }
+
+            protected override object? CreateObject(nint externalComObject, CreateObjectFlags flags) => throw new NotImplementedException();
+            protected override void ReleaseObjects(IEnumerable objects) => throw new NotImplementedException();
+        }
+
+        private sealed class ImplementingObject : IPointProvider
+        {
+            private Point _point;
+
+            public Point GetPoint() => _point;
+            public void SetPoint(Point point) => _point = point;
+
+            public static class ABI
+            {
+                static void* s_vtable = null;
+
+                public static void* VTable
+                {
+                    get
+                    {
+                        if (s_vtable != null)
+                            return s_vtable;
+                        void** vtable = (void**)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(ImplementingObject), sizeof(void*) * 5);
+                        GetIUnknownImpl(out var fpQueryInterface, out var fpAddReference, out var fpRelease);
+                        vtable[0] = (void*)fpQueryInterface;
+                        vtable[1] = (void*)fpAddReference;
+                        vtable[2] = (void*)fpRelease;
+                        vtable[3] = (delegate* unmanaged[MemberFunction]<ComInterfaceDispatch*, Point>)&ImplementingObject.ABI.GetPoint;
+                        vtable[4] = (delegate* unmanaged[MemberFunction]<ComInterfaceDispatch*, Point, int>)&ImplementingObject.ABI.SetPoint;
+                        s_vtable = vtable;
+                        return s_vtable;
+                    }
+                }
+
+                [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvMemberFunction) })]
+                private static Point GetPoint(ComInterfaceDispatch* @this)
+                {
+
+                    try
+                    {
+                        return ComInterfaceDispatch.GetInstance<IPointProvider>(@this).GetPoint();
+                    }
+                    catch (Exception e)
+                    {
+                        _ = Marshal.GetHRForException(e);
+                        return default;
+                    }
+                }
+
+                [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvMemberFunction) })]
+                private static int SetPoint(ComInterfaceDispatch* @this, Point point)
+                {
+
+                    try
+                    {
+                        ComInterfaceDispatch.GetInstance<IPointProvider>(@this).SetPoint(point);
+                        return 0;
+                    }
+                    catch (Exception e)
+                    {
+                        return Marshal.GetHRForException(e);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IPointProvider.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IPointProvider.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SharedTypes.ComInterfaces
+{
+    [GeneratedComInterface]
+    [Guid("E4461914-4202-479F-8427-620E915F84B9")]
+    internal partial interface IPointProvider
+    {
+        [PreserveSig]
+        Point GetPoint();
+
+        void SetPoint(Point point);
+    }
+}


### PR DESCRIPTION
Now that we support PreserveSig, we need to switch the default calling convention in the ComInterfaceGenerator to CallConvMemberFunction to ensure that we don't end up in the same place we did around non-int-returning COM-like methods. As part of adding integration tests for PreserveSig, validate this scenario as well.