### PR TITLE
[wasm] Disable System.Text.Json/AOT tests

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -69,6 +69,9 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\UnitTests\System.Text.RegularExpressions.Unit.Tests.csproj" />
     <!-- Normally run with HighAOT, but disabling there, and for AOT - https://github.com/dotnet/runtime/issues/71848 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\FunctionalTests\System.Text.RegularExpressions.Tests.csproj" />
+
+    <!-- Normally run with HighAOT, but disabling there, and for AOT - https://github.com/dotnet/runtime/issues/86164 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.Tests\System.Text.Json.Tests.csproj" />
   </ItemGroup>
 
   <!-- Projects that don't support code coverage measurement. -->


### PR DESCRIPTION
- this was disabled earlier from highresource_aot builds, but that had a
  side-effect of enabling them for regular aot builds.

Issue: https://github.com/dotnet/runtime/issues/86164
