### PR TITLE
Don't emit nor generate the manifest for NativeRuntimeEventSource

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2234,6 +2234,9 @@
   <data name="EventSource_VarArgsParameterMismatch" xml:space="preserve">
     <value>Event {0} was called with a different type as defined (argument "{1}"). This may cause the event to be displayed incorrectly.</value>
   </data>
+  <data name="EventSource_ChannelUnsupported" xml:space="preserve">
+    <value>Event {0} specifies a channel on a self describing EventSource.</value>
+  </data>
   <data name="Exception_EmptyFieldForCustomAttributeType" xml:space="preserve">
     <value>Custom attribute type '{0}' doesn't contain a field named '{1}'.</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2234,9 +2234,6 @@
   <data name="EventSource_VarArgsParameterMismatch" xml:space="preserve">
     <value>Event {0} was called with a different type as defined (argument "{1}"). This may cause the event to be displayed incorrectly.</value>
   </data>
-  <data name="EventSource_ChannelUnsupported" xml:space="preserve">
-    <value>Event {0} specifies a channel on a self describing EventSource.</value>
-  </data>
   <data name="Exception_EmptyFieldForCustomAttributeType" xml:space="preserve">
     <value>Custom attribute type '{0}' doesn't contain a field named '{1}'.</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -2791,10 +2791,7 @@ namespace System.Diagnostics.Tracing
         // Today, we only send the manifest to ETW, custom listeners don't get it.
         private unsafe void SendManifest(byte[]? rawManifest)
         {
-            if (rawManifest == null
-                // Don't send the manifest for NativeRuntimeEventSource, it is conceptually
-                // an extension of the native coreclr provider
-                || m_name.Equals("Microsoft-Windows-DotNETRuntime"))
+            if (rawManifest == null)
             {
                 return;
             }
@@ -3056,16 +3053,16 @@ namespace System.Diagnostics.Tracing
                 if (eventSourceAttrib != null && eventSourceAttrib.LocalizationResources != null)
                     resources = new ResourceManager(eventSourceAttrib.LocalizationResources, eventSourceType.Assembly);
 
-                if (source is not null)
-                {
+                manifest = (source == null)
+                    ? new ManifestBuilder(GetName(eventSourceType, flags), GetGuid(eventSourceType), eventSourceDllName, resources, flags)
+
+                    // Don’t emit nor generate the manifest for NativeRuntimeEventSource i.e., Microsoft-Windows-DotNETRuntime.
+                    : ((source.GetType() == typeof(NativeRuntimeEventSource))
+                    ? new ManifestBuilder(resources, flags)
+
                     // We have the source so don't need to use reflection to get the Name and Guid
-                    manifest = new ManifestBuilder(source.Name, source.Guid, eventSourceDllName, resources, flags);
-                }
-                else
-                {
-                    manifest = new ManifestBuilder(GetName(eventSourceType, flags), GetGuid(eventSourceType), eventSourceDllName,
-                                               resources, flags);
-                }
+                    : new ManifestBuilder(source.Name, source.Guid, eventSourceDllName, resources, flags));
+                bNeedsManifest &= manifest.WillBuild;
 
                 // Add an entry unconditionally for event ID 0 which will be for a string message.
                 manifest.StartEvent("EventSourceMessage", new EventAttribute(0) { Level = EventLevel.LogAlways, Task = (EventTask)0xFFFE });
@@ -3260,6 +3257,11 @@ namespace System.Diagnostics.Tracing
                             // and is not required for the manifest
                             if (eventAttribute.Channel != EventChannel.None)
                             {
+                                if (!manifest.WillBuild)
+                                {
+                                    throw new ArgumentException(SR.Format(SR.EventSource_ChannelUnsupported), method.Name);
+                                }
+
                                 unchecked
                                 {
                                     eventAttribute.Keywords |= (EventKeywords)manifest.GetChannelKeyword(eventAttribute.Channel, (ulong)eventAttribute.Keywords);
@@ -3308,6 +3310,7 @@ namespace System.Diagnostics.Tracing
                         return null;
 
                     res = manifest.CreateManifest();
+                    res = (res.Length > 0) ? res : null;
                 }
             }
             catch (Exception e)
@@ -5187,22 +5190,15 @@ namespace System.Diagnostics.Tracing
         /// 'resources, is a resource manager.  If specified all messages are localized using that manager.
         /// </summary>
         public ManifestBuilder(string providerName, Guid providerGuid, string? dllName, ResourceManager? resources,
-                               EventManifestOptions flags)
+                               EventManifestOptions flags) : this(resources, flags)
         {
 #if FEATURE_MANAGED_ETW_CHANNELS
             this.providerName = providerName;
 #endif
-            this.flags = flags;
 
-            this.resources = resources;
             sb = new StringBuilder();
             events = new StringBuilder();
             templates = new StringBuilder();
-            opcodeTab = new Dictionary<int, string>();
-            stringTab = new Dictionary<string, string>();
-            errors = new List<string>();
-            perEventByteArrayArgIndices = new Dictionary<string, List<int>>();
-
             sb.AppendLine("<instrumentationManifest xmlns=\"http://schemas.microsoft.com/win/2004/08/events\">");
             sb.AppendLine(" <instrumentation xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:win=\"http://manifests.microsoft.com/win/2004/08/windows/events\">");
             sb.AppendLine("  <events xmlns=\"http://schemas.microsoft.com/win/2004/08/events\">");
@@ -5213,6 +5209,27 @@ namespace System.Diagnostics.Tracing
             string symbolsName = providerName.Replace("-", "").Replace('.', '_');  // Period and - are illegal replace them.
             sb.AppendLine($" symbol=\"{symbolsName}\">");
         }
+
+        /// <summary>
+        /// <term>Will NOT build a manifest!</term> If the intention is to build a manifest don’t use this constructor.
+        ///'resources, is a resource manager.  If specified all messages are localized using that manager.
+        /// </summary>
+        internal ManifestBuilder(ResourceManager? resources, EventManifestOptions flags)
+        {
+            providerName = "";
+
+            this.flags = flags;
+
+            this.resources = resources;
+            sb = null;
+            events = null;
+            templates = null;
+            opcodeTab = new Dictionary<int, string>();
+            stringTab = new Dictionary<string, string>();
+            errors = new List<string>();
+            perEventByteArrayArgIndices = new Dictionary<string, List<int>>();
+        }
+        internal bool WillBuild => sb != null;
 
         public void AddOpcode(string name, int value)
         {
@@ -5351,11 +5368,14 @@ namespace System.Diagnostics.Tracing
             numParams = 0;
             byteArrArgIndices = null;
 
-            events.Append("  <event value=\"").Append(eventAttribute.EventId).
-                 Append("\" version=\"").Append(eventAttribute.Version).
-                 Append("\" level=\"");
-            AppendLevelName(events, eventAttribute.Level);
-            events.Append("\" symbol=\"").Append(eventName).Append('"');
+            if (events != null)
+            {
+                events.Append("  <event value=\"").Append(eventAttribute.EventId).
+                    Append("\" version=\"").Append(eventAttribute.Version).
+                    Append("\" level=\"");
+                AppendLevelName(events, eventAttribute.Level);
+                events.Append("\" symbol=\"").Append(eventName).Append('"');
+            }
 
             // at this point we add to the manifest's stringTab a message that is as-of-yet
             // "untranslated to manifest convention", b/c we don't have the number or position
@@ -5364,25 +5384,28 @@ namespace System.Diagnostics.Tracing
 
             if (eventAttribute.Keywords != 0)
             {
-                events.Append(" keywords=\"");
+                events?.Append(" keywords=\"");
                 AppendKeywords(events, (ulong)eventAttribute.Keywords, eventName);
-                events.Append('"');
+                events?.Append('"');
             }
 
             if (eventAttribute.Opcode != 0)
             {
-                events.Append(" opcode=\"").Append(GetOpcodeName(eventAttribute.Opcode, eventName)).Append('"');
+                string? str = GetOpcodeName(eventAttribute.Opcode, eventName);
+                events?.Append(" opcode=\"").Append(str).Append('"');
             }
 
             if (eventAttribute.Task != 0)
             {
-                events.Append(" task=\"").Append(GetTaskName(eventAttribute.Task, eventName)).Append('"');
+                string? str = GetTaskName(eventAttribute.Task, eventName);
+                events?.Append(" task=\"").Append(str).Append('"');
             }
 
 #if FEATURE_MANAGED_ETW_CHANNELS
             if (eventAttribute.Channel != 0)
             {
-                events.Append(" channel=\"").Append(GetChannelName(eventAttribute.Channel, eventName, eventAttribute.Message)).Append('"');
+                string? str = GetChannelName(eventAttribute.Channel, eventName, eventAttribute.Message);
+                events?.Append(" channel=\"").Append(str).Append('"');
             }
 #endif
         }
@@ -5390,7 +5413,7 @@ namespace System.Diagnostics.Tracing
         public void AddEventParameter(Type type, string name)
         {
             if (numParams == 0)
-                templates.Append("  <template tid=\"").Append(eventName).AppendLine("Args\">");
+                templates?.Append("  <template tid=\"").Append(eventName).AppendLine("Args\">");
             if (type == typeof(byte[]))
             {
                 // mark this index as "extraneous" (it has no parallel in the managed signature)
@@ -5400,38 +5423,44 @@ namespace System.Diagnostics.Tracing
 
                 // add an extra field to the template representing the length of the binary blob
                 numParams++;
-                templates.Append("   <data name=\"").Append(name).AppendLine("Size\" inType=\"win:UInt32\"/>");
+                templates?.Append("   <data name=\"").Append(name).AppendLine("Size\" inType=\"win:UInt32\"/>");
             }
             numParams++;
-            templates.Append("   <data name=\"").Append(name).Append("\" inType=\"").Append(GetTypeName(type)).Append('"');
-            // TODO: for 'byte*' types it assumes the user provided length is named using the same naming convention
-            //       as for 'byte[]' args (blob_arg_name + "Size")
-            if ((type.IsArray || type.IsPointer) && type.GetElementType() == typeof(byte))
+            if (templates != null)
             {
-                // add "length" attribute to the "blob" field in the template (referencing the field added above)
-                templates.Append(" length=\"").Append(name).Append("Size\"");
+                templates.Append("   <data name=\"").Append(name).Append("\" inType=\"").Append(GetTypeName(type)).Append('"');
+                // TODO: for 'byte*' types it assumes the user provided length is named using the same naming convention
+                //       as for 'byte[]' args (blob_arg_name + "Size")
+                if ((type.IsArray || type.IsPointer) && type.GetElementType() == typeof(byte))
+                {
+                    // add "length" attribute to the "blob" field in the template (referencing the field added above)
+                    templates.Append(" length=\"").Append(name).Append("Size\"");
+                }
             }
             // ETW does not support 64-bit value maps, so we don't specify these as ETW maps
             if (type.IsEnum && Enum.GetUnderlyingType(type) != typeof(ulong) && Enum.GetUnderlyingType(type) != typeof(long))
             {
-                templates.Append(" map=\"").Append(type.Name).Append('"');
+                templates?.Append(" map=\"").Append(type.Name).Append('"');
                 mapsTab ??= new Dictionary<string, Type>();
                 if (!mapsTab.ContainsKey(type.Name))
                     mapsTab.Add(type.Name, type);        // Remember that we need to dump the type enumeration
             }
 
-            templates.AppendLine("/>");
+            templates?.AppendLine("/>");
         }
         public void EndEvent()
         {
             Debug.Assert(eventName != null);
 
-            if (numParams > 0)
+            if (events != null)
             {
-                templates.AppendLine("  </template>");
-                events.Append(" template=\"").Append(eventName).Append("Args\"");
+                if (numParams > 0)
+                {
+                    templates?.AppendLine("  </template>");
+                    events.Append(" template=\"").Append(eventName).Append("Args\"");
+                }
+                events.AppendLine("/>");
             }
-            events.AppendLine("/>");
 
             if (byteArrArgIndices != null)
                 perEventByteArrayArgIndices[eventName] = byteArrArgIndices;
@@ -5491,7 +5520,7 @@ namespace System.Diagnostics.Tracing
         public byte[] CreateManifest()
         {
             string str = CreateManifestString();
-            return Encoding.UTF8.GetBytes(str);
+            return (str != "") ? Encoding.UTF8.GetBytes(str) : Array.Empty<byte>();
         }
 
         public IList<string> Errors => errors;
@@ -5521,75 +5550,90 @@ namespace System.Diagnostics.Tracing
             // Write out the channels
             if (channelTab != null)
             {
-                sb.AppendLine(" <channels>");
-                var sortedChannels = new List<KeyValuePair<int, ChannelInfo>>();
-                foreach (KeyValuePair<int, ChannelInfo> p in channelTab) { sortedChannels.Add(p); }
-                sortedChannels.Sort((p1, p2) => -Comparer<ulong>.Default.Compare(p1.Value.Keywords, p2.Value.Keywords));
-                foreach (KeyValuePair<int, ChannelInfo> kvpair in sortedChannels)
+                IEnumerable<KeyValuePair<int, ChannelInfo>> channels = channelTab;
+                if (sb != null)
+                {
+                    sb.AppendLine(" <channels>");
+                    var sortedChannels = new List<KeyValuePair<int, ChannelInfo>>();
+                    foreach (KeyValuePair<int, ChannelInfo> p in channelTab) { sortedChannels.Add(p); }
+                    sortedChannels.Sort((p1, p2) => -Comparer<ulong>.Default.Compare(p1.Value.Keywords, p2.Value.Keywords));
+                    channels = sortedChannels;
+                }
+                foreach (KeyValuePair<int, ChannelInfo> kvpair in channels)
                 {
                     int channel = kvpair.Key;
                     ChannelInfo channelInfo = kvpair.Value;
 
                     string? channelType = null;
                     bool enabled = false;
-                    string? fullName = null;
-#if FEATURE_ADVANCED_MANAGED_ETW_CHANNELS
-                    string? isolation = null;
-                    string? access = null;
-#endif
-                    if (channelInfo.Attribs != null)
+                    if (sb != null)
                     {
-                        EventChannelAttribute attribs = channelInfo.Attribs;
-                        if (Enum.IsDefined(typeof(EventChannelType), attribs.EventChannelType))
-                            channelType = attribs.EventChannelType.ToString();
-                        enabled = attribs.Enabled;
+                        string? fullName = null;
 #if FEATURE_ADVANCED_MANAGED_ETW_CHANNELS
-                        if (attribs.ImportChannel != null)
-                        {
-                            fullName = attribs.ImportChannel;
-                            elementName = "importChannel";
-                        }
-                        if (Enum.IsDefined(typeof(EventChannelIsolation), attribs.Isolation))
-                            isolation = attribs.Isolation.ToString();
-                        access = attribs.Access;
+                        string? isolation = null;
+                        string? access = null;
 #endif
+                        if (channelInfo.Attribs != null)
+                        {
+                            EventChannelAttribute attribs = channelInfo.Attribs;
+                            if (Enum.IsDefined(typeof(EventChannelType), attribs.EventChannelType))
+                                channelType = attribs.EventChannelType.ToString();
+                            enabled = attribs.Enabled;
+#if FEATURE_ADVANCED_MANAGED_ETW_CHANNELS
+                            if (attribs.ImportChannel != null)
+                            {
+                                fullName = attribs.ImportChannel;
+                                elementName = "importChannel";
+                            }
+                            if (Enum.IsDefined(typeof(EventChannelIsolation), attribs.Isolation))
+                                isolation = attribs.Isolation.ToString();
+                            access = attribs.Access;
+#endif
+                        }
+
+                        fullName ??= providerName + "/" + channelInfo.Name;
+
+                        sb.Append("  <channel chid=\"").Append(channelInfo.Name).Append("\" name=\"").Append(fullName).Append('"');
                     }
-
-                    fullName ??= providerName + "/" + channelInfo.Name;
-
-                    sb.Append("  <channel chid=\"").Append(channelInfo.Name).Append("\" name=\"").Append(fullName).Append('"');
-
                     Debug.Assert(channelInfo.Name != null);
                     WriteMessageAttrib(sb, "channel", channelInfo.Name, null);
-                    sb.Append(" value=\"").Append(channel).Append('"');
-                    if (channelType != null)
-                        sb.Append(" type=\"").Append(channelType).Append('"');
-                    sb.Append(" enabled=\"").Append(enabled ? "true" : "false").Append('"');
+                    if (sb != null)
+                    {
+                        sb.Append(" value=\"").Append(channel).Append('"');
+                        if (channelType != null)
+                            sb.Append(" type=\"").Append(channelType).Append('"');
+                        sb.Append(" enabled=\"").Append(enabled ? "true" : "false").Append('"');
 #if FEATURE_ADVANCED_MANAGED_ETW_CHANNELS
-                    if (access != null)
-                        sb.Append(" access=\"").Append(access).Append("\"");
-                    if (isolation != null)
-                        sb.Append(" isolation=\"").Append(isolation).Append("\"");
+                        if (access != null)
+                            sb.Append(" access=\"").Append(access).Append("\"");
+                        if (isolation != null)
+                            sb.Append(" isolation=\"").Append(isolation).Append("\"");
 #endif
-                    sb.AppendLine("/>");
+                        sb.AppendLine("/>");
+                    }
                 }
-                sb.AppendLine(" </channels>");
+                sb?.AppendLine(" </channels>");
             }
 #endif
 
             // Write out the tasks
             if (taskTab != null)
             {
-                sb.AppendLine(" <tasks>");
-                var sortedTasks = new List<int>(taskTab.Keys);
-                sortedTasks.Sort();
-                foreach (int task in sortedTasks)
+                IEnumerable<int> tasks = taskTab.Keys;
+                if (sb != null)
                 {
-                    sb.Append("  <task");
-                    WriteNameAndMessageAttribs(sb, "task", taskTab[task]);
-                    sb.Append(" value=\"").Append(task).AppendLine("\"/>");
+                    sb.AppendLine(" <tasks>");
+                    var sortedTasks = new List<int>(taskTab.Keys);
+                    sortedTasks.Sort();
+                    tasks = sortedTasks;
                 }
-                sb.AppendLine(" </tasks>");
+                foreach (int task in tasks)
+                {
+                    sb?.Append("  <task");
+                    WriteNameAndMessageAttribs(sb, "task", taskTab[task]);
+                    sb?.Append(" value=\"").Append(task).AppendLine("\"/>");
+                }
+                sb?.AppendLine(" </tasks>");
             }
 
             // Write out the maps
@@ -5605,12 +5649,12 @@ namespace System.Diagnostics.Tracing
 
             if (mapsTab != null)
             {
-                sb.AppendLine(" <maps>");
+                sb?.AppendLine(" <maps>");
                 foreach (Type enumType in mapsTab.Values)
                 {
                     bool isbitmap = EventSource.IsCustomAttributeDefinedHelper(enumType, typeof(FlagsAttribute), flags);
                     string mapKind = isbitmap ? "bitMap" : "valueMap";
-                    sb.Append("  <").Append(mapKind).Append(" name=\"").Append(enumType.Name).AppendLine("\">");
+                    sb?.Append("  <").Append(mapKind).Append(" name=\"").Append(enumType.Name).AppendLine("\">");
 
                     // write out each enum value
                     FieldInfo[] staticFields = GetEnumFields(enumType);
@@ -5632,11 +5676,14 @@ namespace System.Diagnostics.Tracing
                             if (isbitmap && !BitOperations.IsPow2(hexValue))
                                 continue;
 
-                            hexValue.TryFormat(ulongHexScratch, out int charsWritten, "x");
-                            Span<char> hexValueFormatted = ulongHexScratch.Slice(0, charsWritten);
-                            sb.Append("   <map value=\"0x").Append(hexValueFormatted).Append('"');
+                            if (sb != null)
+                            {
+                                hexValue.TryFormat(ulongHexScratch, out int charsWritten, "x");
+                                Span<char> hexValueFormatted = ulongHexScratch.Slice(0, charsWritten);
+                                sb.Append("   <map value=\"0x").Append(hexValueFormatted).Append('"');
+                            }
                             WriteMessageAttrib(sb, "map", enumType.Name + "." + staticField.Name, staticField.Name);
-                            sb.AppendLine("/>");
+                            sb?.AppendLine("/>");
                             anyValuesWritten = true;
                         }
                     }
@@ -5645,95 +5692,111 @@ namespace System.Diagnostics.Tracing
                     // To avoid that put a 'None' entry if there are no other values.
                     if (!anyValuesWritten)
                     {
-                        sb.Append("   <map value=\"0x0\"");
+                        sb?.Append("   <map value=\"0x0\"");
                         WriteMessageAttrib(sb, "map", enumType.Name + ".None", "None");
-                        sb.AppendLine("/>");
+                        sb?.AppendLine("/>");
                     }
-                    sb.Append("  </").Append(mapKind).AppendLine(">");
+                    sb?.Append("  </").Append(mapKind).AppendLine(">");
                 }
-                sb.AppendLine(" </maps>");
+                sb?.AppendLine(" </maps>");
             }
 
             // Write out the opcodes
-            sb.AppendLine(" <opcodes>");
-            var sortedOpcodes = new List<int>(opcodeTab.Keys);
-            sortedOpcodes.Sort();
-            foreach (int opcode in sortedOpcodes)
+            IEnumerable<int> opcodes = opcodeTab.Keys;
+            if (sb != null)
             {
-                sb.Append("  <opcode");
-                WriteNameAndMessageAttribs(sb, "opcode", opcodeTab[opcode]);
-                sb.Append(" value=\"").Append(opcode).AppendLine("\"/>");
+                sb.AppendLine(" <opcodes>");
+                var sortedOpcodes = new List<int>(opcodeTab.Keys);
+                sortedOpcodes.Sort();
+                opcodes = sortedOpcodes;
             }
-            sb.AppendLine(" </opcodes>");
+            foreach (int opcode in opcodes)
+            {
+                sb?.Append("  <opcode");
+                WriteNameAndMessageAttribs(sb, "opcode", opcodeTab[opcode]);
+                sb?.Append(" value=\"").Append(opcode).AppendLine("\"/>");
+            }
+            sb?.AppendLine(" </opcodes>");
 
             // Write out the keywords
             if (keywordTab != null)
             {
-                sb.AppendLine(" <keywords>");
-                var sortedKeywords = new List<ulong>(keywordTab.Keys);
-                sortedKeywords.Sort();
-                foreach (ulong keyword in sortedKeywords)
+                IEnumerable<ulong> keywords = keywordTab.Keys;
+                if (sb != null)
                 {
-                    sb.Append("  <keyword");
-                    WriteNameAndMessageAttribs(sb, "keyword", keywordTab[keyword]);
-                    keyword.TryFormat(ulongHexScratch, out int charsWritten, "x");
-                    Span<char> keywordFormatted = ulongHexScratch.Slice(0, charsWritten);
-                    sb.Append(" mask=\"0x").Append(keywordFormatted).AppendLine("\"/>");
+                    sb.AppendLine(" <keywords>");
+                    var sortedKeywords = new List<ulong>(keywordTab.Keys);
+                    sortedKeywords.Sort();
                 }
-                sb.AppendLine(" </keywords>");
+                foreach (ulong keyword in keywords)
+                {
+                    sb?.Append("  <keyword");
+                    WriteNameAndMessageAttribs(sb, "keyword", keywordTab[keyword]);
+                    if (sb != null)
+                    {
+                        keyword.TryFormat(ulongHexScratch, out int charsWritten, "x");
+                        Span<char> keywordFormatted = ulongHexScratch.Slice(0, charsWritten);
+                        sb.Append(" mask=\"0x").Append(keywordFormatted).AppendLine("\"/>");
+                    }
+                }
+                sb?.AppendLine(" </keywords>");
             }
 
-            sb.AppendLine(" <events>");
-            sb.Append(events);
-            sb.AppendLine(" </events>");
-
-            sb.AppendLine(" <templates>");
-            if (templates.Length > 0)
+            if (sb != null)
             {
-                sb.Append(templates);
+                sb.AppendLine(" <events>");
+                sb.Append(events);
+                sb.AppendLine(" </events>");
+
+                sb.AppendLine(" <templates>");
+                if (templates?.Length > 0)
+                {
+                    sb.Append(templates);
+                }
+                else
+                {
+                    // Work around a corner-case ETW issue where a manifest with no templates causes
+                    // ETW events to not get sent to their associated channel.
+                    sb.AppendLine("    <template tid=\"_empty\"></template>");
+                }
+                sb.AppendLine(" </templates>");
+
+                sb.AppendLine("</provider>");
+                sb.AppendLine("</events>");
+                sb.AppendLine("</instrumentation>");
+
+                // Output the localization information.
+                sb.AppendLine("<localization>");
+
+                var sortedStrings = new string[stringTab.Keys.Count];
+                stringTab.Keys.CopyTo(sortedStrings, 0);
+                Array.Sort<string>(sortedStrings, StringComparer.Ordinal);
+
+                CultureInfo ci = CultureInfo.CurrentUICulture;
+                sb.Append(" <resources culture=\"").Append(ci.Name).AppendLine("\">");
+                sb.AppendLine("  <stringTable>");
+                foreach (string stringKey in sortedStrings)
+                {
+                    string? val = GetLocalizedMessage(stringKey, ci, etwFormat: true);
+                    sb.Append("   <string id=\"").Append(stringKey).Append("\" value=\"").Append(val).AppendLine("\"/>");
+                }
+                sb.AppendLine("  </stringTable>");
+                sb.AppendLine(" </resources>");
+
+                sb.AppendLine("</localization>");
+                sb.AppendLine("</instrumentationManifest>");
+                return sb.ToString();
             }
-            else
-            {
-                // Work around a corner-case ETW issue where a manifest with no templates causes
-                // ETW events to not get sent to their associated channel.
-                sb.AppendLine("    <template tid=\"_empty\"></template>");
-            }
-            sb.AppendLine(" </templates>");
-
-            sb.AppendLine("</provider>");
-            sb.AppendLine("</events>");
-            sb.AppendLine("</instrumentation>");
-
-            // Output the localization information.
-            sb.AppendLine("<localization>");
-
-            var sortedStrings = new string[stringTab.Keys.Count];
-            stringTab.Keys.CopyTo(sortedStrings, 0);
-            Array.Sort<string>(sortedStrings, StringComparer.Ordinal);
-
-            CultureInfo ci = CultureInfo.CurrentUICulture;
-            sb.Append(" <resources culture=\"").Append(ci.Name).AppendLine("\">");
-            sb.AppendLine("  <stringTable>");
-            foreach (string stringKey in sortedStrings)
-            {
-                string? val = GetLocalizedMessage(stringKey, ci, etwFormat: true);
-                sb.Append("   <string id=\"").Append(stringKey).Append("\" value=\"").Append(val).AppendLine("\"/>");
-            }
-            sb.AppendLine("  </stringTable>");
-            sb.AppendLine(" </resources>");
-
-            sb.AppendLine("</localization>");
-            sb.AppendLine("</instrumentationManifest>");
-            return sb.ToString();
+            return "";
         }
 
 #region private
-        private void WriteNameAndMessageAttribs(StringBuilder stringBuilder, string elementName, string name)
+        private void WriteNameAndMessageAttribs(StringBuilder? stringBuilder, string elementName, string name)
         {
-            stringBuilder.Append(" name=\"").Append(name).Append('"');
+            stringBuilder?.Append(" name=\"").Append(name).Append('"');
             WriteMessageAttrib(sb, elementName, name, name);
         }
-        private void WriteMessageAttrib(StringBuilder stringBuilder, string elementName, string name, string? value)
+        private void WriteMessageAttrib(StringBuilder? stringBuilder, string elementName, string name, string? value)
         {
             string? key = null;
 
@@ -5750,7 +5813,7 @@ namespace System.Diagnostics.Tracing
                 return;
 
             key ??= elementName + "_" + name;
-            stringBuilder.Append(" message=\"$(string.").Append(key).Append(")\"");
+            stringBuilder?.Append(" message=\"$(string.").Append(key).Append(")\"");
 
             if (stringTab.TryGetValue(key, out string? prevValue) && !prevValue.Equals(value))
             {
@@ -5879,7 +5942,7 @@ namespace System.Diagnostics.Tracing
             return ret;
         }
 
-        private void AppendKeywords(StringBuilder sb, ulong keywords, string eventName)
+        private void AppendKeywords(StringBuilder? sb, ulong keywords, string eventName)
         {
 #if FEATURE_MANAGED_ETW_CHANNELS
             // ignore keywords associate with channels
@@ -5910,10 +5973,10 @@ namespace System.Diagnostics.Tracing
                     {
                         if (appended)
                         {
-                            sb.Append(' ');
+                            sb?.Append(' ');
                         }
 
-                        sb.Append(keyword);
+                        sb?.Append(keyword);
                         appended = true;
                     }
                 }
@@ -6105,9 +6168,9 @@ namespace System.Diagnostics.Tracing
         private const int MaxCountChannels = 8; // a manifest can defined at most 8 ETW channels
 #endif
 
-        private readonly StringBuilder sb;               // Holds the provider information.
-        private readonly StringBuilder events;           // Holds the events.
-        private readonly StringBuilder templates;
+        private readonly StringBuilder? sb;               // Holds the provider information.
+        private readonly StringBuilder? events;           // Holds the events.
+        private readonly StringBuilder? templates;
 
 #if FEATURE_MANAGED_ETW_CHANNELS
         private readonly string providerName;

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -5200,7 +5200,6 @@ namespace System.Diagnostics.Tracing
             sb = new StringBuilder();
             events = new StringBuilder();
             templates = new StringBuilder();
-            WillBuild = true;
             sb.AppendLine("<instrumentationManifest xmlns=\"http://schemas.microsoft.com/win/2004/08/events\">");
             sb.AppendLine(" <instrumentation xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:win=\"http://manifests.microsoft.com/win/2004/08/windows/events\">");
             sb.AppendLine("  <events xmlns=\"http://schemas.microsoft.com/win/2004/08/events\">");
@@ -5231,7 +5230,7 @@ namespace System.Diagnostics.Tracing
             errors = new List<string>();
             perEventByteArrayArgIndices = new Dictionary<string, List<int>>();
         }
-        internal readonly bool WillBuild = false;
+        internal bool WillBuild => sb is not null;
 
         public void AddOpcode(string name, int value)
         {


### PR DESCRIPTION
In issue #83127 [@devmason](https://github.com/davmason) requests that the manifest for NativeRuntimeEventSource i.e., Microsoft-Windows-DotNETRuntime no longer be generated.

This PR intends to rectify that issue by adding optional functionality to the ManifestBuilder to continue with all its checks, however at a much lower memory cost. And have the NativeRuntimeEventSource utilize this functionality.

After building and testing the runtime changes in DotNet7 here are some results.

We can see that there are far fewer string and char[] allocations and no big byte[] allocation which makes sense considering that was the intent.

DotNet7 no changes:
![OldNet7Screenshot 2023-05-28 110155](https://github.com/dotnet/runtime/assets/43690021/0a446beb-9cb5-452e-a8a5-8f1e2599f647)

DotNet7 with changes:
![NewNET7Screenshot 2023-05-28 105813](https://github.com/dotnet/runtime/assets/43690021/6e0fbda5-f027-4bd4-bbc0-a0fdbc30068c)