### PR TITLE
Stop testing UnregisterFrozenSegment

### DIFF
--- a/src/tests/GC/API/Frozen/Frozen.cs
+++ b/src/tests/GC/API/Frozen/Frozen.cs
@@ -22,6 +22,7 @@ namespace HelloFrozenSegment
         public void Release()
         {
             // Workaround for GitHub 85863
+            // We are not aware of anyone calling this API so it's low priority to fix
             // GCHelpers.UnregisterFrozenSegment(this.underlyingSegment);
             // Marshal.FreeHGlobal(this.underlyingBuffer);
         }

--- a/src/tests/GC/API/Frozen/Frozen.cs
+++ b/src/tests/GC/API/Frozen/Frozen.cs
@@ -21,8 +21,9 @@ namespace HelloFrozenSegment
 
         public void Release()
         {
-            GCHelpers.UnregisterFrozenSegment(this.underlyingSegment);
-            Marshal.FreeHGlobal(this.underlyingBuffer);
+            // Workaround for GitHub 85863
+            // GCHelpers.UnregisterFrozenSegment(this.underlyingSegment);
+            // Marshal.FreeHGlobal(this.underlyingBuffer);
         }
     }
 


### PR DESCRIPTION
The `UnregisterFrozenSegment` private API call in the `Frozen` test case is causing repeated CI failures. I attempted to fix it multiple times, but there are still crashes.

We are unaware of anyone actually using it, so we decided this is a low priority and disabled testing it for now.