### PR TITLE
BashToZero if both locals of `SUB` are same

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -9398,6 +9398,15 @@ DONE_MORPHING_CHILDREN:
 
         case GT_SUB:
 
+            if (op1->OperIsLocalRead() && op2->OperIsLocalRead())
+            {
+                if (op1->AsLclVarCommon()->GetLclNum() == op2->AsLclVarCommon()->GetLclNum())
+                {
+                    tree->BashToZeroConst(tree->TypeGet());
+                    return tree;
+                }
+            }
+
             if (tree->gtOverflow())
             {
                 goto CM_OVF_OP;


### PR DESCRIPTION
Not sure why we didn't have this earlier, but I noticed the IL produced by roslyn sometimes do not bash the two same locals to 0. 

```c#
    [MethodImpl(MethodImplOptions.NoInlining)]
    public int Result(int i) {
        return i - i;
    }
```

I am seeing the IL of this form

```
# Microsoft (R) Visual C# Compiler version 4.5.2-3.23171.7 (d17f7415)

IL_0000  03                ldarg.1     
IL_0001  03                ldarg.1     
IL_0002  59                sub         
IL_0003  2a                ret 
```

and we end up generating:

```asm
G_M34868_IG01:  ;; offset=0000H
       push     rdi
       push     rsi
                                                ;; size=2 bbWeight=1 PerfScore 2.00
G_M34868_IG02:  ;; offset=0002H
       mov      esi, edx
       mov      edi, edx
       sub      esi, edi
       mov      eax, esi
                                                ;; size=8 bbWeight=1 PerfScore 1.00
G_M34868_IG03:  ;; offset=000AH
       pop      rsi
       pop      rdi
       ret
```

Fix this in morph to bash it to zero const.