### PR TITLE
FileConfigurationProvider.Dispose should dispose FileProvider when it owns it

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationExtensions.cs
@@ -29,6 +29,9 @@ namespace Microsoft.Extensions.Configuration
             return builder;
         }
 
+        internal static IFileProvider? GetUserDefinedFileProvider(this IConfigurationBuilder builder)
+            => builder.Properties.TryGetValue(FileProviderKey, out object? provider) ? (IFileProvider)provider : null;
+
         /// <summary>
         /// Gets the default <see cref="IFileProvider"/> to be used for file-based providers.
         /// </summary>
@@ -38,12 +41,7 @@ namespace Microsoft.Extensions.Configuration
         {
             ThrowHelper.ThrowIfNull(builder);
 
-            if (builder.Properties.TryGetValue(FileProviderKey, out object? provider))
-            {
-                return (IFileProvider)provider;
-            }
-
-            return new PhysicalFileProvider(AppContext.BaseDirectory ?? string.Empty);
+            return GetUserDefinedFileProvider(builder) ?? new PhysicalFileProvider(AppContext.BaseDirectory ?? string.Empty);
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -162,6 +162,11 @@ namespace Microsoft.Extensions.Configuration
         protected virtual void Dispose(bool disposing)
         {
             _changeTokenRegistration?.Dispose();
+
+            if (Source.OwnsFileProvider)
+            {
+                (Source.FileProvider as IDisposable)?.Dispose();
+            }
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationSource.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationSource.cs
@@ -19,6 +19,11 @@ namespace Microsoft.Extensions.Configuration
         public IFileProvider? FileProvider { get; set; }
 
         /// <summary>
+        /// Set to true when <see cref="FileProvider"/> was not provided by user and can be safely disposed.
+        /// </summary>
+        internal bool OwnsFileProvider { get; private set; }
+
+        /// <summary>
         /// The path to the file.
         /// </summary>
         [DisallowNull]
@@ -58,6 +63,11 @@ namespace Microsoft.Extensions.Configuration
         /// <param name="builder">The <see cref="IConfigurationBuilder"/>.</param>
         public void EnsureDefaults(IConfigurationBuilder builder)
         {
+            if (FileProvider is null && builder.GetUserDefinedFileProvider() is null)
+            {
+                OwnsFileProvider = true;
+            }
+
             FileProvider ??= builder.GetFileProvider();
             OnLoadException ??= builder.GetFileLoadExceptionHandler();
         }
@@ -81,6 +91,7 @@ namespace Microsoft.Extensions.Configuration
                 }
                 if (Directory.Exists(directory))
                 {
+                    OwnsFileProvider = true;
                     FileProvider = new PhysicalFileProvider(directory);
                     Path = pathToFile;
                 }


### PR DESCRIPTION
The app that I've used for leak detection and confirmation of the fix:

<details>

```xml
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>net7.0</TargetFramework>
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>enable</Nullable>
  </PropertyGroup>
  <ItemGroup>
    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="7.0.0" />
  </ItemGroup>
  <ItemGroup>
    <None Update="settings.xml">
      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
    </None>
  </ItemGroup>
</Project>
```

```xml
<?xml version="1.0" encoding="utf-8" ?>
<configuration>
	<MySettings>
		<SomeSetting>Test</SomeSetting>
		<Another>true</Another>
	</MySettings>
</configuration>
```

```cs
using Microsoft.Extensions.Configuration;

namespace ConfigLeak
{
    internal class Program
    {
        static void Main()
        {
            const int iterations = 2;

            Console.WriteLine("Press a key");
            Console.ReadKey();

            for (var i = 0; i < iterations; i++)
            {
                Test();

                Console.WriteLine("Take a snapshot and press a key");
                Console.ReadKey();
            }
        }

        static void Test()
        {
            var config = new ConfigurationBuilder().AddXmlFile("settings.xml", false, true).Build();

            (config as IDisposable)?.Dispose();
        }
    }
}
```

</details>

Before:

![image](https://github.com/dotnet/runtime/assets/6011991/efe90f38-7789-46a5-b4f9-7758e3a9e8c6)

After:

![image](https://github.com/dotnet/runtime/assets/6011991/48f3f28c-2f00-4756-8f47-5d09344a0d12)

The only tricky thing is that the `FileProvider` can be also provided by the user, so we can not just always dispose it.

fixes #86146