### PR TITLE
Fix WCHAR definition on non-Windows for nativeaot

### DIFF
--- a/src/coreclr/nativeaot/Runtime/clretwallmain.h
+++ b/src/coreclr/nativeaot/Runtime/clretwallmain.h
@@ -28,8 +28,8 @@ inline ULONG FireEtwDestroyGCHandle(
 inline BOOL EventEnabledExceptionThrown_V1(void) {return EventPipeEventEnabledExceptionThrown_V1();}
 
 inline ULONG FireEtwExceptionThrown_V1(
-    wchar_t* ExceptionType,
-    wchar_t* ExceptionMessage,
+    const WCHAR* ExceptionType,
+    const WCHAR* ExceptionMessage,
     void*  ExceptionEIP,
     const unsigned int  ExceptionHRESULT,
     const unsigned short  ExceptionFlags,
@@ -70,7 +70,7 @@ inline ULONG FireEtwGCAllocationTick_V2(
     const unsigned short  ClrInstanceID,
     const unsigned __int64  AllocationAmount64,
     void*  TypeID,
-    wchar_t*  TypeName,
+    const WCHAR*  TypeName,
     const unsigned int  HeapIndex,
     const GUID * ActivityId = nullptr,
     const GUID * RelatedActivityId = nullptr
@@ -91,7 +91,7 @@ inline ULONG FireEtwGCAllocationTick_V3(
     const unsigned short  ClrInstanceID,
     const unsigned __int64  AllocationAmount64,
     void*  TypeID,
-    wchar_t*  TypeName,
+    const WCHAR*  TypeName,
     const unsigned int  HeapIndex,
     void*  Address,
     const GUID * ActivityId = nullptr,
@@ -561,15 +561,15 @@ inline ULONG FireEtwModuleLoad_V2(
     const unsigned __int64  AssemblyID,
     const unsigned int  ModuleFlags,
     const unsigned int  Reserved1,
-    wchar_t*  ModuleILPath,
-    wchar_t*  ModuleNativePath,
+    const WCHAR*  ModuleILPath,
+    const WCHAR*  ModuleNativePath,
     const unsigned short  ClrInstanceID,
     const GUID* ManagedPdbSignature,
     const unsigned int  ManagedPdbAge,
-    wchar_t*  ManagedPdbBuildPath,
+    const WCHAR*  ManagedPdbBuildPath,
     const GUID* NativePdbSignature,
     const unsigned int  NativePdbAge,
-    wchar_t*  NativePdbBuildPath,
+    const WCHAR*  NativePdbBuildPath,
     const GUID * ActivityId = nullptr,
     const GUID * RelatedActivityId = nullptr
 )

--- a/src/coreclr/nativeaot/Runtime/clreventpipewriteevents.h
+++ b/src/coreclr/nativeaot/Runtime/clreventpipewriteevents.h
@@ -15,8 +15,8 @@ ULONG EventPipeWriteEventDestroyGCHandle(
 );
 BOOL EventPipeEventEnabledExceptionThrown_V1(void);
 ULONG EventPipeWriteEventExceptionThrown_V1(
-    const wchar_t* ExceptionType,
-    const wchar_t* ExceptionMessage,
+    const WCHAR* ExceptionType,
+    const WCHAR* ExceptionMessage,
     const void*  ExceptionEIP,
     const unsigned int  ExceptionHRESULT,
     const unsigned short  ExceptionFlags,
@@ -39,7 +39,7 @@ ULONG EventPipeWriteEventGCAllocationTick_V2(
     const unsigned short  ClrInstanceID,
     const unsigned __int64  AllocationAmount64,
     const void*  TypeID,
-    const wchar_t*  TypeName,
+    const WCHAR*  TypeName,
     const unsigned int  HeapIndex,
     const GUID * ActivityId = nullptr,
     const GUID * RelatedActivityId = nullptr
@@ -51,7 +51,7 @@ ULONG EventPipeWriteEventGCAllocationTick_V3(
     const unsigned short  ClrInstanceID,
     const unsigned __int64  AllocationAmount64,
     const void*  TypeID,
-    const wchar_t*  TypeName,
+    const WCHAR*  TypeName,
     const unsigned int  HeapIndex,
     const void*  Address,
     const GUID * ActivityId = nullptr,
@@ -296,15 +296,15 @@ ULONG EventPipeWriteEventModuleLoad_V2(
     const unsigned __int64  AssemblyID,
     const unsigned int  ModuleFlags,
     const unsigned int  Reserved1,
-    const wchar_t*  ModuleILPath,
-    const wchar_t*  ModuleNativePath,
+    const WCHAR*  ModuleILPath,
+    const WCHAR*  ModuleNativePath,
     const unsigned short  ClrInstanceID,
     const GUID* ManagedPdbSignature,
     const unsigned int  ManagedPdbAge,
-    const wchar_t*  ManagedPdbBuildPath,
+    const WCHAR*  ManagedPdbBuildPath,
     const GUID* NativePdbSignature,
     const unsigned int  NativePdbAge,
-    const wchar_t*  NativePdbBuildPath,
+    const WCHAR*  NativePdbBuildPath,
     const GUID * ActivityId = nullptr,
     const GUID * RelatedActivityId = nullptr
 );

--- a/src/coreclr/nativeaot/Runtime/eventpipe/dotnetruntime.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/dotnetruntime.cpp
@@ -91,7 +91,7 @@ bool ResizeBuffer(BYTE *&buffer, size_t& size, size_t currLen, size_t newSize, b
 
 // shipping criteria: no EVENTPIPE-NATIVEAOT-TODO left in the codebase
 // @TODO - Events need to be audited
-const WCHAR* DotNETRuntimeName = L"Microsoft-Windows-DotNETRuntime";
+const WCHAR* DotNETRuntimeName = W("Microsoft-Windows-DotNETRuntime");
 EventPipeProvider *EventPipeProviderDotNETRuntime = nullptr;
 EventPipeEvent *EventPipeEventDestroyGCHandle = nullptr;
 EventPipeEvent *EventPipeEventExceptionThrown_V1 = nullptr;
@@ -177,8 +177,8 @@ BOOL EventPipeEventEnabledExceptionThrown_V1(void)
 }
 
 ULONG EventPipeWriteEventExceptionThrown_V1(
-    const wchar_t* ExceptionType,
-    const wchar_t* ExceptionMessage,
+    const WCHAR* ExceptionType,
+    const WCHAR* ExceptionMessage,
     const void* ExceptionEIP,
     const unsigned int ExceptionHRESULT,
     const unsigned short ExceptionFlags,
@@ -196,8 +196,8 @@ ULONG EventPipeWriteEventExceptionThrown_V1(
     bool fixedBuffer = true;
     bool success = true;
 
-    if (!ExceptionType) { ExceptionType = L"NULL"; }
-    if (!ExceptionMessage) { ExceptionMessage = L"NULL"; }
+    if (!ExceptionType) { ExceptionType = W("NULL"); }
+    if (!ExceptionMessage) { ExceptionMessage = W("NULL"); }
     success &= WriteToBuffer(ExceptionType, buffer, offset, size, fixedBuffer);
     success &= WriteToBuffer(ExceptionMessage, buffer, offset, size, fixedBuffer);
     success &= WriteToBuffer(ExceptionEIP, buffer, offset, size, fixedBuffer);
@@ -274,7 +274,7 @@ ULONG EventPipeWriteEventGCAllocationTick_V2(
     const unsigned short ClrInstanceID,
     const unsigned __int64 AllocationAmount64,
     const void* TypeID,
-    const wchar_t* TypeName,
+    const WCHAR* TypeName,
     const unsigned int HeapIndex,
     const GUID * ActivityId,
     const GUID * RelatedActivityId)
@@ -289,7 +289,7 @@ ULONG EventPipeWriteEventGCAllocationTick_V2(
     bool fixedBuffer = true;
     bool success = true;
 
-    if (!TypeName) { TypeName = L"NULL"; }
+    if (!TypeName) { TypeName = W("NULL"); }
     success &= WriteToBuffer(AllocationAmount, buffer, offset, size, fixedBuffer);
     success &= WriteToBuffer(AllocationKind, buffer, offset, size, fixedBuffer);
     success &= WriteToBuffer(ClrInstanceID, buffer, offset, size, fixedBuffer);
@@ -325,7 +325,7 @@ ULONG EventPipeWriteEventGCAllocationTick_V3(
     const unsigned short ClrInstanceID,
     const unsigned __int64 AllocationAmount64,
     const void* TypeID,
-    const wchar_t* TypeName,
+    const WCHAR* TypeName,
     const unsigned int HeapIndex,
     const void* Address,
     const GUID * ActivityId,
@@ -341,7 +341,7 @@ ULONG EventPipeWriteEventGCAllocationTick_V3(
     bool fixedBuffer = true;
     bool success = true;
 
-    if (!TypeName) { TypeName = L"NULL"; }
+    if (!TypeName) { TypeName = W("NULL"); }
     success &= WriteToBuffer(AllocationAmount, buffer, offset, size, fixedBuffer);
     success &= WriteToBuffer(AllocationKind, buffer, offset, size, fixedBuffer);
     success &= WriteToBuffer(ClrInstanceID, buffer, offset, size, fixedBuffer);
@@ -1458,15 +1458,15 @@ ULONG EventPipeWriteEventModuleLoad_V2(
     const unsigned __int64 AssemblyID,
     const unsigned int ModuleFlags,
     const unsigned int Reserved1,
-    const wchar_t* ModuleILPath,
-    const wchar_t* ModuleNativePath,
+    const WCHAR* ModuleILPath,
+    const WCHAR* ModuleNativePath,
     const unsigned short ClrInstanceID,
     const GUID* ManagedPdbSignature,
     const unsigned int ManagedPdbAge,
-    const wchar_t* ManagedPdbBuildPath,
+    const WCHAR* ManagedPdbBuildPath,
     const GUID* NativePdbSignature,
     const unsigned int NativePdbAge,
-    const wchar_t* NativePdbBuildPath,
+    const WCHAR* NativePdbBuildPath,
     const GUID * ActivityId,
     const GUID * RelatedActivityId)
 {
@@ -1480,10 +1480,10 @@ ULONG EventPipeWriteEventModuleLoad_V2(
     bool fixedBuffer = true;
     bool success = true;
 
-    if (!ModuleILPath) { ModuleILPath = L"NULL"; }
-    if (!ModuleNativePath) { ModuleNativePath = L"NULL"; }
-    if (!ManagedPdbBuildPath) { ManagedPdbBuildPath = L"NULL"; }
-    if (!NativePdbBuildPath) { NativePdbBuildPath = L"NULL"; }
+    if (!ModuleILPath) { ModuleILPath = W("NULL"); }
+    if (!ModuleNativePath) { ModuleNativePath = W("NULL"); }
+    if (!ManagedPdbBuildPath) { ManagedPdbBuildPath = W("NULL"); }
+    if (!NativePdbBuildPath) { NativePdbBuildPath = W("NULL"); }
     success &= WriteToBuffer(ModuleID, buffer, offset, size, fixedBuffer);
     success &= WriteToBuffer(AssemblyID, buffer, offset, size, fixedBuffer);
     success &= WriteToBuffer(ModuleFlags, buffer, offset, size, fixedBuffer);

--- a/src/coreclr/nativeaot/Runtime/gctoclreventsink.cpp
+++ b/src/coreclr/nativeaot/Runtime/gctoclreventsink.cpp
@@ -27,14 +27,14 @@ void GCToCLREventSink::FireGCStart_V2(uint32_t count, uint32_t depth, uint32_t r
 {
     LIMITED_METHOD_CONTRACT;
 
-#ifdef FEATURE_ETW
+#ifdef FEATURE_EVENT_TRACE
     ETW::GCLog::ETW_GC_INFO gcStartInfo;
     gcStartInfo.GCStart.Count = count;
     gcStartInfo.GCStart.Depth = depth;
     gcStartInfo.GCStart.Reason = static_cast<ETW::GCLog::ETW_GC_INFO::GC_REASON>(reason);
     gcStartInfo.GCStart.Type = static_cast<ETW::GCLog::ETW_GC_INFO::GC_TYPE>(type);
     ETW::GCLog::FireGcStart(&gcStartInfo);
-#endif // FEATURE_ETW
+#endif // FEATURE_EVENT_TRACE
 }
 
 void GCToCLREventSink::FireGCGenerationRange(uint8_t generation, void* rangeStart, uint64_t rangeUsedLength, uint64_t rangeReservedLength)

--- a/src/coreclr/nativeaot/Runtime/inc/CommonTypes.h
+++ b/src/coreclr/nativeaot/Runtime/inc/CommonTypes.h
@@ -24,7 +24,14 @@ using std::size_t;
 using std::uintptr_t;
 using std::intptr_t;
 
+
+#ifdef TARGET_WINDOWS
 typedef wchar_t             WCHAR;
+#define W(str) L##str
+#else
+typedef char16_t             WCHAR;
+#define W(str) u##str
+#endif
 typedef void *              HANDLE;
 
 typedef uint32_t            UInt32_BOOL;    // windows 4-byte BOOL, 0 -> false, everything else -> true

--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -613,7 +613,7 @@ extern "C" UInt32_BOOL CloseHandle(HANDLE handle)
     return success ? UInt32_TRUE : UInt32_FALSE;
 }
 
-REDHAWK_PALEXPORT HANDLE REDHAWK_PALAPI PalCreateEventW(_In_opt_ LPSECURITY_ATTRIBUTES pEventAttributes, UInt32_BOOL manualReset, UInt32_BOOL initialState, _In_opt_z_ const wchar_t* pName)
+REDHAWK_PALEXPORT HANDLE REDHAWK_PALAPI PalCreateEventW(_In_opt_ LPSECURITY_ATTRIBUTES pEventAttributes, UInt32_BOOL manualReset, UInt32_BOOL initialState, _In_opt_z_ const WCHAR* pName)
 {
     UnixEvent event = UnixEvent(manualReset, initialState);
     if (!event.Initialize())


### PR DESCRIPTION
In combination with https://github.com/dotnet/runtime/pull/87430, this fixes enabling of runtime events on non-Windows. We were using wchar_t on non-Windows and expecting it to be 2 bytes (when it is 4) - as a result, the string length / conversion functions were not working properly and providers were not properly enabled.

The GC events that don't go through ETW::GCLog are now fired/collected on non-Windows. There is still work needed to pull in the ETW::GCLog implementation on non-Windows.

Contributes to https://github.com/dotnet/runtime/issues/87445

cc @LakshanF