### PR TITLE
Tune inliner for callees with pinvokes

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -5463,6 +5463,12 @@ void Compiler::impCheckForPInvokeCall(
                     return;
                 }
 
+                // Respect noinline flag ([MethodImpl(MethodImplOptions.NoInlining)] in C#)
+                if ((mflags & CORINFO_FLG_DONT_INLINE) == 0)
+                {
+                    return;
+                }
+
                 // Size-speed tradeoff: don't use inline pinvoke at rarely
                 // executed call sites.  The non-inline version is more
                 // compact.

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -5464,7 +5464,7 @@ void Compiler::impCheckForPInvokeCall(
                 }
 
                 // Respect noinline flag ([MethodImpl(MethodImplOptions.NoInlining)] in C#)
-                if ((mflags & CORINFO_FLG_DONT_INLINE) == 0)
+                if ((mflags & CORINFO_FLG_DONT_INLINE) != 0)
                 {
                     return;
                 }


### PR DESCRIPTION
Callees with pinvokes quite often work as Trojan Horses by injecting a lot of stuff (GC transition machinery) into caller's prolog/epilog even if the path with the pinvokes is rarely taken:
```csharp
[DllImport("user32.dll")]
static extern byte MessageBeep(uint uType);

static void Foo() => MessageBeep(100);

static void Bar(int a)
{
    if (a == 42)
        Foo(); // Let's imagine PGO tells us this path is rarely taken
}
```
Codegen for `Bar()` after inlining `Foo`:
```asm
; Method Program:Bar(int)
G_M36311_IG01:  ;; offset=0000H
       push     rbp
       push     r15
       push     r14
       push     r13
       push     r12
       push     rdi
       push     rsi
       push     rbx
       sub      rsp, 104
       lea      rbp, [rsp+A0H]
       mov      esi, ecx
G_M36311_IG02:  
       lea      rcx, [rbp-78H]
       mov      rdx, r10
       call     CORINFO_HELP_INIT_PINVOKE_FRAME
       mov      rdi, rax
       mov      rcx, rsp
       mov      qword ptr [rbp-58H], rcx
       mov      rcx, rbp
       mov      qword ptr [rbp-48H], rcx
       cmp      esi, 42
       jne      SHORT G_M36311_IG07
G_M36311_IG03:  
       mov      ecx, 100
       mov      rax, 0x7FFB54257850      
       mov      qword ptr [rbp-68H], rax
       lea      rax, G_M36311_IG05
       mov      qword ptr [rbp-50H], rax
       lea      rax, bword ptr [rbp-78H]
       mov      qword ptr [rdi+10H], rax
       mov      byte  ptr [rdi+0CH], 0
G_M36311_IG04:  
       call     [Program:MessageBeep(uint):ubyte]
G_M36311_IG05:  
       mov      byte  ptr [rdi+0CH], 1
       cmp      dword ptr [(reloc 0x7ffbb379a0e4)], 0
       je       SHORT G_M36311_IG06
       call     [CORINFO_HELP_STOP_FOR_GC]
G_M36311_IG06:  
       mov      rax, bword ptr [rbp-70H]
       mov      qword ptr [rdi+10H], rax
G_M36311_IG07:  
       add      rsp, 104
       pop      rbx
       pop      rsi
       pop      rdi
       pop      r12
       pop      r13
       pop      r14
       pop      r15
       pop      rbp
       ret      
; Total bytes of code: 152
```
^ we hit quite an overhead despite not needing the pinvoke

Another problem that sometimes inlining may produce dynamic pinvoke stubs, see https://github.com/dotnet/runtime/issues/79125

```csharp
[DllImport("user32.dll")]
static extern byte MessageBeep(uint uType);

static void Foo()
{
    MessageBeep(42);
}

static void Bar()
{
    try
    {
        Foo();
    }
    catch
    {
    }
}
```
JIT can't inline pinvokes inside EH blocks so now it has to create a dynamic FullOpts method in run-time:
```
  21: JIT compiled (dynamicClass):IL_STUB_PInvoke(uint):ubyte [FullOpts, IL size=34, code size=152, hash=0xeb066932]
```
At the same time if we don't inline it - we'll inline pinvoke in the `Foo()` itself.
