### PR TITLE
Revert "Revert "Change our Android build and test legs to use the new CBL-Mariner-based images.""

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -580,6 +580,26 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
+# Android x64 with Docker-in-Docker
+
+- ${{ if containsValue(parameters.platforms, 'android_x64_docker') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: android
+      archType: x64
+      targetRid: android-x64
+      platform: android_x64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: android_docker
+      jobParameters:
+        runtimeFlavor: mono
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
+
 # Android x86
 
 - ${{ if containsValue(parameters.platforms, 'android_x86') }}:

--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -33,10 +33,14 @@ resources:
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64-alpine
       env:
         ROOTFS_DIR: /crossrootfs/arm64
-    # This container contains all required toolsets to build for Android and for Linux with bionic libc.
 
+    # This container contains all required toolsets to build for Android and for Linux with bionic libc.
     - container: linux_bionic
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-android
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-android
+
+    # This container contains all required toolsets to build for Android as well as tooling to build docker images.
+    - container: android_docker
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-android-docker
 
     - container: linux_x64
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64

--- a/eng/pipelines/runtime-android-grpc-client-tests.yml
+++ b/eng/pipelines/runtime-android-grpc-client-tests.yml
@@ -36,7 +36,7 @@ extends:
           buildConfig: Release
           runtimeFlavor: mono
           platforms:
-          - android_x64
+          - android_x64_docker
           jobParameters:
             testGroup: innerloop
             nameSuffix: AllSubsets_Mono_gRPC


### PR DESCRIPTION
The image has been updated to fix the linux-bionic build, so it should work now.