### PR TITLE
Do not use ValueTuple in SynchronizationContext

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SynchronizationContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SynchronizationContext.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+
 namespace System.Threading
 {
     public partial class SynchronizationContext
@@ -19,7 +21,8 @@ namespace System.Threading
 
         public virtual void Send(SendOrPostCallback d, object? state) => d(state);
 
-        public virtual void Post(SendOrPostCallback d, object? state) => ThreadPool.QueueUserWorkItem(static s => s.d(s.state), (d, state), preferLocal: false);
+        public virtual void Post(SendOrPostCallback d, object? state)
+            => ThreadPool.QueueUserWorkItem(static s => s.Key(s.Value), new KeyValuePair<SendOrPostCallback, object?>(d, state), preferLocal: false);
 
         /// <summary>
         ///     Optional override for subclasses, for responding to notification that operation is starting.


### PR DESCRIPTION
This is the same issue as e.g. #84206. The compiler needs to consider delegate Invoke methods always reflectable because of trimming warning suppressions around this in the framework. But that means the compiler is going to create type loader templates for all types in the `Invoke` signature. If one of those is a `ValueTuple`, it will root the ability to runtime-create arbitrary comparers at runtime (`ValueTuple` annoying implements `Equals` using `EqualityComparer.Default`) and with it the entire type loader.

For a sample app in #82607 this causes about 200 kB of bloat to be generated (more than 10% of the app size).

Closes #82607.