### PR TITLE
Add and use ConfigureAwaitOptions

### DIFF
--- a/src/libraries/Common/tests/System/TimeProviderTests.cs
+++ b/src/libraries/Common/tests/System/TimeProviderTests.cs
@@ -321,7 +321,7 @@ namespace Tests.System
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [MemberData(nameof(TimersProvidersWithTaskFactorData))]
-        public static async void RunWaitAsyncTests(TimeProvider provider, ITestTaskFactory taskFactory)
+        public static async Task RunWaitAsyncTests(TimeProvider provider, ITestTaskFactory taskFactory)
         {
             CancellationTokenSource cts = new CancellationTokenSource();
 
@@ -377,7 +377,7 @@ namespace Tests.System
 #if !NETFRAMEWORK
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [MemberData(nameof(TimersProvidersListData))]
-        public static async void PeriodicTimerTests(TimeProvider provider)
+        public static async Task PeriodicTimerTests(TimeProvider provider)
         {
             var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(1), provider);
             Assert.True(await timer.WaitForNextTickAsync());

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/AsyncStreamReader.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/AsyncStreamReader.cs
@@ -72,7 +72,7 @@ namespace System.Diagnostics
             if (_sb == null)
             {
                 _sb = new StringBuilder(DefaultBufferSize);
-                _readToBufferTask = Task.Run((Func<Task>)ReadBufferAsync);
+                _readToBufferTask = ReadBufferAsync();
             }
             else
             {
@@ -88,6 +88,8 @@ namespace System.Diagnostics
         // This is the async callback function. Only one thread could/should call this.
         private async Task ReadBufferAsync()
         {
+            await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
+
             while (true)
             {
                 try

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessWaitState.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessWaitState.Unix.cs
@@ -532,12 +532,8 @@ namespace System.Diagnostics
                         }
 
                         // Wait
-                        try
-                        {
-                            await Task.Delay(pollingIntervalMs, cancellationToken).ConfigureAwait(false);
-                            pollingIntervalMs = Math.Min(pollingIntervalMs * 2, MaxPollingIntervalMs);
-                        }
-                        catch (OperationCanceledException) { }
+                        await Task.Delay(pollingIntervalMs, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+                        pollingIntervalMs = Math.Min(pollingIntervalMs * 2, MaxPollingIntervalMs);
                     }
                 }
                 finally

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -204,16 +204,14 @@ namespace System.Net.Http
                 {
                     if (request.Content is StringContent)
                     {
-                        string body = await request.Content.ReadAsStringAsync(cancellationToken)
-                            .ConfigureAwait(true);
+                        string body = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(true);
                         cancellationToken.ThrowIfCancellationRequested();
 
                         promise = BrowserHttpInterop.Fetch(uri, headerNames.ToArray(), headerValues.ToArray(), optionNames, optionValues, abortController, body);
                     }
                     else
                     {
-                        byte[] buffer = await request.Content.ReadAsByteArrayAsync(cancellationToken)
-                            .ConfigureAwait(true);
+                        byte[] buffer = await request.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(true);
                         cancellationToken.ThrowIfCancellationRequested();
 
                         promise = BrowserHttpInterop.Fetch(uri, headerNames.ToArray(), headerValues.ToArray(), optionNames, optionValues, abortController, buffer);
@@ -225,8 +223,7 @@ namespace System.Net.Http
                 }
 
                 cancellationToken.ThrowIfCancellationRequested();
-                ValueTask<JSObject> wrappedTask = BrowserHttpInterop.CancelationHelper(promise, cancellationToken, abortController);
-                JSObject fetchResponse = await wrappedTask.ConfigureAwait(true);
+                JSObject fetchResponse = await BrowserHttpInterop.CancelationHelper(promise, cancellationToken, abortController).ConfigureAwait(true);
                 return new WasmFetchResponse(fetchResponse, abortRegistration.Value);
             }
             catch (Exception)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -368,7 +368,7 @@ namespace System.Net.Http
 
         // Returns true to indicate at least one stream is available
         // Returns false to indicate that the connection is shutting down and cannot be used anymore
-        public ValueTask<bool> WaitForAvailableStreamsAsync()
+        public Task<bool> WaitForAvailableStreamsAsync()
         {
             lock (SyncObject)
             {
@@ -379,17 +379,17 @@ namespace System.Net.Http
 
                 if (_shutdown)
                 {
-                    return ValueTask.FromResult(false);
+                    return Task.FromResult(false);
                 }
 
                 if (_streamsInUse < _maxConcurrentStreams)
                 {
-                    return ValueTask.FromResult(true);
+                    return Task.FromResult(true);
                 }
 
                 // Need to wait for streams to become available.
                 _availableStreamsWaiter = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                return new ValueTask<bool>(_availableStreamsWaiter.Task);
+                return _availableStreamsWaiter.Task;
             }
         }
 

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpResponseStream.Managed.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpResponseStream.Managed.cs
@@ -159,7 +159,7 @@ namespace System.Net
 
         private async Task InternalWriteIgnoreErrorsAsync(byte[] buffer, int offset, int count)
         {
-            try { await _stream.WriteAsync(buffer.AsMemory(offset, count)).ConfigureAwait(bool); }
+            try { await _stream.WriteAsync(buffer.AsMemory(offset, count)).ConfigureAwait(false); }
             catch { }
         }
 

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpResponseStream.Managed.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpResponseStream.Managed.cs
@@ -159,7 +159,7 @@ namespace System.Net
 
         private async Task InternalWriteIgnoreErrorsAsync(byte[] buffer, int offset, int count)
         {
-            try { await _stream.WriteAsync(buffer.AsMemory(offset, count)).ConfigureAwait(false); }
+            try { await _stream.WriteAsync(buffer.AsMemory(offset, count)).ConfigureAwait(bool); }
             catch { }
         }
 

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/HttpWebSocket.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/HttpWebSocket.Windows.cs
@@ -90,7 +90,7 @@ namespace System.Net.WebSockets
                     NetEventSource.Info(null, $"{HttpKnownHeaderNames.SecWebSocketProtocol} = {outgoingSecWebSocketProtocolString}");
                 }
 
-                await response.OutputStream.FlushAsync().SuppressContextFlow();
+                await response.OutputStream.FlushAsync().ConfigureAwait(false);
 
                 HttpResponseStream responseStream = (response.OutputStream as HttpResponseStream)!;
                 Debug.Assert(responseStream != null, "'responseStream' MUST be castable to System.Net.HttpResponseStream.");
@@ -135,22 +135,6 @@ namespace System.Net.WebSockets
             }
 
             return webSocketContext;
-        }
-
-        internal static ConfiguredTaskAwaitable SuppressContextFlow(this Task task)
-        {
-            // We don't flow the synchronization context within WebSocket.xxxAsync - but the calling application
-            // can decide whether the completion callback for the task returned from WebSocket.xxxAsync runs
-            // under the caller's synchronization context.
-            return task.ConfigureAwait(false);
-        }
-
-        internal static ConfiguredTaskAwaitable<T> SuppressContextFlow<T>(this Task<T> task)
-        {
-            // We don't flow the synchronization context within WebSocket.xxxAsync - but the calling application
-            // can decide whether the completion callback for the task returned from WebSocket.xxxAsync runs
-            // under the caller's synchronization context.
-            return task.ConfigureAwait(false);
         }
 
         private static unsafe ulong SendWebSocketHeaders(HttpListenerResponse response)

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketBase.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketBase.cs
@@ -180,7 +180,7 @@ namespace System.Net.WebSockets
                 }
 
                 EnsureReceiveOperation();
-                receiveResult = (await _receiveOperation!.Process(buffer, linkedCancellationToken).SuppressContextFlow())!;
+                receiveResult = (await _receiveOperation!.Process(buffer, linkedCancellationToken).ConfigureAwait(false))!;
 
                 if (NetEventSource.Log.IsEnabled() && receiveResult.Count > 0)
                 {
@@ -268,7 +268,7 @@ namespace System.Net.WebSockets
                         }
                     }
 
-                    await keepAliveTask.SuppressContextFlow();
+                    await keepAliveTask.ConfigureAwait(false);
                     ThrowIfPendingException();
 
                     _sendOutstandingOperationHelper.CompleteOperation(ownsCancellationTokenSource);
@@ -281,7 +281,7 @@ namespace System.Net.WebSockets
 
                 EnsureSendOperation();
                 _sendOperation!.BufferType = GetBufferType(messageType, endOfMessage);
-                await _sendOperation.Process(buffer, linkedCancellationToken).SuppressContextFlow();
+                await _sendOperation.Process(buffer, linkedCancellationToken).ConfigureAwait(false);
             }
             catch (Exception exception)
             {
@@ -301,7 +301,7 @@ namespace System.Net.WebSockets
             bool sendFrameLockTaken = false;
             try
             {
-                await _sendFrameThrottle.WaitAsync(cancellationToken).SuppressContextFlow();
+                await _sendFrameThrottle.WaitAsync(cancellationToken).ConfigureAwait(false);
                 sendFrameLockTaken = true;
 
                 if (sendBuffers.Count > 1 &&
@@ -309,16 +309,14 @@ namespace System.Net.WebSockets
                     _innerStreamAsWebSocketStream.SupportsMultipleWrite)
                 {
                     await _innerStreamAsWebSocketStream.MultipleWriteAsync(sendBuffers,
-                        cancellationToken).SuppressContextFlow();
+                        cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
                     foreach (ArraySegment<byte> buffer in sendBuffers)
                     {
-                        await _innerStream.WriteAsync(buffer.Array!,
-                            buffer.Offset,
-                            buffer.Count,
-                            cancellationToken).SuppressContextFlow();
+                        await _innerStream.WriteAsync(buffer.Array!.AsMemory(buffer.Offset, buffer.Count),
+                            cancellationToken).ConfigureAwait(false);
                     }
                 }
             }
@@ -425,7 +423,7 @@ namespace System.Net.WebSockets
                     if (closeOutputTask != null)
                     {
                         ReleaseLocks(ref thisLockTaken, ref sessionHandleLockTaken);
-                        await closeOutputTask.SuppressContextFlow();
+                        await closeOutputTask.ConfigureAwait(false);
                         TakeLocks(ref thisLockTaken, ref sessionHandleLockTaken);
                     }
                 }
@@ -441,7 +439,7 @@ namespace System.Net.WebSockets
                             Task keepAliveTask = _keepAliveTask;
 
                             ReleaseLocks(ref thisLockTaken, ref sessionHandleLockTaken);
-                            await keepAliveTask.SuppressContextFlow();
+                            await keepAliveTask.ConfigureAwait(false);
                             TakeLocks(ref thisLockTaken, ref sessionHandleLockTaken);
 
                             ThrowIfPendingException();
@@ -461,7 +459,7 @@ namespace System.Net.WebSockets
                     _closeOutputTask = _closeOutputOperation!.Process(null, linkedCancellationToken);
 
                     ReleaseLocks(ref thisLockTaken, ref sessionHandleLockTaken);
-                    await _closeOutputTask.SuppressContextFlow();
+                    await _closeOutputTask.ConfigureAwait(false);
                     TakeLocks(ref thisLockTaken, ref sessionHandleLockTaken);
 
                     if (OnCloseOutputCompleted())
@@ -471,7 +469,7 @@ namespace System.Net.WebSockets
                         try
                         {
                             callCompleteOnCloseCompleted = await StartOnCloseCompleted(
-                                thisLockTaken, sessionHandleLockTaken, linkedCancellationToken).SuppressContextFlow();
+                                thisLockTaken, sessionHandleLockTaken, linkedCancellationToken).ConfigureAwait(false);
                         }
                         catch (Exception)
                         {
@@ -570,7 +568,7 @@ namespace System.Net.WebSockets
                         ReleaseLock(_thisLock, ref thisLockTaken);
                     }
 
-                    await _closeNetworkConnectionTask.SuppressContextFlow();
+                    await _closeNetworkConnectionTask.ConfigureAwait(false);
                 }
                 catch (Exception closeNetworkConnectionTaskException)
                 {
@@ -654,7 +652,7 @@ namespace System.Net.WebSockets
                     ReleaseLock(_thisLock, ref lockTaken);
                     try
                     {
-                        await closeOutputTask.SuppressContextFlow();
+                        await closeOutputTask.ConfigureAwait(false);
                     }
                     catch (Exception closeOutputError)
                     {
@@ -687,7 +685,7 @@ namespace System.Net.WebSockets
                         // linkedCancellationToken can be CancellationToken.None if ownsCloseCancellationTokenSource==false
                         // This is still ok because OnCloseOutputCompleted won't start any IO operation in this case
                         callCompleteOnCloseCompleted = await StartOnCloseCompleted(
-                            lockTaken, false, linkedCancellationToken).SuppressContextFlow();
+                            lockTaken, false, linkedCancellationToken).ConfigureAwait(false);
                     }
                     catch (Exception)
                     {
@@ -725,7 +723,7 @@ namespace System.Net.WebSockets
                     WebSocketReceiveResult? receiveResult = null;
                     try
                     {
-                        receiveResult = await receiveAsyncTask.SuppressContextFlow();
+                        receiveResult = await receiveAsyncTask.ConfigureAwait(false);
                     }
                     catch (Exception receiveException)
                     {
@@ -766,7 +764,7 @@ namespace System.Net.WebSockets
                 {
                     _receiveOutstandingOperationHelper.CompleteOperation(ownsReceiveCancellationTokenSource);
                     ReleaseLock(_thisLock, ref lockTaken);
-                    await _closeReceivedTaskCompletionSource!.Task.SuppressContextFlow();
+                    await _closeReceivedTaskCompletionSource!.Task.ConfigureAwait(false);
                 }
 
                 // When ownsReceiveCancellationTokenSource is true and an exception is thrown, the lock will be taken.
@@ -793,7 +791,7 @@ namespace System.Net.WebSockets
                             // linkedCancellationToken can be CancellationToken.None if ownsCloseCancellationTokenSource==false
                             // This is still ok because OnCloseOutputCompleted won't start any IO operation in this case
                             callCompleteOnCloseCompleted = await StartOnCloseCompleted(
-                                lockTaken, false, linkedCancellationToken).SuppressContextFlow();
+                                lockTaken, false, linkedCancellationToken).ConfigureAwait(false);
                         }
                         catch (Exception)
                         {
@@ -1278,7 +1276,7 @@ namespace System.Net.WebSockets
                             thisPtr.EnsureKeepAliveOperation();
                             thisPtr._keepAliveTask = thisPtr._keepAliveOperation!.Process(null, linkedCancellationToken);
                             ReleaseLock(thisPtr.SessionHandle, ref lockTaken);
-                            await thisPtr._keepAliveTask!.SuppressContextFlow();
+                            await thisPtr._keepAliveTask!.ConfigureAwait(false);
                         }
                     }
                     finally
@@ -1411,7 +1409,7 @@ namespace System.Net.WebSockets
                                                 try
                                                 {
                                                     callCompleteOnCloseCompleted = await _webSocket.StartOnCloseCompleted(
-                                                        thisLockTaken, sessionHandleLockTaken, cancellationToken).SuppressContextFlow();
+                                                        thisLockTaken, sessionHandleLockTaken, cancellationToken).ConfigureAwait(false);
                                                 }
                                                 catch (Exception)
                                                 {
@@ -1461,7 +1459,7 @@ namespace System.Net.WebSockets
                                                 payload.Offset,
                                                 payload.Count,
                                                 cancellationToken);
-                                            count = await readTask.SuppressContextFlow();
+                                            count = await readTask.ConfigureAwait(false);
                                             _webSocket._keepAliveTracker.OnDataReceived();
                                         }
                                         catch (ObjectDisposedException objectDisposedException)
@@ -1491,7 +1489,7 @@ namespace System.Net.WebSockets
                                     WebSocketProtocolComponent.WebSocketCompleteAction(_webSocket, actionContext, 0);
                                     AsyncOperationCompleted = true;
                                     ReleaseLock(_webSocket.SessionHandle, ref sessionHandleLockTaken);
-                                    await _webSocket._innerStream.FlushAsync(cancellationToken).SuppressContextFlow();
+                                    await _webSocket._innerStream.FlushAsync(cancellationToken).ConfigureAwait(false);
                                     Monitor.Enter(_webSocket.SessionHandle, ref sessionHandleLockTaken);
                                     break;
                                 case WebSocketProtocolComponent.Action.SendToNetwork:
@@ -1539,7 +1537,7 @@ namespace System.Net.WebSockets
 
                                             ReleaseLock(_webSocket.SessionHandle, ref sessionHandleLockTaken);
                                             HttpWebSocket.ThrowIfConnectionAborted(_webSocket._innerStream, false);
-                                            await _webSocket.SendFrameAsync(sendBuffers, cancellationToken).SuppressContextFlow();
+                                            await _webSocket.SendFrameAsync(sendBuffers, cancellationToken).ConfigureAwait(false);
                                             Monitor.Enter(_webSocket.SessionHandle, ref sessionHandleLockTaken);
                                             _webSocket.ThrowIfPendingException();
                                             bytesSent += sendBufferSize;

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketHttpListenerDuplexStream.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketHttpListenerDuplexStream.cs
@@ -141,7 +141,7 @@ namespace System.Net.WebSockets
 
                 if (!_inOpaqueMode)
                 {
-                    bytesRead = await _inputStream.ReadAsync(buffer, offset, count, cancellationToken).SuppressContextFlow<int>();
+                    bytesRead = await _inputStream.ReadAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
@@ -165,7 +165,7 @@ namespace System.Net.WebSockets
                     }
                     else
                     {
-                        bytesRead = await _readTaskCompletionSource.Task.SuppressContextFlow<int>();
+                        bytesRead = await _readTaskCompletionSource.Task.ConfigureAwait(false);
                     }
                 }
             }
@@ -355,7 +355,7 @@ namespace System.Net.WebSockets
                 _writeEventArgs.BufferList = sendBuffers;
                 if (WriteAsyncFast(_writeEventArgs))
                 {
-                    await _writeTaskCompletionSource.Task.SuppressContextFlow();
+                    await _writeTaskCompletionSource.Task.ConfigureAwait(false);
                 }
             }
             catch (Exception error)
@@ -398,7 +398,7 @@ namespace System.Net.WebSockets
 
                 if (!_inOpaqueMode)
                 {
-                    await _outputStream.WriteAsync(buffer, offset, count, cancellationToken).SuppressContextFlow();
+                    await _outputStream.WriteAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
@@ -414,7 +414,7 @@ namespace System.Net.WebSockets
                     _writeEventArgs.SetBuffer(buffer, offset, count);
                     if (WriteAsyncFast(_writeEventArgs))
                     {
-                        await _writeTaskCompletionSource.Task.SuppressContextFlow();
+                        await _writeTaskCompletionSource.Task.ConfigureAwait(false);
                     }
                 }
             }
@@ -573,7 +573,7 @@ namespace System.Net.WebSockets
                 _writeEventArgs!.SetShouldCloseOutput();
                 if (WriteAsyncFast(_writeEventArgs))
                 {
-                    await _writeTaskCompletionSource.Task.SuppressContextFlow();
+                    await _writeTaskCompletionSource.Task.ConfigureAwait(false);
                 }
             }
             catch (Exception error)

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -2412,11 +2412,7 @@ namespace System.Net.Sockets
         {
             Task<int> ti = TaskToAsyncResult.Unwrap<int>(asyncResult);
 
-            if (!ti.IsCompleted)
-            {
-                // TODO https://github.com/dotnet/runtime/issues/17148: Wait without throwing
-                ((IAsyncResult)ti).AsyncWaitHandle.WaitOne();
-            }
+            ((Task)ti).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing).GetAwaiter().GetResult();
 
             if (ti.IsCompletedSuccessfully)
             {

--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
@@ -190,9 +190,8 @@ namespace System.Net.WebSockets
 
                 _innerWebSocket = BrowserInterop.UnsafeCreate(uri.ToString(), subProtocols, responseStatusHandle.Value, onClose);
                 var openTask = BrowserInterop.WebSocketOpen(_innerWebSocket);
-                var wrappedTask = CancelationHelper(openTask!, cancellationToken, _state);
 
-                await wrappedTask.ConfigureAwait(true);
+                await CancelationHelper(openTask!, cancellationToken, _state).ConfigureAwait(true);
                 if (State == WebSocketState.Connecting)
                 {
                     _state = WebSocketState.Open;
@@ -224,13 +223,8 @@ namespace System.Net.WebSockets
                     // return synchronously
                     return;
                 }
-                var wrappedTask = CancelationHelper(sendTask, cancellationToken, _state);
 
-                await wrappedTask.ConfigureAwait(true);
-            }
-            catch (OperationCanceledException)
-            {
-                throw;
+                await CancelationHelper(sendTask, cancellationToken, _state).ConfigureAwait(true);
             }
             catch (JSException ex)
             {
@@ -256,15 +250,10 @@ namespace System.Net.WebSockets
                         return ConvertResponse();
                     }
 
-                    var wrappedTask = CancelationHelper(receiveTask, cancellationToken, _state);
-                    await wrappedTask.ConfigureAwait(true);
+                    await CancelationHelper(receiveTask, cancellationToken, _state).ConfigureAwait(true);
 
                     return ConvertResponse();
                 }
-            }
-            catch (OperationCanceledException)
-            {
-                throw;
             }
             catch (JSException ex)
             {
@@ -298,8 +287,7 @@ namespace System.Net.WebSockets
             var closeTask = BrowserInterop.WebSocketClose(_innerWebSocket!, (int)closeStatus, statusDescription, waitForCloseReceived);
             if (closeTask != null)
             {
-                var wrappedTask = CancelationHelper(closeTask, cancellationToken, _state);
-                await wrappedTask.ConfigureAwait(true);
+                await CancelationHelper(closeTask, cancellationToken, _state).ConfigureAwait(true);
             }
 
             var state = State;

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -3509,6 +3509,9 @@
   <data name="Task_WaitMulti_NullTask" xml:space="preserve">
     <value>The tasks array included at least one null element.</value>
   </data>
+  <data name="TaskT_ConfigureAwait_InvalidOptions" xml:space="preserve">
+    <value>Task&lt;TResult&gt;.ConfigureAwait does not support ConfigureAwaitOptions.SuppressThrowing. To suppress throwing, instead cast the Task&lt;TResult&gt; to its base class Task and await that with SuppressThrowing.</value>
+  </data>
   <data name="TaskCanceledException_ctor_DefaultMessage" xml:space="preserve">
     <value>A task was canceled.</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -1175,6 +1175,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\AsyncCausalityTracerConstants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\CachedCompletedInt32Task.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\ConcurrentExclusiveSchedulerPair.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\ConfigureAwaitOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\Future.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\FutureFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\Sources\IValueTaskSource.cs" />
@@ -1274,7 +1275,7 @@
     <Compile Include="$(CommonPath)Interop\Interop.Collation.cs">
       <Link>Common\Interop\Interop.Collation.cs</Link>
     </Compile>
-     <Compile Include="$(CommonPath)Interop\Interop.Collation.OSX.cs" Condition="'$(IsOSXLike)' == 'true'">
+    <Compile Include="$(CommonPath)Interop\Interop.Collation.OSX.cs" Condition="'$(IsOSXLike)' == 'true'">
       <Link>Common\Interop\Interop.Collation.OSX.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)Interop\Interop.ICU.cs">

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -109,7 +109,7 @@ namespace System.Runtime.CompilerServices
             else if ((null != (object?)default(TAwaiter)) && (awaiter is IConfiguredTaskAwaiter))
             {
                 ref ConfiguredTaskAwaitable.ConfiguredTaskAwaiter ta = ref Unsafe.As<TAwaiter, ConfiguredTaskAwaitable.ConfiguredTaskAwaiter>(ref awaiter);
-                TaskAwaiter.UnsafeOnCompletedInternal(ta.m_task, box, ta.m_continueOnCapturedContext);
+                TaskAwaiter.UnsafeOnCompletedInternal(ta.m_task, box, (ta.m_options & ConfigureAwaitOptions.ContinueOnCapturedContext) != 0);
             }
             else if ((null != (object?)default(TAwaiter)) && (awaiter is IStateMachineBoxAwareAwaiter))
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
@@ -1,41 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// =+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
-//
-//
-//
-// Types for awaiting Task and Task<T>. These types are emitted from Task{<T>}.GetAwaiter
-// and Task{<T>}.ConfigureAwait.  They are meant to be used only by the compiler, e.g.
-//
-//   await nonGenericTask;
-//   =====================
-//       var $awaiter = nonGenericTask.GetAwaiter();
-//       if (!$awaiter.IsCompleted)
-//       {
-//           SPILL:
-//           $builder.AwaitUnsafeOnCompleted(ref $awaiter, ref this);
-//           return;
-//           Label:
-//           UNSPILL;
-//       }
-//       $awaiter.GetResult();
-//
-//   result += await genericTask.ConfigureAwait(false);
-//   ===================================================================================
-//       var $awaiter = genericTask.ConfigureAwait(false).GetAwaiter();
-//       if (!$awaiter.IsCompleted)
-//       {
-//           SPILL;
-//           $builder.AwaitUnsafeOnCompleted(ref $awaiter, ref this);
-//           return;
-//           Label:
-//           UNSPILL;
-//       }
-//       result += $awaiter.GetResult();
-//
-// =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
@@ -108,15 +73,17 @@ namespace System.Runtime.CompilerServices
         /// prior to completing the await.
         /// </summary>
         /// <param name="task">The awaited task.</param>
+        /// <param name="options">The options used to configure an await.</param>
         [StackTraceHidden]
-        internal static void ValidateEnd(Task task)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void ValidateEnd(Task task, ConfigureAwaitOptions options = ConfigureAwaitOptions.None)
         {
             // Fast checks that can be inlined.
             if (task.IsWaitNotificationEnabledOrNotRanToCompletion)
             {
                 // If either the end await bit is set or we're not completed successfully,
                 // fall back to the slower path.
-                HandleNonSuccessAndDebuggerNotification(task);
+                HandleNonSuccessAndDebuggerNotification(task, options);
             }
         }
 
@@ -125,12 +92,11 @@ namespace System.Runtime.CompilerServices
         /// the await on the task, and throws an exception if the task did not complete successfully.
         /// </summary>
         /// <param name="task">The awaited task.</param>
+        /// <param name="options">The options used to configure an await.</param>
         [StackTraceHidden]
-        private static void HandleNonSuccessAndDebuggerNotification(Task task)
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void HandleNonSuccessAndDebuggerNotification(Task task, ConfigureAwaitOptions options)
         {
-            // NOTE: The JIT refuses to inline ValidateEnd when it contains the contents
-            // of HandleNonSuccessAndDebuggerNotification, hence the separation.
-
             // Synchronously wait for the task to complete.  When used by the compiler,
             // the task will already be complete.  This code exists only for direct GetResult use,
             // for cases where the same exception propagation semantics used by "await" are desired,
@@ -145,7 +111,15 @@ namespace System.Runtime.CompilerServices
             task.NotifyDebuggerOfWaitCompletionIfNecessary();
 
             // And throw an exception if the task is faulted or canceled.
-            if (!task.IsCompletedSuccessfully) ThrowForNonSuccess(task);
+            if (!task.IsCompletedSuccessfully)
+            {
+                if ((options & ConfigureAwaitOptions.SuppressThrowing) == 0)
+                {
+                    ThrowForNonSuccess(task);
+                }
+
+                task.MarkExceptionsAsHandled();
+            }
         }
 
         /// <summary>Throws an exception to handle a task that completed in a state other than RanToCompletion.</summary>
@@ -386,13 +360,11 @@ namespace System.Runtime.CompilerServices
 
         /// <summary>Initializes the <see cref="ConfiguredTaskAwaitable"/>.</summary>
         /// <param name="task">The awaitable <see cref="System.Threading.Tasks.Task"/>.</param>
-        /// <param name="continueOnCapturedContext">
-        /// true to attempt to marshal the continuation back to the original context captured; otherwise, false.
-        /// </param>
-        internal ConfiguredTaskAwaitable(Task task, bool continueOnCapturedContext)
+        /// <param name="options">Options to control the behavior of the awaiter.</param>
+        internal ConfiguredTaskAwaitable(Task task, ConfigureAwaitOptions options)
         {
             Debug.Assert(task != null, "Constructing an awaitable requires a task to await.");
-            m_configuredTaskAwaiter = new ConfiguredTaskAwaitable.ConfiguredTaskAwaiter(task, continueOnCapturedContext);
+            m_configuredTaskAwaiter = new ConfiguredTaskAwaiter(task, options);
         }
 
         /// <summary>Gets an awaiter for this awaitable.</summary>
@@ -411,26 +383,24 @@ namespace System.Runtime.CompilerServices
 
             /// <summary>The task being awaited.</summary>
             internal readonly Task m_task;
-            /// <summary>Whether to attempt marshaling back to the original context.</summary>
-            internal readonly bool m_continueOnCapturedContext;
+            /// <summary>Options for how this awaiter behaves. This is a bit field with values from <see cref="ConfigureAwaitOptions"/>.</summary>
+            internal readonly ConfigureAwaitOptions m_options;
 
             /// <summary>Initializes the <see cref="ConfiguredTaskAwaiter"/>.</summary>
-            /// <param name="task">The <see cref="System.Threading.Tasks.Task"/> to await.</param>
-            /// <param name="continueOnCapturedContext">
-            /// true to attempt to marshal the continuation back to the original context captured
-            /// when BeginAwait is called; otherwise, false.
-            /// </param>
-            internal ConfiguredTaskAwaiter(Task task, bool continueOnCapturedContext)
+            /// <param name="task">The <see cref="Task"/> to await.</param>
+            /// <param name="options">Options used to configure how an await is performed.</param>
+            internal ConfiguredTaskAwaiter(Task task, ConfigureAwaitOptions options)
             {
                 Debug.Assert(task != null, "Constructing an awaiter requires a task to await.");
+                Debug.Assert((options & ~(ConfigureAwaitOptions.ContinueOnCapturedContext | ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ForceYielding)) == 0);
                 m_task = task;
-                m_continueOnCapturedContext = continueOnCapturedContext;
+                m_options = options;
             }
 
             /// <summary>Gets whether the task being awaited is completed.</summary>
             /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
             /// <exception cref="System.NullReferenceException">The awaiter was not properly initialized.</exception>
-            public bool IsCompleted => m_task.IsCompleted;
+            public bool IsCompleted => ((m_options & ConfigureAwaitOptions.ForceYielding) == 0) && m_task.IsCompleted;
 
             /// <summary>Schedules the continuation onto the <see cref="System.Threading.Tasks.Task"/> associated with this <see cref="TaskAwaiter"/>.</summary>
             /// <param name="continuation">The action to invoke when the await operation completes.</param>
@@ -439,7 +409,7 @@ namespace System.Runtime.CompilerServices
             /// <remarks>This method is intended for compiler use rather than use directly in code.</remarks>
             public void OnCompleted(Action continuation)
             {
-                TaskAwaiter.OnCompletedInternal(m_task, continuation, m_continueOnCapturedContext, flowExecutionContext: true);
+                TaskAwaiter.OnCompletedInternal(m_task, continuation, (m_options & ConfigureAwaitOptions.ContinueOnCapturedContext) != 0, flowExecutionContext: true);
             }
 
             /// <summary>Schedules the continuation onto the <see cref="System.Threading.Tasks.Task"/> associated with this <see cref="TaskAwaiter"/>.</summary>
@@ -449,7 +419,7 @@ namespace System.Runtime.CompilerServices
             /// <remarks>This method is intended for compiler use rather than use directly in code.</remarks>
             public void UnsafeOnCompleted(Action continuation)
             {
-                TaskAwaiter.OnCompletedInternal(m_task, continuation, m_continueOnCapturedContext, flowExecutionContext: false);
+                TaskAwaiter.OnCompletedInternal(m_task, continuation, (m_options & ConfigureAwaitOptions.ContinueOnCapturedContext) != 0, flowExecutionContext: false);
             }
 
             /// <summary>Ends the await on the completed <see cref="System.Threading.Tasks.Task"/>.</summary>
@@ -459,7 +429,7 @@ namespace System.Runtime.CompilerServices
             [StackTraceHidden]
             public void GetResult()
             {
-                TaskAwaiter.ValidateEnd(m_task);
+                TaskAwaiter.ValidateEnd(m_task, m_options);
             }
         }
     }
@@ -473,12 +443,10 @@ namespace System.Runtime.CompilerServices
 
         /// <summary>Initializes the <see cref="ConfiguredTaskAwaitable{TResult}"/>.</summary>
         /// <param name="task">The awaitable <see cref="System.Threading.Tasks.Task{TResult}"/>.</param>
-        /// <param name="continueOnCapturedContext">
-        /// true to attempt to marshal the continuation back to the original context captured; otherwise, false.
-        /// </param>
-        internal ConfiguredTaskAwaitable(Task<TResult> task, bool continueOnCapturedContext)
+        /// <param name="options">Options to control the behavior of the awaiter.</param>
+        internal ConfiguredTaskAwaitable(Task<TResult> task, ConfigureAwaitOptions options)
         {
-            m_configuredTaskAwaiter = new ConfiguredTaskAwaitable<TResult>.ConfiguredTaskAwaiter(task, continueOnCapturedContext);
+            m_configuredTaskAwaiter = new ConfiguredTaskAwaitable<TResult>.ConfiguredTaskAwaiter(task, options);
         }
 
         /// <summary>Gets an awaiter for this awaitable.</summary>
@@ -497,25 +465,24 @@ namespace System.Runtime.CompilerServices
 
             /// <summary>The task being awaited.</summary>
             private readonly Task<TResult> m_task;
-            /// <summary>Whether to attempt marshaling back to the original context.</summary>
-            private readonly bool m_continueOnCapturedContext;
+            /// <summary>Options for how this awaiter behaves. This is a bit field with values from <see cref="ConfigureAwaitOptions"/>.</summary>
+            internal readonly ConfigureAwaitOptions m_options;
 
             /// <summary>Initializes the <see cref="ConfiguredTaskAwaiter"/>.</summary>
-            /// <param name="task">The awaitable <see cref="System.Threading.Tasks.Task{TResult}"/>.</param>
-            /// <param name="continueOnCapturedContext">
-            /// true to attempt to marshal the continuation back to the original context captured; otherwise, false.
-            /// </param>
-            internal ConfiguredTaskAwaiter(Task<TResult> task, bool continueOnCapturedContext)
+            /// <param name="task">The awaitable <see cref="Task{TResult}"/>.</param>
+            /// <param name="options">The options used to configure the await's behavior.</param>
+            internal ConfiguredTaskAwaiter(Task<TResult> task, ConfigureAwaitOptions options)
             {
                 Debug.Assert(task != null, "Constructing an awaiter requires a task to await.");
+                Debug.Assert((options & ~(ConfigureAwaitOptions.ContinueOnCapturedContext | ConfigureAwaitOptions.ForceYielding)) == 0);
                 m_task = task;
-                m_continueOnCapturedContext = continueOnCapturedContext;
+                m_options = options;
             }
 
             /// <summary>Gets whether the task being awaited is completed.</summary>
             /// <remarks>This property is intended for compiler user rather than use directly in code.</remarks>
             /// <exception cref="System.NullReferenceException">The awaiter was not properly initialized.</exception>
-            public bool IsCompleted => m_task.IsCompleted;
+            public bool IsCompleted => ((m_options & ConfigureAwaitOptions.ForceYielding) == 0) && m_task.IsCompleted;
 
             /// <summary>Schedules the continuation onto the <see cref="System.Threading.Tasks.Task"/> associated with this <see cref="TaskAwaiter"/>.</summary>
             /// <param name="continuation">The action to invoke when the await operation completes.</param>
@@ -524,7 +491,7 @@ namespace System.Runtime.CompilerServices
             /// <remarks>This method is intended for compiler use rather than use directly in code.</remarks>
             public void OnCompleted(Action continuation)
             {
-                TaskAwaiter.OnCompletedInternal(m_task, continuation, m_continueOnCapturedContext, flowExecutionContext: true);
+                TaskAwaiter.OnCompletedInternal(m_task, continuation, (m_options & ConfigureAwaitOptions.ContinueOnCapturedContext) != 0, flowExecutionContext: true);
             }
 
             /// <summary>Schedules the continuation onto the <see cref="System.Threading.Tasks.Task"/> associated with this <see cref="TaskAwaiter"/>.</summary>
@@ -534,7 +501,7 @@ namespace System.Runtime.CompilerServices
             /// <remarks>This method is intended for compiler use rather than use directly in code.</remarks>
             public void UnsafeOnCompleted(Action continuation)
             {
-                TaskAwaiter.OnCompletedInternal(m_task, continuation, m_continueOnCapturedContext, flowExecutionContext: false);
+                TaskAwaiter.OnCompletedInternal(m_task, continuation, (m_options & ConfigureAwaitOptions.ContinueOnCapturedContext) != 0, flowExecutionContext: false);
             }
 
             /// <summary>Ends the await on the completed <see cref="System.Threading.Tasks.Task{TResult}"/>.</summary>
@@ -545,7 +512,7 @@ namespace System.Runtime.CompilerServices
             [StackTraceHidden]
             public TResult GetResult()
             {
-                TaskAwaiter.ValidateEnd(m_task);
+                TaskAwaiter.ValidateEnd(m_task); // no need to pass options as SuppressThrowing isn't supported
                 return m_task.ResultOnSuccess;
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ConfigureAwaitOptions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ConfigureAwaitOptions.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Threading.Tasks
+{
+    /// <summary>Options to control the behavior of an await on a <see cref="Task"/>.</summary>
+    [Flags]
+    public enum ConfigureAwaitOptions
+    {
+        /// <summary>No options specified.</summary>
+        /// <remarks>
+        /// <see cref="Task.ConfigureAwait(ConfigureAwaitOptions)"/> with a <see cref="None"/> argument behaves
+        /// identically to using <see cref="Task.ConfigureAwait(bool)"/> with a <see langword="false"/> argument.
+        /// </remarks>
+        None = 0x0,
+
+        /// <summary>
+        /// Attempt to marshal the continuation back to the original <see cref="SynchronizationContext"/> or
+        /// <see cref="TaskScheduler"/> present on the originating thread at the time of the await.
+        /// </summary>
+        /// <remarks>
+        /// If there is no such context/scheduler, or if this option is not specified, the thread on
+        /// which the continuation is invoked is unspecified and left up to the determination of the system.
+        /// </remarks>
+        ContinueOnCapturedContext = 0x1,
+
+        /// <summary>
+        /// Avoids throwing an exception at the completion of an await on a <see cref="Task"/> that ends
+        /// in the <see cref="TaskStatus.Faulted"/> or <see cref="TaskStatus.Canceled"/> state.
+        /// </summary>
+        /// <remarks>
+        /// This option is supported only for <see cref="Task.ConfigureAwait(ConfigureAwaitOptions)"/>,
+        /// not <see cref="Task{TResult}.ConfigureAwait(ConfigureAwaitOptions)"/>, as for a <see cref="Task{TResult}"/> the
+        /// operation could end up returning an incorrect and/or invalid result. To use with a <see cref="Task{TResult}"/>,
+        /// cast to the base <see cref="Task"/> type in order to use its <see cref="Task.ConfigureAwait(ConfigureAwaitOptions)"/>.
+        /// </remarks>
+        SuppressThrowing = 0x2,
+
+        /// <summary>
+        /// Forces an await on an already completed <see cref="Task"/> to behave as if the <see cref="Task"/>
+        /// wasn't yet completed, such that the current asynchronous method will be forced to yield its execution.
+        /// </summary>
+        ForceYielding = 0x4,
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ConfigureAwaitOptions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ConfigureAwaitOptions.cs
@@ -3,7 +3,7 @@
 
 namespace System.Threading.Tasks
 {
-    /// <summary>Options to control the behavior of an await on a <see cref="Task"/>.</summary>
+    /// <summary>Options to control behavior when awaiting.</summary>
     [Flags]
     public enum ConfigureAwaitOptions
     {
@@ -21,11 +21,13 @@ namespace System.Threading.Tasks
         /// <remarks>
         /// If there is no such context/scheduler, or if this option is not specified, the thread on
         /// which the continuation is invoked is unspecified and left up to the determination of the system.
+        /// <see cref="Task.ConfigureAwait(ConfigureAwaitOptions)"/> with a <see cref="ContinueOnCapturedContext"/> argument
+        /// behaves identically to using <see cref="Task.ConfigureAwait(bool)"/> with a <see langword="true"/> argument.
         /// </remarks>
         ContinueOnCapturedContext = 0x1,
 
         /// <summary>
-        /// Avoids throwing an exception at the completion of an await on a <see cref="Task"/> that ends
+        /// Avoids throwing an exception at the completion of awaiting a <see cref="Task"/> that ends
         /// in the <see cref="TaskStatus.Faulted"/> or <see cref="TaskStatus.Canceled"/> state.
         /// </summary>
         /// <remarks>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
@@ -526,7 +526,27 @@ namespace System.Threading.Tasks
         /// <returns>An object used to await this task.</returns>
         public new ConfiguredTaskAwaitable<TResult> ConfigureAwait(bool continueOnCapturedContext)
         {
-            return new ConfiguredTaskAwaitable<TResult>(this, continueOnCapturedContext);
+            return new ConfiguredTaskAwaitable<TResult>(this, continueOnCapturedContext ? ConfigureAwaitOptions.ContinueOnCapturedContext : ConfigureAwaitOptions.None);
+        }
+
+        /// <summary>Configures an awaiter used to await this <see cref="Task"/>.</summary>
+        /// <param name="options">Options used to configure how awaits on this task are performed.</param>
+        /// <returns>An object used to await this task.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">The <paramref name="options"/> argument specifies an invalid value.</exception>
+        public new ConfiguredTaskAwaitable<TResult> ConfigureAwait(ConfigureAwaitOptions options)
+        {
+            if ((options & ~(ConfigureAwaitOptions.ContinueOnCapturedContext |
+                             ConfigureAwaitOptions.ForceYielding)) != 0)
+            {
+                ThrowForInvalidOptions(options);
+            }
+
+            return new ConfiguredTaskAwaitable<TResult>(this, options);
+
+            static void ThrowForInvalidOptions(ConfigureAwaitOptions options) =>
+                throw ((options & ConfigureAwaitOptions.SuppressThrowing) == 0 ?
+                    new ArgumentOutOfRangeException(nameof(options)) :
+                    new ArgumentOutOfRangeException(nameof(options), SR.TaskT_ConfigureAwait_InvalidOptions));
         }
 
         #endregion

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskScheduler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskScheduler.cs
@@ -532,31 +532,6 @@ namespace System.Threading.Tasks
             // returns the scheduler's GetScheduledTasks
             public IEnumerable<Task>? ScheduledTasks => m_taskScheduler.GetScheduledTasks();
         }
-
-        // TODO https://github.com/dotnet/runtime/issues/20025: Consider exposing publicly.
-        /// <summary>Gets an awaiter used to queue a continuation to this TaskScheduler.</summary>
-        internal TaskSchedulerAwaiter GetAwaiter() => new TaskSchedulerAwaiter(this);
-
-        /// <summary>Awaiter used to queue a continuation to a specified task scheduler.</summary>
-        internal readonly struct TaskSchedulerAwaiter : ICriticalNotifyCompletion
-        {
-            private readonly TaskScheduler _scheduler;
-            public TaskSchedulerAwaiter(TaskScheduler scheduler) => _scheduler = scheduler;
-            public bool IsCompleted => false;
-            public void GetResult() { }
-            public void OnCompleted(Action continuation) => Task.Factory.StartNew(continuation, CancellationToken.None, TaskCreationOptions.DenyChildAttach, _scheduler);
-            public void UnsafeOnCompleted(Action continuation)
-            {
-                if (ReferenceEquals(_scheduler, Default))
-                {
-                    ThreadPool.UnsafeQueueUserWorkItem(s => s(), continuation, preferLocal: true);
-                }
-                else
-                {
-                    OnCompleted(continuation);
-                }
-            }
-        }
     }
 
     /// <summary>

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.cs
@@ -131,8 +131,9 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             Task<JSObject> modulePromise = JavaScriptImports.DynamicImport(moduleName, moduleUrl);
             var wrappedTask = CancelationHelper(modulePromise, cancellationToken);
-            await Task.Yield();// this helps to finish the import before we bind the module in [JSImport]
-            return await wrappedTask.ConfigureAwait(true);
+            return await wrappedTask.ConfigureAwait(
+                ConfigureAwaitOptions.ContinueOnCapturedContext |
+                ConfigureAwaitOptions.ForceYielding); // this helps to finish the import before we bind the module in [JSImport]
         }
 
         public static async Task<JSObject> CancelationHelper(Task<JSObject> jsTask, CancellationToken cancellationToken)

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -14928,6 +14928,14 @@ namespace System.Threading
 }
 namespace System.Threading.Tasks
 {
+    [System.FlagsAttribute]
+    public enum ConfigureAwaitOptions
+    {
+        None = 0x0,
+        ContinueOnCapturedContext = 0x1,
+        SuppressThrowing = 0x2,
+        ForceYielding = 0x4,
+    }
     public partial class ConcurrentExclusiveSchedulerPair
     {
         public ConcurrentExclusiveSchedulerPair() { }
@@ -14965,6 +14973,7 @@ namespace System.Threading.Tasks
         System.Threading.WaitHandle System.IAsyncResult.AsyncWaitHandle { get { throw null; } }
         bool System.IAsyncResult.CompletedSynchronously { get { throw null; } }
         public System.Runtime.CompilerServices.ConfiguredTaskAwaitable ConfigureAwait(bool continueOnCapturedContext) { throw null; }
+        public System.Runtime.CompilerServices.ConfiguredTaskAwaitable ConfigureAwait(System.Threading.Tasks.ConfigureAwaitOptions options) { throw null; }
         public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task, object?> continuationAction, object? state) { throw null; }
         public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task, object?> continuationAction, object? state, System.Threading.CancellationToken cancellationToken) { throw null; }
         public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task, object?> continuationAction, object? state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }
@@ -15318,6 +15327,7 @@ namespace System.Threading.Tasks
         public static new System.Threading.Tasks.TaskFactory<TResult> Factory { get { throw null; } }
         public TResult Result { get { throw null; } }
         public new System.Runtime.CompilerServices.ConfiguredTaskAwaitable<TResult> ConfigureAwait(bool continueOnCapturedContext) { throw null; }
+        public new System.Runtime.CompilerServices.ConfiguredTaskAwaitable<TResult> ConfigureAwait(System.Threading.Tasks.ConfigureAwaitOptions options) { throw null; }
         public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task<TResult>, object?> continuationAction, object? state) { throw null; }
         public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task<TResult>, object?> continuationAction, object? state, System.Threading.CancellationToken cancellationToken) { throw null; }
         public System.Threading.Tasks.Task ContinueWith(System.Action<System.Threading.Tasks.Task<TResult>, object?> continuationAction, object? state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler) { throw null; }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.WriteHelpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.WriteHelpers.cs
@@ -149,15 +149,16 @@ namespace System.Text.Json.Serialization.Metadata
                             // Note that pending tasks are always awaited, even if an exception has been thrown or the cancellation token has fired.
                             if (state.PendingTask is not null)
                             {
+                                // Exceptions should only be propagated by the resuming converter
+#if NET8_0_OR_GREATER
+                                await state.PendingTask.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+#else
                                 try
                                 {
                                     await state.PendingTask.ConfigureAwait(false);
                                 }
-                                catch
-                                {
-                                    // Exceptions should only be propagated by the resuming converter
-                                    // TODO https://github.com/dotnet/runtime/issues/22144
-                                }
+                                catch { }
+#endif
                             }
 
                             // Dispose any pending async disposables (currently these can only be completed IAsyncEnumerators).

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/DefaultPartitionedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/DefaultPartitionedRateLimiter.cs
@@ -45,7 +45,6 @@ namespace System.Threading.RateLimiting
             _limiters = new Dictionary<TKey, Lazy<RateLimiter>>(equalityComparer);
             _partitioner = partitioner;
 
-            // TODO: Figure out what interval we should use
             _timer = new TimerAwaitable(timerInterval, timerInterval);
             _timerTask = RunTimer();
         }
@@ -57,9 +56,14 @@ namespace System.Threading.RateLimiting
             {
                 try
                 {
-                    await Heartbeat().ConfigureAwait(false);
+                    await Heartbeat().ConfigureAwait(
+#if NET8_0_OR_GREATER
+                        ConfigureAwaitOptions.SuppressThrowing
+#else
+                        false
+#endif
+                        );
                 }
-                // TODO: Can we log to EventSource or somewhere? Maybe dispatch throwing the exception so it is at least an unhandled exception?
                 catch { }
             }
             _timer.Dispose();


### PR DESCRIPTION
Adds the ability to further control how awaits are performed, with the ConfigureAwaitOptions enum.  For .NET 8 this is just for `Task` / `Task<TResult>`, and for the latter, the `SuppressThrowing` option isn't supported (as it can make the TResult erroneous).

Mostly everything here works as I'd like.  The one thing I'm not happy about is this adds an extra branch to the configured awaiter's IsCompleted property that's now incurred on every `await task.ConfigureAwait(false)`.  That branch should be elidable by the JIT, as the input is invariably constant (`false`) and it should be able to then see that constant value through to the IsCompleted call immediately after the awaiter is constructed.  However, because in the async method the awaiter is later passed by ref to the method builder, it's considered address exposed, the struct won't be promoted, and the JIT loses track of the known constant value, such that even though everything is inlined, it still does the `(options & ForceYielding) != 0` check in IsCompleted.  I'm talking with @EgorBo about whether there are any options here.  It's not worth introducing a whole new set of awaitables/awaiters for this, but hopefully we can come up with a way in the existing ones to remove the few additional instructions incurred.
```diff
+xor      edx, edx
+mov      dword ptr [rbp-08H], edx
+test     byte  ptr [rbp-08H], 4
+jne      SHORT G_M000_IG04
 mov      rdx, gword ptr [rbp-10H]
 test     dword ptr [rdx+34H], 0x1600000
 jne      SHORT G_M000_IG07
```

On the positive front, I've used the new overload throughout the repo to replace various custom awaiters, use of Task.Run, and places we were catching all exceptions to suppress them with awaits.  Some of these just help to clean up the code; others have / enable meaningful perf improvements.  For example:

|         Method |         Toolchain | Cancelable |     Mean | Ratio | Allocated | Alloc Ratio |
|--------------- |------------------ |----------- |---------:|------:|----------:|------------:|
| ReadWriteAsync | \main\corerun.exe |      False | 3.856 us |  1.00 |     181 B |       1.000 |
| ReadWriteAsync |   \pr\corerun.exe |      False | 3.060 us |  0.78 |       1 B |       0.006 |
|                |                   |            |          |       |           |             |
| ReadWriteAsync | \main\corerun.exe |       True | 4.108 us |  1.00 |     184 B |        1.00 |
| ReadWriteAsync |   \pr\corerun.exe |       True | 3.415 us |  0.83 |      82 B |        0.45 |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.IO.Pipes;
using System.Threading.Tasks;
using System.Threading;

[MemoryDiagnoser(false)]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    private readonly CancellationTokenSource _cts = new CancellationTokenSource();
    private readonly byte[] _buffer = new byte[1];
    private AnonymousPipeServerStream _server;
    private AnonymousPipeClientStream _client;

    [Params(false, true)]
    public bool Cancelable { get; set; }

    [GlobalSetup]
    public void Setup()
    {
        _server = new AnonymousPipeServerStream(PipeDirection.Out);
        _client = new AnonymousPipeClientStream(PipeDirection.In, _server.ClientSafePipeHandle);
    }

    [GlobalCleanup]
    public void Cleanup()
    {
        _server.Dispose();
        _client.Dispose();
    }

    [Benchmark(OperationsPerInvoke = 1000)]
    public async Task ReadWriteAsync()
    {
        CancellationToken ct = Cancelable ? _cts.Token : default;
        for (int i = 0; i < 1000; i++)
        {
            ValueTask<int> read = _client.ReadAsync(_buffer, ct);
            await _server.WriteAsync(_buffer, ct);
            await read;
        }
    }
}
```