### PR TITLE
Ensure the correct `typeToConvert` parameter is being passed to constructor parameter converters.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Large.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Large.cs
@@ -17,9 +17,8 @@ namespace System.Text.Json.Serialization.Converters
         protected sealed override bool ReadAndCacheConstructorArgument(scoped ref ReadStack state, ref Utf8JsonReader reader, JsonParameterInfo jsonParameterInfo)
         {
             Debug.Assert(jsonParameterInfo.ShouldDeserialize);
-            Debug.Assert(jsonParameterInfo.Options != null);
 
-            bool success = jsonParameterInfo.EffectiveConverter.TryReadAsObject(ref reader, TypeToConvert, jsonParameterInfo.Options!, ref state, out object? arg);
+            bool success = jsonParameterInfo.EffectiveConverter.TryReadAsObject(ref reader, jsonParameterInfo.ParameterType, jsonParameterInfo.Options, ref state, out object? arg);
 
             if (success && !(arg == null && jsonParameterInfo.IgnoreNullTokensOnRead))
             {

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
@@ -1602,5 +1602,32 @@ namespace System.Text.Json.Serialization.Tests
 
             public ClassWithIgnoredPropertyDefaultParam(int x, int y = 5) => (X, Y) = (x, y);
         }
+
+        [Fact]
+        public async Task TestClassWithCustomConverterOnCtorParameter_ShouldPassCorrectTypeToConvertParameter()
+        {
+            ClassWithCustomConverterOnCtorParameter result = await Serializer.DeserializeWrapper<ClassWithCustomConverterOnCtorParameter>("""{"Id":"id"}""");
+            Assert.Equal("id", result.Id);
+        }
+
+        public class ClassWithCustomConverterOnCtorParameter
+        {
+            public ClassWithCustomConverterOnCtorParameter(string id) => Id = id;
+
+            [JsonConverter(typeof(CustomCtorParameterConverter))]
+            public string Id { get; }
+        }
+
+        public class CustomCtorParameterConverter : JsonConverter<string>
+        {
+            public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                Assert.Equal(typeof(string), typeToConvert);
+                return reader.GetString();
+            }
+
+            public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+                => writer.WriteStringValue(value);
+        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/ConstructorTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/ConstructorTests.cs
@@ -149,6 +149,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(ClassWithInvalidDictionary))]
         [JsonSerializable(typeof(TypeWithEnumParameters))]
         [JsonSerializable(typeof(ClassWithIgnoredPropertyDefaultParam))]
+        [JsonSerializable(typeof(ClassWithCustomConverterOnCtorParameter))]
         internal sealed partial class ConstructorTestsContext_Metadata : JsonSerializerContext
         {
         }
@@ -293,6 +294,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(ClassWithInvalidDictionary))]
         [JsonSerializable(typeof(TypeWithEnumParameters))]
         [JsonSerializable(typeof(ClassWithIgnoredPropertyDefaultParam))]
+        [JsonSerializable(typeof(ClassWithCustomConverterOnCtorParameter))]
         internal sealed partial class ConstructorTestsContext_Default : JsonSerializerContext
         {
         }


### PR DESCRIPTION
Addressing an issue reported by @stephentoub.