### PR TITLE
Add get AppContext properties diagnostic IPC command

### DIFF
--- a/src/coreclr/inc/configuration.h
+++ b/src/coreclr/inc/configuration.h
@@ -14,10 +14,20 @@
 #ifndef __configuration_h__
 #define __configuration_h__
 
+typedef HRESULT (*config_knob_fn)(
+    const LPCWSTR& name,
+    const LPCWSTR& value,
+    void* context
+    );
+
 class Configuration
 {
 public:
     static void InitializeConfigurationKnobs(int numberOfConfigs, LPCWSTR *configNames, LPCWSTR *configValues);
+
+    // Invokes callback with given context for each configuration knob.
+    // Returns S_OK for successful enumeration; otherwise HRESULT from failed callback.
+    static HRESULT EnumerateKnobs(config_knob_fn callback, void* context);
 
     // Returns (in priority order):
     //    - The value of the ConfigDWORDInfo if it's set

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.h
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.h
@@ -272,6 +272,13 @@ ds_rt_disable_perfmap (void)
     return DS_IPC_E_NOTSUPPORTED;
 }
 
+static
+uint32_t
+ds_rt_appcontext_properties_get (dn_vector_ptr_t *props_array)
+{
+    return DS_IPC_E_NOTSUPPORTED;
+}
+
 /*
 * DiagnosticServer.
 */

--- a/src/coreclr/utilcode/configuration.cpp
+++ b/src/coreclr/utilcode/configuration.cpp
@@ -29,6 +29,20 @@ void Configuration::InitializeConfigurationKnobs(int numberOfConfigs, LPCWSTR *n
     knobValues = values;
 }
 
+HRESULT Configuration::EnumerateKnobs(config_knob_fn callback, void* context)
+{
+    HRESULT hr = S_OK;
+
+    for (int i = 0; i < numberOfKnobs; ++i)
+    {
+        _ASSERT(knobNames[i] != nullptr);
+        if (FAILED(hr = callback(knobNames[i], knobValues[i], context)))
+            return hr;
+    }
+
+    return S_OK;
+}
+
 static LPCWSTR GetConfigurationValue(LPCWSTR name)
 {
     _ASSERT(name != nullptr);

--- a/src/mono/mono/eventpipe/ds-rt-mono.h
+++ b/src/mono/mono/eventpipe/ds-rt-mono.h
@@ -239,6 +239,14 @@ ds_rt_disable_perfmap (void)
 	return DS_IPC_E_NOTSUPPORTED;
 }
 
+static
+uint32_t
+ds_rt_appcontext_properties_get (dn_vector_ptr_t *props_array)
+{
+	// TODO: Implement.
+	return DS_IPC_E_NOTSUPPORTED;
+}
+
 /*
 * DiagnosticServer.
 */

--- a/src/native/eventpipe/ds-process-protocol.c
+++ b/src/native/eventpipe/ds-process-protocol.c
@@ -1015,7 +1015,7 @@ process_protocol_helper_get_appcontext_properties (
 	bool result = false;
 
 	DiagnosticsAppContextPropertiesPayload payload;
-	DiagnosticsAppContextPropertiesPayload *props_payload = nullptr;
+	DiagnosticsAppContextPropertiesPayload *props_payload = NULL;
 
 	dn_vector_ptr_t *props_array = dn_vector_ptr_alloc ();
 	ep_raise_error_if_nok (props_array);

--- a/src/native/eventpipe/ds-process-protocol.h
+++ b/src/native/eventpipe/ds-process-protocol.h
@@ -191,6 +191,35 @@ void
 ds_enable_perfmap_payload_free (DiagnosticsEnablePerfmapPayload *payload);
 
 /*
+* DiagnosticsAppContextPropertiesPayload
+*/
+
+#if defined(DS_INLINE_GETTER_SETTER) || defined(DS_IMPL_PROCESS_PROTOCOL_GETTER_SETTER)
+struct _DiagnosticsAppContextPropertiesPayload {
+#else
+struct _DiagnosticsAppContextPropertiesPayload_Internal {
+#endif
+	// The appcontext properties are sent back as an optional continuation stream of data.
+	// It is encoded in the typical length-prefixed array format as defined in
+	// the Diagnostics IPC Spec: https://github.com/dotnet/diagnostics/blob/main/documentation/design-docs/ipc-protocol.md
+	uint32_t incoming_bytes;
+	uint16_t future;
+	const dn_vector_ptr_t *props_array;
+};
+
+#if !defined(DS_INLINE_GETTER_SETTER) && !defined(DS_IMPL_PROCESS_PROTOCOL_GETTER_SETTER)
+struct _DiagnosticsAppContextPropertiesPayload {
+	uint8_t _internal [sizeof (struct _DiagnosticsAppContextPropertiesPayload_Internal)];
+};
+#endif
+
+DiagnosticsAppContextPropertiesPayload *
+ds_appcontext_properties_payload_init (DiagnosticsAppContextPropertiesPayload *payload, const dn_vector_ptr_t *props_array);
+
+void
+ds_appcontext_properties_payload_fini (DiagnosticsAppContextPropertiesPayload *payload);
+
+/*
  * DiagnosticsProcessProtocolHelper.
  */
 

--- a/src/native/eventpipe/ds-rt.h
+++ b/src/native/eventpipe/ds-rt.h
@@ -118,6 +118,10 @@ static
 uint32_t
 ds_rt_disable_perfmap (void);
 
+static
+uint32_t
+ds_rt_appcontext_properties_get (dn_vector_ptr_t *props_array);
+
 /*
 * DiagnosticServer.
 */

--- a/src/native/eventpipe/ds-types.h
+++ b/src/native/eventpipe/ds-types.h
@@ -15,6 +15,7 @@
  * Diagnostics Structs.
  */
 
+typedef struct _DiagnosticsAppContextPropertiesPayload DiagnosticsAppContextPropertiesPayload;
 typedef struct _DiagnosticsAttachProfilerCommandPayload DiagnosticsAttachProfilerCommandPayload;
 typedef struct _DiagnosticsStartupProfilerCommandPayload DiagnosticsStartupProfilerCommandPayload;
 typedef struct _DiagnosticsConnectPort DiagnosticsConnectPort;
@@ -74,7 +75,8 @@ typedef enum {
 	DS_PROCESS_COMMANDID_SET_ENV_VAR = 0x03,
 	DS_PROCESS_COMMANDID_GET_PROCESS_INFO_2 = 0x04,
 	DS_PROCESS_COMMANDID_ENABLE_PERFMAP = 0x05,
-	DS_PROCESS_COMMANDID_DISABLE_PERFMAP = 0x06
+	DS_PROCESS_COMMANDID_DISABLE_PERFMAP = 0x06,
+	DS_PROCESS_COMMANDID_GET_APPCONTEXT_PROPERTIES = 0x07
 	// future
 } DiagnosticsProcessCommandId;
 


### PR DESCRIPTION
These changes allow diagnostic tools to enumerate the AppContext properties of a running application over the diagnostic communication channel for CoreCLR (I'm not sure if Mono has the AppContext notion and have opted out of implementing it there by returning DS_IPC_E_NOTSUPPORTED; similarly for NativeAOT).

The returned payload is exactly the same as the DS_PROCESS_COMMANDID_GET_PROCESS_ENV command. Each property name and value is concatenated together with an equal sign character (`=`) and delimited with a null-terminator; this represents a single entry in the AppContext.

Corresponding diagnostic repo change is https://github.com/dotnet/diagnostics/pull/3901

Partially addresses #83756 

cc @dotnet/dotnet-monitor 