### PR TITLE
Fix neutral cultures created with the underscore

### DIFF
--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoCtor.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoCtor.cs
@@ -463,6 +463,8 @@ namespace System.Globalization.Tests
         [InlineData("xx-u-XX-u-yy", "xx-u-xx-u-yy")]
         [InlineData("xx-t-ja-JP", "xx-t-ja-jp")]
         [InlineData("qps-plocm", "qps-PLOCM")] // ICU normalize this name to "qps--plocm" which we normalize it back to "qps-plocm"
+        [InlineData("zh_CN", "zh_cn")]
+        [InlineData("km_KH", "km_kh")]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsIcuGlobalization))]
         public void TestCreationWithICUNormalizedNames(string cultureName, string expectedCultureName)
         {

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoCtor.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoCtor.cs
@@ -452,13 +452,6 @@ namespace System.Globalization.Tests
             Assert.Equal(expectedSortName, ci.CompareInfo.Name);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsIcuGlobalization))]
-        public void TestNeutralCultureWithCollationName()
-        {
-            Assert.Throws<CultureNotFoundException>(() => CultureInfo.GetCultureInfo("zh-u-co-zhuyin"));
-            Assert.Throws<CultureNotFoundException>(() => CultureInfo.GetCultureInfo("de-u-co-phonebk"));
-        }
-
         [InlineData("xx-u-XX", "xx-u-xx")]
         [InlineData("xx-u-XX-u-yy", "xx-u-xx-u-yy")]
         [InlineData("xx-t-ja-JP", "xx-t-ja-jp")]

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
@@ -138,13 +138,9 @@ namespace System.Globalization
             _bNeutral = TwoLetterISOCountryName.Length == 0;
             _sSpecificCulture = _bNeutral ? IcuLocaleData.GetSpecificCultureName(_sRealName) : _sRealName;
 
-            if (_bNeutral && collationStart > 0)
-            {
-                return false; // neutral cultures cannot have collation
-            }
-
             // Remove the sort from sName unless custom culture
-            _sName = collationStart < 0 ? _sRealName : _sRealName.Substring(0, collationStart);
+            // To ensure compatibility, it is necessary to allow the creation of cultures like zh_CN (using ICU notation) in the case of _bNeutral.
+            _sName = collationStart < 0 || _bNeutral ? _sRealName : _sRealName.Substring(0, collationStart);
 
             return true;
         }


### PR DESCRIPTION
This is a delta change to the original fix https://github.com/dotnet/runtime/issues/86441


https://github.com/dotnet/runtime/issues/87394