### PR TITLE
[wasm] Remove dependency on definition of MonoClass

### DIFF
--- a/src/mono/mono/metadata/class-accessors.c
+++ b/src/mono/mono/metadata/class-accessors.c
@@ -694,17 +694,6 @@ mono_class_has_metadata_update_info (MonoClass *klass)
 	}
 }
 
-#if HOST_BROWSER
-void
-mono_jiterp_class_get_member_offsets (guint32 *element_class_offset, guint32 *rank_offset)
-{
-	if (element_class_offset)
-		*element_class_offset = offsetof (MonoClass, element_class);
-	if (rank_offset)
-		*rank_offset = offsetof (MonoClass, rank);
-}
-#endif
-
 
 #ifdef MONO_CLASS_DEF_PRIVATE
 #define MONO_CLASS_GETTER(funcname, rettype, optref, argtype, fieldname) rettype funcname (argtype *klass) { return optref klass-> fieldname ; }

--- a/src/mono/mono/metadata/class-accessors.c
+++ b/src/mono/mono/metadata/class-accessors.c
@@ -581,7 +581,7 @@ mono_class_set_failure (MonoClass *klass, MonoErrorBoxed *boxed_error)
 /**
  * mono_class_set_deferred_failure:
  * \param klass class in which the failure was detected
-
+ 
  * This method marks the class with a deferred failure, indicating that a failure was detected but it will be processed during AOT runtime..
  * Note that only the first failure is kept.
  *

--- a/src/mono/mono/metadata/class-accessors.c
+++ b/src/mono/mono/metadata/class-accessors.c
@@ -581,7 +581,7 @@ mono_class_set_failure (MonoClass *klass, MonoErrorBoxed *boxed_error)
 /**
  * mono_class_set_deferred_failure:
  * \param klass class in which the failure was detected
- 
+
  * This method marks the class with a deferred failure, indicating that a failure was detected but it will be processed during AOT runtime..
  * Note that only the first failure is kept.
  *
@@ -693,6 +693,17 @@ mono_class_has_metadata_update_info (MonoClass *klass)
 		g_assert_not_reached ();
 	}
 }
+
+#if HOST_BROWSER
+void
+mono_jiterp_class_get_member_offsets (guint32 *element_class_offset, guint32 *rank_offset)
+{
+	if (element_class_offset)
+		*element_class_offset = offsetof (MonoClass, element_class);
+	if (rank_offset)
+		*rank_offset = offsetof (MonoClass, rank);
+}
+#endif
 
 
 #ifdef MONO_CLASS_DEF_PRIVATE

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -30,6 +30,7 @@ void jiterp_preserve_module (void);
 #include <mono/metadata/mono-config.h>
 #include <mono/utils/mono-threads.h>
 #include <mono/metadata/gc-internals.h>
+#include <mono/metadata/class-abi-details.h>
 
 #include "interp.h"
 #include "interp-internals.h"
@@ -1137,8 +1138,6 @@ mono_jiterp_trace_transfer (
 // we use these helpers at JIT time to figure out where to do memory loads and stores
 EMSCRIPTEN_KEEPALIVE size_t
 mono_jiterp_get_member_offset (int member) {
-	guint32 temp = 0;
-
 	switch (member) {
 		case JITERP_MEMBER_VT_INITIALIZED:
 			return MONO_STRUCT_OFFSET (MonoVTable, initialized);

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -1134,30 +1134,14 @@ mono_jiterp_trace_transfer (
 #define JITERP_MEMBER_CLASS_ELEMENT_CLASS 17
 #define JITERP_MEMBER_BOXED_VALUE_DATA 18
 
-// Keep in sync with class-private-definition.h
-typedef struct {
-	/* element class for arrays and enum basetype for enums */
-	MonoClass *element_class;
-	/* used for subtype checks */
-	MonoClass *cast_class;
-
-	/* for fast subtype checks */
-	MonoClass **supertypes;
-	guint16     idepth;
-
-	/* array dimension */
-	guint8     rank;
-
-	/* One of the values from MonoTypeKind */
-	guint8     class_kind;
-
-	int        instance_size; /* object instance size */
-	/* the rest is omitted */
-} MonoClassHeader;
+void
+mono_jiterp_class_get_member_offsets (guint32 *element_class_offset, guint32 *rank_offset);
 
 // we use these helpers at JIT time to figure out where to do memory loads and stores
 EMSCRIPTEN_KEEPALIVE size_t
 mono_jiterp_get_member_offset (int member) {
+	guint32 temp = 0;
+
 	switch (member) {
 		case JITERP_MEMBER_VT_INITIALIZED:
 			return MONO_STRUCT_OFFSET (MonoVTable, initialized);
@@ -1192,9 +1176,11 @@ mono_jiterp_get_member_offset (int member) {
 		case JITERP_MEMBER_VTABLE_KLASS:
 			return offsetof (MonoVTable, klass);
 		case JITERP_MEMBER_CLASS_RANK:
-			return offsetof (MonoClassHeader, rank);
+			mono_jiterp_class_get_member_offsets(NULL, &temp);
+			return temp;
 		case JITERP_MEMBER_CLASS_ELEMENT_CLASS:
-			return offsetof (MonoClassHeader, element_class);
+			mono_jiterp_class_get_member_offsets(&temp, NULL);
+			return temp;
 		// see mono_object_get_data
 		case JITERP_MEMBER_BOXED_VALUE_DATA:
 			return MONO_ABI_SIZEOF (MonoObject);

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -1134,9 +1134,6 @@ mono_jiterp_trace_transfer (
 #define JITERP_MEMBER_CLASS_ELEMENT_CLASS 17
 #define JITERP_MEMBER_BOXED_VALUE_DATA 18
 
-void
-mono_jiterp_class_get_member_offsets (guint32 *element_class_offset, guint32 *rank_offset);
-
 // we use these helpers at JIT time to figure out where to do memory loads and stores
 EMSCRIPTEN_KEEPALIVE size_t
 mono_jiterp_get_member_offset (int member) {
@@ -1176,11 +1173,9 @@ mono_jiterp_get_member_offset (int member) {
 		case JITERP_MEMBER_VTABLE_KLASS:
 			return offsetof (MonoVTable, klass);
 		case JITERP_MEMBER_CLASS_RANK:
-			mono_jiterp_class_get_member_offsets(NULL, &temp);
-			return temp;
+			return m_class_offsetof_rank();
 		case JITERP_MEMBER_CLASS_ELEMENT_CLASS:
-			mono_jiterp_class_get_member_offsets(&temp, NULL);
-			return temp;
+			return m_class_offsetof_element_class();
 		// see mono_object_get_data
 		case JITERP_MEMBER_BOXED_VALUE_DATA:
 			return MONO_ABI_SIZEOF (MonoObject);

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -1134,6 +1134,27 @@ mono_jiterp_trace_transfer (
 #define JITERP_MEMBER_CLASS_ELEMENT_CLASS 17
 #define JITERP_MEMBER_BOXED_VALUE_DATA 18
 
+// Keep in sync with class-private-definition.h
+typedef struct {
+	/* element class for arrays and enum basetype for enums */
+	MonoClass *element_class;
+	/* used for subtype checks */
+	MonoClass *cast_class;
+
+	/* for fast subtype checks */
+	MonoClass **supertypes;
+	guint16     idepth;
+
+	/* array dimension */
+	guint8     rank;
+
+	/* One of the values from MonoTypeKind */
+	guint8     class_kind;
+
+	int        instance_size; /* object instance size */
+	/* the rest is omitted */
+} MonoClassHeader;
+
 // we use these helpers at JIT time to figure out where to do memory loads and stores
 EMSCRIPTEN_KEEPALIVE size_t
 mono_jiterp_get_member_offset (int member) {
@@ -1171,9 +1192,9 @@ mono_jiterp_get_member_offset (int member) {
 		case JITERP_MEMBER_VTABLE_KLASS:
 			return offsetof (MonoVTable, klass);
 		case JITERP_MEMBER_CLASS_RANK:
-			return offsetof (MonoClass, rank);
+			return offsetof (MonoClassHeader, rank);
 		case JITERP_MEMBER_CLASS_ELEMENT_CLASS:
-			return offsetof (MonoClass, element_class);
+			return offsetof (MonoClassHeader, element_class);
 		// see mono_object_get_data
 		case JITERP_MEMBER_BOXED_VALUE_DATA:
 			return MONO_ABI_SIZEOF (MonoObject);


### PR DESCRIPTION
A recent change to the Jiterpreter added a dependency on the definition of MonoClass which broke debug builds.

cc @pavelsavara @maraf 