### PR TITLE
adding vzeroupper before helper function call

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -5854,6 +5854,10 @@ void CodeGen::genCall(GenTreeCall* call)
         assert(compiler->canUseVexEncoding());
         instGen(INS_vzeroupper);
     }
+    else if (call->IsHelperCall(compiler, CORINFO_HELP_DBL2ULNG))
+    {
+        instGen(INS_vzeroupper);
+    }
 
     genCallInstruction(call X86_ARG(stackArgBytes));
 


### PR DESCRIPTION
Since the vector register is used for the double argument, clearing he upper bits will make the call faster