### PR TITLE
JIT: Stop specifying general JitStress in OSR/largefuncletframe

### DIFF
--- a/src/tests/JIT/opt/OSR/largefuncletframe.csproj
+++ b/src/tests/JIT/opt/OSR/largefuncletframe.csproj
@@ -14,6 +14,6 @@
     <CLRTestEnvironmentVariable Include="DOTNET_TC_OnStackReplacement" Value="1" />
     <CLRTestEnvironmentVariable Include="DOTNET_OSR_HitLimit" Value="2" />
     <CLRTestEnvironmentVariable Include="DOTNET_JitRandomOnStackReplacement" Value="15" />
-    <CLRTestEnvironmentVariable Include="DOTNET_JitStress" Value="2" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitStressModeNames" Value="STRESS_GENERIC_VARN STRESS_UNSAFE_BUFFER_CHECKS" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Otherwise new stress modes can change what the test is testing. I verified that these stress modes reproduced the original issue back when the test was introduced.

Fix #86185