### PR TITLE
Fix an SSA bug from the `ASG` refactoring

### DIFF
--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1634,7 +1634,7 @@ public:
 
     bool OperIsSsaDef() const
     {
-        return OperIs(GT_CALL) || OperIsLocalStore();
+        return OperIsLocalStore() || OperIs(GT_CALL);
     }
 
     static bool OperIsHWIntrinsic(genTreeOps gtOper)

--- a/src/coreclr/jit/ssabuilder.cpp
+++ b/src/coreclr/jit/ssabuilder.cpp
@@ -743,7 +743,7 @@ void SsaBuilder::InsertPhiFunctions(BasicBlock** postOrder, int count)
 //
 void SsaBuilder::RenameDef(GenTree* defNode, BasicBlock* block)
 {
-    assert(defNode->OperIsSsaDef());
+    assert(defNode->OperIsStore() || defNode->OperIs(GT_CALL));
 
     GenTreeLclVarCommon* lclNode;
     bool                 isFullDef = false;
@@ -1114,7 +1114,7 @@ void SsaBuilder::BlockRenameVariables(BasicBlock* block)
     {
         for (GenTree* const tree : stmt->TreeList())
         {
-            if (tree->OperIsSsaDef())
+            if (tree->OperIsStore() || tree->OperIs(GT_CALL))
             {
                 RenameDef(tree, block);
             }

--- a/src/tests/JIT/opt/SSA/MemorySsa.cs
+++ b/src/tests/JIT/opt/SSA/MemorySsa.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public class MemorySsaTests
+{
+    private static int _intStatic;
+
+    public static int Main()
+    {
+        return ProblemWithHandlerPhis(new int[0]) ? 101 : 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool ProblemWithHandlerPhis(int[] x)
+    {
+        _intStatic = 2;
+
+        try
+        {
+            _intStatic = 1;
+            _ = x[0];
+            _intStatic = 2;
+        }        
+        catch (Exception)
+        {
+            // Memory PHIs in handlers must consider all intermediate states
+            // that might arise from stores between throwing expressions.
+            if (_intStatic == 2)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/tests/JIT/opt/SSA/MemorySsa.csproj
+++ b/src/tests/JIT/opt/SSA/MemorySsa.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The SSA renaming code was changed in an incompatible way s.t. memory stores in protected blocks were no longer considered to induce PHIs in the corresponding handlers.