### PR TITLE
Fix scanning synchronized methods

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -143,6 +143,16 @@ namespace Internal.IL
                 {
                     _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.MonitorEnterStatic), reason);
                     _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.MonitorExitStatic), reason);
+
+                    MethodDesc method = _methodIL.OwningMethod;
+                    if (method.OwningType.IsRuntimeDeterminedSubtype)
+                    {
+                        _dependencies.Add(GetGenericLookupHelper(ReadyToRunHelperId.NecessaryTypeHandle, method.OwningType), reason);
+                    }
+                    else
+                    {
+                        _dependencies.Add(_factory.NecessaryTypeSymbol(method.OwningType), reason);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
After #85810 we need to generate reflection metadata for owning types of static synchronized methods. Before that change, obtaining a RuntimeType for locking would obtain a reflection blocked type. We now need a named type and scanner must predict it.

Found in Pri0 testing.

Cc @dotnet/ilc-contrib 