### PR TITLE
update snap authoring for June and resolve segfaults

### DIFF
--- a/src/installer/pkg/snap/6.0/snap/snapcraft.yaml
+++ b/src/installer/pkg/snap/6.0/snap/snapcraft.yaml
@@ -1,22 +1,18 @@
 name: dotnet-runtime-60
 base: core18
-version: 6.0.0-preview.2.21154.6
+version: 6.0.18
 summary: Cross-Platform .NET Core Runtime. 
 description: |
   .NET Core runtimes and libraries which are optimized for running .NET Core apps in production. See https://dot.net/core.
   .NET Core is a general purpose development platform maintained by Microsoft. 
 
+architectures:
+  - build-on: amd64
+    run-on: amd64
+
 grade: stable
 confinement: strict
-
-apps:
-  dotnet:
-    command: dotnet
-    plugs:
-      - network
-      - network-bind
-      - removable-media
-      - home
+base: core20
 
 slots:
   dotnet-runtime:
@@ -27,12 +23,12 @@ slots:
 parts:
   dotnet-runtime:
     plugin: dump
-    source: https://download.visualstudio.microsoft.com/download/pr/2c88db43-4d92-433d-b95f-81bc9118a67e/08ec34f28dca0af4e8cf551299aa4367/dotnet-runtime-6.0.0-preview.2.21154.6-linux-x64.tar.gz
-    source-checksum: sha512/88ba8c4fe252fb76e0c40a4dcd2fe3e9c2960f445dd97a8044be9900f3641f18b2687ec10a36545a141a1e6820bb61278d2047cacd93365954a124c92463b17b
+    source: https://download.visualstudio.microsoft.com/download/pr/53fce0ba-88f8-44e0-8174-16fb7d6f1a33/7e4ee56d0aa754deed6cf4db31dd9e25/dotnet-runtime-6.0.18-linux-x64.tar.gz
+    source-checksum: sha512/bcfc88238f901c14d203a33eff036106fcbcfc40de7e3717f61434dffd86b5444c176dec5beeddcf80e7193f77bf793ab1e2284c91d54b93931a4668ba77c634
     stage-packages:
-      - libicu60
-      - libssl1.0.0
-      - libcurl3
+      - libicu66
+      - libssl1.1
+      - libcurl4
       - libgssapi-krb5-2
       - liblttng-ust0
       - libstdc++6
@@ -41,3 +37,12 @@ parts:
       - libtinfo5
       - libdb5.3
       - libc6
+
+apps:
+  dotnet:
+    command: dotnet
+    plugs:
+      - network
+      - network-bind
+      - removable-media
+      - home

--- a/src/installer/pkg/snap/7.0/snap/snapcraft.yaml
+++ b/src/installer/pkg/snap/7.0/snap/snapcraft.yaml
@@ -1,0 +1,48 @@
+name: dotnet-runtime-70
+base: core18
+version: 7.0.7
+summary: Cross-Platform .NET Core Runtime. 
+description: |
+  .NET Core runtimes and libraries which are optimized for running .NET Core apps in production. See https://dot.net/core.
+  .NET Core is a general purpose development platform maintained by Microsoft. 
+
+architectures:
+  - build-on: amd64
+    run-on: amd64
+
+grade: stable
+confinement: strict
+base: core20
+
+slots:
+  dotnet-runtime:
+    content: dotnet-runtime-60
+    interface: content
+    read: [/]
+
+parts:
+  dotnet-runtime:
+    plugin: dump
+    source: https://download.visualstudio.microsoft.com/download/pr/123d8ec6-beb4-4acf-8e9d-b54d2b99bb20/32f203246f4a87d70c339e8e06dc9c36/dotnet-runtime-7.0.7-linux-x64.tar.gz
+    source-checksum: sha512/02c4949f2edd4c0e63286443e11f961ee2cbd173eda93b5ba192e7c95dcefe74754222f3986d00f71b213271c184d5c12796a4345d19936a38c45293ac76dd94
+    stage-packages:
+      - libicu66
+      - libssl1.1
+      - libcurl4
+      - libgssapi-krb5-2
+      - liblttng-ust0
+      - libstdc++6
+      - zlib1g
+      - libgcc1
+      - libtinfo5
+      - libdb5.3
+      - libc6
+
+apps:
+  dotnet:
+    command: dotnet
+    plugs:
+      - network
+      - network-bind
+      - removable-media
+      - home

--- a/src/installer/pkg/snap/8.0/snap/snapcraft.yaml
+++ b/src/installer/pkg/snap/8.0/snap/snapcraft.yaml
@@ -1,0 +1,48 @@
+name: dotnet-runtime-80
+base: core18
+version: 8.0.0-preview.5.23280.8
+summary: Cross-Platform .NET Core Runtime. 
+description: |
+  .NET Core runtimes and libraries which are optimized for running .NET Core apps in production. See https://dot.net/core.
+  .NET Core is a general purpose development platform maintained by Microsoft. 
+
+architectures:
+  - build-on: amd64
+    run-on: amd64
+
+grade: stable
+confinement: strict
+base: core20
+
+slots:
+  dotnet-runtime:
+    content: dotnet-runtime-60
+    interface: content
+    read: [/]
+
+parts:
+  dotnet-runtime:
+    plugin: dump
+    source: https://download.visualstudio.microsoft.com/download/pr/bbdc7ec0-d87e-4b6b-bb3f-9dbe5db3078e/6cda9733bbedf8f4fb9e18829e301051/dotnet-runtime-8.0.0-preview.5.23280.8-linux-x64.tar.gz
+    source-checksum: sha512/0fa3d9bef5300533b4f266fc1983c7bc8eb55c6c9e8ddf86978a3adb911663a2069c9ed9e428f8d2361558a40edef5bfad6ef75ea2a728cf700a23cd38e7bbcc
+    stage-packages:
+      - libicu66
+      - libssl1.1
+      - libcurl4
+      - libgssapi-krb5-2
+      - liblttng-ust0
+      - libstdc++6
+      - zlib1g
+      - libgcc1
+      - libtinfo5
+      - libdb5.3
+      - libc6
+
+apps:
+  dotnet:
+    command: dotnet
+    plugs:
+      - network
+      - network-bind
+      - removable-media
+      - home


### PR DESCRIPTION
Changes include upgrading to Core20, updated libs and removing explicit glibc6 reference. These changes seem to have resolved some fundamental issues when running on newer OS versions (e.g. Ubuntu 22+ and Fedora 36+). Critically, segfaults during a number of operations are resolved. 

/cc @ashnaga 