### PR TITLE
[codespaces] Fix V8 error when running lib tests

### DIFF
--- a/.devcontainer/wasm/Dockerfile
+++ b/.devcontainer/wasm/Dockerfile
@@ -33,7 +33,7 @@ SHELL ["/bin/bash", "-c"]
 RUN source /usr/local/share/nvm/nvm.sh && nvm install --lts
 
 # Install V8 Engine
-RUN curl -sSL "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/linux/chromium-v8/v8-linux64-rel-8.5.183.zip" -o ./v8.zip \
+RUN curl -sSL "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/linux/chromium-v8/v8-linux64-rel-10.8.168.zip" -o ./v8.zip \
     && unzip ./v8.zip -d /usr/local/v8 \
     && echo $'#!/usr/bin/env bash\n\
 "/usr/local/v8/d8" --snapshot_blob="/usr/local/v8/snapshot_blob.bin" "$@"\n' > /usr/local/bin/v8 \


### PR DESCRIPTION
Running lib testse.g.
```
./dotnet.sh build -bl /t:Test src/libraries/System.Globalization/tests/Hybrid/System.Globalization.Hybrid.WASM.Tests.csproj  /p:Configuration=Release /p:TargetOS=browser
```
 in codespaces finishes like this:
```
  [40m[32minfo[39m[22m[49m: await run();
  [40m[32minfo[39m[22m[49m: ^^^^^
  [40m[32minfo[39m[22m[49m: SyntaxError: Unexpected reserved word
  [40m[32minfo[39m[22m[49m: 
  [41m[30mfail[39m[22m[49m: Application has finished with exit code 1 but 0 was expected
  XHarness exit code: 71 (GENERAL_FAILURE)
```

The update fixes it.