### PR TITLE
Fix ndpinfinal test with JitStress

### DIFF
--- a/src/tests/GC/Scenarios/NDPin/ndpinfinal.cs
+++ b/src/tests/GC/Scenarios/NDPin/ndpinfinal.cs
@@ -73,12 +73,16 @@ namespace DefaultNamespace {
             }
         }
 
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static bool ObjectsAreSame()
+        {
+            return m_o == m_n.p;
+        }
 
         public static bool RunTest(int iObj)
         {
-
             GC.Collect();
-            if (m_o != m_n.p)
+            if (!ObjectsAreSame())
             {
                 return false;
             }
@@ -105,7 +109,6 @@ namespace DefaultNamespace {
                 Console.WriteLine (" objects have been finalized!" );
                 return false;
             }
-
         }
 
         public static int Main( String [] args )
@@ -125,8 +128,6 @@ namespace DefaultNamespace {
                     return 1;
                 }
             }
-            
-
 
             CreateObj(iObj);
             if (RunTest(iObj))


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/86853

From what I see, JitStress extends lifecycle of `m_o != m_n.p` objects in `RunTest` so not all of the test objects executed their finalizers as part of the test.

Alternative fix is to mark the test as optimization sensitive but this change should be enough (tested)