### PR TITLE
Avoid capturing the ExecutionContext for the whole HTTP connection lifetime

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Asynchrony.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Asynchrony.cs
@@ -31,6 +31,11 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
+            if (UseVersion.Major != 1)
+            {
+                return;
+            }
+
             await Task.Run(async delegate // escape xunit's sync ctx
             {
                 await LoopbackServer.CreateClientAndServerAsync(uri =>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -239,7 +239,13 @@ namespace System.Net.Http
 
                 // Processing the incoming frames before sending the client preface and SETTINGS is necessary when using a NamedPipe as a transport.
                 // If the preface and SETTINGS coming from the server are not read first the below WriteAsync and the ProcessIncomingFramesAsync fall into a deadlock.
-                _ = ProcessIncomingFramesAsync();
+
+                // Avoid capturing the initial request's ExecutionContext for the entire lifetime of the new connection.
+                using (ExecutionContext.SuppressFlow())
+                {
+                    _ = ProcessIncomingFramesAsync();
+                }
+
                 await _stream.WriteAsync(_outgoingBuffer.ActiveMemory, cancellationToken).ConfigureAwait(false);
                 _rttEstimator.OnInitialSettingsSent();
                 _outgoingBuffer.ClearAndReturnBuffer();
@@ -262,7 +268,11 @@ namespace System.Net.Http
                 throw new IOException(SR.net_http_http2_connection_not_established, e);
             }
 
-            _ = ProcessOutgoingFramesAsync();
+            // Avoid capturing the initial request's ExecutionContext for the entire lifetime of the new connection.
+            using (ExecutionContext.SuppressFlow())
+            {
+                _ = ProcessOutgoingFramesAsync();
+            }
         }
 
         // This will complete when the connection begins to shut down and cannot be used anymore, or if it is disposed.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -99,11 +99,15 @@ namespace System.Net.Http
                 _markedByTelemetryStatus = TelemetryStatus_Opened;
             }
 
-            // Errors are observed via Abort().
-            _ = SendSettingsAsync();
+            // Avoid capturing the initial request's ExecutionContext for the entire lifetime of the new connection.
+            using (ExecutionContext.SuppressFlow())
+            {
+                // Errors are observed via Abort().
+                _ = SendSettingsAsync();
 
-            // This process is cleaned up when _connection is disposed, and errors are observed via Abort().
-            _ = AcceptStreamsAsync();
+                // This process is cleaned up when _connection is disposed, and errors are observed via Abort().
+                _ = AcceptStreamsAsync();
+            }
         }
 
         /// <summary>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -722,6 +722,9 @@ namespace System.Net.Http
                 }
             }
 
+            // Avoid capturing the initial request's ExecutionContext for the entire lifetime of the new connection.
+            using AsyncFlowControl _ = ExecutionContext.SuppressFlow();
+
             if (connection is not null)
             {
                 // Register for shutdown notification.


### PR DESCRIPTION
Fixes #80232