### PR TITLE
[mono][interp] Fix alignment problems with calls and simd types in unoptimized methods

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -3641,53 +3641,6 @@ static long total_executed_opcodes;
 #define SET_TEMP_POINTER(value) (*((MonoObject **)context->stack_start) = value)
 #endif
 
-static MONO_NEVER_INLINE int
-interp_newobj_slow_unopt (InterpFrame *frame, InterpMethod *cmethod, const guint16* ip, MonoError *error)
-{
-	char *locals = (char*)frame->stack;
-	int return_offset = ip [1];
-	int start_param_offset = ip [2];
-	guint16 param_size = ip [4];
-	guint16 ret_size = ip [5];
-	gpointer this_ptr;
-
-	// Should only be called in unoptimized code. This opcode moves the params around
-	// to compensate for the lack of use of a proper offset allocator in unoptimized code.
-	gboolean is_vt = ret_size != 0;
-	if (!is_vt)
-		ret_size = MINT_STACK_SLOT_SIZE;
-
-	MonoClass *newobj_class = cmethod->method->klass;
-
-	int call_args_offset = ALIGN_TO (return_offset + ret_size, MINT_STACK_ALIGNMENT);
-	// We allocate space on the stack for return value and for this pointer, that is passed to ctor
-	if (param_size) {
-		int param_offset;
-		if (ip [6]) // Check if first arg is simd type, which requires realigning param area
-			param_offset = ALIGN_TO (call_args_offset + MINT_STACK_SLOT_SIZE, MINT_SIMD_ALIGNMENT);
-		else
-			param_offset = call_args_offset + MINT_STACK_SLOT_SIZE;
-		memmove (locals + param_offset, locals + start_param_offset, param_size);
-	}
-
-	if (is_vt) {
-		this_ptr = locals + return_offset;
-		memset (this_ptr, 0, ret_size);
-	} else {
-		// FIXME push/pop LMF
-		MonoVTable *vtable = mono_class_vtable_checked (newobj_class, error);
-		return_val_if_nok (error, -1);
-		mono_runtime_class_init_full (vtable, error);
-		return_val_if_nok (error, -1);
-
-		this_ptr = mono_object_new_checked (newobj_class, error);
-		return_val_if_nok (error, -1);
-		LOCAL_VAR (return_offset, gpointer) = this_ptr; // return value
-	}
-	LOCAL_VAR (call_args_offset, gpointer) = this_ptr;
-	return call_args_offset;
-}
-
 /*
  * Custom C implementations of the min/max operations for float and double.
  * We cannot directly use the C stdlib functions because their semantics do not match
@@ -5741,19 +5694,6 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			mono_interp_error_cleanup (error); // FIXME: do not swallow the error
 			EXCEPTION_CHECKPOINT;
 			ip += 4;
-			goto call;
-		}
-		MINT_IN_CASE(MINT_NEWOBJ_SLOW_UNOPT) {
-			cmethod = (InterpMethod*)frame->imethod->data_items [ip [3]];
-			int offset = interp_newobj_slow_unopt (frame, cmethod, ip, error);
-			if (offset == -1) {
-				MonoException *exc = interp_error_convert_to_exception (frame, error, ip);
-				g_assert (exc);
-				THROW_EX (exc, ip);
-			}
-			return_offset = 0; // unused, ctor has void return
-			call_args_offset = offset;
-			ip += 7;
 			goto call;
 		}
 

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -3987,13 +3987,13 @@ main_loop:
 			ip = frame->imethod->code;
 			MINT_IN_BREAK;
 		}
-		MINT_IN_CASE(MINT_CALL_ALIGN_STACK) {
-			int call_offset = ip [1];
-			int aligned_call_offset = call_offset + MINT_STACK_SLOT_SIZE;
-			int params_stack_size = ip [2];
+		MINT_IN_CASE(MINT_MOV_STACK_UNOPT) {
+			int src_offset = ip [1];
+			int dst_offset = src_offset + (gint16)ip [2];
+			int size = ip [3];
 
-			memmove (locals + aligned_call_offset, locals + call_offset, params_stack_size);
-			ip += 3;
+			memmove (locals + dst_offset, locals + src_offset, size);
+			ip += 4;
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_CALL_DELEGATE) {

--- a/src/mono/mono/mini/interp/mintops.def
+++ b/src/mono/mono/mini/interp/mintops.def
@@ -354,7 +354,6 @@ OPDEF(MINT_ENDFILTER, "endfilter", 2, 0, 1, MintOpNoArgs)
 
 OPDEF(MINT_MOV_STACK_UNOPT, "mov_stack_unopt", 4, 0, 0, MintOpTwoShorts)
 
-OPDEF(MINT_NEWOBJ_SLOW_UNOPT, "newobj_slow_unopt", 7, 1, 1, MintOpMethodToken)
 OPDEF(MINT_NEWOBJ_STRING_UNOPT, "newobj_string_unopt", 4, 1, 0, MintOpMethodToken)
 OPDEF(MINT_NEWOBJ_SLOW, "newobj_slow", 4, 1, 1, MintOpMethodToken)
 OPDEF(MINT_NEWOBJ_ARRAY, "newobj_array", 5, 1, 1, MintOpMethodToken)

--- a/src/mono/mono/mini/interp/mintops.def
+++ b/src/mono/mono/mini/interp/mintops.def
@@ -352,6 +352,8 @@ OPDEF(MINT_JMP, "jmp", 2, 0, 0, MintOpMethodToken)
 
 OPDEF(MINT_ENDFILTER, "endfilter", 2, 0, 1, MintOpNoArgs)
 
+OPDEF(MINT_MOV_STACK_UNOPT, "mov_stack_unopt", 4, 0, 0, MintOpTwoShorts)
+
 OPDEF(MINT_NEWOBJ_SLOW_UNOPT, "newobj_slow_unopt", 7, 1, 1, MintOpMethodToken)
 OPDEF(MINT_NEWOBJ_STRING_UNOPT, "newobj_string_unopt", 4, 1, 0, MintOpMethodToken)
 OPDEF(MINT_NEWOBJ_SLOW, "newobj_slow", 4, 1, 1, MintOpMethodToken)
@@ -680,8 +682,6 @@ OPDEF(MINT_GETCHR, "getchr", 4, 1, 2, MintOpNoArgs)
 OPDEF(MINT_STRLEN, "strlen", 3, 1, 1, MintOpNoArgs)
 OPDEF(MINT_ARRAY_RANK, "array_rank", 3, 1, 1, MintOpNoArgs)
 OPDEF(MINT_ARRAY_ELEMENT_SIZE, "array_element_size", 3, 1, 1, MintOpNoArgs)
-
-OPDEF(MINT_CALL_ALIGN_STACK, "call_align_stack", 3, 0, 0, MintOpTwoShorts)
 
 /* Calls */
 OPDEF(MINT_CALL, "call", 4, 1, 1, MintOpMethodToken)

--- a/src/mono/mono/mini/interp/transform.h
+++ b/src/mono/mono/mini/interp/transform.h
@@ -42,7 +42,7 @@ typedef struct
 	int local;
 	/* The offset from the execution stack start where this is stored. Used by the fast offset allocator */
 	int offset;
-	/* Saves how much stack this is using. It is a multiple of MINT_VT_ALIGNMENT */
+	/* Saves how much stack this is using. It is a multiple of MINT_STACK_SLOT_SIZE*/
 	int size;
 } StackInfo;
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_85920/Runtime_85920.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_85920/Runtime_85920.cs
@@ -1,0 +1,185 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+public static class Test
+{
+    public const uint val0 = 0x00112233;
+    public const uint val1 = 0x44556677;
+    public const uint val2 = 0x8899aabb;
+    public const uint val3 = 0xccddeeff;
+
+    public static void CheckVector(Vector128<uint> v)
+    {
+        if (v.GetElement(0) != val0)
+            Environment.Exit(1);
+        if (v.GetElement(1) != val1)
+            Environment.Exit(2);
+        if (v.GetElement(2) != val2)
+            Environment.Exit(3);
+        if (v.GetElement(3) != val3)
+            Environment.Exit(4);
+    }
+
+    public static void HoldInt<T>(int i1, T arg)
+    {
+        // In the caller method, keeps first arg on the stack before second arg is computed
+    }
+
+    public static Vector128<uint> GetVector()
+    {
+        return Vector128.Create(val0, val1, val2, val3);
+    }
+}
+
+public class Obj {
+    long field;
+
+    public Obj(Vector128<uint> v1)
+    {
+        Test.CheckVector(v1);
+        field = 0;
+    }
+
+    public Obj(int i1, Vector128<uint> v1)
+    {
+        Test.CheckVector(v1);
+        field = i1;
+    }
+
+    public Obj(int i1, int i2, Vector128<uint> v1)
+    {
+        Test.CheckVector(v1);
+        field = i1 + i2;
+    }
+
+    public static int Method1(Vector128<uint> v1)
+    {
+        Test.CheckVector(v1);
+        return 0;
+    }
+
+    public static int Method2(int i1, Vector128<uint> v1)
+    {
+        Test.CheckVector(v1);
+        return 0;
+    }
+
+    public static int Method3(int i1, int i2, Vector128<uint> v1)
+    {
+        Test.CheckVector(v1);
+        return 0;
+    }
+}
+
+public struct VT8
+{
+    long field;
+
+    public VT8(Vector128<uint> v1)
+    {
+        Test.CheckVector(v1);
+        field = 0;
+    }
+
+    public VT8(int i1, Vector128<uint> v1)
+    {
+        Test.CheckVector(v1);
+        field = i1;
+    }
+
+    public VT8(int i1, int i2, Vector128<uint> v1)
+    {
+        Test.CheckVector(v1);
+        field = i1 + i2;
+    }
+}
+
+public struct VT16
+{
+    long field1;
+    long field2;
+
+    public VT16(Vector128<uint> v1)
+    {
+        Test.CheckVector(v1);
+        field1 = 0;
+        field2 = 0;
+    }
+
+    public VT16(int i1, Vector128<uint> v1)
+    {
+        Test.CheckVector(v1);
+        field1 = i1;
+        field2 = 0;
+    }
+
+    public VT16(int i1, int i2, Vector128<uint> v1)
+    {
+        Test.CheckVector(v1);
+        field1 = i1;
+        field2 = i2;
+    }
+}
+
+public class Program 
+{
+    [Fact]
+    public static void TestCall ()
+    {
+        Vector128<uint> vec = Test.GetVector();
+        Obj.Method1(vec);
+        Obj.Method2(2, vec);
+        Obj.Method3(2, 3, vec);
+        Console.WriteLine("OK call empty stack");
+        Test.HoldInt(1, Obj.Method1(vec));
+        Test.HoldInt(1, Obj.Method2(2, vec));
+        Test.HoldInt(1, Obj.Method3(2, 3, vec));
+        Console.WriteLine("OK call nonempty stack");
+    }
+
+    [Fact]
+    public static void TestNewobj ()
+    {
+        Vector128<uint> vec = Test.GetVector();
+        Obj o = new Obj(vec);
+        o = new Obj(2, vec);
+        o = new Obj(2, 3, vec);
+        Console.WriteLine("OK newobj empty stack");
+        Test.HoldInt(1, new Obj(vec));
+        Test.HoldInt(1, new Obj(2, vec));
+        Test.HoldInt(1, new Obj(2, 3, vec));
+        Console.WriteLine("OK newobj nonempty stack");
+    }
+
+    [Fact]
+    public static void TestNewobjVT8 ()
+    {
+        Vector128<uint> vec = Test.GetVector();
+        VT8 vt = new VT8(vec);
+        vt = new VT8(2, vec);
+        vt = new VT8(2, 3, vec);
+        Console.WriteLine("OK newobj vt8 empty stack");
+        Test.HoldInt(1, new VT8(vec));
+        Test.HoldInt(1, new VT8(2, vec));
+        Test.HoldInt(1, new VT8(2, 3, vec));
+        Console.WriteLine("OK newobj vt8 nonempty stack");
+    }
+
+    [Fact]
+    public static void TestNewobjVT16 ()
+    {
+        Vector128<uint> vec = Test.GetVector();
+        VT16 vt = new VT16(vec);
+        vt = new VT16(2, vec);
+        vt = new VT16(2, 3, vec);
+        Console.WriteLine("OK newobj vt16 empty stack");
+        Test.HoldInt(1, new VT16(vec));
+        Test.HoldInt(1, new VT16(2, vec));
+        Test.HoldInt(1, new VT16(2, 3, vec));
+        Console.WriteLine("OK newobj vt16 nonempty stack");
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_85920/Runtime_85920.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_85920/Runtime_85920.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
In order to properly support v128 acceleration, all v128 vars have to be aligned to 16bytes. In order to support this, the frame stack must also be aligned to 16 bytes. In optimized code, we run an offset allocator pass, at the end of codegen. In unoptimized code we allocate these offsets on the fly, as we push the vars on the execution stack, and this can be tricky at times.

In unoptimized case, whenever we detect that a call is made, we need to ensure that the first argument is aligned. To achieve this we will insert a `MINT_MOV_STACK_UNOPT` which will move the whole param area before the call is actually made.  Each time we push a v128 on the stack, the offset of this var is automatically aligned. The problem that we can encounter is if we later detect that this value is part of a call args which have been moved to respect frame alignment. This means, that we will need to do a second alignment starting at the location of the first simd argument. The fact that we align by default when pushing v128 values on the stack means that once we realign the param area starting at the first v128 argument, any following v128 values would also be aligned.

In the case of newobj, we had a separate confusing opcode for unoptimized  code which was attempting to handle the alignment, with same issue. This PR refactors the code, so that we use the same newobj opcodes as with optimized code, and insert explicitly `MINT_MOV_STACK_UNOPT` opcodes to move the newobj params to the right location, in a similar fashion that we do with normal calls.