### PR TITLE
Use `u8` literals in `ManagedTextSection`.

### DIFF
--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
@@ -788,7 +788,7 @@ namespace System.Reflection.Metadata
             WriteBytes(buffer.AsSpan(start, byteCount));
         }
 
-        private void WriteBytes(ReadOnlySpan<byte> buffer)
+        internal void WriteBytes(ReadOnlySpan<byte> buffer)
         {
             if (!IsHead)
             {

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/ManagedTextSection.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/ManagedTextSection.cs
@@ -96,8 +96,8 @@ namespace System.Reflection.PortableExecutable
 
         public const int ManagedResourcesDataAlignment = 8;
 
-        private const string CorEntryPointDll = "mscoree.dll";
-        private string CorEntryPointName => (ImageCharacteristics & Characteristics.Dll) != 0 ? "_CorDllMain" : "_CorExeMain";
+        private static ReadOnlySpan<byte> CorEntryPointDll => "mscoree.dll"u8;
+        private ReadOnlySpan<byte> CorEntryPointName => (ImageCharacteristics & Characteristics.Dll) != 0 ? "_CorDllMain"u8 : "_CorExeMain"u8;
 
         private int SizeOfImportAddressTable => RequiresStartupStub ? (Is32Bit ? 2 * sizeof(uint) : 2 * sizeof(ulong)) : 0;
 
@@ -365,11 +365,7 @@ namespace System.Reflection.PortableExecutable
             // Hint table
             builder.WriteUInt16(0); // Hint 54|58
 
-            foreach (char ch in CorEntryPointName)
-            {
-                builder.WriteByte((byte)ch); // 65|69
-            }
-
+            builder.WriteBytes(CorEntryPointName); // 65|69
             builder.WriteByte(0); // 66|70
             Debug.Assert(builder.Count - start == SizeOfImportTable);
         }
@@ -378,11 +374,7 @@ namespace System.Reflection.PortableExecutable
         {
             int start = builder.Count;
 
-            foreach (char ch in CorEntryPointDll)
-            {
-                builder.WriteByte((byte)ch);
-            }
-
+            builder.WriteBytes(CorEntryPointDll);
             builder.WriteByte(0);
             builder.WriteUInt16(0);
             Debug.Assert(builder.Count - start == SizeOfNameTable);


### PR DESCRIPTION
Instead of iterating the characters of a string, casting them into bytes and writing them, we use `u8` literals and directly write the UTF-8 span of them.