### PR TITLE
[release/8.0-preview5] Use fully qualified type names for parameters and don't copy parameter attributes

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComMethodContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComMethodContext.cs
@@ -109,6 +109,7 @@ namespace Microsoft.Interop
                 .WithAttributeLists(List<AttributeListSyntax>())
                 .WithExplicitInterfaceSpecifier(ExplicitInterfaceSpecifier(
                     ParseName(OriginalDeclaringInterface.Info.Type.FullTypeName)))
+                .WithParameterList(ParameterList(SeparatedList(GenerationContext.SignatureContext.StubParameters)))
                 .WithExpressionBody(ArrowExpressionClause(
                     ThrowExpression(
                         ObjectCreationExpression(

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/CodeSnippets.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/CodeSnippets.cs
@@ -291,6 +291,24 @@ namespace ComInterfaceGenerator.Unit.Tests
             }
             """;
 
+        public string ComInterfaceInheritanceWithParametersWithAttributes => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+
+            {{GeneratedComInterface}}
+            partial interface IComInterface
+            {
+                void Method([MarshalUsing(typeof(Utf8StringMarshaller))] string myString);
+            }
+            {{GeneratedComInterface}}
+            partial interface IComInterface1 : IComInterface
+            {
+                void Method2([MarshalUsing(typeof(Utf8StringMarshaller))] string myString);
+            }
+
+            """;
+
         public class ManagedToUnmanaged : IVirtualMethodIndexSignatureProvider
         {
             public MarshalDirection Direction => MarshalDirection.ManagedToUnmanaged;

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/Compiles.cs
@@ -335,6 +335,7 @@ namespace ComInterfaceGenerator.Unit.Tests
             CodeSnippets codeSnippets = new(new GeneratedComInterfaceAttributeProvider());
             yield return new object[] { ID(), codeSnippets.DerivedComInterfaceType };
             yield return new object[] { ID(), codeSnippets.ComInterfaceParameters };
+            yield return new object[] { ID(), codeSnippets.ComInterfaceInheritanceWithParametersWithAttributes };
         }
 
         [Theory]


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3483 by not copying the attributes for the parameters on generated base implementation methods since they're not strictly necessary.