### PR TITLE
[RISC-V][JIT] Fix floating-point args passing

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -5141,8 +5141,15 @@ void CodeGen::genPutArgReg(GenTreeOp* tree)
     GenTree* op1 = tree->gtOp1;
     genConsumeReg(op1);
 
+    if (varTypeIsFloating(tree) && emitter::isGeneralRegister(targetReg))
+    {
+        // Pass the float args by integer register
+        targetType = emitActualTypeSize(targetType) == EA_4BYTE ? TYP_INT : TYP_LONG;
+    }
+
     // If child node is not already in the register we need, move it
-    GetEmitter()->emitIns_Mov(ins_Copy(targetType), emitActualTypeSize(targetType), targetReg, op1->GetRegNum(), true);
+    GetEmitter()->emitIns_Mov(ins_Copy(op1->GetRegNum(), targetType), emitActualTypeSize(targetType), targetReg,
+                              op1->GetRegNum(), true);
     genProduceReg(tree);
 }
 

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -541,13 +541,27 @@ void emitter::emitIns_Mov(
     if (!canSkip || (dstReg != srcReg))
     {
         if ((EA_4BYTE == attr) && (INS_mov == ins))
+        {
+            assert(isGeneralRegisterOrR0(srcReg));
+            assert(isGeneralRegisterOrR0(dstReg));
             emitIns_R_R_I(INS_addiw, attr, dstReg, srcReg, 0);
+        }
         else if (INS_fsgnj_s == ins || INS_fsgnj_d == ins)
+        {
+            assert(isFloatReg(srcReg));
+            assert(isFloatReg(dstReg));
             emitIns_R_R_R(ins, attr, dstReg, srcReg, srcReg);
+        }
         else if (genIsValidFloatReg(srcReg) || genIsValidFloatReg(dstReg))
+        {
             emitIns_R_R(ins, attr, dstReg, srcReg);
+        }
         else
+        {
+            assert(isGeneralRegisterOrR0(srcReg));
+            assert(isGeneralRegisterOrR0(dstReg));
             emitIns_R_R_I(INS_addi, attr, dstReg, srcReg, 0);
+        }
     }
 }
 


### PR DESCRIPTION
- Move floating point values to integer argument registers correctly and add some asserts
- Fix some HFA tests: hfa_nd2A_d, hfa_nf2A_d, hfa_sd2A, hfa_sf2A, hfa_nd2G_d, hfa_nf2G_d, hfa_sd2G_d, hfa_sf2G_d
- Now, all JIT/jit64/hfa tests pass in RISCV64
- https://github.com/dotnet/runtime/issues/84834