### PR TITLE
[mono][jit] Fix float to int/uint casting behavior

### DIFF
--- a/src/mono/mono/mini/mini-arm64.c
+++ b/src/mono/mono/mini/mini-arm64.c
@@ -4954,19 +4954,19 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			arm_fneg_s (code, dreg, sreg1);
 			break;
 		case OP_RCONV_TO_I1:
-			arm_fcvtzs_sw (code, dreg, sreg1);
+			arm_fcvtzs_sx (code, dreg, sreg1);
 			arm_sxtbx (code, dreg, dreg);
 			break;
 		case OP_RCONV_TO_U1:
-			arm_fcvtzu_sw (code, dreg, sreg1);
+			arm_fcvtzu_sx (code, dreg, sreg1);
 			arm_uxtbw (code, dreg, dreg);
 			break;
 		case OP_RCONV_TO_I2:
-			arm_fcvtzs_sw (code, dreg, sreg1);
+			arm_fcvtzs_sx (code, dreg, sreg1);
 			arm_sxthx (code, dreg, dreg);
 			break;
 		case OP_RCONV_TO_U2:
-			arm_fcvtzu_sw (code, dreg, sreg1);
+			arm_fcvtzu_sx (code, dreg, sreg1);
 			arm_uxthw (code, dreg, dreg);
 			break;
 		case OP_RCONV_TO_I4:

--- a/src/mono/mono/mini/mini-arm64.c
+++ b/src/mono/mono/mini/mini-arm64.c
@@ -4954,27 +4954,26 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			arm_fneg_s (code, dreg, sreg1);
 			break;
 		case OP_RCONV_TO_I1:
-			arm_fcvtzs_sx (code, dreg, sreg1);
+			arm_fcvtzs_sw (code, dreg, sreg1);
 			arm_sxtbx (code, dreg, dreg);
 			break;
 		case OP_RCONV_TO_U1:
-			arm_fcvtzu_sx (code, dreg, sreg1);
+			arm_fcvtzu_sw (code, dreg, sreg1);
 			arm_uxtbw (code, dreg, dreg);
 			break;
 		case OP_RCONV_TO_I2:
-			arm_fcvtzs_sx (code, dreg, sreg1);
+			arm_fcvtzs_sw (code, dreg, sreg1);
 			arm_sxthx (code, dreg, dreg);
 			break;
 		case OP_RCONV_TO_U2:
-			arm_fcvtzu_sx (code, dreg, sreg1);
+			arm_fcvtzu_sw (code, dreg, sreg1);
 			arm_uxthw (code, dreg, dreg);
 			break;
 		case OP_RCONV_TO_I4:
-			arm_fcvtzs_sx (code, dreg, sreg1);
-			arm_sxtwx (code, dreg, dreg);
+			arm_fcvtzs_sw (code, dreg, sreg1);
 			break;
 		case OP_RCONV_TO_U4:
-			arm_fcvtzu_sx (code, dreg, sreg1);
+			arm_fcvtzu_sw (code, dreg, sreg1);
 			break;
 		case OP_RCONV_TO_I8:
 			arm_fcvtzs_sx (code, dreg, sreg1);

--- a/src/mono/mono/mini/mini-arm64.c
+++ b/src/mono/mono/mini/mini-arm64.c
@@ -4869,11 +4869,10 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			arm_uxthw (code, dreg, dreg);
 			break;
 		case OP_FCONV_TO_I4:
-			arm_fcvtzs_dx (code, dreg, sreg1);
-			arm_sxtwx (code, dreg, dreg);
+			arm_fcvtzs_dw (code, dreg, sreg1);
 			break;
 		case OP_FCONV_TO_U4:
-			arm_fcvtzu_dx (code, dreg, sreg1);
+			arm_fcvtzu_dw (code, dreg, sreg1);
 			break;
 		case OP_FCONV_TO_I8:
 			arm_fcvtzs_dx (code, dreg, sreg1);

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2927,12 +2927,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Exceptions/ForeignThread/ForeignThreadExceptions/**">
             <Issue>https://github.com/dotnet/runtime/issues/82859</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/SIMD/VectorConvert_r_Target_64Bit/**">
-            <Issue>https://github.com/dotnet/runtime/issues/85316</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/SIMD/VectorConvert_ro_Target_64Bit/**">
-            <Issue>https://github.com/dotnet/runtime/issues/85316</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <ItemGroup Condition=" '$(RuntimeFlavor)' == 'mono' and '$(TargetArchitecture)' == 'arm64' and '$(TargetsWindows)' != 'true' " >


### PR DESCRIPTION
Modifies `f32` to `i32` and `u32` casting behavior on arm64 so that overflow cases saturate. 16-bit and 8-bit integers retain previous casting model. Addresses https://github.com/dotnet/runtime/issues/85316. Enables SIMD f->i casting tests.