### PR TITLE
Linker parallel OutputStep

### DIFF
--- a/src/tools/illink/src/linker/Linker.Steps/BaseParallelPerAssemblyStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/BaseParallelPerAssemblyStep.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using Mono.Cecil;
+
+namespace Mono.Linker.Steps;
+
+public abstract class BaseParallelPerAssemblyStep : IStep
+{
+	public void Process (LinkContext context)
+	{
+		Initialize(context);
+
+		if (!ConditionToProcess (context))
+			return;
+
+		BeginProcess (context);
+
+		ProcessAssemblies(context);
+
+		EndProcess (context);
+	}
+
+	void ProcessAssemblies (LinkContext context)
+	{
+		var safeContext = new ParallelSafeLinkContext (context);
+		Parallel.ForEach(context.GetAssemblies(), asm => ProcessAssembly(safeContext, asm));
+	}
+
+	protected virtual void Initialize (LinkContext context)
+	{
+	}
+
+	protected virtual void ProcessAssembly (ParallelSafeLinkContext context, AssemblyDefinition assembly)
+	{
+	}
+
+	protected virtual bool ConditionToProcess (LinkContext context)
+	{
+		return true;
+	}
+
+	protected virtual void BeginProcess (LinkContext context)
+	{
+	}
+
+	protected virtual void EndProcess (LinkContext context)
+	{
+	}
+}

--- a/src/tools/illink/src/linker/Linker/Annotations.cs
+++ b/src/tools/illink/src/linker/Linker/Annotations.cs
@@ -530,6 +530,14 @@ namespace Mono.Linker
 			symbolReader.Dispose ();
 		}
 
+		public void CloseAllSymbolReaders ()
+		{
+			foreach (var reader in symbol_readers.Values)
+				reader.Dispose ();
+
+			symbol_readers.Clear ();
+		}
+
 		public object? GetCustomAnnotation (object key, IMetadataTokenProvider item)
 		{
 			if (!custom_annotations.TryGetValue (key, out Dictionary<IMetadataTokenProvider, object>? slots))

--- a/src/tools/illink/src/linker/Linker/ParallelSafeAnnotationStore.cs
+++ b/src/tools/illink/src/linker/Linker/ParallelSafeAnnotationStore.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Mono.Cecil;
+
+namespace Mono.Linker;
+
+public class ParallelSafeAnnotationStore
+{
+	private readonly AnnotationStore _annotations;
+
+	public ParallelSafeAnnotationStore (AnnotationStore annotations)
+	{
+		_annotations = annotations;
+	}
+
+	public bool ProcessSatelliteAssemblies => _annotations.ProcessSatelliteAssemblies;
+
+	public AssemblyAction GetAction (AssemblyDefinition assembly) => _annotations.GetAction (assembly);
+}

--- a/src/tools/illink/src/linker/Linker/ParallelSafeLinkContext.cs
+++ b/src/tools/illink/src/linker/Linker/ParallelSafeLinkContext.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Mono.Cecil;
+
+namespace Mono.Linker;
+
+public class ParallelSafeLinkContext
+{
+	private readonly LinkContext _context;
+	private readonly ParallelSafeAnnotationStore _annotations;
+	private readonly object _logLock = new object ();
+
+	public ParallelSafeLinkContext (LinkContext context)
+	{
+		_context = context;
+		_annotations = new ParallelSafeAnnotationStore (context.Annotations);
+	}
+
+	public ParallelSafeAnnotationStore Annotations => _annotations;
+
+	public bool DeterministicOutput => _context.DeterministicOutput;
+	public bool LinkSymbols => _context.LinkSymbols;
+
+	public string OutputDirectory => _context.OutputDirectory;
+
+	public string GetAssemblyLocation (AssemblyDefinition assembly) => _context.GetAssemblyLocation (assembly);
+
+	public void LogMessage (string message)
+	{
+		// Logging is not currently thread safe, so we need to lock
+		lock (_logLock)
+			_context.LogMessage (message);
+	}
+}


### PR DESCRIPTION
The `OutputStep` is the second most costly step behind the `MarkStep`.  The operations that the `OutputStep` is performing are easier to make thread safe than the `MarkStep`, so if we wanted to squeeze a performance improvement out of going wide this would be the place to try.  

Here are some performance numbers from our `UnityLinker` where I prototyped the same functionality in this PR in our linker.

Today using our older linker code base
```
Project 1
0>UnityLinker.exe   | 6.099  | 5.986  | 5.986  | 6.088  | 6.224
Project 2
0>UnityLinker.exe   | 9.674  | 8.76   | 10.761 | 8.76   | 9.501
Project 3
0>UnityLinker.exe   | 10.828 | 9.861  | 12.475 | 9.861  | 10.148
```

Equivalent changes to this PR in our older linker code base
```
Project 1
0>UnityLinker.exe   | 5.339  | 5.174  | 5.665  | 5.179  | 5.174
Project 2
0>UnityLinker.exe   | 6.952  | 6.899  | 6.953  | 7.005  | 6.899
Project 3
0>UnityLinker.exe   | 9.214  | 9.101  | 9.412  | 9.128  | 9.101
```

These numbers were collected by processing the assemblies from 3 unity projects that we use as performance benchmarks.

You can see there is a tangible reduction in runtime.  The impact will vary.

For example, `Project 3` is constrained by having an assembly that is rather large.  Roughly the last 40% of the total `OutputStep` duration is spent writing a single assembly.

Another contributor will be machine specs.  These numbers are from a 32 core (64 thread) threadripper.  I will try test on lower end hardware (or simulate it if I can't find lower end hardware).  

I believe the `OutputStep` is safe from race conditions in practice today.  However, it is too easy to access things on the `context` that are not thread safe and race conditions could easily be introduced by accident.

Before I get into the changes, let me establish some constraints that I believe are true during the execution of the `OutputStep`.  If they are not, please correct me as these are important to ensuring this is thread safe.

1) All assemblies that are needed to write the assembly have been resolved.  In other words, no new assemblies will be added to the `AssemblyResolver` on the `LinkContext`

2) The `OutputStep` makes no new annotations.

3) Cecil's `AssemblyDefinition.Write` will not cross over to access another AssemblyDefinition instance.

4) Cecil's `AssemblyDefinition.Write` can trigger `Resolve` calls.  More on this later.

Now some comments on the changes I have so far

* I intentionally avoided making API breaking changes to `BaseStep`
* I've added `BaseParallelPerAssemblyStep` that attempts to mirror `BaseStep` only with the API modified to be safer for parallelizing per assembly.    The key changes being that there is no longer a `Context` property.  And `LinkContext` is only available during the callbacks that are not ran in parallel.
* I created a `ParallelSafeLinkContext` that wraps `LinkContext` and provides access only to things that have been vetted as safe to do from multiple threads.
* Along the same lines, I created `ParallelSafeAnnotationStore` to prevent accessing things that have not been deemed thread safe.
* I refactored the stateful setup of `architectureMap`.  Instead, set this up before going parallel.
* I refactored how symbols are closed.   Rather than making `Annotations.CloseSymbolReader` thread safe (it's not because it modifies a dictionary).  I changed the output step to close all of the symbols at the end as part of `EndProcess`
* `LogMessage` didn't look thread safe so I added a lock

There are still a few loose ends before I'd want to land this.  However, before I polish it off I'd like to make sure there is interesting in doing this.  As well as get a second set of eyes to make sure I'm not overlooking other complications.

 The remaining things I know of are:

* Make `OutputStep.assembliesWritten` thread safe.  This was a minor oversight.  The easiest thing is probably to switch to a `ConcurrentBag`.  
* Circling back to (4) above.  `AssemblyDefinition.Write` can trigger calls to the `MetadataResolver` and/or the `AssemblyResolver` that were used while reading the assembly.  These are potential sources of race conditions.  I was thinking of adding a `ReadOnly` or `Freeze` style flagging to put the `AssemblyResolver` into a mode where it will throw if a new assembly is resolved.  I believe this will effectively close the door to potential race conditions in the resolver code.  It's also probably not a bad thing as any new assemblies being pulled in after the `MarkStep` would technically be a problem regardless of this parallel effort.