### PR TITLE
Fix DeserializeAsyncEnumerable generic recursion issue.

### DIFF
--- a/src/libraries/System.Text.Json/Common/JsonHelpers.cs
+++ b/src/libraries/System.Text.Json/Common/JsonHelpers.cs
@@ -1,20 +1,21 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.InteropServices;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 
 namespace System.Text.Json
 {
     internal static partial class JsonHelpers
     {
+#if !NETCOREAPP
         /// <summary>
-        /// Emulates Dictionary.TryAdd on netstandard.
+        /// netstandard/netfx polyfill for Dictionary.TryAdd
         /// </summary>
-        public static bool TryAdd<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, in TKey key, in TValue value) where TKey : notnull
+        public static bool TryAdd<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue value) where TKey : notnull
         {
-#if NETSTANDARD2_0 || NETFRAMEWORK
             if (!dictionary.ContainsKey(key))
             {
                 dictionary[key] = value;
@@ -22,10 +23,23 @@ namespace System.Text.Json
             }
 
             return false;
-#else
-            return dictionary.TryAdd(key, value);
-#endif
         }
+
+        /// <summary>
+        /// netstandard/netfx polyfill for Queue.TryDequeue
+        /// </summary>
+        public static bool TryDequeue<T>(this Queue<T> queue, [NotNullWhen(true)] out T? result)
+        {
+            if (queue.Count > 0)
+            {
+                result = queue.Dequeue();
+                return true;
+            }
+
+            result = default;
+            return false;
+        }
+#endif
 
         /// <summary>
         /// Provides an in-place, stable sorting implementation for List.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.cs
@@ -94,7 +94,7 @@ namespace System.Text.Json
         public static string Utf8GetString(ReadOnlySpan<byte> bytes)
         {
             return Encoding.UTF8.GetString(bytes
-#if NETSTANDARD2_0 || NETFRAMEWORK
+#if !NETCOREAPP
                         .ToArray()
 #endif
                 );
@@ -108,7 +108,7 @@ namespace System.Text.Json
             IEqualityComparer<TKey> comparer)
             where TKey : notnull
         {
-#if NETSTANDARD2_0 || NETFRAMEWORK
+#if !NETCOREAPP
             var dictionary = new Dictionary<TKey, TValue>(comparer);
 
             foreach (KeyValuePair<TKey, TValue> item in collection)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.cs
@@ -228,7 +228,7 @@ namespace System.Text.Json
             if (_propertyDictionary != null)
             {
                 // Fast path if item doesn't exist in dictionary.
-                if (JsonHelpers.TryAdd(_propertyDictionary, propertyName, value))
+                if (_propertyDictionary.TryAdd(propertyName, value))
                 {
                     assignParent?.Invoke();
                     _propertyList.Add(new KeyValuePair<string, T>(propertyName, value));
@@ -303,7 +303,7 @@ namespace System.Text.Json
             }
             else
             {
-                if (!JsonHelpers.TryAdd(_propertyDictionary, propertyName, value))
+                if (!_propertyDictionary.TryAdd(propertyName, value))
                 {
                     return false;
                 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -1125,7 +1125,7 @@ namespace System.Text.Json.Serialization.Metadata
                 ParameterLookupKey key = new(propertyName, jsonProperty.PropertyType);
                 ParameterLookupValue value = new(jsonProperty);
 
-                if (!JsonHelpers.TryAdd(nameLookup, key, value))
+                if (!nameLookup.TryAdd(key, value))
                 {
                     // More than one property has the same case-insensitive name and Type.
                     // Remember so we can throw a nice exception if this property is used as a parameter name.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.ReadHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.ReadHelper.cs
@@ -79,49 +79,11 @@ namespace System.Text.Json.Serialization.Metadata
         }
 
         /// <summary>
-        /// Creating a queue JsonTypeInfo from within the DeserializeAsyncEnumerable method
-        /// triggers generic recursion warnings from the AOT compiler so we instead
-        /// have the caller do it for us externally (cf. https://github.com/dotnet/runtime/issues/85184)
+        /// Caches a JsonTypeInfo&lt;Queue&lt;T&gt;&gt; instance used by the DeserializeAsyncEnumerable method.
+        /// Store as a non-generic type to avoid triggering generic recursion in the AOT compiler.
+        /// cf. https://github.com/dotnet/runtime/issues/85184
         /// </summary>
-        internal JsonTypeInfo<Queue<T>>? _asyncEnumerableQueueTypeInfo;
-
-        internal async IAsyncEnumerable<T> DeserializeAsyncEnumerable(Stream utf8Json, [EnumeratorCancellation] CancellationToken cancellationToken)
-        {
-            Debug.Assert(_asyncEnumerableQueueTypeInfo?.IsConfigured == true, "must be populated before calling the method.");
-            JsonTypeInfo<Queue<T>> queueTypeInfo = _asyncEnumerableQueueTypeInfo;
-            JsonSerializerOptions options = queueTypeInfo.Options;
-            var bufferState = new ReadBufferState(options.DefaultBufferSize);
-            ReadStack readStack = default;
-            readStack.Initialize(queueTypeInfo, supportContinuation: true);
-
-            var jsonReaderState = new JsonReaderState(options.GetReaderOptions());
-
-            try
-            {
-                do
-                {
-                    bufferState = await bufferState.ReadFromStreamAsync(utf8Json, cancellationToken, fillBuffer: false).ConfigureAwait(false);
-                    queueTypeInfo.ContinueDeserialize(
-                        ref bufferState,
-                        ref jsonReaderState,
-                        ref readStack);
-
-                    if (readStack.Current.ReturnValue is { } returnValue)
-                    {
-                        var queue = (Queue<T>)returnValue!;
-                        while (queue.Count > 0)
-                        {
-                            yield return queue.Dequeue();
-                        }
-                    }
-                }
-                while (!bufferState.IsFinalBlock);
-            }
-            finally
-            {
-                bufferState.Dispose();
-            }
-        }
+        internal JsonTypeInfo? _asyncEnumerableQueueTypeInfo;
 
         internal sealed override object? DeserializeAsObject(ref Utf8JsonReader reader, ref ReadStack state)
             => Deserialize(ref reader, ref state);
@@ -135,7 +97,7 @@ namespace System.Text.Json.Serialization.Metadata
         internal sealed override object? DeserializeAsObject(Stream utf8Json)
             => Deserialize(utf8Json);
 
-        private T? ContinueDeserialize(
+        internal T? ContinueDeserialize(
             ref ReadBufferState bufferState,
             ref JsonReaderState jsonReaderState,
             ref ReadStack readStack)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/PreserveReferenceResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/PreserveReferenceResolver.cs
@@ -32,7 +32,7 @@ namespace System.Text.Json.Serialization
         {
             Debug.Assert(_referenceIdToObjectMap != null);
 
-            if (!JsonHelpers.TryAdd(_referenceIdToObjectMap, referenceId, value))
+            if (!_referenceIdToObjectMap.TryAdd(referenceId, value))
             {
                 ThrowHelper.ThrowJsonException_MetadataDuplicateIdFound(referenceId);
             }


### PR DESCRIPTION
Refactors the `DeserializeAsyncEnumerable` moving the logic away from `JsonTypeInfo<T>` and into a static method in `JsonSerializer`. This should fully address the generic recursion issues we've been seeing creep up in AOT.

## System.Text.Json.SourceGeneration.Tests AOT size

### main

![image](https://github.com/dotnet/runtime/assets/2813363/8de0ab63-ddd5-4220-a74c-502d4caf89ff)

Total accounted size: 106.5 MB

### PR branch

![image](https://github.com/dotnet/runtime/assets/2813363/abe6ba27-d4d6-4e34-ae18-ec75f8b5695c)

Total accounted size: 60.6 MB

Contributes to #87078.


