### PR TITLE
[6.0-staging] Bump branding to 6.0.20

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,11 +1,11 @@
 <Project>
   <PropertyGroup>
     <!-- The .NET product branding version -->
-    <ProductVersion>6.0.19</ProductVersion>
+    <ProductVersion>6.0.20</ProductVersion>
     <!-- File version numbers -->
     <MajorVersion>6</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>19</PatchVersion>
+    <PatchVersion>20</PatchVersion>
     <SdkBandVersion>6.0.400</SdkBandVersion>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>


### PR DESCRIPTION
Do not merge this until after we merge https://github.com/dotnet/runtime/pull/87451