### PR TITLE
Move the CreateCastingConverter<T>() method to the base JsonConverter type.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/CastingConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/CastingConverter.cs
@@ -19,7 +19,7 @@ namespace System.Text.Json.Serialization.Converters
         public override bool HandleNull { get; }
         internal override bool SupportsCreateObjectDelegate => _sourceConverter.SupportsCreateObjectDelegate;
 
-        internal CastingConverter(JsonConverter sourceConverter, bool handleNull, bool handleNullOnRead, bool handleNullOnWrite)
+        internal CastingConverter(JsonConverter sourceConverter)
         {
             Debug.Assert(typeof(T).IsInSubtypeRelationshipWith(sourceConverter.TypeToConvert));
             Debug.Assert(sourceConverter.SourceConverterForCastingConverter is null, "casting converters should not be layered.");
@@ -31,9 +31,9 @@ namespace System.Text.Json.Serialization.Converters
             CanBePolymorphic = sourceConverter.CanBePolymorphic;
 
             // Ensure HandleNull values reflect the exact configuration of the source converter
-            HandleNullOnRead = handleNullOnRead;
-            HandleNullOnWrite = handleNullOnWrite;
-            HandleNull = handleNull;
+            HandleNullOnRead = sourceConverter.HandleNullOnRead;
+            HandleNullOnWrite = sourceConverter.HandleNullOnWrite;
+            HandleNull = sourceConverter.HandleNullOnWrite;
         }
 
         internal override JsonConverter? SourceConverterForCastingConverter => _sourceConverter;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -102,7 +102,41 @@ namespace System.Text.Json.Serialization
             throw new InvalidOperationException();
         }
 
-        internal abstract JsonConverter<TTarget> CreateCastingConverter<TTarget>();
+        internal JsonConverter<TTarget> CreateCastingConverter<TTarget>()
+        {
+            Debug.Assert(this is not JsonConverterFactory);
+
+            if (this is JsonConverter<TTarget> conv)
+            {
+                return conv;
+            }
+            else
+            {
+                JsonSerializerOptions.CheckConverterNullabilityIsSameAsPropertyType(this, typeof(TTarget));
+
+                // Avoid layering casting converters by consulting any source converters directly.
+                return
+                    SourceConverterForCastingConverter?.CreateCastingConverter<TTarget>()
+                    ?? new CastingConverter<TTarget>(this);
+            }
+        }
+
+        /// <summary>
+        /// Tracks whether the JsonConverter&lt;T&gt;.HandleNull property has been overridden by a derived converter.
+        /// </summary>
+        internal bool UsesDefaultHandleNull { get; private protected set; }
+
+        /// <summary>
+        /// Does the converter want to be called when reading null tokens.
+        /// When JsonConverter&lt;T&gt;.HandleNull isn't overridden this can still be true for non-nullable structs.
+        /// </summary>
+        internal bool HandleNullOnRead { get; private protected init; }
+
+        /// <summary>
+        /// Does the converter want to be called for null values.
+        /// Should always match the precise value of the JsonConverter&lt;T&gt;.HandleNull virtual property.
+        /// </summary>
+        internal bool HandleNullOnWrite { get; private protected init; }
 
         /// <summary>
         /// Set if this converter is itself a casting converter.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
@@ -161,11 +161,5 @@ namespace System.Text.Json.Serialization
 
             throw new InvalidOperationException();
         }
-
-        internal sealed override JsonConverter<TTarget> CreateCastingConverter<TTarget>()
-        {
-            ThrowHelper.ThrowInvalidOperationException_ConverterCanConvertMultipleTypes(typeof(TTarget), this);
-            return null!;
-        }
     }
 }


### PR DESCRIPTION
This generic virtual method was necessary back when CastingConverter was strongly typed, but since https://github.com/dotnet/runtime/pull/80755 got merged this is not strictly necessary so it can be refactored to something that is more code size friendly.

Contributes to #87078.