### PR TITLE
Fix ClrEtwAllMeta.lst for the ContentionLockCreated event

### DIFF
--- a/src/coreclr/vm/ClrEtwAllMeta.lst
+++ b/src/coreclr/vm/ClrEtwAllMeta.lst
@@ -190,7 +190,7 @@ nostack:Contention:::ContentionStop
 nomac:Contention:::ContentionStop
 nostack:Contention:::ContentionStop_V1
 nomac:Contention:::ContentionStop_V1
-nomac:Contention:::LockCreated
+nomac:Contention:::ContentionLockCreated
 
 ##################
 # StackWalk events


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/runtime/pull/86817, where the LockCreated event was renamed to ContentionLockCreated.