### PR TITLE
[RISC-V][JIT] Fix encoding of CallGCregs

### DIFF
--- a/src/coreclr/jit/emitinl.h
+++ b/src/coreclr/jit/emitinl.h
@@ -376,23 +376,23 @@ inline ssize_t emitter::emitGetInsAmdAny(instrDesc* id)
         encodeMask |= 0x08;
     if ((regmask & RBM_S5) != RBM_NONE)
         encodeMask |= 0x10;
+    if ((regmask & RBM_S6) != RBM_NONE)
+        encodeMask |= 0x20;
 
     id->idReg1((regNumber)encodeMask); // Save in idReg1
 
     encodeMask = 0;
 
-    if ((regmask & RBM_S6) != RBM_NONE)
-        encodeMask |= 0x01;
     if ((regmask & RBM_S7) != RBM_NONE)
-        encodeMask |= 0x02;
+        encodeMask |= 0x01;
     if ((regmask & RBM_S8) != RBM_NONE)
-        encodeMask |= 0x04;
+        encodeMask |= 0x02;
     if ((regmask & RBM_S9) != RBM_NONE)
-        encodeMask |= 0x08;
+        encodeMask |= 0x04;
     if ((regmask & RBM_S10) != RBM_NONE)
-        encodeMask |= 0x10;
+        encodeMask |= 0x08;
     if ((regmask & RBM_S11) != RBM_NONE)
-        encodeMask |= 0x20;
+        encodeMask |= 0x10;
 
     id->idReg2((regNumber)encodeMask); // Save in idReg2
 


### PR DESCRIPTION
- It fixes what Encoding and Decoding logic handle CallGCregs differently.

Below tests are fixed (on CHECKED BUILD)
```
./JIT/Methodical/VT/port/lcs_gcref_do/lcs_gcref_do.sh
./JIT/Methodical/VT/port/lcs_gcref_ro/lcs_gcref_ro.sh
./JIT/Methodical/int64/arrays/lcs_long_do/lcs_long_do.sh
./JIT/Methodical/int64/arrays/lcs_long_il_r/lcs_long_il_r.sh
./JIT/Methodical/int64/arrays/lcs_long_ro/lcs_long_ro.sh
./JIT/Methodical/int64/arrays/lcs_ulong_do/lcs_ulong_do.sh
./JIT/Methodical/int64/arrays/lcs_ulong_ro/lcs_ulong_ro.sh
./JIT/Methodical/int64/arrays/lcs_ulong_il_r/lcs_ulong_il_r.sh
./JIT/opt/OSR/pinnedlocal/pinnedlocal.sh
```

Part of https://github.com/dotnet/runtime/issues/84834
cc @wscho77 @HJLeee @JongHeonChoi @t-mustafin @alpencolt @gbalykov