### PR TITLE
Fix assert failure in grow_heap_segment for SVR GC.

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -6995,7 +6995,6 @@ void gc_heap::gc_thread_function ()
             {
                 update_collection_counts_for_no_gc();
                 proceed_with_gc_p = FALSE;
-                gradual_decommit_in_progress_p = FALSE;
             }
             else
             {
@@ -22934,6 +22933,11 @@ BOOL gc_heap::should_proceed_for_no_gc()
     BOOL soh_full_gc_requested = FALSE;
     BOOL no_gc_requested = FALSE;
     BOOL get_new_loh_segments = FALSE;
+
+#ifdef MULTIPLE_HEAPS
+    // need to turn off this flag here because of the call to grow_heap_segment below
+    gradual_decommit_in_progress_p = FALSE;
+#endif //MULTIPLE_HEAPS
 
     gc_heap* hp = nullptr;
     if (current_no_gc_region_info.soh_allocation_size)


### PR DESCRIPTION
For my previous change, I overlooked the fact that we may call grow_heap_segment from within `should_proceed_for_no_gc()`, so it's too late to turn off `gradual_decommit_in_progress_p `after this method returns.

The fix is to turn off `gradual_decommit_in_progress_p ` at the beginning of `should_proceed_for_no_gc()`. If it turns out we still want to do a GC, the flag will get turned on again by that GC, if appropriate.