### PR TITLE
Fix validation on build

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
@@ -316,13 +316,9 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                         callSitesByIndex.Add(new(index, callSite));
                     }
                 }
-
-                ResultCache resultCache = ResultCache.None;
-                if (cacheLocation == CallSiteResultCacheLocation.Scope || cacheLocation == CallSiteResultCacheLocation.Root)
-                {
-                    resultCache = new ResultCache(cacheLocation, callSiteKey);
-                }
-
+                ResultCache resultCache = (cacheLocation == CallSiteResultCacheLocation.Scope || cacheLocation == CallSiteResultCacheLocation.Root)
+                    ? new ResultCache(cacheLocation, callSiteKey)
+                    : new ResultCache(CallSiteResultCacheLocation.None, callSiteKey);
                 return _callSiteCache[callSiteKey] = new IEnumerableCallSite(resultCache, itemType, callSites);
             }
             finally

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteValidator.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteValidator.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             Type? scoped = VisitCallSite(callSite, default);
             if (scoped != null)
             {
-                _scopedServices[GetCacheKey(callSite)] = scoped;
+                _scopedServices[callSite.Cache.Key] = scoped;
             }
         }
 
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             Type serviceType = callSite.ServiceType;
             if (ReferenceEquals(scope, rootScope)
-                && _scopedServices.TryGetValue(GetCacheKey(callSite), out Type? scopedService))
+                && _scopedServices.TryGetValue(callSite.Cache.Key, out Type? scopedService))
             {
                 if (serviceType == scopedService)
                 {
@@ -97,12 +97,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         protected override Type? VisitServiceProvider(ServiceProviderCallSite serviceProviderCallSite, CallSiteValidatorState state) => null;
 
         protected override Type? VisitFactory(FactoryCallSite factoryCallSite, CallSiteValidatorState state) => null;
-
-        private static ServiceCacheKey GetCacheKey(ServiceCallSite callSite)
-        {
-            return callSite.Cache.Key.Equals(ServiceCacheKey.Empty)
-                ? new ServiceCacheKey(callSite.ServiceType, 0) : callSite.Cache.Key;
-        }
 
         internal struct CallSiteValidatorState
         {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteValidator.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteValidator.cs
@@ -23,10 +23,10 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         public void ValidateResolution(ServiceCallSite callSite, IServiceScope scope, IServiceScope rootScope)
         {
-            Type serviceType = callSite.ServiceType;
             if (ReferenceEquals(scope, rootScope)
                 && _scopedServices.TryGetValue(callSite.Cache.Key, out Type? scopedService))
             {
+                Type serviceType = callSite.ServiceType;
                 if (serviceType == scopedService)
                 {
                     throw new InvalidOperationException(

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ConstantCallSite.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ConstantCallSite.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         private readonly Type _serviceType;
         internal object? DefaultValue => Value;
 
-        public ConstantCallSite(Type serviceType, object? defaultValue): base(ResultCache.None)
+        public ConstantCallSite(Type serviceType, object? defaultValue) : base(ResultCache.None(serviceType))
         {
             _serviceType = serviceType ?? throw new ArgumentNullException(nameof(serviceType));
             if (defaultValue != null && !serviceType.IsInstanceOfType(defaultValue))

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ResultCache.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ResultCache.cs
@@ -8,7 +8,11 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal struct ResultCache
     {
-        public static ResultCache None { get; } = new ResultCache(CallSiteResultCacheLocation.None, ServiceCacheKey.Empty);
+        public static ResultCache None(Type serviceType)
+        {
+            var cacheKey = new ServiceCacheKey(serviceType, 0);
+            return new ResultCache(CallSiteResultCacheLocation.None, cacheKey);
+        }
 
         internal ResultCache(CallSiteResultCacheLocation lifetime, ServiceCacheKey cacheKey)
         {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceCacheKey.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceCacheKey.cs
@@ -8,8 +8,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal readonly struct ServiceCacheKey : IEquatable<ServiceCacheKey>
     {
-        public static ServiceCacheKey Empty { get; } = new ServiceCacheKey(null, 0);
-
         /// <summary>
         /// Type of service being cached
         /// </summary>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderCallSite.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderCallSite.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal sealed class ServiceProviderCallSite : ServiceCallSite
     {
-        public ServiceProviderCallSite() : base(ResultCache.None)
+        public ServiceProviderCallSite() : base(ResultCache.None(typeof(IServiceProvider)))
         {
         }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 {
                     OnResolve(callSite, scope);
                     DependencyInjectionEventSource.Log.ServiceResolved(this, serviceType);
-                    return realizedService.Invoke(scope);
+                    return realizedService(scope);
                 };
             }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
@@ -786,17 +786,10 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var callSite = factory(typeof(IEnumerable<FakeService>));
 
             var expectedLocation = (CallSiteResultCacheLocation)expectedCacheLocation;
-            Assert.Equal(expectedLocation, callSite.Cache.Location);
 
-            if (expectedLocation != CallSiteResultCacheLocation.None)
-            {
-                Assert.Equal(0, callSite.Cache.Key.Slot);
-                Assert.Equal(typeof(IEnumerable<FakeService>), callSite.Cache.Key.Type);
-            }
-            else
-            {
-                Assert.Equal(ResultCache.None, callSite.Cache);
-            }
+            Assert.Equal(expectedLocation, callSite.Cache.Location);
+            Assert.Equal(0, callSite.Cache.Key.Slot);
+            Assert.Equal(typeof(IEnumerable<FakeService>), callSite.Cache.Key.Type);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderValidationTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderValidationTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
 using Xunit;
 
@@ -95,6 +97,49 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             // Act + Assert
             var exception = Assert.Throws<InvalidOperationException>(() => serviceProvider.GetService(typeof(IFoo)));
             Assert.Equal($"Cannot resolve '{typeof(IFoo)}' from root provider because it requires scoped service '{typeof(IBar)}'.", exception.Message);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void GetService_DoesNotThrow_WhenGetServiceForPolymorphicServiceIsCalledOnRoot_AndTheLastOneIsNotScoped(bool validateOnBuild)
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddScoped<IBar, Bar>();
+            serviceCollection.AddTransient<IBar, Bar3>();
+            using var serviceProvider = serviceCollection.BuildServiceProvider(new ServiceProviderOptions
+            {
+                ValidateScopes = true,
+                ValidateOnBuild = validateOnBuild
+            });
+
+            // Act
+            var actual = serviceProvider.GetService<IBar>();
+
+            // Assert
+            Assert.IsType<Bar3>(actual);
+        }
+
+        [Fact]
+        public void ScopeValidation_ShouldBeAbleToDistingushGenericCollections_WhenGetServiceIsCalledOnRoot()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient<IBar, Bar>();
+            serviceCollection.AddScoped<IBar, Bar3>();
+
+            serviceCollection.AddTransient<IBaz, Baz>();
+            serviceCollection.AddTransient<IBaz, Baz2>();
+
+            // Act
+            using var serviceProvider = serviceCollection.BuildServiceProvider(validateScopes: true);
+            Assert.Throws<InvalidOperationException>(() => serviceProvider.GetService<IEnumerable<IBar>>());
+            var actual = serviceProvider.GetService<IEnumerable<IBaz>>();
+
+            // Assert
+            Assert.IsType<Baz>(actual.First());
+            Assert.IsType<Baz2>(actual.Last());
         }
 
         [Fact]
@@ -206,6 +251,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         {
         }
 
+
         private class Bar2 : IBar
         {
             public Bar2(IBaz baz)
@@ -213,11 +259,19 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             }
         }
 
+        private class Bar3 : IBar
+        {
+        }
+
         private interface IBaz
         {
         }
 
         private class Baz : IBaz
+        {
+        }
+
+        private class Baz2 : IBaz
         {
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/87429

Let's look at the following example

```c#
interface IBar {}
class Bar1 : IBar {}
class Bar2 : IBar {}

services.AddScoped<IBar, Bar1>();  // Slot: 1
services.AddTransient<IBar, Bar2>(); // Slot: 0

var sp = services.BuildServiceProvider(validateScopes: true);
Debug.Assert(sp.GetService<IBar>() is Bar2)
```
The last implementation will be resolved by convention. For more details see the `CallSiteFactory` class and the `DefaultSlot` property. The scope validation is fine with a service lifetime (GetService for Transient service on the Root scope).
But the behavior breaks when we set the `ValidateOnBuild` property to 'true'. Please see unit tests that reproduce the issue. 