### PR TITLE
Add adjacency row length check in System.Text.Json Topological Sort

### DIFF
--- a/src/libraries/System.Text.Json/Common/JsonHelpers.cs
+++ b/src/libraries/System.Text.Json/Common/JsonHelpers.cs
@@ -133,7 +133,7 @@ namespace System.Text.Json
                 // Iterate over the adjacency matrix, removing any occurrence of nextIndex.
                 for (int i = 0; i < adjacency.Count; i++)
                 {
-                    if (adjacency[i] is { } childMap && childMap[nextIndex])
+                    if (adjacency[i] is { } childMap && nextIndex < childMap.Length && childMap[nextIndex])
                     {
                         childMap[nextIndex] = false;
 


### PR DESCRIPTION
The added check is purely code correctness, the current call sites invoke the method with parameters not triggering a possible IndexOutOfRangeException.

Fixes #86702 