### PR TITLE
[WIP] System.Linq.Expressions.Interpreter.CallInstruction.CanCreateArbitraryDelegates should respect IsDynamicCodeSupported

### DIFF
--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -16,7 +16,7 @@ namespace System.Linq.Expressions.Interpreter
         /// </summary>
         public abstract int ArgumentCount { get; }
 
-        private static bool CanCreateArbitraryDelegates => true;
+        private static bool CanCreateArbitraryDelegates => RuntimeFeature.IsDynamicCodeSupported;
 
         #region Construction
 


### PR DESCRIPTION
This PR is marked as draft as its sole purpose is to test potential issues with the change.

The work reflects what @MichalStrehovsky noted regarding adaptations of `Linq.Expressions` to be AOT compilation friendly: https://github.com/dotnet/runtime/issues/69410#issuecomment-1149334036 and the suggested way of enabling the mentioned codepath proposed by @rolfbjarne 