### PR TITLE
Remove ZMM_RECOMMENDED_THRESHOLD workaround

### DIFF
--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -1488,13 +1488,7 @@ int LinearScan::BuildBlockStore(GenTreeBlk* blkNode)
                 // Lowering was expected to get rid of memmove in case of zero
                 assert(size > 0);
 
-                unsigned simdSize = compiler->roundDownSIMDSize(size);
-                if (size <= ZMM_RECOMMENDED_THRESHOLD)
-                {
-                    // Only use ZMM for large data due to possible CPU throttle issues
-                    simdSize = min(YMM_REGSIZE_BYTES, compiler->roundDownSIMDSize(size));
-                }
-
+                const unsigned simdSize = compiler->roundDownSIMDSize(size);
                 if ((size >= simdSize) && (simdSize > 0))
                 {
                     unsigned simdRegs = size / simdSize;

--- a/src/coreclr/jit/targetamd64.h
+++ b/src/coreclr/jit/targetamd64.h
@@ -112,8 +112,6 @@
   #define STACK_ALIGN              16      // stack alignment requirement
   #define STACK_ALIGN_SHIFT        4       // Shift-right amount to convert size in bytes to size in STACK_ALIGN units == log2(STACK_ALIGN)
 
-  #define ZMM_RECOMMENDED_THRESHOLD 128    // A general recommendation to use ZMM for data starting from this size in bytes
-
 #if ETW_EBP_FRAMED
   #define RBM_ETW_FRAMED_EBP        RBM_NONE
   #define RBM_ETW_FRAMED_EBP_LIST

--- a/src/coreclr/jit/targetx86.h
+++ b/src/coreclr/jit/targetx86.h
@@ -116,8 +116,6 @@
   #define YMM_REGSIZE_BYTES        32      // YMM register size in bytes
   #define ZMM_REGSIZE_BYTES        64      // ZMM register size in bytes
 
-  #define ZMM_RECOMMENDED_THRESHOLD 128    // A general recommendation to use ZMM for data starting from this size in bytes
-
   #define REGNUM_BITS              6       // number of bits in a REG_*
 
   #define REGSIZE_BYTES            4       // number of bytes in one register


### PR DESCRIPTION
This was a weird-looking workaround for the avx-512 throttle problem, since it is no more - I delete the workaround. Expecting a few diffs in aspnet collection, e.g.:
```cpp
bool Test(ReadOnlySpan<byte> a, Span<byte> b) => 
    a.Slice(0, 100).TryCopyTo(b);
```
Codegen:
```diff
; Method Program:Test
       sub      rsp, 40
       vzeroupper 
       cmp      dword ptr [rdx+08H], 100
       jb       SHORT G_M62689_IG06
       mov      rax, bword ptr [rdx]
       mov      rdx, bword ptr [r8]
       mov      ecx, dword ptr [r8+08H]
       xor      r8d, r8d
       cmp      ecx, 100
       jb       SHORT G_M62689_IG04
-      vmovdqu  ymm0, ymmword ptr [rax]
-      vmovdqu  ymm1, ymmword ptr [rax+20H]
-      vmovdqu  ymm2, ymmword ptr [rax+40H]
-      vmovdqu  xmm3, xmmword ptr [rax+54H]
-      vmovdqu  ymmword ptr [rdx], ymm0
-      vmovdqu  ymmword ptr [rdx+20H], ymm1
-      vmovdqu  ymmword ptr [rdx+40H], ymm2
-      vmovdqu  xmmword ptr [rdx+54H], xmm3
+      vmovdqu32 zmm0, zmmword ptr [rax]
+      vmovdqu32 zmm1, zmmword ptr [rax+24H]
+      vmovdqu32 zmmword ptr [rdx], zmm0
+      vmovdqu32 zmmword ptr [rdx+24H], zmm1
       mov      r8d, 1
G_M62689_IG04:  
       mov      eax, r8d
       add      rsp, 40
       ret      
G_M62689_IG06: 
       call     [System.ThrowHelper:ThrowArgumentOutOfRangeException()]
       int3     
; Total bytes of code: 90
```