### PR TITLE
Don't use GetEarlyNode in impGetSpecialIntrinsicExactReturnType

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -7588,7 +7588,7 @@ CORINFO_CLASS_HANDLE Compiler::impGetSpecialIntrinsicExactReturnType(GenTreeCall
                 if (instParam != nullptr)
                 {
                     assert(instParam->GetNext() == nullptr);
-                    CORINFO_CLASS_HANDLE hClass = gtGetHelperArgClassHandle(instParam->GetEarlyNode());
+                    CORINFO_CLASS_HANDLE hClass = gtGetHelperArgClassHandle(instParam->GetNode());
                     if (hClass != NO_CLASS_HANDLE)
                     {
                         hClass = getTypeInstantiationArgument(hClass, 0);


### PR DESCRIPTION
This function now can be invoked in VN phase so GetEarlyNode can't be used

Fixes https://github.com/dotnet/runtime/issues/87258