### PR TITLE
Faster ConstructorInfo.Invoke

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/IntrinsicSupport/ComparerHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/IntrinsicSupport/ComparerHelpers.cs
@@ -88,7 +88,7 @@ namespace Internal.IntrinsicSupport
                 Environment.FailFast("Unable to create comparer");
             }
 
-            return RuntimeAugments.NewObject(comparerType);
+            return RuntimeAugments.RawNewObject(comparerType);
         }
 
         // This one is an intrinsic that is used to make enum comparisons more efficient.

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/IntrinsicSupport/EqualityComparerHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/IntrinsicSupport/EqualityComparerHelpers.cs
@@ -91,7 +91,7 @@ namespace Internal.IntrinsicSupport
                 Environment.FailFast("Unable to create comparer");
             }
 
-            return RuntimeAugments.NewObject(comparerType);
+            return RuntimeAugments.RawNewObject(comparerType);
         }
 
         //-----------------------------------------------------------------------

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
@@ -27,7 +27,6 @@ namespace Internal.Reflection.Core.Execution
         //==============================================================================================
         // Access to the underlying execution engine's object allocation routines.
         //==============================================================================================
-        public abstract object NewObject(RuntimeTypeHandle typeHandle);
         public abstract Array NewArray(RuntimeTypeHandle typeHandleForArrayType, int count);
         public abstract Array NewMultiDimArray(RuntimeTypeHandle typeHandleForArrayType, int[] lengths, int[] lowerBounds);
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/MethodInvoker.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/MethodInvoker.cs
@@ -29,7 +29,19 @@ namespace Internal.Reflection.Core.Execution
             System.Diagnostics.DebugAnnotations.PreviousCallContainsDebuggerStepInCode();
             return result;
         }
+
+        [DebuggerGuidedStepThrough]
+        public object CreateInstance(object?[] arguments, Binder? binder, BindingFlags invokeAttr, CultureInfo? cultureInfo)
+        {
+            BinderBundle binderBundle = binder.ToBinderBundle(invokeAttr, cultureInfo);
+            bool wrapInTargetInvocationException = (invokeAttr & BindingFlags.DoNotWrapExceptions) == 0;
+            object result = CreateInstance(arguments, binderBundle, wrapInTargetInvocationException);
+            System.Diagnostics.DebugAnnotations.PreviousCallContainsDebuggerStepInCode();
+            return result;
+        }
+
         protected abstract object? Invoke(object? thisObject, object?[]? arguments, BinderBundle binderBundle, bool wrapInTargetInvocationException);
+        protected abstract object CreateInstance(object?[]? arguments, BinderBundle binderBundle, bool wrapInTargetInvocationException);
         public abstract Delegate CreateDelegate(RuntimeTypeHandle delegateType, object target, bool isStatic, bool isVirtual, bool isOpen);
 
         // This property is used to retrieve the target method pointer. It is used by the RuntimeMethodHandle.GetFunctionPointer API

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -67,33 +67,8 @@ namespace Internal.Runtime.Augments
         //==============================================================================================
 
         //
-        // Perform the equivalent of a "newobj", but without invoking any constructors. Other than the MethodTable, the result object is zero-initialized.
-        //
-        // Special cases:
-        //
-        //    Strings: The .ctor performs both the construction and initialization
-        //      and compiler special cases these.
-        //
-        //    Nullable<T>: the boxed result is the underlying type rather than Nullable so the constructor
-        //      cannot truly initialize it.
-        //
-        //    In these cases, this helper returns "null" and ConstructorInfo.Invoke() must deal with these specially.
-        //
-        public static object NewObject(RuntimeTypeHandle typeHandle)
-        {
-            EETypePtr eeType = typeHandle.ToEETypePtr();
-            if (eeType.IsNullable
-                || eeType == EETypePtr.EETypePtrOf<string>()
-               )
-                return null;
-            if (eeType.IsByRefLike)
-                throw new System.Reflection.TargetException();
-            return RuntimeImports.RhNewObject(eeType);
-        }
-
-        //
         // Helper API to perform the equivalent of a "newobj" for any MethodTable.
-        // Unlike the NewObject API, this is the raw version that does not special case any MethodTable, and should be used with
+        // This is the raw version that does not special case any MethodTable, and should be used with
         // caution for very specific scenarios.
         //
         public static object RawNewObject(RuntimeTypeHandle typeHandle)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ActivatorImplementation.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ActivatorImplementation.cs
@@ -32,12 +32,15 @@ namespace System
             {
                 if (type.IsValueType)
                 {
-                    if (type.IsByRefLike)
+                    RuntimeTypeHandle typeHandle = type.TypeHandle;
+
+                    if (RuntimeAugments.IsByRefLike(typeHandle))
                         throw new TargetException();
 
-                    Debug.Assert(Nullable.GetUnderlyingType(type) == null);
+                    if (RuntimeAugments.IsNullable(typeHandle))
+                        return null;
 
-                    return RuntimeAugments.RawNewObject(type.TypeHandle);
+                    return RuntimeAugments.RawNewObject(typeHandle);
                 }
 
                 throw new MissingMethodException(SR.Format(SR.Arg_NoDefCTor, type));
@@ -85,12 +88,15 @@ namespace System
             {
                 if (numArgs == 0 && type.IsValueType)
                 {
-                    if (type.IsByRefLike)
+                    RuntimeTypeHandle typeHandle = type.TypeHandle;
+
+                    if (RuntimeAugments.IsByRefLike(typeHandle))
                         throw new TargetException();
 
-                    Debug.Assert(Nullable.GetUnderlyingType(type) == null);
+                    if (RuntimeAugments.IsNullable(typeHandle))
+                        return null;
 
-                    return RuntimeAugments.RawNewObject(type.TypeHandle);
+                    return RuntimeAugments.RawNewObject(typeHandle);
                 }
 
                 throw new MissingMethodException(SR.Format(SR.Arg_NoDefCTor, type));

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ActivatorImplementation.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ActivatorImplementation.cs
@@ -34,9 +34,6 @@ namespace System
                 {
                     RuntimeTypeHandle typeHandle = type.TypeHandle;
 
-                    if (RuntimeAugments.IsByRefLike(typeHandle))
-                        throw new TargetException();
-
                     if (RuntimeAugments.IsNullable(typeHandle))
                         return null;
 
@@ -89,9 +86,6 @@ namespace System
                 if (numArgs == 0 && type.IsValueType)
                 {
                     RuntimeTypeHandle typeHandle = type.TypeHandle;
-
-                    if (RuntimeAugments.IsByRefLike(typeHandle))
-                        throw new TargetException();
 
                     if (RuntimeAugments.IsNullable(typeHandle))
                         return null;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ActivatorImplementation.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ActivatorImplementation.cs
@@ -31,7 +31,14 @@ namespace System
             if (constructor == null)
             {
                 if (type.IsValueType)
-                    return RuntimeAugments.NewObject(type.TypeHandle);
+                {
+                    if (type.IsByRefLike)
+                        throw new TargetException();
+
+                    Debug.Assert(Nullable.GetUnderlyingType(type) == null);
+
+                    return RuntimeAugments.RawNewObject(type.TypeHandle);
+                }
 
                 throw new MissingMethodException(SR.Format(SR.Arg_NoDefCTor, type));
             }
@@ -77,7 +84,14 @@ namespace System
             if (matches.Count == 0)
             {
                 if (numArgs == 0 && type.IsValueType)
-                    return RuntimeAugments.NewObject(type.TypeHandle);
+                {
+                    if (type.IsByRefLike)
+                        throw new TargetException();
+
+                    Debug.Assert(Nullable.GetUnderlyingType(type) == null);
+
+                    return RuntimeAugments.RawNewObject(type.TypeHandle);
+                }
 
                 throw new MissingMethodException(SR.Format(SR.Arg_NoDefCTor, type));
             }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/CustomMethodInvoker.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/CustomMethodInvoker.cs
@@ -48,6 +48,12 @@ namespace System.Reflection.Runtime.MethodInfos
             return result;
         }
 
+        protected sealed override object CreateInstance(object?[]? arguments, BinderBundle binderBundle, bool wrapInTargetInvocationException)
+        {
+            // Custom method invokers need to also create the instance, so we just pass a null this.
+            return Invoke(null, arguments, binderBundle, wrapInTargetInvocationException);
+        }
+
         public sealed override Delegate CreateDelegate(RuntimeTypeHandle delegateType, object target, bool isStatic, bool isVirtual, bool isOpen)
         {
             if (_thisType.IsConstructedGenericType && _thisType.GetGenericTypeDefinition() == typeof(Nullable<>))

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/CustomMethodInvoker.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/CustomMethodInvoker.cs
@@ -51,6 +51,7 @@ namespace System.Reflection.Runtime.MethodInfos
         protected sealed override object CreateInstance(object?[]? arguments, BinderBundle binderBundle, bool wrapInTargetInvocationException)
         {
             // Custom method invokers need to also create the instance, so we just pass a null this.
+            Debug.Assert((_options & InvokerOptions.AllowNullThis) != 0);
             return Invoke(null, arguments, binderBundle, wrapInTargetInvocationException);
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/OpenMethodInvoker.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/OpenMethodInvoker.cs
@@ -19,6 +19,11 @@ namespace System.Reflection.Runtime.MethodInfos
             throw new InvalidOperationException(SR.Arg_UnboundGenParam);
         }
 
+        protected sealed override object CreateInstance(object?[]? arguments, BinderBundle binderBundle, bool wrapInTargetInvocationException)
+        {
+            throw new InvalidOperationException(SR.Arg_UnboundGenParam);
+        }
+
         public sealed override Delegate CreateDelegate(RuntimeTypeHandle delegateType, object target, bool isStatic, bool isVirtual, bool isOpen)
         {
             throw new InvalidOperationException(SR.Arg_UnboundGenParam);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/RuntimePlainConstructorInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/RuntimePlainConstructorInfo.cs
@@ -78,14 +78,9 @@ namespace System.Reflection.Runtime.MethodInfos
         [DebuggerGuidedStepThrough]
         public sealed override object Invoke(BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
         {
-            // Most objects are allocated by NewObject and their constructors return "void". But in many frameworks,
-            // there are "weird" cases (e.g. String) where the constructor must do both the allocation and initialization.
-            // Reflection.Core does not hardcode these special cases. It's up to the ExecutionEnvironment to steer
-            // us the right way by coordinating the implementation of NewObject and MethodInvoker.
-            object newObject = ReflectionCoreExecution.ExecutionEnvironment.NewObject(this.DeclaringType.TypeHandle);
-            object ctorAllocatedObject = this.MethodInvoker.Invoke(newObject, parameters, binder, invokeAttr, culture)!;
+            object ctorAllocatedObject = this.MethodInvoker.CreateInstance(parameters, binder, invokeAttr, culture);
             System.Diagnostics.DebugAnnotations.PreviousCallContainsDebuggerStepInCode();
-            return newObject ?? ctorAllocatedObject;
+            return ctorAllocatedObject;
         }
 
         public sealed override MethodBase MetadataDefinitionMethod

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.Runtime.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.Runtime.cs
@@ -21,11 +21,6 @@ namespace Internal.Reflection.Execution
     //==========================================================================================================
     internal sealed partial class ExecutionEnvironmentImplementation : ExecutionEnvironment
     {
-        public sealed override object NewObject(RuntimeTypeHandle typeHandle)
-        {
-            return RuntimeAugments.NewObject(typeHandle);
-        }
-
         public sealed override Array NewArray(RuntimeTypeHandle typeHandleForArrayType, int count)
         {
             return RuntimeAugments.NewArray(typeHandleForArrayType, count);

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/StaticMethodInvoker.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/StaticMethodInvoker.cs
@@ -36,6 +36,11 @@ namespace Internal.Reflection.Execution.MethodInvokers
             return result;
         }
 
+        protected sealed override object CreateInstance(object[] arguments, BinderBundle binderBundle, bool wrapInTargetInvocationException)
+        {
+            throw NotImplemented.ByDesign;
+        }
+
         public sealed override IntPtr LdFtnResult => MethodInvokeInfo.LdFtnResult;
     }
 }

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/VirtualMethodInvoker.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/VirtualMethodInvoker.cs
@@ -79,6 +79,11 @@ namespace Internal.Reflection.Execution.MethodInvokers
             return result;
         }
 
+        protected sealed override object CreateInstance(object[] arguments, BinderBundle binderBundle, bool wrapInTargetInvocationException)
+        {
+            throw NotImplemented.ByDesign;
+        }
+
         internal IntPtr ResolveTarget(RuntimeTypeHandle type)
         {
             return OpenMethodResolver.ResolveMethod(MethodInvokeInfo.VirtualResolveData, type);

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -369,7 +369,7 @@ namespace Internal.Runtime.TypeLoader
                 if (state.GcDataSize != 0)
                 {
                     // Statics are allocated on GC heap
-                    object obj = RuntimeAugments.NewObject(((MethodTable*)state.GcStaticDesc)->ToRuntimeTypeHandle());
+                    object obj = RuntimeAugments.RawNewObject(((MethodTable*)state.GcStaticDesc)->ToRuntimeTypeHandle());
                     gcStaticData = RuntimeAugments.RhHandleAlloc(obj, GCHandleType.Normal);
 
                     pEEType->DynamicGcStaticsData = gcStaticData;


### PR DESCRIPTION
Speeds up reflection-invoking constructors by about 30%.

Noticed we spend some time in the `ConstructorInfo` invocation infrastructure for no good reason.

* We'd first allocate an instance of the object using a general purpose allocator (that first needs to dissect the `MethodTable` to figure out how to allocate), and then
* We'd call into general-purpose Invoke infrastructure that would validate the `this` is valid.

Neither of those are necessary - we can figure out the right allocator at the time the method invoker is first accessed, and validating `this` is not necessary because we _just_ allocated the right one.

Cc @dotnet/ilc-contrib 