### PR TITLE
Fix formatting issues in DependencyGraphViewer

### DIFF
--- a/src/coreclr/tools/aot/DependencyGraphViewer/NodeForm.cs
+++ b/src/coreclr/tools/aot/DependencyGraphViewer/NodeForm.cs
@@ -67,5 +67,5 @@ namespace DependencyLogViewer
             string dMessage = "Dependent nodes depend on the current node. The current node depends on the dependees.";
             MessageBox.Show(dMessage);
         }
-    }   
+    }
 }

--- a/src/coreclr/tools/aot/DependencyGraphViewer/Program.cs
+++ b/src/coreclr/tools/aot/DependencyGraphViewer/Program.cs
@@ -17,7 +17,7 @@ using Microsoft.Diagnostics.Tracing.Session;
 
 namespace DependencyLogViewer
 {
-	public class BoxDisplay
+    public class BoxDisplay
     {
         public Node node;
         public List<string> reason;


### PR DESCRIPTION
Whitespace only change, to fix tabs/spaces and trailing spaces. Without this the tool doesn't build.