### PR TITLE
[6.0-staging] Disable DllImportSearchPathsTest in mobile

### DIFF
--- a/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.cs
+++ b/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.cs
@@ -10,13 +10,19 @@ using Xunit;
 public class DllImportSearchPathsTest
 {
     private static string Subdirectory => Path.Combine(NativeLibraryToLoad.GetDirectory(), "subdirectory");
+    private static bool CanLoadAssemblyInSubdirectory =>
+        !TestLibrary.Utilities.IsMonoLLVMFULLAOT &&
+        !OperatingSystem.IsAndroid() &&
+        !OperatingSystem.IsIOS() &&
+        !OperatingSystem.IsTvOS() &&
+        !OperatingSystem.IsBrowser();
 
     static int Main(string[] args)
     {
         try
         {
             AssemblyDirectory_NotFound();
-            if (!TestLibrary.Utilities.IsMonoLLVMFULLAOT)
+            if (CanLoadAssemblyInSubdirectory)
                 AssemblyDirectory_Found();
 
             if (OperatingSystem.IsWindows())

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2895,6 +2895,9 @@
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/Regression/JitBlue/DevDiv_461649/DevDiv_461649/**">
             <Issue>https://github.com/dotnet/runtime/issues/53353</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/DllImportSearchPaths/DllImportSearchPathsTest/**">
+            <Issue>Loads an assembly from file</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <ItemGroup Condition=" $(TargetOS) == 'Android' And '$(TargetArchitecture)' == 'arm64' " >


### PR DESCRIPTION
Loading assemblies from subdirectories is not supported, this ports the fix from main to 6.0

Fixes https://github.com/dotnet/runtime/issues/86271