### PR TITLE
Remove extraneous VN code

### DIFF
--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -244,7 +244,6 @@ public:
         }
         ~VNMap()
         {
-            ~VNMap<fromType, keyfuncs>::JitHashTable();
         }
 
         bool Set(fromType k, ValueNum val)

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -242,9 +242,6 @@ public:
         VNMap(CompAllocator alloc) : JitHashTable<fromType, keyfuncs, ValueNum>(alloc)
         {
         }
-        ~VNMap()
-        {
-        }
 
         bool Set(fromType k, ValueNum val)
         {


### PR DESCRIPTION
This wasn't invoking the JitHashTable destructor as evidently intended, though the destructor was already being invoked by default.

Fixes #86372