### PR TITLE
[release/7.0-staging][wasm] CI: Fix EAT/AOT tests build

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -68,6 +68,8 @@
 
   <!-- wasm EAT/AOT -->
   <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(RunDisabledWasmTests)' != 'true' and '$(EnableAggressiveTrimming)' == 'true'">
+    <!-- https://github.com/dotnet/runtime/issues/86916 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Formats.Cbor\tests\System.Formats.Cbor.Tests.csproj" />
   </ItemGroup>
 
   <!-- Wasm aot on all platforms -->


### PR DESCRIPTION
The builds for wasm EAT/AOT tests are broken because building `System.Format.Cbor.Tests` fails with:
```
resource ILLink.Substitutions.xml in FSharp.Core, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a(5,6): error IL2040: FSharp.Core: Could not find embedded resource 'FSharpSignatureCompressedData.FSharp.Core' to remove in assembly 'FSharp.Core'. [/__w/1/s/src/libraries/System.Formats.Cbor/tests/System.Formats.Cbor.Tests.csproj::TargetFramework=net7.0]
##[error]resource ILLink.Substitutions.xml in FSharp.Core, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a(5,6): error IL2040: (NETCORE_ENGINEERING_TELEMETRY=Build) FSharp.Core: Could not find embedded resource 'FSharpSignatureCompressedData.FSharp.Core' to remove in assembly 'FSharp.Core'.
resource ILLink.Substitutions.xml in FSharp.Core, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a(3,6): error IL2040: FSharp.Core: Could not find embedded resource 'FSharpOptimizationCompressedData.FSharp.Core' to remove in assembly 'FSharp.Core'. [/__w/1/s/src/libraries/System.Formats.Cbor/tests/System.Formats.Cbor.Tests.csproj::TargetFramework=net7.0]
##[error]resource ILLink.Substitutions.xml in FSharp.Core, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a(3,6): error IL2040: (NETCORE_ENGINEERING_TELEMETRY=Build) FSharp.Core: Could not find embedded resource 'FSharpOptimizationCompressedData.FSharp.Core' to remove in assembly 'FSharp.Core'.
```

Disable failing `System.Formats.Cbor.Tests`

Issue: https://github.com/dotnet/runtime/issues/86916