### PR TITLE
Ensure JsonSerializerOptions always returns a JsonTypeInfo for `object`.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectConverter.cs
@@ -3,16 +3,95 @@
 
 using System.Diagnostics;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json.Serialization.Converters
 {
-    internal sealed class ObjectConverter : JsonConverter<object?>
+    internal abstract class ObjectConverter : JsonConverter<object?>
     {
         private protected override ConverterStrategy GetDefaultConverterStrategy() => ConverterStrategy.Object;
 
         public ObjectConverter()
         {
             CanBePolymorphic = true;
+        }
+
+        public sealed override object ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            ThrowHelper.ThrowNotSupportedException_DictionaryKeyTypeNotSupported(TypeToConvert, this);
+            return null!;
+        }
+
+        internal sealed override object ReadAsPropertyNameCore(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            ThrowHelper.ThrowNotSupportedException_DictionaryKeyTypeNotSupported(TypeToConvert, this);
+            return null!;
+        }
+
+        public sealed override void Write(Utf8JsonWriter writer, object? value, JsonSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            writer.WriteStartObject();
+            writer.WriteEndObject();
+        }
+
+        public sealed override void WriteAsPropertyName(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
+        {
+            WriteAsPropertyNameCore(writer, value, options, isWritingExtensionDataProperty: false);
+        }
+
+        internal sealed override void WriteAsPropertyNameCore(Utf8JsonWriter writer, object value, JsonSerializerOptions options, bool isWritingExtensionDataProperty)
+        {
+            if (value is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(nameof(value));
+            }
+
+            Type runtimeType = value.GetType();
+            if (runtimeType == TypeToConvert)
+            {
+                ThrowHelper.ThrowNotSupportedException_DictionaryKeyTypeNotSupported(runtimeType, this);
+            }
+
+            JsonConverter runtimeConverter = options.GetConverterInternal(runtimeType);
+            runtimeConverter.WriteAsPropertyNameCoreAsObject(writer, value, options, isWritingExtensionDataProperty);
+        }
+    }
+
+    /// <summary>
+    /// Defines an object converter that only supports (polymorphic) serialization but not deserialization.
+    /// This is done to avoid rooting dependencies to JsonNode/JsonElement necessary to drive object deserialization.
+    /// Source generator users need to explicitly declare support for object so that the derived converter gets used.
+    /// </summary>
+    internal sealed class SlimObjectConverter : ObjectConverter
+    {
+        // Keep track of the originating resolver so that the converter surfaces
+        // an accurate error message whenever deserialization is attempted.
+        private readonly IJsonTypeInfoResolver _originatingResolver;
+
+        public SlimObjectConverter(IJsonTypeInfoResolver originatingResolver)
+            => _originatingResolver = originatingResolver;
+
+        public override object? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            ThrowHelper.ThrowNotSupportedException_NoMetadataForType(typeToConvert, _originatingResolver);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Defines an object converter that supports deserialization via JsonElement/JsonNode representations.
+    /// Used as the default in reflection or if object is declared in the JsonSerializerContext type graph.
+    /// </summary>
+    internal sealed class DeserializingObjectConverter : ObjectConverter
+    {
+        public DeserializingObjectConverter()
+        {
             // JsonElement/JsonNode parsing does not support async; force read ahead for now.
             RequiresReadAhead = true;
         }
@@ -26,18 +105,6 @@ namespace System.Text.Json.Serialization.Converters
 
             Debug.Assert(options.UnknownTypeHandling == JsonUnknownTypeHandling.JsonNode);
             return JsonNodeConverter.Instance.Read(ref reader, typeToConvert, options);
-        }
-
-        public override void Write(Utf8JsonWriter writer, object? value, JsonSerializerOptions options)
-        {
-            if (value is null)
-            {
-                writer.WriteNullValue();
-                return;
-            }
-
-            writer.WriteStartObject();
-            writer.WriteEndObject();
         }
 
         internal override bool OnTryRead(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options, scoped ref ReadStack state, out object? value)
@@ -77,65 +144,6 @@ namespace System.Text.Json.Serialization.Converters
             }
 
             return true;
-        }
-
-        public override object ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            ThrowHelper.ThrowNotSupportedException_DictionaryKeyTypeNotSupported(TypeToConvert, this);
-            return null!;
-        }
-
-        internal override object ReadAsPropertyNameCore(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            ThrowHelper.ThrowNotSupportedException_DictionaryKeyTypeNotSupported(TypeToConvert, this);
-            return null!;
-        }
-
-        public override void WriteAsPropertyName(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
-        {
-            WriteAsPropertyNameCore(writer, value, options, isWritingExtensionDataProperty: false);
-        }
-
-        internal override void WriteAsPropertyNameCore(Utf8JsonWriter writer, object value, JsonSerializerOptions options, bool isWritingExtensionDataProperty)
-        {
-            if (value is null)
-            {
-                ThrowHelper.ThrowArgumentNullException(nameof(value));
-            }
-
-            Type runtimeType = value.GetType();
-            JsonConverter runtimeConverter = options.GetConverterInternal(runtimeType);
-            if (runtimeConverter == this)
-            {
-                ThrowHelper.ThrowNotSupportedException_DictionaryKeyTypeNotSupported(runtimeType, this);
-            }
-
-            runtimeConverter.WriteAsPropertyNameCoreAsObject(writer, value, options, isWritingExtensionDataProperty);
-        }
-    }
-
-    /// <summary>
-    /// A placeholder ObjectConverter used for driving object root value
-    /// serialization only and does not root JsonNode/JsonDocument.
-    /// </summary>
-    internal sealed class ObjectConverterSlim : JsonConverter<object?>
-    {
-        private protected override ConverterStrategy GetDefaultConverterStrategy() => ConverterStrategy.Object;
-
-        public ObjectConverterSlim()
-        {
-            CanBePolymorphic = true;
-        }
-
-        public override object? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            Debug.Fail("Converter should only be used to drive root-level object serialization.");
-            return null;
-        }
-
-        public override void Write(Utf8JsonWriter writer, object? value, JsonSerializerOptions options)
-        {
-            Debug.Fail("Converter should only be used to drive root-level object serialization.");
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectConverter.cs
@@ -88,9 +88,9 @@ namespace System.Text.Json.Serialization.Converters
     /// Defines an object converter that supports deserialization via JsonElement/JsonNode representations.
     /// Used as the default in reflection or if object is declared in the JsonSerializerContext type graph.
     /// </summary>
-    internal sealed class DeserializingObjectConverter : ObjectConverter
+    internal sealed class DefaultObjectConverter : ObjectConverter
     {
-        public DeserializingObjectConverter()
+        public DefaultObjectConverter()
         {
             // JsonElement/JsonNode parsing does not support async; force read ahead for now.
             RequiresReadAhead = true;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -255,7 +255,7 @@ namespace System.Text.Json.Serialization
             {
                 // Special case object converters since they don't
                 // require the expensive ReadStack.Push()/Pop() operations.
-                Debug.Assert(this is ObjectConverter or ObjectConverterSlim);
+                Debug.Assert(this is ObjectConverter);
                 success = OnTryRead(ref reader, typeToConvert, options, ref state, out value);
                 Debug.Assert(success);
                 isPopulatedValue = false;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -183,22 +183,7 @@ namespace System.Text.Json
             get
             {
                 Debug.Assert(IsReadOnly);
-                return _objectTypeInfo ??= GetObjectTypeInfo(this);
-
-                static JsonTypeInfo GetObjectTypeInfo(JsonSerializerOptions options)
-                {
-                    JsonTypeInfo? typeInfo = options.GetTypeInfoInternal(JsonTypeInfo.ObjectType, ensureNotNull: null);
-                    if (typeInfo is null)
-                    {
-                        // If the user-supplied resolver does not provide a JsonTypeInfo<object>,
-                        // use a placeholder value to drive root-level boxed value serialization.
-                        var converter = new ObjectConverterSlim();
-                        typeInfo = new JsonTypeInfo<object>(converter, options);
-                        typeInfo.EnsureConfigured();
-                    }
-
-                    return typeInfo;
-                }
+                return _objectTypeInfo ??= GetTypeInfoInternal(JsonTypeInfo.ObjectType);
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Converters.cs
@@ -154,7 +154,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="object"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<object?> ObjectConverter => s_objectConverter ??= new DeserializingObjectConverter();
+        public static JsonConverter<object?> ObjectConverter => s_objectConverter ??= new DefaultObjectConverter();
         private static JsonConverter<object?>? s_objectConverter;
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Converters.cs
@@ -154,7 +154,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="object"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<object?> ObjectConverter => s_objectConverter ??= new ObjectConverter();
+        public static JsonConverter<object?> ObjectConverter => s_objectConverter ??= new DeserializingObjectConverter();
         private static JsonConverter<object?>? s_objectConverter;
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -1287,7 +1287,7 @@ namespace System.Text.Json.Serialization.Metadata
             if (type == typeof(object) && converter.CanBePolymorphic)
             {
                 // System.Object is polymorphic and will not respect Properties
-                Debug.Assert(converter is ObjectConverter or ObjectConverterSlim);
+                Debug.Assert(converter is ObjectConverter);
                 return JsonTypeInfoKind.None;
             }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
@@ -125,11 +125,17 @@ namespace System.Text.Json.SourceGeneration.Tests
             PersonJsonContext context = PersonJsonContext.Default;
             object person = new Person("John", "Smith");
             string expectedJson = """{"firstName":"John","lastName":"Smith"}""";
-            // Sanity check -- context does not specify object metadata
-            Assert.Null(context.GetTypeInfo(typeof(object)));
+            // Sanity check -- context resolver does not specify object metadata
+            Assert.Null(((IJsonTypeInfoResolver)context).GetTypeInfo(typeof(object), new()));
 
             string json = JsonSerializer.Serialize(person, context.Options);
             Assert.Equal(expectedJson, json);
+
+            json = JsonSerializer.Serialize(person, typeof(object), context);
+            Assert.Equal(expectedJson, json);
+
+            json = JsonSerializer.Serialize(person, context.GetTypeInfo(typeof(object)));
+            Assert.NotNull(context.GetTypeInfo(typeof(object)));
 
             var stream = new Utf8MemoryStream();
             await JsonSerializer.SerializeAsync(stream, person, context.Options);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/JsonTypeInfoResolverTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/JsonTypeInfoResolverTests.cs
@@ -158,5 +158,21 @@ namespace System.Text.Json.Serialization.Tests
 
             return list;
         }
+
+        [Fact]
+        public static void NullResolver_ReturnsObjectMetadata()
+        {
+            var options = new JsonSerializerOptions();
+            var resolver = new NullResolver();
+            Assert.Null(resolver.GetTypeInfo(typeof(object), options));
+
+            options.TypeInfoResolver = resolver;
+            Assert.IsAssignableFrom<JsonTypeInfo<object>>(options.GetTypeInfo(typeof(object)));
+        }
+
+        public sealed class NullResolver : IJsonTypeInfoResolver
+        {
+            public JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options) => null;
+        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
@@ -464,7 +464,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void Options_GetConverterForObjectJsonElement_GivesCorrectConverter()
         {
-            GenericObjectOrJsonElementConverterTestHelper<object>("ObjectConverter", new object(), "{}");
+            GenericObjectOrJsonElementConverterTestHelper<object>("DeserializingObjectConverter", new object(), "{}");
             JsonElement element = JsonDocument.Parse("[3]").RootElement;
             GenericObjectOrJsonElementConverterTestHelper<JsonElement>("JsonElementConverter", element, "[3]");
         }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
@@ -464,7 +464,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void Options_GetConverterForObjectJsonElement_GivesCorrectConverter()
         {
-            GenericObjectOrJsonElementConverterTestHelper<object>("DeserializingObjectConverter", new object(), "{}");
+            GenericObjectOrJsonElementConverterTestHelper<object>("DefaultObjectConverter", new object(), "{}");
             JsonElement element = JsonDocument.Parse("[3]").RootElement;
             GenericObjectOrJsonElementConverterTestHelper<JsonElement>("JsonElementConverter", element, "[3]");
         }


### PR DESCRIPTION
Fix #87073.