### PR TITLE
Remove RequiredAttribute.DisallowAllDefaultValues

### DIFF
--- a/src/libraries/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
+++ b/src/libraries/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
@@ -281,7 +281,6 @@ namespace System.ComponentModel.DataAnnotations
     {
         public RequiredAttribute() { }
         public bool AllowEmptyStrings { get { throw null; } set { } }
-        public bool DisallowAllDefaultValues { get { throw null; } set { } }
         public override bool IsValid(object? value) { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Property, AllowMultiple=false)]

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RequiredAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RequiredAttribute.cs
@@ -1,10 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-
 namespace System.ComponentModel.DataAnnotations
 {
     /// <summary>
@@ -32,76 +28,22 @@ namespace System.ComponentModel.DataAnnotations
         public bool AllowEmptyStrings { get; set; }
 
         /// <summary>
-        ///     Gets or sets a flag indicating whether the attribute should also disallow non-null default values.
-        /// </summary>
-        public bool DisallowAllDefaultValues { get; set; }
-
-        /// <summary>
         ///     Override of <see cref="ValidationAttribute.IsValid(object)" />
         /// </summary>
         /// <param name="value">The value to test</param>
         /// <returns>
         ///     Returns <see langword="false" /> if the <paramref name="value" /> is null or an empty string.
         ///     If <see cref="AllowEmptyStrings" /> then <see langword="true" /> is returned for empty strings.
-        ///     If <see cref="DisallowAllDefaultValues"/> then <see langword="false" /> is returned for values
-        ///     that are equal to the <see langword="default" /> of the declared type.
         /// </returns>
         public override bool IsValid(object? value)
-            => IsValidCore(value, validationContext: null);
-
-        /// <inheritdoc />
-        protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
-        {
-            return IsValidCore(value, validationContext)
-                ? ValidationResult.Success
-                : CreateFailedValidationResult(validationContext);
-        }
-
-        private bool IsValidCore(object? value, ValidationContext? validationContext)
         {
             if (value is null)
             {
                 return false;
             }
 
-            if (DisallowAllDefaultValues)
-            {
-                // To determine the default value of non-nullable types we need the declaring type of the value.
-                // This is the property type in a validation context falling back to the runtime type for root values.
-                Type declaringType = validationContext?.MemberType ?? value.GetType();
-                if (GetDefaultValueForNonNullableValueType(declaringType) is object defaultValue)
-                {
-                    return !defaultValue.Equals(value);
-                }
-            }
-
             // only check string length if empty strings are not allowed
             return AllowEmptyStrings || value is not string stringValue || !string.IsNullOrWhiteSpace(stringValue);
         }
-
-
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2067:UnrecognizedReflectionPattern",
-            Justification = "GetUninitializedObject is only called struct types. You can always create an instance of a struct.")]
-        private object? GetDefaultValueForNonNullableValueType(Type type)
-        {
-            object? defaultValue = _defaultValueCache;
-
-            if (defaultValue != null && defaultValue.GetType() == type)
-            {
-                Debug.Assert(type.IsValueType && Nullable.GetUnderlyingType(type) is null);
-            }
-            else if (type.IsValueType && Nullable.GetUnderlyingType(type) is null)
-            {
-                _defaultValueCache = defaultValue = RuntimeHelpers.GetUninitializedObject(type);
-            }
-            else
-            {
-                defaultValue = null;
-            }
-
-            return defaultValue;
-        }
-
-        private object? _defaultValueCache;
     }
 }


### PR DESCRIPTION
The `RequiredAttribute.DisallowAllDefaultValues` property added in #82311 has been controversial since its inclusion, primarily because it can result in misunderstandings of its expected behavior. For example:

1. It fails validation on numeric properties that have been explicitly set to zero, and
2. It does not fail validation for nullable properties containing `(T?)default(T)`, as reported in #83797.

After long discussion, we have concluded that there isn't much we could do to rectify these rough edges in a consistent manner, so we have instead decided to remove the feature altogether.

Fix #83797.