### PR TITLE
Switch RhConfig from TCHAR to char

### DIFF
--- a/src/coreclr/nativeaot/Runtime/PalRedhawk.h
+++ b/src/coreclr/nativeaot/Runtime/PalRedhawk.h
@@ -780,16 +780,6 @@ REDHAWK_PALIMPORT void PalPrintFatalError(const char* message);
 REDHAWK_PALIMPORT int32_t __cdecl _stricmp(const char *string1, const char *string2);
 #endif // TARGET_UNIX
 
-#ifdef UNICODE
-#define _tcsicmp _wcsicmp
-#define _tcscat wcscat
-#define _tcslen wcslen
-#else
-#define _tcsicmp _stricmp
-#define _tcscat strcat
-#define _tcslen strlen
-#endif
-
 #if defined(HOST_X86) || defined(HOST_AMD64)
 
 #ifdef TARGET_UNIX

--- a/src/coreclr/nativeaot/Runtime/PalRedhawkFunctions.h
+++ b/src/coreclr/nativeaot/Runtime/PalRedhawkFunctions.h
@@ -79,12 +79,21 @@ inline HANDLE PalGetCurrentThread()
     return GetCurrentThread();
 }
 
+#ifdef UNICODE
+_Success_(return != 0 && return < nSize)
+extern "C" uint32_t __stdcall GetEnvironmentVariableW(_In_opt_ LPCWSTR lpName, _Out_writes_to_opt_(nSize, return + 1) LPWSTR lpBuffer, _In_ uint32_t nSize);
+inline uint32_t PalGetEnvironmentVariable(_In_opt_ LPCWSTR lpName, _Out_writes_to_opt_(nSize, return + 1) LPWSTR lpBuffer, _In_ uint32_t nSize)
+{
+    return GetEnvironmentVariableW(lpName, lpBuffer, nSize);
+}
+#else
 _Success_(return != 0 && return < nSize)
 extern "C" uint32_t __stdcall GetEnvironmentVariableA(_In_opt_ LPCSTR lpName, _Out_writes_to_opt_(nSize, return + 1) LPSTR lpBuffer, _In_ uint32_t nSize);
-inline uint32_t PalGetEnvironmentVariableA(_In_opt_ LPCSTR lpName, _Out_writes_to_opt_(nSize, return + 1) LPSTR lpBuffer, _In_ uint32_t nSize)
+inline uint32_t PalGetEnvironmentVariable(_In_opt_ LPCSTR lpName, _Out_writes_to_opt_(nSize, return + 1) LPSTR lpBuffer, _In_ uint32_t nSize)
 {
     return GetEnvironmentVariableA(lpName, lpBuffer, nSize);
 }
+#endif
 
 extern "C" void * __stdcall GetProcAddress(HANDLE, const char *);
 inline void * PalGetProcAddress(HANDLE arg1, const char * arg2)

--- a/src/coreclr/nativeaot/Runtime/PalRedhawkFunctions.h
+++ b/src/coreclr/nativeaot/Runtime/PalRedhawkFunctions.h
@@ -79,21 +79,12 @@ inline HANDLE PalGetCurrentThread()
     return GetCurrentThread();
 }
 
-#ifdef UNICODE
-_Success_(return != 0 && return < nSize)
-extern "C" uint32_t __stdcall GetEnvironmentVariableW(_In_opt_ LPCWSTR lpName, _Out_writes_to_opt_(nSize, return + 1) LPWSTR lpBuffer, _In_ uint32_t nSize);
-inline uint32_t PalGetEnvironmentVariable(_In_opt_ LPCWSTR lpName, _Out_writes_to_opt_(nSize, return + 1) LPWSTR lpBuffer, _In_ uint32_t nSize)
-{
-    return GetEnvironmentVariableW(lpName, lpBuffer, nSize);
-}
-#else
 _Success_(return != 0 && return < nSize)
 extern "C" uint32_t __stdcall GetEnvironmentVariableA(_In_opt_ LPCSTR lpName, _Out_writes_to_opt_(nSize, return + 1) LPSTR lpBuffer, _In_ uint32_t nSize);
-inline uint32_t PalGetEnvironmentVariable(_In_opt_ LPCSTR lpName, _Out_writes_to_opt_(nSize, return + 1) LPSTR lpBuffer, _In_ uint32_t nSize)
+inline uint32_t PalGetEnvironmentVariableA(_In_opt_ LPCSTR lpName, _Out_writes_to_opt_(nSize, return + 1) LPSTR lpBuffer, _In_ uint32_t nSize)
 {
     return GetEnvironmentVariableA(lpName, lpBuffer, nSize);
 }
-#endif
 
 extern "C" void * __stdcall GetProcAddress(HANDLE, const char *);
 inline void * PalGetProcAddress(HANDLE arg1, const char * arg2)

--- a/src/coreclr/nativeaot/Runtime/RhConfig.cpp
+++ b/src/coreclr/nativeaot/Runtime/RhConfig.cpp
@@ -13,116 +13,99 @@
 
 bool RhConfig::ReadConfigValue(_In_z_ const char *name, uint64_t* pValue, bool decimal)
 {
-    char buffer[CONFIG_VAL_MAXLEN + 1]; // hex digits plus a nul terminator.
+    TCHAR buffer[CONFIG_VAL_MAXLEN + 1]; // hex digits plus a nul terminator.
     const uint32_t cchBuffer = ARRAY_SIZE(buffer);
 
     uint32_t cchResult = 0;
-
-    char variableName[64] = "DOTNET_";
-    assert(strlen(variableName) + strlen(name) < ARRAY_SIZE(variableName));
-    strcat(variableName, name);
-    cchResult = PalGetEnvironmentVariableA(variableName, buffer, cchBuffer);
-
-#ifdef FEATURE_EMBEDDED_CONFIG
-    // if the config key wasn't found in the ini file
-    if ((cchResult == 0) || (cchResult >= cchBuffer))
-        cchResult = GetEmbeddedVariable(name, buffer, cchBuffer);
-#endif // FEATURE_EMBEDDED_CONFIG
-
-    if ((cchResult == 0) || (cchResult >= cchBuffer))
-        return false; // not found
-
-    uint64_t uiResult = 0;
-
-    for (uint32_t i = 0; i < cchResult; i++)
+    TCHAR variableName[64] = _T("DOTNET_");
+    assert(ARRAY_SIZE("DOTNET_") - 1 + strlen(name) < ARRAY_SIZE(variableName));
+#ifdef TARGET_WINDOWS
+    for (size_t i = 0; i < strlen(name); i++)
     {
-        char ch = buffer[i];
+        variableName[ARRAY_SIZE("DOTNET_") - 1 + i] = name[i];
+    }
+#else
+    strcat(variableName, name);
+#endif
 
-        if (decimal)
+    cchResult = PalGetEnvironmentVariable(variableName, buffer, cchBuffer);
+    if (cchResult != 0 && cchResult < cchBuffer)
+    {
+        // Environment variable was set. Convert it to an integer.
+        uint64_t uiResult = 0;
+        for (uint32_t i = 0; i < cchResult; i++)
         {
-            uiResult *= 10;
+            TCHAR ch = buffer[i];
 
-            if ((ch >= '0') && (ch <= '9'))
-                uiResult += ch - '0';
-            else
-                return false; // parse error
-        }
-        else
-        {
-            uiResult *= 16;
+            if (decimal)
+            {
+                uiResult *= 10;
 
-            if ((ch >= '0') && (ch <= '9'))
-                uiResult += ch - '0';
-            else if ((ch >= 'a') && (ch <= 'f'))
-                uiResult += (ch - 'a') + 10;
-            else if ((ch >= 'A') && (ch <= 'F'))
-                uiResult += (ch - 'A') + 10;
+                if ((ch >= '0') && (ch <= '9'))
+                    uiResult += ch - '0';
+                else
+                    return false; // parse error
+            }
             else
-                return false; // parse error
+            {
+                uiResult *= 16;
+
+                if ((ch >= '0') && (ch <= '9'))
+                    uiResult += ch - '0';
+                else if ((ch >= 'a') && (ch <= 'f'))
+                    uiResult += (ch - 'a') + 10;
+                else if ((ch >= 'A') && (ch <= 'F'))
+                    uiResult += (ch - 'A') + 10;
+                else
+                    return false; // parse error
+            }
         }
+
+        *pValue = uiResult;
+        return true;
     }
 
-    *pValue = uiResult;
-    return true;
+    // Check the embedded configuration
+    const char *embeddedValue = nullptr;
+    if (GetEmbeddedVariable(name, &embeddedValue))
+    {
+        *pValue = strtoull(embeddedValue, NULL, decimal ? 10 : 16);
+        return true;
+    }
+
+    return false;
 }
 
-#ifdef FEATURE_EMBEDDED_CONFIG
-uint32_t RhConfig::GetEmbeddedVariable(_In_z_ const char* configName, _Out_writes_all_(cchOutputBuffer) char* outputBuffer, _In_ uint32_t cchOutputBuffer)
+bool RhConfig::GetEmbeddedVariable(_In_z_ const char* configName, _Out_ const char** configValue)
 {
-    //the buffer needs to be big enough to read the value buffer + null terminator
-    if (cchOutputBuffer < CONFIG_VAL_MAXLEN + 1)
-    {
-        return 0;
-    }
-
-    //if we haven't read the config yet try to read
+    // Read the config if we haven't yet
     if (g_embeddedSettings == NULL)
     {
         ReadEmbeddedSettings();
     }
 
-    //if the config wasn't read or reading failed return 0 immediately
+    // Config wasn't read or reading failed
     if (g_embeddedSettings == CONFIG_INI_NOT_AVAIL)
     {
-        return 0;
+        return false;
     }
 
-    return GetConfigVariable(configName, (ConfigPair*)g_embeddedSettings, outputBuffer, cchOutputBuffer);
-}
-#endif // FEATURE_EMBEDDED_CONFIG
+    const ConfigPair* configPairs = (const ConfigPair*)g_embeddedSettings;
 
-uint32_t RhConfig::GetConfigVariable(_In_z_ const char* configName, const ConfigPair* configPairs, _Out_writes_all_(cchOutputBuffer) char* outputBuffer, _In_ uint32_t cchOutputBuffer)
-{
-    //find the first name which matches (case insensitive to be compat with environment variable counterpart)
+    // Find the first name which matches (case insensitive to be compat with environment variable counterpart)
     for (int iSettings = 0; iSettings < RCV_Count; iSettings++)
     {
         if (_stricmp(configName, configPairs[iSettings].Key) == 0)
         {
-            bool nullTerm = FALSE;
-
-            uint32_t iValue;
-
-            for (iValue = 0; (iValue < CONFIG_VAL_MAXLEN + 1) && (iValue < cchOutputBuffer); iValue++)
-            {
-                outputBuffer[iValue] = configPairs[iSettings].Value[iValue];
-
-                if (outputBuffer[iValue] == '\0')
-                {
-                    nullTerm = true;
-                    break;
-                }
-            }
-
-            //return the length of the config value if null terminated else return zero
-            return nullTerm ? iValue : 0;
+            *configValue = configPairs[iSettings].Value;
+            return true;
         }
     }
 
-    //if the config key was not found return 0
-    return 0;
+    // Config key was not found
+    return false;
 }
 
-#ifdef FEATURE_EMBEDDED_CONFIG
 struct CompilerEmbeddedSettingsBlob
 {
     uint32_t Size;
@@ -195,7 +178,6 @@ void RhConfig::ReadEmbeddedSettings()
 
     return;
 }
-#endif // FEATURE_EMBEDDED_CONFIG
 
 //Parses one line of config and populates values in the passed in configPair
 //returns: true if the parsing was successful, false if the parsing failed.

--- a/src/coreclr/nativeaot/Runtime/RhConfig.h
+++ b/src/coreclr/nativeaot/Runtime/RhConfig.h
@@ -15,7 +15,6 @@
 #ifndef DACCESS_COMPILE
 
 #define FEATURE_EMBEDDED_CONFIG
-#define FEATURE_ENVIRONMENT_VARIABLE_CONFIG
 
 class RhConfig
 {
@@ -28,8 +27,8 @@ private:
     struct ConfigPair
     {
     public:
-        TCHAR Key[CONFIG_KEY_MAXLEN + 1];  //maxlen + null terminator
-        TCHAR Value[CONFIG_VAL_MAXLEN + 1]; //maxlen + null terminator
+        char Key[CONFIG_KEY_MAXLEN + 1];  //maxlen + null terminator
+        char Value[CONFIG_VAL_MAXLEN + 1]; //maxlen + null terminator
     };
 
 #ifdef FEATURE_EMBEDDED_CONFIG
@@ -42,7 +41,7 @@ private:
 
 public:
 
-    bool ReadConfigValue(_In_z_ const TCHAR* wszName, uint64_t* pValue, bool decimal = false);
+    bool ReadConfigValue(_In_z_ const char* wszName, uint64_t* pValue, bool decimal = false);
 
 #define DEFINE_VALUE_ACCESSOR(_name, defaultVal)        \
     uint64_t Get##_name()                                 \
@@ -50,7 +49,7 @@ public:
         if (m_uiConfigValuesRead & (1 << RCV_##_name))  \
             return m_uiConfigValues[RCV_##_name];       \
         uint64_t uiValue;                               \
-        m_uiConfigValues[RCV_##_name] = ReadConfigValue(_T(#_name), &uiValue) ? uiValue : defaultVal; \
+        m_uiConfigValues[RCV_##_name] = ReadConfigValue(#_name, &uiValue) ? uiValue : defaultVal; \
         m_uiConfigValuesRead |= 1 << RCV_##_name;       \
         return m_uiConfigValues[RCV_##_name];           \
     }
@@ -99,16 +98,10 @@ private:
 #ifdef FEATURE_EMBEDDED_CONFIG
     void ReadEmbeddedSettings();
 
-    uint32_t GetEmbeddedVariable(_In_z_ const TCHAR* configName, _Out_writes_all_(cchOutputBuffer) TCHAR* outputBuffer, _In_ uint32_t cchOutputBuffer);
+    uint32_t GetEmbeddedVariable(_In_z_ const char* configName, _Out_writes_all_(cchOutputBuffer) char* outputBuffer, _In_ uint32_t cchOutputBuffer);
 #endif // FEATURE_EMBEDDED_CONFIG
 
-    uint32_t GetConfigVariable(_In_z_ const TCHAR* configName, const ConfigPair* configPairs, _Out_writes_all_(cchOutputBuffer) TCHAR* outputBuffer, _In_ uint32_t cchOutputBuffer);
-
-    static bool priv_isspace(char c)
-    {
-        return (c == ' ') || (c == '\t') || (c == '\n') || (c == '\r');
-    }
-
+    uint32_t GetConfigVariable(_In_z_ const char* configName, const ConfigPair* configPairs, _Out_writes_all_(cchOutputBuffer) char* outputBuffer, _In_ uint32_t cchOutputBuffer);
 
     uint32_t  m_uiConfigValuesRead;
     uint64_t  m_uiConfigValues[RCV_Count];

--- a/src/coreclr/nativeaot/Runtime/RhConfig.h
+++ b/src/coreclr/nativeaot/Runtime/RhConfig.h
@@ -14,8 +14,6 @@
 
 #ifndef DACCESS_COMPILE
 
-#define FEATURE_EMBEDDED_CONFIG
-
 class RhConfig
 {
 
@@ -31,13 +29,11 @@ private:
         char Value[CONFIG_VAL_MAXLEN + 1]; //maxlen + null terminator
     };
 
-#ifdef FEATURE_EMBEDDED_CONFIG
     // g_embeddedSettings is a buffer of ConfigPair structs embedded in the compiled binary.
     //
     //NOTE: g_embeddedSettings is only set in ReadEmbeddedSettings and must be set atomically only once
     //      using PalInterlockedCompareExchangePointer to avoid races when initializing
     void* volatile g_embeddedSettings = NULL;
-#endif // FEATURE_EMBEDDED_CONFIG
 
 public:
 
@@ -95,13 +91,11 @@ private:
     //NOTE: if the method fails configPair is left in an uninitialized state
     bool ParseConfigLine(_Out_ ConfigPair* configPair, _In_z_ const char * line);
 
-#ifdef FEATURE_EMBEDDED_CONFIG
     void ReadEmbeddedSettings();
 
-    uint32_t GetEmbeddedVariable(_In_z_ const char* configName, _Out_writes_all_(cchOutputBuffer) char* outputBuffer, _In_ uint32_t cchOutputBuffer);
-#endif // FEATURE_EMBEDDED_CONFIG
-
-    uint32_t GetConfigVariable(_In_z_ const char* configName, const ConfigPair* configPairs, _Out_writes_all_(cchOutputBuffer) char* outputBuffer, _In_ uint32_t cchOutputBuffer);
+    // Gets a pointer to the embedded configuration value. Memory is held by the callee.
+    // Returns true if the variable was found, false otherwise
+    bool GetEmbeddedVariable(_In_z_ const char* configName, _Out_ const char** configValue);
 
     uint32_t  m_uiConfigValuesRead;
     uint64_t  m_uiConfigValues[RCV_Count];

--- a/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
@@ -1366,17 +1366,8 @@ bool GCToEEInterface::GetBooleanConfigValue(const char* privateKey, const char* 
         return true;
     }
 
-#ifdef UNICODE
-    size_t keyLength = strlen(privateKey) + 1;
-    TCHAR* pKey = (TCHAR*)_alloca(sizeof(TCHAR) * keyLength);
-    for (size_t i = 0; i < keyLength; i++)
-        pKey[i] = privateKey[i];
-#else
-    const TCHAR* pKey = privateKey;
-#endif
-
     uint64_t uiValue;
-    if (!g_pRhConfig->ReadConfigValue(pKey, &uiValue))
+    if (!g_pRhConfig->ReadConfigValue(privateKey, &uiValue))
         return false;
 
     *value = uiValue != 0;
@@ -1385,17 +1376,8 @@ bool GCToEEInterface::GetBooleanConfigValue(const char* privateKey, const char* 
 
 bool GCToEEInterface::GetIntConfigValue(const char* privateKey, const char* publicKey, int64_t* value)
 {
-#ifdef UNICODE
-    size_t keyLength = strlen(privateKey) + 1;
-    TCHAR* pKey = (TCHAR*)_alloca(sizeof(TCHAR) * keyLength);
-    for (size_t i = 0; i < keyLength; i++)
-        pKey[i] = privateKey[i];
-#else
-    const TCHAR* pKey = privateKey;
-#endif
-
     uint64_t uiValue;
-    if (!g_pRhConfig->ReadConfigValue(pKey, &uiValue))
+    if (!g_pRhConfig->ReadConfigValue(privateKey, &uiValue))
         return false;
 
     *value = uiValue;

--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -354,7 +354,7 @@ void InitializeCurrentProcessCpuCount()
     const unsigned int MAX_PROCESSOR_COUNT = 0xffff;
     uint64_t configValue;
 
-    if (g_pRhConfig->ReadConfigValue(_T("PROCESSOR_COUNT"), &configValue, true /* decimal */) &&
+    if (g_pRhConfig->ReadConfigValue("PROCESSOR_COUNT", &configValue, true /* decimal */) &&
         0 < configValue && configValue <= MAX_PROCESSOR_COUNT)
     {
         count = configValue;

--- a/src/coreclr/nativeaot/Runtime/windows/PalRedhawkMinWin.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/PalRedhawkMinWin.cpp
@@ -72,7 +72,7 @@ void InitializeCurrentProcessCpuCount()
     const unsigned int MAX_PROCESSOR_COUNT = 0xffff;
     uint64_t configValue;
 
-    if (g_pRhConfig->ReadConfigValue(_T("PROCESSOR_COUNT"), &configValue, true /* decimal */) &&
+    if (g_pRhConfig->ReadConfigValue("PROCESSOR_COUNT", &configValue, true /* decimal */) &&
         0 < configValue && configValue <= MAX_PROCESSOR_COUNT)
     {
         count = (DWORD)configValue;


### PR DESCRIPTION
I didn't see a reason for NativeAOT's `RhConfig` to be use `TCHAR` - `wchar_t` on windows, `char` otherwise. We can hide away the details of reading the environment variable as `wchar` vs `char` and the embedded variables are embedded as ASCII (and read as such) already. This makes it stop using `TCHAR` for the exposed API which seemed to just be more confusing to consume (this also makes it so that `RhConfig.h` no longer just assumes some header included before it defines `TCHAR`/`_T`).