### PR TITLE
[mono][debugger][docs] How we run debugger tests

### DIFF
--- a/src/mono/wasm/threads.md
+++ b/src/mono/wasm/threads.md
@@ -87,7 +87,7 @@ a worker thread will use `async_run_in_main_thread` to queue up work for the mai
 
 ## Debugger tests ##
 
-Debugger supports multithreading when the runtime is built with `WasmEnableThreads=true`. To run the debugger tests in multithreading mode we use:
+To run the debugger tests in the runtime [built with enabled support for multi-threading](https://github.com/dotnet/runtime/blob/main/src/mono/wasm/threads.md#building-the-runtime) we use:
 ```
 dotnet test src/mono/wasm/debugger/DebuggerTestSuite -e RuntimeConfiguration=Debug -e Configuration=Debug -e DebuggerHost=chrome -e WasmEnableThreads=true -e WASM_TESTS_USING_VARIANT=multithreaded
 ```

--- a/src/mono/wasm/threads.md
+++ b/src/mono/wasm/threads.md
@@ -87,7 +87,7 @@ a worker thread will use `async_run_in_main_thread` to queue up work for the mai
 
 ## Debugger tests ##
 
-To run the debugger tests in the runtime [built with enabled support for multi-threading](https://github.com/dotnet/runtime/blob/main/src/mono/wasm/threads.md#building-the-runtime) we use:
+To run the debugger tests in the runtime [built with enabled support for multi-threading](#building-the-runtime) we use:
 ```
 dotnet test src/mono/wasm/debugger/DebuggerTestSuite -e RuntimeConfiguration=Debug -e Configuration=Debug -e DebuggerHost=chrome -e WasmEnableThreads=true -e WASM_TESTS_USING_VARIANT=multithreaded
 ```


### PR DESCRIPTION
It seems I made a mistake when publishing https://github.com/dotnet/runtime/pull/86325 - the docs said we build for multithreading debugger tests in a different way than generally for multithreading.

To be sure, cc @lambdageek we will wait with @thaystg for approval from you.