### PR TITLE
Enable GDV with multiple guesses for NativeAOT

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7149,6 +7149,28 @@ public:
                                              unsigned              classAttr,
                                              unsigned              likelihood);
 
+    int getGDVMaxTypeChecks()
+    {
+        int typeChecks = JitConfig.JitGuardedDevirtualizationMaxTypeChecks();
+        if (typeChecks < 0)
+        {
+            // Negative value means "it's up to JIT to decide"
+            if (IsTargetAbi(CORINFO_NATIVEAOT_ABI) && !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_SIZE_OPT))
+            {
+                return 3;
+            }
+
+            // We plan to use 3 for CoreCLR too, but we need to make sure it doesn't regress performance
+            // as CoreCLR heavily relies on Dynamic PGO while for NativeAOT we *usually* don't have it and
+            // can only perform the "exact" devirtualization.
+            return 1;
+        }
+
+        // MAX_GDV_TYPE_CHECKS is the upper limit. The constant can be changed, we just suspect that even
+        // 4 type checks is already too much.
+        return min(MAX_GDV_TYPE_CHECKS, typeChecks);
+    }
+
     bool doesMethodHaveExpRuntimeLookup()
     {
         return (optMethodFlags & OMF_HAS_EXPRUNTIMELOOKUP) != 0;

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -5730,7 +5730,7 @@ void Compiler::pickGDV(GenTreeCall*           call,
     // Prefer class guess as it is cheaper
     if (numberOfClasses > 0)
     {
-        const int maxNumberOfGuesses = min(MAX_GDV_TYPE_CHECKS, JitConfig.JitGuardedDevirtualizationMaxTypeChecks());
+        const int maxNumberOfGuesses = getGDVMaxTypeChecks();
         if (maxNumberOfGuesses == 0)
         {
             // DOTNET_JitGuardedDevirtualizationMaxTypeChecks=0 means we don't want to do any guarded devirtualization
@@ -5931,7 +5931,7 @@ void Compiler::considerGuardedDevirtualization(GenTreeCall*            call,
     {
         pickGDV(call, ilOffset, isInterface, likelyClasses, likelyMethodes, &candidatesCount, likelihoods);
         assert((unsigned)candidatesCount <= MAX_GDV_TYPE_CHECKS);
-        assert((unsigned)candidatesCount <= (unsigned)JitConfig.JitGuardedDevirtualizationMaxTypeChecks());
+        assert((unsigned)candidatesCount <= (unsigned)getGDVMaxTypeChecks());
         if (candidatesCount == 0)
         {
             hasPgoData = false;
@@ -5944,7 +5944,7 @@ void Compiler::considerGuardedDevirtualization(GenTreeCall*            call,
     // from both.
     if (!hasPgoData && (baseClass != NO_CLASS_HANDLE) && JitConfig.JitEnableExactDevirtualization())
     {
-        int maxTypeChecks = min(JitConfig.JitGuardedDevirtualizationMaxTypeChecks(), MAX_GDV_TYPE_CHECKS);
+        int maxTypeChecks = min(getGDVMaxTypeChecks(), MAX_GDV_TYPE_CHECKS);
 
         CORINFO_CLASS_HANDLE exactClasses[MAX_GDV_TYPE_CHECKS];
         int numExactClasses = info.compCompHnd->getExactClasses(baseClass, MAX_GDV_TYPE_CHECKS, exactClasses);

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -527,8 +527,8 @@ CONFIG_INTEGER(JitEnableGuardedDevirtualization, W("JitEnableGuardedDevirtualiza
 
 #define MAX_GDV_TYPE_CHECKS 5
 // Number of types to probe for polymorphic virtual call-sites to devirtualize them,
-// Max number is MAX_GDV_TYPE_CHECKS defined above ^
-CONFIG_INTEGER(JitGuardedDevirtualizationMaxTypeChecks, W("JitGuardedDevirtualizationMaxTypeChecks"), 1)
+// Max number is MAX_GDV_TYPE_CHECKS defined above ^. -1 means it's up to JIT to decide
+CONFIG_INTEGER(JitGuardedDevirtualizationMaxTypeChecks, W("JitGuardedDevirtualizationMaxTypeChecks"), -1)
 
 // Various policies for GuardedDevirtualization
 CONFIG_INTEGER(JitGuardedDevirtualizationChainLikelihood, W("JitGuardedDevirtualizationChainLikelihood"), 0x4B) // 75

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilationBuilder.cs
@@ -43,14 +43,6 @@ namespace ILCompiler
         {
             var builder = default(ArrayBuilder<KeyValuePair<string, string>>);
 
-            if (_optimizationMode != OptimizationMode.PreferSize)
-            {
-                // Enable GDV with multiple guesses - it's useful even without PGO as we can still
-                // devirtualize virtual calls when we know that the number of their targets is limited.
-                // It can be overridden by --codegenopt:JitGuardedDevirtualizationMaxTypeChecks=X
-                builder.Add(new KeyValuePair<string, string>("JitGuardedDevirtualizationMaxTypeChecks", "3"));
-            }
-
             foreach (string param in options)
             {
                 int indexOfEquals = param.IndexOf('=');

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilationBuilder.cs
@@ -43,6 +43,14 @@ namespace ILCompiler
         {
             var builder = default(ArrayBuilder<KeyValuePair<string, string>>);
 
+            if (_optimizationMode != OptimizationMode.PreferSize)
+            {
+                // Enable GDV with multiple guesses - it's useful even without PGO as we can still
+                // devirtualize virtual calls when we know that the number of their targets is limited.
+                // It can be overridden by --codegenopt:JitGuardedDevirtualizationMaxTypeChecks=X
+                builder.Add(new KeyValuePair<string, string>("JitGuardedDevirtualizationMaxTypeChecks", "3"));
+            }
+
             foreach (string param in options)
             {
                 int indexOfEquals = param.IndexOf('=');


### PR DESCRIPTION
I've tested the size impact on the [Minimal API TodosApp](https://github.com/aspnet/Benchmarks/tree/main/src/BenchmarksApps/TodosApi):

| MaxTypeChecks        | -O (default), KB | -Ot (Prefer Speed), KB |
|----------------------|------------------|------------------------|
| 0                    | 28466            | 30212                  |
| 1 (Current default)  | **28468**            | 30216                  |
| 2                    | 28504            | 30267                  |
| 3 (Proposed default) | **28552**            | 30321                  |
| 4                    | 28577            | 30362                  |
| 5                    | 28706            | 30501                  |

_(for reference, -Os is 27980)_

Numbers are sizes (in KB) for differen values of `--codegenopt:JitGuardedDevirtualizationMaxTypeChecks=X`

See https://github.com/dotnet/runtime/pull/87055 for an example of what GDV with multiple guesses can do.

so `+84kb` for -O and `+105kb` for -Ot (more aggressive inliner inlines more GDV guesses).

We (@AndyAyersMS) think that 3 is the optimal number for number of guesses because e.g. 5 means that if the last guess is the correct one we'll pay an overhead of 4 type checks before we hit it and that can make it slower than just a virtual call.

