### PR TITLE
Do interface dispatch through a helper

### DIFF
--- a/src/coreclr/nativeaot/Runtime/AsmOffsets.h
+++ b/src/coreclr/nativeaot/Runtime/AsmOffsets.h
@@ -68,8 +68,10 @@ ASM_OFFSET(    4,     8, InterfaceDispatchCell, m_pCache)
 #ifdef INTERFACE_DISPATCH_CACHE_HAS_CELL_BACKPOINTER
 ASM_OFFSET(    8,     0, InterfaceDispatchCache, m_pCell)
 #endif
+ASM_OFFSET(    C,    18, InterfaceDispatchCache, m_cEntries)
 ASM_OFFSET(   10,    20, InterfaceDispatchCache, m_rgEntries)
 ASM_SIZEOF(    8,    10, InterfaceDispatchCacheEntry)
+ASM_CONST(     3,     3, IDC_CACHE_POINTER_MASK)
 #endif
 
 #ifdef FEATURE_DYNAMIC_CODE

--- a/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
@@ -291,6 +291,10 @@ EXTERN_C void * RhpByRefAssignRefAVLocation1;
 EXTERN_C void * RhpByRefAssignRefAVLocation2;
 #endif
 
+#if defined(HOST_AMD64) && defined(HOST_WINDOWS)
+EXTERN_C void * RhpResolveInterfaceMethodFastAVLocation;
+#endif
+
 #if defined(HOST_ARM64) && !defined(LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT)
 EXTERN_C void* RhpCheckedLockCmpXchgAVLocation2;
 EXTERN_C void* RhpCheckedXchgAVLocation2;
@@ -310,6 +314,9 @@ static bool InWriteBarrierHelper(uintptr_t faultingIP)
         (uintptr_t)&RhpByRefAssignRefAVLocation1,
 #if !defined(HOST_ARM64)
         (uintptr_t)&RhpByRefAssignRefAVLocation2,
+#endif
+#if defined(HOST_AMD64) && defined(HOST_WINDOWS)
+        (uintptr_t)&RhpResolveInterfaceMethodFastAVLocation,
 #endif
 #if defined(HOST_ARM64) && !defined(LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT)
         (uintptr_t)&RhpCheckedLockCmpXchgAVLocation2,

--- a/src/coreclr/nativeaot/Runtime/inc/rhbinder.h
+++ b/src/coreclr/nativeaot/Runtime/inc/rhbinder.h
@@ -99,6 +99,8 @@ private:
     uint32_t      m_slotIndexOrMetadataTokenEncoded;
 };
 
+#define IDC_CACHE_POINTER_MASK (InterfaceDispatchCell::Flags::IDC_CachePointerMask)
+
 // One of these is allocated per interface call site. It holds the stub to call, data to pass to that stub
 // (cache information) and the interface contract, i.e. the interface type and slot being called.
 struct InterfaceDispatchCell

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -200,7 +200,10 @@ namespace ILCompiler.DependencyAnalysis
                         if (targetMethod.OwningType.IsInterface)
                         {
                             encoder.EmitLEAQ(encoder.TargetRegister.Arg1, factory.InterfaceDispatchCell(targetMethod));
-                            encoder.EmitJMP(factory.ExternSymbol("RhpResolveInterfaceMethod"));
+                            if (factory.Target.IsWindows && factory.Target.Architecture == TargetArchitecture.X64)
+                                encoder.EmitJMP(factory.ExternSymbol("RhpResolveInterfaceMethodFast"));
+                            else
+                                encoder.EmitJMP(factory.ExternSymbol("RhpResolveInterfaceMethod"));
                         }
                         else
                         {

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -1552,10 +1552,10 @@ namespace Internal.JitInterface
             else if ((flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_LDFTN) == 0
                 && targetMethod.OwningType.IsInterface)
             {
-                pResult->kind = CORINFO_CALL_KIND.CORINFO_VIRTUALCALL_STUB;
-
                 if (pResult->exactContextNeedsRuntimeLookup)
                 {
+                    pResult->kind = CORINFO_CALL_KIND.CORINFO_VIRTUALCALL_STUB;
+
                     ComputeLookup(ref pResolvedToken,
                         GetRuntimeDeterminedObjectForToken(ref pResolvedToken),
                         ReadyToRunHelperId.VirtualDispatchCell,
@@ -1564,16 +1564,12 @@ namespace Internal.JitInterface
                 }
                 else
                 {
+                    pResult->kind = CORINFO_CALL_KIND.CORINFO_VIRTUALCALL_LDVIRTFTN;
+
                     pResult->codePointerOrStubLookup.lookupKind.needsRuntimeLookup = false;
-                    pResult->codePointerOrStubLookup.constLookup.accessType = InfoAccessType.IAT_PVALUE;
-#pragma warning disable SA1001, SA1113, SA1115 // Commas should be spaced correctly
-                    pResult->codePointerOrStubLookup.constLookup.addr = (void*)ObjectToHandle(
-                        _compilation.NodeFactory.InterfaceDispatchCell(targetMethod
-#if !SUPPORT_JIT
-                        , _methodCodeNode
-#endif
-                        ));
-#pragma warning restore SA1001, SA1113, SA1115 // Commas should be spaced correctly
+                    pResult->codePointerOrStubLookup.constLookup =
+                        CreateConstLookupToSymbol(
+                            _compilation.NodeFactory.ReadyToRunHelper(ReadyToRunHelperId.ResolveVirtualFunction, targetMethod));
                 }
 
                 pResult->nullInstanceCheck = false;


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/86235#issuecomment-1547182795

The following program gets worse by about 30% for all of the measurements.

```csharp
using System.Diagnostics;
using System.Runtime.CompilerServices;

IFoo f1 = new C1();
IFoo f2 = new C2();

var sw = Stopwatch.StartNew();
for (int i = 0; i < 100_000_000; i++)
{
    Do1(f1);
    Do2(f2);
    Do1(f1);
    Do2(f2);
}
Console.WriteLine(sw.ElapsedMilliseconds);

sw = Stopwatch.StartNew();
for (int i = 0; i < 100_000_000; i++)
{
    Do1(f1);
    Do1(f2);
    Do1(f1);
    Do1(f2);
}
Console.WriteLine(sw.ElapsedMilliseconds);

sw = Stopwatch.StartNew();
for (int i = 0; i < 100_000_000; i++)
{
    Do2(f1);
    Do1(f2);
    Do1(f1);
    Do1(f2);
}
Console.WriteLine(sw.ElapsedMilliseconds);

[MethodImpl(MethodImplOptions.NoInlining)]
static void Do1(IFoo f) => f.Method();
[MethodImpl(MethodImplOptions.NoInlining)]
static void Do2(IFoo f) => f.Method();

class C1 : IFoo
{
    public void Method() { }
}

class C2 : IFoo
{
    public void Method() { }
}

interface IFoo
{
    void Method();
}
```

Cc @dotnet/ilc-contrib 