### PR TITLE
Upgrading SpanHelpers with Vector512

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2298,7 +2298,7 @@ void Compiler::compSetProcessor()
 
         instructionSetFlags.AddInstructionSet(InstructionSet_Vector512);
 
-        if ((preferredVectorByteLength == 0) && jitFlags.IsSet(JitFlags::JIT_FLAG_VECTOR512_THROTTLING))
+        if ((preferredVectorByteLength == 0) && opts.Vector512Throttling())
         {
             // Some architectures can experience frequency throttling when
             // executing 512-bit width instructions. To account for this we set the

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9508,6 +9508,16 @@ public:
             return jitFlags->IsSet(JitFlags::JIT_FLAG_REVERSE_PINVOKE);
         }
 
+        // true if JitFlags::JIT_FLAG_VECTOR512_THROTTLING is set to true
+        bool Vector512Throttling()
+        {
+#if defined(TARGET_XARCH)
+            return jitFlags->IsSet(JitFlags::JIT_FLAG_VECTOR512_THROTTLING);
+#else
+            return false;
+#endif
+        }
+
         bool compScopeInfo; // Generate the LocalVar info ?
         bool compDbgCode;   // Generate debugger-friendly code?
         bool compDbgInfo;   // Gather debugging info?

--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -550,6 +550,12 @@ NamedIntrinsic HWIntrinsicInfo::lookupId(Compiler*         comp,
 
         if (isIsaSupported && comp->compSupportsHWIntrinsic(isa))
         {
+#ifdef TARGET_XARCH
+            if ((isa == InstructionSet_Vector512) && (comp->opts.Vector512Throttling()))
+            {
+                return NI_IsSupported_False;
+            }
+#endif
             if (!comp->IsTargetAbi(CORINFO_NATIVEAOT_ABI) || comp->compExactlyDependsOn(isa))
             {
                 return NI_IsSupported_True;

--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -515,6 +515,11 @@ NamedIntrinsic HWIntrinsicInfo::lookupId(Compiler*         comp,
         }
         else if (strcmp(className, "Vector512") == 0)
         {
+            // If the JitFlags::JIT_FLAG_VECTOR512_THROTTLING flag is set, we do not need to do any further checks.
+            if (comp->opts.Vector512Throttling())
+            {
+                return NI_IsSupported_False;
+            }
             isa = InstructionSet_AVX512F;
         }
     }
@@ -550,12 +555,6 @@ NamedIntrinsic HWIntrinsicInfo::lookupId(Compiler*         comp,
 
         if (isIsaSupported && comp->compSupportsHWIntrinsic(isa))
         {
-#ifdef TARGET_XARCH
-            if ((isa == InstructionSet_Vector512) && (comp->opts.Vector512Throttling()))
-            {
-                return NI_IsSupported_False;
-            }
-#endif
             if (!comp->IsTargetAbi(CORINFO_NATIVEAOT_ABI) || comp->compExactlyDependsOn(isa))
             {
                 return NI_IsSupported_True;

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -945,6 +945,17 @@ namespace System.Numerics
         }
 
         /// <summary>
+        /// Reset specific bit in the given value
+        /// Reset the lowest significant bit in the given value
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static ulong ResetLowestSetBit(ulong value)
+        {
+            // It's lowered to BLSR on x86
+            return value & (value - 1);
+        }
+
+        /// <summary>
         /// Flip the bit at a specific position in a given value.
         /// Similar in behavior to the x86 instruction BTC (Bit Test and Complement).
         /// </summary>
@@ -956,6 +967,20 @@ namespace System.Numerics
         internal static uint FlipBit(uint value, int index)
         {
             return value ^ (1u << index);
+        }
+
+        /// <summary>
+        /// Flip the bit at a specific position in a given value.
+        /// Similar in behavior to the x86 instruction BTC (Bit Test and Complement).
+        /// /// </summary>
+        /// <param name="value">The value.</param>
+        /// <param name="index">The zero-based index of the bit to flip.
+        /// Any value outside the range [0..63] is treated as congruent mod 64.</param>
+        /// <returns>The new value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static ulong FlipBit(ulong value, int index)
+        {
+            return value ^ (ulong)((ulong)1u << index);
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -980,7 +980,7 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static ulong FlipBit(ulong value, int index)
         {
-            return value ^ (1UL << index);
+            return value ^ (1ul << index);
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -980,7 +980,7 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static ulong FlipBit(ulong value, int index)
         {
-            return value ^ (ulong)((ulong)1u << index);
+            return value ^ (1UL << index);
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512.cs
@@ -1791,6 +1791,21 @@ namespace System.Runtime.Intrinsics
             return Unsafe.ReadUnaligned<Vector512<T>>(ref Unsafe.As<T, byte>(ref source));
         }
 
+        /// <summary>Loads a vector from the given source and reinterprets it as <see cref="ushort"/>.</summary>
+        /// <param name="source">The source from which the vector will be loaded.</param>
+        /// <returns>The vector loaded from <paramref name="source" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static Vector512<ushort> LoadUnsafe(ref char source) =>
+            LoadUnsafe(ref Unsafe.As<char, ushort>(ref source));
+
+        /// <summary>Loads a vector from the given source and element offset and reinterprets it as <see cref="ushort"/>.</summary>
+        /// <param name="source">The source to which <paramref name="elementOffset" /> will be added before loading the vector.</param>
+        /// <param name="elementOffset">The element offset from <paramref name="source" /> from which the vector will be loaded.</param>
+        /// <returns>The vector loaded from <paramref name="source" /> plus <paramref name="elementOffset" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static Vector512<ushort> LoadUnsafe(ref char source, nuint elementOffset) =>
+            LoadUnsafe(ref Unsafe.As<char, ushort>(ref source), elementOffset);
+
         /// <summary>Computes the maximum of two vectors on a per-element basis.</summary>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>
         /// <param name="left">The vector to compare with <paramref name="right" />.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -551,9 +551,9 @@ namespace System
 
                     if ((((nuint)(uint)searchSpace + offset) & (nuint)(Vector512<byte>.Count - 1)) != 0)
                     {
-                        // Not currently aligned to Vector256 (is aligned to Vector128); this can cause a problem for searches
+                        // Not currently aligned to Vector512 (is aligned to Vector256); this can cause a problem for searches
                         // with no upper bound e.g. String.strlen.
-                        // Start with a check on Vector128 to align to Vector256, before moving to processing Vector256.
+                        // Start with a check on Vector256 to align to Vector512, before moving to processing Vector256.
                         // This ensures we do not fault across memory pages while searching for an end of string.
                         Vector256<byte> search = Vector256.Load(searchSpace + offset);
 

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -63,7 +63,68 @@ namespace System
             // Based on http://0x80.pl/articles/simd-strfind.html#algorithm-1-generic-simd "Algorithm 1: Generic SIMD" by Wojciech Mula
             // Some details about the implementation can also be found in https://github.com/dotnet/runtime/pull/63285
         SEARCH_TWO_BYTES:
-            if (Vector256.IsHardwareAccelerated && searchSpaceMinusValueTailLength - Vector256<byte>.Count >= 0)
+            if (Vector512.IsHardwareAccelerated && searchSpaceMinusValueTailLength - Vector512<byte>.Count >= 0)
+            {
+                // Find the last unique (which is not equal to ch1) byte
+                // the algorithm is fine if both are equal, just a little bit less efficient
+                byte ch2Val = Unsafe.Add(ref value, valueTailLength);
+                nint ch1ch2Distance = (nint)(uint)valueTailLength;
+                while (ch2Val == value && ch1ch2Distance > 1)
+                    ch2Val = Unsafe.Add(ref value, --ch1ch2Distance);
+
+                Vector512<byte> ch1 = Vector512.Create(value);
+                Vector512<byte> ch2 = Vector512.Create(ch2Val);
+
+                nint searchSpaceMinusValueTailLengthAndVector =
+                    searchSpaceMinusValueTailLength - (nint)Vector512<byte>.Count;
+
+                do
+                {
+                    Debug.Assert(offset >= 0);
+                    // Make sure we don't go out of bounds
+                    Debug.Assert(offset + ch1ch2Distance + Vector512<byte>.Count <= searchSpaceLength);
+
+                    Vector512<byte> cmpCh2 = Vector512.Equals(ch2, Vector512.LoadUnsafe(ref searchSpace, (nuint)(offset + ch1ch2Distance)));
+                    Vector512<byte> cmpCh1 = Vector512.Equals(ch1, Vector512.LoadUnsafe(ref searchSpace, (nuint)offset));
+                    Vector512<byte> cmpAnd = (cmpCh1 & cmpCh2).AsByte();
+
+                    // Early out: cmpAnd is all zeros
+                    if (cmpAnd != Vector512<byte>.Zero)
+                    {
+                        goto CANDIDATE_FOUND;
+                    }
+
+                LOOP_FOOTER:
+                    offset += Vector512<byte>.Count;
+
+                    if (offset == searchSpaceMinusValueTailLength)
+                        return -1;
+
+                    // Overlap with the current chunk for trailing elements
+                    if (offset > searchSpaceMinusValueTailLengthAndVector)
+                        offset = searchSpaceMinusValueTailLengthAndVector;
+
+                    continue;
+
+                CANDIDATE_FOUND:
+                    ulong mask = cmpAnd.ExtractMostSignificantBits();
+                    do
+                    {
+                        int bitPos = BitOperations.TrailingZeroCount(mask);
+                        if (valueLength == 2 || // we already matched two bytes
+                            SequenceEqual(
+                                ref Unsafe.Add(ref searchSpace, offset + bitPos),
+                                ref value, (nuint)(uint)valueLength)) // The (nuint)-cast is necessary to pick the correct overload
+                        {
+                            return (int)(offset + bitPos);
+                        }
+                        mask = BitOperations.ResetLowestSetBit(mask); // Clear the lowest set bit
+                    } while (mask != 0);
+                    goto LOOP_FOOTER;
+
+                } while (true);
+            }
+            else if (Vector256.IsHardwareAccelerated && searchSpaceMinusValueTailLength - Vector256<byte>.Count >= 0)
             {
                 // Find the last unique (which is not equal to ch1) byte
                 // the algorithm is fine if both are equal, just a little bit less efficient
@@ -235,7 +296,54 @@ namespace System
         // Based on http://0x80.pl/articles/simd-strfind.html#algorithm-1-generic-simd "Algorithm 1: Generic SIMD" by Wojciech Mula
         // Some details about the implementation can also be found in https://github.com/dotnet/runtime/pull/63285
         SEARCH_TWO_BYTES:
-            if (Vector256.IsHardwareAccelerated && searchSpaceMinusValueTailLength >= Vector256<byte>.Count)
+            if (Vector512.IsHardwareAccelerated && searchSpaceMinusValueTailLength >= Vector512<byte>.Count)
+            {
+                offset = searchSpaceMinusValueTailLength - Vector512<byte>.Count;
+
+                // Find the last unique (which is not equal to ch1) byte
+                // the algorithm is fine if both are equal, just a little bit less efficient
+                byte ch2Val = Unsafe.Add(ref value, valueTailLength);
+                int ch1ch2Distance = valueTailLength;
+                while (ch2Val == value && ch1ch2Distance > 1)
+                    ch2Val = Unsafe.Add(ref value, --ch1ch2Distance);
+
+                Vector512<byte> ch1 = Vector512.Create(value);
+                Vector512<byte> ch2 = Vector512.Create(ch2Val);
+                do
+                {
+                    Vector512<byte> cmpCh1 = Vector512.Equals(ch1, Vector512.LoadUnsafe(ref searchSpace, (nuint)offset));
+                    Vector512<byte> cmpCh2 = Vector512.Equals(ch2, Vector512.LoadUnsafe(ref searchSpace, (nuint)(offset + ch1ch2Distance)));
+                    Vector512<byte> cmpAnd = (cmpCh1 & cmpCh2).AsByte();
+
+                    // Early out: cmpAnd is all zeros
+                    if (cmpAnd != Vector512<byte>.Zero)
+                    {
+                        ulong mask = cmpAnd.ExtractMostSignificantBits();
+                        do
+                        {
+                            // unlike IndexOf, here we use LZCNT to process matches starting from the end
+                            int highestSetBitIndex = 63 - BitOperations.LeadingZeroCount(mask);
+                            if (valueLength == 2 || // we already matched two bytes
+                                SequenceEqual(
+                                    ref Unsafe.Add(ref searchSpace, offset + highestSetBitIndex),
+                                    ref value, (nuint)(uint)valueLength)) // The (nuint)-cast is necessary to pick the correct overload
+                            {
+                                return highestSetBitIndex + offset;
+                            }
+                            // Clear the highest set bit.
+                            mask = BitOperations.FlipBit(mask, highestSetBitIndex);
+                        } while (mask != 0);
+                    }
+
+                    offset -= Vector512<byte>.Count;
+                    if (offset == -Vector512<byte>.Count)
+                        return -1;
+                    // Overlap with the current chunk if there is not enough room for the next one
+                    if (offset < 0)
+                        offset = 0;
+                } while (true) ;
+            }
+            else if (Vector256.IsHardwareAccelerated && searchSpaceMinusValueTailLength >= Vector256<byte>.Count)
             {
                 offset = searchSpaceMinusValueTailLength - Vector256<byte>.Count;
 
@@ -345,7 +453,6 @@ namespace System
         internal static unsafe int IndexOfNullByte(byte* searchSpace)
         {
             const int Length = int.MaxValue;
-
             const uint uValue = 0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             nuint offset = 0; // Use nuint for arithmetic to avoid unnecessary 64->32->64 truncations
             nuint lengthToExamine = (nuint)(uint)Length;
@@ -416,7 +523,120 @@ namespace System
             // We get past SequentialScan only if IsHardwareAccelerated is true; and remain length is greater than Vector length.
             // However, we still have the redundant check to allow the JIT to see that the code is unreachable and eliminate it when the platform does not
             // have hardware accelerated. After processing Vector lengths we return to SequentialScan to finish any remaining.
-            if (Vector256.IsHardwareAccelerated)
+            if (Vector512.IsHardwareAccelerated)
+            {
+                if (offset < (nuint)(uint)Length)
+                {
+                    if ((((nuint)(uint)searchSpace + offset) & (nuint)(Vector256<byte>.Count - 1)) != 0)
+                    {
+                        // Not currently aligned to Vector256 (is aligned to Vector128); this can cause a problem for searches
+                        // with no upper bound e.g. String.strlen.
+                        // Start with a check on Vector128 to align to Vector256, before moving to processing Vector256.
+                        // This ensures we do not fault across memory pages while searching for an end of string.
+                        Vector128<byte> search = Vector128.Load(searchSpace + offset);
+
+                        // Same method as below
+                        uint matches = Vector128.Equals(Vector128<byte>.Zero, search).ExtractMostSignificantBits();
+                        if (matches == 0)
+                        {
+                            // Zero flags set so no matches
+                            offset += (nuint)Vector128<byte>.Count;
+                        }
+                        else
+                        {
+                            // Find bitflag offset of first match and add to current offset
+                            return (int)(offset + (uint)BitOperations.TrailingZeroCount(matches));
+                        }
+                    }
+
+                    if ((((nuint)(uint)searchSpace + offset) & (nuint)(Vector512<byte>.Count - 1)) != 0)
+                    {
+                        // Not currently aligned to Vector256 (is aligned to Vector128); this can cause a problem for searches
+                        // with no upper bound e.g. String.strlen.
+                        // Start with a check on Vector128 to align to Vector256, before moving to processing Vector256.
+                        // This ensures we do not fault across memory pages while searching for an end of string.
+                        Vector256<byte> search = Vector256.Load(searchSpace + offset);
+
+                        // Same method as below
+                        uint matches = Vector256.Equals(Vector256<byte>.Zero, search).ExtractMostSignificantBits();
+                        if (matches == 0)
+                        {
+                            // Zero flags set so no matches
+                            offset += (nuint)Vector256<byte>.Count;
+                        }
+                        else
+                        {
+                            // Find bitflag offset of first match and add to current offset
+                            return (int)(offset + (uint)BitOperations.TrailingZeroCount(matches));
+                        }
+                    }
+                    lengthToExamine = GetByteVector512SpanLength(offset, Length);
+                    if (lengthToExamine > offset)
+                    {
+                        do
+                        {
+                            Vector512<byte> search = Vector512.Load(searchSpace + offset);
+                            ulong matches = Vector512.Equals(Vector512<byte>.Zero, search).ExtractMostSignificantBits();
+                            // Note that MoveMask has converted the equal vector elements into a set of bit flags,
+                            // So the bit position in 'matches' corresponds to the element offset.
+                            if (matches == 0)
+                            {
+                                // Zero flags set so no matches
+                                offset += (nuint)Vector512<byte>.Count;
+                                continue;
+                            }
+
+                            // Find bitflag offset of first match and add to current offset
+                            return (int)(offset + (uint)BitOperations.TrailingZeroCount(matches));
+                        } while (lengthToExamine > offset);
+                    }
+
+                    lengthToExamine = GetByteVector256SpanLength(offset, Length);
+                    if (lengthToExamine > offset)
+                    {
+                        Vector256<byte> search = Vector256.Load(searchSpace + offset);
+
+                        // Same method as above
+                        uint matches = Vector256.Equals(Vector256<byte>.Zero, search).ExtractMostSignificantBits();
+                        if (matches == 0)
+                        {
+                            // Zero flags set so no matches
+                            offset += (nuint)Vector256<byte>.Count;
+                        }
+                        else
+                        {
+                            // Find bitflag offset of first match and add to current offset
+                            return (int)(offset + (uint)BitOperations.TrailingZeroCount(matches));
+                        }
+                    }
+
+                    lengthToExamine = GetByteVector128SpanLength(offset, Length);
+                    if (lengthToExamine > offset)
+                    {
+                        Vector128<byte> search = Vector128.Load(searchSpace + offset);
+
+                        // Same method as above
+                        uint matches = Vector128.Equals(Vector128<byte>.Zero, search).ExtractMostSignificantBits();
+                        if (matches == 0)
+                        {
+                            // Zero flags set so no matches
+                            offset += (nuint)Vector128<byte>.Count;
+                        }
+                        else
+                        {
+                            // Find bitflag offset of first match and add to current offset
+                            return (int)(offset + (uint)BitOperations.TrailingZeroCount(matches));
+                        }
+                    }
+
+                    if (offset < (nuint)(uint)Length)
+                    {
+                        lengthToExamine = ((nuint)(uint)Length - offset);
+                        goto SequentialScan;
+                    }
+                }
+            }
+            else if (Vector256.IsHardwareAccelerated)
             {
                 if (offset < (nuint)(uint)Length)
                 {
@@ -634,7 +854,37 @@ namespace System
         Vector:
             if (Vector128.IsHardwareAccelerated)
             {
-                if (Vector256.IsHardwareAccelerated && length >= (nuint)Vector256<byte>.Count)
+                if (Vector512.IsHardwareAccelerated && length >= (nuint)Vector512<byte>.Count)
+                {
+                    nuint offset = 0;
+                    nuint lengthToExamine = length - (nuint)Vector512<byte>.Count;
+                    // Unsigned, so it shouldn't have overflowed larger than length (rather than negative)
+                    Debug.Assert(lengthToExamine < length);
+                    if (lengthToExamine != 0)
+                    {
+                        do
+                        {
+                            if (Vector512.LoadUnsafe(ref first, offset) !=
+                                Vector512.LoadUnsafe(ref second, offset))
+                            {
+                                goto NotEqual;
+                            }
+                            offset += (nuint)Vector512<byte>.Count;
+                        } while (lengthToExamine > offset);
+                    }
+
+                    // Do final compare as Vector512<byte>.Count from end rather than start
+                    if (Vector512.LoadUnsafe(ref first, lengthToExamine) ==
+                        Vector512.LoadUnsafe(ref second, lengthToExamine))
+                    {
+                        // C# compiler inverts this test, making the outer goto the conditional jmp.
+                        goto Equal;
+                    }
+
+                    // This becomes a conditional jmp forward to not favor it.
+                    goto NotEqual;
+                }
+                else if (Vector256.IsHardwareAccelerated && length >= (nuint)Vector256<byte>.Count)
                 {
                     nuint offset = 0;
                     nuint lengthToExamine = length - (nuint)Vector256<byte>.Count;
@@ -789,6 +1039,47 @@ namespace System
 
             if (Vector256.IsHardwareAccelerated)
             {
+                if (Vector512.IsHardwareAccelerated && (lengthToExamine >= (nuint)Vector512<byte>.Count))
+                {
+                    lengthToExamine -= (nuint)Vector512<byte>.Count;
+                    ulong matches;
+                    while (lengthToExamine > offset)
+                    {
+                        matches = Vector512.Equals(Vector512.LoadUnsafe(ref first, offset), Vector512.LoadUnsafe(ref second, offset)).ExtractMostSignificantBits();
+                        // Note that MoveMask has converted the equal vector elements into a set of bit flags,
+                        // So the bit position in 'matches' corresponds to the element offset.
+
+                        // 32 elements in Vector256<byte> so we compare to uint.MaxValue to check if everything matched
+                        if (matches == ulong.MaxValue)
+                        {
+                            // All matched
+                            offset += (nuint)Vector512<byte>.Count;
+                            continue;
+                        }
+
+                        goto Difference;
+                    }
+                    // Move to Vector length from end for final compare
+                    offset = lengthToExamine;
+                    // Same as method as above
+                    matches = Vector512.Equals(Vector512.LoadUnsafe(ref first, offset), Vector512.LoadUnsafe(ref second, offset)).ExtractMostSignificantBits();
+                    if (matches == ulong.MaxValue)
+                    {
+                        // All matched
+                        goto Equal;
+                    }
+                Difference:
+                    // Invert matches to find differences
+                    ulong differences = ~matches;
+                    // Find bitflag offset of first difference and add to current offset
+                    offset += (uint)BitOperations.TrailingZeroCount(differences);
+
+                    int result = Unsafe.AddByteOffset(ref first, offset).CompareTo(Unsafe.AddByteOffset(ref second, offset));
+                    Debug.Assert(result != 0);
+
+                    return result;
+                }
+
                 if (lengthToExamine >= (nuint)Vector256<byte>.Count)
                 {
                     lengthToExamine -= (nuint)Vector256<byte>.Count;
@@ -1140,6 +1431,10 @@ namespace System
             => (nuint)(uint)((length - (int)offset) & ~(Vector256<byte>.Count - 1));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static nuint GetByteVector512SpanLength(nuint offset, int length)
+            => (nuint)(uint)((length - (int)offset) & ~(Vector512<byte>.Count - 1));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe nuint UnalignedCountVector128(byte* searchSpace)
         {
             nint unaligned = (nint)searchSpace & (Vector128<byte>.Count - 1);
@@ -1153,8 +1448,45 @@ namespace System
             nint remainder = (nint)length;
             nint offset = 0;
 
-            // overlapping has a positive performance benefit around 48 elements
-            if (Avx2.IsSupported && remainder >= (nint)(Vector256<byte>.Count * 1.5))
+            if (Vector512.IsHardwareAccelerated && remainder >= Vector512<byte>.Count * 2)
+            {
+                nint lastOffset = remainder - Vector512<byte>.Count;
+                do
+                {
+                    // Load the values into vectors
+                    Vector512<byte> tempFirst = Vector512.LoadUnsafe(ref buf, (nuint)offset);
+                    Vector512<byte> tempLast = Vector512.LoadUnsafe(ref buf, (nuint)lastOffset);
+
+                    // Shuffle to reverse each vector:
+                    //     +---------------------------------------------------------------+
+                    //     | A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P |
+                    //     +---------------------------------------------------------------+
+                    //          --->
+                    //     +---------------------------------------------------------------+
+                    //     | P | O | N | M | L | K | J | I | H | G | F | E | D | C | B | A |
+                    //     +---------------------------------------------------------------+
+                    tempFirst = Vector512.Shuffle(tempFirst, Vector512.Create(
+                        (byte)63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48,
+                        47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32,
+                        31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16,
+                        15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0));
+                    tempLast = Vector512.Shuffle(tempLast, Vector512.Create(
+                        (byte)63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48,
+                        47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32,
+                        31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16,
+                        15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0));
+
+                    // Store the reversed vectors
+                    tempLast.StoreUnsafe(ref buf, (nuint)offset);
+                    tempFirst.StoreUnsafe(ref buf, (nuint)lastOffset);
+
+                    offset += Vector512<byte>.Count;
+                    lastOffset -= Vector512<byte>.Count;
+                } while (lastOffset >= offset);
+
+                remainder = lastOffset + Vector512<byte>.Count - offset;
+            }
+            else if (Avx2.IsSupported && remainder >= (nint)(Vector256<byte>.Count * 1.5))
             {
                 Vector256<byte> reverseMask = Vector256.Create(
                     (byte)15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, // first 128-bit lane

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -68,7 +68,74 @@ namespace System
             // Based on http://0x80.pl/articles/simd-strfind.html#algorithm-1-generic-simd "Algorithm 1: Generic SIMD" by Wojciech Mula
             // Some details about the implementation can also be found in https://github.com/dotnet/runtime/pull/63285
         SEARCH_TWO_CHARS:
-            if (Vector256.IsHardwareAccelerated && searchSpaceMinusValueTailLength - Vector256<ushort>.Count >= 0)
+            if (Vector512.IsHardwareAccelerated && searchSpaceMinusValueTailLength - Vector512<ushort>.Count >= 0)
+            {
+                // Find the last unique (which is not equal to ch1) character
+                // the algorithm is fine if both are equal, just a little bit less efficient
+                ushort ch2Val = Unsafe.Add(ref value, valueTailLength);
+                nint ch1ch2Distance = (nint)(uint)valueTailLength;
+                while (ch2Val == valueHead && ch1ch2Distance > 1)
+                    ch2Val = Unsafe.Add(ref value, --ch1ch2Distance);
+
+                Vector512<ushort> ch1 = Vector512.Create((ushort)valueHead);
+                Vector512<ushort> ch2 = Vector512.Create(ch2Val);
+
+                nint searchSpaceMinusValueTailLengthAndVector =
+                    searchSpaceMinusValueTailLength - (nint)Vector512<ushort>.Count;
+
+                do
+                {
+                    // Make sure we don't go out of bounds
+                    Debug.Assert(offset + ch1ch2Distance + Vector512<ushort>.Count <= searchSpaceLength);
+
+                    Vector512<ushort> cmpCh2 = Vector512.Equals(ch2, Vector512.LoadUnsafe(ref searchSpace, (nuint)(offset + ch1ch2Distance)));
+                    Vector512<ushort> cmpCh1 = Vector512.Equals(ch1, Vector512.LoadUnsafe(ref searchSpace, (nuint)offset));
+                    Vector512<byte> cmpAnd = (cmpCh1 & cmpCh2).AsByte();
+
+                    // Early out: cmpAnd is all zeros
+                    if (cmpAnd != Vector512<byte>.Zero)
+                    {
+                        goto CANDIDATE_FOUND;
+                    }
+
+                LOOP_FOOTER:
+                    offset += Vector512<ushort>.Count;
+
+                    if (offset == searchSpaceMinusValueTailLength)
+                        return -1;
+
+                    // Overlap with the current chunk for trailing elements
+                    if (offset > searchSpaceMinusValueTailLengthAndVector)
+                        offset = searchSpaceMinusValueTailLengthAndVector;
+
+                    continue;
+
+                CANDIDATE_FOUND:
+                    ulong mask = cmpAnd.ExtractMostSignificantBits();
+                    do
+                    {
+                        int bitPos = BitOperations.TrailingZeroCount(mask);
+                        // div by 2 (shr) because we work with 2-byte chars
+                        nint charPos = (nint)((uint)bitPos / 2);
+                        if (valueLength == 2 || // we already matched two chars
+                            SequenceEqual(
+                                ref Unsafe.As<char, byte>(ref Unsafe.Add(ref searchSpace, offset + charPos)),
+                                ref Unsafe.As<char, byte>(ref value), (nuint)(uint)valueLength * 2))
+                        {
+                            return (int)(offset + charPos);
+                        }
+
+                        // Clear two the lowest set bits
+                        if (Bmi1.X64.IsSupported)
+                            mask = Bmi1.X64.ResetLowestSetBit(Bmi1.X64.ResetLowestSetBit(mask));
+                        else
+                            mask &= ~(ulong)((ulong)0b11 << bitPos);
+                    } while (mask != 0);
+                    goto LOOP_FOOTER;
+
+                } while (true);
+            }
+            else if (Vector256.IsHardwareAccelerated && searchSpaceMinusValueTailLength - Vector256<ushort>.Count >= 0)
             {
                 // Find the last unique (which is not equal to ch1) character
                 // the algorithm is fine if both are equal, just a little bit less efficient
@@ -253,7 +320,57 @@ namespace System
             // Based on http://0x80.pl/articles/simd-strfind.html#algorithm-1-generic-simd "Algorithm 1: Generic SIMD" by Wojciech Mula
             // Some details about the implementation can also be found in https://github.com/dotnet/runtime/pull/63285
         SEARCH_TWO_CHARS:
-            if (Vector256.IsHardwareAccelerated && searchSpaceMinusValueTailLength >= Vector256<ushort>.Count)
+            if (Vector512.IsHardwareAccelerated && searchSpaceMinusValueTailLength >= Vector512<ushort>.Count)
+            {
+                offset = searchSpaceMinusValueTailLength - Vector512<ushort>.Count;
+
+                // Find the last unique (which is not equal to ch1) char
+                // the algorithm is fine if both are equal, just a little bit less efficient
+                char ch2Val = Unsafe.Add(ref value, valueTailLength);
+                int ch1ch2Distance = valueTailLength;
+                while (ch2Val == valueHead && ch1ch2Distance > 1)
+                    ch2Val = Unsafe.Add(ref value, --ch1ch2Distance);
+
+                Vector512<ushort> ch1 = Vector512.Create((ushort)valueHead);
+                Vector512<ushort> ch2 = Vector512.Create((ushort)ch2Val);
+
+                do
+                {
+
+                    Vector512<ushort> cmpCh1 = Vector512.Equals(ch1, Vector512.LoadUnsafe(ref searchSpace, (nuint)offset));
+                    Vector512<ushort> cmpCh2 = Vector512.Equals(ch2, Vector512.LoadUnsafe(ref searchSpace, (nuint)(offset + ch1ch2Distance)));
+                    Vector512<byte> cmpAnd = (cmpCh1 & cmpCh2).AsByte();
+
+                    // Early out: cmpAnd is all zeros
+                    if (cmpAnd != Vector512<byte>.Zero)
+                    {
+                        ulong mask = cmpAnd.ExtractMostSignificantBits();
+                        do
+                        {
+                            // unlike IndexOf, here we use LZCNT to process matches starting from the end
+                            int bitPos = 62 - BitOperations.LeadingZeroCount(mask);
+                            int charPos = (int)((uint)bitPos / 2);
+
+                            if (valueLength == 2 || // we already matched two chars
+                                SequenceEqual(
+                                    ref Unsafe.As<char, byte>(ref Unsafe.Add(ref searchSpace, offset + charPos)),
+                                    ref Unsafe.As<char, byte>(ref value), (nuint)(uint)valueLength * 2))
+                            {
+                                return charPos + offset;
+                            }
+                            mask &= ~(ulong)((ulong)0b11 << bitPos); // clear two highest set bits.
+                        } while (mask != 0);
+                    }
+
+                    offset -= Vector512<ushort>.Count;
+                    if (offset == -Vector512<ushort>.Count)
+                        return -1;
+                    // Overlap with the current chunk if there is not enough room for the next one
+                    if (offset < 0)
+                        offset = 0;
+                } while (true);
+            }
+            else if (Vector256.IsHardwareAccelerated && searchSpaceMinusValueTailLength >= Vector256<ushort>.Count)
             {
                 offset = searchSpaceMinusValueTailLength - Vector256<ushort>.Count;
 
@@ -478,7 +595,145 @@ namespace System
 
             // We get past SequentialScan only if IsHardwareAccelerated is true. However, we still have the redundant check to allow
             // the JIT to see that the code is unreachable and eliminate it when the platform does not have hardware accelerated.
-            if (Vector256.IsHardwareAccelerated)
+            if (Vector512.IsHardwareAccelerated)
+            {
+                if (offset < length)
+                {
+                    Debug.Assert(length - offset >= Vector128<ushort>.Count);
+                    if (((nint)(searchSpace + (nint)offset) & (nint)(Vector256<byte>.Count - 1)) != 0)
+                    {
+                        // Not currently aligned to Vector256 (is aligned to Vector128); this can cause a problem for searches
+                        // with no upper bound e.g. String.wcslen. Start with a check on Vector128 to align to Vector256,
+                        // before moving to processing Vector256.
+
+                        // This ensures we do not fault across memory pages
+                        // while searching for an end of string. Specifically that this assumes that the length is either correct
+                        // or that the data is pinned otherwise it may cause an AccessViolation from crossing a page boundary into an
+                        // unowned page. If the search is unbounded (e.g. null terminator in wcslen) and the search value is not found,
+                        // again this will likely cause an AccessViolation. However, correctly bounded searches will return -1 rather
+                        // than ever causing an AV.
+                        Vector128<ushort> search = *(Vector128<ushort>*)(searchSpace + (nuint)offset);
+
+                        // Same method as below
+                        uint matches = Vector128.Equals(Vector128<ushort>.Zero, search).AsByte().ExtractMostSignificantBits();
+                        if (matches == 0)
+                        {
+                            // Zero flags set so no matches
+                            offset += Vector128<ushort>.Count;
+                        }
+                        else
+                        {
+                            // Find bitflag offset of first match and add to current offset
+                            return (int)(offset + ((uint)BitOperations.TrailingZeroCount(matches) / sizeof(char)));
+                        }
+                    }
+                    if (((nint)(searchSpace + (nint)offset) & (nint)(Vector512<byte>.Count - 1)) != 0)
+                    {
+                        // Not currently aligned to Vector256 (is aligned to Vector128); this can cause a problem for searches
+                        // with no upper bound e.g. String.wcslen. Start with a check on Vector128 to align to Vector256,
+                        // before moving to processing Vector256.
+
+                        // This ensures we do not fault across memory pages
+                        // while searching for an end of string. Specifically that this assumes that the length is either correct
+                        // or that the data is pinned otherwise it may cause an AccessViolation from crossing a page boundary into an
+                        // unowned page. If the search is unbounded (e.g. null terminator in wcslen) and the search value is not found,
+                        // again this will likely cause an AccessViolation. However, correctly bounded searches will return -1 rather
+                        // than ever causing an AV.
+                        Vector256<ushort> search = *(Vector256<ushort>*)(searchSpace + (nuint)offset);
+
+                        // Same method as below
+                        uint matches = Vector256.Equals(Vector256<ushort>.Zero, search).AsByte().ExtractMostSignificantBits();
+                        if (matches == 0)
+                        {
+                            // Zero flags set so no matches
+                            offset += Vector256<ushort>.Count;
+                        }
+                        else
+                        {
+                            // Find bitflag offset of first match and add to current offset
+                            return (int)(offset + ((uint)BitOperations.TrailingZeroCount(matches) / sizeof(char)));
+                        }
+                    }
+
+                    lengthToExamine = GetCharVector512SpanLength(offset, length);
+                    if (lengthToExamine > 0)
+                    {
+                        do
+                        {
+                            Debug.Assert(lengthToExamine >= Vector512<ushort>.Count);
+
+                            Vector512<ushort> search = *(Vector512<ushort>*)(searchSpace + (nuint)offset);
+                            ulong matches = Vector512.Equals(Vector512<ushort>.Zero, search).AsByte().ExtractMostSignificantBits();
+                            // Note that MoveMask has converted the equal vector elements into a set of bit flags,
+                            // So the bit position in 'matches' corresponds to the element offset.
+                            if (matches == 0)
+                            {
+                                // Zero flags set so no matches
+                                offset += Vector512<ushort>.Count;
+                                lengthToExamine -= Vector512<ushort>.Count;
+                                continue;
+                            }
+
+                            // Find bitflag offset of first match and add to current offset,
+                            // flags are in bytes so divide for chars
+                            return (int)(offset + ((uint)BitOperations.TrailingZeroCount(matches) / sizeof(char)));
+                        } while (lengthToExamine > 0);
+                    }
+
+                    lengthToExamine = GetCharVector256SpanLength(offset, length);
+                    if (lengthToExamine > 0)
+                    {
+                        Debug.Assert(lengthToExamine >= Vector256<ushort>.Count);
+
+                        Vector256<ushort> search = *(Vector256<ushort>*)(searchSpace + (nuint)offset);
+
+                        // Same method as above
+                        uint matches = Vector256.Equals(Vector256<ushort>.Zero, search).AsByte().ExtractMostSignificantBits();
+                        if (matches == 0)
+                        {
+                            // Zero flags set so no matches
+                            offset += Vector256<ushort>.Count;
+                            // Don't need to change lengthToExamine here as we don't use its current value again.
+                        }
+                        else
+                        {
+                            // Find bitflag offset of first match and add to current offset,
+                            // flags are in bytes so divide for chars
+                            return (int)(offset + ((uint)BitOperations.TrailingZeroCount(matches) / sizeof(char)));
+                        }
+                    }
+
+                    lengthToExamine = GetCharVector128SpanLength(offset, length);
+                    if (lengthToExamine > 0)
+                    {
+                        Debug.Assert(lengthToExamine >= Vector128<ushort>.Count);
+
+                        Vector128<ushort> search = *(Vector128<ushort>*)(searchSpace + (nuint)offset);
+
+                        // Same method as above
+                        uint matches = Vector128.Equals(Vector128<ushort>.Zero, search).AsByte().ExtractMostSignificantBits();
+                        if (matches == 0)
+                        {
+                            // Zero flags set so no matches
+                            offset += Vector128<ushort>.Count;
+                            // Don't need to change lengthToExamine here as we don't use its current value again.
+                        }
+                        else
+                        {
+                            // Find bitflag offset of first match and add to current offset,
+                            // flags are in bytes so divide for chars
+                            return (int)(offset + ((uint)BitOperations.TrailingZeroCount(matches) / sizeof(char)));
+                        }
+                    }
+
+                    if (offset < length)
+                    {
+                        lengthToExamine = length - offset;
+                        goto SequentialScan;
+                    }
+                }
+            }
+            else if (Vector256.IsHardwareAccelerated)
             {
                 if (offset < length)
                 {
@@ -708,6 +963,10 @@ namespace System
             => (length - offset) & ~(Vector256<ushort>.Count - 1);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static nint GetCharVector512SpanLength(nint offset, nint length)
+            => (length - offset) & ~(Vector512<ushort>.Count - 1);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe nint UnalignedCountVector128(char* searchSpace)
         {
             const int ElementsPerByte = sizeof(ushort) / sizeof(byte);
@@ -721,8 +980,42 @@ namespace System
             nint remainder = (nint)length;
             nint offset = 0;
 
+            if (Vector512.IsHardwareAccelerated && remainder >= Vector512<ushort>.Count * 2)
+            {
+                nint lastOffset = remainder - Vector512<ushort>.Count;
+                do
+                {
+                    ref ushort first = ref Unsafe.As<char, ushort>(ref Unsafe.Add(ref buf, offset));
+                    ref ushort last = ref Unsafe.As<char, ushort>(ref Unsafe.Add(ref buf, lastOffset));
+
+                    Vector512<ushort> tempFirst = Vector512.LoadUnsafe(ref first);
+                    Vector512<ushort> tempLast = Vector512.LoadUnsafe(ref last);
+
+                    // Shuffle to reverse each vector:
+                    //     +-------------------------------+
+                    //     | A | B | C | D | E | F | G | H |
+                    //     +-------------------------------+
+                    //          --->
+                    //     +-------------------------------+
+                    //     | H | G | F | E | D | C | B | A |
+                    //     +-------------------------------+
+                    tempFirst = Vector512.Shuffle(tempFirst, Vector512.Create((ushort)31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16,
+                        15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0));
+                    tempLast = Vector512.Shuffle(tempLast, Vector512.Create((ushort)31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16,
+                        15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0));
+
+                    // Store the reversed vectors
+                    tempLast.StoreUnsafe(ref first);
+                    tempFirst.StoreUnsafe(ref last);
+
+                    offset += Vector512<ushort>.Count;
+                    lastOffset -= Vector512<ushort>.Count;
+                } while (lastOffset >= offset);
+
+                remainder = (lastOffset + Vector512<ushort>.Count - offset);
+            }
             // overlapping has a positive performance benefit around 24 elements
-            if (Avx2.IsSupported && remainder >= (nint)(Vector256<ushort>.Count * 1.5))
+            else if (Avx2.IsSupported && remainder >= (nint)(Vector256<ushort>.Count * 1.5))
             {
                 Vector256<byte> reverseMask = Vector256.Create(
                     (byte)14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1, // first 128-bit lane

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -629,8 +629,8 @@ namespace System
                     }
                     if (((nint)(searchSpace + (nint)offset) & (nint)(Vector512<byte>.Count - 1)) != 0)
                     {
-                        // Not currently aligned to Vector256 (is aligned to Vector128); this can cause a problem for searches
-                        // with no upper bound e.g. String.wcslen. Start with a check on Vector128 to align to Vector256,
+                        // Not currently aligned to Vector512 (is aligned to Vector256); this can cause a problem for searches
+                        // with no upper bound e.g. String.wcslen. Start with a check on Vector256 to align to Vector512,
                         // before moving to processing Vector256.
 
                         // This ensures we do not fault across memory pages

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Packed.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Packed.cs
@@ -122,7 +122,7 @@ namespace System
                     if (length > 2 * Vector512<short>.Count)
                     {
                         // Process the input in chunks of 64 characters (2 * Vector512<short>).
-                        // If the input length is a multiple of 32, don't consume the last 16 characters in this loop.
+                        // If the input length is a multiple of 64, don't consume the last 16 characters in this loop.
                         // Let the fallback below handle it instead. This is why the condition is
                         // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
                         ref short twoVectorsAwayFromEnd = ref Unsafe.Add(ref searchSpace, length - (2 * Vector512<short>.Count));
@@ -321,8 +321,8 @@ namespace System
 
                     if (length > 2 * Vector512<short>.Count)
                     {
-                        // Process the input in chunks of 32 characters (2 * Vector256<short>).
-                        // If the input length is a multiple of 32, don't consume the last 16 characters in this loop.
+                        // Process the input in chunks of 64 characters (2 * Vector512<short>).
+                        // If the input length is a multiple of 64, don't consume the last 16 characters in this loop.
                         // Let the fallback below handle it instead. This is why the condition is
                         // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
                         ref short twoVectorsAwayFromEnd = ref Unsafe.Add(ref searchSpace, length - (2 * Vector512<short>.Count));
@@ -534,8 +534,8 @@ namespace System
 
                     if (length > 2 * Vector512<short>.Count)
                     {
-                        // Process the input in chunks of 32 characters (2 * Vector256<short>).
-                        // If the input length is a multiple of 32, don't consume the last 16 characters in this loop.
+                        // Process the input in chunks of 64 characters (2 * Vector512<short>).
+                        // If the input length is a multiple of 64, don't consume the last 16 characters in this loop.
                         // Let the fallback below handle it instead. This is why the condition is
                         // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
                         ref short twoVectorsAwayFromEnd = ref Unsafe.Add(ref searchSpace, length - (2 * Vector512<short>.Count));
@@ -752,8 +752,8 @@ namespace System
 
                     if (length > 2 * Vector512<short>.Count)
                     {
-                        // Process the input in chunks of 32 characters (2 * Vector256<short>).
-                        // If the input length is a multiple of 32, don't consume the last 16 characters in this loop.
+                        // Process the input in chunks of 64 characters (2 * Vector512<short>).
+                        // If the input length is a multiple of 64, don't consume the last 16 characters in this loop.
                         // Let the fallback below handle it instead. This is why the condition is
                         // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
                         ref short twoVectorsAwayFromEnd = ref Unsafe.Add(ref searchSpace, length - (2 * Vector512<short>.Count));
@@ -761,7 +761,7 @@ namespace System
                         do
                         {
                             Vector512<short> source0 = Vector512.LoadUnsafe(ref currentSearchSpace);
-                            Vector512<short> source1 = Vector512.LoadUnsafe(ref currentSearchSpace, (nuint)Vector256<short>.Count);
+                            Vector512<short> source1 = Vector512.LoadUnsafe(ref currentSearchSpace, (nuint)Vector512<short>.Count);
                             Vector512<byte> packedSource = PackSources(source0, source1);
                             Vector512<byte> result = Vector512.Equals(packedValue0, packedSource) | Vector512.Equals(packedValue1, packedSource) | Vector512.Equals(packedValue2, packedSource);
                             result = NegateIfNeeded<TNegator>(result);
@@ -953,8 +953,8 @@ namespace System
 
                     if (length > 2 * Vector512<short>.Count)
                     {
-                        // Process the input in chunks of 32 characters (2 * Vector256<short>).
-                        // If the input length is a multiple of 32, don't consume the last 16 characters in this loop.
+                        // Process the input in chunks of 64 characters (2 * Vector512<short>).
+                        // If the input length is a multiple of 64, don't consume the last 16 characters in this loop.
                         // Let the fallback below handle it instead. This is why the condition is
                         // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
                         ref short twoVectorsAwayFromEnd = ref Unsafe.Add(ref searchSpace, length - (2 * Vector512<short>.Count));
@@ -1128,7 +1128,6 @@ namespace System
             // - Values <= 32767 result in min(value, 255).
             // - Values  > 32767 result in 0. Because of this we can't accept needles that contain 0.
             return Avx512BW.PackUnsignedSaturate(source0, source1).AsByte();
-            //return Avx512BW.PackUnsignedSaturate(source0, source1).AsByte();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1229,7 +1228,7 @@ namespace System
         [CompExactlyDependsOn(typeof(Avx512F))]
         private static int ComputeFirstIndexOverlapped(ref short searchSpace, ref short current0, ref short current1, Vector512<byte> equals)
         {
-            ulong notEqualsElements = equals.ExtractMostSignificantBits();
+            ulong notEqualsElements = FixUpPackedVector512Result(equals).ExtractMostSignificantBits();
             int offsetInVector = BitOperations.TrailingZeroCount(notEqualsElements);
             if (offsetInVector >= Vector512<short>.Count)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -1367,6 +1367,36 @@ namespace System
                     offset += 1;
                 }
             }
+            else if (Vector512.IsHardwareAccelerated && length >= Vector512<T>.Count)
+            {
+                Vector512<T> equals, values = Vector512.Create(value);
+                ref T currentSearchSpace = ref searchSpace;
+                ref T oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, (uint)(length - Vector512<T>.Count));
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    equals = Vector512.Equals(values, Vector512.LoadUnsafe(ref currentSearchSpace));
+                    if (equals == Vector512<T>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector512<T>.Count);
+                        continue;
+                    }
+
+                    return true;
+                }
+                while (!Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAwayFromEnd));
+
+                // If any elements remain, process the last vector in the search space.
+                if ((uint)length % Vector512<T>.Count != 0)
+                {
+                    equals = Vector512.Equals(values, Vector512.LoadUnsafe(ref oneVectorAwayFromEnd));
+                    if (equals != Vector512<T>.Zero)
+                    {
+                        return true;
+                    }
+                }
+            }
             else if (Vector256.IsHardwareAccelerated && length >= Vector256<T>.Count)
             {
                 Vector256<T> equals, values = Vector256.Create(value);
@@ -1526,6 +1556,36 @@ namespace System
                 return (int)(offset + 1);
             Found:
                 return (int)(offset);
+            }
+            else if (Vector512.IsHardwareAccelerated && length >= Vector512<TValue>.Count)
+            {
+                Vector512<TValue> equals, values = Vector512.Create(value);
+                ref TValue currentSearchSpace = ref searchSpace;
+                ref TValue oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, length - Vector512<TValue>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    equals = TNegator.NegateIfNeeded(Vector512.Equals(values, Vector512.LoadUnsafe(ref currentSearchSpace)));
+                    if (equals == Vector512<TValue>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector512<TValue>.Count);
+                        continue;
+                    }
+
+                    return ComputeFirstIndex(ref searchSpace, ref currentSearchSpace, equals);
+                }
+                while (!Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAwayFromEnd));
+
+                // If any elements remain, process the last vector in the search space.
+                if ((uint)length % Vector512<TValue>.Count != 0)
+                {
+                    equals = TNegator.NegateIfNeeded(Vector512.Equals(values, Vector512.LoadUnsafe(ref oneVectorAwayFromEnd)));
+                    if (equals != Vector512<TValue>.Zero)
+                    {
+                        return ComputeFirstIndex(ref searchSpace, ref oneVectorAwayFromEnd, equals);
+                    }
+                }
             }
             else if (Vector256.IsHardwareAccelerated && length >= Vector256<TValue>.Count)
             {
@@ -1703,6 +1763,38 @@ namespace System
             Found:
                 return (int)(offset);
             }
+            else if (Vector512.IsHardwareAccelerated && length >= Vector512<TValue>.Count)
+            {
+                Vector512<TValue> equals, current, values0 = Vector512.Create(value0), values1 = Vector512.Create(value1);
+                ref TValue currentSearchSpace = ref searchSpace;
+                ref TValue oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, length - Vector512<TValue>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    current = Vector512.LoadUnsafe(ref currentSearchSpace);
+                    equals = TNegator.NegateIfNeeded(Vector512.Equals(values0, current) | Vector512.Equals(values1, current));
+                    if (equals == Vector512<TValue>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector512<TValue>.Count);
+                        continue;
+                    }
+
+                    return ComputeFirstIndex(ref searchSpace, ref currentSearchSpace, equals);
+                }
+                while (!Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAwayFromEnd));
+
+                // If any elements remain, process the last vector in the search space.
+                if ((uint)length % Vector512<TValue>.Count != 0)
+                {
+                    current = Vector512.LoadUnsafe(ref oneVectorAwayFromEnd);
+                    equals = TNegator.NegateIfNeeded(Vector512.Equals(values0, current) | Vector512.Equals(values1, current));
+                    if (equals != Vector512<TValue>.Zero)
+                    {
+                        return ComputeFirstIndex(ref searchSpace, ref oneVectorAwayFromEnd, equals);
+                    }
+                }
+            }
             else if (Vector256.IsHardwareAccelerated && length >= Vector256<TValue>.Count)
             {
                 Vector256<TValue> equals, current, values0 = Vector256.Create(value0), values1 = Vector256.Create(value1);
@@ -1878,6 +1970,38 @@ namespace System
             Found:
                 return (int)(offset);
             }
+            else if (Vector512.IsHardwareAccelerated && length >= Vector512<TValue>.Count)
+            {
+                Vector512<TValue> equals, current, values0 = Vector512.Create(value0), values1 = Vector512.Create(value1), values2 = Vector512.Create(value2);
+                ref TValue currentSearchSpace = ref searchSpace;
+                ref TValue oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, length - Vector512<TValue>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    current = Vector512.LoadUnsafe(ref currentSearchSpace);
+                    equals = TNegator.NegateIfNeeded(Vector512.Equals(values0, current) | Vector512.Equals(values1, current) | Vector512.Equals(values2, current));
+                    if (equals == Vector512<TValue>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector512<TValue>.Count);
+                        continue;
+                    }
+
+                    return ComputeFirstIndex(ref searchSpace, ref currentSearchSpace, equals);
+                }
+                while (!Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAwayFromEnd));
+
+                // If any elements remain, process the last vector in the search space.
+                if ((uint)length % Vector512<TValue>.Count != 0)
+                {
+                    current = Vector512.LoadUnsafe(ref oneVectorAwayFromEnd);
+                    equals = TNegator.NegateIfNeeded(Vector512.Equals(values0, current) | Vector512.Equals(values1, current) | Vector512.Equals(values2, current));
+                    if (equals != Vector512<TValue>.Zero)
+                    {
+                        return ComputeFirstIndex(ref searchSpace, ref oneVectorAwayFromEnd, equals);
+                    }
+                }
+            }
             else if (Vector256.IsHardwareAccelerated && length >= Vector256<TValue>.Count)
             {
                 Vector256<TValue> equals, current, values0 = Vector256.Create(value0), values1 = Vector256.Create(value1), values2 = Vector256.Create(value2);
@@ -2001,6 +2125,40 @@ namespace System
                 return (int)(offset + 1);
             Found:
                 return (int)(offset);
+            }
+            else if (Vector512.IsHardwareAccelerated && length >= Vector512<TValue>.Count)
+            {
+                Vector512<TValue> equals, current, values0 = Vector512.Create(value0), values1 = Vector512.Create(value1), values2 = Vector512.Create(value2), values3 = Vector512.Create(value3);
+                ref TValue currentSearchSpace = ref searchSpace;
+                ref TValue oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, length - Vector512<TValue>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    current = Vector512.LoadUnsafe(ref currentSearchSpace);
+                    equals = TNegator.NegateIfNeeded(Vector512.Equals(values0, current) | Vector512.Equals(values1, current)
+                        | Vector512.Equals(values2, current) | Vector512.Equals(values3, current));
+                    if (equals == Vector512<TValue>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector512<TValue>.Count);
+                        continue;
+                    }
+
+                    return ComputeFirstIndex(ref searchSpace, ref currentSearchSpace, equals);
+                }
+                while (!Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAwayFromEnd));
+
+                // If any elements remain, process the last vector in the search space.
+                if ((uint)length % Vector512<TValue>.Count != 0)
+                {
+                    current = Vector512.LoadUnsafe(ref oneVectorAwayFromEnd);
+                    equals = TNegator.NegateIfNeeded(Vector512.Equals(values0, current) | Vector512.Equals(values1, current)
+                        | Vector512.Equals(values2, current) | Vector512.Equals(values3, current));
+                    if (equals != Vector512<TValue>.Zero)
+                    {
+                        return ComputeFirstIndex(ref searchSpace, ref oneVectorAwayFromEnd, equals);
+                    }
+                }
             }
             else if (Vector256.IsHardwareAccelerated && length >= Vector256<TValue>.Count)
             {
@@ -2130,6 +2288,41 @@ namespace System
                 return (int)(offset + 1);
             Found:
                 return (int)(offset);
+            }
+            else if (Vector512.IsHardwareAccelerated && length >= Vector512<TValue>.Count)
+            {
+                Vector512<TValue> equals, current, values0 = Vector512.Create(value0), values1 = Vector512.Create(value1),
+                    values2 = Vector512.Create(value2), values3 = Vector512.Create(value3), values4 = Vector512.Create(value4);
+                ref TValue currentSearchSpace = ref searchSpace;
+                ref TValue oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, (uint)(length - Vector512<TValue>.Count));
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    current = Vector512.LoadUnsafe(ref currentSearchSpace);
+                    equals = TNegator.NegateIfNeeded(Vector512.Equals(values0, current) | Vector512.Equals(values1, current) | Vector512.Equals(values2, current)
+                           | Vector512.Equals(values3, current) | Vector512.Equals(values4, current));
+                    if (equals == Vector512<TValue>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector512<TValue>.Count);
+                        continue;
+                    }
+
+                    return ComputeFirstIndex(ref searchSpace, ref currentSearchSpace, equals);
+                }
+                while (!Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAwayFromEnd));
+
+                // If any elements remain, process the last vector in the search space.
+                if ((uint)length % Vector512<TValue>.Count != 0)
+                {
+                    current = Vector512.LoadUnsafe(ref oneVectorAwayFromEnd);
+                    equals = TNegator.NegateIfNeeded(Vector512.Equals(values0, current) | Vector512.Equals(values1, current) | Vector512.Equals(values2, current)
+                           | Vector512.Equals(values3, current) | Vector512.Equals(values4, current));
+                    if (equals != Vector512<TValue>.Zero)
+                    {
+                        return ComputeFirstIndex(ref searchSpace, ref oneVectorAwayFromEnd, equals);
+                    }
+                }
             }
             else if (Vector256.IsHardwareAccelerated && length >= Vector256<TValue>.Count)
             {
@@ -2277,6 +2470,34 @@ namespace System
                 return (int)(offset - 1);
             Found:
                 return (int)(offset);
+            }
+            else if (Vector512.IsHardwareAccelerated && length >= Vector512<TValue>.Count)
+            {
+                Vector512<TValue> equals, values = Vector512.Create(value);
+                nint offset = length - Vector512<TValue>.Count;
+
+                // Loop until either we've finished all elements -or- there's one or less than a vector's-worth remaining.
+                while (offset > 0)
+                {
+                    equals = TNegator.NegateIfNeeded(Vector512.Equals(values, Vector512.LoadUnsafe(ref searchSpace, (nuint)(offset))));
+
+                    if (equals == Vector512<TValue>.Zero)
+                    {
+                        offset -= Vector512<TValue>.Count;
+                        continue;
+                    }
+
+                    return ComputeLastIndex(offset, equals);
+                }
+
+                // Process the first vector in the search space.
+
+                equals = TNegator.NegateIfNeeded(Vector512.Equals(values, Vector512.LoadUnsafe(ref searchSpace)));
+
+                if (equals != Vector512<TValue>.Zero)
+                {
+                    return ComputeLastIndex(offset: 0, equals);
+                }
             }
             else if (Vector256.IsHardwareAccelerated && length >= Vector256<TValue>.Count)
             {
@@ -2430,6 +2651,36 @@ namespace System
                 return (int)(offset - 1);
             Found:
                 return (int)(offset);
+            }
+            else if (Vector512.IsHardwareAccelerated && length >= Vector512<TValue>.Count)
+            {
+                Vector512<TValue> equals, current, values0 = Vector512.Create(value0), values1 = Vector512.Create(value1);
+                nint offset = length - Vector512<TValue>.Count;
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                while (offset > 0)
+                {
+                    current = Vector512.LoadUnsafe(ref searchSpace, (nuint)(offset));
+                    equals = TNegator.NegateIfNeeded(Vector512.Equals(current, values0) | Vector512.Equals(current, values1));
+
+                    if (equals == Vector512<TValue>.Zero)
+                    {
+                        offset -= Vector512<TValue>.Count;
+                        continue;
+                    }
+
+                    return ComputeLastIndex(offset, equals);
+                }
+
+                // Process the first vector in the search space.
+
+                current = Vector512.LoadUnsafe(ref searchSpace);
+                equals = TNegator.NegateIfNeeded(Vector512.Equals(current, values0) | Vector512.Equals(current, values1));
+
+                if (equals != Vector512<TValue>.Zero)
+                {
+                    return ComputeLastIndex(offset: 0, equals);
+                }
             }
             else if (Vector256.IsHardwareAccelerated && length >= Vector256<TValue>.Count)
             {
@@ -2586,6 +2837,36 @@ namespace System
             Found:
                 return (int)(offset);
             }
+            else if (Vector512.IsHardwareAccelerated && length >= Vector512<TValue>.Count)
+            {
+                Vector512<TValue> equals, current, values0 = Vector512.Create(value0), values1 = Vector512.Create(value1), values2 = Vector512.Create(value2);
+                nint offset = length - Vector512<TValue>.Count;
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                while (offset > 0)
+                {
+                    current = Vector512.LoadUnsafe(ref searchSpace, (nuint)(offset));
+                    equals = TNegator.NegateIfNeeded(Vector512.Equals(current, values0) | Vector512.Equals(current, values1) | Vector512.Equals(current, values2));
+
+                    if (equals == Vector512<TValue>.Zero)
+                    {
+                        offset -= Vector512<TValue>.Count;
+                        continue;
+                    }
+
+                    return ComputeLastIndex(offset, equals);
+                }
+
+                // Process the first vector in the search space.
+
+                current = Vector512.LoadUnsafe(ref searchSpace);
+                equals = TNegator.NegateIfNeeded(Vector512.Equals(current, values0) | Vector512.Equals(current, values1) | Vector512.Equals(current, values2));
+
+                if (equals != Vector512<TValue>.Zero)
+                {
+                    return ComputeLastIndex(offset: 0, equals);
+                }
+            }
             else if (Vector256.IsHardwareAccelerated && length >= Vector256<TValue>.Count)
             {
                 Vector256<TValue> equals, current, values0 = Vector256.Create(value0), values1 = Vector256.Create(value1), values2 = Vector256.Create(value2);
@@ -2705,6 +2986,36 @@ namespace System
                 return (int)(offset - 1);
             Found:
                 return (int)(offset);
+            }
+            else if (Vector512.IsHardwareAccelerated && length >= Vector512<TValue>.Count)
+            {
+                Vector512<TValue> equals, current, values0 = Vector512.Create(value0), values1 = Vector512.Create(value1), values2 = Vector512.Create(value2), values3 = Vector512.Create(value3);
+                nint offset = length - Vector512<TValue>.Count;
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                while (offset > 0)
+                {
+                    current = Vector512.LoadUnsafe(ref searchSpace, (nuint)(offset));
+                    equals = TNegator.NegateIfNeeded(Vector512.Equals(current, values0) | Vector512.Equals(current, values1)
+                                            | Vector512.Equals(current, values2) | Vector512.Equals(current, values3));
+                    if (equals == Vector512<TValue>.Zero)
+                    {
+                        offset -= Vector512<TValue>.Count;
+                        continue;
+                    }
+
+                    return ComputeLastIndex(offset, equals);
+                }
+
+                // Process the first vector in the search space.
+
+                current = Vector512.LoadUnsafe(ref searchSpace);
+                equals = TNegator.NegateIfNeeded(Vector512.Equals(current, values0) | Vector512.Equals(current, values1) | Vector512.Equals(current, values2) | Vector512.Equals(current, values3));
+
+                if (equals != Vector512<TValue>.Zero)
+                {
+                    return ComputeLastIndex(offset: 0, equals);
+                }
             }
             else if (Vector256.IsHardwareAccelerated && length >= Vector256<TValue>.Count)
             {
@@ -2836,10 +3147,8 @@ namespace System
                     result = Vector128.ConditionalSelect(mask, newValues, original);
                     result.StoreUnsafe(ref dst, lastVectorIndex);
                 }
-                else
+                else if (!Vector512.IsHardwareAccelerated || length < (uint)Vector512<T>.Count)
                 {
-                    Debug.Assert(Vector256.IsHardwareAccelerated && Vector256<T>.IsSupported, "Vector256 is not HW-accelerated or not supported");
-
                     nuint lastVectorIndex = length - (uint)Vector256<T>.Count;
                     Vector256<T> oldValues = Vector256.Create(oldValue);
                     Vector256<T> newValues = Vector256.Create(newValue);
@@ -2859,6 +3168,31 @@ namespace System
                     original = Vector256.LoadUnsafe(ref src, lastVectorIndex);
                     mask = Vector256.Equals(oldValues, original);
                     result = Vector256.ConditionalSelect(mask, newValues, original);
+                    result.StoreUnsafe(ref dst, lastVectorIndex);
+                }
+                else
+                {
+                    Debug.Assert(Vector512.IsHardwareAccelerated && Vector512<T>.IsSupported, "Vector512 is not HW-accelerated or not supported");
+
+                    nuint lastVectorIndex = length - (uint)Vector512<T>.Count;
+                    Vector512<T> oldValues = Vector512.Create(oldValue);
+                    Vector512<T> newValues = Vector512.Create(newValue);
+                    Vector512<T> original, mask, result;
+
+                    do
+                    {
+                        original = Vector512.LoadUnsafe(ref src, idx);
+                        mask = Vector512.Equals(oldValues, original);
+                        result = Vector512.ConditionalSelect(mask, newValues, original);
+                        result.StoreUnsafe(ref dst, idx);
+
+                        idx += (uint)Vector512<T>.Count;
+                    }
+                    while (idx < lastVectorIndex);
+
+                    original = Vector512.LoadUnsafe(ref src, lastVectorIndex);
+                    mask = Vector512.Equals(oldValues, original);
+                    result = Vector512.ConditionalSelect(mask, newValues, original);
                     result.StoreUnsafe(ref dst, lastVectorIndex);
                 }
             }
@@ -2909,6 +3243,38 @@ namespace System
                     if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3 || lookUp == value4)) return (int)offset;
 
                     offset -= 1;
+                }
+            }
+            else if (Vector512.IsHardwareAccelerated && length >= Vector512<TValue>.Count)
+            {
+                Vector512<TValue> equals, current, values0 = Vector512.Create(value0), values1 = Vector512.Create(value1),
+                    values2 = Vector512.Create(value2), values3 = Vector512.Create(value3), values4 = Vector512.Create(value4);
+                nint offset = length - Vector512<TValue>.Count;
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                while (offset > 0)
+                {
+                    current = Vector512.LoadUnsafe(ref searchSpace, (nuint)(offset));
+                    equals = TNegator.NegateIfNeeded(Vector512.Equals(current, values0) | Vector512.Equals(current, values1) | Vector512.Equals(current, values2)
+                        | Vector512.Equals(current, values3) | Vector512.Equals(current, values4));
+                    if (equals == Vector512<TValue>.Zero)
+                    {
+                        offset -= Vector512<TValue>.Count;
+                        continue;
+                    }
+
+                    return ComputeLastIndex(offset, equals);
+                }
+
+                // Process the first vector in the search space.
+
+                current = Vector512.LoadUnsafe(ref searchSpace);
+                equals = TNegator.NegateIfNeeded(Vector512.Equals(current, values0) | Vector512.Equals(current, values1) | Vector512.Equals(current, values2)
+                    | Vector512.Equals(current, values3) | Vector512.Equals(current, values4));
+
+                if (equals != Vector512<TValue>.Zero)
+                {
+                    return ComputeLastIndex(offset: 0, equals);
                 }
             }
             else if (Vector256.IsHardwareAccelerated && length >= Vector256<TValue>.Count)
@@ -2997,6 +3363,14 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe int ComputeFirstIndex<T>(ref T searchSpace, ref T current, Vector512<T> equals) where T : struct
+        {
+            ulong notEqualsElements = equals.ExtractMostSignificantBits();
+            int index = BitOperations.TrailingZeroCount(notEqualsElements);
+            return index + (int)((nuint)Unsafe.ByteOffset(ref searchSpace, ref current) / (nuint)sizeof(T));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int ComputeLastIndex<T>(nint offset, Vector128<T> equals) where T : struct
         {
             uint notEqualsElements = equals.ExtractMostSignificantBits();
@@ -3012,11 +3386,20 @@ namespace System
             return (int)offset + index;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int ComputeLastIndex<T>(nint offset, Vector512<T> equals) where T : struct
+        {
+            ulong notEqualsElements = equals.ExtractMostSignificantBits();
+            int index = 63 - BitOperations.LeadingZeroCount(notEqualsElements); // 31 = 32 (bits in Int32) - 1 (indexing from zero)
+            return (int)offset + index;
+        }
+
         internal interface INegator<T> where T : struct
         {
             static abstract bool NegateIfNeeded(bool equals);
             static abstract Vector128<T> NegateIfNeeded(Vector128<T> equals);
             static abstract Vector256<T> NegateIfNeeded(Vector256<T> equals);
+            static abstract Vector512<T> NegateIfNeeded(Vector512<T> equals);
         }
 
         internal readonly struct DontNegate<T> : INegator<T> where T : struct
@@ -3024,6 +3407,7 @@ namespace System
             public static bool NegateIfNeeded(bool equals) => equals;
             public static Vector128<T> NegateIfNeeded(Vector128<T> equals) => equals;
             public static Vector256<T> NegateIfNeeded(Vector256<T> equals) => equals;
+            public static Vector512<T> NegateIfNeeded(Vector512<T> equals) => equals;
         }
 
         internal readonly struct Negate<T> : INegator<T> where T : struct
@@ -3031,6 +3415,7 @@ namespace System
             public static bool NegateIfNeeded(bool equals) => !equals;
             public static Vector128<T> NegateIfNeeded(Vector128<T> equals) => ~equals;
             public static Vector256<T> NegateIfNeeded(Vector256<T> equals) => ~equals;
+            public static Vector512<T> NegateIfNeeded(Vector512<T> equals) => ~equals;
         }
 
         internal static int IndexOfAnyInRange<T>(ref T searchSpace, T lowInclusive, T highInclusive, int length)
@@ -3137,7 +3522,7 @@ namespace System
                     return ComputeFirstIndex(ref searchSpace, ref oneVectorAwayFromEnd, inRangeVector);
                 }
             }
-            else
+            else if (!Vector512.IsHardwareAccelerated || length < (uint)Vector512<T>.Count)
             {
                 Vector256<T> lowVector = Vector256.Create(lowInclusive);
                 Vector256<T> rangeVector = Vector256.Create(highInclusive - lowInclusive);
@@ -3162,6 +3547,35 @@ namespace System
                 // Process the last vector in the search space (which might overlap with already processed elements).
                 inRangeVector = TNegator.NegateIfNeeded(Vector256.LessThanOrEqual(Vector256.LoadUnsafe(ref oneVectorAwayFromEnd) - lowVector, rangeVector));
                 if (inRangeVector != Vector256<T>.Zero)
+                {
+                    return ComputeFirstIndex(ref searchSpace, ref oneVectorAwayFromEnd, inRangeVector);
+                }
+            }
+            else
+            {
+                Vector512<T> lowVector = Vector512.Create(lowInclusive);
+                Vector512<T> rangeVector = Vector512.Create(highInclusive - lowInclusive);
+                Vector512<T> inRangeVector;
+
+                ref T current = ref searchSpace;
+                ref T oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, (uint)(length - Vector512<T>.Count));
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    inRangeVector = TNegator.NegateIfNeeded(Vector512.LessThanOrEqual(Vector512.LoadUnsafe(ref current) - lowVector, rangeVector));
+                    if (inRangeVector != Vector512<T>.Zero)
+                    {
+                        return ComputeFirstIndex(ref searchSpace, ref current, inRangeVector);
+                    }
+
+                    current = ref Unsafe.Add(ref current, Vector256<T>.Count);
+                }
+                while (Unsafe.IsAddressLessThan(ref current, ref oneVectorAwayFromEnd));
+
+                // Process the last vector in the search space (which might overlap with already processed elements).
+                inRangeVector = TNegator.NegateIfNeeded(Vector512.LessThanOrEqual(Vector512.LoadUnsafe(ref oneVectorAwayFromEnd) - lowVector, rangeVector));
+                if (inRangeVector != Vector512<T>.Zero)
                 {
                     return ComputeFirstIndex(ref searchSpace, ref oneVectorAwayFromEnd, inRangeVector);
                 }
@@ -3253,7 +3667,7 @@ namespace System
                     return ComputeLastIndex(offset: 0, inRangeVector);
                 }
             }
-            else
+            else if (!Vector512.IsHardwareAccelerated || length < Vector512<T>.Count)
             {
                 Vector256<T> lowVector = Vector256.Create(lowInclusive);
                 Vector256<T> rangeVector = Vector256.Create(highInclusive - lowInclusive);
@@ -3276,6 +3690,33 @@ namespace System
                 // Process the first vector in the search space.
                 inRangeVector = TNegator.NegateIfNeeded(Vector256.LessThanOrEqual(Vector256.LoadUnsafe(ref searchSpace) - lowVector, rangeVector));
                 if (inRangeVector != Vector256<T>.Zero)
+                {
+                    return ComputeLastIndex(offset: 0, inRangeVector);
+                }
+            }
+            else
+            {
+                Vector512<T> lowVector = Vector512.Create(lowInclusive);
+                Vector512<T> rangeVector = Vector512.Create(highInclusive - lowInclusive);
+                Vector512<T> inRangeVector;
+
+                nint offset = length - Vector512<T>.Count;
+
+                // Loop until either we've finished all elements or there's a vector's-worth or less remaining.
+                while (offset > 0)
+                {
+                    inRangeVector = TNegator.NegateIfNeeded(Vector512.LessThanOrEqual(Vector512.LoadUnsafe(ref searchSpace, (nuint)offset) - lowVector, rangeVector));
+                    if (inRangeVector != Vector512<T>.Zero)
+                    {
+                        return ComputeLastIndex(offset, inRangeVector);
+                    }
+
+                    offset -= Vector512<T>.Count;
+                }
+
+                // Process the first vector in the search space.
+                inRangeVector = TNegator.NegateIfNeeded(Vector512.LessThanOrEqual(Vector512.LoadUnsafe(ref searchSpace) - lowVector, rangeVector));
+                if (inRangeVector != Vector512<T>.Zero)
                 {
                     return ComputeLastIndex(offset: 0, inRangeVector);
                 }
@@ -3324,7 +3765,48 @@ namespace System
 
             if (Vector128.IsHardwareAccelerated && length >= Vector128<T>.Count)
             {
-                if (Vector256.IsHardwareAccelerated && length >= Vector256<T>.Count)
+                if (Vector512.IsHardwareAccelerated && length >= Vector512<T>.Count)
+                {
+                    Vector512<T> targetVector = Vector512.Create(value);
+                    ref T oneVectorAwayFromEnd = ref Unsafe.Subtract(ref end, Vector512<T>.Count);
+                    do
+                    {
+                        count += BitOperations.PopCount(Vector512.Equals(Vector512.LoadUnsafe(ref current), targetVector).ExtractMostSignificantBits());
+                        current = ref Unsafe.Add(ref current, Vector512<T>.Count);
+                    }
+                    while (!Unsafe.IsAddressGreaterThan(ref current, ref oneVectorAwayFromEnd));
+
+                    // If there are just a few elements remaining, then processing these elements by the scalar loop
+                    // is cheaper than doing bitmask + popcount on the full last vector. To avoid complicated type
+                    // based checks, other remainder-count based logic to determine the correct cut-off, for simplicity
+                    // a half-vector size is chosen (based on benchmarks).
+                    uint remaining = (uint)Unsafe.ByteOffset(ref current, ref end) / (uint)Unsafe.SizeOf<T>();
+                    if (remaining > Vector512<T>.Count / 2)
+                    {
+                        ulong mask = Vector512.Equals(Vector512.LoadUnsafe(ref oneVectorAwayFromEnd), targetVector).ExtractMostSignificantBits();
+
+                        // The mask contains some elements that may be double-checked, so shift them away in order to get the correct pop-count.
+                        uint overlaps = (uint)Vector512<T>.Count - remaining;
+                        mask >>= (int)overlaps;
+                        count += BitOperations.PopCount(mask);
+
+                        return count;
+                    }
+                    // TODO : Verify this makes sense
+                    /*if (remaining > Vector256<T>.Count / 2)
+                    {
+                        Vector256<T> targetVector256 = Vector256.Create(value);
+                        uint mask = Vector256.Equals(Vector256.LoadUnsafe(ref oneVectorAwayFromEnd), targetVector256).ExtractMostSignificantBits();
+
+                        // The mask contains some elements that may be double-checked, so shift them away in order to get the correct pop-count.
+                        uint overlaps = (uint)Vector256<T>.Count - remaining;
+                        mask >>= (int)overlaps;
+                        count += BitOperations.PopCount(mask);
+
+                        return count;
+                    }*/
+                }
+                else if (Vector256.IsHardwareAccelerated && length >= Vector256<T>.Count)
                 {
                     Vector256<T> targetVector = Vector256.Create(value);
                     ref T oneVectorAwayFromEnd = ref Unsafe.Subtract(ref end, Vector256<T>.Count);

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -3792,19 +3792,6 @@ namespace System
 
                         return count;
                     }
-                    // TODO : Verify this makes sense
-                    /*if (remaining > Vector256<T>.Count / 2)
-                    {
-                        Vector256<T> targetVector256 = Vector256.Create(value);
-                        uint mask = Vector256.Equals(Vector256.LoadUnsafe(ref oneVectorAwayFromEnd), targetVector256).ExtractMostSignificantBits();
-
-                        // The mask contains some elements that may be double-checked, so shift them away in order to get the correct pop-count.
-                        uint overlaps = (uint)Vector256<T>.Count - remaining;
-                        mask >>= (int)overlaps;
-                        count += BitOperations.PopCount(mask);
-
-                        return count;
-                    }*/
                 }
                 else if (Vector256.IsHardwareAccelerated && length >= Vector256<T>.Count)
                 {

--- a/src/tests/JIT/HardwareIntrinsics/X86/X86Base/CpuId.cs
+++ b/src/tests/JIT/HardwareIntrinsics/X86/X86Base/CpuId.cs
@@ -64,6 +64,8 @@ namespace XarchHardwareIntrinsicTest._CpuId
 
             (eax, ebx, ecx, edx) = X86Base.CpuId(0x00000001, 0x00000000);
 
+            int xarchCpuInfo = eax;
+
             if (IsBitIncorrect(edx, 25, typeof(Sse), Sse.IsSupported, "SSE", ref isHierarchyDisabled))
             {
                 testResult = Fail;
@@ -214,6 +216,37 @@ namespace XarchHardwareIntrinsicTest._CpuId
             }
 
             bool isAvx512HierarchyDisabled = isHierarchyDisabled;
+            if (isGenuineIntel && !isAvx512HierarchyDisabled)
+            {
+                int steppingId = xarchCpuInfo & (int)0b1111;
+                int model = (xarchCpuInfo >> 4) & (int)0b1111;
+                int familyID = (xarchCpuInfo >> 8) & (int)0b1111;
+                int extendedModelID = (xarchCpuInfo >> 16) & (int)0b1111;
+                if (familyID == 0x06)
+                {
+                    if (extendedModelID == 0x05)
+                    {
+                        if (model == 0x05)
+                        {
+                            // * Skylake (Server)
+                            // * Cascade Lake
+                            // * Cooper Lake
+
+                            isAvx512HierarchyDisabled = true;
+                        }
+                    }
+                    else if (extendedModelID == 0x06)
+                    {
+                        if (model == 0x06)
+                        {
+                            // * Cannon Lake
+
+                            isAvx512HierarchyDisabled = true;
+                        }
+                    }
+                }
+
+            }
 
             if (IsBitIncorrect(ecx, 1, typeof(Avx512Vbmi), Avx512Vbmi.IsSupported, "AVX512VBMI", ref isHierarchyDisabled))
             {

--- a/src/tests/readytorun/HardwareIntrinsics/X86/CpuId.cs
+++ b/src/tests/readytorun/HardwareIntrinsics/X86/CpuId.cs
@@ -60,6 +60,8 @@ namespace XarchHardwareIntrinsicTest._CpuId
 
             (eax, ebx, ecx, edx) = X86Base.CpuId(0x00000001, 0x00000000);
 
+            int xarchCpuInfo = eax;
+
             if (IsBitIncorrect(edx, 25, typeof(Sse), Sse.IsSupported, "SSE", ref isHierarchyDisabled))
             {
                 testResult = Fail;
@@ -209,6 +211,37 @@ namespace XarchHardwareIntrinsicTest._CpuId
             }
 
             bool isAvx512HierarchyDisabled = isHierarchyDisabled;
+            if (isGenuineIntel && !isAvx512HierarchyDisabled)
+            {
+                int steppingId = xarchCpuInfo & (int)0b1111;
+                int model = (xarchCpuInfo >> 4) & (int)0b1111;
+                int familyID = (xarchCpuInfo >> 8) & (int)0b1111;
+                int extendedModelID = (xarchCpuInfo >> 16) & (int)0b1111;
+                if (familyID == 0x06)
+                {
+                    if (extendedModelID == 0x05)
+                    {
+                        if (model == 0x05)
+                        {
+                            // * Skylake (Server)
+                            // * Cascade Lake
+                            // * Cooper Lake
+
+                            isAvx512HierarchyDisabled = true;
+                        }
+                    }
+                    else if (extendedModelID == 0x06)
+                    {
+                        if (model == 0x06)
+                        {
+                            // * Cannon Lake
+
+                            isAvx512HierarchyDisabled = true;
+                        }
+                    }
+                }
+
+            }
 
             if (IsBitIncorrect(ecx, 1, typeof(Avx512Vbmi), Avx512Vbmi.IsSupported, "AVX512VBMI", ref isHierarchyDisabled))
             {


### PR DESCRIPTION
### What this PR does:
1. This PR upgrades `Span` implementation by enabling acceleration using AVX512 instructions when possible. This is achieved using. This is achieved by adding `Vector512 `paths in relevant `SpanHelper `implementations.
2. It also modified `Vector512.IsHardwareAccelerated` implementation so that it now returns `TRUE` only on targets where there is no throttling for AVX512(this is based on discussion with Tanner)

### Performance testing for the PR
Ran Microbenchmark( _--filter "System.Memory.*"_) and compared with main branch : This was with following thresholds for ResultComparator on ICX( _--threshold 5% --noise 1ns_). I have re-run the ones showing regression locally and DO NOT see any which are consistently slower
![image](https://github.com/dotnet/runtime/assets/17969209/0affe3cd-d299-445e-8d68-1693b54de326)



