### PR TITLE
[wasi] Remove DotNetCoreWeb from ProjectCapability

### DIFF
--- a/src/mono/wasi/build/WasiApp.targets
+++ b/src/mono/wasi/build/WasiApp.targets
@@ -125,9 +125,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Allow running/debugging from VS -->
-    <ProjectCapability Include="DotNetCoreWeb"/>
-
     <SupportedPlatform Condition="'$(IsWasiProject)' == 'true'"        Remove="@(SupportedPlatform)" />
     <SupportedPlatform Condition="'$(IsBrowserWasmProject)' == 'true'" Include="browser" />
     <SupportedPlatform Condition="'$(IsWasiProject)' == 'true'"        Include="wasi" />


### PR DESCRIPTION
Visual Studio thinks it's an ASP.NET Core project when `ProjectCapability` includes `DotNetCoreWeb`.

Contributes to https://github.com/dotnet/runtime/issues/65895