### PR TITLE
Move ternlog recognition to lower

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2047,6 +2047,7 @@ GenTree* Lowering::LowerCallMemcmp(GenTreeCall* call)
                     GenTree* zeroCns   = comp->gtNewZeroConNode(actualLoadType);
                     result             = newBinaryOp(comp, GT_EQ, TYP_INT, resultOr, zeroCns);
 
+#ifdef FEATURE_SIMD
                     // Special case for AVX512: we can use ternary logic instruction to perform
                     // "lXor | (l2Indir ^ r2Indir)" in a single instruction.
                     if (comp->compOpportunisticallyDependsOn(InstructionSet_AVX512F_VL) &&
@@ -2062,6 +2063,7 @@ GenTree* Lowering::LowerCallMemcmp(GenTreeCall* call)
                         rXor   = control;
                         result = newBinaryOp(comp, GT_EQ, TYP_INT, resultOr, zeroCns);
                     }
+#endif
 
                     BlockRange().InsertAfter(rArgClone, l1Indir, r1Indir, l2Offs, l2AddOffs);
                     BlockRange().InsertAfter(l2AddOffs, l2Indir, r2Offs, r2AddOffs, r2Indir);

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2047,7 +2047,7 @@ GenTree* Lowering::LowerCallMemcmp(GenTreeCall* call)
                     GenTree* zeroCns   = comp->gtNewZeroConNode(actualLoadType);
                     result             = newBinaryOp(comp, GT_EQ, TYP_INT, resultOr, zeroCns);
 
-#ifdef FEATURE_SIMD
+#if defined(FEATURE_SIMD) && defined(TARGET_XARCH)
                     // Special case for AVX512: we can use ternary logic instruction to perform
                     // "lXor | (l2Indir ^ r2Indir)" in a single instruction.
                     if (comp->compOpportunisticallyDependsOn(InstructionSet_AVX512F_VL) &&

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2050,8 +2050,7 @@ GenTree* Lowering::LowerCallMemcmp(GenTreeCall* call)
 #if defined(FEATURE_SIMD) && defined(TARGET_XARCH)
                     // Special case for AVX512: we can use ternary logic instruction to perform
                     // "lXor | (l2Indir ^ r2Indir)" in a single instruction.
-                    if (comp->compOpportunisticallyDependsOn(InstructionSet_AVX512F_VL) &&
-                        resultOr->TypeIs(TYP_SIMD32, TYP_SIMD64))
+                    if (comp->compOpportunisticallyDependsOn(InstructionSet_AVX512F_VL) && varTypeIsSIMD(resultOr))
                     {
                         // Create a mask representing "A | (B ^ C))" expression.
                         GenTree*    control  = comp->gtNewIconNode(static_cast<uint8_t>(0xF0 | (0xCC ^ 0xAA)));

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2048,14 +2048,14 @@ GenTree* Lowering::LowerCallMemcmp(GenTreeCall* call)
                     result             = newBinaryOp(comp, GT_EQ, TYP_INT, resultOr, zeroCns);
 
                     // Special case for AVX512: we can use ternary logic instruction to perform
-                    // "(l2Indir | r2Indir) ^ lXor" in a single instruction.
+                    // "lXor | (l2Indir ^ r2Indir)" in a single instruction.
                     if (comp->compOpportunisticallyDependsOn(InstructionSet_AVX512F_VL) &&
                         resultOr->TypeIs(TYP_SIMD32, TYP_SIMD64))
                     {
-                        // Create a mask representing "(A | B)) ^ C" expression.
-                        GenTree*    control  = comp->gtNewIconNode(static_cast<uint8_t>((0xF0 | 0xCC) ^ 0xAA));
+                        // Create a mask representing "A | (B ^ C))" expression.
+                        GenTree*    control  = comp->gtNewIconNode(static_cast<uint8_t>(0xF0 | (0xCC ^ 0xAA)));
                         CorInfoType baseType = resultOr->AsHWIntrinsic()->GetSimdBaseJitType();
-                        resultOr = comp->gtNewSimdTernaryLogicNode(loadType, l2Indir, r2Indir, lXor, control, baseType,
+                        resultOr = comp->gtNewSimdTernaryLogicNode(loadType, lXor, l2Indir, r2Indir, control, baseType,
                                                                    genTypeSize(loadType));
 
                         // Change exising nodes so we can re-using exising path for node insertion


### PR DESCRIPTION
Move ternlog insertion from importvectorization.cpp to lower to also handle user's case + LowerMemcmp vectorization. Handling for other cases where we can insert ternlog is left up for grabs.

As a bonus, it now handles unrollings like these:
```c
bool Test(int[] a, int[] b) => 
    a.AsSpan(0, 10).SequenceEqual(b);
```
```diff
       vmovups  ymm0, ymmword ptr [rcx]
       vmovups  ymm1, ymmword ptr [rax]
       vmovups  ymm2, ymmword ptr [rcx+08H]
       vmovups  ymm3, ymmword ptr [rax+08H]
       vpxor    ymm0, ymm0, ymm1
-      vpxor    ymm1, ymm2, ymm3
-      vpor     ymm0, ymm0, ymm1
+      vpternlogq ymm0, ymm2, ymm3, -10
       vptest   ymm0, ymm0
       sete     al
       movzx    rax, al
```