### PR TITLE
[mono][arm64] Handle sysctlbyname failing to find system options.

### DIFF
--- a/src/mono/mono/utils/mono-hwcap-arm64.c
+++ b/src/mono/mono/utils/mono-hwcap-arm64.c
@@ -25,44 +25,62 @@ mono_hwcap_arch_init (void)
 	val_len = sizeof (val);
 	prop = "hw.optional.armv8_crc32";
 	res = sysctlbyname (prop, val, &val_len, NULL, 0);
-	g_assert (res == 0);
-	g_assert (val_len == 4);
-	mono_hwcap_arm64_has_crc32 = *(int*)val;
+	if (res == 0) {
+		g_assert (val_len == 4);
+		mono_hwcap_arm64_has_crc32 = *(int*)val;
+	} else {
+		mono_hwcap_arm64_has_crc32 = 0;
+	}
 
 	val_len = sizeof (val);
 	prop = "hw.optional.arm.FEAT_RDM";
 	res = sysctlbyname (prop, val, &val_len, NULL, 0);
-	g_assert (res == 0);
-	g_assert (val_len == 4);
-	mono_hwcap_arm64_has_rdm = *(int*)val;
+	if (res == 0) {
+		g_assert (val_len == 4);
+		mono_hwcap_arm64_has_rdm = *(int*)val;
+	} else {
+		mono_hwcap_arm64_has_rdm = 0;
+	}
 
 	val_len = sizeof (val);
 	prop = "hw.optional.arm.FEAT_DotProd";
 	res = sysctlbyname (prop, val, &val_len, NULL, 0);
-	g_assert (res == 0);
-	g_assert (val_len == 4);
-	mono_hwcap_arm64_has_dot = *(int*)val;
+	if (res == 0) {
+		g_assert (val_len == 4);
+		mono_hwcap_arm64_has_dot = *(int*)val;
+	} else {
+		mono_hwcap_arm64_has_dot = 0;
+	}
 
 	val_len = sizeof (val);
 	prop = "hw.optional.arm.FEAT_SHA1";
 	res = sysctlbyname (prop, val, &val_len, NULL, 0);
-	g_assert (res == 0);
-	g_assert (val_len == 4);
-	mono_hwcap_arm64_has_sha1 = *(int*)val;
+	if (res == 0) {
+		g_assert (val_len == 4);
+		mono_hwcap_arm64_has_sha1 = *(int*)val;
+	} else {
+		mono_hwcap_arm64_has_sha1 = 0;
+	}
 
 	val_len = sizeof (val);
 	prop = "hw.optional.arm.FEAT_SHA256";
 	res = sysctlbyname (prop, val, &val_len, NULL, 0);
-	g_assert (res == 0);
-	g_assert (val_len == 4);
-	mono_hwcap_arm64_has_sha256 = *(int*)val;
+	if (res == 0) {
+		g_assert (val_len == 4);
+		mono_hwcap_arm64_has_sha256 = *(int*)val;
+	} else {
+		mono_hwcap_arm64_has_sha256 = 0;
+	}
 
 	val_len = sizeof (val);
 	prop = "hw.optional.arm.FEAT_AES";
 	res = sysctlbyname (prop, val, &val_len, NULL, 0);
-	g_assert (res == 0);
-	g_assert (val_len == 4);
-	mono_hwcap_arm64_has_aes = *(int*)val;
+	if (res == 0) {
+		g_assert (val_len == 4);
+		mono_hwcap_arm64_has_aes = *(int*)val;
+	} else {
+		mono_hwcap_arm64_has_aes = 0;
+	}
 
 #endif
 }


### PR DESCRIPTION
This fixes a startup crash on Big Sur:

> error: * Assertion at /Users/runner/work/1/s/src/mono/mono/utils/mono-hwcap-arm64.c:35, condition `res == 0' not met

Because sysctl can't find some of these options:

    $ sysctl hw.optional.armv8_crc32
    hw.optional.armv8_crc32: 1
    $ sysctl hw.optional.arm.FEAT_RDM
    sysctl: unknown oid 'hw.optional.arm.FEAT_RDM'
    $ sysctl hw.optional.arm.FEAT_DotProd
    sysctl: unknown oid 'hw.optional.arm.FEAT_DotProd'
    $ sysctl hw.optional.arm.FEAT_SHA1
    sysctl: unknown oid 'hw.optional.arm.FEAT_SHA1'
    $ sysctl hw.optional.arm.FEAT_SHA256
    sysctl: unknown oid 'hw.optional.arm.FEAT_SHA256'
    $ sysctl hw.optional.arm.FEAT_AES
    sysctl: unknown oid 'hw.optional.arm.FEAT_AES'

Full stack trace:

	* thread #1, queue = 'com.apple.main-thread', stop reason = breakpoint 2.1
	  * frame #0: 0x0000010ef37560 libmonosgen-2.0.dylib`monoeg_assertion_message
	    frame #1: 0x0000010ef375cc libmonosgen-2.0.dylib`mono_assertion_message + 32
	    frame #2: 0x0000010ef40d6c libmonosgen-2.0.dylib`mono_hwcap_arch_init + 544
	    frame #3: 0x0000010ef54bd8 libmonosgen-2.0.dylib`mono_hwcap_init + 72
	    frame #4: 0x0000010ee14dc0 libmonosgen-2.0.dylib`parse_optimizations + 52
	    frame #5: 0x0000010edbed48 libmonosgen-2.0.dylib`mono_init
	    frame #6: 0x0000010ee18968 libmonosgen-2.0.dylib`mono_jit_init_version
	    frame #7: 0x0000010f48a300 libxamarin-dotnet-debug.dylib`xamarin_bridge_initialize + 216
	    frame #8: 0x0000010f4900a4 libxamarin-dotnet-debug.dylib`xamarin_main + 376