### PR TITLE
[NativeAOT] allow creating CCW for resurrected objects

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -536,7 +536,14 @@ namespace System.Runtime.InteropServices
         {
             ArgumentNullException.ThrowIfNull(instance);
 
-            ManagedObjectWrapperHolder ccwValue = _ccwTable.GetValue(instance, (c) =>
+            ManagedObjectWrapperHolder? ccwValue;
+            if (_ccwTable.TryGetValue(instance, out ccwValue))
+            {
+                ccwValue.AddRef();
+                return ccwValue.ComIp;
+            }
+
+            ccwValue = _ccwTable.GetValue(instance, (c) =>
             {
                 ManagedObjectWrapper* value = CreateCCW(c, flags);
                 return new ManagedObjectWrapperHolder(value, c);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -409,7 +409,7 @@ namespace System.Runtime.InteropServices
 #pragma warning restore CS8500
             }
 
-            private ManagedObjectWrapper* _wrapper;
+            private readonly ManagedObjectWrapper* _wrapper;
             private readonly ManagedObjectWrapperReleaser _releaser;
             private readonly object _wrappedObject;
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -448,8 +448,8 @@ namespace System.Runtime.InteropServices
                 if (_exposed && _wrappedObject.Target != null)
                 {
                     // The wrapped object has not been fully collected, so it is still
-                    // potentially reachable via the CWT. Keep ourselves alive in case
-                    // the wrapped object is resurrected.
+                    // potentially reachable via the Conditional Weak Table.
+                    // Keep ourselves alive in case the wrapped object is resurrected.
                     GC.ReRegisterForFinalize(this);
                     return;
                 }

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -375,12 +375,12 @@ namespace ComWrappersTests
                 Assert.NotEqual(IntPtr.Zero, nativeInstance);
 
                 var iid = typeof(ITest).GUID;
-                IntPtr itestPtr;
+                nint itestPtr;
                 Assert.Equal(0, Marshal.QueryInterface(nativeInstance, ref iid, out itestPtr));
 
-                var inst = Marshal.PtrToStructure<VtblPtr>(itestPtr);
-                var vtbl = Marshal.PtrToStructure<ITestVtbl>(inst.Vtbl);
-                var setValue = (delegate* unmanaged<IntPtr, int, int>)vtbl.SetValue;
+                var inst = (ComWrappers.ComInterfaceDispatch*)itestPtr;
+                var vtbl = (ITestVtbl*)(inst->Vtable);
+                var setValue = (delegate* unmanaged<nint, int, int>)vtbl->SetValue;
 
                 Assert.Equal(0, setValue(itestPtr, 42));
                 Assert.Equal(42, Test.Resurrected.GetValue());
@@ -388,7 +388,7 @@ namespace ComWrappersTests
                 // release for QueryInterface
                 Assert.Equal(1, Marshal.Release(itestPtr));
                 // release for GetOrCreateComInterfaceForObject
-                Assert.Equal(0, Marshal.Release(itestPtr));
+                Assert.Equal(0, Marshal.Release(nativeInstance));
             }
         }
 

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -319,12 +319,12 @@ namespace ComWrappersTests
                 Assert.NotEqual(IntPtr.Zero, nativeInstance);
 
                 var iid = typeof(ITest).GUID;
-                IntPtr itestPtr;
+                nint itestPtr;
                 Assert.Equal(0, Marshal.QueryInterface(nativeInstance, ref iid, out itestPtr));
 
-                var inst = Marshal.PtrToStructure<VtblPtr>(itestPtr);
-                var vtbl = Marshal.PtrToStructure<ITestVtbl>(inst.Vtbl);
-                var setValue = (delegate* unmanaged<IntPtr, int, int>)vtbl.SetValue;
+                var inst = (ComWrappers.ComInterfaceDispatch*)itestPtr;
+                var vtbl = (ITestVtbl*)(inst->Vtable);
+                var setValue = (delegate* unmanaged<nint, int, int>)vtbl->SetValue;
 
                 Assert.Equal(0, setValue(itestPtr, value));
                 Assert.Equal(value, testInstance.GetValue());
@@ -332,7 +332,7 @@ namespace ComWrappersTests
                 // release for QueryInterface
                 Assert.Equal(1, Marshal.Release(itestPtr));
                 // release for GetOrCreateComInterfaceForObject
-                Assert.Equal(0, Marshal.Release(itestPtr));
+                Assert.Equal(0, Marshal.Release(nativeInstance));
             }
         }
 

--- a/src/tests/Interop/COM/ComWrappers/Common.cs
+++ b/src/tests/Interop/COM/ComWrappers/Common.cs
@@ -19,17 +19,25 @@ namespace ComWrappersTests.Common
 
     class Test : ITest, ICustomQueryInterface
     {
+        public static Test Resurrected;
         public static int InstanceCount = 0;
 
         private int id;
         private int value = -1;
         public Test() { id = Interlocked.Increment(ref InstanceCount); }
-        ~Test() { Interlocked.Decrement(ref InstanceCount); id = -1; }
+        ~Test()
+        {
+            Interlocked.Decrement(ref InstanceCount);
+            id = -1;
+            if (EnableResurrection)
+                Resurrected = this;
+        }
 
         public void SetValue(int i) => this.value = i;
         public int GetValue() => this.value;
 
         public bool EnableICustomQueryInterface { get; set; } = false;
+        public bool EnableResurrection { get; set; } = false;
         public Guid ICustomQueryInterface_GetInterfaceIID { get; set; }
         public IntPtr ICustomQueryInterface_GetInterfaceResult { get; set; }
 


### PR DESCRIPTION
This PR adds a test that on main passes for CoreCLR but segfaults for NativeAOT. It also includes fixes to make the test pass for NativeAOT.

The key problem is the conditional weak table will keep the `ManagedObjectWrapperHolder` alive but not prevent it from being finalized. This means that if the wrapped object is resurrected, calls to `GetOrCreateComInterfaceForObject` could return a pointer freed memory.

The solution this PR implements is to move the finialization of the `ManagedObjectWrapper` to a separate class. This class defers finialization until the wrapped object has been completely collected. The new `ManagedObjectWrapperReleaser` is referenced by the `ManagedObjectWrapperHolder` class, so it should not be finialized until the wrapped object becomes eligible for finialization.

The references between objects looks like this:

```mermaid
graph TD
WO[wrapped object];
MOW["ManagedObjectWrapper (unmanaged struct)"];
MOWH[ManagedObjectWrapperHolder];
Releaser[ManagedObjectWrapperReleaser];
WO -->|conditional weak table| MOWH;
MOWH --> WO;
MOWH --> MOW;
MOW -->|ref-counted handle| MOWH;
Releaser --> MOW;
MOWH --> Releaser;
```

Some other race conditions are also fixed by this PR:
* Previously the ref-counted handle in the `ManagedObjectWrapper` was not set until after the `ManagedObjectWrapperHolder` was added to the CWT. Hypothetically if a holder was added to the CWT but not yet initialized with the ref-counted handle, another thread could read the object out of the CWT and observe the null handle. This is fixed by doing all the initialization of the holder in its constructor.
* The `GetOrCreateComInterfaceForObject` was assuming that `ConditionalWeakTable.GetValue` always returns a new object and calling `AddRef` on the holder was not needed. However, `GetValue` can potentially call `TryGetValue` and return an existing instance. This means that if many threads called `GetOrCreateComInterfaceForObject` at the same time, the ref count on the `ManagedObjectWrapper` might not be as high as it should be. This is fixed by unconditionally calling `AddRef` on the holder.