### PR TITLE
[wasm] [jiterp] Fix jit calls and interp entry wrappers

### DIFF
--- a/src/mono/wasm/runtime/jiterpreter-interp-entry.ts
+++ b/src/mono/wasm/runtime/jiterpreter-interp-entry.ts
@@ -292,6 +292,10 @@ function flush_wasm_entry_trampoline_jit_queue() {
             builder.defineImportedFunction("i", trampImports[i][0], trampImports[i][1], true, trampImports[i][2]);
         }
 
+        // Assign import indices so they get emitted in the import section
+        for (let i = 0; i < trampImports.length; i++)
+            builder.markImportAsUsed(trampImports[i][0]);
+
         builder._generateImportSection();
 
         // Function section

--- a/src/mono/wasm/runtime/jiterpreter-jit-call.ts
+++ b/src/mono/wasm/runtime/jiterpreter-jit-call.ts
@@ -394,7 +394,12 @@ export function mono_interp_flush_jitcall_queue(): void {
 
         // Emit function imports
         for (let i = 0; i < trampImports.length; i++)
-            builder.defineImportedFunction("i", trampImports[i][0], trampImports[i][1], true, trampImports[i][2]);
+            builder.defineImportedFunction("i", trampImports[i][0], trampImports[i][1], false, trampImports[i][2]);
+
+        // Assign import indices so they get emitted in the import section
+        for (let i = 0; i < trampImports.length; i++)
+            builder.markImportAsUsed(trampImports[i][0]);
+
         builder._generateImportSection();
 
         // Function section


### PR DESCRIPTION
The import usage tracking was incorrect for jitcall and interp entry wrappers, which was causing them to fail to compile and then shut off the jiterpreter due to the error(s) when running AOT'd applications like browser-bench.