### PR TITLE
[7.0] Disable DllImportSearchPathsTest in mobile

### DIFF
--- a/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.cs
+++ b/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.cs
@@ -19,7 +19,12 @@ public class DllImportSearchPathsTest
     }
 
     public static bool CanLoadAssemblyInSubdirectory =>
-        !TestLibrary.Utilities.IsNativeAot && !TestLibrary.PlatformDetection.IsMonoLLVMFULLAOT;
+        !TestLibrary.Utilities.IsNativeAot &&
+        !TestLibrary.PlatformDetection.IsMonoLLVMFULLAOT &&
+        !OperatingSystem.IsAndroid() &&
+        !OperatingSystem.IsIOS() &&
+        !OperatingSystem.IsTvOS() &&
+        !OperatingSystem.IsBrowser();
 
     [ConditionalFact(nameof(CanLoadAssemblyInSubdirectory))]
     public static void AssemblyDirectory_Found()

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3857,6 +3857,9 @@
         <ExcludeList Include = "$(XunitTestBinBase)/Loader/classloader/StaticVirtualMethods/GenericContext/**">
             <Issue>https://github.com/dotnet/runtime/issues/67359</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/DllImportSearchPaths/DllImportSearchPathsTest/**">
+            <Issue>Loads an assembly from file</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <ItemGroup Condition=" $(TargetOS) == 'Android' And '$(TargetArchitecture)' == 'arm64' " >


### PR DESCRIPTION
Port of https://github.com/dotnet/runtime/pull/86576 to 7.0