### PR TITLE
Fold obj.GetType to a constant

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -17888,6 +17888,7 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTree* tree, bool* pIsExact, b
                 {
                     // if we managed to get a class handle it's definitely not null
                     *pIsNonNull = true;
+                    *pIsExact   = true;
                 }
             }
             break;

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -11331,10 +11331,14 @@ void Compiler::fgValueNumberIntrinsic(GenTree* tree)
 
         if ((cls != NO_CLASS_HANDLE) && isExact)
         {
-            CORINFO_OBJECT_HANDLE typeObj  = info.compCompHnd->getRuntimeTypePointer(cls);
-            ValueNum              handleVN = vnStore->VNForHandle((ssize_t)typeObj, GTF_ICON_OBJ_HDL);
-            intrinsic->gtVNPair            = vnStore->VNPWithExc(ValueNumPair(handleVN, handleVN), arg0VNPx);
-            return;
+            CORINFO_OBJECT_HANDLE typeObj = info.compCompHnd->getRuntimeTypePointer(cls);
+            if (typeObj != nullptr)
+            {
+                setMethodHasFrozenObjects();
+                ValueNum handleVN   = vnStore->VNForHandle((ssize_t)typeObj, GTF_ICON_OBJ_HDL);
+                intrinsic->gtVNPair = vnStore->VNPWithExc(ValueNumPair(handleVN, handleVN), arg0VNPx);
+                return;
+            }
         }
     }
 

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -11340,7 +11340,7 @@ void Compiler::fgValueNumberIntrinsic(GenTree* tree)
         bool                 isExact   = false;
         bool                 isNonNull = false;
         CORINFO_CLASS_HANDLE cls       = gtGetClassHandle(tree->gtGetOp1(), &isExact, &isNonNull);
-        if ((cls != NO_CLASS_HANDLE) && isExact)
+        if ((cls != NO_CLASS_HANDLE) && isExact && isNonNull)
         {
             CORINFO_OBJECT_HANDLE typeObj = info.compCompHnd->getRuntimeTypePointer(cls);
             if (typeObj != nullptr)

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -11308,6 +11308,36 @@ void Compiler::fgValueNumberIntrinsic(GenTree* tree)
 
     vnStore->VNPUnpackExc(intrinsic->AsOp()->gtOp1->gtVNPair, &arg0VNP, &arg0VNPx);
 
+    // Try to fold obj.GetType() if we know the exact type of obj.
+    if (intrinsic->gtIntrinsicName == NI_System_Object_GetType)
+    {
+        bool isExact = false, isNonNull = false;
+
+        // First, let's try to guess the type via gtGetClassHandle
+        CORINFO_CLASS_HANDLE cls = gtGetClassHandle(tree->gtGetOp1(), &isExact, &isNonNull);
+        if (cls == NO_CLASS_HANDLE)
+        {
+            assert(!isExact);
+
+            // If we couldn't get the type via gtGetClassHandle, let's see if the argument is a
+            // object handle via VN.
+            ValueNum arg0VN = arg0VNP.GetLiberal();
+            if (arg0VNP.BothEqual() && vnStore->IsVNObjHandle(arg0VN))
+            {
+                cls     = info.compCompHnd->getObjectType(vnStore->ConstantObjHandle(arg0VN));
+                isExact = true;
+            }
+        }
+
+        if ((cls != NO_CLASS_HANDLE) && isExact)
+        {
+            CORINFO_OBJECT_HANDLE typeObj  = info.compCompHnd->getRuntimeTypePointer(cls);
+            ValueNum              handleVN = vnStore->VNForHandle((ssize_t)typeObj, GTF_ICON_OBJ_HDL);
+            intrinsic->gtVNPair            = vnStore->VNPWithExc(ValueNumPair(handleVN, handleVN), arg0VNPx);
+            return;
+        }
+    }
+
     if (intrinsic->AsOp()->gtOp2 != nullptr)
     {
         vnStore->VNPUnpackExc(intrinsic->AsOp()->gtOp2->gtVNPair, &arg1VNP, &arg1VNPx);


### PR DESCRIPTION
```csharp
Type Test() => "test".GetType();
```
Was:
```asm
; Method X:Test():System.Type:this
       sub      rsp, 40
       mov      rcx, 0xD1FFAB1E      ; 'test'
       call     System.Object:GetType():System.Type:this
       nop      
       add      rsp, 40
       ret      
; Total bytes of code: 25
```
Now:
```asm
; Method X:Test():System.Type:this
       mov      rax, 0xD1FFAB1E      ; RuntimeType frozen object representing 'System.String'
       ret      
; Total bytes of code: 11
```