### PR TITLE
Implement GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/RuntimeDetermined/FunctionPointerType.RuntimeDetermined.cs
+++ b/src/coreclr/tools/Common/TypeSystem/RuntimeDetermined/FunctionPointerType.RuntimeDetermined.cs
@@ -24,8 +24,12 @@ namespace Internal.TypeSystem
 
         public override TypeDesc GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(Instantiation typeInstantiation, Instantiation methodInstantiation)
         {
-            Debug.Assert(false);
-            return this;
+            var sigBuilder = new MethodSignatureBuilder(_signature);
+            sigBuilder.ReturnType = _signature.ReturnType.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(typeInstantiation, methodInstantiation);
+            for (int i = 0; i < _signature.Length; i++)
+                sigBuilder[i] = _signature[i].GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(typeInstantiation, methodInstantiation);
+            MethodSignature newSig = sigBuilder.ToSignature();
+            return newSig == _signature ? this : Context.GetFunctionPointerType(newSig);
         }
     }
 }


### PR DESCRIPTION
This was reached in the Pri0 test suite. Not clear why we didn't run into this with crossgen2 but I guess now we have coverage.

Cc @dotnet/ilc-contrib 