### PR TITLE
JIT: Handle commas in physical promotion

### DIFF
--- a/src/coreclr/jit/promotion.h
+++ b/src/coreclr/jit/promotion.h
@@ -299,6 +299,7 @@ public:
 private:
     GenTree** InsertMidTreeReadBacksIfNecessary(GenTree** use);
     void LoadStoreAroundCall(GenTreeCall* call, GenTree* user);
+    GenTree** EffectiveUse(GenTree** use);
     bool IsPromotedStructLocalDying(GenTreeLclVarCommon* structLcl);
     void ReplaceLocal(GenTree** use, GenTree* user);
     void CheckForwardSubForLastUse(unsigned lclNum);


### PR DESCRIPTION
Physical promotion was not properly handling accounting in the presence of commas and was not properly handling struct commas during replacement.

No diffs are expected as we don't see any struct commas in physical promotion currently.