### PR TITLE
[PERF][Mono] Update HelloiOS.app publish folder path.

### DIFF
--- a/eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
@@ -137,7 +137,7 @@ steps:
         artifactName:  ${{ parameters.artifactName }}
     - template: /eng/pipelines/common/upload-artifact-step.yml
       parameters:
-        rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT/bin/Bundle/HelloiOS/Release-iphoneos/HelloiOS.app
+        rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT/bin/publish/app/HelloiOS/Release-iphoneos/HelloiOS.app
         includeRootFolder: true
         displayName: iOS Sample App Symbols
         artifactName: iOSSampleAppSymbols
@@ -159,7 +159,7 @@ steps:
         artifactName:  ${{ parameters.artifactName }}
     - template: /eng/pipelines/common/upload-artifact-step.yml
       parameters:
-        rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT/bin/Bundle/HelloiOS/Release-iphoneos/HelloiOS.app
+        rootFolder: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT/bin/publish/app/HelloiOS/Release-iphoneos/HelloiOS.app
         includeRootFolder: true
         displayName: iOS Sample App NoSymbols
         artifactName: iOSSampleAppNoSymbols


### PR DESCRIPTION
This PR updates the path that is pointed to for zipping for the iOS NativeAOT apps. The new path was found by looking at the end of the build log which gave the path to the app. 

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2199003&view=results

