### PR TITLE
 [browser][debugger][MT] Make operations on dictionary thread-safe.

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/FirefoxInspectorClient.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/FirefoxInspectorClient.cs
@@ -234,12 +234,7 @@ class FirefoxInspectorClient : InspectorClient
             throw new Exception($"No 'to' field found in '{args}'");
 
         msgId = new FirefoxMessageId("", 0, to_str);
-        pending_cmds.AddOrUpdate(msgId, tcs, (key, oldValue) => {
-            if (oldValue != tcs)
-                logger.LogDebug($"Updating the pending command, key = {key}, oldValue= {oldValue}, newValue = {tcs}");
-            logger.LogTrace($"SendCommand: to: {args}");
-            return tcs;
-        });
+        pending_cmds.AddOrUpdate(msgId, tcs,  (key, oldValue) => tcs);
 
         var msg = args.ToString(Formatting.None);
         var bytes = Encoding.UTF8.GetBytes(msg);

--- a/src/mono/wasm/debugger/DebuggerTestSuite/FirefoxInspectorClient.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/FirefoxInspectorClient.cs
@@ -143,7 +143,7 @@ class FirefoxInspectorClient : InspectorClient
                     return null;
 
                 var messageId = new FirefoxMessageId("", 0, from_str);
-                if (pending_cmds.Remove(messageId, out var item))
+                if (pending_cmds.TryRemove(messageId, out var item))
                     item.SetResult(Result.FromJsonFirefox(res));
                 else
                     logger.LogDebug($"HandleMessage: Could not find any pending cmd for {messageId}. msg: {msg}");
@@ -156,7 +156,7 @@ class FirefoxInspectorClient : InspectorClient
                 return null;
 
             var messageId = new FirefoxMessageId("", 0, from_str);
-            if (pending_cmds.Remove(messageId, out var item))
+            if (pending_cmds.TryRemove(messageId, out var item))
             {
                 item.SetResult(Result.FromJsonFirefox(res));
                 return null;
@@ -234,8 +234,12 @@ class FirefoxInspectorClient : InspectorClient
             throw new Exception($"No 'to' field found in '{args}'");
 
         msgId = new FirefoxMessageId("", 0, to_str);
-        pending_cmds[msgId] = tcs;
-        logger.LogTrace($"SendCommand: to: {args}");
+        pending_cmds.AddOrUpdate(msgId, tcs, (key, oldValue) => {
+            if (oldValue != tcs)
+                logger.LogDebug($"Updating the pending command, key = {key}, oldValue= {oldValue}, newValue = {tcs}");
+            logger.LogTrace($"SendCommand: to: {args}");
+            return tcs;
+        });
 
         var msg = args.ToString(Formatting.None);
         var bytes = Encoding.UTF8.GetBytes(msg);

--- a/src/mono/wasm/debugger/DebuggerTestSuite/InspectorClient.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/InspectorClient.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Sockets;

--- a/src/mono/wasm/debugger/DebuggerTestSuite/InspectorClient.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/InspectorClient.cs
@@ -97,11 +97,7 @@ namespace DebuggerTests
             var tcs = new TaskCompletionSource<Result>();
 
             MessageId msgId = new MessageId(sessionId.sessionId, id);
-            pending_cmds.AddOrUpdate(msgId, tcs, (key, oldValue) => {
-                if (oldValue != tcs)
-                    logger.LogDebug($"Updating the pending command, key = {key}, oldValue= {oldValue}, newValue = {tcs}");
-                return tcs;
-            });
+            pending_cmds.AddOrUpdate(msgId, tcs,  (key, oldValue) => tcs);
 
             var str = o.ToString();
 

--- a/src/mono/wasm/debugger/DebuggerTestSuite/InspectorClient.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/InspectorClient.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Sockets;
 using System.Net.WebSockets;
@@ -17,7 +18,7 @@ namespace DebuggerTests
 {
     internal class InspectorClient : DevToolsClient
     {
-        protected Dictionary<MessageId, TaskCompletionSource<Result>> pending_cmds = new Dictionary<MessageId, TaskCompletionSource<Result>>();
+        protected ConcurrentDictionary<MessageId, TaskCompletionSource<Result>> pending_cmds = new ConcurrentDictionary<MessageId, TaskCompletionSource<Result>>();
         protected Func<string, string, JObject, CancellationToken, Task> onEvent;
         protected int next_cmd_id;
 
@@ -39,7 +40,7 @@ namespace DebuggerTests
                 return onEvent(res["sessionId"]?.Value<string>(), res["method"].Value<string>(), res["params"] as JObject, token);
 
             var id = res.ToObject<MessageId>();
-            if (!pending_cmds.Remove(id, out var item))
+            if (!pending_cmds.TryRemove(id, out var item))
                 logger.LogError($"Unable to find command {id}");
 
             item.SetResult(Result.FromJson(res));
@@ -95,7 +96,13 @@ namespace DebuggerTests
             if (sessionId != SessionId.Null)
                 o.Add("sessionId", sessionId.sessionId);
             var tcs = new TaskCompletionSource<Result>();
-            pending_cmds[new MessageId(sessionId.sessionId, id)] = tcs;
+
+            MessageId msgId = new MessageId(sessionId.sessionId, id);
+            pending_cmds.AddOrUpdate(msgId, tcs, (key, oldValue) => {
+                if (oldValue != tcs)
+                    logger.LogDebug($"Updating the pending command, key = {key}, oldValue= {oldValue}, newValue = {tcs}");
+                return tcs;
+            });
 
             var str = o.ToString();
 

--- a/src/mono/wasm/debugger/DebuggerTestSuite/InspectorClient.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/InspectorClient.cs
@@ -17,7 +17,7 @@ namespace DebuggerTests
 {
     internal class InspectorClient : DevToolsClient
     {
-        protected ConcurrentDictionary<MessageId, TaskCompletionSource<Result>> pending_cmds = new ConcurrentDictionary<MessageId, TaskCompletionSource<Result>>();
+        protected readonly ConcurrentDictionary<MessageId, TaskCompletionSource<Result>> pending_cmds = new();
         protected Func<string, string, JObject, CancellationToken, Task> onEvent;
         protected int next_cmd_id;
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/87315.

`ConcurrentDictionary` should be thread-safe, [doc](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2?view=net-7.0#thread-safety).