### PR TITLE
[wasm] Perf blazor scenarios: Use the correct wasm sdk pack

### DIFF
--- a/eng/pipelines/coreclr/perf-wasm-prepare-artifacts-steps.yml
+++ b/eng/pipelines/coreclr/perf-wasm-prepare-artifacts-steps.yml
@@ -12,10 +12,11 @@ steps:
     displayName: "Install workload using artifacts"
 
   - script: >-
-      mkdir -p $(Build.SourcesDirectory)/artifacts/staging &&
+      mkdir -p $(Build.SourcesDirectory)/artifacts/staging/built-nugets &&
       cp -r $(Build.SourcesDirectory)/artifacts/bin/dotnet-latest $(Build.SourcesDirectory)/artifacts/staging &&
       cp -r $(Build.SourcesDirectory)/artifacts/bin/microsoft.netcore.app.runtime.browser-wasm $(Build.SourcesDirectory)/artifacts/staging &&
-      cp -r $(Build.SourcesDirectory)/artifacts/bin/microsoft.netcore.app.ref $(Build.SourcesDirectory)/artifacts/staging
+      cp -r $(Build.SourcesDirectory)/artifacts/bin/microsoft.netcore.app.ref $(Build.SourcesDirectory)/artifacts/staging &&
+      cp -r $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping/Microsoft.NET.Sdk.WebAssembly.Pack* $(Build.SourcesDirectory)/artifacts/staging/built-nugets
     displayName: "Prepare artifacts staging directory"
 
   - template: /eng/pipelines/common/upload-artifact-step.yml

--- a/eng/pipelines/coreclr/templates/perf-job.yml
+++ b/eng/pipelines/coreclr/templates/perf-job.yml
@@ -194,6 +194,7 @@ jobs:
           mkdir -p $(librariesDownloadDir)/bin/wasm/wasm-data &&
           mkdir -p $(librariesDownloadDir)/bin/wasm/dotnet &&
           cp -r $(librariesDownloadDir)/BrowserWasm/staging/dotnet-latest/* $(librariesDownloadDir)/bin/wasm/dotnet &&
+          cp -r $(librariesDownloadDir)/BrowserWasm/staging/built-nugets $(librariesDownloadDir)/bin/wasm &&
           cp src/mono/wasm/Wasm.Build.Tests/data/test-main-7.0.js $(librariesDownloadDir)/bin/wasm/wasm-data/test-main.js &&
           find $(librariesDownloadDir)/bin/wasm -type d &&
           find $(librariesDownloadDir)/bin/wasm -type f -exec chmod 664 {} \;

--- a/eng/pipelines/coreclr/templates/run-scenarios-job.yml
+++ b/eng/pipelines/coreclr/templates/run-scenarios-job.yml
@@ -142,6 +142,7 @@ jobs:
     - script: >-
         mkdir -p $(librariesDownloadDir)/bin/wasm/data &&
         cp -r $(librariesDownloadDir)/BrowserWasm/staging/dotnet-latest $(librariesDownloadDir)/bin/wasm &&
+        cp -r $(librariesDownloadDir)/BrowserWasm/staging/built-nugets $(librariesDownloadDir)/bin/wasm &&
         cp src/mono/wasm/Wasm.Build.Tests/data/test-main-7.0.js $(librariesDownloadDir)/bin/wasm/data/test-main.js &&
         find $(librariesDownloadDir)/bin/wasm -type f -exec chmod 664 {} \;
       displayName: "Create wasm directory (Linux)"

--- a/eng/testing/performance/blazor_perf.proj
+++ b/eng/testing/performance/blazor_perf.proj
@@ -3,11 +3,14 @@
     <LogDirectory Condition="'$(AGENT_OS)' == 'Windows_NT'">%HELIX_WORKITEM_UPLOAD_ROOT%\</LogDirectory>
     <LogDirectory Condition="'$(AGENT_OS)' != 'Windows_NT'">%24{HELIX_WORKITEM_UPLOAD_ROOT}/</LogDirectory>
 
+    <EnvVars Condition="'$(AGENT_OS)' == 'Windows_NT'">set RestoreAdditionalProjectSources=%HELIX_CORRELATION_PAYLOAD%\built-nugets &amp; </EnvVars>
+    <EnvVars Condition="'$(AGENT_OS)' != 'Windows_NT'">export RestoreAdditionalProjectSources=$HELIX_CORRELATION_PAYLOAD/built-nugets &amp;&amp; </EnvVars>
+
     <Python>python3</Python>
     <HelixPreCommands Condition="'$(AGENT_OS)' != 'Windows_NT'">$(HelixPreCommands);chmod +x $HELIX_WORKITEM_PAYLOAD/SOD/SizeOnDisk</HelixPreCommands>
 
     <PublishArgs>--has-workload --readonly-dotnet --msbuild "/p:_TrimmerDumpDependencies=true" --msbuild /warnaserror:NU1602,NU1604 --msbuild-static AdditionalMonoLinkerOptions=%27&quot;%24(AdditionalMonoLinkerOptions) --dump-dependencies&quot;%27 --binlog $(LogDirectory)blazor_publish.binlog</PublishArgs>
-    <PublishCommand>$(Python) pre.py publish $(PublishArgs)</PublishCommand>
+    <PublishCommand>$(EnvVars) $(Python) pre.py publish $(PublishArgs)</PublishCommand>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(AGENT_OS)' == 'Windows_NT'">


### PR DESCRIPTION
- Make the built nuget for wasm sdk pack available when running the
  blazor scenarios.

```
/home/helixbot/work/B975098B/p/performance/src/scenarios/blazorpizza/app/BlazingPizza.Client/BlazingPizza.Client.csproj
: warning NU1603: BlazingPizza.Client depends on Microsoft.NET.Sdk.WebAssembly.Pack (>= 8.0.0-ci) but Microsoft.NET.Sdk.WebAssembly.Pack 8.0.0-ci was not found. An approximate best match of Microsoft.NET.Sdk.WebAssembly.Pack 8.0.0-preview.4.23213.11 was resolved.
```

.. otherwise it resolves to an older package from the published sources.