### PR TITLE
JIT: make global morph its own phase, morph blocks in RPO

### DIFF
--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -1396,6 +1396,11 @@ BasicBlock* Compiler::bbNewBasicBlock(BBjumpKinds jumpKind)
 
     block = new (this, CMK_BasicBlock) BasicBlock;
 
+    if (fgTrackNewBlockCreation)
+    {
+        fgNewBBs->push_back(block);
+    }
+
 #if MEASURE_BLOCK_SIZE
     BasicBlock::s_Count += 1;
     BasicBlock::s_Size += sizeof(*block);
@@ -1495,6 +1500,35 @@ BasicBlock* Compiler::bbNewBasicBlock(BBjumpKinds jumpKind)
     block->bbPostorderNum = 0;
 
     return block;
+}
+
+//------------------------------------------------------------------------
+// fgEnableNewBlockTracking: start tracking creation of new blocks
+//
+void Compiler::fgEnableNewBlockTracking()
+{
+    assert(!fgTrackNewBlockCreation);
+    fgTrackNewBlockCreation = true;
+
+    if (fgNewBBs == nullptr)
+    {
+        CompAllocator allocator = getAllocator(CMK_BasicBlock);
+        fgNewBBs                = new (allocator) jitstd::vector<BasicBlock*>(allocator);
+    }
+
+    fgNewBBs->clear();
+}
+
+//------------------------------------------------------------------------
+// fgDisableNewBlockTracking: stop tracking creation of new blocks
+//
+// Notes:
+//   Does not alter fgNewBBs
+//
+void Compiler::fgDisableNewBlockTracking()
+{
+    assert(fgTrackNewBlockCreation);
+    fgTrackNewBlockCreation = false;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4765,9 +4765,10 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
 
     // Morph the trees in all the blocks of the method
     //
-    auto morphGlobalPhase = [this]() {
-        unsigned prevBBCount = fgBBcount;
-        fgMorphBlocks();
+    unsigned const preMorphBBCount = fgBBcount;
+    DoPhase(this, PHASE_MORPH_GLOBAL, &Compiler::fgMorphBlocks);
+
+    auto postMorphPhase = [this]() {
 
         // Fix any LclVar annotations on discarded struct promotion temps for implicit by-ref args
         fgMarkDemotedImplicitByRefArgs();
@@ -4783,16 +4784,17 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         compCurBB = nullptr;
 #endif // DEBUG
 
-        // If we needed to create any new BasicBlocks then renumber the blocks
-        if (fgBBcount > prevBBCount)
-        {
-            fgRenumberBlocks();
-        }
-
         // Enable IR checks
         activePhaseChecks |= PhaseChecks::CHECK_IR;
     };
-    DoPhase(this, PHASE_MORPH_GLOBAL, morphGlobalPhase);
+    DoPhase(this, PHASE_POST_MORPH, postMorphPhase);
+
+    // If we needed to create any new BasicBlocks then renumber the blocks
+    //
+    if (fgBBcount > preMorphBBCount)
+    {
+        fgRenumberBlocks();
+    }
 
     // GS security checks for unsafe buffers
     //

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4751,9 +4751,9 @@ public:
 
     FoldResult fgFoldConditional(BasicBlock* block);
 
+    PhaseStatus fgMorphBlocks();
+    void fgMorphBlock(BasicBlock* block);
     void fgMorphStmts(BasicBlock* block);
-    void fgMorphBlocks();
-
     void fgMergeBlockReturn(BasicBlock* block);
 
     bool fgMorphBlockStmt(BasicBlock* block, Statement* stmt DEBUGARG(const char* msg));

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3182,6 +3182,12 @@ public:
     bool fgSafeBasicBlockCreation;
 #endif
 
+    bool fgTrackNewBlockCreation;
+    jitstd::vector<BasicBlock*>* fgNewBBs;
+
+    void fgEnableNewBlockTracking();
+    void fgDisableNewBlockTracking();
+
     BasicBlock* bbNewBasicBlock(BBjumpKinds jumpKind);
 
     /*

--- a/src/coreclr/jit/compphases.h
+++ b/src/coreclr/jit/compphases.h
@@ -48,6 +48,7 @@ CompPhaseNameMacro(PHASE_FWD_SUB,                    "Forward Substitution",    
 CompPhaseNameMacro(PHASE_MORPH_IMPBYREF,             "Morph - ByRefs",                 false, -1, false)
 CompPhaseNameMacro(PHASE_PROMOTE_STRUCTS,            "Morph - Promote Structs",        false, -1, false)
 CompPhaseNameMacro(PHASE_MORPH_GLOBAL,               "Morph - Global",                 false, -1, false)
+CompPhaseNameMacro(PHASE_POST_MORPH,                 "Post-Morph",                     false, -1, false)
 CompPhaseNameMacro(PHASE_MORPH_END,                  "Morph - Finish",                 false, -1, true)
 CompPhaseNameMacro(PHASE_GS_COOKIE,                  "GS Cookie",                      false, -1, false)
 CompPhaseNameMacro(PHASE_COMPUTE_EDGE_WEIGHTS,       "Compute edge weights (1, false)",false, -1, false)

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -84,6 +84,9 @@ void Compiler::fgInit()
     fgSafeBasicBlockCreation = true;
 #endif // DEBUG
 
+    fgTrackNewBlockCreation = false;
+    fgNewBBs                = nullptr;
+
     fgLocalVarLivenessDone = false;
     fgIsDoingEarlyLiveness = false;
     fgDidEarlyLiveness     = false;

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2785,6 +2785,10 @@ void Compiler::fgDebugCheckBBlist(bool checkBBNum /* = false */, bool checkBBRef
     fgDebugCheckBlockLinks();
     fgFirstBBisScratch();
 
+    // We should not be leaving new block tracking enabled across phases
+    //
+    assert(!fgTrackNewBlockCreation);
+
     if (fgBBcount > 10000 && expensiveDebugCheckLevel < 1)
     {
         // The basic block checks are too expensive if there are too many blocks,

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -831,6 +831,7 @@ void MorphCopyBlockHelper::MorphStructCases()
         bool srcFldIsProfitable = ((m_srcVarDsc != nullptr) && (!m_srcVarDsc->lvDoNotEnregister ||
                                                                 (m_srcVarDsc->HasGCPtr() && (m_dstVarDsc == nullptr)) ||
                                                                 (m_srcVarDsc->lvFieldCnt == 1)));
+
         // Are both dest and src promoted structs?
         if (m_dstDoFldStore && m_srcDoFldStore && (dstFldIsProfitable || srcFldIsProfitable))
         {


### PR DESCRIPTION
Some refactoring in antcipation of enabling cross-block local assertion prop during global morph.

Process blocks in RPO. Try and verify that no newly added blocks can alter the set of assertions that flow into the pre-existing ones.