### PR TITLE
fix the regs conflicts within the `addResolution` for LoongArch64 and RISC-V.

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -8102,7 +8102,8 @@ void LinearScan::handleOutgoingCriticalEdges(BasicBlock* block)
         }
     }
 
-    LclVarDsc* terminatorNodeLclVarDsc = nullptr;
+    LclVarDsc* terminatorNodeLclVarDsc  = nullptr;
+    LclVarDsc* terminatorNodeLclVarDsc2 = nullptr;
     // Next, if this blocks ends with a switch table, or for Arm64, ends with JCMP/JTEST instruction,
     // make sure to not copy into the registers that are consumed at the end of this block.
     //
@@ -8181,7 +8182,7 @@ void LinearScan::handleOutgoingCriticalEdges(BasicBlock* block)
                 else if (op->IsLocal())
                 {
                     GenTreeLclVarCommon* lcl = op->AsLclVarCommon();
-                    terminatorNodeLclVarDsc  = &compiler->lvaTable[lcl->GetLclNum()];
+                    terminatorNodeLclVarDsc2 = &compiler->lvaTable[lcl->GetLclNum()];
                 }
             }
         }
@@ -8264,6 +8265,11 @@ void LinearScan::handleOutgoingCriticalEdges(BasicBlock* block)
 #if defined(TARGET_ARM64) || defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
             if ((terminatorNodeLclVarDsc != nullptr) &&
                 (terminatorNodeLclVarDsc->lvVarIndex == outResolutionSetVarIndex))
+            {
+                sameToReg = REG_NA;
+            }
+            else if ((terminatorNodeLclVarDsc2 != nullptr) &&
+                     (terminatorNodeLclVarDsc2->lvVarIndex == outResolutionSetVarIndex))
             {
                 sameToReg = REG_NA;
             }


### PR DESCRIPTION
This PR is part of the issue https://github.com/dotnet/runtime/issues/69705 to amend the LA's port.

 The LoongArch64 is very different with the AArch64 and AMD64.
```
// For AArch64 and AMD64:                       |  // For LoongArch64
// cmp $reg1, $reg2  <--just compare.           |  the compare and branch can be written in one instruction.
// branch.condition  <--the condition is here.  |  so the comparing registers should be alive for branch.
```
If insert move before the branch just liking AArch64 or AMD64, there maybe conflicts.

This should be also valid for RISCV64. cc @clamp03 