### PR TITLE
Special-case array/list/ReadOnlyDictionary in Dictionary(IEnumerable, …) ctors

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 
 namespace System.Collections.Generic
@@ -83,7 +85,7 @@ namespace System.Collections.Generic
         public Dictionary(IDictionary<TKey, TValue> dictionary) : this(dictionary, null) { }
 
         public Dictionary(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey>? comparer) :
-            this(dictionary != null ? dictionary.Count : 0, comparer)
+            this(dictionary?.Count ?? 0, comparer)
         {
             if (dictionary == null)
             {
@@ -106,15 +108,26 @@ namespace System.Collections.Generic
             AddRange(collection);
         }
 
-        private void AddRange(IEnumerable<KeyValuePair<TKey, TValue>> collection)
+        private void AddRange(IEnumerable<KeyValuePair<TKey, TValue>> enumerable)
         {
-            // It is likely that the passed-in dictionary is Dictionary<TKey,TValue>. When this is the case,
+            // Special-case ReadOnlyDictionary<TKey, TValue> to extract its underlying dictionary
+            // rather than going through it as a wrapper. ReadOnlyDictionary's GetEnumerator just returns
+            // the underlying dictionary's GetEnumerator, so this doesn't reduce iteration costs if
+            // the wrapped type isn't known; rather, this exposes the wrapped type to the subsequent
+            // type checks, so in the very common case where the wrapped collection is a Dictionary<TKey, TValue>,
+            // we get to take the fast path below.
+            if (enumerable.GetType() == typeof(ReadOnlyDictionary<TKey, TValue>))
+            {
+                enumerable = ((ReadOnlyDictionary<TKey, TValue>)enumerable).m_dictionary;
+            }
+
+            // It is likely that the passed-in enumerable is Dictionary<TKey,TValue>. When this is the case,
             // avoid the enumerator allocation and overhead by looping through the entries array directly.
             // We only do this when dictionary is Dictionary<TKey,TValue> and not a subclass, to maintain
             // back-compat with subclasses that may have overridden the enumerator behavior.
-            if (collection.GetType() == typeof(Dictionary<TKey, TValue>))
+            if (enumerable.GetType() == typeof(Dictionary<TKey, TValue>))
             {
-                Dictionary<TKey, TValue> source = (Dictionary<TKey, TValue>)collection;
+                Dictionary<TKey, TValue> source = (Dictionary<TKey, TValue>)enumerable;
 
                 if (source.Count == 0)
                 {
@@ -150,8 +163,30 @@ namespace System.Collections.Generic
                 return;
             }
 
-            // Fallback path for IEnumerable that isn't a non-subclassed Dictionary<TKey,TValue>.
-            foreach (KeyValuePair<TKey, TValue> pair in collection)
+            // We similarly special-case KVP<>[] and List<KVP<>>, as they're commonly used to seed dictionaries, and
+            // we want to avoid the enumerator costs (e.g. allocation) for them as well.
+
+            if (enumerable is KeyValuePair<TKey, TValue>[] array)
+            {
+                foreach (KeyValuePair<TKey, TValue> pair in array)
+                {
+                    Add(pair.Key, pair.Value);
+                }
+                return;
+            }
+
+            if (enumerable.GetType() == typeof(List<KeyValuePair<TKey, TValue>>))
+            {
+                foreach (KeyValuePair<TKey, TValue> pair in CollectionsMarshal.AsSpan((List<KeyValuePair<TKey, TValue>>)enumerable))
+                {
+                    Add(pair.Key, pair.Value);
+                }
+                return;
+            }
+
+            // Fallback path for all other enumerables
+
+            foreach (KeyValuePair<TKey, TValue> pair in enumerable)
             {
                 Add(pair.Key, pair.Value);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/ObjectModel/ReadOnlyDictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/ObjectModel/ReadOnlyDictionary.cs
@@ -13,7 +13,7 @@ namespace System.Collections.ObjectModel
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class ReadOnlyDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue> where TKey : notnull
     {
-        internal readonly IDictionary<TKey, TValue> m_dictionary; // Do not rename (binary serialization)
+        private readonly IDictionary<TKey, TValue> m_dictionary; // Do not rename (binary serialization)
 
         [NonSerialized]
         private KeyCollection? _keys;

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/ObjectModel/ReadOnlyDictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/ObjectModel/ReadOnlyDictionary.cs
@@ -13,7 +13,7 @@ namespace System.Collections.ObjectModel
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class ReadOnlyDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue> where TKey : notnull
     {
-        private readonly IDictionary<TKey, TValue> m_dictionary; // Do not rename (binary serialization)
+        internal readonly IDictionary<TKey, TValue> m_dictionary; // Do not rename (binary serialization)
 
         [NonSerialized]
         private KeyCollection? _keys;


### PR DESCRIPTION
It's reasonably common to construct a dictionary from a `KeyValuePair<TKey, TValue>[]` or a `List<KeyValuePair<TKey, TValue>>`, and we can make both cheaper.  We can also unwrap a Dictionary wrapped in a ReadOnlyDictionary in order to better utliize the existing optimizations around Dictionary.

|                 Method |         Toolchain | Length |         Mean | Ratio | Allocated | Alloc Ratio |
|----------------------- |------------------ |------- |-------------:|------:|----------:|------------:|
|              FromArray | \main\corerun.exe |      1 |     60.18 ns |  1.00 |     224 B |        1.00 |
|              FromArray |   \pr\corerun.exe |      1 |     45.21 ns |  0.75 |     192 B |        0.86 |
|                        |                   |        |              |       |           |             |
|               FromList | \main\corerun.exe |      1 |     66.58 ns |  1.00 |     232 B |        1.00 |
|               FromList |   \pr\corerun.exe |      1 |     46.90 ns |  0.70 |     192 B |        0.83 |
|                        |                   |        |              |       |           |             |
|              FromOther | \main\corerun.exe |      1 |     67.22 ns |  1.00 |     240 B |        1.00 |
|              FromOther |   \pr\corerun.exe |      1 |     72.64 ns |  1.07 |     240 B |        1.00 |
|                        |                   |        |              |       |           |             |
| FromReadOnlyDictionary | \main\corerun.exe |      1 |     70.60 ns |  1.00 |     240 B |        1.00 |
| FromReadOnlyDictionary |   \pr\corerun.exe |      1 |     45.04 ns |  0.64 |     192 B |        0.80 |
|                        |                   |        |              |       |           |             |
|              FromArray | \main\corerun.exe |     10 |    161.57 ns |  1.00 |     384 B |        1.00 |
|              FromArray |   \pr\corerun.exe |     10 |    123.19 ns |  0.75 |     352 B |        0.92 |
|                        |                   |        |              |       |           |             |
|               FromList | \main\corerun.exe |     10 |    194.36 ns |  1.00 |     392 B |        1.00 |
|               FromList |   \pr\corerun.exe |     10 |    118.41 ns |  0.61 |     352 B |        0.90 |
|                        |                   |        |              |       |           |             |
|              FromOther | \main\corerun.exe |     10 |    282.64 ns |  1.00 |     824 B |        1.00 |
|              FromOther |   \pr\corerun.exe |     10 |    281.12 ns |  0.98 |     824 B |        1.00 |
|                        |                   |        |              |       |           |             |
| FromReadOnlyDictionary | \main\corerun.exe |     10 |    218.75 ns |  1.00 |     400 B |        1.00 |
| FromReadOnlyDictionary |   \pr\corerun.exe |     10 |     78.69 ns |  0.36 |     352 B |        0.88 |
|                        |                   |        |              |       |           |             |
|              FromArray | \main\corerun.exe |    100 |  1,068.79 ns |  1.00 |    2304 B |        1.00 |
|              FromArray |   \pr\corerun.exe |    100 |    764.88 ns |  0.71 |    2272 B |        0.99 |
|                        |                   |        |              |       |           |             |
|               FromList | \main\corerun.exe |    100 |  1,365.59 ns |  1.00 |    2312 B |        1.00 |
|               FromList |   \pr\corerun.exe |    100 |    834.13 ns |  0.61 |    2272 B |        0.98 |
|                        |                   |        |              |       |           |             |
|              FromOther | \main\corerun.exe |    100 |  2,122.52 ns |  1.00 |    7440 B |        1.00 |
|              FromOther |   \pr\corerun.exe |    100 |  2,136.31 ns |  1.01 |    7440 B |        1.00 |
|                        |                   |        |              |       |           |             |
| FromReadOnlyDictionary | \main\corerun.exe |    100 |  1,660.43 ns |  1.00 |    2320 B |        1.00 |
| FromReadOnlyDictionary |   \pr\corerun.exe |    100 |    421.00 ns |  0.25 |    2272 B |        0.98 |
|                        |                   |        |              |       |           |             |
|              FromArray | \main\corerun.exe |   1000 | 10,293.70 ns |  1.00 |   22224 B |        1.00 |
|              FromArray |   \pr\corerun.exe |   1000 |  7,303.10 ns |  0.71 |   22192 B |        1.00 |
|                        |                   |        |              |       |           |             |
|               FromList | \main\corerun.exe |   1000 | 12,777.52 ns |  1.00 |   22232 B |        1.00 |
|               FromList |   \pr\corerun.exe |   1000 |  7,868.13 ns |  0.62 |   22192 B |        1.00 |
|                        |                   |        |              |       |           |             |
|              FromOther | \main\corerun.exe |   1000 | 20,186.57 ns |  1.00 |   73216 B |        1.00 |
|              FromOther |   \pr\corerun.exe |   1000 | 20,459.95 ns |  1.01 |   73216 B |        1.00 |
|                        |                   |        |              |       |           |             |
| FromReadOnlyDictionary | \main\corerun.exe |   1000 | 16,134.17 ns |  1.00 |   22240 B |        1.00 |
| FromReadOnlyDictionary |   \pr\corerun.exe |   1000 |  4,001.67 ns |  0.25 |   22192 B |        1.00 |

```C#
private KeyValuePair<int, int>[] _array;
private List<KeyValuePair<int, int>> _list;
private IEnumerable<KeyValuePair<int, int>> _other;
private ReadOnlyDictionary<int, int> _rod;

[Params(1, 10, 100, 1000)]
public int Length { get; set; }

[GlobalSetup]
public void Setup()
{
    _array = Enumerable.Range(0, Length).Select(i => new KeyValuePair<int, int>(i, i)).ToArray();
    _list = new List<KeyValuePair<int, int>>(_array);
    _other = _array.Select(kvp => kvp);
    _rod = new ReadOnlyDictionary<int, int>(_array.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
}

[Benchmark] public Dictionary<int, int> FromArray() => new Dictionary<int, int>(_array);
[Benchmark] public Dictionary<int, int> FromList() => new Dictionary<int, int>(_list);
[Benchmark] public Dictionary<int, int> FromOther() => new Dictionary<int, int>(_other);
[Benchmark] public Dictionary<int, int> FromReadOnlyDictionary() => new Dictionary<int, int>(_rod);
```