### PR TITLE
Fix missing link libraries in host components

### DIFF
--- a/src/native/corehost/common.cmake
+++ b/src/native/corehost/common.cmake
@@ -40,8 +40,6 @@ function(set_common_libs TargetType)
         if((CLR_CMAKE_TARGET_LINUX OR CLR_CMAKE_TARGET_FREEBSD) AND NOT CLR_CMAKE_TARGET_ANDROID)
             target_link_libraries (${DOTNET_PROJECT_NAME} PRIVATE "pthread")
         endif()
-
-        target_link_libraries (${DOTNET_PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
     endif()
 
     if (NOT ${TargetType} STREQUAL "lib-static")
@@ -53,5 +51,7 @@ function(set_common_libs TargetType)
                 target_link_libraries(${DOTNET_PROJECT_NAME} PRIVATE atomic.a)
             endif()
         endif()
+
+        target_link_libraries (${DOTNET_PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
     endif()
 endfunction()

--- a/src/native/corehost/hostpolicy/standalone/CMakeLists.txt
+++ b/src/native/corehost/hostpolicy/standalone/CMakeLists.txt
@@ -34,3 +34,7 @@ endif(CLR_CMAKE_HOST_UNIX)
 
 install_with_stripped_symbols(hostpolicy TARGETS corehost)
 target_link_libraries(hostpolicy PRIVATE libhostcommon)
+
+if((CLR_CMAKE_TARGET_LINUX OR CLR_CMAKE_TARGET_FREEBSD) AND NOT CLR_CMAKE_TARGET_ANDROID)
+    target_link_libraries (hostpolicy PRIVATE pthread)
+endif()


### PR DESCRIPTION
- All host components link against `dl` - effectively, this handles `hostfxr`, `hostpolicy`, and `nethost` which were missing it
- `hostpolicy` links against `pthread`

Fixes https://github.com/dotnet/runtime/issues/43036

Checked that before this change, `ld` reported undefined references and a C program that just `dlopen`s  the shared libraries failed with undefined symbols and after this change, they succeed.