### PR TITLE
Avoid NRE in networking EventSources

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.AnyOS.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.AnyOS.cs
@@ -23,21 +23,21 @@ namespace System.Net.Http
         [NonEvent]
         public void Http11RequestLeftQueue(double timeOnQueueMilliseconds)
         {
-            _http11RequestsQueueDurationCounter!.WriteMetric(timeOnQueueMilliseconds);
+            _http11RequestsQueueDurationCounter?.WriteMetric(timeOnQueueMilliseconds);
             RequestLeftQueue(timeOnQueueMilliseconds, versionMajor: 1, versionMinor: 1);
         }
 
         [NonEvent]
         public void Http20RequestLeftQueue(double timeOnQueueMilliseconds)
         {
-            _http20RequestsQueueDurationCounter!.WriteMetric(timeOnQueueMilliseconds);
+            _http20RequestsQueueDurationCounter?.WriteMetric(timeOnQueueMilliseconds);
             RequestLeftQueue(timeOnQueueMilliseconds, versionMajor: 2, versionMinor: 0);
         }
 
         [NonEvent]
         public void Http30RequestLeftQueue(double timeOnQueueMilliseconds)
         {
-            _http30RequestsQueueDurationCounter!.WriteMetric(timeOnQueueMilliseconds);
+            _http30RequestsQueueDurationCounter?.WriteMetric(timeOnQueueMilliseconds);
             RequestLeftQueue(timeOnQueueMilliseconds, versionMajor: 3, versionMinor: 0);
         }
 

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionTelemetry.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionTelemetry.cs
@@ -101,7 +101,7 @@ namespace System.Net
             {
                 Interlocked.Decrement(ref _currentLookups);
 
-                _lookupsDuration!.WriteMetric(Stopwatch.GetElapsedTime(startingTimestamp).TotalMilliseconds);
+                _lookupsDuration?.WriteMetric(Stopwatch.GetElapsedTime(startingTimestamp).TotalMilliseconds);
 
                 if (IsEnabled(EventLevel.Informational, EventKeywords.None))
                 {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/NetSecurityTelemetry.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/NetSecurityTelemetry.cs
@@ -209,7 +209,7 @@ namespace System.Net.Security
 
             double duration = Stopwatch.GetElapsedTime(startingTimestamp).TotalMilliseconds;
             handshakeDurationCounter?.WriteMetric(duration);
-            _handshakeDurationCounter!.WriteMetric(duration);
+            _handshakeDurationCounter?.WriteMetric(duration);
 
             HandshakeStop(protocol);
         }


### PR DESCRIPTION
Fixes #77434

YARP tests keep hitting this every once in a while as we're not using tools like `RemoteExecutor`.