### PR TITLE
[7.0] Missing version number bump

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- The .NET product branding version -->
-    <ProductVersion>7.0.7</ProductVersion>
+    <ProductVersion>7.0.8</ProductVersion>
     <!-- File version numbers -->
     <MajorVersion>7</MajorVersion>
     <MinorVersion>0</MinorVersion>


### PR DESCRIPTION
Missed a version number bump in the original PR: https://github.com/dotnet/runtime/pull/86297
Fixes: https://github.com/dotnet/runtime/issues/86518

cc @elinor-fung @vitek-karas sorry for the noise.