### PR TITLE
Don't return `0` from `getMaxVectorByteLength` when intrinsics are disabled

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8719,8 +8719,11 @@ private:
         }
         else
         {
+            // TODO: We should be returning 0 here, but there are a number of
+            // places that don't quite get handled correctly in that scenario
+
             assert((JitConfig.EnableHWIntrinsic() == 0) || (JitConfig.EnableSSE() == 0));
-            return 0;
+            return XMM_REGSIZE_BYTES;
         }
 #elif defined(TARGET_ARM64)
         if (compOpportunisticallyDependsOn(InstructionSet_AdvSimd))
@@ -8729,8 +8732,11 @@ private:
         }
         else
         {
+            // TODO: We should be returning 0 here, but there are a number of
+            // places that don't quite get handled correctly in that scenario
+
             assert((JitConfig.EnableHWIntrinsic() == 0) || (JitConfig.EnableArm64AdvSimd() == 0));
-            return 0;
+            return FP_REGSIZE_BYTES;
         }
 #else
         assert(!"getMaxVectorByteLength() unimplemented on target arch");


### PR DESCRIPTION
This works around the issues tracked by:
* https://github.com/dotnet/runtime/issues/87388
* https://github.com/dotnet/runtime/issues/87389
* https://github.com/dotnet/runtime/issues/87408
* https://github.com/dotnet/runtime/issues/87409

These represent existing issues that were exposed by https://github.com/dotnet/runtime/pull/85551 as it started having `getMaxVectorByteLength` return 0 if the relevant ISAs were disabled and therefore caused the JIT to go down its fallback paths (i.e. the path that might be executed on x86 Unix or Arm32).

The proper fixes for these are likely going to be a bit more involved and may require distinguishing what exists as required ABI handling (and therefore must use SIMD) vs what only exists as a perf optimization and therefore needs its fallback path to operate correctly even if the ISA is not available.