### PR TITLE
Hardcode the path to libclang from Mariner, not Clang 9 on CentOS 7

### DIFF
--- a/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+++ b/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
@@ -46,7 +46,7 @@ steps:
                 -arch ${{ parameters.archType }}
                 /p:BuildMonoAotCrossCompiler=true
                 /p:BuildMonoAotCrossCompilerOnly=true
-                /p:MonoLibClang="/usr/lib/llvm-9/lib/libclang-9.so.1"
+                /p:MonoLibClang="/usr/local/lib/libclang.so.12"
                 /p:MonoAOTEnableLLVM=true
                 /p:MonoAOTLLVMUseCxx11Abi=true
                 /p:CrossBuild=true

--- a/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+++ b/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
@@ -46,7 +46,7 @@ steps:
                 -arch ${{ parameters.archType }}
                 /p:BuildMonoAotCrossCompiler=true
                 /p:BuildMonoAotCrossCompilerOnly=true
-                /p:MonoLibClang="/usr/local/lib/libclang.so.12"
+                /p:MonoLibClang="/usr/local/lib/libclang.so.16"
                 /p:MonoAOTEnableLLVM=true
                 /p:MonoAOTLLVMUseCxx11Abi=true
                 /p:CrossBuild=true

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -291,7 +291,7 @@ jobs:
                   -arch $(archType)
                   /p:BuildMonoAotCrossCompiler=true
                   /p:BuildMonoAotCrossCompilerOnly=true
-                  /p:MonoLibClang="/usr/lib/llvm-9/lib/libclang-9.so.1"
+                  /p:MonoLibClang="/usr/local/lib/libclang.so.12"
                   /p:MonoAOTEnableLLVM=true
                   /p:MonoAOTLLVMUseCxx11Abi=true
           displayName: "Build Mono LLVM AOT cross compiler"

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -291,7 +291,7 @@ jobs:
                   -arch $(archType)
                   /p:BuildMonoAotCrossCompiler=true
                   /p:BuildMonoAotCrossCompilerOnly=true
-                  /p:MonoLibClang="/usr/local/lib/libclang.so.12"
+                  /p:MonoLibClang="/usr/local/lib/libclang.so.16"
                   /p:MonoAOTEnableLLVM=true
                   /p:MonoAOTLLVMUseCxx11Abi=true
           displayName: "Build Mono LLVM AOT cross compiler"


### PR DESCRIPTION
Closes: https://github.com/dotnet/runtime/issues/85529