### PR TITLE
Unreachable filter end

### DIFF
--- a/src/coreclr/tools/aot/Mono.Linker.Tests/TestCases/TestDatabase.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/TestCases/TestDatabase.cs
@@ -54,6 +54,11 @@ namespace Mono.Linker.Tests.TestCases
 			return TestNamesBySuiteName ();
 		}
 
+		public static IEnumerable<object[]> UnreachableBlock ()
+		{
+			return TestNamesBySuiteName ();
+		}
+
 		public static IEnumerable<object[]> Warnings ()
 		{
 			return TestNamesBySuiteName ();

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/TestCases/TestSuites.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/TestCases/TestSuites.cs
@@ -74,6 +74,20 @@ namespace Mono.Linker.Tests.TestCases
 		}
 
 		[Theory]
+		[MemberData (nameof (TestDatabase.UnreachableBlock), MemberType = typeof (TestDatabase))]
+		public void UnreachableBlock (string t)
+		{
+			switch (t) {
+			case "TryCatchBlocks":
+				Run (t);
+				break;
+			default:
+				// Skip the rest for now
+				break;
+			}
+		}
+
+		[Theory]
 		[MemberData (nameof (TestDatabase.Warnings), MemberType = typeof (TestDatabase))]
 		public void Warnings (string t)
 		{

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -93,8 +93,8 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			bool HasActiveSkipKeptItemsValidationAttribute(ICustomAttributeProvider provider)
 			{
 				if (TryGetCustomAttribute(provider, nameof(SkipKeptItemsValidationAttribute), out var attribute)) {
-					object? keptBy = attribute.GetPropertyValue (nameof (SkipKeptItemsValidationAttribute.By));
-					return keptBy is null ? true : ((Tool) keptBy).HasFlag (Tool.NativeAot);
+					object? by = attribute.GetPropertyValue (nameof (SkipKeptItemsValidationAttribute.By));
+					return by is null ? true : ((Tool) by).HasFlag (Tool.NativeAot);
 				}
 
 				return false;

--- a/src/tools/illink/src/linker/Linker.Steps/UnreachableBlocksOptimizer.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/UnreachableBlocksOptimizer.cs
@@ -1125,8 +1125,20 @@ namespace Mono.Linker.Steps
 							condBranches ??= new Stack<int> ();
 
 							condBranches.Push (GetInstructionIndex (handler.HandlerStart));
-							if (handler.FilterStart != null)
+							if (handler.FilterStart != null) {
 								condBranches.Push (GetInstructionIndex (handler.FilterStart));
+								int filterEnd = GetInstructionIndex (handler.HandlerStart) - 1;
+								if (filterEnd >= 0 && FoldedInstructions[filterEnd].OpCode == OpCodes.Endfilter) {
+									// The endfilter instruction must be at the end of each filter block, even if it's not reachable:
+									//
+									// ECMA 335
+									// I.12.4.2.8.2.5 endfilter:
+									// 1.Shall appear as the lexically last instruction in the filter.
+									// [Note: The endfilter is required even if no control - flow path reaches it.This can happen if, for
+									// example, the filter does a throw.end note]
+									reachable[filterEnd] = true;
+								}
+							}
 						}
 
 						if (condBranches?.Count > 0) {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/TryCatchBlocks.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/TryCatchBlocks.cs
@@ -6,6 +6,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 	[SetupCSharpCompilerToUse ("csc")]
 	[SetupCompileArgument ("/optimize+")]
 	[SetupLinkerArgument ("--enable-opt", "ipconstprop")]
+	[SkipKeptItemsValidation (By = Tool.NativeAot)]
 	public class TryCatchBlocks
 	{
 		public static void Main ()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/TryCatchBlocks.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/TryCatchBlocks.cs
@@ -12,6 +12,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 		{
 			TryCatchInRemovedBranch.Test ();
 			TryCatchInKeptBranchBeforeRemovedBranch.Test ();
+			RemovedBranchInFilterBlock.Test ();
 		}
 
 		class TryCatchInRemovedBranch
@@ -86,6 +87,45 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 			static void Reached_2 () { }
 
 			static void Unreached () { }
+		}
+
+		class RemovedBranchInFilterBlock
+		{
+			[Kept]
+			[ExpectedInstructionSequence (new[] {
+				".try",
+				"newobj System.Void System.Exception::.ctor()",
+				"throw",
+				".endtry",
+				".filter",
+				"pop",
+				"ldc.i4.0",
+				"brfalse.s il_a",
+				"newobj System.Void System.Exception::.ctor()",
+				"throw",
+				"endfilter",
+				".catch",
+				"pop",
+				"call System.Void Mono.Linker.Tests.Cases.UnreachableBlock.TryCatchBlocks/RemovedBranchInFilterBlock::Reached()",
+				"leave.s il_1a",
+				".endcatch",
+				"ret"
+			})]
+			public static void Test ()
+			{
+				try {
+					throw new System.Exception ();
+				} catch when (Prop == 0 ? throw new System.Exception() : true) {
+					// Technically this is unreachable as well, since the filter will always throw
+					// but illink is not clever enough to figure this out yet.
+					Reached ();
+				}
+			}
+
+			static int Prop { get => 0; }
+
+			[Kept]
+			static void Reached () { }
 		}
 	}
 }

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -93,7 +93,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 					PerformOutputAssemblyChecks (original, linkResult.OutputAssemblyPath.Parent);
 					PerformOutputSymbolChecks (original, linkResult.OutputAssemblyPath.Parent);
 
-					if (!HasAttribute (original.MainModule.GetType (linkResult.TestCase.ReconstructedFullTypeName), nameof (SkipKeptItemsValidationAttribute))) {
+					if (!HasActiveSkipKeptItemsValidationAttribute(original.MainModule.GetType (linkResult.TestCase.ReconstructedFullTypeName))) {
 						CreateAssemblyChecker (original, linked, linkResult).Verify ();
 					}
 				}
@@ -103,6 +103,16 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			} finally {
 				_originalsResolver.Dispose ();
 				_linkedResolver.Dispose ();
+			}
+
+			bool HasActiveSkipKeptItemsValidationAttribute (ICustomAttributeProvider provider)
+			{
+				if (TryGetCustomAttribute (provider, nameof (SkipKeptItemsValidationAttribute), out var attribute)) {
+					object by = attribute.GetPropertyValue (nameof (SkipKeptItemsValidationAttribute.By));
+					return by is null ? true : ((Tool) by).HasFlag (Tool.Trimmer);
+				}
+
+				return false;
 			}
 		}
 


### PR DESCRIPTION
Fixes the problem described in https://github.com/dotnet/roslyn/issues/67494 for illink.

`endfilter` instruction must be kept if the filter block is kept, even if the instruction itself is unreachable - per the ECMA spec. Fix the branch removal code to preserve the instruction unconditionally.

Adds a test to validate the new behavior.

I also enabled the test to run on NativeAOT, since it has code to handle this as well. We only validate that the compiler will not crash/warn, the Kept validation is disabled, since we can't really inspect IL of the produced methods in AOT.

Also fixes a bug in the illink test infra where the `By` property on `SkipKeptItemsValidationAttribute` was ignored.

/cc @MichalStrehovsky 