### PR TITLE
Specify NUnit test runner for illink tests

### DIFF
--- a/src/tools/illink/Directory.Build.props
+++ b/src/tools/illink/Directory.Build.props
@@ -9,8 +9,6 @@
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <DisableImplicitNamespaceImports_DotNet>true</DisableImplicitNamespaceImports_DotNet>
-    <!-- Arcade uses by default xunit as test runner, illink uses nunit instead. -->
-    <TestRunnerName>NUnit</TestRunnerName>
     <!-- TODO: Fix the api differences between the ref and src illink. -->
     <ApiCompatValidateAssemblies>false</ApiCompatValidateAssemblies>
   </PropertyGroup>

--- a/src/tools/illink/Directory.Build.props
+++ b/src/tools/illink/Directory.Build.props
@@ -9,9 +9,8 @@
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <DisableImplicitNamespaceImports_DotNet>true</DisableImplicitNamespaceImports_DotNet>
-    <!-- Arcade uses by default xunit as test runner, illink uses nunit instead. 
-         We need to setup UseVSTestRunner to use the runner VS is using (in this case nunit) -->
-    <UseVSTestRunner>true</UseVSTestRunner>
+    <!-- Arcade uses by default xunit as test runner, illink uses nunit instead. -->
+    <TestRunnerName>NUnit</TestRunnerName>
     <!-- TODO: Fix the api differences between the ref and src illink. -->
     <ApiCompatValidateAssemblies>false</ApiCompatValidateAssemblies>
   </PropertyGroup>

--- a/src/tools/illink/test/Mono.Linker.Tests/Mono.Linker.Tests.csproj
+++ b/src/tools/illink/test/Mono.Linker.Tests/Mono.Linker.Tests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Arcade uses by default xunit as test runner, illink uses nunit instead. -->
+    <TestRunnerName>NUnit</TestRunnerName>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,8 +18,6 @@
     <PackageReference Include="Microsoft.DotNet.Cecil" Version="$(MicrosoftDotNetCecilVersion)" PrivateAssets="All" Publish="True" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />
     <ProjectReference Include="$(RepoRoot)\src\coreclr\tools\ILVerification\ILVerification.csproj" />
-    <PackageReference Include="nunit" Version="$(NUnitVersion)" />
-    <PackageReference Include="NUnit3TestAdapter" Version="$(NUnitTestAdapterVersion)" />
     <!-- This reference is purely so that the ILLink can resolve this
          dependency of mscorlib. It is not actually required to build
          the tests. -->


### PR DESCRIPTION
Specify that we use NUnit for these tests instead of saying "xunit but use dotnet test". This mainly provides clarity, but if Arcade ever adds NUnit-specific testing enhancements, this change will ensure that our tests will pick it up automatically.