### PR TITLE
avoid GCHandle in ConnectEx and SendTo on Windows

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WSASendTo.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WSASendTo.cs
@@ -18,7 +18,7 @@ internal static partial class Interop
             int bufferCount,
             out int bytesTransferred,
             SocketFlags socketFlags,
-            Span<byte> socketAddress,
+            ReadOnlySpan<byte> socketAddress,
             int socketAddressSize,
             NativeOverlapped* overlapped,
             IntPtr completionRoutine);
@@ -29,7 +29,7 @@ internal static partial class Interop
             int bufferCount,
             out int bytesTransferred,
             SocketFlags socketFlags,
-            Span<byte> socketAddress,
+            ReadOnlySpan<byte> socketAddress,
             NativeOverlapped* overlapped,
             IntPtr completionRoutine)
         {
@@ -46,7 +46,7 @@ internal static partial class Interop
             int bufferCount,
             [Out] out int bytesTransferred,
             SocketFlags socketFlags,
-            Span<byte> socketAddress,
+            ReadOnlySpan<byte> socketAddress,
             NativeOverlapped* overlapped,
             IntPtr completionRoutine)
         {

--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WSASendTo.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WSASendTo.cs
@@ -18,7 +18,7 @@ internal static partial class Interop
             int bufferCount,
             out int bytesTransferred,
             SocketFlags socketFlags,
-            IntPtr socketAddress,
+            Span<byte> socketAddress,
             int socketAddressSize,
             NativeOverlapped* overlapped,
             IntPtr completionRoutine);
@@ -29,8 +29,7 @@ internal static partial class Interop
             int bufferCount,
             out int bytesTransferred,
             SocketFlags socketFlags,
-            IntPtr socketAddress,
-            int socketAddressSize,
+            Span<byte> socketAddress,
             NativeOverlapped* overlapped,
             IntPtr completionRoutine)
         {
@@ -38,7 +37,7 @@ internal static partial class Interop
             // We don't want to cause a race in async scenarios.
             // The WSABuffer struct should be unchanged anyway.
             WSABuffer localBuffer = buffer;
-            return WSASendTo(socketHandle, &localBuffer, bufferCount, out bytesTransferred, socketFlags, socketAddress, socketAddressSize, overlapped, completionRoutine);
+            return WSASendTo(socketHandle, &localBuffer, bufferCount, out bytesTransferred, socketFlags, socketAddress, socketAddress.Length, overlapped, completionRoutine);
         }
 
         internal static unsafe SocketError WSASendTo(
@@ -47,15 +46,14 @@ internal static partial class Interop
             int bufferCount,
             [Out] out int bytesTransferred,
             SocketFlags socketFlags,
-            IntPtr socketAddress,
-            int socketAddressSize,
+            Span<byte> socketAddress,
             NativeOverlapped* overlapped,
             IntPtr completionRoutine)
         {
             Debug.Assert(buffers != null && buffers.Length > 0);
             fixed (WSABuffer* buffersPtr = &buffers[0])
             {
-                return WSASendTo(socketHandle, buffersPtr, bufferCount, out bytesTransferred, socketFlags, socketAddress, socketAddressSize, overlapped, completionRoutine);
+                return WSASendTo(socketHandle, buffersPtr, bufferCount, out bytesTransferred, socketFlags, socketAddress, socketAddress.Length, overlapped, completionRoutine);
             }
         }
     }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/DynamicWinsockMethods.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/DynamicWinsockMethods.cs
@@ -174,7 +174,7 @@ namespace System.Net.Sockets
                 Marshal.SetLastPInvokeError(Marshal.GetLastSystemError());
 
             }
-            internal unsafe bool ConnectEx(SafeSocketHandle socketHandle, Span<byte> socketAddress, IntPtr buffer, int dataLength, out int bytesSent, NativeOverlapped* overlapped)
+            internal unsafe bool ConnectEx(SafeSocketHandle socketHandle, ReadOnlySpan<byte> socketAddress, IntPtr buffer, int dataLength, out int bytesSent, NativeOverlapped* overlapped)
             {
                 IntPtr __socketHandle_gen_native = default;
                 bytesSent = default;
@@ -192,7 +192,7 @@ namespace System.Net.Sockets
                     socketHandle.DangerousAddRef(ref socketHandle__addRefd);
                     __socketHandle_gen_native = socketHandle.DangerousGetHandle();
                     fixed (int* __bytesSent_gen_native = &bytesSent)
-                    fixed (void* socketAddressPtr = socketAddress)
+                    fixed (void* socketAddressPtr = &MemoryMarshal.GetReference(socketAddress))
                     {
                         __retVal_gen_native = ((delegate* unmanaged<IntPtr, void*, int, IntPtr, int, int*, NativeOverlapped*, int>)_target)(__socketHandle_gen_native, socketAddressPtr, socketAddress.Length, buffer, dataLength, __bytesSent_gen_native, overlapped);
                     }
@@ -339,7 +339,7 @@ namespace System.Net.Sockets
 
     internal unsafe delegate bool ConnectExDelegate(
                 SafeSocketHandle socketHandle,
-                Span<byte> socketAddress,
+                ReadOnlySpan<byte> socketAddress,
                 IntPtr buffer,
                 int dataLength,
                 out int bytesSent,

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/DynamicWinsockMethods.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/DynamicWinsockMethods.cs
@@ -174,7 +174,7 @@ namespace System.Net.Sockets
                 Marshal.SetLastPInvokeError(Marshal.GetLastSystemError());
 
             }
-            internal unsafe bool ConnectEx(SafeSocketHandle socketHandle, IntPtr socketAddress, int socketAddressSize, IntPtr buffer, int dataLength, out int bytesSent, NativeOverlapped* overlapped)
+            internal unsafe bool ConnectEx(SafeSocketHandle socketHandle, Span<byte> socketAddress, IntPtr buffer, int dataLength, out int bytesSent, NativeOverlapped* overlapped)
             {
                 IntPtr __socketHandle_gen_native = default;
                 bytesSent = default;
@@ -192,8 +192,9 @@ namespace System.Net.Sockets
                     socketHandle.DangerousAddRef(ref socketHandle__addRefd);
                     __socketHandle_gen_native = socketHandle.DangerousGetHandle();
                     fixed (int* __bytesSent_gen_native = &bytesSent)
+                    fixed (void* socketAddressPtr = socketAddress)
                     {
-                        __retVal_gen_native = ((delegate* unmanaged<IntPtr, IntPtr, int, IntPtr, int, int*, NativeOverlapped*, int>)_target)(__socketHandle_gen_native, socketAddress, socketAddressSize, buffer, dataLength, __bytesSent_gen_native, overlapped);
+                        __retVal_gen_native = ((delegate* unmanaged<IntPtr, void*, int, IntPtr, int, int*, NativeOverlapped*, int>)_target)(__socketHandle_gen_native, socketAddressPtr, socketAddress.Length, buffer, dataLength, __bytesSent_gen_native, overlapped);
                     }
                     Marshal.SetLastPInvokeError(Marshal.GetLastSystemError());
                     //
@@ -338,8 +339,7 @@ namespace System.Net.Sockets
 
     internal unsafe delegate bool ConnectExDelegate(
                 SafeSocketHandle socketHandle,
-                IntPtr socketAddress,
-                int socketAddressSize,
+                Span<byte> socketAddress,
                 IntPtr buffer,
                 int dataLength,
                 out int bytesSent,

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
@@ -266,7 +266,7 @@ namespace System.Net.Sockets
         }
 
         internal unsafe bool ConnectEx(SafeSocketHandle socketHandle,
-            Span<byte> socketAddress,
+            ReadOnlySpan<byte> socketAddress,
             IntPtr buffer,
             int dataLength,
             out int bytesSent,

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
@@ -266,8 +266,7 @@ namespace System.Net.Sockets
         }
 
         internal unsafe bool ConnectEx(SafeSocketHandle socketHandle,
-            IntPtr socketAddress,
-            int socketAddressSize,
+            Span<byte> socketAddress,
             IntPtr buffer,
             int dataLength,
             out int bytesSent,
@@ -275,7 +274,7 @@ namespace System.Net.Sockets
         {
             ConnectExDelegate connectEx = GetDynamicWinsockMethods().GetConnectExDelegate(socketHandle);
 
-            return connectEx(socketHandle, socketAddress, socketAddressSize, buffer, dataLength, out bytesSent, overlapped);
+            return connectEx(socketHandle, socketAddress, buffer, dataLength, out bytesSent, overlapped);
         }
 
         internal unsafe SocketError WSARecvMsg(SafeSocketHandle socketHandle, IntPtr msg, out int bytesTransferred, NativeOverlapped* overlapped, IntPtr completionRoutine)

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -295,8 +295,6 @@ namespace System.Net.Sockets
 
             // ConnectEx uses a sockaddr buffer containing the remote address to which to connect.
             // It can also optionally take a single buffer of data to send after the connection is complete.
-            // The sockaddr is pinned with a GCHandle to avoid having to use the object array form of UnsafePack.
-            PinSocketAddressBuffer();
 
             fixed (byte* bufferPtr = &MemoryMarshal.GetReference(_buffer.Span))
             {
@@ -305,8 +303,7 @@ namespace System.Net.Sockets
                 {
                     bool success = socket.ConnectEx(
                         handle,
-                        PtrSocketAddressBuffer,
-                        _socketAddress!.Size,
+                        _socketAddress!.Buffer.AsSpan(),
                         (IntPtr)(bufferPtr + _offset),
                         _count,
                         out int bytesTransferred,
@@ -743,9 +740,6 @@ namespace System.Net.Sockets
             // receive data and from which to send data respectively. Single and multiple buffers
             // are handled differently so as to optimize performance for the more common single buffer case.
             //
-            // WSARecvFrom and WSASendTo also uses a sockaddr buffer in which to store the address from which the data was received.
-            // The sockaddr is pinned with a GCHandle to avoid having to use the object array form of UnsafePack.
-            PinSocketAddressBuffer();
 
             return _bufferList == null ?
                 DoOperationSendToSingleBuffer(handle, cancellationToken) :
@@ -769,8 +763,7 @@ namespace System.Net.Sockets
                         1,
                         out int bytesTransferred,
                         _socketFlags,
-                        PtrSocketAddressBuffer,
-                        _socketAddress!.Size,
+                        _socketAddress!.Buffer.AsSpan(),
                         overlapped,
                         IntPtr.Zero);
 
@@ -797,8 +790,7 @@ namespace System.Net.Sockets
                     _bufferListInternal!.Count,
                     out int bytesTransferred,
                     _socketFlags,
-                    PtrSocketAddressBuffer,
-                    _socketAddress!.Size,
+                    _socketAddress!.Buffer.AsSpan(),
                     overlapped,
                     IntPtr.Zero);
 


### PR DESCRIPTION
SocketAddress needs to be preserved only for initial call of ConnextEx and SendTo. There is no need to allocate GCHandle (and hold do it through connection time)

AFAIK interop should now generate `fixed` automatically for `Span` so we can simply pass it in. 

This helps to avoid memory fragmentation through small pinned buffers and contributes to #86513 and https://github.com/dotnet/runtime/issues/30797.

I  will follow up on `ReceiveFrom` separatelly as this part at least fixes TCP and issue observed by customer. 