### PR TITLE
Tweak dotnet-pgo to be flexible to changes from class to valuetype for application types

### DIFF
--- a/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemType.cs
+++ b/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemType.cs
@@ -46,10 +46,10 @@ namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
             }
             else
             {
-                if (_isValueType.Value != isValueType)
-                {
-                    throw new Exception($"Same type `{ToString()}` used as both ValueType and non-ValueType");
-                }
+                // Do nothing. We cannot choose a correct choice, and failing is also unhelpful, as dotnet-pgo is supposed
+                // to work with traces from the same app over time where a type may have transformed from class to struct
+                // or vice versa. With this approach, the first assembly on the commandline to push a type to be struct
+                // or class will reliably win.
             }
         }
 


### PR DESCRIPTION
Fix #61604 by simply removing the possibility of throwing an exception in those cases. We'll now pick the first one.