### PR TITLE
Fix typo in object.h

### DIFF
--- a/src/coreclr/vm/object.h
+++ b/src/coreclr/vm/object.h
@@ -123,7 +123,7 @@ struct RCW;
 // The only fields mandated by all objects are
 //
 //     * a pointer to the code:MethodTable at offset 0
-//     * a poiner to a code:ObjHeader at a negative offset. This is often zero.  It holds information that
+//     * a pointer to a code:ObjHeader at a negative offset. This is often zero.  It holds information that
 //         any addition information that we might need to attach to arbitrary objects.
 //
 class Object


### PR DESCRIPTION
The sentence:

> a **poiner** to a code:ObjHeader ...

Should read:

> a **pointer** to a code:ObjHeader ...