### PR TITLE
[release/7.0-staging] Fix neutral cultures created with the underscore

### DIFF
--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoCtor.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoCtor.cs
@@ -471,6 +471,8 @@ namespace System.Globalization.Tests
         [InlineData("xx-u-XX-u-yy", "xx-u-xx-u-yy")]
         [InlineData("xx-t-ja-JP", "xx-t-ja-jp")]
         [InlineData("qps-plocm", "qps-PLOCM")] // ICU normalize this name to "qps--plocm" which we normalize it back to "qps-plocm"
+        [InlineData("zh_CN", "zh_cn")]
+        [InlineData("km_KH", "km_kh")]
         [ConditionalTheory(nameof(SupportRemoteExecutionWithIcu))]
         public void TestCreationWithICUNormalizedNames(string cultureName, string expectedCultureName)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
@@ -138,13 +138,9 @@ namespace System.Globalization
             _bNeutral = TwoLetterISOCountryName.Length == 0;
             _sSpecificCulture = _bNeutral ? IcuLocaleData.GetSpecificCultureName(_sRealName) : _sRealName;
 
-            if (_bNeutral && collationStart > 0)
-            {
-                return false; // neutral cultures cannot have collation
-            }
-
             // Remove the sort from sName unless custom culture
-            _sName = collationStart < 0 ? _sRealName : _sRealName.Substring(0, collationStart);
+            // To ensure compatibility, it is necessary to allow the creation of cultures like zh_CN (using ICU notation) in the case of _bNeutral.
+            _sName = collationStart < 0 || _bNeutral ? _sRealName : _sRealName.Substring(0, collationStart);
 
             return true;
         }


### PR DESCRIPTION
Backport of #87411 to release/7.0-staging

/cc @tarekgh

## Customer Impact
This is a delta change to the original fix we did in https://github.com/dotnet/runtime/pull/87152

## Testing
Ran regression tests and added more test cases.

## Risk
Low as we are not changing any logic other than ensuring compatibility.

**IMPORTANT**: If this backport is for a servicing release, please verify that:

- The PR target branch is `release/X.0-staging`, not `release/X.0`.

- If the change touches code that ships in a NuGet package, you have added the necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.
