### PR TITLE
Ifdef out DynamicDependencies that are not necessary

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
@@ -71,12 +71,12 @@ namespace System
         }
 
 #pragma warning disable CS0067 // events raised by the VM
-#if !NATIVEAOT
+#if MONO
         [field: DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(UnhandledExceptionEventArgs))]
 #endif
         internal static event UnhandledExceptionEventHandler? UnhandledException;
 
-#if !NATIVEAOT
+#if MONO
         [field: DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(FirstChanceExceptionEventArgs))]
 #endif
         internal static event EventHandler<FirstChanceExceptionEventArgs>? FirstChanceException;

--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
@@ -71,10 +71,14 @@ namespace System
         }
 
 #pragma warning disable CS0067 // events raised by the VM
+#if !NATIVEAOT
         [field: DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(UnhandledExceptionEventArgs))]
+#endif
         internal static event UnhandledExceptionEventHandler? UnhandledException;
 
+#if !NATIVEAOT
         [field: DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(FirstChanceExceptionEventArgs))]
+#endif
         internal static event EventHandler<FirstChanceExceptionEventArgs>? FirstChanceException;
 #pragma warning restore CS0067
 

--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -69,7 +69,7 @@ namespace System
          */
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-#if !NATIVEAOT
+#if MONO
         [DynamicDependency("Ctor(System.Char[])")]
 #endif
         public extern String(char[]? value);
@@ -90,7 +90,7 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-#if !NATIVEAOT
+#if MONO
         [DynamicDependency("Ctor(System.Char[],System.Int32,System.Int32)")]
 #endif
         public extern String(char[] value, int startIndex, int length);
@@ -117,7 +117,7 @@ namespace System
 
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.InternalCall)]
-#if !NATIVEAOT
+#if MONO
         [DynamicDependency("Ctor(System.Char*)")]
 #endif
         public extern unsafe String(char* value);
@@ -143,7 +143,7 @@ namespace System
 
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.InternalCall)]
-#if !NATIVEAOT
+#if MONO
         [DynamicDependency("Ctor(System.Char*,System.Int32,System.Int32)")]
 #endif
         public extern unsafe String(char* value, int startIndex, int length);
@@ -177,7 +177,7 @@ namespace System
 
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.InternalCall)]
-#if !NATIVEAOT
+#if MONO
         [DynamicDependency("Ctor(System.SByte*)")]
 #endif
         public extern unsafe String(sbyte* value);
@@ -195,7 +195,7 @@ namespace System
 
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.InternalCall)]
-#if !NATIVEAOT
+#if MONO
         [DynamicDependency("Ctor(System.SByte*,System.Int32,System.Int32)")]
 #endif
         public extern unsafe String(sbyte* value, int startIndex, int length);
@@ -251,7 +251,7 @@ namespace System
 
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.InternalCall)]
-#if !NATIVEAOT
+#if MONO
         [DynamicDependency("Ctor(System.SByte*,System.Int32,System.Int32,System.Text.Encoding)")]
 #endif
         public extern unsafe String(sbyte* value, int startIndex, int length, Encoding enc);
@@ -282,7 +282,7 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-#if !NATIVEAOT
+#if MONO
         [DynamicDependency("Ctor(System.Char,System.Int32)")]
 #endif
         public extern String(char c, int count);
@@ -304,7 +304,7 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-#if !NATIVEAOT
+#if MONO
         [DynamicDependency("Ctor(System.ReadOnlySpan{System.Char})")]
 #endif
         public extern String(ReadOnlySpan<char> value);

--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -69,7 +69,9 @@ namespace System
          */
 
         [MethodImpl(MethodImplOptions.InternalCall)]
+#if !NATIVEAOT
         [DynamicDependency("Ctor(System.Char[])")]
+#endif
         public extern String(char[]? value);
 
         private static string Ctor(char[]? value)
@@ -88,7 +90,9 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
+#if !NATIVEAOT
         [DynamicDependency("Ctor(System.Char[],System.Int32,System.Int32)")]
+#endif
         public extern String(char[] value, int startIndex, int length);
 
         private static string Ctor(char[] value, int startIndex, int length)
@@ -113,7 +117,9 @@ namespace System
 
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.InternalCall)]
+#if !NATIVEAOT
         [DynamicDependency("Ctor(System.Char*)")]
+#endif
         public extern unsafe String(char* value);
 
         private static unsafe string Ctor(char* ptr)
@@ -137,7 +143,9 @@ namespace System
 
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.InternalCall)]
+#if !NATIVEAOT
         [DynamicDependency("Ctor(System.Char*,System.Int32,System.Int32)")]
+#endif
         public extern unsafe String(char* value, int startIndex, int length);
 
         private static unsafe string Ctor(char* ptr, int startIndex, int length)
@@ -169,7 +177,9 @@ namespace System
 
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.InternalCall)]
+#if !NATIVEAOT
         [DynamicDependency("Ctor(System.SByte*)")]
+#endif
         public extern unsafe String(sbyte* value);
 
         private static unsafe string Ctor(sbyte* value)
@@ -185,7 +195,9 @@ namespace System
 
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.InternalCall)]
+#if !NATIVEAOT
         [DynamicDependency("Ctor(System.SByte*,System.Int32,System.Int32)")]
+#endif
         public extern unsafe String(sbyte* value, int startIndex, int length);
 
         private static unsafe string Ctor(sbyte* value, int startIndex, int length)
@@ -239,7 +251,9 @@ namespace System
 
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.InternalCall)]
+#if !NATIVEAOT
         [DynamicDependency("Ctor(System.SByte*,System.Int32,System.Int32,System.Text.Encoding)")]
+#endif
         public extern unsafe String(sbyte* value, int startIndex, int length, Encoding enc);
 
         private static unsafe string Ctor(sbyte* value, int startIndex, int length, Encoding? enc)
@@ -268,7 +282,9 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
+#if !NATIVEAOT
         [DynamicDependency("Ctor(System.Char,System.Int32)")]
+#endif
         public extern String(char c, int count);
 
         private static string Ctor(char c, int count)
@@ -288,7 +304,9 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
+#if !NATIVEAOT
         [DynamicDependency("Ctor(System.ReadOnlySpan{System.Char})")]
+#endif
         public extern String(ReadOnlySpan<char> value);
 
         private static unsafe string Ctor(ReadOnlySpan<char> value)


### PR DESCRIPTION
These create unnecessary reflection targets. Trimming done by NativeAOT will do the right thing.

Cc @dotnet/ilc-contrib 