### PR TITLE
Enable EventPipe support in MacOS

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -212,7 +212,7 @@ extends:
             extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
             extraStepsParameters:
               creator: dotnet-bot
-              testBuildArgs: 'nativeaot tree ";nativeaot;tracing/eventpipe/simpleprovidervalidation;"'
+              testBuildArgs: nativeaot tree nativeaot
               liveLibrariesBuildConfig: Release
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
             extraVariablesTemplates:
@@ -290,7 +290,7 @@ extends:
             extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
             extraStepsParameters:
               creator: dotnet-bot
-              testBuildArgs: nativeaot tree nativeaot
+              testBuildArgs: 'nativeaot tree ";nativeaot;tracing/eventpipe/simpleprovidervalidation;"'
               liveLibrariesBuildConfig: Release
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
             extraVariablesTemplates:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -212,7 +212,7 @@ extends:
             extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
             extraStepsParameters:
               creator: dotnet-bot
-              testBuildArgs: nativeaot tree nativeaot
+              testBuildArgs: 'nativeaot tree ";nativeaot;tracing/eventpipe/simpleprovidervalidation;"'
               liveLibrariesBuildConfig: Release
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
             extraVariablesTemplates:
@@ -248,7 +248,7 @@ extends:
             extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
             extraStepsParameters:
               creator: dotnet-bot
-              testBuildArgs: 'nativeaot tree ";nativeaot;Loader;Interop;tracing/eventpipe/config;tracing/eventpipe/simpleprovidervalidation;" test tracing/eventcounter/runtimecounters.csproj /p:BuildNativeAotFrameworkObjects=true'
+              testBuildArgs: 'nativeaot tree ";nativeaot;Loader;Interop;tracing/eventpipe/config;" test tracing/eventcounter/runtimecounters.csproj /p:BuildNativeAotFrameworkObjects=true'
               liveLibrariesBuildConfig: Release
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
             extraVariablesTemplates:

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -48,7 +48,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcRPath Condition="'$(IlcRPath)' == '' and '$(_IsApplePlatform)' == 'true'">@executable_path</IlcRPath>
 
       <EventPipeName>libeventpipe-disabled</EventPipeName>
-      <EventPipeName Condition="'$(EnableNativeEventPipe)' == 'true' or ('$(EventSourceSupport)' == 'true' and '$(_IsApplePlatform)' != 'true')">libeventpipe-enabled</EventPipeName>
+      <EventPipeName Condition="'$(EnableNativeEventPipe)' == 'true' or '$(EventSourceSupport)' == 'true'">libeventpipe-enabled</EventPipeName>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/coreclr/nativeaot/Directory.Build.props
+++ b/src/coreclr/nativeaot/Directory.Build.props
@@ -65,8 +65,7 @@
     <DefineConstants Condition="'$(FeatureObjCMarshal)' == 'true'">FEATURE_OBJCMARSHAL;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
-    <FeaturePerfTracing>false</FeaturePerfTracing>
-    <FeaturePerfTracing Condition="'$(TargetsWindows)' == 'true' or ('$(TargetsUnix)' == 'true' and '$(TargetsOSX)' != 'true' and '$(TargetsiOS)' != 'true' and '$(TargetsMacCatalyst)' != 'true' and '$(TargetstvOS)' != 'true')">true</FeaturePerfTracing>
+    <FeaturePerfTracing>true</FeaturePerfTracing>
   </PropertyGroup>
   <PropertyGroup>
     <DefineConstants Condition="'$(FeaturePerfTracing)' == 'true'">FEATURE_PERFTRACING;$(DefineConstants)</DefineConstants>

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.cpp
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#include <sys/types.h>
+
 #ifdef __APPLE__
 #include <sys/sysctl.h>
 #endif

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.cpp
@@ -1,6 +1,22 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#ifdef __APPLE__
+#include <sys/sysctl.h>
+#endif
+
+#ifdef __NetBSD__
+#include <sys/cdefs.h>
+#include <sys/param.h>
+#include <sys/sysctl.h>
+#include <kvm.h>
+#endif
+
+#ifdef __FreeBSD__
+#include <sys/sysctl.h>
+#include <sys/user.h>
+#endif
+
 #include <eventpipe/ep-rt-config.h>
 
 #ifdef ENABLE_PERFTRACING
@@ -26,7 +42,54 @@ aot_ipc_get_process_id_disambiguation_key(
     *key = 0;
 
 // Mono implementation, restricted just to Unix
-#ifdef TARGET_UNIX
+#if defined (__APPLE__) || defined (__FreeBSD__)
+	// On OS X, we return the process start time expressed in Unix time (the number of seconds
+	// since the start of the Unix epoch).
+	struct kinfo_proc info = {};
+	size_t size = sizeof (info);
+	int mib [4] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, process_id };
+
+	const int result_sysctl = sysctl (mib, sizeof(mib)/sizeof(*mib), &info, &size, NULL, 0);
+	if (result_sysctl == 0) {
+#if defined (__APPLE__)
+		struct timeval proc_starttime = info.kp_proc.p_starttime;
+#else // __FreeBSD__
+		struct timeval proc_starttime = info.ki_start;
+#endif
+		long seconds_since_epoch = proc_starttime.tv_sec;
+		*key = seconds_since_epoch;
+		return true;
+	} else {
+		EP_ASSERT (!"Failed to get start time of a process.");
+		return false;
+	}
+#elif defined (__NetBSD__)
+	// On NetBSD, we return the process start time expressed in Unix time (the number of seconds
+	// since the start of the Unix epoch).
+	kvm_t *kd;
+	int cnt;
+	struct kinfo_proc2 *info;
+
+	kd = kvm_open (NULL, NULL, NULL, KVM_NO_FILES, "kvm_open");
+	if (!kd) {
+		EP_ASSERT (!"Failed to get start time of a process.");
+		return false;
+	}
+
+	info = kvm_getproc2 (kd, KERN_PROC_PID, process_id, sizeof (struct kinfo_proc2), &cnt);
+	if (!info || cnt < 1) {
+		kvm_close (kd);
+		EP_ASSERT (!"Failed to get start time of a process.");
+		return false;
+	}
+
+	kvm_close (kd);
+
+	long seconds_since_epoch = info->p_ustart_sec;
+	*key = seconds_since_epoch;
+
+	return true;
+#elif defined (__linux__)
 
     // Here we read /proc/<pid>/stat file to get the start time for the process.
     // We return this value (which is expressed in jiffies since boot time).

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.cpp
@@ -31,6 +31,7 @@
 
 bool aot_ipc_get_process_id_disambiguation_key(uint32_t process_id, uint64_t *key);
 
+// Consider moving this code to shared library code. See https://github.com/dotnet/runtime/issues/87069
 bool
 aot_ipc_get_process_id_disambiguation_key(
     uint32_t process_id,


### PR DESCRIPTION
Enabled `EventPipe` support in MacOS by removing the restriction for the OS platform. Also added a simple `EventPipe `test (in addition to the existing `smoketests`) to `CoreCLR NativeAOT `release builds.