### PR TITLE
JIT: Use unsigned native return types for small structs

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -529,11 +529,11 @@ var_types Compiler::getPrimitiveTypeForStruct(unsigned structSize, CORINFO_CLASS
     switch (structSize)
     {
         case 1:
-            useType = TYP_BYTE;
+            useType = TYP_UBYTE;
             break;
 
         case 2:
-            useType = TYP_SHORT;
+            useType = TYP_USHORT;
             break;
 
 #if !defined(TARGET_XARCH) || defined(UNIX_AMD64_ABI)


### PR DESCRIPTION
Prefer the return type to be unsigned when small structs are returned in registers. This causes the backend to use zero extension instead of sign extension in a few cases, which has a smaller encoding on xarch.

Fixes a few small regressions I saw in #86388.

E.g.
```csharp
[MethodImpl(MethodImplOptions.NoInlining)]
public static (byte, byte) Foo(in (byte, byte) arg) => arg;
```
Before:
```asm
G_M50947_IG02:  ;; offset=0000H
       movsx    rax, word  ptr [rcx]
						;; size=4 bbWeight=1 PerfScore 4.00

G_M50947_IG03:  ;; offset=0004H
       ret      
```
After:
```asm
G_M50947_IG02:  ;; offset=0000H
       movzx    rax, word  ptr [rcx]
						;; size=3 bbWeight=1 PerfScore 2.00

G_M50947_IG03:  ;; offset=0003H
       ret      
```