### PR TITLE
Make IDerivedTest.CallBaseInterfaceMethod_EnsureQiCalledOnce trim-friendly

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/IDerivedTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/IDerivedTests.cs
@@ -34,6 +34,7 @@ namespace ComInterfaceGenerator.Tests
 
             Assert.True(expected.SequenceEqual(actual));
         }
+
         [Fact]
         public unsafe void CallBaseInterfaceMethod_EnsureQiCalledOnce()
         {
@@ -52,7 +53,9 @@ namespace ComInterfaceGenerator.Tests
             //iface.SetName("updated");
             //Assert.Equal("updated", iface.GetName());
 
-            var qiCallCountObj = obj.GetType().GetRuntimeProperties().Where(p => p.Name == "IUnknownStrategy").Single().GetValue(obj);
+            var iUnknownStrategyProperty = typeof(ComObject).GetProperties().Single(p => p.Name == "IUnknownStrategy");
+
+            var qiCallCountObj = iUnknownStrategyProperty.GetValue(obj);
             var countQi = (SingleQIComWrapper.CountQI)qiCallCountObj;
             Assert.Equal(1, countQi.QiCallCount);
         }

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/IDerivedTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/IDerivedTests.cs
@@ -53,9 +53,11 @@ namespace ComInterfaceGenerator.Tests
             //iface.SetName("updated");
             //Assert.Equal("updated", iface.GetName());
 
-            var iUnknownStrategyProperty = typeof(ComObject).GetProperties().Single(p => p.Name == "IUnknownStrategy");
+            var iUnknownStrategyProperty = typeof(ComObject).GetProperty("IUnknownStrategy", BindingFlags.NonPublic | BindingFlags.Instance);
 
-            var qiCallCountObj = iUnknownStrategyProperty.GetValue(obj);
+            Assert.NotNull(iUnknownStrategyProperty);
+
+            var qiCallCountObj = iUnknownStrategyProperty!.GetValue(obj);
             var countQi = (SingleQIComWrapper.CountQI)qiCallCountObj;
             Assert.Equal(1, countQi.QiCallCount);
         }


### PR DESCRIPTION
>  This is not trim safe and is crashing in the runtime-extra-platforms runs. Any chance we can rewrite this to be trim safe? What is this reflecting on? Can it be `Type.GetType("Some type")`?
>_Originally posted by @MichalStrehovsky in https://github.com/dotnet/runtime/pull/86344#discussion_r1196157227_
            
Change the reflection usage to be trim friendly.