### PR TITLE
Fix assert failure in grow_heap_segment in no GC region.

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -6853,6 +6853,7 @@ void gc_heap::gc_thread_function ()
             {
                 update_collection_counts_for_no_gc();
                 proceed_with_gc_p = FALSE;
+                gradual_decommit_in_progress_p = FALSE;
             }
             else
             {


### PR DESCRIPTION
This addresses issue #86612.

We won't actually decommit anything once we enter a no GC region, so the assert was overeager for this case, but it seems better to keep the assert and turn off the `gradual_decommit_in_progress_p` flag when we enter a no GC region.