### PR TITLE
Block "Convert To LibraryImport" in more unsupported cases

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportAnalyzer.cs
@@ -91,6 +91,12 @@ namespace Microsoft.Interop.Analyzers
                 }
             }
 
+            if (method.IsVararg)
+            {
+                // LibraryImportGenerator doesn't support varargs
+                return;
+            }
+
             // Ignore methods already marked LibraryImport
             // This can be the case when the generator creates an extern partial function for blittable signatures.
             foreach (AttributeData attr in method.GetAttributes())

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportAnalyzer.cs
@@ -82,13 +82,10 @@ namespace Microsoft.Interop.Analyzers
                 return;
             }
 
-            if (dllImportData.BestFitMapping != false)
+            // LibraryImportGenerator doesn't support BestFitMapping = true
+            if (IsBestFitMapping(method, dllImportData))
             {
-                // LibraryImportGenerator doesn't support BestFitMapping = true
-                if (IsBestFitMapping(method, dllImportData))
-                {
-                    return;
-                }
+                return;
             }
 
             if (method.IsVararg)
@@ -162,15 +159,17 @@ namespace Microsoft.Interop.Analyzers
 
         private static bool IsBestFitMapping(IMethodSymbol method, DllImportData? dllImportData)
         {
-            if (dllImportData.BestFitMapping == true)
+            if (dllImportData.BestFitMapping.HasValue)
             {
-                return true;
+                return dllImportData.BestFitMapping.Value;
             }
+
             AttributeData? bestFitMappingContainingType = method.ContainingType.GetAttributes().FirstOrDefault(attr => attr.AttributeClass.ToDisplayString() == TypeNames.System_Runtime_InteropServices_BestFitMappingAttribute);
             if (bestFitMappingContainingType is not null)
             {
                 return bestFitMappingContainingType.ConstructorArguments[0].Value is true;
             }
+
             AttributeData? bestFitMappingContainingAssembly = method.ContainingAssembly.GetAttributes().FirstOrDefault(attr => attr.AttributeClass.ToDisplayString() == TypeNames.System_Runtime_InteropServices_BestFitMappingAttribute);
             if (bestFitMappingContainingAssembly is not null)
             {

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportAnalyzer.cs
@@ -76,6 +76,21 @@ namespace Microsoft.Interop.Analyzers
             if (dllImportData == null)
                 return;
 
+            if (dllImportData.ThrowOnUnmappableCharacter == true)
+            {
+                // LibraryImportGenerator doesn't support ThrowOnUnmappableCharacter = true
+                return;
+            }
+
+            if (dllImportData.BestFitMapping != false)
+            {
+                // LibraryImportGenerator doesn't support BestFitMapping = true
+                if (IsBestFitMapping(method, dllImportData))
+                {
+                    return;
+                }
+            }
+
             // Ignore methods already marked LibraryImport
             // This can be the case when the generator creates an extern partial function for blittable signatures.
             foreach (AttributeData attr in method.GetAttributes())
@@ -137,6 +152,26 @@ namespace Microsoft.Interop.Analyzers
             properties.Add(MayRequireAdditionalWork, mayRequireAdditionalWork.ToString());
 
             context.ReportDiagnostic(method.CreateDiagnosticInfo(ConvertToLibraryImport, properties.ToImmutable(), method.Name).ToDiagnostic());
+        }
+
+        private static bool IsBestFitMapping(IMethodSymbol method, DllImportData? dllImportData)
+        {
+            if (dllImportData.BestFitMapping == true)
+            {
+                return true;
+            }
+            AttributeData? bestFitMappingContainingType = method.ContainingType.GetAttributes().FirstOrDefault(attr => attr.AttributeClass.ToDisplayString() == TypeNames.System_Runtime_InteropServices_BestFitMappingAttribute);
+            if (bestFitMappingContainingType is not null)
+            {
+                return bestFitMappingContainingType.ConstructorArguments[0].Value is true;
+            }
+            AttributeData? bestFitMappingContainingAssembly = method.ContainingAssembly.GetAttributes().FirstOrDefault(attr => attr.AttributeClass.ToDisplayString() == TypeNames.System_Runtime_InteropServices_BestFitMappingAttribute);
+            if (bestFitMappingContainingAssembly is not null)
+            {
+                return bestFitMappingContainingAssembly.ConstructorArguments[0].Value is true;
+            }
+
+            return false;
         }
 
         private static bool HasUnsupportedMarshalAsInfo(TypePositionInfo info)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
@@ -152,5 +152,7 @@ namespace Microsoft.Interop
         public const string System_Runtime_InteropServices_Marshalling_ComInterfaceMarshaller_Metadata = "System.Runtime.InteropServices.Marshalling.ComInterfaceMarshaller`1";
 
         public const string System_Runtime_InteropServices_Marshalling_ComObject = "System.Runtime.InteropServices.Marshalling.ComObject";
+
+        public const string System_Runtime_InteropServices_BestFitMappingAttribute = "System.Runtime.InteropServices.BestFitMappingAttribute";
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/ConvertToLibraryImportAnalyzerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/ConvertToLibraryImportAnalyzerTests.cs
@@ -317,5 +317,20 @@ namespace LibraryImportGenerator.UnitTests
                """;
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
+
+        [Fact]
+        public async Task Varargs_NoDiagnostic()
+        {
+            string source = """
+              using System.Runtime.InteropServices;
+              partial class Test
+              {
+                  [DllImport("DoesNotExist")]
+                  public static extern void Method2(__arglist);
+              }
+
+              """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/ConvertToLibraryImportAnalyzerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/ConvertToLibraryImportAnalyzerTests.cs
@@ -223,5 +223,99 @@ namespace LibraryImportGenerator.UnitTests
                 public static extern {{typeName}} {|#1:Method_Return|}();
             }
             """;
+
+        [Fact]
+        public async Task BestFitMapping_True_NoDiagnostic()
+        {
+            string source = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [DllImport("DoesNotExist", BestFitMapping = true)]
+                    public static extern void Method2();
+                }
+
+               """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task ThrowOnUnmappableChar_True_NoDiagnostic()
+        {
+            string source = """
+               using System.Runtime.InteropServices;
+               partial class Test
+               {
+                   [DllImport("DoesNotExist", ThrowOnUnmappableChar = true)]
+                   public static extern void Method2();
+               }
+
+               """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task BestFitMapping_Assembly_True_NoDiagnostic()
+        {
+            string source = """
+               using System.Runtime.InteropServices;
+               [assembly:BestFitMapping(true)]
+               partial class Test
+               {
+                   [DllImport("DoesNotExist")]
+                   public static extern void Method2();
+               }
+
+               """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task BestFitMapping_Type_True_NoDiagnostic()
+        {
+            string source = """
+               using System.Runtime.InteropServices;
+               [BestFitMapping(true)]
+               partial class Test
+               {
+                   [DllImport("DoesNotExist")]
+                   public static extern void Method2();
+               }
+
+               """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task BestFitMapping_Assembly_False_Diagnostic()
+        {
+            string source = """
+               using System.Runtime.InteropServices;
+               [assembly:BestFitMapping(false)]
+               partial class Test
+               {
+                   [DllImport("DoesNotExist")]
+                   public static extern void [|Method2|]();
+               }
+
+               """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task BestFitMapping_Type_False_Diagnostic()
+        {
+            string source = """
+               using System.Runtime.InteropServices;
+               [BestFitMapping(false)]
+               partial class Test
+               {
+                   [DllImport("DoesNotExist")]
+                   public static extern void [|Method2|]();
+               }
+
+               """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/ConvertToLibraryImportFixerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/ConvertToLibraryImportFixerTests.cs
@@ -1109,6 +1109,58 @@ namespace LibraryImportGenerator.UnitTests
                 new Dictionary<string, Option> { { Option.MayRequireAdditionalWork, new Option.Bool(true) } });
         }
 
+        [Fact]
+        public async Task BestFitMappingExplicitFalse()
+        {
+            string source = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [DllImport("DoesNotExist", BestFitMapping = false)]
+                    public static extern void [|Method|]();
+                }
+
+               """;
+
+            string fixedSource = """
+                 using System.Runtime.InteropServices;
+                 partial class Test
+                 {
+                     [LibraryImport("DoesNotExist")]
+                     public static partial void {|CS8795:Method|}();
+                 }
+
+                """;
+
+            await VerifyCodeFixAsync(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task ThrowOnUnmappableCharExplicitFalse()
+        {
+            string source = """
+                using System.Runtime.InteropServices;
+                partial class Test
+                {
+                    [DllImport("DoesNotExist", ThrowOnUnmappableChar = false)]
+                    public static extern void [|Method|]();
+                }
+
+               """;
+
+            string fixedSource = """
+                 using System.Runtime.InteropServices;
+                 partial class Test
+                 {
+                     [LibraryImport("DoesNotExist")]
+                     public static partial void {|CS8795:Method|}();
+                 }
+
+                """;
+
+            await VerifyCodeFixAsync(source, fixedSource);
+        }
+
         private static async Task VerifyCodeFixAsync(string source, string fixedSource)
         {
             var test = new VerifyCS.Test


### PR DESCRIPTION
Block "Convert to LibraryImport" in cases where the user has specified `BestFitMapping` or `ThrowUnmappableChar` in settings other than the one configuration `LibraryImport` supports. Also block `__arglist` varargs as we don't support that in `LibraryImport` either.

Fixes #79159