### PR TITLE
Add delay load hook for singlefilehost and enable delay load of version.dll

### DIFF
--- a/src/coreclr/dlls/mscoree/CMakeLists.txt
+++ b/src/coreclr/dlls/mscoree/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CLR_SOURCES
 
 if(CLR_CMAKE_TARGET_WIN32)
 list(APPEND CLR_SOURCES
-    delayloadhook.cpp
+    ${CLR_SRC_NATIVE_DIR}/libs/Common/delayloadhook_windows.cpp
     Native.rc
 )
 

--- a/src/native/corehost/apphost/static/CMakeLists.txt
+++ b/src/native/corehost/apphost/static/CMakeLists.txt
@@ -56,7 +56,9 @@ endif()
 if(CLR_CMAKE_TARGET_WIN32)
     add_definitions(-DUNICODE)
     list(APPEND SOURCES
-        ../apphost.windows.cpp)
+        ../apphost.windows.cpp
+        ${CLR_SRC_NATIVE_DIR}/libs/Common/delayloadhook_windows.cpp
+    )
 
     list(APPEND HEADERS
         ../apphost.windows.h)
@@ -106,6 +108,9 @@ if(CLR_CMAKE_TARGET_WIN32)
 
     # Delay load libraries required for WinRT as that is not supported on all platforms
     add_linker_flag("/DELAYLOAD:api-ms-win-core-winrt-l1-1-0.dll")
+
+    # Delay load version.dll so that we can specify how to search when loading it as it is not part of Windows' known DLLs
+    add_linker_flag("/DELAYLOAD:version.dll")
 endif()
 
 if(CLR_CMAKE_TARGET_WIN32)

--- a/src/native/libs/Common/delayloadhook_windows.cpp
+++ b/src/native/libs/Common/delayloadhook_windows.cpp
@@ -4,8 +4,7 @@
 // File: delayloadhook.cpp
 //
 
-#include "stdafx.h"
-
+#include <windows.h>
 #include <delayimp.h>
 
 FARPROC WINAPI secureDelayHook(unsigned dliNotify, PDelayLoadInfo pdli)


### PR DESCRIPTION
`coreclr` delay loads `version.dll` and adds a hook such that it loads from the system directory. In single-file, we lost this behaviour since it uses static library version of `coreclr`. This adds the same mechanism to single-file.