### PR TITLE
Improve Microsoft.Extensions.Configuration debugging

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationItemDebugView.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationItemDebugView.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Extensions.Configuration
+{
+    internal sealed class ConfigurationItemDebugView
+    {
+        public ConfigurationItemDebugView(string path, string? value, IConfigurationProvider? provider)
+        {
+            Path = path;
+            Value = value;
+            Provider = provider;
+        }
+
+        public string Path { get; }
+        public string? Value { get; }
+        public IConfigurationProvider? Provider { get; }
+
+        public override string ToString()
+        {
+            var s = $"Path = {Path}";
+            if (Value is not null)
+            {
+                s += $", Value = {Value}";
+            }
+            if (Provider is not null)
+            {
+                s += $", Provider = {Provider}";
+            }
+            return s;
+        }
+
+        internal static List<ConfigurationItemDebugView> FromConfiguration(IConfiguration current, IConfigurationRoot root, bool makePathsRelative = true)
+        {
+            var data = new List<ConfigurationItemDebugView>();
+
+            var stack = new Stack<IConfiguration>();
+            stack.Push(current);
+            int prefixLength = (makePathsRelative && current is IConfigurationSection rootSection) ? rootSection.Path.Length + 1 : 0;
+            while (stack.Count > 0)
+            {
+                IConfiguration config = stack.Pop();
+                // Don't include the sections value if we are removing paths, since it will be an empty key
+                if (config is IConfigurationSection section && (!makePathsRelative || config != current))
+                {
+                    (string? value, IConfigurationProvider? provider) = GetValueAndProvider(root, section.Path);
+
+                    data.Add(new ConfigurationItemDebugView(section.Path.Substring(prefixLength), value, provider));
+                }
+                foreach (IConfigurationSection child in config.GetChildren())
+                {
+                    stack.Push(child);
+                }
+            }
+
+            data.Sort((i1, i2) => ConfigurationKeyComparer.Instance.Compare(i1.Path, i2.Path));
+            return data;
+        }
+
+        internal static (string? Value, IConfigurationProvider? Provider) GetValueAndProvider(IConfigurationRoot root, string key)
+        {
+            foreach (IConfigurationProvider provider in root.Providers.Reverse())
+            {
+                if (provider.TryGet(key, out string? value))
+                {
+                    return (value, provider);
+                }
+            }
+
+            return (null, null);
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationManager.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationManager.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Extensions.Configuration
 
         private string DebuggerToString()
         {
-            return $"Data = {ConfigurationItemDebugView.FromConfiguration(this, this).Count}";
+            return $"Sections = {ConfigurationSectionDebugView.FromConfiguration(this, this).Count}";
         }
 
         private sealed class ConfigurationManagerDebugView
@@ -177,7 +177,7 @@ namespace Microsoft.Extensions.Configuration
             }
 
             [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-            public ConfigurationItemDebugView[] Items => ConfigurationItemDebugView.FromConfiguration(_current, _current).ToArray();
+            public ConfigurationSectionDebugView[] Items => ConfigurationSectionDebugView.FromConfiguration(_current, _current).ToArray();
         }
 
         private sealed class ConfigurationSources : IList<IConfigurationSource>

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationManager.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationManager.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
@@ -16,6 +17,8 @@ namespace Microsoft.Extensions.Configuration
     /// ConfigurationManager is a mutable configuration object. It is both an <see cref="IConfigurationBuilder"/> and an <see cref="IConfigurationRoot"/>.
     /// As sources are added, it updates its current view of configuration.
     /// </summary>
+    [DebuggerDisplay("{DebuggerToString(),nq}")]
+    [DebuggerTypeProxy(typeof(ConfigurationManagerDebugView))]
     public sealed class ConfigurationManager : IConfigurationBuilder, IConfigurationRoot, IDisposable
     {
         // Concurrently modifying config sources or properties is not thread-safe. However, it is thread-safe to read config while modifying sources or properties.
@@ -157,6 +160,24 @@ namespace Microsoft.Extensions.Configuration
             {
                 registration.Dispose();
             }
+        }
+
+        private string DebuggerToString()
+        {
+            return $"Data = {ConfigurationItemDebugView.FromConfiguration(this, this).Count}";
+        }
+
+        private sealed class ConfigurationManagerDebugView
+        {
+            private readonly ConfigurationManager _current;
+
+            public ConfigurationManagerDebugView(ConfigurationManager current)
+            {
+                _current = current;
+            }
+
+            [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+            public ConfigurationItemDebugView[] Items => ConfigurationItemDebugView.FromConfiguration(_current, _current).ToArray();
         }
 
         private sealed class ConfigurationSources : IList<IConfigurationSource>

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationRoot.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationRoot.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using Microsoft.Extensions.Primitives;
 
@@ -11,6 +13,8 @@ namespace Microsoft.Extensions.Configuration
     /// <summary>
     /// The root node for a configuration.
     /// </summary>
+    [DebuggerDisplay("{DebuggerToString(),nq}")]
+    [DebuggerTypeProxy(typeof(ConfigurationRootDebugView))]
     public class ConfigurationRoot : IConfigurationRoot, IDisposable
     {
         private readonly IList<IConfigurationProvider> _providers;
@@ -134,6 +138,24 @@ namespace Microsoft.Extensions.Configuration
             {
                 provider.Set(key, value);
             }
+        }
+
+        private string DebuggerToString()
+        {
+            return $"Children = {ConfigurationItemDebugView.FromConfiguration(this, this).Count}";
+        }
+
+        private sealed class ConfigurationRootDebugView
+        {
+            private readonly ConfigurationRoot _current;
+
+            public ConfigurationRootDebugView(ConfigurationRoot current)
+            {
+                _current = current;
+            }
+
+            [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+            public ConfigurationItemDebugView[] Items => ConfigurationItemDebugView.FromConfiguration(_current, _current).ToArray();
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationRoot.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationRoot.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using Microsoft.Extensions.Primitives;
 

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationRoot.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationRoot.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Extensions.Configuration
 
         private string DebuggerToString()
         {
-            return $"Children = {ConfigurationItemDebugView.FromConfiguration(this, this).Count}";
+            return $"Sections = {ConfigurationSectionDebugView.FromConfiguration(this, this).Count}";
         }
 
         private sealed class ConfigurationRootDebugView
@@ -154,7 +154,7 @@ namespace Microsoft.Extensions.Configuration
             }
 
             [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-            public ConfigurationItemDebugView[] Items => ConfigurationItemDebugView.FromConfiguration(_current, _current).ToArray();
+            public ConfigurationSectionDebugView[] Items => ConfigurationSectionDebugView.FromConfiguration(_current, _current).ToArray();
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationSection.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationSection.cs
@@ -103,15 +103,15 @@ namespace Microsoft.Extensions.Configuration
         private string DebuggerToString()
         {
             var s = $"Path = {Path}";
-            var childCount = ConfigurationItemDebugView.FromConfiguration(this, _root).Count;
+            var childCount = Configuration.ConfigurationSectionDebugView.FromConfiguration(this, _root).Count;
             if (childCount > 0)
             {
-                s += $", Children = {childCount}";
+                s += $", Sections = {childCount}";
             }
             if (Value is not null)
             {
                 s += $", Value = {Value}";
-                (_, IConfigurationProvider? provider) = ConfigurationItemDebugView.GetValueAndProvider(_root, Path);
+                IConfigurationProvider? provider = Configuration.ConfigurationSectionDebugView.GetValueProvider(_root, Path);
                 if (provider != null)
                 {
                     s += $", Provider = {provider}";
@@ -128,13 +128,14 @@ namespace Microsoft.Extensions.Configuration
             public ConfigurationSectionDebugView(ConfigurationSection current)
             {
                 _current = current;
-                (_, _provider) = ConfigurationItemDebugView.GetValueAndProvider(_current._root, _current.Path);
+                _provider = Configuration.ConfigurationSectionDebugView.GetValueProvider(_current._root, _current.Path);
             }
 
             public string Path => _current.Path;
+            public string Key => _current.Key;
             public string? Value => _current.Value;
             public IConfigurationProvider? Provider => _provider;
-            public List<ConfigurationItemDebugView> Children => ConfigurationItemDebugView.FromConfiguration(_current, _current._root);
+            public List<Configuration.ConfigurationSectionDebugView> Sections => Configuration.ConfigurationSectionDebugView.FromConfiguration(_current, _current._root);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationSection.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationSection.cs
@@ -4,9 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using Microsoft.Extensions.Primitives;
-using static System.Collections.Specialized.BitVector32;
 
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationSection.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationSection.cs
@@ -123,22 +123,17 @@ namespace Microsoft.Extensions.Configuration
         private sealed class ConfigurationSectionDebugView
         {
             private readonly ConfigurationSection _current;
+            private readonly IConfigurationProvider? _provider;
 
             public ConfigurationSectionDebugView(ConfigurationSection current)
             {
                 _current = current;
+                (_, _provider) = ConfigurationItemDebugView.GetValueAndProvider(_current._root, _current.Path);
             }
 
             public string Path => _current.Path;
             public string? Value => _current.Value;
-            public IConfigurationProvider? Provider
-            {
-                get
-                {
-                    (_, IConfigurationProvider? provider) = ConfigurationItemDebugView.GetValueAndProvider(_current._root, _current.Path);
-                    return provider;
-                }
-            }
+            public IConfigurationProvider? Provider => _provider;
             public List<ConfigurationItemDebugView> Children => ConfigurationItemDebugView.FromConfiguration(_current, _current._root);
         }
     }

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationSectionDebugViewTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationSectionDebugViewTest.cs
@@ -1,0 +1,163 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration.Memory;
+using Xunit;
+
+namespace Microsoft.Extensions.Configuration.Test
+{
+    public class ConfigurationSectionDebugViewTest
+    {
+        [Fact]
+        public void FromConfiguration_Root()
+        {
+            var config = new ConfigurationManager();
+
+            config.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                {"Mem1:", "NoKeyValue1"},
+                {"Mem1:KeyInMem1", "ValueInMem1"},
+                {"Mem1:KeyInMem1:Deep1", "ValueDeep1"}
+            });
+
+            var items = ConfigurationSectionDebugView.FromConfiguration(config, config);
+
+            Assert.Collection(items,
+                i =>
+                {
+                    Assert.Equal("Mem1", i.Path);
+                    Assert.Null(i.Value);
+                    Assert.Null(i.Provider);
+                },
+                i =>
+                {
+                    Assert.Equal("Mem1:", i.Path);
+                    Assert.Equal("NoKeyValue1", i.Value);
+                    Assert.IsType<MemoryConfigurationProvider>(i.Provider);
+                },
+                i =>
+                {
+                    Assert.Equal("Mem1:KeyInMem1", i.Path);
+                    Assert.Equal("ValueInMem1", i.Value);
+                    Assert.IsType<MemoryConfigurationProvider>(i.Provider);
+                },
+                i =>
+                {
+                    Assert.Equal("Mem1:KeyInMem1:Deep1", i.Path);
+                    Assert.Equal("ValueDeep1", i.Value);
+                    Assert.IsType<MemoryConfigurationProvider>(i.Provider);
+                });
+        }
+
+        [Fact]
+        public void FromConfiguration_Section()
+        {
+            var config = new ConfigurationManager();
+
+            config.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                {"Mem1:", "NoKeyValue1"},
+                {"Mem1:KeyInMem1", "ValueInMem1"},
+                {"Mem1:KeyInMem1:", "NoKeyValue2"},
+                {"Mem1:KeyInMem1:Deep1", "ValueDeep1"},
+                {"Mem1:KeyInMem2", "ValueInMem1"}
+            });
+
+            var section = config.GetSection("Mem1:KeyInMem1");
+
+            var items = ConfigurationSectionDebugView.FromConfiguration(section, config);
+
+            Assert.Collection(items,
+                i =>
+                {
+                    Assert.Equal("", i.Path);
+                    Assert.Equal("NoKeyValue2", i.Value);
+                    Assert.IsType<MemoryConfigurationProvider>(i.Provider);
+                },
+                i =>
+                {
+                    Assert.Equal("Deep1", i.Path);
+                    Assert.Equal("ValueDeep1", i.Value);
+                    Assert.IsType<MemoryConfigurationProvider>(i.Provider);
+                });
+        }
+
+        [Fact]
+        public void FromConfiguration_MultipleProviders()
+        {
+            var provider1 = new TestMemorySourceProvider(new Dictionary<string, string>
+            {
+                {"Mem1:", "NoKeyValue1"},
+                {"Key1", "ValueInMem1"}
+            });
+            var provider2 = new TestMemorySourceProvider(new Dictionary<string, string>
+            {
+                {"Mem2:", "NoKeyValue2"},
+                {"Key2", "ValueInMem2"}
+            });
+
+            var config = new ConfigurationManager();
+            config.Sources.Add(provider1);
+            config.Sources.Add(provider2);
+
+            var items = ConfigurationSectionDebugView.FromConfiguration(config, config);
+
+            Assert.Collection(items,
+                i =>
+                {
+                    Assert.Equal("Key1", i.Path);
+                    Assert.Equal("Key1", i.Key);
+                    Assert.Equal("ValueInMem1", i.Value);
+                    Assert.Equal(provider1, i.Provider);
+                },
+                i =>
+                {
+                    Assert.Equal("Key2", i.Path);
+                    Assert.Equal("Key2", i.Key);
+                    Assert.Equal("ValueInMem2", i.Value);
+                    Assert.Equal(provider2, i.Provider);
+                },
+                i =>
+                {
+                    Assert.Equal("Mem1", i.Path);
+                    Assert.Equal("Mem1", i.Key);
+                    Assert.Null(i.Value);
+                    Assert.Null(i.Provider);
+                },
+                i =>
+                {
+                    Assert.Equal("Mem1:", i.Path);
+                    Assert.Equal(string.Empty, i.Key);
+                    Assert.Equal("NoKeyValue1", i.Value);
+                    Assert.Equal(provider1, i.Provider);
+                },
+                i =>
+                {
+                    Assert.Equal("Mem2", i.Path);
+                    Assert.Equal("Mem2", i.Key);
+                    Assert.Null(i.Value);
+                    Assert.Null(i.Provider);
+                },
+                i =>
+                {
+                    Assert.Equal("Mem2:", i.Path);
+                    Assert.Equal(string.Empty, i.Key);
+                    Assert.Equal("NoKeyValue2", i.Value);
+                    Assert.Equal(provider2, i.Provider);
+                });
+        }
+
+        public class TestMemorySourceProvider : MemoryConfigurationProvider, IConfigurationSource
+        {
+            public TestMemorySourceProvider(Dictionary<string, string> initialData)
+                : base(new MemoryConfigurationSource { InitialData = initialData })
+            { }
+
+            public IConfigurationProvider Build(IConfigurationBuilder builder)
+            {
+                return this;
+            }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationTest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Extensions.Configuration.Test
         }
 
         [Fact]
-        private void GetChildKeys_CanChainEmptyKeys()
+        public void GetChildKeys_CanChainEmptyKeys()
         {
             var input = new Dictionary<string, string>() { };
             for (int i = 0; i < 1000; i++)
@@ -90,7 +90,7 @@ namespace Microsoft.Extensions.Configuration.Test
         }
 
         [Fact]
-        private void GetChildKeys_CanChainKeyWithNoDelimiter()
+        public void GetChildKeys_CanChainKeyWithNoDelimiter()
         {
             var input = new Dictionary<string, string>() { };
             for (int i = 1000; i < 2000; i++)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/86550

This PR adds DebuggerDisplay and DebuggerTypeProxy to commonly used Microsoft.Extensions.Configuration types.

## `ConfigurationManager`/`ConfigurationRoot`

These root config options now display children values.

**Before:**

![image](https://github.com/dotnet/runtime/assets/303201/aeaf5e17-7932-4ebe-a91e-06da4f9da892)

**After:**

![image](https://github.com/dotnet/runtime/assets/303201/109e44d9-b84c-4dcc-b598-8b7442202231)

## `ConfigurationSection`

`ConfigurationSection` now displays its path from the configuration root. Depending on the present data, it conditionally displays the section value, provider, and children.

**Before:**

![image](https://github.com/dotnet/runtime/assets/303201/af0b3b45-5c4c-43fa-98db-b278e8e98c53)

**After:**

![image](https://github.com/dotnet/runtime/assets/303201/6e5dc369-cabf-4dc3-abaa-d7c07805aa1f)

