### PR TITLE
Bump HandleHistogram32::SIZE to 16

### DIFF
--- a/src/coreclr/inc/corjit.h
+++ b/src/coreclr/inc/corjit.h
@@ -340,7 +340,7 @@ public:
     {
         enum
         {
-            SIZE = 8,
+            SIZE = 16,
             SAMPLE_INTERVAL = 32,
             CLASS_FLAG     = 0x80000000,
             INTERFACE_FLAG = 0x40000000,

--- a/src/coreclr/inc/corjit.h
+++ b/src/coreclr/inc/corjit.h
@@ -341,7 +341,7 @@ public:
         enum
         {
             SIZE = 32,
-            SAMPLE_INTERVAL = 32,
+            SAMPLE_INTERVAL = 64,
             CLASS_FLAG     = 0x80000000,
             INTERFACE_FLAG = 0x40000000,
             DELEGATE_FLAG  = 0x20000000,

--- a/src/coreclr/inc/corjit.h
+++ b/src/coreclr/inc/corjit.h
@@ -340,7 +340,7 @@ public:
     {
         enum
         {
-            SIZE = 16,
+            SIZE = 32,
             SAMPLE_INTERVAL = 32,
             CLASS_FLAG     = 0x80000000,
             INTERFACE_FLAG = 0x40000000,


### PR DESCRIPTION
We think that one of the reasons we see a big noise in microbenchmarks after we enabled Dynamic PGO is mispredicted classes for virtual calls. https://github.com/dotnet/runtime/issues/87324 (although, could happend previously with the static pgo as well).

The actual list of affect benchmarks is bigger. Especially it's well visualized in [these benchmarks](https://pvscmdupload.blob.core.windows.net/reports/allTestHistory%2frefs%2fheads%2fmain_x64_Windows%2010.0.18362%2fGuardedDevirtualization.TwoClassVirtual.Call(testInput%3a%20pB%20%3d%200.30).html): 

![image](https://github.com/dotnet/runtime/assets/523221/932a0ce7-ae35-4311-bb55-b161efb0dd1c)

I investigated this benchmark and confirmed that it's caused by "random" GDV decisions while for P=0.3 we should always perform GDV for the class that has P=0.7.

A simple repro:
```csharp

using System.Runtime.CompilerServices;

public class B
{
    public virtual int F() => 33;
}

public class D : B
{
    public override int F() => 44;
}

public class Prog
{

    [MethodImpl(MethodImplOptions.NoInlining)]
    static long Test(B b)
    {
        return b.F() + b.F();
    }

    static void Main()
    {
        for (int i = 0; i < 100; i++)
        {
            Thread.Sleep(16);
            Test((i % 10 >= 3) ? new D() : new B());
        }
        Console.ReadKey();
    }
}
```
_(note: run in Release or change `DOTNET_TC_*` args in Checked - Checked tries to tier up too aggressivly)_

In this case we expect `Test` to devirtualize both calls for `D` class because it happens more frequently, instead we get this:
```
  0) Class D - 7
  1) Class B - 1
Picked:   'D'

  0) Class B - 5
  1) Class D - 3
Picked:   'B'
```
and it **varies** between runs, so we might end up in a situation where two calls on the same object are devirtualized differently. In my case I could do GDV for both calls for `B` and `B`, `B` and `D`, etc... while it should always be `D` and `D` here.

Once I bumped the size to 16 it is now way more stable:
```
  0) Class D - 10
  1) Class B - 6
Picked:   'D'

  0) Class D - 10
  1) Class B - 6
Picked:   'D'
```
We might want to bump it to 32 or higher, but I propose we do it iteratively and watch benchmark's behavior.

PS: Since we now only instrument hot tier0/r2r code we no longer allocate these tables for **every** method so presumably we can afford extra `8*sizof(void*)` bytes per **instrumented** virtual call-site.

cc @AndyAyersMS @jakobbotsch @davidwrighton 