### PR TITLE
Change CreateObjectFlags.Unwrap to be ComWrappers-instance-specific

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -718,7 +718,7 @@ namespace System.Runtime.InteropServices
                     // managed object wrappers for A created with C1 and C2 respectively.
                     // If we are asked to create an EOC for B1 with the unwrap flag on the C2 ComWrappers instance,
                     // we will create a new wrapper. In this scenario, we'll only unwrap B2.
-                    var unwrapped = ComInterfaceDispatch.GetInstance<object>(comInterfaceDispatch);
+                    object unwrapped = ComInterfaceDispatch.GetInstance<object>(comInterfaceDispatch);
                     if (_ccwTable.TryGetValue(unwrapped, out ManagedObjectWrapperHolder? unwrappedWrapperInThisContext))
                     {
                         // The unwrapped object has a CCW in this context. Get the IUnknown for the externalComObject

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -706,11 +706,35 @@ namespace System.Runtime.InteropServices
 
             if (flags.HasFlag(CreateObjectFlags.Unwrap))
             {
-                var comInterfaceDispatch = TryGetComInterfaceDispatch(externalComObject);
+                ComInterfaceDispatch* comInterfaceDispatch = TryGetComInterfaceDispatch(externalComObject);
                 if (comInterfaceDispatch != null)
                 {
-                    retValue = ComInterfaceDispatch.GetInstance<object>(comInterfaceDispatch);
-                    return true;
+                    // If we found a managed object wrapper in this ComWrappers instance
+                    // and it's has the same identity pointer as the one we're creating a NativeObjectWrapper for,
+                    // unwrap it. We don't AddRef the wrapper as we don't take a reference to it.
+                    //
+                    // A managed object can have multiple managed object wrappers, with a max of one per context.
+                    // Let's say we have a managed object A and ComWrappers instances C1 and C2. Let B1 and B2 be the
+                    // managed object wrappers for A created with C1 and C2 respectively.
+                    // If we are asked to create an EOC for B1 with the unwrap flag on the C2 ComWrappers instance,
+                    // we will create a new wrapper. In this scenario, we'll only unwrap B2.
+                    var unwrapped = ComInterfaceDispatch.GetInstance<object>(comInterfaceDispatch);
+                    if (_ccwTable.TryGetValue(unwrapped, out ManagedObjectWrapperHolder? unwrappedWrapperInThisContext))
+                    {
+                        // The unwrapped object has a CCW in this context. Get the IUnknown for the externalComObject
+                        // so we can see if it's the CCW for the unwrapped object in this context.
+                        Guid iid = IID_IUnknown;
+                        int hr = Marshal.QueryInterface(externalComObject, ref iid, out IntPtr externalIUnknown);
+                        Debug.Assert(hr == 0); // An external COM object that came from a ComWrappers instance
+                                               // will always be well-formed.
+                        if (unwrappedWrapperInThisContext.ComIp == externalIUnknown)
+                        {
+                            Marshal.Release(externalIUnknown);
+                            retValue = unwrapped;
+                            return true;
+                        }
+                        Marshal.Release(externalIUnknown);
+                    }
                 }
             }
 

--- a/src/coreclr/vm/interoplibinterface_comwrappers.cpp
+++ b/src/coreclr/vm/interoplibinterface_comwrappers.cpp
@@ -880,18 +880,19 @@ namespace
             InteropSyncBlockInfo* interopInfo = syncBlock->GetInteropInfo();
             _ASSERTE(syncBlock->IsPrecious());
 
+            // If we found a managed object wrapper in this ComWrappers instance
+            // and it's has the same identity pointer as the one we're creating an EOC for,
+            // unwrap it. We don't AddRef the wrapper as we don't take a reference to it.
+            //
+            // A managed object can have multiple managed object wrappers, with a max of one per context.
+            // Let's say we have a managed object A and ComWrappers instances C1 and C2. Let B1 and B2 be the
+            // managed object wrappers for A created with C1 and C2 respectively.
+            // If we are asked to create an EOC for B1 with the unwrap flag on the C2 ComWrappers instance,
+            // we will create a new wrapper. In this scenario, we'll only unwrap B2.
             void* wrapperRawMaybe = NULL;
-            if (interopInfo->TryGetManagedObjectComWrapper(wrapperId, &wrapperRawMaybe))
+            if (interopInfo->TryGetManagedObjectComWrapper(wrapperId, &wrapperRawMaybe)
+                && wrapperRawMaybe == identity)
             {
-                // If we found a managed object wrapper in this ComWrappers instance,
-                // unwrap it. We don't AddRef the wrapper as we aren't using it.
-                // We're only checking if it exists.
-
-                // TODO: A managed object can have multiple managed object wrappers, with a max of one per context.
-                // Let's say we have a managed object A and ComWrappers instances C1 and C2. Let B1 and B2 be the
-                // managed object wrappers for A created with C1 and C2 respectively.
-                // If we are asked to create an EOC for B1 with the unwrap flag on the C2 ComWrappers instance,
-                // should we unwrap B1 to get A, or should we only unwrap if B2 is passed in?
                 gc.objRefMaybe = objRef;
             }
             GCPROTECT_END();

--- a/src/coreclr/vm/interoplibinterface_comwrappers.cpp
+++ b/src/coreclr/vm/interoplibinterface_comwrappers.cpp
@@ -878,10 +878,9 @@ namespace
 
             SyncBlock* syncBlock = objRef->GetSyncBlock();
             InteropSyncBlockInfo* interopInfo = syncBlock->GetInteropInfo();
-            _ASSERTE(syncBlock->IsPrecious());
 
             // If we found a managed object wrapper in this ComWrappers instance
-            // and it's has the same identity pointer as the one we're creating an EOC for,
+            // and it's the same identity pointer as the one we're creating an EOC for,
             // unwrap it. We don't AddRef the wrapper as we don't take a reference to it.
             //
             // A managed object can have multiple managed object wrappers, with a max of one per context.
@@ -894,6 +893,10 @@ namespace
                 && wrapperRawMaybe == identity)
             {
                 gc.objRefMaybe = objRef;
+            }
+            else
+            {
+                STRESS_LOG2(LF_INTEROP, LL_INFO1000, "Not unwrapping handle (0x%p) because the object's MOW in this ComWrappers instance (if any) (0x%p) is not the provided identity\n", handle, wrapperRawMaybe);
             }
             GCPROTECT_END();
         }

--- a/src/coreclr/vm/interoplibinterface_comwrappers.cpp
+++ b/src/coreclr/vm/interoplibinterface_comwrappers.cpp
@@ -866,12 +866,38 @@ namespace
         }
         else if (handle != NULL)
         {
-            // We have an object handle from the COM instance which is a CCW. Use that object.
-            // This allows for the round-trip from object -> COM instance -> object.
+            // We have an object handle from the COM instance which is a CCW.
             ::OBJECTHANDLE objectHandle = static_cast<::OBJECTHANDLE>(handle);
-            gc.objRefMaybe = ObjectFromHandle(objectHandle);
+
+            // Now we need to check if this object is a CCW from the same ComWrappers instance
+            // as the one creating the EOC. If it is not, we need to create a new EOC for it.
+            // Otherwise, use it. This allows for the round-trip from object -> COM instance -> object.
+            OBJECTREF objRef = NULL;
+            GCPROTECT_BEGIN(objRef);
+            objRef = ObjectFromHandle(objectHandle);
+
+            SyncBlock* syncBlock = objRef->GetSyncBlock();
+            InteropSyncBlockInfo* interopInfo = syncBlock->GetInteropInfo();
+            _ASSERTE(syncBlock->IsPrecious());
+
+            void* wrapperRawMaybe = NULL;
+            if (interopInfo->TryGetManagedObjectComWrapper(wrapperId, &wrapperRawMaybe))
+            {
+                // If we found a managed object wrapper in this ComWrappers instance,
+                // unwrap it. We don't AddRef the wrapper as we aren't using it.
+                // We're only checking if it exists.
+
+                // TODO: A managed object can have multiple managed object wrappers, with a max of one per context.
+                // Let's say we have a managed object A and ComWrappers instances C1 and C2. Let B1 and B2 be the
+                // managed object wrappers for A created with C1 and C2 respectively.
+                // If we are asked to create an EOC for B1 with the unwrap flag on the C2 ComWrappers instance,
+                // should we unwrap B1 to get A, or should we only unwrap if B2 is passed in?
+                gc.objRefMaybe = objRef;
+            }
+            GCPROTECT_END();
         }
-        else
+
+        if (gc.objRefMaybe == NULL)
         {
             // Create context instance for the possibly new external object.
             ExternalWrapperResultHolder resultHolder;

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -193,7 +193,6 @@ namespace ComWrappersTests
             Assert.Equal(0, count);
         }
 
-
         [MethodImpl(MethodImplOptions.NoInlining)]
         [Fact]
         public void ValidateComInterfaceUnwrapWrapperSpecific()

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -175,7 +175,36 @@ namespace ComWrappersTests
             Assert.NotEqual(IntPtr.Zero, comWrapper);
 
             var testObjUnwrapped = wrappers.GetOrCreateObjectForComInstance(comWrapper, CreateObjectFlags.Unwrap);
-            Assert.Equal(testObj, testObjUnwrapped);
+            Assert.Same(testObj, testObjUnwrapped);
+
+            // Release the wrapper
+            int count = Marshal.Release(comWrapper);
+            Assert.Equal(0, count);
+        }
+
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [Fact]
+        public void ValidateComInterfaceUnwrapWrapperSpecific()
+        {
+            Console.WriteLine($"Running {nameof(ValidateComInterfaceUnwrapWrapperSpecific)}...");
+
+            var testObj = new Test();
+
+            var wrappers = new TestComWrappers();
+
+            // Allocate a wrapper for the object
+            IntPtr comWrapper = wrappers.GetOrCreateComInterfaceForObject(testObj, CreateComInterfaceFlags.None);
+            Assert.NotEqual(IntPtr.Zero, comWrapper);
+
+            // Make sure that unwrapping the wrapper in the same ComWrappers context gets back the same object
+            var testObjUnwrapped = wrappers.GetOrCreateObjectForComInstance(comWrapper, CreateObjectFlags.Unwrap);
+            Assert.Same(testObj, testObjUnwrapped);
+
+            // Make sure that unwrapping the wrapper in a different ComWrappers context gets back a different object
+            var wrappers2 = new TestComWrappers();
+            var testObjUnwrapped2 = wrappers2.GetOrCreateObjectForComInstance(comWrapper, CreateObjectFlags.Unwrap);
+            Assert.NotSame(testObj, testObjUnwrapped2);
 
             // Release the wrapper
             int count = Marshal.Release(comWrapper);

--- a/src/tests/Interop/COM/ComWrappers/Common.cs
+++ b/src/tests/Interop/COM/ComWrappers/Common.cs
@@ -85,6 +85,30 @@ namespace ComWrappersTests.Common
         }
     }
 
+    public class ITestObjectWrapper : ITest
+    {
+        private readonly ITestVtbl._SetValue _setValue;
+        private readonly IntPtr _ptr;
+
+        public ITestObjectWrapper(IntPtr ptr)
+        {
+            _ptr = ptr;
+            VtblPtr inst = Marshal.PtrToStructure<VtblPtr>(ptr);
+            ITestVtbl _vtbl = Marshal.PtrToStructure<ITestVtbl>(inst.Vtbl);
+            _setValue = Marshal.GetDelegateForFunctionPointer<ITestVtbl._SetValue>(_vtbl.SetValue);
+        }
+
+        ~ITestObjectWrapper()
+        {
+            if (_ptr != IntPtr.Zero)
+            {
+                Marshal.Release(_ptr);
+            }
+        }
+
+        public void SetValue(int i) => _setValue(_ptr, i);
+    }
+
     //
     // Native interface definition with managed wrapper for tracker object
     //


### PR DESCRIPTION
This PR changes the `CreateObjectFlags.Unwrap` flag to be ComWrappers-instance specific. With this change, a `ComWrappers` instance will only unwrap an external COM object when the provided external COM object represents a CCW created by that specific `ComWrappers` instance, instead of the existing behavior of unwrapping any external COM object that represents a CCW created by any `ComWrappers` instance.


Fixes #86189