### PR TITLE
Fix missing GC counter data on non-Windows

### DIFF
--- a/src/coreclr/nativeaot/Runtime/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/CMakeLists.txt
@@ -213,10 +213,15 @@ include_directories(${ARCH_SOURCES_DIR})
 
 if(NOT CLR_CMAKE_TARGET_ARCH_WASM)
   set(FEATURE_PERFTRACING 1)
+  set(FEATURE_EVENT_TRACE 1)
 endif()
 
 if(FEATURE_PERFTRACING)
   add_definitions(-DFEATURE_PERFTRACING)
+endif()
+
+if(FEATURE_EVENT_TRACE)
+  add_definitions(-DFEATURE_EVENT_TRACE)
 endif()
 
 add_definitions(-DFEATURE_BASICFREEZE)
@@ -238,7 +243,6 @@ add_definitions(-D_LIB)
 
 if(WIN32)
   add_definitions(-DFEATURE_ETW)
-  add_definitions(-DFEATURE_EVENT_TRACE)
   add_definitions(-DFEATURE_SUSPEND_REDIRECTION)
   add_definitions(-DFEATURE_SPECIAL_USER_MODE_APC)
 else()

--- a/src/coreclr/nativeaot/Runtime/clretwallmain.h
+++ b/src/coreclr/nativeaot/Runtime/clretwallmain.h
@@ -7,7 +7,7 @@
 // @TODO: Audit native events in NativeAOT Runtime
 
 #include "clreventpipewriteevents.h"
-#include "etwevents.h"
+#include "EtwEvents.h"
 
 inline BOOL EventEnabledDestroyGCHandle(void) {return EventPipeEventEnabledDestroyGCHandle();}
 

--- a/src/coreclr/nativeaot/Runtime/eventtrace.h
+++ b/src/coreclr/nativeaot/Runtime/eventtrace.h
@@ -325,8 +325,8 @@ inline BOOL ETW::GCLog::ShouldWalkStaticsAndCOMForEtw() { return FALSE; }
 inline void ETW::GCLog::FireGcStart(ETW_GC_INFO * pGcInfo) { }
 inline void ETW::GCLog::EndHeapDump(ProfilerWalkHeapContext * profilerWalkHeapContext) { }
 inline void ETW::GCLog::BeginMovedReferences(size_t * pProfilingContext) { }
-inline void ETW::GCLog::MovedReference(BYTE * pbMemBlockStart, BYTE * pbMemBlockEnd, ptrdiff_t cbRelocDistance, size_t profilingContext, BOOL fCompacting) { }
-inline void ETW::GCLog::EndMovedReferences(size_t profilingContext) { }
+inline void ETW::GCLog::MovedReference(BYTE * pbMemBlockStart, BYTE * pbMemBlockEnd, ptrdiff_t cbRelocDistance, size_t profilingContext, BOOL fCompacting, BOOL fAllowProfApiNotification) { }
+inline void ETW::GCLog::EndMovedReferences(size_t profilingContext, BOOL fAllowProfApiNotification) { }
 inline void ETW::GCLog::WalkStaticsAndCOMForETW() { }
 inline void ETW::GCLog::RootReference(
     LPVOID pvHandle,

--- a/src/coreclr/nativeaot/Runtime/gcenv.h
+++ b/src/coreclr/nativeaot/Runtime/gcenv.h
@@ -44,8 +44,7 @@
 #include "gcenv.inl"
 
 #include "stressLog.h"
-#ifdef FEATURE_ETW
-
+#ifdef FEATURE_EVENT_TRACE
     #ifndef _INC_WINDOWS
         typedef void* LPVOID;
         typedef uint32_t UINT;
@@ -58,15 +57,14 @@
     #endif // _INC_WINDOWS
 
     #include "clretwallmain.h"
-    #include "etwevents.h"
     #include "eventtrace.h"
 
-#else // FEATURE_ETW
+#else // FEATURE_EVENT_TRACE
 
     #include "etmdummy.h"
     #define ETW_EVENT_ENABLED(e,f) false
 
-#endif // FEATURE_ETW
+#endif // FEATURE_EVENT_TRACE
 
 #define LOG(x)
 
@@ -88,7 +86,11 @@ public:
 EXTERN_C uint32_t _tls_index;
 inline uint16_t GetClrInstanceId()
 {
+#ifdef HOST_WINDOWS
     return (uint16_t)_tls_index;
+#else
+    return 0;
+#endif
 }
 
 class IGCHeap;

--- a/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
@@ -49,25 +49,6 @@
 #include "holder.h"
 #include "volatile.h"
 
-#ifdef FEATURE_ETW
-    #ifndef _INC_WINDOWS
-        typedef void* LPVOID;
-        typedef uint32_t UINT;
-        typedef void* PVOID;
-        typedef uint64_t ULONGLONG;
-        typedef uint32_t ULONG;
-        typedef int64_t LONGLONG;
-        typedef uint8_t BYTE;
-        typedef uint16_t UINT16;
-    #endif // _INC_WINDOWS
-
-    #include "etwevents.h"
-    #include "eventtrace.h"
-#else // FEATURE_ETW
-    #include "etmdummy.h"
-    #define ETW_EVENT_ENABLED(e,f) false
-#endif // FEATURE_ETW
-
 GPTR_IMPL(MethodTable, g_pFreeObjectEEType);
 
 #include "gctoclreventsink.h"


### PR DESCRIPTION
This sets `FEATURE_EVENT_TRACE` on non-Windows platforms as well, such that GC counter information is tracked and provided when requested.

This is only enough to enable the counter tracking (https://github.com/dotnet/runtime/issues/87325). It does not fully enable event tracing via EventPipe on non-Windows.

I manually verified by running `dotnet-counters monitor`. The automated tests just verify the counters can be retrieved - which they could before, but some of them were just always 0.

Pulling in whatever is under `FEATURE_EVENT_TRACE` seems to be about +25kB on my helloworld app.