### PR TITLE
Ensure Avx512Vbmi has [Intrinsic] on the right members

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -18825,6 +18825,7 @@ emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(ins
         case INS_vinserti32x8:
         case INS_vinserti64x2:
         case INS_vinserti64x4:
+        case INS_vpermb:
         case INS_vpermi2d:
         case INS_vpermi2pd:
         case INS_vpermi2ps:

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512Vbmi.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512Vbmi.PlatformNotSupported.cs
@@ -7,7 +7,6 @@ using System.Runtime.CompilerServices;
 namespace System.Runtime.Intrinsics.X86
 {
     /// <summary>This class provides access to X86 AVX512VBMI hardware instructions via intrinsics</summary>
-    [Intrinsic]
     [CLSCompliant(false)]
     public abstract class Avx512Vbmi : Avx512BW
     {
@@ -15,7 +14,6 @@ namespace System.Runtime.Intrinsics.X86
 
         public static new bool IsSupported { [Intrinsic] get { return false; } }
 
-        [Intrinsic]
         public new abstract class VL : Avx512BW.VL
         {
             internal VL() { }
@@ -71,7 +69,6 @@ namespace System.Runtime.Intrinsics.X86
             public static Vector256<sbyte> PermuteVar32x8x2(Vector256<sbyte> lower, Vector256<sbyte> indices, Vector256<sbyte> upper) { throw new PlatformNotSupportedException(); }
         }
 
-        [Intrinsic]
         public new abstract class X64 : Avx512BW.X64
         {
             internal X64() { }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512Vbmi.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512Vbmi.cs
@@ -9,6 +9,7 @@ using System.Runtime.Intrinsics;
 namespace System.Runtime.Intrinsics.X86
 {
     /// <summary>This class provides access to X86 AVX512VBMI hardware instructions via intrinsics</summary>
+    [Intrinsic]
     [CLSCompliant(false)]
     public abstract class Avx512Vbmi : Avx512BW
     {
@@ -16,6 +17,7 @@ namespace System.Runtime.Intrinsics.X86
 
         public static new bool IsSupported { get => IsSupported; }
 
+        [Intrinsic]
         public new abstract class VL : Avx512BW.VL
         {
             internal VL() { }
@@ -71,6 +73,7 @@ namespace System.Runtime.Intrinsics.X86
             public static Vector256<sbyte> PermuteVar32x8x2(Vector256<sbyte> lower, Vector256<sbyte> indices, Vector256<sbyte> upper) => PermuteVar32x8x2(lower, indices, upper);
         }
 
+        [Intrinsic]
         public new abstract class X64 : Avx512BW.X64
         {
             internal X64() { }


### PR DESCRIPTION
Extracted from https://github.com/dotnet/runtime/pull/86486 as its a straightforward fix.