### PR TITLE
[release/7.0-staging] Reset OOB packages from 7.0.8

### DIFF
--- a/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -25,7 +25,7 @@
     <!-- When building from source, ensure the RID we're building for is part of the RID graph -->
     <AdditionalRuntimeIdentifiers Condition="'$(DotNetBuildFromSource)' == 'true'">$(AdditionalRuntimeIdentifiers);$(OutputRID)</AdditionalRuntimeIdentifiers>
     <ServicingVersion>4</ServicingVersion>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">


### PR DESCRIPTION
Important: Merge on code-complete day for the August Release (7.0.8).

The PR that reset OOB packages for 7.0.7: https://github.com/dotnet/runtime/pull/86300

The OOBs that need to be reset this month are:

- Microsoft.NETCore.Platforms

If any of the packages from that list gets built again this month, revert the reset change from this PR for that package.

Packages that will be enabled in 7.0.8 and should be reset next month:

None