### PR TITLE
Fix reading runtime settings early in startup

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RuntimeConfigurationRootProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RuntimeConfigurationRootProvider.cs
@@ -30,7 +30,7 @@ namespace ILCompiler
             rootProvider.AddCompilationRoot(new RuntimeConfigurationBlobNode(_blobName, _runtimeOptions), "Runtime configuration");
         }
 
-        private sealed class RuntimeConfigurationBlobNode : DehydratableObjectNode, ISymbolDefinitionNode
+        private sealed class RuntimeConfigurationBlobNode : ObjectNode, ISymbolDefinitionNode
         {
             private readonly string _blobName;
             private readonly IReadOnlyCollection<string> _runtimeOptions;
@@ -54,11 +54,11 @@ namespace ILCompiler
                 sb.Append(_blobName);
             }
 
-            protected override ObjectNodeSection GetDehydratedSection(NodeFactory factory) => ObjectNodeSection.ReadOnlyDataSection;
+            public override ObjectNodeSection GetSection(NodeFactory factory) => ObjectNodeSection.ReadOnlyDataSection;
 
             protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
-            protected override ObjectData GetDehydratableData(NodeFactory factory, bool relocsOnly = false)
+            public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
             {
                 var builder = new ObjectDataBuilder(factory.TypeSystemContext.Target, relocsOnly);
                 builder.AddSymbol(this);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RuntimeConfigurationRootProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RuntimeConfigurationRootProvider.cs
@@ -54,7 +54,8 @@ namespace ILCompiler
                 sb.Append(_blobName);
             }
 
-            public override ObjectNodeSection GetSection(NodeFactory factory) => ObjectNodeSection.ReadOnlyDataSection;
+            public override ObjectNodeSection GetSection(NodeFactory factory) =>
+                factory.Target.IsWindows ? ObjectNodeSection.ReadOnlyDataSection : ObjectNodeSection.DataSection;
 
             protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 

--- a/src/coreclr/tools/aot/ILCompiler/repro/repro.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/repro/repro.csproj
@@ -23,6 +23,7 @@
       <ReproResponseLines Include="-r:$(MicrosoftNetCoreAppRuntimePackRidLibTfmDir)*.dll" />
       <ReproResponseLines Include="-g" />
       <ReproResponseLines Include="-O" Condition="'$(Optimize)' == 'true'" />
+      <ReproResponseLines Include="--dehydrate" />
       <ReproResponseLines Include="--generateunmanagedentrypoints:System.Private.CoreLib" />
       <ReproResponseLines Include="--initassembly:System.Private.CoreLib" />
       <ReproResponseLines Include="--initassembly:System.Private.StackTraceMetadata" />

--- a/src/tests/nativeaot/SmokeTests/Exceptions/Exceptions.cs
+++ b/src/tests/nativeaot/SmokeTests/Exceptions/Exceptions.cs
@@ -25,6 +25,10 @@ public class BringUpTest
 
     public static int Main()
     {
+        // This test also doubles as server GC test
+        if (!System.Runtime.GCSettings.IsServerGC)
+            return 42;
+
         if (string.Empty.Length > 0)
         {
             // Just something to make sure we generate reflection metadata for the type

--- a/src/tests/nativeaot/SmokeTests/Exceptions/Exceptions.csproj
+++ b/src/tests/nativeaot/SmokeTests/Exceptions/Exceptions.csproj
@@ -4,6 +4,7 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Exceptions.cs" />


### PR DESCRIPTION
* Since runtime settings are read before we had a chance to run dehydration, they cannot go to the dehydrated section. This is a 48-byte penalty per setting on Linux. Hopefully we won't have too many of these.
* Fix the repro project to enable dehydration. When testing the original change, I used repro project where this worked because of no dehydration. We should mirror the shipping configuration.
* Add a regression test. Picked a random test as a "victim" so that we don't unnecessarily regress testing time.

Cc @dotnet/ilc-contrib 