### PR TITLE
Delay reg free for tbx_1reg

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -24348,7 +24348,7 @@ GenTree* Compiler::gtNewSimdWidenLowerNode(var_types type, GenTree* op1, CorInfo
     }
 
     assert(intrinsic != NI_Illegal);
-    tmp1 = gtNewSimdHWIntrinsicNode(type, tmp1, intrinsic, simdBaseJitType, 8);
+    tmp1 = gtNewSimdHWIntrinsicNode(TYP_SIMD16, tmp1, intrinsic, simdBaseJitType, 8);
 
     if (simdSize == 8)
     {
@@ -24543,8 +24543,6 @@ GenTree* Compiler::gtNewSimdWidenUpperNode(var_types type, GenTree* op1, CorInfo
         return gtNewSimdHWIntrinsicNode(type, op1, tmp1, NI_SSE2_UnpackHigh, simdBaseJitType, simdSize);
     }
 #elif defined(TARGET_ARM64)
-    GenTree* zero;
-
     if (simdSize == 16)
     {
         if (varTypeIsFloating(simdBaseType))
@@ -24586,7 +24584,6 @@ GenTree* Compiler::gtNewSimdWidenUpperNode(var_types type, GenTree* op1, CorInfo
         assert(intrinsic != NI_Illegal);
 
         tmp1 = gtNewSimdHWIntrinsicNode(TYP_SIMD16, op1, intrinsic, simdBaseJitType, simdSize);
-        zero = gtNewZeroConNode(TYP_SIMD16);
         return gtNewSimdGetUpperNode(TYP_SIMD8, tmp1, simdBaseJitType, 16);
     }
 #else

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -1779,7 +1779,6 @@ int LinearScan::BuildConsecutiveRegistersForUse(GenTree* treeNode, GenTree* rmwN
         if (rmwNode != nullptr)
         {
             // Check all the newly created Refpositions for delay free
-            RefPositionIterator tailRefPos = refPositions.backPosition();
             RefPositionIterator iter       = refPositionMark;
             INDEBUG(int refPositionsIterated = 0);
 

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -1780,7 +1780,6 @@ int LinearScan::BuildConsecutiveRegistersForUse(GenTree* treeNode, GenTree* rmwN
         {
             // Check all the newly created Refpositions for delay free
             RefPositionIterator iter = refPositionMark;
-            INDEBUG(int refPositionsIterated = 0);
 
             for (iter++; iter != refPositions.end(); iter++)
             {
@@ -1791,11 +1790,7 @@ int LinearScan::BuildConsecutiveRegistersForUse(GenTree* treeNode, GenTree* rmwN
                 {
                     setDelayFree(refPositionAdded);
                 }
-
-                INDEBUG(refPositionsIterated++);
             }
-
-            assert(refPositionsIterated == refPositionsAdded);
         }
 
         srcCount += refPositionsAdded;

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -1779,7 +1779,7 @@ int LinearScan::BuildConsecutiveRegistersForUse(GenTree* treeNode, GenTree* rmwN
         if (rmwNode != nullptr)
         {
             // Check all the newly created Refpositions for delay free
-            RefPositionIterator iter       = refPositionMark;
+            RefPositionIterator iter = refPositionMark;
             INDEBUG(int refPositionsIterated = 0);
 
             for (iter++; iter != refPositions.end(); iter++)


### PR DESCRIPTION
- Setting the operand as "delay reg free" was missing for the scenario of `VectorTableLookupExtension()` that takes 1 row. Fixed that.
- Also we were incorrectly setting the return type of `WidenLower()` to `SIMD8` instead of `SIMD16`. Fixed that as well.

Fixes: #86234