### PR TITLE
Attempt to optimize the Vector4 element constructor in mono interp

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector4.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector4.cs
@@ -15,6 +15,7 @@ namespace System.Numerics
     /// [!INCLUDE[vectors-are-rows-paragraph](~/includes/system-numerics-vectors-are-rows.md)]
     /// ]]></format></remarks>
     [Intrinsic]
+    [StructLayout(LayoutKind.Sequential)]
     public partial struct Vector4 : IEquatable<Vector4>, IFormattable
     {
         /// <summary>The X component of the vector.</summary>
@@ -63,10 +64,18 @@ namespace System.Numerics
         [Intrinsic]
         public Vector4(float x, float y, float z, float w)
         {
-            X = x;
-            Y = y;
-            Z = z;
-            W = w;
+            if (Vector128.IsHardwareAccelerated)
+            {
+                Unsafe.SkipInit(out this);
+                Unsafe.As<float, Vector128<float>>(ref this.X) = Vector128.Create(x, y, z, w);
+            }
+            else
+            {
+                X = x;
+                Y = y;
+                Z = z;
+                W = w;
+            }
         }
 
         /// <summary>Constructs a vector from the given <see cref="ReadOnlySpan{Single}" />. The span must contain at least 4 elements.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector4.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector4.cs
@@ -15,7 +15,6 @@ namespace System.Numerics
     /// [!INCLUDE[vectors-are-rows-paragraph](~/includes/system-numerics-vectors-are-rows.md)]
     /// ]]></format></remarks>
     [Intrinsic]
-    [StructLayout(LayoutKind.Sequential)]
     public partial struct Vector4 : IEquatable<Vector4>, IFormattable
     {
         /// <summary>The X component of the vector.</summary>
@@ -67,7 +66,7 @@ namespace System.Numerics
             if (Vector128.IsHardwareAccelerated)
             {
                 Unsafe.SkipInit(out this);
-                Unsafe.As<float, Vector128<float>>(ref this.X) = Vector128.Create(x, y, z, w);
+                Unsafe.As<Vector4, Vector128<float>>(ref this) = Vector128.Create(x, y, z, w);
             }
             else
             {


### PR DESCRIPTION
Looking at https://github.com/dotnet/perf-autofiling-issues/issues/18031 in wasm+interp, the hot path of some of the failures boils down to `foo.AsVector128()`, where `AsVector128` itself boils down to `new Vector4(this, ...)`, which then translates to `new Vector4(this.X, this.Y, ...)`. Because the Vector4 ctor just assigns 4 fields sequentially, this generates a bunch of interp opcodes.

If we initialize Vector4 as if it were a Vector128<float>, we can tap into the interpreter's SIMD support and initialize it in (almost) one vectorized operation, and then on WASM that will use the native vector instruction set.

With these changes a `Vector2.AsVector128()` call looks roughly like this in the mono interpreter, annotated with my reading of the opcodes:
```
1b42dba ldc.r4  -> 192                 // 0f
1b42dc2 ldc.r4  -> 200                 // 0f
1b42dca newobj_vt_inlined 96 -> 112    // result = default(Vector4);
1b42dd2 mov.4 88 -> 176                // load src.X
1b42dd8 mov.4 92 -> 184                // load src.Y
1b42dde ldflda 112 -> 112              // &result.X
1b42de6 simd_v128_i4_create 176 -> 128 // Vector128.Create(src.X, src.Y, 0f, 0f)
1b42dec stobj.vt.noref 112, 128        // result = (Vector4)Vector128.Create(src.X, src.Y, 0f, 0f)
```

I don't know if we want to do this, or whether this is a good way to do it. But I figured a draft PR is a good way to start the discussion. I suspect if we optimize this one ctor a bunch of stuff will get faster in the wasm interp scenario (and maybe all interp targets, but it's hard to be certain).