### PR TITLE
[release/6.0-staging] Reset OOB packages from 6.0.19

### DIFF
--- a/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -20,7 +20,7 @@
     <!-- When building from source, ensure the RID we're building for is part of the RID graph -->
     <AdditionalRuntimeIdentifiers Condition="'$(DotNetBuildFromSource)' == 'true'">$(AdditionalRuntimeIdentifiers);$(OutputRID)</AdditionalRuntimeIdentifiers>
     <ServicingVersion>11</ServicingVersion>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">


### PR DESCRIPTION
Important: Merge on code-complete day for the August Release (6.0.19).

The PR that reset OOB packages for 6.0.18: https://github.com/dotnet/runtime/pull/86299

The OOBs that need to be reset this month are:

- Microsoft.NETCore.Platforms

If any of the packages from that list gets built again this month, revert the reset change from this PR for that package.

Packages that will be enabled in 6.0.20 and should be reset next month:

- None 