### PR TITLE
[browser] Fix using startupOptions when loadBootResource is not specified

### DIFF
--- a/src/mono/wasm/runtime/loader/blazor/BootConfig.ts
+++ b/src/mono/wasm/runtime/loader/blazor/BootConfig.ts
@@ -11,7 +11,7 @@ export class BootConfigResult {
     private constructor(public bootConfig: BootJsonData, public applicationEnvironment: string) {
     }
 
-    static fromFetchResponse(bootConfigResponse: Response, bootConfig: BootJsonData, environment?: string): BootConfigResult {
+    static fromFetchResponse(bootConfigResponse: Response, bootConfig: BootJsonData, environment: string | undefined): BootConfigResult {
         const applicationEnvironment = environment || (loaderHelpers.getApplicationEnvironment && loaderHelpers.getApplicationEnvironment(bootConfigResponse)) || "Production";
         bootConfig.modifiableAssemblies = bootConfigResponse.headers.get("DOTNET-MODIFIABLE-ASSEMBLIES");
         bootConfig.aspnetCoreBrowserTools = bootConfigResponse.headers.get("ASPNETCORE-BROWSER-TOOLS");

--- a/src/mono/wasm/runtime/loader/blazor/_Integration.ts
+++ b/src/mono/wasm/runtime/loader/blazor/_Integration.ts
@@ -14,14 +14,9 @@ import { ICUDataMode } from "../../types/blazor";
 let resourceLoader: WebAssemblyResourceLoader;
 
 export async function loadBootConfig(config: MonoConfigInternal, module: DotnetModuleInternal) {
-    const environment = getApplicationEnvironmentFromConfig(config);
-    const bootConfigPromise = BootConfigResult.initAsync(config.startupOptions?.loadBootResource, environment);
+    const bootConfigPromise = BootConfigResult.initAsync(config.startupOptions?.loadBootResource, config.applicationEnvironment);
     const bootConfigResult: BootConfigResult = await bootConfigPromise;
     await initializeBootConfig(bootConfigResult, module, config.startupOptions);
-}
-
-export function getApplicationEnvironmentFromConfig(config: MonoConfigInternal): string | undefined {
-    return config.applicationEnvironment ?? config.startupOptions?.environment;
 }
 
 export async function initializeBootConfig(bootConfigResult: BootConfigResult, module: DotnetModuleInternal, startupOptions?: Partial<WebAssemblyStartOptions>) {

--- a/src/mono/wasm/runtime/loader/blazor/_Integration.ts
+++ b/src/mono/wasm/runtime/loader/blazor/_Integration.ts
@@ -14,11 +14,14 @@ import { ICUDataMode } from "../../types/blazor";
 let resourceLoader: WebAssemblyResourceLoader;
 
 export async function loadBootConfig(config: MonoConfigInternal, module: DotnetModuleInternal) {
-    const candidateOptions = config.startupOptions ?? {};
-    const environment = candidateOptions.environment;
-    const bootConfigPromise = BootConfigResult.initAsync(candidateOptions.loadBootResource, environment);
+    const environment = getApplicationEnvironmentFromConfig(config);
+    const bootConfigPromise = BootConfigResult.initAsync(config.startupOptions?.loadBootResource, environment);
     const bootConfigResult: BootConfigResult = await bootConfigPromise;
-    await initializeBootConfig(bootConfigResult, module, candidateOptions);
+    await initializeBootConfig(bootConfigResult, module, config.startupOptions);
+}
+
+export function getApplicationEnvironmentFromConfig(config: MonoConfigInternal): string | undefined {
+    return config.applicationEnvironment ?? config.startupOptions?.environment;
 }
 
 export async function initializeBootConfig(bootConfigResult: BootConfigResult, module: DotnetModuleInternal, startupOptions?: Partial<WebAssemblyStartOptions>) {

--- a/src/mono/wasm/runtime/loader/config.ts
+++ b/src/mono/wasm/runtime/loader/config.ts
@@ -5,7 +5,7 @@ import BuildConfiguration from "consts:configuration";
 import type { DotnetModuleInternal, MonoConfigInternal } from "../types/internal";
 import type { DotnetModuleConfig } from "../types";
 import { exportedRuntimeAPI, loaderHelpers, runtimeHelpers } from "./globals";
-import { getApplicationEnvironmentFromConfig, initializeBootConfig, loadBootConfig } from "./blazor/_Integration";
+import { initializeBootConfig, loadBootConfig } from "./blazor/_Integration";
 import { BootConfigResult } from "./blazor/BootConfig";
 import { BootJsonData } from "../types/blazor";
 
@@ -81,6 +81,8 @@ export async function mono_wasm_load_config(module: DotnetModuleInternal): Promi
     }
     if (loaderHelpers.diagnosticTracing) console.debug("MONO_WASM: mono_wasm_load_config");
     try {
+        loaderHelpers.config.applicationEnvironment = loaderHelpers.config.applicationEnvironment ?? loaderHelpers.config.startupOptions?.environment ?? "Production";
+
         if (loaderHelpers.config.startupOptions && loaderHelpers.config.startupOptions.loadBootResource) {
             // If we have custom loadBootResource
             await loadBootConfig(loaderHelpers.config, module);
@@ -91,7 +93,7 @@ export async function mono_wasm_load_config(module: DotnetModuleInternal): Promi
             const loadedAnyConfig: any = (await configResponse.json()) || {};
             if (loadedAnyConfig.resources) {
                 // If we found boot config schema
-                await initializeBootConfig(BootConfigResult.fromFetchResponse(configResponse, loadedAnyConfig as BootJsonData, getApplicationEnvironmentFromConfig(loaderHelpers.config)), module, loaderHelpers.config.startupOptions);
+                await initializeBootConfig(BootConfigResult.fromFetchResponse(configResponse, loadedAnyConfig as BootJsonData, loaderHelpers.config.applicationEnvironment), module, loaderHelpers.config.startupOptions);
             } else {
                 // Otherwise we found mono config schema
                 const loadedConfig = loadedAnyConfig as MonoConfigInternal;

--- a/src/mono/wasm/runtime/loader/config.ts
+++ b/src/mono/wasm/runtime/loader/config.ts
@@ -91,7 +91,7 @@ export async function mono_wasm_load_config(module: DotnetModuleInternal): Promi
             const loadedAnyConfig: any = (await configResponse.json()) || {};
             if (loadedAnyConfig.resources) {
                 // If we found boot config schema
-                await initializeBootConfig(BootConfigResult.fromFetchResponse(configResponse, loadedAnyConfig as BootJsonData), module);
+                await initializeBootConfig(BootConfigResult.fromFetchResponse(configResponse, loadedAnyConfig as BootJsonData), module, loaderHelpers.config.startupOptions);
             } else {
                 // Otherwise we found mono config schema
                 const loadedConfig = loadedAnyConfig as MonoConfigInternal;

--- a/src/mono/wasm/runtime/loader/config.ts
+++ b/src/mono/wasm/runtime/loader/config.ts
@@ -5,7 +5,7 @@ import BuildConfiguration from "consts:configuration";
 import type { DotnetModuleInternal, MonoConfigInternal } from "../types/internal";
 import type { DotnetModuleConfig } from "../types";
 import { exportedRuntimeAPI, loaderHelpers, runtimeHelpers } from "./globals";
-import { initializeBootConfig, loadBootConfig } from "./blazor/_Integration";
+import { getApplicationEnvironmentFromConfig, initializeBootConfig, loadBootConfig } from "./blazor/_Integration";
 import { BootConfigResult } from "./blazor/BootConfig";
 import { BootJsonData } from "../types/blazor";
 
@@ -91,7 +91,7 @@ export async function mono_wasm_load_config(module: DotnetModuleInternal): Promi
             const loadedAnyConfig: any = (await configResponse.json()) || {};
             if (loadedAnyConfig.resources) {
                 // If we found boot config schema
-                await initializeBootConfig(BootConfigResult.fromFetchResponse(configResponse, loadedAnyConfig as BootJsonData), module, loaderHelpers.config.startupOptions);
+                await initializeBootConfig(BootConfigResult.fromFetchResponse(configResponse, loadedAnyConfig as BootJsonData, getApplicationEnvironmentFromConfig(loaderHelpers.config)), module, loaderHelpers.config.startupOptions);
             } else {
                 // Otherwise we found mono config schema
                 const loadedConfig = loadedAnyConfig as MonoConfigInternal;


### PR DESCRIPTION
- Additional blazor startupOptions were used only when `loadBootResource` was specified
- Regression from https://github.com/dotnet/runtime/pull/85763