### PR TITLE
Ensure that Vector<T> is tracked as "optimistic" for crossgen2

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -65,9 +65,17 @@ namespace ILCompiler
             if (outputFilePath == null)
                 throw new CommandLineException("Output filename must be specified (/out <file>)");
 
+            // NativeAOT is full AOT and its pre-compiled methods can not be
+            // thrown away at runtime if they mismatch in required ISAs or
+            // computed layouts of structs. The worst case scenario is simply
+            // that the image targets a higher machine than the user has and
+            // it fails to launch. Thus we want to have usage of Vector<T>
+            // directly encoded as part of the required ISAs.
+            bool isVectorTOptimistic = false;
+
             TargetArchitecture targetArchitecture = Get(_command.TargetArchitecture);
             TargetOS targetOS = Get(_command.TargetOS);
-            InstructionSetSupport instructionSetSupport = Helpers.ConfigureInstructionSetSupport(Get(_command.InstructionSet), Get(_command.MaxVectorTBitWidth), targetArchitecture, targetOS,
+            InstructionSetSupport instructionSetSupport = Helpers.ConfigureInstructionSetSupport(Get(_command.InstructionSet), Get(_command.MaxVectorTBitWidth), isVectorTOptimistic, targetArchitecture, targetOS,
                 "Unrecognized instruction set {0}", "Unsupported combination of instruction sets: {0}/{1}");
 
             string systemModuleName = Get(_command.SystemModuleName);

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -74,9 +74,16 @@ namespace ILCompiler
             if (_singleFileCompilation && !_outNearInput)
                 throw new CommandLineException(SR.MissingOutNearInput);
 
+            // Crossgen2 is partial AOT and its pre-compiled methods can be
+            // thrown away at runtime if they mismatch in required ISAs or
+            // computed layouts of structs. Thus we want to ensure that usage
+            // of Vector<T> is only optimistic and doesn't hard code a dependency
+            // that would cause the entire image to be invalidated.
+            bool isVectorTOptimistic = true;
+
             TargetArchitecture targetArchitecture = Get(_command.TargetArchitecture);
             TargetOS targetOS = Get(_command.TargetOS);
-            InstructionSetSupport instructionSetSupport = Helpers.ConfigureInstructionSetSupport(Get(_command.InstructionSet), Get(_command.MaxVectorTBitWidth), targetArchitecture, targetOS,
+            InstructionSetSupport instructionSetSupport = Helpers.ConfigureInstructionSetSupport(Get(_command.InstructionSet), Get(_command.MaxVectorTBitWidth), isVectorTOptimistic, targetArchitecture, targetOS,
                 SR.InstructionSetMustNotBe, SR.InstructionSetInvalidImplication);
             SharedGenericsMode genericsMode = SharedGenericsMode.CanonicalReferenceTypes;
             var targetDetails = new TargetDetails(targetArchitecture, targetOS, Crossgen2RootCommand.IsArmel ? TargetAbi.NativeAotArmel : TargetAbi.NativeAot, instructionSetSupport.GetVectorTSimdVector());


### PR DESCRIPTION
This resolves #87235 

The issue was introduced in https://github.com/dotnet/runtime/pull/85551 as the `InstructionSet_VectorT###` was included as part of the `supportedInstructionSet` and was therefore getting encoded as part of the required ISAs for a given image.

What this meant was that when we hit `TryIncrementalLoad` for `System.Private.Corelib` we'd try to apply the `EagerFixups`, find that the host machine supported `InstructionSet_VectorT256` while the image said it required `InstructionSet_VectorT128`. This caused the entire image to be thrown away as invalid.

By instead tracking the `Vector<T>` size that's being targeted as the opportunistic set, we get the dependency flagged per method alongside any layout check required for `Vector<T>`. This allows just the method in question to be thrown away instead.