### PR TITLE
JIT: Optimize const ShiftRightLogical for byte values on XArch

### DIFF
--- a/src/coreclr/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/jit/hwintrinsicxarch.cpp
@@ -2636,12 +2636,6 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
         {
             assert(sig->numArgs == 2);
 
-            if (varTypeIsByte(simdBaseType))
-            {
-                // byte and sbyte would require more work to support
-                break;
-            }
-
             if ((simdSize != 32) || compOpportunisticallyDependsOn(InstructionSet_AVX2))
             {
                 op2 = impPopStack().val;

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/IndexOfAnyAsciiSearcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/IndexOfAnyAsciiSearcher.cs
@@ -879,10 +879,10 @@ namespace System.Buffers
 
             // On ARM, we have an instruction for an arithmetic right shift of 1-byte signed values.
             // The shift will map values above 127 to values above 16, which the shuffle will then map to 0.
-            // On X86 and WASM, use a 4-byte value shift with AND 15 to emulate a 1-byte value logical shift.
+            // On X86 and WASM, use a logical right shift instead.
             Vector128<byte> highNibbles = AdvSimd.IsSupported
                 ? AdvSimd.ShiftRightArithmetic(source.AsSByte(), 4).AsByte()
-                : (source.AsInt32() >>> 4).AsByte() & Vector128.Create((byte)0xF);
+                : source >>> 4;
 
             // The bitmapLookup represents a 8x16 table of bits, indicating whether a character is present in the needle.
             // Lookup the rows via the lower nibble and the column via the higher nibble.
@@ -913,7 +913,7 @@ namespace System.Buffers
         private static Vector256<byte> IndexOfAnyLookupCore(Vector256<byte> source, Vector256<byte> bitmapLookup)
         {
             // See comments in IndexOfAnyLookupCore(Vector128<byte>) above for more details.
-            Vector256<byte> highNibbles = Vector256.ShiftRightLogical(source.AsInt32(), 4).AsByte() & Vector256.Create((byte)0xF);
+            Vector256<byte> highNibbles = source >>> 4;
             Vector256<byte> bitMask = Avx2.Shuffle(bitmapLookup, source);
             Vector256<byte> bitPositions = Avx2.Shuffle(Vector256.Create(0x8040201008040201).AsByte(), highNibbles);
             Vector256<byte> result = bitMask & bitPositions;

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMap.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMap.cs
@@ -131,10 +131,9 @@ namespace System.Buffers
         [CompExactlyDependsOn(typeof(Avx2))]
         private static Vector256<byte> IsCharBitSetAvx2(Vector256<byte> charMapLower, Vector256<byte> charMapUpper, Vector256<byte> values)
         {
-            // X86 doesn't have a logical right shift intrinsic for bytes: https://github.com/dotnet/runtime/issues/82564
-            Vector256<byte> highNibble = (values.AsInt32() >>> VectorizedIndexShift).AsByte() & Vector256.Create((byte)15);
+            Vector256<byte> shifted = values >>> VectorizedIndexShift;
 
-            Vector256<byte> bitPositions = Avx2.Shuffle(Vector256.Create(0x8040201008040201).AsByte(), highNibble);
+            Vector256<byte> bitPositions = Avx2.Shuffle(Vector256.Create(0x8040201008040201).AsByte(), shifted);
 
             Vector256<byte> index = values & Vector256.Create((byte)VectorizedIndexMask);
             Vector256<byte> bitMaskLower = Avx2.Shuffle(charMapLower, index);
@@ -175,12 +174,9 @@ namespace System.Buffers
         [CompExactlyDependsOn(typeof(PackedSimd))]
         private static Vector128<byte> IsCharBitSet(Vector128<byte> charMapLower, Vector128<byte> charMapUpper, Vector128<byte> values)
         {
-            // X86 doesn't have a logical right shift intrinsic for bytes: https://github.com/dotnet/runtime/issues/82564
-            Vector128<byte> highNibble = Sse2.IsSupported
-                ? (values.AsInt32() >>> VectorizedIndexShift).AsByte() & Vector128.Create((byte)15)
-                : values >>> VectorizedIndexShift;
+            Vector128<byte> shifted = values >>> VectorizedIndexShift;
 
-            Vector128<byte> bitPositions = Vector128.ShuffleUnsafe(Vector128.Create(0x8040201008040201).AsByte(), highNibble);
+            Vector128<byte> bitPositions = Vector128.ShuffleUnsafe(Vector128.Create(0x8040201008040201).AsByte(), shifted);
 
             Vector128<byte> index = values & Vector128.Create((byte)VectorizedIndexMask);
             Vector128<byte> bitMask;


### PR DESCRIPTION
Contributes to #82564

(First time touching the JIT so I don't really know what I'm doing)

```c#
Vector128<byte> v0;

// Expands patterns like
v0 >>> 4;
// to
(v0.AsInt32() >>> 4).AsByte() & Vector128.Create((byte)15);

// and
v0 >>> nonConstAmount;
// to
int maskedShiftAmount = nonConstAmount & 7;
Vector128<int> shiftVector = Sse2.ConvertScalarToVector128Int32(maskedShiftAmount);
Vector128<byte> shiftedInput = Sse2.ShiftRightLogical(v0.AsInt32(), shiftVector).AsByte();
return shiftedInput & Vector128.Create((byte)(255 >> maskedShiftAmount));
```

Codegen for
```c#
[Benchmark]
[Arguments(42)]
public Vector128<byte> SimpleShift(byte input) =>
    Vector128.Create(input) >>> 4;
```

<details>
<summary>Before</summary>

```assembly
; VectorTest.SimpleShift(Byte)
       sub       rsp,48
       vzeroupper
       movzx     eax,r8b
       vpbroadcastb xmm0,eax
       vmovaps   [rsp+30],xmm0
       mov       rax,[rsp+30]
       mov       [rsp+20],rax
       movzx     eax,byte ptr [rsp+20]
       shr       eax,4
       movzx     eax,al
       mov       [rsp+28],al
       movzx     eax,byte ptr [rsp+21]
       shr       eax,4
       movzx     eax,al
       mov       [rsp+29],al
       movzx     eax,byte ptr [rsp+22]
       shr       eax,4
       movzx     eax,al
       mov       [rsp+2A],al
       movzx     eax,byte ptr [rsp+23]
       shr       eax,4
       movzx     eax,al
       mov       [rsp+2B],al
       movzx     eax,byte ptr [rsp+24]
       shr       eax,4
       movzx     eax,al
       mov       [rsp+2C],al
       movzx     eax,byte ptr [rsp+25]
       shr       eax,4
       movzx     eax,al
       mov       [rsp+2D],al
       movzx     eax,byte ptr [rsp+26]
       shr       eax,4
       movzx     eax,al
       mov       [rsp+2E],al
       movzx     eax,byte ptr [rsp+27]
       shr       eax,4
       movzx     eax,al
       mov       [rsp+2F],al
       mov       rax,[rsp+28]
       mov       rcx,[rsp+38]
       mov       [rsp+10],rcx
       movzx     ecx,byte ptr [rsp+10]
       shr       ecx,4
       movzx     ecx,cl
       mov       [rsp+18],cl
       movzx     ecx,byte ptr [rsp+11]
       shr       ecx,4
       movzx     ecx,cl
       mov       [rsp+19],cl
       movzx     ecx,byte ptr [rsp+12]
       shr       ecx,4
       movzx     ecx,cl
       mov       [rsp+1A],cl
       movzx     ecx,byte ptr [rsp+13]
       shr       ecx,4
       movzx     ecx,cl
       mov       [rsp+1B],cl
       movzx     ecx,byte ptr [rsp+14]
       shr       ecx,4
       movzx     ecx,cl
       mov       [rsp+1C],cl
       movzx     ecx,byte ptr [rsp+15]
       shr       ecx,4
       movzx     ecx,cl
       mov       [rsp+1D],cl
       movzx     ecx,byte ptr [rsp+16]
       shr       ecx,4
       movzx     ecx,cl
       mov       [rsp+1E],cl
       movzx     ecx,byte ptr [rsp+17]
       shr       ecx,4
       movzx     ecx,cl
       mov       [rsp+1F],cl
       mov       rcx,[rsp+18]
       mov       [rsp],rax
       mov       [rsp+8],rcx
       vmovaps   xmm0,[rsp]
       vmovups   [rdx],xmm0
       mov       rax,rdx
       add       rsp,48
       ret
; Total bytes of code 319
```

</details>

<details>
<summary>After</summary>

```assembly
; VectorTest.SimpleShift(Byte)
       vzeroupper
       movzx     eax,r8b
       vpbroadcastb xmm0,eax
       vpsrld    xmm0,xmm0,4
       vpand     xmm0,xmm0,[7FFC6F58A2E0]
       vmovups   [rdx],xmm0
       mov       rax,rdx
       ret
; Total bytes of code 34
```

</details>

Codegen for
```c#
[Benchmark]
[Arguments(3)]
public Vector128<byte> SimpleShift(int shiftCount) =>
    Vector128.Create((byte)42) >>> shiftCount;
```

<details>
<summary>Before</summary>

```assembly
; VectorTest.SimpleShift(Int32)
       sub       rsp,58
       vzeroupper
       vmovups   xmm0,[7FFC74E11BB0]
       vmovaps   [rsp+40],xmm0
       mov       rax,[rsp+40]
       mov       [rsp+20],rax
       xor       eax,eax
       mov       ecx,r8d
       and       ecx,7
M00_L00:
       lea       r9,[rsp+20]
       movsxd    r10,eax
       movzx     r9d,byte ptr [r9+r10]
       shrx      r9d,r9d,ecx
       movzx     r9d,r9b
       lea       r11,[rsp+28]
       mov       [r11+r10],r9b
       inc       eax
       cmp       eax,8
       jl        short M00_L00
       vmovaps   [rsp+30],xmm0
       mov       rax,[rsp+28]
       mov       rcx,[rsp+38]
       mov       [rsp+10],rcx
       xor       ecx,ecx
       and       r8d,7
M00_L01:
       lea       r9,[rsp+10]
       movsxd    r10,ecx
       movzx     r9d,byte ptr [r9+r10]
       shrx      r9d,r9d,r8d
       movzx     r9d,r9b
       lea       r11,[rsp+18]
       mov       [r11+r10],r9b
       inc       ecx
       cmp       ecx,8
       jl        short M00_L01
       mov       rcx,[rsp+18]
       mov       [rsp],rax
       mov       [rsp+8],rcx
       vmovaps   xmm0,[rsp]
       vmovups   [rdx],xmm0
       mov       rax,rdx
       add       rsp,58
       ret
; Total bytes of code 173
```

</details>

<details>
<summary>After</summary>

```assembly
; VectorTest.SimpleShift(Int32)
       vzeroupper
       and       r8d,7
       vmovd     xmm0,r8d
       vmovups   xmm1,[7FFCEB69A330]
       vpsrld    xmm0,xmm1,xmm0
       mov       eax,0FF
       shrx      eax,eax,r8d
       vpbroadcastb xmm1,eax
       vpand     xmm0,xmm0,xmm1
       vmovups   [rdx],xmm0
       mov       rax,rdx
       ret
; Total bytes of code 52
```

</details>