### PR TITLE
Address Metrics APIs issues

### DIFF
--- a/src/libraries/Common/src/System/Diagnostics/DiagnosticsHelper.cs
+++ b/src/libraries/Common/src/System/Diagnostics/DiagnosticsHelper.cs
@@ -7,61 +7,10 @@ namespace System.Diagnostics
 {
     internal static class DiagnosticsHelper
     {
-        // This is similar to System.Linq ToArray. We are not using System.Linq here to avoid the dependency.
-        internal static KeyValuePair<string, object?>[]? ToArray(IEnumerable<KeyValuePair<string, object?>>? tags)
-        {
-            if (tags is null)
-            {
-                return null;
-            }
-
-            KeyValuePair<string, object?>[]? array = null;
-            if (tags is ICollection<KeyValuePair<string, object?>> tagsCol)
-            {
-                array = new KeyValuePair<string, object?>[tagsCol.Count];
-                if (tagsCol is IList<KeyValuePair<string, object?>> secondList)
-                {
-                    for (int i = 0; i < tagsCol.Count; i++)
-                    {
-                        array[i] = secondList[i];
-                    }
-
-                    return array;
-                }
-            }
-
-            if (array is null)
-            {
-                int count = 0;
-                using (IEnumerator<KeyValuePair<string, object?>> enumerator = tags.GetEnumerator())
-                {
-                    while (enumerator.MoveNext())
-                    {
-                        count++;
-                    }
-                }
-
-                array = new KeyValuePair<string, object?>[count];
-            }
-
-            Debug.Assert(array is not null);
-
-            int index = 0;
-            using (IEnumerator<KeyValuePair<string, object?>> enumerator = tags.GetEnumerator())
-            {
-                while (enumerator.MoveNext())
-                {
-                    array[index++] = enumerator.Current;
-                }
-            }
-
-            return array;
-        }
-
         /// <summary>
         /// Compares two tag collections for equality.
         /// </summary>
-        /// <param name="sortedTags">The first collection of tags. it has to be a sorted array</param>
+        /// <param name="sortedTags">The first collection of tags. it has to be a sorted List</param>
         /// <param name="tags2">The second collection of tags. This one doesn't have to be sorted nor be specific collection type</param>
         /// <returns>True if the two collections are equal, false otherwise</returns>
         /// <remarks>
@@ -70,7 +19,7 @@ namespace System.Diagnostics
         /// we avoid the allocation of a new array by using the second collection as is and not converting it to an array. the reason
         /// is we call this every time we try to create a meter or instrument and we don't want to allocate a new array every time.
         /// </remarks>
-        internal static bool CompareTags(KeyValuePair<string, object?>[]? sortedTags, IEnumerable<KeyValuePair<string, object?>>? tags2)
+        internal static bool CompareTags(List<KeyValuePair<string, object?>>? sortedTags, IEnumerable<KeyValuePair<string, object?>>? tags2)
         {
             if (sortedTags == tags2)
             {
@@ -85,7 +34,7 @@ namespace System.Diagnostics
             // creating with 2 longs which can initially handle 2 * 64 = 128 tags
             BitMapper bitMapper = new BitMapper(stackalloc ulong[2], true);
 
-            int count = sortedTags.Length;
+            int count = sortedTags.Count;
             if (tags2 is ICollection<KeyValuePair<string, object?>> tagsCol)
             {
                 if (tagsCol.Count != count)
@@ -132,7 +81,7 @@ namespace System.Diagnostics
                 while (enumerator.MoveNext())
                 {
                     listCount++;
-                    if (listCount > sortedTags.Length)
+                    if (listCount > sortedTags.Count)
                     {
                         return false;
                     }
@@ -161,7 +110,7 @@ namespace System.Diagnostics
                     }
                 }
 
-                return listCount == sortedTags.Length;
+                return listCount == sortedTags.Count;
             }
         }
     }

--- a/src/libraries/Common/src/System/Diagnostics/DiagnosticsHelper.cs
+++ b/src/libraries/Common/src/System/Diagnostics/DiagnosticsHelper.cs
@@ -162,7 +162,7 @@ namespace System.Diagnostics
         {
             if (index < 0)
             {
-                throw new OutOfMemoryException(nameof(index));
+                throw new ArgumentOutOfRangeException (nameof(index));
             }
 
             if (index >= _maxIndex)
@@ -180,7 +180,7 @@ namespace System.Diagnostics
         {
             if (index < 0)
             {
-                throw new OutOfMemoryException(nameof(index));
+                throw new ArgumentOutOfRangeException(nameof(index));
             }
 
             if (index >= _maxIndex)

--- a/src/libraries/Common/src/System/Diagnostics/DiagnosticsHelper.cs
+++ b/src/libraries/Common/src/System/Diagnostics/DiagnosticsHelper.cs
@@ -7,35 +7,118 @@ namespace System.Diagnostics
 {
     internal static class DiagnosticsHelper
     {
-        internal static bool CompareTags(IEnumerable<KeyValuePair<string, object?>>? tags1, IEnumerable<KeyValuePair<string, object?>>? tags2)
+        // This is similar to System.Linq ToArray. We are not using System.Linq here to avoid the dependency.
+        internal static KeyValuePair<string, object?>[]? ToArray(IEnumerable<KeyValuePair<string, object?>>? tags)
         {
-            if (tags1 == tags2)
+            if (tags is null)
+            {
+                return null;
+            }
+
+            KeyValuePair<string, object?>[]? array = null;
+            if (tags is ICollection<KeyValuePair<string, object?>> tagsCol)
+            {
+                array = new KeyValuePair<string, object?>[tagsCol.Count];
+                if (tagsCol is IList<KeyValuePair<string, object?>> secondList)
+                {
+                    for (int i = 0; i < tagsCol.Count; i++)
+                    {
+                        array[i] = secondList[i];
+                    }
+
+                    return array;
+                }
+            }
+
+            if (array is null)
+            {
+                int count = 0;
+                using (IEnumerator<KeyValuePair<string, object?>> enumerator = tags.GetEnumerator())
+                {
+                    while (enumerator.MoveNext())
+                    {
+                        count++;
+                    }
+                }
+
+                array = new KeyValuePair<string, object?>[count];
+            }
+
+            Debug.Assert(array is not null);
+
+            int index = 0;
+            using (IEnumerator<KeyValuePair<string, object?>> enumerator = tags.GetEnumerator())
+            {
+                while (enumerator.MoveNext())
+                {
+                    array[index++] = enumerator.Current;
+                }
+            }
+
+            return array;
+        }
+
+        /// <summary>
+        /// Compares two tag collections for equality.
+        /// </summary>
+        /// <param name="sortedTags">The first collection of tags. it has to be a sorted array</param>
+        /// <param name="tags2">The second collection of tags. This one doesn't have to be sorted nor be specific collection type</param>
+        /// <returns>True if the two collections are equal, false otherwise</returns>
+        /// <remarks>
+        /// This method is used to compare two collections of tags for equality. The first collection is expected to be a sorted array
+        /// of tags. The second collection can be any collection of tags.
+        /// we avoid the allocation of a new array by using the second collection as is and not converting it to an array. the reason
+        /// is we call this every time we try to create a meter or instrument and we don't want to allocate a new array every time.
+        /// </remarks>
+        internal static bool CompareTags(KeyValuePair<string, object?>[]? sortedTags, IEnumerable<KeyValuePair<string, object?>>? tags2)
+        {
+            if (sortedTags == tags2)
             {
                 return true;
             }
 
-            if (tags1 is null || tags2 is null)
+            if (sortedTags is null || tags2 is null)
             {
                 return false;
             }
 
-            if (tags1 is ICollection<KeyValuePair<string, object?>> firstCol && tags2 is ICollection<KeyValuePair<string, object?>> secondCol)
+            // creating with 2 longs which can initially handle 2 * 64 = 128 tags
+            BitMapper bitMapper = new BitMapper(stackalloc ulong[2], true);
+
+            int count = sortedTags.Length;
+            if (tags2 is ICollection<KeyValuePair<string, object?>> tagsCol)
             {
-                int count = firstCol.Count;
-                if (count != secondCol.Count)
+                if (tagsCol.Count != count)
                 {
                     return false;
                 }
 
-                if (firstCol is IList<KeyValuePair<string, object?>> firstList && secondCol is IList<KeyValuePair<string, object?>> secondList)
+                if (tagsCol is IList<KeyValuePair<string, object?>> secondList)
                 {
                     for (int i = 0; i < count; i++)
                     {
-                        KeyValuePair<string, object?> pair1 = firstList[i];
-                        KeyValuePair<string, object?> pair2 = secondList[i];
-                        if (pair1.Key != pair2.Key || !object.Equals(pair1.Value, pair2.Value))
+                        KeyValuePair<string, object?> pair = secondList[i];
+
+                        for (int j = 0; j < count; j++)
                         {
-                            return false;
+                            if (bitMapper.IsSet(j))
+                            {
+                                continue;
+                            }
+
+                            KeyValuePair<string, object?> pair1 = sortedTags[j];
+
+                            int compareResult = string.CompareOrdinal(pair.Key, pair1.Key);
+                            if (compareResult == 0 && object.Equals(pair.Value, pair1.Value))
+                            {
+                                bitMapper.SetBit(j);
+                                break;
+                            }
+
+                            if (compareResult < 0 || j == count - 1)
+                            {
+                                return false;
+                            }
                         }
                     }
 
@@ -43,26 +126,122 @@ namespace System.Diagnostics
                 }
             }
 
-            using (IEnumerator<KeyValuePair<string, object?>> e1 = tags1.GetEnumerator())
-            using (IEnumerator<KeyValuePair<string, object?>> e2 = tags2.GetEnumerator())
+            int listCount = 0;
+            using (IEnumerator<KeyValuePair<string, object?>> enumerator = tags2.GetEnumerator())
             {
-                while (e1.MoveNext())
+                while (enumerator.MoveNext())
                 {
-                    KeyValuePair<string, object?> pair1 = e1.Current;
-                    if (!e2.MoveNext())
+                    listCount++;
+                    if (listCount > sortedTags.Length)
                     {
                         return false;
                     }
 
-                    KeyValuePair<string, object?> pair2 = e2.Current;
-                    if (pair1.Key != pair2.Key || !object.Equals(pair1.Value, pair2.Value))
+                    KeyValuePair<string, object?> pair = enumerator.Current;
+                    for (int j = 0; j < count; j++)
                     {
-                        return false;
+                        if (bitMapper.IsSet(j))
+                        {
+                            continue;
+                        }
+
+                        KeyValuePair<string, object?> pair1 = sortedTags[j];
+
+                        int compareResult = string.CompareOrdinal(pair.Key, pair1.Key);
+                        if (compareResult == 0 && object.Equals(pair.Value, pair1.Value))
+                        {
+                            bitMapper.SetBit(j);
+                            break;
+                        }
+
+                        if (compareResult < 0 || j == count - 1)
+                        {
+                            return false;
+                        }
                     }
                 }
 
-                return !e2.MoveNext();
+                return listCount == sortedTags.Length;
             }
+        }
+    }
+
+    internal ref struct BitMapper
+    {
+        private int _maxIndex;
+        private Span<ulong> _bitMap;
+
+        public BitMapper(Span<ulong> bitMap, bool zeroInitialize = false)
+        {
+            _bitMap = bitMap;
+            _maxIndex = bitMap.Length * sizeof(long) * 8;
+
+            if (zeroInitialize)
+            {
+                for (int i = 0; i < _bitMap.Length; i++)
+                {
+                    _bitMap[i] = 0;
+                }
+            }
+        }
+
+        public int MaxIndex => _maxIndex;
+
+        private void Expand(int index)
+        {
+            if (_maxIndex > index)
+            {
+                return;
+            }
+
+            int newMax = (index / sizeof(long)) + 10;
+
+            Span<ulong> newBitMap = new ulong[newMax];
+            _bitMap.CopyTo(newBitMap);
+            _bitMap = newBitMap;
+            _maxIndex = newMax * sizeof(long);
+        }
+
+        private static void GetIndexAndMask(int index, out int bitIndex, out ulong mask)
+        {
+            bitIndex = index >> sizeof(long);
+            int bit = index & (sizeof(long) - 1);
+            mask = 1UL << bit;
+        }
+
+        public bool SetBit(int index)
+        {
+            if (index < 0)
+            {
+                throw new OutOfMemoryException(nameof(index));
+            }
+
+            if (index >= _maxIndex)
+            {
+                Expand(index);
+            }
+
+            GetIndexAndMask(index, out int bitIndex, out ulong mask);
+            ulong value = _bitMap[bitIndex];
+            _bitMap[bitIndex] = value | mask;
+            return true;
+        }
+
+        public bool IsSet(int index)
+        {
+            if (index < 0)
+            {
+                throw new OutOfMemoryException(nameof(index));
+            }
+
+            if (index >= _maxIndex)
+            {
+                return false;
+            }
+
+            GetIndexAndMask(index, out int bitIndex, out ulong mask);
+            ulong value = _bitMap[bitIndex];
+            return ((value & mask) != 0);
         }
     }
 }

--- a/src/libraries/Common/src/System/Diagnostics/DiagnosticsHelper.cs
+++ b/src/libraries/Common/src/System/Diagnostics/DiagnosticsHelper.cs
@@ -152,7 +152,6 @@ namespace System.Diagnostics
             Debug.Assert(index >= 0);
             Debug.Assert(index < _maxIndex);
 
-
             GetIndexAndMask(index, out int bitIndex, out ulong mask);
             ulong value = _bitMap[bitIndex];
             return ((value & mask) != 0);

--- a/src/libraries/Common/src/System/Diagnostics/DiagnosticsHelper.cs
+++ b/src/libraries/Common/src/System/Diagnostics/DiagnosticsHelper.cs
@@ -149,15 +149,9 @@ namespace System.Diagnostics
 
         public bool IsSet(int index)
         {
-            if (index < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index));
-            }
+            Debug.Assert(index >= 0);
+            Debug.Assert(index < _maxIndex);
 
-            if (index >= _maxIndex)
-            {
-                return false;
-            }
 
             GetIndexAndMask(index, out int bitIndex, out ulong mask);
             ulong value = _bitMap[bitIndex];

--- a/src/libraries/Microsoft.Bcl.TimeProvider/src/System/Threading/Tasks/TimeProviderTaskExtensions.cs
+++ b/src/libraries/Microsoft.Bcl.TimeProvider/src/System/Threading/Tasks/TimeProviderTaskExtensions.cs
@@ -96,7 +96,7 @@ namespace System.Threading.Tasks
 
             // There are race conditions where the timer fires after we have attached the cancellation callback but before the
             // registration is stored in state.Registration, or where cancellation is requested prior to the registration being
-            // stored into state.Registration, or where the timer could fire after it's been createdbut before it's been stored
+            // stored into state.Registration, or where the timer could fire after it's been created but before it's been stored
             // in state.Timer. In such cases, the cancellation registration and/or the Timer might be stored into state after the
             // callbacks and thus left undisposed.  So, we do a subsequent check here. If the task isn't completed by this point,
             // then the callbacks won't have called TrySetResult (the callbacks invoke TrySetResult before disposing of the fields),

--- a/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/ref/Microsoft.Extensions.Diagnostics.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/ref/Microsoft.Extensions.Diagnostics.Abstractions.cs
@@ -7,4 +7,8 @@ namespace Microsoft.Extensions.Diagnostics.Metrics
     {
         System.Diagnostics.Metrics.Meter Create(System.Diagnostics.Metrics.MeterOptions options);
     }
+    public static class MeterFactoryExtensions
+    {
+        public static System.Diagnostics.Metrics.Meter Create(this Microsoft.Extensions.Diagnostics.Metrics.IMeterFactory meterFactory, string name, string? version = null, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object?>>? tags = null) { return null!; }
+    }
 }

--- a/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/src/Metrics/MeterFactoryExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/src/Metrics/MeterFactoryExtensions.cs
@@ -13,15 +13,14 @@ namespace Microsoft.Extensions.Diagnostics.Metrics
     public static class MeterFactoryExtensions
     {
         /// <summary>
-        /// Creates a <see cref="Meter" /> with the specified <paramref name="name" />, <paramref name="version" />, <paramref name="tags" />, and <paramref name="scope" />.
+        /// Creates a <see cref="Meter" /> with the specified <paramref name="name" />, <paramref name="version" />, and <paramref name="tags" />.
         /// </summary>
         /// <param name="meterFactory">The <see cref="IMeterFactory" /> to use to create the <see cref="Meter" />.</param>
         /// <param name="name">The name of the <see cref="Meter" />.</param>
         /// <param name="version">The version of the <see cref="Meter" />.</param>
         /// <param name="tags">The tags to associate with the <see cref="Meter" />.</param>
-        /// <param name="scope">The scope to associate with the <see cref="Meter" />.</param>
-        /// <returns>A <see cref="Meter" /> with the specified <paramref name="name" />, <paramref name="version" />, <paramref name="tags" />, and <paramref name="scope" />.</returns>
-        public static Meter Create(this IMeterFactory meterFactory, string name, string? version = null, IEnumerable<KeyValuePair<string, object?>>? tags = null, object? scope = null)
+        /// <returns>A <see cref="Meter" /> with the specified <paramref name="name" />, <paramref name="version" />, and <paramref name="tags" />.</returns>
+        public static Meter Create(this IMeterFactory meterFactory, string name, string? version = null, IEnumerable<KeyValuePair<string, object?>>? tags = null)
         {
             if (meterFactory is null)
             {
@@ -32,7 +31,7 @@ namespace Microsoft.Extensions.Diagnostics.Metrics
             {
                 Version = version,
                 Tags = tags,
-                Scope = scope
+                Scope = meterFactory
             });
         }
     }

--- a/src/libraries/Microsoft.Extensions.Diagnostics/ref/Microsoft.Extensions.Diagnostics.cs
+++ b/src/libraries/Microsoft.Extensions.Diagnostics/ref/Microsoft.Extensions.Diagnostics.cs
@@ -7,8 +7,4 @@ namespace Microsoft.Extensions.Diagnostics.Metrics
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddMetrics(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) { return null!; }
     }
-    public static class MeterFactoryExtensions
-    {
-        public static System.Diagnostics.Metrics.Meter Create(this Microsoft.Extensions.Diagnostics.Metrics.IMeterFactory meterFactory, string name, string? version = null, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object?>>? tags = null,  object? scope = null) { return null!; }
-    }
 }

--- a/src/libraries/Microsoft.Extensions.Diagnostics/src/Metrics/DefaultMeterFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Diagnostics/src/Metrics/DefaultMeterFactory.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Extensions.Diagnostics.Metrics
                 {
                     foreach (Meter meter in meterList)
                     {
-                        if (meter.Version == options.Version && DiagnosticsHelper.CompareTags(meter.Tags as KeyValuePair<string, object?>[], options.Tags))
+                        if (meter.Version == options.Version && DiagnosticsHelper.CompareTags(meter.Tags as List<KeyValuePair<string, object?>>, options.Tags))
                         {
                             return meter;
                         }

--- a/src/libraries/Microsoft.Extensions.Diagnostics/src/Metrics/DefaultMeterFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Diagnostics/src/Metrics/DefaultMeterFactory.cs
@@ -52,7 +52,11 @@ namespace Microsoft.Extensions.Diagnostics.Metrics
                     _cachedMeters.Add(options.Name, meterList);
                 }
 
+                object? scope = options.Scope;
+                options.Scope = this;
                 FactoryMeter m = new FactoryMeter(options.Name, options.Version, options.Tags, scope: this);
+                options.Scope = scope;
+
                 meterList.Add(m);
                 return m;
             }

--- a/src/libraries/Microsoft.Extensions.Diagnostics/src/Metrics/DefaultMeterFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Diagnostics/src/Metrics/DefaultMeterFactory.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.Diagnostics.Metrics
 {
     internal sealed class DefaultMeterFactory : IMeterFactory
     {
-        private readonly Dictionary<string, List<Meter>> _cachedMeters = new();
+        private readonly Dictionary<string, List<FactoryMeter>> _cachedMeters = new();
         private bool _disposed;
 
         public DefaultMeterFactory() { }
@@ -22,6 +22,11 @@ namespace Microsoft.Extensions.Diagnostics.Metrics
                 throw new ArgumentNullException(nameof(options));
             }
 
+            if (options.Scope is not null && !object.ReferenceEquals(options.Scope, this))
+            {
+                throw new InvalidOperationException(SR.InvalidScope);
+            }
+
             Debug.Assert(options.Name is not null);
 
             lock (_cachedMeters)
@@ -31,11 +36,11 @@ namespace Microsoft.Extensions.Diagnostics.Metrics
                     throw new ObjectDisposedException(nameof(DefaultMeterFactory));
                 }
 
-                if (_cachedMeters.TryGetValue(options.Name, out List<Meter>? meterList))
+                if (_cachedMeters.TryGetValue(options.Name, out List<FactoryMeter>? meterList))
                 {
                     foreach (Meter meter in meterList)
                     {
-                        if (meter.Version == options.Version && DiagnosticsHelper.CompareTags(meter.Tags, options.Tags))
+                        if (meter.Version == options.Version && DiagnosticsHelper.CompareTags(meter.Tags as KeyValuePair<string, object?>[], options.Tags))
                         {
                             return meter;
                         }
@@ -43,11 +48,11 @@ namespace Microsoft.Extensions.Diagnostics.Metrics
                 }
                 else
                 {
-                    meterList = new List<Meter>();
+                    meterList = new List<FactoryMeter>();
                     _cachedMeters.Add(options.Name, meterList);
                 }
 
-                Meter m = new Meter(options.Name, options.Version, options.Tags, scope: this);
+                FactoryMeter m = new FactoryMeter(options.Name, options.Version, options.Tags, scope: this);
                 meterList.Add(m);
                 return m;
             }
@@ -64,16 +69,31 @@ namespace Microsoft.Extensions.Diagnostics.Metrics
 
                 _disposed = true;
 
-                foreach (List<Meter> meterList in _cachedMeters.Values)
+                foreach (List<FactoryMeter> meterList in _cachedMeters.Values)
                 {
-                    foreach (Meter meter in meterList)
+                    foreach (FactoryMeter meter in meterList)
                     {
-                        meter.Dispose();
+                        meter.Release();
                     }
                 }
 
                 _cachedMeters.Clear();
             }
+        }
+    }
+
+    internal sealed class FactoryMeter : Meter
+    {
+        public FactoryMeter(string name, string? version, IEnumerable<KeyValuePair<string, object?>>? tags, object? scope)
+            : base(name, version, tags, scope)
+        {
+        }
+
+        public void Release() => base.Dispose(true); // call the protected Dispose(bool)
+
+        protected override void Dispose(bool disposing)
+        {
+            // no-op, disallow users from disposing of the meters created from the factory.
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Diagnostics/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Diagnostics/src/Resources/Strings.resx
@@ -1,0 +1,63 @@
+﻿<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InvalidScope" xml:space="preserve">
+    <value>The meter factory does not allow a custom scope value when creating a meter.</value>
+  </data>
+</root>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -126,7 +126,6 @@ System.Diagnostics.DiagnosticSource</PackageDescription>
     <Reference Include="System.Collections" />
     <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Diagnostics.Tracing" />
-    <Reference Include="System.Linq" />
     <Reference Include="System.Memory" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.InteropServices" />

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Instrument.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Instrument.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Linq;
 
 namespace System.Diagnostics.Metrics
 {
@@ -54,8 +53,9 @@ namespace System.Diagnostics.Metrics
             Unit = unit;
             if (tags is not null)
             {
-                var tagsArray = tags.ToArray();
-                // Array.Sort(tagsArray, (left, right) => string.Compare(left.Key, right.Key, StringComparison.Ordinal));
+                var tagsArray = DiagnosticsHelper.ToArray(tags);
+                Debug.Assert(tagsArray is not null);
+                Array.Sort(tagsArray, (left, right) => string.Compare(left.Key, right.Key, StringComparison.Ordinal));
                 Tags = tagsArray;
             }
         }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Instrument.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Instrument.cs
@@ -53,10 +53,9 @@ namespace System.Diagnostics.Metrics
             Unit = unit;
             if (tags is not null)
             {
-                var tagsArray = DiagnosticsHelper.ToArray(tags);
-                Debug.Assert(tagsArray is not null);
-                Array.Sort(tagsArray, (left, right) => string.Compare(left.Key, right.Key, StringComparison.Ordinal));
-                Tags = tagsArray;
+                var tagList = new List<KeyValuePair<string, object?>>(tags);
+                tagList.Sort((left, right) => string.Compare(left.Key, right.Key, StringComparison.Ordinal));
+                Tags = tagList;
             }
         }
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Meter.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Meter.cs
@@ -71,10 +71,9 @@ namespace System.Diagnostics.Metrics
             Version = version;
             if (tags is not null)
             {
-                var tagsArray = DiagnosticsHelper.ToArray(tags);
-                Debug.Assert(tagsArray is not null);
-                Array.Sort(tagsArray, (left, right) => string.Compare(left.Key, right.Key, StringComparison.Ordinal));
-                Tags = tagsArray;
+                var tagList = new List<KeyValuePair<string, object?>>(tags);
+                tagList.Sort((left, right) => string.Compare(left.Key, right.Key, StringComparison.Ordinal));
+                Tags = tagList;
             }
             Scope = scope;
 
@@ -462,7 +461,7 @@ namespace System.Diagnostics.Metrics
             foreach (Instrument instrument in instrumentList)
             {
                 if (instrument.GetType() == instrumentType && instrument.Unit == unit &&
-                    instrument.Description == description && DiagnosticsHelper.CompareTags(instrument.Tags as KeyValuePair<string, object?>[], tags))
+                    instrument.Description == description && DiagnosticsHelper.CompareTags(instrument.Tags as List<KeyValuePair<string, object?>>, tags))
                 {
                     return instrument;
                 }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Meter.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Meter.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 
 namespace System.Diagnostics.Metrics
@@ -72,8 +71,9 @@ namespace System.Diagnostics.Metrics
             Version = version;
             if (tags is not null)
             {
-                var tagsArray = tags.ToArray();
-                // Array.Sort(tagsArray, (left, right) => string.Compare(left.Key, right.Key, StringComparison.Ordinal));
+                var tagsArray = DiagnosticsHelper.ToArray(tags);
+                Debug.Assert(tagsArray is not null);
+                Array.Sort(tagsArray, (left, right) => string.Compare(left.Key, right.Key, StringComparison.Ordinal));
                 Tags = tagsArray;
             }
             Scope = scope;
@@ -462,7 +462,7 @@ namespace System.Diagnostics.Metrics
             foreach (Instrument instrument in instrumentList)
             {
                 if (instrument.GetType() == instrumentType && instrument.Unit == unit &&
-                    instrument.Description == description && DiagnosticsHelper.CompareTags(instrument.Tags, tags))
+                    instrument.Description == description && DiagnosticsHelper.CompareTags(instrument.Tags as KeyValuePair<string, object?>[], tags))
                 {
                     return instrument;
                 }


### PR DESCRIPTION
The changes here addressing the following issues:
- To ensure the factory owns the meter's lifetime, the factory's created meter should have a no-op disposal operation. https://github.com/dotnet/runtime/issues/86592
- Ignore the order of the tags when caching instruments and meters to make them order insensitive. https://github.com/dotnet/runtime/issues/86614
- Remove the scope parameter from the IMeterFactory extension `Create` method.
- Throw exception when the user calls IMeterFactory passing MeterOptions with non-null scope and not equal to IMeterFactory instance. https://github.com/dotnet/runtime/issues/86684
- Moved the IMeterFactory Create method from `Microsoft.Extensions.Diagnostics` to `Microsoft.Extensions.Diagnostics.Abstraction` library.
- Remove the added dependency on the System.Linq in the system.Diagnostics.DiagnosticSource library.