### PR TITLE
Fix jitdump issues introduced by #85801

### DIFF
--- a/src/coreclr/pal/src/misc/perfjitdump.cpp
+++ b/src/coreclr/pal/src/misc/perfjitdump.cpp
@@ -213,9 +213,6 @@ struct PerfJitDumpState
         enabled = true;
 
 exit:
-        if (result != 0)
-            return FatalError();
-
         return 0;
     }
 
@@ -298,10 +295,8 @@ exit:
                 } while (result > 0);
             } while (true);
 
-exit:
-            if (result != 0)
-                return FatalError();
         }
+exit:
         return 0;
     }
 
@@ -337,10 +332,8 @@ exit:
                 return FatalError();
 
             fd = -1;
-exit:
-            if (result != 0)
-                return -1;
         }
+exit:
         return 0;
     }
 };

--- a/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
@@ -303,7 +303,7 @@ ds_rt_enable_perfmap (uint32_t type)
 
 #ifdef FEATURE_PERFMAP
 	PerfMap::PerfMapType perfMapType = (PerfMap::PerfMapType)type;
-	if (perfMapType == PerfMap::PerfMapType::DISABLED || perfMapType > PerfMap::PerfMapType::JITDUMP)
+	if (perfMapType == PerfMap::PerfMapType::DISABLED || perfMapType > PerfMap::PerfMapType::PERFMAP)
 	{
 		return DS_IPC_E_INVALIDARG;
 	}

--- a/src/coreclr/vm/perfmap.cpp
+++ b/src/coreclr/vm/perfmap.cpp
@@ -157,6 +157,7 @@ void PerfMap::Enable(PerfMapType type, bool sendExisting)
                 IJitManager::MethodRegionInfo methodRegionInfo;
                 codeInfo.GetMethodRegionInfo(&methodRegionInfo);
                 _ASSERTE(methodRegionInfo.hotStartAddress == codeStart);
+                _ASSERTE(methodRegionInfo.hotSize > 0);
                     
                 PrepareCodeConfig config(!nativeCodeVersion.IsNull() ? nativeCodeVersion : NativeCodeVersion(pMethod), FALSE, FALSE);
                 PerfMap::LogJITCompiledMethod(pMethod, codeStart, methodRegionInfo.hotSize, &config);


### PR DESCRIPTION
In #85801 I removed the jitdump specific locks in favor of the global perfmap lock, but left the checks that `pthread_mutex_unlock` returned `0` in place. Result would be the number of bytes written after logging a method and would cause a call to `FatalError()` and prematurely shut down the jitdump support.