### PR TITLE
Remove comment in ZipFile.Create.cs

### DIFF
--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.cs
@@ -461,9 +461,6 @@ namespace System.IO.Compression
 
             // Rely on Path.GetFullPath for validation of sourceDirectoryName
 
-            // Checking of compressionLevel is passed down to DeflateStream and the IDeflater implementation
-            // as it is a pluggable component that completely encapsulates the meaning of compressionLevel.
-
             sourceDirectoryName = Path.GetFullPath(sourceDirectoryName);
 
             using ZipArchive archive = new ZipArchive(destination, ZipArchiveMode.Create, leaveOpen: true, entryNameEncoding);

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.cs
@@ -459,7 +459,7 @@ namespace System.IO.Compression
                 throw new ArgumentOutOfRangeException(nameof(compressionLevel));
             }
 
-            // Rely on Path.GetFullPath for validation of sourceDirectoryName and destinationArchive
+            // Rely on Path.GetFullPath for validation of sourceDirectoryName
 
             // Checking of compressionLevel is passed down to DeflateStream and the IDeflater implementation
             // as it is a pluggable component that completely encapsulates the meaning of compressionLevel.


### PR DESCRIPTION
In #85491 the stream-based version of the `DoCreateFromDirectory` override copy-pasted comments from the string-based version
```csharp
// Rely on Path.GetFullPath for validation of sourceDirectoryName and destinationArchive
```
The last clause of that comment is not relevant in the stream-based version (the argument is `Stream destination`) so deleted that clause.

It's possible that the other comment is also misleading as we test the `compressionLevel` argument just above (unlike in the `String destinationArchive` version)
```csharp
// Checking of compressionLevel is passed down to DeflateStream and the IDeflater implementation
// as it is a pluggable component that completely encapsulates the meaning of compressionLevel.
```