### PR TITLE
JIT: Support last-use copy omission for commas

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2498,6 +2498,8 @@ public:
 
     GenTree* gtNewConWithPattern(var_types type, uint8_t pattern);
 
+    GenTree* gtNewGenericCon(var_types type, uint8_t* cnsVal);
+
     GenTreeLclVar* gtNewStoreLclVarNode(unsigned lclNum, GenTree* data);
 
     GenTreeLclFld* gtNewStoreLclFldNode(

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -1468,7 +1468,7 @@ CallArgs::CallArgs()
     , m_hasRegArgs(false)
     , m_hasStackArgs(false)
     , m_argsComplete(false)
-    , m_needsTemps(false)
+    , m_needsEarlyEvaluation(false)
 #ifdef UNIX_X86_ABI
     , m_alignmentDone(false)
 #endif
@@ -9296,7 +9296,7 @@ void CallArgs::InternalCopyFrom(Compiler* comp, CallArgs* other, CopyNodeFunc co
     m_hasRegArgs               = other->m_hasRegArgs;
     m_hasStackArgs             = other->m_hasStackArgs;
     m_argsComplete             = other->m_argsComplete;
-    m_needsTemps               = other->m_needsTemps;
+    m_needsEarlyEvaluation     = other->m_needsEarlyEvaluation;
 
     // Unix x86 flags related to stack alignment intentionally not copied as
     // they depend on where the call will be inserted.
@@ -9311,7 +9311,7 @@ void CallArgs::InternalCopyFrom(Compiler* comp, CallArgs* other, CopyNodeFunc co
         carg->m_tmpNum          = arg.m_tmpNum;
         carg->m_signatureType   = arg.m_signatureType;
         carg->m_wellKnownArg    = arg.m_wellKnownArg;
-        carg->m_needTmp         = arg.m_needTmp;
+        carg->m_evaluateEarly   = arg.m_evaluateEarly;
         carg->m_needPlace       = arg.m_needPlace;
         carg->m_isTmp           = arg.m_isTmp;
         carg->m_processed       = arg.m_processed;

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -7738,15 +7738,15 @@ GenTree* Compiler::gtNewGenericCon(var_types type, uint8_t* cnsVal)
     typ val;                                                                                                           \
     memcpy(&val, cnsVal, sizeof(typ));
 
+        case TYP_BYTE:
+        {
+            READ_VALUE(int8_t);
+            return gtNewIconNode(val);
+        }
         case TYP_BOOL:
         case TYP_UBYTE:
         {
             READ_VALUE(uint8_t);
-            return gtNewIconNode(val);
-        }
-        case TYP_BYTE:
-        {
-            READ_VALUE(int8_t);
             return gtNewIconNode(val);
         }
         case TYP_SHORT:

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -7793,10 +7793,10 @@ GenTree* Compiler::gtNewGenericCon(var_types type, uint8_t* cnsVal)
         case TYP_SIMD32:
         case TYP_SIMD64:
 #endif // TARGET_XARCH
-#endif // FEATURE_SIMD
         {
             return gtNewVconNode(type, cnsVal);
         }
+#endif // FEATURE_SIMD
         default:
             unreached();
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4571,8 +4571,9 @@ class CallArg
     var_types m_signatureType : 5;
     // The type of well-known argument this is.
     WellKnownArg m_wellKnownArg : 5;
-    // True when we force this argument's evaluation into a temp LclVar.
-    bool m_needTmp : 1;
+    // True if this argument needs to be evaluated in the early list (usually
+    // by introducing a copy into a temp LclVar).
+    bool m_evaluateEarly : 1;
     // True when we must replace this argument with a placeholder node.
     bool m_needPlace : 1;
     // True when we setup a temp LclVar for this argument.
@@ -4590,7 +4591,7 @@ private:
         , m_tmpNum(BAD_VAR_NUM)
         , m_signatureType(TYP_UNDEF)
         , m_wellKnownArg(WellKnownArg::None)
-        , m_needTmp(false)
+        , m_evaluateEarly(false)
         , m_needPlace(false)
         , m_isTmp(false)
         , m_processed(false)
@@ -4679,8 +4680,8 @@ class CallArgs
     // True if we have one or more stack arguments.
     bool m_hasStackArgs : 1;
     bool m_argsComplete : 1;
-    // One or more arguments must be copied to a temp by EvalArgsToTemps.
-    bool m_needsTemps : 1;
+    // One or more arguments must be evaluated early by EvalArgsEarly.
+    bool m_needsEarlyEvaluation : 1;
 #ifdef UNIX_X86_ABI
     // Updateable flag, set to 'true' after we've done any required alignment.
     bool m_alignmentDone : 1;
@@ -4736,8 +4737,8 @@ public:
     void AddFinalArgsAndDetermineABIInfo(Compiler* comp, GenTreeCall* call);
 
     void ArgsComplete(Compiler* comp, GenTreeCall* call);
-    void EvalArgsToTemps(Compiler* comp, GenTreeCall* call);
-    void SetNeedsTemp(CallArg* arg);
+    void EvalArgsEarly(Compiler* comp, GenTreeCall* call);
+    void SetEvaluateEarly(CallArg* arg);
     bool IsNonStandard(Compiler* comp, GenTreeCall* call, CallArg* arg);
 
     GenTree* MakeTmpArgNode(Compiler* comp, CallArg* arg);
@@ -4753,7 +4754,7 @@ public:
     bool AreArgsComplete() const { return m_argsComplete; }
     bool HasRegArgs() const { return m_hasRegArgs; }
     bool HasStackArgs() const { return m_hasStackArgs; }
-    bool NeedsTemps() const { return m_needsTemps; }
+    bool NeedsEarlyEvaluation() const { return m_needsEarlyEvaluation; }
 
 #ifdef UNIX_X86_ABI
     void ComputeStackAlignment(unsigned curStackLevelInBytes)

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3649,7 +3649,7 @@ GenTree* Compiler::impImportCnsTreeFromBuffer(uint8_t* buffer, var_types valueTy
         else
         {
             setMethodHasFrozenObjects();
-            tree         = gtNewIconEmbHndNode((void*)ptr, nullptr, GTF_ICON_OBJ_HDL, nullptr);
+            tree         = gtNewIconEmbHndNode((void*)(ssize_t)ptr, nullptr, GTF_ICON_OBJ_HDL, nullptr);
             tree->gtType = TYP_REF;
             INDEBUG(tree->AsIntCon()->gtTargetHandle = ptr);
         }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -3705,7 +3705,7 @@ GenTree* Compiler::fgMorphMultiregStructArg(CallArg* arg)
         //
         if (!argNode->OperIs(GT_LCL_VAR, GT_LCL_FLD))
         {
-            assert(argNode->OperIs(GT_BLK));
+            assert(argNode->OperIs(GT_BLK, GT_CNS_VEC));
 
             unsigned lastElemExactSize = structSize - lastElem.Offset;
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -3844,6 +3844,18 @@ GenTree* Compiler::fgMorphMultiregStructArg(CallArg* arg)
 
             lvaSetVarDoNotEnregister(lclNum DEBUGARG(DoNotEnregisterReason::LocalField));
         }
+        else if (argNode->IsCnsVec())
+        {
+            GenTreeVecCon* vecCon = argNode->AsVecCon();
+            newArg                = new (this, GT_FIELD_LIST) GenTreeFieldList();
+            for (unsigned inx = 0; inx < elemCount; inx++)
+            {
+                unsigned offset = elems[inx].Offset;
+                assert(offset + genTypeSize(elems[inx].Type) <= sizeof(vecCon->gtSimdVal));
+                GenTree* cns = gtNewGenericCon(elems[inx].Type, (uint8_t*)&vecCon->gtSimdVal + offset);
+                newArg->AddField(this, cns, offset, cns->TypeGet());
+            }
+        }
         else
         {
             assert(argNode->OperIsIndir());


### PR DESCRIPTION
Allow last-use copy omission to kick in when the argument is a comma (typically created by physical promotion).

Also handle this pattern in arg evaluation: avoid creating a new local for the COMMA(..., LCL_ADDR) created for this pattern. As part of this rename the "needs temp" terminology to "needs early evaluation" since these cases do not actually need or create a temp. There were other cases already where we did not create a temp (specifically handling of GT_MKREFANY), so the terminology was already a bit misleading.

Fix #87471