### PR TITLE
Fix timeouts in resourcemanager test

### DIFF
--- a/src/libraries/System.Resources.Extensions/tests/BinaryResourceWriterUnitTest.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryResourceWriterUnitTest.cs
@@ -534,7 +534,7 @@ namespace System.Resources.Extensions.Tests
                     TaskScheduler.Default))
                 .ToArray();
 
-            Assert.True(task.Wait(TimeSpan.FromSeconds(30)));
+            Assert.True(Task.WaitAll(tasks, TimeSpan.FromSeconds(30)));
 
             void WaitForBarrierThenEnumerateResources()
             {

--- a/src/libraries/System.Resources.Extensions/tests/BinaryResourceWriterUnitTest.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryResourceWriterUnitTest.cs
@@ -526,7 +526,13 @@ namespace System.Resources.Extensions.Tests
 
             const int Threads = 10;
             using Barrier barrier = new(Threads);
-            Task task = Task.WhenAll(Enumerable.Range(0, Threads).Select(_ => Task.Run(WaitForBarrierThenEnumerateResources)));
+            Task[] tasks = Enumerable.Range(0, Threads)
+                .Select(_ => Task.Factory.StartNew(
+                    WaitForBarrierThenEnumerateResources,
+                    CancellationToken.None,
+                    TaskCreationOptions.LongRunning,
+                    TaskScheduler.Default))
+                .ToArray();
 
             Assert.True(task.Wait(TimeSpan.FromSeconds(30)));
 


### PR DESCRIPTION
Apply suggestion from https://github.com/dotnet/runtime/issues/86013#issuecomment-1560231543

Fixes https://github.com/dotnet/runtime/issues/86013