### PR TITLE
Unmark loop align regardless if we found block to align or not

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5371,11 +5371,8 @@ PhaseStatus Compiler::placeLoopAlignInstructions()
                             bbHavingAlign->bbNum, loopTop->bbNum);
                 }
 
-                if (bbHavingAlign != nullptr)
-                {
-                    madeChanges = true;
-                    bbHavingAlign->bbFlags |= BBF_HAS_ALIGN;
-                }
+                madeChanges = true;
+                bbHavingAlign->bbFlags |= BBF_HAS_ALIGN;
             }
 
             minBlockSoFar         = BB_MAX_WEIGHT;

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5311,68 +5311,71 @@ PhaseStatus Compiler::placeLoopAlignInstructions()
         {
             // Loop alignment is disabled for cold blocks
             assert((block->bbFlags & BBF_COLD) == 0);
-            BasicBlock* const loopTop = block->bbNext;
+            BasicBlock* const loopTop              = block->bbNext;
+            bool              isSpecialCallFinally = block->isBBCallAlwaysPairTail();
+            bool              unmarkedLoopAlign    = false;
 
-            // If jmp was not found, then block before the loop start is where align instruction will be added.
-            // There are two special cases:
-            // 1. If the block before the loop start is a retless BBJ_CALLFINALLY with
-            //    FEATURE_EH_CALLFINALLY_THUNKS, we can't add alignment because it will affect reported EH
-            //    region range.
-            // 2. If the previous block is the BBJ_ALWAYS of a BBJ_CALLFINALLY/BBJ_ALWAYS pair, then we
-            //    can't add alignment because we can't add instructions in that block. In the
-            //    FEATURE_EH_CALLFINALLY_THUNKS case, it would affect the reported EH, as above.
-            //
-            // Currently, we don't align loops for these cases.
-            //
-            if (bbHavingAlign == nullptr)
-            {
-                bool isSpecialCallFinally = block->isBBCallAlwaysPairTail();
 #if FEATURE_EH_CALLFINALLY_THUNKS
-                if (block->bbJumpKind == BBJ_CALLFINALLY)
-                {
-                    // It must be a retless BBJ_CALLFINALLY if we get here.
-                    assert(!block->isBBCallAlwaysPair());
+            if (block->bbJumpKind == BBJ_CALLFINALLY)
+            {
+                // It must be a retless BBJ_CALLFINALLY if we get here.
+                assert(!block->isBBCallAlwaysPair());
 
-                    // In the case of FEATURE_EH_CALLFINALLY_THUNKS, we can't put the align instruction in a retless
-                    // BBJ_CALLFINALLY either, because it alters the "cloned finally" region reported to the VM.
-                    // In the x86 case (the only !FEATURE_EH_CALLFINALLY_THUNKS that supports retless
-                    // BBJ_CALLFINALLY), we allow it.
-                    isSpecialCallFinally = true;
-                }
+                // In the case of FEATURE_EH_CALLFINALLY_THUNKS, we can't put the align instruction in a retless
+                // BBJ_CALLFINALLY either, because it alters the "cloned finally" region reported to the VM.
+                // In the x86 case (the only !FEATURE_EH_CALLFINALLY_THUNKS that supports retless
+                // BBJ_CALLFINALLY), we allow it.
+                isSpecialCallFinally = true;
+            }
 #endif // FEATURE_EH_CALLFINALLY_THUNKS
 
-                if (isSpecialCallFinally)
+            if (isSpecialCallFinally)
+            {
+                // There are two special cases:
+                // 1. If the block before the loop start is a retless BBJ_CALLFINALLY with
+                //    FEATURE_EH_CALLFINALLY_THUNKS, we can't add alignment because it will affect reported EH
+                //    region range.
+                // 2. If the previous block is the BBJ_ALWAYS of a BBJ_CALLFINALLY/BBJ_ALWAYS pair, then we
+                //    can't add alignment because we can't add instructions in that block. In the
+                //    FEATURE_EH_CALLFINALLY_THUNKS case, it would affect the reported EH, as above.
+                // Currently, we don't align loops for these cases.
+
+                loopTop->unmarkLoopAlign(this DEBUG_ARG("block before loop is special callfinally/always block"));
+                madeChanges       = true;
+                unmarkedLoopAlign = true;
+            }
+            else if ((block->bbNatLoopNum != BasicBlock::NOT_IN_LOOP) && (block->bbNatLoopNum == loopTop->bbNatLoopNum))
+            {
+                // In some odd cases we may see blocks within the loop before we see the
+                // top block of the loop. Just bail on aligning such loops.
+                //
+                loopTop->unmarkLoopAlign(this DEBUG_ARG("loop block appears before top of loop"));
+                madeChanges       = true;
+                unmarkedLoopAlign = true;
+            }
+
+            if (!unmarkedLoopAlign)
+            {
+                if (bbHavingAlign == nullptr)
                 {
-                    loopTop->unmarkLoopAlign(this DEBUG_ARG("block before loop is special callfinally/always block"));
-                    madeChanges = true;
-                }
-                else if ((block->bbNatLoopNum != BasicBlock::NOT_IN_LOOP) &&
-                         (block->bbNatLoopNum == loopTop->bbNatLoopNum))
-                {
-                    // In some odd cases we may see blocks within the loop before we see the
-                    // top block of the loop. Just bail on aligning such loops.
-                    //
-                    loopTop->unmarkLoopAlign(this DEBUG_ARG("loop block appears before top of loop"));
-                    madeChanges = true;
-                }
-                else
-                {
+                    // If jmp was not found, then block before the loop start is where align instruction will be added.
+
                     bbHavingAlign = block;
                     JITDUMP("Marking " FMT_BB " before the loop with BBF_HAS_ALIGN for loop at " FMT_BB "\n",
                             block->bbNum, loopTop->bbNum);
                 }
-            }
-            else
-            {
-                JITDUMP("Marking " FMT_BB " that ends with unconditional jump with BBF_HAS_ALIGN for loop at " FMT_BB
-                        "\n",
-                        bbHavingAlign->bbNum, loopTop->bbNum);
-            }
+                else
+                {
+                    JITDUMP("Marking " FMT_BB
+                            " that ends with unconditional jump with BBF_HAS_ALIGN for loop at " FMT_BB "\n",
+                            bbHavingAlign->bbNum, loopTop->bbNum);
+                }
 
-            if (bbHavingAlign != nullptr)
-            {
-                madeChanges = true;
-                bbHavingAlign->bbFlags |= BBF_HAS_ALIGN;
+                if (bbHavingAlign != nullptr)
+                {
+                    madeChanges = true;
+                    bbHavingAlign->bbFlags |= BBF_HAS_ALIGN;
+                }
             }
 
             minBlockSoFar         = BB_MAX_WEIGHT;


### PR DESCRIPTION
When we place `align` instructions, there are few scenarios we check where we decide to not align the loop. However, we were incorrectly making that decision only if we don't find a block where we can place the align instruction. Instead, this should be checked regardless if we find such block or not.

For the problem reported in #85839, we were having loop block before loop top and we should have disabled loop alignment for such case, but were not doing it. Because of that we were not able to locate the back-edge of that loop leading to assert.

In case it helps to visualize, here is section of basic blocks:

```
BB197 [0329]  2       BB194,BB196          12.03      541 14 [2A0..2A1)-> BB199 ( cond )                     i bwd IBC LIR 
BB198 [0330]  1       BB197                12.03      541 14 [2A0..2A1)-> BB199 ( cond )                     i bwd bwd-src IBC LIR 
BB196 [0328]  1       BB198                11.50      517 14 [2A0..2A1)-> BB197 (always)                     i Loop Loop0 bwd bwd-target IBC LIR align 
BB160 [0036]  1       BB159                 2.22      100    [279..27A)-> BB161 ( cond )                     i IBC LIR 
BB162 [0303]  1       BB160                 2.22      100    [279..27A)-> BB165 ( cond )                     i IBC LIR 
BB164 [0308]  2       BB162,BB363          42.96     1933 10 [279..27A)-> BB165 ( cond )                     i Loop Loop0 nullcheck bwd bwd-target IBC LIR align 
BB363 [0532]  1       BB164                42.96          10 [???..???)-> BB164 (always)                     internal LIR 
```

The loop that starts at `BB196` had the loop block `BB197` before the loop top block (`BB196`).

```
Mapped BB196 to G_M24672_IG114
Marking BB134 that ends with unconditional jump with BBF_HAS_ALIGN for loop at BB196

BB197 [0329]  2       BB194,BB196          12.03      541 14 [2A0..2A1)-> BB199 ( cond )                     i bwd IBC LIR 
BB198 [0330]  1       BB197                12.03      541 14 [2A0..2A1)-> BB199 ( cond )                     i bwd bwd-src IBC LIR 
BB196 [0328]  1       BB198                11.50      517 14 [2A0..2A1)-> BB197 (always)                     i Loop Loop0 bwd bwd-target IBC LIR align 
```
Because of this, we don't find the back-edge for `IG114` as seen in the assert:

```
Mismatch in align instruction.
Containing IG: IG98
loopHeadPredIG: IG113
loopHeadIG: IG114
igInLoop: IG116
igInLoop->backEdge: IG116
igInLoop has align instruction for : IG117
Loop:
	IG114
	IG115
	IG116
	IG117
        ...
```



Thanks @AndyAyersMS for the repro. It was very quick to spot the problem.

Fixes: https://github.com/dotnet/runtime/issues/85839