### PR TITLE
Account for rank 1 array special casing in RyuJIT

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -308,7 +308,10 @@ namespace Internal.IL
                     {
                         // RyuJIT is going to call the "MdArray" creation helper even if this is an SzArray,
                         // hence the IsArray check above. Note that the MdArray helper can handle SzArrays.
-                        _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.NewMultiDimArr), reason);
+                        if (((ArrayType)owningType).Rank == 1)
+                            _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.NewMultiDimArrRare), reason);
+                        else
+                            _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.NewMultiDimArr), reason);
                         return;
                     }
                     else


### PR DESCRIPTION
Should have been done in #84205.

Found by pri0 tests.

Cc @dotnet/ilc-contrib 