### PR TITLE
[wasm] CI: Add more wasm specific paths

### DIFF
--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -17,7 +17,9 @@ parameters:
         src/libraries/sendtohelix-wasi.targets
         src/mono/mono/**/*wasm*
         src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Sdk/*
+        src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Wasi.Sdk/*
         src/mono/nuget/Microsoft.NET.Runtime.wasm.Sample.Mono/*
+        src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/*
         src/mono/nuget/Microsoft.NETCore.BrowserDebugHost.Transport/*
         src/mono/nuget/Microsoft.NET.Workload*
         src/mono/sample/wasm/*
@@ -27,6 +29,7 @@ parameters:
         src/tasks/WasmAppBuilder/*
         src/tasks/WasmBuildTasks/*
         src/tasks/WorkloadBuildTasks/*
+        src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/*
         src/tests/Common/wasm-test-runner/*
     ]
     _wasm_pipelines: [
@@ -185,6 +188,8 @@ jobs:
       - src/mono/nuget/Microsoft.NET.Runtime.MonoAOTCompiler.Task/*
       - src/mono/nuget/Microsoft.NET.Runtime.MonoTargets.Sdk/*
       - src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Sdk/*
+      - src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Wasi.Sdk/*
+      - src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/*
       - src/mono/nuget/Microsoft.NET.Runtime.wasm.Sample.Mono/*
       - src/mono/nuget/Microsoft.NET.Workload*
       - src/mono/nuget/Microsoft.NETCore.BrowserDebugHost.Transport/*
@@ -248,6 +253,7 @@ jobs:
       - src/mono/wasm/debugger/*
       - src/mono/wasm/Wasm.Build.Tests/*
       - src/mono/nuget/Microsoft.NET.Runtime*
+        src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/*
       - src/mono/nuget/Microsoft.NET.Workload*
       - src/mono/nuget/Microsoft.NETCore.BrowserDebugHost.Transport/*
       - ${{ parameters._const_paths._always_exclude }}


### PR DESCRIPTION
`src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Wasi.Sdk/`
`src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/`
`src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/`

- Adding these ensures that changes in these will trigger only wasm jobs.