### PR TITLE
Disable SslStreamSniTest.UnencodedHostName_ValidatesCertificate on Android

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
@@ -237,6 +237,7 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/68206", TestPlatforms.Android)]
         public async Task UnencodedHostName_ValidatesCertificate()
         {
             string rawHostname = "räksmörgås.josefsson.org";


### PR DESCRIPTION
It fails with the following exception:

```
System.Security.Authentication.AuthenticationException : Authentication failed, see inner exception.
---- Interop+AndroidCrypto+SslException : Exception of type 'Interop+AndroidCrypto+SslException' was thrown.

Stack trace
   at System.Net.Security.SslStream.<ForceAuthenticationAsync>d__149`1[[System.Net.Security.AsyncReadWriteAdapter, System.Net.Security, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]].MoveNext()
   at System.Threading.Tasks.TaskTimeoutExtensions.GetRealException(Task task) in /_/src/libraries/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs:line 120
--- End of stack trace from previous location ---
   at System.Threading.Tasks.TaskTimeoutExtensions.WhenAllOrAnyFailed(Task[] tasks) in /_/src/libraries/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs:line 90
   at System.Threading.Tasks.TaskTimeoutExtensions.WhenAllOrAnyFailed(Task[] tasks, Int32 millisecondsTimeout) in /_/src/libraries/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs:line 55
   at System.Net.Security.Tests.SslStreamSniTest.UnencodedHostName_ValidatesCertificate() in /_/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs:line 266
--- End of stack trace from previous location ---
----- Inner Stack Trace -----
```

Similar tests were disabled in https://github.com/dotnet/runtime/issues/68206.