### PR TITLE
Ensure that the generated JsonSerializerContext.Default static property returns a sigleton.

### DIFF
--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -22,7 +22,6 @@ namespace System.Text.Json.SourceGeneration
             private const string CreateValueInfoMethodName = "CreateValueInfo";
             private const string CtorParamInitMethodNameSuffix = "CtorParamInit";
             private const string DefaultOptionsStaticVarName = "s_defaultOptions";
-            private const string DefaultContextBackingStaticVarName = "s_defaultContext";
             private const string OriginatingResolverPropertyName = "OriginatingResolver";
             private const string InfoVarName = "info";
             private const string NumberHandlingPropName = "NumberHandling";
@@ -1026,12 +1025,10 @@ namespace System.Text.Json.SourceGeneration
                 writer.WriteLine();
 
                 writer.WriteLine($$"""
-                    private static {{contextTypeRef}}? {{DefaultContextBackingStaticVarName}};
-
                     /// <summary>
                     /// The default <see cref="{{JsonSerializerContextTypeRef}}"/> associated with a default <see cref="{{JsonSerializerOptionsTypeRef}}"/> instance.
                     /// </summary>
-                    public static {{contextTypeRef}} Default => {{DefaultContextBackingStaticVarName}} ??= new {{contextTypeRef}}(new {{JsonSerializerOptionsTypeRef}}({{DefaultOptionsStaticVarName}}));
+                    public static {{contextTypeRef}} Default { get; } = new {{contextTypeRef}}(new {{JsonSerializerOptionsTypeRef}}({{DefaultOptionsStaticVarName}}));
 
                     /// <summary>
                     /// The source-generated options associated with this context.

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
@@ -171,6 +171,22 @@ namespace System.Text.Json.SourceGeneration.Tests
                 }).Dispose();
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public static void JsonSerializerContext_GeneratedDefault_IsSingleton()
+        {
+            RemoteExecutor.Invoke(
+                static () =>
+                {
+                    const int Count = 30;
+                    var contexts = new MetadataContext[Count];
+                    Parallel.For(0, Count, i => contexts[i] = MetadataContext.Default);
+
+                    Assert.All(contexts, ctx => Assert.Same(MetadataContext.Default, ctx));
+
+                }).Dispose();
+        }
+
         [Fact]
         public static void SupportsReservedLanguageKeywordsAsProperties()
         {


### PR DESCRIPTION
As currently implemented, the generated `JsonSerializerContext.Default` static property is initialised lazily, which can result `JsonTypeInfo` metadata generation being duplicated in cases where multiple components try to access the same property concurrently. This PR moves initialization to the generated context's static constructor to make sure the same context is always returned.