### PR TITLE
Enable event pipe tests in NativeAOT CI run

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -243,7 +243,7 @@ extends:
             extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
             extraStepsParameters:
               creator: dotnet-bot
-              testBuildArgs: 'nativeaot tree ";nativeaot;Loader;Interop;" /p:BuildNativeAotFrameworkObjects=true'
+              testBuildArgs: 'nativeaot tree ";nativeaot;Loader;Interop;tracing;" /p:BuildNativeAotFrameworkObjects=true'
               liveLibrariesBuildConfig: Release
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
             extraVariablesTemplates:

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1060,7 +1060,10 @@
         <ExcludeList Include="$(XunitTestBinBase)/reflection/SetValue/TrySetReadonlyStaticField/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/200</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/**/*">
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventactivityidcontrol/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventlistener/**">
             <Issue>EventPipe</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b426654/b426654/*">

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1060,10 +1060,79 @@
         <ExcludeList Include="$(XunitTestBinBase)/reflection/SetValue/TrySetReadonlyStaticField/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/200</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventcounter/eventcounter/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventcounter/gh53564/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventcounter/incrementingeventcounter/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventcounter/incrementingpollingcounter/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventcounter/pollingcounter/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventcounter/regression-25709/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventcounter/regression-46938/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventactivityidcontrol/**">
             <Issue>EventPipe</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventlistener/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/bigevent/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/buffersize/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/config/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/diagnosticport/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/enabledisable/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/eventsourceerror/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/gcdump/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/pauseonstart/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/processenvironment/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/processinfo/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/processinfo2/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/providervalidation/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/reverse/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/reverseouter/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/rundownvalidation/**">
+            <Issue>EventPipe</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/runtimeeventsource/**">
             <Issue>EventPipe</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b426654/b426654/*">

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1061,79 +1061,79 @@
             <Issue>https://github.com/dotnet/runtimelab/issues/200</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventcounter/eventcounter/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventcounter/gh53564/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventcounter/incrementingeventcounter/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventcounter/incrementingpollingcounter/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventcounter/pollingcounter/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventcounter/regression-25709/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventcounter/regression-46938/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventactivityidcontrol/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventlistener/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/bigevent/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/buffersize/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/config/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/diagnosticport/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/enabledisable/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/eventsourceerror/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/gcdump/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/pauseonstart/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/processenvironment/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/processinfo/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/processinfo2/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/providervalidation/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/reverse/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/reverseouter/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/rundownvalidation/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/runtimeeventsource/**">
-            <Issue>EventPipe</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b426654/b426654/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/208</Issue>

--- a/src/tests/tracing/eventcounter/runtimecounters.csproj
+++ b/src/tests/tracing/eventcounter/runtimecounters.csproj
@@ -4,7 +4,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
-    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <JitOptimizationSensitive Condition="'$(TestBuildMode)' != 'nativeaot'">true</JitOptimizationSensitive>
     <!-- This test has a secondary thread with an infinite loop -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <EventSourceSupport Condition="'$(TestBuildMode)' == 'nativeaot'">true</EventSourceSupport>

--- a/src/tests/tracing/eventpipe/Directory.Build.targets
+++ b/src/tests/tracing/eventpipe/Directory.Build.targets
@@ -3,8 +3,7 @@
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
 
-  <!-- Hack to get NativeAOT assemblies into IlcReference
-       In CoreCLR tests, these assemblies get copied to CORE_ROOT, which NativeAOT doesn't use
+  <!-- EventPipe tests use Microsoft.Extensions.Logging and getting its dependencies require this workaround for NativeAOT
   -->
   <Import Project="$(RepoRoot)eng/liveBuilds.targets" Condition="'$(TestBuildMode)' == 'nativeaot'" />
   <!-- Get all the *.dll files that has IsNative != "true"-->

--- a/src/tests/tracing/eventpipe/Directory.Build.targets
+++ b/src/tests/tracing/eventpipe/Directory.Build.targets
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
+
+  <!-- Hack to get NativeAOT assemblies into IlcReference
+       In CoreCLR tests, these assemblies get copied to CORE_ROOT, which NativeAOT doesn't use
+  -->
+  <Import Project="$(RepoRoot)eng/liveBuilds.targets" Condition="'$(TestBuildMode)' == 'nativeaot'" />
+  <!-- Get all the *.dll files that has IsNative != "true"-->
+  <Target Name="GetRequiredNativeAOTAssemblies" 
+      DependsOnTargets="ResolveLibrariesRuntimeFilesFromLocalBuild"
+      BeforeTargets="ComputeIlcCompileInputs"
+      Condition="'$(TestBuildMode)' == 'nativeaot'">
+    <ItemGroup>
+      <IlcReference Include="@(LibrariesRuntimeFiles)" Condition="'%(Extension)' == '.dll' and '%(LibrariesRuntimeFiles.IsNative)' != 'true'"/>
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/tests/tracing/eventpipe/simpleprovidervalidation/simpleprovidervalidation.csproj
+++ b/src/tests/tracing/eventpipe/simpleprovidervalidation/simpleprovidervalidation.csproj
@@ -8,7 +8,6 @@
     <GCStressIncompatible>true</GCStressIncompatible>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <EventSourceSupport Condition="'$(TestBuildMode)' == 'nativeaot'">true</EventSourceSupport>
-    <EnableNativeEventPipe Condition="'$(TestBuildMode)' == 'nativeaot'">true</EnableNativeEventPipe>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/tracing/eventpipe/simpleprovidervalidation/simpleprovidervalidation.csproj
+++ b/src/tests/tracing/eventpipe/simpleprovidervalidation/simpleprovidervalidation.csproj
@@ -6,7 +6,7 @@
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <!-- Tracing tests routinely time out with jitstress and gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
-    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <JitOptimizationSensitive Condition="'$(TestBuildMode)' != 'nativeaot'">true</JitOptimizationSensitive>
     <EventSourceSupport Condition="'$(TestBuildMode)' == 'nativeaot'">true</EventSourceSupport>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Enables 2 tracing tests to run in NativeAOT validating EventPipe:
 - [SimpleProviderValidation](https://github.com/dotnet/runtime/tree/main/src/tests/tracing/eventpipe/simpleprovidervalidation)
 - [RuntimeCounters](https://github.com/dotnet/runtime/blob/main/src/tests/tracing/eventcounter/runtimecounters.cs)

The CI results can be seen [here](https://helixre107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-pull-86389-merge-fd22b9b459ae4680ba/PayloadGroup0/1/console.25ca933f.log?helixlogtype=result) with [SimpleProviderValidation](https://helixre107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-pull-86389-merge-fd22b9b459ae4680ba/PayloadGroup0/1/Reports/tracing.eventpipe/simpleprovidervalidation/simpleprovidervalidation/simpleprovidervalidation.output.txt?helixlogtype=result) and [RuntimeCounters](https://helixre107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-pull-86389-merge-fd22b9b459ae4680ba/PayloadGroup0/1/Reports/tracing.eventcounter/runtimecounters/runtimecounters.output.txt?helixlogtype=result).

There was an old PR #84891 related to this that was closed since it was old.




