### PR TITLE
[mono][aot] Use an mrgctx for all gshared methods on iOS

### DIFF
--- a/src/mono/mono/utils/options-def.h
+++ b/src/mono/mono/utils/options-def.h
@@ -147,7 +147,7 @@ DEFINE_INT(jiterpreter_interp_entry_queue_flush_threshold, "jiterpreter-interp-e
 DEFINE_INT(jiterpreter_wasm_bytes_limit, "jiterpreter-wasm-bytes-limit", 6 * 1024 * 1024, "Disable jiterpreter code generation once this many bytes of WASM have been generated")
 #endif // HOST_BROWSER
 
-#ifdef TARGET_WASM
+#if defined(TARGET_WASM) || defined(TARGET_IOS)  || defined(TARGET_TVOS) || defined (TARGET_MACCAT)
 DEFINE_BOOL_READONLY(experimental_gshared_mrgctx, "experimental-gshared-mrgctx", TRUE, "Use a mrgctx for all gshared methods")
 #else
 DEFINE_BOOL(experimental_gshared_mrgctx, "experimental-gshared-mrgctx", FALSE, "Use a mrgctx for all gshared methods")


### PR DESCRIPTION
This PR enables the use of the `MonoMethodRuntimeGenericContext` structure for all gshared methods, eliminating the need for generating rgctx fetch trampolines. Preliminary size saving on HelloiOS app is approximately 160kb or -0.646% in release LLVM mode.

HelloiOS .app | Baseline (main branch) | Target (this branch)
--|--|--
HelloiOS	| 20393904		| 20186936
Info.plist	| 	982		| 982
PkgInfo		| 8		| 8
Program.aotdata		| 5888		| 5952
Program.deps.json		| 12781		| 12781
Program.dll		| 6144	| 	6144
Program.runtimeconfig.json		| 1064		| 1064
System.Console.aotdata	| 	2976		| 3032
System.Console.dll	| 	17408	| 	17408
System.Private.CoreLib.aotdata		| 679712		|  703584
System.Private.CoreLib.dll		| 1158144	| 	1158144
aot-instances.aotdata	| 	531200	| 	554824
icudt.dat		| 1859648		| 1859648

Considering potential speed implications of such a change, I suggest merging this PR after the Preview 5 snap.

Fixes https://github.com/dotnet/runtime/issues/82906