### PR TITLE
[browser] Update Wasm SDK pack version in workload manifest

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.targets.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.targets.in
@@ -138,6 +138,7 @@
   <PropertyGroup Condition="'$(TargetsCurrent)' == 'true' and ('$(UsingMobileWorkload)' == 'true' or '$(RuntimeIdentifier)' == 'browser-wasm' or '$(RuntimeIdentifier)' == 'wasi-wasm')">
     <_MonoWorkloadTargetsMobile>true</_MonoWorkloadTargetsMobile>
     <_MonoWorkloadRuntimePackPackageVersion>$(_RuntimePackInWorkloadVersionCurrent)</_MonoWorkloadRuntimePackPackageVersion>
+    <_KnownWebAssemblySdkPackVersion>$(_RuntimePackInWorkloadVersionCurrent)</_KnownWebAssemblySdkPackVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetsCurrent)' == 'true' and '$(_MonoWorkloadTargetsMobile)' == 'true'">
@@ -150,6 +151,9 @@
       <RuntimePackNamePatterns Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(WasmEnableThreads)' == 'true'">Microsoft.NETCore.App.Runtime.Mono.multithread.**RID**</RuntimePackNamePatterns>
       <RuntimePackNamePatterns Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(WasmEnablePerfTracing)' == 'true'">Microsoft.NETCore.App.Runtime.Mono.perftrace.**RID**</RuntimePackNamePatterns>
     </KnownRuntimePack>
+    <KnownWebAssemblySdkPack Update="@(KnownWebAssemblySdkPack)">
+      <WebAssemblySdkPackVersion Condition="'%(KnownWebAssemblySdkPack.TargetFramework)' == '${NetCoreAppCurrent}'">$(_KnownWebAssemblySdkPackVersion)</WebAssemblySdkPackVersion>
+    </KnownWebAssemblySdkPack>
   </ItemGroup>
 
   <!-- we can't condition sdk imports on the item @(NativeFileReference). Instead, explicitly check before the build

--- a/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
+++ b/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
@@ -117,8 +117,6 @@ namespace Microsoft.Workload.Build.Tasks
                     if (!ExecuteInternal(req) && !req.IgnoreErrors)
                         return false;
 
-                    OverrideWebAssemblySdkPack(req.TargetPath, LocalNuGetsPath);
-
                     File.WriteAllText(req.StampPath, string.Empty);
                 }
 
@@ -133,26 +131,6 @@ namespace Microsoft.Workload.Build.Tasks
             {
                 if (!string.IsNullOrEmpty(_tempDir) && Directory.Exists(_tempDir))
                     Directory.Delete(_tempDir, recursive: true);
-            }
-        }
-
-        private static void OverrideWebAssemblySdkPack(string targetPath, string localNuGetsPath)
-        {
-            string nupkgName = "Microsoft.NET.Sdk.WebAssembly.Pack";
-            string? nupkg = Directory.EnumerateFiles(localNuGetsPath, $"{nupkgName}.*.nupkg").FirstOrDefault();
-            if (nupkg == null)
-                return;
-
-            string nupkgVersion = Path.GetFileNameWithoutExtension(nupkg).Substring(nupkgName.Length + 1);
-
-            string bundledVersions = Directory.EnumerateFiles(targetPath, @"Microsoft.NETCoreSdk.BundledVersions.props", SearchOption.AllDirectories).Single();
-            var document = XDocument.Load(bundledVersions);
-            if (document != null)
-            {
-                foreach (var element in document.Descendants("KnownWebAssemblySdkPack"))
-                    element.SetAttributeValue("WebAssemblySdkPackVersion", nupkgVersion);
-
-                document.Save(bundledVersions);
             }
         }
 


### PR DESCRIPTION
- Update `KnownWebAssemblySdkPack` version in `WorkloadManifest.targets`
  - This change ensures that runtime pack and sdk pack has always the same version
- Drop `OverrideWebAssemblySdkPack` from `InstallWorkloadFromArtifacts`