### PR TITLE
[mono] Prevent memory corruption when decoding UCO entry point

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -5352,10 +5352,16 @@ MONO_RESTORE_WARNING
 				for (j = 0; j < decoded_args->named_args_num; ++j) {
 					if (decoded_args->named_args_info [j].field && !strcmp (decoded_args->named_args_info [j].field->name, "EntryPoint")) {
 						named = (const char *)decoded_args->named_args[j]->value.primitive;
-						slen = mono_metadata_decode_value (named, &named) + (int)strlen(acfg->user_symbol_prefix);
-						export_name = (char *)g_malloc (slen + 1);
-						sprintf (export_name, "%s%s", acfg->user_symbol_prefix, named);
-						export_name [slen] = 0;
+						slen = mono_metadata_decode_value (named, &named);
+						
+						int prefix_len = (int)strlen (acfg->user_symbol_prefix);
+						g_assert (prefix_len < 2);
+						
+						export_name = (char *)g_malloc (prefix_len + slen + 1);
+						if (prefix_len == 1)
+							export_name[0] = *acfg->user_symbol_prefix;
+						memcpy (export_name + prefix_len, named, slen);
+						export_name [prefix_len + slen] = '\0';
 
 						g_ptr_array_add (acfg->exported_methods, method);
 					}


### PR DESCRIPTION
### Description

This PR fixes an issue with memory corruption when MonoAOT compiler decodes the name of the exported symbols specified via `EntryPoint` of a `UnmanagedCallersOnly` method.

The offending lines were assuming that the entry point string in the metadata blob is null terminated, which caused `sprintf` to corrupt the memory around `export_name`.

I haven't been able to reproduce the issue with a smaller example other than how it is described in the tracking issue. If I manage to find a simple repro, I will add a unit test.

PS Not sure how this was not noticed before. One possibility is that the UCOs causing the problem have different encoding in the metadata blob, as they are generated by Cecil library not Roslyn.

--- 

Fixes #86264 