### PR TITLE
[QUIC] Fix rooted connection when hanshake failed

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicExtensions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicExtensions.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net.Quic;
+
+namespace Microsoft.Quic;
+
+internal unsafe partial struct QUIC_NEW_CONNECTION_INFO
+{
+    public override string ToString()
+        => $"{{ {nameof(QuicVersion)} = {QuicVersion}, {nameof(LocalAddress)} = {LocalAddress->ToIPEndPoint()}, {nameof(RemoteAddress)} = {RemoteAddress->ToIPEndPoint()} }}";
+}
+
+internal unsafe partial struct QUIC_LISTENER_EVENT
+{
+    public override string ToString()
+        => Type switch
+        {
+            QUIC_LISTENER_EVENT_TYPE.NEW_CONNECTION
+                => $"{{ {nameof(NEW_CONNECTION.Info)} = {{ {nameof(QUIC_NEW_CONNECTION_INFO.QuicVersion)} = {NEW_CONNECTION.Info->QuicVersion}, {nameof(QUIC_NEW_CONNECTION_INFO.LocalAddress)} = {NEW_CONNECTION.Info->LocalAddress->ToIPEndPoint()}, {nameof(QUIC_NEW_CONNECTION_INFO.RemoteAddress)} = {NEW_CONNECTION.Info->RemoteAddress->ToIPEndPoint()} }} }}",
+            _ => string.Empty
+        };
+}
+
+internal unsafe partial struct QUIC_CONNECTION_EVENT
+{
+    public override string ToString()
+        => Type switch
+        {
+            QUIC_CONNECTION_EVENT_TYPE.CONNECTED
+                => $"{{ {nameof(CONNECTED.SessionResumed)} = {CONNECTED.SessionResumed} }}",
+            QUIC_CONNECTION_EVENT_TYPE.SHUTDOWN_INITIATED_BY_TRANSPORT
+                => $"{{ {nameof(SHUTDOWN_INITIATED_BY_TRANSPORT.Status)} = {SHUTDOWN_INITIATED_BY_TRANSPORT.Status}, {nameof(SHUTDOWN_INITIATED_BY_TRANSPORT.ErrorCode)} = {SHUTDOWN_INITIATED_BY_TRANSPORT.ErrorCode} }}",
+            QUIC_CONNECTION_EVENT_TYPE.SHUTDOWN_INITIATED_BY_PEER
+                => $"{{ {nameof(SHUTDOWN_INITIATED_BY_PEER.ErrorCode)} = {SHUTDOWN_INITIATED_BY_PEER.ErrorCode} }}",
+            QUIC_CONNECTION_EVENT_TYPE.SHUTDOWN_COMPLETE
+                => $"{{ {nameof(SHUTDOWN_COMPLETE.HandshakeCompleted)} = {SHUTDOWN_COMPLETE.HandshakeCompleted}, {nameof(SHUTDOWN_COMPLETE.PeerAcknowledgedShutdown)} = {SHUTDOWN_COMPLETE.PeerAcknowledgedShutdown}, {nameof(SHUTDOWN_COMPLETE.AppCloseInProgress)} = {SHUTDOWN_COMPLETE.AppCloseInProgress} }}",
+            QUIC_CONNECTION_EVENT_TYPE.LOCAL_ADDRESS_CHANGED
+                => $"{{ {nameof(LOCAL_ADDRESS_CHANGED.Address)} = {LOCAL_ADDRESS_CHANGED.Address->ToIPEndPoint()} }}",
+            QUIC_CONNECTION_EVENT_TYPE.PEER_ADDRESS_CHANGED
+                => $"{{ {nameof(PEER_ADDRESS_CHANGED.Address)} = {PEER_ADDRESS_CHANGED.Address->ToIPEndPoint()} }}",
+            QUIC_CONNECTION_EVENT_TYPE.PEER_STREAM_STARTED
+                => $"{{ {nameof(PEER_STREAM_STARTED.Flags)} = {PEER_STREAM_STARTED.Flags} }}",
+            QUIC_CONNECTION_EVENT_TYPE.PEER_CERTIFICATE_RECEIVED
+                => $"{{ {nameof(PEER_CERTIFICATE_RECEIVED.DeferredStatus)} = {PEER_CERTIFICATE_RECEIVED.DeferredStatus}, {nameof(PEER_CERTIFICATE_RECEIVED.DeferredErrorFlags)} = {PEER_CERTIFICATE_RECEIVED.DeferredErrorFlags} }}",
+            _ => string.Empty
+        };
+}
+
+internal unsafe partial struct QUIC_STREAM_EVENT
+{
+    public override string ToString()
+        => Type switch
+        {
+            QUIC_STREAM_EVENT_TYPE.START_COMPLETE
+                => $"{{ {nameof(START_COMPLETE.Status)} = {START_COMPLETE.Status}, {nameof(START_COMPLETE.ID)} = {START_COMPLETE.ID}, {nameof(START_COMPLETE.PeerAccepted)} = {START_COMPLETE.PeerAccepted} }}",
+            QUIC_STREAM_EVENT_TYPE.RECEIVE
+                => $"{{ {nameof(RECEIVE.AbsoluteOffset)} = {RECEIVE.AbsoluteOffset}, {nameof(RECEIVE.TotalBufferLength)} = {RECEIVE.TotalBufferLength}, {nameof(RECEIVE.Flags)} = {RECEIVE.Flags} }}",
+            QUIC_STREAM_EVENT_TYPE.SEND_COMPLETE
+                => $"{{ {nameof(SEND_COMPLETE.Canceled)} = {SEND_COMPLETE.Canceled} }}",
+            QUIC_STREAM_EVENT_TYPE.PEER_SEND_ABORTED
+                => $"{{ {nameof(PEER_SEND_ABORTED.ErrorCode)} = {PEER_SEND_ABORTED.ErrorCode} }}",
+            QUIC_STREAM_EVENT_TYPE.PEER_RECEIVE_ABORTED
+                => $"{{ {nameof(PEER_RECEIVE_ABORTED.ErrorCode)} = {PEER_RECEIVE_ABORTED.ErrorCode} }}",
+            QUIC_STREAM_EVENT_TYPE.SEND_SHUTDOWN_COMPLETE
+                => $"{{ {nameof(SEND_SHUTDOWN_COMPLETE.Graceful)} = {SEND_SHUTDOWN_COMPLETE.Graceful} }}",
+            QUIC_STREAM_EVENT_TYPE.SHUTDOWN_COMPLETE
+                => $"{{ {nameof(SHUTDOWN_COMPLETE.ConnectionShutdown)} = {SHUTDOWN_COMPLETE.ConnectionShutdown}, {nameof(SHUTDOWN_COMPLETE.ConnectionShutdownByApp)} = {SHUTDOWN_COMPLETE.ConnectionShutdownByApp}, {nameof(SHUTDOWN_COMPLETE.ConnectionClosedRemotely)} = {SHUTDOWN_COMPLETE.ConnectionClosedRemotely}, {nameof(SHUTDOWN_COMPLETE.ConnectionErrorCode)} = {SHUTDOWN_COMPLETE.ConnectionErrorCode}, {nameof(SHUTDOWN_COMPLETE.ConnectionCloseStatus)} = {SHUTDOWN_COMPLETE.ConnectionCloseStatus} }}",
+            _ => string.Empty
+        };
+}

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicHelpers.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicHelpers.cs
@@ -42,13 +42,13 @@ internal static class MsQuicHelpers
         return new Internals.SocketAddress(addressFamilyOverride ?? SocketAddressPal.GetAddressFamily(addressBytes), addressBytes).GetIPEndPoint();
     }
 
-    internal static unsafe QuicAddr ToQuicAddr(this IPEndPoint iPEndPoint)
+    internal static unsafe QuicAddr ToQuicAddr(this IPEndPoint ipEndPoint)
     {
         // TODO: is the layout same for SocketAddress.Buffer and QuicAddr on all platforms?
         QuicAddr result = default;
         Span<byte> rawAddress = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref result, 1));
 
-        Internals.SocketAddress address = IPEndPointExtensions.Serialize(iPEndPoint);
+        Internals.SocketAddress address = IPEndPointExtensions.Serialize(ipEndPoint);
         Debug.Assert(address.Size <= rawAddress.Length);
 
         address.Buffer.AsSpan(0, address.Size).CopyTo(rawAddress);

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ResettableValueTaskSource.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ResettableValueTaskSource.cs
@@ -56,6 +56,18 @@ internal sealed class ResettableValueTaskSource : IValueTaskSource
     /// </summary>
     public bool IsCompleted => (State)Volatile.Read(ref Unsafe.As<State, byte>(ref _state)) == State.Completed;
 
+    // TODO: Revisit this with https://github.com/dotnet/runtime/issues/79818 and https://github.com/dotnet/runtime/issues/79911
+    public bool KeepAliveReleased
+    {
+        get
+        {
+            lock (this)
+            {
+                return !_keepAlive.IsAllocated;
+            }
+        }
+    }
+
     /// <summary>
     /// Tries to get a value task representing this task source. If this task source is <see cref="State.None"/>, it'll also transition it into <see cref="State.Awaiting"/> state.
     /// It prevents concurrent operations from being invoked since it'll return <c>false</c> if the task source was already in <see cref="State.Awaiting"/> state.
@@ -153,7 +165,7 @@ internal sealed class ResettableValueTaskSource : IValueTaskSource
                     // Unblock the current task source and in case of a final also the final task source.
                     if (exception is not null)
                     {
-                        // Set up the exception stack strace for the caller.
+                        // Set up the exception stack trace for the caller.
                         exception = exception.StackTrace is null ? ExceptionDispatchInfo.SetCurrentStackTrace(exception) : exception;
                         if (state == State.None ||
                             state == State.Awaiting)

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -235,8 +235,6 @@ public sealed partial class QuicConnection : IAsyncDisposable
 
     private async ValueTask FinishConnectAsync(QuicClientConnectionOptions options, CancellationToken cancellationToken = default)
     {
-        ObjectDisposedException.ThrowIf(_disposed == 1, this);
-
         if (_connectedTcs.TryInitialize(out ValueTask valueTask, this, cancellationToken))
         {
             _canAccept = options.MaxInboundBidirectionalStreams > 0 || options.MaxInboundUnidirectionalStreams > 0;
@@ -332,8 +330,6 @@ public sealed partial class QuicConnection : IAsyncDisposable
 
     internal ValueTask FinishHandshakeAsync(QuicServerConnectionOptions options, string targetHost, CancellationToken cancellationToken = default)
     {
-        ObjectDisposedException.ThrowIf(_disposed == 1, this);
-
         if (_connectedTcs.TryInitialize(out ValueTask valueTask, this, cancellationToken))
         {
             _canAccept = options.MaxInboundBidirectionalStreams > 0 || options.MaxInboundUnidirectionalStreams > 0;

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
@@ -617,6 +618,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
 
         // Wait for SHUTDOWN_COMPLETE, the last event, so that all resources can be safely released.
         await valueTask.ConfigureAwait(false);
+        Debug.Assert(_connectedTcs.IsCompleted);
         _handle.Dispose();
 
         _configuration?.Dispose();

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -496,7 +496,9 @@ public sealed partial class QuicConnection : IAsyncDisposable
     }
     private unsafe int HandleEventShutdownComplete()
     {
-        _acceptQueue.Writer.TryComplete(ExceptionDispatchInfo.SetCurrentStackTrace(ThrowHelper.GetOperationAbortedException()));
+        Exception exception = ExceptionDispatchInfo.SetCurrentStackTrace(ThrowHelper.GetOperationAbortedException());
+        _acceptQueue.Writer.TryComplete(exception);
+        _connectedTcs.TrySetException(exception);
         _shutdownTcs.TrySetResult();
         return QUIC_STATUS_SUCCESS;
     }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
@@ -333,7 +333,7 @@ public sealed partial class QuicListener : IAsyncDisposable
             // Process the event.
             if (NetEventSource.Log.IsEnabled())
             {
-                NetEventSource.Info(instance, $"{instance} Received event {listenerEvent->Type}");
+                NetEventSource.Info(instance, $"{instance} Received event {listenerEvent->Type} {listenerEvent->ToString()}");
             }
             return instance.HandleListenerEvent(ref *listenerEvent);
         }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -234,8 +234,6 @@ public sealed partial class QuicStream
     /// <returns>An asynchronous task that completes with the opened <see cref="QuicStream" />.</returns>
     internal ValueTask StartAsync(CancellationToken cancellationToken = default)
     {
-        ObjectDisposedException.ThrowIf(_disposed == 1, this);
-
         _startedTcs.TryInitialize(out ValueTask valueTask, this, cancellationToken);
         {
             unsafe

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -695,6 +696,10 @@ public sealed partial class QuicStream
 
         // Wait for SHUTDOWN_COMPLETE, the last event, so that all resources can be safely released.
         await valueTask.ConfigureAwait(false);
+        Debug.Assert(_startedTcs.IsCompleted);
+        // TODO: Revisit this with https://github.com/dotnet/runtime/issues/79818 and https://github.com/dotnet/runtime/issues/79911
+        Debug.Assert(_receiveTcs.KeepAliveReleased);
+        Debug.Assert(_sendTcs.KeepAliveReleased);
         _handle.Dispose();
 
         lock (_sendBuffersLock)

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -116,16 +116,18 @@ namespace System.Net.Quic.Tests
 
                 await Task.Delay(100 * i);
 
-                if (wrListener.TryGetTarget(out _) ||
-                    wrClientConnection.TryGetTarget(out _) ||
-                    wrServerConnection.TryGetTarget(out _) ||
-                    wrClientStream.TryGetTarget(out _) ||
-                    wrServerStream.TryGetTarget(out _))
+                if (TestWeakReferences())
                 {
                     continue;
                 }
-
                 break;
+
+                bool TestWeakReferences()
+                    => wrListener.TryGetTarget(out _) ||
+                       wrClientConnection.TryGetTarget(out _) ||
+                       wrServerConnection.TryGetTarget(out _) ||
+                       wrClientStream.TryGetTarget(out _) ||
+                       wrServerStream.TryGetTarget(out _);
             }
 
             Assert.False(wrListener.TryGetTarget(out _));
@@ -138,8 +140,6 @@ namespace System.Net.Quic.Tests
         [Fact]
         public async Task QuicRootedConnectionGetsReleased_ConnectFails()
         {
-            using var x = new TestEventListener(_output, "Private.InternalDiagnostics.System.Net.Quic");
-
             WeakReference<QuicConnection> wrServerConnection = default;
             // Set up all objects, keep their weak reference.
             var listenerOptions = CreateQuicListenerOptions();
@@ -164,10 +164,12 @@ namespace System.Net.Quic.Tests
 
                 await Task.Delay(100 * i);
 
-                if (wrServerConnection.TryGetTarget(out _))
+                if (TestWeakReferences())
                 {
                     continue;
                 }
+                bool TestWeakReferences()
+                    => wrServerConnection.TryGetTarget(out _);
 
                 break;
             }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -58,7 +58,7 @@ namespace System.Net.Quic.Tests
             _certificates = setup;
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoRuntime))]
         public async Task QuicRootedObjectGetReleased()
         {
             async Task<(WeakReference<QuicListener>, WeakReference<QuicConnection>, WeakReference<QuicConnection>, WeakReference<QuicStream>, WeakReference<QuicStream>)> GetWeakReferencesAsync()
@@ -137,7 +137,7 @@ namespace System.Net.Quic.Tests
             Assert.False(wrServerStream.TryGetTarget(out _));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoRuntime))]
         public async Task QuicRootedConnectionGetsReleased_ConnectFails()
         {
             WeakReference<QuicConnection> wrServerConnection = default;

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -19,6 +19,7 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 using Xunit.Abstractions;
+using TestUtilities;
 
 namespace System.Net.Quic.Tests
 {
@@ -55,6 +56,123 @@ namespace System.Net.Quic.Tests
         public MsQuicTests(ITestOutputHelper output, CertificateSetup setup) : base(output)
         {
             _certificates = setup;
+        }
+
+        [Fact]
+        public async Task QuicRootedObjectGetReleased()
+        {
+            async Task<(WeakReference<QuicListener>, WeakReference<QuicConnection>, WeakReference<QuicConnection>, WeakReference<QuicStream>, WeakReference<QuicStream>)> GetWeakReferencesAsync()
+            {
+                // Set up all objects, keep their weak reference.
+                QuicListener listener = await CreateQuicListener();
+                WeakReference<QuicListener> wrListener = new WeakReference<QuicListener>(listener);
+
+                var (clientConnection, serverConnection) = await CreateConnectedQuicConnection(listener);
+                WeakReference<QuicConnection> wrClientConnection = new WeakReference<QuicConnection>(clientConnection);
+                WeakReference<QuicConnection> wrServerConnection = new WeakReference<QuicConnection>(serverConnection);
+
+                QuicStream clientStream = await clientConnection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional);
+                await clientStream.WriteAsync(new byte[5], completeWrites: true);
+
+                QuicStream serverStream = await serverConnection.AcceptInboundStreamAsync();
+                await serverStream.WriteAsync(new byte[10], completeWrites: true);
+
+                WeakReference<QuicStream> wrClientStream = new WeakReference<QuicStream>(clientStream);
+                WeakReference<QuicStream> wrServerStream = new WeakReference<QuicStream>(serverStream);
+
+                while (!clientStream.ReadsClosed.IsCompleted)
+                {
+                    int bytes = await clientStream.ReadAsync(new byte[10]);
+                    if (bytes == 0)
+                    {
+                        break;
+                    }
+                }
+                while (!serverStream.ReadsClosed.IsCompleted)
+                {
+                    int bytes = await serverStream.ReadAsync(new byte[10]);
+                    if (bytes == 0)
+                    {
+                        break;
+                    }
+                }
+
+                // Dispose everything and check if all weak references are dead.
+                await clientStream.DisposeAsync();
+                await serverStream.DisposeAsync();
+                await clientConnection.DisposeAsync();
+                await serverConnection.DisposeAsync();
+                await listener.DisposeAsync();
+
+                return (wrListener, wrClientConnection, wrServerConnection, wrClientStream, wrServerStream);
+            }
+
+            var (wrListener, wrClientConnection, wrServerConnection, wrClientStream, wrServerStream) = await GetWeakReferencesAsync();
+
+            for (int i = 0; i < 20; ++i)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+
+                await Task.Delay(100 * i);
+
+                if (wrListener.TryGetTarget(out _) ||
+                    wrClientConnection.TryGetTarget(out _) ||
+                    wrServerConnection.TryGetTarget(out _) ||
+                    wrClientStream.TryGetTarget(out _) ||
+                    wrServerStream.TryGetTarget(out _))
+                {
+                    continue;
+                }
+
+                break;
+            }
+
+            Assert.False(wrListener.TryGetTarget(out _));
+            Assert.False(wrClientConnection.TryGetTarget(out _));
+            Assert.False(wrServerConnection.TryGetTarget(out _));
+            Assert.False(wrClientStream.TryGetTarget(out _));
+            Assert.False(wrServerStream.TryGetTarget(out _));
+        }
+
+        [Fact]
+        public async Task QuicRootedConnectionGetsReleased_ConnectFails()
+        {
+            using var x = new TestEventListener(_output, "Private.InternalDiagnostics.System.Net.Quic");
+
+            WeakReference<QuicConnection> wrServerConnection = default;
+            // Set up all objects, keep their weak reference.
+            var listenerOptions = CreateQuicListenerOptions();
+            listenerOptions.ConnectionOptionsCallback = (connection, _, _) =>
+            {
+                wrServerConnection = new WeakReference<QuicConnection>(connection);
+                var serverConnectionOptions = CreateQuicServerOptions();
+                serverConnectionOptions.ServerAuthenticationOptions = new SslServerAuthenticationOptions();
+                return ValueTask.FromResult(serverConnectionOptions);
+            };
+            QuicListener listener = await CreateQuicListener(listenerOptions);
+
+            await Assert.ThrowsAsync<AuthenticationException>(async () => await CreateConnectedQuicConnection(listener));
+
+            // Dispose everything and check if all weak references are dead.
+            await listener.DisposeAsync();
+
+            for (int i = 0; i < 20; ++i)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+
+                await Task.Delay(100 * i);
+
+                if (wrServerConnection.TryGetTarget(out _))
+                {
+                    continue;
+                }
+
+                break;
+            }
+
+            Assert.False(wrServerConnection.TryGetTarget(out _));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #87291

Added tests cover the exact same scenario as happened in ASP. Tested before and after the change to confirm the fix. Also tested with ASP test by replacing System.Net.Quic.dll in shared runtime by the tests - it passes after the change.

The fix is in [QuicConnection.cs:501](https://github.com/dotnet/runtime/compare/main...ManickaP:mapichov/quic-rooted-connection?expand=1#diff-a9b6f4bb4f623894b968d15166375e929e14716f6910febcadd9a13e20a15b46R501), which will complete and thus unroot anything stored in `_connectedTcs`. Note that event `SHUTDOWN_COMPLETE` happens for all msquic objects and is awaited by `DisposeAsync` which is called in all failed connection attempts (client and server). 

I also checked the code for other task sources that could cause a similar issue and made sure they do get always completed in `SHUTDOWN_COMPLETE`.

Minor stuff sneaked in:
While at it, fixed and cleaned up logging - the logs contained bogus event names and I had this stashed elsewhere.
Also fixed some small typos and misnamed aliases which I also had stashed elsewhere.

cc: @amcasey 