### PR TITLE
Remove invalid assert in EvpPKeyDuplicate

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.cs
@@ -22,8 +22,6 @@ internal static partial class Interop
             SafeEvpPKeyHandle currentKey,
             EvpAlgorithmId algorithmId)
         {
-            Debug.Assert(!currentKey.IsInvalid);
-
             SafeEvpPKeyHandle pkey = CryptoNative_EvpPKeyDuplicate(
                 currentKey,
                 algorithmId);


### PR DESCRIPTION
`EvpPKeyDuplicate` has an invalid assert in it where it asserts that the handle it was passed is not IsInvalid. This may not be true in a multi-threaded scenario where an object is disposed by one thread while another thread is trying to use the resource.

Since we are marshaling the handle as a SafeHandle, just let it do the right thing of throwing an ObjectDisposedException when the marshaller attempts to add a reference to the handle.

Fixes #85073