### PR TITLE
Add the ability to set  Browsable property value in runtime by reflection

### DIFF
--- a/src/libraries/System.ComponentModel.Primitives/src/System/ComponentModel/BrowsableAttribute.cs
+++ b/src/libraries/System.ComponentModel.Primitives/src/System/ComponentModel/BrowsableAttribute.cs
@@ -42,7 +42,7 @@ namespace System.ComponentModel
         /// <summary>
         /// Gets a value indicating whether an object is browsable.
         /// </summary>
-        public bool Browsable { get; }
+        public bool Browsable { get; set; }
 
         public override bool Equals([NotNullWhen(true)] object? obj) =>
             obj is BrowsableAttribute other && other.Browsable == Browsable;


### PR DESCRIPTION
Example:

```
PropertyDescriptor descriptor = TypeDescriptor.GetProperties(modelName)[propertyName];
BrowsableAttribute attribute = (BrowsableAttribute)descriptor.Attributes[typeof(BrowsableAttribute)];
PropertyInfo propertyToChange = attribute.GetType().GetProperty("browsable", BindingFlags.NonPublic | BindingFlags.Instance);
propertyToChange?.SetValue(attribute, value);
```