### PR TITLE
[mono][tests] Enable DriveInfoUnix test on tvOS

### DIFF
--- a/src/libraries/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Unix.Tests.cs
+++ b/src/libraries/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Unix.Tests.cs
@@ -24,7 +24,6 @@ namespace System.IO.FileSystem.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/60586", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public void TestGetDrives()
         {
             var drives = DriveInfo.GetDrives();


### PR DESCRIPTION
This PR aims to enable the `DriveInfoUnix` test on tvOS. The test has passed locally on an iOS device.

Fixes https://github.com/dotnet/runtime/issues/60586