### PR TITLE
Fix incorrect usage of u16_strcmp instead of u16_strncmp

### DIFF
--- a/src/coreclr/md/compiler/emit.cpp
+++ b/src/coreclr/md/compiler/emit.cpp
@@ -114,7 +114,7 @@ STDMETHODIMP RegMeta::DefineMethod(           // S_OK or error.
 
     if (!u16_strcmp(szName, W(".ctor")) || // COR_CTOR_METHOD_NAME_W
         !u16_strcmp(szName, W(".cctor")) || // COR_CCTOR_METHOD_NAME_W
-        !u16_strcmp(szName, W("_VtblGap")) )
+        !u16_strncmp(szName, W("_VtblGap"), 8) ) // All methods that begin with the characters "_VtblGap" are considered to be VTable Gap methods
     {
         dwMethodFlags |= mdRTSpecialName | mdSpecialName;
     }


### PR DESCRIPTION
This causes emission of VtblGap methods to lack the rtspecialname flag.

Fixes #86232