### PR TITLE
[browser] improve CSP

### DIFF
--- a/src/mono/sample/wasm/browser-advanced/index.html
+++ b/src/mono/sample/wasm/browser-advanced/index.html
@@ -7,6 +7,7 @@
   <title>Wasm Browser Advanced Sample</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval';" />
   <script type='module' src="./main.js"></script>
   <script type='module' src="./dotnet.js"></script>
   <link rel="preload" href="./mono-config.json" as="fetch" crossorigin="anonymous">

--- a/src/mono/sample/wasm/browser-advanced/main.js
+++ b/src/mono/sample/wasm/browser-advanced/main.js
@@ -11,11 +11,25 @@ let testAbort = true;
 let testError = true;
 
 try {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (url, fetchArgs) => {
+        console.log("fetching " + url);
+        // we are testing that we can retry loading of the assembly
+        if (testAbort && url.indexOf('System.Private.CoreLib') != -1) {
+            testAbort = false;
+            return originalFetch(url + "?testAbort=true", fetchArgs);
+        }
+        if (testError && url.indexOf('System.Console') != -1) {
+            testError = false;
+            return originalFetch(url + "?testError=true", fetchArgs);
+        }
+        return originalFetch(url, fetchArgs);
+    };
     const { runtimeBuildInfo, setModuleImports, getAssemblyExports, runMain, getConfig, Module } = await dotnet
         .withElementOnExit()
         // 'withModuleConfig' is internal lower level API 
         // here we show how emscripten could be further configured
-        // It is prefered to use specific 'with***' methods instead in all other cases.
+        // It is preferred to use specific 'with***' methods instead in all other cases.
         .withModuleConfig({
             configSrc: "./mono-config.json",
             onConfigLoaded: (config) => {
@@ -24,21 +38,6 @@ try {
                 // config is loaded and could be tweaked before the rest of the runtime startup sequence
                 config.environmentVariables["MONO_LOG_LEVEL"] = "debug";
                 config.browserProfilerOptions = {};
-            },
-            imports: {
-                fetch: (url, fetchArgs) => {
-                    console.log("fetching " + url);
-                    // we are testing that we can retry loading of the assembly
-                    if (testAbort && url.indexOf('System.Private.CoreLib') != -1) {
-                        testAbort = false;
-                        return fetch(url + "?testAbort=true", fetchArgs);
-                    }
-                    if (testError && url.indexOf('System.Console') != -1) {
-                        testError = false;
-                        return fetch(url + "?testError=true", fetchArgs);
-                    }
-                    return fetch(url, fetchArgs);
-                }
             },
             preInit: () => { console.log('user code Module.preInit'); },
             preRun: () => { console.log('user code Module.preRun'); },

--- a/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
@@ -29,7 +29,7 @@ import {
     sizeOfDataItem, sizeOfV128, sizeOfStackval,
 
     disabledOpcodes, countCallTargets,
-    callTargetCounts, trapTraceErrors,
+    callTargetCounts,
     trace, traceOnError, traceOnRuntimeError,
     emitPadding, traceBranchDisplacements,
     traceEip, nullCheckValidation,
@@ -1262,7 +1262,7 @@ export function generateWasmBody(
                         (opcode <= MintOpcode.MINT_RET_I8_IMM)
                     )
                 ) {
-                    if (isConditionallyExecuted || trapTraceErrors || builder.options.countBailouts) {
+                    if (isConditionallyExecuted || builder.options.countBailouts) {
                         // Not an exit, because returns are normal and we don't want to make them more expensive.
                         // FIXME: Or do we want to record them? Early conditional returns might reduce the value of a trace,
                         //  but the main problem is more likely to be calls early in traces. Worth testing later.


### PR DESCRIPTION
- removed `wrap_trace_function` which was `eval()` and @kg said she didn't use it for long time
- added CSP meta into Advanced Sample to test that we are compliant.
- fixed fetch replacement in advanced sample
- some white space formatting

Contributes to https://github.com/dotnet/aspnetcore/issues/37787