### PR TITLE
[VM] Fix potential double free

### DIFF
--- a/src/coreclr/vm/stackingallocator.h
+++ b/src/coreclr/vm/stackingallocator.h
@@ -227,7 +227,7 @@ private :
   Thread *pThread__ACQUIRE_STACKING_ALLOCATOR = GetThread(); \
   StackingAllocator *stackingAllocatorName = pThread__ACQUIRE_STACKING_ALLOCATOR->m_stackLocalAllocator; \
   bool allocatorOwner__ACQUIRE_STACKING_ALLOCATOR = false; \
-  NewHolder<StackingAllocator> heapAllocatedStackingBuffer__ACQUIRE_STACKING_ALLOCATOR; \
+  NewArrayHolder<char> heapAllocatedStackingBuffer__ACQUIRE_STACKING_ALLOCATOR; \
 \
   if (stackingAllocatorName == NULL) \
   { \
@@ -237,10 +237,11 @@ private :
       } \
       else \
       {\
-          stackingAllocatorName = new (nothrow) StackingAllocator; \
-          if (stackingAllocatorName == NULL) \
+          char *pBuffer__ACQUIRE_STACKING_ALLOCATOR = new (nothrow) char[sizeof(StackingAllocator)]; \
+          if (pBuffer__ACQUIRE_STACKING_ALLOCATOR == NULL) \
               ThrowOutOfMemory(); \
-          heapAllocatedStackingBuffer__ACQUIRE_STACKING_ALLOCATOR = stackingAllocatorName; \
+          heapAllocatedStackingBuffer__ACQUIRE_STACKING_ALLOCATOR = pBuffer__ACQUIRE_STACKING_ALLOCATOR; \
+          stackingAllocatorName = new (pBuffer__ACQUIRE_STACKING_ALLOCATOR) StackingAllocator; \
       }\
       allocatorOwner__ACQUIRE_STACKING_ALLOCATOR = true; \
   } \


### PR DESCRIPTION
Use a raw char `NewArrayHolder` instead of a `NewHolder` to store the `StackingAllocator` to prevent its destructor from being called twice since `StackingAllocatorHolder` has already taken care of the destruction.

This fixes a double free error when `ACQUIRE_STACKING_ALLOCATOR` is called in environments/OSes with smaller per-thread stack sizes, such as in [this port](https://github.com/dotnet/runtime/issues/55803#issuecomment-1545730293).