### PR TITLE
Vectorize shorter buffers for CRC-32 on Intel

### DIFF
--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc64.Vectorized.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc64.Vectorized.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.InteropServices;
+using static System.IO.Hashing.VectorHelper;
 
 namespace System.IO.Hashing
 {
@@ -72,7 +73,7 @@ namespace System.IO.Hashing
                 // Load and XOR the initial CRC value
                 // CRC value does not need to be byte-reflected, but it needs to be moved to the high part of the register.
                 // because data will be byte-reflected and will align with initial crc at correct place.
-                x0 ^= VectorHelper.ShiftLowerToUpper(Vector128.CreateScalar(crc));
+                x0 ^= ShiftLowerToUpper(Vector128.CreateScalar(crc));
 
                 kConstants = Vector128.Create(0x5cf79dea9ac37d6UL, 0x001067e571d7d5c2UL); // k3, k4
 
@@ -81,36 +82,36 @@ namespace System.IO.Hashing
                 {
                     Vector128<ulong> y1 = LoadFromSource(ref srcRef, 0);
                     Vector128<ulong> y2 = LoadFromSource(ref srcRef, 16);
-                    x0 = VectorHelper.FoldPolynomialPair(y1, x0, kConstants);
-                    x1 = VectorHelper.FoldPolynomialPair(y2, x1, kConstants);
+                    x0 = FoldPolynomialPair(y1, x0, kConstants);
+                    x1 = FoldPolynomialPair(y2, x1, kConstants);
 
                     y1 = LoadFromSource(ref srcRef, 32);
                     y2 = LoadFromSource(ref srcRef, 48);
-                    x2 = VectorHelper.FoldPolynomialPair(y1, x2, kConstants);
-                    x3 = VectorHelper.FoldPolynomialPair(y2, x3, kConstants);
+                    x2 = FoldPolynomialPair(y1, x2, kConstants);
+                    x3 = FoldPolynomialPair(y2, x3, kConstants);
 
                     y1 = LoadFromSource(ref srcRef, 64);
                     y2 = LoadFromSource(ref srcRef, 80);
-                    x4 = VectorHelper.FoldPolynomialPair(y1, x4, kConstants);
-                    x5 = VectorHelper.FoldPolynomialPair(y2, x5, kConstants);
+                    x4 = FoldPolynomialPair(y1, x4, kConstants);
+                    x5 = FoldPolynomialPair(y2, x5, kConstants);
 
                     y1 = LoadFromSource(ref srcRef, 96);
                     y2 = LoadFromSource(ref srcRef, 112);
-                    x6 = VectorHelper.FoldPolynomialPair(y1, x6, kConstants);
-                    x7 = VectorHelper.FoldPolynomialPair(y2, x7, kConstants);
+                    x6 = FoldPolynomialPair(y1, x6, kConstants);
+                    x7 = FoldPolynomialPair(y2, x7, kConstants);
 
                     srcRef = ref Unsafe.Add(ref srcRef, Vector128<byte>.Count * 8);
                     length -= Vector128<byte>.Count * 8;
                 } while (length >= Vector128<byte>.Count * 8);
 
                 // Fold into 128-bits in x7
-                x7 = VectorHelper.FoldPolynomialPair(x7, x0, Vector128.Create(0xe464f4df5fb60ac1UL, 0xb649c5b35a759cf2UL)); // k9, k10
-                x7 = VectorHelper.FoldPolynomialPair(x7, x1, Vector128.Create(0x9af04e1eff82d0ddUL, 0x6e82e609297f8fe8UL)); // k11, k12
-                x7 = VectorHelper.FoldPolynomialPair(x7, x2, Vector128.Create(0x97c516e98bd2e73UL, 0xb76477b31e22e7bUL)); // k13, k14
-                x7 = VectorHelper.FoldPolynomialPair(x7, x3, Vector128.Create(0x5f6843ca540df020UL, 0xddf4b6981205b83fUL)); // k15, k16
-                x7 = VectorHelper.FoldPolynomialPair(x7, x4, Vector128.Create(0x54819d8713758b2cUL, 0x4a6b90073eb0af5aUL)); // k17, k18
-                x7 = VectorHelper.FoldPolynomialPair(x7, x5, Vector128.Create(0x571bee0a227ef92bUL, 0x44bef2a201b5200cUL)); // k19, k20
-                x7 = VectorHelper.FoldPolynomialPair(x7, x6, Vector128.Create(0x5f5c3c7eb52fab6UL, 0x4eb938a7d257740eUL)); // k1, k2
+                x7 = FoldPolynomialPair(x7, x0, Vector128.Create(0xe464f4df5fb60ac1UL, 0xb649c5b35a759cf2UL)); // k9, k10
+                x7 = FoldPolynomialPair(x7, x1, Vector128.Create(0x9af04e1eff82d0ddUL, 0x6e82e609297f8fe8UL)); // k11, k12
+                x7 = FoldPolynomialPair(x7, x2, Vector128.Create(0x97c516e98bd2e73UL, 0xb76477b31e22e7bUL)); // k13, k14
+                x7 = FoldPolynomialPair(x7, x3, Vector128.Create(0x5f6843ca540df020UL, 0xddf4b6981205b83fUL)); // k15, k16
+                x7 = FoldPolynomialPair(x7, x4, Vector128.Create(0x54819d8713758b2cUL, 0x4a6b90073eb0af5aUL)); // k17, k18
+                x7 = FoldPolynomialPair(x7, x5, Vector128.Create(0x571bee0a227ef92bUL, 0x44bef2a201b5200cUL)); // k19, k20
+                x7 = FoldPolynomialPair(x7, x6, Vector128.Create(0x5f5c3c7eb52fab6UL, 0x4eb938a7d257740eUL)); // k1, k2
             }
             else
             {
@@ -122,7 +123,7 @@ namespace System.IO.Hashing
                 // Load and XOR the initial CRC value
                 // CRC value does not need to be byte-reflected, but it needs to be moved to the high part of the register.
                 // because the data will be byte-reflected and will align with initial crc at correct place.
-                x7 ^= VectorHelper.ShiftLowerToUpper(Vector128.CreateScalar(crc));
+                x7 ^= ShiftLowerToUpper(Vector128.CreateScalar(crc));
 
                 srcRef = ref Unsafe.Add(ref srcRef, Vector128<byte>.Count);
                 length -= Vector128<byte>.Count;
@@ -131,7 +132,7 @@ namespace System.IO.Hashing
             // Single fold blocks of 16, if any, into x7
             while (length >= Vector128<byte>.Count)
             {
-                x7 = VectorHelper.FoldPolynomialPair(LoadFromSource(ref srcRef, 0), x7,
+                x7 = FoldPolynomialPair(LoadFromSource(ref srcRef, 0), x7,
                     Vector128.Create(0x5f5c3c7eb52fab6UL, 0x4eb938a7d257740eUL)); // k1, k2
 
                 srcRef = ref Unsafe.Add(ref srcRef, Vector128<byte>.Count);
@@ -139,14 +140,14 @@ namespace System.IO.Hashing
             }
 
             // Compute CRC of a 128-bit value and fold to the upper 64-bits
-            x7 = VectorHelper.CarrylessMultiplyLeftUpperRightLower(x7, Vector128.CreateScalar(0x5f5c3c7eb52fab6UL)) ^ // k5
-                 VectorHelper.ShiftLowerToUpper(x7);
+            x7 = CarrylessMultiplyLeftUpperRightLower(x7, Vector128.CreateScalar(0x5f5c3c7eb52fab6UL)) ^ // k5
+                 ShiftLowerToUpper(x7);
 
             // Barrett reduction
             kConstants = Vector128.Create(0x578d29d06cc4f872UL, 0x42f0e1eba9ea3693UL); // k7, k8
             Vector128<ulong> temp = x7;
-            x7 = VectorHelper.CarrylessMultiplyLeftUpperRightLower(x7, kConstants) ^ (x7 & Vector128.Create(0UL, ~0UL));
-            x7 = VectorHelper.CarrylessMultiplyUpper(x7, kConstants);
+            x7 = CarrylessMultiplyLeftUpperRightLower(x7, kConstants) ^ (x7 & Vector128.Create(0UL, ~0UL));
+            x7 = CarrylessMultiplyUpper(x7, kConstants);
             x7 ^= temp;
 
             // Process the remaining bytes, if any


### PR DESCRIPTION
The current vectorized implementation for CRC-32 requires at least 64 bytes to function. However, it is possible to vectorize spans as short as 16 bytes for significant performance gains for spans from 16 to 63 bytes in length on Intel.

Additionally, when processing on ARM it appears CRC-32 intrinsics are actually preferable for lengths up to approximately 128 bytes. This change therefore no longer vectorizes from 64 to 127 bytes on ARM if the CRC-32 intrinsics are available.

Finally, reuse VectorHelper methods added with CRC-64 support for a cleaner implementation. This also appears to produce better JIT output, showing some minor performance improvements on vectorized processing.

## x64

BenchmarkDotNet=v0.13.2.2052-nightly, OS=Windows 11 (10.0.22621.1776)
Intel Core i7-10850H CPU 2.70GHz, 1 CPU, 12 logical and 6 physical cores
.NET SDK=8.0.100-preview.4.23260.5
  [Host]     : .NET 8.0.0 (8.0.23.25905), X64 RyuJIT AVX2
  Job-BLNPAG : .NET 8.0.0 (42.42.42.42424), X64 RyuJIT AVX2
  Job-XFRTDF : .NET 8.0.0 (42.42.42.42424), X64 RyuJIT AVX2

PowerPlanMode=00000000-0000-0000-0000-000000000000  Arguments=/p:EnableUnsafeBinaryFormatterSerialization=true  IterationTime=250.0000 ms
MaxIterationCount=20  MinIterationCount=15  WarmupCount=1

| Method |     Job | BufferSize |      Mean |     Error |    StdDev |    Median |       Min |       Max | Ratio |
|------- |-------- |----------- |----------:|----------:|----------:|----------:|----------:|----------:|------:|
| Append | Current |         16 | 27.322 ns | 0.4068 ns | 0.3606 ns | 27.334 ns | 26.834 ns | 28.051 ns |  1.00 |
| Append |     New |         16 |  8.069 ns | 0.0169 ns | 0.0141 ns |  8.068 ns |  8.045 ns |  8.102 ns |  0.29 |
|        |         |            |           |           |           |           |           |           |       |
| Append | Current |         32 | 54.541 ns | 0.3201 ns | 0.2994 ns | 54.431 ns | 54.078 ns | 55.090 ns |  1.00 |
| Append |     New |         32 | 10.021 ns | 0.0296 ns | 0.0247 ns | 10.009 ns | 10.001 ns | 10.087 ns |  0.18 |
|        |         |            |           |           |           |           |           |           |       |
| Append | Current |         64 | 13.722 ns | 0.0278 ns | 0.0246 ns | 13.726 ns | 13.687 ns | 13.773 ns |  1.00 |
| Append |     New |         64 | 13.811 ns | 0.0454 ns | 0.0402 ns | 13.792 ns | 13.777 ns | 13.909 ns |  1.01 |
|        |         |            |           |           |           |           |           |           |       |
| Append | Current |       1024 | 46.089 ns | 0.6261 ns | 0.5857 ns | 45.768 ns | 45.654 ns | 47.135 ns |  1.00 |
| Append |     New |       1024 | 43.048 ns | 0.0765 ns | 0.0716 ns | 43.030 ns | 42.970 ns | 43.187 ns |  0.93 |

## Arm64

BenchmarkDotNet=v0.13.2.2052-nightly, OS=ubuntu 22.04
AWS m6g.xlarge Graviton2
  [Host]     : .NET 8.0.0 (8.0.23.25905), Arm64 RyuJIT AdvSIMD
  Job-FJUDNU : .NET 8.0.0 (42.42.42.42424), Arm64 RyuJIT AdvSIMD
  Job-JYHJTX : .NET 8.0.0 (42.42.42.42424), Arm64 RyuJIT AdvSIMD

PowerPlanMode=00000000-0000-0000-0000-000000000000  Arguments=/p:EnableUnsafeBinaryFormatterSerialization=true  IterationTime=250.0000 ms
MaxIterationCount=20  MinIterationCount=15  WarmupCount=1

| Method |     Job | BufferSize |      Mean |     Error |    StdDev |    Median |       Min |       Max | Ratio |
|------- |-------- |----------- |----------:|----------:|----------:|----------:|----------:|----------:|------:|
| Append | Current |         64 | 24.849 ns | 0.0079 ns | 0.0074 ns | 24.847 ns | 24.840 ns | 24.861 ns |  1.00 |
| Append |     New |         64 | 10.546 ns | 0.0635 ns | 0.0594 ns | 10.517 ns | 10.484 ns | 10.652 ns |  0.42 |
|        |         |            |           |           |           |           |           |           |        
| Append | Current |        128 | 28.898 ns | 0.0318 ns | 0.0297 ns | 28.907 ns | 28.843 ns | 28.926 ns |  1.00 |
| Append |     New |        128 | 27.023 ns | 0.0131 ns | 0.0122 ns | 27.019 ns | 27.003 ns | 27.041 ns |  0.94 |
|        |         |            |           |           |           |           |           |           |        
| Append | Current |       1024 | 90.481 ns | 0.0451 ns | 0.0400 ns | 90.487 ns | 90.404 ns | 90.532 ns |  1.00 |
| Append |     New |       1024 | 72.729 ns | 0.0619 ns | 0.0549 ns | 72.700 ns | 72.684 ns | 72.858 ns |  0.80 |