### PR TITLE
[release/7.0] Ensure that the shuffle zero mask copies all bits

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -21830,13 +21830,11 @@ GenTree* Compiler::gtNewSimdShuffleNode(var_types   type,
 
     if (needsZero)
     {
-        assert(!compIsaSupportedDebugOnly(InstructionSet_SSSE3));
+        assert((simdSize == 32) || !compIsaSupportedDebugOnly(InstructionSet_SSSE3));
 
         op2                          = gtNewVconNode(type, simdBaseJitType);
-        op2->AsVecCon()->gtSimd16Val = mskCns.v128[0];
-
-        GenTree* zero = gtNewZeroConNode(type, simdBaseJitType);
-        retNode       = gtNewSimdCndSelNode(type, op2, retNode, zero, simdBaseJitType, simdSize, isSimdAsHWIntrinsic);
+        op2->AsVecCon()->gtSimd32Val = mskCns;
+        retNode = gtNewSimdBinOpNode(GT_AND, type, op2, retNode, simdBaseJitType, simdSize, isSimdAsHWIntrinsic);
     }
 
     return retNode;

--- a/src/tests/JIT/Regression/JitBlue/GitHub_85129/GitHub_85129.cs
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_85129/GitHub_85129.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+public class Program
+{
+    [Fact]
+    public static int TestEntryPoint()
+    {
+
+        Vector256<int> v256Shuffle = Vector256.Create(100, 101, 102, 103, 104, 105, 106, 107);
+        Vector256<int> v256ShuffleExpectedResult = Vector256.Create(107, 105, 0, 101, 106, 104, 0, 100);
+        Vector256<int> v256ShuffleActualResult = Vector256Shuffle(v256Shuffle);
+        if(v256ShuffleExpectedResult != v256ShuffleActualResult)
+        {
+            return 1;
+        }
+
+        Vector512<int> v512Shuffle = Vector512.Create(100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115);
+        Vector512<int> v512ShuffleExpectedResult = Vector512.Create(115, 113, 111, 0, 107, 105, 103, 101, 114, 112, 110, 108, 0, 104, 102, 100);
+        Vector512<int> v512ShuffleActualResult = Vector512Shuffle(v512Shuffle);
+        if (v512ShuffleExpectedResult != v512ShuffleActualResult)
+        {
+            return 1;
+        }
+        return 100;
+    }
+
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static Vector256<int> Vector256Shuffle(Vector256<int> v1)
+    {
+        return Vector256.Shuffle(v1, Vector256.Create(7, 5, 132, 1, 6, 4, -3, 0));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static  Vector512<int> Vector512Shuffle(Vector512<int> v1)
+    {
+        return Vector512.Shuffle(v1, Vector512.Create(15, 13, 11, 99, 7, 5, 3, 1, 14, 12, 10, 8, -11, 4, 2, 0));
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/GitHub_85129/GitHub_85129.cs
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_85129/GitHub_85129.cs
@@ -13,7 +13,6 @@ public class Program
     [Fact]
     public static int TestEntryPoint()
     {
-
         Vector256<int> v256Shuffle = Vector256.Create(100, 101, 102, 103, 104, 105, 106, 107);
         Vector256<int> v256ShuffleExpectedResult = Vector256.Create(107, 105, 0, 101, 106, 104, 0, 100);
         Vector256<int> v256ShuffleActualResult = Vector256Shuffle(v256Shuffle);
@@ -22,13 +21,6 @@ public class Program
             return 1;
         }
 
-        Vector512<int> v512Shuffle = Vector512.Create(100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115);
-        Vector512<int> v512ShuffleExpectedResult = Vector512.Create(115, 113, 111, 0, 107, 105, 103, 101, 114, 112, 110, 108, 0, 104, 102, 100);
-        Vector512<int> v512ShuffleActualResult = Vector512Shuffle(v512Shuffle);
-        if (v512ShuffleExpectedResult != v512ShuffleActualResult)
-        {
-            return 1;
-        }
         return 100;
     }
 
@@ -38,10 +30,3 @@ public class Program
     {
         return Vector256.Shuffle(v1, Vector256.Create(7, 5, 132, 1, 6, 4, -3, 0));
     }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    public static  Vector512<int> Vector512Shuffle(Vector512<int> v1)
-    {
-        return Vector512.Shuffle(v1, Vector512.Create(15, 13, 11, 99, 7, 5, 3, 1, 14, 12, 10, 8, -11, 4, 2, 0));
-    }
-}

--- a/src/tests/JIT/Regression/JitBlue/GitHub_85129/GitHub_85129.cs
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_85129/GitHub_85129.cs
@@ -8,10 +8,9 @@ using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using Xunit;
 
-public class Program
+public class Program_85129
 {
-    [Fact]
-    public static int TestEntryPoint()
+    public static int Main()
     {
         Vector256<int> v256Shuffle = Vector256.Create(100, 101, 102, 103, 104, 105, 106, 107);
         Vector256<int> v256ShuffleExpectedResult = Vector256.Create(107, 105, 0, 101, 106, 104, 0, 100);

--- a/src/tests/JIT/Regression/JitBlue/GitHub_85129/GitHub_85129.cs
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_85129/GitHub_85129.cs
@@ -30,3 +30,4 @@ public class Program
     {
         return Vector256.Shuffle(v1, Vector256.Create(7, 5, 132, 1, 6, 4, -3, 0));
     }
+}

--- a/src/tests/JIT/Regression/JitBlue/GitHub_85129/GitHub_85129.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_85129/GitHub_85129.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType>None</DebugType>
-    <Optimize>True</Optimize>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/JitBlue/GitHub_85129/GitHub_85129.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_85129/GitHub_85129.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Backport of a fix from https://github.com/dotnet/runtime/pull/85129 to release/7.0

/cc @dotnet/area-system-runtime-intrinsics 

### Customer Impact

Customers expecting elements in the upper 128-bits of a `Vector256<T>` to be zero'd by the shuffle will not see the correct behavior and may end up with non-zero result for the corresponding element.

### Testing

A unit test covering the faulty behavior was added to validate the fix.

### Risk

Low. The bug was for a new API introduced in .NET 7 and is covering a specific edge case scenario where the mask was only copying the lower 128-bits. We've had the fix in .NET for several previews now with no issues.

This resolves #85132