### PR TITLE
[wasm] Implement I2 and I4 shuffles in the jiterpreter

### DIFF
--- a/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
@@ -3245,45 +3245,63 @@ function emit_simd_3(builder: WasmBuilder, ip: MintOpcodePtr, index: SimdIntrins
                 builder.appendU8(WasmOpcode.i32_eqz);
             append_stloc_tail(builder, getArgU16(ip, 1), WasmOpcode.i32_store);
             return true;
-        case SimdIntrinsic3.V128_I2_SHUFFLE: {
-            builder.local("pLocals");
-            // Load vec
-            append_ldloc(builder, getArgU16(ip, 2), WasmOpcode.PREFIX_simd, WasmSimdOpcode.v128_load);
-            // Load indices (in chars)
-            append_ldloc(builder, getArgU16(ip, 3), WasmOpcode.PREFIX_simd, WasmSimdOpcode.v128_load);
-            // Load a zero vector (narrow takes two vectors)
-            builder.i52_const(0);
-            builder.appendSimd(WasmSimdOpcode.i64x2_splat);
-            // i16{lane0 ... lane7} -> i8{lane0 ... lane7, 0 ...}
-            builder.appendSimd(WasmSimdOpcode.i8x16_narrow_i16x8_u);
-            // i8{0, 1, 2, 3 ...} -> i8{0, 0, 1, 1, 2, 2, 3, 3 ...}
-            builder.appendSimd(WasmSimdOpcode.v128_const);
-            for (let i = 0; i < 8; i++) {
-                builder.appendU8(i);
-                builder.appendU8(i);
-            }
-            builder.appendSimd(WasmSimdOpcode.i8x16_swizzle);
-            // multiply indices by 2 to scale from char indices to byte indices
-            builder.i32_const(1);
-            builder.appendSimd(WasmSimdOpcode.i8x16_shl);
-            // now add 1 to the secondary lane of each char
-            builder.appendSimd(WasmSimdOpcode.v128_const);
-            for (let i = 0; i < 8; i++) {
-                builder.appendU8(0);
-                builder.appendU8(1);
-            }
-            // we can do a bitwise or since we know we previously multiplied all the lanes by 2
-            builder.appendSimd(WasmSimdOpcode.v128_or);
-            // we now have two vectors on the stack, the values and the byte indices
-            builder.appendSimd(WasmSimdOpcode.i8x16_swizzle);
-            append_simd_store(builder, ip);
-            return true;
-        }
+        case SimdIntrinsic3.V128_I2_SHUFFLE:
+        case SimdIntrinsic3.V128_I4_SHUFFLE:
+            // FIXME: I8
+            // FIXME: Many uses of these shuffles have constant shuffle indices,
+            //  which we could convert into bytes at compile time for vastly improved performance
+            return emit_shuffle(builder, ip, index === SimdIntrinsic3.V128_I2_SHUFFLE ? 8 : 4);
         default:
             return false;
     }
 
     return false;
+}
+
+// implement i16 and i32 shuffles on top of wasm's only shuffle opcode by expanding the
+//  element shuffle indices into byte indices
+function emit_shuffle(builder: WasmBuilder, ip: MintOpcodePtr, elementCount: number): boolean {
+    const elementSize = 16 / elementCount;
+    mono_assert((elementSize === 2) || (elementSize === 4), "Unsupported shuffle element size");
+    builder.local("pLocals");
+    // Load vec
+    append_ldloc(builder, getArgU16(ip, 2), WasmOpcode.PREFIX_simd, WasmSimdOpcode.v128_load);
+    // Load indices (in chars)
+    append_ldloc(builder, getArgU16(ip, 3), WasmOpcode.PREFIX_simd, WasmSimdOpcode.v128_load);
+    // There's no direct narrowing opcode for i32 -> i8, so we have to do two steps :(
+    if (elementCount === 4) {
+        // i32{lane0 ... lane3} -> i16{lane0 ... lane3, 0 ...}
+        builder.i52_const(0);
+        builder.appendSimd(WasmSimdOpcode.i64x2_splat);
+        builder.appendSimd(WasmSimdOpcode.i16x8_narrow_i32x4_u);
+    }
+    // Load a zero vector (narrow takes two vectors)
+    builder.i52_const(0);
+    builder.appendSimd(WasmSimdOpcode.i64x2_splat);
+    // i16{lane0 ... lane7} -> i8{lane0 ... lane7, 0 ...}
+    builder.appendSimd(WasmSimdOpcode.i8x16_narrow_i16x8_u);
+    // i8{0, 1, 2, 3 ...} -> i8{0, 0, 1, 1, 2, 2, 3, 3 ...}
+    builder.appendSimd(WasmSimdOpcode.v128_const);
+    for (let i = 0; i < elementCount; i++) {
+        for (let j = 0; j < elementSize; j++)
+            builder.appendU8(i);
+    }
+    builder.appendSimd(WasmSimdOpcode.i8x16_swizzle);
+    // multiply indices by 2 to scale from char indices to byte indices
+    builder.i32_const(elementCount === 4 ? 2 : 1);
+    builder.appendSimd(WasmSimdOpcode.i8x16_shl);
+    // now add 1 to the secondary lane of each char
+    builder.appendSimd(WasmSimdOpcode.v128_const);
+    for (let i = 0; i < elementCount; i++) {
+        for (let j = 0; j < elementSize; j++)
+            builder.appendU8(j);
+    }
+    // we can do a bitwise or since we know we previously multiplied all the lanes by 2
+    builder.appendSimd(WasmSimdOpcode.v128_or);
+    // we now have two vectors on the stack, the values and the byte indices
+    builder.appendSimd(WasmSimdOpcode.i8x16_swizzle);
+    append_simd_store(builder, ip);
+    return true;
 }
 
 function emit_simd_4(builder: WasmBuilder, ip: MintOpcodePtr, index: SimdIntrinsic4): boolean {


### PR DESCRIPTION
Enabling v128 and packedsimd support causes code that relies on i2/i4 shuffle to run. The scalar fallback implementation of these is *extremely* slow, so that makes algorithms dependent on those shuffles much slower at least according to browser-bench.

This PR adds implementations for those shuffles by taking the short/int sized shuffle vectors, narrowing them to bytes, then replicating the narrowed vector across all the lanes and adding bits in order to produce an equivalent byte shuffle vector. Then it uses the wasm swizzle bytes intrinsic to emulate the desired shuffle operation.

In my testing this speeds up 'Span, Reverse chars' from browser-bench considerably (~0.12ms -> 0.04ms) but does not seem to speed up IndexOf or SequenceEqual for chars. I'm not sure why, but one guess is that the cost of converting the shuffle vectors every operation is too significant. A future improvement would be to detect constant shuffle vectors and perform the full expansion at JIT time, which might close the gap. You can see an example of how a constant shuffle vector still generates the full emulation logic here:
![image](https://github.com/dotnet/runtime/assets/198130/de071679-3782-4e37-b8b8-46b6ec02e96b)
Since we know the vector at offset 160 is constant we can safely remove all of that work at some point. I'm not sure whether it makes sense to try and do this in the interp at transform time, it's probably better to do it in jiterp.