### PR TITLE
Crossgen2 determinism fix and stress mode

### DIFF
--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -6710,7 +6710,8 @@ struct GenTreeVecCon : public GenTree
     {
         assert(varTypeIsSIMD(type));
 
-        // Some uses of GenTreeVecCon do not specify all bits in the vector they are using but failing to zero out the buffer will cause determinism issues with the compiler.
+        // Some uses of GenTreeVecCon do not specify all bits in the vector they are using but failing to zero out the
+        // buffer will cause determinism issues with the compiler.
         memset(&gtSimdVal, 0, sizeof(gtSimdVal));
 
 #if defined(TARGET_XARCH)

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -6710,6 +6710,9 @@ struct GenTreeVecCon : public GenTree
     {
         assert(varTypeIsSIMD(type));
 
+        // Some uses of GenTreeVecCon do not specify all bits in the vector they are using but failing to zero out the buffer will cause determinism issues with the compiler.
+        memset(&gtSimdVal, 0, sizeof(gtSimdVal));
+
 #if defined(TARGET_XARCH)
         assert(sizeof(simd_t) == sizeof(simd64_t));
 #else

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -47,6 +47,8 @@ namespace ILCompiler.DependencyAnalysis
     public sealed class NodeFactoryOptimizationFlags
     {
         public bool OptimizeAsyncMethods;
+        public int DeterminismStress;
+        public bool PrintReproArgs;
     }
 
     // To make the code future compatible to the composite R2R story

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -256,6 +256,8 @@ namespace ILCompiler
 
         public ProfileDataManager ProfileData => _profileData;
 
+        public bool DeterminismCheckFailed { get; set; }
+
         public ReadyToRunSymbolNodeFactory SymbolNodeFactory { get; }
         public ReadyToRunCompilationModuleGroupBase CompilationModuleGroup { get; }
         private readonly int _customPESectionAlignment;
@@ -806,9 +808,9 @@ namespace ILCompiler
                     Logger.Writer.WriteLine("Compiling " + methodName);
                 }
 
-                if (_printReproInstructions != null)
+                if (_nodeFactory.OptimizationFlags.PrintReproArgs)
                 {
-                    Logger.Writer.WriteLine($"Single method repro args:{_printReproInstructions(method)}");
+                    Logger.Writer.WriteLine($"Single method repro args:{GetReproInstructions(method)}");
                 }
 
                 try
@@ -884,6 +886,11 @@ namespace ILCompiler
         public override void Dispose()
         {
             Array.Clear(_corInfoImpls);
+        }
+
+        public string GetReproInstructions(MethodDesc method)
+        {
+            return _printReproInstructions(method);
         }
     }
 }

--- a/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
+++ b/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
@@ -183,6 +183,9 @@ namespace ILCompiler
         public Option<bool> SynthesizeRandomMibc { get; } =
             new(new[] { "--synthesize-random-mibc" });
 
+        public Option<int> DeterminismStress { get; } =
+            new(new[] { "--determinism-stress" });
+
         public bool CompositeOrInputBubble { get; private set; }
         public OptimizationMode OptimizationMode { get; private set; }
         public ParseResult Result { get; private set; }
@@ -249,6 +252,7 @@ namespace ILCompiler
             AddOption(MakeReproPath);
             AddOption(HotColdSplitting);
             AddOption(SynthesizeRandomMibc);
+            AddOption(DeterminismStress);
 
             this.SetHandler(context =>
             {

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -581,6 +581,8 @@ namespace ILCompiler
 
                     NodeFactoryOptimizationFlags nodeFactoryFlags = new NodeFactoryOptimizationFlags();
                     nodeFactoryFlags.OptimizeAsyncMethods = Get(_command.AsyncMethodOptimization);
+                    nodeFactoryFlags.DeterminismStress = Get(_command.DeterminismStress);
+                    nodeFactoryFlags.PrintReproArgs = Get(_command.PrintReproInstructions);
 
                     builder
                         .UseMapFile(Get(_command.Map))
@@ -608,8 +610,7 @@ namespace ILCompiler
                         .UseCompilationRoots(compilationRoots)
                         .UseOptimizationMode(optimizationMode);
 
-                    if (Get(_command.PrintReproInstructions))
-                        builder.UsePrintReproInstructions(CreateReproArgumentString);
+                    builder.UsePrintReproInstructions(CreateReproArgumentString);
 
                     compilation = builder.ToCompilation();
 
@@ -620,6 +621,9 @@ namespace ILCompiler
                     compilation.WriteDependencyLog(dgmlLogFileName);
 
                 compilation.Dispose();
+
+                if (((ReadyToRunCodegenCompilation)compilation).DeterminismCheckFailed)
+                    throw new Exception("Determinism Check Failed");
             }
         }
 

--- a/src/tests/Common/scripts/crossgen2_comparison.py
+++ b/src/tests/Common/scripts/crossgen2_comparison.py
@@ -528,6 +528,8 @@ class CrossGenRunner:
         args.append('-r')
         args.append('"' + platform_assemblies_paths + self.platform_directory_sep + '*.dll"' )
         args.append('-O')
+        args.append('--determinism-stress')
+        args.append('10')
         args.append('--out')
         args.append(ni_filename)
         args.append('--targetos ')

--- a/src/tests/Common/scripts/crossgen2_comparison.py
+++ b/src/tests/Common/scripts/crossgen2_comparison.py
@@ -529,7 +529,7 @@ class CrossGenRunner:
         args.append('"' + platform_assemblies_paths + self.platform_directory_sep + '*.dll"' )
         args.append('-O')
         args.append('--determinism-stress')
-        args.append('10')
+        args.append('3')
         args.append('--out')
         args.append(ni_filename)
         args.append('--targetos ')


### PR DESCRIPTION
Fix determinism issue found in JIT

Fixed by always zero-initializing the GenTreeVcon's gtSimdVal field

The exact issue that I debugged to find was at
https://github.com/dotnet/runtime/blob/d88f9a0ed3ac7387d4c16905ff279f4310c03667/src/coreclr/jit/importercalls.cpp#LL3538C1-L3547C18  In particular the issue is that the code constructs a vector constant, but does not zero out the entire constant.

In addition, build a stress mode to make finding this sort of issue a bit easier, and use it in the rolling outerloop determinism tests