### PR TITLE
Disable StressTestDeepNestingOfLoops for NonBacktracking engine

### DIFF
--- a/docs/workflow/testing/libraries/testing.md
+++ b/docs/workflow/testing/libraries/testing.md
@@ -79,13 +79,25 @@ cd src\libraries\System.Collections.Immutable\tests
 dotnet build /t:Test
 ```
 
-It is possible to pass parameters to the underlying xunit runner via the `XUnitOptions` parameter, e.g.:
+This one command builds the library under test, then the test library, then runs the tests in the test library.
+
+### Running only certain tests
+
+It is possible to pass parameters to the underlying xunit runner via the `XUnitOptions` parameter, e.g., to filter to tests in just one fixture (class):
 
 ```cmd
 dotnet build /t:Test /p:XUnitOptions="-class Test.ClassUnderTests"
 ```
 
-Which is very useful when you want to run tests as `x86` on a `x64` machine:
+or to just one test method:
+
+```cmd
+dotnet build /t:test /p:outerloop=true /p:xunitoptions="-method System.Text.RegularExpressions.Tests.RegexMatchTests.StressTestDeepNestingOfLoops"
+```
+
+### Running only specific architectures
+
+To run tests as `x86` on a `x64` machine:
 
 ```cmd
 dotnet build /t:Test /p:TargetArchitecture=x86
@@ -145,3 +157,6 @@ It is important to highlight that these tests do not use the standard XUnit test
 - `-nonamespace`
 - `-parallel`
 
+### Viewing XUnit logs
+
+It's usually sufficient to see the test failure output in the console. There is a test log file though and you can find it in a location like `...\runtime\artifacts\bin\System.Text.RegularExpressions.Tests\Debug\net8.0\testResults.xml`. It can be helpful for example to grep through a series of failures, or see how long a slow test actually took.

--- a/docs/workflow/testing/libraries/testing.md
+++ b/docs/workflow/testing/libraries/testing.md
@@ -79,7 +79,6 @@ cd src\libraries\System.Collections.Immutable\tests
 dotnet build /t:Test
 ```
 
-
 ### Running only certain tests
 
 It is possible to pass parameters to the underlying xunit runner via the `XUnitOptions` parameter, e.g., to filter to tests in just one fixture (class):

--- a/docs/workflow/testing/libraries/testing.md
+++ b/docs/workflow/testing/libraries/testing.md
@@ -79,7 +79,6 @@ cd src\libraries\System.Collections.Immutable\tests
 dotnet build /t:Test
 ```
 
-This one command builds the library under test, then the test library, then runs the tests in the test library.
 
 ### Running only certain tests
 
@@ -159,4 +158,4 @@ It is important to highlight that these tests do not use the standard XUnit test
 
 ### Viewing XUnit logs
 
-It's usually sufficient to see the test failure output in the console. There is a test log file though and you can find it in a location like `...\runtime\artifacts\bin\System.Text.RegularExpressions.Tests\Debug\net8.0\testResults.xml`. It can be helpful for example to grep through a series of failures, or see how long a slow test actually took.
+It's usually sufficient to see the test failure output in the console. There is also a test log file, which you can find in a location like `...\runtime\artifacts\bin\System.Text.RegularExpressions.Tests\Debug\net8.0\testResults.xml`. It can be helpful, for example, to grep through a series of failures, or to see how long a slow test actually took.

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -2161,7 +2161,7 @@ namespace System.Text.RegularExpressions.Tests
             {
                 if (engine != RegexEngine.NonBacktracking) // Hangs, or effectively hangs. https://github.com/dotnet/runtime/issues/84188
                 {
-                    yield return new object[] { engine, "(", "a", ")*", "a", 2000, 1 };
+                    yield return new object[] { engine, "(", "a", ")*", "a", 2000, 1000 };
                 }
 
                 yield return new object[] { engine, "(", "[aA]", ")+", "aA", 2000, 3000 };

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -2159,6 +2159,9 @@ namespace System.Text.RegularExpressions.Tests
         {
             foreach (RegexEngine engine in RegexHelpers.AvailableEngines)
             {
+                if (engine == RegexEngine.NonBacktracking)
+                    yield break; // Hangs, or effectively hangs. https://github.com/dotnet/runtime/issues/84188
+
                 yield return new object[] { engine, "(", "a", ")*", "a", 2000, 1000 };
                 yield return new object[] { engine, "(", "[aA]", ")+", "aA", 2000, 3000 };
                 yield return new object[] { engine, "(", "ab", "){0,1}", "ab", 2000, 1000 };

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -2159,16 +2159,17 @@ namespace System.Text.RegularExpressions.Tests
         {
             foreach (RegexEngine engine in RegexHelpers.AvailableEngines)
             {
-                if (engine == RegexEngine.NonBacktracking)
-                    yield break; // Hangs, or effectively hangs. https://github.com/dotnet/runtime/issues/84188
+                if (engine != RegexEngine.NonBacktracking) // Hangs, or effectively hangs. https://github.com/dotnet/runtime/issues/84188
+                {
+                    yield return new object[] { engine, "(", "a", ")*", "a", 2000, 1 };
+                }
 
-                yield return new object[] { engine, "(", "a", ")*", "a", 2000, 1000 };
                 yield return new object[] { engine, "(", "[aA]", ")+", "aA", 2000, 3000 };
                 yield return new object[] { engine, "(", "ab", "){0,1}", "ab", 2000, 1000 };
             }
         }
 
-        [OuterLoop("Can take over 10 seconds")]
+        [OuterLoop("Can take a few seconds")]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))] // consumes a lot of memory
         [MemberData(nameof(StressTestDeepNestingOfLoops_TestData))]
         public async Task StressTestDeepNestingOfLoops(RegexEngine engine, string begin, string inner, string end, string input, int pattern_repetition, int input_repetition)


### PR DESCRIPTION
Relates to https://github.com/dotnet/runtime/issues/84188

I ran this for over 30 mins and it still didn't complete.