### PR TITLE
[wasm] Don't use `_WasmDevel=true` when publishing

### DIFF
--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -13,6 +13,7 @@ parameters:
         eng/testing/tests.browser.targets
         eng/testing/tests.was*.targets
         eng/testing/was*provisioning.targets
+        eng/testing/workloads-testing.targets
         src/libraries/sendtohelix-wasm.targets
         src/libraries/sendtohelix-wasi.targets
         src/mono/mono/**/*wasm*

--- a/eng/testing/scenarios/BuildWasmAppsJobsList.txt
+++ b/eng/testing/scenarios/BuildWasmAppsJobsList.txt
@@ -7,6 +7,7 @@ Wasm.Build.Tests.Blazor.BuildPublishTests
 Wasm.Build.Tests.Blazor.MiscTests
 Wasm.Build.Tests.Blazor.MiscTests2
 Wasm.Build.Tests.Blazor.NativeRefTests
+Wasm.Build.Tests.Blazor.AppsettingsTests
 Wasm.Build.Tests.BuildPublishTests
 Wasm.Build.Tests.CleanTests
 Wasm.Build.Tests.ConfigSrcTests

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -174,7 +174,7 @@
 
       <_DriverGenCNeeded Condition="'$(_DriverGenCNeeded)' == '' and '$(_WasmShouldAOT)' == 'true'">true</_DriverGenCNeeded>
 
-      <_WasmDevel Condition="'$(_WasmDevel)' == '' and '$(WasmBuildNative)' == 'true' and '$(Configuration)' == 'Debug'">true</_WasmDevel>
+      <_WasmDevel Condition="'$(_WasmDevel)' == '' and '$(WasmBuildNative)' == 'true' and '$(Configuration)' == 'Debug' and '$(WasmBuildingForNestedPublish)' != 'true'">true</_WasmDevel>
 
       <_EmccOptimizationFlagDefault Condition="'$(_WasmDevel)' == 'true'">-O0</_EmccOptimizationFlagDefault>
       <_EmccOptimizationFlagDefault Condition="'$(_EmccOptimizationFlagDefault)' == '' and '$(Configuration)' == 'Debug' and '$(WasmBuildingForNestedPublish)' != 'true'">-O1</_EmccOptimizationFlagDefault>

--- a/src/mono/wasm/host/CommonConfiguration.cs
+++ b/src/mono/wasm/host/CommonConfiguration.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using Mono.Options;
 using System.Linq;
 using System;
@@ -23,6 +21,7 @@ internal sealed class CommonConfiguration
     public HostConfig HostConfig { get; init; }
     public WasmHostProperties HostProperties { get; init; }
     public IEnumerable<string> HostArguments { get; init; }
+    public bool Silent { get; private set; } = true;
 
     private string? hostArg;
     private string? _runtimeConfigPath;
@@ -38,6 +37,7 @@ internal sealed class CommonConfiguration
             { "host|h=", "Host config name", v => hostArg = v },
             { "runtime-config|r=", "runtimeconfig.json path for the app", v => _runtimeConfigPath = v },
             { "extra-host-arg=", "Extra argument to be passed to the host", hostArgsList.Add },
+            { "no-silent", "Verbose output from WasmAppHost", _ => Silent = false }
         };
 
         RemainingArgs = options.Parse(args);

--- a/src/mono/wasm/host/JSEngineHost.cs
+++ b/src/mono/wasm/host/JSEngineHost.cs
@@ -92,7 +92,7 @@ internal sealed class JSEngineHost
                                     silent: !_args.CommonConfig.Silent);
 
         if (_args.CommonConfig.Silent)
-            Console.WriteLine ($"{_args.Host} exited with {exitCode}");
+            Console.WriteLine($"{_args.Host} exited with {exitCode}");
         return exitCode;
     }
 }

--- a/src/mono/wasm/host/JSEngineHost.cs
+++ b/src/mono/wasm/host/JSEngineHost.cs
@@ -25,14 +25,14 @@ internal sealed class JSEngineHost
         _logger = logger;
     }
 
-    public static async Task<int> InvokeAsync(CommonConfiguration commonArgs,
+    public static Task<int> InvokeAsync(CommonConfiguration commonArgs,
                                               ILoggerFactory _,
                                               ILogger logger,
                                               CancellationToken _1)
     {
         var args = new JSEngineArguments(commonArgs);
         args.Validate();
-        return await new JSEngineHost(args, logger).RunAsync();
+        return new JSEngineHost(args, logger).RunAsync();
     }
 
     private async Task<int> RunAsync()
@@ -88,8 +88,11 @@ internal sealed class JSEngineHost
         int exitCode = await Utils.TryRunProcess(psi,
                                     _logger,
                                     msg => { if (msg != null) _logger.LogInformation(msg); },
-                                    msg => { if (msg != null) _logger.LogInformation(msg); });
+                                    msg => { if (msg != null) _logger.LogInformation(msg); },
+                                    silent: !_args.CommonConfig.Silent);
 
+        if (_args.CommonConfig.Silent)
+            Console.WriteLine ($"{_args.Host} exited with {exitCode}");
         return exitCode;
     }
 }

--- a/src/mono/wasm/host/JSEngineHost.cs
+++ b/src/mono/wasm/host/JSEngineHost.cs
@@ -89,9 +89,9 @@ internal sealed class JSEngineHost
                                     _logger,
                                     msg => { if (msg != null) _logger.LogInformation(msg); },
                                     msg => { if (msg != null) _logger.LogInformation(msg); },
-                                    silent: !_args.CommonConfig.Silent);
+                                    silent: _args.CommonConfig.Silent);
 
-        if (_args.CommonConfig.Silent)
+        if (!_args.CommonConfig.Silent)
             Console.WriteLine($"{_args.Host} exited with {exitCode}");
         return exitCode;
     }

--- a/src/mono/wasm/host/Utils.cs
+++ b/src/mono/wasm/host/Utils.cs
@@ -17,10 +17,12 @@ public class Utils
         ILogger logger,
         Action<string?>? logStdOut = null,
         Action<string?>? logStdErr = null,
+        bool silent = false,
         string? label = null)
     {
         string msgPrefix = label == null ? string.Empty : $"[{label}] ";
-        logger.LogInformation($"{msgPrefix}Running: {psi.FileName} {string.Join(" ", psi.ArgumentList)}");
+        if (!silent)
+            logger.LogInformation($"{msgPrefix}Running: {psi.FileName} {string.Join(" ", psi.ArgumentList)}");
 
         psi.UseShellExecute = false;
         psi.CreateNoWindow = true;
@@ -29,7 +31,8 @@ public class Utils
         if (logStdErr != null)
             psi.RedirectStandardError = true;
 
-        logger.LogDebug($"{msgPrefix}Using working directory: {psi.WorkingDirectory ?? Environment.CurrentDirectory}", msgPrefix);
+        if (!silent)
+            logger.LogDebug($"{msgPrefix}Using working directory: {psi.WorkingDirectory ?? Environment.CurrentDirectory}", msgPrefix);
 
         // if (psi.EnvironmentVariables.Count > 0)
             // logger.LogDebug($"{msgPrefix}Setting environment variables for execution:", msgPrefix);


### PR DESCRIPTION
`_WasmDevel=true` causes the optimization flags to be `-O0`.

- This *was* automatically set whenever `Configuration=Debug`, and
`WasmBuildNative=true`, which is useful when relinking in inner loop.
- But when publishing, and relinking/AOT, `-O0` results in larger output.
- Instead, this is changed to never use `_WasmDevel` when publishing.

### [wasm] host: Add `--no-silent` command line parameter

- this is the equivalent to `--verbose`
- The default is "silent" behavior

Cannot use `--verbose` because that conflicts with `dotnet run`.

### Also:
- CI: Trigger only wasm jobs on workload-testing.targets changes, since only wasm is using this currently
- Add missing Wasm.Build.Tests.Blazor.AppsettingsTests to list of tests to run

Fixes https://github.com/dotnet/runtime/issues/87414 - side effect of the `_WasmDevel` change.