### PR TITLE
Fix official build after removing win-arm runtime build

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -524,7 +524,6 @@ extends:
             - Build_windows_x64_release_CrossAOT_Mono
             - installer__coreclr__windows_x64_Release_
             - installer__coreclr__windows_x86_Release_
-            - installer__coreclr__windows_arm_Release_
             - installer__coreclr__windows_arm64_Release_
 
     - ${{ if eq(variables.isOfficialBuild, true) }}:

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.json.in
@@ -148,7 +148,6 @@
       "packs": [
         "Microsoft.NETCore.App.Runtime.win-x64",
         "Microsoft.NETCore.App.Runtime.win-x86",
-        "Microsoft.NETCore.App.Runtime.win-arm",
         "Microsoft.NETCore.App.Runtime.win-arm64"
       ]
     },
@@ -390,10 +389,6 @@
       "version": "${PackageVersion}"
     },
     "Microsoft.NETCore.App.Runtime.win-x86" : {
-      "kind": "framework",
-      "version": "${PackageVersion}"
-    },
-    "Microsoft.NETCore.App.Runtime.win-arm" : {
       "kind": "framework",
       "version": "${PackageVersion}"
     },


### PR DESCRIPTION
win-arm CI builds were removed with https://github.com/dotnet/runtime/pull/85947

Hopefully fixes https://github.com/dotnet/runtime/issues/86073