### PR TITLE
Fix the test build error

### DIFF
--- a/src/tests/JIT/opt/SSA/MemorySsa.cs
+++ b/src/tests/JIT/opt/SSA/MemorySsa.cs
@@ -3,12 +3,14 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class MemorySsaTests
 {
     private static int _intStatic;
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         return ProblemWithHandlerPhis(new int[0]) ? 101 : 100;
     }

--- a/src/tests/JIT/opt/SSA/MemorySsa.csproj
+++ b/src/tests/JIT/opt/SSA/MemorySsa.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -17,6 +17,9 @@
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/opt/ValueNumbering/ExposedLocalsNumbering/**">
             <Issue>https://github.com/dotnet/runtime/issues/80184</Issue>
         </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/JIT/opt/SSA/MemorySsa/**">
+            <Issue>https://github.com/dotnet/runtime/issues/86112</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- All OS/Arch CoreCLR excludes -->


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/86108 added a test that was failing the merge test checks.

https://dev.azure.com/dnceng-public/public/_build/results?buildId=272279&view=logs&j=c92f2c34-43c3-5f9c-356c-2e863ce9eb4e&t=1bb8c7f3-fff6-5069-c97d-796b6a1413a0&l=3934

```
/__w/1/s/src/tests/Directory.Build.targets(130,5): error : Tests in merged test directories should not set OutputType to Exe unless they are RequiresProcessIsolation, BuildAsStandalone, or IsMergedTestRunnerAssembly. [/__w/1/s/src/tests/JIT/opt/SSA/MemorySsa.csproj] [/__w/1/s/src/tests/build.proj]
```

@markples 