### PR TITLE
[wasm] Refactor name convention

### DIFF
--- a/src/mono/sample/wasm/browser-threads-minimal/main.js
+++ b/src/mono/sample/wasm/browser-threads-minimal/main.js
@@ -26,7 +26,7 @@ try {
     console.log ("smoke: running FetchBackground(blurst.txt)");
     let s = await exports.Sample.Test.FetchBackground("./blurst.txt");
     console.log ("smoke: FetchBackground(blurst.txt) done");
-    if (s !== "It was the best of times, it was the blurst of times.\n") {
+    if (!s.startsWith("It was the best of times, it was the blurst of times.")) {
         const msg = `Unexpected FetchBackground result ${s}`;
         document.getElementById("out").innerHTML = msg;
         throw new Error (msg);

--- a/src/mono/wasm/runtime/exports-linker.ts
+++ b/src/mono/wasm/runtime/exports-linker.ts
@@ -11,7 +11,7 @@ import { mono_interp_tier_prepare_jiterpreter } from "./jiterpreter";
 import { mono_interp_jit_wasm_entry_trampoline, mono_interp_record_interp_entry } from "./jiterpreter-interp-entry";
 import { mono_interp_jit_wasm_jit_call_trampoline, mono_interp_invoke_wasm_jit_call_trampoline, mono_interp_flush_jitcall_queue, mono_jiterp_do_jit_call_indirect } from "./jiterpreter-jit-call";
 import { mono_wasm_marshal_promise } from "./marshal-to-js";
-import { monoWasmEventLoopHasUnsettledInteropPromises } from "./pthreads/shared/eventloop";
+import { mono_wasm_eventloop_has_unsettled_interop_promises } from "./pthreads/shared/eventloop";
 import { mono_wasm_pthread_on_pthread_attached } from "./pthreads/worker";
 import { mono_set_timeout, schedule_background_exec } from "./scheduling";
 import { mono_wasm_asm_loaded } from "./startup";
@@ -35,7 +35,7 @@ const mono_wasm_threads_exports = !MonoWasmThreads ? undefined : {
     // mono-threads-wasm.c
     mono_wasm_pthread_on_pthread_attached,
     // threads.c
-    mono_wasm_eventloop_has_unsettled_interop_promises: monoWasmEventLoopHasUnsettledInteropPromises,
+    mono_wasm_eventloop_has_unsettled_interop_promises,
     // diagnostics_server.c
     mono_wasm_diagnostic_server_on_server_thread_created,
     mono_wasm_diagnostic_server_on_runtime_server_init,

--- a/src/mono/wasm/runtime/exports-linker.ts
+++ b/src/mono/wasm/runtime/exports-linker.ts
@@ -11,7 +11,7 @@ import { mono_interp_tier_prepare_jiterpreter } from "./jiterpreter";
 import { mono_interp_jit_wasm_entry_trampoline, mono_interp_record_interp_entry } from "./jiterpreter-interp-entry";
 import { mono_interp_jit_wasm_jit_call_trampoline, mono_interp_invoke_wasm_jit_call_trampoline, mono_interp_flush_jitcall_queue, mono_jiterp_do_jit_call_indirect } from "./jiterpreter-jit-call";
 import { mono_wasm_marshal_promise } from "./marshal-to-js";
-import { mono_wasm_eventloop_has_unsettled_interop_promises } from "./pthreads/shared/eventloop";
+import { monoWasmEventLoopHasUnsettledInteropPromises } from "./pthreads/shared/eventloop";
 import { mono_wasm_pthread_on_pthread_attached } from "./pthreads/worker";
 import { mono_set_timeout, schedule_background_exec } from "./scheduling";
 import { mono_wasm_asm_loaded } from "./startup";
@@ -35,7 +35,7 @@ const mono_wasm_threads_exports = !MonoWasmThreads ? undefined : {
     // mono-threads-wasm.c
     mono_wasm_pthread_on_pthread_attached,
     // threads.c
-    mono_wasm_eventloop_has_unsettled_interop_promises,
+    mono_wasm_eventloop_has_unsettled_interop_promises: monoWasmEventLoopHasUnsettledInteropPromises,
     // diagnostics_server.c
     mono_wasm_diagnostic_server_on_server_thread_created,
     mono_wasm_diagnostic_server_on_runtime_server_init,

--- a/src/mono/wasm/runtime/loader/worker.ts
+++ b/src/mono/wasm/runtime/loader/worker.ts
@@ -42,13 +42,13 @@ function onMonoConfigReceived(config: MonoConfigInternal): void {
 export function makePreloadMonoMessage<TPort>(port: TPort): any {
     return {
         [monoSymbol]: {
-            mono_cmd: WorkerMonoCommandType.preload,
+            monoCmd: WorkerMonoCommandType.preload,
             port
         }
     };
 }
 
 const enum WorkerMonoCommandType {
-    channel_created = "channel_created",
+    channelCreated = "channel_created",
     preload = "preload",
 }

--- a/src/mono/wasm/runtime/pthreads/browser/index.ts
+++ b/src/mono/wasm/runtime/pthreads/browser/index.ts
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { isMonoWorkerMessageChannelCreated, monoSymbol, makeMonoThreadMessageApplyMonoConfig, isMonoWorkerMessagePreload, MonoWorkerMessage } from "../shared";
-import { pthread_ptr } from "../shared/types";
+import { pthreadPtr } from "../shared/types";
 import { MonoThreadMessage } from "../shared";
 import Internals from "../shared/emscripten-internals";
 import { createPromiseController, runtimeHelpers } from "../../globals";
@@ -10,67 +10,67 @@ import { PromiseController } from "../../types/internal";
 import { MonoConfig } from "../../types";
 import { mono_log_debug } from "../../logging";
 
-const threads: Map<pthread_ptr, Thread> = new Map();
+const threads: Map<pthreadPtr, Thread> = new Map();
 
 export interface Thread {
-    readonly pthread_ptr: pthread_ptr;
+    readonly pthreadPtr: pthreadPtr;
     readonly worker: Worker;
     readonly port: MessagePort;
     postMessageToWorker<T extends MonoThreadMessage>(message: T): void;
 }
 
 class ThreadImpl implements Thread {
-    constructor(readonly pthread_ptr: pthread_ptr, readonly worker: Worker, readonly port: MessagePort) { }
+    constructor(readonly pthreadPtr: pthreadPtr, readonly worker: Worker, readonly port: MessagePort) { }
     postMessageToWorker<T extends MonoThreadMessage>(message: T): void {
         this.port.postMessage(message);
     }
 }
 
-const thread_promises: Map<pthread_ptr, PromiseController<Thread>[]> = new Map();
+const threadPromises: Map<pthreadPtr, PromiseController<Thread>[]> = new Map();
 
 /// wait until the thread with the given id has set up a message port to the runtime
-export function waitForThread(pthread_ptr: pthread_ptr): Promise<Thread> {
-    if (threads.has(pthread_ptr)) {
-        return Promise.resolve(threads.get(pthread_ptr)!);
+export function waitForThread(pthreadPtr: pthreadPtr): Promise<Thread> {
+    if (threads.has(pthreadPtr)) {
+        return Promise.resolve(threads.get(pthreadPtr)!);
     }
     const promiseAndController = createPromiseController<Thread>();
-    const arr = thread_promises.get(pthread_ptr);
+    const arr = threadPromises.get(pthreadPtr);
     if (arr === undefined) {
-        thread_promises.set(pthread_ptr, [promiseAndController.promise_control]);
+        threadPromises.set(pthreadPtr, [promiseAndController.promise_control]);
     } else {
         arr.push(promiseAndController.promise_control);
     }
     return promiseAndController.promise;
 }
 
-function resolvePromises(pthread_ptr: pthread_ptr, thread: Thread): void {
-    const arr = thread_promises.get(pthread_ptr);
+function resolvePromises(pthreadPtr: pthreadPtr, thread: Thread): void {
+    const arr = threadPromises.get(pthreadPtr);
     if (arr !== undefined) {
         arr.forEach((controller) => controller.resolve(thread));
-        thread_promises.delete(pthread_ptr);
+        threadPromises.delete(pthreadPtr);
     }
 }
 
-function addThread(pthread_ptr: pthread_ptr, worker: Worker, port: MessagePort): Thread {
-    const thread = new ThreadImpl(pthread_ptr, worker, port);
-    threads.set(pthread_ptr, thread);
+function addThread(pthreadPtr: pthreadPtr, worker: Worker, port: MessagePort): Thread {
+    const thread = new ThreadImpl(pthreadPtr, worker, port);
+    threads.set(pthreadPtr, thread);
     return thread;
 }
 
-function removeThread(pthread_ptr: pthread_ptr): void {
-    threads.delete(pthread_ptr);
+function removeThread(pthreadPtr: pthreadPtr): void {
+    threads.delete(pthreadPtr);
 }
 
 /// Given a thread id, return the thread object with the worker where the thread is running, and a message port.
-export function getThread(pthread_ptr: pthread_ptr): Thread | undefined {
-    const thread = threads.get(pthread_ptr);
+export function getThread(pthreadPtr: pthreadPtr): Thread | undefined {
+    const thread = threads.get(pthreadPtr);
     if (thread === undefined) {
         return undefined;
     }
-    // validate that the worker is still running pthread_ptr
+    // validate that the worker is still running pthreadPtr
     const worker = thread.worker;
-    if (Internals.getThreadId(worker) !== pthread_ptr) {
-        removeThread(pthread_ptr);
+    if (Internals.getThreadId(worker) !== pthreadPtr) {
+        removeThread(pthreadPtr);
         thread.port.close();
         return undefined;
     }
@@ -78,7 +78,7 @@ export function getThread(pthread_ptr: pthread_ptr): Thread | undefined {
 }
 
 /// Returns all the threads we know about
-export const getThreadIds = (): IterableIterator<pthread_ptr> => threads.keys();
+export const getThreadIds = (): IterableIterator<pthreadPtr> => threads.keys();
 
 function monoDedicatedChannelMessageFromWorkerToMain(event: MessageEvent<unknown>, thread: Thread): void {
     // TODO: add callbacks that will be called from here
@@ -96,11 +96,11 @@ function monoWorkerMessageHandler(worker: Worker, ev: MessageEvent<MonoWorkerMes
     else if (isMonoWorkerMessageChannelCreated(data)) {
         mono_log_debug("received the channel created message", data, worker);
         const port = data[monoSymbol].port;
-        const pthread_id = data[monoSymbol].thread_id;
-        const thread = addThread(pthread_id, worker, port);
+        const pthreadId = data[monoSymbol].threadId;
+        const thread = addThread(pthreadId, worker, port);
         port.addEventListener("message", (ev) => monoDedicatedChannelMessageFromWorkerToMain(ev, thread));
         port.start();
-        resolvePromises(pthread_id, thread);
+        resolvePromises(pthreadId, thread);
     }
 }
 

--- a/src/mono/wasm/runtime/pthreads/shared/emscripten-internals.ts
+++ b/src/mono/wasm/runtime/pthreads/shared/emscripten-internals.ts
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { Module } from "../../globals";
-import { pthread_ptr } from "./types";
+import { pthreadPtr } from "./types";
 
 /** @module emscripten-internals accessors to the functions in the emscripten PThreads library, including
- * the low-level representations of {@linkcode pthread_ptr} thread info structs, etc.
+ * the low-level representations of {@linkcode pthreadPtr} thread info structs, etc.
  * Additionally, note that some of these functions are replaced by {@linkcode file://./emscripten-replacements.ts}.
  * These have a hard dependency on the version of Emscripten that we are using and may need to be kept in sync with
  *    {@linkcode file://./../../../emsdk/upstream/emscripten/src/library_pthread.js}
@@ -20,7 +20,7 @@ interface PThreadLibrary {
 }
 
 interface EmscriptenPThreadInfo {
-    threadInfoStruct: pthread_ptr;
+    threadInfoStruct: pthreadPtr;
 }
 
 /// N.B. emscripten deletes the `pthread` property from the worker when it is not actively running a pthread
@@ -33,7 +33,7 @@ interface PThreadObject {
 }
 
 interface PThreadInfoMap {
-    [key: pthread_ptr]: PThreadObject | undefined;
+    [key: pthreadPtr]: PThreadObject | undefined;
 }
 
 
@@ -46,11 +46,11 @@ const Internals = {
     get modulePThread(): PThreadLibrary {
         return (<any>Module).PThread as PThreadLibrary;
     },
-    getWorker: (pthread_ptr: pthread_ptr): PThreadWorker | undefined => {
+    getWorker: (pthreadPtr: pthreadPtr): PThreadWorker | undefined => {
         // see https://github.com/emscripten-core/emscripten/pull/16239
-        return Internals.modulePThread.pthreads[pthread_ptr]?.worker;
+        return Internals.modulePThread.pthreads[pthreadPtr]?.worker;
     },
-    getThreadId: (worker: Worker): pthread_ptr | undefined => {
+    getThreadId: (worker: Worker): pthreadPtr | undefined => {
         /// See library_pthread.js in Emscripten.
         /// They hang a "pthread" object from the worker if the worker is running a thread, and remove it when the thread stops by doing `pthread_exit` or when it's joined using `pthread_join`.
         if (!isRunningPThreadWorker(worker))

--- a/src/mono/wasm/runtime/pthreads/shared/eventloop.ts
+++ b/src/mono/wasm/runtime/pthreads/shared/eventloop.ts
@@ -2,18 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
-let _per_thread_unsettled_promise_count = 0;
+let perThreadUnsettledPromiseCount = 0;
 
 export function addUnsettledPromise() {
-    _per_thread_unsettled_promise_count++;
+    perThreadUnsettledPromiseCount++;
 }
 
 export function settleUnsettledPromise() {
-    _per_thread_unsettled_promise_count--;
+    perThreadUnsettledPromiseCount--;
 }
 
 /// Called from the C# threadpool worker loop to find out if there are any
 /// unsettled JS promises that need to keep the worker alive
-export function mono_wasm_eventloop_has_unsettled_interop_promises(): boolean {
-    return _per_thread_unsettled_promise_count > 0;
+export function monoWasmEventLoopHasUnsettledInteropPromises(): boolean {
+    return perThreadUnsettledPromiseCount > 0;
 }

--- a/src/mono/wasm/runtime/pthreads/shared/eventloop.ts
+++ b/src/mono/wasm/runtime/pthreads/shared/eventloop.ts
@@ -14,6 +14,6 @@ export function settleUnsettledPromise() {
 
 /// Called from the C# threadpool worker loop to find out if there are any
 /// unsettled JS promises that need to keep the worker alive
-export function monoWasmEventLoopHasUnsettledInteropPromises(): boolean {
+export function mono_wasm_eventloop_has_unsettled_interop_promises(): boolean {
     return perThreadUnsettledPromiseCount > 0;
 }

--- a/src/mono/wasm/runtime/pthreads/shared/index.ts
+++ b/src/mono/wasm/runtime/pthreads/shared/index.ts
@@ -3,30 +3,30 @@
 
 import { Module } from "../../globals";
 import { MonoConfig } from "../../types";
-import { pthread_ptr } from "./types";
+import { pthreadPtr } from "./types";
 
 export interface PThreadInfo {
-    readonly pthread_id: pthread_ptr;
+    readonly pthreadId: pthreadPtr;
     readonly isBrowserThread: boolean;
 }
 
 export const MainThread: PThreadInfo = {
-    get pthread_id(): pthread_ptr {
+    get pthreadId(): pthreadPtr {
         return getBrowserThreadID();
     },
     isBrowserThread: true
 };
 
-let browser_thread_id_lazy: pthread_ptr | undefined;
-export function getBrowserThreadID(): pthread_ptr {
-    if (browser_thread_id_lazy === undefined) {
-        browser_thread_id_lazy = (<any>Module)["_emscripten_main_runtime_thread_id"]() as pthread_ptr;
+let browserThreadIdLazy: pthreadPtr | undefined;
+export function getBrowserThreadID(): pthreadPtr {
+    if (browserThreadIdLazy === undefined) {
+        browserThreadIdLazy = (<any>Module)["_emscripten_main_runtime_thread_id"]() as pthreadPtr;
     }
-    return browser_thread_id_lazy;
+    return browserThreadIdLazy;
 }
 
 const enum WorkerMonoCommandType {
-    channel_created = "channel_created",
+    channelCreated = "channel_created",
     preload = "preload",
 }
 
@@ -74,7 +74,7 @@ export const monoSymbol = "__mono_message_please_dont_collide__"; //Symbol("mono
 /// We should just use this to establish a dedicated MessagePort for Mono's uses.
 export interface MonoWorkerMessage<TPort> {
     [monoSymbol]: {
-        mono_cmd: WorkerMonoCommandType;
+        monoCmd: WorkerMonoCommandType;
         port: TPort;
     };
 }
@@ -82,24 +82,24 @@ export interface MonoWorkerMessage<TPort> {
 /// The message sent early during pthread creation to set up a dedicated MessagePort for Mono between the main thread and the pthread.
 export interface MonoWorkerMessageChannelCreated<TPort> extends MonoWorkerMessage<TPort> {
     [monoSymbol]: {
-        mono_cmd: WorkerMonoCommandType.channel_created;
-        thread_id: pthread_ptr;
+        monoCmd: WorkerMonoCommandType.channelCreated;
+        threadId: pthreadPtr;
         port: TPort;
     };
 }
 
 export interface MonoWorkerMessagePreload<TPort> extends MonoWorkerMessage<TPort> {
     [monoSymbol]: {
-        mono_cmd: WorkerMonoCommandType.preload;
+        monoCmd: WorkerMonoCommandType.preload;
         port: TPort;
     };
 }
 
-export function makeChannelCreatedMonoMessage<TPort>(thread_id: pthread_ptr, port: TPort): MonoWorkerMessageChannelCreated<TPort> {
+export function makeChannelCreatedMonoMessage<TPort>(threadId: pthreadPtr, port: TPort): MonoWorkerMessageChannelCreated<TPort> {
     return {
         [monoSymbol]: {
-            mono_cmd: WorkerMonoCommandType.channel_created,
-            thread_id,
+            monoCmd: WorkerMonoCommandType.channelCreated,
+            threadId: threadId,
             port
         }
     };
@@ -112,7 +112,7 @@ export function isMonoWorkerMessage(message: unknown): message is MonoWorkerMess
 export function isMonoWorkerMessageChannelCreated<TPort>(message: MonoWorkerMessage<TPort>): message is MonoWorkerMessageChannelCreated<TPort> {
     if (isMonoWorkerMessage(message)) {
         const monoMessage = message[monoSymbol];
-        if (monoMessage.mono_cmd === WorkerMonoCommandType.channel_created) {
+        if (monoMessage.monoCmd === WorkerMonoCommandType.channelCreated) {
             return true;
         }
     }
@@ -122,7 +122,7 @@ export function isMonoWorkerMessageChannelCreated<TPort>(message: MonoWorkerMess
 export function isMonoWorkerMessagePreload<TPort>(message: MonoWorkerMessage<TPort>): message is MonoWorkerMessagePreload<TPort> {
     if (isMonoWorkerMessage(message)) {
         const monoMessage = message[monoSymbol];
-        if (monoMessage.mono_cmd === WorkerMonoCommandType.preload) {
+        if (monoMessage.monoCmd === WorkerMonoCommandType.preload) {
             return true;
         }
     }

--- a/src/mono/wasm/runtime/pthreads/shared/types.ts
+++ b/src/mono/wasm/runtime/pthreads/shared/types.ts
@@ -2,4 +2,4 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 /// pthread_t in C
-export type pthread_ptr = number;
+export type pthreadPtr = number;

--- a/src/mono/wasm/runtime/pthreads/worker/events.ts
+++ b/src/mono/wasm/runtime/pthreads/worker/events.ts
@@ -2,12 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import MonoWasmThreads from "consts:monoWasmThreads";
-import type { pthread_ptr } from "../shared/types";
+import type { pthreadPtr } from "../shared/types";
 import type { PThreadInfo, MonoThreadMessage } from "../shared";
 
 /// Identification of the current thread executing on a worker
 export interface PThreadSelf extends PThreadInfo {
-    readonly pthread_id: pthread_ptr;
+    readonly pthreadId: pthreadPtr;
     readonly portToBrowser: MessagePort;
     readonly isBrowserThread: boolean;
     postMessageToBrowser: <T extends MonoThreadMessage>(message: T, transfer?: Transferable[]) => void;

--- a/src/mono/wasm/runtime/pthreads/worker/index.ts
+++ b/src/mono/wasm/runtime/pthreads/worker/index.ts
@@ -6,7 +6,7 @@
 import MonoWasmThreads from "consts:monoWasmThreads";
 import { Module, ENVIRONMENT_IS_PTHREAD } from "../../globals";
 import { makeChannelCreatedMonoMessage } from "../shared";
-import type { pthread_ptr } from "../shared/types";
+import type { pthreadPtr } from "../shared/types";
 import { is_nullish } from "../../types/internal";
 import type { MonoThreadMessage } from "../shared";
 import {
@@ -30,7 +30,7 @@ export {
 
 class WorkerSelf implements PThreadSelf {
     readonly isBrowserThread = false;
-    constructor(readonly pthread_id: pthread_ptr, readonly portToBrowser: MessagePort) { }
+    constructor(readonly pthreadId: pthreadPtr, readonly portToBrowser: MessagePort) { }
     postMessageToBrowser(message: MonoThreadMessage, transfer?: Transferable[]) {
         if (transfer) {
             this.portToBrowser.postMessage(message, transfer);
@@ -64,7 +64,7 @@ function monoDedicatedChannelMessageFromMainToWorker(event: MessageEvent<string>
 }
 
 
-function setupChannelToMainThread(pthread_ptr: pthread_ptr): PThreadSelf {
+function setupChannelToMainThread(pthread_ptr: pthreadPtr): PThreadSelf {
     mono_log_debug("creating a channel", pthread_ptr);
     const channel = new MessageChannel();
     const workerPort = channel.port1;
@@ -79,9 +79,9 @@ function setupChannelToMainThread(pthread_ptr: pthread_ptr): PThreadSelf {
 
 /// This is an implementation detail function.
 /// Called in the worker thread from mono when a pthread becomes attached to the mono runtime.
-export function mono_wasm_pthread_on_pthread_attached(pthread_id: pthread_ptr): void {
+export function mono_wasm_pthread_on_pthread_attached(pthread_id: pthreadPtr): void {
     const self = pthread_self;
-    mono_assert(self !== null && self.pthread_id == pthread_id, "expected pthread_self to be set already when attaching");
+    mono_assert(self !== null && self.pthreadId == pthread_id, "expected pthread_self to be set already when attaching");
     mono_log_debug("attaching pthread to runtime 0x" + pthread_id.toString(16));
     preRunWorker();
     currentWorkerThreadEvents.dispatchEvent(makeWorkerThreadEvent(dotnetPthreadAttached, self));

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -645,7 +645,7 @@ export function mono_wasm_set_main_args(name: string, allRuntimeArguments: strin
 export async function configureWorkerStartup(module: DotnetModuleInternal): Promise<void> {
     // This is a good place for subsystems to attach listeners for pthreads_worker.currentWorkerThreadEvents
     pthreads_worker.currentWorkerThreadEvents.addEventListener(pthreads_worker.dotnetPthreadCreated, (ev) => {
-        mono_log_debug("pthread created 0x" + ev.pthread_self.pthread_id.toString(16));
+        mono_log_debug("pthread created 0x" + ev.pthread_self.pthreadId.toString(16));
     });
 
     // these are the only events which are called on worker


### PR DESCRIPTION
First batch of TS refactoring. It is restricted to files connected with threading.
- Some names e.g. `mono_log_debug` used in threading are widely used in other locations so were left temporarily unchanged
- Functions exported to C will ~~be translated from one convention to the other, see: `monoWasmEventLoopHasUnsettledInteropPromises`. Is it a good approach?~~ will keep their C-style names for consistency.