### PR TITLE
Stop using LocalizationResources within framework

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CustomAttributeBasedDependencyAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CustomAttributeBasedDependencyAlgorithm.cs
@@ -137,25 +137,6 @@ namespace ILCompiler.DependencyAnalysis
                         dependencies.AddRange(caDependencies);
                         dependencies.Add(factory.CustomAttributeMetadata(new ReflectableCustomAttribute(module, caHandle)), "Attribute metadata");
                     }
-
-                    // Works around https://github.com/dotnet/runtime/issues/81459
-                    if (constructor.OwningType is MetadataType { Name: "EventSourceAttribute" } eventSourceAttributeType)
-                    {
-                        foreach (var namedArg in decodedValue.NamedArguments)
-                        {
-                            if (namedArg.Name == "LocalizationResources" && namedArg.Value is string resName
-                                && InlineableStringsResourceNode.IsInlineableStringsResource(module, resName + ".resources"))
-                            {
-                                dependencies ??= new DependencyList();
-                                var accessorMethod = module.GetType(
-                                    InlineableStringsResourceNode.ResourceAccessorTypeNamespace,
-                                    InlineableStringsResourceNode.ResourceAccessorTypeName)
-                                    .GetMethod(InlineableStringsResourceNode.ResourceAccessorGetStringMethodName, null);
-                                dependencies.Add(factory.ReflectedMethod(accessorMethod), "EventSource used resource");
-                            }
-                        }
-                    }
-                    // End of workaround for https://github.com/dotnet/runtime/issues/81459
                 }
                 catch (TypeSystemException)
                 {

--- a/src/libraries/Common/src/System/Net/Security/NetEventSource.Security.Windows.cs
+++ b/src/libraries/Common/src/System/Net/Security/NetEventSource.Security.Windows.cs
@@ -60,7 +60,7 @@ namespace System.Net
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
             Justification = "parameter errorCode is an enum and is trimmer safe")]
-        [Event(OperationReturnedSomethingId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(OperationReturnedSomethingId, Keywords = Keywords.Default, Level = EventLevel.Informational, Message = "{0} returned {1}.")]
         public void OperationReturnedSomething(string operation, Interop.SECURITY_STATUS errorCode) =>
             WriteEvent(OperationReturnedSomethingId, operation, errorCode);
 

--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/CDSCollectionETWBCLProvider.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/CDSCollectionETWBCLProvider.cs
@@ -21,8 +21,6 @@ namespace System.Collections.Concurrent
     [EventSource(
         Name = "System.Collections.Concurrent.ConcurrentCollectionsEventSource",
         Guid = "35167F8E-49B2-4b96-AB86-435B59336B5E"
-        //TODO:Bug455853:Add support for reading localized string in the EventSource il2il transform
-        //,LocalizationResources = "mscorlib"
         )]
     internal sealed class CDSCollectionETWBCLProvider : EventSource
     {

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Utils/PLINQETWProvider.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Utils/PLINQETWProvider.cs
@@ -22,7 +22,6 @@ namespace System.Linq.Parallel
     [EventSource(
         Name = "System.Linq.Parallel.PlinqEventSource",
         Guid = "159eeeec-4a14-4418-a8fe-faabcd987887")]
-    /* LocalizationResources = "System.Linq")]*/
     internal sealed class PlinqEtwProvider : EventSource
     {
         /// <summary>

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/NetEventSource.WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/NetEventSource.WinHttpHandler.cs
@@ -5,6 +5,6 @@ using System.Diagnostics.Tracing;
 
 namespace System.Net
 {
-    [EventSource(Name = "Private.InternalDiagnostics.System.Net.Http.WinHttpHandler", LocalizationResources = "FxResources.System.Net.Http.WinHttpHandler.SR")]
+    [EventSource(Name = "Private.InternalDiagnostics.System.Net.Http.WinHttpHandler")]
     internal sealed partial class NetEventSource { }
 }

--- a/src/libraries/System.Net.Http/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Http/src/Resources/Strings.resx
@@ -423,9 +423,6 @@
   <data name="net_MethodNotImplementedException" xml:space="preserve">
     <value>This method is not implemented by this class.</value>
   </data>
-  <data name="event_OperationReturnedSomething" xml:space="preserve">
-    <value>{0} returned {1}.</value>
-  </data>
   <data name="net_log_operation_failed_with_error" xml:space="preserve">
     <value>{0} failed with error {1}.</value>
   </data>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/NetEventSource.Http.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/NetEventSource.Http.cs
@@ -7,7 +7,7 @@ using System.Diagnostics.Tracing;
 
 namespace System.Net
 {
-    [EventSource(Name = "Private.InternalDiagnostics.System.Net.Http", LocalizationResources = "FxResources.System.Net.Http.SR")]
+    [EventSource(Name = "Private.InternalDiagnostics.System.Net.Http")]
     internal sealed partial class NetEventSource
     {
         private const int UriBaseAddressId = NextAvailableEventId;

--- a/src/libraries/System.Net.HttpListener/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.HttpListener/src/Resources/Strings.resx
@@ -350,9 +350,6 @@
   <data name="net_MethodNotImplementedException" xml:space="preserve">
     <value>This method is not implemented by this class.</value>
   </data>
-  <data name="event_OperationReturnedSomething" xml:space="preserve">
-    <value>{0} returned {1}.</value>
-  </data>
   <data name="net_invalid_enum" xml:space="preserve">
     <value>The specified value is not valid in the '{0}' enumeration.</value>
   </data>

--- a/src/libraries/System.Net.HttpListener/src/System/Net/NetEventSource.HttpListener.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/NetEventSource.HttpListener.cs
@@ -5,6 +5,6 @@ using System.Diagnostics.Tracing;
 
 namespace System.Net
 {
-    [EventSource(Name = "Private.InternalDiagnostics.System.Net.HttpListener", LocalizationResources = "FxResources.System.Net.HttpListener.SR")]
+    [EventSource(Name = "Private.InternalDiagnostics.System.Net.HttpListener")]
     internal sealed partial class NetEventSource { }
 }

--- a/src/libraries/System.Net.Mail/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Mail/src/Resources/Strings.resx
@@ -70,9 +70,6 @@
   <data name="net_MethodNotImplementedException" xml:space="preserve">
     <value>This method is not implemented by this class.</value>
   </data>
-  <data name="event_OperationReturnedSomething" xml:space="preserve">
-    <value>{0} returned {1}.</value>
-  </data>
   <data name="net_context_buffer_too_small" xml:space="preserve">
     <value>Insufficient buffer space. Required: {0} Actual: {1}.</value>
   </data>

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/NetEventSource.Mail.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/NetEventSource.Mail.cs
@@ -7,6 +7,6 @@ using System.Runtime.CompilerServices;
 
 namespace System.Net
 {
-    [EventSource(Name = "Private.InternalDiagnostics.System.Net.Mail", LocalizationResources = "FxResources.System.Net.Mail.SR")]
+    [EventSource(Name = "Private.InternalDiagnostics.System.Net.Mail")]
     internal sealed partial class NetEventSource { }
 }

--- a/src/libraries/System.Net.Security/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Security/src/Resources/Strings.resx
@@ -299,9 +299,6 @@
   <data name="net_log_remote_cert_name_mismatch" xml:space="preserve">
     <value>Certificate name mismatch.</value>
   </data>
-  <data name="event_OperationReturnedSomething" xml:space="preserve">
-    <value>{0} returned {1}.</value>
-  </data>
   <data name="net_log_operation_failed_with_error" xml:space="preserve">
     <value>{0} failed with error {1}.</value>
   </data>

--- a/src/libraries/System.Net.Security/src/System/Net/Security/NetEventSource.Security.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/NetEventSource.Security.cs
@@ -11,7 +11,7 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace System.Net
 {
-    [EventSource(Name = "Private.InternalDiagnostics.System.Net.Security", LocalizationResources = "FxResources.System.Net.Security.SR")]
+    [EventSource(Name = "Private.InternalDiagnostics.System.Net.Security")]
     internal sealed partial class NetEventSource
     {
 #if WINDOWS

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/NetEventSource.Sockets.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/NetEventSource.Sockets.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 
 namespace System.Net
 {
-    [EventSource(Name = "Private.InternalDiagnostics.System.Net.Sockets", LocalizationResources = "FxResources.System.Net.Sockets.SR")]
+    [EventSource(Name = "Private.InternalDiagnostics.System.Net.Sockets")]
     internal sealed partial class NetEventSource
     {
         private const int AcceptedId = NextAvailableEventId;

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2042,21 +2042,6 @@
   <data name="CustomMarshaler_NullReturnForGetInstance" xml:space="preserve">
     <value>A call to GetInstance() for custom marshaler '{0}' returned null, which is not allowed.</value>
   </data>
-  <data name="event_TaskCompleted" xml:space="preserve">
-    <value>Task {2} completed.</value>
-  </data>
-  <data name="event_TaskScheduled" xml:space="preserve">
-    <value>Task {2} scheduled to TaskScheduler {0}.</value>
-  </data>
-  <data name="event_TaskStarted" xml:space="preserve">
-    <value>Task {2} executing.</value>
-  </data>
-  <data name="event_TaskWaitBegin" xml:space="preserve">
-    <value>Beginning wait ({3}) on Task {2}.</value>
-  </data>
-  <data name="event_TaskWaitEnd" xml:space="preserve">
-    <value>Ending wait on Task {2}.</value>
-  </data>
   <data name="EventSource_AbstractMustNotDeclareEventMethods" xml:space="preserve">
     <value>Abstract event source must not declare event methods ({0} with ID {1}).</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TplEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TplEventSource.cs
@@ -10,13 +10,7 @@ namespace System.Threading.Tasks
     /// <summary>Provides an event source for tracing TPL information.</summary>
     [EventSource(
         Name = "System.Threading.Tasks.TplEventSource",
-        Guid = "2e5dba47-a3d2-4d16-8ee0-6671ffdcd7b5",
-        LocalizationResources =
-#if CORECLR
-            "System.Private.CoreLib.Strings"
-#else
-            null
-#endif
+        Guid = "2e5dba47-a3d2-4d16-8ee0-6671ffdcd7b5"
         )]
     [EventSourceAutoGenerate]
     internal sealed partial class TplEventSource : EventSource
@@ -193,7 +187,8 @@ namespace System.Threading.Tasks
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
                    Justification = EventSourceSuppressMessage)]
         [Event(TASKSCHEDULED_ID, Task = Tasks.TaskScheduled, Version = 1, Opcode = EventOpcode.Send,
-         Level = EventLevel.Informational, Keywords = Keywords.TaskTransfer | Keywords.Tasks)]
+         Level = EventLevel.Informational, Keywords = Keywords.TaskTransfer | Keywords.Tasks,
+         Message = "Task {2} scheduled to TaskScheduler {0}.")]
         public void TaskScheduled(
             int OriginatingTaskSchedulerID, int OriginatingTaskID,  // PFX_COMMON_EVENT_HEADER
             int TaskID, int CreatingTaskID, int TaskCreationOptions, int appDomain = DefaultAppDomainID)
@@ -242,7 +237,8 @@ namespace System.Threading.Tasks
         /// <param name="OriginatingTaskID">The task ID.</param>
         /// <param name="TaskID">The task ID.</param>
         [Event(TASKSTARTED_ID,
-         Level = EventLevel.Informational, Keywords = Keywords.Tasks)]
+         Level = EventLevel.Informational, Keywords = Keywords.Tasks,
+         Message = "Task {2} executing.")]
         public void TaskStarted(
             int OriginatingTaskSchedulerID, int OriginatingTaskID,  // PFX_COMMON_EVENT_HEADER
             int TaskID)
@@ -263,7 +259,8 @@ namespace System.Threading.Tasks
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
                    Justification = EventSourceSuppressMessage)]
         [Event(TASKCOMPLETED_ID, Version = 1,
-         Level = EventLevel.Informational, Keywords = Keywords.TaskStops)]
+         Level = EventLevel.Informational, Keywords = Keywords.TaskStops,
+         Message = "Task {2} completed.")]
         public void TaskCompleted(
             int OriginatingTaskSchedulerID, int OriginatingTaskID,  // PFX_COMMON_EVENT_HEADER
             int TaskID, bool IsExceptional)
@@ -307,7 +304,8 @@ namespace System.Threading.Tasks
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
                    Justification = EventSourceSuppressMessage)]
         [Event(TASKWAITBEGIN_ID, Version = 3, Task = TplEventSource.Tasks.TaskWait, Opcode = EventOpcode.Send,
-         Level = EventLevel.Informational, Keywords = Keywords.TaskTransfer | Keywords.Tasks)]
+         Level = EventLevel.Informational, Keywords = Keywords.TaskTransfer | Keywords.Tasks,
+         Message = "Beginning wait ({3}) on Task {2}.")]
         public void TaskWaitBegin(
             int OriginatingTaskSchedulerID, int OriginatingTaskID,  // PFX_COMMON_EVENT_HEADER
             int TaskID, TaskWaitBehavior Behavior, int ContinueWithTaskID)
@@ -353,7 +351,8 @@ namespace System.Threading.Tasks
         /// <param name="OriginatingTaskID">The task ID.</param>
         /// <param name="TaskID">The task ID.</param>
         [Event(TASKWAITEND_ID,
-         Level = EventLevel.Verbose, Keywords = Keywords.Tasks)]
+         Level = EventLevel.Verbose, Keywords = Keywords.Tasks,
+         Message = "Ending wait on Task {2}.")]
         public void TaskWaitEnd(
             int OriginatingTaskSchedulerID, int OriginatingTaskID,  // PFX_COMMON_EVENT_HEADER
             int TaskID)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationEventSource.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationEventSource.cs
@@ -6,8 +6,7 @@ using System.Diagnostics.Tracing;
 namespace System.Xml.Serialization
 {
     [EventSource(
-        Name = "System.Xml.Serialzation.XmlSerialization",
-        LocalizationResources = "FxResources.System.Private.Xml.SR")]
+        Name = "System.Xml.Serialzation.XmlSerialization")]
     internal sealed class XmlSerializationEventSource : EventSource
     {
         internal static XmlSerializationEventSource Log = new XmlSerializationEventSource();

--- a/src/libraries/System.Threading.Tasks.Dataflow/src/Internal/DataflowEtwProvider.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/Internal/DataflowEtwProvider.cs
@@ -21,8 +21,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
     /// <summary>Provides an event source for tracing Dataflow information.</summary>
     [EventSource(
         Name = "System.Threading.Tasks.Dataflow.DataflowEventSource",
-        Guid = "16F53577-E41D-43D4-B47E-C17025BF4025",
-        LocalizationResources = "FxResources.System.Threading.Tasks.Dataflow.SR")]
+        Guid = "16F53577-E41D-43D4-B47E-C17025BF4025")]
     internal sealed class DataflowEtwProvider : EventSource
     {
         /// <summary>

--- a/src/libraries/System.Threading/src/System/Threading/CDSsyncETWBCLProvider.cs
+++ b/src/libraries/System.Threading/src/System/Threading/CDSsyncETWBCLProvider.cs
@@ -24,8 +24,6 @@ namespace System.Threading
     [EventSource(
         Name = "System.Threading.SynchronizationEventSource",
         Guid = "EC631D38-466B-4290-9306-834971BA0217"
-        //TODO:(TFS455853):Add support for reading localized string in the EventSource il2il transform
-        //,LocalizationResources = "mscorlib"
         )]
     internal sealed class CdsSyncEtwBCLProvider : EventSource
     {

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionsEtwProvider.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionsEtwProvider.cs
@@ -73,8 +73,7 @@ namespace System.Transactions
     /// <summary>Provides an event source for tracing Transactions information.</summary>
     [EventSource(
         Name = "System.Transactions.TransactionsEventSource",
-        Guid = "8ac2d80a-1f1a-431b-ace4-bff8824aef0b",
-        LocalizationResources = "FxResources.System.Transactions.Local.SR")]
+        Guid = "8ac2d80a-1f1a-431b-ace4-bff8824aef0b")]
     internal sealed class TransactionsEtwProvider : EventSource
     {
         /// <summary>


### PR DESCRIPTION
Fixes #81459.

I moved the messages to `EventAttribute.Message` which I believe should be equivalent, but I would appreciate if someone could double-check. I also removed all the now-unused resource strings. I believe they all need to be prefixed by one of well-known prefixes. I would appreciate if someone could double-check.

Cc @noahfalk @brianrob @eerhardt @dotnet/ilc-contrib 