### PR TITLE
[wasm] Add helix retries for debugger tests

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -4,6 +4,7 @@
   "localRerunCount": 2,
   "retryOnRules": [
     { "testAssembly": { "wildcard": "System.Net.*" } },
-    { "failureMessage": { "regex": ".*Timed out after .* waiting for the browser to be ready.*" } }
+    { "failureMessage": { "regex": ".*Timed out after .* waiting for the browser to be ready.*" } },
+    { "failureMessage": { "regex": "System.IO.IOException : Process for .*chrome .* unexpectedly exited.* during startup" } }
   ]
 }


### PR DESCRIPTION
.. when chrome fails to launch. For example:

```
  Error Message:
   System.IO.IOException : Process for /root/helix/work/correlation/chrome-linux/chrome unexpectedly exited with 127 during startup.
  Stack Trace:
     at DebuggerTests.WasmHostProvider.LaunchHostAsync(ProcessStartInfo psi, HttpContext context, Func`2 checkBrowserReady, String messagePrefix, Int32 hostReadyTimeoutMs, CancellationToken token) in /_/src/mono/wasm/debugger/DebuggerTestSuite/WasmHostProvider.cs:line 77
   at DebuggerTests.ChromeProvider.StartBrowserAndProxyAsync(HttpContext context, String targetUrl, Int32 remoteDebuggingPort, String messagePrefix, ILoggerFactory loggerFactory, CancellationTokenSource cts, Int32 browserReadyTimeoutMs, String locale) in /_/src/mono/wasm/debugger/DebuggerTestSuite/ChromeProvider.cs:line 60
   at DebuggerTests.TestHarnessStartup.<>c__DisplayClass13_0.<<Configure>b__2>d.MoveNext() in /_/src/mono/wasm/debugger/DebuggerTestSuite/TestHarnessStartup.cs:line 143
--- End of stack trace from previous location ---
   at DebuggerTests.Inspector.OpenSessionAsync(Func`3 getInitCmds, String urlToInspect, TimeSpan span) in /_/src/mono/wasm/debugger/DebuggerTestSuite/Inspector.cs:line 414
   at DebuggerTests.DebuggerTestBase.InitializeAsync() in /_/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs:line 173
```
