### PR TITLE
Fix DAC syncblk API so the SOS tests stop failing intermittently 

### DIFF
--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -3680,16 +3680,16 @@ ClrDataAccess::GetSyncBlockData(unsigned int SBNumber, struct DacpSyncBlockData 
             {
                 PTR_SyncBlock pBlock = ste->m_SyncBlock;
                 pSyncBlockData->SyncBlockPointer = HOST_CDADDR(pBlock);
-#ifd    ef FEATURE_COMINTEROP
+#ifdef FEATURE_COMINTEROP
                 if (pBlock->m_pInteropInfo)
                 {
                     pSyncBlockData->COMFlags |= (pBlock->m_pInteropInfo->DacGetRawRCW() != 0) ? SYNCBLOCKDATA_COMFLAGS_RCW : 0;
                     pSyncBlockData->COMFlags |= (pBlock->m_pInteropInfo->GetCCW() != NULL) ? SYNCBLOCKDATA_COMFLAGS_CCW : 0;
-#ifd    ef FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
+#ifdef FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
                     pSyncBlockData->COMFlags |= (pBlock->m_pInteropInfo->GetComClassFactory() != NULL) ? SYNCBLOCKDATA_COMFLAGS_CF : 0;
-#end    if // FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
+#endif // FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
                 }
-#end    if // FEATURE_COMINTEROP
+#endif // FEATURE_COMINTEROP
 
                 pSyncBlockData->MonitorHeld = pBlock->m_Monitor.GetMonitorHeldStateVolatile();
                 pSyncBlockData->Recursion = pBlock->m_Monitor.GetRecursionLevel();

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -3676,7 +3676,7 @@ ClrDataAccess::GetSyncBlockData(unsigned int SBNumber, struct DacpSyncBlockData 
 
         if (ste->m_SyncBlock != NULL)
         {
-            SyncBlock *pBlock = PTR_SyncBlock(ste->m_SyncBlock);
+            PTR_SyncBlock pBlock = ste->m_SyncBlock;
             pSyncBlockData->SyncBlockPointer = HOST_CDADDR(pBlock);
 #ifdef FEATURE_COMINTEROP
             if (pBlock->m_pInteropInfo)

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -3667,7 +3667,8 @@ ClrDataAccess::GetSyncBlockData(unsigned int SBNumber, struct DacpSyncBlockData 
 
     ZeroMemory(pSyncBlockData,sizeof(DacpSyncBlockData));
     pSyncBlockData->SyncBlockCount = (SyncBlockCache::s_pSyncBlockCache->m_FreeSyncTableIndex) - 1;
-    if (pSyncBlockData->SyncBlockCount > 0)
+    pSyncBlockData->bFree = TRUE;
+    if (pSyncBlockData->SyncBlockCount > 0 && SBNumber <= pSyncBlockData->SyncBlockCount)
     {
         PTR_SyncTableEntry ste = PTR_SyncTableEntry(dac_cast<TADDR>(g_pSyncTable)+(sizeof(SyncTableEntry) * SBNumber));
         pSyncBlockData->bFree = ((dac_cast<TADDR>(ste->m_Object.Load())) & 1);

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -3668,6 +3668,7 @@ ClrDataAccess::GetSyncBlockData(unsigned int SBNumber, struct DacpSyncBlockData 
     ZeroMemory(pSyncBlockData,sizeof(DacpSyncBlockData));
     pSyncBlockData->SyncBlockCount = (SyncBlockCache::s_pSyncBlockCache->m_FreeSyncTableIndex) - 1;
     pSyncBlockData->bFree = TRUE;
+
     if (pSyncBlockData->SyncBlockCount > 0 && SBNumber <= pSyncBlockData->SyncBlockCount)
     {
         PTR_SyncTableEntry ste = PTR_SyncTableEntry(dac_cast<TADDR>(g_pSyncTable)+(sizeof(SyncTableEntry) * SBNumber));
@@ -3679,7 +3680,7 @@ ClrDataAccess::GetSyncBlockData(unsigned int SBNumber, struct DacpSyncBlockData 
 
             if (ste->m_SyncBlock != NULL)
             {
-                PTR_SyncBlock pBlock = ste->m_SyncBlock;
+                SyncBlock *pBlock = PTR_SyncBlock(ste->m_SyncBlock);
                 pSyncBlockData->SyncBlockPointer = HOST_CDADDR(pBlock);
 #ifdef FEATURE_COMINTEROP
                 if (pBlock->m_pInteropInfo)


### PR DESCRIPTION
There was an access that wasn't properly DAC'ized.