### PR TITLE
For Wasi build on windows, do not set CLR_CMAKE_TARGET_WIN32

### DIFF
--- a/eng/native/configureplatform.cmake
+++ b/eng/native/configureplatform.cmake
@@ -461,11 +461,11 @@ if(CLR_CMAKE_TARGET_UNIX)
     else()
         clr_unknown_arch()
     endif()
-else()
-    if(NOT (CLR_CMAKE_TARGET_WASI))
-        set(CLR_CMAKE_TARGET_WIN32 1)
-    endif()
 endif(CLR_CMAKE_TARGET_UNIX)
+
+if(CLR_CMAKE_TARGET_OS STREQUAL windows)
+    set(CLR_CMAKE_TARGET_WIN32 1)
+endif()
 
 # check if host & target os/arch combination are valid
 if (NOT (CLR_CMAKE_TARGET_OS STREQUAL CLR_CMAKE_HOST_OS) AND NOT CLR_CMAKE_TARGET_WASI)

--- a/eng/native/configureplatform.cmake
+++ b/eng/native/configureplatform.cmake
@@ -462,7 +462,9 @@ if(CLR_CMAKE_TARGET_UNIX)
         clr_unknown_arch()
     endif()
 else()
-    set(CLR_CMAKE_TARGET_WIN32 1)
+    if(NOT (CLR_CMAKE_TARGET_WASI))
+        set(CLR_CMAKE_TARGET_WIN32 1)
+    endif()
 endif(CLR_CMAKE_TARGET_UNIX)
 
 # check if host & target os/arch combination are valid


### PR DESCRIPTION
This PR removes `CLR_CMAKE_TARGET_WIN32` from  `eng\native\configureplatform.cmake` for the native build of WebAssembly Wasi on windows.  Follows discussion at https://github.com/dotnet/runtimelab/pull/2268#discussion_r1192802324