### PR TITLE
[wasm] Disable System.Text.Json AOT tests due to crashes

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -33,7 +33,8 @@
     <HighAOTResourceRequiringProject Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\FunctionalTests\System.Text.RegularExpressions.Tests.csproj" />
 
     <!-- https://github.com/dotnet/runtime/issues/61524 - OOM while linking -->
-    <HighAOTResourceRequiringProject Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.Tests\System.Text.Json.Tests.csproj" />
+    <!-- Disabled due to crash - https://github.com/dotnet/runtime/issues/86164 -->
+    <!--<HighAOTResourceRequiringProject Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.Tests\System.Text.Json.Tests.csproj" />-->
   </ItemGroup>
 
   <!-- Samples which are too complex for CI -->


### PR DESCRIPTION
V8, and chrome crash currently when running the tests.

Issue: https://github.com/dotnet/runtime/issues/86164
