### PR TITLE
System.Data: override System.Data.Sql tfm only when ArcadeBuildFromSource.

### DIFF
--- a/src/libraries/shims/System.Data/Directory.Build.props
+++ b/src/libraries/shims/System.Data/Directory.Build.props
@@ -7,7 +7,7 @@
     <StrongNameKeyId>ECMA</StrongNameKeyId>
     <SystemDataSqlClientTFM>netcoreapp2.1</SystemDataSqlClientTFM>
     <!-- Keep in sync with TFM exposed in source-build-reference-packages/src/referencePackages/src/system.data.sqlclient/4.8.5 -->
-    <SystemDataSqlClientTFM Condition="'$(DotNetBuildFromSource)' == 'true'">net6.0</SystemDataSqlClientTFM>
+    <SystemDataSqlClientTFM Condition="'$(ArcadeBuildFromSource)' == 'true'">net6.0</SystemDataSqlClientTFM>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/86946

@MichaelSimons @ViktorHofer ptal.