### PR TITLE
Make merged test wrappers single file friendly

### DIFF
--- a/src/tests/Common/CoreCLRTestLibrary/OutOfProcessTest.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/OutOfProcessTest.cs
@@ -25,7 +25,7 @@ namespace TestLibrary
         static OutOfProcessTest()
         {
             reportBase = Directory.GetCurrentDirectory();
-            testBinaryBase = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+            testBinaryBase = AppContext.BaseDirectory;
             helixUploadRoot = Environment.GetEnvironmentVariable("HELIX_WORKITEM_UPLOAD_ROOT");
             if (!String.IsNullOrEmpty(helixUploadRoot))
             {
@@ -49,10 +49,10 @@ namespace TestLibrary
             && !OperatingSystem.IsBrowser()
             && !OperatingSystem.IsOSPlatform("Wasi");
 
-        public static void RunOutOfProcessTest(string basePath, string assemblyPath)
+        public static void RunOutOfProcessTest(string assemblyPath)
         {
             int ret = -100;
-            string baseDir = Path.GetDirectoryName(basePath);
+            string baseDir = AppContext.BaseDirectory;
             string outputDir = System.IO.Path.GetFullPath(Path.Combine(reportBase, Path.GetDirectoryName(assemblyPath)));
             string outputFile = Path.Combine(outputDir, "output.txt");
             string errorFile = Path.Combine(outputDir, "error.txt");

--- a/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
@@ -309,7 +309,7 @@ public sealed class OutOfProcessTest : ITestInfo
         ExecutionStatement.AppendLine("if (TestLibrary.OutOfProcessTest.OutOfProcessTestsSupported)");
         using (ExecutionStatement.NewBracesScope())
         {
-            ExecutionStatement.AppendLine($@"TestLibrary.OutOfProcessTest.RunOutOfProcessTest(typeof(Program).Assembly.Location, @""{relativeAssemblyPath}"");");
+            ExecutionStatement.AppendLine($@"TestLibrary.OutOfProcessTest.RunOutOfProcessTest(@""{relativeAssemblyPath}"");");
         }
     }
 


### PR DESCRIPTION
Assembly.Location returns an empty string in single file.

Cc @dotnet/ilc-contrib 