### PR TITLE
Update area-owners.json to reflect change in area-owners.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -96,3 +96,8 @@
 
 /docs/project/list-of-diagnostics.md                @jeffhandley
 /src/libraries/Common/src/System/Obsoletions.cs     @jeffhandley
+
+# Area ownership and repo automation
+/docs/area-owners.*                                 @jeffhandley
+/docs/issue*.md                                     @jeffhandley
+/.github/fabricbot.json                             @jeffhandley

--- a/docs/area-owners.json
+++ b/docs/area-owners.json
@@ -248,7 +248,7 @@
       "label": "area-Diagnostics-mono"
     },
     {
-      "lead": "marek-safar",
+      "lead": "SamMonoRT",
       "owners": [
         "lambdageek"
       ],


### PR DESCRIPTION
Complements #87121, updating the `area-owners.json` file to match `area-owners.md`. `area-owners.json` is what drives https://issuesof.net queries.

This PR also adds me to the CODEOWNERS file for changes to the area ownership and repo automation files.