### PR TITLE
Remove Architecture Property

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/GCRefMap.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/GCRefMap.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using System.IO;
 
@@ -116,7 +117,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
         public uint ReadStackPop()
         {
-            Debug.Assert(_reader.Architecture == Architecture.X86);
+            Debug.Assert(_reader.Machine == Machine.I386);
 
             int x = GetTwoBit();
 
@@ -159,7 +160,7 @@ namespace ILCompiler.Reflection.ReadyToRun
             List<GCRefMapEntry> entries = new List<GCRefMapEntry>();
             uint stackPop = GCRefMap.InvalidStackPop;
 
-            if (_reader.Architecture == Architecture.X86)
+            if (_reader.Machine == Machine.I386)
             {
                 stackPop = ReadStackPop();
             }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -97,7 +97,6 @@ namespace ILCompiler.Reflection.ReadyToRun
         // Header
         private OperatingSystem _operatingSystem;
         private Machine _machine;
-        private Architecture _architecture;
         private int _pointerSize;
         private bool _composite;
         private ulong _imageBase;
@@ -189,18 +188,6 @@ namespace ILCompiler.Reflection.ReadyToRun
             {
                 EnsureHeader();
                 return _operatingSystem;
-            }
-        }
-
-        /// <summary>
-        /// Targeting processor architecture of the R2R executable
-        /// </summary>
-        public Architecture Architecture
-        {
-            get
-            {
-                EnsureHeader();
-                return _architecture;
             }
         }
 
@@ -637,36 +624,21 @@ namespace ILCompiler.Reflection.ReadyToRun
             switch (_machine)
             {
                 case Machine.I386:
-                    _architecture = Architecture.X86;
+                case Machine.Arm:
+                case Machine.Thumb:
+                case Machine.ArmThumb2:
                     _pointerSize = 4;
                     break;
 
                 case Machine.Amd64:
-                    _architecture = Architecture.X64;
-                    _pointerSize = 8;
-                    break;
-
-                case Machine.Arm:
-                case Machine.Thumb:
-                case Machine.ArmThumb2:
-                    _architecture = Architecture.Arm;
-                    _pointerSize = 4;
-                    break;
-
                 case Machine.Arm64:
-                    _architecture = Architecture.Arm64;
-                    _pointerSize = 8;
-                    break;
-
-                case (Machine)0x6264: /* LoongArch64 */
-                    _architecture = (Architecture)6; /* LoongArch64 */
+                case Machine.LoongArch64:
                     _pointerSize = 8;
                     break;
 
                 default:
                     throw new NotImplementedException(Machine.ToString());
             }
-
 
             _imageBase = CompositeReader.PEHeaders.PEHeader.ImageBase;
 

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/TransitionBlock.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/TransitionBlock.cs
@@ -15,18 +15,20 @@ namespace ILCompiler.Reflection.ReadyToRun
 
         public static TransitionBlock FromReader(ReadyToRunReader reader)
         {
-            switch (reader.Architecture)
+            switch (reader.Machine)
             {
-                case Architecture.X86:
+                case Machine.I386:
                     return X86TransitionBlock.Instance;
 
-                case Architecture.X64:
+                case Machine.Amd64:
                     return reader.OperatingSystem == OperatingSystem.Windows ? X64WindowsTransitionBlock.Instance : X64UnixTransitionBlock.Instance;
 
-                case Architecture.Arm:
+                case Machine.Arm:
+                case Machine.Thumb:
+                case Machine.ArmThumb2:
                     return ArmTransitionBlock.Instance;
 
-                case Architecture.Arm64:
+                case Machine.Arm64:
                     return Arm64TransitionBlock.Instance;
 
                 default:


### PR DESCRIPTION
The [`Architecture`](https://github.com/dotnet/runtime/blob/0c2e4c13dd3e69d0b6902e87d67cb8c6413ddfeb/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs#LL198C29-L198C41) property of the [`ReadyToRunReader`](https://github.com/dotnet/runtime/blob/0c2e4c13dd3e69d0b6902e87d67cb8c6413ddfeb/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs#L79) class has type `System.Runtime.InteropServices.Architecture` defined in `System.Private.CoreLib`. This makes the library depends on the runtime. 

This is usually ok, but we also need to target `netstandard2.0`, so that makes us impossible to use newer features in that class. In this case, as we are targeting new architecture, we were trying to use a new enum value and failed.

It turns out that the property is only used internally, and it can be easily replaced by using the `Machine` property instead, so I simply removed the property.  