### PR TITLE
Avoid unnecessary closure in ServiceProviderEngineScope.CaptureDisposable

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
@@ -82,7 +82,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 else
                 {
                     // sync over async, for the rare case that an object only implements IAsyncDisposable and may end up starving the thread pool.
-                    Task.Run(() => ((IAsyncDisposable)service).DisposeAsync().AsTask()).GetAwaiter().GetResult();
+                    object? localService = service; // copy to avoid closure on other paths
+                    Task.Run(() => ((IAsyncDisposable)localService).DisposeAsync().AsTask()).GetAwaiter().GetResult();
                 }
 
                 ThrowHelper.ThrowObjectDisposedException();


### PR DESCRIPTION
Every call to this method is allocating a closure object, in order to capture `service`, even though it's only needed for a rare case.