### PR TITLE
Fix rounding error in getLikelyClassesOrMethods

### DIFF
--- a/src/coreclr/jit/likelyclass.cpp
+++ b/src/coreclr/jit/likelyclass.cpp
@@ -121,6 +121,11 @@ static unsigned getLikelyClassesOrMethods(LikelyClassMethodRecord*              
                                           int32_t                                ilOffset,
                                           bool                                   types)
 {
+    if (maxLikelyClasses == 0)
+    {
+        return 0;
+    }
+
     ICorJitInfo::PgoInstrumentationKind histogramKind =
         types ? ICorJitInfo::PgoInstrumentationKind::HandleHistogramTypes
               : ICorJitInfo::PgoInstrumentationKind::HandleHistogramMethods;
@@ -235,6 +240,12 @@ static unsigned getLikelyClassesOrMethods(LikelyClassMethodRecord*              
                         }
                     }
 
+                    if (knownHandles == 0)
+                    {
+                        // We don't have known handles
+                        return 0;
+                    }
+
                     // sort by m_count (descending)
                     jitstd::sort(sortedEntries, sortedEntries + knownHandles,
                                  [](const LikelyClassMethodHistogramEntry& h1,
@@ -257,8 +268,9 @@ static unsigned getLikelyClassesOrMethods(LikelyClassMethodRecord*              
 
                     // Distribute the rounding error and just apply it to the first entry.
                     // Assume that there is no error If we have unknown handles.
-                    if ((numberOfClasses > 0) && (numberOfClasses == h.m_totalCount))
+                    if (numberOfClasses == h.m_totalCount)
                     {
+                        assert(numberOfClasses > 0);
                         assert(totalLikelihood > 0);
                         pLikelyEntries[0].likelihood += 100 - totalLikelihood;
                         assert(pLikelyEntries[0].likelihood <= 100);

--- a/src/coreclr/jit/likelyclass.cpp
+++ b/src/coreclr/jit/likelyclass.cpp
@@ -266,7 +266,10 @@ static unsigned getLikelyClassesOrMethods(LikelyClassMethodRecord*              
                     {
                         assert(numberOfClasses > 0);
                         pLikelyEntries[0].likelihood += (UINT32)totalLikelihoodDbl - totalLikelihoodInt;
+                        assert(pLikelyEntries[0].likelihood <= 100);
                     }
+
+                    assert(totalLikelihoodDbl <= 100.0);
 
                     return numberOfClasses;
                 }

--- a/src/coreclr/jit/likelyclass.cpp
+++ b/src/coreclr/jit/likelyclass.cpp
@@ -244,32 +244,26 @@ static unsigned getLikelyClassesOrMethods(LikelyClassMethodRecord*              
 
                     const UINT32 numberOfClasses = min(knownHandles, maxLikelyClasses);
 
-                    // Accumulate the total likelihood and distribute the rounding error
-                    UINT32 totalLikelihoodInt = 0;
-                    double totalLikelihoodDbl = 0.0;
-
+                    double roundingError = 0.0;
                     for (size_t hIdx = 0; hIdx < numberOfClasses; hIdx++)
                     {
                         LikelyClassMethodHistogramEntry const hc         = sortedEntries[hIdx];
                         const double                          likelihood = hc.m_count * 100.0 / h.m_totalCount;
+                        pLikelyEntries[hIdx].handle                      = hc.m_handle;
+                        pLikelyEntries[hIdx].likelihood                  = (UINT32)likelihood;
 
-                        pLikelyEntries[hIdx].handle     = hc.m_handle;
-                        pLikelyEntries[hIdx].likelihood = (UINT32)likelihood;
-
-                        totalLikelihoodDbl += likelihood;
-                        totalLikelihoodInt += (UINT32)likelihood;
+                        // Accumulate the rounding error
+                        roundingError += likelihood - (double)(UINT32)likelihood;
                     }
 
                     // Distribute the rounding error, just apply it to the first entry
                     // so we can avoid marking fallback case as e.g. 1% likely while in fact it's 0.
-                    if ((UINT32)totalLikelihoodDbl > totalLikelihoodInt)
+                    if (roundingError >= 1.0)
                     {
                         assert(numberOfClasses > 0);
-                        pLikelyEntries[0].likelihood += (UINT32)totalLikelihoodDbl - totalLikelihoodInt;
+                        pLikelyEntries[0].likelihood += (UINT32)roundingError;
                         assert(pLikelyEntries[0].likelihood <= 100);
                     }
-
-                    assert(totalLikelihoodDbl <= 100.0);
 
                     return numberOfClasses;
                 }

--- a/src/coreclr/jit/likelyclass.cpp
+++ b/src/coreclr/jit/likelyclass.cpp
@@ -250,11 +250,11 @@ static unsigned getLikelyClassesOrMethods(LikelyClassMethodRecord*              
 
                     for (size_t hIdx = 0; hIdx < numberOfClasses; hIdx++)
                     {
-                        LikelyClassMethodHistogramEntry const hc = sortedEntries[hIdx];
-                        const double likelihood = hc.m_count * 100.0 / h.m_totalCount;
+                        LikelyClassMethodHistogramEntry const hc         = sortedEntries[hIdx];
+                        const double                          likelihood = hc.m_count * 100.0 / h.m_totalCount;
 
-                        pLikelyEntries[hIdx].handle              = hc.m_handle;
-                        pLikelyEntries[hIdx].likelihood          = (UINT32)likelihood;
+                        pLikelyEntries[hIdx].handle     = hc.m_handle;
+                        pLikelyEntries[hIdx].likelihood = (UINT32)likelihood;
 
                         totalLikelihoodDbl += likelihood;
                         totalLikelihoodInt += (UINT32)likelihood;


### PR DESCRIPTION
It seems that sometimes `getLikelyClasses` reports that fallback has e.g. 1% likelihood where in fact it's 0. It happens because of the rounding error accumulated in `getLikelyClassesOrMethods`. It prevents JIT from moving that fallback to a cold section.
