### PR TITLE
Exclude profiler/r2r tests from building

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1051,12 +1051,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Loader/ContextualReflection/ContextualReflection/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/165</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/profiler/**/*">
-            <Issue>CoreCLR test</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/readytorun/**/*">
-            <Issue>CoreCLR test</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/reflection/Modifiers/modifiers/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/201</Issue>
         </ExcludeList>

--- a/src/tests/profiler/Directory.Build.props
+++ b/src/tests/profiler/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
+
+  <PropertyGroup>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
+  </PropertyGroup>
+</Project>

--- a/src/tests/readytorun/Directory.Build.props
+++ b/src/tests/readytorun/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
+
+  <PropertyGroup>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
These are excluded in issues.targets, but we shouldn't even build them.

Cc @dotnet/ilc-contrib 