### PR TITLE
[NativeAOT] A few changes to make stack walks a bit faster

### DIFF
--- a/src/coreclr/nativeaot/Runtime/unix/UnwindHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/UnwindHelpers.cpp
@@ -775,7 +775,6 @@ struct ProcInfoCacheEntry
     uint32_t    format;           /* compact unwind encoding, or zero if none */
     uint32_t    unwind_info_size; /* size of DWARF unwind info, or zero if none */
     unw_word_t  lsda;             /* address of language specific data area, */
-    unw_word_t  handler;          /* personality routine, or zero if not used */
     unw_word_t  unwind_info;      /* address of DWARF unwind info, or zero */
 
 #ifdef __APPLE__
@@ -784,7 +783,7 @@ struct ProcInfoCacheEntry
 };
 
 // we use static array with 1024 entries as a cache.
-// that is about 57Kb and what we can reasonably afford.
+// that is about 49Kb and what we can reasonably afford.
 static const int CACHE_BITS = 10;
 static ProcInfoCacheEntry cache[1 << CACHE_BITS];
 #endif
@@ -826,7 +825,6 @@ static void SetCachedProcInfo(PCODE pc, unw_proc_info_t* procInfo)
     pEntry->format = procInfo->format;
     pEntry->unwind_info_size = procInfo->unwind_info_size;
     pEntry->lsda = procInfo->lsda;
-    pEntry->handler = procInfo->handler;
     pEntry->unwind_info = procInfo->unwind_info;
 
 #ifdef __APPLE__
@@ -855,7 +853,7 @@ static bool TryGetCachedProcInfo(PCODE pc, unw_proc_info_t* procInfo)
         procInfo->format = pEntry->format;
         procInfo->unwind_info_size = pEntry->unwind_info_size;
         procInfo->lsda = pEntry->lsda;
-        procInfo->handler = pEntry->handler;
+        procInfo->handler = 0;  // not used in our scenarios
         procInfo->unwind_info = pEntry->unwind_info;
 
 #ifdef __APPLE__

--- a/src/native/external/llvm-libunwind-version.txt
+++ b/src/native/external/llvm-libunwind-version.txt
@@ -3,4 +3,4 @@ https://github.com/llvm/llvm-project/releases/tag/llvmorg-16.0.2
 
 Apply https://github.com/dotnet/runtime/commit/1bafb60792b91747d9c2a9dd38461cf090a987a4
 Apply https://github.com/dotnet/runtime/commit/0ee8827547405408b37d1aae2a83629c1632eea8
-
+Apply https://github.com/dotnet/runtime/commit/3ebe51f51f6f7df31a4a73d0755c4be604406577

--- a/src/native/external/llvm-libunwind/src/UnwindCursor.hpp
+++ b/src/native/external/llvm-libunwind/src/UnwindCursor.hpp
@@ -932,6 +932,7 @@ public:
   virtual void        setFloatReg(int, unw_fpreg_t);
   virtual int         step(bool stage2 = false);
   virtual void        getInfo(unw_proc_info_t *);
+  virtual void        setInfo(unw_proc_info_t *);
   virtual void        jumpto();
   virtual bool        isSignalFrame();
   virtual bool        getFunctionName(char *buf, size_t len, unw_word_t *off);
@@ -2883,6 +2884,11 @@ void UnwindCursor<A, R>::getInfo(unw_proc_info_t *info) {
     memset(info, 0, sizeof(*info));
   else
     *info = _info;
+}
+
+template <typename A, typename R>
+void UnwindCursor<A, R>::setInfo(unw_proc_info_t* info) {
+  _info = *info;
 }
 
 template <typename A, typename R>


### PR DESCRIPTION
Stack walks for GC purposes require that EE is suspended and thus contribute directly to GC pauses which is especially noticed when workstation GC is used.

A few changes here to cache the looked up unwind/method infos, as stack walks are fairly repetitive and often look up for the same methods infos.

