### PR TITLE
Enable async-over-sync FileStream read/writes to be cancelable on Windows

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -253,9 +253,6 @@
     <Compile Include="$(CommonPath)\System\Runtime\InteropServices\Variant.cs">
       <Link>System\Runtime\InteropServices\Variant.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetCurrentThreadId.cs">
-      <Link>Interop\Windows\Kernel32\Interop.GetCurrentThreadId.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.IsDebuggerPresent.cs">
       <Link>Interop\Windows\Kernel32\Interop.IsDebuggerPresent.cs</Link>
     </Compile>

--- a/src/libraries/Common/src/System/Threading/AsyncOverSyncWithIoCancellation.cs
+++ b/src/libraries/Common/src/System/Threading/AsyncOverSyncWithIoCancellation.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
 
@@ -16,25 +15,58 @@ namespace System.Threading
     /// </summary>
     internal sealed class AsyncOverSyncWithIoCancellation
     {
-        /// <summary>A thread handle for the current OS thread.</summary>
-        /// <remarks>This is lazily-initialized for the current OS thread. We rely on finalization to clean up after it when the thread goes away.</remarks>
+        /// <summary>The <see cref="AsyncOverSyncWithIoCancellation"/> for the current thread.</summary>
+        /// <remarks>
+        /// The safety of caching this on the current thread is based on the fact that all work performed
+        /// is synchronous on this thread.  If a cancellation callback occurs on a different thread, that
+        /// could be using this instance, but only between the time that the operation is initiated on this
+        /// thread and disposal completes on this thread.
+        /// </remarks>
         [ThreadStatic]
-        private static SafeThreadHandle? t_currentThreadHandle;
+        private static AsyncOverSyncWithIoCancellation? t_instance;
 
         /// <summary>The OS handle of the thread performing the I/O.</summary>
-        private SafeThreadHandle? ThreadHandle;
+        /// <remarks>This is stored as part of the object's construction because the objects are thread affinitized.</remarks>
+        private readonly SafeThreadHandle? _threadHandle;
+
         /// <summary>Whether the call to CancellationToken.UnsafeRegister completed.</summary>
-        private volatile bool FinishedCancellationRegistration;
+        private bool _finishedCancellationRegistration;
         /// <summary>Whether the I/O operation has finished (successfully or unsuccessfully) and is requesting cancellation attempts stop.</summary>
-        private volatile bool ContinueTryingToCancel = true;
+        private bool _continueTryingToCancel;
         /// <summary>
         /// A task that may be checked after the <see cref="CancellationTokenRegistration"/> has been disposed.  If it's null at that point,
         /// the callback wasn't and will never be invoked.  If it's non-null, its completion represents the completion of the asynchronous callback.
         /// </summary>
-        private volatile Task? CallbackCompleted;
+        private Task? _callbackCompleted;
 
-        /// <summary>Prevent external instantiation.</summary>
-        private AsyncOverSyncWithIoCancellation() { }
+        /// <summary>Initialize the instance.  This should be done once per thread.</summary>
+        private AsyncOverSyncWithIoCancellation()
+        {
+            // Get a handle for the current thread. This is stored and used to cancel the I/O on this thread
+            // in response to the cancellation token having cancellation requested.  If the handle is invalid,
+            // which could happen if OpenThread fails, skip attempts at cancellation. The handle needs to be
+            // opened with THREAD_TERMINATE in order to be able to call CancelSynchronousIo.
+            SafeThreadHandle handle = Interop.Kernel32.OpenThread(Interop.Kernel32.THREAD_TERMINATE, bInheritHandle: false, Interop.Kernel32.GetCurrentThreadId());
+            if (!handle.IsInvalid)
+            {
+                _threadHandle = handle;
+            }
+#if DEBUG
+            else
+            {
+                int lastError = Marshal.GetLastPInvokeError();
+                Debug.Fail($"{nameof(Interop.Kernel32.OpenThread)} unexpectedly failed with 0x{lastError:X8}: {Marshal.GetPInvokeErrorMessage(lastError)}");
+            }
+#endif
+        }
+
+        /// <summary>Resets this instance's state to be ready for another use on this thread.</summary>
+        private void Reset()
+        {
+            _finishedCancellationRegistration = false;
+            _continueTryingToCancel = true;
+            _callbackCompleted = null;
+        }
 
         /// <summary>Queues the invocation of <paramref name="action"/> to the thread pool.</summary>
         /// <typeparam name="TState">The type of the state passed to <paramref name="action"/>.</typeparam>
@@ -51,12 +83,13 @@ namespace System.Threading
         [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
         public static async ValueTask InvokeAsync<TState>(Action<TState> action, TState state, CancellationToken cancellationToken)
         {
-            // Queue the work to complete asynchronously.
+            // Queue the work to complete asynchronously. Logically, this is just queueing a work item to the thread pool.
+            // We use a ForceYielding awaiter in combination with the PoolingAsyncValueTaskMethodBuilder to reduce allocation.
             await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
 
-            // Register for cancellation, perform the work, and clean up. Even though we're in an async method, awaits _must not_ be used inside
-            // the using block, or else the I/O cancellation could both not work and negatively interact with I/O on another thread.  The func
-            // _must_ be invoked on the same thread that invoked RegisterCancellation, with no intervening work.
+            // Register for cancellation, perform the work, and clean up. Even though we're in an async method, awaits _must not_ be used
+            // after this point, or else the I/O cancellation could both not work and negatively interact with I/O on another thread.
+            // The func _must_ be invoked on the same thread that invoked RegisterCancellation, with no intervening work.
             SyncAsyncWorkItemRegistration reg = RegisterCancellation(cancellationToken);
             try
             {
@@ -68,7 +101,7 @@ namespace System.Threading
             }
             finally
             {
-                await reg.DisposeAsync().ConfigureAwait(false);
+                reg.Dispose();
             }
         }
 
@@ -88,12 +121,13 @@ namespace System.Threading
         [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
         public static async ValueTask<TResult> InvokeAsync<TState, TResult>(Func<TState, TResult> func, TState state, CancellationToken cancellationToken)
         {
-            // Queue the work to complete asynchronously.
+            // Queue the work to complete asynchronously. Logically, this is just queueing a work item to the thread pool.
+            // We use a ForceYielding awaiter in combination with the PoolingAsyncValueTaskMethodBuilder to reduce allocation.
             await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
 
-            // Register for cancellation, perform the work, and clean up. Even though we're in an async method, awaits _must not_ be used inside
-            // the using block, or else the I/O cancellation could both not work and negatively interact with I/O on another thread.  The func
-            // _must_ be invoked on the same thread that invoked RegisterCancellation, with no intervening work.
+            // Register for cancellation, perform the work, and clean up. Even though we're in an async method, awaits _must not_ be used
+            // after this point, or else the I/O cancellation could both not work and negatively interact with I/O on another thread.
+            // The func _must_ be invoked on the same thread that invoked RegisterCancellation, with no intervening work.
             SyncAsyncWorkItemRegistration reg = RegisterCancellation(cancellationToken);
             try
             {
@@ -105,7 +139,7 @@ namespace System.Threading
             }
             finally
             {
-                await reg.DisposeAsync().ConfigureAwait(false);
+                reg.Dispose();
             }
         }
 
@@ -126,7 +160,16 @@ namespace System.Threading
         }
 
         /// <summary>The struct IDisposable returned from RegisterCancellation in order to clean up after the registration.</summary>
-        private struct SyncAsyncWorkItemRegistration : IDisposable, IAsyncDisposable
+        /// <remarks>
+        /// This does not implement IAsyncDisposable, even though async disposal could await both cancellation registration disposal
+        /// and the callback completion.  By only supporting synchronous disposal, we can ensure that all relevant work happens
+        /// on the calling thread, which in turn allows us to use a per-thread singleton that avoids allocation in the most
+        /// common case (an operation being performed with a cancelable token).  The benefit of async disposal would be that _if_
+        /// cancellation occurred while the operation was in progress, we could avoid blocking the disposing thread until the
+        /// cancellation request completes.  However, this is a rare case, and even when it occurs, it's expected to be very fast,
+        /// and in general should be completed by the time we even get to the disposal itself.
+        /// </remarks>
+        private struct SyncAsyncWorkItemRegistration : IDisposable
         {
             public AsyncOverSyncWithIoCancellation WorkItem;
             public CancellationTokenRegistration CancellationRegistration;
@@ -141,7 +184,7 @@ namespace System.Threading
 
                 // Prior to calling Dispose on the CancellationTokenRegistration, we need to tell
                 // the registration callback to exit if it's currently running; otherwise, we could deadlock.
-                WorkItem.ContinueTryingToCancel = false;
+                Volatile.Write(ref WorkItem._continueTryingToCancel, false);
 
                 // Then we need to dispose of the registration.  Upon Dispose returning, we know that
                 // either the synchronous invocation of the callback completed or that the callback
@@ -150,64 +193,33 @@ namespace System.Threading
 
                 // Now that we know the synchronous callback has quiesced, check to see whether it scheduled
                 // asynchronous work.  If it did, wait for that work to complete.
-                WorkItem.CallbackCompleted?.GetAwaiter().GetResult();
-            }
-
-            /// <summary>Asynchronously waits for any pending cancellation callback to complete and cleans up resources.</summary>
-            public async ValueTask DisposeAsync()
-            {
-                if (WorkItem is null)
-                {
-                    return;
-                }
-
-                // Prior to calling Dispose on the CancellationTokenRegistration, we need to tell
-                // the registration callback to exit if it's currently running; otherwise, we could deadlock.
-                WorkItem.ContinueTryingToCancel = false;
-
-                // Then we need to dispose of the registration.  Upon Dispose returning, we know that
-                // either the synchronous invocation of the callback completed or that the callback
-                // will never be invoked.
-                await CancellationRegistration.DisposeAsync().ConfigureAwait(false);
-
-                // Now that we know the synchronous callback has quiesced, check to see whether it scheduled
-                // asynchronous work.  If it did, wait for that work to complete.
-                if (WorkItem.CallbackCompleted is Task t)
-                {
-                    await t.ConfigureAwait(false);
-                }
+                WorkItem._callbackCompleted?.GetAwaiter().GetResult();
             }
         }
 
         /// <summary>Registers for cancellation with the specified token.</summary>
         /// <remarks>Upon cancellation being requested, the implementation will attempt to CancelSynchronousIo for the thread calling RegisterCancellation.</remarks>
-        private static SyncAsyncWorkItemRegistration RegisterCancellation(CancellationToken cancellationToken) =>
-            cancellationToken.CanBeCanceled ? RegisterCancellation(new AsyncOverSyncWithIoCancellation(), cancellationToken) :
-            default; // If the token can't be canceled, there's nothing to register.
-
-        /// <summary>Registers for cancellation with the specified token.</summary>
-        /// <remarks>Upon cancellation being requested, the implementation will attempt to CancelSynchronousIo for the thread calling RegisterCancellation.</remarks>
-        private static SyncAsyncWorkItemRegistration RegisterCancellation(AsyncOverSyncWithIoCancellation instance, CancellationToken cancellationToken)
+        private static SyncAsyncWorkItemRegistration RegisterCancellation(CancellationToken cancellationToken)
         {
-            // Get a handle for the current thread. This is stored and used to cancel the I/O on this thread
-            // in response to the cancellation token having cancellation requested.  If the handle is invalid,
-            // which could happen if OpenThread fails, skip attempts at cancellation. The handle needs to be
-            // opened with THREAD_TERMINATE in order to be able to call CancelSynchronousIo.
-            instance.ThreadHandle = t_currentThreadHandle;
-            if (instance.ThreadHandle is null)
+            if (!cancellationToken.CanBeCanceled)
             {
-                instance.ThreadHandle = Interop.Kernel32.OpenThread(Interop.Kernel32.THREAD_TERMINATE, bInheritHandle: false, Interop.Kernel32.GetCurrentThreadId());
-                if (instance.ThreadHandle.IsInvalid)
-                {
-                    int lastError = Marshal.GetLastPInvokeError();
-                    Debug.Fail($"{nameof(Interop.Kernel32.OpenThread)} unexpectedly failed with 0x{lastError:X8}: {Marshal.GetPInvokeErrorMessage(lastError)}");
-                    return default;
-                }
-
-                t_currentThreadHandle = instance.ThreadHandle;
+                return default;
             }
 
-            // Register with the token.
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Get the instance for this thread. If the instance doesn't have a thread handle, that
+            // means we were unable to obtain one previously, and we shouldn't try to cancel I/O.
+            AsyncOverSyncWithIoCancellation instance = t_instance ??= new AsyncOverSyncWithIoCancellation();
+            if (instance._threadHandle is null)
+            {
+                return default;
+            }
+
+            // Reset the instance's state so we can use it again.
+            instance.Reset();
+
+            // Register with the caller's cancellation token.
             SyncAsyncWorkItemRegistration reg = default;
             reg.WorkItem = instance;
             reg.CancellationRegistration = cancellationToken.UnsafeRegister(static s =>
@@ -218,7 +230,7 @@ namespace System.Threading
                 // the callback immediately.  If we allowed that to loop until cancellation was successful,
                 // we'd deadlock, as we'd never perform the very I/O it was waiting for.  As such, if
                 // the callback is invoked prior to be ready for it, we ignore the callback.
-                if (!instance.FinishedCancellationRegistration)
+                if (!Volatile.Read(ref instance._finishedCancellationRegistration))
                 {
                     return;
                 }
@@ -230,7 +242,7 @@ namespace System.Threading
                 // this looping synchronously, we instead queue the invocation of the looping so that it
                 // runs asynchronously from the Cancel call.  Then in order to be able to track its completion,
                 // we store the Task representing that asynchronous work, such that cleanup can wait for the Task.
-                instance.CallbackCompleted = Task.Factory.StartNew(static s =>
+                instance._callbackCompleted = Task.Factory.StartNew(static s =>
                 {
                     var instance = (AsyncOverSyncWithIoCancellation)s!;
 
@@ -238,9 +250,9 @@ namespace System.Threading
                     // the synchronous operation, CancelSynchronousIo will fail with ERROR_NOT_FOUND, and
                     // we'll loop to try again.
                     SpinWait sw = default;
-                    while (instance.ContinueTryingToCancel)
+                    while (Volatile.Read(ref instance._continueTryingToCancel))
                     {
-                        if (Interop.Kernel32.CancelSynchronousIo(instance.ThreadHandle!))
+                        if (Interop.Kernel32.CancelSynchronousIo(instance._threadHandle!))
                         {
                             // Successfully canceled I/O.
                             break;
@@ -261,7 +273,7 @@ namespace System.Threading
 
             // Now that we've registered with the token, tell the callback it's safe to enter
             // its cancellation loop if the callback is invoked.
-            instance.FinishedCancellationRegistration = true;
+            Volatile.Write(ref instance._finishedCancellationRegistration, true);
 
             // And now since cancellation may have been requested and we may have suppressed it
             // until the previous line, check to see if cancellation has now been requested, and

--- a/src/libraries/Common/src/System/Threading/AsyncOverSyncWithIoCancellation.cs
+++ b/src/libraries/Common/src/System/Threading/AsyncOverSyncWithIoCancellation.cs
@@ -51,13 +51,14 @@ namespace System.Threading
             {
                 _threadHandle = handle;
             }
-#if DEBUG
             else
             {
+#if DEBUG
                 int lastError = Marshal.GetLastPInvokeError();
                 Debug.Fail($"{nameof(Interop.Kernel32.OpenThread)} unexpectedly failed with 0x{lastError:X8}: {Marshal.GetPInvokeErrorMessage(lastError)}");
-            }
 #endif
+                handle.Dispose();
+            }
         }
 
         /// <summary>Resets this instance's state to be ready for another use on this thread.</summary>

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/FileStreamConformanceTests.Windows.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/FileStreamConformanceTests.Windows.cs
@@ -35,7 +35,7 @@ namespace System.IO.Tests
 
         protected override Type UnsupportedConcurrentExceptionType => null;
         protected override bool UsableAfterCanceledReads => false;
-        protected override bool FullyCancelableOperations => false;
+        protected override bool FullyCancelableOperations => OperatingSystem.IsWindows();
         protected override bool BlocksOnZeroByteReads => OperatingSystem.IsWindows();
         protected override bool SupportsConcurrentBidirectionalUse => false;
     }

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/FileStreamConformanceTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/FileStreamConformanceTests.cs
@@ -241,7 +241,7 @@ namespace System.IO.Tests
 
         protected override Type UnsupportedConcurrentExceptionType => null;
         protected override bool UsableAfterCanceledReads => false;
-        protected override bool FullyCancelableOperations => false;
+        protected override bool FullyCancelableOperations => OperatingSystem.IsWindows();
         protected override bool BlocksOnZeroByteReads => OperatingSystem.IsWindows();
         protected override bool SupportsConcurrentBidirectionalUse => false;
     }
@@ -268,7 +268,7 @@ namespace System.IO.Tests
 
         protected override Type UnsupportedConcurrentExceptionType => null;
         protected override bool UsableAfterCanceledReads => false;
-        protected override bool FullyCancelableOperations => false;
+        protected override bool FullyCancelableOperations => OperatingSystem.IsWindows();
         protected override bool BlocksOnZeroByteReads => OperatingSystem.IsWindows();
         protected override bool SupportsConcurrentBidirectionalUse => false;
     }

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/ReadAsync.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/ReadAsync.cs
@@ -95,8 +95,6 @@ namespace System.IO.Tests
                     // Ideally we'd be doing an Assert.Throws<OperationCanceledException>
                     // but since cancellation is a race condition we accept either outcome
                     Assert.Equal(cts.Token, oce.CancellationToken);
-
-                    Assert.Equal(0, fs.Position); // if read was cancelled, the Position should remain unchanged
                 }
             }
         }

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
@@ -123,9 +123,6 @@ namespace System.IO.Tests
                     // Ideally we'd be doing an Assert.Throws<OperationCanceledException>
                     // but since cancellation is a race condition we accept either outcome
                     Assert.Equal(cts.Token, oce.CancellationToken);
-
-                    Assert.Equal(0, fs.Length); // if write was cancelled, the file should be empty
-                    Assert.Equal(0, fs.Position); // if write was cancelled, the Position should remain unchanged
                 }
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -75,7 +75,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeHandleMinusOneIsInvalid.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeHandleZeroOrMinusOneIsInvalid.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeFileHandle.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeFileHandle.ThreadPoolValueTaskSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeWaitHandle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\AccessViolationException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Action.cs" />
@@ -1582,6 +1581,9 @@
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CancelIoEx.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.CancelIoEx.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CancelSynchronousIo.cs">
+      <Link>Interop\Windows\Kernel32\Interop.CancelSynchronousIo.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CompletionPort.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.CompletionPort.cs</Link>
     </Compile>
@@ -1717,6 +1719,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetCurrentProcessId.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetCurrentProcessId.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetCurrentThreadId.cs">
+      <Link>Interop\Windows\Kernel32\Interop.GetCurrentThreadId.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetFileAttributesEx.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetFileAttributesEx.cs</Link>
     </Compile>
@@ -1815,6 +1820,9 @@
     </Compile>
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.MoveFileEx.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.MoveFileEx.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.OpenThread.cs">
+      <Link>Interop\Windows\Kernel32\Interop.OpenThread.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.OSVERSIONINFOEX.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.OSVERSIONINFOEX.cs</Link>
@@ -2017,6 +2025,9 @@
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeTokenHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeTokenHandle.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeThreadHandle.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeThreadHandle.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)System\IO\FileSystem.Attributes.Windows.cs">
       <Link>Common\System\IO\FileSystem.Attributes.Windows.cs</Link>
     </Compile>
@@ -2025,6 +2036,9 @@
     </Compile>
     <Compile Include="$(CommonPath)System\IO\PathInternal.Windows.cs">
       <Link>Common\System\IO\PathInternal.Windows.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)System\Threading\AsyncOverSyncWithIoCancellation.cs">
+      <Link>Common\System\Threading\AsyncOverSyncWithIoCancellation.cs</Link>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Internal\Console.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\Win32\RegistryKey.cs" />
@@ -2346,6 +2360,7 @@
     <Compile Include="$(CommonPath)Interop\Android\Interop.Libraries.cs" Condition="'$(TargetsAndroid)' == 'true'">
       <Link>Common\Interop\Android\Interop.Libraries.cs</Link>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeFileHandle.ThreadPoolValueTaskSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeFileHandle.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\AppDomain.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffer.Unix.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Unix.cs
@@ -92,11 +92,10 @@ namespace System.IO
         }
 
         internal static ValueTask<int> ReadAtOffsetAsync(SafeFileHandle handle, Memory<byte> buffer, long fileOffset, CancellationToken cancellationToken, OSFileStreamStrategy? strategy = null)
-            => ScheduleSyncReadAtOffsetAsync(handle, buffer, fileOffset, cancellationToken, strategy);
+            => handle.GetThreadPoolValueTaskSource().QueueRead(buffer, fileOffset, cancellationToken, strategy);
 
-        private static ValueTask<long> ReadScatterAtOffsetAsync(SafeFileHandle handle, IReadOnlyList<Memory<byte>> buffers,
-            long fileOffset, CancellationToken cancellationToken)
-            => ScheduleSyncReadScatterAtOffsetAsync(handle, buffers, fileOffset, cancellationToken);
+        private static ValueTask<long> ReadScatterAtOffsetAsync(SafeFileHandle handle, IReadOnlyList<Memory<byte>> buffers, long fileOffset, CancellationToken cancellationToken)
+            => handle.GetThreadPoolValueTaskSource().QueueReadScatter(buffers, fileOffset, cancellationToken);
 
         internal static unsafe void WriteAtOffset(SafeFileHandle handle, ReadOnlySpan<byte> buffer, long fileOffset)
         {
@@ -240,10 +239,9 @@ namespace System.IO
         }
 
         internal static ValueTask WriteAtOffsetAsync(SafeFileHandle handle, ReadOnlyMemory<byte> buffer, long fileOffset, CancellationToken cancellationToken, OSFileStreamStrategy? strategy = null)
-            => ScheduleSyncWriteAtOffsetAsync(handle, buffer, fileOffset, cancellationToken, strategy);
+            => handle.GetThreadPoolValueTaskSource().QueueWrite(buffer, fileOffset, cancellationToken, strategy);
 
-        private static ValueTask WriteGatherAtOffsetAsync(SafeFileHandle handle, IReadOnlyList<ReadOnlyMemory<byte>> buffers,
-            long fileOffset, CancellationToken cancellationToken)
-            => ScheduleSyncWriteGatherAtOffsetAsync(handle, buffers, fileOffset, cancellationToken);
+        private static ValueTask WriteGatherAtOffsetAsync(SafeFileHandle handle, IReadOnlyList<ReadOnlyMemory<byte>> buffers, long fileOffset, CancellationToken cancellationToken)
+            => handle.GetThreadPoolValueTaskSource().QueueWriteGather(buffers, fileOffset, cancellationToken);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.IO.Strategies;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
@@ -283,30 +282,6 @@ namespace System.IO
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.buffers);
             }
-        }
-
-        private static ValueTask<int> ScheduleSyncReadAtOffsetAsync(SafeFileHandle handle, Memory<byte> buffer,
-            long fileOffset, CancellationToken cancellationToken, OSFileStreamStrategy? strategy)
-        {
-            return handle.GetThreadPoolValueTaskSource().QueueRead(buffer, fileOffset, cancellationToken, strategy);
-        }
-
-        private static ValueTask<long> ScheduleSyncReadScatterAtOffsetAsync(SafeFileHandle handle, IReadOnlyList<Memory<byte>> buffers,
-            long fileOffset, CancellationToken cancellationToken)
-        {
-            return handle.GetThreadPoolValueTaskSource().QueueReadScatter(buffers, fileOffset, cancellationToken);
-        }
-
-        private static ValueTask ScheduleSyncWriteAtOffsetAsync(SafeFileHandle handle, ReadOnlyMemory<byte> buffer,
-            long fileOffset, CancellationToken cancellationToken, OSFileStreamStrategy? strategy)
-        {
-            return handle.GetThreadPoolValueTaskSource().QueueWrite(buffer, fileOffset, cancellationToken, strategy);
-        }
-
-        private static ValueTask ScheduleSyncWriteGatherAtOffsetAsync(SafeFileHandle handle, IReadOnlyList<ReadOnlyMemory<byte>> buffers,
-            long fileOffset, CancellationToken cancellationToken)
-        {
-            return handle.GetThreadPoolValueTaskSource().QueueWriteGather(buffers, fileOffset, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
Using the same helpers we previously used to enable this in pipe streams on Windows, enable FileStream.Read/WriteAsync on a FileStream created for synchronous I/O to be cancelable.  This also makes some tweaks to those helpers to reduce allocation when a cancelable token is supplied.

Fixes https://github.com/dotnet/runtime/issues/84290

This also makes some tweaks to those helpers to reduce allocation when a cancelable token is supplied.  There's no meaningful improvement for FileStream, since it was effectively ignoring the CancellationToken previously.  So here's a benchmark showing the impact on PipeStream, which as noted was already cancelable using this mechanism:

|         Method |         Toolchain |     Mean | Ratio | Allocated | Alloc Ratio |
|--------------- |------------------ |---------:|------:|----------:|------------:|
| ReadWriteAsync | \main\corerun.exe | 3.979 us |  1.00 |      84 B |        1.00 |
| ReadWriteAsync |   \pr\corerun.exe | 3.342 us |  0.85 |       2 B |        0.02 |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.IO.Pipes;
using System.Threading.Tasks;
using System.Threading;

[MemoryDiagnoser(false)]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    private readonly CancellationTokenSource _cts = new CancellationTokenSource();
    private readonly byte[] _buffer = new byte[1];
    private AnonymousPipeServerStream _server;
    private AnonymousPipeClientStream _client;

    [GlobalSetup]
    public void Setup()
    {
        _server = new AnonymousPipeServerStream(PipeDirection.Out);
        _client = new AnonymousPipeClientStream(PipeDirection.In, _server.ClientSafePipeHandle);
    }

    [GlobalCleanup]
    public void Cleanup()
    {
        _server.Dispose();
        _client.Dispose();
    }

    [Benchmark(OperationsPerInvoke = 1000)]
    public async Task ReadWriteAsync()
    {
        for (int i = 0; i < 1000; i++)
        {
            ValueTask<int> read = _client.ReadAsync(_buffer, _cts.Token);
            await _server.WriteAsync(_buffer, _cts.Token);
            await read;
        }
    }
}
```