### PR TITLE
Impove StringComparer.OrdinalIgnoreCase.Equals

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/StringComparer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/StringComparer.cs
@@ -395,10 +395,7 @@ namespace System
 
         public override int GetHashCode(string obj)
         {
-            if (obj == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.obj);
-            }
+            ArgumentNullException.ThrowIfNull(obj);
             return obj.GetHashCode();
         }
 
@@ -420,50 +417,17 @@ namespace System
 
         public override int Compare(string? x, string? y)
         {
-            if (ReferenceEquals(x, y))
-            {
-                return 0;
-            }
-
-            if (x == null)
-            {
-                return -1;
-            }
-
-            if (y == null)
-            {
-                return 1;
-            }
-
-            return System.Globalization.Ordinal.CompareStringIgnoreCase(ref x.GetRawStringData(), x.Length, ref y.GetRawStringData(), y.Length);
+            return string.Compare(x, y, StringComparison.OrdinalIgnoreCase);
         }
 
         public override bool Equals(string? x, string? y)
         {
-            if (ReferenceEquals(x, y))
-            {
-                return true;
-            }
-
-            if (x is null || y is null)
-            {
-                return false;
-            }
-
-            if (x.Length != y.Length)
-            {
-                return false;
-            }
-
-            return System.Globalization.Ordinal.EqualsIgnoreCase(ref x.GetRawStringData(), ref y.GetRawStringData(), x.Length);
+            return string.Equals(x, y, StringComparison.OrdinalIgnoreCase);
         }
 
         public override int GetHashCode(string obj)
         {
-            if (obj == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.obj);
-            }
+            ArgumentNullException.ThrowIfNull(obj);
             return obj.GetHashCodeOrdinalIgnoreCase();
         }
 


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/86999

Unifies `OrdinalIgnoreCaseComparer` with `OrdinalCaseSensitiveComparer` to just call `String`'s APIs.

```cs
static bool Test(string s) => 
    StringComparer.OrdinalIgnoreCase.Equals(s, "hello");
```
```asm
; Assembly listing for method Program:Test(System.String):bool
       test     rcx, rcx
       je       SHORT G_M18217_IG05
       cmp      dword ptr [rcx+08H], 5
       jne      SHORT G_M18217_IG05
       mov      rax, 0x20002000200020
       or       rax, qword ptr [rcx+0CH]
       mov      rdx, 0x6C006C00650068
       xor      rax, rdx
       mov      edx, dword ptr [rcx+12H]
       or       edx, 0x200020
       xor      edx, 0x6F006C
       or       rax, rdx
       sete     al
       movzx    rax, al
       jmp      SHORT G_M18217_IG06
G_M18217_IG05:  ;; offset=0040H
       xor      eax, eax
G_M18217_IG06:  ;; offset=0042H
       movzx    rax, al
       ret      
; Total bytes of code 70
```
