### PR TITLE
Add DebuggerDisplay for SearchValues

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.T.cs
@@ -14,13 +14,14 @@ namespace System.Buffers
     /// <remarks>
     /// <see cref="SearchValues{T}"/> are optimized for situations where the same set of values is frequently used for searching at runtime.
     /// </remarks>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     [DebuggerTypeProxy(typeof(SearchValuesDebugView<>))]
     public class SearchValues<T> where T : IEquatable<T>?
     {
         // Only CoreLib can create derived types
         private protected SearchValues() { }
 
-        /// <summary>Used by <see cref="SearchValuesDebugView{T}"/>.</summary>
+        /// <summary>Used by <see cref="DebuggerDisplay"/>s and <see cref="DebuggerTypeProxyAttribute"/>s for <see cref="SearchValues{T}"/>.</summary>
         internal virtual T[] GetValues() => throw new UnreachableException();
 
         /// <summary>
@@ -79,6 +80,25 @@ namespace System.Buffers
             }
 
             return values.LastIndexOfAnyExcept(span);
+        }
+
+        private string DebuggerDisplay
+        {
+            get
+            {
+                T[] values = GetValues();
+
+                string display = $"{GetType().Name}, Count={values.Length}";
+                if (values.Length > 0)
+                {
+                    display += ", Values=";
+                    display += typeof(T) == typeof(char) ?
+                        "\"" + new string(Unsafe.As<T[], char[]>(ref values)) + "\"" :
+                        string.Join(",", values);
+                }
+
+                return display;
+            }
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValuesDebugView.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValuesDebugView.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+
 namespace System.Buffers
 {
     internal sealed class SearchValuesDebugView<T> where T : IEquatable<T>?
@@ -13,6 +15,7 @@ namespace System.Buffers
             _values = values;
         }
 
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
         public T[] Values => _values.GetValues();
     }
 }


### PR DESCRIPTION
Before:
<img width="473" alt="image" src="https://github.com/dotnet/runtime/assets/2642209/c3874e66-971d-4e77-ad75-e5e4153d26ae">

After:
<img width="362" alt="image" src="https://github.com/dotnet/runtime/assets/2642209/4fc1eda3-e7a4-45ea-92c6-399a50002bdd">
