### PR TITLE
Use /INCREMENTAL:NO for Debug

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -85,6 +85,14 @@ if (MSVC)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /sourcelink:${CLR_SOURCELINK_FILE_PATH}")
   endif(EXISTS ${CLR_SOURCELINK_FILE_PATH})
 
+  if (CMAKE_GENERATOR MATCHES "(Visual Studio)")
+    # Debug build specific flags
+    # until https://github.com/dotnet/runtime/issues/64082 is fixed.
+    add_linker_flag(/INCREMENTAL:NO DEBUG)
+    add_linker_flag(/OPT:REF DEBUG)
+    add_linker_flag(/OPT:NOICF DEBUG)
+  endif (CMAKE_GENERATOR MATCHES "(Visual Studio)")
+
   # Checked build specific flags
   add_linker_flag(/INCREMENTAL:NO CHECKED) # prevent "warning LNK4075: ignoring '/INCREMENTAL' due to '/OPT:REF' specification"
   add_linker_flag(/OPT:REF CHECKED)

--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -85,7 +85,7 @@ if (MSVC)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /sourcelink:${CLR_SOURCELINK_FILE_PATH}")
   endif(EXISTS ${CLR_SOURCELINK_FILE_PATH})
 
-  if (CMAKE_GENERATOR MATCHES "(Visual Studio)")
+  if (CMAKE_GENERATOR MATCHES "^Visual Studio.*$")
     # Debug build specific flags
     # until https://github.com/dotnet/runtime/issues/64082 is fixed.
     add_linker_flag(/INCREMENTAL:NO DEBUG)

--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -87,7 +87,8 @@ if (MSVC)
 
   if (CMAKE_GENERATOR MATCHES "^Visual Studio.*$")
     # Debug build specific flags
-    # until https://github.com/dotnet/runtime/issues/64082 is fixed.
+    # The Ninja generator doesn't appear to have the default `/INCREMENTAL:ON` that
+    # the Visual Studio generator has. Therefore we will override the default for Visual Studio only.
     add_linker_flag(/INCREMENTAL:NO DEBUG)
     add_linker_flag(/OPT:REF DEBUG)
     add_linker_flag(/OPT:NOICF DEBUG)

--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -91,7 +91,7 @@ if (MSVC)
     add_linker_flag(/INCREMENTAL:NO DEBUG)
     add_linker_flag(/OPT:REF DEBUG)
     add_linker_flag(/OPT:NOICF DEBUG)
-  endif (CMAKE_GENERATOR MATCHES "(Visual Studio)")
+  endif (CMAKE_GENERATOR MATCHES "^Visual Studio.*$")
 
   # Checked build specific flags
   add_linker_flag(/INCREMENTAL:NO CHECKED) # prevent "warning LNK4075: ignoring '/INCREMENTAL' due to '/OPT:REF' specification"


### PR DESCRIPTION
Stop doing `/INCREMENTAL:YES` 

Fixes https://github.com/dotnet/runtime/issues/64082.