### PR TITLE
[browser] mono_wasm_invoke_method_bound with exception root and GC region

### DIFF
--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -3,7 +3,7 @@
 
 import type {
     MonoArray, MonoAssembly, MonoClass,
-    MonoMethod, MonoObject, MonoString,
+    MonoMethod, MonoObject,
     MonoType, MonoObjectRef, MonoStringRef, JSMarshalerArguments
 } from "./types/internal";
 import type { VoidPtr, CharPtrPtr, Int32Ptr, CharPtr, ManagedPointer } from "./types/emscripten";
@@ -79,7 +79,7 @@ const fn_signatures: SigLine[] = [
     [true, "mono_wasm_profiler_init_aot", "void", ["string"]],
     [true, "mono_wasm_profiler_init_browser", "void", ["number"]],
     [false, "mono_wasm_exec_regression", "number", ["number", "string"]],
-    [false, "mono_wasm_invoke_method_bound", "number", ["number", "number"]],
+    [false, "mono_wasm_invoke_method_bound", "number", ["number", "number", "number"]],
     [true, "mono_wasm_write_managed_pointer_unsafe", "void", ["number", "number"]],
     [true, "mono_wasm_copy_managed_pointer", "void", ["number", "number"]],
     [true, "mono_wasm_i52_to_f64", "number", ["number", "number"]],
@@ -200,7 +200,7 @@ export interface t_Cwraps {
     mono_wasm_profiler_init_aot(desc: string): void;
     mono_wasm_profiler_init_browser(desc: string): void;
     mono_wasm_exec_regression(verbose_level: number, image: string): number;
-    mono_wasm_invoke_method_bound(method: MonoMethod, args: JSMarshalerArguments): MonoString;
+    mono_wasm_invoke_method_bound(method: MonoMethod, args: JSMarshalerArguments, fail: MonoStringRef): number;
     mono_wasm_write_managed_pointer_unsafe(destination: VoidPtr | MonoObjectRef, pointer: ManagedPointer): void;
     mono_wasm_copy_managed_pointer(destination: VoidPtr | MonoObjectRef, source: VoidPtr | MonoObjectRef): void;
     mono_wasm_i52_to_f64(source: VoidPtr, error: Int32Ptr): number;

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -685,23 +685,27 @@ mono_wasm_invoke_method_ref (MonoMethod *method, MonoObject **this_arg_in, void 
 	MONO_EXIT_GC_UNSAFE;
 }
 
-EMSCRIPTEN_KEEPALIVE MonoObject*
-mono_wasm_invoke_method_bound (MonoMethod *method, void* args)// JSMarshalerArguments
+EMSCRIPTEN_KEEPALIVE int
+mono_wasm_invoke_method_bound (MonoMethod *method, void* args /*JSMarshalerArguments*/, MonoObject **_out_exc)
 {
-	MonoObject *exc = NULL;
-	MonoObject *res;
-
+	PPVOLATILE(MonoObject) out_exc = _out_exc;
 	void *invoke_args[1] = { args };
+	int is_err = 0;
 
-	mono_runtime_invoke (method, NULL, invoke_args, &exc);
-	if (exc) {
-		MonoObject *exc2 = NULL;
-		res = (MonoObject*)mono_object_to_string (exc, &exc2);
+	MONO_ENTER_GC_UNSAFE;
+	mono_runtime_invoke (method, NULL, invoke_args, (MonoObject **)out_exc);
+
+	// this failure is unlikely because it would be runtime error, not application exception.
+	// the application exception is passed inside JSMarshalerArguments `args`
+	if (*_out_exc) {
+		PVOLATILE(MonoObject) exc2 = NULL;
+		store_volatile(_out_exc, (MonoObject*)mono_object_to_string (*out_exc, (MonoObject **)&exc2));
 		if (exc2)
-			res = (MonoObject*) mono_string_new (root_domain, "Exception Double Fault");
-		return res;
+			store_volatile(_out_exc, (MonoObject*)mono_string_new (root_domain, "Exception Double Fault"));
+		is_err = 1;
 	}
-	return NULL;
+	MONO_EXIT_GC_UNSAFE;
+	return is_err;
 }
 
 EMSCRIPTEN_KEEPALIVE MonoMethod*

--- a/src/mono/wasm/runtime/net6-legacy/cs-to-js.ts
+++ b/src/mono/wasm/runtime/net6-legacy/cs-to-js.ts
@@ -10,13 +10,14 @@ import { wrap_error_root, wrap_no_error_root } from "../invoke-js";
 import { ManagedObject } from "../marshal";
 import { getU32, getI32, getF32, getF64, setI32_unchecked } from "../memory";
 import { mono_wasm_new_root, mono_wasm_new_external_root } from "../roots";
-import { monoStringToString, monoStringToStringUnsafe } from "../strings";
+import { monoStringToString } from "../strings";
 import { legacyManagedExports } from "./corebindings";
 import { legacyHelpers } from "./globals";
 import { js_to_mono_obj_root } from "./js-to-cs";
 import { mono_bind_method, mono_method_get_call_signature_ref } from "./method-binding";
 import { createPromiseController } from "../globals";
 import { assert_legacy_interop } from "../pthreads/shared";
+import { monoStringToStringUnsafe } from "./strings";
 
 const delegate_invoke_symbol = Symbol.for("wasm delegate_invoke");
 

--- a/src/mono/wasm/runtime/net6-legacy/strings.ts
+++ b/src/mono/wasm/runtime/net6-legacy/strings.ts
@@ -3,8 +3,10 @@
 
 import { assert_legacy_interop } from "../pthreads/shared";
 import { mono_wasm_new_root } from "../roots";
-import { interned_string_table, mono_wasm_empty_string, stringToInternedMonoStringRoot, stringToMonoStringRoot } from "../strings";
-import { MonoString, is_nullish } from "../types/internal";
+import { interned_string_table, monoStringToString, mono_wasm_empty_string, stringToInternedMonoStringRoot, stringToMonoStringRoot } from "../strings";
+import { MonoString, MonoStringNull, is_nullish } from "../types/internal";
+
+let mono_wasm_string_root: any;
 
 /**
  * @deprecated Not GC or thread safe
@@ -35,4 +37,17 @@ export function stringToMonoStringIntern(string: string): string {
     finally {
         root.release();
     }
+}
+
+/* @deprecated not GC safe, use monoStringToString */
+export function monoStringToStringUnsafe(mono_string: MonoString): string | null {
+    if (mono_string === MonoStringNull)
+        return null;
+    if (!mono_wasm_string_root)
+        mono_wasm_string_root = mono_wasm_new_root();
+
+    mono_wasm_string_root.value = mono_string;
+    const result = monoStringToString(mono_wasm_string_root);
+    mono_wasm_string_root.value = MonoStringNull;
+    return result;
 }

--- a/src/mono/wasm/runtime/strings.ts
+++ b/src/mono/wasm/runtime/strings.ts
@@ -5,13 +5,11 @@ import { mono_wasm_new_root_buffer } from "./roots";
 import { MonoString, MonoStringNull, WasmRoot, WasmRootBuffer } from "./types/internal";
 import { Module } from "./globals";
 import cwraps from "./cwraps";
-import { mono_wasm_new_root } from "./roots";
 import { isSharedArrayBuffer, localHeapViewU8, getU32_local, setU16_local, localHeapViewU32, getU16_local, localHeapViewU16 } from "./memory";
 import { NativePointer, CharPtr } from "./types/emscripten";
 
 export const interned_js_string_table = new Map<string, MonoString>();
 export const mono_wasm_empty_string = "";
-let mono_wasm_string_root: any;
 let mono_wasm_string_decoder_buffer: NativePointer | undefined;
 export const interned_string_table = new Map<MonoString, string>();
 let _empty_string_ptr: MonoString = <any>0;
@@ -31,7 +29,6 @@ export function strings_init(): void {
             _text_decoder_utf8_validating = new TextDecoder("utf-8");
             _text_encoder_utf8 = new TextEncoder();
         }
-        mono_wasm_string_root = mono_wasm_new_root();
         mono_wasm_string_decoder_buffer = Module._malloc(12);
     }
 }
@@ -98,17 +95,6 @@ export function stringToUTF16(dstPtr: number, endPtr: number, text: string) {
         dstPtr += 2;
         if (dstPtr >= endPtr) break;
     }
-}
-
-/* @deprecated not GC safe, use monoStringToString */
-export function monoStringToStringUnsafe(mono_string: MonoString): string | null {
-    if (mono_string === MonoStringNull)
-        return null;
-
-    mono_wasm_string_root.value = mono_string;
-    const result = monoStringToString(mono_wasm_string_root);
-    mono_wasm_string_root.value = MonoStringNull;
-    return result;
 }
 
 export function monoStringToString(root: WasmRoot<MonoString>): string | null {


### PR DESCRIPTION
- make `mono_wasm_invoke_method_bound` safer with exception root 
- add `MONO_ENTER_GC_UNSAFE`/`MONO_EXIT_GC_UNSAFE.` boundary
- move the `monoStringToStringUnsafe` to legacy interop folder