### PR TITLE
Update to use the cbl-mariner webassembly images.

### DIFF
--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -81,10 +81,10 @@ resources:
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8
 
     - container: browser_wasm
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-webassembly-net8
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-webassembly
 
     - container: wasi_wasm
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-webassembly-net8
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-webassembly
 
     - container: freebsd_x64
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-freebsd-12

--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -82,9 +82,13 @@ resources:
 
     - container: browser_wasm
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-webassembly
+      env:
+        ROOTFS_DIR: /crossrootfs/x64
 
     - container: wasi_wasm
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-webassembly
+      env:
+        ROOTFS_DIR: /crossrootfs/x64
 
     - container: freebsd_x64
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-freebsd-12

--- a/eng/pipelines/common/templates/wasm-build-tests.yml
+++ b/eng/pipelines/common/templates/wasm-build-tests.yml
@@ -4,6 +4,7 @@ parameters:
   isWasmOnlyBuild: false
   platforms: []
   shouldContinueOnError: false
+  extraBuildArgs: ''
 
 jobs:
 
@@ -39,7 +40,7 @@ jobs:
       isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
       testGroup: innerloop
       nameSuffix: WasmBuildTests
-      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:TestWasmBuildTests=true /p:TestAssemblies=false /p:BrowserHost=$(_hostedOs) /p:WorkloadsTestPreviousVersions=$(workloadsTestPreviousVersionsVar)
+      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:TestWasmBuildTests=true /p:TestAssemblies=false /p:BrowserHost=$(_hostedOs) /p:WorkloadsTestPreviousVersions=$(workloadsTestPreviousVersionsVar) ${{ parameters.extraBuildArgs }}
       timeoutInMinutes: 180
       condition: >-
         or(

--- a/eng/pipelines/common/templates/wasm-runtime-tests.yml
+++ b/eng/pipelines/common/templates/wasm-runtime-tests.yml
@@ -3,6 +3,7 @@ parameters:
   isExtraPlatformsBuild: false
   isWasmOnlyBuild: false
   platforms: []
+  extraBuildArgs: ''
 
 jobs:
 
@@ -35,7 +36,7 @@ jobs:
       isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
       nameSuffix: AllSubsets_Mono_RuntimeTests
       runtimeVariant: monointerpreter
-      buildArgs: -s mono+libs -c $(_BuildConfig)
+      buildArgs: -s mono+libs -c $(_BuildConfig) ${{ parameters.extraBuildArgs }}
       timeoutInMinutes: 180
       condition: >-
         or(

--- a/eng/pipelines/coreclr/perf-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-wasm-jobs.yml
@@ -22,7 +22,7 @@ jobs:
         platforms:
         - browser_wasm
         jobParameters:
-          buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+          buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:AotHostArchitecture=x64
           nameSuffix: wasm
           isOfficialBuild: false
           extraStepsTemplate: /eng/pipelines/coreclr/perf-wasm-prepare-artifacts-steps.yml
@@ -89,7 +89,7 @@ jobs:
         platforms:
         - browser_wasm
         jobParameters:
-          buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+          buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:AotHostArchitecture=x64
           nameSuffix: wasm
           isOfficialBuild: false
           extraStepsTemplate: /eng/pipelines/coreclr/perf-wasm-prepare-artifacts-steps.yml

--- a/eng/pipelines/coreclr/perf-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-wasm-jobs.yml
@@ -22,7 +22,7 @@ jobs:
         platforms:
         - browser_wasm
         jobParameters:
-          buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:AotHostArchitecture=x64
+          buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
           nameSuffix: wasm
           isOfficialBuild: false
           extraStepsTemplate: /eng/pipelines/coreclr/perf-wasm-prepare-artifacts-steps.yml
@@ -89,7 +89,7 @@ jobs:
         platforms:
         - browser_wasm
         jobParameters:
-          buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:AotHostArchitecture=x64
+          buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
           nameSuffix: wasm
           isOfficialBuild: false
           extraStepsTemplate: /eng/pipelines/coreclr/perf-wasm-prepare-artifacts-steps.yml

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -27,6 +27,7 @@ jobs:
         - browser_wasm
         - browser_wasm_win
       nameSuffix: _AOT
+      extraBuildArgs: /p:AotHostArchitecture=x64
       runAOT: true
       alwaysRun: true
 
@@ -37,7 +38,7 @@ jobs:
         - browser_wasm
         - browser_wasm_win
       nameSuffix: _HighResource_AOT
-      extraBuildArgs: /p:TestAssemblies=false /p:RunHighAOTResourceRequiringTestsOnly=true
+      extraBuildArgs: /p:TestAssemblies=false /p:RunHighAOTResourceRequiringTestsOnly=true /p:AotHostArchitecture=x64
       buildAOTOnHelix: false
       runAOT: true
       alwaysRun: true
@@ -48,6 +49,7 @@ jobs:
       platforms:
         - browser_wasm_firefox
       browser: firefox
+      extraBuildArgs: /p:AotHostArchitecture=x64
       ## ff tests are unstable currently
       shouldContinueOnError: true
       alwaysRun: true
@@ -71,6 +73,7 @@ jobs:
       platforms:
         - browser_wasm
       # Don't run for rolling builds, as this is covered
+      extraBuildArgs: /p:AotHostArchitecture=x64
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       scenarios:
@@ -83,6 +86,7 @@ jobs:
       platforms:
         - browser_wasm
       nameSuffix: _NodeJs
+      extraBuildArgs: /p:AotHostArchitecture=x64
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
@@ -108,7 +112,7 @@ jobs:
         - browser_wasm
         #- browser_wasm_win
       nameSuffix: _Threading_Smoke
-      extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:_WasmPThreadPoolSize=8
+      extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:_WasmPThreadPoolSize=8 /p:AotHostArchitecture=x64
       shouldRunSmokeOnly: true
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
@@ -124,7 +128,7 @@ jobs:
         - browser_wasm
         #- browser_wasm_win
       nameSuffix: _Threading
-      extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:_WasmPThreadPoolSize=8
+      extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:_WasmPThreadPoolSize=8 /p:AotHostArchitecture=x64
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       # Always run for runtime-wasm because tests are not run in runtime
@@ -144,7 +148,7 @@ jobs:
         - browser_wasm
         #- browser_wasm_win
       nameSuffix: _Threading_PerfTracing
-      extraBuildArgs: /p:MonoWasmBuildVariant=perftrace
+      extraBuildArgs: /p:MonoWasmBuildVariant=perftrace /p:AotHostArchitecture=x64
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       # Always run for runtime-wasm because tests are not run in runtime
@@ -163,6 +167,7 @@ jobs:
       platforms:
         - browser_wasm
       nameSuffix: _EAT
+      extraBuildArgs: /p:AotHostArchitecture=x64
       runAOT: false
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
@@ -174,6 +179,7 @@ jobs:
         - browser_wasm
         - browser_wasm_win
       nameSuffix: _AOT
+      extraBuildArgs: /p:AotHostArchitecture=x64
       runAOT: true
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
@@ -186,7 +192,7 @@ jobs:
         - browser_wasm
         - browser_wasm_win
       nameSuffix: _HighResource_AOT
-      extraBuildArgs: /p:TestAssemblies=false /p:RunHighAOTResourceRequiringTestsOnly=true
+      extraBuildArgs: /p:TestAssemblies=false /p:RunHighAOTResourceRequiringTestsOnly=true /p:AotHostArchitecture=x64
       buildAOTOnHelix: false
       runAOT: true
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
@@ -200,7 +206,7 @@ jobs:
         - wasi_wasm
         - wasi_wasm_win
       nameSuffix: '_Smoke'
-      extraBuildArgs: /p:EnableAggressiveTrimming=true /p:RunWasmSamples=true
+      extraBuildArgs: /p:EnableAggressiveTrimming=true /p:RunWasmSamples=true /p:AotHostArchitecture=x64
       shouldRunSmokeOnly: true
       # ignore test failures for runtime-extra-platforms, but not when this
       # is run as part of a wasm specific pipeline like runtime-wasm
@@ -218,6 +224,7 @@ jobs:
         - browser_wasm_win
         - wasi_wasm
         - wasi_wasm_win
+      extraBuildArgs: /p:AotHostArchitecture=x64
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
 
@@ -225,6 +232,7 @@ jobs:
     parameters:
       platforms:
         - browser_wasm
+      extraBuildArgs: /p:AotHostArchitecture=x64
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
 
@@ -235,6 +243,7 @@ jobs:
       platforms:
         - browser_wasm
         - browser_wasm_win
+      extraBuildArgs: /p:AotHostArchitecture=x64
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
 
@@ -243,6 +252,7 @@ jobs:
       platforms:
         - browser_wasm_firefox
       browser: firefox
+      extraBuildArgs: /p:AotHostArchitecture=x64
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
@@ -254,7 +264,7 @@ jobs:
       platforms:
         - Browser_wasm
         - Browser_wasm_win
-      extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:WasmEnableThreads=true
+      extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:WasmEnableThreads=true /p:AotHostArchitecture=x64
       nameSuffix: DebuggerTests_MultiThreaded
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
@@ -273,7 +283,7 @@ jobs:
       platforms:
         - wasi_wasm
         - wasi_wasm_win
-      extraBuildArgs: /p:EnableAggressiveTrimming=true /p:RunWasmSamples=true
+      extraBuildArgs: /p:EnableAggressiveTrimming=true /p:RunWasmSamples=true /p:AotHostArchitecture=x64
       # always run for wasm only pipelines
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -27,7 +27,7 @@ jobs:
         - browser_wasm
         - browser_wasm_win
       nameSuffix: _AOT
-      extraBuildArgs: /p:AotHostArchitecture=x64
+      extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       runAOT: true
       alwaysRun: true
 
@@ -38,7 +38,7 @@ jobs:
         - browser_wasm
         - browser_wasm_win
       nameSuffix: _HighResource_AOT
-      extraBuildArgs: /p:TestAssemblies=false /p:RunHighAOTResourceRequiringTestsOnly=true /p:AotHostArchitecture=x64
+      extraBuildArgs: /p:TestAssemblies=false /p:RunHighAOTResourceRequiringTestsOnly=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       buildAOTOnHelix: false
       runAOT: true
       alwaysRun: true
@@ -49,7 +49,7 @@ jobs:
       platforms:
         - browser_wasm_firefox
       browser: firefox
-      extraBuildArgs: /p:AotHostArchitecture=x64
+      extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       ## ff tests are unstable currently
       shouldContinueOnError: true
       alwaysRun: true
@@ -73,7 +73,7 @@ jobs:
       platforms:
         - browser_wasm
       # Don't run for rolling builds, as this is covered
-      extraBuildArgs: /p:AotHostArchitecture=x64
+      extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       scenarios:
@@ -86,7 +86,7 @@ jobs:
       platforms:
         - browser_wasm
       nameSuffix: _NodeJs
-      extraBuildArgs: /p:AotHostArchitecture=x64
+      extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
@@ -112,7 +112,7 @@ jobs:
         - browser_wasm
         #- browser_wasm_win
       nameSuffix: _Threading_Smoke
-      extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:_WasmPThreadPoolSize=8 /p:AotHostArchitecture=x64
+      extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:_WasmPThreadPoolSize=8 /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       shouldRunSmokeOnly: true
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
@@ -128,7 +128,7 @@ jobs:
         - browser_wasm
         #- browser_wasm_win
       nameSuffix: _Threading
-      extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:_WasmPThreadPoolSize=8 /p:AotHostArchitecture=x64
+      extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:_WasmPThreadPoolSize=8 /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       # Always run for runtime-wasm because tests are not run in runtime
@@ -148,7 +148,7 @@ jobs:
         - browser_wasm
         #- browser_wasm_win
       nameSuffix: _Threading_PerfTracing
-      extraBuildArgs: /p:MonoWasmBuildVariant=perftrace /p:AotHostArchitecture=x64
+      extraBuildArgs: /p:MonoWasmBuildVariant=perftrace /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       # Always run for runtime-wasm because tests are not run in runtime
@@ -167,7 +167,7 @@ jobs:
       platforms:
         - browser_wasm
       nameSuffix: _EAT
-      extraBuildArgs: /p:AotHostArchitecture=x64
+      extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       runAOT: false
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
@@ -179,7 +179,7 @@ jobs:
         - browser_wasm
         - browser_wasm_win
       nameSuffix: _AOT
-      extraBuildArgs: /p:AotHostArchitecture=x64
+      extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       runAOT: true
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
@@ -192,7 +192,7 @@ jobs:
         - browser_wasm
         - browser_wasm_win
       nameSuffix: _HighResource_AOT
-      extraBuildArgs: /p:TestAssemblies=false /p:RunHighAOTResourceRequiringTestsOnly=true /p:AotHostArchitecture=x64
+      extraBuildArgs: /p:TestAssemblies=false /p:RunHighAOTResourceRequiringTestsOnly=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       buildAOTOnHelix: false
       runAOT: true
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
@@ -206,7 +206,7 @@ jobs:
         - wasi_wasm
         - wasi_wasm_win
       nameSuffix: '_Smoke'
-      extraBuildArgs: /p:EnableAggressiveTrimming=true /p:RunWasmSamples=true /p:AotHostArchitecture=x64
+      extraBuildArgs: /p:EnableAggressiveTrimming=true /p:RunWasmSamples=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       shouldRunSmokeOnly: true
       # ignore test failures for runtime-extra-platforms, but not when this
       # is run as part of a wasm specific pipeline like runtime-wasm
@@ -224,7 +224,7 @@ jobs:
         - browser_wasm_win
         - wasi_wasm
         - wasi_wasm_win
-      extraBuildArgs: /p:AotHostArchitecture=x64
+      extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
 
@@ -232,7 +232,7 @@ jobs:
     parameters:
       platforms:
         - browser_wasm
-      extraBuildArgs: /p:AotHostArchitecture=x64
+      extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
 
@@ -243,7 +243,7 @@ jobs:
       platforms:
         - browser_wasm
         - browser_wasm_win
-      extraBuildArgs: /p:AotHostArchitecture=x64
+      extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
 
@@ -252,7 +252,7 @@ jobs:
       platforms:
         - browser_wasm_firefox
       browser: firefox
-      extraBuildArgs: /p:AotHostArchitecture=x64
+      extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
@@ -264,7 +264,7 @@ jobs:
       platforms:
         - Browser_wasm
         - Browser_wasm_win
-      extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:WasmEnableThreads=true /p:AotHostArchitecture=x64
+      extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:WasmEnableThreads=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       nameSuffix: DebuggerTests_MultiThreaded
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
@@ -283,7 +283,7 @@ jobs:
       platforms:
         - wasi_wasm
         - wasi_wasm_win
-      extraBuildArgs: /p:EnableAggressiveTrimming=true /p:RunWasmSamples=true /p:AotHostArchitecture=x64
+      extraBuildArgs: /p:EnableAggressiveTrimming=true /p:RunWasmSamples=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       # always run for wasm only pipelines
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}

--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -118,7 +118,7 @@ extends:
             testGroup: innerloop
             timeoutInMinutes: 120
             nameSuffix: Runtime_Release
-            buildArgs: -s mono+libs -c $(_BuildConfig) -p:WasmBuildNative=false -p:AotHostArchitecture=x64
+            buildArgs: -s mono+libs -c $(_BuildConfig) -p:WasmBuildNative=false -p:AotHostArchitecture=x64 -p:AotHostOS=$(_hostedOS)
             condition:
               or(
                 eq(variables['isRollingBuild'], true),

--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -118,7 +118,7 @@ extends:
             testGroup: innerloop
             timeoutInMinutes: 120
             nameSuffix: Runtime_Release
-            buildArgs: -s mono+libs -c $(_BuildConfig) -p:WasmBuildNative=false
+            buildArgs: -s mono+libs -c $(_BuildConfig) -p:WasmBuildNative=false -p:AotHostArchitecture=x64
             condition:
               or(
                 eq(variables['isRollingBuild'], true),

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -422,6 +422,7 @@ extends:
           platforms:
             - browser_wasm
           alwaysRun: ${{ variables.isRollingBuild }}
+          extraBuildArgs: /p:AotHostArchitecture=x64
           scenarios:
             - normal
             - WasmTestOnBrowser
@@ -431,6 +432,7 @@ extends:
           platforms:
             - browser_wasm_win
           alwaysRun: ${{ variables.isRollingBuild }}
+          extraBuildArgs: /p:AotHostArchitecture=x64
           scenarios:
             - WasmTestOnBrowser
 
@@ -443,6 +445,7 @@ extends:
           runAOT: false
           shouldRunSmokeOnly: false
           alwaysRun: ${{ variables.isRollingBuild }}
+          extraBuildArgs: /p:AotHostArchitecture=x64
 
       # AOT Library tests
       - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -453,6 +456,7 @@ extends:
           runAOT: true
           shouldRunSmokeOnly: true
           alwaysRun: ${{ variables.isRollingBuild }}
+          extraBuildArgs: /p:AotHostArchitecture=x64
 
       - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
         parameters:
@@ -470,6 +474,7 @@ extends:
             - browser_wasm
             - browser_wasm_win
           alwaysRun: ${{ variables.isRollingBuild }}
+          extraBuildArgs: /p:AotHostArchitecture=x64
 
       # Wasm Debugger tests
       - template: /eng/pipelines/common/templates/wasm-debugger-tests.yml
@@ -478,6 +483,7 @@ extends:
             - browser_wasm
             - browser_wasm_win
           alwaysRun: ${{ variables.isRollingBuild }}
+          extraBuildArgs: /p:AotHostArchitecture=x64
 
       # Wasm runtime tests
       - template: /eng/pipelines/common/templates/wasm-runtime-tests.yml
@@ -485,6 +491,7 @@ extends:
           platforms:
             - browser_wasm
           alwaysRun: ${{ variables.isRollingBuild }}
+          extraBuildArgs: /p:AotHostArchitecture=x64
 
       # Build and Smoke Tests only - Wasm Threading Legs
       - template: /eng/pipelines/common/templates/wasm-library-tests.yml
@@ -492,7 +499,7 @@ extends:
           platforms:
             - browser_wasm
           nameSuffix: _Threading_Smoke
-          extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:_WasmPThreadPoolSize=8
+          extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:_WasmPThreadPoolSize=8 /p:AotHostArchitecture=x64
           shouldRunSmokeOnly: true
           alwaysRun: ${{ variables.isRollingBuild }}
           scenarios:
@@ -503,7 +510,7 @@ extends:
           platforms:
             - browser_wasm
           nameSuffix: _Threading_PerfTracing
-          extraBuildArgs: /p:MonoWasmBuildVariant=perftrace
+          extraBuildArgs: /p:MonoWasmBuildVariant=perftrace /p:AotHostArchitecture=x64
           alwaysRun: ${{ variables.isRollingBuild }}
 
       # WASI/WASM
@@ -514,7 +521,7 @@ extends:
             - wasi_wasm
             - wasi_wasm_win
           nameSuffix: '_Smoke'
-          extraBuildArgs: /p:EnableAggressiveTrimming=true /p:RunWasmSamples=true
+          extraBuildArgs: /p:EnableAggressiveTrimming=true /p:RunWasmSamples=true /p:AotHostArchitecture=x64
           shouldContinueOnError: true
           shouldRunSmokeOnly: true
           alwaysRun: ${{ variables.isRollingBuild }}
@@ -526,6 +533,7 @@ extends:
           platforms:
             - wasi_wasm
             - wasi_wasm_win
+          extraBuildArgs: /p:AotHostArchitecture=x64
           alwaysRun: ${{ variables.isRollingBuild }}
 
       #

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -422,7 +422,7 @@ extends:
           platforms:
             - browser_wasm
           alwaysRun: ${{ variables.isRollingBuild }}
-          extraBuildArgs: /p:AotHostArchitecture=x64
+          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
           scenarios:
             - normal
             - WasmTestOnBrowser
@@ -432,7 +432,7 @@ extends:
           platforms:
             - browser_wasm_win
           alwaysRun: ${{ variables.isRollingBuild }}
-          extraBuildArgs: /p:AotHostArchitecture=x64
+          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
           scenarios:
             - WasmTestOnBrowser
 
@@ -445,7 +445,7 @@ extends:
           runAOT: false
           shouldRunSmokeOnly: false
           alwaysRun: ${{ variables.isRollingBuild }}
-          extraBuildArgs: /p:AotHostArchitecture=x64
+          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
 
       # AOT Library tests
       - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -456,7 +456,7 @@ extends:
           runAOT: true
           shouldRunSmokeOnly: true
           alwaysRun: ${{ variables.isRollingBuild }}
-          extraBuildArgs: /p:AotHostArchitecture=x64
+          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
 
       - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
         parameters:
@@ -474,7 +474,7 @@ extends:
             - browser_wasm
             - browser_wasm_win
           alwaysRun: ${{ variables.isRollingBuild }}
-          extraBuildArgs: /p:AotHostArchitecture=x64
+          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
 
       # Wasm Debugger tests
       - template: /eng/pipelines/common/templates/wasm-debugger-tests.yml
@@ -483,7 +483,7 @@ extends:
             - browser_wasm
             - browser_wasm_win
           alwaysRun: ${{ variables.isRollingBuild }}
-          extraBuildArgs: /p:AotHostArchitecture=x64
+          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
 
       # Wasm runtime tests
       - template: /eng/pipelines/common/templates/wasm-runtime-tests.yml
@@ -491,7 +491,7 @@ extends:
           platforms:
             - browser_wasm
           alwaysRun: ${{ variables.isRollingBuild }}
-          extraBuildArgs: /p:AotHostArchitecture=x64
+          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
 
       # Build and Smoke Tests only - Wasm Threading Legs
       - template: /eng/pipelines/common/templates/wasm-library-tests.yml
@@ -499,7 +499,7 @@ extends:
           platforms:
             - browser_wasm
           nameSuffix: _Threading_Smoke
-          extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:_WasmPThreadPoolSize=8 /p:AotHostArchitecture=x64
+          extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:_WasmPThreadPoolSize=8 /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
           shouldRunSmokeOnly: true
           alwaysRun: ${{ variables.isRollingBuild }}
           scenarios:
@@ -510,7 +510,7 @@ extends:
           platforms:
             - browser_wasm
           nameSuffix: _Threading_PerfTracing
-          extraBuildArgs: /p:MonoWasmBuildVariant=perftrace /p:AotHostArchitecture=x64
+          extraBuildArgs: /p:MonoWasmBuildVariant=perftrace /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
           alwaysRun: ${{ variables.isRollingBuild }}
 
       # WASI/WASM
@@ -521,7 +521,7 @@ extends:
             - wasi_wasm
             - wasi_wasm_win
           nameSuffix: '_Smoke'
-          extraBuildArgs: /p:EnableAggressiveTrimming=true /p:RunWasmSamples=true /p:AotHostArchitecture=x64
+          extraBuildArgs: /p:EnableAggressiveTrimming=true /p:RunWasmSamples=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
           shouldContinueOnError: true
           shouldRunSmokeOnly: true
           alwaysRun: ${{ variables.isRollingBuild }}
@@ -533,7 +533,7 @@ extends:
           platforms:
             - wasi_wasm
             - wasi_wasm_win
-          extraBuildArgs: /p:AotHostArchitecture=x64
+          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
           alwaysRun: ${{ variables.isRollingBuild }}
 
       #

--- a/src/mono/llvm/llvm-init.proj
+++ b/src/mono/llvm/llvm-init.proj
@@ -17,10 +17,10 @@
                       Version="$(MonoLLVMToolsVersion)"
                       PackageArch="$(TargetArchitecture)"
                       Condition="'$(TargetArchitecture)' != ''" />
-    <PackageReference Include="runtime.$(MonoLLVMHostOS)-$(RealTargetArchitecture).Microsoft.NETCore.Runtime.Mono.LLVM.Tools"
+    <PackageReference Include="runtime.$(MonoLLVMHostOS)-$(AotHostArchitecture).Microsoft.NETCore.Runtime.Mono.LLVM.Tools"
                       Version="$(MonoLLVMToolsVersion)"
-                      PackageArch="$(RealTargetArchitecture)"
-                      Condition="'$(RealTargetArchitecture)' != ''" />
+                      PackageArch="$(AotHostArchitecture)"
+                      Condition="'$(AotHostArchitecture)' != ''" />
     <PackageReference Include="runtime.$(MonoLLVMHostOS)-$(BuildArchitecture).Microsoft.NETCore.Runtime.Mono.LLVM.Tools"
                       Version="$(MonoLLVMToolsVersion)"
                       PackageArch="$(BuildArchitecture)"
@@ -29,10 +29,10 @@
                       Version="$(MonoLLVMSDKVersion)"
                       PackageArch="$(TargetArchitecture)"
                       Condition="'$(TargetArchitecture)' != ''" />
-    <PackageReference Include="runtime.$(MonoLLVMHostOS)-$(RealTargetArchitecture).Microsoft.NETCore.Runtime.Mono.LLVM.Sdk"
+    <PackageReference Include="runtime.$(MonoLLVMHostOS)-$(AotHostArchitecture).Microsoft.NETCore.Runtime.Mono.LLVM.Sdk"
                       Version="$(MonoLLVMSDKVersion)"
-                      PackageArch="$(RealTargetArchitecture)"
-                      Condition="'$(RealTargetArchitecture)' != ''" />
+                      PackageArch="$(AotHostArchitecture)"
+                      Condition="'$(AotHostArchitecture)' != ''" />
     <PackageReference Include="runtime.$(MonoLLVMHostOS)-$(BuildArchitecture).Microsoft.NETCore.Runtime.Mono.LLVM.Sdk"
                       Version="$(MonoLLVMSDKVersion)"
                       PackageArch="$(BuildArchitecture)"

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -49,8 +49,8 @@
     <MonoAOTBundleLLVMOptimizer Condition="'$(MonoAOTEnableLLVM)' == 'true' and '$(TargetsBrowser)' != 'true' and '$(TargetsWasi)' != 'true'">true</MonoAOTBundleLLVMOptimizer>
     <MonoCCompiler>$(Compiler)</MonoCCompiler>
     <MonoCCompiler Condition="'$(MonoCCompiler)' == ''">clang</MonoCCompiler>
-    <_CompilerTargetArch Condition="'$(RealTargetArchitecture)' == ''">$(Platform)</_CompilerTargetArch>
-    <_CompilerTargetArch Condition="'$(RealTargetArchitecture)' != ''">$(RealTargetArchitecture)</_CompilerTargetArch>
+    <_CompilerTargetArch Condition="'$(AotHostArchitecture)' == ''">$(Platform)</_CompilerTargetArch>
+    <_CompilerTargetArch Condition="'$(AotHostArchitecture)' != ''">$(AotHostArchitecture)</_CompilerTargetArch>
     <RepositoryEngineeringCommonDir>$([MSBuild]::NormalizeDirectory('$(RepositoryEngineeringDir)', 'common'))</RepositoryEngineeringCommonDir>
     <CrossToolchainFile>$([MSBuild]::NormalizePath('$(RepositoryEngineeringCommonDir)', 'cross', 'toolchain.cmake'))</CrossToolchainFile>
     <MonoWasmThreads Condition="'$(MonoWasmBuildVariant)' == 'singlethread'">false</MonoWasmThreads>
@@ -563,11 +563,11 @@
       <_MonoCXXFLAGS Include="-Wl,--build-id=sha1" />
       <_MonoCXXFLAGS Condition="'$(Platform)' == 'arm'" Include="-march=armv7-a" />
     </ItemGroup>
-    <ItemGroup Condition="'$(RealTargetOS)' == 'linux'">
+    <ItemGroup Condition="'$(AotHostOS)' == 'linux'">
       <_MonoAOTCFLAGS Include="-Wl,--build-id=sha1" />
-      <_MonoAOTCFLAGS Condition="'$(RealTargetArchitecture)' == 'arm'" Include="-march=armv7-a" />
+      <_MonoAOTCFLAGS Condition="'$(AotHostArchitecture)' == 'arm'" Include="-march=armv7-a" />
       <_MonoAOTCXXFLAGS Include="-Wl,--build-id=sha1" />
-      <_MonoAOTCXXFLAGS Condition="'$(RealTargetArchitecture)' == 'arm'" Include="-march=armv7-a" />
+      <_MonoAOTCXXFLAGS Condition="'$(AotHostArchitecture)' == 'arm'" Include="-march=armv7-a" />
     </ItemGroup>
 
     <!-- Devloop features -->
@@ -697,7 +697,7 @@
     </PropertyGroup>
 
     <!-- Linux specific options -->
-    <ItemGroup Condition="'$(RealTargetOS)' == 'linux' or $([MSBuild]::IsOSPlatform('Linux'))">
+    <ItemGroup Condition="'$(AotHostOS)' == 'linux' or $([MSBuild]::IsOSPlatform('Linux'))">
       <_LibClang Include="$(ANDROID_NDK_ROOT)/toolchains/llvm/prebuilt/$(MonoToolchainPrebuiltOS)/lib64/libclang.so.*"/>
     </ItemGroup>
     <PropertyGroup Condition="'$(TargetsLinux)' == 'true' and '$(Platform)' == 'arm64'">
@@ -710,19 +710,19 @@
 
     <PropertyGroup>
       <_MonoLLVMTargetArchitecture>$(BuildArchitecture)</_MonoLLVMTargetArchitecture>
-      <_MonoLLVMTargetArchitecture Condition="'$(RealTargetArchitecture)' != ''">$(RealTargetArchitecture)</_MonoLLVMTargetArchitecture>
+      <_MonoLLVMTargetArchitecture Condition="'$(AotHostArchitecture)' != ''">$(AotHostArchitecture)</_MonoLLVMTargetArchitecture>
     </PropertyGroup>
 
     <!-- macOS host specific options -->
-    <ItemGroup Condition="'$(RealTargetOS)' == 'osx' or $([MSBuild]::IsOSPlatform('OSX'))">
+    <ItemGroup Condition="'$(AotHostOS)' == 'osx' or $([MSBuild]::IsOSPlatform('OSX'))">
       <MonoAOTCMakeArgs Condition="'$(_MonoLLVMTargetArchitecture)' == 'x64'" Include="-DCMAKE_OSX_ARCHITECTURES=x86_64" />
       <MonoAOTCMakeArgs Condition="'$(_MonoLLVMTargetArchitecture)' == 'x86'" Include="-DCMAKE_OSX_ARCHITECTURES=i386" />
       <MonoAOTCMakeArgs Condition="'$(_MonoLLVMTargetArchitecture)' == 'arm64'" Include="-DCMAKE_OSX_ARCHITECTURES=arm64" />
       <MonoAOTCMakeArgs Condition="'$(_MonoLLVMTargetArchitecture)' == 'arm'" Include="&quot;-DCMAKE_OSX_ARCHITECTURES=armv7%3Barmv7s&quot;" />
       <MonoAOTCMakeArgs Include="-DCMAKE_OSX_DEPLOYMENT_TARGET=$(macOSVersionMin)" />
       <MonoAOTCMakeArgs Include="-DENABLE_ICALL_EXPORT=1"/>
-      <_MonoAOTCFLAGS Condition="'$(RealTargetArchitecture)' == 'arm64'" Include="-arch arm64" />
-      <_MonoAOTCXXFLAGS Condition="'$(RealTargetArchitecture)' == 'arm64'" Include="-arch arm64" />
+      <_MonoAOTCFLAGS Condition="'$(AotHostArchitecture)' == 'arm64'" Include="-arch arm64" />
+      <_MonoAOTCXXFLAGS Condition="'$(AotHostArchitecture)' == 'arm64'" Include="-arch arm64" />
       <!-- Force running as arm64 even when invoked from an x86 msbuild process -->
       <_MonoAotBuildEnv Condition="'$(BuildArchitecture)' == 'arm64'" Include="arch -arch arm64" />
     </ItemGroup>
@@ -730,7 +730,6 @@
     <!-- WASM specific options -->
     <PropertyGroup Condition="'$(TargetsBrowser)' == 'true' or '$(TargetsWasi)' == 'true'">
       <MonoUseCrossTool>true</MonoUseCrossTool>
-      <_MonoSkipInitCompiler>true</_MonoSkipInitCompiler>
       <MonoAotAbi Condition="'$(TargetsBrowser)' == 'true'">wasm32-unknown-none</MonoAotAbi>
       <MonoAotAbi Condition="'$(TargetsWasi)' == 'true'">wasm32-unknown-wasi</MonoAotAbi>
       <MonoAotOffsetsFile>$(MonoObjCrossDir)offsets-wasm32-unknown-none.h</MonoAotOffsetsFile>
@@ -741,7 +740,7 @@
     </PropertyGroup>
 
     <!-- Windows specific options -->
-    <ItemGroup Condition="'$(RealTargetOS)' == 'windows' or $([MSBuild]::IsOSPlatform('Windows'))">
+    <ItemGroup Condition="'$(AotHostOS)' == 'windows' or $([MSBuild]::IsOSPlatform('Windows'))">
       <_MonoAOTCPPFLAGS Include="-DHOST_WIN32" />
       <_MonoAOTCPPFLAGS Include="-D__WIN32__" />
       <_MonoAOTCPPFLAGS Include="-DWIN32" />
@@ -809,14 +808,14 @@
     </ItemGroup>
 
     <!-- x64 Linux cross build options -->
-    <ItemGroup Condition="'$(RealTargetArchitecture)' == 'x64' and '$(RealTargetOS)' == 'linux'">
+    <ItemGroup Condition="'$(AotHostArchitecture)' == 'x64' and '$(AotHostOS)' == 'linux'">
       <MonoAOTCMakeArgs Include="-DCMAKE_TOOLCHAIN_FILE=$(CrossToolchainFile)" />
       <_MonoAotBuildEnv Include="TARGET_BUILD_ARCH=x64" />
       <_MonoAotBuildEnv Include="PKG_CONFIG_PATH=$(MonoCrossDir)/usr/lib/x86_64-linux-gnu/pkgconfig" />
     </ItemGroup>
 
     <!-- ARM Linux cross build options on CI -->
-    <ItemGroup Condition="'$(RealTargetArchitecture)' == 'arm64' and '$(RealTargetOS)' == 'linux'">
+    <ItemGroup Condition="'$(AotHostArchitecture)' == 'arm64' and '$(AotHostOS)' == 'linux'">
       <MonoAOTCMakeArgs Include="-DCMAKE_TOOLCHAIN_FILE=$(CrossToolchainFile)" />
       <_MonoAotBuildEnv Include="TARGET_BUILD_ARCH=arm64" />
       <_MonoAotBuildEnv Include="PKG_CONFIG_PATH=$(MonoCrossDir)/usr/lib/aarch64-linux-gnu/pkgconfig" />
@@ -850,7 +849,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <_MonoSkipInitCompiler Condition="'$(RealTargetArchitecture)' != '' and '$(RealTargetArchitecture)' != '$(BuildArchitecture)'">false</_MonoSkipInitCompiler>
+      <_MonoSkipInitCompiler Condition="'$(AotHostArchitecture)' != '' and '$(AotHostArchitecture)' != '$(BuildArchitecture)'">false</_MonoSkipInitCompiler>
       <_MonoSkipInitCompiler Condition="'$(CrossBuild)' == 'true'">false</_MonoSkipInitCompiler>
       <_MonoAotCrossOffsetsCommand Condition="'$(MonoUseCrossTool)' == 'true'">$(PythonCmd) $(MonoProjectRoot)mono/tools/offsets-tool/offsets-tool.py @(MonoAotCrossOffsetsToolParams, ' ')</_MonoAotCrossOffsetsCommand>
       <_MonoAotCMakeConfigureCommand>cmake @(MonoAOTCMakeArgs, ' ') $(MonoCMakeExtraArgs) &quot;$(MonoProjectRoot.TrimEnd('\/'))&quot;</_MonoAotCMakeConfigureCommand>
@@ -922,7 +921,7 @@
     </PropertyGroup>
     <PropertyGroup>
       <_MonoLLVMTargetArchitecture>$(BuildArchitecture)</_MonoLLVMTargetArchitecture>
-      <_MonoLLVMTargetArchitecture Condition="'$(TargetArchitecture)' != 'wasm' and '$(RealTargetArchitecture)' != ''">$(RealTargetArchitecture)</_MonoLLVMTargetArchitecture>
+      <_MonoLLVMTargetArchitecture Condition="'$(TargetArchitecture)' != 'wasm' and '$(AotHostArchitecture)' != ''">$(AotHostArchitecture)</_MonoLLVMTargetArchitecture>
     </PropertyGroup>
 
     <!-- Copy Mono runtime files to artifacts directory -->

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -808,7 +808,7 @@
     </ItemGroup>
 
     <!-- AOT compiler cross-build options  -->
-    <ItemGroup Condition="'$(AotHostArchitecture)' != ''">
+    <ItemGroup Condition="'$(AotHostArchitecture)' != '' and '$(MonoCrossDir)' != ''">
       <MonoAOTCMakeArgs Include="-DCMAKE_TOOLCHAIN_FILE=$(CrossToolchainFile)" />
       <_MonoAotBuildEnv Include="TARGET_BUILD_ARCH=$(AotHostArchitecture)" />
     </ItemGroup>

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -807,17 +807,19 @@
       <MonoAotCrossOffsetsToolParams Condition="'$(TargetsWasi)' == 'true'" Include="--wasi-sdk=&quot;$([MSBuild]::NormalizePath('$(WASI_SDK_PATH)'))&quot;" />
     </ItemGroup>
 
+    <!-- AOT compiler cross-build options  -->
+    <ItemGroup Condition="'$(AotHostArchitecture)' != ''">
+      <MonoAOTCMakeArgs Include="-DCMAKE_TOOLCHAIN_FILE=$(CrossToolchainFile)" />
+      <_MonoAotBuildEnv Include="TARGET_BUILD_ARCH=$(AotHostArchitecture)" />
+    </ItemGroup>
+
     <!-- x64 Linux cross build options -->
     <ItemGroup Condition="'$(AotHostArchitecture)' == 'x64' and '$(AotHostOS)' == 'linux'">
-      <MonoAOTCMakeArgs Include="-DCMAKE_TOOLCHAIN_FILE=$(CrossToolchainFile)" />
-      <_MonoAotBuildEnv Include="TARGET_BUILD_ARCH=x64" />
       <_MonoAotBuildEnv Include="PKG_CONFIG_PATH=$(MonoCrossDir)/usr/lib/x86_64-linux-gnu/pkgconfig" />
     </ItemGroup>
 
     <!-- ARM Linux cross build options on CI -->
     <ItemGroup Condition="'$(AotHostArchitecture)' == 'arm64' and '$(AotHostOS)' == 'linux'">
-      <MonoAOTCMakeArgs Include="-DCMAKE_TOOLCHAIN_FILE=$(CrossToolchainFile)" />
-      <_MonoAotBuildEnv Include="TARGET_BUILD_ARCH=arm64" />
       <_MonoAotBuildEnv Include="PKG_CONFIG_PATH=$(MonoCrossDir)/usr/lib/aarch64-linux-gnu/pkgconfig" />
     </ItemGroup>
 

--- a/src/mono/monoaotcross.proj
+++ b/src/mono/monoaotcross.proj
@@ -38,11 +38,11 @@
 
     <MSBuild Targets="Build"
              Projects="$(MSBuildThisFileDirectory)llvm\llvm-init.proj"
-             Properties="TargetArchitecture=$(MonoAotTargetArchitecture);TargetOS=$(MonoAotTargetOS);RealTargetArchitecture=$(TargetArchitecture)" />
+             Properties="TargetArchitecture=$(MonoAotTargetArchitecture);TargetOS=$(MonoAotTargetOS);AotHostArchitecture=$(TargetArchitecture)" />
 
     <MSBuild Targets="BuildMono"
              Projects="$(MSBuildThisFileDirectory)mono.proj"
-             Properties="RealTargetOS=$(TargetOS);RealTargetArchitecture=$(TargetArchitecture);BuildMonoAOTCrossCompilerOnly=true;SkipMonoCrossJitConfigure=$(SkipMonoCrossJitConfigure);TargetArchitecture=$(MonoAotTargetArchitecture);TargetOS=$(MonoAotTargetOS)" />
+             Properties="AotHostOS=$(TargetOS);AotHostArchitecture=$(TargetArchitecture);BuildMonoAOTCrossCompilerOnly=true;SkipMonoCrossJitConfigure=$(SkipMonoCrossJitConfigure);TargetArchitecture=$(MonoAotTargetArchitecture);TargetOS=$(MonoAotTargetOS)" />
 
     <ItemGroup>
       <_MonoAOTCrossFiles Include="$(ArtifactsBinDir)mono\$(MonoAotTargetOS).$(MonoAotTargetArchitecture).$(Configuration)\cross\$(MonoAotTargetRid.ToLower())\**" />

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -421,12 +421,14 @@
     <PropertyGroup>
       <WasmRunV8ScriptPath Condition="'$(WasmRunV8ScriptPath)' == ''">$(WasmAppDir)run-v8.sh</WasmRunV8ScriptPath>
       <_WasmMainJSFileName>$([System.IO.Path]::GetFileName('$(WasmMainJSPath)'))</_WasmMainJSFileName>
+      <V8ScriptShebang Condition="'$(OS)' != 'Windows_NT'">#!/bin/sh</V8ScriptShebang>
     </PropertyGroup>
 
     <Error Condition="'$(WasmMainAssemblyFileName)' == ''" Text="%24(WasmMainAssemblyFileName) property needs to be set for generating $(WasmRunV8ScriptPath)." />
+    
     <WriteLinesToFile
       File="$(WasmRunV8ScriptPath)"
-      Lines="v8 --expose_wasm --module $(_WasmMainJSFileName) -- ${RUNTIME_ARGS} --run $(WasmMainAssemblyFileName) $*"
+      Lines="$(V8ScriptShebang);v8 --expose_wasm --module $(_WasmMainJSFileName) -- ${RUNTIME_ARGS} --run $(WasmMainAssemblyFileName) $*"
       Overwrite="true">
     </WriteLinesToFile>
 


### PR DESCRIPTION
This is one of the last official build targets that we weren't already using CBL-Mariner to build with.