### PR TITLE
[RISC-V] Fix ReversePInvoke typo

### DIFF
--- a/src/coreclr/vm/riscv64/stubs.cpp
+++ b/src/coreclr/vm/riscv64/stubs.cpp
@@ -934,7 +934,7 @@ void UMEntryThunkCode::Encode(UMEntryThunkCode *pEntryThunkCodeRX, BYTE* pTarget
     // m_pTargetCode data
     // m_pvSecretParam data
 
-    m_code[0] = 0x00009f97; // auipc t6, 0
+    m_code[0] = 0x00000f97; // auipc t6, 0
     m_code[1] = 0x018fb383; // ld    t2, 24(t6)
     m_code[2] = 0x010fbf83; // ld    t6, 16(t6)
     m_code[3] = 0x000f8067; // jalr  x0, 0(t6)


### PR DESCRIPTION
Fixes SIGSEGV in `JIT/Methodical/structs/systemvbringup/structinregs/structinregs.sh`.

Part of #84834.

@alpencolt @clamp03 @gbalykov.