### PR TITLE
add nuget.projectmodel to version.details

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -377,5 +377,11 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>
       <Sha>85af145192ce699ffcc16bd1a7b565820b6a2dff</Sha>
     </Dependency>
+    <!-- Necessary for source-build. This allows the package to be retrieved from previously-source-built artifacts
+         and flow in as dependencies of the packages produced by runtime. -->
+    <Dependency Name="Nuget.ProjectModel" Version="6.2.2">
+      <Uri>https://github.com/NuGet/NuGet.Client</Uri>
+      <Sha>027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d</Sha>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/3043

Declaring the `Nuget.ProjectModel` dependency in `Version.Details.xml` will allow source-build to replace the currently used `6.2.2` version with the `n-1` version coming from previously source-built artifacts in the product / VMR build.

Without this change, once repo PvP is enabled for `runtime`, `Nuget.ProjectModel` will be marked as a pre-built. 