### PR TITLE
Fix packs subset build

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -62,7 +62,7 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <ItemGroup>
       <NetCoreAppNativeLibrary Include="System.Native" />
-      <NetCoreAppNativeLibrary Include="System.Globalization.Native" Condition="'$(StaticICULinking)' != 'true'" />
+      <NetCoreAppNativeLibrary Include="System.Globalization.Native" Condition="'$(StaticICULinking)' != 'true' and '$(InvariantGlobalization)' != 'true'" />
       <NetCoreAppNativeLibrary Include="System.IO.Compression.Native" />
       <NetCoreAppNativeLibrary Include="System.Net.Security.Native" />
       <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.Apple" Condition="'$(_IsApplePlatform)' == 'true'" />
@@ -78,7 +78,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <NativeLibrary Include="@(NetCoreAppNativeLibrary->'%(EscapedPath)')" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(StaticICULinking)' == 'true' and '$(NativeLib)' != 'Static'">
+    <ItemGroup Condition="'$(StaticICULinking)' == 'true' and '$(NativeLib)' != 'Static' and '$(InvariantGlobalization)' != 'true'">
       <NativeLibrary Include="$(IntermediateOutputPath)libs/System.Globalization.Native/build/libSystem.Globalization.Native.a" />
       <DirectPInvoke Include="libSystem.Globalization.Native" />
       <StaticICULibs Include="-Wl,-Bstatic" Condition="'$(StaticExecutable)' != 'true'" />
@@ -218,7 +218,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     </Exec>
 
     <Exec Command="CC=&quot;$(CppLinker)&quot; &quot;$(IlcHostPackagePath)/native/src/libs/build-local.sh&quot; &quot;$(IlcHostPackagePath)/&quot; &quot;$(IntermediateOutputPath)&quot; System.Globalization.Native"
-        Condition="'$(StaticICULinking)' == 'true'" />
+        Condition="'$(StaticICULinking)' == 'true' and '$(InvariantGlobalization)' != 'true'" />
 
     <Exec Command="CC=&quot;$(CppLinker)&quot; &quot;$(IlcHostPackagePath)/native/src/libs/build-local.sh&quot; &quot;$(IlcHostPackagePath)/&quot; &quot;$(IntermediateOutputPath)&quot; System.Security.Cryptography.Native"
         Condition="'$(StaticOpenSslLinking)' == 'true'" />


### PR DESCRIPTION
osx-arm64 build is failing since https://github.com/dotnet/runtime/commit/99bcf66f5e1b8df2ed1d6885470a4fa823e366ad:

```sh
$ ./build.sh clr+libs+packs
...
  ILCompiler.ReadyToRun -> /Users/am11/projects/runtime/artifacts/bin/ILCompiler.ReadyToRun/arm64/Debug/ILCompiler.ReadyToRun.dll
  crossgen2 -> /Users/am11/projects/runtime/artifacts/bin/coreclr/osx.arm64.Debug/crossgen2/crossgen2.dll
  Generating native code
  Undefined symbols for architecture arm64:
    "_u_charsToUChars_ptr", referenced from:
        _u_charsToUChars_safe in libSystem.Globalization.Native.a(pal_locale.c.o)
    "_u_strcmp_ptr", referenced from:
        _FixupTimeZoneGenericDisplayName in libSystem.Globalization.Native.a(pal_timeZoneInfo.c.o)
    "_u_strcpy_ptr", referenced from:
        _FixupTimeZoneGenericDisplayName in libSystem.Globalization.Native.a(pal_timeZoneInfo.c.o)
    "_u_strlen_ptr", referenced from:
        _NormalizeNumericPattern in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
        _FixupTimeZoneGenericDisplayName in libSystem.Globalization.Native.a(pal_timeZoneInfo.c.o)
    "_u_uastrncpy_ptr", referenced from:
        _FixupTimeZoneGenericDisplayName in libSystem.Globalization.Native.a(pal_timeZoneInfo.c.o)
    "_ucal_add_ptr", referenced from:
        _GlobalizationNative_GetJapaneseEraStartDate in libSystem.Globalization.Native.a(pal_calendarData.c.o)
    "_ucal_close_ptr", referenced from:
        _EnumSymbols in libSystem.Globalization.Native.a(pal_calendarData.c.o)
        _GlobalizationNative_GetLatestJapaneseEra in libSystem.Globalization.Native.a(pal_calendarData.c.o)
        _GlobalizationNative_GetJapaneseEraStartDate in libSystem.Globalization.Native.a(pal_calendarData.c.o)
        _GlobalizationNative_GetLocaleInfoInt in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
        _GetTimeZoneDisplayName_FromCalendar in libSystem.Globalization.Native.a(pal_timeZoneInfo.c.o)
        _FixupTimeZoneGenericDisplayName in libSystem.Globalization.Native.a(pal_timeZoneInfo.c.o)
    "_ucal_getAttribute_ptr", referenced from:
        _GlobalizationNative_GetLocaleInfoInt in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
    "_ucal_getKeywordValuesForLocale_ptr", referenced from:
        _GlobalizationNative_GetCalendars in libSystem.Globalization.Native.a(pal_calendarData.c.o)
    "_ucal_getNow_ptr", referenced from:
        _GlobalizationNative_GetTimeZoneDisplayName in libSystem.Globalization.Native.a(pal_timeZoneInfo.c.o)
    "_ucal_getTimeZoneDisplayName_ptr", referenced from:
        _GetTimeZoneDisplayName_FromCalendar in libSystem.Globalization.Native.a(pal_timeZoneInfo.c.o)
        _FixupTimeZoneGenericDisplayName in libSystem.Globalization.Native.a(pal_timeZoneInfo.c.o)
    "_ucal_getTimeZoneIDForWindowsID_ptr", referenced from:
        _GlobalizationNative_WindowsIdToIanaId in libSystem.Globalization.Native.a(pal_timeZoneInfo.c.o)
    "_ucal_getWindowsTimeZoneID_ptr", referenced from:
        _GlobalizationNative_IanaIdToWindowsId in libSystem.Globalization.Native.a(pal_timeZoneInfo.c.o)
    "_ucal_get_ptr", referenced from:
        _GlobalizationNative_GetLatestJapaneseEra in libSystem.Globalization.Native.a(pal_calendarData.c.o)
        _GlobalizationNative_GetJapaneseEraStartDate in libSystem.Globalization.Native.a(pal_calendarData.c.o)
        _FixupTimeZoneGenericDisplayName in libSystem.Globalization.Native.a(pal_timeZoneInfo.c.o)
    "_ucal_openTimeZoneIDEnumeration_ptr", referenced from:
        _FixupTimeZoneGenericDisplayName in libSystem.Globalization.Native.a(pal_timeZoneInfo.c.o)
    "_ucal_open_ptr", referenced from:
        _EnumSymbols in libSystem.Globalization.Native.a(pal_calendarData.c.o)
        _GlobalizationNative_GetLatestJapaneseEra in libSystem.Globalization.Native.a(pal_calendarData.c.o)
        _GlobalizationNative_GetJapaneseEraStartDate in libSystem.Globalization.Native.a(pal_calendarData.c.o)
        _GlobalizationNative_GetLocaleInfoInt in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
        _GetTimeZoneDisplayName_FromCalendar in libSystem.Globalization.Native.a(pal_timeZoneInfo.c.o)
        _FixupTimeZoneGenericDisplayName in libSystem.Globalization.Native.a(pal_timeZoneInfo.c.o)
    "_ucal_setMillis_ptr", referenced from:
        _GetTimeZoneDisplayName_FromCalendar in libSystem.Globalization.Native.a(pal_timeZoneInfo.c.o)
        _FixupTimeZoneGenericDisplayName in libSystem.Globalization.Native.a(pal_timeZoneInfo.c.o)
    "_ucal_set_ptr", referenced from:
        _GlobalizationNative_GetLatestJapaneseEra in libSystem.Globalization.Native.a(pal_calendarData.c.o)
        _GlobalizationNative_GetJapaneseEraStartDate in libSystem.Globalization.Native.a(pal_calendarData.c.o)
    "_udat_close_ptr", referenced from:
        _InvokeCallbackForDatePattern in libSystem.Globalization.Native.a(pal_calendarData.c.o)
        _EnumSymbols in libSystem.Globalization.Native.a(pal_calendarData.c.o)
        _GlobalizationNative_GetLocaleTimeFormat in libSystem.Globalization.Native.a(pal_locale.c.o)
        _GetTimeZoneDisplayName_FromPattern in libSystem.Globalization.Native.a(pal_timeZoneInfo.c.o)
    "_udat_countSymbols_ptr", referenced from:
        _EnumSymbols in libSystem.Globalization.Native.a(pal_calendarData.c.o)
    "_udat_format_ptr", referenced from:
        _GetTimeZoneDisplayName_FromPattern in libSystem.Globalization.Native.a(pal_timeZoneInfo.c.o)
    "_udat_getSymbols_ptr", referenced from:
        _EnumSymbols in libSystem.Globalization.Native.a(pal_calendarData.c.o)
    "_udat_open_ptr", referenced from:
        _InvokeCallbackForDatePattern in libSystem.Globalization.Native.a(pal_calendarData.c.o)
        _EnumSymbols in libSystem.Globalization.Native.a(pal_calendarData.c.o)
        _GlobalizationNative_GetLocaleTimeFormat in libSystem.Globalization.Native.a(pal_locale.c.o)
        _GetTimeZoneDisplayName_FromPattern in libSystem.Globalization.Native.a(pal_timeZoneInfo.c.o)
    "_udat_setCalendar_ptr", referenced from:
        _EnumSymbols in libSystem.Globalization.Native.a(pal_calendarData.c.o)
    "_udat_toPattern_ptr", referenced from:
        _InvokeCallbackForDatePattern in libSystem.Globalization.Native.a(pal_calendarData.c.o)
        _GlobalizationNative_GetLocaleTimeFormat in libSystem.Globalization.Native.a(pal_locale.c.o)
    "_udatpg_close_ptr", referenced from:
        _GetMonthDayPattern in libSystem.Globalization.Native.a(pal_calendarData.c.o)
        _InvokeCallbackForDateTimePattern in libSystem.Globalization.Native.a(pal_calendarData.c.o)
    "_udatpg_getBestPattern_ptr", referenced from:
        _GetMonthDayPattern in libSystem.Globalization.Native.a(pal_calendarData.c.o)
        _InvokeCallbackForDateTimePattern in libSystem.Globalization.Native.a(pal_calendarData.c.o)
    "_udatpg_open_ptr", referenced from:
        _GetMonthDayPattern in libSystem.Globalization.Native.a(pal_calendarData.c.o)
        _InvokeCallbackForDateTimePattern in libSystem.Globalization.Native.a(pal_calendarData.c.o)
    "_uenum_close_ptr", referenced from:
        _GlobalizationNative_GetCalendars in libSystem.Globalization.Native.a(pal_calendarData.c.o)
        _FixupTimeZoneGenericDisplayName in libSystem.Globalization.Native.a(pal_timeZoneInfo.c.o)
    "_uenum_count_ptr", referenced from:
        _GlobalizationNative_GetCalendars in libSystem.Globalization.Native.a(pal_calendarData.c.o)
        _FixupTimeZoneGenericDisplayName in libSystem.Globalization.Native.a(pal_timeZoneInfo.c.o)
    "_uenum_next_ptr", referenced from:
        _GlobalizationNative_GetCalendars in libSystem.Globalization.Native.a(pal_calendarData.c.o)
        _FixupTimeZoneGenericDisplayName in libSystem.Globalization.Native.a(pal_timeZoneInfo.c.o)
    "_uldn_close_ptr", referenced from:
        _GetNativeCalendarName in libSystem.Globalization.Native.a(pal_calendarData.c.o)
    "_uldn_keyValueDisplayName_ptr", referenced from:
        _GetNativeCalendarName in libSystem.Globalization.Native.a(pal_calendarData.c.o)
    "_uldn_open_ptr", referenced from:
        _GetNativeCalendarName in libSystem.Globalization.Native.a(pal_calendarData.c.o)
    "_uloc_canonicalize_ptr", referenced from:
        _GetLocale in libSystem.Globalization.Native.a(pal_locale.c.o)
    "_uloc_countAvailable_ptr", referenced from:
        _GlobalizationNative_GetLocales in libSystem.Globalization.Native.a(pal_locale.c.o)
    "_uloc_getAvailable_ptr", referenced from:
        _GlobalizationNative_GetLocales in libSystem.Globalization.Native.a(pal_locale.c.o)
    "_uloc_getBaseName_ptr", referenced from:
        _GlobalizationNative_GetDefaultLocaleName in libSystem.Globalization.Native.a(pal_locale.c.o)
    "_uloc_getCharacterOrientation_ptr", referenced from:
        _GlobalizationNative_GetLocaleInfoInt in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
    "_uloc_getDefault_ptr", referenced from:
        _DetectDefaultLocaleName in libSystem.Globalization.Native.a(pal_locale.c.o)
    "_uloc_getKeywordValue_ptr", referenced from:
        _GlobalizationNative_GetDefaultLocaleName in libSystem.Globalization.Native.a(pal_locale.c.o)
    "_uloc_getLCID_ptr", referenced from:
        _GlobalizationNative_GetLocaleInfoInt in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
    "_uloc_getLanguage_ptr", referenced from:
        _GetLocale in libSystem.Globalization.Native.a(pal_locale.c.o)
    "_uloc_getName_ptr", referenced from:
        _GetLocale in libSystem.Globalization.Native.a(pal_locale.c.o)
    "_uloc_getParent_ptr", referenced from:
        _EnumAbbrevEraNames in libSystem.Globalization.Native.a(pal_calendarData.c.o)
    "_uloc_setKeywordValue_ptr", referenced from:
        _EnumSymbols in libSystem.Globalization.Native.a(pal_calendarData.c.o)
    "_ulocdata_getMeasurementSystem_ptr", referenced from:
        _GetMeasurementSystem in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
    "_unum_close_ptr", referenced from:
        _GlobalizationNative_GetLocaleInfoInt in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
        _GetNumberNegativePattern in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
        _GetCurrencyPositivePattern in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
        _GetCurrencyNegativePattern in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
        _GetPercentNegativePattern in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
        _GetPercentPositivePattern in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
        _GlobalizationNative_GetLocaleInfoGroupingSizes in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
        ...
    "_unum_getAttribute_ptr", referenced from:
        _GlobalizationNative_GetLocaleInfoInt in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
        _GlobalizationNative_GetLocaleInfoGroupingSizes in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
    "_unum_open_ptr", referenced from:
        _GlobalizationNative_GetLocaleInfoInt in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
        _GetNumberNegativePattern in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
        _GetCurrencyPositivePattern in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
        _GetCurrencyNegativePattern in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
        _GetPercentNegativePattern in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
        _GetPercentPositivePattern in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
        _GlobalizationNative_GetLocaleInfoGroupingSizes in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
        ...
    "_unum_toPattern_ptr", referenced from:
        _GetNumericPattern in libSystem.Globalization.Native.a(pal_localeNumberData.c.o)
    "_ures_close_ptr", referenced from:
        _CloseResBundle in libSystem.Globalization.Native.a(pal_calendarData.c.o)
        _GlobalizationNative_IsPredefinedLocale in libSystem.Globalization.Native.a(pal_locale.c.o)
    "_ures_getByKey_ptr", referenced from:
        _EnumAbbrevEraNames in libSystem.Globalization.Native.a(pal_calendarData.c.o)
    "_ures_getSize_ptr", referenced from:
        _EnumUResourceBundle in libSystem.Globalization.Native.a(pal_calendarData.c.o)
    "_ures_getStringByIndex_ptr", referenced from:
        _EnumUResourceBundle in libSystem.Globalization.Native.a(pal_calendarData.c.o)
    "_ures_open_ptr", referenced from:
        _EnumAbbrevEraNames in libSystem.Globalization.Native.a(pal_calendarData.c.o)
        _GlobalizationNative_IsPredefinedLocale in libSystem.Globalization.Native.a(pal_locale.c.o)
  ld: symbol(s) not found for architecture arm64
  clang: error: linker command failed with exit code 1 (use -v to see invocation)
/Users/am11/projects/runtime/artifacts/bin/coreclr/osx.arm64.Debug/build/Microsoft.NETCore.Native.targets(344,5): error MSB3073: The command ""/usr/bin/clang" "/Users/am11/projects/runtime/artifacts/obj/coreclr/crossgen2/arm64/Debug/native/crossgen2.o" -o "/Users/am11/projects/runtime/artifacts/bin/coreclr/osx.arm64.Debug/crossgen2/native/crossgen2" /Users/am11/projects/runtime/artifacts/bin/coreclr/osx.arm64.Debug/aotsdk/libbootstrapper.a /Users/am11/projects/runtime/artifacts/bin/coreclr/osx.arm64.Debug/aotsdk/libRuntime.ServerGC.a /Users/am11/projects/runtime/artifacts/bin/coreclr/osx.arm64.Debug/aotsdk/libeventpipe-disabled.a /Users/am11/projects/runtime/artifacts/bin/coreclr/osx.arm64.Debug/aotsdk/libstdc++compat.a /Users/am11/projects/runtime/artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Debug/runtimes/osx-arm64/native/libSystem.Native.a /Users/am11/projects/runtime/artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Debug/runtimes/osx-arm64/native/libSystem.Globalization.Native.a /Users/am11/projects/runtime/artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Debug/runtimes/osx-arm64/native/libSystem.IO.Compression.Native.a /Users/am11/projects/runtime/artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Debug/runtimes/osx-arm64/native/libSystem.Net.Security.Native.a /Users/am11/projects/runtime/artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Debug/runtimes/osx-arm64/native/libSystem.Security.Cryptography.Native.Apple.a /Users/am11/projects/runtime/artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Debug/runtimes/osx-arm64/native/libSystem.Security.Cryptography.Native.OpenSsl.a -g -Wl,-rpath,'@executable_path' -ldl -lobjc -lswiftCore -lswiftFoundation -lz -licucore -L/usr/lib/swift -lm -framework CoreFoundation -framework CryptoKit -framework Foundation -framework Security -framework GSS" exited with code 1. [/Users/am11/projects/runtime/src/coreclr/tools/aot/crossgen2/crossgen2.csproj]
```

Fix is to not link any globalization object when InvariantGlobalization=true is set on the project.