### PR TITLE
Reduce allocation in Activity.{Parent}Id

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -225,8 +225,12 @@ namespace System.Diagnostics
                     // Convert flags to binary.
                     Span<char> flagsChars = stackalloc char[2];
                     HexConverter.ToCharsBuffer((byte)((~ActivityTraceFlagsIsSet) & _w3CIdFlags), flagsChars, 0, HexConverter.Casing.Lower);
-                    string id = "00-" + _traceId + "-" + _spanId + "-" + flagsChars.ToString();
-
+                    string id =
+#if NET6_0_OR_GREATER
+                        string.Create(null, stackalloc char[128], $"00-{_traceId}-{_spanId}-{flagsChars}");
+#else
+                        "00-" + _traceId + "-" + _spanId + "-" + flagsChars.ToString();
+#endif
                     Interlocked.CompareExchange(ref _id, id, null);
 
                 }
@@ -253,7 +257,12 @@ namespace System.Diagnostics
                     {
                         Span<char> flagsChars = stackalloc char[2];
                         HexConverter.ToCharsBuffer((byte)((~ActivityTraceFlagsIsSet) & _parentTraceFlags), flagsChars, 0, HexConverter.Casing.Lower);
-                        string parentId = "00-" + _traceId + "-" + _parentSpanId + "-" + flagsChars.ToString();
+                        string parentId =
+#if NET6_0_OR_GREATER
+                            string.Create(null, stackalloc char[128], $"00-{_traceId}-{_parentSpanId}-{flagsChars}");
+#else
+                            "00-" + _traceId + "-" + _parentSpanId + "-" + flagsChars.ToString();
+#endif
                         Interlocked.CompareExchange(ref _parentId, parentId, null);
                     }
                     else if (Parent != null)


### PR DESCRIPTION
When activities are enabled, we end up allocating Activity.Id eg once per HTTP request, and in addition to the result string, Id is allocating both a two-char string from a span as well as a string[6], both of which can be avoided.

| Method |         Toolchain |     Mean | Ratio | Allocated | Alloc Ratio |
|------- |------------------ |---------:|------:|----------:|------------:|
|   Test | \main\corerun.exe | 7.814 ms |  1.00 |  22.89 MB |        1.00 |
|   Test |   \pr\corerun.exe | 4.240 ms |  0.54 |  12.97 MB |        0.57 |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System;
using System.Diagnostics;
using System.Linq.Expressions;
using System.Reflection;

[MemoryDiagnoser(false)]
[HideColumns("Error", "StdDev", "Median")]
public class Program
{
    public static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    private Action<Activity, string> _setter;

    [GlobalSetup]
    public void Setup()
    {
        Activity.DefaultIdFormat = ActivityIdFormat.W3C;
        _setter = BuildSetter<Activity, string>(typeof(Activity).GetField("_id", BindingFlags.NonPublic | BindingFlags.Instance));
    }

    [Benchmark]
    public void Test()
    {
        using Activity activity = new Activity("Test");
        activity.Start();
        Action<Activity, string> setter = _setter;
        for (int i = 0; i < 100_000; i++)
        {
            _ = activity.Id;
            setter(activity, null);
        }
        activity.Stop();
    }

    private static Action<TSource, TArg> BuildSetter<TSource, TArg>(FieldInfo field)
    {
        ParameterExpression target = Expression.Parameter(typeof(TSource));
        ParameterExpression value = Expression.Parameter(typeof(TArg));
        return Expression.Lambda<Action<TSource, TArg>>(
            Expression.Assign(Expression.Field(target, field), value),
            target,
            value).Compile();
    }
}
```