### PR TITLE
Tweak new OutOfMemory_StringTooLong exception message

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -4224,6 +4224,6 @@
     <value>An unexpected state object was encountered. This is usually a sign of a bug in async method custom infrastructure, such as a custom awaiter or IValueTaskSource implementation.</value>
   </data>
   <data name="OutOfMemory_StringTooLong" xml:space="preserve">
-    <value>The resulting string's length would be longer than the maximum length supported.</value>
+    <value>String length exceeded supported range.</value>
   </data>
 </root>

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -4224,6 +4224,6 @@
     <value>An unexpected state object was encountered. This is usually a sign of a bug in async method custom infrastructure, such as a custom awaiter or IValueTaskSource implementation.</value>
   </data>
   <data name="OutOfMemory_StringTooLong" xml:space="preserve">
-    <value>The resulting string is too long</value>
+    <value>The resulting string's length would be longer than the maximum length supported.</value>
   </data>
 </root>


### PR DESCRIPTION
Add a period, fix the tense (the string isn't created yet), and clarify what it means to be too long.