### PR TITLE
[mono][interp] Add new call fast path opcodes

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -7623,6 +7623,27 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			ip += 3;
 			MINT_IN_BREAK;
 		}
+
+		// Call intrinsic fast paths
+		MINT_IN_CASE(MINT_CALL_FAST_PATH_RT_FLAG) {
+			MonoObject *rt_obj = LOCAL_VAR (ip [2], MonoObject*);
+			MonoObject *tc_obj = *(MonoObject**)((char*)rt_obj + ip [3]);
+			if (tc_obj) {
+				gint32 flags = *(gint32*)((char*)tc_obj + ip [4]);
+				gint32 cached = *(gint32*)((char*)tc_obj + ip [4] + 4);
+				gint32 mask = ip [5];
+				if (cached & mask) {
+					if (flags & mask)
+						LOCAL_VAR (ip [1], gint32) = TRUE;
+					else
+						LOCAL_VAR (ip [1], gint32) = FALSE;
+					// Skip also the call
+					ip += 4;
+				}
+			}
+			ip += 6;
+			MINT_IN_BREAK;
+		}
 		MINT_IN_CASE(MINT_METADATA_UPDATE_LDFLDA) {
 			MonoObject *inst = LOCAL_VAR (ip [2], MonoObject*);
 			MonoType *field_type = frame->imethod->data_items [ip [3]];

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -7644,6 +7644,23 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			ip += 6;
 			MINT_IN_BREAK;
 		}
+		MINT_IN_CASE(MINT_CALL_FAST_PATH_RT_FIELD) {
+			MonoObject *rt_obj = LOCAL_VAR (ip [2], MonoObject*);
+			MonoObject *tc_obj = *(MonoObject**)((char*)rt_obj + ip [3]);
+			if (tc_obj) {
+				gint32 cached = *(gint32*)((char*)tc_obj + ip [4]);
+				gint32 mask = ip [6];
+				if (cached & mask) {
+					gpointer field = (char*)tc_obj + ip [5];
+					// We might overcopy here so we have unified path for int32/obj.
+					memcpy (locals + ip [1], field, MINT_STACK_SLOT_SIZE);
+					// Skip also the call
+					ip += 4;
+				}
+			}
+			ip += 7;
+			MINT_IN_BREAK;
+		}
 		MINT_IN_CASE(MINT_METADATA_UPDATE_LDFLDA) {
 			MonoObject *inst = LOCAL_VAR (ip [2], MonoObject*);
 			MonoType *field_type = frame->imethod->data_items [ip [3]];

--- a/src/mono/mono/mini/interp/mintops.def
+++ b/src/mono/mono/mini/interp/mintops.def
@@ -685,6 +685,7 @@ OPDEF(MINT_ARRAY_ELEMENT_SIZE, "array_element_size", 3, 1, 1, MintOpNoArgs)
 
 // Call fast paths
 OPDEF(MINT_CALL_FAST_PATH_RT_FLAG, "call.fp.rt.flag", 6, 0, 0, MintOpNoArgs)
+OPDEF(MINT_CALL_FAST_PATH_RT_FIELD, "call.fp.rt.field", 7, 0, 0, MintOpNoArgs)
 
 /* Calls */
 OPDEF(MINT_CALL, "call", 4, 1, 1, MintOpMethodToken)

--- a/src/mono/mono/mini/interp/mintops.def
+++ b/src/mono/mono/mini/interp/mintops.def
@@ -683,6 +683,9 @@ OPDEF(MINT_STRLEN, "strlen", 3, 1, 1, MintOpNoArgs)
 OPDEF(MINT_ARRAY_RANK, "array_rank", 3, 1, 1, MintOpNoArgs)
 OPDEF(MINT_ARRAY_ELEMENT_SIZE, "array_element_size", 3, 1, 1, MintOpNoArgs)
 
+// Call fast paths
+OPDEF(MINT_CALL_FAST_PATH_RT_FLAG, "call.fp.rt.flag", 6, 0, 0, MintOpNoArgs)
+
 /* Calls */
 OPDEF(MINT_CALL, "call", 4, 1, 1, MintOpMethodToken)
 OPDEF(MINT_CALLVIRT_FAST, "callvirt.fast", 5, 1, 1, MintOpMethodToken)

--- a/src/mono/mono/mini/interp/transform.h
+++ b/src/mono/mono/mini/interp/transform.h
@@ -151,6 +151,9 @@ struct _InterpCallInfo {
 	// all source vars for these types of opcodes. This is terminated with -1.
 	int *call_args;
 	int call_offset;
+	// Intrinsic fast path for this call. This instruction must be emitted immediately
+	// before the actual call instruction.
+	InterpInst *fast_path;
 	union {
 		// Array of call dependencies that need to be resolved before
 		GSList *call_deps;


### PR DESCRIPTION
Some bcl methods might be hot enough that it is worth intrinsifying in the interpreter, but the full implementation might be too complex. However, for the common case the implementation could be very simple. This PR experiments with the idea of adding opcodes that intrinsify only the fastpath of the managed method. If the fastpath fails the next opcode executed is the call (that immediately follows), otherwise the call opcode is skipped.

The added opcodes implement some getters on `RuntimeType`, used in various reflection scenarios, representing a rather conservative scenario. The fastpath is run every time except on the first call on a type object, and the methods are mono SPC specific. If this seems reasonable and productive we can experiment for other methods. This makes the getters about 4-5x faster.