### PR TITLE
add pre-built detection

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <!-- Don't use any higher level config files.
        Our builds need to be isolated from user/machine state -->
@@ -16,6 +16,8 @@
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
+    <!-- Required for System.CommandLine SB intermediate -->
+    <add key="dotnet-libraries-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries-transport/nuget/v3/index.json" />
     <!-- TODO: Remove dotnet7 feeds when dependencies publish into dotnet8 feeds: https://github.com/dotnet/runtime/issues/63375. -->
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="dotnet7-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7-transport/nuget/v3/index.json" />

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -37,6 +37,8 @@
       <!-- BaseOS is an expected known rid in the graph that TargetRid is compatible with.
            It's used to add TargetRid in the graph if the parent can't be detected. -->
       <InnerBuildArgs>$(InnerBuildArgs) /p:AdditionalRuntimeIdentifierParent=$(BaseOS)</InnerBuildArgs>
+      <!-- This prop needs to be passed to the inner build manually as the BaseInnerSourceBuildCommand gets overriden above -->
+      <InnerBuildArgs>$(InnerBuildArgs) /p:ArcadeBuildFromSource=true</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(OfficialBuildId)' != ''">$(InnerBuildArgs) /p:OfficialBuildId=$(OfficialBuildId)</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(ContinuousIntegrationBuild)' != ''">$(InnerBuildArgs) /p:ContinuousIntegrationBuild=$(ContinuousIntegrationBuild)</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(SourceBuildUseMonoRuntime)' == 'true'">$(InnerBuildArgs) --usemonoruntime</InnerBuildArgs>

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -8,6 +8,10 @@
   <PropertyGroup>
     <BaseInnerSourceBuildCommand>./build.sh</BaseInnerSourceBuildCommand>
 
+    <!-- AfterSourceBuild.proj will fail the build if project path has `test` in it (example: src/libraries/pretest.proj) -->
+    <!-- Will be removed by https://github.com/dotnet/arcade/issues/13542 -->
+    <AllowTestProjectUsage>true</AllowTestProjectUsage>
+
     <!-- TargetRid names what gets built. -->
     <TargetRid Condition="'$(TargetRid)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier)</TargetRid>
 

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -6,17 +6,12 @@
     <UsagePattern IdentityGlob="Microsoft.NETCore.App.Crossgen2.linux-x64/*8.*" />
     <UsagePattern IdentityGlob="Microsoft.NETCore.App.Runtime.linux-x64/*8.*" />
     <UsagePattern IdentityGlob="*Microsoft.DotNet.ILCompiler/*8.*" />
-
-    <!-- Will be removed once the package is added to SBRP -->
-    <UsagePattern IdentityGlob="Microsoft.CodeAnalysis*/*4.5.0*" />
     
     <UsagePattern IdentityGlob="Microsoft.CodeAnalysis.Analyzers/*" />
   </IgnorePatterns>
   <Usages>
     <!-- Should be removed as part of https://github.com/dotnet/runtime/issues/82298 -->
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies*" Version="1.0.3" />
-    <!-- Transitive dependency of Microsoft.CodeAnalysis 4.5.0, will be removed by SBRP -->
-    <Usage Id="System.Threading.Channels" Version="6.0.0" />
 
     <!-- Temporary exclusion while an issue with SharedFrameworks is investigated -->
     <Usage Id="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23259.5" />

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,5 +1,27 @@
+<!-- See aka.ms/dotnet/prebuilts for guidance on what pre-builts are and how to eliminate them. -->
 <UsageData>
   <IgnorePatterns>
-    <UsagePattern IdentityGlob="*/*" />
+    <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*" />
+    <!-- Allowed and pinned to major version due to https://github.com/dotnet/source-build/issues/3228 -->
+    <UsagePattern IdentityGlob="Microsoft.NETCore.App.Crossgen2.linux-x64/*8.*" />
+    <UsagePattern IdentityGlob="Microsoft.NETCore.App.Runtime.linux-x64/*8.*" />
+    <UsagePattern IdentityGlob="*Microsoft.DotNet.ILCompiler/*8.*" />
+
+    <!-- Will be removed once the package is added to SBRP -->
+    <UsagePattern IdentityGlob="Microsoft.CodeAnalysis*/*4.5.0*" />
+    
+    <UsagePattern IdentityGlob="Microsoft.CodeAnalysis.Analyzers/*" />
   </IgnorePatterns>
+  <Usages>
+    <!-- Should be removed as part of https://github.com/dotnet/runtime/issues/82298 -->
+    <Usage Id="Microsoft.NETFramework.ReferenceAssemblies*" Version="1.0.3" />
+    <!-- Transitive dependency of Microsoft.CodeAnalysis 4.5.0, will be removed by SBRP -->
+    <Usage Id="System.Threading.Channels" Version="6.0.0" />
+
+    <!-- Temporary exclusion while an issue with SharedFrameworks is investigated -->
+    <Usage Id="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23259.5" />
+    <Usage Id="Microsoft.DotNet.Build.Tasks.TargetFramework" Version="8.0.0-beta.23259.5" />
+    <Usage Id="Microsoft.DotNet.SharedFramework.Sdk" Version="8.0.0-beta.23259.5" />
+    <Usage Id="Microsoft.DotNet.SourceBuild.Tasks" Version="8.0.0-beta.23259.5" />
+  </Usages>
 </UsageData>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -2,21 +2,17 @@
 <UsageData>
   <IgnorePatterns>
     <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*" />
+    
     <!-- Allowed and pinned to major version due to https://github.com/dotnet/source-build/issues/3228 -->
     <UsagePattern IdentityGlob="Microsoft.NETCore.App.Crossgen2.linux-x64/*8.*" />
     <UsagePattern IdentityGlob="Microsoft.NETCore.App.Runtime.linux-x64/*8.*" />
     <UsagePattern IdentityGlob="*Microsoft.DotNet.ILCompiler/*8.*" />
     
+    <!-- Will be removed once https://github.com/NuGet/Home/issues/11059 is resolved -->
+    <UsagePattern IdentityGlob="Nuget.*/*" />
+
+    <!-- Analyzers cannot be SBRPed + an older release version is being used, meaning there is no intermediate for it
+         In full source build, this version is overridden by previous repo outputs or come from previously source-built artifacts. -->
     <UsagePattern IdentityGlob="Microsoft.CodeAnalysis.Analyzers/*" />
   </IgnorePatterns>
-  <Usages>
-    <!-- Should be removed as part of https://github.com/dotnet/runtime/issues/82298 -->
-    <Usage Id="Microsoft.NETFramework.ReferenceAssemblies*" Version="1.0.3" />
-
-    <!-- Temporary exclusion while an issue with SharedFrameworks is investigated -->
-    <Usage Id="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23259.5" />
-    <Usage Id="Microsoft.DotNet.Build.Tasks.TargetFramework" Version="8.0.0-beta.23259.5" />
-    <Usage Id="Microsoft.DotNet.SharedFramework.Sdk" Version="8.0.0-beta.23259.5" />
-    <Usage Id="Microsoft.DotNet.SourceBuild.Tasks" Version="8.0.0-beta.23259.5" />
-  </Usages>
 </UsageData>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -95,7 +95,7 @@
       <Sha>ab09b0b8d6768d58e09c033beea1570d4ca74c1f</Sha>
       <SourceBuild RepoName="emsdk" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.23265.3">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.23266.3">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
       <Sha>e2e64d25662c00a35726d3c52f969a50edaa4f48</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
@@ -107,82 +107,82 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23265.1">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23267.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2d8d59065b5e090584a8e90c4371fc06ed60bdc5</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceLink.GitHub" Version="8.0.0-beta.23218.3" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
+    <Dependency Name="Microsoft.SourceLink.GitHub" Version="8.0.0-beta.23252.2" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
       <Uri>https://github.com/dotnet/sourcelink</Uri>
       <Sha>3f43bf1b2dead2cb51f20dc47f6dfd7981248820</Sha>
       <SourceBuild RepoName="sourcelink" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.23256.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
+    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.23266.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
       <Uri>https://github.com/dotnet/xliff-tasks</Uri>
       <Sha>b7fb98b199d0b1b6188da4f4bf4f5accddac98d4</Sha>
       <SourceBuild RepoName="xliff-tasks" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="8.0.0-beta.23265.1">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="8.0.0-beta.23267.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2d8d59065b5e090584a8e90c4371fc06ed60bdc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="8.0.0-beta.23265.1">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="8.0.0-beta.23267.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2d8d59065b5e090584a8e90c4371fc06ed60bdc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenFacades" Version="8.0.0-beta.23265.1">
+    <Dependency Name="Microsoft.DotNet.GenFacades" Version="8.0.0-beta.23267.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2d8d59065b5e090584a8e90c4371fc06ed60bdc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="8.0.0-beta.23265.1">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="8.0.0-beta.23267.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2d8d59065b5e090584a8e90c4371fc06ed60bdc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitConsoleRunner" Version="2.5.1-beta.23265.1">
+    <Dependency Name="Microsoft.DotNet.XUnitConsoleRunner" Version="2.5.1-beta.23267.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2d8d59065b5e090584a8e90c4371fc06ed60bdc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Archives" Version="8.0.0-beta.23265.1">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Archives" Version="8.0.0-beta.23267.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2d8d59065b5e090584a8e90c4371fc06ed60bdc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="8.0.0-beta.23265.1">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="8.0.0-beta.23267.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2d8d59065b5e090584a8e90c4371fc06ed60bdc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="8.0.0-beta.23265.1">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="8.0.0-beta.23267.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2d8d59065b5e090584a8e90c4371fc06ed60bdc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="8.0.0-beta.23265.1">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="8.0.0-beta.23267.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2d8d59065b5e090584a8e90c4371fc06ed60bdc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="8.0.0-beta.23265.1">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="8.0.0-beta.23267.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2d8d59065b5e090584a8e90c4371fc06ed60bdc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="8.0.0-beta.23265.1">
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="8.0.0-beta.23267.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2d8d59065b5e090584a8e90c4371fc06ed60bdc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.TargetFramework" Version="8.0.0-beta.23265.1">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.TargetFramework" Version="8.0.0-beta.23267.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2d8d59065b5e090584a8e90c4371fc06ed60bdc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="8.0.0-beta.23265.1">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="8.0.0-beta.23267.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2d8d59065b5e090584a8e90c4371fc06ed60bdc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="8.0.0-beta.23265.1">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="8.0.0-beta.23267.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2d8d59065b5e090584a8e90c4371fc06ed60bdc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.VersionTools.Tasks" Version="8.0.0-beta.23265.1">
+    <Dependency Name="Microsoft.DotNet.VersionTools.Tasks" Version="8.0.0-beta.23267.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2d8d59065b5e090584a8e90c4371fc06ed60bdc5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="8.0.0-beta.23265.1">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="8.0.0-beta.23267.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2d8d59065b5e090584a8e90c4371fc06ed60bdc5</Sha>
     </Dependency>
@@ -315,7 +315,7 @@
       <Uri>https://github.com/dotnet/xharness</Uri>
       <Sha>aa434d0c7e6eb46df1ec11b3c63add37d835c4d0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.PackageTesting" Version="8.0.0-beta.23265.1">
+    <Dependency Name="Microsoft.DotNet.PackageTesting" Version="8.0.0-beta.23267.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2d8d59065b5e090584a8e90c4371fc06ed60bdc5</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -110,10 +110,6 @@
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23265.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2d8d59065b5e090584a8e90c4371fc06ed60bdc5</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23260.3">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>06faa97f3e5232df0ddad42caaf28eea39d4ad1a</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceLink.GitHub" Version="8.0.0-beta.23218.3" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -76,9 +76,14 @@
       <Uri>https://github.com/dotnet/llvm-project</Uri>
       <Sha>76f334f354eb653a7b409a5319b591ea09df5a43</Sha>
     </Dependency>
-    <Dependency Name="System.CommandLine" Version="2.0.0-beta4.22355.1">
+    <Dependency Name="System.CommandLine" Version="2.0.0-beta4.22564.1">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
-      <Sha>5618b2d243ccdeb5c7e50a298b33b13036b4351b</Sha>
+      <Sha>8374d5fca634a93458c84414b1604c12f765d1ab</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.command-line-api" Version="0.1.356401">
+      <Uri>https://github.com/dotnet/command-line-api</Uri>
+      <Sha>8374d5fca634a93458c84414b1604c12f765d1ab</Sha>
+      <SourceBuild RepoName="command-line-api" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Cecil" Version="0.11.4-alpha.23252.1">
       <Uri>https://github.com/dotnet/cecil</Uri>
@@ -90,11 +95,36 @@
       <Sha>ab09b0b8d6768d58e09c033beea1570d4ca74c1f</Sha>
       <SourceBuild RepoName="emsdk" ManagedOnly="true" />
     </Dependency>
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.23214.4">
+      <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
+      <Sha>05b4fdac346e01716abda4c92fcf0b7880e73792</Sha>
+      <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.23214.1">
+      <Uri>https://github.com/dotnet/source-build-externals</Uri>
+      <Sha>de4dda48d0cf31e13182bc24107b2246c61ed483</Sha>
+      <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23265.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2d8d59065b5e090584a8e90c4371fc06ed60bdc5</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23260.3">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>06faa97f3e5232df0ddad42caaf28eea39d4ad1a</Sha>
+      <SourceBuild RepoName="arcade" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.SourceLink.GitHub" Version="8.0.0-beta.23218.3" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
+      <Uri>https://github.com/dotnet/sourcelink</Uri>
+      <Sha>3f43bf1b2dead2cb51f20dc47f6dfd7981248820</Sha>
+      <SourceBuild RepoName="sourcelink" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.23256.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
+      <Uri>https://github.com/dotnet/xliff-tasks</Uri>
+      <Sha>b7fb98b199d0b1b6188da4f4bf4f5accddac98d4</Sha>
+      <SourceBuild RepoName="xliff-tasks" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="8.0.0-beta.23265.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
@@ -271,6 +301,7 @@
     <Dependency Name="System.Text.Json" Version="8.0.0-preview.5.23251.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>25f09dea3cebc63ef4d780daa90943fcaaacdd35</Sha>
+      <SourceBuild RepoName="runtime" ManagedOnly="false" />
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="8.0.0-preview.5.23251.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
@@ -323,6 +354,7 @@
     <Dependency Name="Microsoft.CodeAnalysis" Version="4.7.0-1.23259.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>1d3e90428043f6b18f517e89b8e21328dca99e56</Sha>
+      <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.7.0-1.23259.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>
@@ -339,6 +371,7 @@
     <Dependency Name="Microsoft.DotNet.ApiCompat.Task" Version="8.0.100-preview.2.23107.1">
       <Uri>https://github.com/dotnet/sdk</Uri>
       <Sha>2fd62c3936f5336b836f6b12df170aa0e90da767</Sha>
+      <SourceBuild RepoName="sdk" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="optimization.windows_nt-arm64.MIBC.Runtime" Version="1.0.0-prerelease.23260.3">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -95,9 +95,9 @@
       <Sha>ab09b0b8d6768d58e09c033beea1570d4ca74c1f</Sha>
       <SourceBuild RepoName="emsdk" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.23214.4">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.23265.3">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>05b4fdac346e01716abda4c92fcf0b7880e73792</Sha>
+      <Sha>e2e64d25662c00a35726d3c52f969a50edaa4f48</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.23214.1">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -84,23 +84,21 @@
     <!-- SDK dependencies -->
     <MicrosoftDotNetApiCompatTaskVersion>8.0.100-preview.2.23107.1</MicrosoftDotNetApiCompatTaskVersion>
     <!-- Arcade dependencies -->
-    <MicrosoftDotNetBuildTasksFeedVersion>8.0.0-beta.23265.1</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetCodeAnalysisVersion>8.0.0-beta.23265.1</MicrosoftDotNetCodeAnalysisVersion>
-    <MicrosoftDotNetGenAPIVersion>8.0.0-beta.23265.1</MicrosoftDotNetGenAPIVersion>
-    <MicrosoftDotNetGenFacadesVersion>8.0.0-beta.23265.1</MicrosoftDotNetGenFacadesVersion>
-    <MicrosoftDotNetXUnitExtensionsVersion>8.0.0-beta.23265.1</MicrosoftDotNetXUnitExtensionsVersion>
-    <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.23265.1</MicrosoftDotNetXUnitConsoleRunnerVersion>
-    <MicrosoftDotNetBuildTasksArchivesVersion>8.0.0-beta.23265.1</MicrosoftDotNetBuildTasksArchivesVersion>
-    <MicrosoftDotNetBuildTasksInstallersVersion>8.0.0-beta.23265.1</MicrosoftDotNetBuildTasksInstallersVersion>
-    <MicrosoftDotNetBuildTasksPackagingVersion>8.0.0-beta.23265.1</MicrosoftDotNetBuildTasksPackagingVersion>
-    <!-- Will be removed once latest SBRP flows into Arcade -->
-    <MicrosoftDotNetBuildTasksTargetFrameworkVersion>8.0.0-beta.23259.5</MicrosoftDotNetBuildTasksTargetFrameworkVersion>
-    <!-- <MicrosoftDotNetBuildTasksTargetFrameworkVersion>8.0.0-beta.23265.1</MicrosoftDotNetBuildTasksTargetFrameworkVersion> -->
-    <MicrosoftDotNetBuildTasksTemplatingVersion>8.0.0-beta.23265.1</MicrosoftDotNetBuildTasksTemplatingVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>8.0.0-beta.23265.1</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetRemoteExecutorVersion>8.0.0-beta.23265.1</MicrosoftDotNetRemoteExecutorVersion>
-    <MicrosoftDotNetVersionToolsTasksVersion>8.0.0-beta.23265.1</MicrosoftDotNetVersionToolsTasksVersion>
-    <MicrosoftDotNetPackageTestingVersion>8.0.0-beta.23265.1</MicrosoftDotNetPackageTestingVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>8.0.0-beta.23267.2</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetCodeAnalysisVersion>8.0.0-beta.23267.2</MicrosoftDotNetCodeAnalysisVersion>
+    <MicrosoftDotNetGenAPIVersion>8.0.0-beta.23267.2</MicrosoftDotNetGenAPIVersion>
+    <MicrosoftDotNetGenFacadesVersion>8.0.0-beta.23267.2</MicrosoftDotNetGenFacadesVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>8.0.0-beta.23267.2</MicrosoftDotNetXUnitExtensionsVersion>
+    <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.23267.2</MicrosoftDotNetXUnitConsoleRunnerVersion>
+    <MicrosoftDotNetBuildTasksArchivesVersion>8.0.0-beta.23267.2</MicrosoftDotNetBuildTasksArchivesVersion>
+    <MicrosoftDotNetBuildTasksInstallersVersion>8.0.0-beta.23267.2</MicrosoftDotNetBuildTasksInstallersVersion>
+    <MicrosoftDotNetBuildTasksPackagingVersion>8.0.0-beta.23267.2</MicrosoftDotNetBuildTasksPackagingVersion>
+    <MicrosoftDotNetBuildTasksTargetFrameworkVersion>8.0.0-beta.23267.2</MicrosoftDotNetBuildTasksTargetFrameworkVersion>
+    <MicrosoftDotNetBuildTasksTemplatingVersion>8.0.0-beta.23267.2</MicrosoftDotNetBuildTasksTemplatingVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>8.0.0-beta.23267.2</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorVersion>8.0.0-beta.23267.2</MicrosoftDotNetRemoteExecutorVersion>
+    <MicrosoftDotNetVersionToolsTasksVersion>8.0.0-beta.23267.2</MicrosoftDotNetVersionToolsTasksVersion>
+    <MicrosoftDotNetPackageTestingVersion>8.0.0-beta.23267.2</MicrosoftDotNetPackageTestingVersion>
     <!-- NuGet dependencies -->
     <NuGetBuildTasksPackVersion>6.0.0-preview.1.102</NuGetBuildTasksPackVersion>
     <!-- Installer dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -93,7 +93,9 @@
     <MicrosoftDotNetBuildTasksArchivesVersion>8.0.0-beta.23265.1</MicrosoftDotNetBuildTasksArchivesVersion>
     <MicrosoftDotNetBuildTasksInstallersVersion>8.0.0-beta.23265.1</MicrosoftDotNetBuildTasksInstallersVersion>
     <MicrosoftDotNetBuildTasksPackagingVersion>8.0.0-beta.23265.1</MicrosoftDotNetBuildTasksPackagingVersion>
-    <MicrosoftDotNetBuildTasksTargetFrameworkVersion>8.0.0-beta.23265.1</MicrosoftDotNetBuildTasksTargetFrameworkVersion>
+    <!-- Will be removed once latest SBRP flows into Arcade -->
+    <MicrosoftDotNetBuildTasksTargetFrameworkVersion>8.0.0-beta.23259.5</MicrosoftDotNetBuildTasksTargetFrameworkVersion>
+    <!-- <MicrosoftDotNetBuildTasksTargetFrameworkVersion>8.0.0-beta.23265.1</MicrosoftDotNetBuildTasksTargetFrameworkVersion> -->
     <MicrosoftDotNetBuildTasksTemplatingVersion>8.0.0-beta.23265.1</MicrosoftDotNetBuildTasksTemplatingVersion>
     <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>8.0.0-beta.23265.1</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
     <MicrosoftDotNetRemoteExecutorVersion>8.0.0-beta.23265.1</MicrosoftDotNetRemoteExecutorVersion>

--- a/global.json
+++ b/global.json
@@ -8,9 +8,9 @@
     "dotnet": "8.0.100-preview.3.23178.7"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23265.1",
-    "Microsoft.DotNet.Helix.Sdk": "8.0.0-beta.23265.1",
-    "Microsoft.DotNet.SharedFramework.Sdk": "8.0.0-beta.23265.1",
+    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23267.2",
+    "Microsoft.DotNet.Helix.Sdk": "8.0.0-beta.23267.2",
+    "Microsoft.DotNet.SharedFramework.Sdk": "8.0.0-beta.23267.2",
     "Microsoft.Build.NoTargets": "3.7.0",
     "Microsoft.Build.Traversal": "3.4.0",
     "Microsoft.NET.Sdk.IL": "8.0.0-preview.5.23251.1"


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/81468

Existing issues:

- [x] `Microsoft.CodeAnalysis 4.5.0` - https://github.com/dotnet/source-build-reference-packages/pull/669
- [x] `DotNet.Build.Tasks` issue - https://github.com/dotnet/runtime/pull/86151#issuecomment-1549669873, solved by https://github.com/dotnet/source-build-reference-packages/pull/673
- [x] `runtime/src/libraries/pretest.proj` - source-build logic has a [check](https://github.com/dotnet/arcade/blob/f38f6d1439ff6546a97f568f3e6bd3eea3ac8e6c/src/Microsoft.DotNet.SourceBuild/tasks/src/UsageReport/WriteUsageReports.cs#L253) for test projects & the check complains about `src/libraries/pretest.proj`. Silenced it for the repo as requested in https://github.com/dotnet/runtime/pull/86151#issuecomment-1548252281. Additionally, created https://github.com/dotnet/source-build/issues/3453 to get rid of the check completely

CC: @MichaelSimons @ViktorHofer 