### PR TITLE
Remove call to morph on hoisted trees

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -6511,11 +6511,6 @@ void Compiler::optPerformHoistExpr(GenTree* origExpr, BasicBlock* exprBb, unsign
 
     BasicBlock* preHead = optLoopTable[lnum].lpHead;
 
-    // fgMorphTree requires that compCurBB be the block that contains
-    // (or in this case, will contain) the expression.
-    compCurBB = preHead;
-    hoist     = fgMorphTree(hoist);
-
     // Scan the tree for any new SSA uses.
     //
     optRecordSsaUses(hoist, preHead);


### PR DESCRIPTION
It is unnecessary (this causes no diffs). And theoretically if it did cause diffs, the morphed tree would then not match the tree being hoisted, meaning CSE wouldn't "find" it and consider it a CSE.