### PR TITLE
[browser][debugger][MT] Make operations on dictionary thread-safe follow-up

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/FirefoxInspectorClient.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/FirefoxInspectorClient.cs
@@ -235,6 +235,7 @@ class FirefoxInspectorClient : InspectorClient
 
         msgId = new FirefoxMessageId("", 0, to_str);
         pending_cmds.AddOrUpdate(msgId, tcs,  (key, oldValue) => tcs);
+        logger.LogTrace($"SendCommand: to: {args}");
 
         var msg = args.ToString(Formatting.None);
         var bytes = Encoding.UTF8.GetBytes(msg);

--- a/src/mono/wasm/debugger/DebuggerTestSuite/InspectorClient.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/InspectorClient.cs
@@ -98,7 +98,6 @@ namespace DebuggerTests
 
             MessageId msgId = new MessageId(sessionId.sessionId, id);
             pending_cmds.AddOrUpdate(msgId, tcs,  (key, oldValue) => tcs);
-            logger.LogTrace($"SendCommand: to: {args}");
 
             var str = o.ToString();
 

--- a/src/mono/wasm/debugger/DebuggerTestSuite/InspectorClient.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/InspectorClient.cs
@@ -98,6 +98,7 @@ namespace DebuggerTests
 
             MessageId msgId = new MessageId(sessionId.sessionId, id);
             pending_cmds.AddOrUpdate(msgId, tcs,  (key, oldValue) => tcs);
+            logger.LogTrace($"SendCommand: to: {args}");
 
             var str = o.ToString();
 


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/87405 was a too fast merge, I removed logging in Firefox by mistake. This PR reverts it.