### PR TITLE
[wasm] InstallWorkloadFromArtifacts: remove unnecessary workaround

### DIFF
--- a/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
+++ b/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
@@ -65,7 +65,6 @@ namespace Microsoft.Workload.Build.Tasks
                     throw new LogAsErrorException($"Cannot find {nameof(LocalNuGetsPath)}={LocalNuGetsPath} . " +
                                                     "Set it to the Shipping packages directory in artifacts.");
 
-                ExecuteHackForRenamedManifest();
                 if (!InstallAllManifests())
                     return false;
 
@@ -175,29 +174,6 @@ namespace Microsoft.Workload.Build.Tasks
             UpdateAppRef(req.TargetPath, req.Version);
 
             return !Log.HasLoggedErrors;
-        }
-
-        private void ExecuteHackForRenamedManifest()
-        {
-            // HACK - Because the microsoft.net.workload.mono.toolchain is being renamed to microsoft.net.workload.mono.toolchain.current
-            // but the sdk doesn't have the change yet.
-            string? txtPath = Directory.EnumerateFiles(Path.Combine(SdkWithNoWorkloadInstalledPath, "sdk"), "IncludedWorkloadManifests.txt",
-                                            new EnumerationOptions { RecurseSubdirectories = true, MaxRecursionDepth = 2})
-                                .FirstOrDefault();
-            if (txtPath is null)
-                throw new LogAsErrorException($"Could not find IncludedWorkloadManifests.txt in {SdkWithNoWorkloadInstalledPath}");
-
-            string stampPath = Path.Combine(Path.GetDirectoryName(txtPath)!, ".stamp");
-            if (File.Exists(stampPath))
-                return;
-
-            var lines = File.ReadAllLines(txtPath)
-                            .Select(line => line == "microsoft.net.workload.mono.toolchain"
-                                                ? "microsoft.net.workload.mono.toolchain.current"
-                                                : line);
-            File.WriteAllLines(txtPath, lines);
-
-            File.WriteAllText(stampPath, "");
         }
 
         private bool InstallAllManifests()


### PR DESCRIPTION
Prompted by WBT failing with:
```
/Users/ankj/dev/r2/eng/testing/workloads-testing.targets(191,5): error : Could not find IncludedWorkloadManifests.txt in /Users/ankj/dev/r2/artifacts/bin/dotnet-none/
```

.. which seems to have been renamed to `KnownWorkloadManifests.txt`.

Fixes https://github.com/dotnet/runtime/issues/86192 .