### PR TITLE
Don't set mark array bits for UOH objects during concurrent marking

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -44352,14 +44352,7 @@ CObjectHeader* gc_heap::allocate_uoh_object (size_t jsize, uint32_t flags, int g
         uint8_t* current_lowest_address = background_saved_lowest_address;
         uint8_t* current_highest_address = background_saved_highest_address;
 
-        if ((result < current_highest_address) && (result >= current_lowest_address))
-        {
-            dprintf (3, ("Clearing mark bit at address %zx",
-                     (size_t)(&mark_array [mark_word_of (result)])));
-
-            mark_array_clear_marked (result);
-        }
-        if (current_c_gc_state != c_gc_state_free)
+        if (current_c_gc_state == c_gc_state_planning)
         {
             dprintf (3, ("Concurrent allocation of a large object %zx",
                         (size_t)obj));


### PR DESCRIPTION
marking UOH objects was a historical thing from a policy we had a long time ago. and I had been meaning to get rid of it. a recent workitem we needed to do makes this actually a necessity. 

I've done quite a bit testing on this - with stress framework (SVR and WKS) with lots of BGCs and UOH objects allocated during the current marking phase; with various outerloop tests (all passed except I gave up on libraries outerloop as it has so many failures normally. runtime outerloop tests all succeeded). 