### PR TITLE
Allow bigger json parsing to JsonDocument

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.MetadataDb.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.MetadataDb.cs
@@ -234,17 +234,16 @@ namespace System.Text.Json
 
                 // Allow the data to grow up to maximum possible capacity (~2G bytes) before encountering overflow.
                 // Note: Array.MaxLength exists only on .NET 6 or greater,
-                // so for the other versions value is hardcoded and taken from internal Array.MaxArrayLength
+                // so for the other versions value is hardcoded
+                const int MaxArrayLength = 0x7FFFFFC7;
 #if NET6_0_OR_GREATER
-                int maxArrayLength = Array.MaxLength;
-#else
-                const int maxArrayLength = 0x7FEFFFFF;
+                Debug.Assert(MaxArrayLength == Array.MaxLength);
 #endif
 
                 int newCapacity = toReturn.Length * 2;
 
                 // Note that this check works even when newCapacity overflowed thanks to the (uint) cast
-                if ((uint)newCapacity > maxArrayLength) newCapacity = maxArrayLength;
+                if ((uint)newCapacity > MaxArrayLength) newCapacity = MaxArrayLength;
 
                 _data = ArrayPool<byte>.Shared.Rent(newCapacity);
                 Buffer.BlockCopy(toReturn, 0, _data, 0, toReturn.Length);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.MetadataDb.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.MetadataDb.cs
@@ -245,6 +245,11 @@ namespace System.Text.Json
                 // Note that this check works even when newCapacity overflowed thanks to the (uint) cast
                 if ((uint)newCapacity > MaxArrayLength) newCapacity = MaxArrayLength;
 
+                // If the maximum capacity has already been reached,
+                // then set the new capacity to be larger than what is possible
+                // so that ArrayPool.Rent throws an OutOfMemoryException for us.
+                if (newCapacity == toReturn.Length) newCapacity = int.MaxValue;
+
                 _data = ArrayPool<byte>.Shared.Rent(newCapacity);
                 Buffer.BlockCopy(toReturn, 0, _data, 0, toReturn.Length);
 


### PR DESCRIPTION
Big json would cause internal metadata array length to overflow, thus throwing an exception.

After this change, this case is handled similar to List\<T\>.Grow allowing array to expand to it's possible maximum.

I don't think it is reasonable to include a test for this case, because it uses too much memory.

Closes #70785