### PR TITLE
Enable Dynamic PGO for IsIntanceOfAny and ChkCastAny

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5536,11 +5536,7 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
                 if ((likelyCls != NO_CLASS_HANDLE) &&
                     (likelyClass.likelihood > (UINT32)JitConfig.JitGuardedDevirtualizationChainLikelihood()))
                 {
-                    // Legality check: make sure it's at least possible to cast the likely class
-                    // to the base class, e.g. String -> T will return TypeCompareState::May
-                    // Int -> String will be MustNot.
-                    if ((info.compCompHnd->compareTypesForCast(likelyCls, pResolvedToken->hClass) !=
-                         TypeCompareState::MustNot))
+                    if ((info.compCompHnd->compareTypesForCast(likelyCls, pResolvedToken->hClass) == TypeCompareState::Must))
                     {
                         bool isAbstract = (info.compCompHnd->getClassAttribs(likelyCls) &
                                            (CORINFO_FLG_INTERFACE | CORINFO_FLG_ABSTRACT)) != 0;

--- a/src/tests/Common/testenvironment.proj
+++ b/src/tests/Common/testenvironment.proj
@@ -71,6 +71,7 @@
       DOTNET_JitRandomOnStackReplacement;
       DOTNET_JitRandomlyCollect64BitCounts;
       DOTNET_TieredPGO_InstrumentedTierAlwaysOptimized;
+      DOTNET_JitProfileCasts;
       DOTNET_JitForceControlFlowGuard;
       DOTNET_JitCFGUseDispatcher;
       RunningIlasmRoundTrip;
@@ -224,13 +225,13 @@
     <TestEnvironment Include="clrinterpreter" TieredCompilation="1" />
     <TestEnvironment Include="defaultpgo" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" />
     <TestEnvironment Include="fullpgo" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0"/>
-    <TestEnvironment Include="fullpgo_methodprofiling" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitDelegateProfiling="1" JitVTableProfiling="1" />
+    <TestEnvironment Include="fullpgo_methodprofiling" TieredPGO="1" JitProfileCasts="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitDelegateProfiling="1" JitVTableProfiling="1" />
     <TestEnvironment Include="fullpgo_methodprofiling_always_optimized" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitDelegateProfiling="1" JitVTableProfiling="1" TieredPGO_InstrumentedTierAlwaysOptimized="1" />
-    <TestEnvironment Include="fullpgo_random_gdv" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitRandomGuardedDevirtualization="1" JitRandomlyCollect64BitCounts="1" />
+    <TestEnvironment Include="fullpgo_random_gdv" TieredPGO="1" JitProfileCasts="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitRandomGuardedDevirtualization="1" JitRandomlyCollect64BitCounts="1" />
     <TestEnvironment Include="fullpgo_random_gdv_methodprofiling_only" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitRandomGuardedDevirtualization="1" JitClassProfiling="0" JitDelegateProfiling="1" JitVTableProfiling="1" JitRandomlyCollect64BitCounts="1" />
     <TestEnvironment Include="fullpgo_random_gdv_edge" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitRandomGuardedDevirtualization="1" JitRandomEdgeCounts="1" JitRandomlyCollect64BitCounts="1" />
     <TestEnvironment Include="syntheticpgo" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitSynthesizeCounts="1" JitCheckSynthesizedProfile="1" />
-    <TestEnvironment Include="syntheticpgo_blend" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitSynthesizeCounts="3" JitCheckSynthesizedProfile="1" />
+    <TestEnvironment Include="syntheticpgo_blend" TieredPGO="1" JitProfileCasts="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitSynthesizeCounts="3" JitCheckSynthesizedProfile="1" />
     <TestEnvironment Include="gcstandalone" Condition="'$(TargetsWindows)' == 'true'" GCName="clrgc.dll"/>
     <TestEnvironment Include="gcstandalone" Condition="'$(TargetsWindows)' != 'true'" GCName="libclrgc.so"/>
     <TestEnvironment Include="gcstandaloneserver" Condition="'$(TargetsWindows)' == 'true'" gcServer="1" GCName="clrgc.dll"/>


### PR DESCRIPTION
```csharp
public class Class1 {}
public class Class2 : Class1 {}

[Benchmark]
public bool Test() => GenericCast<Class1>(new Class2());

[MethodImpl(MethodImplOptions.NoInlining)]
public bool GenericCast<T>(object o) => o is T;
```
| Method |                   Toolchain |     Mean | Ratio | Code Size |
|------- |---------------------------- |---------:|------:|----------:|
|   Test |      \Core_Root_PR\corerun.exe | **2.292 ns** |  1.00 |     112 B |
|   Test | \Core_Root_base\corerun.exe | 3.489 ns |  1.54 |      89 B |

```diff
; Assembly listing for method Program:GenericCast[System.__Canon](System.Object):bool:this
       sub      rsp, 40
       mov      qword ptr [rsp+20H], rdx
+      mov      rax, r8
+      test     rax, rax
+      je       SHORT G_M24407_IG05
+      mov      rcx, 0x7FFBE47CAF78  ;; Class2
+      cmp      qword ptr [rax], rcx
+      je       SHORT G_M24407_IG05
       mov      rcx, qword ptr [rdx+38H]
       mov      rcx, qword ptr [rcx]
       mov      rdx, r8
       call     [CORINFO_HELP_ISINSTANCEOFANY]
+G_M24407_IG05:  
       test     rax, rax
       setne    al
       movzx    rax, al
       add      rsp, 40
       ret      
-; Total bytes of code 39
+; Total bytes of code 62
```
`(T)o` is also improved because in https://github.com/dotnet/runtime/pull/86728 we made it to use `T` as a fast path which won't help here (T is `Class1` while the actual object is `Class2`).