### PR TITLE
Expand CORINFO_HELP_CHKCASTANY cast

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5486,7 +5486,8 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
         else if (isCastClass)
         {
             // Jit can only inline expand CHKCASTCLASS and CHKCASTARRAY helpers.
-            canExpandInline = (helper == CORINFO_HELP_CHKCASTCLASS) || (helper == CORINFO_HELP_CHKCASTARRAY);
+            canExpandInline = (helper == CORINFO_HELP_CHKCASTCLASS) || (helper == CORINFO_HELP_CHKCASTARRAY) ||
+                              (helper == CORINFO_HELP_CHKCASTANY);
         }
         else if ((helper == CORINFO_HELP_ISINSTANCEOFCLASS) || (helper == CORINFO_HELP_ISINSTANCEOFARRAY))
         {
@@ -5625,7 +5626,7 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
     if (isCastClass)
     {
         assert((helper == CORINFO_HELP_CHKCASTCLASS) || (helper == CORINFO_HELP_CHKCASTARRAY) ||
-               (helper == CORINFO_HELP_CHKCASTINTERFACE));
+               (helper == CORINFO_HELP_CHKCASTANY) || (helper == CORINFO_HELP_CHKCASTINTERFACE));
 
         CorInfoHelpFunc specialHelper = helper;
         if ((helper == CORINFO_HELP_CHKCASTCLASS) &&

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5486,8 +5486,15 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
         else if (isCastClass)
         {
             // Jit can only inline expand CHKCASTCLASS and CHKCASTARRAY helpers.
-            canExpandInline = (helper == CORINFO_HELP_CHKCASTCLASS) || (helper == CORINFO_HELP_CHKCASTARRAY) ||
-                              (helper == CORINFO_HELP_CHKCASTANY);
+            canExpandInline = (helper == CORINFO_HELP_CHKCASTCLASS) || (helper == CORINFO_HELP_CHKCASTARRAY);
+
+            // For ChkCastAny we ignore cases where the class is known to be abstract or is an interface.
+            if (helper == CORINFO_HELP_CHKCASTANY)
+            {
+                const bool isAbstract = (info.compCompHnd->getClassAttribs(pResolvedToken->hClass) &
+                                         (CORINFO_FLG_INTERFACE | CORINFO_FLG_ABSTRACT)) != 0;
+                canExpandInline = !isAbstract;
+            }
         }
         else if ((helper == CORINFO_HELP_ISINSTANCEOFCLASS) || (helper == CORINFO_HELP_ISINSTANCEOFARRAY))
         {


### PR DESCRIPTION
I am curious if we can expand this helper too, e.g.:
```csharp
[Benchmark]
public void Test() => GenericCast<string>("");


[MethodImpl(MethodImplOptions.NoInlining)]
public T GenericCast<T>(object o) => (T)o;
```

Codegen diff for `GenericCast`. Basically, we use T as a fast-path check (with null check)

```diff
; Program.GenericCast[[System.__Canon, System.Private.CoreLib]](System.Object)
       sub       rsp,28
       mov       [rsp+20],rdx
+      mov       rax,r8
+      test      rax,rax
+      je        short M01_L00
       mov       rcx,[rdx+10]
       mov       rcx,[rcx]
+      cmp       [rax],rcx
+      je        short M01_L00
       mov       rdx,r8
       call      [CastHelpers.ChkCastAny(Void*, System.Object)]
       nop
       add       rsp,28
       ret
-; Total bytes of code 31
+; Total bytes of code 44
```

| Method |                   Toolchain |     Mean | Ratio | Code Size |
|------- |---------------------------- |---------:|------:|----------:|
|   Test |   \Core_Root_PR\corerun.exe | **1.120 ns** |  1.00 |      80 B |
|   Test | \Core_Root_base\corerun.exe | 1.500 ns |  1.34 |      67 B |

Basically, we inline these things:

![image](https://github.com/dotnet/runtime/assets/523221/6631370f-6f7b-415e-a24d-3ed8546c709d)

(Technically, we can introduce a new helper without the fast-paths)