### PR TITLE
Refactor our linear collection marshalling implementation

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ElementsMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ElementsMarshalling.cs
@@ -326,11 +326,11 @@ namespace Microsoft.Interop
                 managedValuesDeclaration,
                 unmanagedValuesDeclaration,
                 GenerateContentsMarshallingStatement(
-                        info,
-                        context,
-                        IdentifierName(numElementsIdentifier),
-                        StubCodeContext.Stage.UnmarshalCapture,
-                        StubCodeContext.Stage.Unmarshal));
+                    info,
+                    context,
+                    IdentifierName(numElementsIdentifier),
+                    StubCodeContext.Stage.UnmarshalCapture,
+                    StubCodeContext.Stage.Unmarshal));
         }
 
         public StatementSyntax GenerateElementCleanupStatement(TypePositionInfo info, StubCodeContext context)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ElementsMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ElementsMarshalling.cs
@@ -11,26 +11,41 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.Interop
 {
+    internal interface IElementsMarshallingCollectionSource
+    {
+        StatementSyntax GetManagedValuesNumElementsAssignment(TypePositionInfo info, StubCodeContext context);
+        InvocationExpressionSyntax GetUnmanagedValuesDestination(TypePositionInfo info, StubCodeContext context);
+        InvocationExpressionSyntax GetManagedValuesSource(TypePositionInfo info, StubCodeContext context);
+        InvocationExpressionSyntax GetUnmanagedValuesSource(TypePositionInfo info, StubCodeContext context);
+        InvocationExpressionSyntax GetManagedValuesDestination(TypePositionInfo info, StubCodeContext context);
+    }
+
+    internal interface IElementsMarshalling
+    {
+        StatementSyntax GenerateByValueOutMarshalStatement(TypePositionInfo info, StubCodeContext context);
+        StatementSyntax GenerateMarshalStatement(TypePositionInfo info, StubCodeContext context);
+        StatementSyntax GenerateByValueOutUnmarshalStatement(TypePositionInfo info, StubCodeContext context);
+        StatementSyntax GenerateUnmarshalStatement(TypePositionInfo info, StubCodeContext context);
+        StatementSyntax GenerateElementCleanupStatement(TypePositionInfo info, StubCodeContext context);
+    }
+
     /// <summary>
     /// Support for marshalling blittable elements
     /// </summary>
-    internal abstract class BlittableElementsMarshalling
+    internal sealed class BlittableElementsMarshalling : IElementsMarshalling
     {
         private readonly TypeSyntax _managedElementType;
         private readonly TypeSyntax _unmanagedElementType;
+        private readonly IElementsMarshallingCollectionSource _collectionSource;
 
-        public BlittableElementsMarshalling(TypeSyntax managedElementType, TypeSyntax unmanagedElementType)
+        public BlittableElementsMarshalling(TypeSyntax managedElementType, TypeSyntax unmanagedElementType, IElementsMarshallingCollectionSource collectionSource)
         {
             _managedElementType = managedElementType;
             _unmanagedElementType = unmanagedElementType;
+            _collectionSource = collectionSource;
         }
 
-        protected abstract InvocationExpressionSyntax GetUnmanagedValuesDestination(TypePositionInfo info, StubCodeContext context);
-        protected abstract InvocationExpressionSyntax GetManagedValuesSource(TypePositionInfo info, StubCodeContext context);
-        protected abstract InvocationExpressionSyntax GetUnmanagedValuesSource(TypePositionInfo info, StubCodeContext context);
-        protected abstract InvocationExpressionSyntax GetManagedValuesDestination(TypePositionInfo info, StubCodeContext context);
-
-        protected StatementSyntax GenerateByValueOutMarshalStatement(TypePositionInfo info, StubCodeContext context)
+        public StatementSyntax GenerateByValueOutMarshalStatement(TypePositionInfo info, StubCodeContext context)
         {
             // If the parameter is marshalled by-value [Out], then we don't marshal the contents of the collection.
             // We do clear the span, so that if the invoke target doesn't fill it, we aren't left with undefined content.
@@ -39,28 +54,28 @@ namespace Microsoft.Interop
                 InvocationExpression(
                     MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
-                        GetUnmanagedValuesDestination(info, context),
+                        _collectionSource.GetUnmanagedValuesDestination(info, context),
                         IdentifierName("Clear"))));
         }
 
-        protected StatementSyntax GenerateMarshalStatement(TypePositionInfo info, StubCodeContext context)
+        public StatementSyntax GenerateMarshalStatement(TypePositionInfo info, StubCodeContext context)
         {
-            ExpressionSyntax destination = CastToManagedIfNecessary(GetUnmanagedValuesDestination(info, context));
+            ExpressionSyntax destination = CastToManagedIfNecessary(_collectionSource.GetUnmanagedValuesDestination(info, context));
 
             // <GetManagedValuesSource>.CopyTo(<destination>);
             return ExpressionStatement(
                 InvocationExpression(
                     MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
-                        GetManagedValuesSource(info, context),
+                        _collectionSource.GetManagedValuesSource(info, context),
                         IdentifierName("CopyTo")))
                 .AddArgumentListArguments(
                     Argument(destination)));
         }
 
-        protected StatementSyntax GenerateByValueOutUnmarshalStatement(TypePositionInfo info, StubCodeContext context)
+        public StatementSyntax GenerateByValueOutUnmarshalStatement(TypePositionInfo info, StubCodeContext context)
         {
-            ExpressionSyntax source = CastToManagedIfNecessary(GetUnmanagedValuesDestination(info, context));
+            ExpressionSyntax source = CastToManagedIfNecessary(_collectionSource.GetUnmanagedValuesDestination(info, context));
 
             // MemoryMarshal.CreateSpan(ref MemoryMarshal.GetReference(<GetManagedValuesSource>), <GetManagedValuesSource>.Length)
             ExpressionSyntax destination = InvocationExpression(
@@ -77,12 +92,12 @@ namespace Microsoft.Interop
                                     ParseName(TypeNames.System_Runtime_InteropServices_MemoryMarshal),
                                     IdentifierName("GetReference")),
                                 ArgumentList(SingletonSeparatedList(
-                                    Argument(GetManagedValuesSource(info, context))))))
+                                    Argument(_collectionSource.GetManagedValuesSource(info, context))))))
                             .WithRefKindKeyword(
                                 Token(SyntaxKind.RefKeyword)),
                         Argument(
                             MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                GetManagedValuesSource(info, context),
+                                _collectionSource.GetManagedValuesSource(info, context),
                                 IdentifierName("Length")))
                     })));
 
@@ -99,7 +114,7 @@ namespace Microsoft.Interop
 
         public StatementSyntax GenerateUnmarshalStatement(TypePositionInfo info, StubCodeContext context)
         {
-            ExpressionSyntax source = CastToManagedIfNecessary(GetUnmanagedValuesSource(info, context));
+            ExpressionSyntax source = CastToManagedIfNecessary(_collectionSource.GetUnmanagedValuesSource(info, context));
 
             // <source>.CopyTo(<GetManagedValuesDestination>);
             return ExpressionStatement(
@@ -109,7 +124,7 @@ namespace Microsoft.Interop
                         source,
                         IdentifierName("CopyTo")))
                 .AddArgumentListArguments(
-                    Argument(GetManagedValuesDestination(info, context))));
+                    Argument(_collectionSource.GetManagedValuesDestination(info, context))));
         }
 
         private ExpressionSyntax CastToManagedIfNecessary(ExpressionSyntax expression)
@@ -134,33 +149,33 @@ namespace Microsoft.Interop
                 ArgumentList(SingletonSeparatedList(
                     Argument(expression))));
         }
+
+        public StatementSyntax GenerateElementCleanupStatement(TypePositionInfo info, StubCodeContext context) => EmptyStatement();
     }
 
     /// <summary>
     /// Support for marshalling non-blittable elements
     /// </summary>
-    internal abstract class NonBlittableElementsMarshalling
+    internal sealed class NonBlittableElementsMarshalling : IElementsMarshalling
     {
         private readonly TypeSyntax _unmanagedElementType;
         private readonly IMarshallingGenerator _elementMarshaller;
         private readonly TypePositionInfo _elementInfo;
+        private readonly IElementsMarshallingCollectionSource _collectionSource;
 
         public NonBlittableElementsMarshalling(
             TypeSyntax unmanagedElementType,
             IMarshallingGenerator elementMarshaller,
-            TypePositionInfo elementInfo)
+            TypePositionInfo elementInfo,
+            IElementsMarshallingCollectionSource collectionSource)
         {
             _unmanagedElementType = unmanagedElementType;
             _elementMarshaller = elementMarshaller;
             _elementInfo = elementInfo;
+            _collectionSource = collectionSource;
         }
 
-        protected abstract InvocationExpressionSyntax GetUnmanagedValuesDestination(TypePositionInfo info, StubCodeContext context);
-        protected abstract InvocationExpressionSyntax GetManagedValuesSource(TypePositionInfo info, StubCodeContext context);
-        protected abstract InvocationExpressionSyntax GetUnmanagedValuesSource(TypePositionInfo info, StubCodeContext context);
-        protected abstract InvocationExpressionSyntax GetManagedValuesDestination(TypePositionInfo info, StubCodeContext context);
-
-        protected StatementSyntax GenerateByValueOutMarshalStatement(TypePositionInfo info, StubCodeContext context)
+        public StatementSyntax GenerateByValueOutMarshalStatement(TypePositionInfo info, StubCodeContext context)
         {
             // If the parameter is marshalled by-value [Out], then we don't marshal the contents of the collection.
             // We do clear the span, so that if the invoke target doesn't fill it, we aren't left with undefined content.
@@ -169,11 +184,11 @@ namespace Microsoft.Interop
                 InvocationExpression(
                     MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
-                        GetUnmanagedValuesDestination(info, context),
+                        _collectionSource.GetUnmanagedValuesDestination(info, context),
                         IdentifierName("Clear"))));
         }
 
-        protected StatementSyntax GenerateMarshalStatement(TypePositionInfo info, StubCodeContext context)
+        public StatementSyntax GenerateMarshalStatement(TypePositionInfo info, StubCodeContext context)
         {
             string managedSpanIdentifier = MarshallerHelpers.GetManagedSpanIdentifier(info, context);
             string nativeSpanIdentifier = MarshallerHelpers.GetNativeSpanIdentifier(info, context);
@@ -189,7 +204,7 @@ namespace Microsoft.Interop
                     SingletonSeparatedList(
                         VariableDeclarator(Identifier(managedSpanIdentifier))
                         .WithInitializer(EqualsValueClause(
-                            GetManagedValuesSource(info, context)))))),
+                            _collectionSource.GetManagedValuesSource(info, context)))))),
                 LocalDeclarationStatement(VariableDeclaration(
                     GenericName(
                         Identifier(TypeNames.System_Span),
@@ -198,7 +213,7 @@ namespace Microsoft.Interop
                         VariableDeclarator(
                             Identifier(nativeSpanIdentifier))
                         .WithInitializer(EqualsValueClause(
-                            GetUnmanagedValuesDestination(info, context)))))),
+                            _collectionSource.GetUnmanagedValuesDestination(info, context)))))),
                 GenerateContentsMarshallingStatement(
                     info,
                     context,
@@ -226,7 +241,7 @@ namespace Microsoft.Interop
                         VariableDeclarator(
                             Identifier(nativeSpanIdentifier))
                         .WithInitializer(EqualsValueClause(
-                            GetUnmanagedValuesSource(info, context)))))),
+                            _collectionSource.GetUnmanagedValuesSource(info, context)))))),
                 LocalDeclarationStatement(VariableDeclaration(
                     GenericName(
                         Identifier(TypeNames.System_Span),
@@ -235,7 +250,7 @@ namespace Microsoft.Interop
                         VariableDeclarator(
                             Identifier(managedSpanIdentifier))
                         .WithInitializer(EqualsValueClause(
-                            GetManagedValuesDestination(info, context)))))),
+                            _collectionSource.GetManagedValuesDestination(info, context)))))),
                 GenerateContentsMarshallingStatement(
                     info,
                     context,
@@ -244,7 +259,7 @@ namespace Microsoft.Interop
                     StubCodeContext.Stage.Unmarshal));
         }
 
-        protected StatementSyntax GenerateByValueOutUnmarshalStatement(TypePositionInfo info, StubCodeContext context)
+        public StatementSyntax GenerateByValueOutUnmarshalStatement(TypePositionInfo info, StubCodeContext context)
         {
             // Use ManagedSource and NativeDestination spans for by-value marshalling since we're just marshalling back the contents,
             // not the array itself.
@@ -252,6 +267,8 @@ namespace Microsoft.Interop
             // but this is an uncommon case so we don't want to design the API around enabling just it.
             string numElementsIdentifier = MarshallerHelpers.GetNumElementsIdentifier(info, context);
             string managedSpanIdentifier = MarshallerHelpers.GetManagedSpanIdentifier(info, context);
+
+            var setNumElements = _collectionSource.GetManagedValuesNumElementsAssignment(info, context);
 
             // Span<TElement> <managedSpan> = MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in <GetManagedValuesSource>.GetPinnableReference(), <numElements>));
             LocalDeclarationStatementSyntax managedValuesDeclaration = LocalDeclarationStatement(VariableDeclaration(
@@ -281,7 +298,7 @@ namespace Microsoft.Interop
                                                     InvocationExpression(
                                                         MemberAccessExpression(
                                                             SyntaxKind.SimpleMemberAccessExpression,
-                                                            GetManagedValuesSource(info, context),
+                                                            _collectionSource.GetManagedValuesSource(info, context),
                                                             IdentifierName("GetPinnableReference")),
                                                             ArgumentList()))
                                                 .WithRefKindKeyword(
@@ -302,20 +319,21 @@ namespace Microsoft.Interop
                     VariableDeclarator(
                         Identifier(nativeSpanIdentifier))
                     .WithInitializer(EqualsValueClause(
-                        GetUnmanagedValuesDestination(info, context))))));
+                        _collectionSource.GetUnmanagedValuesDestination(info, context))))));
 
             return Block(
+                setNumElements,
                 managedValuesDeclaration,
                 unmanagedValuesDeclaration,
                 GenerateContentsMarshallingStatement(
-                    info,
-                    context,
-                    IdentifierName(numElementsIdentifier),
-                    StubCodeContext.Stage.UnmarshalCapture,
-                    StubCodeContext.Stage.Unmarshal));
+                        info,
+                        context,
+                        IdentifierName(numElementsIdentifier),
+                        StubCodeContext.Stage.UnmarshalCapture,
+                        StubCodeContext.Stage.Unmarshal));
         }
 
-        protected StatementSyntax GenerateElementCleanupStatement(TypePositionInfo info, StubCodeContext context)
+        public StatementSyntax GenerateElementCleanupStatement(TypePositionInfo info, StubCodeContext context)
         {
             string nativeSpanIdentifier = MarshallerHelpers.GetNativeSpanIdentifier(info, context);
             StatementSyntax contentsCleanupStatements = GenerateContentsMarshallingStatement(info, context,
@@ -338,11 +356,11 @@ namespace Microsoft.Interop
                     VariableDeclarator(
                         Identifier(nativeSpanIdentifier))
                     .WithInitializer(EqualsValueClause(
-                        GetUnmanagedValuesDestination(info, context)))))),
+                        _collectionSource.GetUnmanagedValuesDestination(info, context)))))),
                 contentsCleanupStatements);
         }
 
-        protected StatementSyntax GenerateContentsMarshallingStatement(
+        private StatementSyntax GenerateContentsMarshallingStatement(
             TypePositionInfo info,
             StubCodeContext context,
             ExpressionSyntax lengthExpression,

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatefulMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatefulMarshallingStrategy.cs
@@ -288,85 +288,9 @@ namespace Microsoft.Interop
         public IEnumerable<StatementSyntax> GenerateNotifyForSuccessfulInvokeStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GenerateNotifyForSuccessfulInvokeStatements(info, context);
     }
 
-    /// <summary>
-    /// Marshaller that enables support for marshalling blittable elements of a collection via a native type that implements the LinearCollection marshalling spec.
-    /// </summary>
-    internal sealed class StatefulLinearCollectionBlittableElementsMarshalling : BlittableElementsMarshalling, ICustomTypeMarshallingStrategy
+    internal sealed class StatefulLinearCollectionSource : IElementsMarshallingCollectionSource
     {
-        private readonly ICustomTypeMarshallingStrategy _innerMarshaller;
-        private readonly MarshallerShape _shape;
-        private readonly ExpressionSyntax _numElementsExpression;
-
-        public StatefulLinearCollectionBlittableElementsMarshalling(
-            ICustomTypeMarshallingStrategy innerMarshaller, MarshallerShape shape, TypeSyntax managedElementType, TypeSyntax unmanagedElementType, ExpressionSyntax numElementsExpression)
-            : base (managedElementType, unmanagedElementType)
-        {
-            _innerMarshaller = innerMarshaller;
-            _shape = shape;
-            _numElementsExpression = numElementsExpression;
-        }
-
-        public ManagedTypeInfo AsNativeType(TypePositionInfo info) => _innerMarshaller.AsNativeType(info);
-        public IEnumerable<StatementSyntax> GenerateCleanupStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GenerateCleanupStatements(info, context);
-        public IEnumerable<StatementSyntax> GenerateGuaranteedUnmarshalStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GenerateGuaranteedUnmarshalStatements(info, context);
-
-        public IEnumerable<StatementSyntax> GenerateMarshalStatements(TypePositionInfo info, StubCodeContext context)
-        {
-            if (!_shape.HasFlag(MarshallerShape.ToUnmanaged) && !_shape.HasFlag(MarshallerShape.CallerAllocatedBuffer))
-                yield break;
-
-            foreach (StatementSyntax statement in _innerMarshaller.GenerateMarshalStatements(info, context))
-            {
-                yield return statement;
-            }
-
-            if (!info.IsByRef && info.ByValueContentsMarshalKind == ByValueContentsMarshalKind.Out)
-            {
-                yield return GenerateByValueOutMarshalStatement(info, context);
-                yield break;
-            }
-
-            yield return GenerateMarshalStatement(info, context);
-        }
-
-        public IEnumerable<StatementSyntax> GenerateNotifyForSuccessfulInvokeStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GenerateNotifyForSuccessfulInvokeStatements(info, context);
-        public IEnumerable<StatementSyntax> GeneratePinnedMarshalStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GeneratePinnedMarshalStatements(info, context);
-        public IEnumerable<StatementSyntax> GeneratePinStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GeneratePinStatements(info, context);
-        public IEnumerable<StatementSyntax> GenerateSetupStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GenerateSetupStatements(info, context);
-        public IEnumerable<StatementSyntax> GenerateUnmarshalCaptureStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GenerateUnmarshalCaptureStatements(info, context);
-
-        public IEnumerable<StatementSyntax> GenerateUnmarshalStatements(TypePositionInfo info, StubCodeContext context)
-        {
-            if (!_shape.HasFlag(MarshallerShape.ToManaged))
-                yield break;
-
-            if (!info.IsByRef && info.ByValueContentsMarshalKind.HasFlag(ByValueContentsMarshalKind.Out))
-            {
-                yield return GenerateByValueOutUnmarshalStatement(info, context);
-            }
-            else
-            {
-                // int <numElements> = <numElementExpression>
-                string numElementsIdentifier = MarshallerHelpers.GetNumElementsIdentifier(info, context);
-                yield return LocalDeclarationStatement(
-                    VariableDeclaration(
-                        PredefinedType(Token(SyntaxKind.IntKeyword)),
-                        SingletonSeparatedList(
-                            VariableDeclarator(numElementsIdentifier)
-                                .WithInitializer(EqualsValueClause(_numElementsExpression)))));
-
-                yield return GenerateUnmarshalStatement(info, context);
-            }
-
-            foreach (StatementSyntax statement in _innerMarshaller.GenerateUnmarshalStatements(info, context))
-            {
-                yield return statement;
-            }
-        }
-
-        public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.UsesNativeIdentifier(info, context);
-
-        protected override InvocationExpressionSyntax GetUnmanagedValuesDestination(TypePositionInfo info, StubCodeContext context)
+        public InvocationExpressionSyntax GetUnmanagedValuesDestination(TypePositionInfo info, StubCodeContext context)
         {
             string marshaller = StatefulValueMarshalling.GetMarshallerIdentifier(info, context);
 
@@ -375,11 +299,11 @@ namespace Microsoft.Interop
                 MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     IdentifierName(marshaller),
-                    IdentifierName(ShapeMemberNames.LinearCollection.Stateful.GetUnmanagedValuesDestination)),
+                    IdentifierName(ShapeMemberNames.LinearCollection.Stateless.GetUnmanagedValuesDestination)),
                 ArgumentList());
         }
 
-        protected override InvocationExpressionSyntax GetManagedValuesSource(TypePositionInfo info, StubCodeContext context)
+        public InvocationExpressionSyntax GetManagedValuesSource(TypePositionInfo info, StubCodeContext context)
         {
             string marshaller = StatefulValueMarshalling.GetMarshallerIdentifier(info, context);
 
@@ -392,7 +316,7 @@ namespace Microsoft.Interop
                 ArgumentList());
         }
 
-        protected override InvocationExpressionSyntax GetUnmanagedValuesSource(TypePositionInfo info, StubCodeContext context)
+        public InvocationExpressionSyntax GetUnmanagedValuesSource(TypePositionInfo info, StubCodeContext context)
         {
             string marshaller = StatefulValueMarshalling.GetMarshallerIdentifier(info, context);
             string numElementsIdentifier = MarshallerHelpers.GetNumElementsIdentifier(info, context);
@@ -407,7 +331,7 @@ namespace Microsoft.Interop
                     Argument(IdentifierName(numElementsIdentifier)))));
         }
 
-        protected override InvocationExpressionSyntax GetManagedValuesDestination(TypePositionInfo info, StubCodeContext context)
+        public InvocationExpressionSyntax GetManagedValuesDestination(TypePositionInfo info, StubCodeContext context)
         {
             string marshaller = StatefulValueMarshalling.GetMarshallerIdentifier(info, context);
             string numElementsIdentifier = MarshallerHelpers.GetNumElementsIdentifier(info, context);
@@ -417,39 +341,54 @@ namespace Microsoft.Interop
                 MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     IdentifierName(marshaller),
-                    IdentifierName(ShapeMemberNames.LinearCollection.Stateful.GetManagedValuesDestination)),
+                    IdentifierName(ShapeMemberNames.LinearCollection.Stateless.GetManagedValuesDestination)),
                 ArgumentList(SingletonSeparatedList(
                     Argument(IdentifierName(numElementsIdentifier)))));
+        }
+
+        public StatementSyntax GetManagedValuesNumElementsAssignment(TypePositionInfo info, StubCodeContext context)
+        {
+            string numElementsIdentifier = MarshallerHelpers.GetNumElementsIdentifier(info, context);
+            // int <numElements> = <GetManagedValuesSource>.Length;
+            return LocalDeclarationStatement(
+                VariableDeclaration(
+                    PredefinedType(Token(SyntaxKind.IntKeyword)),
+                    SingletonSeparatedList(
+                        VariableDeclarator(numElementsIdentifier)
+                            .WithInitializer(EqualsValueClause(
+                                MemberAccessExpression(
+                                    SyntaxKind.SimpleMemberAccessExpression,
+                                    GetManagedValuesSource(info, context),
+                                    IdentifierName("Length")))))));
         }
     }
 
     /// <summary>
-    /// Marshaller that enables support for marshalling non-blittable elements of a collection via a native type that implements the LinearCollection marshalling spec.
+    /// Marshaller that enables support for marshalling elements of a collection via a native type that implements the LinearCollection marshalling spec.
     /// </summary>
-    internal sealed class StatefulLinearCollectionNonBlittableElementsMarshalling : NonBlittableElementsMarshalling, ICustomTypeMarshallingStrategy
+    internal sealed class StatefulLinearCollectionMarshalling : ICustomTypeMarshallingStrategy
     {
         private readonly ICustomTypeMarshallingStrategy _innerMarshaller;
         private readonly MarshallerShape _shape;
         private readonly ExpressionSyntax _numElementsExpression;
+        private readonly IElementsMarshalling _elementsMarshalling;
 
-        public StatefulLinearCollectionNonBlittableElementsMarshalling(
+        public StatefulLinearCollectionMarshalling(
             ICustomTypeMarshallingStrategy innerMarshaller,
             MarshallerShape shape,
-            TypeSyntax unmanagedElementType,
-            IMarshallingGenerator elementMarshaller,
-            TypePositionInfo elementInfo,
-            ExpressionSyntax numElementsExpression)
-            : base (unmanagedElementType, elementMarshaller, elementInfo)
+            ExpressionSyntax numElementsExpression,
+            IElementsMarshalling elementsMarshalling)
         {
             _innerMarshaller = innerMarshaller;
             _shape = shape;
             _numElementsExpression = numElementsExpression;
+            _elementsMarshalling = elementsMarshalling;
         }
 
         public ManagedTypeInfo AsNativeType(TypePositionInfo info) => _innerMarshaller.AsNativeType(info);
         public IEnumerable<StatementSyntax> GenerateCleanupStatements(TypePositionInfo info, StubCodeContext context)
         {
-            StatementSyntax elementCleanup = GenerateElementCleanupStatement(info, context);
+            StatementSyntax elementCleanup = _elementsMarshalling.GenerateElementCleanupStatement(info, context);
 
             if (!elementCleanup.IsKind(SyntaxKind.EmptyStatement))
             {
@@ -482,14 +421,11 @@ namespace Microsoft.Interop
 
             if (!info.IsByRef && info.ByValueContentsMarshalKind == ByValueContentsMarshalKind.Out)
             {
-                yield return GenerateByValueOutMarshalStatement(info, context);
+                yield return _elementsMarshalling.GenerateByValueOutMarshalStatement(info, context);
                 yield break;
             }
 
-            // ReadOnlySpan<T> <managedSpan> = <marshaller>.GetManagedValuesSource()
-            // Span<TUnmanagedElement> <nativeSpan> = <marshaller>.GetUnmanagedValuesDestination()
-            // << marshal contents >>
-            yield return GenerateMarshalStatement(info, context);
+            yield return _elementsMarshalling.GenerateMarshalStatement(info, context);
         }
 
         public IEnumerable<StatementSyntax> GenerateNotifyForSuccessfulInvokeStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GenerateNotifyForSuccessfulInvokeStatements(info, context);
@@ -503,18 +439,7 @@ namespace Microsoft.Interop
 
             if (!info.IsByRef && info.ByValueContentsMarshalKind.HasFlag(ByValueContentsMarshalKind.Out))
             {
-                // int <numElements> = <GetManagedValuesSource>.Length;
-                yield return LocalDeclarationStatement(
-                    VariableDeclaration(
-                        PredefinedType(Token(SyntaxKind.IntKeyword)),
-                        SingletonSeparatedList(
-                            VariableDeclarator(numElementsIdentifier)
-                                .WithInitializer(EqualsValueClause(
-                                    MemberAccessExpression(
-                                        SyntaxKind.SimpleMemberAccessExpression,
-                                        GetManagedValuesSource(info, context),
-                                        IdentifierName("Length")))))));
-                yield return GenerateByValueOutUnmarshalStatement(info, context);
+                yield return _elementsMarshalling.GenerateByValueOutUnmarshalStatement(info, context);
             }
 
             if (!_shape.HasFlag(MarshallerShape.ToManaged))
@@ -531,10 +456,7 @@ namespace Microsoft.Interop
                             VariableDeclarator(numElementsIdentifier)
                                 .WithInitializer(EqualsValueClause(_numElementsExpression)))));
 
-                // ReadOnlySpan<TUnmanagedElement> <nativeSpan> = <marshaller>.GetUnmanagedValuesSource(<nativeIdentifier>, <numElements>)
-                // Span<T> <managedSpan> = <marshaller>.GetManagedValuesDestination(<managedIdentifier>)
-                // << unmarshal contents >>
-                yield return GenerateUnmarshalStatement(info, context);
+                yield return _elementsMarshalling.GenerateUnmarshalStatement(info, context);
             }
 
             foreach (StatementSyntax statement in _innerMarshaller.GenerateUnmarshalStatements(info, context))
@@ -546,61 +468,5 @@ namespace Microsoft.Interop
         public IEnumerable<StatementSyntax> GenerateUnmarshalCaptureStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GenerateUnmarshalCaptureStatements(info, context);
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context) => true;
-
-        protected override InvocationExpressionSyntax GetUnmanagedValuesDestination(TypePositionInfo info, StubCodeContext context)
-        {
-            string marshaller = StatefulValueMarshalling.GetMarshallerIdentifier(info, context);
-
-            // <marshaller>.GetUnmanagedValuesDestination()
-            return InvocationExpression(
-                MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
-                    IdentifierName(marshaller),
-                    IdentifierName(ShapeMemberNames.LinearCollection.Stateless.GetUnmanagedValuesDestination)),
-                ArgumentList());
-        }
-
-        protected override InvocationExpressionSyntax GetManagedValuesSource(TypePositionInfo info, StubCodeContext context)
-        {
-            string marshaller = StatefulValueMarshalling.GetMarshallerIdentifier(info, context);
-
-            // <marshaller>.GetManagedValuesSource()
-            return InvocationExpression(
-                MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
-                    IdentifierName(marshaller),
-                    IdentifierName(ShapeMemberNames.LinearCollection.Stateful.GetManagedValuesSource)),
-                ArgumentList());
-        }
-
-        protected override InvocationExpressionSyntax GetUnmanagedValuesSource(TypePositionInfo info, StubCodeContext context)
-        {
-            string marshaller = StatefulValueMarshalling.GetMarshallerIdentifier(info, context);
-            string numElementsIdentifier = MarshallerHelpers.GetNumElementsIdentifier(info, context);
-
-            // <marshaller>.GetUnmanagedValuesSource(<numElements>)
-            return InvocationExpression(
-                MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
-                    IdentifierName(marshaller),
-                    IdentifierName(ShapeMemberNames.LinearCollection.Stateful.GetUnmanagedValuesSource)),
-                ArgumentList(SingletonSeparatedList(
-                    Argument(IdentifierName(numElementsIdentifier)))));
-        }
-
-        protected override InvocationExpressionSyntax GetManagedValuesDestination(TypePositionInfo info, StubCodeContext context)
-        {
-            string marshaller = StatefulValueMarshalling.GetMarshallerIdentifier(info, context);
-            string numElementsIdentifier = MarshallerHelpers.GetNumElementsIdentifier(info, context);
-
-            // <marshaller>.GetManagedValuesDestination(<numElements>)
-            return InvocationExpression(
-                MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
-                    IdentifierName(marshaller),
-                    IdentifierName(ShapeMemberNames.LinearCollection.Stateless.GetManagedValuesDestination)),
-                ArgumentList(SingletonSeparatedList(
-                    Argument(IdentifierName(numElementsIdentifier)))));
-        }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatefulMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatefulMarshallingStrategy.cs
@@ -299,7 +299,7 @@ namespace Microsoft.Interop
                 MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     IdentifierName(marshaller),
-                    IdentifierName(ShapeMemberNames.LinearCollection.Stateless.GetUnmanagedValuesDestination)),
+                    IdentifierName(ShapeMemberNames.LinearCollection.Stateful.GetUnmanagedValuesDestination)),
                 ArgumentList());
         }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatefulMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatefulMarshallingStrategy.cs
@@ -341,7 +341,7 @@ namespace Microsoft.Interop
                 MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     IdentifierName(marshaller),
-                    IdentifierName(ShapeMemberNames.LinearCollection.Stateless.GetManagedValuesDestination)),
+                    IdentifierName(ShapeMemberNames.LinearCollection.Stateful.GetManagedValuesDestination)),
                 ArgumentList(SingletonSeparatedList(
                     Argument(IdentifierName(numElementsIdentifier)))));
         }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatelessMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatelessMarshallingStrategy.cs
@@ -296,17 +296,16 @@ namespace Microsoft.Interop
     }
 
     /// <summary>
-    /// Marshaller that enables support for marshalling blittable elements of a collection via a native type that implements the LinearCollection marshalling spec.
+    /// Marshaller type that enables allocating space for marshalling a linear collection using a marshaller that implements the LinearCollection marshalling spec.
     /// </summary>
-    internal sealed class StatelessLinearCollectionBlittableElementsMarshalling : BlittableElementsMarshalling, ICustomTypeMarshallingStrategy
+    internal sealed class StatelessLinearCollectionSpaceAllocator : ICustomTypeMarshallingStrategy
     {
         private readonly TypeSyntax _marshallerTypeSyntax;
         private readonly ManagedTypeInfo _unmanagedType;
         private readonly MarshallerShape _shape;
         private readonly ExpressionSyntax _numElementsExpression;
 
-        public StatelessLinearCollectionBlittableElementsMarshalling(TypeSyntax marshallerTypeSyntax, ManagedTypeInfo unmanagedType, MarshallerShape shape, TypeSyntax managedElementType, TypeSyntax unmanagedElementType, ExpressionSyntax numElementsExpression)
-            : base(managedElementType, unmanagedElementType)
+        public StatelessLinearCollectionSpaceAllocator(TypeSyntax marshallerTypeSyntax, ManagedTypeInfo unmanagedType, MarshallerShape shape, ExpressionSyntax numElementsExpression)
         {
             _marshallerTypeSyntax = marshallerTypeSyntax;
             _unmanagedType = unmanagedType;
@@ -346,8 +345,8 @@ namespace Microsoft.Interop
                             IdentifierName(ShapeMemberNames.LinearCollection.Stateless.AllocateContainerForManagedElementsFinally)),
                         ArgumentList(SeparatedList(new ArgumentSyntax[]
                         {
-                            Argument(IdentifierName(nativeIdentifier)),
-                            Argument(IdentifierName(numElementsIdentifier))
+                       Argument(IdentifierName(nativeIdentifier)),
+                       Argument(IdentifierName(numElementsIdentifier))
                         })))));
         }
 
@@ -374,19 +373,10 @@ namespace Microsoft.Interop
                                 IdentifierName(ShapeMemberNames.LinearCollection.Stateless.AllocateContainerForUnmanagedElements)),
                             ArgumentList(SeparatedList(new ArgumentSyntax[]
                             {
-                                Argument(IdentifierName(managedIdentifier)),
-                                Argument(IdentifierName(numElementsIdentifier))
-                                    .WithRefOrOutKeyword(Token(SyntaxKind.OutKeyword))
+                           Argument(IdentifierName(managedIdentifier)),
+                           Argument(IdentifierName(numElementsIdentifier))
+                               .WithRefOrOutKeyword(Token(SyntaxKind.OutKeyword))
                             })))));
-            }
-
-            if (!info.IsByRef && info.ByValueContentsMarshalKind == ByValueContentsMarshalKind.Out)
-            {
-                yield return GenerateByValueOutMarshalStatement(info, context);
-            }
-            else
-            {
-                yield return GenerateMarshalStatement(info, context);
             }
         }
 
@@ -416,7 +406,6 @@ namespace Microsoft.Interop
         {
             if (!info.IsByRef && info.ByValueContentsMarshalKind.HasFlag(ByValueContentsMarshalKind.Out))
             {
-                yield return GenerateByValueOutUnmarshalStatement(info, context);
                 yield break;
             }
 
@@ -443,16 +432,24 @@ namespace Microsoft.Interop
                             IdentifierName(ShapeMemberNames.LinearCollection.Stateless.AllocateContainerForManagedElements)),
                         ArgumentList(SeparatedList(new ArgumentSyntax[]
                         {
-                            Argument(IdentifierName(nativeIdentifier)),
-                            Argument(IdentifierName(numElementsIdentifier))
+                       Argument(IdentifierName(nativeIdentifier)),
+                       Argument(IdentifierName(numElementsIdentifier))
                         })))));
-
-            yield return GenerateUnmarshalStatement(info, context);
         }
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context) => true;
+    }
 
-        protected override InvocationExpressionSyntax GetUnmanagedValuesDestination(TypePositionInfo info, StubCodeContext context)
+    internal sealed class StatelessLinearCollectionSource : IElementsMarshallingCollectionSource
+    {
+        private readonly TypeSyntax _marshallerTypeSyntax;
+
+        public StatelessLinearCollectionSource(TypeSyntax marshallerTypeSyntax)
+        {
+            _marshallerTypeSyntax = marshallerTypeSyntax;
+        }
+
+        public InvocationExpressionSyntax GetUnmanagedValuesDestination(TypePositionInfo info, StubCodeContext context)
         {
             string numElementsIdentifier = MarshallerHelpers.GetNumElementsIdentifier(info, context);
             string nativeIdentifier = context.GetIdentifiers(info).native;
@@ -470,7 +467,7 @@ namespace Microsoft.Interop
                 })));
         }
 
-        protected override InvocationExpressionSyntax GetManagedValuesSource(TypePositionInfo info, StubCodeContext context)
+        public InvocationExpressionSyntax GetManagedValuesSource(TypePositionInfo info, StubCodeContext context)
         {
             // <marshallerType>.GetManagedValuesSource(<managedIdentifier>)
             string managedIdentifier = context.GetIdentifiers(info).managed;
@@ -483,7 +480,7 @@ namespace Microsoft.Interop
                     Argument(IdentifierName(managedIdentifier)))));
         }
 
-        protected override InvocationExpressionSyntax GetUnmanagedValuesSource(TypePositionInfo info, StubCodeContext context)
+        public InvocationExpressionSyntax GetUnmanagedValuesSource(TypePositionInfo info, StubCodeContext context)
         {
             string numElementsIdentifier = MarshallerHelpers.GetNumElementsIdentifier(info, context);
             string nativeIdentifier = context.GetIdentifiers(info).native;
@@ -501,7 +498,7 @@ namespace Microsoft.Interop
                 })));
         }
 
-        protected override InvocationExpressionSyntax GetManagedValuesDestination(TypePositionInfo info, StubCodeContext context)
+        public InvocationExpressionSyntax GetManagedValuesDestination(TypePositionInfo info, StubCodeContext context)
         {
             string managedIdentifier = context.GetIdentifiers(info).managed;
 
@@ -513,154 +510,96 @@ namespace Microsoft.Interop
                     IdentifierName(ShapeMemberNames.LinearCollection.Stateless.GetManagedValuesDestination)),
                 ArgumentList(SingletonSeparatedList(Argument(IdentifierName(managedIdentifier)))));
         }
+
+        public StatementSyntax GetManagedValuesNumElementsAssignment(TypePositionInfo info, StubCodeContext context)
+        {
+            var numElementsIdentifier = MarshallerHelpers.GetNumElementsIdentifier(info, context);
+            // <numElements> = <GetManagedValuesSource>.Length;
+            return ExpressionStatement(
+                AssignmentExpression(
+                    SyntaxKind.SimpleAssignmentExpression,
+                    IdentifierName(numElementsIdentifier),
+                    MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        GetManagedValuesSource(info, context),
+                        IdentifierName("Length"))));
+        }
     }
 
     /// <summary>
-    /// Marshaller that enables support for marshalling non-blittable elements of a collection via a native type that implements the LinearCollection marshalling spec.
+    /// Marshaller that enables support for marshalling elements of a collection via a marshaller type that implements the contiguous collection marshalling shape.
     /// </summary>
-    internal sealed class StatelessLinearCollectionNonBlittableElementsMarshalling : NonBlittableElementsMarshalling, ICustomTypeMarshallingStrategy
+    internal sealed class StatelessLinearCollectionMarshalling : ICustomTypeMarshallingStrategy
     {
-        private readonly TypeSyntax _marshallerTypeSyntax;
+        private readonly ICustomTypeMarshallingStrategy _spaceMarshallingStrategy;
+        private readonly IElementsMarshalling _elementsMarshalling;
         private readonly ManagedTypeInfo _unmanagedType;
         private readonly MarshallerShape _shape;
-        private readonly ExpressionSyntax _numElementsExpression;
 
-        public StatelessLinearCollectionNonBlittableElementsMarshalling(
-            TypeSyntax marshallerTypeSyntax,
+        public StatelessLinearCollectionMarshalling(
+            ICustomTypeMarshallingStrategy spaceMarshallingStrategy,
+            IElementsMarshalling elementsMarshalling,
             ManagedTypeInfo unmanagedType,
-            MarshallerShape shape,
-            TypeSyntax unmanagedElementType,
-            IMarshallingGenerator elementMarshaller,
-            TypePositionInfo elementInfo,
-            ExpressionSyntax numElementsExpression)
-            : base(unmanagedElementType, elementMarshaller, elementInfo)
+            MarshallerShape shape)
         {
-            _marshallerTypeSyntax = marshallerTypeSyntax;
+            _spaceMarshallingStrategy = spaceMarshallingStrategy;
+            _elementsMarshalling = elementsMarshalling;
             _unmanagedType = unmanagedType;
             _shape = shape;
-            _numElementsExpression = numElementsExpression;
         }
 
         public ManagedTypeInfo AsNativeType(TypePositionInfo info) => _unmanagedType;
 
         public IEnumerable<StatementSyntax> GenerateCleanupStatements(TypePositionInfo info, StubCodeContext context)
         {
-            StatementSyntax elementCleanup = GenerateElementCleanupStatement(info, context);
+            StatementSyntax elementCleanup = _elementsMarshalling.GenerateElementCleanupStatement(info, context);
 
             if (!elementCleanup.IsKind(SyntaxKind.EmptyStatement))
             {
                 yield return elementCleanup;
             }
+
+            foreach (var statement in _spaceMarshallingStrategy.GenerateCleanupStatements(info, context))
+            {
+                yield return statement;
+            }
         }
 
-        public IEnumerable<StatementSyntax> GenerateGuaranteedUnmarshalStatements(TypePositionInfo info, StubCodeContext context)
-        {
-            if (!_shape.HasFlag(MarshallerShape.GuaranteedUnmarshal))
-                yield break;
-
-            (string managedIdentifier, string nativeIdentifier) = context.GetIdentifiers(info);
-            string numElementsIdentifier = MarshallerHelpers.GetNumElementsIdentifier(info, context);
-
-            yield return ExpressionStatement(
-                AssignmentExpression(
-                    SyntaxKind.SimpleAssignmentExpression,
-                    IdentifierName(numElementsIdentifier),
-                    _numElementsExpression));
-
-            // <managedIdentifier> = <marshallerType>.AllocateContainerForManagedElementsFinally(<nativeIdentifier>, <numElements>);
-            yield return ExpressionStatement(
-                AssignmentExpression(
-                    SyntaxKind.SimpleAssignmentExpression,
-                    IdentifierName(managedIdentifier),
-                    InvocationExpression(
-                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                            _marshallerTypeSyntax,
-                            IdentifierName(ShapeMemberNames.LinearCollection.Stateless.AllocateContainerForManagedElementsFinally)),
-                        ArgumentList(SeparatedList(new ArgumentSyntax[]
-                        {
-                            Argument(IdentifierName(nativeIdentifier)),
-                            Argument(IdentifierName(numElementsIdentifier))
-                        })))));
-        }
+        public IEnumerable<StatementSyntax> GenerateGuaranteedUnmarshalStatements(TypePositionInfo info, StubCodeContext context) => _spaceMarshallingStrategy.GenerateGuaranteedUnmarshalStatements(info, context);
 
         public IEnumerable<StatementSyntax> GenerateMarshalStatements(TypePositionInfo info, StubCodeContext context)
         {
+            foreach (var statement in _spaceMarshallingStrategy.GenerateMarshalStatements(info, context))
+            {
+                yield return statement;
+            }
             if (!_shape.HasFlag(MarshallerShape.ToUnmanaged) && !_shape.HasFlag(MarshallerShape.CallerAllocatedBuffer))
                 yield break;
 
-            if (_shape.HasFlag(MarshallerShape.ToUnmanaged)
-                && !(_shape.HasFlag(MarshallerShape.CallerAllocatedBuffer) && MarshallerHelpers.CanUseCallerAllocatedBuffer(info, context)))
-            {
-                (string managedIdentifier, string nativeIdentifier) = context.GetIdentifiers(info);
-                string numElementsIdentifier = MarshallerHelpers.GetNumElementsIdentifier(info, context);
-
-                // <nativeIdentifier> = <marshallerType>.AllocateContainerForUnmanagedElements(<managedIdentifier>, out <numElements>);
-                yield return ExpressionStatement(
-                    AssignmentExpression(
-                        SyntaxKind.SimpleAssignmentExpression,
-                        IdentifierName(nativeIdentifier),
-                        InvocationExpression(
-                            MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                _marshallerTypeSyntax,
-                                IdentifierName(ShapeMemberNames.LinearCollection.Stateless.AllocateContainerForUnmanagedElements)),
-                            ArgumentList(SeparatedList(new ArgumentSyntax[]
-                            {
-                                Argument(IdentifierName(managedIdentifier)),
-                                Argument(IdentifierName(numElementsIdentifier))
-                                    .WithRefOrOutKeyword(Token(SyntaxKind.OutKeyword))
-                            })))));
-            }
-
             if (!info.IsByRef && info.ByValueContentsMarshalKind == ByValueContentsMarshalKind.Out)
             {
-                yield return GenerateByValueOutMarshalStatement(info, context);
+                yield return _elementsMarshalling.GenerateByValueOutMarshalStatement(info, context);
             }
             else
             {
-                yield return GenerateMarshalStatement(info, context);
+                yield return _elementsMarshalling.GenerateMarshalStatement(info, context);
             }
         }
 
-        public IEnumerable<StatementSyntax> GenerateNotifyForSuccessfulInvokeStatements(TypePositionInfo info, StubCodeContext context) => Array.Empty<StatementSyntax>();
-        public IEnumerable<StatementSyntax> GeneratePinnedMarshalStatements(TypePositionInfo info, StubCodeContext context) => Array.Empty<StatementSyntax>();
-        public IEnumerable<StatementSyntax> GeneratePinStatements(TypePositionInfo info, StubCodeContext context) => Array.Empty<StatementSyntax>();
+        public IEnumerable<StatementSyntax> GenerateNotifyForSuccessfulInvokeStatements(TypePositionInfo info, StubCodeContext context) => _spaceMarshallingStrategy.GenerateNotifyForSuccessfulInvokeStatements(info, context);
+        public IEnumerable<StatementSyntax> GeneratePinnedMarshalStatements(TypePositionInfo info, StubCodeContext context) => _spaceMarshallingStrategy.GeneratePinnedMarshalStatements(info, context);
+        public IEnumerable<StatementSyntax> GeneratePinStatements(TypePositionInfo info, StubCodeContext context) => _spaceMarshallingStrategy.GeneratePinStatements(info, context);
 
-        public IEnumerable<StatementSyntax> GenerateSetupStatements(TypePositionInfo info, StubCodeContext context)
-        {
-            string numElementsIdentifier = MarshallerHelpers.GetNumElementsIdentifier(info, context);
-            yield return LocalDeclarationStatement(
-                VariableDeclaration(
-                    PredefinedType(Token(SyntaxKind.IntKeyword)),
-                    SingletonSeparatedList(
-                        VariableDeclarator(numElementsIdentifier))));
-            // Use the numElements local to ensure the compiler doesn't give errors for using an uninitialized variable.
-            // The value will never be used unless it has been initialized, so this is safe.
-            yield return MarshallerHelpers.SkipInitOrDefaultInit(
-                new TypePositionInfo(SpecialTypeInfo.Int32, NoMarshallingInfo.Instance)
-                {
-                    InstanceIdentifier = numElementsIdentifier
-                }, context);
-        }
+        public IEnumerable<StatementSyntax> GenerateSetupStatements(TypePositionInfo info, StubCodeContext context) => _spaceMarshallingStrategy.GenerateSetupStatements(info, context);
 
         public IEnumerable<StatementSyntax> GenerateUnmarshalCaptureStatements(TypePositionInfo info, StubCodeContext context) => Array.Empty<StatementSyntax>();
 
         public IEnumerable<StatementSyntax> GenerateUnmarshalStatements(TypePositionInfo info, StubCodeContext context)
         {
-            (string managedIdentifier, string nativeIdentifier) = context.GetIdentifiers(info);
-            string numElementsIdentifier = MarshallerHelpers.GetNumElementsIdentifier(info, context);
-
             if (!info.IsByRef && info.ByValueContentsMarshalKind.HasFlag(ByValueContentsMarshalKind.Out))
             {
-                // <numElements> = <GetManagedValuesSource.Length;
-                yield return ExpressionStatement(
-                    AssignmentExpression(
-                        SyntaxKind.SimpleAssignmentExpression,
-                        IdentifierName(numElementsIdentifier),
-                        MemberAccessExpression(
-                            SyntaxKind.SimpleMemberAccessExpression,
-                            GetManagedValuesSource(info, context),
-                            IdentifierName("Length"))));
-                yield return GenerateByValueOutUnmarshalStatement(info, context);
+                yield return _elementsMarshalling.GenerateByValueOutUnmarshalStatement(info, context);
+                yield break;
             }
 
             if (!_shape.HasFlag(MarshallerShape.ToManaged))
@@ -669,97 +608,15 @@ namespace Microsoft.Interop
             }
             else
             {
-                // <numElements> = <numElementsExpression>;
-                yield return ExpressionStatement(
-                    AssignmentExpression(
-                        SyntaxKind.SimpleAssignmentExpression,
-                        IdentifierName(numElementsIdentifier),
-                        _numElementsExpression));
+                foreach (var statement in _spaceMarshallingStrategy.GenerateUnmarshalStatements(info, context))
+                {
+                    yield return statement;
+                }
 
-                // <managedIdentifier> = <marshallerType>.AllocateContainerForManagedElements(<nativeIdentifier>, <numElements>);
-                yield return ExpressionStatement(
-                    AssignmentExpression(
-                        SyntaxKind.SimpleAssignmentExpression,
-                        IdentifierName(managedIdentifier),
-                        InvocationExpression(
-                            MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                _marshallerTypeSyntax,
-                                IdentifierName(ShapeMemberNames.LinearCollection.Stateless.AllocateContainerForManagedElements)),
-                            ArgumentList(SeparatedList(new ArgumentSyntax[]
-                            {
-                                Argument(IdentifierName(nativeIdentifier)),
-                                Argument(IdentifierName(numElementsIdentifier))
-                            })))));
-
-                // ReadOnlySpan<TUnmanagedElement> <nativeSpan> = <marshallerType>.GetUnmanagedValuesSource(<nativeIdentifier>, <numElements>)
-                // Span<T> <managedSpan> = <marshallerType>.GetManagedValuesDestination(<managedIdentifier>)
-                // << unmarshal contents >>
-                yield return GenerateUnmarshalStatement(info, context);
+                yield return _elementsMarshalling.GenerateUnmarshalStatement(info, context);
             }
         }
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context) => true;
-
-        protected override InvocationExpressionSyntax GetUnmanagedValuesDestination(TypePositionInfo info, StubCodeContext context)
-        {
-            string numElementsIdentifier = MarshallerHelpers.GetNumElementsIdentifier(info, context);
-            string nativeIdentifier = context.GetIdentifiers(info).native;
-
-            // <marshallerType>.GetUnmanagedValuesDestination(<nativeIdentifier>, <numElements>)
-            return InvocationExpression(
-                MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
-                    _marshallerTypeSyntax,
-                    IdentifierName(ShapeMemberNames.LinearCollection.Stateless.GetUnmanagedValuesDestination)),
-                ArgumentList(SeparatedList(new ArgumentSyntax[]
-                {
-                    Argument(IdentifierName(nativeIdentifier)),
-                    Argument(IdentifierName(numElementsIdentifier)),
-                })));
-        }
-
-        protected override InvocationExpressionSyntax GetManagedValuesSource(TypePositionInfo info, StubCodeContext context)
-        {
-            // <marshallerType>.GetManagedValuesSource(<managedIdentifier>)
-            string managedIdentifier = context.GetIdentifiers(info).managed;
-            return InvocationExpression(
-                MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
-                    _marshallerTypeSyntax,
-                    IdentifierName(ShapeMemberNames.LinearCollection.Stateless.GetManagedValuesSource)),
-                ArgumentList(SingletonSeparatedList(
-                    Argument(IdentifierName(managedIdentifier)))));
-        }
-
-        protected override InvocationExpressionSyntax GetUnmanagedValuesSource(TypePositionInfo info, StubCodeContext context)
-        {
-            string numElementsIdentifier = MarshallerHelpers.GetNumElementsIdentifier(info, context);
-            string nativeIdentifier = context.GetIdentifiers(info).native;
-
-            // <marshallerType>.GetUnmanagedValuesSource(<nativeIdentifier>, <numElements>)
-            return InvocationExpression(
-                MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
-                    _marshallerTypeSyntax,
-                    IdentifierName(ShapeMemberNames.LinearCollection.Stateless.GetUnmanagedValuesSource)),
-                ArgumentList(SeparatedList(new ArgumentSyntax[]
-                {
-                        Argument(IdentifierName(nativeIdentifier)),
-                        Argument(IdentifierName(numElementsIdentifier))
-                })));
-        }
-
-        protected override InvocationExpressionSyntax GetManagedValuesDestination(TypePositionInfo info, StubCodeContext context)
-        {
-            string managedIdentifier = context.GetIdentifiers(info).managed;
-
-            // <marshallerType>.GetManagedValuesDestination(<managedIdentifier>)
-            return InvocationExpression(
-                MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
-                    _marshallerTypeSyntax,
-                    IdentifierName(ShapeMemberNames.LinearCollection.Stateless.GetManagedValuesDestination)),
-                ArgumentList(SingletonSeparatedList(Argument(IdentifierName(managedIdentifier)))));
-        }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatelessMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatelessMarshallingStrategy.cs
@@ -345,8 +345,8 @@ namespace Microsoft.Interop
                             IdentifierName(ShapeMemberNames.LinearCollection.Stateless.AllocateContainerForManagedElementsFinally)),
                         ArgumentList(SeparatedList(new ArgumentSyntax[]
                         {
-                       Argument(IdentifierName(nativeIdentifier)),
-                       Argument(IdentifierName(numElementsIdentifier))
+                            Argument(IdentifierName(nativeIdentifier)),
+                            Argument(IdentifierName(numElementsIdentifier))
                         })))));
         }
 
@@ -373,9 +373,9 @@ namespace Microsoft.Interop
                                 IdentifierName(ShapeMemberNames.LinearCollection.Stateless.AllocateContainerForUnmanagedElements)),
                             ArgumentList(SeparatedList(new ArgumentSyntax[]
                             {
-                           Argument(IdentifierName(managedIdentifier)),
-                           Argument(IdentifierName(numElementsIdentifier))
-                               .WithRefOrOutKeyword(Token(SyntaxKind.OutKeyword))
+                                Argument(IdentifierName(managedIdentifier)),
+                                Argument(IdentifierName(numElementsIdentifier))
+                                    .WithRefOrOutKeyword(Token(SyntaxKind.OutKeyword))
                             })))));
             }
         }
@@ -432,8 +432,8 @@ namespace Microsoft.Interop
                             IdentifierName(ShapeMemberNames.LinearCollection.Stateless.AllocateContainerForManagedElements)),
                         ArgumentList(SeparatedList(new ArgumentSyntax[]
                         {
-                       Argument(IdentifierName(nativeIdentifier)),
-                       Argument(IdentifierName(numElementsIdentifier))
+                            Argument(IdentifierName(nativeIdentifier)),
+                            Argument(IdentifierName(numElementsIdentifier))
                         })))));
         }
 


### PR DESCRIPTION
Refactor the elements marshalling logic to split out space allocation and source/destination span construction from the elements marshalling logic. Pull out the element marshalling logic to a common base class and separate it out from the actual marshalling strategies.

This refactoring is required to provide customization points to author the fix for #85795.

I've validated that this change is a zero-diff change on all of the generated code for the LibraryImportGenerator integration tests.