### PR TITLE
Add natstepfilter to skip over object allocators

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/NativeAOT.natstepfilter
+++ b/src/coreclr/nativeaot/BuildIntegration/NativeAOT.natstepfilter
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StepFilter xmlns="http://schemas.microsoft.com/vstudio/debugger/natstepfilter/2010">
+    <Function>
+        <Name>RhpNewFast|RhpNewFinalizable|RhpNewFastAlign8|RhpNewFastMisalign|RhpNewFinalizableAlign8|RhpNewArray|RhpNewArrayAlign8</Name>
+        <Action>NoStepInto</Action>
+    </Function>
+</StepFilter>

--- a/src/coreclr/tools/aot/ILCompiler/reproNative/reproNative.vcxproj
+++ b/src/coreclr/tools/aot/ILCompiler/reproNative/reproNative.vcxproj
@@ -130,6 +130,7 @@
   </ItemGroup>
   <ItemGroup>
     <Natvis Include="$(NativeAotSourceRoot)\BuildIntegration\NativeAOT.natvis" />
+    <None Include="$(NativeAotSourceRoot)\BuildIntegration\NativeAOT.natstepfilter" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
VS 17.6 added support for natstepfilter in project files. Take advantage of it to skip over object allocators that we pretty much never want to step into.

Before:

![beforestep](https://github.com/dotnet/runtime/assets/13110571/08b4974b-e778-4a36-b663-48a15686a3da)


After:

![afterstep](https://github.com/dotnet/runtime/assets/13110571/4c5837b6-5f53-4386-9459-21cdabd43630)

I'm following up with some VS debugger people to see if there's any plans to allow embedding this in the PDB like natvis. Having this in the vcxproj helps the repro project, but doesn't help end user scenarios.

Cc @dotnet/ilc-contrib 