### PR TITLE
[wasm] Change optimization flag to workaround llvm issue

### DIFF
--- a/eng/testing/tests.browser.targets
+++ b/eng/testing/tests.browser.targets
@@ -213,7 +213,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <EmccLinkOptimizationFlag Condition="'$(EmccLinkOptimizationFlag)' == ''">-Oz -Wl,-O0 -Wl,--lto-O0</EmccLinkOptimizationFlag>
+      <EmccLinkOptimizationFlag Condition="'$(EmccLinkOptimizationFlag)' == ''">-O2 -Wl,-O0 -Wl,--lto-O0</EmccLinkOptimizationFlag>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This is a workaround for https://github.com/dotnet/runtime/issues/87423 . When running the `System.Runtime.Intrinsics.Tests` for AOT on helix, the compile time flags used are `-Oz -Wl,-O0 -Wl,--lto-O0`. This PR changes it from `-Oz` to `-O2`.