### PR TITLE
Don't disable AutoreleasePoolSupport by default when enabling trimming.

### DIFF
--- a/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
+++ b/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
@@ -38,7 +38,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EnableUnsafeBinaryFormatterSerialization Condition="'$(EnableUnsafeBinaryFormatterSerialization)' == ''">false</EnableUnsafeBinaryFormatterSerialization>
     <EnableUnsafeUTF7Encoding Condition="'$(EnableUnsafeUTF7Encoding)' == ''">false</EnableUnsafeUTF7Encoding>
     <BuiltInComInteropSupport Condition="'$(BuiltInComInteropSupport)' == ''">false</BuiltInComInteropSupport>
-    <AutoreleasePoolSupport Condition="'$(AutoreleasePoolSupport)' == ''">false</AutoreleasePoolSupport>
     <EnableCppCLIHostActivation Condition="'$(EnableCppCLIHostActivation)' == ''">false</EnableCppCLIHostActivation>
     <!-- C++/CLI activation requires native hosting -->
     <_EnableConsumingManagedCodeFromNativeHosting Condition="'$(EnableCppCLIHostActivation)' == 'true'">true</_EnableConsumingManagedCodeFromNativeHosting>


### PR DESCRIPTION
Disabling AutoreleasePoolSupport is a behavioral change that might affect
apps negatively by increasing memory usage, and it won't be noticed until apps
starts misbehaving by using too much memory (or someone happens to profile
them).

As such, it does not make sense to change the default value for
AutoreleasePoolSupport when trimming, because trimming is supposed to not
change behavior (and certainly not increase memory usage).