### PR TITLE
link to the latest version of Framework Design Guidelines

### DIFF
--- a/docs/coding-guidelines/api-guidelines/README.md
+++ b/docs/coding-guidelines/api-guidelines/README.md
@@ -2,7 +2,7 @@
 
 The guidelines in this folder represent work in progress API design guidelines.
 The official guidelines can be found in the [documentation][docs] and as an
-actual [book].
+actual [book][FDG].
 
 ## Process
 
@@ -10,4 +10,4 @@ To submit new proposals for design guidelines, simply create a PR adding or
 modifying an existing file.
 
 [docs]: https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/
-[book]: https://amazon.com/dp/0321545613
+[FDG]: https://amazon.com/dp/0135896460

--- a/docs/coding-guidelines/framework-design-guidelines-digest.md
+++ b/docs/coding-guidelines/framework-design-guidelines-digest.md
@@ -3,7 +3,8 @@ Framework Design Guidelines - Digest
 
 This page is a distillation and a simplification of the most basic
 guidelines described in detail in a book titled
-[Framework Design Guidelines][FDG] by Krzysztof Cwalina and Brad Abrams.
+[Framework Design Guidelines][FDG] by Krzysztof Cwalina, Jeremy Barton and Brad
+Abrams.
 
 Framework Design Guidelines were created in the early days of .NET Framework
 development. They started as a small set of naming and design conventions but
@@ -12,7 +13,7 @@ considered the canonical way to design frameworks at Microsoft. They carry the
 experience and cumulative wisdom of thousands of developer hours over several
 versions of the .NET Framework.
 
-[FDG]: http://amazon.com/dp/0321545613
+[FDG]: https://amazon.com/dp/0135896460
 
 # General Design Principles
 

--- a/docs/project/api-review-process.md
+++ b/docs/project/api-review-process.md
@@ -77,9 +77,11 @@ If you want to collaborate with other people on the design, feel free to perform
 
 ## API Design Guidelines
 
-The .NET design guidelines are captured in the famous book [Framework Design Guidelines](https://www.amazon.com/dp/0135896460) by Krzysztof Cwalina, Jeremy Barton and Brad Abrams.
+The .NET design guidelines are captured in the famous book [Framework Design Guidelines][FDG] by Krzysztof Cwalina, Jeremy Barton and Brad Abrams.
 
 A digest with the most important guidelines are available in our [documentation](../coding-guidelines/framework-design-guidelines-digest.md). Long term, we'd like to publish the individual guidelines in standalone repo on which we can also accept PRs and -- more importantly for API reviews -- link to.
+
+[FDG]: https://amazon.com/dp/0135896460
 
 ## API Review Notes
 


### PR DESCRIPTION
also added Jeremy Barton because he was inconsistently mentioned