### PR TITLE
[mono][infra] Upgrade iOS performance queue to OSX 13 

### DIFF
--- a/eng/testing/performance/performance-setup.sh
+++ b/eng/testing/performance/performance-setup.sh
@@ -267,7 +267,7 @@ if [[ "$internal" == true ]]; then
     extra_benchmark_dotnet_arguments=
 
     if [[ "$logical_machine" == "perfiphone12mini" ]]; then
-        queue=OSX.1015.Amd64.Iphone.Perf
+        queue=OSX.13.Amd64.Iphone.Perf
     elif [[ "$logical_machine" == "perfampere" ]]; then
         queue=Ubuntu.2004.Arm64.Perf
     elif [[ "$logical_machine" == "cloudvm" ]]; then


### PR DESCRIPTION
This PR upgrades iOS performance helix queue to `osx.13.amd64.iphone.perf`, as the helix queue `osx.1015.amd64.iphone.perf` is set for estimated removal date of 2023-05-31.