### PR TITLE
Add debugging attributes to System.Security.Claims types

### DIFF
--- a/src/libraries/System.Security.Claims/ref/System.Security.Claims.cs
+++ b/src/libraries/System.Security.Claims/ref/System.Security.Claims.cs
@@ -4,6 +4,8 @@
 // Changes to this file must follow the https://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
+using System.Diagnostics;
+
 namespace System.Security.Claims
 {
     public partial class Claim
@@ -31,6 +33,7 @@ namespace System.Security.Claims
         public virtual void WriteTo(System.IO.BinaryWriter writer) { }
         protected virtual void WriteTo(System.IO.BinaryWriter writer, byte[]? userData) { }
     }
+    [DebuggerDisplay("{DebuggerToString(),nq}")]
     public partial class ClaimsIdentity : System.Security.Principal.IIdentity
     {
         public const string DefaultIssuer = "LOCAL AUTHORITY";
@@ -41,11 +44,11 @@ namespace System.Security.Claims
         public ClaimsIdentity(System.Collections.Generic.IEnumerable<System.Security.Claims.Claim>? claims, string? authenticationType) { }
         public ClaimsIdentity(System.Collections.Generic.IEnumerable<System.Security.Claims.Claim>? claims, string? authenticationType, string? nameType, string? roleType) { }
         public ClaimsIdentity(System.IO.BinaryReader reader) { }
-        [System.ObsoleteAttribute("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId = "SYSLIB0051", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId="SYSLIB0051", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
         protected ClaimsIdentity(System.Runtime.Serialization.SerializationInfo info) { }
-        [System.ObsoleteAttribute("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId = "SYSLIB0051", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId="SYSLIB0051", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
         protected ClaimsIdentity(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         protected ClaimsIdentity(System.Security.Claims.ClaimsIdentity other) { }
         public ClaimsIdentity(System.Security.Principal.IIdentity? identity) { }
@@ -79,13 +82,14 @@ namespace System.Security.Claims
         public virtual void WriteTo(System.IO.BinaryWriter writer) { }
         protected virtual void WriteTo(System.IO.BinaryWriter writer, byte[]? userData) { }
     }
+    [DebuggerDisplay("{DebuggerToString(),nq}")]
     public partial class ClaimsPrincipal : System.Security.Principal.IPrincipal
     {
         public ClaimsPrincipal() { }
         public ClaimsPrincipal(System.Collections.Generic.IEnumerable<System.Security.Claims.ClaimsIdentity> identities) { }
         public ClaimsPrincipal(System.IO.BinaryReader reader) { }
-        [System.ObsoleteAttribute("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId = "SYSLIB0051", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId="SYSLIB0051", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
         protected ClaimsPrincipal(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public ClaimsPrincipal(System.Security.Principal.IIdentity identity) { }
         public ClaimsPrincipal(System.Security.Principal.IPrincipal principal) { }

--- a/src/libraries/System.Security.Claims/ref/System.Security.Claims.cs
+++ b/src/libraries/System.Security.Claims/ref/System.Security.Claims.cs
@@ -4,8 +4,6 @@
 // Changes to this file must follow the https://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-using System.Diagnostics;
-
 namespace System.Security.Claims
 {
     public partial class Claim
@@ -33,7 +31,6 @@ namespace System.Security.Claims
         public virtual void WriteTo(System.IO.BinaryWriter writer) { }
         protected virtual void WriteTo(System.IO.BinaryWriter writer, byte[]? userData) { }
     }
-    [DebuggerDisplay("{DebuggerToString(),nq}")]
     public partial class ClaimsIdentity : System.Security.Principal.IIdentity
     {
         public const string DefaultIssuer = "LOCAL AUTHORITY";
@@ -82,7 +79,6 @@ namespace System.Security.Claims
         public virtual void WriteTo(System.IO.BinaryWriter writer) { }
         protected virtual void WriteTo(System.IO.BinaryWriter writer, byte[]? userData) { }
     }
-    [DebuggerDisplay("{DebuggerToString(),nq}")]
     public partial class ClaimsPrincipal : System.Security.Principal.IPrincipal
     {
         public ClaimsPrincipal() { }

--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Security.Principal;
@@ -12,6 +13,7 @@ namespace System.Security.Claims
     /// <summary>
     /// An Identity that is represented by a set of claims.
     /// </summary>
+    [DebuggerDisplay("{DebuggerToString(),nq}")]
     public class ClaimsIdentity : IIdentity
     {
         private enum SerializationMask
@@ -932,6 +934,18 @@ namespace System.Security.Claims
         protected virtual void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             throw new PlatformNotSupportedException();
+        }
+
+        internal string DebuggerToString()
+        {
+            // DebuggerDisplayAttribute is inherited. Use virtual members instead of private fields to gather data.
+            int claimsCount = 0;
+            foreach (var item in Claims)
+            {
+                claimsCount++;
+            }
+
+            return $"Identity Name = {Name}, IsAuthenticated = {IsAuthenticated}, Claims Count = {claimsCount}";
         }
     }
 }

--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
@@ -945,7 +945,7 @@ namespace System.Security.Claims
                 claimsCount++;
             }
 
-            return $"Identity Name = {Name}, IsAuthenticated = {IsAuthenticated}, Claims Count = {claimsCount}";
+            return $"Identity Name = {Name ?? "(null)"}, IsAuthenticated = {IsAuthenticated}, Claims Count = {claimsCount}";
         }
     }
 }

--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
@@ -14,6 +14,7 @@ namespace System.Security.Claims
     /// An Identity that is represented by a set of claims.
     /// </summary>
     [DebuggerDisplay("{DebuggerToString(),nq}")]
+    [DebuggerTypeProxy(typeof(ClaimsIdentityDebugProxy))]
     public class ClaimsIdentity : IIdentity
     {
         private enum SerializationMask
@@ -946,6 +947,37 @@ namespace System.Security.Claims
             }
 
             return $"Identity Name = {Name ?? "(null)"}, IsAuthenticated = {IsAuthenticated}, Claims Count = {claimsCount}";
+        }
+
+        private sealed class ClaimsIdentityDebugProxy
+        {
+            private readonly ClaimsIdentity _identity;
+
+            public ClaimsIdentityDebugProxy(ClaimsIdentity identity)
+            {
+                _identity = identity;
+            }
+
+            public ClaimsIdentity? Actor => _identity.Actor;
+            public string? AuthenticationType => _identity.AuthenticationType;
+            public object? BootstrapContext => _identity.BootstrapContext;
+            public IEnumerable<Claim> Claims
+            {
+                get
+                {
+                    List<Claim> claims = new List<Claim>();
+                    foreach (var c in _identity.Claims)
+                    {
+                        claims.Add(c);
+                    }
+                    return claims;
+                }
+            }
+            public bool IsAuthenticated => _identity.IsAuthenticated;
+            public string? Label => _identity.Label;
+            public string? Name => _identity.Name;
+            public string NameClaimType => _identity.NameClaimType;
+            public string RoleClaimType => _identity.RoleClaimType;
         }
     }
 }

--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
@@ -941,7 +941,7 @@ namespace System.Security.Claims
         {
             // DebuggerDisplayAttribute is inherited. Use virtual members instead of private fields to gather data.
             int claimsCount = 0;
-            foreach (var item in Claims)
+            foreach (Claim item in Claims)
             {
                 claimsCount++;
             }
@@ -961,18 +961,7 @@ namespace System.Security.Claims
             public ClaimsIdentity? Actor => _identity.Actor;
             public string? AuthenticationType => _identity.AuthenticationType;
             public object? BootstrapContext => _identity.BootstrapContext;
-            public IEnumerable<Claim> Claims
-            {
-                get
-                {
-                    List<Claim> claims = new List<Claim>();
-                    foreach (var c in _identity.Claims)
-                    {
-                        claims.Add(c);
-                    }
-                    return claims;
-                }
-            }
+            public IEnumerable<Claim> Claims => new List<Claim>(_identity.Claims);
             public bool IsAuthenticated => _identity.IsAuthenticated;
             public string? Label => _identity.Label;
             public string? Name => _identity.Name;

--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
@@ -961,7 +961,8 @@ namespace System.Security.Claims
             public ClaimsIdentity? Actor => _identity.Actor;
             public string? AuthenticationType => _identity.AuthenticationType;
             public object? BootstrapContext => _identity.BootstrapContext;
-            public IEnumerable<Claim> Claims => new List<Claim>(_identity.Claims);
+            // List type has a friendly debugger view
+            public List<Claim> Claims => new List<Claim>(_identity.Claims);
             public bool IsAuthenticated => _identity.IsAuthenticated;
             public string? Label => _identity.Label;
             public string? Name => _identity.Name;

--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsPrincipal.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsPrincipal.cs
@@ -604,8 +604,9 @@ namespace System.Security.Claims
                 _principal = principal;
             }
 
-            public IEnumerable<Claim> Claims => new List<Claim>(_principal.Claims);
-            public IEnumerable<ClaimsIdentity> Identities => new List<ClaimsIdentity>(_principal.Identities);
+            // List type has a friendly debugger view
+            public List<Claim> Claims => new List<Claim>(_principal.Claims);
+            public List<ClaimsIdentity> Identities => new List<ClaimsIdentity>(_principal.Identities);
             public IIdentity? Identity => _principal.Identity;
         }
     }

--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsPrincipal.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsPrincipal.cs
@@ -571,17 +571,17 @@ namespace System.Security.Claims
             throw new PlatformNotSupportedException();
         }
 
-        internal string DebuggerToString()
+        private string DebuggerToString()
         {
             // DebuggerDisplayAttribute is inherited. Use virtual members instead of private fields to gather data.
             int identitiesCount = 0;
-            foreach (var items in Identities)
+            foreach (ClaimsIdentity items in Identities)
             {
                 identitiesCount++;
             }
 
             int claimsCount = 0;
-            foreach (var item in Claims)
+            foreach (Claim item in Claims)
             {
                 claimsCount++;
             }
@@ -604,32 +604,8 @@ namespace System.Security.Claims
                 _principal = principal;
             }
 
-            public IEnumerable<Claim> Claims
-            {
-                get
-                {
-                    List<Claim> claims = new List<Claim>();
-                    foreach (var c in _principal.Claims)
-                    {
-                        claims.Add(c);
-                    }
-                    return claims;
-                }
-            }
-
-            public IEnumerable<ClaimsIdentity> Identities
-            {
-                get
-                {
-                    List<ClaimsIdentity> identities = new List<ClaimsIdentity>();
-                    foreach (var i in _principal.Identities)
-                    {
-                        identities.Add(i);
-                    }
-                    return identities;
-                }
-            }
-
+            public IEnumerable<Claim> Claims => new List<Claim>(_principal.Claims);
+            public IEnumerable<ClaimsIdentity> Identities => new List<ClaimsIdentity>(_principal.Identities);
             public IIdentity? Identity => _principal.Identity;
         }
     }

--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsPrincipal.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsPrincipal.cs
@@ -588,7 +588,7 @@ namespace System.Security.Claims
             // Return debug string optimized for the case of one identity.
             if (identitiesCount == 1 && Identity is ClaimsIdentity claimsIdentity)
             {
-                return claimsIdentity.DebuggerToString();
+                return $"Principal {claimsIdentity.DebuggerToString()}";
             }
 
             return $"Principal Identities Count: {identitiesCount}, Claims Count: {claimsCount}";

--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsPrincipal.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsPrincipal.cs
@@ -15,6 +15,7 @@ namespace System.Security.Claims
     /// Concrete IPrincipal supporting multiple claims-based identities
     /// </summary>
     [DebuggerDisplay("{DebuggerToString(),nq}")]
+    [DebuggerTypeProxy(typeof(ClaimsPrincipalDebugProxy))]
     public class ClaimsPrincipal : IPrincipal
     {
         private enum SerializationMask
@@ -592,6 +593,44 @@ namespace System.Security.Claims
             }
 
             return $"Principal Identities Count: {identitiesCount}, Claims Count: {claimsCount}";
+        }
+
+        private sealed class ClaimsPrincipalDebugProxy
+        {
+            private readonly ClaimsPrincipal _principal;
+
+            public ClaimsPrincipalDebugProxy(ClaimsPrincipal principal)
+            {
+                _principal = principal;
+            }
+
+            public IEnumerable<Claim> Claims
+            {
+                get
+                {
+                    List<Claim> claims = new List<Claim>();
+                    foreach (var c in _principal.Claims)
+                    {
+                        claims.Add(c);
+                    }
+                    return claims;
+                }
+            }
+
+            public IEnumerable<ClaimsIdentity> Identities
+            {
+                get
+                {
+                    List<ClaimsIdentity> identities = new List<ClaimsIdentity>();
+                    foreach (var i in _principal.Identities)
+                    {
+                        identities.Add(i);
+                    }
+                    return identities;
+                }
+            }
+
+            public IIdentity? Identity => _principal.Identity;
         }
     }
 }

--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsPrincipal.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsPrincipal.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Security.Principal;
@@ -13,6 +14,7 @@ namespace System.Security.Claims
     /// <summary>
     /// Concrete IPrincipal supporting multiple claims-based identities
     /// </summary>
+    [DebuggerDisplay("{DebuggerToString(),nq}")]
     public class ClaimsPrincipal : IPrincipal
     {
         private enum SerializationMask
@@ -566,6 +568,30 @@ namespace System.Security.Claims
         protected virtual void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             throw new PlatformNotSupportedException();
+        }
+
+        internal string DebuggerToString()
+        {
+            // DebuggerDisplayAttribute is inherited. Use virtual members instead of private fields to gather data.
+            int identitiesCount = 0;
+            foreach (var items in Identities)
+            {
+                identitiesCount++;
+            }
+
+            int claimsCount = 0;
+            foreach (var item in Claims)
+            {
+                claimsCount++;
+            }
+
+            // Return debug string optimized for the case of one identity.
+            if (identitiesCount == 1 && Identity is ClaimsIdentity claimsIdentity)
+            {
+                return claimsIdentity.DebuggerToString();
+            }
+
+            return $"Principal Identities Count: {identitiesCount}, Claims Count: {claimsCount}";
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/86421

After changes:

![image](https://github.com/dotnet/runtime/assets/303201/5ad628c0-5d68-48ef-b434-f92b6bb8cdeb)

I have a question about `DebuggerDisplayAttribute` and ref assemblies. I added them to the implementation classes and ran the ref update command - `dotnet msbuild /t:GenerateReferenceAssemblySource` - but they weren't added to the reference file. I had to do it manually. What should I do here?

Extra work: It's worth adding debugger proxy views for `ClaimsPrincipal` and `ClaimsIdentity`. The proxy can remove the private/internal fields and display the counts from the claims collections. Proxies are more work so I'll hold off on that for now.

Thoughts so far?

**Update:**

With type proxies:

**ClaimsPrincipal:**

![image](https://github.com/dotnet/runtime/assets/303201/d54e9e6e-2ef6-4bdb-be9d-40e88b34a4ff)

**ClaimsIdentity:**

![image](https://github.com/dotnet/runtime/assets/303201/956972dc-c031-434e-89f9-9d785b001e56)
