### PR TITLE
[release/7.0-staging] Bump branding to 7.0.8

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,7 @@
     <!-- File version numbers -->
     <MajorVersion>7</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>7</PatchVersion>
+    <PatchVersion>8</PatchVersion>
     <SdkBandVersion>7.0.100</SdkBandVersion>
     <PackageVersionNet6>6.0.$([MSBuild]::Add($(PatchVersion), 11))</PackageVersionNet6>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>


### PR DESCRIPTION
@lewing @steveisok @radical feel free to add commits to bump mono/wasm branding if needed.

Don't merge this until after we merge https://github.com/dotnet/runtime/pull/86296