### PR TITLE
[Mono] Add the capability of trimming IL code of individual methods

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -14831,7 +14831,7 @@ aot_assembly (MonoAssembly *ass, guint32 jit_opts, MonoAotOptions *aot_options)
 
 	if (acfg->aot_opts.compiled_methods_outfile && acfg->dedup_phase != DEDUP_COLLECT) {
 		acfg->compiled_methods_outfile = fopen (acfg->aot_opts.compiled_methods_outfile, "w+");
-		fprintf(acfg->compiled_methods_outfile, "%s\n", ass->aname.name);
+		fprintf(acfg->compiled_methods_outfile, "%s\n", ass->image->filename);
 
 		if (!acfg->compiled_methods_outfile)
 			aot_printerrf (acfg, "Unable to open compiled-methods-outfile specified file %s\n", acfg->aot_opts.compiled_methods_outfile);

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -9829,7 +9829,7 @@ compile_method (MonoAotCompile *acfg, MonoMethod *method)
 
 	if (acfg->aot_opts.compiled_methods_outfile && acfg->compiled_methods_outfile != NULL) {
 		if (!mono_method_is_generic_impl (method) && method->token != 0) {
-			fprintf (acfg->compiled_methods_outfile, "%d\n", method->token);
+			fprintf (acfg->compiled_methods_outfile, "%x\n", method->token);
 		}
 	}
 }

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -9828,8 +9828,9 @@ compile_method (MonoAotCompile *acfg, MonoMethod *method)
 	mono_atomic_inc_i32 (&acfg->stats.ccount);
 
 	if (acfg->aot_opts.compiled_methods_outfile && acfg->compiled_methods_outfile != NULL) {
-		if (!mono_method_is_generic_impl (method) && method->token != 0)
-			fprintf (acfg->compiled_methods_outfile, "%x\n", method->token);
+		if (!mono_method_is_generic_impl (method) && method->token != 0) {
+			fprintf (acfg->compiled_methods_outfile, "%d\n", method->token);
+		}
 	}
 }
 

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -14830,6 +14830,8 @@ aot_assembly (MonoAssembly *ass, guint32 jit_opts, MonoAotOptions *aot_options)
 
 	if (acfg->aot_opts.compiled_methods_outfile && acfg->dedup_phase != DEDUP_COLLECT) {
 		acfg->compiled_methods_outfile = fopen (acfg->aot_opts.compiled_methods_outfile, "w+");
+		fprintf(acfg->compiled_methods_outfile, "%s\n", ass->aname.name);
+
 		if (!acfg->compiled_methods_outfile)
 			aot_printerrf (acfg, "Unable to open compiled-methods-outfile specified file %s\n", acfg->aot_opts.compiled_methods_outfile);
 	}

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -14831,10 +14831,12 @@ aot_assembly (MonoAssembly *ass, guint32 jit_opts, MonoAotOptions *aot_options)
 
 	if (acfg->aot_opts.compiled_methods_outfile && acfg->dedup_phase != DEDUP_COLLECT) {
 		acfg->compiled_methods_outfile = fopen (acfg->aot_opts.compiled_methods_outfile, "w+");
-		fprintf(acfg->compiled_methods_outfile, "%s\n", ass->image->filename);
-
 		if (!acfg->compiled_methods_outfile)
 			aot_printerrf (acfg, "Unable to open compiled-methods-outfile specified file %s\n", acfg->aot_opts.compiled_methods_outfile);
+		else {
+			fprintf(acfg->compiled_methods_outfile, "%s\n", ass->image->filename);
+			fprintf(acfg->compiled_methods_outfile, "%s\n", ass->image->guid);
+		}
 	}
 
 	if (acfg->aot_opts.data_outfile) {

--- a/src/mono/sample/HelloWorld/HelloWorld.csproj
+++ b/src/mono/sample/HelloWorld/HelloWorld.csproj
@@ -25,6 +25,8 @@
       LibraryFormat="$(_AotLibraryFormat)"
       Assemblies="@(AotInputAssemblies)"
       OutputDir="$(PublishDir)"
+      CollectCompiledMethods="$(StripILCode)"
+      CompiledMethodsOutputPath="$(MethodTokenFilePath)"
       IntermediateOutputPath="$(IntermediateOutputPath)"
       UseAotDataFile="$(UseAotDataFile)"
       CacheFilePath="$(IntermediateOutputPath)aot_compiler_cache.json"
@@ -34,5 +36,24 @@
       MibcProfilePath="$(MibcProfilePath)">
       <Output TaskParameter="CompiledAssemblies" ItemName="BundleAssemblies" />
     </MonoAOTCompiler>
+  </Target>
+
+  <UsingTask TaskName="ILStrip"
+             AssemblyFile="$(MonoTargetsTasksAssemblyPath)" />
+
+  <Target Name="StripILCode" Condition="'$(StripILCode)' == 'true'" AfterTargets="AOTCompileApp">
+    <PropertyGroup>
+      <TrimIndividualMethods>true</TrimIndividualMethods>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <MethodTokenFiles Include="$(MethodTokenFilePath)/*.txt" />
+    </ItemGroup>
+
+    <ILStrip
+      TrimIndividualMethods="$(TrimIndividualMethods)"
+      MethodTokenFiles="@(MethodTokenFiles)"
+      AssemblyPath="$(PublishDir)">
+    </ILStrip>
   </Target>
 </Project>

--- a/src/mono/sample/HelloWorld/HelloWorld.csproj
+++ b/src/mono/sample/HelloWorld/HelloWorld.csproj
@@ -46,14 +46,9 @@
       <TrimIndividualMethods>true</TrimIndividualMethods>
     </PropertyGroup>
 
-    <ItemGroup>
-      <MethodTokenFiles Include="$(MethodTokenFilePath)/*.txt" />
-    </ItemGroup>
-
     <ILStrip
       TrimIndividualMethods="$(TrimIndividualMethods)"
-      MethodTokenFiles="@(MethodTokenFiles)"
-      AssemblyPath="$(PublishDir)">
+      MethodTokenFiles="@(BundleAssemblies->'%(MethodTokenFile)')">
     </ILStrip>
   </Target>
 </Project>

--- a/src/mono/sample/HelloWorld/HelloWorld.csproj
+++ b/src/mono/sample/HelloWorld/HelloWorld.csproj
@@ -48,7 +48,7 @@
 
     <ILStrip
       TrimIndividualMethods="$(TrimIndividualMethods)"
-      MethodTokenFiles="@(BundleAssemblies->'%(MethodTokenFile)')">
+      Assemblies="@(BundleAssemblies)">
     </ILStrip>
   </Target>
 </Project>

--- a/src/mono/sample/HelloWorld/HelloWorld.csproj
+++ b/src/mono/sample/HelloWorld/HelloWorld.csproj
@@ -26,7 +26,7 @@
       Assemblies="@(AotInputAssemblies)"
       OutputDir="$(PublishDir)"
       CollectCompiledMethods="$(StripILCode)"
-      CompiledMethodsOutputPath="$(MethodTokenFilePath)"
+      CompiledMethodsOutputDirectory="$(CompiledMethodsOutputDirectory)"
       IntermediateOutputPath="$(IntermediateOutputPath)"
       UseAotDataFile="$(UseAotDataFile)"
       CacheFilePath="$(IntermediateOutputPath)aot_compiler_cache.json"

--- a/src/mono/sample/HelloWorld/HelloWorld.csproj
+++ b/src/mono/sample/HelloWorld/HelloWorld.csproj
@@ -49,6 +49,13 @@
     <ILStrip
       TrimIndividualMethods="$(TrimIndividualMethods)"
       Assemblies="@(BundleAssemblies)">
+      <Output TaskParameter="TrimmedAssemblies" ItemName="TrimmedAssemblies" />
     </ILStrip>
+
+    <Copy
+        SourceFiles="@(TrimmedAssemblies->Metadata('TrimmedAssemblyFileName'))"
+        DestinationFiles="@(TrimmedAssemblies)"
+        OverwriteReadOnlyFiles="true"
+    />
   </Target>
 </Project>

--- a/src/mono/sample/HelloWorld/HelloWorld.csproj
+++ b/src/mono/sample/HelloWorld/HelloWorld.csproj
@@ -57,5 +57,6 @@
         DestinationFiles="@(TrimmedAssemblies)"
         OverwriteReadOnlyFiles="true"
     />
+    <Delete Files="@(TrimmedAssemblies->Metadata('TrimmedAssemblyFileName'))" />
   </Target>
 </Project>

--- a/src/mono/sample/HelloWorld/Makefile
+++ b/src/mono/sample/HelloWorld/Makefile
@@ -6,6 +6,8 @@ MONO_CONFIG?=Debug
 MONO_ARCH?=$(shell . $(TOP)eng/native/init-os-and-arch.sh && echo $${arch})
 TARGET_OS?=$(shell . $(TOP)eng/native/init-os-and-arch.sh && echo $${os})
 AOT?=false
+StripILCode?=false
+MethodTokenFilePath?= #<path-to-a-writable-directory>
 
 #NET_TRACE_PATH=<path-to-trace-of-sample>
 #PGO_BINARY_PATH=<path-to-dotnet-pgo-executable>
@@ -18,6 +20,8 @@ publish:
 	-c $(MONO_CONFIG) \
 	-r $(TARGET_OS)-$(MONO_ARCH) \
 	/p:RunAOTCompilation=$(AOT) \
+	/p:StripILCode=$(StripILCode) \
+	/p:MethodTokenFilePath=$(MethodTokenFilePath) \
 	'/p:NetTracePath="$(NET_TRACE_PATH)"' \
 	'/p:PgoBinaryPath="$(PGO_BINARY_PATH)"' \
 	'/p:MibcProfilePath="$(MIBC_PROFILE_PATH)"'

--- a/src/mono/sample/HelloWorld/Makefile
+++ b/src/mono/sample/HelloWorld/Makefile
@@ -21,7 +21,7 @@ publish:
 	-r $(TARGET_OS)-$(MONO_ARCH) \
 	/p:RunAOTCompilation=$(AOT) \
 	/p:StripILCode=$(StripILCode) \
-	/p:MethodTokenFilePath=$(MethodTokenFilePath) \
+	/p:CompiledMethodsOutputDirectory=$(CompiledMethodsOutputDirectory) \
 	'/p:NetTracePath="$(NET_TRACE_PATH)"' \
 	'/p:PgoBinaryPath="$(PGO_BINARY_PATH)"' \
 	'/p:MibcProfilePath="$(MIBC_PROFILE_PATH)"'

--- a/src/mono/sample/HelloWorld/Makefile
+++ b/src/mono/sample/HelloWorld/Makefile
@@ -7,7 +7,7 @@ MONO_ARCH?=$(shell . $(TOP)eng/native/init-os-and-arch.sh && echo $${arch})
 TARGET_OS?=$(shell . $(TOP)eng/native/init-os-and-arch.sh && echo $${os})
 AOT?=false
 StripILCode?=false
-MethodTokenFilePath?= #<path-to-a-writable-directory>
+CompiledMethodsOutputDirectory?= #<path-to-a-writable-directory>
 
 #NET_TRACE_PATH=<path-to-trace-of-sample>
 #PGO_BINARY_PATH=<path-to-dotnet-pgo-executable>

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -726,7 +726,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
         {
             if (string.IsNullOrEmpty(CompiledMethodsOutputPath))
             {
-                Log.LogMessage(MessageImportance.Low, "Skipping collecting the list of aot compiled methods, cause the value of CompiledMethodsOutputPath is empty.");
+                Log.LogMessage(MessageImportance.Low, $"Skipping collecting the list of aot compiled methods, because the value of {nameof(CompiledMethodsOutputPath)} is empty.");
             }
             else
             {

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -738,7 +738,15 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
             string assemblyFileName = Path.GetFileName(assembly);
             string assemblyName = assemblyFileName.Replace(".", "_");
             string outputFileName = assemblyName + "_compiled_methods.txt";
-            string outputFilePath = Path.Combine(CompiledMethodsOutputDirectory, outputFileName);
+            string outputFilePath;
+            if (string.IsNullOrEmpty(CompiledMethodsOutputDirectory))
+            {
+                outputFilePath = outputFileName;
+            }
+            else
+            {
+                outputFilePath = Path.Combine(CompiledMethodsOutputDirectory, outputFileName);
+            }
             aotArgs.Add($"compiled-methods-outfile={outputFilePath}");
             aotAssembly.SetMetadata("MethodTokenFile", outputFilePath);
         }

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -67,6 +67,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
     ///   - LlvmObjectFile (if using LLVM)
     ///   - LlvmBitcodeFile (if using LLVM-only)
     ///   - ExportsFile (used in LibraryMode only)
+    ///   - MethodTokenFile (when using CollectCompiledMethods=true)
     /// </summary>
     [Output]
     public ITaskItem[]? CompiledAssemblies { get; set; }
@@ -738,6 +739,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
                 string outputFileName = assemblyName + "_compiled_methods.txt";
                 string outputFilePath = Path.Combine(CompiledMethodsOutputPath, outputFileName);
                 aotArgs.Add($"compiled-methods-outfile={outputFilePath}");
+                aotAssembly.SetMetadata("MethodTokenFile", outputFilePath);
             }
         }
 

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -153,6 +153,16 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
     public bool UseDwarfDebug { get; set; }
 
     /// <summary>
+    /// Instructs the AOT compiler to print the list of aot compiled methods
+    /// </summary>
+    public bool CollectCompiledMethods { get; set; }
+
+    /// <summary>
+    /// Directory to store the aot output when using switch compiled-methods-outfile
+    /// </summary>
+    public string? CompiledMethodsOutputPath { get; set; }
+
+    /// <summary>
     /// File to use for profile-guided optimization, *only* the methods described in the file will be AOT compiled.
     /// </summary>
     public string[]? AotProfilePath { get; set; }
@@ -709,6 +719,26 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
         else if (!string.IsNullOrEmpty (DedupAssembly))
         {
             aotArgs.Add("dedup-skip");
+        }
+
+        if (CollectCompiledMethods)
+        {
+            if (string.IsNullOrEmpty(CompiledMethodsOutputPath))
+            {
+                Log.LogMessage(MessageImportance.Low, "Skipping collecting the list of aot compiled methods, cause the value of CompiledMethodsOutputPath is empty.");
+            }
+            else
+            {
+                if (!Directory.Exists(CompiledMethodsOutputPath))
+                {
+                    Directory.CreateDirectory(CompiledMethodsOutputPath);
+                }
+                string assemblyFileName = Path.GetFileName(assembly);
+                string assemblyName = assemblyFileName.Replace(".", "_");
+                string outputFileName = assemblyName + "_compiled_methods.txt";
+                string outputFilePath = Path.Combine(CompiledMethodsOutputPath, outputFileName);
+                aotArgs.Add($"compiled-methods-outfile={outputFilePath}");
+            }
         }
 
         // compute output mode and file names

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -735,8 +735,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
 
         if (CollectCompiledMethods)
         {
-            string assemblyFileName = Path.GetFileName(assembly);
-            string assemblyName = assemblyFileName.Replace(".", "_");
+            string assemblyName = assemblyFilename.Replace(".", "_");
             string outputFileName = assemblyName + "_compiled_methods.txt";
             string outputFilePath;
             if (string.IsNullOrEmpty(CompiledMethodsOutputDirectory))

--- a/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
+++ b/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
@@ -234,11 +234,7 @@ public class ILStrip : Microsoft.Build.Utilities.Task
         }
     }
 
-    private static int ComputeMethodSize(PEReader peReader, int rva)
-    {
-        MethodBodyBlock mb = peReader.GetMethodBody(rva);
-        return mb.Size;
-    }
+    private static int ComputeMethodSize(PEReader peReader, int rva) => peReader.GetMethodBody(rva).Size;
 
     private static int ComputeMethodHash(PEReader peReader, int rva)
     {

--- a/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
+++ b/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
@@ -210,7 +210,7 @@ public class ILStrip : Microsoft.Build.Utilities.Task
 
     private static void CreateTrimmedAssembly(PEReader peReader, string trimmedAssemblyFilePath, FileStream fs, Dictionary<int, int> method_body_uses)
     {
-        using (FileStream os = File.Open(trimmedAssemblyFilePath, FileMode.Create))
+        using FileStream os = File.Open(trimmedAssemblyFilePath, FileMode.Create);
         {
             fs.Position = 0;
             MemoryStream memStream = new MemoryStream((int)fs.Length);

--- a/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
+++ b/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
@@ -117,7 +117,7 @@ public class ILStrip : Microsoft.Build.Utilities.Task
 
             if (!File.Exists(assemblyFilePath))
             {
-                Log.LogMessage(MessageImportance.Low, $"[ILStrip] {assemblyFilePath} doesn't exit.");
+                Log.LogMessage(MessageImportance.Low, $"{assemblyFilePath} read from {methodTokenFile} doesn't exist.");
                 return true;
             }
 

--- a/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
+++ b/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
@@ -107,7 +107,7 @@ public class ILStrip : Microsoft.Build.Utilities.Task
             return true;
         }
 
-        using (StreamReader sr = new StreamReader(methodTokenFile))
+        using StreamReader sr = new(methodTokenFile);
         {
             string? assemblyFilePath = sr.ReadLine();
             if (string.IsNullOrEmpty(assemblyFilePath))

--- a/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
+++ b/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
@@ -124,7 +124,7 @@ public class ILStrip : Microsoft.Build.Utilities.Task
             string trimmedAssemblyFilePath = ComputeTrimmedAssemblyPath(assemblyFilePath);
             bool isTrimmed = false;
 
-            using (FileStream fs = File.Open(assemblyFilePath, FileMode.Open))
+            using FileStream fs = File.Open(assemblyFilePath, FileMode.Open);
             {
                 PEReader peReader = new PEReader(fs, PEStreamOptions.LeaveOpen);
                 MetadataReader mr = peReader.GetMetadataReader();

--- a/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
+++ b/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
@@ -177,8 +177,8 @@ public class ILStrip : Microsoft.Build.Utilities.Task
 
     private static Dictionary<int, int> ComputeMethodBodyUsage(MetadataReader mr, StreamReader sr, string? line)
     {
-        Dictionary<int, int> token_to_rva = new Dictionary<int, int>();
-        Dictionary<int, int> method_body_uses = new Dictionary<int, int>();
+        Dictionary<int, int> token_to_rva = new();
+        Dictionary<int, int> method_body_uses = new();
 
         foreach (MethodDefinitionHandle mdefh in mr.MethodDefinitions)
         {

--- a/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
+++ b/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
@@ -103,7 +103,7 @@ public class ILStrip : Microsoft.Build.Utilities.Task
         string methodTokenFile = assemblyItem.GetMetadata("MethodTokenFile");
         if (!File.Exists(methodTokenFile))
         {
-            Log.LogMessage(MessageImportance.Low, $"[ILStrip] {methodTokenFile} doesn't exit.");
+            Log.LogMessage(MessageImportance.Low, $"{methodTokenFile} doesn't exist.");
             return true;
         }
 

--- a/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
+++ b/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
@@ -126,7 +126,7 @@ public class ILStrip : Microsoft.Build.Utilities.Task
 
             using FileStream fs = File.Open(assemblyFilePath, FileMode.Open);
             {
-                PEReader peReader = new PEReader(fs, PEStreamOptions.LeaveOpen);
+                using PEReader peReader = new(fs, PEStreamOptions.LeaveOpen);
                 MetadataReader mr = peReader.GetMetadataReader();
 
                 string guidValue = ComputeGuid(mr);

--- a/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
+++ b/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
@@ -29,10 +29,19 @@ public class ILStrip : Microsoft.Build.Utilities.Task
     /// </summary>
     public bool DisableParallelStripping { get; set; }
 
+    /// <summary>
+    /// Enable the feature of trimming indiviual methods
+    /// </summary>
     public bool TrimIndividualMethods { get; set; }
 
+    /// <summary>
+    /// Methods to be trimmed, identified by method token
+    /// </summary>
     public ITaskItem[] MethodTokenFiles { get; set; } = Array.Empty<ITaskItem>();
 
+    /// <summary>
+    /// Directory where all the assemblies are stored
+    /// </summary>
     public string AssemblyPath { get; set; } = "";
 
     public override bool Execute()

--- a/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
+++ b/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
@@ -169,9 +169,6 @@ public class ILStrip : Microsoft.Build.Utilities.Task
                         MethodDefinition mdef = mr.GetMethodDefinition(mdefh);
                         int rva = mdef.RelativeVirtualAddress;
 
-                        Console.WriteLine(mr.GetString(mdef.Name));
-                        Console.WriteLine(methodToken);
-
                         MethodBodyBlock mb = peReader.GetMethodBody(rva);
                         int methodSize = mb.Size;
                         int sectionIndex = peReader.PEHeaders.GetContainingSectionIndex(rva);
@@ -186,12 +183,8 @@ public class ILStrip : Microsoft.Build.Utilities.Task
 
                         memStream.Position = actualLoc;
                         int firstbyte = memStream.ReadByte();
-                        Console.WriteLine(firstbyte);
-
                         int headerFlag = firstbyte & 0b11;
-
                         int headerSize = headerFlag == 2 ? 1 : 4;
-                        Console.WriteLine(headerSize);
 
                         memStream.Position = actualLoc + headerSize;
                         memStream.Write(zeroBuffer, 0, methodSize - headerSize);

--- a/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
+++ b/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
@@ -45,7 +45,7 @@ public class ILStrip : Microsoft.Build.Utilities.Task
     [Output]
     public ITaskItem[]? TrimmedAssemblies { get; set; }
 
-    private List<ITaskItem> trimmedAssemblies = new List<ITaskItem>();
+    private readonly List<ITaskItem> _trimmedAssemblies = new();
 
     public override bool Execute()
     {

--- a/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
+++ b/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
@@ -75,7 +75,7 @@ public class ILStrip : Microsoft.Build.Utilities.Task
 
         if (TrimIndividualMethods)
         {
-            TrimmedAssemblies = trimmedAssemblies.ToArray();
+            TrimmedAssemblies = _trimmedAssemblies.ToArray();
         }
 
         if (!result.IsCompleted && !Log.HasLoggedErrors)
@@ -147,9 +147,9 @@ public class ILStrip : Microsoft.Build.Utilities.Task
         using FileStream fs = File.Open(assemblyFilePath, FileMode.Open);
         using PEReader peReader = new(fs, PEStreamOptions.LeaveOpen);
         MetadataReader mr = peReader.GetMetadataReader();
-        string guidValue = ComputeGuid(mr);
+        string actualGuidValue = ComputeGuid(mr);
         string? expectedGuidValue = sr.ReadLine();
-        if (!string.Equals(guidValue, expectedGuidValue, StringComparison.OrdinalIgnoreCase))
+        if (!string.Equals(actualGuidValue, expectedGuidValue, StringComparison.OrdinalIgnoreCase))
         {
             Log.LogError($"[ILStrip] GUID value of {assemblyFilePath} doesn't match the value listed in {methodTokenFile}.");
             return true;
@@ -297,6 +297,6 @@ public class ILStrip : Microsoft.Build.Utilities.Task
     {
         var trimmedAssemblyItem = new TaskItem(assemblyFilePath);
         trimmedAssemblyItem.SetMetadata("TrimmedAssemblyFileName", trimmedAssemblyFilePath);
-        trimmedAssemblies.Add(trimmedAssemblyItem);
+        _trimmedAssemblies.Add(trimmedAssemblyItem);
     }
 }


### PR DESCRIPTION
Contributes to #44855

@jonathanpeppers After this is merged. It should be adoptable by Android. I have updated the HelloWorld sample as an example to showcase how to use this feature.

**Usage of this feature:**

1. Enable AOT to log compiled methods. This could be achieved by setting `CollectCompiledMethods` and `CompiledMethodsOutputDirectory` for `MonoAOTCompiler`
2. Run `ILStrip` after `MonoAOTCompiler`
3. Overwrite the assemblies with the trimmed ones.

For more details, please refer to the HelloWorld sample app change included in this PR.