### PR TITLE
[wasm][debugger] Fix calling multiple times mono_wasm_asm_loaded when webcil is enabled

### DIFF
--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -219,11 +219,7 @@ mono_wasm_assembly_already_added (const char *assembly_name)
 
 	WasmAssembly *entry = assemblies;
 	while (entry != NULL) {
-		int entry_name_minus_extn_len = strlen(entry->assembly.name);
-		if (entry->assembly.name[entry_name_minus_extn_len - 4] == '.')
-			entry_name_minus_extn_len -= 4; //.dll (webcil disabled)
-		else
-			entry_name_minus_extn_len -= 5; //.wasm (webcil enabled)
+		int entry_name_minus_extn_len = strrchr (entry->assembly.name, '.') - entry->assembly.name;
 		if (entry_name_minus_extn_len == strlen(assembly_name) && strncmp (entry->assembly.name, assembly_name, entry_name_minus_extn_len) == 0)
 			return 1;
 		entry = entry->next;

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -219,7 +219,11 @@ mono_wasm_assembly_already_added (const char *assembly_name)
 
 	WasmAssembly *entry = assemblies;
 	while (entry != NULL) {
-		int entry_name_minus_extn_len = strlen(entry->assembly.name) - 4;
+		int entry_name_minus_extn_len = strlen(entry->assembly.name);
+		if (entry->assembly.name[entry_name_minus_extn_len - 4] == '.')
+			entry_name_minus_extn_len -= 4; //.dll (webcil disabled)
+		else
+			entry_name_minus_extn_len -= 5; //.wasm (webcil enabled)
 		if (entry_name_minus_extn_len == strlen(assembly_name) && strncmp (entry->assembly.name, assembly_name, entry_name_minus_extn_len) == 0)
 			return 1;
 		entry = entry->next;


### PR DESCRIPTION
The comparison was considering that the extension always had 4 characteres like ".dll" or ".exe" which is not true when webcil is enabled and the extension is ".wasm".