### PR TITLE
Set ApiCompatIgnoreTargetPlatformMoniker for packable projects

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -16,6 +16,8 @@
     <!-- Don't include target platform specific dependencies, since we use the target platform to represent RIDs instead -->
     <IncludeBuildOutput Condition="'$(PackageUsePlatformTargeting)' != 'true' and '$(TargetPlatformIdentifier)' != '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking Condition="'$(PackageUsePlatformTargeting)' != 'true' and '$(TargetPlatformIdentifier)' != '' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">true</SuppressDependenciesWhenPacking>
+    <!-- Don't treat the TPM as an input to APICompat PackageValidation's reference assembly calculation. -->
+    <ApiCompatIgnoreTargetPlatformMoniker Condition="'$(SuppressDependenciesWhenPacking)' == 'true'">true</ApiCompatIgnoreTargetPlatformMoniker>
     <PackageDesignerMarkerFile>$(MSBuildThisFileDirectory)useSharedDesignerContext.txt</PackageDesignerMarkerFile>
     <PackageReadmeFile Condition="'$(PackageReadmeFile)' == '' and Exists('PACKAGE.md')">PACKAGE.md</PackageReadmeFile>
     <!-- Generate packages for rid specific projects or for allconfigurations during build. -->


### PR DESCRIPTION
Follow-up change to a bugfix in APICompat: https://github.com/dotnet/sdk/pull/33036#issuecomment-1578610022