### PR TITLE
Multiple GDV: ignore non-inlineable candidates

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2197,7 +2197,7 @@ InlineCandidateInfo* GenTreeCall::GetGDVCandidateInfo(uint8_t index)
     if (gtInlineInfoCount > 1)
     {
         // In this case we should access it through gtInlineCandidateInfoList
-        return &gtInlineCandidateInfoList->at(index);
+        return gtInlineCandidateInfoList->at(index);
     }
     return gtInlineCandidateInfo;
 }
@@ -2223,15 +2223,15 @@ void GenTreeCall::AddGDVCandidateInfo(Compiler* comp, InlineCandidateInfo* candi
     else if (gtInlineInfoCount == 1)
     {
         // Upgrade gtInlineCandidateInfo to gtInlineCandidateInfoList (vector)
-        CompAllocator       allocator          = comp->getAllocator(CMK_Inlining);
-        InlineCandidateInfo firstCandidateInfo = *gtInlineCandidateInfo;
-        gtInlineCandidateInfoList              = new (allocator) jitstd::vector<InlineCandidateInfo>(allocator);
-        gtInlineCandidateInfoList->push_back(firstCandidateInfo);
-        gtInlineCandidateInfoList->push_back(*candidateInfo);
+        CompAllocator        allocator      = comp->getAllocator(CMK_Inlining);
+        InlineCandidateInfo* firstCandidate = gtInlineCandidateInfo;
+        gtInlineCandidateInfoList           = new (allocator) jitstd::vector<InlineCandidateInfo*>(allocator);
+        gtInlineCandidateInfoList->push_back(firstCandidate);
+        gtInlineCandidateInfoList->push_back(candidateInfo);
     }
     else
     {
-        gtInlineCandidateInfoList->push_back(*candidateInfo);
+        gtInlineCandidateInfoList->push_back(candidateInfo);
     }
     gtCallMoreFlags |= GTF_CALL_M_GUARDED_DEVIRT;
     gtInlineInfoCount++;
@@ -2263,10 +2263,7 @@ void GenTreeCall::RemoveGDVCandidateInfo(Compiler* comp, uint8_t index)
     // Downgrade gtInlineCandidateInfoList to gtInlineCandidateInfo
     if (gtInlineInfoCount == 1)
     {
-        InlineCandidateInfo firstItem = gtInlineCandidateInfoList->at(0);
-        gtInlineCandidateInfoList->clear();
-        gtInlineCandidateInfo  = new (comp, CMK_Inlining) InlineCandidateInfo;
-        *gtInlineCandidateInfo = firstItem;
+        gtInlineCandidateInfo = gtInlineCandidateInfoList->at(0);
     }
 }
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2194,7 +2194,12 @@ void GenTreeCall::SetSingleInlineCandidateInfo(InlineCandidateInfo* candidateInf
 InlineCandidateInfo* GenTreeCall::GetGDVCandidateInfo(uint8_t index)
 {
     assert(index < gtInlineInfoCount);
-    return &gtInlineCandidateInfo[index];
+    if (gtInlineInfoCount > 1)
+    {
+        // In this case we should access it through gtInlineCandidateInfoList
+        return &gtInlineCandidateInfoList->at(index);
+    }
+    return gtInlineCandidateInfo;
 }
 
 //-------------------------------------------------------------------------
@@ -2212,20 +2217,57 @@ void GenTreeCall::AddGDVCandidateInfo(Compiler* comp, InlineCandidateInfo* candi
 
     if (gtInlineInfoCount == 0)
     {
+        // Most calls are monomorphic, so we don't need to allocate a vector
         gtInlineCandidateInfo = candidateInfo;
     }
     else if (gtInlineInfoCount == 1)
     {
-        gtInlineCandidateInfo =
-            new (comp, CMK_Inlining) InlineCandidateInfo[MAX_GDV_TYPE_CHECKS]{*gtInlineCandidateInfo, *candidateInfo};
+        // Upgrade gtInlineCandidateInfo to gtInlineCandidateInfoList (vector)
+        CompAllocator       allocator          = comp->getAllocator(CMK_Inlining);
+        InlineCandidateInfo firstCandidateInfo = *gtInlineCandidateInfo;
+        gtInlineCandidateInfoList              = new (allocator) jitstd::vector<InlineCandidateInfo>(allocator);
+        gtInlineCandidateInfoList->push_back(firstCandidateInfo);
+        gtInlineCandidateInfoList->push_back(*candidateInfo);
     }
     else
     {
-        gtInlineCandidateInfo[gtInlineInfoCount] = *candidateInfo;
+        gtInlineCandidateInfoList->push_back(*candidateInfo);
     }
-
     gtCallMoreFlags |= GTF_CALL_M_GUARDED_DEVIRT;
     gtInlineInfoCount++;
+}
+
+//-------------------------------------------------------------------------
+// RemoveGDVCandidateInfo: Remove a guarded devirtualization (GDV) candidate info
+//     by its index. Index must not be greater than gtInlineInfoCount
+//     the call will be marked as "has no inline candidates" if the last candidate is removed
+//
+// Arguments:
+//     comp    - Compiler instance
+//     index   - GDV candidate to remove
+//
+void GenTreeCall::RemoveGDVCandidateInfo(Compiler* comp, uint8_t index)
+{
+    assert(index < gtInlineInfoCount);
+
+    if (gtInlineInfoCount == 1)
+    {
+        // No longer have any inline candidates
+        ClearInlineInfo();
+        assert(gtInlineInfoCount == 0);
+        return;
+    }
+    gtInlineCandidateInfoList->erase(gtInlineCandidateInfoList->begin() + index);
+    gtInlineInfoCount--;
+
+    // Downgrade gtInlineCandidateInfoList to gtInlineCandidateInfo
+    if (gtInlineInfoCount == 1)
+    {
+        InlineCandidateInfo firstItem = gtInlineCandidateInfoList->at(0);
+        gtInlineCandidateInfoList->clear();
+        gtInlineCandidateInfo  = new (comp, CMK_Inlining) InlineCandidateInfo;
+        *gtInlineCandidateInfo = firstItem;
+    }
 }
 
 //-------------------------------------------------------------------------

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -5548,7 +5548,7 @@ struct GenTreeCall final : public GenTree
         // gtInlineCandidateInfo is only used when inlining methods
         InlineCandidateInfo* gtInlineCandidateInfo;
         // gtInlineCandidateInfoList is used when we have more than one GDV candidate
-        jitstd::vector<InlineCandidateInfo>* gtInlineCandidateInfoList;
+        jitstd::vector<InlineCandidateInfo*>* gtInlineCandidateInfoList;
 
         HandleHistogramProfileCandidateInfo* gtHandleHistogramProfileCandidateInfo;
         LateDevirtualizationInfo*            gtLateDevirtualizationInfo;

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -5447,6 +5447,8 @@ struct GenTreeCall final : public GenTree
 
     void AddGDVCandidateInfo(Compiler* comp, InlineCandidateInfo* candidateInfo);
 
+    void RemoveGDVCandidateInfo(Compiler* comp, uint8_t index);
+
     void ClearInlineInfo()
     {
         SetSingleInlineCandidateInfo(nullptr);
@@ -5542,8 +5544,12 @@ struct GenTreeCall final : public GenTree
     union {
         // only used for CALLI unmanaged calls (CT_INDIRECT)
         GenTree* gtCallCookie;
+
         // gtInlineCandidateInfo is only used when inlining methods
-        InlineCandidateInfo*                 gtInlineCandidateInfo;
+        InlineCandidateInfo* gtInlineCandidateInfo;
+        // gtInlineCandidateInfoList is used when we have more than one GDV candidate
+        jitstd::vector<InlineCandidateInfo>* gtInlineCandidateInfoList;
+
         HandleHistogramProfileCandidateInfo* gtHandleHistogramProfileCandidateInfo;
         LateDevirtualizationInfo*            gtLateDevirtualizationInfo;
         CORINFO_GENERIC_HANDLE compileTimeHelperArgumentHandle; // Used to track type handle argument of dynamic helpers


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/86769

The current logic used to give up on **all of them** if at least one of the candidates was non-inlineable (for any reason)
E.g.:
```csharp
public interface IValue
{
    int GetValue();
}

public class MyClass1 : IValue
{
    public int GetValue() => 10;
}

public class MyClass2 : IValue
{
    [MethodImpl(MethodImplOptions.NoInlining)]
    public int GetValue() => 50;
}

public class MyClass3 : IValue
{
    public int GetValue() => 100;
}
```

Was:
```asm
; Assembly listing for method Program:Test(IValue):int
       sub      rsp, 40
       mov      r11, 0x7FFBC9420318
       call     [r11]IValue:GetValue():int:this
       nop      
       add      rsp, 40
       ret      
; Total bytes of code 23
```
Now:
```asm
; Assembly listing for method Program:Test(IValue):int
       sub      rsp, 40
       mov      r11, 0x7FFBC9FE8B40
       cmp      qword ptr [rcx], r11       ;; is it MyClass1 ?
       jne      SHORT G_M7592_IG04
       mov      eax, 10
       jmp      SHORT G_M7592_IG07
G_M7592_IG04:
       mov      rax, 0x7FFBC9FE8ED0
       cmp      qword ptr [rcx], rax       ;; is it MyClass3 ?
       jne      SHORT G_M7592_IG06
       mov      eax, 100
       jmp      SHORT G_M7592_IG07
G_M7592_IG06:
       mov      r11, 0x7FFBC9400318
       call     [r11]IValue:GetValue():int:this  ;; no longer cold, we have MyClass2
G_M7592_IG07:
       nop      
       add      rsp, 40
       ret      
; Total bytes of code 67
```