### PR TITLE
[mono] Use underlying type in RuntimeHelpers.GetSpanDataFrom

### DIFF
--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -985,7 +985,7 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_GetSpanDataFrom (MonoCl
 		return NULL;
 	}
 
-	MonoType *type = targetTypeHandle;
+	MonoType *type = mono_type_get_underlying_type (targetTypeHandle);
 	if (MONO_TYPE_IS_REFERENCE (type) || type->type == MONO_TYPE_VALUETYPE) {
 		mono_error_set_argument (error, "array", "Cannot initialize array of non-primitive type");
 		return NULL;

--- a/src/tests/Regressions/coreclr/GitHub_86865/test86865.cs
+++ b/src/tests/Regressions/coreclr/GitHub_86865/test86865.cs
@@ -39,7 +39,13 @@ public class test86865
 
         var fi = pid.GetField("0B77DC554B4A81403D62BE25FB5404020AD451151D4203D544BF60E3FEDBD8AE4", BindingFlags.Static | BindingFlags.NonPublic);
         if (fi == null)
+        {
+            Console.WriteLine("Could not find the expected array data in <PrivateImplementationDetails>. The available static non-public fields are:");
+            foreach (var f in pid.GetFields(BindingFlags.Static | BindingFlags.NonPublic)) {
+                Console.WriteLine($" - '{f}'");
+            }
             return 4;
+        }
 
         var parms = new object[] {
             fi.FieldHandle,
@@ -49,7 +55,7 @@ public class test86865
         var result = mi.Invoke(null, parms);
         if (result == null)
             return 6;
-        if ((int)parms[2] != 5)
+        if ((int)parms[2] != myEnums.Length)
             return 7;
 
         return 100;
@@ -62,4 +68,3 @@ enum MyEnum
     B,
     C
 }
-

--- a/src/tests/Regressions/coreclr/GitHub_86865/test86865.cs
+++ b/src/tests/Regressions/coreclr/GitHub_86865/test86865.cs
@@ -49,7 +49,7 @@ public class test86865
         var result = mi.Invoke(null, parms);
         if (result == null)
             return 6;
-        if (parms[2] != 5)
+        if ((int)parms[2] != 5)
             return 7;
 
         return 100;

--- a/src/tests/Regressions/coreclr/GitHub_86865/test86865.cs
+++ b/src/tests/Regressions/coreclr/GitHub_86865/test86865.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Reflection;
+
+namespace test86865;
+
+public class test86865
+{
+    public static int Main()
+    {
+
+        // Regression test for https://github.com/dotnet/runtime/issues/86865
+        // Verify that the RuntimeHelpers.GetSpanDataFrom method underlying RuntimeHelpers.CreateSpan<T>
+        // works correctly with enums.
+
+        ReadOnlySpan<MyEnum> myEnums = new[]
+        {
+            MyEnum.A,
+            MyEnum.B,
+            MyEnum.C,
+            MyEnum.B,
+            MyEnum.C,
+        };
+
+        if (string.Join(", ", myEnums.ToArray()) != "A, B, C, B, C")
+            return 1;
+
+        var types = new Type[] {
+            typeof(RuntimeFieldHandle),
+            typeof(RuntimeTypeHandle),
+            typeof(int).MakeByRefType(),
+        };
+        var mi = typeof(System.Runtime.CompilerServices.RuntimeHelpers).GetMethod("GetSpanDataFrom", BindingFlags.Static | BindingFlags.NonPublic, types);
+        if (mi == null)
+            return 2;
+
+        var pid = typeof(MyEnum).Assembly.GetType("<PrivateImplementationDetails>");
+        if (pid == null)
+            return 3;
+
+        var fi = pid.GetField("0B77DC554B4A81403D62BE25FB5404020AD451151D4203D544BF60E3FEDBD8AE4", BindingFlags.Static | BindingFlags.NonPublic);
+        if (fi == null)
+            return 4;
+
+        var parms = new object[] {
+            fi.FieldHandle,
+            typeof(MyEnum).TypeHandle,
+            new int()
+        };
+        var result = mi.Invoke(null, parms);
+        if (result == null)
+            return 6;
+        if (parms[2] != 5)
+            return 7;
+
+        return 100;
+    }
+}
+                
+enum MyEnum
+{
+    A,
+    B,
+    C
+}
+

--- a/src/tests/Regressions/coreclr/GitHub_86865/test86865.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_86865/test86865.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test86865.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Make it work correctly for spans of enums

Fixes https://github.com/dotnet/runtime/issues/86865

Note that in net8 RuntimeHelpers.CreateSpan<T> is an intrinsic, so GetSpanDataFrom is never called directly.

But in net7 CreateSpan is not intrinsified on Mono, so the underlying method really does get called.