### PR TITLE
{U}Int128 support for Utf8Formatter/Parser

### DIFF
--- a/src/libraries/System.Memory/ref/System.Memory.cs
+++ b/src/libraries/System.Memory/ref/System.Memory.cs
@@ -624,6 +624,7 @@ namespace System.Buffers.Text
         public static bool TryFormat(short value, System.Span<byte> destination, out int bytesWritten, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { throw null; }
         public static bool TryFormat(int value, System.Span<byte> destination, out int bytesWritten, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { throw null; }
         public static bool TryFormat(long value, System.Span<byte> destination, out int bytesWritten, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { throw null; }
+        public static bool TryFormat(Int128 value, System.Span<byte> destination, out int bytesWritten, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static bool TryFormat(sbyte value, System.Span<byte> destination, out int bytesWritten, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { throw null; }
         public static bool TryFormat(float value, System.Span<byte> destination, out int bytesWritten, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { throw null; }
@@ -634,6 +635,9 @@ namespace System.Buffers.Text
         public static bool TryFormat(uint value, System.Span<byte> destination, out int bytesWritten, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static bool TryFormat(ulong value, System.Span<byte> destination, out int bytesWritten, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryFormat(UInt128 value, System.Span<byte> destination, out int bytesWritten, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { throw null; }
+
     }
     public static partial class Utf8Parser
     {
@@ -647,6 +651,7 @@ namespace System.Buffers.Text
         public static bool TryParse(System.ReadOnlySpan<byte> source, out short value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
         public static bool TryParse(System.ReadOnlySpan<byte> source, out int value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
         public static bool TryParse(System.ReadOnlySpan<byte> source, out long value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
+        public static bool TryParse(System.ReadOnlySpan<byte> source, out Int128 value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static bool TryParse(System.ReadOnlySpan<byte> source, out sbyte value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
         public static bool TryParse(System.ReadOnlySpan<byte> source, out float value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
@@ -657,6 +662,8 @@ namespace System.Buffers.Text
         public static bool TryParse(System.ReadOnlySpan<byte> source, out uint value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static bool TryParse(System.ReadOnlySpan<byte> source, out ulong value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool TryParse(System.ReadOnlySpan<byte> source, out UInt128 value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
     }
 }
 namespace System.Runtime.InteropServices

--- a/src/libraries/System.Memory/tests/ParsersAndFormatters/Formatter/FormatterTests.cs
+++ b/src/libraries/System.Memory/tests/ParsersAndFormatters/Formatter/FormatterTests.cs
@@ -71,6 +71,20 @@ namespace System.Buffers.Text.Tests
         }
 
         [Theory]
+        [MemberData(nameof(TestData.Int128FormatterTheoryData), MemberType = typeof(TestData))]
+        public static void TestFormatterInt128(FormatterTestData<Int128> testData)
+        {
+            ValidateFormatter(testData);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestData.UInt128FormatterTheoryData), MemberType = typeof(TestData))]
+        public static void TestFormatterUInt128(FormatterTestData<UInt128> testData)
+        {
+            ValidateFormatter(testData);
+        }
+
+        [Theory]
         [MemberData(nameof(TestData.DecimalFormatterTheoryData), MemberType = typeof(TestData))]
         public static void TestFormatterDecimal(FormatterTestData<decimal> testData)
         {

--- a/src/libraries/System.Memory/tests/ParsersAndFormatters/Formatter/TestData.Formatter.cs
+++ b/src/libraries/System.Memory/tests/ParsersAndFormatters/Formatter/TestData.Formatter.cs
@@ -41,6 +41,8 @@ namespace System.Buffers.Text.Tests
         public static IEnumerable<object[]> UInt32FormatterTheoryData => UInt32FormatterTestData.Select(td => new object[] { td });
         public static IEnumerable<object[]> Int64FormatterTheoryData => Int64FormatterTestData.Select(td => new object[] { td });
         public static IEnumerable<object[]> UInt64FormatterTheoryData => UInt64FormatterTestData.Select(td => new object[] { td });
+        public static IEnumerable<object[]> Int128FormatterTheoryData => Int128FormatterTestData.Select(td => new object[] { td });
+        public static IEnumerable<object[]> UInt128FormatterTheoryData => UInt128FormatterTestData.Select(td => new object[] { td });
         public static IEnumerable<object[]> DecimalFormatterTheoryData => DecimalFormatterTestData.Select(td => new object[] { td });
         public static IEnumerable<object[]> DoubleFormatterTheoryData => DoubleFormatterTestData.Select(td => new object[] { td });
         public static IEnumerable<object[]> SingleFormatterTheoryData => SingleFormatterTestData.Select(td => new object[] { td });
@@ -58,6 +60,8 @@ namespace System.Buffers.Text.Tests
         public static IEnumerable<FormatterTestData<uint>> UInt32FormatterTestData => CreateFormatterTestData(UInt32TestData, IntegerFormats);
         public static IEnumerable<FormatterTestData<long>> Int64FormatterTestData => CreateFormatterTestData(Int64TestData, IntegerFormats);
         public static IEnumerable<FormatterTestData<ulong>> UInt64FormatterTestData => CreateFormatterTestData(UInt64TestData, IntegerFormats);
+        public static IEnumerable<FormatterTestData<Int128>> Int128FormatterTestData => CreateFormatterTestData(Int128TestData, IntegerFormats);
+        public static IEnumerable<FormatterTestData<UInt128>> UInt128FormatterTestData => CreateFormatterTestData(UInt128TestData, IntegerFormats);
         public static IEnumerable<FormatterTestData<decimal>> DecimalFormatterTestData => CreateFormatterTestData(DecimalTestData, DecimalFormats);
         public static IEnumerable<FormatterTestData<double>> DoubleFormatterTestData => CreateFormatterTestData(DoubleTestData, FloatingPointFormats);
         public static IEnumerable<FormatterTestData<float>> SingleFormatterTestData => CreateFormatterTestData(SingleTestData, FloatingPointFormats);

--- a/src/libraries/System.Memory/tests/ParsersAndFormatters/Formatter/ValidateFormatter.cs
+++ b/src/libraries/System.Memory/tests/ParsersAndFormatters/Formatter/ValidateFormatter.cs
@@ -147,8 +147,14 @@ namespace System.Buffers.Text.Tests
             if (typeof(T) == typeof(long))
                 return Utf8Formatter.TryFormat((long)(object)value, buffer, out bytesWritten, format);
 
+            if (typeof(T) == typeof(Int128))
+                return Utf8Formatter.TryFormat((Int128)(object)value, buffer, out bytesWritten, format);
+
             if (typeof(T) == typeof(ulong))
                 return Utf8Formatter.TryFormat((ulong)(object)value, buffer, out bytesWritten, format);
+
+            if (typeof(T) == typeof(UInt128))
+                return Utf8Formatter.TryFormat((UInt128)(object)value, buffer, out bytesWritten, format);
 
             if (typeof(T) == typeof(decimal))
                 return Utf8Formatter.TryFormat((decimal)(object)value, buffer, out bytesWritten, format);
@@ -172,60 +178,6 @@ namespace System.Buffers.Text.Tests
                 return Utf8Formatter.TryFormat((TimeSpan)(object)value, buffer, out bytesWritten, format);
 
             throw new Exception("No formatter for type " + typeof(T));
-        }
-
-        private static bool TryFormatUtf8(object value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default)
-        {
-            Type t = value.GetType();
-            if (t == typeof(bool))
-                return Utf8Formatter.TryFormat((bool)value, buffer, out bytesWritten, format);
-
-            if (t == typeof(byte))
-                return Utf8Formatter.TryFormat((byte)value, buffer, out bytesWritten, format);
-
-            if (t == typeof(sbyte))
-                return Utf8Formatter.TryFormat((sbyte)value, buffer, out bytesWritten, format);
-
-            if (t == typeof(short))
-                return Utf8Formatter.TryFormat((short)value, buffer, out bytesWritten, format);
-
-            if (t == typeof(ushort))
-                return Utf8Formatter.TryFormat((ushort)value, buffer, out bytesWritten, format);
-
-            if (t == typeof(int))
-                return Utf8Formatter.TryFormat((int)value, buffer, out bytesWritten, format);
-
-            if (t == typeof(uint))
-                return Utf8Formatter.TryFormat((uint)value, buffer, out bytesWritten, format);
-
-            if (t == typeof(long))
-                return Utf8Formatter.TryFormat((long)value, buffer, out bytesWritten, format);
-
-            if (t == typeof(ulong))
-                return Utf8Formatter.TryFormat((ulong)value, buffer, out bytesWritten, format);
-
-            if (t == typeof(decimal))
-                return Utf8Formatter.TryFormat((decimal)value, buffer, out bytesWritten, format);
-
-            if (t == typeof(double))
-                return Utf8Formatter.TryFormat((double)value, buffer, out bytesWritten, format);
-
-            if (t == typeof(float))
-                return Utf8Formatter.TryFormat((float)value, buffer, out bytesWritten, format);
-
-            if (t == typeof(Guid))
-                return Utf8Formatter.TryFormat((Guid)value, buffer, out bytesWritten, format);
-
-            if (t == typeof(DateTime))
-                return Utf8Formatter.TryFormat((DateTime)value, buffer, out bytesWritten, format);
-
-            if (t == typeof(DateTimeOffset))
-                return Utf8Formatter.TryFormat((DateTimeOffset)value, buffer, out bytesWritten, format);
-
-            if (t == typeof(TimeSpan))
-                return Utf8Formatter.TryFormat((TimeSpan)value, buffer, out bytesWritten, format);
-
-            throw new Exception("No formatter for type " + t);
         }
     }
 }

--- a/src/libraries/System.Memory/tests/ParsersAndFormatters/Parser/ParserTests.cs
+++ b/src/libraries/System.Memory/tests/ParsersAndFormatters/Parser/ParserTests.cs
@@ -71,6 +71,20 @@ namespace System.Buffers.Text.Tests
         }
 
         [Theory]
+        [MemberData(nameof(TestData.Int128ParserTheoryData), MemberType = typeof(TestData))]
+        public static void TestParserInt128(ParserTestData<Int128> testData)
+        {
+            ValidateParser(testData);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestData.UInt128ParserTheoryData), MemberType = typeof(TestData))]
+        public static void TestParserUInt128(ParserTestData<UInt128> testData)
+        {
+            ValidateParser(testData);
+        }
+
+        [Theory]
         [MemberData(nameof(TestData.DecimalParserTheoryData), MemberType = typeof(TestData))]
         public static void TestParserDecimal(ParserTestData<decimal> testData)
         {

--- a/src/libraries/System.Memory/tests/ParsersAndFormatters/Parser/TestData.Parser.Integer.cs
+++ b/src/libraries/System.Memory/tests/ParsersAndFormatters/Parser/TestData.Parser.Integer.cs
@@ -181,6 +181,48 @@ namespace System.Buffers.Text.Tests
             }
         }
 
+        public static IEnumerable<ParserTestData<Int128>> Int128ParserTestData
+        {
+            get
+            {
+                foreach (ParserTestData<Int128> testData in Int128FormatterTestData.ToParserTheoryDataCollection())
+                {
+                    yield return testData;
+                }
+
+                foreach (ParserTestData<Int128> testData in GeneralIntegerParserTestData<Int128>())
+                {
+                    yield return testData;
+                }
+
+                // Code coverage
+                yield return new ParserTestData<Int128>("5$", 5, 'D', expectedSuccess: true) { ExpectedBytesConsumed = 1 };
+                yield return new ParserTestData<Int128>("5$", 5, 'x', expectedSuccess: true) { ExpectedBytesConsumed = 1 };
+                yield return new ParserTestData<Int128>("5faaccbb11223344f", 0, 'x', expectedSuccess: false);
+            }
+        }
+
+        public static IEnumerable<ParserTestData<UInt128>> UInt128ParserTestData
+        {
+            get
+            {
+                foreach (ParserTestData<UInt128> testData in UInt128FormatterTestData.ToParserTheoryDataCollection())
+                {
+                    yield return testData;
+                }
+
+                foreach (ParserTestData<UInt128> testData in GeneralIntegerParserTestData<UInt128>())
+                {
+                    yield return testData;
+                }
+
+                // Code coverage
+                yield return new ParserTestData<UInt128>("5$", 5, 'D', expectedSuccess: true) { ExpectedBytesConsumed = 1 };
+                yield return new ParserTestData<UInt128>("5$", 5, 'x', expectedSuccess: true) { ExpectedBytesConsumed = 1 };
+                yield return new ParserTestData<UInt128>("5faaccbb11223344f", 0, 'x', expectedSuccess: false);
+            }
+        }
+
         private static IEnumerable<ParserTestData<T>> GeneralIntegerParserTestData<T>()
         {
             string[] GeneralIntegerNegativeInputs =

--- a/src/libraries/System.Memory/tests/ParsersAndFormatters/Parser/TestData.Parser.cs
+++ b/src/libraries/System.Memory/tests/ParsersAndFormatters/Parser/TestData.Parser.cs
@@ -41,6 +41,8 @@ namespace System.Buffers.Text.Tests
         public static IEnumerable<object[]> UInt32ParserTheoryData => UInt32ParserTestData.Select(td => new object[] { td });
         public static IEnumerable<object[]> Int64ParserTheoryData => Int64ParserTestData.Select(td => new object[] { td });
         public static IEnumerable<object[]> UInt64ParserTheoryData => UInt64ParserTestData.Select(td => new object[] { td });
+        public static IEnumerable<object[]> Int128ParserTheoryData => Int128ParserTestData.Select(td => new object[] { td });
+        public static IEnumerable<object[]> UInt128ParserTheoryData => UInt128ParserTestData.Select(td => new object[] { td });
         public static IEnumerable<object[]> DecimalParserTheoryData => DecimalParserTestData.Select(td => new object[] { td });
         public static IEnumerable<object[]> DoubleParserTheoryData => DoubleParserTestData.Select(td => new object[] { td });
         public static IEnumerable<object[]> SingleParserTheoryData => SingleParserTestData.Select(td => new object[] { td });

--- a/src/libraries/System.Memory/tests/ParsersAndFormatters/TestData.cs
+++ b/src/libraries/System.Memory/tests/ParsersAndFormatters/TestData.cs
@@ -215,6 +215,34 @@ namespace System.Buffers.Text.Tests
             }
         }
 
+        public static IEnumerable<Int128> Int128TestData
+        {
+            get
+            {
+                foreach (long l in Int64TestData)
+                {
+                    yield return l;
+                }
+
+                yield return Int128.MaxValue;
+                yield return Int128.MinValue;
+            }
+        }
+
+        public static IEnumerable<UInt128> UInt128TestData
+        {
+            get
+            {
+                foreach (ulong l in UInt64TestData)
+                {
+                    yield return l;
+                }
+
+                yield return UInt128.MaxValue;
+                yield return UInt128.MinValue;
+            }
+        }
+
         public static IEnumerable<decimal> DecimalTestData
         {
             get

--- a/src/libraries/System.Memory/tests/ParsersAndFormatters/TestUtils.cs
+++ b/src/libraries/System.Memory/tests/ParsersAndFormatters/TestUtils.cs
@@ -94,8 +94,14 @@ namespace System.Buffers.Text.Tests
             if (typeof(T) == typeof(long))
                 return long.MinValue;
 
+            if (typeof(T) == typeof(Int128))
+                return Int128.MinValue;
+
             if (typeof(T) == typeof(ulong))
                 return ulong.MinValue;
+
+            if (typeof(T) == typeof(UInt128))
+                return UInt128.MinValue;
 
             if (typeof(T) == typeof(decimal))
                 return new BigInteger(decimal.MinValue);
@@ -126,8 +132,14 @@ namespace System.Buffers.Text.Tests
             if (typeof(T) == typeof(long))
                 return long.MaxValue;
 
+            if (typeof(T) == typeof(Int128))
+                return Int128.MaxValue;
+
             if (typeof(T) == typeof(ulong))
                 return ulong.MaxValue;
+
+            if (typeof(T) == typeof(UInt128))
+                return UInt128.MaxValue;
 
             if (typeof(T) == typeof(decimal))
                 return new BigInteger(decimal.MaxValue);

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/ParserHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/ParserHelpers.cs
@@ -15,8 +15,8 @@ namespace System.Buffers.Text
         public const int UInt16OverflowLengthHex = 4;
         public const int UInt32OverflowLength = 10;
         public const int UInt32OverflowLengthHex = 8;
-        public const int UInt64OverflowLength = 32;
-        public const int UInt64OverflowLengthHex = 32;
+        public const int UInt64OverflowLength = 20;
+        public const int UInt64OverflowLengthHex = 16;
         public const int UInt128OverflowLength = 39;
         public const int UInt128OverflowLengthHex = 32;
 
@@ -29,7 +29,7 @@ namespace System.Buffers.Text
         public const int Int64OverflowLength = 19;
         public const int Int64OverflowLengthHex = 16;
         public const int Int128OverflowLength = 39;
-        public const int Int128OverflowLengthHex = 39;
+        public const int Int128OverflowLengthHex = 32;
 
         // The consts below are the smallest unsigned x for which "x * 10 + 9"
         // might overflow {U}Int128.MaxValue. If the current accumulator is below

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/ParserHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/ParserHelpers.cs
@@ -15,8 +15,10 @@ namespace System.Buffers.Text
         public const int UInt16OverflowLengthHex = 4;
         public const int UInt32OverflowLength = 10;
         public const int UInt32OverflowLengthHex = 8;
-        public const int UInt64OverflowLength = 20;
-        public const int UInt64OverflowLengthHex = 16;
+        public const int UInt64OverflowLength = 32;
+        public const int UInt64OverflowLengthHex = 32;
+        public const int UInt128OverflowLength = 39;
+        public const int UInt128OverflowLengthHex = 32;
 
         public const int SByteOverflowLength = 3;
         public const int SByteOverflowLengthHex = 2;
@@ -26,6 +28,14 @@ namespace System.Buffers.Text
         public const int Int32OverflowLengthHex = 8;
         public const int Int64OverflowLength = 19;
         public const int Int64OverflowLengthHex = 16;
+        public const int Int128OverflowLength = 39;
+        public const int Int128OverflowLengthHex = 39;
+
+        // The consts below are the smallest unsigned x for which "x * 10 + 9"
+        // might overflow {U}Int128.MaxValue. If the current accumulator is below
+        // this const, there's no risk of overflowing.
+        public static readonly UInt128 UInt128OverflowRisk = UInt128.MaxValue / 10;
+        public static readonly UInt128 Int128OverlowRisk = (UInt128)(Int128.MaxValue / 10);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsDigit(int i)

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.N.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.N.cs
@@ -430,7 +430,7 @@ namespace System.Buffers.Text
                 if (!ParserHelpers.IsDigit(c))
                     goto Done;
 
-                if (((ulong)answer) > Int128.MaxValue / 10)
+                if (((UInt128)answer) > Int128.MaxValue / 10)
                     goto FalseExit;
 
                 answer = answer * 10 + c - '0';

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.N.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.N.cs
@@ -378,5 +378,100 @@ namespace System.Buffers.Text
             value = answer * sign;
             return true;
         }
+
+        private static bool TryParseInt128N(ReadOnlySpan<byte> source, out Int128 value, out int bytesConsumed)
+        {
+            if (source.Length < 1)
+                goto FalseExit;
+
+            int sign = 1;
+            int index = 0;
+            int c = source[index];
+            if (c == '-')
+            {
+                sign = -1;
+                index++;
+                if ((uint)index >= (uint)source.Length)
+                    goto FalseExit;
+                c = source[index];
+            }
+            else if (c == '+')
+            {
+                index++;
+                if ((uint)index >= (uint)source.Length)
+                    goto FalseExit;
+                c = source[index];
+            }
+
+            Int128 answer;
+
+            // Handle the first digit (or period) as a special case. This ensures some compatible edge-case behavior with the classic parse routines
+            // (at least one digit must precede any commas, and a string without any digits prior to the decimal point must have at least
+            // one digit after the decimal point.)
+            if (c == Utf8Constants.Period)
+                goto FractionalPartWithoutLeadingDigits;
+            if (!ParserHelpers.IsDigit(c))
+                goto FalseExit;
+            answer = c - '0';
+
+            while (true)
+            {
+                index++;
+                if ((uint)index >= (uint)source.Length)
+                    goto Done;
+
+                c = source[index];
+                if (c == Utf8Constants.Comma)
+                    continue;
+
+                if (c == Utf8Constants.Period)
+                    goto FractionalDigits;
+
+                if (!ParserHelpers.IsDigit(c))
+                    goto Done;
+
+                if (((ulong)answer) > Int128.MaxValue / 10)
+                    goto FalseExit;
+
+                answer = answer * 10 + c - '0';
+
+                // if sign < 0, (-1 * sign + 1) / 2 = 1
+                // else, (-1 * sign + 1) / 2 = 0
+                if ((UInt128)answer > (UInt128)(Int128.MaxValue + (-1 * sign + 1) / 2))
+                    goto FalseExit; // Overflow
+            }
+
+        FractionalPartWithoutLeadingDigits: // If we got here, we found a decimal point before we found any digits. This is legal as long as there's at least one zero after the decimal point.
+            answer = 0;
+            index++;
+            if ((uint)index >= (uint)source.Length)
+                goto FalseExit;
+            if (source[index] != '0')
+                goto FalseExit;
+
+            FractionalDigits: // "N" format allows a fractional portion despite being an integer format but only if the post-fraction digits are all 0.
+            do
+            {
+                index++;
+                if ((uint)index >= (uint)source.Length)
+                    goto Done;
+                c = source[index];
+            }
+            while (c == '0');
+
+            if (ParserHelpers.IsDigit(c))
+                goto FalseExit; // The fractional portion contained a non-zero digit. Treat this as an error, not an early termination.
+            goto Done;
+
+        FalseExit:
+            bytesConsumed = default;
+            value = default;
+            return false;
+
+        Done:
+            bytesConsumed = index;
+            value = answer * sign;
+            return true;
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.N.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.N.cs
@@ -430,7 +430,7 @@ namespace System.Buffers.Text
                 if (!ParserHelpers.IsDigit(c))
                     goto Done;
 
-                if (((UInt128)answer) > Int128.MaxValue / 10)
+                if ((UInt128)answer > (UInt128)(Int128.MaxValue / 10))
                     goto FalseExit;
 
                 answer = answer * 10 + c - '0';

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.cs
@@ -211,5 +211,57 @@ namespace System.Buffers.Text
                     return ParserHelpers.TryParseThrowFormatException(source, out value, out bytesConsumed);
             }
         }
+
+        /// <summary>
+        /// Parses a UInt128 at the start of a Utf8 string.
+        /// </summary>
+        /// <param name="source">The Utf8 string to parse</param>
+        /// <param name="value">Receives the parsed value</param>
+        /// <param name="bytesConsumed">On a successful parse, receives the length in bytes of the substring that was parsed </param>
+        /// <param name="standardFormat">Expected format of the Utf8 string</param>
+        /// <returns>
+        /// true for success. "bytesConsumed" contains the length in bytes of the substring that was parsed.
+        /// false if the string was not syntactically valid or an overflow or underflow occurred. "bytesConsumed" is set to 0.
+        /// </returns>
+        /// <remarks>
+        /// Formats supported:
+        ///     G/g (default)
+        ///     D/d             32767
+        ///     N/n             32,767
+        ///     X/x             7fff
+        /// </remarks>
+        /// <exceptions>
+        /// <cref>System.FormatException</cref> if the format is not valid for this data type.
+        /// </exceptions>
+        [CLSCompliant(false)]
+        public static bool TryParse(ReadOnlySpan<byte> source, out UInt128 value, out int bytesConsumed, char standardFormat = default)
+        {
+            FastPath:
+            if (standardFormat == default)
+            {
+                return TryParseUInt128D(source, out value, out bytesConsumed);
+            }
+
+            // There's small but measurable overhead when entering the switch block below.
+            // We optimize for the default case by hoisting it above the switch block.
+
+            switch (standardFormat | 0x20) // convert to lowercase
+            {
+                case 'g':
+                case 'd':
+                case 'r':
+                    standardFormat = default;
+                    goto FastPath;
+
+                case 'n':
+                    return TryParseUInt128N(source, out value, out bytesConsumed);
+
+                case 'x':
+                    return TryParseUInt128X(source, out value, out bytesConsumed);
+
+                default:
+                    return ParserHelpers.TryParseThrowFormatException(source, out value, out bytesConsumed);
+            }
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
@@ -2536,7 +2536,7 @@ namespace System
             return result;
         }
 
-        private static unsafe bool TryNegativeInt128ToDecStr<TChar>(Int128 value, int digits, ReadOnlySpan<TChar> sNegative, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
+        internal static unsafe bool TryNegativeInt128ToDecStr<TChar>(Int128 value, int digits, ReadOnlySpan<TChar> sNegative, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             Debug.Assert(Int128.IsNegative(value));
@@ -2589,7 +2589,7 @@ namespace System
             return result;
         }
 
-        private static unsafe bool TryInt128ToHexStr<TChar>(Int128 value, char hexBase, int digits, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
+        internal static unsafe bool TryInt128ToHexStr<TChar>(Int128 value, char hexBase, int digits, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
 
@@ -2789,7 +2789,27 @@ namespace System
             return result;
         }
 
-        private static unsafe bool TryUInt128ToDecStr<TChar>(UInt128 value, int digits, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
+        internal static unsafe bool TryUInt128ToDecStr<TChar>(UInt128 value, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
+        {
+            int bufferLength = FormattingHelpers.CountDigits(value);
+
+            if (bufferLength <= destination.Length)
+            {
+                charsWritten = bufferLength;
+                fixed (TChar* buffer = &MemoryMarshal.GetReference(destination))
+                {
+                    TChar* p = buffer + bufferLength;
+                    p = UInt128ToDecChars(p, value);
+                    Debug.Assert(p == buffer);
+                }
+                return true;
+            }
+
+            charsWritten = 0;
+            return false;
+        }
+
+        internal static unsafe bool TryUInt128ToDecStr<TChar>(UInt128 value, int digits, Span<TChar> destination, out int charsWritten) where TChar : unmanaged, IUtfChar<TChar>
         {
             int countedDigits = FormattingHelpers.CountDigits(value);
             int bufferLength = Math.Max(digits, countedDigits);


### PR DESCRIPTION
Close #73842

The implementation is almost copy-paste from {U}Int64 as same as other integer types doing for previous size types. I can try to reduce some duplication, but not sure if it's possible without any performance losses

Holding draft to see CI tests, fix missed type casts and possible typos

Blocked by https://github.com/dotnet/runtime/issues/73842#issuecomment-1552197928