### PR TITLE
Update ClaimsIdentity debug display

### DIFF
--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
@@ -946,7 +946,7 @@ namespace System.Security.Claims
                 claimsCount++;
             }
 
-            return $"Identity Name = {Name ?? "(null)"}, IsAuthenticated = {IsAuthenticated}, Claims Count = {claimsCount}";
+            return $"Identity Name = {Name ?? "(null)"}, IsAuthenticated = {IsAuthenticated ? "true" : "false"}, Claims Count = {claimsCount}";
         }
 
         private sealed class ClaimsIdentityDebugProxy

--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
@@ -946,7 +946,7 @@ namespace System.Security.Claims
                 claimsCount++;
             }
 
-            return $"Identity Name = {Name ?? "(null)"}, IsAuthenticated = {IsAuthenticated ? "true" : "false"}, Claims Count = {claimsCount}";
+            return $"Identity Name = {Name ?? "(null)"}, IsAuthenticated = {(IsAuthenticated ? "true" : "false")}, Claims Count = {claimsCount}";
         }
 
         private sealed class ClaimsIdentityDebugProxy


### PR DESCRIPTION
Boolean values are displayed as lowercase in debug display.

For example:
https://github.com/dotnet/runtime/blob/268962e022cd66180eea2c2b90ad278dec9e74eb/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationToken.cs#L29
This displays `IsCancellationRequested = true`

`ClaimsIdentity` builds the debug string in a method so it doesn't automatically use lowercase bool. Update it to be consistent with other debug display bool values.