### PR TITLE
[wasm] Optimize jiterpreter type cast opcodes & add zero page optimizations

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -8717,6 +8717,7 @@ mono_jiterp_frame_data_allocator_alloc (FrameDataAllocator *stack, InterpFrame *
 	return frame_data_allocator_alloc(stack, frame, size);
 }
 
+// NOTE: This does not perform a null check and passing a null object or klass is an error!
 MONO_ALWAYS_INLINE gboolean
 mono_jiterp_isinst (MonoObject* object, MonoClass* klass)
 {

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -8717,7 +8717,7 @@ mono_jiterp_frame_data_allocator_alloc (FrameDataAllocator *stack, InterpFrame *
 	return frame_data_allocator_alloc(stack, frame, size);
 }
 
-MONO_ALWAYS_INLINE gboolean
+EMSCRIPTEN_KEEPALIVE MONO_ALWAYS_INLINE gboolean
 mono_jiterp_isinst (MonoObject* object, MonoClass* klass)
 {
 	return mono_interp_isinst (object, klass);

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -8717,7 +8717,7 @@ mono_jiterp_frame_data_allocator_alloc (FrameDataAllocator *stack, InterpFrame *
 	return frame_data_allocator_alloc(stack, frame, size);
 }
 
-EMSCRIPTEN_KEEPALIVE MONO_ALWAYS_INLINE gboolean
+MONO_ALWAYS_INLINE gboolean
 mono_jiterp_isinst (MonoObject* object, MonoClass* klass)
 {
 	return mono_interp_isinst (object, klass);

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -163,35 +163,6 @@ mono_jiterp_object_unbox (MonoObject *obj) {
 	return mono_object_unbox_internal(obj);
 }
 
-EMSCRIPTEN_KEEPALIVE MonoClass*
-mono_jiterp_get_element_class (MonoClass *klass) {
-	g_assert (klass);
-	return m_class_get_element_class (klass);
-}
-
-EMSCRIPTEN_KEEPALIVE int
-mono_jiterp_try_unbox_ref (
-	MonoClass *klass, void **dest, MonoObject **src
-) {
-	if (!klass)
-		return 0;
-
-	MonoObject *o = *src;
-	if (!o)
-		return 0;
-
-	if (
-		!(
-			(m_class_get_rank (o->vtable->klass) == 0) &&
-			(m_class_get_element_class (o->vtable->klass) == m_class_get_element_class (klass))
-		)
-	)
-		return 0;
-
-	*dest = mono_object_unbox_internal(o);
-	return 1;
-}
-
 EMSCRIPTEN_KEEPALIVE int
 mono_jiterp_type_is_byref (MonoType *type) {
 	if (!type)

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -163,6 +163,12 @@ mono_jiterp_object_unbox (MonoObject *obj) {
 	return mono_object_unbox_internal(obj);
 }
 
+EMSCRIPTEN_KEEPALIVE MonoClass*
+mono_jiterp_get_element_class (MonoClass *klass) {
+	g_assert (klass);
+	return m_class_get_element_class (klass);
+}
+
 EMSCRIPTEN_KEEPALIVE int
 mono_jiterp_try_unbox_ref (
 	MonoClass *klass, void **dest, MonoObject **src
@@ -1153,6 +1159,9 @@ mono_jiterp_trace_transfer (
 #define JITERP_MEMBER_PARAMS_COUNT 13
 #define JITERP_MEMBER_VTABLE 14
 #define JITERP_MEMBER_VTABLE_KLASS 15
+#define JITERP_MEMBER_CLASS_RANK 16
+#define JITERP_MEMBER_CLASS_ELEMENT_CLASS 17
+#define JITERP_MEMBER_BOXED_VALUE_DATA 18
 
 // we use these helpers at JIT time to figure out where to do memory loads and stores
 EMSCRIPTEN_KEEPALIVE size_t
@@ -1190,6 +1199,13 @@ mono_jiterp_get_member_offset (int member) {
 			return offsetof (MonoObject, vtable);
 		case JITERP_MEMBER_VTABLE_KLASS:
 			return offsetof (MonoVTable, klass);
+		case JITERP_MEMBER_CLASS_RANK:
+			return offsetof (MonoClass, rank);
+		case JITERP_MEMBER_CLASS_ELEMENT_CLASS:
+			return offsetof (MonoClass, element_class);
+		// see mono_object_get_data
+		case JITERP_MEMBER_BOXED_VALUE_DATA:
+			return MONO_ABI_SIZEOF (MonoObject);
 		default:
 			g_assert_not_reached();
 	}

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -253,7 +253,11 @@ mono_jiterp_implements_interface (
 	// If null check fusion is active, vtable->max_interface_id will be 0
 	if (MONO_VTABLE_IMPLEMENTS_INTERFACE (vtable, m_class_get_interface_id (klass)))
 		return 1;
-	else if (m_class_is_array_special_interface (klass))
+	// For special interfaces we need to do a more complex check to see whether the
+	//  cast to the interface is valid in case obj is an array.
+	// It's not safe to assume that mono_jiterp_isinst will handle nulls, and we don't
+	//  want to waste time running the full isinst machinery on nulls anyway, so nullcheck
+	else if (m_class_is_array_special_interface (klass) && obj)
 		return mono_jiterp_isinst (obj, klass);
 	else // HACK: Support null check fusion by returning 1 if the obj ptr was null
 		return (obj == 0);

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -266,38 +266,20 @@ mono_jiterp_cast_v2 (
 	MonoClass *klass, MintOpcode opcode
 ) {
 	if (!obj) {
-		*destination = 0;
+		*destination = NULL;
 		return 1;
-	}
-
-	if (obj->vtable->klass == klass) {
+		// FIXME push/pop LMF
+	} else if (!mono_jiterp_isinst (obj, klass)) {
+		// FIXME: do not swallow the error
+		if (opcode == MINT_ISINST) {
+			*destination = NULL;
+			return 1;
+		} else
+			return 0; // bailout
+	} else {
 		*destination = obj;
 		return 1;
 	}
-
-	switch (opcode) {
-		case MINT_CASTCLASS:
-		case MINT_ISINST: {
-			if (obj) {
-				// FIXME push/pop LMF
-				if (!mono_jiterp_isinst (obj, klass)) { // FIXME: do not swallow the error
-					if (opcode == MINT_ISINST)
-						*destination = NULL;
-					else {
-						return 0; // bailout
-					}
-				} else {
-					*destination = obj;
-				}
-			} else {
-				*destination = NULL;
-			}
-			return 1;
-		}
-	}
-
-	g_assert_not_reached();
-	return 0;
 }
 
 EMSCRIPTEN_KEEPALIVE void

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -249,7 +249,6 @@ EMSCRIPTEN_KEEPALIVE int
 mono_jiterp_implements_interface (
 	MonoVTable *vtable, MonoClass *klass
 ) {
-	// FIXME: Perform some of this work at JIT time
 	// If null check fusion is active, vtable->max_interface_id will be 0
 	return MONO_VTABLE_IMPLEMENTS_INTERFACE (vtable, m_class_get_interface_id (klass)) || (vtable == NULL);
 }
@@ -264,7 +263,6 @@ EMSCRIPTEN_KEEPALIVE int
 mono_jiterp_implements_special_interface (
 	MonoObject *obj, MonoVTable *vtable, MonoClass *klass
 ) {
-	// FIXME: Perform some of this work at JIT time
 	// If null check fusion is active, vtable->max_interface_id will be 0
 	if (MONO_VTABLE_IMPLEMENTS_INTERFACE (vtable, m_class_get_interface_id (klass)))
 		return 1;

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -239,6 +239,7 @@ mono_jiterp_has_parent_fast (
 ) {
 	// HACK: Support null check fusion: a null obj will produce a null obj->vtable->klass,
 	//  so we can return 1 to make the cast "succeed" and store null to the destination
+	// Based on instrumentation, null pointers flowing into this location are not very common
 	if (!klass)
 		return 1;
 	else

--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -131,6 +131,7 @@ const fn_signatures: SigLine[] = [
     [true, "mono_jiterp_get_arg_offset", "number", ["number", "number", "number"]],
     [true, "mono_jiterp_get_opcode_info", "number", ["number", "number"]],
     [true, "mono_wasm_is_zero_page_reserved", "number", []],
+    [true, "mono_jiterp_is_special_interface", "number", ["number"]],
     ...legacy_interop_cwraps
 ];
 
@@ -257,6 +258,7 @@ export interface t_Cwraps {
     mono_jiterp_get_arg_offset(imethod: number, sig: number, index: number): number;
     mono_jiterp_get_opcode_info(opcode: number, type: number): number;
     mono_wasm_is_zero_page_reserved(): number;
+    mono_jiterp_is_special_interface(klass: number): number;
 }
 
 const wrapped_c_functions: t_Cwraps = <any>{};

--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -131,7 +131,6 @@ const fn_signatures: SigLine[] = [
     [true, "mono_jiterp_get_arg_offset", "number", ["number", "number", "number"]],
     [true, "mono_jiterp_get_opcode_info", "number", ["number", "number"]],
     [true, "mono_wasm_is_zero_page_reserved", "number", []],
-    [true, "mono_jiterp_get_cast_counter", "number", ["number"]],
     ...legacy_interop_cwraps
 ];
 
@@ -258,7 +257,6 @@ export interface t_Cwraps {
     mono_jiterp_get_arg_offset(imethod: number, sig: number, index: number): number;
     mono_jiterp_get_opcode_info(opcode: number, type: number): number;
     mono_wasm_is_zero_page_reserved(): number;
-    mono_jiterp_get_cast_counter(type: number): number;
 }
 
 const wrapped_c_functions: t_Cwraps = <any>{};

--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -131,6 +131,7 @@ const fn_signatures: SigLine[] = [
     [true, "mono_jiterp_get_arg_offset", "number", ["number", "number", "number"]],
     [true, "mono_jiterp_get_opcode_info", "number", ["number", "number"]],
     [true, "mono_wasm_is_zero_page_reserved", "number", []],
+    [true, "mono_jiterp_get_cast_counter", "number", ["number"]],
     ...legacy_interop_cwraps
 ];
 
@@ -257,6 +258,7 @@ export interface t_Cwraps {
     mono_jiterp_get_arg_offset(imethod: number, sig: number, index: number): number;
     mono_jiterp_get_opcode_info(opcode: number, type: number): number;
     mono_wasm_is_zero_page_reserved(): number;
+    mono_jiterp_get_cast_counter(type: number): number;
 }
 
 const wrapped_c_functions: t_Cwraps = <any>{};

--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -1742,6 +1742,9 @@ export const enum JiterpMember {
     ParamsCount = 13,
     VTable = 14,
     VTableKlass = 15,
+    ClassRank = 16,
+    ClassElementClass = 17,
+    BoxedValueData = 18,
 }
 
 const memberOffsets: { [index: number]: number } = {};

--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+import MonoWasmThreads from "consts:monoWasmThreads";
 import { NativePointer, ManagedPointer, VoidPtr } from "./types/emscripten";
 import { Module, runtimeHelpers } from "./globals";
 import { WasmOpcode, WasmSimdOpcode } from "./jiterpreter-opcodes";
@@ -1783,6 +1784,9 @@ export function bytesFromHex(hex: string): Uint8Array {
 export function isZeroPageReserved(): boolean {
     // FIXME: This check will always return true on worker threads.
     // Right now the jiterpreter is disabled when threading is active, so that's not an issue.
+    if (MonoWasmThreads)
+        return false;
+
     if (!cwraps.mono_wasm_is_zero_page_reserved())
         return false;
 

--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -1739,6 +1739,8 @@ export const enum JiterpMember {
     BackwardBranchOffsetsCount = 11,
     ClauseDataOffsets = 12,
     ParamsCount = 13,
+    VTable = 14,
+    VTableKlass = 15,
 }
 
 const memberOffsets: { [index: number]: number } = {};

--- a/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
@@ -913,7 +913,7 @@ export function generateWasmBody(
                 builder.appendU8(WasmOpcode.else_); // else cast failed
                 if (bailoutOnFailure) {
                     // so bailout
-                    append_exit(builder, ip, exitOpcodeCounter, BailoutReason.CastFailed);
+                    append_bailout(builder, ip, BailoutReason.CastFailed);
                 } else {
                     // this is isinst, so write 0 to destination instead
                     builder.local("pLocals");

--- a/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
@@ -849,7 +849,7 @@ export function generateWasmBody(
             case MintOpcode.MINT_CASTCLASS_INTERFACE:
             case MintOpcode.MINT_ISINST_INTERFACE: {
                 const klass = get_imethod_data(frame, getArgU16(ip, 3)),
-                    isSpecialInterface = cwraps.mono_jiterp_is_special_interface(<any>klass),
+                    isSpecialInterface = cwraps.mono_jiterp_is_special_interface(klass),
                     bailoutOnFailure = (opcode === MintOpcode.MINT_CASTCLASS_INTERFACE),
                     destOffset = getArgU16(ip, 1);
                 if (!klass) {

--- a/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
@@ -1102,7 +1102,7 @@ export function generateWasmBody(
 
                 // Check klass->rank == 0
                 builder.local("temp_ptr2");
-                builder.appendU8(WasmOpcode.i32_load);
+                builder.appendU8(WasmOpcode.i32_load8_u); // rank is a uint8
                 builder.appendMemarg(getMemberOffset(JiterpMember.ClassRank), 0);
                 builder.appendU8(WasmOpcode.i32_eqz);
 

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -267,7 +267,6 @@ function getTraceImports() {
         importDef("hasparent", getRawCwrap("mono_jiterp_has_parent_fast")),
         importDef("imp_iface", getRawCwrap("mono_jiterp_implements_interface")),
         importDef("imp_iface_s", getRawCwrap("mono_jiterp_implements_special_interface")),
-        importDef("try_unbox", getRawCwrap("mono_jiterp_try_unbox_ref")),
         importDef("box", getRawCwrap("mono_jiterp_box_ref")),
         importDef("localloc", getRawCwrap("mono_jiterp_localloc")),
         ["ckovr_i4", "overflow_check_i4", getRawCwrap("mono_jiterp_overflow_check_i4")],
@@ -534,15 +533,6 @@ function initialize_builder(builder: WasmBuilder) {
             "obj": WasmValtype.i32,
             "vtable": WasmValtype.i32,
             "klass": WasmValtype.i32,
-        },
-        WasmValtype.i32, true
-    );
-    builder.defineType(
-        "try_unbox",
-        {
-            "klass": WasmValtype.i32,
-            "destination": WasmValtype.i32,
-            "source": WasmValtype.i32,
         },
         WasmValtype.i32, true
     );

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -265,6 +265,7 @@ function getTraceImports() {
         importDef("gettype", getRawCwrap("mono_jiterp_gettype_ref")),
         importDef("castv2", getRawCwrap("mono_jiterp_cast_v2")),
         importDef("hasparent", getRawCwrap("mono_jiterp_has_parent_fast")),
+        importDef("imp_iface", getRawCwrap("mono_jiterp_implements_interface")),
         // importDef("isinst", getRawCwrap("mono_jiterp_isinst")),
         importDef("try_unbox", getRawCwrap("mono_jiterp_try_unbox_ref")),
         importDef("box", getRawCwrap("mono_jiterp_box_ref")),
@@ -516,6 +517,15 @@ function initialize_builder(builder: WasmBuilder) {
         {
             "klass": WasmValtype.i32,
             "parent": WasmValtype.i32,
+        },
+        WasmValtype.i32, true
+    );
+    builder.defineType(
+        "imp_iface",
+        {
+            "obj": WasmValtype.i32,
+            "vtable": WasmValtype.i32,
+            "klass": WasmValtype.i32,
         },
         WasmValtype.i32, true
     );

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -266,7 +266,6 @@ function getTraceImports() {
         importDef("castv2", getRawCwrap("mono_jiterp_cast_v2")),
         importDef("hasparent", getRawCwrap("mono_jiterp_has_parent_fast")),
         importDef("imp_iface", getRawCwrap("mono_jiterp_implements_interface")),
-        // importDef("isinst", getRawCwrap("mono_jiterp_isinst")),
         importDef("try_unbox", getRawCwrap("mono_jiterp_try_unbox_ref")),
         importDef("box", getRawCwrap("mono_jiterp_box_ref")),
         importDef("localloc", getRawCwrap("mono_jiterp_localloc")),

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -266,6 +266,7 @@ function getTraceImports() {
         importDef("castv2", getRawCwrap("mono_jiterp_cast_v2")),
         importDef("hasparent", getRawCwrap("mono_jiterp_has_parent_fast")),
         importDef("imp_iface", getRawCwrap("mono_jiterp_implements_interface")),
+        importDef("imp_iface_s", getRawCwrap("mono_jiterp_implements_special_interface")),
         importDef("try_unbox", getRawCwrap("mono_jiterp_try_unbox_ref")),
         importDef("box", getRawCwrap("mono_jiterp_box_ref")),
         importDef("localloc", getRawCwrap("mono_jiterp_localloc")),
@@ -521,6 +522,14 @@ function initialize_builder(builder: WasmBuilder) {
     );
     builder.defineType(
         "imp_iface",
+        {
+            "vtable": WasmValtype.i32,
+            "klass": WasmValtype.i32,
+        },
+        WasmValtype.i32, true
+    );
+    builder.defineType(
+        "imp_iface_s",
         {
             "obj": WasmValtype.i32,
             "vtable": WasmValtype.i32,


### PR DESCRIPTION
This PR inlines a sizable portion of MINT_CASTCLASS/MINT_ISINST logic into jiterpreter traces to create fast paths for exact matches/null pointers that avoids running all the type check machinery we normally would run. Based on my instrumentation these fast paths will be used ~30% of the time, and measurements show a 1-3% improvement for the json section of browser-bench (this is pretty hard to measure, I may try to construct a decent synthetic benchmark for this).

This PR also applies zero page optimizations if available, by fusing the null check into the `obj->vtable` load. The helper code is all tweaked so that in the event a check fails due to a null ptr (null inputs are fairly uncommon in the instrumentation) it is converted into a success since MINT_CASTCLASS and MINT_ISINST both succeed for null instead of throwing.

It may be worth inlining the interface check entirely, but I haven't done the work to test that yet. The existence of special interfaces for arrays makes that harder to do.

This PR also fully inlines the implementation of MINT_UNBOX.