### PR TITLE
Fix StrictlyBlittable check to work for "source Compilation" references.

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/CustomMarshallerAttributeAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/CustomMarshallerAttributeAnalyzer.cs
@@ -882,7 +882,7 @@ namespace Microsoft.Interop.Analyzers
                         // First verify all usages in the managed->unmanaged shape.
                         IMethodSymbol toUnmanagedMethod = methods.ToUnmanaged ?? methods.ToUnmanagedWithBuffer;
                         unmanagedType = toUnmanagedMethod.ReturnType;
-                        if (!unmanagedType.IsUnmanagedType && !unmanagedType.IsStrictlyBlittable())
+                        if (!unmanagedType.IsUnmanagedType && !unmanagedType.IsStrictlyBlittableInContext(_compilation))
                         {
                             diagnosticReporter.CreateAndReportDiagnostic(UnmanagedTypeMustBeUnmanagedRule, toUnmanagedMethod.ToDisplayString());
                         }
@@ -1198,7 +1198,7 @@ namespace Microsoft.Interop.Analyzers
                     {
                         // First verify all usages in the managed->unmanaged shape.
                         unmanagedType = methods.ToUnmanaged.ReturnType;
-                        if (!unmanagedType.IsUnmanagedType && !unmanagedType.IsStrictlyBlittable())
+                        if (!unmanagedType.IsUnmanagedType && !unmanagedType.IsStrictlyBlittableInContext(_compilation))
                         {
                             diagnosticReporter.CreateAndReportDiagnostic(UnmanagedTypeMustBeUnmanagedRule, methods.ToUnmanaged.ToDisplayString());
                         }
@@ -1217,7 +1217,7 @@ namespace Microsoft.Interop.Analyzers
                         {
                             unmanagedType = fromUnmanagedMethod.Parameters[0].Type;
 
-                            if (!unmanagedType.IsUnmanagedType && !unmanagedType.IsStrictlyBlittable())
+                            if (!unmanagedType.IsUnmanagedType && !unmanagedType.IsStrictlyBlittableInContext(_compilation))
                             {
                                 diagnosticReporter.CreateAndReportDiagnostic(UnmanagedTypeMustBeUnmanagedRule, fromUnmanagedMethod.ToDisplayString());
                             }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/BlittableTypeMarshallingInfoProvider.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/BlittableTypeMarshallingInfoProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Interop
             }
             else
             {
-                return new UnmanagedBlittableMarshallingInfo(type.IsStrictlyBlittable());
+                return new UnmanagedBlittableMarshallingInfo(type.IsStrictlyBlittableInContext(_compilation));
             }
         }
     }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManualTypeMarshallingHelper.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManualTypeMarshallingHelper.cs
@@ -526,7 +526,7 @@ namespace Microsoft.Interop
                 ManagedTypeInfo.CreateTypeInfoForTypeSymbol(nativeType),
                 HasState: false,
                 shape,
-                nativeType.IsStrictlyBlittable(),
+                nativeType.IsStrictlyBlittableInContext(compilation),
                 bufferElementType,
                 collectionElementTypeInfo,
                 collectionElementMarshallingInfo);
@@ -606,7 +606,7 @@ namespace Microsoft.Interop
                 ManagedTypeInfo.CreateTypeInfoForTypeSymbol(nativeType),
                 HasState: true,
                 shape,
-                nativeType.IsStrictlyBlittable(),
+                nativeType.IsStrictlyBlittableInContext(compilation),
                 bufferElementType,
                 CollectionElementType: collectionElementTypeInfo,
                 CollectionElementMarshallingInfo: collectionElementMarshallingInfo);

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeSymbolExtensions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeSymbolExtensions.cs
@@ -30,7 +30,8 @@ namespace Microsoft.Interop
         {
             unsafe
             {
-                return IsBlittableWorker(type, ImmutableHashSet.Create<ITypeSymbol>(SymbolEqualityComparer.Default), compilation: null, &IsConsideredBlittableWorker);
+                // We can pass a null Compilation here since our blittability check does not depend on the compilation.
+                return IsBlittableWorker(type, ImmutableHashSet.Create<ITypeSymbol>(SymbolEqualityComparer.Default), compilation: null!, &IsConsideredBlittableWorker);
             }
 
             static bool IsConsideredBlittableWorker(ITypeSymbol t, ImmutableHashSet<ITypeSymbol> seenTypes, Compilation compilation)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeSymbolExtensions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeSymbolExtensions.cs
@@ -67,9 +67,8 @@ namespace Microsoft.Interop
                 }
                 else if (t.IsValueType)
                 {
-                    // If the containing assembly for the type is backed by metadata (non-null),
-                    // then the type is not internal and therefore coming from a reference assembly
-                    // that we can not confirm is strictly blittable.
+                    // If the containing assembly for the type is not the same assembly as the assembly defining the interop stub,
+                    // then we can't trust the type definition as it may differ at runtime from the compile-time definition.
                     if (t.ContainingAssembly is not ISourceAssemblySymbol sourceAssembly
                         || sourceAssembly.Compilation != compilation)
                     {
@@ -91,6 +90,13 @@ namespace Microsoft.Interop
             {
                 return true;
             }
+
+            // Treat pointers as always blittable.
+            if (type.TypeKind is TypeKind.Pointer or TypeKind.FunctionPointer)
+            {
+                return true;
+            }
+
             if (type.IsAutoLayout() || !isBlittable(type, seenTypes, compilation))
             {
                 return false;


### PR DESCRIPTION
Fixes #84739.