### PR TITLE
[RISC-V][JIT] Implement genCodeForIncSaturate

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -1308,7 +1308,25 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
 // Produce code for a GT_INC_SATURATE node.
 void CodeGen::genCodeForIncSaturate(GenTree* tree)
 {
-    NYI_RISCV64("genCodeForIncSaturate-----unimplemented/unused on RISCV64 yet----");
+    regNumber targetReg = tree->GetRegNum();
+
+    // The arithmetic node must be sitting in a register (since it's not contained)
+    assert(!tree->isContained());
+    // The dst can only be a register.
+    assert(targetReg != REG_NA);
+
+    GenTree* operand = tree->gtGetOp1();
+    assert(!operand->isContained());
+    // The src must be a register.
+    regNumber operandReg = genConsumeReg(operand);
+    emitAttr  attr       = emitActualTypeSize(tree);
+
+    GetEmitter()->emitIns_R_R_I(INS_addi, attr, targetReg, operandReg, 1);
+    // bne targetReg, zero, 2 * 4
+    GetEmitter()->emitIns_R_R_I(INS_bne, attr, targetReg, REG_R0, 8);
+    GetEmitter()->emitIns_R_R_I(INS_xori, attr, targetReg, targetReg, -1);
+
+    genProduceReg(tree);
 }
 
 // Generate code to get the high N bits of a N*N=2N bit multiplication result


### PR DESCRIPTION
- Fixed a failure in ./JIT/opt/AssertionPropagation/ArrBoundBinaryOp/ArrBoundBinaryOp.sh (CHECKED build)

Part of https://github.com/dotnet/runtime/issues/84834
cc @wscho77 @HJLeee @JongHeonChoi @t-mustafin @alpencolt @gbalykov