### PR TITLE
Enable identical code folding on Linux

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -151,6 +151,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-Wl,-segprot,__THUNKS,rx,rx" Condition="'$(_IsiOSLikePlatform)' == 'true'" />
       <LinkerArg Include="@(NativeFramework->'-framework %(Identity)')" Condition="'$(_IsApplePlatform)' == 'true'" />
       <LinkerArg Include="-Wl,--eh-frame-hdr" Condition="'$(_IsApplePlatform)' != 'true'" />
+      <LinkerArg Include="-Wl,--icf=all" Condition="'$(LinkerFlavor)' == 'lld' or '$(LinkerFlavor)' == 'gold'" />
     </ItemGroup>
 
     <Exec Command="command -v &quot;$(CppLinker)&quot;" IgnoreExitCode="true" StandardOutputImportance="Low">

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/ObjectNodeSection.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/ObjectNodeSection.cs
@@ -37,7 +37,13 @@ namespace ILCompiler.DependencyAnalysis
         {
             get
             {
-                return this == DataSection || this == ReadOnlyDataSection || this == FoldableReadOnlyDataSection || this == TextSection || this == XDataSection || this == BssSection;
+                return this == DataSection
+                    || this == ReadOnlyDataSection
+                    || this == FoldableReadOnlyDataSection
+                    || this == TextSection
+                    || this == FoldableTextSection
+                    || this == XDataSection
+                    || this == BssSection;
             }
         }
 
@@ -46,6 +52,7 @@ namespace ILCompiler.DependencyAnalysis
         public static readonly ObjectNodeSection ReadOnlyDataSection = new ObjectNodeSection("rdata", SectionType.ReadOnly);
         public static readonly ObjectNodeSection FoldableReadOnlyDataSection = new ObjectNodeSection("rdata", SectionType.ReadOnly);
         public static readonly ObjectNodeSection TextSection = new ObjectNodeSection("text", SectionType.Executable);
+        public static readonly ObjectNodeSection FoldableTextSection = new ObjectNodeSection("text", SectionType.Executable);
         public static readonly ObjectNodeSection TLSSection = new ObjectNodeSection("TLS", SectionType.Writeable);
         public static readonly ObjectNodeSection BssSection = new ObjectNodeSection("bss", SectionType.Uninitialized);
         public static readonly ObjectNodeSection HydrationTargetSection = new ObjectNodeSection("hydrated", SectionType.Uninitialized);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
@@ -49,22 +49,21 @@ namespace ILCompiler.DependencyAnalysis
 
         public virtual ObjectNodeSection DictionarySection(NodeFactory factory)
         {
-            if (factory.Target.IsWindows)
+            (ObjectNodeSection foldableSection, ObjectNodeSection unfoldableSection) = factory.Target.OperatingSystem switch
             {
-                if (_owningMethodOrType is TypeDesc)
-                {
-                    return ObjectNodeSection.FoldableReadOnlyDataSection;
-                }
-                else
-                {
-                    // Method dictionary serves as an identity at runtime which means they are not foldable.
-                    Debug.Assert(_owningMethodOrType is MethodDesc);
-                    return ObjectNodeSection.ReadOnlyDataSection;
-                }
+                TargetOS.Windows => (ObjectNodeSection.FoldableReadOnlyDataSection, ObjectNodeSection.ReadOnlyDataSection),
+                _ => (ObjectNodeSection.FoldableTextSection, ObjectNodeSection.TextSection),
+            };
+
+            if (_owningMethodOrType is TypeDesc)
+            {
+                return foldableSection;
             }
             else
             {
-                return ObjectNodeSection.DataSection;
+                // Method dictionary serves as an identity at runtime which means they are not foldable.
+                Debug.Assert(_owningMethodOrType is MethodDesc);
+                return unfoldableSection;
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeOptionalFieldsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeOptionalFieldsNode.cs
@@ -19,7 +19,7 @@ namespace ILCompiler.DependencyAnalysis
             if (factory.Target.IsWindows)
                 return ObjectNodeSection.FoldableReadOnlyDataSection;
             else
-                return ObjectNodeSection.DataSection;
+                return ObjectNodeSection.FoldableTextSection;
         }
 
         public override bool StaticDependenciesAreComputed => true;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericCompositionNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericCompositionNode.cs
@@ -42,7 +42,7 @@ namespace ILCompiler.DependencyAnalysis
             if (factory.Target.IsWindows)
                 return ObjectNodeSection.FoldableReadOnlyDataSection;
             else
-                return ObjectNodeSection.DataSection;
+                return ObjectNodeSection.FoldableTextSection;
         }
 
         public override bool IsShareable => true;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericVarianceNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericVarianceNode.cs
@@ -41,7 +41,7 @@ namespace ILCompiler.DependencyAnalysis
             if (factory.Target.IsWindows)
                 return ObjectNodeSection.FoldableReadOnlyDataSection;
             else
-                return ObjectNodeSection.DataSection;
+                return ObjectNodeSection.FoldableTextSection;
         }
 
         public override bool IsShareable => true;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -44,7 +44,7 @@ namespace ILCompiler.DependencyAnalysis
             if (factory.Target.IsWindows)
                 return ObjectNodeSection.FoldableReadOnlyDataSection;
             else
-                return ObjectNodeSection.DataSection;
+                return ObjectNodeSection.FoldableTextSection;
         }
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/MethodExceptionHandlingInfoNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/MethodExceptionHandlingInfoNode.cs
@@ -24,7 +24,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override ObjectNodeSection GetSection(NodeFactory factory) => _owningMethod.Context.Target.IsWindows
             ? ObjectNodeSection.FoldableReadOnlyDataSection
-            : ObjectNodeSection.DataSection;
+            : ObjectNodeSection.FoldableTextSection;
 
         public override bool StaticDependenciesAreComputed => true;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -607,7 +607,11 @@ namespace ILCompiler.DependencyAnalysis
                 int len = frameInfo.BlobData.Length;
                 byte[] blob = frameInfo.BlobData;
 
-                ObjectNodeSection lsdaSection = GetSharedSection(ObjectNodeSection.TextSection, ((ISymbolNode)node).GetMangledName(_nodeFactory.NameMangler));
+                ObjectNodeSection lsdaSection = ObjectNodeSection.TextSection;
+                if (ShouldShareSymbol(node))
+                {
+                    lsdaSection = GetSharedSection(lsdaSection, ((ISymbolNode)node).GetMangledName(_nodeFactory.NameMangler));
+                }
                 SwitchSection(_nativeObjectWriter, lsdaSection.Name, GetCustomSectionAttributes(lsdaSection), lsdaSection.ComdatName);
 
                 _sb.Clear().Append("_lsda").Append(i.ToStringInvariant()).Append(_currentNodeZeroTerminatedName);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/SealedVTableNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/SealedVTableNode.cs
@@ -28,7 +28,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
-        public override ObjectNodeSection GetSection(NodeFactory factory) => _type.Context.Target.IsWindows ? ObjectNodeSection.FoldableReadOnlyDataSection : ObjectNodeSection.DataSection;
+        public override ObjectNodeSection GetSection(NodeFactory factory) => _type.Context.Target.IsWindows ? ObjectNodeSection.FoldableReadOnlyDataSection : ObjectNodeSection.FoldableTextSection;
 
         public virtual void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {


### PR DESCRIPTION
This instructs the linker to deduplicate identical sections on Linux. We were previously not doing this for two reasons:

1. We weren't passing the command line switch.
2. We had trouble getting linker to actually fold things. Linux linkers are particularly picky on what they're willing to fold. We've been historically putting these things to RW sections (dotnet/corert#686) and that doesn't help. Looking at C++, it looks like it places vtables into `.text` section, so let's just do the same.

I also found out why `--foldmethodbodies` doesn't work outside Windows - we place managed code into a `__managedcode` section and Linux linkers won't fold sections that have names that are valid C identifiers (would need to name this `.managedcode` like on Windows) - https://github.com/dotnet/llvm-project/blob/c01ca3bc8a420b3796d816c43bdd06e337c72ea6/lld/ELF/ICF.cpp#L192. Not addressing that part because the whole thing looks like a hairy yak and this option is not supported anyway.

Cc @dotnet/ilc-contrib 