### PR TITLE
update QuicConnection.ConnectAsync exceptions

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -52,7 +52,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
     /// <param name="options">Options for the connection.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
     /// <returns>An asynchronous task that completes with the connected connection.</returns>
-    public static async ValueTask<QuicConnection> ConnectAsync(QuicClientConnectionOptions options, CancellationToken cancellationToken = default)
+    public static ValueTask<QuicConnection> ConnectAsync(QuicClientConnectionOptions options, CancellationToken cancellationToken = default)
     {
         if (!IsSupported)
         {
@@ -61,18 +61,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
 
         // Validate and fill in defaults for the options.
         options.Validate(nameof(options));
-
-        QuicConnection connection = new QuicConnection();
-        try
-        {
-            await connection.FinishConnectAsync(options, cancellationToken).ConfigureAwait(false);
-        }
-        catch
-        {
-            await connection.DisposeAsync().ConfigureAwait(false);
-            throw;
-        }
-        return connection;
+        return StartConnectAsync(options, cancellationToken);
     }
 
     /// <summary>
@@ -227,10 +216,23 @@ public sealed partial class QuicConnection : IAsyncDisposable
         _localEndPoint = info->LocalAddress->ToIPEndPoint();
     }
 
+    private static async ValueTask<QuicConnection> StartConnectAsync(QuicClientConnectionOptions options, CancellationToken cancellationToken = default)
+    {
+        QuicConnection connection = new QuicConnection();
+        try
+        {
+            await connection.FinishConnectAsync(options, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            await connection.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+        return connection;
+    }
+
     private async ValueTask FinishConnectAsync(QuicClientConnectionOptions options, CancellationToken cancellationToken = default)
     {
-        ObjectDisposedException.ThrowIf(_disposed == 1, this);
-
         if (_connectedTcs.TryInitialize(out ValueTask valueTask, this, cancellationToken))
         {
             _canAccept = options.MaxInboundBidirectionalStreams > 0 || options.MaxInboundUnidirectionalStreams > 0;

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -62,6 +62,22 @@ public sealed partial class QuicConnection : IAsyncDisposable
         // Validate and fill in defaults for the options.
         options.Validate(nameof(options));
         return StartConnectAsync(options, cancellationToken);
+
+        static async ValueTask<QuicConnection> StartConnectAsync(QuicClientConnectionOptions options, CancellationToken cancellationToken)
+        {
+            QuicConnection connection = new QuicConnection();
+            try
+            {
+                await connection.FinishConnectAsync(options, cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                await connection.DisposeAsync().ConfigureAwait(false);
+                throw;
+            }
+
+            return connection;
+        }
     }
 
     /// <summary>
@@ -214,21 +230,6 @@ public sealed partial class QuicConnection : IAsyncDisposable
 
         _remoteEndPoint = info->RemoteAddress->ToIPEndPoint();
         _localEndPoint = info->LocalAddress->ToIPEndPoint();
-    }
-
-    private static async ValueTask<QuicConnection> StartConnectAsync(QuicClientConnectionOptions options, CancellationToken cancellationToken = default)
-    {
-        QuicConnection connection = new QuicConnection();
-        try
-        {
-            await connection.FinishConnectAsync(options, cancellationToken).ConfigureAwait(false);
-        }
-        catch
-        {
-            await connection.DisposeAsync().ConfigureAwait(false);
-            throw;
-        }
-        return connection;
     }
 
     private async ValueTask FinishConnectAsync(QuicClientConnectionOptions options, CancellationToken cancellationToken = default)

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnectionOptions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnectionOptions.cs
@@ -62,11 +62,11 @@ public abstract class QuicConnectionOptions
     {
         if (MaxInboundBidirectionalStreams < 0 || MaxInboundBidirectionalStreams > ushort.MaxValue)
         {
-            throw new ArgumentNullException(SR.Format(SR.net_quic_in_range, nameof(QuicConnectionOptions.MaxInboundBidirectionalStreams), ushort.MaxValue), argumentName);
+            throw new ArgumentOutOfRangeException(SR.Format(SR.net_quic_in_range, nameof(QuicConnectionOptions.MaxInboundBidirectionalStreams), ushort.MaxValue), argumentName);
         }
         if (MaxInboundUnidirectionalStreams < 0 || MaxInboundUnidirectionalStreams > ushort.MaxValue)
         {
-            throw new ArgumentNullException(SR.Format(SR.net_quic_in_range, nameof(QuicConnectionOptions.MaxInboundUnidirectionalStreams), ushort.MaxValue), argumentName);
+            throw new ArgumentOutOfRangeException(SR.Format(SR.net_quic_in_range, nameof(QuicConnectionOptions.MaxInboundUnidirectionalStreams), ushort.MaxValue), argumentName);
         }
         if (IdleTimeout < TimeSpan.Zero && IdleTimeout != Timeout.InfiniteTimeSpan)
         {
@@ -74,11 +74,11 @@ public abstract class QuicConnectionOptions
         }
         if (DefaultStreamErrorCode < 0 || DefaultStreamErrorCode > QuicDefaults.MaxErrorCodeValue)
         {
-            throw new ArgumentNullException(SR.Format(SR.net_quic_in_range, nameof(QuicConnectionOptions.DefaultStreamErrorCode), QuicDefaults.MaxErrorCodeValue), argumentName);
+            throw new ArgumentOutOfRangeException(SR.Format(SR.net_quic_in_range, nameof(QuicConnectionOptions.DefaultStreamErrorCode), QuicDefaults.MaxErrorCodeValue), argumentName);
         }
         if (DefaultCloseErrorCode < 0 || DefaultCloseErrorCode > QuicDefaults.MaxErrorCodeValue)
         {
-            throw new ArgumentNullException(SR.Format(SR.net_quic_in_range, nameof(QuicConnectionOptions.DefaultCloseErrorCode), QuicDefaults.MaxErrorCodeValue), argumentName);
+            throw new ArgumentOutOfRangeException(SR.Format(SR.net_quic_in_range, nameof(QuicConnectionOptions.DefaultCloseErrorCode), QuicDefaults.MaxErrorCodeValue), argumentName);
         }
     }
 }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -366,6 +367,47 @@ namespace System.Net.Quic.Tests
                     await using var stream = await connection.OpenOutboundStreamAsync(QuicStreamType.Unidirectional);
                     await stream.WriteAsync(new byte[1] { data }, completeWrites: true);
                 }).WaitAsync(TimeSpan.FromSeconds(5)));
+        }
+
+        [Fact]
+        public async Task ConnectAsync_InvalidName_ThrowsSocketException()
+        {
+            string name = $"{Guid.NewGuid().ToString("N")}.microsoft.com.";
+            var options = new QuicClientConnectionOptions()
+            {
+                DefaultStreamErrorCode = DefaultStreamErrorCodeClient,
+                DefaultCloseErrorCode = DefaultCloseErrorCodeClient,
+                RemoteEndPoint = new DnsEndPoint(name, 10000),
+                ClientAuthenticationOptions = GetSslClientAuthenticationOptions()
+            };
+
+            SocketException ex = await Assert.ThrowsAsync<SocketException>(() => QuicConnection.ConnectAsync(options).AsTask());
+            Assert.Equal(SocketError.HostNotFound, ((SocketException)ex).SocketErrorCode );
+        }
+
+        [Fact]
+        public void ConnectAsync_MissingName_ThrowsInvalidArgument()
+        {
+            var options = new QuicClientConnectionOptions()
+            {
+                DefaultStreamErrorCode = DefaultStreamErrorCodeClient,
+                DefaultCloseErrorCode = DefaultCloseErrorCodeClient,
+                ClientAuthenticationOptions = GetSslClientAuthenticationOptions()
+            };
+
+            Assert.Throws<ArgumentNullException>(() => QuicConnection.ConnectAsync(options));
+        }
+
+        [Fact]
+        public void ConnectAsync_MissingDefaults_ThrowsInvalidArgument()
+        {
+            var options = new QuicClientConnectionOptions()
+            {
+                RemoteEndPoint = new DnsEndPoint("localhost", 10000),
+                ClientAuthenticationOptions = GetSslClientAuthenticationOptions()
+            };
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => QuicConnection.ConnectAsync(options));
         }
     }
 }


### PR DESCRIPTION
contributes to #78751
contributes to https://github.com/dotnet/runtime/issues/82262

We agreed that transport errors will throw `SocketException` so outcome of  #78751 is new expected. I added test for that case.  
I also add few more test cases and noticed `ArgumentNullException` for wrong values and so I updated them to `ArgumentOutOfRangeException` for cases when value is too small or too large. 

Lastly I updated `ConnectAsync` to throw validation errors synchronously to match `Socket.ConnectAsync`.
https://github.com/dotnet/runtime/blob/7febca6802545d8c96e386187d536bc100d40337/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs#L161

This is generally programmers error and the Task will not even start. 



