### PR TITLE
Fix HTTP/1.1 concurrent request content read race condition

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -66,7 +66,6 @@ namespace System.Net.Http
         private bool _inUse;
         private bool _detachedFromPool;
         private bool _canRetry;
-        private bool _startedSendingRequestBody;
         private bool _connectionClose; // Connection: close was seen on last response
 
         private const int Status_Disposed = 1;
@@ -524,7 +523,6 @@ namespace System.Net.Http
             HttpMethod normalizedMethod = HttpMethod.Normalize(request.Method);
 
             _canRetry = false;
-            _startedSendingRequestBody = false;
 
             // Send the request.
             if (NetEventSource.Log.IsEnabled()) Trace($"Sending request: {request}");
@@ -630,7 +628,7 @@ namespace System.Net.Http
                     // The server shutdown the connection on their end, likely because of an idle timeout.
                     // If we haven't started sending the request body yet (or there is no request body),
                     // then we allow the request to be retried.
-                    if (!_startedSendingRequestBody)
+                    if (request.Content is null || allowExpect100ToContinue is not null)
                     {
                         _canRetry = true;
                     }
@@ -825,7 +823,11 @@ namespace System.Net.Http
                 cancellationRegistration.Dispose();
 
                 // Make sure to complete the allowExpect100ToContinue task if it exists.
-                allowExpect100ToContinue?.TrySetResult(false);
+                if (allowExpect100ToContinue is not null && !allowExpect100ToContinue.TrySetResult(false))
+                {
+                    // allowExpect100ToContinue was already signaled and we may have started sending the request body.
+                    _canRetry = false;
+                }
 
                 if (_readAheadTask != default)
                 {
@@ -939,9 +941,6 @@ namespace System.Net.Http
 
         private async ValueTask SendRequestContentAsync(HttpRequestMessage request, HttpContentWriteStream stream, bool async, CancellationToken cancellationToken)
         {
-            // Now that we're sending content, prohibit retries of this request by setting this flag.
-            _startedSendingRequestBody = true;
-
             Debug.Assert(stream.BytesWritten == 0);
             if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.RequestContentStart();
 


### PR DESCRIPTION
Fixes the HTTP/1.1 part of https://github.com/dotnet/runtime/issues/53914#issuecomment-900486971

> From reading the code, it looks like it is possible that the request content will be read multiple times concurrently on HTTP 1:
> - Thread A creates an [`expect100Timer`](https://github.com/dotnet/runtime/blob/3e3b00c53b127ec20e1d4d74bb75992fb650e08a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs#L531-L535)
> - Thread A [reads an EOF from the server, sees `_startedSendingRequestBody == false`, sets `_canRetry = true` and throws an IO exception](https://github.com/dotnet/runtime/blob/3e3b00c53b127ec20e1d4d74bb75992fb650e08a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs#L583-L594)
> - Timer wakes up thread B, signals `allowExpect100ToContinue` with true and starts reading the request content
> - Thread A enters `catch`, [sees `sendRequestContentTask` hasn't completed, but doesn't await it](https://github.com/dotnet/runtime/blob/3e3b00c53b127ec20e1d4d74bb75992fb650e08a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs#L790-L808)
> - Thread A throws a retryable exception and retries the request on a new connection, reading the request content again
> - Both A and B are reading the content, the CT may not be signaled for either

This change fixes that by checking whether `allowExpect100ToContinue` was already signaled when we encounter an exception and disables retries if so.