### PR TITLE
Move the GCC and CLR Tools Unit Tests legs to use the global build template

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -353,7 +353,6 @@ jobs:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        compilerName: gcc
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Mono LLVMAot test build

--- a/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+++ b/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
@@ -30,12 +30,14 @@ parameters:
   shouldContinueOnError: false
 
 steps:
-  - ${{ if eq(parameters.osGroup, 'windows') }}:
-    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(crossArg) ci ${{ parameters.archType }} $(buildConfigUpper) $(priorityArg) $(runtimeFlavorArgs) ${{ parameters.testBuildArgs }} $(runtimeVariantArg) /p:LibrariesConfiguration=${{ coalesce(parameters.liveLibrariesBuildConfig, parameters.buildConfig) }}
-      displayName: Build Tests
-  - ${{ if ne(parameters.osGroup, 'windows') }}:
-    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(crossArg) ci os ${{ parameters.osGroup }} ${{ parameters.archType }} $(buildConfigUpper) $(priorityArg) $(runtimeFlavorArgs) ${{ parameters.testBuildArgs }} $(runtimeVariantArg) /p:LibrariesConfiguration=${{ coalesce(parameters.liveLibrariesBuildConfig, parameters.buildConfig) }}
-      displayName: Build Tests
+  - template: /eng/pipelines/common/templates/runtimes/build-runtime-tests.yml
+    parameters:
+      osGroup: ${{ parameters.osGroup }}
+      osSubgroup: ${{ parameters.osSubgroup }}
+      archType: ${{ parameters.archType }}
+      buildConfig: ${{ parameters.buildConfig }}
+      liveLibrariesBuildConfig: ${{ parameters.liveLibrariesBuildConfig }}
+      testBuildArgs: ${{ parameters.testBuildArgs }}
 
   # Build a Mono LLVM AOT cross-compiler for non-amd64 targets (in this case, just arm64)
   - ${{ if and(eq(parameters.runtimeFlavor, 'mono'), or(eq(parameters.runtimeVariant, 'llvmaot'), eq(parameters.runtimeVariant, 'llvmfullaot'))) }}:

--- a/eng/pipelines/common/templates/runtimes/build-runtime-tests.yml
+++ b/eng/pipelines/common/templates/runtimes/build-runtime-tests.yml
@@ -1,0 +1,24 @@
+parameters:
+  osGroup: ''
+  osSubgroup: ''
+  archType: ''
+  buildConfig: ''
+  liveLibrariesBuildConfig: ''
+  testBuildArgs: ''
+  #arcade-specific parameters
+  condition: always()
+  continueOnError: false
+  displayName: ''
+  timeoutInMinutes: ''
+  enableMicrobuild: ''
+  gatherAssetManifests: false
+  shouldContinueOnError: false
+
+
+steps:
+  - ${{ if eq(parameters.osGroup, 'windows') }}:
+    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(crossArg) ci ${{ parameters.archType }} $(buildConfigUpper) $(priorityArg) $(runtimeFlavorArgs) ${{ parameters.testBuildArgs }} $(runtimeVariantArg) /p:LibrariesConfiguration=${{ coalesce(parameters.liveLibrariesBuildConfig, parameters.buildConfig) }}
+      displayName: Build Tests
+  - ${{ if ne(parameters.osGroup, 'windows') }}:
+    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(crossArg) ci os ${{ parameters.osGroup }} ${{ parameters.archType }} $(buildConfigUpper) $(priorityArg) $(runtimeFlavorArgs) ${{ parameters.testBuildArgs }} $(runtimeVariantArg) /p:LibrariesConfiguration=${{ coalesce(parameters.liveLibrariesBuildConfig, parameters.buildConfig) }}
+      displayName: Build Tests

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -39,22 +39,18 @@ jobs:
     pgoType: ${{ parameters.pgoType }}
 
     # Compute job name from template parameters
-    ${{ if ne(parameters.testGroup, 'clrTools') }}:
-      name: ${{ format('coreclr_{0}_product_build_{1}{2}_{3}_{4}{5}',
-        parameters.runtimeVariant,
-        parameters.osGroup,
-        parameters.osSubgroup,
-        parameters.archType,
-        parameters.buildConfig,
-        parameters.pgoType) }}
-      displayName: ${{ format('CoreCLR {0} Product Build {1}{2} {3} {4} {5}',
-        parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup,
-        parameters.archType,
-        parameters.buildConfig,
-        parameters.pgoType) }}
-    ${{ if eq(parameters.testGroup, 'clrTools') }}:
-      name: ${{ format('coreclr_{0}_tools_unittests_{1}{2}_{3}_{4}', parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-      displayName: ${{ format('CoreCLR {0} Tools Unit Tests {1}{2} {3} {4}', parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
+    name: ${{ format('coreclr_{0}_product_build_{1}{2}_{3}_{4}{5}',
+      parameters.runtimeVariant,
+      parameters.osGroup,
+      parameters.osSubgroup,
+      parameters.archType,
+      parameters.buildConfig,
+      parameters.pgoType) }}
+    displayName: ${{ format('CoreCLR {0} Product Build {1}{2} {3} {4} {5}',
+      parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup,
+      parameters.archType,
+      parameters.buildConfig,
+      parameters.pgoType) }}
 
     # Run all steps in the container.
     # Note that the containers are defined in platform-matrix.yml
@@ -74,9 +70,6 @@ jobs:
       value: ''
     - name: publishLogsArtifactPrefix
       value: 'BuildLogs_CoreCLR'
-    - ${{ if eq(parameters.testGroup, 'clrTools') }}:
-      - name: publishLogsArtifactPrefix
-        value: 'BuildLogs_CoreCLR_ToolsUnitTests'
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
       # Variables used to publish packages to blob feed
       - name: dotnetfeedUrl
@@ -205,13 +198,6 @@ jobs:
       - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -subset clr.corelib $(crossArg) -arch $(archType) $(osArg) -c $(buildConfig) $(pgoInstrumentArg) $(officialBuildIdArg) -ci
         displayName: Build managed product components and packages
 
-    # Run CoreCLR Tools unit tests
-    - ${{ if eq(parameters.testGroup, 'clrTools') }}:
-      - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -subset libs $(crossArg) -arch $(archType) $(osArg) -c $(buildConfig) $(officialBuildIdArg) -ci
-        displayName: Build libs
-      - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -subset clr.toolstests $(crossArg) -arch $(archType) $(osArg) -c $(buildConfig) $(officialBuildIdArg) -ci -test
-        displayName: Run CoreCLR Tools unit tests
-
     # Build native test components
     - ${{ if and(ne(parameters.isOfficialBuild, true), ne(parameters.disableClrTest, true)) }}:
       - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) skipmanaged skipgeneratelayout $(buildConfig) $(archType) $(crossArg) $(osArg) $(priorityArg) $(compilerArg)
@@ -247,7 +233,7 @@ jobs:
           timeoutInMinutes: 30
 
     # clrTools unitests do not publish the build artifacts
-    - ${{ if and(ne(parameters.testGroup, 'clrTools'), ne(parameters.disableClrTest, true)) }}:
+    - ${{ if ne(parameters.disableClrTest, true) }}:
       # Publish product output directory for consumption by tests.
       - template: /eng/pipelines/common/upload-artifact-step.yml
         parameters:
@@ -259,7 +245,7 @@ jobs:
           artifactName: $(buildProductArtifactName)
           displayName: 'product build'
 
-    - ${{ if and(in(parameters.osGroup, 'windows', 'linux'), ne(parameters.archType, 'x86'), ne(parameters.testGroup, 'clrTools'), eq(parameters.pgoType, '')) }}:
+    - ${{ if and(in(parameters.osGroup, 'windows', 'linux'), ne(parameters.archType, 'x86'), eq(parameters.pgoType, '')) }}:
         - template: /eng/pipelines/coreclr/templates/crossdac-build.yml
           parameters:
             archType: ${{ parameters.archType }}
@@ -271,7 +257,7 @@ jobs:
             ${{ else }}:
               hostArchType: x64
 
-    - ${{ if and(in(parameters.osGroup, 'windows'), eq(parameters.archType, 'x86'), ne(parameters.testGroup, 'clrTools'), eq(parameters.pgoType, '')) }}:
+    - ${{ if and(in(parameters.osGroup, 'windows'), eq(parameters.archType, 'x86'), eq(parameters.pgoType, '')) }}:
         - template: /eng/pipelines/coreclr/templates/crossdac-build.yml
           parameters:
             archType: arm
@@ -280,7 +266,7 @@ jobs:
             isOfficialBuild: ${{ parameters.signBinaries }}
             hostArchType: x86
 
-    - ${{ if and(ne(parameters.testGroup, ''), ne(parameters.testGroup, 'clrTools'), ne(parameters.disableClrTest, true)) }}:
+    - ${{ if and(ne(parameters.testGroup, ''), ne(parameters.disableClrTest, true)) }}:
       # Publish test native components for consumption by test execution.
       - ${{ if and(ne(parameters.isOfficialBuild, true), eq(parameters.pgoType, '')) }}:
         - template: /eng/pipelines/common/upload-artifact-step.yml
@@ -302,21 +288,10 @@ jobs:
           SecretsFilter: 'dotnetfeed-storage-access-key-1,microsoft-symbol-server-pat,symweb-symbol-server-pat'
 
     # Save packages using the prepare-signed-artifacts format.
-    - ${{ if and(eq(parameters.isOfficialBuild, true), ne(parameters.testGroup, 'clrTools'), eq(parameters.pgoType, '')) }}:
+    - ${{ if and(eq(parameters.isOfficialBuild, true), eq(parameters.pgoType, '')) }}:
       - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
         parameters:
           name: ${{ parameters.platform }}
-
-    # Publish unit tests results if executing unit tests
-    - ${{ if eq(parameters.testGroup, 'clrTools') }}:
-      - task: PublishTestResults@2
-        inputs:
-          testResultsFormat: 'xUnit'
-          testResultsFiles: '*.xml'
-          testRunTitle: CoreCLR-Tools-Unittests-$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)
-          searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
-        continueOnError: true
-        condition: always()
 
     # Publish Logs
     - task: PublishPipelineArtifact@1

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -1,9 +1,6 @@
 parameters:
   archType: ''
   buildConfig: ''
-  # compilerName specifies the compiler to use to do the builds. This can either be 'gcc' or left
-  # unset to use the default (clang on Linux/Mac, Visual C++ on Windows).
-  compilerName: ''
   condition: true
   container: ''
   crossBuild: false
@@ -42,10 +39,7 @@ jobs:
     pgoType: ${{ parameters.pgoType }}
 
     # Compute job name from template parameters
-    ${{ if and(ne(parameters.testGroup, 'clrTools'), eq(parameters.compilerName, 'gcc')) }}:
-      name: ${{ format('coreclr_{0}_product_build_{1}{1}_{3}_{4}', parameters.compilerName, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-      displayName: ${{ format('GCC Product Build {0}{1} {2} {3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-    ${{ if and(ne(parameters.testGroup, 'clrTools'), ne(parameters.compilerName, 'gcc')) }}:
+    ${{ if ne(parameters.testGroup, 'clrTools') }}:
       name: ${{ format('coreclr_{0}_product_build_{1}{2}_{3}_{4}{5}',
         parameters.runtimeVariant,
         parameters.osGroup,
@@ -83,11 +77,6 @@ jobs:
     - ${{ if eq(parameters.testGroup, 'clrTools') }}:
       - name: publishLogsArtifactPrefix
         value: 'BuildLogs_CoreCLR_ToolsUnitTests'
-    - ${{ if eq(parameters.compilerName, 'gcc') }}:
-      - name: compilerArg
-        value: '-gcc'
-      - name: publishLogsArtifactPrefix
-        value: 'BuildLogs_CoreCLR_GCC'
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
       # Variables used to publish packages to blob feed
       - name: dotnetfeedUrl
@@ -228,11 +217,6 @@ jobs:
       - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) skipmanaged skipgeneratelayout $(buildConfig) $(archType) $(crossArg) $(osArg) $(priorityArg) $(compilerArg)
         displayName: Build native test components
 
-    # Build libs.native, host.native and mono with gcc
-    - ${{ if eq(parameters.compilerName, 'gcc') }}:
-      - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) libs.native+host.native+mono $(compilerArg) $(crossArg) -arch $(archType) $(osArg) -c $(buildConfig) $(pgoInstrumentArg) $(officialBuildIdArg) -ci
-        displayName: Build libs.native+host.native+mono
-
     # Sign and add entitlements to these MacOS binaries
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - ${{ if eq(parameters.osGroup, 'osx') }}:
@@ -262,8 +246,8 @@ jobs:
           isOfficialBuild: ${{ parameters.signBinaries }}
           timeoutInMinutes: 30
 
-    # Builds using gcc are not tested, and clrTools unitests do not publish the build artifacts
-    - ${{ if and(ne(parameters.compilerName, 'gcc'), ne(parameters.testGroup, 'clrTools'), ne(parameters.disableClrTest, true)) }}:
+    # clrTools unitests do not publish the build artifacts
+    - ${{ if and(ne(parameters.testGroup, 'clrTools'), ne(parameters.disableClrTest, true)) }}:
       # Publish product output directory for consumption by tests.
       - template: /eng/pipelines/common/upload-artifact-step.yml
         parameters:
@@ -275,7 +259,7 @@ jobs:
           artifactName: $(buildProductArtifactName)
           displayName: 'product build'
 
-    - ${{ if and(in(parameters.osGroup, 'windows', 'linux'), ne(parameters.archType, 'x86'), ne(parameters.compilerName, 'gcc'), ne(parameters.testGroup, 'clrTools'), eq(parameters.pgoType, '')) }}:
+    - ${{ if and(in(parameters.osGroup, 'windows', 'linux'), ne(parameters.archType, 'x86'), ne(parameters.testGroup, 'clrTools'), eq(parameters.pgoType, '')) }}:
         - template: /eng/pipelines/coreclr/templates/crossdac-build.yml
           parameters:
             archType: ${{ parameters.archType }}
@@ -296,7 +280,7 @@ jobs:
             isOfficialBuild: ${{ parameters.signBinaries }}
             hostArchType: x86
 
-    - ${{ if and(ne(parameters.compilerName, 'gcc'), ne(parameters.testGroup, ''), ne(parameters.testGroup, 'clrTools'), ne(parameters.disableClrTest, true)) }}:
+    - ${{ if and(ne(parameters.testGroup, ''), ne(parameters.testGroup, 'clrTools'), ne(parameters.disableClrTest, true)) }}:
       # Publish test native components for consumption by test execution.
       - ${{ if and(ne(parameters.isOfficialBuild, true), eq(parameters.pgoType, '')) }}:
         - template: /eng/pipelines/common/upload-artifact-step.yml

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -232,7 +232,6 @@ jobs:
           isOfficialBuild: ${{ parameters.signBinaries }}
           timeoutInMinutes: 30
 
-    # clrTools unitests do not publish the build artifacts
     - ${{ if ne(parameters.disableClrTest, true) }}:
       # Publish product output directory for consumption by tests.
       - template: /eng/pipelines/common/upload-artifact-step.yml

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -343,7 +343,7 @@ extends:
           jobParameters:
             timeoutInMinutes: 120
             nameSuffix: CLR_Tools_Tests
-            buildArgs: -s clr.aot+libs+clr.toolstests -c $(_BuildConfig) -test
+            buildArgs: -s clr.aot+clr.iltools+libs+clr.toolstests -c $(_BuildConfig) -test
             enablePublishTestResults: true
             testResultsFormat: 'xunit'
             condition: >-

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -336,13 +336,16 @@ extends:
       # Build and test clr tools
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
           buildConfig: checked
           platforms:
           - linux_x64
           jobParameters:
-            testGroup: clrTools
             timeoutInMinutes: 120
+            nameSuffix: CLR_Tools_Tests
+            buildArgs: -s clr.aot+libs+clr.toolstests -c $(_BuildConfig) -test
+            enablePublishTestResults: true
+            testResultsFormat: 'xunit'
             condition: >-
               or(
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -97,12 +97,17 @@ extends:
       #
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
           buildConfig: checked
           platforms:
           - gcc_linux_x64
           jobParameters:
             testGroup: innerloop
+            nameSuffix: Native_GCC
+            buildArgs: -s clr.native+libs.native+mono+host.native -c $(_BuildConfig) -gcc
+            extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests.yml
+            extraStepsParameters:
+              testBuildArgs: skipmanaged skipgeneratelayout skiprestorepackages
             condition: >-
               or(
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -107,7 +107,7 @@ extends:
             buildArgs: -s clr.native+libs.native+mono+host.native -c $(_BuildConfig) -gcc
             extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests.yml
             extraStepsParameters:
-              testBuildArgs: skipmanaged skipgeneratelayout skiprestorepackages
+              testBuildArgs: skipmanaged skipgeneratelayout skiprestorepackages -gcc
             condition: >-
               or(
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),


### PR DESCRIPTION
Currently the GCC job and the CoreCLR Tools Unit Tests job both use the CoreCLR build job template. These two jobs function quite differently than the rest of the jobs that go through this template. This PR moves these two jobs to use the global-build-job template and removes the various separate paths in the CoreCLR build job template that were only for these two jobs.