### PR TITLE
JIT: Fix gtGetClassHandle with commas

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -17881,9 +17881,9 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTree* tree, bool* pIsExact, b
 
         case GT_CNS_INT:
         {
-            if (tree->IsIconHandle(GTF_ICON_OBJ_HDL))
+            if (obj->IsIconHandle(GTF_ICON_OBJ_HDL))
             {
-                objClass = info.compCompHnd->getObjectType((CORINFO_OBJECT_HANDLE)tree->AsIntCon()->IconValue());
+                objClass = info.compCompHnd->getObjectType((CORINFO_OBJECT_HANDLE)obj->AsIntCon()->IconValue());
                 if (objClass != NO_CLASS_HANDLE)
                 {
                     // if we managed to get a class handle it's definitely not null
@@ -17898,14 +17898,14 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTree* tree, bool* pIsExact, b
         {
             // If we see a RET_EXPR, recurse through to examine the
             // return value expression.
-            GenTree* retExpr = tree->AsRetExpr()->gtInlineCandidate;
+            GenTree* retExpr = obj->AsRetExpr()->gtInlineCandidate;
             objClass         = gtGetClassHandle(retExpr, pIsExact, pIsNonNull);
             break;
         }
 
         case GT_CALL:
         {
-            GenTreeCall* call = tree->AsCall();
+            GenTreeCall* call = obj->AsCall();
             if (call->gtCallMoreFlags & GTF_CALL_M_SPECIAL_INTRINSIC)
             {
                 NamedIntrinsic ni = lookupNamedIntrinsic(call->gtCallMethHnd);


### PR DESCRIPTION
gtGetClassHandle has a comment about "Tunnel through commas", yet several of the cases then do not actually use the effective value, resulting in possible asserts when this function is passed a comma.

Fixes an issue I saw in #87265 when morph invokes gtFoldTypeCompare for the following IR:

```
fgMorphTree BB19, STMT00013 (before)
               [000045] -ACXG------                         *  JTRUE     void
               [000044] -ACXG------                         \--*  NE        int
               [000623] -ACXG------                            +--*  COMMA     ref
               [000622] DA---------                            |  +--*  STORE_LCL_VAR ref    V29 tmp18
               [000621] -----------                            |  |  \--*  LCL_FLD   ref    V07 loc3         [+0]
               [000041] -ACXG------                            |  \--*  CALL nullcheck ref    Microsoft.Extensions.Configuration.Test.ConfigurationProviderTestBase+TestKeyValue:get_AsArray():System.String[]:this
               [000620] -A--------- this                       |     \--*  COMMA     ref
               [000619] DA---------                            |        +--*  STORE_LCL_VAR ref    V30 tmp19
               [000618] -----------                            |        |  \--*  LCL_FLD   ref    V07 loc3         [+8]
               [000617] -----------                            |        \--*  LCL_VAR   ref    V30 tmp19
               [000043] -----------                            \--*  CNS_INT   ref    null
```