### PR TITLE
[LoongArch64] just skip the array type.

### DIFF
--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -3445,10 +3445,6 @@ int MethodTable::GetLoongArch64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE cl
                 }
                 else if (fieldType == ELEMENT_TYPE_CLASS)
                 {
-                    // Here is just skip the array as its elements' count greater than 1.
-                    // The `struct {int array[1]; float field_2;}` which the array field is only one element,
-                    // just skip it although it can be passed by registers one integer and one float-register.
-                    // Details see github https://github.com/dotnet/runtime/pull/62885#discussion_r821878981
                     size = STRUCT_NO_FLOAT_FIELD;
                     goto _End_arg;
                 }

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -3443,6 +3443,15 @@ int MethodTable::GetLoongArch64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE cl
                         size = STRUCT_FIRST_FIELD_SIZE_IS8;
                     }
                 }
+                else if (fieldType == ELEMENT_TYPE_CLASS)
+                {
+                    // Here is just skip the array as its elements' count greater than 1.
+                    // The `struct {int array[1]; float field_2;}` which the array field is only one element,
+                    // just skip it although it can be passed by registers one integer and one float-register.
+                    // Details see github https://github.com/dotnet/runtime/pull/62885#discussion_r821878981
+                    size = STRUCT_NO_FLOAT_FIELD;
+                    goto _End_arg;
+                }
                 else if (pFieldStart[0].GetSize() == 8)
                 {
                     size = STRUCT_FIRST_FIELD_SIZE_IS8;
@@ -3533,6 +3542,15 @@ int MethodTable::GetLoongArch64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE cl
                     {
                         size |= STRUCT_SECOND_FIELD_SIZE_IS8;
                     }
+                }
+                else if (fieldType == ELEMENT_TYPE_CLASS)
+                {
+                    // Here is just skip the array as its elements' count greater than 1.
+                    // The `struct {int array[1]; float field_2;}` which the array field is only one element,
+                    // just skip it although it can be passed by registers one integer and one float-register.
+                    // Details see github https://github.com/dotnet/runtime/pull/62885#discussion_r821878981
+                    size = STRUCT_NO_FLOAT_FIELD;
+                    goto _End_arg;
                 }
                 else if ((size & STRUCT_FLOAT_FIELD_FIRST) == 0)
                 {

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -3541,10 +3541,6 @@ int MethodTable::GetLoongArch64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE cl
                 }
                 else if (fieldType == ELEMENT_TYPE_CLASS)
                 {
-                    // Here is just skip the array as its elements' count greater than 1.
-                    // The `struct {int array[1]; float field_2;}` which the array field is only one element,
-                    // just skip it although it can be passed by registers one integer and one float-register.
-                    // Details see github https://github.com/dotnet/runtime/pull/62885#discussion_r821878981
                     size = STRUCT_NO_FLOAT_FIELD;
                     goto _End_arg;
                 }


### PR DESCRIPTION
This PR is part of the issue https://github.com/dotnet/runtime/issues/69705 to amend the LA's port.

The `struct {int array[1]; float field_2;}` which the array field is only one element,
just skip it although it can be passed by registers one integer and one float-register.
Details see github https://github.com/dotnet/runtime/pull/62885#discussion_r821878981
