### PR TITLE
[wasm] Block calls into managed code after a runtime assert

### DIFF
--- a/src/mono/sample/wasm/browser-shutdown/Makefile
+++ b/src/mono/sample/wasm/browser-shutdown/Makefile
@@ -1,0 +1,11 @@
+TOP=../../../../..
+
+include ../wasm.mk
+
+ifneq ($(AOT),)
+override MSBUILD_ARGS+=/p:RunAOTCompilation=true
+endif
+
+PROJECT_NAME=Wasm.Browser.Shutdown.Sample.csproj
+
+run: run-browser

--- a/src/mono/sample/wasm/browser-shutdown/Program.cs
+++ b/src/mono/sample/wasm/browser-shutdown/Program.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices.JavaScript;
+using System.Runtime.InteropServices;
+
+namespace Sample
+{
+    public partial class Test
+    {
+        public static int Main(string[] args)
+        {
+            return 0;
+        }
+
+        [JSExport()]
+        public static void DoNothing ()
+        {
+            Console.WriteLine("You got it, boss! Doing nothing!");
+        }
+
+        [JSExport()]
+        public static void ThrowManagedException ()
+        {
+            throw new Exception("I'll make an exception to the rules just this once... and throw one.");
+        }
+
+        [JSExport()]
+        public static void CallFailFast ()
+        {
+            System.Environment.FailFast("User requested FailFast");
+        }
+
+        [JSImport("timerTick", "main.js")]
+        public static partial void TimerTick (int i);
+
+        [JSExport()]
+        public static void StartTimer ()
+        {
+            int i = 0;
+            var timer = new System.Timers.Timer(1000);
+            timer.Elapsed += (s, e) => {
+                TimerTick(i);
+                i += 1;
+            };
+            timer.AutoReset = true;
+            timer.Enabled = true;
+        }
+    }
+}

--- a/src/mono/sample/wasm/browser-shutdown/Wasm.Browser.Shutdown.Sample.csproj
+++ b/src/mono/sample/wasm/browser-shutdown/Wasm.Browser.Shutdown.Sample.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\DefaultBrowserSample.targets" />
+  <ItemGroup>
+    <WasmExtraFilesToDeploy Include="main.js" />
+  </ItemGroup>
+</Project>

--- a/src/mono/sample/wasm/browser-shutdown/index.html
+++ b/src/mono/sample/wasm/browser-shutdown/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<!--  Licensed to the .NET Foundation under one or more agreements. -->
+<!-- The .NET Foundation licenses this file to you under the MIT license. -->
+<html>
+
+<head>
+  <title>Wasm Browser Shutdown Sample</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script type='module' src="./main.js"></script>
+</head>
+
+<body>
+  <h3 id="header">Wasm Browser Shutdown Sample</h3>
+  <button id="throw-managed-exc">Throw Managed Exception</button>
+  <button id="trigger-native-assert">Trigger Native Assert</button>
+  <button id="trigger-failfast">Trigger Environment.FailFast</button>
+  <button id="call-jsexport">Call Harmless JSExport</button>
+  <button id="call-exit">Call exit</button>
+  <button id="start-timer">Start Timer</button><br>
+  Timer Value: <span id="timer-value"></span>
+</body>
+
+</html>

--- a/src/mono/sample/wasm/browser-shutdown/main.js
+++ b/src/mono/sample/wasm/browser-shutdown/main.js
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+import { dotnet, exit } from './dotnet.js'
+
+let exports = undefined,
+    setenv = undefined;
+
+window.addEventListener("load", onLoad);
+
+try {
+    const { setModuleImports, getAssemblyExports, setEnvironmentVariable, getConfig } = await dotnet
+        .withElementOnExit()
+        .create();
+
+    setModuleImports("main.js", {
+        timerTick: (i) => {
+            document.querySelector("#timer-value").textContent = i;
+        },
+    });
+
+    setenv = setEnvironmentVariable;
+    const config = getConfig();
+    exports = await getAssemblyExports(config.mainAssemblyName);
+    await dotnet.run();
+}
+catch (err) {
+    exit(2, err);
+}
+
+function onLoad () {
+    document.querySelector("#throw-managed-exc").addEventListener("click", () => {
+        try {
+            exports.Sample.Test.ThrowManagedException();
+            alert("No JS exception was thrown!");
+        } catch (exc) {
+            alert(exc);
+        }
+    });
+    document.querySelector("#trigger-failfast").addEventListener("click", () => {
+        try {
+            exports.Sample.Test.CallFailFast();
+            alert("No JS exception was thrown!");
+        } catch (exc) {
+            alert(exc);
+        }
+    });
+    document.querySelector("#start-timer").addEventListener("click", () => {
+        try {
+            exports.Sample.Test.StartTimer();
+        } catch (exc) {
+            alert(exc);
+        }
+    });
+    document.querySelector("#trigger-native-assert").addEventListener("click", () => {
+        try {
+            setenv(null, null);
+            alert("No JS exception was thrown!");
+        } catch (exc) {
+            alert(exc);
+        }
+    });
+    document.querySelector("#call-jsexport").addEventListener("click", () => {
+        try {
+            exports.Sample.Test.DoNothing();
+        } catch (exc) {
+            alert(exc);
+        }
+    });
+    document.querySelector("#call-exit").addEventListener("click", () => {
+        try {
+            exit(7, "User clicked exit");
+        } catch (exc) {
+            alert(exc);
+        }
+    });
+}

--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -93,6 +93,9 @@ const fn_signatures: SigLine[] = [
     [true, "mono_wasm_get_i32_unaligned", "number", ["number"]],
     [true, "mono_wasm_get_f32_unaligned", "number", ["number"]],
     [true, "mono_wasm_get_f64_unaligned", "number", ["number"]],
+    [false, "mono_wasm_set_runtime_aborted", "void", ["string"]],
+    [false, "mono_wasm_get_runtime_aborted", "number", []],
+    [false, "mono_wasm_get_runtime_abort_message", "string", []],
 
     // jiterpreter
     [true, "mono_jiterp_trace_bailout", "void", ["number"]],
@@ -215,6 +218,9 @@ export interface t_Cwraps {
     mono_wasm_get_i32_unaligned(source: VoidPtr): number;
     mono_wasm_get_f32_unaligned(source: VoidPtr): number;
     mono_wasm_get_f64_unaligned(source: VoidPtr): number;
+    mono_wasm_set_runtime_aborted(reason?: string): void;
+    mono_wasm_get_runtime_aborted(): number;
+    mono_wasm_get_runtime_abort_message(): string;
 
     mono_jiterp_trace_bailout(reason: number): void;
     mono_jiterp_get_trace_bailout_count(reason: number): number;

--- a/src/mono/wasm/runtime/loader/exit.ts
+++ b/src/mono/wasm/runtime/loader/exit.ts
@@ -6,6 +6,12 @@ import { mono_log_debug, consoleWebSocket, mono_log_error, mono_log_info_no_pref
 
 export function abort_startup(reason: any, should_exit: boolean): void {
     mono_log_debug("abort_startup");
+    // Someone may have already set an abort message or aborted the runtime.
+    // For example, this will happen in the case of Environment.FailFast.
+    // If we don't have a reason message of our own, see if we can get an existing one.
+    if (!reason)
+        reason = runtimeHelpers.get_runtime_abort_message() || reason;
+    runtimeHelpers.set_runtime_aborted(reason);
     loaderHelpers.allDownloadsQueued.promise_control.reject(reason);
     loaderHelpers.afterConfigLoaded.promise_control.reject(reason);
     loaderHelpers.wasmDownloadPromise.promise_control.reject(reason);

--- a/src/mono/wasm/runtime/scheduling.ts
+++ b/src/mono/wasm/runtime/scheduling.ts
@@ -36,12 +36,18 @@ export function prevent_timer_throttling(): void {
 }
 
 function prevent_timer_throttling_tick() {
+    if (cwraps.mono_wasm_get_runtime_aborted())
+        return;
+
     cwraps.mono_wasm_execute_timer();
     pump_count++;
     mono_background_exec_until_done();
 }
 
 function mono_background_exec_until_done() {
+    if (cwraps.mono_wasm_get_runtime_aborted())
+        return;
+
     while (pump_count > 0) {
         --pump_count;
         cwraps.mono_background_exec();
@@ -63,5 +69,8 @@ export function mono_wasm_schedule_timer(shortestDueTimeMs: number): void {
 }
 
 function mono_wasm_schedule_timer_tick() {
+    if (cwraps.mono_wasm_get_runtime_aborted())
+        return;
+
     cwraps.mono_wasm_execute_timer();
 }

--- a/src/mono/wasm/runtime/types/internal.ts
+++ b/src/mono/wasm/runtime/types/internal.ts
@@ -175,6 +175,8 @@ export type RuntimeHelpers = {
     instantiate_asset: (asset: AssetEntry, url: string, bytes: Uint8Array) => void,
     instantiate_symbols_asset: (pendingAsset: AssetEntryInternal) => Promise<void>,
     jiterpreter_dump_stats?: (x: boolean) => string,
+    set_runtime_aborted: (reason: any) => void,
+    get_runtime_abort_message: () => string,
 }
 
 export type AOTProfilerOptions = {


### PR DESCRIPTION
Right now if an assertion is hit in native code at any point, while we call exit and flush buffers and whatnot, it's still possible to call back into managed code.

This PR sets a flag when assertions are hit, and if the flag is set we reject attempts to call into managed code.

The included sample's buttons let you verify that managed exceptions being thrown doesn't set the flag (since the caller can catch and handle them) but a native assert in the runtime will set it.

I initially was setting the flag in response to calls to exit() as well, but then you can't call into managed code after Main returns, which isn't desirable with our current model.

cc @vargaz 