### PR TITLE
Delete more code around reflection blocking

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
@@ -117,28 +117,19 @@ namespace Internal.Reflection.Core.Execution
 
         public Type GetArrayTypeForHandle(RuntimeTypeHandle typeHandle)
         {
-            RuntimeTypeHandle elementTypeHandle;
-            if (!ExecutionEnvironment.TryGetArrayTypeElementType(typeHandle, out elementTypeHandle))
-                throw CreateMissingMetadataException((Type?)null);
-
+            RuntimeTypeHandle elementTypeHandle = ExecutionEnvironment.GetArrayTypeElementType(typeHandle);
             return elementTypeHandle.GetTypeForRuntimeTypeHandle().GetArrayType(typeHandle);
         }
 
         public Type GetMdArrayTypeForHandle(RuntimeTypeHandle typeHandle, int rank)
         {
-            RuntimeTypeHandle elementTypeHandle;
-            if (!ExecutionEnvironment.TryGetArrayTypeElementType(typeHandle, out elementTypeHandle))
-                throw CreateMissingMetadataException((Type?)null);
-
+            RuntimeTypeHandle elementTypeHandle = ExecutionEnvironment.GetArrayTypeElementType(typeHandle);
             return elementTypeHandle.GetTypeForRuntimeTypeHandle().GetMultiDimArrayType(rank, typeHandle);
         }
 
         public Type GetPointerTypeForHandle(RuntimeTypeHandle typeHandle)
         {
-            RuntimeTypeHandle targetTypeHandle;
-            if (!ExecutionEnvironment.TryGetPointerTypeTargetType(typeHandle, out targetTypeHandle))
-                throw CreateMissingMetadataException((Type?)null);
-
+            RuntimeTypeHandle targetTypeHandle = ExecutionEnvironment.GetPointerTypeTargetType(typeHandle);
             return targetTypeHandle.GetTypeForRuntimeTypeHandle().GetPointerType(typeHandle);
         }
 
@@ -161,10 +152,7 @@ namespace Internal.Reflection.Core.Execution
 
         public Type GetByRefTypeForHandle(RuntimeTypeHandle typeHandle)
         {
-            RuntimeTypeHandle targetTypeHandle;
-            if (!ExecutionEnvironment.TryGetByRefTypeTargetType(typeHandle, out targetTypeHandle))
-                throw CreateMissingMetadataException((Type?)null);
-
+            RuntimeTypeHandle targetTypeHandle = ExecutionEnvironment.GetByRefTypeTargetType(typeHandle);
             return targetTypeHandle.GetTypeForRuntimeTypeHandle().GetByRefType(typeHandle);
         }
 
@@ -187,7 +175,7 @@ namespace Internal.Reflection.Core.Execution
         //=======================================================================================
         // Missing metadata exceptions.
         //=======================================================================================
-        public Exception CreateMissingMetadataException(Type? pertainant)
+        public Exception CreateMissingMetadataException(Type pertainant)
         {
             return this.ReflectionDomainSetup.CreateMissingMetadataException(pertainant);
         }
@@ -195,16 +183,6 @@ namespace Internal.Reflection.Core.Execution
         public Exception CreateNonInvokabilityException(MemberInfo pertainant)
         {
             return this.ReflectionDomainSetup.CreateNonInvokabilityException(pertainant);
-        }
-
-        public Exception CreateMissingArrayTypeException(Type elementType, bool isMultiDim, int rank)
-        {
-            return ReflectionDomainSetup.CreateMissingArrayTypeException(elementType, isMultiDim, rank);
-        }
-
-        public Exception CreateMissingConstructedGenericTypeException(Type genericTypeDefinition, Type[] genericTypeArguments)
-        {
-            return ReflectionDomainSetup.CreateMissingConstructedGenericTypeException(genericTypeDefinition, genericTypeArguments);
         }
 
         //=======================================================================================

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
@@ -46,7 +46,6 @@ namespace Internal.Reflection.Core.Execution
         public abstract IEnumerable<RuntimeTypeHandle> TryGetImplementedInterfaces(RuntimeTypeHandle typeHandle);
         public abstract void VerifyInterfaceIsImplemented(RuntimeTypeHandle typeHandle, RuntimeTypeHandle ifaceHandle);
         public abstract void GetInterfaceMap(Type instanceType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] Type interfaceType, out MethodInfo[] interfaceMethods, out MethodInfo[] targetMethods);
-        public abstract string GetLastResortString(RuntimeTypeHandle typeHandle);
 
         //==============================================================================================
         // Reflection Mapping Tables
@@ -55,7 +54,7 @@ namespace Internal.Reflection.Core.Execution
         public abstract bool TryGetNamedTypeForMetadata(QTypeDefinition qTypeDefinition, out RuntimeTypeHandle runtimeTypeHandle);
 
         public abstract bool TryGetArrayTypeForElementType(RuntimeTypeHandle elementTypeHandle, out RuntimeTypeHandle arrayTypeHandle);
-        public abstract bool TryGetArrayTypeElementType(RuntimeTypeHandle arrayTypeHandle, out RuntimeTypeHandle elementTypeHandle);
+        public abstract RuntimeTypeHandle GetArrayTypeElementType(RuntimeTypeHandle arrayTypeHandle);
 
         public abstract bool TryGetMultiDimArrayTypeForElementType(RuntimeTypeHandle elementTypeHandle, int rank, out RuntimeTypeHandle arrayTypeHandle);
 
@@ -63,10 +62,10 @@ namespace Internal.Reflection.Core.Execution
         public abstract void GetFunctionPointerTypeComponents(RuntimeTypeHandle functionPointerHandle, out RuntimeTypeHandle returnTypeHandle, out RuntimeTypeHandle[] parameterHandles, out bool isUnmanaged);
 
         public abstract bool TryGetPointerTypeForTargetType(RuntimeTypeHandle targetTypeHandle, out RuntimeTypeHandle pointerTypeHandle);
-        public abstract bool TryGetPointerTypeTargetType(RuntimeTypeHandle pointerTypeHandle, out RuntimeTypeHandle targetTypeHandle);
+        public abstract RuntimeTypeHandle GetPointerTypeTargetType(RuntimeTypeHandle pointerTypeHandle);
 
         public abstract bool TryGetByRefTypeForTargetType(RuntimeTypeHandle targetTypeHandle, out RuntimeTypeHandle byRefTypeHandle);
-        public abstract bool TryGetByRefTypeTargetType(RuntimeTypeHandle byRefTypeHandle, out RuntimeTypeHandle targetTypeHandle);
+        public abstract RuntimeTypeHandle GetByRefTypeTargetType(RuntimeTypeHandle byRefTypeHandle);
 
         public abstract bool TryGetConstructedGenericTypeForComponents(RuntimeTypeHandle genericTypeDefinitionHandle, RuntimeTypeHandle[] genericTypeArgumentHandles, out RuntimeTypeHandle runtimeTypeHandle);
         public abstract bool TryGetConstructedGenericTypeForComponentsNoConstraintCheck(RuntimeTypeHandle genericTypeDefinitionHandle, RuntimeTypeHandle[] genericTypeArgumentHandles, out RuntimeTypeHandle runtimeTypeHandle);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/ReflectionDomainSetup.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/ReflectionDomainSetup.cs
@@ -13,9 +13,7 @@ namespace Internal.Reflection.Core
     {
         protected ReflectionDomainSetup() { }
         public abstract AssemblyBinder AssemblyBinder { get; }
-        public abstract Exception CreateMissingMetadataException(Type? pertainant);
+        public abstract Exception CreateMissingMetadataException(Type pertainant);
         public abstract Exception CreateNonInvokabilityException(MemberInfo pertainant);
-        public abstract Exception CreateMissingArrayTypeException(Type elementType, bool isMultiDim, int rank);
-        public abstract Exception CreateMissingConstructedGenericTypeException(Type genericTypeDefinition, Type[] genericTypeArguments);
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/ReflectionExecutionDomainCallbacks.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/ReflectionExecutionDomainCallbacks.cs
@@ -41,7 +41,6 @@ namespace Internal.Runtime.Augments
         // Flotsam and jetsam.
         public abstract Exception CreateMissingMetadataException(Type typeWithMissingMetadata);
 
-        public abstract string GetBetterDiagnosticInfoIfAvailable(RuntimeTypeHandle runtimeTypeHandle);
         public abstract MethodBase GetMethodBaseFromStartAddressIfAvailable(IntPtr methodStartAddress);
         public abstract Assembly GetAssemblyForHandle(RuntimeTypeHandle typeHandle);
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -914,11 +914,6 @@ namespace Internal.Runtime.Augments
             return Delegate.CreateObjectArrayDelegate(delegateType, invoker);
         }
 
-        public static string GetLastResortString(RuntimeTypeHandle typeHandle)
-        {
-            return typeHandle.LastResortToString;
-        }
-
         public static IntPtr RhHandleAlloc(object value, GCHandleType type)
         {
             return RuntimeImports.RhHandleAlloc(value, type);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/RuntimeInteropData.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/RuntimeInteropData.cs
@@ -20,13 +20,15 @@ namespace Internal.Runtime.CompilerHelpers
                 return offset;
             }
 
+            Type structureType = Type.GetTypeFromHandle(structureTypeHandle)!;
+
             // if we can find the struct but couldn't find its field, throw Argument Exception
             if (structExists)
             {
-                throw new ArgumentException(SR.Format(SR.Argument_OffsetOfFieldNotFound, RuntimeAugments.GetLastResortString(structureTypeHandle)), nameof(fieldName));
+                throw new ArgumentException(SR.Format(SR.Argument_OffsetOfFieldNotFound, structureType), nameof(fieldName));
             }
 
-            throw new NotSupportedException(SR.Format(SR.StructMarshalling_MissingInteropData, Type.GetTypeFromHandle(structureTypeHandle)));
+            throw new NotSupportedException(SR.Format(SR.StructMarshalling_MissingInteropData, structureType));
         }
 
         public static int GetStructUnsafeStructSize(RuntimeTypeHandle structureTypeHandle)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/Helpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/Helpers.cs
@@ -62,11 +62,6 @@ namespace System.Reflection.Runtime.General
             return typeInfos;
         }
 
-        public static string LastResortString(this RuntimeTypeHandle typeHandle)
-        {
-            return ReflectionCoreExecution.ExecutionEnvironment.GetLastResortString(typeHandle);
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static RuntimeNamedTypeInfo CastToRuntimeNamedTypeInfo(this Type type)
         {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/TypeUnifier.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/TypeUnifier.cs
@@ -70,7 +70,7 @@ namespace System.Reflection.Runtime.General
                 && !(elementType is RuntimeCLSIDTypeInfo)
 #endif
                 )
-                throw ReflectionCoreExecution.ExecutionDomain.CreateMissingArrayTypeException(elementType, isMultiDim: false, 1);
+                throw ReflectionCoreExecution.ExecutionDomain.CreateMissingMetadataException(arrayType);
 
             return arrayType;
         }
@@ -109,7 +109,7 @@ namespace System.Reflection.Runtime.General
                         atLeastOneOpenType = true;
                 }
                 if (!atLeastOneOpenType)
-                    throw ReflectionCoreExecution.ExecutionDomain.CreateMissingConstructedGenericTypeException(genericType.GetGenericTypeDefinition(), genericTypeArguments.CloneTypeArray());
+                    throw ReflectionCoreExecution.ExecutionDomain.CreateMissingMetadataException(genericType);
             }
 
             return genericType;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeConstructedGenericTypeInfo.cs
@@ -213,10 +213,7 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
-                RuntimeTypeInfo genericTypeDefinition = this.GenericTypeDefinitionTypeInfo;
-                if (!(genericTypeDefinition is RuntimeNamedTypeInfo genericTypeDefinitionNamedTypeInfo))
-                    throw ReflectionCoreExecution.ExecutionDomain.CreateMissingMetadataException(genericTypeDefinition);
-                return genericTypeDefinitionNamedTypeInfo;
+                return (RuntimeNamedTypeInfo)GenericTypeDefinitionTypeInfo;
             }
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.NativeAot.cs
@@ -117,7 +117,7 @@ namespace System.Runtime.InteropServices
                 structureTypeHandle.IsInterface() ||
                 InteropExtensions.AreTypesAssignable(typeof(Delegate).TypeHandle, structureTypeHandle))
             {
-                throw new ArgumentException(SR.Format(SR.Argument_MustHaveLayoutOrBeBlittable, structureTypeHandle.LastResortToString));
+                throw new ArgumentException(SR.Format(SR.Argument_MustHaveLayoutOrBeBlittable, structuretype));
             }
 
             if (structureTypeHandle.IsBlittable())
@@ -128,7 +128,7 @@ namespace System.Runtime.InteropServices
 
             IntPtr destroyStructureStub = RuntimeInteropData.GetDestroyStructureStub(structureTypeHandle, out bool hasInvalidLayout);
             if (hasInvalidLayout)
-                throw new ArgumentException(SR.Format(SR.Argument_MustHaveLayoutOrBeBlittable, structureTypeHandle.LastResortToString));
+                throw new ArgumentException(SR.Format(SR.Argument_MustHaveLayoutOrBeBlittable, structuretype));
             // DestroyStructureStub == IntPtr.Zero means its fields don't need to be destroyed
             if (destroyStructureStub != IntPtr.Zero)
             {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeTypeHandle.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeTypeHandle.cs
@@ -124,36 +124,6 @@ namespace System
             }
         }
 
-        // Last resort string for Type.ToString() when no metadata around.
-        internal string LastResortToString
-        {
-            get
-            {
-                string s;
-                EETypePtr eeType = this.ToEETypePtr();
-                IntPtr rawEEType = eeType.RawValue;
-                IntPtr moduleBase = RuntimeImports.RhGetOSModuleFromEEType(rawEEType);
-                if (moduleBase != IntPtr.Zero)
-                {
-                    uint rva = (uint)(rawEEType.ToInt64() - moduleBase.ToInt64());
-                    s = "EETypeRva:0x" + rva.LowLevelToString();
-                }
-                else
-                {
-                    s = "EETypePointer:0x" + rawEEType.LowLevelToString();
-                }
-
-                ReflectionExecutionDomainCallbacks callbacks = RuntimeAugments.CallbacksIfAvailable;
-                if (callbacks != null)
-                {
-                    string penultimateLastResortString = callbacks.GetBetterDiagnosticInfoIfAvailable(this);
-                    if (penultimateLastResortString != null)
-                        s += "(" + penultimateLastResortString + ")";
-                }
-                return s;
-            }
-        }
-
         private IntPtr _value;
     }
 }

--- a/src/coreclr/nativeaot/System.Private.DisabledReflection/src/Internal/Reflection/ReflectionExecutionDomainCallbacksImplementation.cs
+++ b/src/coreclr/nativeaot/System.Private.DisabledReflection/src/Internal/Reflection/ReflectionExecutionDomainCallbacksImplementation.cs
@@ -13,7 +13,6 @@ namespace Internal.Reflection
         public override Exception CreateMissingMetadataException(Type typeWithMissingMetadata) => throw new NotImplementedException();
         public override Type GetArrayTypeForHandle(RuntimeTypeHandle typeHandle) => RuntimeTypeInfo.GetRuntimeTypeInfo(typeHandle);
         public override Assembly GetAssemblyForHandle(RuntimeTypeHandle typeHandle) => new RuntimeAssemblyInfo(typeHandle);
-        public override string GetBetterDiagnosticInfoIfAvailable(RuntimeTypeHandle runtimeTypeHandle) => null;
         public override Type GetByRefTypeForHandle(RuntimeTypeHandle typeHandle) => RuntimeTypeInfo.GetRuntimeTypeInfo(typeHandle);
         public override Type GetConstructedGenericTypeForHandle(RuntimeTypeHandle typeHandle) => RuntimeTypeInfo.GetRuntimeTypeInfo(typeHandle);
         public override MethodInfo GetDelegateMethod(Delegate del) => throw new NotSupportedException(SR.Reflection_Disabled);

--- a/src/coreclr/nativeaot/System.Private.DisabledReflection/src/Internal/Reflection/RuntimeTypeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.DisabledReflection/src/Internal/Reflection/RuntimeTypeInfo.cs
@@ -33,7 +33,7 @@ namespace Internal.Reflection
 
         public override bool IsGenericType => RuntimeAugments.IsGenericTypeDefinition(_typeHandle) || RuntimeAugments.IsGenericType(_typeHandle);
 
-        public override string Name => DoNotThrowForNames ? RuntimeAugments.GetLastResortString(_typeHandle) : throw new NotSupportedException(SR.Reflection_Disabled);
+        public override string Name => DoNotThrowForNames ? ToString() : throw new NotSupportedException(SR.Reflection_Disabled);
 
         public override string Namespace => DoNotThrowForNames ? "" : throw new NotSupportedException(SR.Reflection_Disabled);
 
@@ -76,7 +76,7 @@ namespace Internal.Reflection
 
         public override string ToString()
         {
-            return RuntimeAugments.GetLastResortString(_typeHandle);
+            return "MT" + _typeHandle.Value.ToString();
         }
 
         public override int GetHashCode()

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -159,10 +159,9 @@ namespace Internal.Reflection.Execution
         //
         // This is not equivalent to calling TryGetMultiDimTypeElementType() with a rank of 1!
         //
-        public sealed override unsafe bool TryGetArrayTypeElementType(RuntimeTypeHandle arrayTypeHandle, out RuntimeTypeHandle elementTypeHandle)
+        public sealed override RuntimeTypeHandle GetArrayTypeElementType(RuntimeTypeHandle arrayTypeHandle)
         {
-            elementTypeHandle = RuntimeAugments.GetRelatedParameterTypeHandle(arrayTypeHandle);
-            return true;
+            return RuntimeAugments.GetRelatedParameterTypeHandle(arrayTypeHandle);
         }
 
 
@@ -210,10 +209,9 @@ namespace Internal.Reflection.Execution
         // Preconditions:
         //      pointerTypeHandle is a valid RuntimeTypeHandle of type pointer.
         //
-        public sealed override unsafe bool TryGetPointerTypeTargetType(RuntimeTypeHandle pointerTypeHandle, out RuntimeTypeHandle targetTypeHandle)
+        public sealed override RuntimeTypeHandle GetPointerTypeTargetType(RuntimeTypeHandle pointerTypeHandle)
         {
-            targetTypeHandle = RuntimeAugments.GetRelatedParameterTypeHandle(pointerTypeHandle);
-            return true;
+            return RuntimeAugments.GetRelatedParameterTypeHandle(pointerTypeHandle);
         }
 
         public override bool TryGetFunctionPointerTypeForComponents(RuntimeTypeHandle returnTypeHandle, RuntimeTypeHandle[] parameterHandles, bool isUnmanaged, out RuntimeTypeHandle functionPointerTypeHandle)
@@ -253,10 +251,9 @@ namespace Internal.Reflection.Execution
         // Preconditions:
         //      byRefTypeHandle is a valid RuntimeTypeHandle of a byref.
         //
-        public sealed override unsafe bool TryGetByRefTypeTargetType(RuntimeTypeHandle byRefTypeHandle, out RuntimeTypeHandle targetTypeHandle)
+        public sealed override unsafe RuntimeTypeHandle GetByRefTypeTargetType(RuntimeTypeHandle byRefTypeHandle)
         {
-            targetTypeHandle = RuntimeAugments.GetRelatedParameterTypeHandle(byRefTypeHandle);
-            return true;
+            return RuntimeAugments.GetRelatedParameterTypeHandle(byRefTypeHandle);
         }
 
         //

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.Runtime.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.Runtime.cs
@@ -115,11 +115,6 @@ namespace Internal.Reflection.Execution
             targetMethods = tMethods;
         }
 
-        public sealed override string GetLastResortString(RuntimeTypeHandle typeHandle)
-        {
-            return RuntimeAugments.GetLastResortString(typeHandle);
-        }
-
         //==============================================================================================
         // Miscellaneous
         //==============================================================================================

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/PayForPlayExperience/MissingMetadataExceptionCreator.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/PayForPlayExperience/MissingMetadataExceptionCreator.cs
@@ -4,59 +4,20 @@
 using global::System;
 using global::System.Text;
 using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
-
-using global::Internal.Runtime.Augments;
-
-using global::Internal.Reflection.Core.Execution;
 
 namespace Internal.Reflection.Execution.PayForPlayExperience
 {
     public static class MissingMetadataExceptionCreator
     {
-        internal static NotSupportedException Create(Type? pertainant)
+        internal static NotSupportedException Create(Type pertainant)
         {
-            return CreateFromMetadataObject(SR.Reflection_InsufficientMetadata_EdbNeeded, pertainant);
-        }
-
-        private static NotSupportedException CreateFromString(string? pertainant)
-        {
-            if (pertainant == null)
-                return new NotSupportedException(SR.Format(SR.Reflection_InsufficientMetadata_NoHelpAvailable, "<unavailable>"));
-            else
-                return new NotSupportedException(SR.Format(SR.Reflection_InsufficientMetadata_EdbNeeded, pertainant));
-        }
-
-        internal static NotSupportedException CreateMissingArrayTypeException(Type elementType, bool isMultiDim, int rank)
-        {
-            Debug.Assert(rank == 1 || isMultiDim);
-            string s = CreateArrayTypeStringIfAvailable(elementType, rank);
-            return CreateFromString(s);
-        }
-
-        internal static NotSupportedException CreateMissingConstructedGenericTypeException(Type genericTypeDefinition, Type[] genericTypeArguments)
-        {
-            string s = CreateConstructedGenericTypeStringIfAvailable(genericTypeDefinition, genericTypeArguments);
-            return CreateFromString(s);
-        }
-
-        internal static NotSupportedException CreateFromMetadataObject(string resourceId, Type? pertainant)
-        {
-            if (pertainant == null)
-                return new NotSupportedException(SR.Format(SR.Reflection_InsufficientMetadata_NoHelpAvailable, "<unavailable>"));
-
-            string usefulPertainant = pertainant.ToDisplayStringIfAvailable();
-            if (usefulPertainant == null)
-                return new NotSupportedException(SR.Format(SR.Reflection_InsufficientMetadata_NoHelpAvailable, pertainant.ToString()));
-            else
-                return new NotSupportedException(SR.Format(resourceId, usefulPertainant));
+            return new NotSupportedException(SR.Format(SR.Reflection_InsufficientMetadata_EdbNeeded, pertainant));
         }
 
         public static string ComputeUsefulPertainantIfPossible(MemberInfo memberInfo)
         {
             {
-                StringBuilder friendlyName = new StringBuilder(memberInfo.DeclaringType.ToDisplayStringIfAvailable());
+                StringBuilder friendlyName = new StringBuilder(memberInfo.DeclaringType.ToString());
                 friendlyName.Append('.');
                 friendlyName.Append(memberInfo.Name);
                 if (memberInfo is MethodBase method)
@@ -74,7 +35,7 @@ namespace Internal.Reflection.Execution.PayForPlayExperience
                                 friendlyName.Append(',');
 
                             first = false;
-                            friendlyName.Append(genericParameter.ToDisplayStringIfAvailable());
+                            friendlyName.Append(genericParameter);
                         }
                         friendlyName.Append(']');
                     }
@@ -88,100 +49,13 @@ namespace Internal.Reflection.Execution.PayForPlayExperience
                             friendlyName.Append(',');
 
                         first = false;
-                        friendlyName.Append(parameter.ParameterType.ToDisplayStringIfAvailable());
+                        friendlyName.Append(parameter.ParameterType);
                     }
                     friendlyName.Append(')');
                 }
 
                 return friendlyName.ToString();
             }
-        }
-
-        internal static string ToDisplayStringIfAvailable(this Type type)
-        {
-            RuntimeTypeHandle runtimeTypeHandle = ReflectionCoreExecution.ExecutionDomain.GetTypeHandleIfAvailable(type);
-            bool hasRuntimeTypeHandle = !runtimeTypeHandle.Equals(default(RuntimeTypeHandle));
-
-            if (type.HasElementType)
-            {
-                if (type.IsArray)
-                {
-                    // Multidim arrays. This is the one case where GetElementType() isn't pay-for-play safe so
-                    // talk to the diagnostic mapping tables directly if possible or give up.
-                    if (!hasRuntimeTypeHandle)
-                        return null;
-
-                    int rank = type.GetArrayRank();
-                    return CreateArrayTypeStringIfAvailable(type.GetElementType(), rank);
-                }
-                else
-                {
-                    string s = type.GetElementType().ToDisplayStringIfAvailable();
-                    if (s == null)
-                        return null;
-                    return s + (type.IsPointer ? "*" : "&");
-                }
-            }
-            else if (((hasRuntimeTypeHandle && RuntimeAugments.IsGenericType(runtimeTypeHandle)) || type.IsConstructedGenericType))
-            {
-                Type genericTypeDefinition;
-                Type[] genericTypeArguments;
-                if (hasRuntimeTypeHandle)
-                {
-                    RuntimeTypeHandle genericTypeDefinitionHandle;
-                    RuntimeTypeHandle[] genericTypeArgumentHandles;
-
-                    genericTypeDefinitionHandle = RuntimeAugments.GetGenericInstantiation(runtimeTypeHandle, out genericTypeArgumentHandles);
-                    genericTypeDefinition = Type.GetTypeFromHandle(genericTypeDefinitionHandle);
-                    genericTypeArguments = new Type[genericTypeArgumentHandles.Length];
-                    for (int i = 0; i < genericTypeArguments.Length; i++)
-                        genericTypeArguments[i] = Type.GetTypeFromHandle(genericTypeArgumentHandles[i]);
-                }
-                else
-                {
-                    genericTypeDefinition = type.GetGenericTypeDefinition();
-                    genericTypeArguments = type.GenericTypeArguments;
-                }
-
-                return CreateConstructedGenericTypeStringIfAvailable(genericTypeDefinition, genericTypeArguments);
-            }
-            else if (type.IsGenericParameter)
-            {
-                return type.Name;
-            }
-            else
-            {
-                return type.FullName;
-            }
-        }
-
-        private static string CreateArrayTypeStringIfAvailable(Type elementType, int rank)
-        {
-            string s = elementType.ToDisplayStringIfAvailable();
-            if (s == null)
-                return null;
-
-            return s + "[" + new string(',', rank - 1) + "]";  // This does not bother to display multidims of rank 1 correctly since we bail on that case in the prior statement.
-        }
-
-        private static string CreateConstructedGenericTypeStringIfAvailable(Type genericTypeDefinition, Type[] genericTypeArguments)
-        {
-            string genericTypeDefinitionString = genericTypeDefinition.ToDisplayStringIfAvailable();
-
-            if (genericTypeDefinitionString == null)
-                return null;
-
-            StringBuilder genericTypeName = new StringBuilder(genericTypeDefinitionString);
-            genericTypeName.Append('[');
-            for (int i = 0; i < genericTypeArguments.Length; i++)
-            {
-                if (i > 0)
-                    genericTypeName.Append(", ");
-                genericTypeName.Append(genericTypeArguments[i].ToDisplayStringIfAvailable());
-            }
-            genericTypeName.Append(']');
-
-            return genericTypeName.ToString();
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionDomainSetupImplementation.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionDomainSetupImplementation.cs
@@ -44,15 +44,5 @@ namespace Internal.Reflection.Execution
             string pertainantString = MissingMetadataExceptionCreator.ComputeUsefulPertainantIfPossible(pertainant);
             return new NotSupportedException(SR.Format(resourceName, pertainantString ?? "?"));
         }
-
-        public sealed override Exception CreateMissingArrayTypeException(Type elementType, bool isMultiDim, int rank)
-        {
-            return MissingMetadataExceptionCreator.CreateMissingArrayTypeException(elementType, isMultiDim, rank);
-        }
-
-        public sealed override Exception CreateMissingConstructedGenericTypeException(Type genericTypeDefinition, Type[] genericTypeArguments)
-        {
-            return MissingMetadataExceptionCreator.CreateMissingConstructedGenericTypeException(genericTypeDefinition, genericTypeArguments);
-        }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
@@ -78,13 +78,6 @@ namespace Internal.Reflection.Execution
             return _executionDomain.CreateMissingMetadataException(pertainant);
         }
 
-        // This is called from the ToString() helper of a RuntimeType that does not have full metadata.
-        // This helper makes a "best effort" to give the caller something better than "EETypePtr nnnnnnnnn".
-        public sealed override string GetBetterDiagnosticInfoIfAvailable(RuntimeTypeHandle runtimeTypeHandle)
-        {
-            return Type.GetTypeFromHandle(runtimeTypeHandle).ToDisplayStringIfAvailable();
-        }
-
         public sealed override MethodBase GetMethodBaseFromStartAddressIfAvailable(IntPtr methodStartAddress)
         {
             RuntimeTypeHandle declaringTypeHandle = default(RuntimeTypeHandle);


### PR DESCRIPTION
We had a bunch of code to carefully compute names in situations where the metadata/names might not be available. Such situations no longer exist.

Cc @dotnet/ilc-contrib 