### PR TITLE
Do not assert RyuJIT if InitializeArray cannot be expanded

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -2543,8 +2543,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
     bool betterToExpand = false;
 
     // Allow some lighweight intrinsics in Tier0 which can improve throughput
-    // we introduced betterToExpand here because we're fine if intrinsic decides to not expand itself
-    // in this case unlike mustExpand.
+    // we're fine if intrinsic decides to not expand itself in this case unlike mustExpand.
     // NOTE: MinOpts() is always true for Tier0 so we have to check explicit flags instead.
     // To be fixed in https://github.com/dotnet/runtime/pull/77465
     const bool tier0opts = !opts.compDbgCode && !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_MIN_OPT);
@@ -2613,7 +2612,6 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
         // if it can be, it should expand.
         switch (ni)
         {
-            // CreateSpan must be expanded for NativeAOT
             case NI_System_Runtime_CompilerServices_RuntimeHelpers_CreateSpan:
             case NI_System_Runtime_CompilerServices_RuntimeHelpers_InitializeArray:
             case NI_Internal_Runtime_MethodTable_Of:

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -2606,27 +2606,26 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
         }
     }
 
-    // Intrinsics that we should make every effort to expand for NativeAOT.
-    // If the intrinsic cannot possibly be expanded, it's fine, but
-    // if it can be, it should expand.
-    switch (ni)
+    if (IsTargetAbi(CORINFO_NATIVEAOT_ABI))
     {
-        // CreateSpan must be expanded for NativeAOT
-        case NI_System_Runtime_CompilerServices_RuntimeHelpers_CreateSpan:
-        case NI_System_Runtime_CompilerServices_RuntimeHelpers_InitializeArray:
-            betterToExpand |= IsTargetAbi(CORINFO_NATIVEAOT_ABI);
-            break;
+        // Intrinsics that we should make every effort to expand for NativeAOT.
+        // If the intrinsic cannot possibly be expanded, it's fine, but
+        // if it can be, it should expand.
+        switch (ni)
+        {
+            // CreateSpan must be expanded for NativeAOT
+            case NI_System_Runtime_CompilerServices_RuntimeHelpers_CreateSpan:
+            case NI_System_Runtime_CompilerServices_RuntimeHelpers_InitializeArray:
+            case NI_Internal_Runtime_MethodTable_Of:
+            case NI_System_Activator_AllocatorOf:
+            case NI_System_Activator_DefaultConstructorOf:
+            case NI_System_EETypePtr_EETypePtrOf:
+                betterToExpand = true;
+                break;
 
-        case NI_Internal_Runtime_MethodTable_Of:
-        case NI_System_Activator_AllocatorOf:
-        case NI_System_Activator_DefaultConstructorOf:
-        case NI_System_EETypePtr_EETypePtrOf:
-            betterToExpand = true;
-            break;
-
-        default:
-            break;
-    }
+            default:
+                break;
+        }
 
     GenTree* retNode = nullptr;
 

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -2540,11 +2540,11 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
         return new (this, GT_LABEL) GenTree(GT_LABEL, TYP_I_IMPL);
     }
 
+    bool betterToExpand = false;
+
     // Allow some lighweight intrinsics in Tier0 which can improve throughput
     // we introduced betterToExpand here because we're fine if intrinsic decides to not expand itself
     // in this case unlike mustExpand.
-    bool betterToExpand = false;
-
     // NOTE: MinOpts() is always true for Tier0 so we have to check explicit flags instead.
     // To be fixed in https://github.com/dotnet/runtime/pull/77465
     const bool tier0opts = !opts.compDbgCode && !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_MIN_OPT);
@@ -2626,6 +2626,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
             default:
                 break;
         }
+    }
 
     GenTree* retNode = nullptr;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -494,7 +494,17 @@ namespace ILCompiler
 
         public override void GetDependenciesDueToLdToken(ref DependencyList dependencies, NodeFactory factory, FieldDesc field)
         {
-            if (!IsReflectionBlocked(field))
+            if (!IsReflectionBlocked(field)
+                // Scanning will report many field ldtokens due to InitializeArray/CreateSpan.
+                // We don't consider those reflection because codegen is going to intrinsically
+                // expand them if the pattern match holds. Scanner doesn't replicate the
+                // exact rules that codegen will follow - it will report it all as LDTOKEN
+                // and this can potentially reflection-root things that don't need rooting.
+                // If LDTOKEN with an RVA static field ever becomes an actual user scenario
+                // (outside InitializeArray/CreateSpan) we need to remove this condition, but
+                // we should also replicate the codegen expansion rules in the scanner
+                // so that it doesn't become an unnecessary size regression for the common patterns.
+                && !field.HasRva)
             {
                 dependencies ??= new DependencyList();
                 dependencies.Add(factory.ReflectedField(field), "LDTOKEN field");

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -946,10 +946,8 @@ namespace Internal.IL
                 }
                 _dependencies.Add(reference, "ldtoken");
             }
-            else if (obj is MethodDesc)
+            else if (obj is MethodDesc method)
             {
-                var method = (MethodDesc)obj;
-
                 _factory.MetadataManager.GetDependenciesDueToAccess(ref _dependencies, _factory, _methodIL, (MethodDesc)_canonMethodIL.GetObject(token));
 
                 if (method.IsRuntimeDeterminedExactMethod)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -898,7 +898,7 @@ namespace Internal.IL
         {
             object obj = _methodIL.GetObject(token);
 
-            if (obj is TypeDesc)
+            if (obj is TypeDesc type)
             {
                 // If this is a ldtoken Type / Type.GetTypeFromHandle sequence, we need one more helper.
                 // We might also be able to optimize this a little if this is a ldtoken/GetTypeFromHandle/Equals sequence.
@@ -931,8 +931,6 @@ namespace Internal.IL
                 }
 
                 _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.GetRuntimeTypeHandle), "ldtoken");
-
-                var type = (TypeDesc)obj;
 
                 ISymbolNode reference;
                 if (type.IsRuntimeDeterminedSubtype)


### PR DESCRIPTION
Found in Pri0 tests. `RuntimeHelper.InitializeArray(default, default)` would assert RyuJIT. Do not assert.

The tests also have various invalid combinations of the intrinsic that make it difficult to do optimized builds (we don't want the target field to become reflectable in the common cases but also failing to predict when this doesn't expand results in scanning failures due to unmet reflection dependencies).

Give up on trying to predict when intrinsic expansion kicks in and instead lean into RVA statics not being expressible in C# and the fields not being reflection-invokable anyway.

Cc @dotnet/ilc-contrib 