### PR TITLE
Allow using active host context in hostfxr_get_runtime_delegate

### DIFF
--- a/src/installer/tests/HostActivation.Tests/NativeHosting/HostContext.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/HostContext.cs
@@ -257,7 +257,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
             result.Should().Pass()
                 .And.InitializeContextForConfig(sharedState.RuntimeConfigPath)
-                .And.CreateDelegateMock_COM();
+                .And.CreateDelegateMock_COM()
+                .And.CreateDelegateMock_InMemoryAssembly();
 
             CheckPropertiesValidation propertyValidation = new CheckPropertiesValidation(CheckProperties.None, LogPrefix.Config, SharedTestState.ConfigPropertyName, SharedTestState.ConfigPropertyValue);
             propertyValidation.ValidateActiveContext(result, newPropertyName);

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/HostContext.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/HostContext.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             public const string Mixed = "mixed";
             public const string NonContextMixedAppHost = "non_context_mixed_apphost";
             public const string NonContextMixedDotnet = "non_context_mixed_dotnet";
-            public const string GetRuntimeDelegate = "get_runtime_delegate";
+            public const string GetRuntimeDelegateForActiveContext = "get_runtime_delegate_for_active_context";
         }
 
         public class CheckProperties
@@ -239,13 +239,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Fact]
-        public void GetDelegate_Active()
+        public void GetDelegate_ActiveContext()
         {
             string newPropertyName = "HOST_TEST_PROPERTY";
             string[] args =
             {
                 HostContextArg,
-                Scenario.GetRuntimeDelegate,
+                Scenario.GetRuntimeDelegateForActiveContext,
                 CheckProperties.None,
                 sharedState.HostFxrPath,
                 sharedState.RuntimeConfigPath,

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/HostContext.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/HostContext.cs
@@ -21,6 +21,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             public const string Mixed = "mixed";
             public const string NonContextMixedAppHost = "non_context_mixed_apphost";
             public const string NonContextMixedDotnet = "non_context_mixed_dotnet";
+            public const string GetRuntimeDelegate = "get_runtime_delegate";
         }
 
         public class CheckProperties
@@ -235,6 +236,31 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             CheckPropertiesValidation propertyValidation = new CheckPropertiesValidation(checkProperties, LogPrefix.Config, SharedTestState.ConfigPropertyName, SharedTestState.ConfigPropertyValue);
             propertyValidation.ValidateActiveContext(result, SharedTestState.SecondaryConfigPropertyName);
             propertyValidation.ValidateSecondaryContext(result, SharedTestState.SecondaryConfigPropertyName, SharedTestState.SecondaryConfigPropertyValue);
+        }
+
+        [Fact]
+        public void GetDelegate_Active()
+        {
+            string newPropertyName = "HOST_TEST_PROPERTY";
+            string[] args =
+            {
+                HostContextArg,
+                Scenario.GetRuntimeDelegate,
+                CheckProperties.None,
+                sharedState.HostFxrPath,
+                sharedState.RuntimeConfigPath,
+                SharedTestState.ConfigPropertyName,
+                newPropertyName
+            };
+            CommandResult result = sharedState.CreateNativeHostCommand(args, sharedState.DotNetRoot)
+                .Execute();
+
+            result.Should().Pass()
+                .And.InitializeContextForConfig(sharedState.RuntimeConfigPath)
+                .And.CreateDelegateMock_COM();
+
+            CheckPropertiesValidation propertyValidation = new CheckPropertiesValidation(CheckProperties.None, LogPrefix.Config, SharedTestState.ConfigPropertyName, SharedTestState.ConfigPropertyValue);
+            propertyValidation.ValidateActiveContext(result, newPropertyName);
         }
 
         [Theory]

--- a/src/native/corehost/fxr/fx_muxer.cpp
+++ b/src/native/corehost/fxr/fx_muxer.cpp
@@ -857,6 +857,36 @@ namespace
         g_context_initializing_cv.notify_all();
         return rc;
     }
+
+    int get_runtime_delegate_validate(const host_context_t *context, coreclr_delegate_type type)
+    {
+        switch (type)
+        {
+        case coreclr_delegate_type::com_activation:
+        case coreclr_delegate_type::load_in_memory_assembly:
+        case coreclr_delegate_type::winrt_activation:
+        case coreclr_delegate_type::com_register:
+        case coreclr_delegate_type::com_unregister:
+            if (context->is_app)
+                return StatusCode::HostApiUnsupportedScenario;
+            break;
+        default:
+            // Always allowed
+            break;
+        }
+
+        // last_known_delegate_type was added in 5.0, so old versions won't set it and it will be zero.
+        // But when get_runtime_delegate was originally implemented in 3.0,
+        // it supported up to load_assembly_and_get_function_pointer so we check that first.
+        if (type > coreclr_delegate_type::load_assembly_and_get_function_pointer
+            && (size_t)type > context->hostpolicy_context_contract.last_known_delegate_type)
+        {
+            trace::error(_X("The requested delegate type is not available in the target framework."));
+            return StatusCode::HostApiUnsupportedVersion;
+        }
+
+        return StatusCode::Success;
+    }
 }
 
 int fx_muxer_t::run_app(host_context_t *context)
@@ -884,29 +914,10 @@ int fx_muxer_t::run_app(host_context_t *context)
 
 int fx_muxer_t::get_runtime_delegate(host_context_t *context, coreclr_delegate_type type, void **delegate)
 {
-    switch (type)
+    int rc = get_runtime_delegate_validate(context, type);
+    if (!STATUS_CODE_SUCCEEDED(rc))
     {
-    case coreclr_delegate_type::com_activation:
-    case coreclr_delegate_type::load_in_memory_assembly:
-    case coreclr_delegate_type::winrt_activation:
-    case coreclr_delegate_type::com_register:
-    case coreclr_delegate_type::com_unregister:
-        if (context->is_app)
-            return StatusCode::HostApiUnsupportedScenario;
-        break;
-    default:
-        // Always allowed
-        break;
-    }
-
-    // last_known_delegate_type was added in 5.0, so old versions won't set it and it will be zero.
-    // But when get_runtime_delegate was originally implemented in 3.0,
-    // it supported up to load_assembly_and_get_function_pointer so we check that first.
-    if (type > coreclr_delegate_type::load_assembly_and_get_function_pointer
-        && (size_t)type > context->hostpolicy_context_contract.last_known_delegate_type)
-    {
-        trace::error(_X("The requested delegate type is not available in the target framework."));
-        return StatusCode::HostApiUnsupportedVersion;
+        return rc;
     }
 
     const corehost_context_contract &contract = context->hostpolicy_context_contract;
@@ -915,10 +926,33 @@ int fx_muxer_t::get_runtime_delegate(host_context_t *context, coreclr_delegate_t
 
         if (context->type != host_context_type::secondary)
         {
-            int rc = load_runtime(context);
+            rc = load_runtime(context);
             if (rc != StatusCode::Success)
                 return rc;
         }
+
+        return contract.get_runtime_delegate(type, delegate);
+    }
+}
+
+int fx_muxer_t::get_runtime_delegate_active(coreclr_delegate_type type, void **delegate)
+{
+    const host_context_t *context = get_active_host_context();
+    if (context == nullptr)
+    {
+        trace::error(_X("Hosting components context has not been initialized. Cannot get runtime delegate."));
+        return StatusCode::HostInvalidState;
+    }
+
+    int rc = get_runtime_delegate_validate(context, type);
+    if (!STATUS_CODE_SUCCEEDED(rc))
+    {
+        return rc;
+    }
+
+    const corehost_context_contract &contract = context->hostpolicy_context_contract;
+    {
+        propagate_error_writer_t propagate_error_writer_to_corehost(context->hostpolicy_contract.set_error_writer);
 
         return contract.get_runtime_delegate(type, delegate);
     }

--- a/src/native/corehost/fxr/fx_muxer.h
+++ b/src/native/corehost/fxr/fx_muxer.h
@@ -32,11 +32,12 @@ public:
         hostfxr_handle *host_context_handle);
     static int run_app(host_context_t *context);
     static int get_runtime_delegate(
-        host_context_t *context,
+        const host_context_t *context,
         coreclr_delegate_type delegate_type,
         void** delegate);
     static const host_context_t* get_active_host_context();
     static int close_host_context(host_context_t *context);
+    static int load_runtime(host_context_t *context);
 private:
     static int handle_exec_host_command(
         const pal::string_t& host_command,

--- a/src/native/corehost/fxr/fx_muxer.h
+++ b/src/native/corehost/fxr/fx_muxer.h
@@ -35,6 +35,9 @@ public:
         host_context_t *context,
         coreclr_delegate_type delegate_type,
         void** delegate);
+    static int get_runtime_delegate_active(
+        coreclr_delegate_type delegate_type,
+        void** delegate);
     static const host_context_t* get_active_host_context();
     static int close_host_context(host_context_t *context);
 private:

--- a/src/native/corehost/fxr/fx_muxer.h
+++ b/src/native/corehost/fxr/fx_muxer.h
@@ -35,9 +35,6 @@ public:
         host_context_t *context,
         coreclr_delegate_type delegate_type,
         void** delegate);
-    static int get_runtime_delegate_active(
-        coreclr_delegate_type delegate_type,
-        void** delegate);
     static const host_context_t* get_active_host_context();
     static int close_host_context(host_context_t *context);
 private:

--- a/src/native/corehost/fxr/hostfxr.cpp
+++ b/src/native/corehost/fxr/hostfxr.cpp
@@ -694,7 +694,7 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_get_runtime_delegate(
 
     if (host_context_handle == nullptr)
     {
-        return fx_muxer_t::get_runtime_delegate_active(delegate_type, delegate);
+        return fx_muxer_t::get_runtime_delegate(nullptr, delegate_type, delegate);
     }
     else
     {

--- a/src/native/corehost/fxr/hostfxr.cpp
+++ b/src/native/corehost/fxr/hostfxr.cpp
@@ -688,15 +688,22 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_get_runtime_delegate(
 
     *delegate = nullptr;
 
-    host_context_t *context = host_context_t::from_handle(host_context_handle);
-    if (context == nullptr)
-        return StatusCode::InvalidArgFailure;
-
     coreclr_delegate_type delegate_type = hostfxr_delegate_to_coreclr_delegate(type);
     if (delegate_type == coreclr_delegate_type::invalid)
         return StatusCode::InvalidArgFailure;
 
-    return fx_muxer_t::get_runtime_delegate(context, delegate_type, delegate);
+    if (host_context_handle == nullptr)
+    {
+        return fx_muxer_t::get_runtime_delegate_active(delegate_type, delegate);
+    }
+    else
+    {
+        host_context_t *context = host_context_t::from_handle(host_context_handle);
+        if (context == nullptr)
+            return StatusCode::InvalidArgFailure;
+
+        return fx_muxer_t::get_runtime_delegate(context, delegate_type, delegate);
+    }
 }
 
 SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_get_runtime_property_value(

--- a/src/native/corehost/test/nativehost/host_context_test.cpp
+++ b/src/native/corehost/test/nativehost/host_context_test.cpp
@@ -701,12 +701,27 @@ namespace
         if (!init_for_config(hostfxr, config_path, &handle, log_prefix, test_output))
             return false;
 
-        void *delegate1;
-        bool success = get_runtime_delegate(hostfxr, handle, delegate_type1, &delegate1, log_prefix, test_output);
+        void *delegate1 = nullptr;
+        // Check that using get_runtime_delegate with the active host context will fail
+        // due to the runtime not being loaded yet.
+        bool success = get_runtime_delegate(hostfxr, nullptr, delegate_type1, &delegate1, log_prefix, test_output);
+        if (success)
+        {
+            test_output << log_prefix << _X("get_runtime_delegate with active context succeeded unexpectedly.") << std::endl;
+            return false;
+        }
+        if (nullptr != delegate1)
+        {
+            test_output << log_prefix << _X("Unexpectedly got a runtime delegate when get_runtime_delegate failed.") << std::endl;
+            return false;
+        }
+
+        // Successfully get first delegate with a defined handle.
+        success = get_runtime_delegate(hostfxr, handle, delegate_type1, &delegate1, log_prefix, test_output);
 
         // Testing that using the active host context works for get_runtime_delegate
         // by passing nullptr for handle parameter. The runtime must be loaded for this to succeed;
-        // the first call to get_runtime_delegate with a defined handle ensures that it is loaded.
+        // the first successful call to get_runtime_delegate with a defined handle ensures that it is loaded.
         void *delegate2;
         success &= get_runtime_delegate(hostfxr, nullptr, delegate_type2, &delegate2, log_prefix, test_output);
 

--- a/src/native/corehost/test/nativehost/host_context_test.cpp
+++ b/src/native/corehost/test/nativehost/host_context_test.cpp
@@ -688,6 +688,34 @@ namespace
 
         return success && rcClose == StatusCode::Success;
     }
+
+    bool get_runtime_delegate_test(
+        const hostfxr_exports &hostfxr,
+        const pal::char_t *config_path,
+        hostfxr_delegate_type delegate_type1,
+        hostfxr_delegate_type delegate_type2,
+        const pal::char_t *log_prefix,
+        pal::stringstream_t &test_output)
+    {
+        hostfxr_handle handle;
+        if (!init_for_config(hostfxr, config_path, &handle, log_prefix, test_output))
+            return false;
+
+        void *delegate1;
+        bool success = get_runtime_delegate(hostfxr, handle, delegate_type1, &delegate1, log_prefix, test_output);
+
+        // Testing that using the active host context works for get_runtime_delegate
+        // by passing nullptr for handle parameter. The runtime must be loaded for this to succeed;
+        // the first call to get_runtime_delegate with a defined handle ensures that it is loaded.
+        void *delegate2;
+        success &= get_runtime_delegate(hostfxr, nullptr, delegate_type2, &delegate2, log_prefix, test_output);
+
+        int rcClose = hostfxr.close(handle);
+        if (rcClose != StatusCode::Success)
+            test_output << log_prefix << _X("hostfxr_close failed: ") << std::hex << std::showbase << rcClose << std::endl;
+
+        return success && rcClose == StatusCode::Success;
+    }
 }
 
 host_context_test::check_properties host_context_test::check_properties_from_string(const pal::char_t *str)
@@ -999,4 +1027,14 @@ bool host_context_test::app_get_function_pointer(
     hostfxr_exports hostfxr{ hostfxr_path };
 
     return app_get_function_pointer_test(hostfxr, argc, argv, config_log_prefix, test_output);
+}
+
+bool host_context_test::get_runtime_delegate(
+    const pal::string_t &hostfxr_path,
+    const pal::char_t *config_path,
+    pal::stringstream_t &test_output)
+{
+    hostfxr_exports hostfxr{ hostfxr_path };
+
+    return get_runtime_delegate_test(hostfxr, config_path, first_delegate_type, secondary_delegate_type, config_log_prefix, test_output);
 }

--- a/src/native/corehost/test/nativehost/host_context_test.cpp
+++ b/src/native/corehost/test/nativehost/host_context_test.cpp
@@ -689,7 +689,7 @@ namespace
         return success && rcClose == StatusCode::Success;
     }
 
-    bool get_runtime_delegate_test(
+    bool get_runtime_delegate_for_active_context_test(
         const hostfxr_exports &hostfxr,
         const pal::char_t *config_path,
         hostfxr_delegate_type delegate_type1,
@@ -1029,12 +1029,12 @@ bool host_context_test::app_get_function_pointer(
     return app_get_function_pointer_test(hostfxr, argc, argv, config_log_prefix, test_output);
 }
 
-bool host_context_test::get_runtime_delegate(
+bool host_context_test::get_runtime_delegate_for_active_context(
     const pal::string_t &hostfxr_path,
     const pal::char_t *config_path,
     pal::stringstream_t &test_output)
 {
     hostfxr_exports hostfxr{ hostfxr_path };
 
-    return get_runtime_delegate_test(hostfxr, config_path, first_delegate_type, secondary_delegate_type, config_log_prefix, test_output);
+    return get_runtime_delegate_for_active_context_test(hostfxr, config_path, first_delegate_type, secondary_delegate_type, config_log_prefix, test_output);
 }

--- a/src/native/corehost/test/nativehost/host_context_test.h
+++ b/src/native/corehost/test/nativehost/host_context_test.h
@@ -103,4 +103,8 @@ namespace host_context_test
         int argc,
         const pal::char_t *argv[],
         pal::stringstream_t &test_output);
+    bool get_runtime_delegate(
+        const pal::string_t &hostfxr_path,
+        const pal::char_t *config_path,
+        pal::stringstream_t &test_output);
 }

--- a/src/native/corehost/test/nativehost/host_context_test.h
+++ b/src/native/corehost/test/nativehost/host_context_test.h
@@ -103,7 +103,7 @@ namespace host_context_test
         int argc,
         const pal::char_t *argv[],
         pal::stringstream_t &test_output);
-    bool get_runtime_delegate(
+    bool get_runtime_delegate_for_active_context(
         const pal::string_t &hostfxr_path,
         const pal::char_t *config_path,
         pal::stringstream_t &test_output);

--- a/src/native/corehost/test/nativehost/nativehost.cpp
+++ b/src/native/corehost/test/nativehost/nativehost.cpp
@@ -207,9 +207,9 @@ int main(const int argc, const pal::char_t *argv[])
             bool launch_as_if_dotnet = pal::strcmp(scenario, _X("non_context_mixed_dotnet")) == 0;
             success = host_context_test::non_context_mixed(check_properties, hostfxr_path, app_or_config_path, config_path, remaining_argc, remaining_argv, launch_as_if_dotnet, test_output);
         }
-        else if (pal::strcmp(scenario, _X("get_runtime_delegate")) == 0)
+        else if (pal::strcmp(scenario, _X("get_runtime_delegate_for_active_context")) == 0)
         {
-            success = host_context_test::get_runtime_delegate(hostfxr_path, app_or_config_path, test_output);
+            success = host_context_test::get_runtime_delegate_for_active_context(hostfxr_path, app_or_config_path, test_output);
         }
         else
         {

--- a/src/native/corehost/test/nativehost/nativehost.cpp
+++ b/src/native/corehost/test/nativehost/nativehost.cpp
@@ -207,6 +207,10 @@ int main(const int argc, const pal::char_t *argv[])
             bool launch_as_if_dotnet = pal::strcmp(scenario, _X("non_context_mixed_dotnet")) == 0;
             success = host_context_test::non_context_mixed(check_properties, hostfxr_path, app_or_config_path, config_path, remaining_argc, remaining_argv, launch_as_if_dotnet, test_output);
         }
+        else if (pal::strcmp(scenario, _X("get_runtime_delegate")) == 0)
+        {
+            success = host_context_test::get_runtime_delegate(hostfxr_path, app_or_config_path, test_output);
+        }
         else
         {
             std::cerr << "Invalid scenario" << std::endl;


### PR DESCRIPTION
These changes allow for passing `nullptr` for the handle parameter of the `hostfxr_get_runtime_delegate` function. This allows in-process callers who do not have the real host context handle to invoke this function and get a runtime delegate for the primary runtime instance. Calling `hostfxr_get_runtime_delegate` without the handle will only work if there is an active host context, otherwise it will return `StatusCode::HostInvalidState`.

For testing, I decided to add a new test specifically for ensuring that calling `hostfxr_get_runtime_delegate` without the handle will work instead of updating the existing tests. Most of the other tests would not have worked with this enablement because it requires an active context handle to be set, which only largely occurs if calling `hostfxr_get_runtime_delegate` with an existing handle or calling `fx_muxer_t::run_app`; rather than forcing these to unnecessarily invoke `hostfxr_get_runtime_delegate` twice (one with a handle, the next without), I created a separate test to do just that.

Fixes #84143