### PR TITLE
Add timestamps to XUnitLogChecker output

### DIFF
--- a/src/tests/Common/XUnitLogChecker/XUnitLogChecker.cs
+++ b/src/tests/Common/XUnitLogChecker/XUnitLogChecker.cs
@@ -64,8 +64,7 @@ public class XUnitLogChecker
 
         if (File.Exists(finalLogPath))
         {
-            Console.WriteLine($"[XUnitLogChecker]: Item '{wrapperName}' did"
-                              + " complete successfully!");
+            WriteLineTimestamp($"Item '{wrapperName}' did complete successfully!");
             return SUCCESS;
         }
 
@@ -82,9 +81,9 @@ public class XUnitLogChecker
         {
             WriteLineTimestamp("No logs were found. This work"
                                + " item was skipped.");
-            Console.WriteLine($"[XUnitLogChecker]: If this is a mistake, then"
-                              + " something went very wrong. The expected temp"
-                              + $" log name would be: '{tempLogName}'");
+            WriteLineTimestamp($"If this is a mistake, then"
+                               + " something went very wrong. The expected temp"
+                               + $" log name would be: '{tempLogName}'");
             return SUCCESS;
         }
 
@@ -128,8 +127,8 @@ public class XUnitLogChecker
                                                .ToArray();
 
         // Here goes the main core of the XUnit Log Checker :)
-        Console.WriteLine($"[XUnitLogChecker]: Item '{wrapperName}' did not"
-                        + " finish running. Checking and fixing the log...");
+        WriteLineTimestamp($"Item '{wrapperName}' did not"
+                          + " finish running. Checking and fixing the log...");
 
         bool success = FixTheXml(tempLogPath);
         if (!success)
@@ -309,7 +308,7 @@ public class XUnitLogChecker
 
         if (tags.Count == 0)
         {
-            Console.WriteLine($"[XUnitLogChecker]: XUnit log file '{xFile}' was A-OK!");
+            WriteLineTimestamp($"XUnit log file '{xFile}' was A-OK!");
             return true;
         }
 

--- a/src/tests/Common/XUnitLogChecker/XUnitLogChecker.cs
+++ b/src/tests/Common/XUnitLogChecker/XUnitLogChecker.cs
@@ -166,11 +166,8 @@ public class XUnitLogChecker
         return SUCCESS;
     }
 
-    static void WriteLineTimestamp(string message)
-    {
-        Console.Write($"[XUnitLogChecker]: {System.DateTime.Now:HH:mm:ss.ff}: ");
-        Console.WriteLine(message);
-    }
+    static void WriteLineTimestamp(string message) =>
+        Console.WriteLine($"[XUnitLogChecker]: {System.DateTime.Now:HH:mm:ss.ff}: {message}");
 
     static IEnumerable<string> TryReadFile(string filePath)
     {

--- a/src/tests/Common/XUnitLogChecker/XUnitLogChecker.cs
+++ b/src/tests/Common/XUnitLogChecker/XUnitLogChecker.cs
@@ -169,7 +169,7 @@ public class XUnitLogChecker
 
     static void WriteLineTimestamp(string message)
     {
-        Console.Write($"[XUnitLogChecker]: {System.DateTime.Now}: ");
+        Console.Write($"[XUnitLogChecker]: {System.DateTime.Now:HH:mm:ss.ff}: ");
         Console.WriteLine(message);
     }
 

--- a/src/tests/Common/XUnitLogChecker/XUnitLogChecker.cs
+++ b/src/tests/Common/XUnitLogChecker/XUnitLogChecker.cs
@@ -40,9 +40,9 @@ public class XUnitLogChecker
     {
         if (args.Length < 2)
         {
-            Console.WriteLine("[XUnitLogChecker]: The path to the log file and"
-                              + " the name of the wrapper are required for an"
-                              + " accurate check and fixing.");
+            WriteLineTimestamp("The path to the log file and"
+                               + " the name of the wrapper are required for an"
+                               + " accurate check and fixing.");
             return MISSING_ARGS;
         }
 
@@ -80,8 +80,8 @@ public class XUnitLogChecker
 
         if (!File.Exists(tempLogPath))
         {
-            Console.WriteLine("[XUnitLogChecker]: No logs were found. This work"
-                              + " item was skipped.");
+            WriteLineTimestamp("No logs were found. This work"
+                               + " item was skipped.");
             Console.WriteLine($"[XUnitLogChecker]: If this is a mistake, then"
                               + " something went very wrong. The expected temp"
                               + $" log name would be: '{tempLogName}'");
@@ -95,8 +95,8 @@ public class XUnitLogChecker
 
         if (!File.Exists(statsCsvPath))
         {
-            Console.WriteLine("[XUnitLogChecker]: An error occurred. No stats csv"
-                            + $" was found. The expected name would be '{statsCsvPath}'.");
+            WriteLineTimestamp("An error occurred. No stats csv"
+                             + $" was found. The expected name would be '{statsCsvPath}'.");
             return FAILURE;
         }
 
@@ -105,8 +105,8 @@ public class XUnitLogChecker
 
         if (workItemStats is null)
         {
-            Console.WriteLine("[XUnitLogChecker]: Timed out trying to read the"
-                            + $" stats file '{statsCsvPath}'.");
+            WriteLineTimestamp("Timed out trying to read the"
+                             + $" stats file '{statsCsvPath}'.");
             return FAILURE;
         }
 
@@ -134,7 +134,7 @@ public class XUnitLogChecker
         bool success = FixTheXml(tempLogPath);
         if (!success)
         {
-            Console.WriteLine("[XUnitLogChecker]: Fixing the log failed.");
+            WriteLineTimestamp("Fixing the log failed.");
             return FAILURE;
         }
 
@@ -154,17 +154,23 @@ public class XUnitLogChecker
             }
             else
             {
-                Console.WriteLine("[XUnitLogChecker]: The provided dumps path"
-                                + $" '{dumpsPath}' was not able to be read or"
-                                + " found. Skipping stack traces search...");
+                WriteLineTimestamp("The provided dumps path"
+                                 + $" '{dumpsPath}' was not able to be read or"
+                                 + " found. Skipping stack traces search...");
             }
         }
 
         // Rename the temp log to the final log, so that Helix can use it without
         // knowing what transpired here.
         File.Move(tempLogPath, finalLogPath);
-        Console.WriteLine("[XUnitLogChecker]: Finished!");
+        WriteLineTimestamp("Finished!");
         return SUCCESS;
+    }
+
+    static void WriteLineTimestamp(string message)
+    {
+        Console.Write($"[XUnitLogChecker]: {System.DateTime.Now}: ");
+        Console.WriteLine(message);
     }
 
     static IEnumerable<string> TryReadFile(string filePath)
@@ -187,8 +193,8 @@ public class XUnitLogChecker
             }
             catch (IOException ioEx)
             {
-                Console.WriteLine("[XUnitLogChecker]: Could not read the"
-                                + $" file {filePath}. Retrying...");
+                WriteLineTimestamp("Could not read the"
+                                 + $" file {filePath}. Retrying...");
 
                 // Give it a couple seconds before trying again.
                 Thread.Sleep(2000);
@@ -213,8 +219,8 @@ public class XUnitLogChecker
 
         if (logLines is null)
         {
-            Console.WriteLine("[XUnitLogChecker]: Timed out trying to read the"
-                            + $" log file '{xFile}'.");
+            WriteLineTimestamp("Timed out trying to read the"
+                             + $" log file '{xFile}'.");
             return false;
         }
 
@@ -318,7 +324,7 @@ public class XUnitLogChecker
                 xsw.WriteLine($"</{tag}>");
         }
 
-        Console.WriteLine("[XUnitLogChecker]: XUnit log file has been fixed!");
+        WriteLineTimestamp("XUnit log file has been fixed!");
         return true;
     }
 
@@ -379,7 +385,7 @@ public class XUnitLogChecker
 
     static void PrintStackTracesFromDumps(string dumpsPath, string tempLogPath)
     {
-        Console.WriteLine("[XUnitLogChecker]: Checking for dumps...");
+        WriteLineTimestamp("Checking for dumps...");
 
         // Read our newly fixed log to retrieve the time and date when the
         // test was run. This is to exclude potentially existing older dumps
@@ -401,7 +407,7 @@ public class XUnitLogChecker
 
         if (dumpsFound.Count() == 0)
         {
-            Console.WriteLine("[XUnitLogChecker]: No crash dumps found. Continuing...");
+            WriteLineTimestamp("No crash dumps found. Continuing...");
             return ;
         }
 
@@ -409,9 +415,9 @@ public class XUnitLogChecker
         {
             if (OperatingSystem.IsWindows())
             {
-                Console.WriteLine("[XUnitLogChecker]: Reading crash dump"
-                                + $" '{dumpPath}'...");
-                Console.WriteLine("[XUnitLogChecker]: Stack Trace Found:\n");
+                WriteLineTimestamp("Reading crash dump"
+                                 + $" '{dumpPath}'...");
+                WriteLineTimestamp("Stack Trace Found:\n");
 
                 CoreclrTestWrapperLib.TryPrintStackTraceFromDmp(dumpPath,
                                                                 Console.Out);
@@ -422,14 +428,14 @@ public class XUnitLogChecker
 
                 if (!File.Exists(crashReportPath))
                 {
-                    Console.WriteLine("[XUnitLogChecker]: There was no crash"
-                                    + $" report for dump '{dumpPath}'. Skipping...");
+                    WriteLineTimestamp("There was no crash"
+                                     + $" report for dump '{dumpPath}'. Skipping...");
                     continue;
                 }
 
-                Console.WriteLine("[XUnitLogChecker]: Reading crash report"
-                                + $" '{crashReportPath}'...");
-                Console.WriteLine("[XUnitLogChecker]: Stack Trace Found:\n");
+                WriteLineTimestamp("Reading crash report"
+                                 + $" '{crashReportPath}'...");
+                WriteLineTimestamp("Stack Trace Found:\n");
 
                 CoreclrTestWrapperLib.TryPrintStackTraceFromCrashReport(crashReportPath,
                                                                         Console.Out);


### PR DESCRIPTION
The main motivation here is to give a quick notification whether a timeout was due to taking a long time or coincidentally hitting some external limit at that point.  I think the below is due to the `watchdog 119` hitting, and since 9:31:47 isn't long after 9:31:44, then the thread07 test is probably stuck, but I'm never sure that I'm reading it correctly.

```
/root/helix/work/correlation/watchdog 119 /root/helix/work/correlation/corerun -p System.Reflection.Metadata.MetadataUpdater.IsSupported=false -p System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization=true threading_group2.dll ''
09:31:44.737 Running test: baseservices/threading/generics/Monitor/EnterExit01/EnterExit01.dll
Test Passed
09:31:44.875 Passed test: baseservices/threading/generics/Monitor/EnterExit01/EnterExit01.dll
...
09:31:47.302 Running test: baseservices/threading/generics/TimerCallback/thread07_TimerCallback/thread07_TimerCallback.dll
Test Passed
09:31:47.510 Passed test: baseservices/threading/generics/TimerCallback/thread07_TimerCallback/thread07_TimerCallback.dll
09:31:47.512 Running test: baseservices/threading/generics/WaitCallback/thread07_WaitCallback/thread07_WaitCallback.dll
Child process took too long. Timed out... Exiting...
App Exit Code: 110
Expected: 100
Actual: 110
END EXECUTION - FAILED
+ test_exit_code=1
+ dotnet /root/helix/work/correlation/XUnitLogChecker/XUnitLogChecker.dll baseservices/threading/threading_group2 threading_group2 /home/helixbot/dotnetbuild/dumps
[XUnitLogChecker]: Item 'threading_group2' did not finish running. Checking and fixing the log...
[XUnitLogChecker]: XUnit log file has been fixed!

28/95 tests run.
* 28 tests passed.
* 0 tests failed.
* 0 tests skipped.

[XUnitLogChecker]: Checking for dumps...
```

Here's a snippet from a successful test run for this PR. If the "passed test" line was missing, we would still easily be able to bound the test time under 3 seconds.

```
18:44:42.835 Running test: JIT/jit64/hfa/main/testC/hfa_nd1C_r/hfa_nd1C_r.cmd
<snip>
18:44:45.041 Passed test: JIT/jit64/hfa/main/testC/hfa_nd1C_r/hfa_nd1C_r.cmd
App Exit Code: 100
Expected: 100
Actual: 100
END EXECUTION - PASSED
PASSED
[XUnitLogChecker]: 18:44:45.25: Item 'jit64_1' did complete successfully!