### PR TITLE
Generate debug info even if managed debug info not present

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Ecma/SymbolReader/UnmanagedPdbSymbolReader.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/SymbolReader/UnmanagedPdbSymbolReader.cs
@@ -1343,12 +1343,11 @@ namespace Internal.TypeSystem.Ecma
         // and names for all of them.  This assumes a CSC-like compiler that doesn't re-use
         // local slots in the same method across scopes.
         //
-        public override IEnumerable<ILLocalVariable>? GetLocalVariableNamesForMethod(int methodToken)
+        public override IEnumerable<ILLocalVariable> GetLocalVariableNamesForMethod(int methodToken)
         {
             ISymUnmanagedMethod? symbolMethod;
             if (_symUnmanagedReader.GetMethod(methodToken, out symbolMethod) < 0 || symbolMethod is null)
-                return null;
-            Debug.Assert(symbolMethod is not null);
+                return Array.Empty<ILLocalVariable>();
 
             ISymUnmanagedScope rootScope;
             ThrowExceptionForHR(symbolMethod.GetRootScope(out rootScope));

--- a/src/coreclr/tools/Common/TypeSystem/IL/EcmaMethodIL.Symbols.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/EcmaMethodIL.Symbols.cs
@@ -1,13 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 
 using Internal.TypeSystem.Ecma;
-
-using Debug = System.Diagnostics.Debug;
 
 namespace Internal.IL
 {
@@ -16,12 +15,7 @@ namespace Internal.IL
     {
         public override MethodDebugInformation GetDebugInfo()
         {
-            if (_method.Module.PdbReader != null)
-            {
-                return new EcmaMethodDebugInformation(_method);
-            }
-
-            return MethodDebugInformation.None;
+            return new EcmaMethodDebugInformation(_method);
         }
     }
 
@@ -34,20 +28,34 @@ namespace Internal.IL
 
         public EcmaMethodDebugInformation(EcmaMethod method)
         {
-            Debug.Assert(method.Module.PdbReader != null);
             _method = method;
         }
 
-        public override bool IsStateMachineMoveNextMethod => _method.Module.PdbReader.GetStateMachineKickoffMethod(MetadataTokens.GetToken(_method.Handle)) != 0;
+        public override bool IsStateMachineMoveNextMethod
+        {
+            get
+            {
+                PdbSymbolReader reader = _method.Module.PdbReader;
+                return reader != null
+                    ? reader.GetStateMachineKickoffMethod(MetadataTokens.GetToken(_method.Handle)) != 0
+                    : false;
+            }
+        }
 
         public override IEnumerable<ILSequencePoint> GetSequencePoints()
         {
-            return _method.Module.PdbReader.GetSequencePointsForMethod(MetadataTokens.GetToken(_method.Handle));
+            PdbSymbolReader reader = _method.Module.PdbReader;
+            return reader != null
+                ? reader.GetSequencePointsForMethod(MetadataTokens.GetToken(_method.Handle))
+                : Array.Empty<ILSequencePoint>();
         }
 
         public override IEnumerable<ILLocalVariable> GetLocalVariables()
         {
-            return _method.Module.PdbReader.GetLocalVariableNamesForMethod(MetadataTokens.GetToken(_method.Handle));
+            PdbSymbolReader reader = _method.Module.PdbReader;
+            return reader != null
+                ? reader.GetLocalVariableNamesForMethod(MetadataTokens.GetToken(_method.Handle))
+                : Array.Empty<ILLocalVariable>();
         }
 
         public override IEnumerable<string> GetParameterNames()

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -455,17 +455,6 @@ namespace ILCompiler.DependencyAnalysis
             return (_options & ObjectWritingOptions.GenerateDebugInfo) != 0;
         }
 
-        public bool HasFunctionDebugInfo()
-        {
-            if (_offsetToDebugLoc.Count > 0)
-            {
-                Debug.Assert(HasModuleDebugInfo());
-                return true;
-            }
-
-            return false;
-        }
-
         private int GetDocumentId(string document)
         {
             if (_debugFileToId.TryGetValue(document, out int result))
@@ -1134,7 +1123,7 @@ namespace ILCompiler.DependencyAnalysis
                     // Emit the last CFI to close the frame.
                     objectWriter.EmitCFICodes(nodeContents.Data.Length);
 
-                    if (objectWriter.HasFunctionDebugInfo())
+                    if (objectWriter.HasModuleDebugInfo())
                     {
                         objectWriter.EmitDebugVarInfo(node);
                         objectWriter.EmitDebugEHClauseInfo(node);

--- a/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
+++ b/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
@@ -51,11 +51,11 @@ public class Program
 
         // Just count the number of warnings and errors. There are so many right now that it's not worth enumerating the list
 #if DEBUG
-        const int MinWarnings = 12000;
-        const int MaxWarnings = 20000;
+        const int MinWarnings = 20000;
+        const int MaxWarnings = 24000;
 #else
-        const int MinWarnings = 12000;
-        const int MaxWarnings = 13000;
+        const int MinWarnings = 15000;
+        const int MaxWarnings = 16000;
 #endif
         int count = 0;
         string line;

--- a/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
+++ b/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
@@ -51,11 +51,11 @@ public class Program
 
         // Just count the number of warnings and errors. There are so many right now that it's not worth enumerating the list
 #if DEBUG
-        const int MinWarnings = 20000;
-        const int MaxWarnings = 24000;
+        const int MinWarnings = 12000;
+        const int MaxWarnings = 20000;
 #else
-        const int MinWarnings = 15000;
-        const int MaxWarnings = 16000;
+        const int MinWarnings = 12000;
+        const int MaxWarnings = 13000;
 #endif
         int count = 0;
         string line;


### PR DESCRIPTION
The names/types of parameters are available even without a PDB in .NET - surface them to the native debugger.

We could also surface fake information about locals because the type information is there (just no names/compiler generated bit), but it's unclear if that would be an improvement.

cc @dotnet/ilc-contrib 