### PR TITLE
Revert "Change our Android build and test legs to use the new CBL-Mariner-based images."

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -579,26 +579,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Android x64 with Docker-in-Docker
-
-- ${{ if containsValue(parameters.platforms, 'android_x64_docker') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: android
-      archType: x64
-      targetRid: android-x64
-      platform: android_x64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: android_docker
-      jobParameters:
-        runtimeFlavor: mono
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
-
 # Android x86
 
 - ${{ if containsValue(parameters.platforms, 'android_x86') }}:

--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -33,14 +33,10 @@ resources:
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64-alpine
       env:
         ROOTFS_DIR: /crossrootfs/arm64
-
     # This container contains all required toolsets to build for Android and for Linux with bionic libc.
-    - container: linux_bionic
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-android
 
-    # This container contains all required toolsets to build for Android as well as tooling to build docker images.
-    - container: android_docker
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-android-docker
+    - container: linux_bionic
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-android
 
     - container: linux_x64
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64

--- a/eng/pipelines/runtime-android-grpc-client-tests.yml
+++ b/eng/pipelines/runtime-android-grpc-client-tests.yml
@@ -36,7 +36,7 @@ extends:
           buildConfig: Release
           runtimeFlavor: mono
           platforms:
-          - android_x64_docker
+          - android_x64
           jobParameters:
             testGroup: innerloop
             nameSuffix: AllSubsets_Mono_gRPC


### PR DESCRIPTION
Reverts dotnet/runtime#86776

Submitting to have something ready in case we want to unblock official builds. See https://github.com/dotnet/runtime/pull/86776#issuecomment-1565909230.