### PR TITLE
Mark some loader tests as NativeAotIncompatible

### DIFF
--- a/src/tests/Loader/AssemblyDependencyResolver/AssemblyDependencyResolverTests/AssemblyDependencyResolverTests.csproj
+++ b/src/tests/Loader/AssemblyDependencyResolver/AssemblyDependencyResolverTests/AssemblyDependencyResolverTests.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
+    <!-- AssemblyDependencyResolver is not supported -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyDependencyResolverTests.cs" />

--- a/src/tests/Loader/binding/tracing/BinderTracingTest.Basic.csproj
+++ b/src/tests/Loader/binding/tracing/BinderTracingTest.Basic.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <!-- TestAssemblyLoadContext.Load called from the finalizer -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <!-- Dynamic assembly loads -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BinderTracingTest.Basic.cs" />

--- a/src/tests/Loader/binding/tracing/BinderTracingTest.ResolutionFlow.csproj
+++ b/src/tests/Loader/binding/tracing/BinderTracingTest.ResolutionFlow.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <!-- Test creates non-collectible AssemblyLoadContext -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <!-- Dynamic assembly loads -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BinderTracingTest.EventHandlers.cs" />

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -976,15 +976,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/superpmi/superpmicollect/**">
             <Issue>CoreCLR test</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Loader/AssemblyDependencyResolver/AssemblyDependencyResolverTests/AssemblyDependencyResolverTests/*">
-            <Issue>https://github.com/dotnet/runtimelab/issues/165</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Loader/binding/tracing/BinderTracingTest.Basic/*">
-            <Issue>AOT incompatible</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Loader/binding/tracing/BinderTracingTest.ResolutionFlow/*">
-            <Issue>AOT incompatible</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/DictionaryExpansion/DictionaryExpansion/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/154</Issue>
         </ExcludeList>


### PR DESCRIPTION
These are fundamentally not compatible - mark them as incompatible instead of disabling against an issue so that we stop building them.