### PR TITLE
JIT: Reorder physical promotion and forward sub

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4716,13 +4716,13 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     //
     DoPhase(this, PHASE_EARLY_LIVENESS, &Compiler::fgEarlyLiveness);
 
-    // Promote struct locals based on primitive access patterns
-    //
-    DoPhase(this, PHASE_PHYSICAL_PROMOTION, &Compiler::PhysicalPromotion);
-
     // Run a simple forward substitution pass.
     //
     DoPhase(this, PHASE_FWD_SUB, &Compiler::fgForwardSub);
+
+    // Promote struct locals based on primitive access patterns
+    //
+    DoPhase(this, PHASE_PHYSICAL_PROMOTION, &Compiler::PhysicalPromotion);
 
     // Locals tree list is no longer kept valid.
     fgNodeThreading = NodeThreading::None;

--- a/src/coreclr/jit/promotion.cpp
+++ b/src/coreclr/jit/promotion.cpp
@@ -1555,14 +1555,15 @@ void ReplaceVisitor::ReplaceLocal(GenTree** use, GenTree* user)
 //
 void ReplaceVisitor::CheckForwardSubForLastUse(unsigned lclNum)
 {
-    Statement* prevStmt = m_currentStmt->GetPrevStmt();
-    if (prevStmt == nullptr)
+    if (m_currentBlock->firstStmt() == m_currentStmt)
     {
         return;
     }
 
-    GenTree* node = prevStmt->GetRootNode();
-    if (node->OperIsLocalStore() && (node->AsLclVarCommon()->GetLclNum() == lclNum))
+    Statement* prevStmt = m_currentStmt->GetPrevStmt();
+    GenTree*   prevNode = prevStmt->GetRootNode();
+
+    if (prevNode->OperIsLocalStore() && (prevNode->AsLclVarCommon()->GetLclNum() == lclNum))
     {
         m_mayHaveForwardSub = true;
     }

--- a/src/coreclr/jit/promotion.h
+++ b/src/coreclr/jit/promotion.h
@@ -248,10 +248,14 @@ class DecompositionPlan;
 
 class ReplaceVisitor : public GenTreeVisitor<ReplaceVisitor>
 {
+    friend class DecompositionPlan;
+
     jitstd::vector<AggregateInfo*>& m_aggregates;
     PromotionLiveness*              m_liveness;
     bool                            m_madeChanges         = false;
     bool                            m_hasPendingReadBacks = false;
+    bool                            m_mayHaveForwardSub   = false;
+    Statement*                      m_currentStmt         = nullptr;
     BasicBlock*                     m_currentBlock        = nullptr;
 
 public:
@@ -271,6 +275,11 @@ public:
         return m_madeChanges;
     }
 
+    bool MayHaveForwardSubOpportunity()
+    {
+        return m_mayHaveForwardSub;
+    }
+
     void StartBlock(BasicBlock* block)
     {
         m_currentBlock = block;
@@ -278,9 +287,11 @@ public:
 
     void EndBlock();
 
-    void StartStatement()
+    void StartStatement(Statement* stmt)
     {
-        m_madeChanges = false;
+        m_currentStmt       = stmt;
+        m_madeChanges       = false;
+        m_mayHaveForwardSub = false;
     }
 
     fgWalkResult PostOrderVisit(GenTree** use, GenTree* user);
@@ -290,6 +301,7 @@ private:
     void LoadStoreAroundCall(GenTreeCall* call, GenTree* user);
     bool IsPromotedStructLocalDying(GenTreeLclVarCommon* structLcl);
     void ReplaceLocal(GenTree** use, GenTree* user);
+    void CheckForwardSubForLastUse(unsigned lclNum);
     void StoreBeforeReturn(GenTreeUnOp* ret);
     void WriteBackBefore(GenTree** use, unsigned lcl, unsigned offs, unsigned size);
     bool MarkForReadBack(unsigned lcl, unsigned offs, unsigned size);

--- a/src/coreclr/jit/promotiondecomposition.cpp
+++ b/src/coreclr/jit/promotiondecomposition.cpp
@@ -50,6 +50,7 @@ class DecompositionPlan
     };
 
     Compiler*                       m_compiler;
+    ReplaceVisitor*                 m_replacer;
     jitstd::vector<AggregateInfo*>& m_aggregates;
     PromotionLiveness*              m_liveness;
     GenTree*                        m_store;
@@ -61,6 +62,7 @@ class DecompositionPlan
 
 public:
     DecompositionPlan(Compiler*                       comp,
+                      ReplaceVisitor*                 replacer,
                       jitstd::vector<AggregateInfo*>& aggregates,
                       PromotionLiveness*              liveness,
                       GenTree*                        store,
@@ -68,6 +70,7 @@ public:
                       bool                            dstInvolvesReplacements,
                       bool                            srcInvolvesReplacements)
         : m_compiler(comp)
+        , m_replacer(replacer)
         , m_aggregates(aggregates)
         , m_liveness(liveness)
         , m_store(store)
@@ -731,6 +734,7 @@ private:
                     if (srcDeaths.IsReplacementDying((unsigned)replacementIndex))
                     {
                         src->gtFlags |= GTF_VAR_DEATH;
+                        m_replacer->CheckForwardSubForLastUse(entry.FromLclNum);
                     }
                 }
             }
@@ -1009,7 +1013,7 @@ void ReplaceVisitor::HandleStore(GenTree** use, GenTree* user)
         DecompositionStatementList result;
         EliminateCommasInBlockOp(store, &result);
 
-        DecompositionPlan plan(m_compiler, m_aggregates, m_liveness, store, src, dstInvolvesReplacements,
+        DecompositionPlan plan(m_compiler, this, m_aggregates, m_liveness, store, src, dstInvolvesReplacements,
                                srcInvolvesReplacements);
 
         if (dstInvolvesReplacements)


### PR DESCRIPTION
Physical promotion breaks more forward sub opportunities than it introduces, so reorder these phases. Then teach physical promotion to recognize when it creates new opportunities and selectively reinvoke forward sub for just those cases.