### PR TITLE
Fix Crossgen2 determinism issue

### DIFF
--- a/src/coreclr/inc/corjit.h
+++ b/src/coreclr/inc/corjit.h
@@ -118,6 +118,7 @@ enum CorJitAllocMemFlag
     CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN   = 0x00000004, // The code will be 32-byte aligned
     CORJIT_ALLOCMEM_FLG_RODATA_32BYTE_ALIGN = 0x00000008, // The read-only data will be 32-byte aligned
     CORJIT_ALLOCMEM_FLG_RODATA_64BYTE_ALIGN = 0x00000010, // The read-only data will be 64-byte aligned
+    CORJIT_ALLOCMEM_FLG_RODATA_8BYTE_ALIGN = 0x00000020, // The read-only data will be 8-byte aligned
 };
 
 inline CorJitAllocMemFlag operator |(CorJitAllocMemFlag a, CorJitAllocMemFlag b)

--- a/src/coreclr/inc/corjit.h
+++ b/src/coreclr/inc/corjit.h
@@ -110,6 +110,8 @@ enum CorJitResult
 /*****************************************************************************/
 // These are flags passed to ICorJitInfo::allocMem
 // to guide the memory allocation for the code, readonly data, and read-write data
+// The default will align at either 4 or 8 bytes depending on platform and compilation strategy
+// If an 8 byte alignment is required, then it must be specified
 enum CorJitAllocMemFlag
 {
     CORJIT_ALLOCMEM_DEFAULT_CODE_ALIGN = 0x00000000, // The code will use the normal alignment
@@ -119,6 +121,7 @@ enum CorJitAllocMemFlag
     CORJIT_ALLOCMEM_FLG_RODATA_32BYTE_ALIGN = 0x00000008, // The read-only data will be 32-byte aligned
     CORJIT_ALLOCMEM_FLG_RODATA_64BYTE_ALIGN = 0x00000010, // The read-only data will be 64-byte aligned
     CORJIT_ALLOCMEM_FLG_RODATA_8BYTE_ALIGN = 0x00000020, // The read-only data will be 8-byte aligned
+    CORJIT_ALLOCMEM_FLG_8BYTE_ALIGN   = 0x00000040, // The code will be 8-byte aligned
 };
 
 inline CorJitAllocMemFlag operator |(CorJitAllocMemFlag a, CorJitAllocMemFlag b)

--- a/src/coreclr/inc/jiteeversionguid.h
+++ b/src/coreclr/inc/jiteeversionguid.h
@@ -43,11 +43,11 @@ typedef const GUID *LPCGUID;
 #define GUID_DEFINED
 #endif // !GUID_DEFINED
 
-constexpr GUID JITEEVersionIdentifier = { /* fda2f9dd-6b3e-4ecd-a7b8-79e5edf1f072 */
-    0xfda2f9dd,
-    0x6b3e,
-    0x4ecd,
-    {0xa7, 0xb8, 0x79, 0xe5, 0xed, 0xf1, 0xf0, 0x72}
+constexpr GUID JITEEVersionIdentifier = { /* 9732091b-980f-4f79-b5d7-9c1ad8e3c2eb */
+    0x9732091b,
+    0x980f,
+    0x4f79,
+    {0xb5, 0xd7, 0x9c, 0x1a, 0xd8, 0xe3, 0xc2, 0xeb}
   };
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -6690,8 +6690,8 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
     }
 #endif
 
-    // We support requesting alignment from 4 -> 32 bytes on all platforms. The VM will provide an alignment of at least TARGET_POINTER_SIZE,
-    // but crossgen2 will provide the exactly requested alignment.
+    // We support requesting alignment from 4 -> 32 bytes on all platforms. The VM will provide an alignment of at least
+    // TARGET_POINTER_SIZE, but crossgen2 will provide the exactly requested alignment.
     assert((4 <= codeAlignment) && (codeAlignment <= 32) && isPow2(codeAlignment));
 
     CorJitAllocMemFlag allocMemFlagCodeAlign = CORJIT_ALLOCMEM_DEFAULT_CODE_ALIGN;

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -6703,7 +6703,11 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
     }
 
     CorJitAllocMemFlag allocMemFlagDataAlign = static_cast<CorJitAllocMemFlag>(0);
-    if (dataAlignment == 16)
+    if (dataAlignment == 8)
+    {
+        allocMemFlagDataAlign = CORJIT_ALLOCMEM_FLG_RODATA_8BYTE_ALIGN;
+    }
+    else if (dataAlignment == 16)
     {
         allocMemFlagDataAlign = CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN;
     }
@@ -6743,9 +6747,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
         // in final obj file.
         assert((((size_t)codeBlock & 31) == 0) || emitComp->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PREJIT));
     }
-#if 0
-    // TODO: we should be able to assert the following, but it appears crossgen2 doesn't respect them,
-    // or maybe it respects them in the written image but not in the buffer pointer given to the JIT.
+
     if ((allocMemFlag & CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN) != 0)
     {
         assert(((size_t)codeBlock & 15) == 0);
@@ -6763,7 +6765,10 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
     {
         assert(((size_t)consBlock & 15) == 0);
     }
-#endif // 0
+    else if ((allocMemFlag & CORJIT_ALLOCMEM_FLG_RODATA_8BYTE_ALIGN) != 0)
+    {
+        assert(((size_t)consBlock & 7) == 0);
+    }
 #endif
 
     // if (emitConsDsc.dsdOffs)

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -3478,8 +3478,8 @@ namespace Internal.JitInterface
 
         private void allocMem(ref AllocMemArgs args)
         {
-            int codeAlignment = 1;
-            int roDataAlignment = 1;
+            int codeAlignment = 4;
+            int roDataAlignment = 4;
 
             if ((args.flag & CorJitAllocMemFlag.CORJIT_ALLOCMEM_FLG_RODATA_64BYTE_ALIGN) != 0)
             {
@@ -3497,7 +3497,7 @@ namespace Internal.JitInterface
             {
                 roDataAlignment = 8;
             }
-            else if (args.roDataSize < 8)
+            else
             {
                 roDataAlignment = PointerSize;
             }
@@ -3509,6 +3509,10 @@ namespace Internal.JitInterface
             else if ((args.flag & CorJitAllocMemFlag.CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN) != 0)
             {
                 codeAlignment = 16;
+            }
+            else if ((args.flag & CorJitAllocMemFlag.CORJIT_ALLOCMEM_FLG_8BYTE_ALIGN) != 0)
+            {
+                codeAlignment = 8;
             }
 
             codeAlignment = Math.Max(codeAlignment, _compilation.NodeFactory.Target.MinimumFunctionAlignment);

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -745,6 +745,7 @@ namespace Internal.JitInterface
         CORJIT_ALLOCMEM_FLG_RODATA_32BYTE_ALIGN = 0x00000008, // The read-only data will be 32-byte aligned
         CORJIT_ALLOCMEM_FLG_RODATA_64BYTE_ALIGN = 0x00000010, // The read-only data will be 64-byte aligned
         CORJIT_ALLOCMEM_FLG_RODATA_8BYTE_ALIGN = 0x00000020, // The read-only data will be 8-byte aligned
+        CORJIT_ALLOCMEM_FLG_8BYTE_ALIGN   = 0x00000040, // The code will be 8-byte aligned
     }
 
     public enum CorJitFuncKind

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -744,6 +744,7 @@ namespace Internal.JitInterface
         CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN   = 0x00000004, // The code will be 32-byte aligned
         CORJIT_ALLOCMEM_FLG_RODATA_32BYTE_ALIGN = 0x00000008, // The read-only data will be 32-byte aligned
         CORJIT_ALLOCMEM_FLG_RODATA_64BYTE_ALIGN = 0x00000010, // The read-only data will be 64-byte aligned
+        CORJIT_ALLOCMEM_FLG_RODATA_8BYTE_ALIGN = 0x00000020, // The read-only data will be 8-byte aligned
     }
 
     public enum CorJitFuncKind

--- a/src/coreclr/tools/superpmi/superpmi/icorjitinfo.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/icorjitinfo.cpp
@@ -1617,6 +1617,10 @@ void MyICJI::allocMem(AllocMemArgs* pArgs)
     {
          codeAlignment = 16;
     }
+    else if ((pArgs->flag & CORJIT_ALLOCMEM_FLG_8BYTE_ALIGN) != 0)
+    {
+         codeAlignment = 8;
+    }
     hotCodeAlignedSize = ALIGN_UP_SPMI(hotCodeAlignedSize, codeAlignment);
     hotCodeAlignedSize = hotCodeAlignedSize + (codeAlignment - sizeof(void*));
     pArgs->hotCodeBlock      = jitInstance->mc->cr->allocateMemory(hotCodeAlignedSize);
@@ -1643,6 +1647,10 @@ void MyICJI::allocMem(AllocMemArgs* pArgs)
         else if ((pArgs->flag & CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN) != 0)
         {
             roDataAlignment = 16;
+        }
+        else if ((pArgs->flag & CORJIT_ALLOCMEM_FLG_RODATA_8BYTE_ALIGN) != 0)
+        {
+            roDataAlignment = 8;
         }
         else if (pArgs->roDataSize >= 8)
         {

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -3094,6 +3094,8 @@ void EEJitManager::allocCode(MethodDesc* pMD, size_t blockSize, size_t reserveFo
 
     unsigned alignment = CODE_SIZE_ALIGN;
 
+    _ASSERTE(CODE_SIZE_ALIGN >= 8); // In JIT scenarios we always align to at least 8 bytes. If we stop doing so, we need to check CORJIT_ALLOCMEM_FLG_8BYTE_ALIGN.
+
     if ((flag & CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN) != 0)
     {
         alignment = max(alignment, 32);

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -12165,6 +12165,10 @@ void CEEJitInfo::allocMem (AllocMemArgs *pArgs)
     {
         roDataAlignment = 16;
     }
+    else if ((pArgs->flag & CORJIT_ALLOCMEM_FLG_RODATA_8BYTE_ALIGN)!= 0)
+    {
+        roDataAlignment = 8;
+    }
     else if (pArgs->roDataSize >= 8)
     {
         roDataAlignment = 8;
@@ -12180,6 +12184,10 @@ void CEEJitInfo::allocMem (AllocMemArgs *pArgs)
         else if ((pArgs->flag & CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN) != 0)
         {
             codeAlignment = 16;
+        }
+        else if ((pArgs->flag & CORJIT_ALLOCMEM_FLG_8BYTE_ALIGN) != 0)
+        {
+            codeAlignment = 8;
         }
         totalSize.AlignUp(codeAlignment);
 


### PR DESCRIPTION
- When generating constant data, the JIT sometimes uses the alignment of the data pointers given to it to decide where to place constants
- This change introduces a structure for controlling allocations, which will allocate the memory at a specified alignment, but also not at any higher alignment when compiling in crossgen2.
- In addition, as Crossgen2 has slightly different rules for allocating ro data and code, it turns out that we needed the ability to specify an 8 byte alignment. Crossgen2 has long held the design that the minimum alignment of a method is 4 bytes on all architectures and platforms, and the JIT has been assuming that it would be 8 bytes on 64bit architectures