### PR TITLE
[wasm][build] Don't use GetTempFileName; emit webcil to subdir of obj

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -214,7 +214,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_WasmBuildWebCilPath>$(IntermediateOutputPath)webcil</_WasmBuildWebCilPath>
     </PropertyGroup>
 
-    <ConvertDllsToWebCil Candidates="@(_BuildAssetsCandidates)" OutputPath="$(_WasmBuildWebCilPath)" IsEnabled="$(_WasmEnableWebcil)">
+    <ConvertDllsToWebCil Candidates="@(_BuildAssetsCandidates)" IntermediateOutputPath="$(IntermediateOutputPath)tmp-webcil" OutputPath="$(_WasmBuildWebCilPath)" IsEnabled="$(_WasmEnableWebcil)">
       <Output TaskParameter="WebCilCandidates" ItemName="_WebCilAssetsCandidates" />
       <Output TaskParameter="FileWrites" ItemName="FileWrites" />
     </ConvertDllsToWebCil>
@@ -387,7 +387,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_WasmPublishWebCilPath>$(IntermediateOutputPath)webcil\publish</_WasmPublishWebCilPath>
     </PropertyGroup>
 
-    <ConvertDllsToWebCil Candidates="@(_NewWasmPublishStaticWebAssets)" OutputPath="$(_WasmPublishWebCilPath)" IsEnabled="$(_WasmEnableWebcil)">
+    <ConvertDllsToWebCil Candidates="@(_NewWasmPublishStaticWebAssets)" IntermediateOutputPath="$(ConvertDllsToWebCil)tmp-webcil\publish" OutputPath="$(_WasmPublishWebCilPath)" IsEnabled="$(_WasmEnableWebcil)">
       <Output TaskParameter="WebCilCandidates" ItemName="_NewWebCilPublishStaticWebAssets" />
       <Output TaskParameter="FileWrites" ItemName="FileWrites" />
     </ConvertDllsToWebCil>

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ConvertDllsToWebCil.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ConvertDllsToWebCil.cs
@@ -26,6 +26,9 @@ public class ConvertDllsToWebCil : Task
     public string OutputPath { get; set; }
 
     [Required]
+    public string IntermediateOutputPath { get; set; }
+
+    [Required]
     public bool IsEnabled { get; set; }
 
     [Output]
@@ -35,6 +38,7 @@ public class ConvertDllsToWebCil : Task
 
     [Output]
     public string[]? FileWrites => _fileWrites.ToArray();
+
 
     public override bool Execute()
     {
@@ -52,13 +56,17 @@ public class ConvertDllsToWebCil : Task
 
             var extension = candidate.GetMetadata("Extension");
             var filePath = candidate.ItemSpec;
+            var webcilFileName = Path.GetFileNameWithoutExtension(filePath) + Utils.WebcilInWasmExtension;
 
             if (!Directory.Exists(OutputPath))
                 Directory.CreateDirectory(OutputPath);
 
             if (extension == ".dll")
             {
-                var tmpWebcil = Path.GetTempFileName();
+                var tmpDir = IntermediateOutputPath;
+                if (!Directory.Exists(tmpDir))
+                    Directory.CreateDirectory(tmpDir);
+                var tmpWebcil = string.Concat (tmpDir, webcilFileName);
                 var webcilWriter = Microsoft.WebAssembly.Build.Tasks.WebcilConverter.FromPortableExecutable(inputPath: filePath, outputPath: tmpWebcil, logger: Log);
                 webcilWriter.ConvertToWebcil();
 
@@ -66,7 +74,7 @@ public class ConvertDllsToWebCil : Task
                 if (!Directory.Exists(candicatePath))
                     Directory.CreateDirectory(candicatePath);
 
-                var finalWebcil = Path.Combine(candicatePath, Path.GetFileNameWithoutExtension(filePath) + Utils.WebcilInWasmExtension);
+                var finalWebcil = Path.Combine(candicatePath, webcilFileName);
                 if (Utils.CopyIfDifferent(tmpWebcil, finalWebcil, useHash: true))
                     Log.LogMessage(MessageImportance.Low, $"Generated {finalWebcil} .");
                 else


### PR DESCRIPTION
Instead of using GetTempFileName (which can run out of temp file names on Windows after 64K files, see https://github.com/dotnet/runtime/issues/73793), emit the temporary webcil files to a directory in IntermediateOutputPath before copying them to the final location, if they changed (which is elsewhere in IntermediateOutputPath).

An example of the failure with the old implementation:
```
Error MSB4018     The "ConvertDllsToWebCil" task failed unexpectedly.
System.IO.IOException: The file exists.
 
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.Path.InternalGetTempFileName(Boolean checkHost)
   at Microsoft.NET.Sdk.WebAssembly.ConvertDllsToWebCil.Execute()
   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
   at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext() Wasm.Prerendered.Client C:\Users\jacalvar\.nuget\packages\microsoft.net.sdk.webassembly.pack\8.0.0-preview.5.23276.2\build\Microsoft.NET.Sdk.WebAssembly.Browser.targets      221   
```
