### PR TITLE
Disable DllImportSearchPathsTest and StartupHookTests on mobile

### DIFF
--- a/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.csproj
+++ b/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisVersion_LatestVS)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion_LatestVS)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisVersion_LatestVS)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion_LatestVS)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tests/Common/external/external.csproj
+++ b/src/tests/Common/external/external.csproj
@@ -64,7 +64,7 @@
     <PackageToInclude Include="CommandLineParser"/>
     <PackageToInclude Include="Microsoft.DotNet.XUnitExtensions" />
 
-    <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="$(MicrosoftCodeAnalysisVersion_LatestVS)" />
     <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(TraceEventVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />

--- a/src/tests/Common/external/external.csproj
+++ b/src/tests/Common/external/external.csproj
@@ -56,15 +56,9 @@
     <PackageToInclude Include="Microsoft.Diagnostics.Tracing.TraceEvent"/>
     <PackageToInclude Include="Newtonsoft.Json"/>
     <PackageToInclude Include="Newtonsoft.Json.Bson"/>
-    <PackageToInclude Include="Microsoft.CodeAnalysis.Analyzers"/>
-    <PackageToInclude Include="Microsoft.CodeAnalysis.Common"/>
-    <PackageToInclude Include="Microsoft.CodeAnalysis.Compilers"/>
-    <PackageToInclude Include="Microsoft.CodeAnalysis.CSharp"/>
-    <PackageToInclude Include="Microsoft.CodeAnalysis.VisualBasic"/>
     <PackageToInclude Include="CommandLineParser"/>
     <PackageToInclude Include="Microsoft.DotNet.XUnitExtensions" />
 
-    <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="$(MicrosoftCodeAnalysisVersion_LatestVS)" />
     <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(TraceEventVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />

--- a/src/tests/Common/external/external.csproj
+++ b/src/tests/Common/external/external.csproj
@@ -56,9 +56,15 @@
     <PackageToInclude Include="Microsoft.Diagnostics.Tracing.TraceEvent"/>
     <PackageToInclude Include="Newtonsoft.Json"/>
     <PackageToInclude Include="Newtonsoft.Json.Bson"/>
+    <PackageToInclude Include="Microsoft.CodeAnalysis.Analyzers"/>
+    <PackageToInclude Include="Microsoft.CodeAnalysis.Common"/>
+    <PackageToInclude Include="Microsoft.CodeAnalysis.Compilers"/>
+    <PackageToInclude Include="Microsoft.CodeAnalysis.CSharp"/>
+    <PackageToInclude Include="Microsoft.CodeAnalysis.VisualBasic"/>
     <PackageToInclude Include="CommandLineParser"/>
     <PackageToInclude Include="Microsoft.DotNet.XUnitExtensions" />
 
+    <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="$(MicrosoftCodeAnalysisVersion_LatestVS)" />
     <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(TraceEventVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />

--- a/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.cs
+++ b/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.cs
@@ -19,7 +19,13 @@ public class DllImportSearchPathsTest
     }
 
     public static bool CanLoadAssemblyInSubdirectory =>
-        !TestLibrary.Utilities.IsNativeAot && !TestLibrary.PlatformDetection.IsMonoLLVMFULLAOT;
+        !TestLibrary.Utilities.IsNativeAot &&
+        !TestLibrary.PlatformDetection.IsMonoLLVMFULLAOT &&
+        !OperatingSystem.IsAndroid() &&
+        !OperatingSystem.IsIOS() &&
+        !OperatingSystem.IsTvOS() &&
+        !OperatingSystem.IsBrowser() &&
+        !OperatingSystem.IsWasi();
 
     [ConditionalFact(nameof(CanLoadAssemblyInSubdirectory))]
     public static void AssemblyDirectory_Found()

--- a/src/tests/Loader/StartupHooks/StartupHookTests.cs
+++ b/src/tests/Loader/StartupHooks/StartupHookTests.cs
@@ -16,7 +16,15 @@ public unsafe class StartupHookTests
 
     private static delegate*<void> ProcessStartupHooks = (delegate*<void>)s_startupHookProvider.GetMethod("ProcessStartupHooks", BindingFlags.NonPublic | BindingFlags.Static).MethodHandle.GetFunctionPointer();
 
-    public static bool IsSupported = ((delegate*<bool>)s_startupHookProvider.GetProperty(nameof(IsSupported), BindingFlags.NonPublic | BindingFlags.Static).GetMethod.MethodHandle.GetFunctionPointer())();
+    private static bool IsUnsupportedPlatform =
+        // these platforms need special setup for startup hooks
+        OperatingSystem.IsAndroid() ||
+        OperatingSystem.IsIOS() ||
+        OperatingSystem.IsTvOS() ||
+        OperatingSystem.IsBrowser() ||
+        OperatingSystem.IsWasi();
+
+    public static bool IsSupported = !IsUnsupportedPlatform && ((delegate*<bool>)s_startupHookProvider.GetProperty(nameof(IsSupported), BindingFlags.NonPublic | BindingFlags.Static).GetMethod.MethodHandle.GetFunctionPointer())();
 
     [Fact]
     public static void ValidHookName()

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -115,7 +115,7 @@
     </RemoveDuplicates>
     <ItemGroup>
       <TestsAndAssociatedAssemblies Include="%(TestDirs.Identity)/**/*.dll" Exclude="@(NoMonoAotAssemblyPaths)" />
-      <CoreRootDlls Include="$(CORE_ROOT)/*.dll" Exclude="$(CORE_ROOT)/xunit.performance.api.dll" />
+      <CoreRootDlls Include="$(CORE_ROOT)/*.dll" Exclude="$(CORE_ROOT)/xunit.performance.api.dll;$(CORE_ROOT)/Microsoft.CodeAnalysis.VisualBasic.dll" />
       <AllDlls Condition="'$(MonoFullAot)' == 'true'" Include="@(TestsAndAssociatedAssemblies);@(CoreRootDlls)" />
       <AllDlls Condition="'$(MonoFullAot)' != 'true'" Include="@(TestsAndAssociatedAssemblies)" />
     </ItemGroup>

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -114,7 +114,7 @@
       <Output TaskParameter="Filtered" ItemName="TestDirs" />
     </RemoveDuplicates>
     <ItemGroup>
-      <TestsAndAssociatedAssemblies Include="%(TestDirs.Identity)/*.dll" Exclude="@(NoMonoAotAssemblyPaths)" />
+      <TestsAndAssociatedAssemblies Include="%(TestDirs.Identity)/**/*.dll" Exclude="@(NoMonoAotAssemblyPaths)" />
       <CoreRootDlls Include="$(CORE_ROOT)/*.dll" Exclude="$(CORE_ROOT)/xunit.performance.api.dll" />
       <AllDlls Condition="'$(MonoFullAot)' == 'true'" Include="@(TestsAndAssociatedAssemblies);@(CoreRootDlls)" />
       <AllDlls Condition="'$(MonoFullAot)' != 'true'" Include="@(TestsAndAssociatedAssemblies)" />

--- a/src/tests/tracing/runtimeeventsource/NativeRuntimeEventSourceTest.cs
+++ b/src/tests/tracing/runtimeeventsource/NativeRuntimeEventSourceTest.cs
@@ -40,10 +40,12 @@ namespace Tracing.Tests
 
                     using (Listener listener = new())
                     {
+                        CancellationTokenSource cts = new();
+
                         // Trigger the allocator task.
                         Task.Run(() =>
                         {
-                            while (true)
+                            while (!cts.IsCancellationRequested)
                             {
                                 for (int i = 0; i < 1000; i++)
                                 {
@@ -74,6 +76,8 @@ namespace Tracing.Tests
                                 break;
                             }
                         }
+
+                        cts.Cancel();
 
                         Assert2.True("listener.EventCount > 0", listener.EventCount > 0);
 


### PR DESCRIPTION
Also try to fix the StartupHookTests on LLVM FullAOT by making sure we also AOT dlls in subdirectories.

This uncovered an issue in src/tests/Common/external/external.csproj where an old version of Microsoft.CodeAnalysis.Compilers was referenced which made AOT fail, so I upgraded it.
That uncovered a problem AOTing Microsoft.CodeAnalysis.VisualBasic.dll so had to exclude it from AOTing.