### PR TITLE
[6.0] Missing version number bump

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- The .NET product branding version -->
-    <ProductVersion>6.0.18</ProductVersion>
+    <ProductVersion>6.0.19</ProductVersion>
     <!-- File version numbers -->
     <MajorVersion>6</MajorVersion>
     <MinorVersion>0</MinorVersion>


### PR DESCRIPTION
Missed a version number bump in the original PR: https://github.com/dotnet/runtime/pull/86298
There is already a [6.0 issue](https://github.com/dotnet/runtime/issues/81851) open that preexisted the above PR, but it's unrelated. _Some_ of those failures will go away after merging this, but the issue should stay open.

cc @elinor-fung @vitek-karas sorry for the noise.