### PR TITLE
JIT: Add a simple store-forwarding optimization for structs returned in registers

### DIFF
--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -144,6 +144,7 @@ private:
     void LowerRet(GenTreeUnOp* ret);
     void LowerStoreLocCommon(GenTreeLclVarCommon* lclVar);
     void LowerRetStruct(GenTreeUnOp* ret);
+    void TryStoreForwardStructReturn(GenTreeUnOp* ret);
     void LowerRetSingleRegStructLclVar(GenTreeUnOp* ret);
     void LowerCallStruct(GenTreeCall* call);
     void LowerStoreSingleRegCallStruct(GenTreeBlk* store);


### PR DESCRIPTION
In cases where we see a primitive store into a struct that is then returned in a register we can often optimize to just return the source of the store directly. This is especially important for physical promotion that creates this pattern a lot.