### PR TITLE
[release/6.0-staging] Bump branding to 6.0.19

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,7 @@
     <!-- File version numbers -->
     <MajorVersion>6</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>18</PatchVersion>
+    <PatchVersion>19</PatchVersion>
     <SdkBandVersion>6.0.400</SdkBandVersion>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>


### PR DESCRIPTION
@lewing @steveisok @radical feel free to add commits to bump mono/wasm branding if needed.

Don't merge this until after we merge https://github.com/dotnet/runtime/pull/86295