### PR TITLE
Make BundleLocalizedApp test stop requiring UTF8 output encoding

### DIFF
--- a/src/installer/tests/Assets/TestProjects/LocalizedApp/Hello.kn-IN.resx
+++ b/src/installer/tests/Assets/TestProjects/LocalizedApp/Hello.kn-IN.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Greet" xml:space="preserve">
-    <value>ನಮಸ್ಕಾರ</value>
+    <value>[kn-IN]</value>
   </data>
 </root>

--- a/src/installer/tests/Assets/TestProjects/LocalizedApp/Hello.resx
+++ b/src/installer/tests/Assets/TestProjects/LocalizedApp/Hello.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Greet" xml:space="preserve">
-    <value>Hello</value>
+    <value>[default]</value>
   </data>
 </root>

--- a/src/installer/tests/Assets/TestProjects/LocalizedApp/Hello.ta-IN.resx
+++ b/src/installer/tests/Assets/TestProjects/LocalizedApp/Hello.ta-IN.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Greet" xml:space="preserve">
-    <value>வணக்கம்</value>
+    <value>[ta-IN]</value>
   </data>
 </root>

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleLocalizedApp.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleLocalizedApp.cs
@@ -26,20 +26,12 @@ namespace AppHost.Bundle.Tests
             var fixture = sharedTestState.TestFixture.Copy();
             var singleFile = BundleSelfContainedApp(fixture);
 
-            if (OperatingSystem.IsWindows())
-            {
-                // Set code page to output unicode characters.
-                Command.Create("chcp 65001").Execute();
-            }
-
             Command.Create(singleFile)
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .Execute()
-                .Should()
-                .Pass()
-                .And
-                .HaveStdOutContaining("\u0CA8\u0CAE\u0CB8\u0CCD\u0C95\u0CBE\u0CB0! \u0BB5\u0BA3\u0B95\u0BCD\u0B95\u0BAE\u0BCD! Hello!");
+                .Should().Pass()
+                .And.HaveStdOutContaining("[kn-IN]! [ta-IN]! [default]!");
         }
 
         public class SharedTestState : SharedTestStateBase, IDisposable

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
@@ -192,7 +192,6 @@ namespace Microsoft.NET.HostModel.Tests
         }
 
         [Fact]
-        // If enabled, this tests will need to set the console code page to output unicode characters: Command.Create("chcp 65001").Execute();
         [SkipOnPlatform(TestPlatforms.Windows, "Creating symbolic links requires administrative privilege on Windows, so skip test.")]
         public void Put_satellite_assembly_behind_symlink()
         {
@@ -219,7 +218,7 @@ namespace Microsoft.NET.HostModel.Tests
                 .CaptureStdOut()
                 .Execute()
                 .Should().Pass()
-                .And.HaveStdOutContaining("\u0CA8\u0CAE\u0CB8\u0CCD\u0C95\u0CBE\u0CB0! \u0BB5\u0BA3\u0B95\u0BCD\u0B95\u0BAE\u0BCD! Hello!");
+                .And.HaveStdOutContaining("[kn-IN]! [ta-IN]! [default]!");
         }
 
         public class SharedTestState : IDisposable


### PR DESCRIPTION
The test validates that single-file probing is able to find its embedded resource assemblies. It is currently relying on running `chcp` to set the code page to UTF8 before launching the single-file app - which doesn't seem to always work (I'm not sure why - maybe something else sets it in between). We could have the app explicitly set the `Console.Output.Encoding` and then have the test set the `ProcessStartInfo.StandardOutputEncoding`, but the encoding is irrelevant to the actual test, so I figured it would just be noise and instead we'd avoid depending on it by switching the values in the resource to be ASCII.

FIxes https://github.com/dotnet/runtime/issues/85993