### PR TITLE
CoreCLR: vm: arm: Fix gcc arm asm build error

### DIFF
--- a/src/coreclr/vm/arm/asmhelpers.S
+++ b/src/coreclr/vm/arm/asmhelpers.S
@@ -827,9 +827,13 @@ g_rgWriteBarrierDescriptors:
     LEAF_ENTRY JIT_WriteBarrier_Callable
 
     // Branch to the write barrier
+#if defined(__clang__)
     ldr     r2, =JIT_WriteBarrier_Loc-(1f+4) // or R3? See targetarm.h
 1:
     add     r2, pc
+#else
+    ldr     r2, =JIT_WriteBarrier_Loc
+#endif
     ldr     pc, [r2]
 
     LEAF_END JIT_WriteBarrier_Callable

--- a/src/coreclr/vm/arm/pinvokestubs.S
+++ b/src/coreclr/vm/arm/pinvokestubs.S
@@ -79,9 +79,13 @@
 
         PROLOG_PUSH  "{r4, lr}"
 
+#if defined(__clang__)
         ldr     r1, =s_gsCookie-(1f+4)
 1:
         add     r1, pc
+#else
+        ldr     r1, =s_gsCookie
+#endif
         ldr     r1, [r1]
         str     r1, [r0]
         add     r4, r0, SIZEOF__GSCookie
@@ -89,9 +93,13 @@
         // r4 = pFrame
 
         // set first slot to the value of InlinedCallFrame::`vftable' (checked by runtime code)
+#if defined(__clang__)
         ldr     r1, =_ZTV16InlinedCallFrame+8-(2f+4)
 2:
         add     r1, pc
+#else
+        ldr     r1, =_ZTV16InlinedCallFrame+8
+#endif
         str     r1, [r4]
 
         mov     r1, 0
@@ -141,9 +149,13 @@
         str     r2, [r1, #Thread_m_fPreemptiveGCDisabled]
 
         // Check return trap
+#if defined(__clang__)
         ldr     r2, =g_TrapReturningThreads-(1f+4)
 1:
         add     r2, pc
+#else
+        ldr     r2, =g_TrapReturningThreads
+#endif
         ldr     r2, [r2]
         cbnz    r2, LOCAL_LABEL(RarePath)
 


### PR DESCRIPTION
Building with gcc on Arm architecture leads to error due to missing '0x' prefix on hexadecimal values