### PR TITLE
Improve constant folding for some frozen objects

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -10414,7 +10414,7 @@ static bool GetObjectHandleAndOffset(ValueNumStore*         vnStore,
     if (vnStore->IsVNObjHandle(treeVN))
     {
         *pObj       = vnStore->ConstantObjHandle(treeVN);
-        *byteOffset = (ssize_t)offset;
+        *byteOffset = offset;
         return true;
     }
     return false;

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -10389,20 +10389,20 @@ static bool GetObjectHandleAndOffset(ValueNumStore*         vnStore,
         return false;
     }
 
-    ValueNum  treeVN = tree->gtVNPair.GetLiberal();
-    VNFuncApp funcApp;
-    size_t    offset = 0;
+    ValueNum       treeVN = tree->gtVNPair.GetLiberal();
+    VNFuncApp      funcApp;
+    target_ssize_t offset = 0;
     while (vnStore->GetVNFunc(treeVN, &funcApp) && (funcApp.m_func == (VNFunc)GT_ADD))
     {
         if (vnStore->IsVNConstantNonHandle(funcApp.m_args[0]) && (vnStore->TypeOfVN(funcApp.m_args[0]) == TYP_I_IMPL))
         {
-            offset += vnStore->CoercedConstantValue<ssize_t>(funcApp.m_args[0]);
+            offset += vnStore->ConstantValue<target_ssize_t>(funcApp.m_args[0]);
             treeVN = funcApp.m_args[1];
         }
         else if (vnStore->IsVNConstantNonHandle(funcApp.m_args[1]) &&
                  (vnStore->TypeOfVN(funcApp.m_args[1]) == TYP_I_IMPL))
         {
-            offset += vnStore->CoercedConstantValue<ssize_t>(funcApp.m_args[1]);
+            offset += vnStore->ConstantValue<target_ssize_t>(funcApp.m_args[1]);
             treeVN = funcApp.m_args[0];
         }
         else
@@ -10414,7 +10414,7 @@ static bool GetObjectHandleAndOffset(ValueNumStore*         vnStore,
     if (vnStore->IsVNObjHandle(treeVN))
     {
         *pObj       = vnStore->ConstantObjHandle(treeVN);
-        *byteOffset = offset;
+        *byteOffset = (ssize_t)offset;
         return true;
     }
     return false;

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -5796,6 +5796,11 @@ bool ValueNumStore::IsVNConstant(ValueNum vn)
     }
 }
 
+bool ValueNumStore::IsVNConstantNonHandle(ValueNum vn)
+{
+    return IsVNConstant(vn) && !IsVNHandle(vn);
+}
+
 bool ValueNumStore::IsVNInt32Constant(ValueNum vn)
 {
     if (!IsVNConstant(vn))
@@ -10379,7 +10384,6 @@ static bool GetObjectHandleAndOffset(ValueNumStore*         vnStore,
                                      ssize_t*               byteOffset,
                                      CORINFO_OBJECT_HANDLE* pObj)
 {
-
     if (!tree->gtVNPair.BothEqual())
     {
         return false;
@@ -10387,30 +10391,30 @@ static bool GetObjectHandleAndOffset(ValueNumStore*         vnStore,
 
     ValueNum  treeVN = tree->gtVNPair.GetLiberal();
     VNFuncApp funcApp;
-    if (vnStore->GetVNFunc(treeVN, &funcApp) && (funcApp.m_func == (VNFunc)GT_ADD))
+    size_t    offset = 0;
+    while (vnStore->GetVNFunc(treeVN, &funcApp) && (funcApp.m_func == (VNFunc)GT_ADD))
     {
-        // [objHandle + offset]
-        if (vnStore->IsVNObjHandle(funcApp.m_args[0]) && vnStore->IsVNConstant(funcApp.m_args[1]))
+        if (vnStore->IsVNConstantNonHandle(funcApp.m_args[0]) && (vnStore->TypeOfVN(funcApp.m_args[0]) == TYP_I_IMPL))
         {
-            *pObj       = vnStore->ConstantObjHandle(funcApp.m_args[0]);
-            *byteOffset = vnStore->ConstantValue<ssize_t>(funcApp.m_args[1]);
-            return true;
+            offset += vnStore->CoercedConstantValue<ssize_t>(funcApp.m_args[0]);
+            treeVN = funcApp.m_args[1];
         }
-
-        // [offset + objHandle]
-        // TODO: Introduce a general helper to accumulate offsets for
-        // shapes such as (((X + CNS1) + CNS2) + CNS3) etc.
-        if (vnStore->IsVNObjHandle(funcApp.m_args[1]) && vnStore->IsVNConstant(funcApp.m_args[0]))
+        else if (vnStore->IsVNConstantNonHandle(funcApp.m_args[1]) &&
+                 (vnStore->TypeOfVN(funcApp.m_args[1]) == TYP_I_IMPL))
         {
-            *pObj       = vnStore->ConstantObjHandle(funcApp.m_args[1]);
-            *byteOffset = vnStore->ConstantValue<ssize_t>(funcApp.m_args[0]);
-            return true;
+            offset += vnStore->CoercedConstantValue<ssize_t>(funcApp.m_args[1]);
+            treeVN = funcApp.m_args[0];
+        }
+        else
+        {
+            return false;
         }
     }
-    else if (vnStore->IsVNObjHandle(treeVN))
+
+    if (vnStore->IsVNObjHandle(treeVN))
     {
         *pObj       = vnStore->ConstantObjHandle(treeVN);
-        *byteOffset = 0;
+        *byteOffset = offset;
         return true;
     }
     return false;

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -858,8 +858,11 @@ public:
     // Returns BasicBlock::MAX_LOOP_NUM if the given value number's loop nest is unknown or ill-defined.
     BasicBlock::loopNumber LoopOfVN(ValueNum vn);
 
-    // Returns true iff the VN represents a (non-handle) constant.
+    // Returns true iff the VN represents a constant.
     bool IsVNConstant(ValueNum vn);
+
+    // Returns true iff the VN represents a (non-handle) constant.
+    bool IsVNConstantNonHandle(ValueNum vn);
 
     // Returns true iff the VN represents an integer constant.
     bool IsVNInt32Constant(ValueNum vn);

--- a/src/libraries/System.Private.CoreLib/src/System/Boolean.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Boolean.cs
@@ -236,8 +236,14 @@ namespace System
             return Parse(value.AsSpan());
         }
 
-        public static bool Parse(ReadOnlySpan<char> value) =>
-            TryParse(value, out bool result) ? result : throw new FormatException(SR.Format(SR.Format_BadBoolean, new string(value)));
+        public static bool Parse(ReadOnlySpan<char> value)
+        {
+            if (!TryParse(value, out bool _))
+            {
+                ThrowHelper.ThrowFormatException_BadBoolean(value);
+            }
+            return true;
+        }
 
         // Determines whether a String represents true or false.
         //
@@ -267,6 +273,7 @@ namespace System
 
             return TryParseUncommon(value, out result);
 
+            [MethodImpl(MethodImplOptions.NoInlining)]
             static bool TryParseUncommon(ReadOnlySpan<char> value, out bool result)
             {
                 // With "true" being 4 characters, even if we trim something from <= 4 chars,

--- a/src/libraries/System.Private.CoreLib/src/System/Boolean.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Boolean.cs
@@ -238,11 +238,11 @@ namespace System
 
         public static bool Parse(ReadOnlySpan<char> value)
         {
-            if (!TryParse(value, out bool _))
+            if (!TryParse(value, out bool result))
             {
                 ThrowHelper.ThrowFormatException_BadBoolean(value);
             }
-            return true;
+            return result;
         }
 
         // Determines whether a String represents true or false.

--- a/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
@@ -540,6 +540,12 @@ namespace System
         }
 
         [DoesNotReturn]
+        internal static void ThrowFormatException_BadBoolean(ReadOnlySpan<char> value)
+        {
+            throw new FormatException(SR.Format(SR.Format_BadBoolean, new string(value)));
+        }
+
+        [DoesNotReturn]
         internal static void ThrowArgumentOutOfRangeException_PrecisionTooLarge()
         {
             throw new ArgumentOutOfRangeException("precision", SR.Format(SR.Argument_PrecisionTooLarge, StandardFormat.MaxPrecision));


### PR DESCRIPTION
Just an exercise to improve constant folding in VN around frozen objects. As a demonstration:
```cpp
void Foo() => Bar("TruE");

void Bar(string str)
{
    if (bool.TryParse(str, out bool value))
        Console.WriteLine(value);
}
```
New codegen:
```asm
; Method Program:Foo():this
       sub      rsp, 56
       xor      eax, eax
       mov      qword ptr [rsp+20H], rax
       mov      byte  ptr [rsp+30H], 0
       mov      dword ptr [rsp+30H], 1
       movzx    rcx, byte  ptr [rsp+30H]
       call     [System.Console:WriteLine(bool)]
       nop      
       add      rsp, 56
       ret      
; Total bytes of code: 41
```

<details>
  <summary>old codegen was terrible</summary>

```asm
; Method Program:Foo():this
G_M52879_IG01:  ;; offset=0000H
       push     rsi
       sub      rsp, 112
       vzeroupper 
       vxorps   xmm4, xmm4, xmm4
       vmovdqa  xmmword ptr [rsp+20H], xmm4
       vmovdqa  xmmword ptr [rsp+30H], xmm4
       vmovdqa  xmmword ptr [rsp+40H], xmm4
       vmovdqa  xmmword ptr [rsp+50H], xmm4
       vmovdqa  xmmword ptr [rsp+60H], xmm4
						;; size=42 bbWeight=1 PerfScore 12.58

G_M52879_IG02:  ;; offset=002AH
       mov      rdx, 0x21000209280      ; 'TruE'
       add      rdx, 12
       mov      bword ptr [rsp+60H], rdx
       mov      dword ptr [rsp+68H], 4
       lea      rdx, bword ptr [rsp+60H]
       cmp      dword ptr [rdx+08H], 4
       jne      SHORT G_M52879_IG05
						;; size=38 bbWeight=1 PerfScore 7.00

G_M52879_IG03:  ;; offset=0050H
       mov      rdx, bword ptr [rdx]
       mov      rcx, 0x20002000200020
       or       rcx, qword ptr [rdx]
       mov      rdx, 0x65007500720074
       cmp      rcx, rdx
       jne      SHORT G_M52879_IG05
						;; size=31 bbWeight=0.25 PerfScore 1.69

G_M52879_IG04:  ;; offset=006FH
       mov      ecx, 1
       jmp      G_M52879_IG24
						;; size=10 bbWeight=0.50 PerfScore 1.12

G_M52879_IG05:  ;; offset=0079H
       lea      rcx, bword ptr [rsp+60H]
       mov      rdx, bword ptr [rcx]
       cmp      dword ptr [rcx+08H], 5
       jne      SHORT G_M52879_IG08
						;; size=14 bbWeight=0.50 PerfScore 3.25

G_M52879_IG06:  ;; offset=0087H
       mov      rcx, 0x20002000200020
       or       rcx, qword ptr [rdx]
       mov      rax, 0x73006C00610066
       xor      rcx, rax
       mov      edx, dword ptr [rdx+06H]
       or       edx, 0x200020
       xor      edx, 0x650073
       or       rdx, rcx
       jne      SHORT G_M52879_IG08
						;; size=46 bbWeight=0.25 PerfScore 1.88

G_M52879_IG07:  ;; offset=00B5H
       xor      ecx, ecx
       jmp      G_M52879_IG24
						;; size=7 bbWeight=0.50 PerfScore 1.12

G_M52879_IG08:  ;; offset=00BCH
       vmovdqu  xmm0, xmmword ptr [rsp+60H]
       vmovdqu  xmmword ptr [rsp+50H], xmm0
						;; size=12 bbWeight=0.50 PerfScore 2.00

G_M52879_IG09:  ;; offset=00C8H
       mov      esi, dword ptr [rsp+58H]
       cmp      dword ptr [rsp+58H], 5
       jl       G_M52879_IG22
						;; size=15 bbWeight=0.50 PerfScore 2.00

G_M52879_IG10:  ;; offset=00D7H
       vmovdqu  xmm0, xmmword ptr [rsp+50H]
       vmovdqu  xmmword ptr [rsp+20H], xmm0
						;; size=12 bbWeight=0.50 PerfScore 2.00

G_M52879_IG11:  ;; offset=00E3H
       lea      rdx, [rsp+20H]
       lea      rcx, [rsp+50H]
       call     [System.Boolean:TrimWhiteSpaceAndNull(System.ReadOnlySpan`1[ushort]):System.ReadOnlySpan`1[ushort]]
       cmp      dword ptr [rsp+58H], esi
       je       G_M52879_IG22
						;; size=26 bbWeight=0.50 PerfScore 3.50

G_M52879_IG12:  ;; offset=00FDH
       vmovdqu  xmm0, xmmword ptr [rsp+50H]
       vmovdqu  xmmword ptr [rsp+40H], xmm0
						;; size=12 bbWeight=0.50 PerfScore 2.00

G_M52879_IG13:  ;; offset=0109H
       lea      rcx, bword ptr [rsp+40H]
       cmp      dword ptr [rcx+08H], 4
       jne      SHORT G_M52879_IG16
						;; size=11 bbWeight=0.50 PerfScore 2.25

G_M52879_IG14:  ;; offset=0114H
       mov      rcx, bword ptr [rcx]
       mov      rax, 0x20002000200020
       or       rax, qword ptr [rcx]
       mov      rcx, 0x65007500720074
       cmp      rax, rcx
       jne      SHORT G_M52879_IG16
						;; size=31 bbWeight=0.25 PerfScore 1.69

G_M52879_IG15:  ;; offset=0133H
       mov      ecx, 1
       mov      eax, 1
       jmp      SHORT G_M52879_IG23
						;; size=12 bbWeight=0.50 PerfScore 1.25

G_M52879_IG16:  ;; offset=013FH
       xor      ecx, ecx
						;; size=2 bbWeight=0.50 PerfScore 0.12

G_M52879_IG17:  ;; offset=0141H
       vmovdqu  xmm0, xmmword ptr [rsp+50H]
       vmovdqu  xmmword ptr [rsp+30H], xmm0
						;; size=12 bbWeight=0.50 PerfScore 2.00

G_M52879_IG18:  ;; offset=014DH
       lea      rax, bword ptr [rsp+30H]
       mov      rdx, bword ptr [rax]
       cmp      dword ptr [rax+08H], 5
       jne      SHORT G_M52879_IG20
						;; size=14 bbWeight=0.50 PerfScore 3.25

G_M52879_IG19:  ;; offset=015BH
       mov      rax, 0x20002000200020
       or       rax, qword ptr [rdx]
       mov      r8, 0x73006C00610066
       xor      rax, r8
       mov      edx, dword ptr [rdx+06H]
       or       edx, 0x200020
       xor      edx, 0x650073
       or       rax, rdx
       sete     al
       movzx    rax, al
       jmp      SHORT G_M52879_IG21
						;; size=52 bbWeight=0.25 PerfScore 2.44

G_M52879_IG20:  ;; offset=018FH
       xor      eax, eax
						;; size=2 bbWeight=0.25 PerfScore 0.06

G_M52879_IG21:  ;; offset=0191H
       jmp      SHORT G_M52879_IG23
						;; size=2 bbWeight=0.50 PerfScore 1.00

G_M52879_IG22:  ;; offset=0193H
       xor      ecx, ecx
       xor      eax, eax
						;; size=4 bbWeight=0.50 PerfScore 0.25

G_M52879_IG23:  ;; offset=0197H
       test     eax, eax
       je       SHORT G_M52879_IG25
						;; size=4 bbWeight=0.50 PerfScore 0.62

G_M52879_IG24:  ;; offset=019BH
       call     [System.Console:WriteLine(bool)]
						;; size=6 bbWeight=0.50 PerfScore 1.50

G_M52879_IG25:  ;; offset=01A1H
       nop      
						;; size=1 bbWeight=1 PerfScore 0.25

G_M52879_IG26:  ;; offset=01A2H
       add      rsp, 112
       pop      rsi
       ret      
						;; size=6 bbWeight=1 PerfScore 1.75
; Total bytes of code: 424
```

</details>