### PR TITLE
[mono] Exclude unused bundle files in AppleAppBuilder

### DIFF
--- a/src/mono/sample/iOS/Program.csproj
+++ b/src/mono/sample/iOS/Program.csproj
@@ -46,9 +46,9 @@
     <PropertyGroup Condition="'$(iOSLikeDedup)' == 'true'">
       <_iOSLikeDedupAssembly>$(MSBuildThisFileDirectory)$(PublishDir)\aot-instances.dll</_iOSLikeDedupAssembly>
     </PropertyGroup>
-    <WriteLinesToFile Condition="'$(iOSLikeDedup)' == 'true'" File="$(MSBuildThisFileDirectory)$(PublishDir)/aot-instances.cs" Overwrite="true" Lines="" WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile Condition="'$(iOSLikeDedup)' == 'true'" File="$(IntermediateOutputPath)/aot-instances.cs" Overwrite="true" Lines="" WriteOnlyWhenDifferent="true" />
     <Csc Condition="'$(iOSLikeDedup)' == 'true'"
-      Sources="$(MSBuildThisFileDirectory)$(PublishDir)\aot-instances.cs"
+      Sources="$(IntermediateOutputPath)\aot-instances.cs"
       OutputAssembly="$(_iOSLikeDedupAssembly)"
       TargetType="library"
       Deterministic="true"

--- a/src/mono/sample/iOS/Program.csproj
+++ b/src/mono/sample/iOS/Program.csproj
@@ -62,6 +62,7 @@
         <AotArguments>@(MonoAOTCompilerDefaultAotArguments, ';')</AotArguments>
         <ProcessArguments>@(MonoAOTCompilerDefaultProcessArguments, ';')</ProcessArguments>
       </AotInputAssemblies>
+      <_ExcludeFromAppDir Include="$(_iOSLikeDedupAssembly)" />
     </ItemGroup>
 
     <PropertyGroup>
@@ -109,7 +110,7 @@
         EnableAppSandbox="$(EnableAppSandbox)"
         DiagnosticPorts="$(DiagnosticPorts)"
         StripSymbolTable="$(StripDebugSymbols)"
-        ExcludeFromAppDir="$(_iOSLikeDedupAssembly)"
+        ExcludeFromAppDir="@(_ExcludeFromAppDir)"
         AppDir="$(MSBuildThisFileDirectory)$(PublishDir)">
         <Output TaskParameter="AppBundlePath" PropertyName="AppBundlePath" />
         <Output TaskParameter="XcodeProjectPath" PropertyName="XcodeProjectPath" />

--- a/src/mono/sample/iOS/Program.csproj
+++ b/src/mono/sample/iOS/Program.csproj
@@ -109,6 +109,7 @@
         EnableAppSandbox="$(EnableAppSandbox)"
         DiagnosticPorts="$(DiagnosticPorts)"
         StripSymbolTable="$(StripDebugSymbols)"
+        ExcludeFromAppDir="$(_iOSLikeDedupAssembly)"
         AppDir="$(MSBuildThisFileDirectory)$(PublishDir)">
         <Output TaskParameter="AppBundlePath" PropertyName="AppBundlePath" />
         <Output TaskParameter="XcodeProjectPath" PropertyName="XcodeProjectPath" />

--- a/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
+++ b/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
@@ -322,7 +322,7 @@ public class AppleAppBuilderTask : Task
 
         if (GenerateXcodeProject)
         {
-            XcodeProjectPath = generator.GenerateXCode(ProjectName, MainLibraryFileName, assemblerFiles, assemblerDataFiles, assemblerFilesToLink, extraLinkerArgs,
+            XcodeProjectPath = generator.GenerateXCode(ProjectName, MainLibraryFileName, assemblerFiles, assemblerDataFiles, assemblerFilesToLink, extraLinkerArgs, excludes,
                 AppDir, binDir, MonoRuntimeHeaders, !isDevice, UseConsoleUITemplate, ForceAOT, ForceInterpreter, InvariantGlobalization, HybridGlobalization, Optimized, EnableRuntimeLogging, EnableAppSandbox, DiagnosticPorts, RuntimeComponents, NativeMainSource, UseNativeAOTRuntime);
 
             if (BuildAppBundle)
@@ -348,7 +348,7 @@ public class AppleAppBuilderTask : Task
         }
         else if (GenerateCMakeProject)
         {
-             generator.GenerateCMake(ProjectName, MainLibraryFileName, assemblerFiles, assemblerDataFiles, assemblerFilesToLink, extraLinkerArgs,
+             generator.GenerateCMake(ProjectName, MainLibraryFileName, assemblerFiles, assemblerDataFiles, assemblerFilesToLink, extraLinkerArgs, excludes,
                 AppDir, binDir, MonoRuntimeHeaders, !isDevice, UseConsoleUITemplate, ForceAOT, ForceInterpreter, InvariantGlobalization, HybridGlobalization, Optimized, EnableRuntimeLogging, EnableAppSandbox, DiagnosticPorts, RuntimeComponents, NativeMainSource, UseNativeAOTRuntime);
         }
 

--- a/src/tasks/AppleAppBuilder/Xcode.cs
+++ b/src/tasks/AppleAppBuilder/Xcode.cs
@@ -254,7 +254,7 @@ internal sealed class Xcode
         bool useNativeAOTRuntime = false)
     {
         // bundle everything as resources excluding native files
-        var excludes = new List<string> { ".dll.o", ".dll.s", ".dwarf", ".m", ".h", ".a", ".bc", "libmonosgen-2.0.dylib", "libcoreclr.dylib" };
+        var excludes = new List<string> { ".dll.o", ".dll.s", ".dwarf", ".m", ".h", ".a", ".bc", "libmonosgen-2.0.dylib", "libcoreclr.dylib", "aot-instances.dll", "icudt_EFIGS.dat", "icudt_CJK.dat", "icudt_no_CJK.dat" };
         if (!preferDylibs)
         {
             excludes.Add(".dylib");

--- a/src/tasks/AppleAppBuilder/Xcode.cs
+++ b/src/tasks/AppleAppBuilder/Xcode.cs
@@ -174,6 +174,7 @@ internal sealed class Xcode
         IEnumerable<string> asmDataFiles,
         IEnumerable<string> asmLinkFiles,
         IEnumerable<string> extraLinkerArgs,
+        IEnumerable<string> excludes,
         string workspace,
         string binDir,
         string monoInclude,
@@ -191,7 +192,7 @@ internal sealed class Xcode
         string? nativeMainSource = null,
         bool useNativeAOTRuntime = false)
     {
-        var cmakeDirectoryPath = GenerateCMake(projectName, entryPointLib, asmFiles, asmDataFiles, asmLinkFiles, extraLinkerArgs, workspace, binDir, monoInclude, preferDylibs, useConsoleUiTemplate, forceAOT, forceInterpreter, invariantGlobalization, hybridGlobalization, optimized, enableRuntimeLogging, enableAppSandbox, diagnosticPorts, runtimeComponents, nativeMainSource, useNativeAOTRuntime);
+        var cmakeDirectoryPath = GenerateCMake(projectName, entryPointLib, asmFiles, asmDataFiles, asmLinkFiles, extraLinkerArgs, excludes, workspace, binDir, monoInclude, preferDylibs, useConsoleUiTemplate, forceAOT, forceInterpreter, invariantGlobalization, hybridGlobalization, optimized, enableRuntimeLogging, enableAppSandbox, diagnosticPorts, runtimeComponents, nativeMainSource, useNativeAOTRuntime);
         CreateXcodeProject(projectName, cmakeDirectoryPath);
         return Path.Combine(binDir, projectName, projectName + ".xcodeproj");
     }
@@ -236,6 +237,7 @@ internal sealed class Xcode
         IEnumerable<string> asmDataFiles,
         IEnumerable<string> asmLinkFiles,
         IEnumerable<string> extraLinkerArgs,
+        IEnumerable<string> excludes,
         string workspace,
         string binDir,
         string monoInclude,
@@ -254,18 +256,19 @@ internal sealed class Xcode
         bool useNativeAOTRuntime = false)
     {
         // bundle everything as resources excluding native files
-        var excludes = new List<string> { ".dll.o", ".dll.s", ".dwarf", ".m", ".h", ".a", ".bc", "libmonosgen-2.0.dylib", "libcoreclr.dylib", "aot-instances.dll", "icudt_EFIGS.dat", "icudt_CJK.dat", "icudt_no_CJK.dat" };
+        var predefinedExcludes = new List<string> { ".dll.o", ".dll.s", ".dwarf", ".m", ".h", ".a", ".bc", "libmonosgen-2.0.dylib", "libcoreclr.dylib", "icudt_*" };
+        predefinedExcludes = predefinedExcludes.Concat(excludes).ToList();
         if (!preferDylibs)
         {
-            excludes.Add(".dylib");
+            predefinedExcludes.Add(".dylib");
         }
         if (optimized)
         {
-            excludes.Add(".pdb");
+            predefinedExcludes.Add(".pdb");
         }
 
         string[] resources = Directory.GetFileSystemEntries(workspace, "", SearchOption.TopDirectoryOnly)
-            .Where(f => !excludes.Any(e => f.EndsWith(e, StringComparison.InvariantCultureIgnoreCase)))
+            .Where(f => !predefinedExcludes.Any(e => (!e.EndsWith('*') && f.EndsWith(e, StringComparison.InvariantCultureIgnoreCase)) || (e.EndsWith('*') && Path.GetFileName(f).StartsWith(e.TrimEnd('*'), StringComparison.InvariantCultureIgnoreCase))))
             .ToArray();
 
         if (string.IsNullOrEmpty(nativeMainSource))


### PR DESCRIPTION
This PR aims to reduce the bundle size of the HelloiOS app by excluding unused globalization files and the dedup assembly. These files are currently included in the performance measurements but are not actually used by the app.

Here is an example with the unused bundle files included.

SOD - iOS HelloWorld .app Size
Metric                                          |Average           
------------------------------------------------|-------------------
SOD - iOS HelloWorld .app Size                  |29462794.000 bytes |29462794.000 bytes |29462794.000 bytes
pub/HelloiOS.app/Program.dll                    |6144.000 bytes     |6144.000 bytes     |6144.000 bytes
pub/HelloiOS.app/HelloiOS                       |20916632.000 bytes |20916632.000 bytes |20916632.000 bytes
pub/HelloiOS.app/icudt_EFIGS.dat                |550832.000 bytes   |550832.000 bytes   |550832.000 bytes
pub/HelloiOS.app/System.Console.dll             |17408.000 bytes    |17408.000 bytes    |17408.000 bytes
pub/HelloiOS.app/icudt_CJK.dat                  |956416.000 bytes   |956416.000 bytes   |956416.000 bytes
pub/HelloiOS.app/System.Private.CoreLib.aotdata |1825744.000 bytes  |1825744.000 bytes  |1825744.000 bytes
pub/HelloiOS.app/Program.runtimeconfig.json     |1064.000 bytes     |1064.000 bytes     |1064.000 bytes
pub/HelloiOS.app/System.Console.aotdata         |5800.000 bytes     |5800.000 bytes     |5800.000 bytes
pub/HelloiOS.app/System.Private.CoreLib.dll     |1155072.000 bytes  |1155072.000 bytes  |1155072.000 bytes
pub/HelloiOS.app/aot-instances.aotdata          |1033080.000 bytes  |1033080.000 bytes  |1033080.000 bytes
pub/HelloiOS.app/icudt_no_CJK.dat               |1107168.000 bytes  |1107168.000 bytes  |1107168.000 bytes
pub/HelloiOS.app/Program.aotdata                |10944.000 bytes    |10944.000 bytes    |10944.000 bytes
pub/HelloiOS.app/icudt.dat                      |1859648.000 bytes  |1859648.000 bytes  |1859648.000 bytes
pub/HelloiOS.app/Program.deps.json              |12781.000 bytes    |12781.000 bytes    |12781.000 bytes
pub/HelloiOS.app/aot-instances.dll              |3072.000 bytes     |3072.000 bytes     |3072.000 bytes
pub/HelloiOS.app/Info.plist                     |981.000 bytes      |981.000 bytes      |981.000 bytes
pub/HelloiOS.app/aot-instances.cs               |0.000 bytes        |0.000 bytes        |0.000 bytes
pub/HelloiOS.app/PkgInfo                        |8.000 bytes        |8.000 bytes        |8.000 bytes