### PR TITLE
[NativeAOT] Don't link Swift/CryptoKit on iOS-like platforms

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -96,7 +96,7 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <ItemGroup Condition="'$(_IsApplePlatform)' == 'true'">
       <NativeFramework Include="CoreFoundation" />
-      <NativeFramework Include="CryptoKit" />
+      <NativeFramework Condition="'$(_targetOS)' == 'osx'" Include="CryptoKit" />
       <NativeFramework Include="Foundation" />
       <NativeFramework Include="Security" />
       <!-- The library builds don't reference the GSS API on tvOS builds. -->
@@ -119,8 +119,8 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-lstdc++" Condition="'$(LinkStandardCPlusPlusLibrary)' == 'true'" />
       <LinkerArg Include="-ldl" />
       <LinkerArg Include="-lobjc" Condition="'$(_IsApplePlatform)' == 'true'" />
-      <LinkerArg Include="-lswiftCore" Condition="'$(_IsApplePlatform)' == 'true'" />
-      <LinkerArg Include="-lswiftFoundation" Condition="'$(_IsApplePlatform)' == 'true'" />
+      <LinkerArg Include="-lswiftCore" Condition="'$(_targetOS)' == 'osx'" />
+      <LinkerArg Include="-lswiftFoundation" Condition="'$(_targetOS)' == 'osx'" />
       <LinkerArg Include="-lz" />
       <LinkerArg Include="-lrt" Condition="'$(_IsApplePlatform)' != 'true'" />
       <LinkerArg Include="-licucore" Condition="'$(_IsApplePlatform)' == 'true'" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -124,7 +124,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-lz" />
       <LinkerArg Include="-lrt" Condition="'$(_IsApplePlatform)' != 'true'" />
       <LinkerArg Include="-licucore" Condition="'$(_IsApplePlatform)' == 'true'" />
-      <LinkerArg Include="-L/usr/lib/swift" Condition="'$(_IsApplePlatform)' == 'true'" />
+      <LinkerArg Include="-L/usr/lib/swift" Condition="'$(_targetOS)' == 'osx'" />
       <LinkerArg Include="@(StaticICULibs)" Condition="'$(StaticICULinking)' == 'true'" />
       <LinkerArg Include="@(StaticSslLibs)" Condition="'$(StaticOpenSslLinking)' == 'true'" />
       <LinkerArg Include="-lm" />


### PR DESCRIPTION
We currently don't compile the Swift code in System.Security.Cryptography.Apple for iOS-like platforms, so there's no need to link the Swift runtime libraries either.