### PR TITLE
Fix spurious SuperPMI asm diffs

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9919,6 +9919,14 @@ public:
 
     } info;
 
+#if defined(DEBUG)
+    // Are we running a replay under SuperPMI?
+    bool RunningSuperPmiReplay() const
+    {
+        return info.compMethodSuperPMIIndex != -1;
+    }
+#endif // DEBUG
+
     ReturnTypeDesc compRetTypeDesc; // ABI return type descriptor for the method
 
     //------------------------------------------------------------------------


### PR DESCRIPTION
Under ELT profiler stress, we encode the un-relocated address of the `DummyProfilerELTStub` function in the JIT codebase into the generated code. This can lead to spurious diffs if the address is different between base and diff JITs (which is likely).

To avoid this, under SuperPMI replay (which we only know in DEBUG builds currently), use a fixed constant for this address. The code isn't executed during SuperPMI replay, so it doesn't need to be a valid code address.