### PR TITLE
[wasm] Fix failing blazor tests to handle disabled fingerprinting

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
@@ -822,7 +822,7 @@ namespace Wasm.Build.Tests
             return result;
         }
 
-        protected void AssertBlazorBundle(string config, bool isPublish, bool dotnetWasmFromRuntimePack, string targetFramework = DefaultTargetFrameworkForBlazor, string? binFrameworkDir = null)
+        protected void AssertBlazorBundle(string config, bool isPublish, bool dotnetWasmFromRuntimePack, string targetFramework = DefaultTargetFrameworkForBlazor, string? binFrameworkDir = null, bool expectFingerprinting = false)
         {
             binFrameworkDir ??= FindBlazorBinFrameworkDir(config, isPublish, targetFramework);
 
@@ -832,7 +832,7 @@ namespace Wasm.Build.Tests
                        "Expected dotnet.native.wasm to be same as the runtime pack",
                        same: dotnetWasmFromRuntimePack);
 
-            string? dotnetJsPath = Directory.EnumerateFiles(binFrameworkDir, "dotnet.native.*.js").FirstOrDefault();
+            string? dotnetJsPath = Directory.EnumerateFiles(binFrameworkDir, expectFingerprinting ? "dotnet.native.*.js" : "dotnet.native.js").FirstOrDefault();
             Assert.True(dotnetJsPath != null, $"Could not find blazor's dotnet*js in {binFrameworkDir}");
 
             AssertFile(Path.Combine(s_buildEnv.GetRuntimeNativeDir(targetFramework), "dotnet.native.js"),


### PR DESCRIPTION
https://github.com/dotnet/sdk/pull/31829 disabled fingerprinting by default for blazor projects, and that broke the tests.

Fixes https://github.com/dotnet/runtime/issues/86959 .