### PR TITLE
Fix DependencyContext splitting on semi-colon

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyModel/src/DependencyContextPaths.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/src/DependencyContextPaths.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Extensions.DependencyModel
         private const string DepsFilesProperty = "APP_CONTEXT_DEPS_FILES";
         private const string FxDepsFileProperty = "FX_DEPS_FILE";
 
+        private static readonly char[] s_semicolon = new[] { ';' };
+
         public static DependencyContextPaths Current { get; } = GetCurrent();
 
         public string? Application { get; }
@@ -19,8 +21,6 @@ namespace Microsoft.Extensions.DependencyModel
         public string? SharedRuntime { get; }
 
         public IEnumerable<string> NonApplicationPaths { get; }
-
-        private static readonly char[] s_semicolon = new[] { ';' };
 
         public DependencyContextPaths(
             string? application,

--- a/src/libraries/Microsoft.Extensions.DependencyModel/src/DependencyContextPaths.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/src/DependencyContextPaths.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Extensions.DependencyModel
 #if NETCOREAPP
             const char separator = ';';
 #else
-            // This method is only executed at startup. No need to cache the char[].
+            // This method is only executed once at startup. No need to cache the char[].
             char[] separator = { ';' };
 #endif
             string[]? files = depsFiles?.Split(separator, StringSplitOptions.RemoveEmptyEntries);

--- a/src/libraries/Microsoft.Extensions.DependencyModel/src/DependencyContextPaths.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/src/DependencyContextPaths.cs
@@ -12,8 +12,6 @@ namespace Microsoft.Extensions.DependencyModel
         private const string DepsFilesProperty = "APP_CONTEXT_DEPS_FILES";
         private const string FxDepsFileProperty = "FX_DEPS_FILE";
 
-        private static readonly char[] s_semicolon = new[] { ';' };
-
         public static DependencyContextPaths Current { get; } = GetCurrent();
 
         public string? Application { get; }
@@ -42,7 +40,13 @@ namespace Microsoft.Extensions.DependencyModel
 
         internal static DependencyContextPaths Create(string? depsFiles, string? sharedRuntime)
         {
-            string[]? files = depsFiles?.Split(s_semicolon, StringSplitOptions.RemoveEmptyEntries);
+#if NETCOREAPP
+            const char separator = ';';
+#else
+            // This method is only executed at startup. No need to cache the char[].
+            char[] separator = { ';' };
+#endif
+            string[]? files = depsFiles?.Split(separator, StringSplitOptions.RemoveEmptyEntries);
             string? application = files != null && files.Length > 0 ? files[0] : null;
 
             string[]? nonApplicationPaths = files?

--- a/src/libraries/Microsoft.Extensions.DependencyModel/tests/DependencyContextTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/tests/DependencyContextTests.cs
@@ -277,6 +277,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "GetEntryAssembly() returns null")]
         public void DefaultWorksCorrectly()
         {
             // only need to assert the context contains non-null properties.

--- a/src/libraries/Microsoft.Extensions.DependencyModel/tests/DependencyContextTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/tests/DependencyContextTests.cs
@@ -276,6 +276,18 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                 Subject.Fallbacks.Should().BeEquivalentTo("win7-x64", "win7-x86");
         }
 
+        [Fact]
+        public void DefaultWorksCorrectly()
+        {
+            // only need to assert the context contains non-null properties.
+
+            var context = DependencyContext.Default;
+            Assert.NotNull(context);
+            Assert.NotNull(context.RuntimeGraph);
+            Assert.NotNull(context.RuntimeLibraries);
+            Assert.NotNull(context.Target);
+        }
+
         private TargetInfo CreateTargetInfo()
         {
             return new TargetInfo(


### PR DESCRIPTION
https://github.com/dotnet/runtime/commit/5e67657e20665c32c2bd5c4ac1c8b1af78c9677e introduced a bug in DependencyContextPaths where the static array is not initialized before it is being used in the Create static method.

This fix removes the static array since it is only used once.