### PR TITLE
Fix assertprop assert for missing handle flag

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -10489,10 +10489,32 @@ bool Compiler::fgValueNumberConstLoad(GenTreeIndir* tree)
             uint8_t buffer[maxElementSize] = {0};
             if (info.compCompHnd->getObjectContent(obj, buffer, size, (int)byteOffset))
             {
-                ValueNum vn = vnStore->VNForGenericCon(tree->TypeGet(), buffer);
-                assert(!vnStore->IsVNObjHandle(vn));
-                tree->gtVNPair.SetBoth(vn);
-                return true;
+                // If we have IND<size_t>(frozenObj) then it means we're reading object type
+                // so make sure we report the constant as class handle
+                if ((size == TARGET_POINTER_SIZE) && (byteOffset == 0))
+                {
+                    void* pEmbedClsHnd;
+                    void* embedClsHnd = (void*)info.compCompHnd->embedClassHandle(handle, &pEmbedClsHnd);
+                    if (pEmbedClsHnd == nullptr)
+                    {
+                        // getObjectContent doesn't support reading handles for AOT (NativeAOT) yet
+
+                        // In case of 64bit jit emitting 32bit codegen this handle will be 64bit
+                        // value holding 32bit handle with upper half zeroed (hence, "= NULL").
+                        // It's done to match the current crossgen/ILC behavior.
+                        ssize_t embedClsHnd = NULL;
+                        memcpy(&embedClsHnd, buffer, TARGET_POINTER_SIZE);
+                        tree->gtVNPair.SetBoth(vnStore->VNForHandle(embedClsHnd, GTF_ICON_CLASS_HDL));
+                        return true;
+                    }
+                }
+                else
+                {
+                    ValueNum vn = vnStore->VNForGenericCon(tree->TypeGet(), buffer);
+                    assert(!vnStore->IsVNObjHandle(vn));
+                    tree->gtVNPair.SetBoth(vn);
+                    return true;
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/86398

The issue that we use to fold `IND<ssize_t>(const_object_handle)` as a pure intptr constant (in VN) while we're expected to number it as a handle.