### PR TITLE
[mono][debugger] Don't pass uninitialized context to debugger

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -4451,11 +4451,9 @@ user_break_cb (StackFrameInfo *frame, MonoContext *ctx, gpointer user_data)
 {
 	UserBreakCbData *data = (UserBreakCbData*)user_data;
 
-	if (frame->type == FRAME_TYPE_INTERP_TO_MANAGED || frame->type == FRAME_TYPE_INTERP_TO_MANAGED_WITH_CTX) {
-		data->found = TRUE;
-		return TRUE;
-	}
-	if (frame->managed) {
+	if (frame->managed ||
+			frame->type == FRAME_TYPE_INTERP_TO_MANAGED ||
+			frame->type == FRAME_TYPE_INTERP_TO_MANAGED_WITH_CTX) {
 		data->found = TRUE;
 		*data->ctx = *ctx;
 


### PR DESCRIPTION
mono_dbg_debugger_agent_user_break first tries to initialize a context before sending it to the debugger machinery. If, during unwinding, we don't have a saved context, we were passing uninitialized data (with interpreter for example). On some architectures this was making unwinding break in mono_walk_stack_full, because the stack pointer was invalid. This change makes it so we at least pass a valid context.

Fixes https://github.com/dotnet/runtime/issues/86148