### PR TITLE
The CLA bot can now be rerun with a comment. Fix broken CLA links.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,7 @@ Also do your best to factor commits appropriately, not too large with unrelated 
 
 ### Contributor License Agreement
 
-You must sign a [.NET Foundation Contribution License Agreement (CLA)](https://cla.dotnetfoundation.org) before your PR will be merged. This is a one-time requirement for projects in the .NET Foundation. You can read more about [Contribution License Agreements (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) on Wikipedia.
+You must sign a .NET Foundation Contribution License Agreement (CLA) before your PR will be merged. This is a one-time requirement for projects in the .NET Foundation. You can read more about [Contribution License Agreements (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) on Wikipedia and the [Microsoft Open Source](https://opensource.microsoft.com/cla/) program.
 
 The agreement: [net-foundation-contribution-license-agreement.pdf](https://github.com/dotnet/home/blob/master/guidance/net-foundation-contribution-license-agreement.pdf)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,9 +147,7 @@ Also do your best to factor commits appropriately, not too large with unrelated 
 
 You must sign a .NET Foundation Contribution License Agreement (CLA) before your PR will be merged. This is a one-time requirement for projects in the .NET Foundation. You can read more about [Contribution License Agreements (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) on Wikipedia and the [Microsoft Open Source](https://opensource.microsoft.com/cla/) program.
 
-The agreement: [net-foundation-contribution-license-agreement.pdf](https://github.com/dotnet/home/blob/master/guidance/net-foundation-contribution-license-agreement.pdf)
-
-You don't have to do this up-front. You can simply clone, fork, and submit your pull-request as usual. When your pull-request is created, it is classified by a CLA bot. If the change is trivial (for example, you just fixed a typo), then the PR is labelled with `cla-not-required`. Otherwise it's classified as `cla-required`. Once you signed a CLA, the current and all future pull-requests will be labelled as `cla-signed`.
+You don't have to do this up-front. You can simply clone, fork, and submit your pull-request as usual. When your pull-request is created, it is classified by a CLA bot. If the change is trivial (for example, you just fixed a typo), then the PR is labelled with `cla-not-required`. Otherwise it's classified as `cla-required` and the CLA bot will present the agreement to you on the pull-request. The CLA bot will provide a prompt to sign the CLA through a comment on the pull-request. Once you sign a CLA, the current and all future pull-requests will be labelled as `cla-signed`.
 
 ### File Headers
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,7 @@ Also do your best to factor commits appropriately, not too large with unrelated 
 
 ### Contributor License Agreement
 
-You must sign a .NET Foundation Contribution License Agreement (CLA) before your PR will be merged. This is a one-time requirement for projects in the .NET Foundation. You can read more about [Contribution License Agreements (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) on Wikipedia and the [Microsoft Open Source](https://opensource.microsoft.com/cla/) program.
+You must sign a [.NET Foundation Contribution License Agreement (CLA)](https://cla.dotnetfoundation.org) before your PR will be merged. This is a one-time requirement for projects in the .NET Foundation. You can read more about [Contribution License Agreements (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) on Wikipedia and the [Microsoft Open Source](https://opensource.microsoft.com/cla/) program.
 
 You don't have to do this up-front. You can simply clone, fork, and submit your pull-request as usual. When your pull-request is created, it is classified by a CLA bot. If the change is trivial (for example, you just fixed a typo), then the PR is labelled with `cla-not-required`. Otherwise it's classified as `cla-required` and the CLA bot will present the agreement to you on the pull-request. The CLA bot will provide a prompt to sign the CLA through a comment on the pull-request. Once you sign a CLA, the current and all future pull-requests will be labelled as `cla-signed`.
 

--- a/docs/project/copyright.md
+++ b/docs/project/copyright.md
@@ -14,7 +14,7 @@ We use the following approach for code contributions:
 - Contributions (like ports) can be based on existing code or algorithms that are licensed with a permissive [OSI-approved licenses](https://opensource.org/licenses) (for example, [MIT](https://opensource.org/licenses/MIT), [Apache 2](https://opensource.org/licenses/Apache-2.0), and [BSD](https://opensource.org/licenses/BSD-3-Clause)) and should be ackowledged in the [repo THIRD-PARTY-NOTICE](/THIRD-PARTY-NOTICES.TXT) file.
 - Non-product contributions (like tests) can be based on existing code or algorithms that are licensed with any OSI-approved license (including [GPL](https://opensource.org/licenses/GPL-2.0)) and should be acknowleged in a local THIRD-PARTY-NOTICE file (for example, [SciMark/THIRD-PARTY-NOTICES](/src/tests/JIT/Performance/CodeQuality/SciMark/THIRD-PARTY-NOTICES)).
 - We will typically reject the use of product code licensed with [Creative Commons](https://creativecommons.org/) or [public domain licenses](https://en.wikipedia.org/wiki/Public-domain-equivalent_license) given their lack of universal acceptance.
-- The [.NET Foundation Contribution License Agreement (CLA)](https://cla.dotnetfoundation.org) is used to license contributions from contributors.
+- The [.NET Foundation Contribution License Agreement (CLA)](https://github.com/dotnet-foundation/foundation/blob/master/guidance/net-foundation-contribution-license-agreement.pdf) is used to license contributions from contributors.
 
 References:
 

--- a/docs/project/copyright.md
+++ b/docs/project/copyright.md
@@ -14,7 +14,7 @@ We use the following approach for code contributions:
 - Contributions (like ports) can be based on existing code or algorithms that are licensed with a permissive [OSI-approved licenses](https://opensource.org/licenses) (for example, [MIT](https://opensource.org/licenses/MIT), [Apache 2](https://opensource.org/licenses/Apache-2.0), and [BSD](https://opensource.org/licenses/BSD-3-Clause)) and should be ackowledged in the [repo THIRD-PARTY-NOTICE](/THIRD-PARTY-NOTICES.TXT) file.
 - Non-product contributions (like tests) can be based on existing code or algorithms that are licensed with any OSI-approved license (including [GPL](https://opensource.org/licenses/GPL-2.0)) and should be acknowleged in a local THIRD-PARTY-NOTICE file (for example, [SciMark/THIRD-PARTY-NOTICES](/src/tests/JIT/Performance/CodeQuality/SciMark/THIRD-PARTY-NOTICES)).
 - We will typically reject the use of product code licensed with [Creative Commons](https://creativecommons.org/) or [public domain licenses](https://en.wikipedia.org/wiki/Public-domain-equivalent_license) given their lack of universal acceptance.
-- The [.NET Foundation Contribution License Agreement (CLA)](https://github.com/dotnet-foundation/foundation/blob/master/guidance/net-foundation-contribution-license-agreement.pdf) is used to license contributions from contributors.
+- The .NET Foundation Contribution License Agreement (CLA) is used to license contributions from contributors.
 
 References:
 

--- a/docs/project/copyright.md
+++ b/docs/project/copyright.md
@@ -14,7 +14,7 @@ We use the following approach for code contributions:
 - Contributions (like ports) can be based on existing code or algorithms that are licensed with a permissive [OSI-approved licenses](https://opensource.org/licenses) (for example, [MIT](https://opensource.org/licenses/MIT), [Apache 2](https://opensource.org/licenses/Apache-2.0), and [BSD](https://opensource.org/licenses/BSD-3-Clause)) and should be ackowledged in the [repo THIRD-PARTY-NOTICE](/THIRD-PARTY-NOTICES.TXT) file.
 - Non-product contributions (like tests) can be based on existing code or algorithms that are licensed with any OSI-approved license (including [GPL](https://opensource.org/licenses/GPL-2.0)) and should be acknowleged in a local THIRD-PARTY-NOTICE file (for example, [SciMark/THIRD-PARTY-NOTICES](/src/tests/JIT/Performance/CodeQuality/SciMark/THIRD-PARTY-NOTICES)).
 - We will typically reject the use of product code licensed with [Creative Commons](https://creativecommons.org/) or [public domain licenses](https://en.wikipedia.org/wiki/Public-domain-equivalent_license) given their lack of universal acceptance.
-- The .NET Foundation Contribution License Agreement (CLA) is used to license contributions from contributors.
+- The [.NET Foundation Contribution License Agreement (CLA)](https://cla.dotnetfoundation.org) is used to license contributions from contributors.
 
 References:
 

--- a/docs/workflow/ci/failure-analysis.md
+++ b/docs/workflow/ci/failure-analysis.md
@@ -43,7 +43,7 @@ Validation may fail for several reasons, and for each one we have a different re
   * Or, amend your commit with `--amend --no-edit` and force push to your branch.
 
 ### Additional information:
-  * In the rare case the license/cla check fails to register a response, close and reopen the PR or push an empty commit.
+  * If the license/cla check fails to register a response, the check can be rerun by submitting a `@dotnet-policy-service rerun` comment to the PR.
   * Reach out to the infrastructure team for assistance on [Teams channel](https://teams.microsoft.com/l/channel/19%3ab27b36ecd10a46398da76b02f0411de7%40thread.skype/Infrastructure?groupId=014ca51d-be57-47fa-9628-a15efcc3c376&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47) (for corpnet users) or on [Gitter](https://gitter.im/dotnet/community) in other cases.
 
 ## What to do if you determine the failure is unrelated


### PR DESCRIPTION
With https://github.com/microsoft/ContributorLicenseAgreement/issues/123, we can rerun the CLA bot if it fails. There were also some broken CLA links. I reworked the content since there's no longer a .NET Foundation page for the CLA.

Command to rerun the bot: `@dotnet-policy-service rerun`