### PR TITLE
[wasm] Jiterpreter v128 misc optimizations

### DIFF
--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -378,8 +378,14 @@ export class WasmBuilder {
     v128_const(value: 0 | Uint8Array) {
         if (value === 0) {
             // This encoding is much smaller than a v128_const
-            this.i52_const(0);
-            this.appendSimd(WasmSimdOpcode.i64x2_splat);
+            // But v8 doesn't optimize it :-((((((
+            /*
+                this.i52_const(0);
+                this.appendSimd(WasmSimdOpcode.i64x2_splat);
+            */
+            this.appendSimd(WasmSimdOpcode.v128_const);
+            for (let i = 0; i < 16; i++)
+                this.appendU8(0);
         } else if (typeof (value) === "object") {
             mono_assert(value.byteLength === 16, "Expected v128_const arg to be 16 bytes in size");
             this.appendSimd(WasmSimdOpcode.v128_const);

--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -1522,6 +1522,10 @@ export function try_append_memset_fast(builder: WasmBuilder, localOffset: number
     if (count >= maxMemsetSize)
         return false;
 
+    // FIXME
+    if (value !== 0)
+        return false;
+
     const destLocal = destOnStack ? "math_lhs32" : "pLocals";
     if (destOnStack)
         builder.local("math_lhs32", WasmOpcode.set_local);

--- a/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
@@ -3057,9 +3057,9 @@ function emit_simd(
         case MintOpcode.MINT_SIMD_V128_LDC: {
             if (builder.options.enableSimd && getIsWasmSimdSupported()) {
                 builder.local("pLocals");
-                builder.appendSimd(WasmSimdOpcode.v128_const);
-                const view = Module.HEAPU8.slice(<any>ip + 4, <any>ip + 4 + sizeOfV128);
-                builder.appendBytes(view);
+                builder.v128_const(
+                    Module.HEAPU8.slice(<any>ip + 4, <any>ip + 4 + sizeOfV128)
+                );
                 append_simd_store(builder, ip);
             } else {
                 // dest

--- a/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
@@ -3178,8 +3178,7 @@ function emit_simd_2(builder: WasmBuilder, ip: MintOpcodePtr, index: SimdIntrins
             const tableEntry = createScalarTable[index];
             builder.local("pLocals");
             // Make a zero vector
-            builder.i52_const(0);
-            builder.appendSimd(WasmSimdOpcode.i64x2_splat);
+            builder.v128_const(0);
             // Load the scalar value
             append_ldloc(builder, getArgU16(ip, 2), tableEntry[0]);
             // Replace the first lane
@@ -3267,13 +3266,11 @@ function emit_shuffle(builder: WasmBuilder, ip: MintOpcodePtr, elementCount: num
     // There's no direct narrowing opcode for i32 -> i8, so we have to do two steps :(
     if (elementCount === 4) {
         // i32{lane0 ... lane3} -> i16{lane0 ... lane3, 0 ...}
-        builder.i52_const(0);
-        builder.appendSimd(WasmSimdOpcode.i64x2_splat);
+        builder.v128_const(0);
         builder.appendSimd(WasmSimdOpcode.i16x8_narrow_i32x4_u);
     }
     // Load a zero vector (narrow takes two vectors)
-    builder.i52_const(0);
-    builder.appendSimd(WasmSimdOpcode.i64x2_splat);
+    builder.v128_const(0);
     // i16{lane0 ... lane7} -> i8{lane0 ... lane7, 0 ...}
     builder.appendSimd(WasmSimdOpcode.i8x16_narrow_i16x8_u);
     // i8{0, 1, 2, 3 ...} -> i8{0, 0, 1, 1, 2, 2, 3, 3 ...}


### PR DESCRIPTION
* The encoding I used previously for a v128 zero constant in some places (i64.const 0 + i64 -> v128 splat) isn't optimized by v8, so we can't use it. We're stuck using the enormous v128.const opcode instead.
* Use v128 loads/stores if available when unrolling memsets and memmoves. This appears to improve performance for the BCL in some spots by a measurable amount, and at least for the moves it reduces code size too. (The sets will get worse thanks to the incredible constant representation; using a temp local might help maybe?)