### PR TITLE
[wasm] Add workaround `NuGet-Migrations` issue for a missed case

### DIFF
--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -907,7 +907,7 @@
     <HelixWorkItem Include="@(LegacyPayloads->Metadata('PayloadGroup'))" Condition="'$(TargetHasHelixXHarnessSdkSupport)' != 'true'">
       <PayloadDirectory>%(PayloadDirectory)</PayloadDirectory>
       <Command>$(_WorkaroundForNuGetMigrationsForPrepending) dotnet $(XUnitRunnerDll) %(XUnitWrapperDlls) $(XUnitRunnerArgs)</Command>
-      <Command Condition=" '%(TestGroup)' != '' ">dotnet $(XUnitRunnerDll) %(XUnitWrapperDlls) $(XUnitRunnerArgs) -trait TestGroup=%(TestGroup)</Command>
+      <Command Condition=" '%(TestGroup)' != '' ">$(_WorkaroundForNuGetMigrationsForPrepending) dotnet $(XUnitRunnerDll) %(XUnitWrapperDlls) $(XUnitRunnerArgs) -trait TestGroup=%(TestGroup)</Command>
       <Timeout Condition=" '$(TimeoutPerTestCollectionInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestCollectionInMinutes)))</Timeout>
       <DownloadFilesFromResults Condition=" '$(SuperPmiCollect)' == 'true' ">coreclr_tests.run.$(TargetOS).$(TargetArchitecture).$(Configuration).mch;coreclr_tests.run.$(TargetOS).$(TargetArchitecture).$(Configuration).log</DownloadFilesFromResults>
     </HelixWorkItem>


### PR DESCRIPTION
One case was missed in the earlier attempt at this, which caused some of the tests in wasm runtime tests to not get the workaround script.

One such example - `JIT.PGO`

The other cases had:
```sh
export WasmTestAppArgs="$WasmTestAppArgs --exclusion-list=TestExclusionList.txt"
chmod +x ./RunTests.sh
(CONSOLE_TEMP_DIR="$(mktemp -d)" ; "$DOTNET_ROOT/dotnet" new console -o "$CONSOLE_TEMP_DIR" ; rm -rf "$CONSOLE_TEMP_DIR") || true
./RunTests.sh
```

.. and the broken one has:

```sh
dotnet $CORE_ROOT/xunit/xunit.console.dll profiler/unittest/profiler.unittest.XUnitWrapper.dll -parallel collections -nocolor -noshadow -xml testResults.xml -trait TestGroup=profiler.unittest
```

.. no workaround with `dotnet new ..`.