### PR TITLE
[browser] Don't update downlevel runtime packs when producing prerelease version

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest.pkgproj
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest.pkgproj
@@ -41,6 +41,7 @@
 
     <ItemGroup>
       <_WorkloadManifestValues Include="WorkloadVersion" Value="$(PackageVersion)" />
+      <_WorkloadManifestValues Include="StabilizePackageVersion" Value="$(StabilizePackageVersion)" />
       <_WorkloadManifestValues Include="PackageVersion" Value="$(PackageVersion)" />
       <_WorkloadManifestValues Include="PackageVersionNet6" Value="$(PackageVersionNet6)" />
       <_WorkloadManifestValues Include="PackageVersionNet7" Value="$(PackageVersionNet7)" Condition="'$(PackageVersionNet7)' != ''" />

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.targets.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.targets.in
@@ -2,8 +2,8 @@
 <Project>
   <PropertyGroup>
     <_RuntimePackInWorkloadVersionCurrent>${PackageVersion}</_RuntimePackInWorkloadVersionCurrent>
-    <_RuntimePackInWorkloadVersion7>${PackageVersionNet7}</_RuntimePackInWorkloadVersion7>
-    <_RuntimePackInWorkloadVersion6>${PackageVersionNet6}</_RuntimePackInWorkloadVersion6>
+    <_RuntimePackInWorkloadVersion7 Condition="'${StabilizePackageVersion}' == 'true'">${PackageVersionNet7}</_RuntimePackInWorkloadVersion7>
+    <_RuntimePackInWorkloadVersion6 Condition="'${StabilizePackageVersion}' == 'true'">${PackageVersionNet6}</_RuntimePackInWorkloadVersion6>
 
     <TargetsNet8    Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionEquals('$(TargetFrameworkVersion)', '8.0'))">true</TargetsNet8>
     <TargetsNet6    Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionEquals('$(TargetFrameworkVersion)', '6.0'))">true</TargetsNet6>

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net6.Manifest/WorkloadManifest.targets.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net6.Manifest/WorkloadManifest.targets.in
@@ -67,7 +67,7 @@
     <_MonoWorkloadRuntimePackPackageVersion>$(_RuntimePackInWorkloadVersion6)</_MonoWorkloadRuntimePackPackageVersion>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetsNet6)' == 'true' and '$(_MonoWorkloadTargetsMobile)' == 'true'">
+  <ItemGroup Condition="'$(TargetsNet6)' == 'true' and '$(_MonoWorkloadRuntimePackPackageVersion)' != '' and '$(_MonoWorkloadTargetsMobile)' == 'true'">
     <KnownRuntimePack Update="@(KnownRuntimePack)">
       <LatestRuntimeFrameworkVersion Condition="'%(KnownRuntimePack.TargetFramework)' == 'net6.0' and '%(KnownRuntimePack.RuntimePackLabels)' == 'Mono'">$(_MonoWorkloadRuntimePackPackageVersion)</LatestRuntimeFrameworkVersion>
     </KnownRuntimePack>

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest/WorkloadManifest.targets.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest/WorkloadManifest.targets.in
@@ -62,7 +62,7 @@
     <_MonoWorkloadRuntimePackPackageVersion>$(_RuntimePackInWorkloadVersion7)</_MonoWorkloadRuntimePackPackageVersion>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetsNet7)' == 'true' and '$(_MonoWorkloadTargetsMobile)' == 'true'">
+  <ItemGroup Condition="'$(TargetsNet7)' == 'true' and '$(_MonoWorkloadRuntimePackPackageVersion)' != '' and '$(_MonoWorkloadTargetsMobile)' == 'true'">
     <KnownRuntimePack Update="@(KnownRuntimePack)">
       <LatestRuntimeFrameworkVersion Condition="'%(KnownRuntimePack.TargetFramework)' == 'net7.0' and '%(KnownRuntimePack.RuntimePackLabels)' == 'Mono'">$(_MonoWorkloadRuntimePackPackageVersion)</LatestRuntimeFrameworkVersion>
       <!-- Overrides for wasm threads support -->


### PR DESCRIPTION
Don't update .NET 6/7 packs until `StabilizePackageVersion=true`.

The whole versioning depends on fact that everything is released at the same time. This is not true for previews. So we shouldn't override the downlevel runtime pack version, because it points to a version that is not published yet.

Closes https://github.com/dotnet/sdk/issues/32864