### PR TITLE
[RISC-V][JIT] Fix arithmetics

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -3711,21 +3711,25 @@ void CodeGen::genCodeForJumpCompare(GenTreeOpCC* tree)
             switch (cmpSize)
             {
                 case EA_4BYTE:
+                {
+                    regNumber tmpRegOp1 = rsGetRsvdReg();
+                    assert(regOp1 != tmpRegOp1);
                     if (cond.IsUnsigned())
                     {
                         imm = static_cast<uint32_t>(imm);
 
-                        regNumber tmpRegOp1 = rsGetRsvdReg();
                         assert(regOp1 != tmpRegOp1);
                         emit->emitIns_R_R_I(INS_slli, EA_8BYTE, tmpRegOp1, regOp1, 32);
                         emit->emitIns_R_R_I(INS_srli, EA_8BYTE, tmpRegOp1, tmpRegOp1, 32);
-                        regOp1 = tmpRegOp1;
                     }
                     else
                     {
                         imm = static_cast<int32_t>(imm);
+                        emit->emitIns_R_R_I(INS_addiw, EA_8BYTE, tmpRegOp1, regOp1, 0);
                     }
+                    regOp1 = tmpRegOp1;
                     break;
+                }
                 case EA_8BYTE:
                     break;
                 default:

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -4160,7 +4160,7 @@ regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, 
                     }
                     else
                     {
-                        emitIns_R_R_R(INS_mulhu, attr, codeGen->rsGetRsvdReg(), src1->GetRegNum(), src2->GetRegNum());
+                        emitIns_R_R_R(INS_mulh, attr, codeGen->rsGetRsvdReg(), src1->GetRegNum(), src2->GetRegNum());
                     }
                 }
             }

--- a/src/coreclr/jit/lowerriscv64.cpp
+++ b/src/coreclr/jit/lowerriscv64.cpp
@@ -140,7 +140,7 @@ GenTree* Lowering::LowerJTrue(GenTreeOp* jtrue)
 
     if (op->OperIsCompare() && !varTypeIsFloating(op->gtGetOp1()))
     {
-        // We do not expect any other relops on LA64
+        // We do not expect any other relops on RISCV64
         assert(op->OperIs(GT_EQ, GT_NE, GT_LT, GT_LE, GT_GE, GT_GT));
 
         cond = GenCondition::FromRelop(op);


### PR DESCRIPTION
Fixed below test failures
```
./JIT/Methodical/int64/signed/s_ldc_mulovf_d/s_ldc_mulovf_d.sh
./JIT/Methodical/int64/signed/s_ldc_mulovf_do/s_ldc_mulovf_do.sh
./JIT/Methodical/int64/signed/s_ldc_mulovf_r/s_ldc_mulovf_r.sh
./JIT/Methodical/int64/signed/s_ldc_mulovf_ro/s_ldc_mulovf_ro.sh
./JIT/Methodical/int64/signed/s_ldfld_mulovf_r/s_ldfld_mulovf_r.sh
./JIT/Methodical/int64/signed/s_ldfld_mulovf_r/s_ldfld_mulovf_r.sh
./JIT/Methodical/int64/signed/s_ldfld_mulovf_do/s_ldfld_mulovf_do.sh
./JIT/Methodical/int64/signed/s_ldfld_mulovf_ro/s_ldfld_mulovf_ro.sh
./JIT/Methodical/int64/signed/s_ldsfld_mulovf_d/s_ldsfld_mulovf_d.sh
./JIT/Methodical/int64/signed/s_ldsfld_mulovf_do/s_ldsfld_mulovf_do.sh
./JIT/Methodical/int64/signed/s_ldsfld_mulovf_r/s_ldsfld_mulovf_r.sh
./JIT/Methodical/int64/signed/s_ldsfld_mulovf_ro/s_ldsfld_mulovf_ro.sh

./JIT/Directed/ConstantFolding/value_numbering_checked_arithmetic_with_constants_ro/value_numbering_checked_arithmetic_with_constants_ro.sh
```

Part of https://github.com/dotnet/runtime/issues/84834
cc @wscho77 @HJLeee @JongHeonChoi @t-mustafin @alpencolt @gbalykov