### PR TITLE
Rename setting for using RID graph to System.Runtime.Loader.UseRidGraph

### DIFF
--- a/src/native/corehost/hostpolicy/hostpolicy_context.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy_context.cpp
@@ -137,7 +137,7 @@ namespace
 
 bool hostpolicy_context_t::should_read_rid_fallback_graph(const hostpolicy_init_t &init)
 {
-    const auto &iter = std::find(init.cfg_keys.cbegin(), init.cfg_keys.cend(), _X("System.Host.Resolution.ReadRidGraph"));
+    const auto &iter = std::find(init.cfg_keys.cbegin(), init.cfg_keys.cend(), _X("System.Runtime.Loader.UseRidGraph"));
     if (iter != init.cfg_keys.cend())
     {
         size_t idx = iter - init.cfg_keys.cbegin();


### PR DESCRIPTION
Rename setting for using RID graph to `System.Runtime.Loader.UseRidGraph` in order to better match API naming.

See https://github.com/dotnet/runtime/pull/84100#issuecomment-1557475859

I will update the breaking change issue (https://github.com/dotnet/docs/issues/35398) once this goes in.

cc @jkotas 