### PR TITLE
Use VEX xorps to zero a zmm reg

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -480,7 +480,7 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, simd_t
             }
             else if (val16.IsZero())
             {
-                emit->emitIns_SIMD_R_R_R(INS_xorps, attr, targetReg, targetReg, targetReg);
+                emit->emitIns_SIMD_R_R_R(INS_xorps, EA_16BYTE, targetReg, targetReg, targetReg);
             }
             else
             {
@@ -498,7 +498,7 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, simd_t
             }
             else if (val32.IsZero())
             {
-                emit->emitIns_SIMD_R_R_R(INS_xorps, attr, targetReg, targetReg, targetReg);
+                emit->emitIns_SIMD_R_R_R(INS_xorps, EA_16BYTE, targetReg, targetReg, targetReg);
             }
             else
             {
@@ -517,7 +517,7 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, simd_t
             }
             else if (val64.IsZero())
             {
-                emit->emitIns_SIMD_R_R_R(INS_xorps, attr, targetReg, targetReg, targetReg);
+                emit->emitIns_SIMD_R_R_R(INS_xorps, EA_16BYTE, targetReg, targetReg, targetReg);
             }
             else
             {

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -480,7 +480,7 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, simd_t
             }
             else if (val16.IsZero())
             {
-                emit->emitIns_SIMD_R_R_R(INS_xorps, EA_16BYTE, targetReg, targetReg, targetReg);
+                emit->emitIns_SIMD_R_R_R(INS_xorps, attr, targetReg, targetReg, targetReg);
             }
             else
             {
@@ -498,7 +498,7 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, simd_t
             }
             else if (val32.IsZero())
             {
-                emit->emitIns_SIMD_R_R_R(INS_xorps, EA_16BYTE, targetReg, targetReg, targetReg);
+                emit->emitIns_SIMD_R_R_R(INS_xorps, attr, targetReg, targetReg, targetReg);
             }
             else
             {
@@ -517,6 +517,11 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, simd_t
             }
             else if (val64.IsZero())
             {
+                // Use VEX version because it's smaller (for zmm0-zmm15) than EVEX to zero a zmm register:
+                //
+                //   xorps zmm0, zmm0, zmm0 (6 bytes)
+                //   xorps xmm0, xmm0, xmm0 (4 bytes)
+                //
                 emit->emitIns_SIMD_R_R_R(INS_xorps, EA_16BYTE, targetReg, targetReg, targetReg);
             }
             else

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -517,12 +517,13 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, simd_t
             }
             else if (val64.IsZero())
             {
-                // Use VEX version because it's smaller (for zmm0-zmm15) than EVEX to zero a zmm register and still zeros the entire register:
+                // Use VEX version because it's smaller (for zmm0-zmm15) than EVEX to zero a zmm register and still
+                // zeros the entire register:
                 //
                 //   xorps zmm0, zmm0, zmm0 (6 bytes)
-                //   xorps xmm0, xmm0, xmm0 (4 bytes)
+                //   xorps ymm0, ymm0, ymm0 (4 bytes)
                 //
-                emit->emitIns_SIMD_R_R_R(INS_xorps, EA_16BYTE, targetReg, targetReg, targetReg);
+                emit->emitIns_SIMD_R_R_R(INS_xorps, EA_32BYTE, targetReg, targetReg, targetReg);
             }
             else
             {

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -517,7 +517,7 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, simd_t
             }
             else if (val64.IsZero())
             {
-                // Use VEX version because it's smaller (for zmm0-zmm15) than EVEX to zero a zmm register:
+                // Use VEX version because it's smaller (for zmm0-zmm15) than EVEX to zero a zmm register and still zeros the entire register:
                 //
                 //   xorps zmm0, zmm0, zmm0 (6 bytes)
                 //   xorps xmm0, xmm0, xmm0 (4 bytes)


### PR DESCRIPTION
```cpp
void Test(ref byte b) => Vector512<byte>.Zero.StoreUnsafe(ref b);
```
```diff
; Method Program:Test(byref):this
       vzeroupper 
-      vxorps   zmm0, zmm0, zmm0
+      vxorps   xmm0, xmm0, xmm0
       vmovups  zmmword ptr [rdx], zmm0
       vzeroupper 
       ret      
-; Total bytes of code: 19
+; Total bytes of code: 17
```
Native compilers do the same: https://godbolt.org/z/3MzTWE1bf

We use the same trick to zero 64-bit GRPs e.g. `xor eax, eax` 

[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=281295&view=ms.vss-build-web.run-extensions-tab)