### PR TITLE
[wasm] Fix running debugger tests on windows

### DIFF
--- a/src/mono/wasm/debugger/Wasm.Debugger.Tests/wasm.helix.targets
+++ b/src/mono/wasm/debugger/Wasm.Debugger.Tests/wasm.helix.targets
@@ -27,7 +27,7 @@
         <PayloadArchive>$(TestArchiveTestsDir)Wasm.Debugger.Tests.zip</PayloadArchive>
         <Command>$(HelixCommand)</Command>
         <Timeout>$(_DebuggerTestsWorkItemTimeout)</Timeout>
-        <PreCommands Condition="'$(OS)' == 'Windows_NT'">set &quot;TEST_ARGS=--filter category^!=failing^&amp;FullyQualifiedName~%(Identity)&quot;</PreCommands>
+        <PreCommands Condition="'$(OS)' == 'Windows_NT'">set &quot;TEST_ARGS=--filter category^^!=failing^&amp;FullyQualifiedName~%(Identity)&quot;</PreCommands>
         <PreCommands Condition="'$(OS)' != 'Windows_NT'">export &quot;TEST_ARGS=--filter category!=failing&amp;FullyQualifiedName~%(Identity)&quot;</PreCommands>
       </HelixWorkItem>
     </ItemGroup>

--- a/src/mono/wasm/debugger/Wasm.Debugger.Tests/wasm.helix.targets
+++ b/src/mono/wasm/debugger/Wasm.Debugger.Tests/wasm.helix.targets
@@ -27,7 +27,7 @@
         <PayloadArchive>$(TestArchiveTestsDir)Wasm.Debugger.Tests.zip</PayloadArchive>
         <Command>$(HelixCommand)</Command>
         <Timeout>$(_DebuggerTestsWorkItemTimeout)</Timeout>
-        <PreCommands Condition="'$(OS)' == 'Windows_NT'">set &quot;TEST_ARGS=--filter category!=failing^&amp;FullyQualifiedName~%(Identity)&quot;</PreCommands>
+        <PreCommands Condition="'$(OS)' == 'Windows_NT'">set &quot;TEST_ARGS=--filter category^!=failing^&amp;FullyQualifiedName~%(Identity)&quot;</PreCommands>
         <PreCommands Condition="'$(OS)' != 'Windows_NT'">export &quot;TEST_ARGS=--filter category!=failing&amp;FullyQualifiedName~%(Identity)&quot;</PreCommands>
       </HelixWorkItem>
     </ItemGroup>

--- a/src/mono/wasm/debugger/Wasm.Debugger.Tests/wasm.helix.targets
+++ b/src/mono/wasm/debugger/Wasm.Debugger.Tests/wasm.helix.targets
@@ -27,7 +27,7 @@
         <PayloadArchive>$(TestArchiveTestsDir)Wasm.Debugger.Tests.zip</PayloadArchive>
         <Command>$(HelixCommand)</Command>
         <Timeout>$(_DebuggerTestsWorkItemTimeout)</Timeout>
-        <PreCommands Condition="'$(OS)' == 'Windows_NT'">set &quot;TEST_ARGS=--filter category!=failing&amp;FullyQualifiedName~%(Identity)&quot;</PreCommands>
+        <PreCommands Condition="'$(OS)' == 'Windows_NT'">set &quot;TEST_ARGS=--filter category!=failing^&amp;FullyQualifiedName~%(Identity)&quot;</PreCommands>
         <PreCommands Condition="'$(OS)' != 'Windows_NT'">export &quot;TEST_ARGS=--filter category!=failing&amp;FullyQualifiedName~%(Identity)&quot;</PreCommands>
       </HelixWorkItem>
     </ItemGroup>


### PR DESCRIPTION
.. by making sure to escape `&` in the command line. This was introduced
in:

```
commit e96321db982c3add192381f6ea4ff0a999ee1410
Author: Ilona Tomkowicz <32700855+ilonatommy@users.noreply.github.com>
Date:   Tue Jun 6 05:59:43 2023 +0200

    [wasm][debugger] Disable failing multithreading debugger tests (#86501)
```

.. but missed CI due to the helix outage.

This caused all the debugger test runs on helix to fail, with timeouts, and the testResults.trx showing results only for `SteppingTests`.