### PR TITLE
Add back fixed xunit decimal, IntPtr and UIntPtr commented test cases

### DIFF
--- a/src/libraries/System.Linq.Parallel/tests/ParallelEnumerableTests.cs
+++ b/src/libraries/System.Linq.Parallel/tests/ParallelEnumerableTests.cs
@@ -181,8 +181,7 @@ namespace System.Linq.Parallel.Tests
                     yield return new object[] { element, count };
                     yield return new object[] { (long)element, count };
                     yield return new object[] { (double)element, count };
-                    // [ActiveIssue("https://github.com/xunit/xunit/issues/1771")]
-                    //yield return new object[] { (decimal)element, count };
+                    yield return new object[] { (decimal)element, count };
                     yield return new object[] { "" + element, count };
                 }
                 yield return new object[] { null, count };

--- a/src/libraries/System.Linq.Parallel/tests/QueryOperators/DefaultIfEmptyTests.cs
+++ b/src/libraries/System.Linq.Parallel/tests/QueryOperators/DefaultIfEmptyTests.cs
@@ -109,7 +109,6 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(EmptyData))]
-        [ActiveIssue("https://github.com/xunit/xunit/issues/1771")]
         public static void DefaultIfEmpty_Empty<T>(Labeled<ParallelQuery<T>> labeled, T def)
         {
             ParallelQuery<T> notEmpty = labeled.Item.DefaultIfEmpty();
@@ -125,7 +124,6 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(EmptyData))]
-        [ActiveIssue("https://github.com/xunit/xunit/issues/1771")]
         public static void DefaultIfEmpty_Empty_NotPipelined<T>(Labeled<ParallelQuery<T>> labeled, T def)
         {
             IList<T> notEmpty = labeled.Item.DefaultIfEmpty().ToList();

--- a/src/libraries/System.Runtime/tests/System/ArrayTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ArrayTests.cs
@@ -263,38 +263,37 @@ namespace System.Tests
 
             yield return new object[] { new ulong[0], 0, 0, (ulong)0, null, -1 };
 
-            // // [ActiveIssue("https://github.com/xunit/xunit/issues/1771")]
-            // // IntPtr
+            // IntPtr
 
-            // IntPtr[] intPtrArray = new IntPtr[] { IntPtr.MinValue, (IntPtr)0, (IntPtr)0, IntPtr.MaxValue };
+            IntPtr[] intPtrArray = new IntPtr[] { IntPtr.MinValue, (IntPtr)0, (IntPtr)0, IntPtr.MaxValue };
 
-            // yield return new object[] { intPtrArray, 0, 4, IntPtr.MinValue, null, 0 };
-            // yield return new object[] { intPtrArray, 0, 4, (IntPtr)0, null, 1 };
-            // yield return new object[] { intPtrArray, 0, 4, IntPtr.MaxValue, null, 3 };
-            // yield return new object[] { intPtrArray, 0, 4, (IntPtr)1, null, -4 };
+            yield return new object[] { intPtrArray, 0, 4, IntPtr.MinValue, null, 0 };
+            yield return new object[] { intPtrArray, 0, 4, (IntPtr)0, null, 1 };
+            yield return new object[] { intPtrArray, 0, 4, IntPtr.MaxValue, null, 3 };
+            yield return new object[] { intPtrArray, 0, 4, (IntPtr)1, null, -4 };
 
-            // yield return new object[] { intPtrArray, 0, 1, IntPtr.MinValue, null, 0 };
-            // yield return new object[] { intPtrArray, 1, 3, IntPtr.MaxValue, null, 3 };
-            // yield return new object[] { intPtrArray, 1, 3, IntPtr.MinValue, null, -2 };
-            // yield return new object[] { intPtrArray, 1, 0, (IntPtr)0, null, -2 };
+            yield return new object[] { intPtrArray, 0, 1, IntPtr.MinValue, null, 0 };
+            yield return new object[] { intPtrArray, 1, 3, IntPtr.MaxValue, null, 3 };
+            yield return new object[] { intPtrArray, 1, 3, IntPtr.MinValue, null, -2 };
+            yield return new object[] { intPtrArray, 1, 0, (IntPtr)0, null, -2 };
 
-            // yield return new object[] { new IntPtr[0], 0, 0, (IntPtr)0, null, -1 };
+            yield return new object[] { new IntPtr[0], 0, 0, (IntPtr)0, null, -1 };
 
-            // // UIntPtr
+            // UIntPtr
 
-            // UIntPtr[] uintPtrArray = new UIntPtr[] { UIntPtr.MinValue, (UIntPtr)5, (UIntPtr)5, UIntPtr.MaxValue };
+            UIntPtr[] uintPtrArray = new UIntPtr[] { UIntPtr.MinValue, (UIntPtr)5, (UIntPtr)5, UIntPtr.MaxValue };
 
-            // yield return new object[] { uintPtrArray, 0, 4, UIntPtr.MinValue, null, 0 };
-            // yield return new object[] { uintPtrArray, 0, 4, (UIntPtr)5, null, 1 };
-            // yield return new object[] { uintPtrArray, 0, 4, UIntPtr.MaxValue, null, 3 };
-            // yield return new object[] { uintPtrArray, 0, 4, (UIntPtr)1, null, -2 };
+            yield return new object[] { uintPtrArray, 0, 4, UIntPtr.MinValue, null, 0 };
+            yield return new object[] { uintPtrArray, 0, 4, (UIntPtr)5, null, 1 };
+            yield return new object[] { uintPtrArray, 0, 4, UIntPtr.MaxValue, null, 3 };
+            yield return new object[] { uintPtrArray, 0, 4, (UIntPtr)1, null, -2 };
 
-            // yield return new object[] { uintPtrArray, 0, 1, UIntPtr.MinValue, null, 0 };
-            // yield return new object[] { uintPtrArray, 1, 3, UIntPtr.MaxValue, null, 3 };
-            // yield return new object[] { uintPtrArray, 1, 3, UIntPtr.MinValue, null, -2 };
-            // yield return new object[] { uintPtrArray, 1, 0, (UIntPtr)5, null, -2 };
+            yield return new object[] { uintPtrArray, 0, 1, UIntPtr.MinValue, null, 0 };
+            yield return new object[] { uintPtrArray, 1, 3, UIntPtr.MaxValue, null, 3 };
+            yield return new object[] { uintPtrArray, 1, 3, UIntPtr.MinValue, null, -2 };
+            yield return new object[] { uintPtrArray, 1, 0, (UIntPtr)5, null, -2 };
 
-            // yield return new object[] { new UIntPtr[0], 0, 0, (UIntPtr)0, null, -1 };
+            yield return new object[] { new UIntPtr[0], 0, 0, (UIntPtr)0, null, -1 };
 
             // Char
             char[] charArray = new char[] { char.MinValue, (char)5, (char)5, char.MaxValue };
@@ -2361,25 +2360,23 @@ namespace System.Tests
             yield return new object[] { new double[] { 1, 2, 3, 3 }, (double)1, 0, 0, -1 };
             yield return new object[] { new double[0], (double)1, 0, 0, -1 };
 
-            // [ActiveIssue("https://github.com/xunit/xunit/issues/1771")]
             // IntPtr
-            //yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3 }, (IntPtr)1, 0, 4, 0 };
-            //yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3 }, (IntPtr)3, 0, 4, 2 };
-            //yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3 }, (IntPtr)2, 1, 2, 1 };
-            //yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3 }, (IntPtr)1, 1, 2, -1 };
-            //yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3 }, (IntPtr)1, 4, 0, -1 };
-            //yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3 }, (IntPtr)1, 0, 0, -1 };
-            //yield return new object[] { new IntPtr[0], (IntPtr)1, 0, 0, -1 };
+            yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3 }, (IntPtr)1, 0, 4, 0 };
+            yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3 }, (IntPtr)3, 0, 4, 2 };
+            yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3 }, (IntPtr)2, 1, 2, 1 };
+            yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3 }, (IntPtr)1, 1, 2, -1 };
+            yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3 }, (IntPtr)1, 4, 0, -1 };
+            yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3 }, (IntPtr)1, 0, 0, -1 };
+            yield return new object[] { new IntPtr[0], (IntPtr)1, 0, 0, -1 };
 
-            // [ActiveIssue("https://github.com/xunit/xunit/issues/1771")]
             // UIntPtr
-            //yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3 }, (UIntPtr)1, 0, 4, 0 };
-            //yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3 }, (UIntPtr)3, 0, 4, 2 };
-            //yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3 }, (UIntPtr)2, 1, 2, 1 };
-            //yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3 }, (UIntPtr)1, 1, 2, -1 };
-            //yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3 }, (UIntPtr)1, 4, 0, -1 };
-            //yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3 }, (UIntPtr)1, 0, 0, -1 };
-            //yield return new object[] { new UIntPtr[0], (UIntPtr)1, 0, 0, -1 };
+            yield return new object[] { new UIntptr[] { (uintptr)1, (uintptr)2, (uintptr)3, (uintptr)3 }, (uintptr)1, 0, 4, 0 };
+            yield return new object[] { new uintptr[] { (uintptr)1, (uintptr)2, (uintptr)3, (uintptr)3 }, (uintptr)3, 0, 4, 2 };
+            yield return new object[] { new uintptr[] { (uintptr)1, (uintptr)2, (uintptr)3, (uintptr)3 }, (uintptr)2, 1, 2, 1 };
+            yield return new object[] { new uintptr[] { (uintptr)1, (uintptr)2, (uintptr)3, (uintptr)3 }, (uintptr)1, 1, 2, -1 };
+            yield return new object[] { new uintptr[] { (uintptr)1, (uintptr)2, (uintptr)3, (uintptr)3 }, (uintptr)1, 4, 0, -1 };
+            yield return new object[] { new uintptr[] { (uintptr)1, (uintptr)2, (uintptr)3, (uintptr)3 }, (uintptr)1, 0, 0, -1 };
+            yield return new object[] { new uintptr[0], (uintptr)1, 0, 0, -1 };
 
             // String
             var stringArray = new string[] { null, null, "Hello", "Hello", "Goodbye", "Goodbye", null, null };
@@ -2739,25 +2736,23 @@ namespace System.Tests
             yield return new object[] { new double[] { 1, 2, 3, 3, 4 }, (double)3, 0, 0, -1 };
             yield return new object[] { new double[] { 1, 2, 3, 3, 4 }, (double)3, 3, 0, -1 };
 
-            // [ActiveIssue("https://github.com/xunit/xunit/issues/1771")]
             // IntPtr
-            //yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3, (IntPtr)4 }, (IntPtr)1, 4, 5, 0 };
-            //yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3, (IntPtr)4 }, (IntPtr)3, 4, 5, 3 };
-            //yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3, (IntPtr)4 }, (IntPtr)2, 2, 3, 1 };
-            //yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3, (IntPtr)4 }, (IntPtr)4, 2, 3, -1 };
-            //yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3, (IntPtr)4 }, (IntPtr)5, 4, 5, -1 };
-            //yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3, (IntPtr)4 }, (IntPtr)3, 0, 0, -1 };
-            //yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3, (IntPtr)4 }, (IntPtr)3, 3, 0, -1 };
+            yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3, (IntPtr)4 }, (IntPtr)1, 4, 5, 0 };
+            yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3, (IntPtr)4 }, (IntPtr)3, 4, 5, 3 };
+            yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3, (IntPtr)4 }, (IntPtr)2, 2, 3, 1 };
+            yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3, (IntPtr)4 }, (IntPtr)4, 2, 3, -1 };
+            yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3, (IntPtr)4 }, (IntPtr)5, 4, 5, -1 };
+            yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3, (IntPtr)4 }, (IntPtr)3, 0, 0, -1 };
+            yield return new object[] { new IntPtr[] { (IntPtr)1, (IntPtr)2, (IntPtr)3, (IntPtr)3, (IntPtr)4 }, (IntPtr)3, 3, 0, -1 };
 
-            // [ActiveIssue("https://github.com/xunit/xunit/issues/1771")]
             // UIntPtr
-            //yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3, (UIntPtr)4 }, (UIntPtr)1, 4, 5, 0 };
-            //yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3, (UIntPtr)4 }, (UIntPtr)3, 4, 5, 3 };
-            //yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3, (UIntPtr)4 }, (UIntPtr)2, 2, 3, 1 };
-            //yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3, (UIntPtr)4 }, (UIntPtr)4, 2, 3, -1 };
-            //yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3, (UIntPtr)4 }, (UIntPtr)5, 4, 5, -1 };
-            //yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3, (UIntPtr)4 }, (UIntPtr)3, 0, 0, -1 };
-            //yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3, (UIntPtr)4 }, (UIntPtr)3, 3, 0, -1 };
+            yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3, (UIntPtr)4 }, (UIntPtr)1, 4, 5, 0 };
+            yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3, (UIntPtr)4 }, (UIntPtr)3, 4, 5, 3 };
+            yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3, (UIntPtr)4 }, (UIntPtr)2, 2, 3, 1 };
+            yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3, (UIntPtr)4 }, (UIntPtr)4, 2, 3, -1 };
+            yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3, (UIntPtr)4 }, (UIntPtr)5, 4, 5, -1 };
+            yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3, (UIntPtr)4 }, (UIntPtr)3, 0, 0, -1 };
+            yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3, (UIntPtr)4 }, (UIntPtr)3, 3, 0, -1 };
 
             // String
             var stringArray = new string[] { null, null, "Hello", "Hello", "Goodbye", "Goodbye", null, null };

--- a/src/libraries/System.Runtime/tests/System/ArrayTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ArrayTests.cs
@@ -2370,13 +2370,13 @@ namespace System.Tests
             yield return new object[] { new IntPtr[0], (IntPtr)1, 0, 0, -1 };
 
             // UIntPtr
-            yield return new object[] { new UIntptr[] { (uintptr)1, (uintptr)2, (uintptr)3, (uintptr)3 }, (uintptr)1, 0, 4, 0 };
-            yield return new object[] { new uintptr[] { (uintptr)1, (uintptr)2, (uintptr)3, (uintptr)3 }, (uintptr)3, 0, 4, 2 };
-            yield return new object[] { new uintptr[] { (uintptr)1, (uintptr)2, (uintptr)3, (uintptr)3 }, (uintptr)2, 1, 2, 1 };
-            yield return new object[] { new uintptr[] { (uintptr)1, (uintptr)2, (uintptr)3, (uintptr)3 }, (uintptr)1, 1, 2, -1 };
-            yield return new object[] { new uintptr[] { (uintptr)1, (uintptr)2, (uintptr)3, (uintptr)3 }, (uintptr)1, 4, 0, -1 };
-            yield return new object[] { new uintptr[] { (uintptr)1, (uintptr)2, (uintptr)3, (uintptr)3 }, (uintptr)1, 0, 0, -1 };
-            yield return new object[] { new uintptr[0], (uintptr)1, 0, 0, -1 };
+            yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3 }, (UIntPtr)1, 0, 4, 0 };
+            yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3 }, (UIntPtr)3, 0, 4, 2 };
+            yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3 }, (UIntPtr)2, 1, 2, 1 };
+            yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3 }, (UIntPtr)1, 1, 2, -1 };
+            yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3 }, (UIntPtr)1, 4, 0, -1 };
+            yield return new object[] { new UIntPtr[] { (UIntPtr)1, (UIntPtr)2, (UIntPtr)3, (UIntPtr)3 }, (UIntPtr)1, 0, 0, -1 };
+            yield return new object[] { new UIntPtr[0], (UIntPtr)1, 0, 0, -1 };
 
             // String
             var stringArray = new string[] { null, null, "Hello", "Hello", "Goodbye", "Goodbye", null, null };

--- a/src/libraries/System.Runtime/tests/System/Reflection/InvokeRefReturn.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/InvokeRefReturn.cs
@@ -107,10 +107,9 @@ namespace System.Reflection.Tests
                 yield return new object[] { 42L };
                 yield return new object[] { 43.67f };
                 yield return new object[] { 43.67 };
-                // [ActiveIssue("https://github.com/xunit/xunit/issues/1771")]
-                //yield return new object[] { new IntPtr(42) };
-                //yield return new object[] { new UIntPtr(42) };
-                //yield return new object[] { 232953453454m };
+                yield return new object[] { new IntPtr(42) };
+                yield return new object[] { new UIntPtr(42) };
+                yield return new object[] { 232953453454m };
                 yield return new object[] { BindingFlags.IgnoreCase };
                 yield return new object[] { "Hello" };
                 yield return new object[] { new object() };

--- a/src/libraries/System.Runtime/tests/default.rd.xml
+++ b/src/libraries/System.Runtime/tests/default.rd.xml
@@ -130,7 +130,7 @@
         <Method Name="TestNullRefReturnInvoke" Dynamic="Required All">
           <GenericArgument Name="System.Double, System.Private.CoreLib" />
         </Method>
-        <Method Name="TestRefReturnMethodInvoke" Dynamic="Required All">
+        <Method Name="TestNullRefReturnInvoke" Dynamic="Required All">
           <GenericArgument Name="System.Decimal, System.Private.CoreLib" />
         </Method>
         <Method Name="TestNullRefReturnInvoke" Dynamic="Required All">
@@ -179,7 +179,7 @@
         <Method Name="TestRefReturnPropertyGetValue" Dynamic="Required All">
           <GenericArgument Name="System.Double, System.Private.CoreLib" />
         </Method>
-        <Method Name="TestRefReturnMethodInvoke" Dynamic="Required All">
+        <Method Name="TestRefReturnPropertyGetValue" Dynamic="Required All">
           <GenericArgument Name="System.Decimal, System.Private.CoreLib" />
         </Method>
         <Method Name="TestRefReturnPropertyGetValue" Dynamic="Required All">

--- a/src/libraries/System.Runtime/tests/default.rd.xml
+++ b/src/libraries/System.Runtime/tests/default.rd.xml
@@ -130,6 +130,9 @@
         <Method Name="TestNullRefReturnInvoke" Dynamic="Required All">
           <GenericArgument Name="System.Double, System.Private.CoreLib" />
         </Method>
+        <Method Name="TestRefReturnMethodInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.Decimal, System.Private.CoreLib" />
+        </Method>
         <Method Name="TestNullRefReturnInvoke" Dynamic="Required All">
           <GenericArgument Name="System.Reflection.BindingFlags, System.Private.CoreLib" />
         </Method>
@@ -176,6 +179,9 @@
         <Method Name="TestRefReturnPropertyGetValue" Dynamic="Required All">
           <GenericArgument Name="System.Double, System.Private.CoreLib" />
         </Method>
+        <Method Name="TestRefReturnMethodInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.Decimal, System.Private.CoreLib" />
+        </Method>
         <Method Name="TestRefReturnPropertyGetValue" Dynamic="Required All">
           <GenericArgument Name="System.Reflection.BindingFlags, System.Private.CoreLib" />
         </Method>
@@ -223,6 +229,9 @@
           <GenericArgument Name="System.Double, System.Private.CoreLib" />
         </Method>
         <Method Name="TestRefReturnMethodInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.Decimal, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnMethodInvoke" Dynamic="Required All">
           <GenericArgument Name="System.Reflection.BindingFlags, System.Private.CoreLib" />
         </Method>
       </Type>
@@ -243,6 +252,7 @@
       <Type Name="System.Reflection.Tests.InvokeRefReturnNetcoreTests+TestClass`1[[System.Boolean, System.Private.CoreLib]]" Dynamic="Required All" />
       <Type Name="System.Reflection.Tests.InvokeRefReturnNetcoreTests+TestClass`1[[System.Single, System.Private.CoreLib]]" Dynamic="Required All" />
       <Type Name="System.Reflection.Tests.InvokeRefReturnNetcoreTests+TestClass`1[[System.Double, System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Reflection.Tests.InvokeRefReturnNetcoreTests+TestClass`1[[System.Decimal, System.Private.CoreLib]]" Dynamic="Required All" />
       <Type Name="System.Reflection.Tests.InvokeRefReturnNetcoreTests+TestClass`1[[System.Reflection.BindingFlags, System.Private.CoreLib]]" Dynamic="Required All" />
 
       <Type Name="System.Reflection.Tests.MethodBaseTests">


### PR DESCRIPTION
Closes #27187

These tests were removed due to an issue in xunit that is now resolved on the latest version. The test projects are also on the latest xunit version, so all that is needed is to uncomment the marked tests.