### PR TITLE
Add IHostedLifecycleService

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/ref/Microsoft.Extensions.Hosting.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/ref/Microsoft.Extensions.Hosting.Abstractions.cs
@@ -124,6 +124,13 @@ namespace Microsoft.Extensions.Hosting
         Microsoft.Extensions.Hosting.IHostBuilder UseServiceProviderFactory<TContainerBuilder>(Microsoft.Extensions.DependencyInjection.IServiceProviderFactory<TContainerBuilder> factory) where TContainerBuilder : notnull;
         Microsoft.Extensions.Hosting.IHostBuilder UseServiceProviderFactory<TContainerBuilder>(System.Func<Microsoft.Extensions.Hosting.HostBuilderContext, Microsoft.Extensions.DependencyInjection.IServiceProviderFactory<TContainerBuilder>> factory) where TContainerBuilder : notnull;
     }
+    public partial interface IHostedLifecycleService : Microsoft.Extensions.Hosting.IHostedService
+    {
+        System.Threading.Tasks.Task StartedAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task StartingAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task StoppedAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task StoppingAsync(System.Threading.CancellationToken cancellationToken);
+    }
     public partial interface IHostedService
     {
         System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken);

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostedLifecycleService.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostedLifecycleService.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace Microsoft.Extensions.Hosting
+{
+    /// <summary>
+    /// Defines methods that are run before or after
+    /// <see cref="IHostedService.StartAsync(CancellationToken)"/> and
+    /// <see cref="IHostedService.StopAsync(CancellationToken)"/>.
+    /// </summary>
+    public interface IHostedLifecycleService : IHostedService
+    {
+        /// <summary>
+        /// Triggered before <see cref="IHostedService.StartAsync(CancellationToken)"/>.
+        /// </summary>
+        /// <param name="cancellationToken">Indicates that the start process has been aborted.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        Task StartingAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Triggered after <see cref="IHostedService.StartAsync(CancellationToken)"/>.
+        /// </summary>
+        /// <param name="cancellationToken">Indicates that the start process has been aborted.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        Task StartedAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Triggered before <see cref="IHostedService.StopAsync(CancellationToken)"/>.
+        /// </summary>
+        /// <param name="cancellationToken">Indicates that the start process has been aborted.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        Task StoppingAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Triggered after <see cref="IHostedService.StopAsync(CancellationToken)"/>.
+        /// </summary>
+        /// <param name="cancellationToken">Indicates that the stop process has been aborted.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        Task StoppedAsync(CancellationToken cancellationToken);
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Hosting/ref/Microsoft.Extensions.Hosting.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/ref/Microsoft.Extensions.Hosting.cs
@@ -110,6 +110,7 @@ namespace Microsoft.Extensions.Hosting
         public bool ServicesStartConcurrently { get { throw null; } set { } }
         public bool ServicesStopConcurrently { get { throw null; } set { } }
         public System.TimeSpan ShutdownTimeout { get { throw null; } set { } }
+        public System.TimeSpan StartupTimeout { get { throw null; } set { } }
     }
 }
 namespace Microsoft.Extensions.Hosting.Internal

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostOptions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.Threading;
 using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Extensions.Hosting
@@ -13,9 +14,24 @@ namespace Microsoft.Extensions.Hosting
     public class HostOptions
     {
         /// <summary>
-        /// The default timeout for <see cref="IHost.StopAsync(System.Threading.CancellationToken)"/>.
+        /// The default timeout for <see cref="IHost.StopAsync(CancellationToken)"/>.
         /// </summary>
+        /// <remarks>
+        /// This timeout also encompasses all host services implementing
+        /// <see cref="IHostedLifecycleService.StoppingAsync(CancellationToken)"/> and
+        /// <see cref="IHostedLifecycleService.StoppedAsync(CancellationToken)"/>.
+        /// </remarks>
         public TimeSpan ShutdownTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// The default timeout for <see cref="IHost.StartAsync(CancellationToken)"/>.
+        /// </summary>
+        /// <remarks>
+        /// This timeout also encompasses all host services implementing
+        /// <see cref="IHostedLifecycleService.StartingAsync(CancellationToken)"/> and
+        /// <see cref="IHostedLifecycleService.StartedAsync(CancellationToken)"/>.
+        /// </remarks>
+        public TimeSpan StartupTimeout { get; set; } = Timeout.InfiniteTimeSpan;
 
         /// <summary>
         /// Determines if the <see cref="IHost"/> will start registered instances of <see cref="IHostedService"/> concurrently or sequentially. Defaults to false.
@@ -44,6 +60,13 @@ namespace Microsoft.Extensions.Hosting
                 && int.TryParse(timeoutSeconds, NumberStyles.None, CultureInfo.InvariantCulture, out var seconds))
             {
                 ShutdownTimeout = TimeSpan.FromSeconds(seconds);
+            }
+
+            timeoutSeconds = configuration["startupTimeoutSeconds"];
+            if (!string.IsNullOrEmpty(timeoutSeconds)
+                && int.TryParse(timeoutSeconds, NumberStyles.None, CultureInfo.InvariantCulture, out seconds))
+            {
+                StartupTimeout = TimeSpan.FromSeconds(seconds);
             }
 
             var servicesStartConcurrently = configuration["servicesStartConcurrently"];

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
@@ -97,7 +97,8 @@ namespace Microsoft.Extensions.Hosting.Internal
                 if (_hostedLifecycleServices is not null)
                 {
                     // Call StartingAsync().
-                    await ForeachService(_hostedLifecycleServices, token, concurrent, abortOnFirstException, exceptions, (service, token) => service.StartingAsync(token)).ConfigureAwait(false);
+                    await ForeachService(_hostedLifecycleServices, token, concurrent, abortOnFirstException, exceptions,
+                        (service, token) => service.StartingAsync(token)).ConfigureAwait(false);
                 }
 
                 // Call StartAsync().
@@ -115,7 +116,8 @@ namespace Microsoft.Extensions.Hosting.Internal
                 if (_hostedLifecycleServices is not null)
                 {
                     // Call StartedAsync().
-                    await ForeachService(_hostedLifecycleServices, token, concurrent, abortOnFirstException, exceptions, (service, token) => service.StartedAsync(token)).ConfigureAwait(false);
+                    await ForeachService(_hostedLifecycleServices, token, concurrent, abortOnFirstException, exceptions,
+                        (service, token) => service.StartedAsync(token)).ConfigureAwait(false);
                 }
 
                 if (exceptions.Count > 0)
@@ -225,7 +227,8 @@ namespace Microsoft.Extensions.Hosting.Internal
                     // Call StoppingAsync().
                     if (reversedLifetimeServices is not null)
                     {
-                        await ForeachService(reversedLifetimeServices, token, concurrent, abortOnFirstException: false, exceptions, (service, token) => service.StoppingAsync(token)).ConfigureAwait(false);
+                        await ForeachService(reversedLifetimeServices, token, concurrent, abortOnFirstException: false, exceptions,
+                            (service, token) => service.StoppingAsync(token)).ConfigureAwait(false);
                     }
 
                     // Call IHostApplicationLifetime.ApplicationStopping.
@@ -233,12 +236,14 @@ namespace Microsoft.Extensions.Hosting.Internal
                     _applicationLifetime.StopApplication();
 
                     // Call StopAsync().
-                    await ForeachService(reversedServices, token, concurrent, abortOnFirstException: false, exceptions, (service, token) => service.StopAsync(token)).ConfigureAwait(false);
+                    await ForeachService(reversedServices, token, concurrent, abortOnFirstException: false, exceptions, (service, token) =>
+                        service.StopAsync(token)).ConfigureAwait(false);
 
                     if (reversedLifetimeServices is not null)
                     {
                         // Call StoppedAsync().
-                        await ForeachService(reversedLifetimeServices, token, concurrent, abortOnFirstException: false, exceptions, (service, token) => service.StoppedAsync(token)).ConfigureAwait(false);
+                        await ForeachService(reversedLifetimeServices, token, concurrent, abortOnFirstException: false, exceptions, (service, token) =>
+                            service.StoppedAsync(token)).ConfigureAwait(false);
                     }
                 }
 
@@ -309,13 +314,13 @@ namespace Microsoft.Extensions.Hosting.Internal
                     {
                         if (task.Exception is not null)
                         {
-                            exceptions.Add(task.Exception); // Log exception from async method.
+                            exceptions.AddRange(task.Exception.InnerExceptions); // Log exception from async method.
                         }
                     }
                     else
                     {
                         tasks ??= new();
-                        tasks.Add(Task.Run(async () => await task.ConfigureAwait(false), token));
+                        tasks.Add(Task.Run(() => task, token));
                     }
                 }
 

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/DisposeTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/DisposeTests.cs
@@ -1,0 +1,99 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Extensions.Hosting.Tests
+{
+    public partial class DisposeTests
+    {
+        public static IHostBuilder CreateHostBuilder(Action<IServiceCollection> configure)
+        {
+            return new HostBuilder().ConfigureServices(configure);
+        }
+
+        [Fact]
+        public void DisposeCalled_Interface()
+        {
+            var hostBuilder = CreateHostBuilder(services =>
+            {
+                services.AddSingleton<IMyService>((sp) => new MyService());
+            });
+
+            IMyService obj;
+            using (var host = hostBuilder.Build())
+            {
+                obj = host.Services.GetService<IMyService>();
+            }
+
+            Assert.True(obj.IsDisposed);
+        }
+
+        [Fact]
+        public void DisposeCalled_Class()
+        {
+            var hostBuilder = CreateHostBuilder(services =>
+            {
+                services.AddSingleton<MyService>();
+            });
+
+            MyService obj;
+            using (var host = hostBuilder.Build())
+            {
+                obj = host.Services.GetService<MyService>();
+            }
+
+            Assert.True(obj.IsDisposed);
+        }
+
+        [Fact]
+        public void DisposeNotCalled()
+        {
+            var hostBuilder = CreateHostBuilder(services =>
+            {
+                services.AddSingleton(new MyService());
+            });
+
+            MyService obj;
+            using (var host = hostBuilder.Build())
+            {
+                obj = host.Services.GetService<MyService>();
+            }
+
+            Assert.False(obj.IsDisposed);
+        }
+
+        public interface IMyService : IDisposable
+        {
+            bool IsDisposed { get; }
+        }
+
+        public class MyService : IMyService
+        {
+            private bool _isDisposed;
+
+            public MyService()
+            {
+            }
+
+            public bool IsDisposed => _isDisposed;
+
+            protected virtual void Dispose(bool disposing)
+            {
+                if (!_isDisposed)
+                {
+                    _isDisposed = true;
+                }
+            }
+
+            public void Dispose()
+            {
+                Dispose(disposing: true);
+                GC.SuppressFinalize(this);
+            }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                 })
                 .Build())
             {
-                if (concurrentStartup)
+                if (concurrentStartup && eventCount > 1)
                 {
                     await Assert.ThrowsAsync<AggregateException>(() => host.StartAsync());
                 }
@@ -1159,7 +1159,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                 var started = RegisterCallbacksThatThrow(applicationLifetime.ApplicationStarted);
                 var stopping = RegisterCallbacksThatThrow(applicationLifetime.ApplicationStopping);
 
-                if (concurrentStartup)
+                if (concurrentStartup && eventCount > 1)
                 {
                     await Assert.ThrowsAsync<AggregateException>(() => host.StartAsync());
                 }

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                 })
                 .Build())
             {
-                if (concurrentStartup && eventCount > 1)
+                if (concurrentStartup)
                 {
                     await Assert.ThrowsAsync<AggregateException>(() => host.StartAsync());
                 }
@@ -1159,7 +1159,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                 var started = RegisterCallbacksThatThrow(applicationLifetime.ApplicationStarted);
                 var stopping = RegisterCallbacksThatThrow(applicationLifetime.ApplicationStopping);
 
-                if (concurrentStartup && eventCount > 1)
+                if (concurrentStartup)
                 {
                     await Assert.ThrowsAsync<AggregateException>(() => host.StartAsync());
                 }

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/LifecycleTests.Start.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/LifecycleTests.Start.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Extensions.Hosting.Tests
             {
                 services
                     .AddHostedService<StartingTestClass<Impl1>>()
-                    .AddHostedService<StartingTestClass<Impl2>>();
+                    .AddHostedService<StartingTestClass<Impl2>>()
+                    .Configure<HostOptions>(opts => opts.ServicesStartConcurrently = true);
             });
 
             using (IHost host = hostBuilder.Build())
@@ -235,7 +236,8 @@ namespace Microsoft.Extensions.Hosting.Tests
             {
                 services
                     .AddHostedService<StartedTestClass<Impl1>>()
-                    .AddHostedService<StartedTestClass<Impl2>>();
+                    .AddHostedService<StartedTestClass<Impl2>>()
+                    .Configure<HostOptions>(opts => opts.ServicesStartConcurrently = true);
             });
 
             using (IHost host = hostBuilder.Build())
@@ -313,7 +315,7 @@ namespace Microsoft.Extensions.Hosting.Tests
         [InlineData(false)]
         public async Task StartPhasesException(bool throwAfterAsyncCall)
         {
-            ExceptionImpl impl = new(throwAfterAsyncCall: throwAfterAsyncCall, true, true, true, false, false, false);
+            ExceptionImpl impl = new(throwAfterAsyncCall: throwAfterAsyncCall, throwOnStartup: true, throwOnShutdown: false);
             var hostBuilder = CreateHostBuilder(services =>
             {
                 services.AddHostedService((token) => impl);

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/LifecycleTests.Start.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/LifecycleTests.Start.cs
@@ -117,7 +117,6 @@ namespace Microsoft.Extensions.Hosting.Tests
                 // Both run serially until the await.
                 Task start = host.StartAsync();
                 Verify(1, 1, 0, 0, 0, 0);
-                await Task.Delay(s_superShortDelay);
                 Verify(1, 1, 0, 0, 0, 0);
 
                 // Resume and check that both are not finished.
@@ -328,10 +327,6 @@ namespace Microsoft.Extensions.Hosting.Tests
                 Assert.True(impl.StartingCalled);
                 Assert.True(impl.StartCalled);
                 Assert.True(impl.StartedCalled);
-
-                Assert.Contains("(ThrowOnStarting)", ex.Message);
-                Assert.Contains("(ThrowOnStart)", ex.Message);
-                Assert.Contains("(ThrowOnStarted)", ex.Message);
 
                 Assert.Equal(3, ex.InnerExceptions.Count);
                 Assert.Contains("(ThrowOnStarting)", ex.InnerExceptions[0].Message);

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/LifecycleTests.Start.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/LifecycleTests.Start.cs
@@ -1,0 +1,341 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Extensions.Hosting.Tests
+{
+    public partial class LifecycleTests
+    {
+        [Fact]
+        public async Task StartingConcurrently()
+        {
+            var hostBuilder = CreateHostBuilder(services =>
+            {
+                services
+                    .AddHostedService<StartingTestClass<Impl1>>()
+                    .AddHostedService<StartingTestClass<Impl2>>();
+            });
+
+            using (IHost host = hostBuilder.Build())
+            {
+                StartingTestClass<Impl1>.s_wait1.Wait();
+                StartingTestClass<Impl2>.s_wait1.Wait();
+                StartingTestClass<Impl1>.s_wait2.Wait();
+                StartingTestClass<Impl2>.s_wait2.Wait();
+                StartingTestClass<Impl1>.s_wait3.Wait();
+                StartingTestClass<Impl2>.s_wait3.Wait();
+
+                Verify(0, 0, 0, 0, 0, 0);
+
+                // Both run serially until the await.
+                Task start = host.StartAsync();
+                Verify(1, 1, 0, 0, 0, 0);
+                await Task.Delay(s_superShortDelay);
+                Verify(1, 1, 0, 0, 0, 0);
+
+                // Resume and check that both are not finished.
+                StartingTestClass<Impl1>.s_wait1.Release();
+                await StartingTestClass<Impl1>.s_wait2.WaitAsync();
+                Verify(1, 1, 1, 0, 0, 0);
+
+                StartingTestClass<Impl2>.s_wait1.Release();
+                await StartingTestClass<Impl2>.s_wait2.WaitAsync();
+                Verify(1, 1, 1, 1, 0, 0);
+
+                // Resume and verify they finish.
+                StartingTestClass<Impl1>.s_wait3.Release();
+                StartingTestClass<Impl2>.s_wait3.Release();
+                await start;
+                Verify(1, 1, 1, 1, 1, 1);
+                Assert.True(start.IsCompleted);
+            }
+
+            void Verify(int initial1, int initial2, int pause1, int pause2, int final1, int final2)
+            {
+                Assert.Equal(initial1, StartingTestClass<Impl1>.s_initialCount);
+                Assert.Equal(initial2, StartingTestClass<Impl2>.s_initialCount);
+                Assert.Equal(pause1, StartingTestClass<Impl1>.s_pauseCount);
+                Assert.Equal(pause2, StartingTestClass<Impl2>.s_pauseCount);
+                Assert.Equal(final1, StartingTestClass<Impl1>.s_finalCount);
+                Assert.Equal(final2, StartingTestClass<Impl2>.s_finalCount);
+            }
+        }
+
+        private class StartingTestClass<T> : IHostedLifecycleService
+        {
+            public static int s_initialCount = 0;
+            public static int s_pauseCount = 0;
+            public static int s_finalCount = 0;
+            public static SemaphoreSlim? s_wait1 = new SemaphoreSlim(1);
+            public static SemaphoreSlim? s_wait2 = new SemaphoreSlim(1);
+            public static SemaphoreSlim? s_wait3 = new SemaphoreSlim(1);
+
+            public async Task StartingAsync(CancellationToken cancellationToken)
+            {
+                s_initialCount++;
+                await s_wait1.WaitAsync();
+                s_pauseCount++;
+                s_wait2.Release();
+                await s_wait3.WaitAsync();
+                s_finalCount++;
+            }
+            public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StartedAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StoppingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StoppedAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        }
+
+        [Fact]
+        public async Task StartConcurrently()
+        {
+            var hostBuilder = CreateHostBuilder(services =>
+            {
+                services.
+                    AddHostedService<StartTestClass<Impl1>>().
+                    AddHostedService<StartTestClass<Impl2>>().
+                    Configure<HostOptions>(opts => opts.ServicesStartConcurrently = true);
+            });
+
+            using (IHost host = hostBuilder.Build())
+            {
+                StartTestClass<Impl1>.s_wait1.Wait();
+                StartTestClass<Impl2>.s_wait1.Wait();
+                StartTestClass<Impl1>.s_wait2.Wait();
+                StartTestClass<Impl2>.s_wait2.Wait();
+                StartTestClass<Impl1>.s_wait3.Wait();
+                StartTestClass<Impl2>.s_wait3.Wait();
+
+                Verify(0, 0, 0, 0, 0, 0);
+
+                // Both run serially until the await.
+                Task start = host.StartAsync();
+                Verify(1, 1, 0, 0, 0, 0);
+                await Task.Delay(s_superShortDelay);
+                Verify(1, 1, 0, 0, 0, 0);
+
+                // Resume and check that both are not finished.
+                StartTestClass<Impl1>.s_wait1.Release();
+                await StartTestClass<Impl1>.s_wait2.WaitAsync();
+                Verify(1, 1, 1, 0, 0, 0);
+
+                StartTestClass<Impl2>.s_wait1.Release();
+                await StartTestClass<Impl2>.s_wait2.WaitAsync();
+                Verify(1, 1, 1, 1, 0, 0);
+
+                // Resume and verify they finish.
+                StartTestClass<Impl1>.s_wait3.Release();
+                StartTestClass<Impl2>.s_wait3.Release();
+                await start;
+                Verify(1, 1, 1, 1, 1, 1);
+                Assert.True(start.IsCompleted);
+            }
+
+            void Verify(int initial1, int initial2, int pause1, int pause2, int final1, int final2)
+            {
+                Assert.Equal(initial1, StartTestClass<Impl1>.s_initialCount);
+                Assert.Equal(initial2, StartTestClass<Impl2>.s_initialCount);
+                Assert.Equal(pause1, StartTestClass<Impl1>.s_pauseCount);
+                Assert.Equal(pause2, StartTestClass<Impl2>.s_pauseCount);
+                Assert.Equal(final1, StartTestClass<Impl1>.s_finalCount);
+                Assert.Equal(final2, StartTestClass<Impl2>.s_finalCount);
+            }
+        }
+
+        private class StartTestClass<T> : IHostedLifecycleService
+        {
+            public static int s_initialCount = 0;
+            public static int s_pauseCount = 0;
+            public static int s_finalCount = 0;
+            public static SemaphoreSlim? s_wait1 = new SemaphoreSlim(1);
+            public static SemaphoreSlim? s_wait2 = new SemaphoreSlim(1);
+            public static SemaphoreSlim? s_wait3 = new SemaphoreSlim(1);
+
+            public Task StartingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public async Task StartAsync(CancellationToken cancellationToken)
+            {
+                s_initialCount++;
+                await s_wait1.WaitAsync();
+                s_pauseCount++;
+                s_wait2.Release();
+                await s_wait3.WaitAsync();
+                s_finalCount++;
+            }
+            public Task StartedAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StoppingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StoppedAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        }
+
+        [Fact]
+        public async Task StartNonconcurrently()
+        {
+            var hostBuilder = CreateHostBuilder(services =>
+            {
+                services.
+                    AddHostedService<StartNonconcurrentTestClass<Impl1>>().
+                    AddHostedService<StartNonconcurrentTestClass<Impl2>>().
+                    Configure<HostOptions>(opts => opts.ServicesStartConcurrently = false);
+            });
+
+            using (IHost host = hostBuilder.Build())
+            {
+                StartNonconcurrentTestClass<Impl1>.s_wait.Wait();
+                StartNonconcurrentTestClass<Impl2>.s_wait.Wait();
+
+                Verify(0, 0);
+
+                // Both run serially.
+                Task start = host.StartAsync();
+                Verify(1, 0);
+                await Task.Delay(s_superShortDelay);
+                Verify(1, 0);
+
+                // Resume and verify they finish.
+                StartNonconcurrentTestClass<Impl1>.s_wait.Release();
+                StartNonconcurrentTestClass<Impl2>.s_wait.Release();
+                await start;
+                Verify(1, 1);
+                Assert.True(start.IsCompleted);
+            }
+
+            void Verify(int count1, int count2)
+            {
+                Assert.Equal(count1, StartNonconcurrentTestClass<Impl1>.s_count);
+                Assert.Equal(count2, StartNonconcurrentTestClass<Impl2>.s_count);
+            }
+        }
+
+        private class StartNonconcurrentTestClass<T> : IHostedLifecycleService
+        {
+            public static int s_count = 0;
+            public static SemaphoreSlim? s_wait = new SemaphoreSlim(1);
+
+            public Task StartingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public async Task StartAsync(CancellationToken cancellationToken)
+            {
+                s_count++;
+                await s_wait.WaitAsync();
+            }
+            public Task StartedAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StoppingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StoppedAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        }
+
+        [Fact]
+        public async Task StartedConcurrently()
+        {
+            var hostBuilder = CreateHostBuilder(services =>
+            {
+                services
+                    .AddHostedService<StartedTestClass<Impl1>>()
+                    .AddHostedService<StartedTestClass<Impl2>>();
+            });
+
+            using (IHost host = hostBuilder.Build())
+            {
+                StartedTestClass<Impl1>.s_wait1.Wait();
+                StartedTestClass<Impl2>.s_wait1.Wait();
+                StartedTestClass<Impl1>.s_wait2.Wait();
+                StartedTestClass<Impl2>.s_wait2.Wait();
+                StartedTestClass<Impl1>.s_wait3.Wait();
+                StartedTestClass<Impl2>.s_wait3.Wait();
+
+                Verify(0, 0, 0, 0, 0, 0);
+
+                // Both run serially until the await.
+                Task start = host.StartAsync();
+                Verify(1, 1, 0, 0, 0, 0);
+                await Task.Delay(s_superShortDelay);
+                Verify(1, 1, 0, 0, 0, 0);
+
+                // Resume and check that both are not finished.
+                StartedTestClass<Impl1>.s_wait1.Release();
+                await StartedTestClass<Impl1>.s_wait2.WaitAsync();
+                Verify(1, 1, 1, 0, 0, 0);
+
+                StartedTestClass<Impl2>.s_wait1.Release();
+                await StartedTestClass<Impl2>.s_wait2.WaitAsync();
+                Verify(1, 1, 1, 1, 0, 0);
+
+                // Resume and verify they finish.
+                StartedTestClass<Impl1>.s_wait3.Release();
+                StartedTestClass<Impl2>.s_wait3.Release();
+                await start;
+                Verify(1, 1, 1, 1, 1, 1);
+                Assert.True(start.IsCompleted);
+            }
+
+            void Verify(int initial1, int initial2, int pause1, int pause2, int final1, int final2)
+            {
+                Assert.Equal(initial1, StartedTestClass<Impl1>.s_initialCount);
+                Assert.Equal(initial2, StartedTestClass<Impl2>.s_initialCount);
+                Assert.Equal(pause1, StartedTestClass<Impl1>.s_pauseCount);
+                Assert.Equal(pause2, StartedTestClass<Impl2>.s_pauseCount);
+                Assert.Equal(final1, StartedTestClass<Impl1>.s_finalCount);
+                Assert.Equal(final2, StartedTestClass<Impl2>.s_finalCount);
+            }
+        }
+
+        private class StartedTestClass<T> : IHostedLifecycleService
+        {
+            public static int s_initialCount = 0;
+            public static int s_pauseCount = 0;
+            public static int s_finalCount = 0;
+            public static SemaphoreSlim? s_wait1 = new SemaphoreSlim(1);
+            public static SemaphoreSlim? s_wait2 = new SemaphoreSlim(1);
+            public static SemaphoreSlim? s_wait3 = new SemaphoreSlim(1);
+
+            public Task StartingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public async Task StartedAsync(CancellationToken cancellationToken)
+            {
+                s_initialCount++;
+                await s_wait1.WaitAsync();
+                s_pauseCount++;
+                s_wait2.Release();
+                await s_wait3.WaitAsync();
+                s_finalCount++;
+            }
+            public Task StoppingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StoppedAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task StartPhasesException(bool throwAfterAsyncCall)
+        {
+            ExceptionImpl impl = new(throwAfterAsyncCall: throwAfterAsyncCall, true, true, true, false, false, false);
+            var hostBuilder = CreateHostBuilder(services =>
+            {
+                services.AddHostedService((token) => impl);
+            });
+
+            using (IHost host = hostBuilder.Build())
+            {
+                AggregateException ex = await Assert.ThrowsAnyAsync<AggregateException>(async () => await host.StartAsync());
+
+                Assert.True(impl.StartingCalled);
+                Assert.True(impl.StartCalled);
+                Assert.True(impl.StartedCalled);
+
+                Assert.Contains("(ThrowOnStarting)", ex.Message);
+                Assert.Contains("(ThrowOnStart)", ex.Message);
+                Assert.Contains("(ThrowOnStarted)", ex.Message);
+
+                Assert.Equal(3, ex.InnerExceptions.Count);
+                Assert.Contains("(ThrowOnStarting)", ex.InnerExceptions[0].Message);
+                Assert.Contains("(ThrowOnStart)", ex.InnerExceptions[1].Message);
+                Assert.Contains("(ThrowOnStarted)", ex.InnerExceptions[2].Message);
+            }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/LifecycleTests.Stop.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/LifecycleTests.Stop.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Extensions.Hosting.Tests
             {
                 services
                     .AddHostedService<StoppingTestClass<Impl1>>()
-                    .AddHostedService<StoppingTestClass<Impl2>>();
+                    .AddHostedService<StoppingTestClass<Impl2>>()
+                    .Configure<HostOptions>(opts => opts.ServicesStopConcurrently = true);
             });
 
             using (IHost host = hostBuilder.Build())
@@ -239,7 +240,8 @@ namespace Microsoft.Extensions.Hosting.Tests
             {
                 services
                     .AddHostedService<StoppedTestClass<Impl1>>()
-                    .AddHostedService<StoppedTestClass<Impl2>>();
+                    .AddHostedService<StoppedTestClass<Impl2>>()
+                    .Configure<HostOptions>(opts => opts.ServicesStopConcurrently = true);
             });
 
             using (IHost host = hostBuilder.Build())
@@ -318,7 +320,7 @@ namespace Microsoft.Extensions.Hosting.Tests
         [InlineData(false)]
         public async Task StopPhasesException(bool throwAfterAsyncCall)
         {
-            ExceptionImpl impl = new(throwAfterAsyncCall: throwAfterAsyncCall, false, false, false, true, true, true);
+            ExceptionImpl impl = new(throwAfterAsyncCall: throwAfterAsyncCall, throwOnStartup: false, throwOnShutdown: true);
             var hostBuilder = CreateHostBuilder(services =>
             {
                 services.AddHostedService((token) => impl);

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/LifecycleTests.Stop.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/LifecycleTests.Stop.cs
@@ -1,0 +1,352 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Extensions.Hosting.Tests
+{
+    public partial class LifecycleTests
+    {
+        [Fact]
+        public async Task StoppingConcurrently()
+        {
+            var hostBuilder = CreateHostBuilder(services =>
+            {
+                services
+                    .AddHostedService<StoppingTestClass<Impl1>>()
+                    .AddHostedService<StoppingTestClass<Impl2>>();
+            });
+
+            using (IHost host = hostBuilder.Build())
+            {
+                StoppingTestClass<Impl1>.s_wait1.Wait();
+                StoppingTestClass<Impl2>.s_wait1.Wait();
+                StoppingTestClass<Impl1>.s_wait2.Wait();
+                StoppingTestClass<Impl2>.s_wait2.Wait();
+                StoppingTestClass<Impl1>.s_wait3.Wait();
+                StoppingTestClass<Impl2>.s_wait3.Wait();
+
+                await host.StartAsync();
+                Verify(0, 0, 0, 0, 0, 0);
+
+                // Both run serially until the await.
+                Task stop = host.StopAsync();
+                Verify(1, 1, 0, 0, 0, 0);
+                await Task.Delay(s_superShortDelay);
+                Verify(1, 1, 0, 0, 0, 0);
+
+                // Resume and check that both are not finished.
+                StoppingTestClass<Impl1>.s_wait1.Release();
+                await StoppingTestClass<Impl1>.s_wait2.WaitAsync();
+                Verify(1, 1, 1, 0, 0, 0);
+
+                StoppingTestClass<Impl2>.s_wait1.Release();
+                await StoppingTestClass<Impl2>.s_wait2.WaitAsync();
+                Verify(1, 1, 1, 1, 0, 0);
+
+                // Resume and verify they finish.
+                StoppingTestClass<Impl1>.s_wait3.Release();
+                StoppingTestClass<Impl2>.s_wait3.Release();
+                await stop;
+                Verify(1, 1, 1, 1, 1, 1);
+                Assert.True(stop.IsCompleted);
+            }
+
+            void Verify(int initial1, int initial2, int pause1, int pause2, int final1, int final2)
+            {
+                Assert.Equal(initial1, StoppingTestClass<Impl1>.s_initialCount);
+                Assert.Equal(initial2, StoppingTestClass<Impl2>.s_initialCount);
+                Assert.Equal(pause1, StoppingTestClass<Impl1>.s_pauseCount);
+                Assert.Equal(pause2, StoppingTestClass<Impl2>.s_pauseCount);
+                Assert.Equal(final1, StoppingTestClass<Impl1>.s_finalCount);
+                Assert.Equal(final2, StoppingTestClass<Impl2>.s_finalCount);
+            }
+        }
+
+        private class StoppingTestClass<T> : IHostedLifecycleService
+        {
+            public static int s_initialCount = 0;
+            public static int s_pauseCount = 0;
+            public static int s_finalCount = 0;
+            public static SemaphoreSlim? s_wait1 = new SemaphoreSlim(1);
+            public static SemaphoreSlim? s_wait2 = new SemaphoreSlim(1);
+            public static SemaphoreSlim? s_wait3 = new SemaphoreSlim(1);
+
+            public Task StartingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StartedAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public async Task StoppingAsync(CancellationToken cancellationToken)
+            {
+                s_initialCount++;
+                await s_wait1.WaitAsync();
+                s_pauseCount++;
+                s_wait2.Release();
+                await s_wait3.WaitAsync();
+                s_finalCount++;
+            }
+            public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StoppedAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        }
+
+        [Fact]
+        public async Task StopConcurrently()
+        {
+            var hostBuilder = CreateHostBuilder(services =>
+            {
+                services.
+                    AddHostedService<StopTestClass<Impl1>>().
+                    AddHostedService<StopTestClass<Impl2>>().
+                    Configure<HostOptions>(opts => opts.ServicesStopConcurrently = true);
+            });
+
+            using (IHost host = hostBuilder.Build())
+            {
+                StopTestClass<Impl1>.s_wait1.Wait();
+                StopTestClass<Impl2>.s_wait1.Wait();
+                StopTestClass<Impl1>.s_wait2.Wait();
+                StopTestClass<Impl2>.s_wait2.Wait();
+                StopTestClass<Impl1>.s_wait3.Wait();
+                StopTestClass<Impl2>.s_wait3.Wait();
+
+                await host.StartAsync();
+                Verify(0, 0, 0, 0, 0, 0);
+
+                // Both run serially until the await.
+                Task stop = host.StopAsync();
+                Verify(1, 1, 0, 0, 0, 0);
+                await Task.Delay(s_superShortDelay);
+                Verify(1, 1, 0, 0, 0, 0);
+
+                // Resume and check that both are not finished.
+                StopTestClass<Impl1>.s_wait1.Release();
+                await StopTestClass<Impl1>.s_wait2.WaitAsync();
+                Verify(1, 1, 1, 0, 0, 0);
+
+                StopTestClass<Impl2>.s_wait1.Release();
+                await StopTestClass<Impl2>.s_wait2.WaitAsync();
+                Verify(1, 1, 1, 1, 0, 0);
+
+                // Resume and verify they finish.
+                StopTestClass<Impl1>.s_wait3.Release();
+                StopTestClass<Impl2>.s_wait3.Release();
+                await stop;
+                Verify(1, 1, 1, 1, 1, 1);
+                Assert.True(stop.IsCompleted);
+            }
+
+            void Verify(int initial1, int initial2, int pause1, int pause2, int final1, int final2)
+            {
+                Assert.Equal(initial1, StopTestClass<Impl1>.s_initialCount);
+                Assert.Equal(initial2, StopTestClass<Impl2>.s_initialCount);
+                Assert.Equal(pause1, StopTestClass<Impl1>.s_pauseCount);
+                Assert.Equal(pause2, StopTestClass<Impl2>.s_pauseCount);
+                Assert.Equal(final1, StopTestClass<Impl1>.s_finalCount);
+                Assert.Equal(final2, StopTestClass<Impl2>.s_finalCount);
+            }
+        }
+
+        private class StopTestClass<T> : IHostedLifecycleService
+        {
+            public static int s_initialCount = 0;
+            public static int s_pauseCount = 0;
+            public static int s_finalCount = 0;
+            public static SemaphoreSlim? s_wait1 = new SemaphoreSlim(1);
+            public static SemaphoreSlim? s_wait2 = new SemaphoreSlim(1);
+            public static SemaphoreSlim? s_wait3 = new SemaphoreSlim(1);
+
+            public Task StartingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StartedAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+            public Task StoppingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public async Task StopAsync(CancellationToken cancellationToken)
+            {
+                s_initialCount++;
+                await s_wait1.WaitAsync();
+                s_pauseCount++;
+                s_wait2.Release();
+                await s_wait3.WaitAsync();
+                s_finalCount++;
+            }
+            public Task StoppedAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        }
+
+        [Fact]
+        public async Task StopNonconcurrently()
+        {
+            var hostBuilder = CreateHostBuilder(services =>
+            {
+                services.
+                    AddHostedService<StopNonconcurrentTestClass<Impl1>>().
+                    AddHostedService<StopNonconcurrentTestClass<Impl2>>().
+                    Configure<HostOptions>(opts => opts.ServicesStopConcurrently = false);
+            });
+
+            using (IHost host = hostBuilder.Build())
+            {
+                StopNonconcurrentTestClass<Impl1>.s_wait.Wait();
+                StopNonconcurrentTestClass<Impl2>.s_wait.Wait();
+
+                await host.StartAsync();
+                Verify(0, 0);
+
+                // Both run serially in reverse order.
+                Task stop = host.StopAsync();
+                Verify(0, 1);
+                await Task.Delay(s_superShortDelay);
+                Verify(0, 1);
+
+                // Resume and verify they finish.
+                StopNonconcurrentTestClass<Impl1>.s_wait.Release();
+                StopNonconcurrentTestClass<Impl2>.s_wait.Release();
+                await stop;
+                Verify(1, 1);
+                Assert.True(stop.IsCompleted);
+            }
+
+            void Verify(int count1, int count2)
+            {
+                Assert.Equal(count1, StopNonconcurrentTestClass<Impl1>.s_count);
+                Assert.Equal(count2, StopNonconcurrentTestClass<Impl2>.s_count);
+            }
+        }
+
+        private class StopNonconcurrentTestClass<T> : IHostedLifecycleService
+        {
+            public static int s_count = 0;
+            public static SemaphoreSlim? s_wait = new SemaphoreSlim(1);
+
+            public Task StartingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StartedAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StoppingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public async Task StopAsync(CancellationToken cancellationToken)
+            {
+                s_count++;
+                await s_wait.WaitAsync();
+            }
+            public Task StoppedAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        }
+
+        [Fact]
+        public async Task StoppedConcurrently()
+        {
+            var hostBuilder = CreateHostBuilder(services =>
+            {
+                services
+                    .AddHostedService<StoppedTestClass<Impl1>>()
+                    .AddHostedService<StoppedTestClass<Impl2>>();
+            });
+
+            using (IHost host = hostBuilder.Build())
+            {
+                StoppedTestClass<Impl1>.s_wait1.Wait();
+                StoppedTestClass<Impl2>.s_wait1.Wait();
+                StoppedTestClass<Impl1>.s_wait2.Wait();
+                StoppedTestClass<Impl2>.s_wait2.Wait();
+                StoppedTestClass<Impl1>.s_wait3.Wait();
+                StoppedTestClass<Impl2>.s_wait3.Wait();
+
+                await host.StartAsync();
+                Verify(0, 0, 0, 0, 0, 0);
+
+                // Both run serially until the await.
+                Task stop = host.StopAsync();
+                Verify(1, 1, 0, 0, 0, 0);
+                await Task.Delay(s_superShortDelay);
+                Verify(1, 1, 0, 0, 0, 0);
+
+                // Resume and check that both are not finished.
+                StoppedTestClass<Impl1>.s_wait1.Release();
+                await StoppedTestClass<Impl1>.s_wait2.WaitAsync();
+                Verify(1, 1, 1, 0, 0, 0);
+
+                StoppedTestClass<Impl2>.s_wait1.Release();
+                await StoppedTestClass<Impl2>.s_wait2.WaitAsync();
+                Verify(1, 1, 1, 1, 0, 0);
+
+                // Resume and verify they finish.
+                StoppedTestClass<Impl1>.s_wait3.Release();
+                StoppedTestClass<Impl2>.s_wait3.Release();
+                await stop;
+                Verify(1, 1, 1, 1, 1, 1);
+                Assert.True(stop.IsCompleted);
+            }
+
+            void Verify(int initial1, int initial2, int pause1, int pause2, int final1, int final2)
+            {
+                Assert.Equal(initial1, StoppedTestClass<Impl1>.s_initialCount);
+                Assert.Equal(initial2, StoppedTestClass<Impl2>.s_initialCount);
+                Assert.Equal(pause1, StoppedTestClass<Impl1>.s_pauseCount);
+                Assert.Equal(pause2, StoppedTestClass<Impl2>.s_pauseCount);
+                Assert.Equal(final1, StoppedTestClass<Impl1>.s_finalCount);
+                Assert.Equal(final2, StoppedTestClass<Impl2>.s_finalCount);
+            }
+        }
+
+        private class StoppedTestClass<T> : IHostedLifecycleService
+        {
+            public static int s_initialCount = 0;
+            public static int s_pauseCount = 0;
+            public static int s_finalCount = 0;
+            public static SemaphoreSlim? s_wait1 = new SemaphoreSlim(1);
+            public static SemaphoreSlim? s_wait2 = new SemaphoreSlim(1);
+            public static SemaphoreSlim? s_wait3 = new SemaphoreSlim(1);
+
+            public Task StartingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StartedAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StoppingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public async Task StoppedAsync(CancellationToken cancellationToken)
+            {
+                s_initialCount++;
+                await s_wait1.WaitAsync();
+                s_pauseCount++;
+                s_wait2.Release();
+                await s_wait3.WaitAsync();
+                s_finalCount++;
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task StopPhasesException(bool throwAfterAsyncCall)
+        {
+            ExceptionImpl impl = new(throwAfterAsyncCall: throwAfterAsyncCall, false, false, false, true, true, true);
+            var hostBuilder = CreateHostBuilder(services =>
+            {
+                services.AddHostedService((token) => impl);
+            });
+
+            using (IHost host = hostBuilder.Build())
+            {
+                await host.StartAsync();
+                AggregateException ex = await Assert.ThrowsAnyAsync<AggregateException>(async () => await host.StopAsync());
+
+                Assert.True(impl.StartingCalled);
+                Assert.True(impl.StartCalled);
+                Assert.True(impl.StartedCalled);
+
+                // An exception during a stop phase does not prevent the next ones from running.
+                Assert.True(impl.StoppingCalled);
+                Assert.True(impl.StopCalled);
+                Assert.True(impl.StoppedCalled);
+
+                Assert.Contains("(ThrowOnStopping)", ex.Message);
+                Assert.Contains("(ThrowOnStop)", ex.Message);
+                Assert.Contains("(ThrowOnStopped)", ex.Message);
+
+                Assert.Equal(3, ex.InnerExceptions.Count);
+                Assert.Contains("(ThrowOnStopping)", ex.InnerExceptions[0].Message);
+                Assert.Contains("(ThrowOnStop)", ex.InnerExceptions[1].Message);
+                Assert.Contains("(ThrowOnStopped)", ex.InnerExceptions[2].Message);
+            }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/LifecycleTests.Stop.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/LifecycleTests.Stop.cs
@@ -340,10 +340,6 @@ namespace Microsoft.Extensions.Hosting.Tests
                 Assert.True(impl.StopCalled);
                 Assert.True(impl.StoppedCalled);
 
-                Assert.Contains("(ThrowOnStopping)", ex.Message);
-                Assert.Contains("(ThrowOnStop)", ex.Message);
-                Assert.Contains("(ThrowOnStopped)", ex.Message);
-
                 Assert.Equal(3, ex.InnerExceptions.Count);
                 Assert.Contains("(ThrowOnStopping)", ex.InnerExceptions[0].Message);
                 Assert.Contains("(ThrowOnStop)", ex.InnerExceptions[1].Message);

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/LifecycleTests.Timeouts.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/LifecycleTests.Timeouts.cs
@@ -1,0 +1,169 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Extensions.Hosting.Tests
+{
+    public partial class LifecycleTests
+    {
+        [OuterLoop("Uses Task.Delay")]
+        [Theory]
+        [InlineData(TimeoutService.Phase.Starting)]
+        [InlineData(TimeoutService.Phase.Start)]
+        [InlineData(TimeoutService.Phase.Started)]
+        public async Task StartTimeoutClass_WithValue(TimeoutService.Phase phase)
+        {
+            var host = new HostBuilder()
+                 .ConfigureServices((hostContext, services) =>
+                 {
+                     services.AddHostedService((token) => new TimeoutService(phase));
+                     services.Configure<HostOptions>((opts) =>
+                     {
+                         opts.StartupTimeout = s_shortDelay;
+                     });
+                 })
+                 .UseConsoleLifetime()
+                 .Build();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await host.StartAsync());
+        }
+
+        [OuterLoop("Uses Task.Delay")]
+        [Theory]
+        [InlineData(TimeoutService.Phase.Start)]
+        public async Task StartTimeoutClass_WithValue_Concurrently(TimeoutService.Phase phase)
+        {
+            var host = new HostBuilder()
+                 .ConfigureServices((hostContext, services) =>
+                 {
+                     services.AddHostedService((token) => new TimeoutService(phase));
+                     services.Configure<HostOptions>((opts) =>
+                     {
+                         opts.StartupTimeout = s_shortDelay;
+                         opts.ServicesStartConcurrently = true;
+                     });
+                 })
+                 .UseConsoleLifetime()
+                 .Build();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await host.StartAsync());
+        }
+
+        [OuterLoop("Uses Task.Delay")]
+        [Theory]
+        [InlineData(TimeoutService.Phase.Stopping)]
+        [InlineData(TimeoutService.Phase.Stop)]
+        [InlineData(TimeoutService.Phase.Stopped)]
+        public async Task StopTimeoutClass_WithValue(TimeoutService.Phase phase)
+        {
+            var host = new HostBuilder()
+                 .ConfigureServices((hostContext, services) =>
+                 {
+                     services.AddHostedService((token) => new TimeoutService(phase));
+                     services.Configure<HostOptions>((opts) =>
+                     {
+                         opts.ShutdownTimeout = s_shortDelay;
+                     });
+                 })
+                 .UseConsoleLifetime()
+                 .Build();
+
+            await host.StartAsync();
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await host.StopAsync());
+        }
+
+        [OuterLoop("Uses Task.Delay")]
+        [Theory]
+        [InlineData(TimeoutService.Phase.Stop)]
+        public async Task StopTimeoutClass_WithValue_Concurrently(TimeoutService.Phase phase)
+        {
+            var host = new HostBuilder()
+                 .ConfigureServices((hostContext, services) =>
+                 {
+                     services.AddHostedService((token) => new TimeoutService(phase));
+                     services.Configure<HostOptions>((opts) =>
+                     {
+                         opts.ShutdownTimeout = s_shortDelay;
+                         opts.ServicesStopConcurrently = true;
+                     });
+                 })
+                 .UseConsoleLifetime()
+                 .Build();
+
+            await host.StartAsync();
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await host.StopAsync());
+        }
+
+        public class TimeoutService : IHostedLifecycleService
+        {
+            private Phase _phase;
+
+            public TimeoutService(Phase phase)
+            {
+                _phase = phase;
+            }
+
+            public async Task StartingAsync(CancellationToken cancellationToken)
+            {
+                if (_phase == Phase.Starting)
+                {
+                    await Task.Delay(s_longDelay, cancellationToken);
+                }
+            }
+
+            public async Task StartAsync(CancellationToken cancellationToken)
+            {
+                if (_phase == Phase.Start)
+                {
+                    await Task.Delay(s_longDelay, cancellationToken);
+                }
+            }
+
+            public async Task StartedAsync(CancellationToken cancellationToken)
+            {
+                if (_phase == Phase.Started)
+                {
+                    await Task.Delay(s_longDelay, cancellationToken);
+                }
+            }
+
+            public async Task StoppingAsync(CancellationToken cancellationToken)
+            {
+                if (_phase == Phase.Stopping)
+                {
+                    await Task.Delay(s_longDelay, cancellationToken);
+                }
+            }
+
+            public async Task StopAsync(CancellationToken cancellationToken)
+            {
+                if (_phase == Phase.Stop)
+                {
+                    await Task.Delay(s_longDelay, cancellationToken);
+                }
+            }
+
+            public async Task StoppedAsync(CancellationToken cancellationToken)
+            {
+                if (_phase == Phase.Stopped)
+                {
+                    await Task.Delay(s_longDelay, cancellationToken);
+                }
+            }
+
+            public enum Phase
+            {
+                Starting,
+                Start,
+                Started,
+                Stopping,
+                Stop,
+                Stopped
+            }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/LifecycleTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/LifecycleTests.cs
@@ -1,0 +1,177 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Extensions.Hosting.Tests
+{
+    public partial class LifecycleTests
+    {
+        private static TimeSpan s_superShortDelay = TimeSpan.FromSeconds(.05);
+
+        // Tests that actually delay this long should be [OuterLoop]:
+        private static TimeSpan s_shortDelay = TimeSpan.FromSeconds(.5);
+        private static TimeSpan s_longDelay = TimeSpan.FromSeconds(5); 
+
+        public static IHostBuilder CreateHostBuilder(Action<IServiceCollection> configure) =>
+            new HostBuilder().ConfigureServices(configure);
+
+        [Fact]
+        public async Task HostedService_CallbackOccursOnce()
+        {
+            var hostBuilder = CreateHostBuilder(services =>
+            {
+                services.AddHostedService<HostedService_CallbackOccursOnce_Impl>();
+                services.AddHostedService<HostedService_CallbackOccursOnce_Impl>();
+            });
+
+            using (IHost host = hostBuilder.Build())
+            {
+                await host.StartAsync();
+            }
+
+            Assert.Equal(1, HostedService_CallbackOccursOnce_Impl.s_callbackCallCount);
+        }
+
+        private class HostedService_CallbackOccursOnce_Impl : IHostedService
+        {
+            public static int s_callbackCallCount = 0;
+
+            public Task StartAsync(CancellationToken cancellationToken)
+            {
+                s_callbackCallCount++;
+                return Task.CompletedTask;
+            }
+
+            public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        }
+
+        private class ExceptionImpl : IHostedLifecycleService
+        {
+            private bool _throwAfterAsyncCall;
+            public bool StartingCalled = false;
+            public bool StartCalled = false;
+            public bool StartedCalled = false;
+            public bool StoppingCalled = false;
+            public bool StopCalled = false;
+            public bool StoppedCalled = false;
+
+            public bool ThrowOnStarting;
+            public bool ThrowOnStart;
+            public bool ThrowOnStarted;
+            public bool ThrowOnStopping;
+            public bool ThrowOnStop;
+            public bool ThrowOnStopped;
+
+            public ExceptionImpl(
+                bool throwAfterAsyncCall,
+                bool throwOnStarting,
+                bool throwOnStart,
+                bool throwOnStarted,
+                bool throwOnStopping,
+                bool throwOnStop,
+                bool throwOnStopped)
+            {
+                _throwAfterAsyncCall = throwAfterAsyncCall;
+                ThrowOnStarting = throwOnStarting;
+                ThrowOnStart = throwOnStart;
+                ThrowOnStarted = throwOnStarted;
+                ThrowOnStopping = throwOnStopping;
+                ThrowOnStop = throwOnStop;
+                ThrowOnStopped = throwOnStopped;
+            }
+
+            public async Task StartingAsync(CancellationToken cancellationToken)
+            {
+                StartingCalled = true;
+                if (ThrowOnStarting)
+                {
+                    if (_throwAfterAsyncCall)
+                    {
+                        await Task.Delay(s_superShortDelay);
+                    }
+
+                    throw new Exception("(ThrowOnStarting)");
+                }
+            }
+
+            public async Task StartAsync(CancellationToken cancellationToken)
+            {
+                StartCalled = true;
+                if (ThrowOnStart)
+                {
+                    if (_throwAfterAsyncCall)
+                    {
+                        await Task.Delay(s_superShortDelay);
+                    }
+
+                    throw new Exception("(ThrowOnStart)");
+                }
+            }
+
+            public async Task StartedAsync(CancellationToken cancellationToken)
+            {
+                StartedCalled = true;
+                if (ThrowOnStarted)
+                {
+                    if (_throwAfterAsyncCall)
+                    {
+                        await Task.Delay(s_superShortDelay);
+                    }
+
+                    throw new Exception("(ThrowOnStarted)");
+                }
+            }
+
+            public async Task StoppingAsync(CancellationToken cancellationToken)
+            {
+                StoppingCalled = true;
+                if (ThrowOnStopping)
+                {
+                    if (_throwAfterAsyncCall)
+                    {
+                        await Task.Delay(s_superShortDelay);
+                    }
+
+                    throw new Exception("(ThrowOnStopping)");
+                }
+            }
+
+            public async Task StopAsync(CancellationToken cancellationToken)
+            {
+                StopCalled = true;
+                if (ThrowOnStop)
+                {
+                    if (_throwAfterAsyncCall)
+                    {
+                        await Task.Delay(s_superShortDelay);
+                    }
+
+                    throw new Exception("(ThrowOnStop)");
+                }
+            }
+
+            public async Task StoppedAsync(CancellationToken cancellationToken)
+            {
+                StoppedCalled = true;
+                if (ThrowOnStopped)
+                {
+                    if (_throwAfterAsyncCall)
+                    {
+                        await Task.Delay(s_superShortDelay);
+                    }
+
+                    throw new Exception("(ThrowOnStopped)");
+                }
+            }
+        }
+
+        // These are used to close open generic types:
+        private sealed class Impl1 { }
+        private sealed class Impl2 { }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/86511

Please see the "design notes" section in the linked issue above. Summary:
- Exception semantics are the same:
  - Exceptions are caught, logged, and then re-thrown
- Same guaranteed execution of callbacks
  - Callbacks will be called even if a prior phase had exceptions.
  - Exceptions from IHostApplicationLifetime are logged but do not re-throw.
- There is a "serial+concurrent" model for both new callbacks and the existing StartAsync\StopAsync when [HostOptions.ServicesStartConcurrently](https://learn.microsoft.com/dotnet/api/microsoft.extensions.hosting.hostoptions.servicesstartconcurrently?view=dotnet-plat-ext-8.0) and\or [HostOptions.ServicesStopConcurrently](https://learn.microsoft.com/dotnet/api/microsoft.extensions.hosting.hostoptions.servicesstopconcurrently?view=dotnet-plat-ext-8.0) are enabled.
- The new timeout for start is disabled by default.
- The new callbacks (Started, Stopping, Stopped) come _before_ the corresponding IHostApplicationLifetime callbacks.  The corresponding IHostLifetime callbacks (WaitForStartAsync and StopAsync) always come first\last.