### PR TITLE
Missing symbol crash fix

### DIFF
--- a/src/mono/dlls/mscordbi/CMakeLists.txt
+++ b/src/mono/dlls/mscordbi/CMakeLists.txt
@@ -40,7 +40,6 @@ include_directories(
   ${CLR_DIR}/md/compiler
   ${CLR_DIR}/pal/prebuilt/inc
   ${CLR_DIR}/nativeresources)
-  #${CLR_DIR}/debug/dbgutil)
 
 set(mscorbi_sources_base
     cordb.cpp

--- a/src/mono/dlls/mscordbi/CMakeLists.txt
+++ b/src/mono/dlls/mscordbi/CMakeLists.txt
@@ -40,6 +40,7 @@ include_directories(
   ${CLR_DIR}/md/compiler
   ${CLR_DIR}/pal/prebuilt/inc
   ${CLR_DIR}/nativeresources)
+  #${CLR_DIR}/debug/dbgutil)
 
 set(mscorbi_sources_base
     cordb.cpp
@@ -124,6 +125,7 @@ include_directories(${CLR_DIR}/minipal)
 
 add_subdirectory(${CLR_DIR}/md/enc md/enc)
 add_subdirectory(${CLR_DIR}/utilcode utilcode)
+#add_subdirectory(${CLR_DIR}/debug/dbgutil /debug/dbgutil)
 if (CLR_CMAKE_HOST_UNIX)
     add_subdirectory(${CLR_DIR}/palrt palrt)
     append("-Wno-strict-prototypes -Wno-deprecated -Wno-pointer-arith" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
@@ -135,19 +137,25 @@ add_library(mscordbi SHARED "${mscorbi_sources};${PROJECT_SOURCE_DIR}/../../mono
 
 set_source_files_properties(${PROJECT_SOURCE_DIR}/../../mono/component/debugger-protocol.c PROPERTIES LANGUAGE CXX)
 
+set(START_WHOLE_ARCHIVE -Wl,--whole-archive)
+set(END_WHOLE_ARCHIVE -Wl,--no-whole-archive)
+# IMPORTANT! Please do not rearrange the order of the libraries. The linker on Linux is
+# order dependent and changing the order can result in undefined symbols in the shared
+# library.
 set(COREDBI_LIBRARIES
+    mdruntimerw-dbi
     utilcodestaticnohost
     mdruntime-dbi
     mdcompiler-dbi
-    mdruntimerw-dbi
     socket-dbi
     ${OS_LIBS}
 )
-
 if(CLR_CMAKE_HOST_UNIX)
     list(APPEND COREDBI_LIBRARIES
-        coreclrpal
+        ${START_WHOLE_ARCHIVE}
         palrt
+        coreclrpal
+        ${END_WHOLE_ARCHIVE}
         nativeresourcestring
     )
 endif()

--- a/src/mono/dlls/mscordbi/CMakeLists.txt
+++ b/src/mono/dlls/mscordbi/CMakeLists.txt
@@ -124,7 +124,6 @@ include_directories(${CLR_DIR}/minipal)
 
 add_subdirectory(${CLR_DIR}/md/enc md/enc)
 add_subdirectory(${CLR_DIR}/utilcode utilcode)
-#add_subdirectory(${CLR_DIR}/debug/dbgutil /debug/dbgutil)
 if (CLR_CMAKE_HOST_UNIX)
     add_subdirectory(${CLR_DIR}/palrt palrt)
     append("-Wno-strict-prototypes -Wno-deprecated -Wno-pointer-arith" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)


### PR DESCRIPTION
While working on netcore debugger for mono below symbols were missing from the binary.
 - mdHasSemantic
 - m_zeros
 - CBlobPoolHash
 - StgBlobPool
 - RecordPool
 - SplitPath
 - PEDecoder::CheckCorHeader
 - GetOsPageSize
 - PAL_Random 
 These symbols were part of mdruntime-dbi and mdruntimerw-dbi library. These library was properly linked to mscodbi. Though these were linked properly compiler was unableto find these symbols. Further investigations revealed that the order of linking these libraries plays an important role. After modifying the order of linkage the crash is resolved.