### PR TITLE
Include Native AOT pdbs in Helix payload

### DIFF
--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -262,8 +262,9 @@
 
     <ItemGroup>
       <!-- Remove the managed pdbs from our payloads.
-           This is for performance reasons to reduce our helix payload size  -->
-      <ReducedLegacyPayloadFiles Include="@(_LegacyPayloadFiles)" Condition=" '%(Extension)' != '.pdb' " />
+           This is for performance reasons to reduce our helix payload size
+           Note: for Native AOT the pdb is the native PDB. !analyze wouldn't work without it at all so we keep it -->
+      <ReducedLegacyPayloadFiles Include="@(_LegacyPayloadFiles)" Condition=" '%(Extension)' != '.pdb' or '$(_NativeAotTest)' == 'true'" />
 
       <ReducedLegacyPayloadFilesFinal Include="@(ReducedLegacyPayloadFiles)" Condition=" '%(Extension)' != '.sh' and '$(TestWrapperTargetsWindows)' == 'true' "/>
       <ReducedLegacyPayloadFilesFinal Include="@(ReducedLegacyPayloadFiles)" Condition=" '%(Extension)' != '.cmd' and '$(TestWrapperTargetsWindows)' != 'true' "/>

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Main.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Main.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Runtime.CompilerServices;
 
+System.Diagnostics.Debug.Fail("Fail");
 bool success = RunTest(BasicThreading.Run);
 success &= RunTest(Delegates.Run);
 success &= RunTest(Generics.Run);

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Main.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Main.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Runtime.CompilerServices;
 
-System.Diagnostics.Debug.Fail("Fail");
 bool success = RunTest(BasicThreading.Run);
 success &= RunTest(Delegates.Run);
 success &= RunTest(Generics.Run);


### PR DESCRIPTION
Crashdumps obtained with runfo are not usable without this, and neither are the stack traces generated by the test infra with WinDbg.

Cc @dotnet/ilc-contrib 