### PR TITLE
Print detailed comments for emitIns_R_AI in asm (targeting NativeAOT)

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -407,7 +407,7 @@ void CodeGen::instGen_Set_Reg_To_Imm(emitAttr  size,
         {
             // We will use lea so displacement and not immediate will be relocatable
             size = EA_SET_FLG(EA_REMOVE_FLG(size, EA_CNS_RELOC_FLG), EA_DSP_RELOC_FLG);
-            GetEmitter()->emitIns_R_AI(INS_lea, size, reg, imm);
+            GetEmitter()->emitIns_R_AI(INS_lea, size, reg, imm DEBUGARG(targetHandle) DEBUGARG(gtFlags));
         }
         else
         {

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -7622,7 +7622,10 @@ void emitter::emitIns_R_AR(instruction ins, emitAttr attr, regNumber reg, regNum
     emitIns_R_ARX(ins, attr, reg, base, REG_NA, 1, disp);
 }
 
-void emitter::emitIns_R_AI(instruction ins, emitAttr attr, regNumber ireg, ssize_t disp)
+void emitter::emitIns_R_AI(instruction ins,
+                           emitAttr    attr,
+                           regNumber   ireg,
+                           ssize_t disp DEBUGARG(size_t targetHandle) DEBUGARG(GenTreeFlags gtFlags))
 {
     assert((CodeGen::instIsFP(ins) == false) && (EA_SIZE(attr) <= EA_8BYTE) && (ireg != REG_NA));
     noway_assert(emitVerifyEncodable(ins, EA_SIZE(attr), ireg));
@@ -7637,6 +7640,11 @@ void emitter::emitIns_R_AI(instruction ins, emitAttr attr, regNumber ireg, ssize
 
     id->idAddr()->iiaAddrMode.amBaseReg = REG_NA;
     id->idAddr()->iiaAddrMode.amIndxReg = REG_NA;
+
+#ifdef DEBUG
+    id->idDebugOnlyInfo()->idFlags     = gtFlags;
+    id->idDebugOnlyInfo()->idMemCookie = targetHandle;
+#endif
 
     assert(emitGetInsAmdAny(id) == disp); // make sure "disp" is stored properly
 

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -655,7 +655,10 @@ void emitIns_I_AI(instruction ins, emitAttr attr, int val, ssize_t disp);
 
 void emitIns_R_AR(instruction ins, emitAttr attr, regNumber reg, regNumber base, int disp);
 
-void emitIns_R_AI(instruction ins, emitAttr attr, regNumber ireg, ssize_t disp);
+void emitIns_R_AI(instruction ins,
+                  emitAttr    attr,
+                  regNumber   ireg,
+                  ssize_t disp DEBUGARG(size_t targetHandle = 0) DEBUGARG(GenTreeFlags gtFlags = GTF_EMPTY));
 
 void emitIns_AR_R(instruction ins, emitAttr attr, regNumber reg, regNumber base, cnsval_ssize_t disp);
 


### PR DESCRIPTION
`emitIns_R_I` has this logic to print additional comments in the codegen, e.g. string literals, other frozen objects. This PR extends that for `emitIns_R_AI` since all handles go throught that on R2R/NativeAOT. The main motivation to print type names for GDV checks in NativeAOT. Codegen example:
```cs
static string Foo1() => "hello";

static bool Foo2(object o) => o is string;
```

```diff
; Assembly listing for method Program:Foo1():System.String
G_M24358_IG01:  ;; offset=0000H
						;; size=0 bbWeight=1 PerfScore 0.00
G_M24358_IG02:  ;; offset=0000H
-       lea      rax, gword ptr [(reloc 0x4000000000420058)]
+       lea      rax, gword ptr [(reloc 0x4000000000420058)]      ; '"hello"'
						;; size=7 bbWeight=1 PerfScore 0.50
G_M24358_IG03:  ;; offset=0007H
       ret      
						;; size=1 bbWeight=1 PerfScore 1.00

; Total bytes of code 8,
; ============================================================


; Assembly listing for method Program:Foo2(System.Object):bool
G_M17867_IG01:  ;; offset=0000H
						;; size=0 bbWeight=1 PerfScore 0.00
G_M17867_IG02:  ;; offset=0000H
       test     rcx, rcx
       je       SHORT G_M17867_IG04
						;; size=5 bbWeight=1 PerfScore 1.25
G_M17867_IG03:  ;; offset=0005H
-      lea      rax, [(reloc 0x4000000000422520)]
+      lea      rax, [(reloc 0x4000000000422520)]      ; System.String
       xor      rdx, rdx
       cmp      qword ptr [rcx], rax
       cmovne   rcx, rdx
						;; size=16 bbWeight=0.25 PerfScore 1.00
G_M17867_IG04:  ;; offset=0015H
       xor      eax, eax
       test     rcx, rcx
       setne    al
						;; size=8 bbWeight=1 PerfScore 1.50
G_M17867_IG05:  ;; offset=001DH
       ret      
						;; size=1 bbWeight=1 PerfScore 1.00

; Total bytes of code 30
; ============================================================
```

PS: arm is already doing the same, so I only touched xarch.