### PR TITLE
Revert "[mono][aot] Deduplicate runtime invoke wrappers on iOS"

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -4334,9 +4334,6 @@ collect_dedup_method (MonoAotCompile *acfg, MonoMethod *method)
 static int
 add_method_full (MonoAotCompile *acfg, MonoMethod *method, gboolean extra, int depth)
 {
-	if (collect_dedup_method (acfg, method))
-		return -1;
-
 	int index;
 
 	index = GPOINTER_TO_UINT (g_hash_table_lookup (acfg->method_indexes, method));
@@ -4422,6 +4419,9 @@ add_extra_method_full (MonoAotCompile *acfg, MonoMethod *method, gboolean prefer
 		method = mini_get_shared_method_full (method, SHARE_MODE_GSHAREDVT, error);
 		mono_error_assert_ok (error);
 	}
+
+	if (collect_dedup_method (acfg, method))
+		return;
 
 	if (acfg->aot_opts.log_generics)
 		aot_printf (acfg, "%*sAdding method %s.\n", depth, "", mono_method_get_full_name (method));

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -4556,7 +4556,12 @@ mono_aot_can_dedup (MonoMethod *method)
 	/* Use a set of wrappers/instances which work and useful */
 	switch (method->wrapper_type) {
 	case MONO_WRAPPER_RUNTIME_INVOKE:
+#ifdef TARGET_WASM
 		return TRUE;
+#else
+		return FALSE;
+#endif
+		break;
 	case MONO_WRAPPER_OTHER: {
 		WrapperInfo *info = mono_marshal_get_wrapper_info (method);
 


### PR DESCRIPTION
We have encountered more frequent failures following the merge as outlined in https://github.com/dotnet/runtime/pull/85908#issuecomment-1572750981, so we will revert the change and try to reproduce the issue locally using the same version of macOS and iPhone as on the CI environment.

Reverts dotnet/runtime#85908