### PR TITLE
Fix a bug in type hierarchy marking in the trimmer

### DIFF
--- a/src/tools/illink/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/DynamicallyAccessedMembersTypeHierarchy.cs
@@ -216,7 +216,7 @@ namespace Mono.Linker.Dataflow
 			var baseType = _context.TryResolve (type.BaseType);
 			if (baseType != null) {
 				var baseAnnotation = GetCachedInfoForTypeInHierarchy (baseType);
-				var annotationToApplyToBase = Annotations.GetMissingMemberTypes (annotation, baseAnnotation.annotation);
+				var annotationToApplyToBase = baseAnnotation.applied ? Annotations.GetMissingMemberTypes (annotation, baseAnnotation.annotation) : annotation;
 
 				// Apply any annotations that didn't exist on the base type to the base type.
 				// This may produce redundant warnings when the annotation is DAMT.All or DAMT.PublicConstructors and the base already has a
@@ -234,7 +234,7 @@ namespace Mono.Linker.Dataflow
 						continue;
 
 					var interfaceAnnotation = GetCachedInfoForTypeInHierarchy (interfaceType);
-					if (interfaceAnnotation.annotation.HasFlag (annotationToApplyToInterfaces))
+					if (interfaceAnnotation.applied && interfaceAnnotation.annotation.HasFlag (annotationToApplyToInterfaces))
 						continue;
 
 					// Apply All or Interfaces to the interface type.

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/Inheritance.Interfaces.StaticInterfaceMethodsTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/Inheritance.Interfaces.StaticInterfaceMethodsTests.g.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Xunit;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
@@ -61,6 +61,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			PrivateMembersOnBaseTypesAppliedToDerived.Test ();
 
 			IsInstOf.Test ();
+
+			UsedByDerived.Test ();
 		}
 
 		[Kept]
@@ -1598,6 +1600,133 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			{
 				var target = new Target ();
 				TestIsInstOf (target);
+			}
+		}
+
+		[Kept]
+		class UsedByDerived
+		{
+			class AnnotatedBase
+			{
+				[Kept]
+				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+				class Base
+				{
+					[Kept]
+					public void Method () { }
+				}
+
+				[Kept]
+				[KeptBaseType (typeof (Base))]
+				class Derived : Base
+				{
+				}
+
+				[Kept]
+				static Derived derivedInstance;
+
+				[Kept]
+				public static void Test ()
+				{
+					derivedInstance.GetType ().RequiresPublicMethods ();
+				}
+			}
+
+			class AnnotatedDerived
+			{
+				[Kept]
+				class Base
+				{
+					[Kept]
+					public void Method () { }
+				}
+
+				[Kept]
+				[KeptBaseType (typeof (Base))]
+				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+				class Derived : Base
+				{
+				}
+
+				[Kept]
+				static Derived derivedInstance;
+
+				[Kept]
+				public static void Test ()
+				{
+					derivedInstance.GetType ().RequiresPublicMethods ();
+				}
+			}
+
+			class AnnotatedInterface
+			{
+				[Kept]
+				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+				interface IBase
+				{
+					[Kept]
+					public void Method () { }
+				}
+
+				[Kept]
+				[KeptMember (".ctor()")]
+				[KeptInterface (typeof (IBase))]
+				class Implementation : IBase
+				{
+				}
+
+				[Kept]
+				static Implementation implementationInstance;
+
+				[Kept]
+				public static void Test ()
+				{
+					implementationInstance = new Implementation ();
+					var a = implementationInstance as IBase;
+					implementationInstance.GetType ().RequiresPublicMethods ();
+				}
+			}
+
+			class AnnotatedImplementation
+			{
+				[Kept]
+				interface IBase
+				{
+					[Kept]
+					public void Method () { }
+				}
+
+				[Kept]
+				[KeptMember (".ctor()")]
+				[KeptInterface (typeof (IBase))]
+				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+				class Implementation : IBase
+				{
+				}
+
+				[Kept]
+				static Implementation implementationInstance;
+
+				[Kept]
+				public static void Test ()
+				{
+					implementationInstance = new Implementation ();
+					var a = implementationInstance as IBase;
+					implementationInstance.GetType ().RequiresPublicMethods ();
+				}
+			}
+
+			[Kept]
+			public static void Test ()
+			{
+				AnnotatedBase.Test (); ;
+				AnnotatedDerived.Test ();
+				AnnotatedInterface.Test ();
+				AnnotatedImplementation.Test ();
 			}
 		}
 	}


### PR DESCRIPTION
If the base class has DAM annotation on it, but the only access is through a variable typed as the derived class, the marking of everything on the base class happens during the processing of the derived class.

The bug was that it would only apply marking for the difference in effective annotations between derived and base, so if the annotation is on base, then both have effectively the same annotation and there would be no additional marking on base. So for example private methods would not be marked.

This also affected warnings on virtual methods - see tests for more details.