### PR TITLE
[browser][MT] Make HTTP and WS clients work

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -117,7 +117,7 @@ namespace System
 #endif
 
         public static bool IsThreadingSupported => (!IsWasi && !IsBrowser) || IsWasmThreadingSupported;
-        public static bool IsWasmThreadingSupported => IsBrowser && IsEnvironmentVariableTrue("IsBrowserThreadingSupported");        
+        public static bool IsWasmThreadingSupported => IsBrowser && IsEnvironmentVariableTrue("IsBrowserThreadingSupported");
         public static bool IsBinaryFormatterSupported => IsNotMobile && !IsNativeAot;
 
         public static bool IsStartingProcessesSupported => !IsiOS && !IstvOS;

--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -9,6 +9,7 @@
   <PropertyGroup>
     <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
     <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetPlatformIdentifier)' == ''">SR.PlatformNotSupported_NetHttp</GeneratePlatformNotSupportedAssemblyMessage>
+    <FeatureWasmThreads Condition="'$(TargetPlatformIdentifier)' == 'browser' and '$(MonoWasmBuildVariant)' == 'multithread'">true</FeatureWasmThreads>
     <DefineConstants Condition="'$(TargetPlatformIdentifier)' == 'osx' or '$(TargetPlatformIdentifier)' == 'ios' or '$(TargetPlatformIdentifier)' == 'tvos' or '$(TargetPlatformIdentifier)' == 'maccatalyst'">$(DefineConstants);SYSNETHTTP_NO_OPENSSL</DefineConstants>
     <DefineConstants Condition="'$(TargetPlatformIdentifier)' == 'android' or '$(TargetPlatformIdentifier)' == 'ios' or '$(TargetPlatformIdentifier)' == 'maccatalyst' or '$(TargetPlatformIdentifier)' == 'tvos'">$(DefineConstants);TARGET_MOBILE</DefineConstants>
     <DefineConstants Condition="'$(TargetPlatformIdentifier)' == 'android'">$(DefineConstants);TARGET_ANDROID</DefineConstants>
@@ -17,6 +18,7 @@
     <DefineConstants Condition="'$(TargetPlatformIdentifier)' == 'tvos'">$(DefineConstants);TARGET_TVOS</DefineConstants>
     <DefineConstants Condition="'$(TargetPlatformIdentifier)' == 'browser'">$(DefineConstants);TARGET_BROWSER</DefineConstants>
     <DefineConstants Condition="'$(TargetPlatformIdentifier)' == 'wasi'">$(DefineConstants);TARGET_WASI</DefineConstants>
+    <DefineConstants Condition="'$(FeatureWasmThreads)' == 'true'" >$(DefineConstants);FEATURE_WASM_THREADS</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <ILLinkSubstitutionsXmls Include="$(ILLinkDirectory)ILLink.Substitutions.xml" />
@@ -427,8 +429,6 @@
     <Compile Include="System\Net\Http\BrowserHttpHandler\BrowserHttpInterop.cs" />
     <Compile Include="$(CommonPath)System\Net\Http\HttpHandlerDefaults.cs"
              Link="Common\System\Net\Http\HttpHandlerDefaults.cs" />
-    <Compile Include="$(LibrariesProjectRoot)System.Runtime.InteropServices.JavaScript\src\System\Runtime\InteropServices\JavaScript\CancelablePromise.cs"
-             Link="InteropServices\JavaScript\CancelablePromise.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Win32.Primitives" />
@@ -463,7 +463,7 @@
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'browser'">
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\Microsoft.Interop.SourceGeneration\Microsoft.Interop.SourceGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices.JavaScript\gen\JSImportGenerator\JSImportGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-    <Reference Include="System.Runtime.InteropServices.JavaScript" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices.JavaScript\src\System.Runtime.InteropServices.JavaScript.csproj" SkipUseReferenceAssembly="true" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseManagedNtlm)' == 'true'">
     <ProjectReference Include="$(LibrariesProjectRoot)System.Formats.Asn1\src\System.Formats.Asn1.csproj" />

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -7,16 +7,12 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Runtime.InteropServices.JavaScript;
+using System.Collections.Concurrent;
 
 namespace System.Net.Http
 {
     // **Note** on `Task.ConfigureAwait(continueOnCapturedContext: true)` for the WebAssembly Browser.
-    // The current implementation of WebAssembly for the Browser does not have a SynchronizationContext nor a Scheduler
-    // thus forcing the callbacks to run on the main browser thread.  When threading is eventually implemented using
-    // emscripten's threading model of remote worker threads, via SharedArrayBuffer, any API calls will have to be
-    // remoted back to the main thread.  Most APIs only work on the main browser thread.
-    // During discussions the concensus has been that it will not matter right now which value is used for ConfigureAwait
-    // we should put this in place now.
+    // the JavaScript objects have thread affinity, it is necessary that the continuations run the same thread as the start of the async method.
     internal sealed class BrowserHttpHandler : HttpMessageHandler
     {
         private static readonly HttpRequestOptionsKey<bool> EnableStreamingResponse = new HttpRequestOptionsKey<bool>("WebAssemblyEnableStreamingResponse");
@@ -24,11 +20,6 @@ namespace System.Net.Http
         private bool _allowAutoRedirect = HttpHandlerDefaults.DefaultAutomaticRedirection;
         // flag to determine if the _allowAutoRedirect was explicitly set or not.
         private bool _isAllowAutoRedirectTouched;
-
-        /// <summary>
-        /// Gets whether the current Browser supports streaming responses
-        /// </summary>
-        private static bool StreamingSupported { get; } = BrowserHttpInterop.SupportsStreamingResponse();
 
         #region PlatformNotSupported
 #pragma warning disable CA1822
@@ -120,8 +111,13 @@ namespace System.Net.Http
         public const bool SupportsProxy = false;
         public const bool SupportsRedirectConfiguration = true;
 
+#if FEATURE_WASM_THREADS
+        private ConcurrentDictionary<string, object?>? _properties;
+        public IDictionary<string, object?> Properties => _properties ??= new ConcurrentDictionary<string, object?>();
+#else
         private Dictionary<string, object?>? _properties;
         public IDictionary<string, object?> Properties => _properties ??= new Dictionary<string, object?>();
+#endif
 
         protected internal override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
         {
@@ -136,11 +132,22 @@ namespace System.Net.Http
             JSObject abortController = BrowserHttpInterop.CreateAbortController();
             CancellationTokenRegistration? abortRegistration = cancellationToken.Register(() =>
             {
+#if FEATURE_WASM_THREADS
+                if (!abortController.IsDisposed)
+                {
+                    abortController.SynchronizationContext.Send(static (JSObject _abortController) =>
+                    {
+                        BrowserHttpInterop.AbortRequest(_abortController);
+                        _abortController.Dispose();
+                    }, abortController);
+                }
+#else
                 if (!abortController.IsDisposed)
                 {
                     BrowserHttpInterop.AbortRequest(abortController);
+                    abortController.Dispose();
                 }
-                abortController.Dispose();
+#endif
             });
             try
             {
@@ -236,43 +243,60 @@ namespace System.Net.Http
 
         private static HttpResponseMessage ConvertResponse(HttpRequestMessage request, WasmFetchResponse fetchResponse)
         {
-            string? responseType = fetchResponse.ResponseType;
-            HttpResponseMessage responseMessage = new HttpResponseMessage((HttpStatusCode)fetchResponse.Status);
-            responseMessage.RequestMessage = request;
-            if (responseType == "opaqueredirect")
+#if FEATURE_WASM_THREADS
+            lock (fetchResponse.ThisLock)
             {
-                // Here we will set the ReasonPhrase so that it can be evaluated later.
-                // We do not have a status code but this will signal some type of what happened
-                // after interrogating the status code for success or not i.e. IsSuccessStatusCode
-                //
-                // https://developer.mozilla.org/en-US/docs/Web/API/Response/type
-                // opaqueredirect: The fetch request was made with redirect: "manual".
-                // The Response's status is 0, headers are empty, body is null and trailer is empty.
-                responseMessage.SetReasonPhraseWithoutValidation(fetchResponse.ResponseType);
-            }
+#endif
+                fetchResponse.ThrowIfDisposed();
+                string? responseType = fetchResponse.FetchResponse!.GetPropertyAsString("type")!;
+                int status = fetchResponse.FetchResponse.GetPropertyAsInt32("status");
+                HttpResponseMessage responseMessage = new HttpResponseMessage((HttpStatusCode)status);
+                responseMessage.RequestMessage = request;
+                if (responseType == "opaqueredirect")
+                {
+                    // Here we will set the ReasonPhrase so that it can be evaluated later.
+                    // We do not have a status code but this will signal some type of what happened
+                    // after interrogating the status code for success or not i.e. IsSuccessStatusCode
+                    //
+                    // https://developer.mozilla.org/en-US/docs/Web/API/Response/type
+                    // opaqueredirect: The fetch request was made with redirect: "manual".
+                    // The Response's status is 0, headers are empty, body is null and trailer is empty.
+                    responseMessage.SetReasonPhraseWithoutValidation(responseType);
+                }
 
-            bool streamingEnabled = false;
-            if (StreamingSupported)
-            {
-                request.Options.TryGetValue(EnableStreamingResponse, out streamingEnabled);
-            }
+                bool streamingEnabled = false;
+                if (BrowserHttpInterop.SupportsStreamingResponse())
+                {
+                    request.Options.TryGetValue(EnableStreamingResponse, out streamingEnabled);
+                }
 
-            responseMessage.Content = streamingEnabled
-                ? new StreamContent(new WasmHttpReadStream(fetchResponse))
-                : new BrowserHttpContent(fetchResponse);
+                responseMessage.Content = streamingEnabled
+                    ? new StreamContent(new WasmHttpReadStream(fetchResponse))
+                    : new BrowserHttpContent(fetchResponse);
 
 
-            // Some of the headers may not even be valid header types in .NET thus we use TryAddWithoutValidation
-            // CORS will only allow access to certain headers on browser.
-            BrowserHttpInterop.GetResponseHeaders(fetchResponse.FetchResponse, responseMessage.Headers, responseMessage.Content.Headers);
+                // Some of the headers may not even be valid header types in .NET thus we use TryAddWithoutValidation
+                // CORS will only allow access to certain headers on browser.
+                BrowserHttpInterop.GetResponseHeaders(fetchResponse.FetchResponse, responseMessage.Headers, responseMessage.Content.Headers);
 
-            return responseMessage;
+                return responseMessage;
+#if FEATURE_WASM_THREADS
+            } //lock
+#endif
         }
 
         protected internal override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(request);
-            return Impl(request, cancellationToken, _isAllowAutoRedirectTouched ? AllowAutoRedirect : null);
+            bool? allowAutoRedirect = _isAllowAutoRedirectTouched ? AllowAutoRedirect : null;
+#if FEATURE_WASM_THREADS
+            return JSHost.CurrentOrMainJSSynchronizationContext.Send(() =>
+            {
+#endif
+                return Impl(request, cancellationToken, allowAutoRedirect);
+#if FEATURE_WASM_THREADS
+            });
+#endif
 
             static async Task<HttpResponseMessage> Impl(HttpRequestMessage request, CancellationToken cancellationToken, bool? allowAutoRedirect)
             {
@@ -284,7 +308,10 @@ namespace System.Net.Http
 
     internal sealed class WasmFetchResponse : IDisposable
     {
-        public readonly JSObject FetchResponse;
+#if FEATURE_WASM_THREADS
+        public readonly object ThisLock = new object();
+#endif
+        public JSObject? FetchResponse;
         private readonly CancellationTokenRegistration _abortRegistration;
         private bool _isDisposed;
 
@@ -296,25 +323,16 @@ namespace System.Net.Http
             _abortRegistration = abortRegistration;
         }
 
-        public string ResponseType
-        {
-            get
-            {
-                return FetchResponse.GetPropertyAsString("type")!;
-            }
-        }
-
-        public int Status
-        {
-            get
-            {
-                return FetchResponse.GetPropertyAsInt32("status");
-            }
-        }
-
         public void ThrowIfDisposed()
         {
-            ObjectDisposedException.ThrowIf(_isDisposed && FetchResponse.IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            lock (ThisLock)
+            {
+#endif
+                ObjectDisposedException.ThrowIf(_isDisposed, this);
+#if FEATURE_WASM_THREADS
+            } //lock
+#endif
         }
 
         public void Dispose()
@@ -322,14 +340,37 @@ namespace System.Net.Http
             if (_isDisposed)
                 return;
 
+#if FEATURE_WASM_THREADS
+            FetchResponse?.SynchronizationContext.Send(static (WasmFetchResponse self) =>
+            {
+                lock (self.ThisLock)
+                {
+                    if (self._isDisposed)
+                        return;
+                    self._isDisposed = true;
+                    self._abortRegistration.Dispose();
+                    if (!self.FetchResponse!.IsDisposed)
+                    {
+                        BrowserHttpInterop.AbortResponse(self.FetchResponse);
+                    }
+                    self.FetchResponse.Dispose();
+                    self.FetchResponse = null;
+                }
+            }, this);
+
+#else
             _isDisposed = true;
             _abortRegistration.Dispose();
-
-            if (FetchResponse != null && !FetchResponse.IsDisposed)
+            if (FetchResponse != null)
             {
-                BrowserHttpInterop.AbortResponse(FetchResponse);
+                if (!FetchResponse.IsDisposed)
+                {
+                    BrowserHttpInterop.AbortRequest(FetchResponse);
+                }
+                FetchResponse.Dispose();
+                FetchResponse = null;
             }
-            FetchResponse?.Dispose();
+#endif
         }
     }
 
@@ -342,41 +383,74 @@ namespace System.Net.Http
         public BrowserHttpContent(WasmFetchResponse fetchResponse)
         {
             ArgumentNullException.ThrowIfNull(fetchResponse);
-
             _fetchResponse = fetchResponse;
         }
 
         // TODO alocate smaller buffer and call multiple times
         private async ValueTask<byte[]> GetResponseData(CancellationToken cancellationToken)
         {
-            if (_data != null)
+            Task<int> promise;
+#if FEATURE_WASM_THREADS
+            lock (_fetchResponse.ThisLock)
             {
-                return _data;
-            }
-            _fetchResponse.ThrowIfDisposed();
-            Task<int> promise = BrowserHttpInterop.GetResponseLength(_fetchResponse.FetchResponse);
+#endif
+                if (_data != null)
+                {
+                    return _data;
+                }
+                _fetchResponse.ThrowIfDisposed();
+                promise = BrowserHttpInterop.GetResponseLength(_fetchResponse.FetchResponse!);
+#if FEATURE_WASM_THREADS
+            } //lock
+#endif
             _length = await BrowserHttpInterop.CancelationHelper(promise, cancellationToken, null, _fetchResponse.FetchResponse).ConfigureAwait(true);
-            _data = new byte[_length];
+#if FEATURE_WASM_THREADS
+            lock (_fetchResponse.ThisLock)
+            {
+#endif
+                _data = new byte[_length];
 
-            BrowserHttpInterop.GetResponseBytes(_fetchResponse.FetchResponse, new Span<byte>(_data));
+                BrowserHttpInterop.GetResponseBytes(_fetchResponse.FetchResponse!, new Span<byte>(_data));
 
-            return _data;
+                return _data;
+#if FEATURE_WASM_THREADS
+            } //lock
+#endif
         }
 
-        protected override async Task<Stream> CreateContentReadStreamAsync()
+        protected override Task<Stream> CreateContentReadStreamAsync()
         {
-            byte[] data = await GetResponseData(CancellationToken.None).ConfigureAwait(true);
-            return new MemoryStream(data, writable: false);
+            _fetchResponse.ThrowIfDisposed();
+#if FEATURE_WASM_THREADS
+            return _fetchResponse.FetchResponse!.SynchronizationContext.Send(() => Impl(this));
+#else
+            return Impl(this);
+#endif
+            static async Task<Stream> Impl(BrowserHttpContent self)
+            {
+                byte[] data = await self.GetResponseData(CancellationToken.None).ConfigureAwait(true);
+                return new MemoryStream(data, writable: false);
+            }
         }
 
         protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
             SerializeToStreamAsync(stream, context, CancellationToken.None);
 
-        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(stream, nameof(stream));
-            byte[] data = await GetResponseData(cancellationToken).ConfigureAwait(true);
-            await stream.WriteAsync(data, cancellationToken).ConfigureAwait(true);
+            _fetchResponse.ThrowIfDisposed();
+#if FEATURE_WASM_THREADS
+            return _fetchResponse.FetchResponse!.SynchronizationContext.Send(() => Impl(this, stream, cancellationToken));
+#else
+            return Impl(this, stream, cancellationToken);
+#endif
+
+            static async Task Impl(BrowserHttpContent self, Stream stream, CancellationToken cancellationToken)
+            {
+                byte[] data = await self.GetResponseData(cancellationToken).ConfigureAwait(true);
+                await stream.WriteAsync(data, cancellationToken).ConfigureAwait(true);
+            }
         }
 
         protected internal override bool TryComputeLength(out long length)
@@ -393,7 +467,7 @@ namespace System.Net.Http
 
         protected override void Dispose(bool disposing)
         {
-            _fetchResponse?.Dispose();
+            _fetchResponse.Dispose();
             base.Dispose(disposing);
         }
     }
@@ -410,18 +484,36 @@ namespace System.Net.Http
         public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(buffer, nameof(buffer));
-
             _fetchResponse.ThrowIfDisposed();
             cancellationToken.ThrowIfCancellationRequested();
-            using (Buffers.MemoryHandle handle = buffer.Pin())
-            {
-                Task<int> promise = GetStreamedResponseBytesUnsafe(_fetchResponse, buffer, handle);
-                int response = await BrowserHttpInterop.CancelationHelper(promise, cancellationToken, null, _fetchResponse.FetchResponse).ConfigureAwait(true);
-                return response;
-            }
 
-            unsafe static Task<int> GetStreamedResponseBytesUnsafe(WasmFetchResponse _fetchResponse, Memory<byte> buffer, System.Buffers.MemoryHandle handle)
-                => BrowserHttpInterop.GetStreamedResponseBytes(_fetchResponse.FetchResponse, (IntPtr)handle.Pointer, buffer.Length);
+#if FEATURE_WASM_THREADS
+            return await _fetchResponse.FetchResponse!.SynchronizationContext.Send(() => Impl(this, buffer, cancellationToken)).ConfigureAwait(true);
+#else
+            return await Impl(this, buffer, cancellationToken).ConfigureAwait(true);
+#endif
+
+            static async Task<int> Impl(WasmHttpReadStream self, Memory<byte> buffer, CancellationToken cancellationToken)
+            {
+                Task<int> promise;
+                using (Buffers.MemoryHandle handle = buffer.Pin())
+                {
+#if FEATURE_WASM_THREADS
+                    lock (self._fetchResponse.ThisLock)
+                    {
+#endif
+                        self._fetchResponse.ThrowIfDisposed();
+                        promise = GetStreamedResponseBytesUnsafe(self._fetchResponse, buffer, handle);
+#if FEATURE_WASM_THREADS
+                    } //lock
+#endif
+                    int response = await BrowserHttpInterop.CancelationHelper(promise, cancellationToken, null, self._fetchResponse.FetchResponse).ConfigureAwait(true);
+                    return response;
+                }
+
+                unsafe static Task<int> GetStreamedResponseBytesUnsafe(WasmFetchResponse _fetchResponse, Memory<byte> buffer, Buffers.MemoryHandle handle)
+                    => BrowserHttpInterop.GetStreamedResponseBytes(_fetchResponse.FetchResponse!, (IntPtr)handle.Pointer, buffer.Length);
+            }
         }
 
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
@@ -433,22 +525,24 @@ namespace System.Net.Http
         public override bool CanRead => true;
         public override bool CanSeek => false;
         public override bool CanWrite => false;
-        public override long Length => throw new NotSupportedException();
-        public override long Position
-        {
-            get => throw new NotSupportedException();
-            set => throw new NotSupportedException();
-        }
 
         protected override void Dispose(bool disposing)
         {
-            _fetchResponse?.Dispose();
+            _fetchResponse.Dispose();
         }
 
         public override void Flush()
         {
         }
 
+        #region PlatformNotSupported
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+        public override long Length => throw new NotSupportedException();
         public override int Read(byte[] buffer, int offset, int count)
         {
             throw new NotSupportedException(SR.net_http_synchronous_reads_not_supported);
@@ -468,5 +562,6 @@ namespace System.Net.Http
         {
             throw new NotSupportedException();
         }
+        #endregion
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -230,7 +230,7 @@ namespace System.Net.Http
                 }
 
                 cancellationToken.ThrowIfCancellationRequested();
-                JSObject fetchResponse = await BrowserHttpInterop.CancelationHelper(promise, cancellationToken, abortController).ConfigureAwait(true);
+                JSObject fetchResponse = await BrowserHttpInterop.CancelationHelper(promise, cancellationToken, abortController, null).ConfigureAwait(true);
                 return new WasmFetchResponse(fetchResponse, abortRegistration.Value);
             }
             catch (Exception)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -365,7 +365,7 @@ namespace System.Net.Http
             {
                 if (!FetchResponse.IsDisposed)
                 {
-                    BrowserHttpInterop.AbortRequest(FetchResponse);
+                    BrowserHttpInterop.AbortResponse(FetchResponse);
                 }
                 FetchResponse.Dispose();
                 FetchResponse = null;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
@@ -105,15 +105,30 @@ namespace System.Net.Http
                 using (var operationRegistration = cancellationToken.Register(() =>
                 {
                     CancelablePromise.CancelPromise(promise);
+#pragma warning disable IDE0031
                     if (abortController != null)
                     {
-                        AbortRequest(abortController);
+#if FEATURE_WASM_THREADS
+                        abortController.SynchronizationContext.Send(static (JSObject _abortController) =>
+                        {
+#endif
+                            AbortRequest(_abortController);
+#if FEATURE_WASM_THREADS
+                        }, abortController);
+#endif
                     }
                     if (fetchResponse != null)
                     {
-                        AbortResponse(fetchResponse);
+#if FEATURE_WASM_THREADS
+                        fetchResponse.SynchronizationContext.Send(static (JSObject _fetchResponse) =>
+                        {
+#endif
+                            AbortResponse(_fetchResponse);
+#if FEATURE_WASM_THREADS
+                        }, fetchResponse);
+#endif
+#pragma warning restore IDE0031
                     }
-
                 }))
                 {
                     return await promise.ConfigureAwait(true);

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -26,6 +26,7 @@
     <TestArchiveTestsDir>$(TestArchiveTestsRoot)$(OSPlatformConfig)/</TestArchiveTestsDir>
     <DefineConstants>$(DefineConstants);TARGET_BROWSER</DefineConstants>
     <WasmXHarnessMonoArgs>--setenv=XHARNESS_LOG_TEST_START=true --no-memory-snapshot</WasmXHarnessMonoArgs>
+    <_WasmPThreadPoolSize Condition="'$(MonoWasmBuildVariant)' == 'multithread'">10</_WasmPThreadPoolSize>
     <!-- This WASM test is problematic and slow right now. This sets the xharness timeout but there is also override in sendtohelix-wasm.targets -->
     <WasmXHarnessTestsTimeout>01:15:00</WasmXHarnessTestsTimeout>
   </PropertyGroup>

--- a/src/libraries/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
+++ b/src/libraries/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
@@ -3,8 +3,12 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppCurrent)-browser</TargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetPlatformIdentifier)' == 'browser'">
-    <DefineConstants>$(DefineConstants);TARGET_BROWSER</DefineConstants>
+  <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
+  <PropertyGroup>
+    <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
+    <FeatureWasmThreads Condition="'$(TargetPlatformIdentifier)' == 'browser' and '$(MonoWasmBuildVariant)' == 'multithread'">true</FeatureWasmThreads>
+    <DefineConstants Condition="'$(TargetPlatformIdentifier)' == 'browser'">$(DefineConstants);TARGET_BROWSER</DefineConstants>
+    <DefineConstants Condition="'$(FeatureWasmThreads)' == 'true'" >$(DefineConstants);FEATURE_WASM_THREADS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,7 +28,6 @@
     <Compile Include="System\Net\WebSockets\BrowserWebSockets\BrowserInterop.cs" />
     <Compile Include="System\Net\WebSockets\BrowserWebSockets\BrowserWebSocket.cs" />
     <Compile Include="System\Net\WebSockets\BrowserWebSockets\ClientWebSocketOptions.cs" />
-    <Compile Include="$(LibrariesProjectRoot)System.Runtime.InteropServices.JavaScript\src\System\Runtime\InteropServices\JavaScript\CancelablePromise.cs" Link="InteropServices\JavaScript\CancelablePromise.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Win32.Primitives" />
@@ -46,6 +49,6 @@
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'browser'">
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\Microsoft.Interop.SourceGeneration\Microsoft.Interop.SourceGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices.JavaScript\gen\JSImportGenerator\JSImportGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-    <Reference Include="System.Runtime.InteropServices.JavaScript" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices.JavaScript\src\System.Runtime.InteropServices.JavaScript.csproj" SkipUseReferenceAssembly="true" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
@@ -285,8 +285,8 @@ namespace System.Net.WebSockets
                         return Task.CompletedTask;
                     }
 
-                    promise = CloseAsyncCore(closeStatus, statusDescription, state != WebSocketState.Aborted, cancellationToken);
 #if FEATURE_WASM_THREADS
+                    promise = CloseAsyncCore(closeStatus, statusDescription, state != WebSocketState.Aborted, cancellationToken);
                 } //lock will unlock synchronously before task is resolved!
                 return promise;
             });

--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
@@ -14,6 +14,10 @@ namespace System.Net.WebSockets
     /// </summary>
     internal sealed class BrowserWebSocket : WebSocket
     {
+#if FEATURE_WASM_THREADS
+        private readonly object _thisLock = new object();
+#endif
+
         private WebSocketCloseStatus? _closeStatus;
         private string? _closeStatusDescription;
         private JSObject? _innerWebSocket;
@@ -29,29 +33,112 @@ namespace System.Net.WebSockets
         {
             get
             {
-                if (_innerWebSocket != null && !_disposed && (_state == WebSocketState.Connecting || _state == WebSocketState.Open || _state == WebSocketState.CloseSent))
+#if FEATURE_WASM_THREADS
+                lock (_thisLock)
                 {
-                    _state = GetReadyState();
-                }
-                return _state;
+#endif
+                    if (_innerWebSocket == null || _disposed || (_state != WebSocketState.Connecting && _state != WebSocketState.Open && _state != WebSocketState.CloseSent))
+                    {
+                        return _state;
+                    }
+#if FEATURE_WASM_THREADS
+                } //lock
+#endif
+
+#if FEATURE_WASM_THREADS
+                return FastState = _innerWebSocket!.SynchronizationContext.Send(static (BrowserWebSocket self) =>
+                {
+                    lock (self._thisLock)
+                    {
+                        return GetReadyState(self._innerWebSocket!);
+                    } //lock
+                }, this);
+#else
+                return FastState = GetReadyState(_innerWebSocket!);
+#endif
+            }
+        }
+
+        private WebSocketState FastState
+        {
+            get
+            {
+#if FEATURE_WASM_THREADS
+                lock (_thisLock)
+                {
+#endif
+                    return _state;
+#if FEATURE_WASM_THREADS
+                } //lock
+#endif
+            }
+            set
+            {
+#if FEATURE_WASM_THREADS
+                lock (_thisLock)
+                {
+#endif
+                    _state = value;
+#if FEATURE_WASM_THREADS
+                } //lock
+#endif
             }
         }
 
         public override WebSocketCloseStatus? CloseStatus => _closeStatus;
         public override string? CloseStatusDescription => _closeStatusDescription;
-        public override string? SubProtocol => BrowserInterop.GetProtocol(_innerWebSocket);
+        public override string? SubProtocol
+        {
+            get
+            {
+#if FEATURE_WASM_THREADS
+                lock (_thisLock)
+                {
+#endif
+                    ThrowIfDisposed();
+                    if (_innerWebSocket == null) throw new InvalidOperationException(SR.net_WebSockets_NotConnected);
+#if FEATURE_WASM_THREADS
+                } //lock
+#endif
+
+#if FEATURE_WASM_THREADS
+                return _innerWebSocket.SynchronizationContext.Send(BrowserInterop.GetProtocol, _innerWebSocket);
+#else
+                return BrowserInterop.GetProtocol(_innerWebSocket);
+#endif
+
+            }
+        }
 
         #endregion Properties
 
         internal Task ConnectAsync(Uri uri, List<string>? requestedSubProtocols, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
-            if (_state != WebSocketState.None)
+            if (FastState != WebSocketState.None)
             {
                 throw new InvalidOperationException(SR.net_WebSockets_AlreadyStarted);
             }
-            _state = WebSocketState.Connecting;
-            return ConnectAsyncCore(uri, requestedSubProtocols, cancellationToken);
+#if FEATURE_WASM_THREADS
+            JSHost.CurrentOrMainJSSynchronizationContext!.Send(_ =>
+            {
+                lock (_thisLock)
+                {
+                    ThrowIfDisposed();
+                    FastState = WebSocketState.Connecting;
+                    CreateCore(uri, requestedSubProtocols);
+                }
+            }, null);
+
+            return JSHost.CurrentOrMainJSSynchronizationContext.Send(() =>
+            {
+                return ConnectAsyncCore(cancellationToken);
+            });
+#else
+            FastState = WebSocketState.Connecting;
+            CreateCore(uri, requestedSubProtocols);
+            return ConnectAsyncCore(cancellationToken);
+#endif
         }
 
         public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
@@ -61,7 +148,7 @@ namespace System.Net.WebSockets
             ThrowIfDisposed();
 
             // fast check of previous _state instead of GetReadyState(), the readyState would be validated on JS side
-            if (_state != WebSocketState.Open)
+            if (FastState != WebSocketState.Open)
             {
                 throw new InvalidOperationException(SR.net_WebSockets_NotConnected);
             }
@@ -79,7 +166,21 @@ namespace System.Net.WebSockets
 
             WebSocketValidate.ValidateArraySegment(buffer, nameof(buffer));
 
+#if FEATURE_WASM_THREADS
+            return _innerWebSocket!.SynchronizationContext.Send(() =>
+            {
+                Task promise;
+                lock (_thisLock)
+                {
+                    ThrowIfDisposed();
+                    promise = SendAsyncCore(buffer, messageType, endOfMessage, cancellationToken);
+                } //lock will unlock synchronously before promise is resolved!
+
+                return promise;
+            });
+#else
             return SendAsyncCore(buffer, messageType, endOfMessage, cancellationToken);
+#endif
         }
 
         public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
@@ -90,14 +191,28 @@ namespace System.Net.WebSockets
             }
             ThrowIfDisposed();
             // fast check of previous _state instead of GetReadyState(), the readyState would be validated on JS side
-            if (_state != WebSocketState.Open && _state != WebSocketState.CloseSent)
+            var fastState = FastState;
+            if (fastState != WebSocketState.Open && fastState != WebSocketState.CloseSent)
             {
-                throw new WebSocketException(WebSocketError.InvalidState, SR.Format(SR.net_WebSockets_InvalidState, _state, "Open, CloseSent"));
+                throw new WebSocketException(WebSocketError.InvalidState, SR.Format(SR.net_WebSockets_InvalidState, fastState, "Open, CloseSent"));
             }
 
             WebSocketValidate.ValidateArraySegment(buffer, nameof(buffer));
 
+#if FEATURE_WASM_THREADS
+            return _innerWebSocket!.SynchronizationContext.Send(() =>
+            {
+                Task<WebSocketReceiveResult> promise;
+                lock (_thisLock)
+                {
+                    ThrowIfDisposed();
+                    promise = ReceiveAsyncCore(buffer, cancellationToken);
+                } //lock will unlock synchronously before task is resolved!
+                return promise;
+            });
+#else
             return ReceiveAsyncCore(buffer, cancellationToken);
+#endif
         }
 
         public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken)
@@ -106,16 +221,37 @@ namespace System.Net.WebSockets
             ThrowIfDisposed();
 
             WebSocketValidate.ValidateCloseStatus(closeStatus, statusDescription);
-
-            var state = State;
-            if (state == WebSocketState.None || state == WebSocketState.Closed)
+            var fastState = FastState;
+            if (fastState == WebSocketState.None || fastState == WebSocketState.Closed)
             {
-                throw new WebSocketException(WebSocketError.InvalidState, SR.Format(SR.net_WebSockets_InvalidState, state, "Connecting, Open, CloseSent, Aborted"));
+                throw new WebSocketException(WebSocketError.InvalidState, SR.Format(SR.net_WebSockets_InvalidState, fastState, "Connecting, Open, CloseSent, Aborted"));
             }
 
-            return state == WebSocketState.Open || state == WebSocketState.Connecting || state == WebSocketState.Aborted
-                ? CloseAsyncCore(closeStatus, statusDescription, false, cancellationToken)
-                : Task.CompletedTask;
+#if FEATURE_WASM_THREADS
+            return _innerWebSocket!.SynchronizationContext.Send(() =>
+            {
+                Task promise;
+                lock (_thisLock)
+                {
+                    ThrowIfDisposed();
+#endif
+                    var state = State;
+                    if (state == WebSocketState.None || state == WebSocketState.Closed)
+                    {
+                        throw new WebSocketException(WebSocketError.InvalidState, SR.Format(SR.net_WebSockets_InvalidState, state, "Connecting, Open, CloseSent, Aborted"));
+                    }
+                    if(state != WebSocketState.Open && state != WebSocketState.Connecting && state != WebSocketState.Aborted)
+                    {
+                        return Task.CompletedTask;
+                    }
+#if FEATURE_WASM_THREADS
+                    promise = CloseAsyncCore(closeStatus, statusDescription, false, cancellationToken);
+                } //lock will unlock synchronously before task is resolved!
+                return promise;
+            });
+#else
+            return CloseAsyncCore(closeStatus, statusDescription, false, cancellationToken);
+#endif
         }
 
         public override Task CloseAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken)
@@ -125,51 +261,126 @@ namespace System.Net.WebSockets
 
             WebSocketValidate.ValidateCloseStatus(closeStatus, statusDescription);
 
-            var state = State;
-            if (state == WebSocketState.None || state == WebSocketState.Closed)
+            var fastState = FastState;
+            if (fastState == WebSocketState.None || fastState == WebSocketState.Closed)
             {
-                throw new WebSocketException(WebSocketError.InvalidState, SR.Format(SR.net_WebSockets_InvalidState, state, "Connecting, Open, CloseSent, Aborted"));
+                throw new WebSocketException(WebSocketError.InvalidState, SR.Format(SR.net_WebSockets_InvalidState, fastState, "Connecting, Open, CloseSent, Aborted"));
             }
 
-            return state == WebSocketState.Open || state == WebSocketState.Connecting || state == WebSocketState.Aborted || state == WebSocketState.CloseSent
-                ? CloseAsyncCore(closeStatus, statusDescription, state != WebSocketState.Aborted, cancellationToken)
-                : Task.CompletedTask;
+#if FEATURE_WASM_THREADS
+            return _innerWebSocket!.SynchronizationContext.Send(() =>
+            {
+                Task promise;
+                lock (_thisLock)
+                {
+                    ThrowIfDisposed();
+#endif
+                    var state = State;
+                    if (state == WebSocketState.None || state == WebSocketState.Closed)
+                    {
+                        throw new WebSocketException(WebSocketError.InvalidState, SR.Format(SR.net_WebSockets_InvalidState, state, "Connecting, Open, CloseSent, Aborted"));
+                    }
+                    if (state != WebSocketState.Open && state != WebSocketState.Connecting && state != WebSocketState.Aborted && state != WebSocketState.CloseSent)
+                    {
+                        return Task.CompletedTask;
+                    }
+
+                    promise = CloseAsyncCore(closeStatus, statusDescription, state != WebSocketState.Aborted, cancellationToken);
+#if FEATURE_WASM_THREADS
+                } //lock will unlock synchronously before task is resolved!
+                return promise;
+            });
+#else
+            return CloseAsyncCore(closeStatus, statusDescription, state != WebSocketState.Aborted, cancellationToken);
+#endif
         }
 
         public override void Abort()
         {
-            if (!_disposed && State != WebSocketState.Closed)
+#if FEATURE_WASM_THREADS
+            if (_disposed)
             {
-                _state = WebSocketState.Aborted;
-                _aborted = true;
-                if (_innerWebSocket != null)
-                {
-                    BrowserInterop.WebSocketAbort(_innerWebSocket!);
-                }
+                return;
             }
+            _innerWebSocket?.SynchronizationContext.Send(static (BrowserWebSocket self) =>
+            {
+                lock (self._thisLock)
+                {
+                    AbortCore(self, self.State);
+                }
+            }, this);
+#else
+            AbortCore(this, this.State);
+#endif
         }
 
         public override void Dispose()
         {
-            if (!_disposed)
+#if FEATURE_WASM_THREADS
+            if (_disposed)
             {
-                var state = State;
-                _disposed = true;
+                return;
+            }
+            _innerWebSocket?.SynchronizationContext.Send(static (BrowserWebSocket self) =>
+            {
+                lock (self._thisLock)
+                {
+                    DisposeCore(self);
+                }
+            }, this);
+#else
+            DisposeCore(this);
+#endif
+        }
+
+        private void ThrowIfDisposed()
+        {
+#if FEATURE_WASM_THREADS
+            lock (_thisLock)
+            {
+#endif
+                ObjectDisposedException.ThrowIf(_disposed, this);
+#if FEATURE_WASM_THREADS
+            } //lock
+#endif
+        }
+
+        #region methods always called on one thread only, exclusively
+
+        private static void DisposeCore(BrowserWebSocket self)
+        {
+            if (!self._disposed)
+            {
+                var state = self.State;
+                self._disposed = true;
                 if (state < WebSocketState.Aborted && state != WebSocketState.None)
                 {
-                    Abort();
+                    AbortCore(self, state);
                 }
-                if (state != WebSocketState.Aborted)
+                if (self.FastState != WebSocketState.Aborted)
                 {
-                    _state = WebSocketState.Closed;
+                    self.FastState = WebSocketState.Closed;
                 }
-                _innerWebSocket?.Dispose();
-                _innerWebSocket = null;
-                responseStatusHandle?.Dispose();
+                self._innerWebSocket?.Dispose();
+                self._innerWebSocket = null;
+                self.responseStatusHandle?.Dispose();
             }
         }
 
-        private async Task ConnectAsyncCore(Uri uri, List<string>? requestedSubProtocols, CancellationToken cancellationToken)
+        private static void AbortCore(BrowserWebSocket self, WebSocketState currentState)
+        {
+            if (!self._disposed && currentState != WebSocketState.Closed)
+            {
+                self.FastState = WebSocketState.Aborted;
+                self._aborted = true;
+                if (self._innerWebSocket != null)
+                {
+                    BrowserInterop.WebSocketAbort(self._innerWebSocket!);
+                }
+            }
+        }
+
+        private void CreateCore(Uri uri, List<string>? requestedSubProtocols)
         {
             try
             {
@@ -178,32 +389,79 @@ namespace System.Net.WebSockets
                 {
                     _closeStatus = (WebSocketCloseStatus)code;
                     _closeStatusDescription = reason;
-                    WebSocketState state = State;
-                    if (state == WebSocketState.Connecting || state == WebSocketState.Open || state == WebSocketState.CloseSent)
+#if FEATURE_WASM_THREADS
+                    lock (_thisLock)
                     {
-                        _state = WebSocketState.Closed;
-                    }
+#endif
+                        WebSocketState state = State;
+                        if (state == WebSocketState.Connecting || state == WebSocketState.Open || state == WebSocketState.CloseSent)
+                        {
+                            FastState = WebSocketState.Closed;
+                        }
+#if FEATURE_WASM_THREADS
+                    } //lock
+#endif
                 };
 
                 Memory<int> responseMemory = new Memory<int>(responseStatus);
+
                 responseStatusHandle = responseMemory.Pin();
-
                 _innerWebSocket = BrowserInterop.UnsafeCreate(uri.ToString(), subProtocols, responseStatusHandle.Value, onClose);
-                var openTask = BrowserInterop.WebSocketOpen(_innerWebSocket);
+            }
+            catch (Exception)
+            {
+                Dispose();
+                throw;
+            }
+        }
 
-                await CancelationHelper(openTask!, cancellationToken, _state).ConfigureAwait(true);
-                if (State == WebSocketState.Connecting)
+        private async Task ConnectAsyncCore(CancellationToken cancellationToken)
+        {
+#if FEATURE_WASM_THREADS
+            lock (_thisLock)
+            {
+#endif
+                if (_aborted)
                 {
-                    _state = WebSocketState.Open;
+                    FastState = WebSocketState.Closed;
+                    throw new WebSocketException(WebSocketError.Faulted, SR.net_webstatus_ConnectFailure);
                 }
+                ThrowIfDisposed();
+#if FEATURE_WASM_THREADS
+            } //lock
+#endif
+
+            try
+            {
+                var openTask = BrowserInterop.WebSocketOpen(_innerWebSocket!);
+
+                await CancelationHelper(openTask!, cancellationToken, FastState).ConfigureAwait(true);
+#if FEATURE_WASM_THREADS
+                lock (_thisLock)
+                {
+#endif
+                    if (State == WebSocketState.Connecting)
+                    {
+                        FastState = WebSocketState.Open;
+                    }
+#if FEATURE_WASM_THREADS
+                } //lock
+#endif
             }
             catch (OperationCanceledException ex)
             {
-                _state = WebSocketState.Closed;
-                if (_aborted)
+#if FEATURE_WASM_THREADS
+                lock (_thisLock)
                 {
-                    throw new WebSocketException(WebSocketError.Faulted, SR.net_webstatus_ConnectFailure, ex);
-                }
+#endif
+                    FastState = WebSocketState.Closed;
+                    if (_aborted)
+                    {
+                        throw new WebSocketException(WebSocketError.Faulted, SR.net_webstatus_ConnectFailure, ex);
+                    }
+#if FEATURE_WASM_THREADS
+                } //lock
+#endif
                 throw;
             }
             catch (Exception)
@@ -224,7 +482,7 @@ namespace System.Net.WebSockets
                     return;
                 }
 
-                await CancelationHelper(sendTask, cancellationToken, _state).ConfigureAwait(true);
+                await CancelationHelper(sendTask, cancellationToken, FastState).ConfigureAwait(true);
             }
             catch (JSException ex)
             {
@@ -247,12 +505,25 @@ namespace System.Net.WebSockets
                     if (receiveTask == null)
                     {
                         // return synchronously
-                        return ConvertResponse();
+#if FEATURE_WASM_THREADS
+                        lock (_thisLock)
+                        {
+#endif
+                            return ConvertResponse(this);
+#if FEATURE_WASM_THREADS
+                        } //lock
+#endif
                     }
+                    await CancelationHelper(receiveTask, cancellationToken, FastState).ConfigureAwait(true);
 
-                    await CancelationHelper(receiveTask, cancellationToken, _state).ConfigureAwait(true);
-
-                    return ConvertResponse();
+#if FEATURE_WASM_THREADS
+                    lock (_thisLock)
+                    {
+#endif
+                        return ConvertResponse(this);
+#if FEATURE_WASM_THREADS
+                    } //lock
+#endif
                 }
             }
             catch (JSException ex)
@@ -265,18 +536,18 @@ namespace System.Net.WebSockets
             }
         }
 
-        private WebSocketReceiveResult ConvertResponse()
+        private static WebSocketReceiveResult ConvertResponse(BrowserWebSocket self)
         {
             const int countIndex = 0;
             const int typeIndex = 1;
             const int endIndex = 2;
 
-            WebSocketMessageType messageType = (WebSocketMessageType)responseStatus[typeIndex];
+            WebSocketMessageType messageType = (WebSocketMessageType)self.responseStatus[typeIndex];
             if (messageType == WebSocketMessageType.Close)
             {
-                return new WebSocketReceiveResult(responseStatus[countIndex], messageType, responseStatus[endIndex] != 0, CloseStatus, CloseStatusDescription);
+                return new WebSocketReceiveResult(self.responseStatus[countIndex], messageType, self.responseStatus[endIndex] != 0, self.CloseStatus, self.CloseStatusDescription);
             }
-            return new WebSocketReceiveResult(responseStatus[countIndex], messageType, responseStatus[endIndex] != 0);
+            return new WebSocketReceiveResult(self.responseStatus[countIndex], messageType, self.responseStatus[endIndex] != 0);
         }
 
         private async Task CloseAsyncCore(WebSocketCloseStatus closeStatus, string? statusDescription, bool waitForCloseReceived, CancellationToken cancellationToken)
@@ -284,20 +555,24 @@ namespace System.Net.WebSockets
             _closeStatus = closeStatus;
             _closeStatusDescription = statusDescription;
 
-            var closeTask = BrowserInterop.WebSocketClose(_innerWebSocket!, (int)closeStatus, statusDescription, waitForCloseReceived);
-            if (closeTask != null)
-            {
-                await CancelationHelper(closeTask, cancellationToken, _state).ConfigureAwait(true);
-            }
+            var closeTask = BrowserInterop.WebSocketClose(_innerWebSocket!, (int)closeStatus, statusDescription, waitForCloseReceived) ?? Task.CompletedTask;
+            await CancelationHelper(closeTask, cancellationToken, FastState).ConfigureAwait(true);
 
-            var state = State;
-            if (state == WebSocketState.Open || state == WebSocketState.Connecting || state == WebSocketState.CloseSent)
+#if FEATURE_WASM_THREADS
+            lock (_thisLock)
             {
-                _state = waitForCloseReceived ? WebSocketState.Closed : WebSocketState.CloseSent;
-            }
+#endif
+                var state = State;
+                if (state == WebSocketState.Open || state == WebSocketState.Connecting || state == WebSocketState.CloseSent)
+                {
+                    FastState = waitForCloseReceived ? WebSocketState.Closed : WebSocketState.CloseSent;
+                }
+#if FEATURE_WASM_THREADS
+            } //lock
+#endif
         }
 
-        private async ValueTask CancelationHelper(Task jsTask, CancellationToken cancellationToken, WebSocketState previousState)
+        private async Task CancelationHelper(Task jsTask, CancellationToken cancellationToken, WebSocketState previousState)
         {
             if (jsTask.IsCompletedSuccessfully)
             {
@@ -323,12 +598,12 @@ namespace System.Net.WebSockets
 
                 if (cancellationToken.IsCancellationRequested)
                 {
-                    _state = WebSocketState.Aborted;
+                    FastState = WebSocketState.Aborted;
                     throw new OperationCanceledException(cancellationToken);
                 }
                 if (ex.Message == "OperationCanceledException")
                 {
-                    _state = WebSocketState.Aborted;
+                    FastState = WebSocketState.Aborted;
                     throw new OperationCanceledException("The operation was cancelled.", ex, cancellationToken);
                 }
                 if (previousState == WebSocketState.Connecting)
@@ -339,15 +614,9 @@ namespace System.Net.WebSockets
             }
         }
 
-        private void ThrowIfDisposed()
+        private static WebSocketState GetReadyState(JSObject innerWebSocket)
         {
-            ObjectDisposedException.ThrowIf(_disposed, this);
-        }
-
-        private WebSocketState GetReadyState()
-        {
-            int readyState = BrowserInterop.GetReadyState(_innerWebSocket);
-
+            var readyState = BrowserInterop.GetReadyState(innerWebSocket);
             // https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/readyState
             return readyState switch
             {
@@ -358,5 +627,7 @@ namespace System.Net.WebSockets
                 _ => WebSocketState.None
             };
         }
+
+        #endregion
     }
 }

--- a/src/libraries/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
+++ b/src/libraries/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
@@ -16,6 +16,7 @@
     <TestArchiveTestsDir>$(TestArchiveTestsRoot)$(OSPlatformConfig)/</TestArchiveTestsDir>
     <DefineConstants>$(DefineConstants);TARGET_BROWSER</DefineConstants>
     <WasmXHarnessMonoArgs>--setenv=XHARNESS_LOG_TEST_START=true --no-memory-snapshot</WasmXHarnessMonoArgs>
+    <_WasmPThreadPoolSize Condition="'$(MonoWasmBuildVariant)' == 'multithread'">10</_WasmPThreadPoolSize>
 
     <!-- This WASM test is problematic and slow right now. This sets the xharness timeout but there is also override in sendtohelix-wasm.targets -->
     <WasmXHarnessTestsTimeout>01:15:00</WasmXHarnessTestsTimeout>

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/CompatibilitySuppressions.xml
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/CompatibilitySuppressions.xml
@@ -36,4 +36,35 @@
     <Left>ref/net8.0/System.Runtime.InteropServices.JavaScript.dll</Left>
     <Right>runtimes/browser/lib/net8.0/System.Runtime.InteropServices.JavaScript.dll</Right>
   </Suppression>
+
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:System.Runtime.InteropServices.JavaScript.SynchronizationContextExtension</Target>
+    <Left>ref/net8.0/System.Runtime.InteropServices.JavaScript.dll</Left>
+    <Right>runtimes/browser/lib/net8.0/System.Runtime.InteropServices.JavaScript.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:System.Runtime.InteropServices.JavaScript.WebWorker</Target>
+    <Left>ref/net8.0/System.Runtime.InteropServices.JavaScript.dll</Left>
+    <Right>runtimes/browser/lib/net8.0/System.Runtime.InteropServices.JavaScript.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:System.Runtime.InteropServices.JavaScript.CancelablePromise</Target>
+    <Left>ref/net8.0/System.Runtime.InteropServices.JavaScript.dll</Left>
+    <Right>runtimes/browser/lib/net8.0/System.Runtime.InteropServices.JavaScript.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Runtime.InteropServices.JavaScript.JSObject.get_SynchronizationContext</Target>
+    <Left>ref/net8.0/System.Runtime.InteropServices.JavaScript.dll</Left>
+    <Right>runtimes/browser/lib/net8.0/System.Runtime.InteropServices.JavaScript.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Runtime.InteropServices.JavaScript.JSHost.get_CurrentOrMainJSSynchronizationContext</Target>
+    <Left>ref/net8.0/System.Runtime.InteropServices.JavaScript.dll</Left>
+    <Right>runtimes/browser/lib/net8.0/System.Runtime.InteropServices.JavaScript.dll</Right>
+  </Suppression>
 </Suppressions>

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System.Runtime.InteropServices.JavaScript.csproj
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System.Runtime.InteropServices.JavaScript.csproj
@@ -39,6 +39,7 @@
     <Compile Include="System\Runtime\InteropServices\JavaScript\JSExportAttribute.cs" />
     <Compile Include="System\Runtime\InteropServices\JavaScript\JSImportAttribute.cs" />
     <Compile Include="System\Runtime\InteropServices\JavaScript\CancelablePromise.cs" />
+    <Compile Include="System\Runtime\InteropServices\JavaScript\SynchronizationContextExtensions.cs" />
 
     <Compile Include="System\Runtime\InteropServices\JavaScript\MarshalerType.cs" />
     <Compile Include="System\Runtime\InteropServices\JavaScript\Marshaling\JSMarshalerArgument.BigInt64.cs" />

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/CancelablePromise.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/CancelablePromise.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace System.Runtime.InteropServices.JavaScript
 {
-    internal static partial class CancelablePromise
+    public static partial class CancelablePromise
     {
         [JSImport("INTERNAL.mono_wasm_cancel_promise")]
         private static partial void _CancelPromise(IntPtr promiseGCHandle);
@@ -18,19 +18,19 @@ namespace System.Runtime.InteropServices.JavaScript
             {
                 return;
             }
-            GCHandle? promiseGCHandle = promise.AsyncState as GCHandle?;
-            if (promiseGCHandle == null) throw new InvalidOperationException("Expected Task converted from JS Promise");
+            JSHostImplementation.TaskCallback? holder = promise.AsyncState as JSHostImplementation.TaskCallback;
+            if (holder == null) throw new InvalidOperationException("Expected Task converted from JS Promise");
+
 
 #if FEATURE_WASM_THREADS
-            // TODO JSObject.AssertThreadAffinity(promise);
-            // in order to remember the thread ID of the promise, we would have to allocate holder object for any Task,
-            // which would hold thread ID and the GCHandle
-            // that would be pretty expensive, so we don't do it for now
-            // the consequences are that calling CancelPromise on wrong thread would do nothing
-            // because there would not be any object on JS registered under the same GCHandle
-            // perhaps that's the point when we could throw an exception on JS side.
+            holder.SynchronizationContext!.Send(static (JSHostImplementation.TaskCallback holder) =>
+            {
 #endif
-            _CancelPromise((IntPtr)promiseGCHandle.Value);
+                var handle = JSHostImplementation.GetJSOwnedObjectGCHandle(holder);
+                _CancelPromise(handle);
+#if FEATURE_WASM_THREADS
+            }, holder);
+#endif
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/CancelablePromise.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/CancelablePromise.cs
@@ -26,8 +26,7 @@ namespace System.Runtime.InteropServices.JavaScript
             holder.SynchronizationContext!.Send(static (JSHostImplementation.TaskCallback holder) =>
             {
 #endif
-            var handle = JSHostImplementation.GetJSOwnedObjectGCHandle(holder);
-            _CancelPromise(handle);
+            _CancelPromise(holder.GCHandle);
 #if FEATURE_WASM_THREADS
             }, holder);
 #endif
@@ -45,11 +44,10 @@ namespace System.Runtime.InteropServices.JavaScript
 
 
 #if FEATURE_WASM_THREADS
-            holder.SynchronizationContext!.Send(static (JSHostImplementation.TaskCallback holder) =>
+            holder.SynchronizationContext!.Send((JSHostImplementation.TaskCallback holder) =>
             {
 #endif
-                var handle = JSHostImplementation.GetJSOwnedObjectGCHandle(holder);
-                _CancelPromise(handle);
+                _CancelPromise(holder.GCHandle);
                 callback.Invoke(state1, state2);
 #if FEATURE_WASM_THREADS
             }, holder);

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
@@ -132,7 +132,7 @@ namespace System.Runtime.InteropServices.JavaScript
                 holder.SynchronizationContext = SynchronizationContext.Current ?? new SynchronizationContext();
 #endif
                 arg_return.slot.Type = MarshalerType.Object;
-                arg_return.slot.GCHandle = JSHostImplementation.GetJSOwnedObjectGCHandle(holder);
+                arg_return.slot.GCHandle = holder.GCHandle = JSHostImplementation.GetJSOwnedObjectGCHandle(holder);
             }
             catch (Exception ex)
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 
 namespace System.Runtime.InteropServices.JavaScript
 {
@@ -126,6 +127,10 @@ namespace System.Runtime.InteropServices.JavaScript
             try
             {
                 JSHostImplementation.TaskCallback holder = new JSHostImplementation.TaskCallback();
+#if FEATURE_WASM_THREADS
+                holder.OwnerThreadId = Thread.CurrentThread.ManagedThreadId;
+                holder.SynchronizationContext = SynchronizationContext.Current ?? new SynchronizationContext();
+#endif
                 arg_return.slot.Type = MarshalerType.Object;
                 arg_return.slot.GCHandle = JSHostImplementation.GetJSOwnedObjectGCHandle(holder);
             }
@@ -225,7 +230,7 @@ namespace System.Runtime.InteropServices.JavaScript
             ref JSMarshalerArgument arg_exc = ref arguments_buffer[0]; // initialized by caller in alloc_stack_frame()
             try
             {
-                JSHostImplementation.InstallWebWorkerInterop(true);
+                JSHostImplementation.InstallWebWorkerInterop(true, true);
             }
             catch (Exception ex)
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSException.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSException.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.Versioning;
+using System.Threading;
 
 namespace System.Runtime.InteropServices.JavaScript
 {
@@ -37,6 +38,13 @@ namespace System.Runtime.InteropServices.JavaScript
                 {
                     return bs;
                 }
+
+#if FEATURE_WASM_THREADS
+                if (jsException.OwnerThreadId != Thread.CurrentThread.ManagedThreadId)
+                {
+                    return null;
+                }
+#endif
                 string? jsStackTrace = jsException.GetPropertyAsString("stack");
                 if (jsStackTrace == null)
                 {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSFunctionBinding.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSFunctionBinding.cs
@@ -204,6 +204,13 @@ namespace System.Runtime.InteropServices.JavaScript
 
         internal static unsafe JSFunctionBinding BindJSFunctionImpl(string functionName, string moduleName, ReadOnlySpan<JSMarshalerType> signatures)
         {
+#if FEATURE_WASM_THREADS
+            if (JSSynchronizationContext.CurrentJSSynchronizationContext == null)
+            {
+                throw new InvalidOperationException("Please use dedicated worker for working with JavaScript interop. See https://github.com/dotnet/runtime/blob/main/src/mono/wasm/threads.md#JS-interop-on-dedicated-threads ");
+            }
+#endif
+
             var signature = JSHostImplementation.GetMethodSignature(signatures);
 
             Interop.Runtime.BindJSFunction(functionName, moduleName, signature.Header, out IntPtr jsFunctionHandle, out int isException, out object exceptionMessage);

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHost.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHost.cs
@@ -49,5 +49,18 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             return JSHostImplementation.ImportAsync(moduleName, moduleUrl, cancellationToken);
         }
+
+        public static SynchronizationContext? CurrentOrMainJSSynchronizationContext
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+#if FEATURE_WASM_THREADS
+                return JSSynchronizationContext.CurrentJSSynchronizationContext ?? JSSynchronizationContext.MainJSSynchronizationContext ?? null;
+#else
+                return null;
+#endif
+            }
+        }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.Types.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.Types.cs
@@ -11,6 +11,7 @@ namespace System.Runtime.InteropServices.JavaScript
 
         public sealed class TaskCallback
         {
+            public nint GCHandle;
             public ToManagedCallback? Callback;
 #if FEATURE_WASM_THREADS
             // the JavaScript object could only exist on the single web worker and can't migrate to other workers

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.Types.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.Types.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Threading;
+
 namespace System.Runtime.InteropServices.JavaScript
 {
     internal static partial class JSHostImplementation
@@ -10,6 +12,11 @@ namespace System.Runtime.InteropServices.JavaScript
         public sealed class TaskCallback
         {
             public ToManagedCallback? Callback;
+#if FEATURE_WASM_THREADS
+            // the JavaScript object could only exist on the single web worker and can't migrate to other workers
+            internal int OwnerThreadId;
+            internal SynchronizationContext? SynchronizationContext;
+#endif
         }
 
         [StructLayout(LayoutKind.Explicit)]

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.cs
@@ -199,7 +199,7 @@ namespace System.Runtime.InteropServices.JavaScript
         }
 
 #if FEATURE_WASM_THREADS
-        public static void InstallWebWorkerInterop(bool installJSSynchronizationContext)
+        public static void InstallWebWorkerInterop(bool installJSSynchronizationContext, bool isMainThread)
         {
             Interop.Runtime.InstallWebWorkerInterop(installJSSynchronizationContext);
             if (installJSSynchronizationContext)
@@ -212,6 +212,10 @@ namespace System.Runtime.InteropServices.JavaScript
                     ctx.previousSynchronizationContext = SynchronizationContext.Current;
                     JSSynchronizationContext.CurrentJSSynchronizationContext = ctx;
                     SynchronizationContext.SetSynchronizationContext(ctx);
+                    if (isMainThread)
+                    {
+                        JSSynchronizationContext.MainJSSynchronizationContext = ctx;
+                    }
                 }
                 else if (ctx.TargetThreadId != currentThreadId)
                 {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.References.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.References.cs
@@ -12,6 +12,23 @@ namespace System.Runtime.InteropServices.JavaScript
         internal nint JSHandle;
 
 #if FEATURE_WASM_THREADS
+        private readonly object _thisLock = new object();
+        private SynchronizationContext? m_SynchronizationContext;
+#endif
+
+        public SynchronizationContext SynchronizationContext
+        {
+            get
+            {
+#if FEATURE_WASM_THREADS
+                return m_SynchronizationContext!;
+#else
+                throw new PlatformNotSupportedException();
+#endif
+            }
+        }
+
+#if FEATURE_WASM_THREADS
         // the JavaScript object could only exist on the single web worker and can't migrate to other workers
         internal int OwnerThreadId;
 #endif
@@ -26,6 +43,11 @@ namespace System.Runtime.InteropServices.JavaScript
             JSHandle = jsHandle;
 #if FEATURE_WASM_THREADS
             OwnerThreadId = Thread.CurrentThread.ManagedThreadId;
+            m_SynchronizationContext = JSSynchronizationContext.CurrentJSSynchronizationContext;
+            if (m_SynchronizationContext == null)
+            {
+                throw new InvalidOperationException(); // should not happen
+            }
 #endif
         }
 
@@ -80,9 +102,16 @@ namespace System.Runtime.InteropServices.JavaScript
             }
             if (value is JSException jsException)
             {
-                if(jsException.jsException!=null && jsException.jsException.OwnerThreadId != Thread.CurrentThread.ManagedThreadId)
+                if (jsException.jsException != null && jsException.jsException.OwnerThreadId != Thread.CurrentThread.ManagedThreadId)
                 {
                     throw new InvalidOperationException("The JavaScript object can be used only on the thread where it was created.");
+                }
+            }
+            if (value is JSHostImplementation.TaskCallback holder)
+            {
+                if (holder.OwnerThreadId != Thread.CurrentThread.ManagedThreadId)
+                {
+                    throw new InvalidOperationException("The JavaScript promise can be used only on the thread where it was created.");
                 }
             }
         }
@@ -101,9 +130,22 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             if (!_isDisposed)
             {
+#if FEATURE_WASM_THREADS
+                SynchronizationContext.Send(static (JSObject self) =>
+                {
+                    lock (self._thisLock)
+                    {
+                        JSHostImplementation.ReleaseCSOwnedObject(self.JSHandle);
+                        self._isDisposed = true;
+                        self.JSHandle = IntPtr.Zero;
+                        self.m_SynchronizationContext = null;
+                    } //lock
+                }, this);
+#else
                 JSHostImplementation.ReleaseCSOwnedObject(JSHandle);
                 _isDisposed = true;
                 JSHandle = IntPtr.Zero;
+#endif
             }
         }
 

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
@@ -39,6 +39,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public string GetTypeOfProperty(string propertyName)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             return JavaScriptImports.GetTypeOfProperty(this, propertyName);
         }
 
@@ -54,6 +57,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public bool GetPropertyAsBoolean(string propertyName)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             return JavaScriptImports.GetPropertyAsBoolean(this, propertyName);
         }
 
@@ -69,6 +75,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public int GetPropertyAsInt32(string propertyName)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             return JavaScriptImports.GetPropertyAsInt32(this, propertyName);
         }
 
@@ -84,6 +93,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public double GetPropertyAsDouble(string propertyName)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             return JavaScriptImports.GetPropertyAsDouble(this, propertyName);
         }
 
@@ -99,6 +111,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public string? GetPropertyAsString(string propertyName)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             return JavaScriptImports.GetPropertyAsString(this, propertyName);
         }
 
@@ -114,6 +129,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public JSObject? GetPropertyAsJSObject(string propertyName)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             return JavaScriptImports.GetPropertyAsJSObject(this, propertyName);
         }
 
@@ -130,6 +148,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public byte[]? GetPropertyAsByteArray(string propertyName)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             return JavaScriptImports.GetPropertyAsByteArray(this, propertyName);
         }
 
@@ -142,6 +163,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public void SetProperty(string propertyName, bool value)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             JavaScriptImports.SetPropertyBool(this, propertyName, value);
         }
 
@@ -154,6 +178,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public void SetProperty(string propertyName, int value)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             JavaScriptImports.SetPropertyInt(this, propertyName, value);
         }
 
@@ -166,6 +193,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public void SetProperty(string propertyName, double value)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             JavaScriptImports.SetPropertyDouble(this, propertyName, value);
         }
 
@@ -190,6 +220,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public void SetProperty(string propertyName, JSObject? value)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             JavaScriptImports.SetPropertyJSObject(this, propertyName, value);
         }
 
@@ -203,6 +236,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public void SetProperty(string propertyName, byte[]? value)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             JavaScriptImports.SetPropertyBytes(this, propertyName, value);
         }
     }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSSynchronizationContext.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSSynchronizationContext.cs
@@ -24,6 +24,8 @@ namespace System.Runtime.InteropServices.JavaScript
         public readonly IntPtr TargetThreadId;
         private readonly WorkItemQueueType Queue;
 
+        internal static JSSynchronizationContext? MainJSSynchronizationContext;
+
         [ThreadStatic]
         internal static JSSynchronizationContext? CurrentJSSynchronizationContext;
         internal SynchronizationContext? previousSynchronizationContext;

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Func.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Func.cs
@@ -19,6 +19,10 @@ namespace System.Runtime.InteropServices.JavaScript
                 // JSObject (held by this lambda) would be collected by GC after the lambda is collected
                 // and would also allow the JS function to be collected
 
+#if FEATURE_WASM_THREADS
+                JSObject.AssertThreadAffinity(JSObject);
+#endif
+
                 Span<JSMarshalerArgument> arguments = stackalloc JSMarshalerArgument[4];
                 ref JSMarshalerArgument args_exception = ref arguments[0];
                 ref JSMarshalerArgument args_return = ref arguments[1];
@@ -43,6 +47,10 @@ namespace System.Runtime.InteropServices.JavaScript
 
             public void InvokeJS(T arg1)
             {
+#if FEATURE_WASM_THREADS
+                JSObject.AssertThreadAffinity(JSObject);
+#endif
+
                 Span<JSMarshalerArgument> arguments = stackalloc JSMarshalerArgument[4];
                 ref JSMarshalerArgument args_exception = ref arguments[0];
                 ref JSMarshalerArgument args_return = ref arguments[1];
@@ -71,6 +79,10 @@ namespace System.Runtime.InteropServices.JavaScript
 
             public void InvokeJS(T1 arg1, T2 arg2)
             {
+#if FEATURE_WASM_THREADS
+                JSObject.AssertThreadAffinity(JSObject);
+#endif
+
                 Span<JSMarshalerArgument> arguments = stackalloc JSMarshalerArgument[4];
                 ref JSMarshalerArgument args_exception = ref arguments[0];
                 ref JSMarshalerArgument args_return = ref arguments[1];
@@ -103,6 +115,10 @@ namespace System.Runtime.InteropServices.JavaScript
 
             public void InvokeJS(T1 arg1, T2 arg2, T3 arg3)
             {
+#if FEATURE_WASM_THREADS
+                JSObject.AssertThreadAffinity(JSObject);
+#endif
+
                 Span<JSMarshalerArgument> arguments = stackalloc JSMarshalerArgument[5];
                 ref JSMarshalerArgument args_exception = ref arguments[0];
                 ref JSMarshalerArgument args_return = ref arguments[1];
@@ -209,6 +225,10 @@ namespace System.Runtime.InteropServices.JavaScript
 
             public TResult InvokeJS()
             {
+#if FEATURE_WASM_THREADS
+                JSObject.AssertThreadAffinity(JSObject);
+#endif
+
                 // JSObject (held by this lambda) would be collected by GC after the lambda is collected
                 // and would also allow the JS function to be collected
 
@@ -241,6 +261,10 @@ namespace System.Runtime.InteropServices.JavaScript
 
             public TResult InvokeJS(T arg1)
             {
+#if FEATURE_WASM_THREADS
+                JSObject.AssertThreadAffinity(JSObject);
+#endif
+
                 Span<JSMarshalerArgument> arguments = stackalloc JSMarshalerArgument[4];
                 ref JSMarshalerArgument args_exception = ref arguments[0];
                 ref JSMarshalerArgument args_return = ref arguments[1];
@@ -274,6 +298,10 @@ namespace System.Runtime.InteropServices.JavaScript
 
             public TResult InvokeJS(T1 arg1, T2 arg2)
             {
+#if FEATURE_WASM_THREADS
+                JSObject.AssertThreadAffinity(JSObject);
+#endif
+
                 Span<JSMarshalerArgument> arguments = stackalloc JSMarshalerArgument[4];
                 ref JSMarshalerArgument args_exception = ref arguments[0];
                 ref JSMarshalerArgument args_return = ref arguments[1];
@@ -311,6 +339,10 @@ namespace System.Runtime.InteropServices.JavaScript
 
             public TResult InvokeJS(T1 arg1, T2 arg2, T3 arg3)
             {
+#if FEATURE_WASM_THREADS
+                JSObject.AssertThreadAffinity(JSObject);
+#endif
+
                 Span<JSMarshalerArgument> arguments = stackalloc JSMarshalerArgument[5];
                 ref JSMarshalerArgument args_exception = ref arguments[0];
                 ref JSMarshalerArgument args_return = ref arguments[1];

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/SynchronizationContextExtensions.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/SynchronizationContextExtensions.cs
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Runtime.InteropServices.JavaScript
+{
+    /// <summary>
+    /// This is draft for possible public API of SynchronizationContext
+    /// </summary>
+    public static class SynchronizationContextExtension
+    {
+        public static void Send<T>(this SynchronizationContext? self, Action<T> body, T value)
+        {
+            if (self == null)
+            {
+                body(value);
+                return;
+            }
+
+            Exception? exc = default;
+            self.Send((_value) =>
+            {
+                try
+                {
+                    body((T)_value!);
+                }
+                catch (Exception ex)
+                {
+                    exc = ex;
+                }
+            }, value);
+            if (exc != null)
+            {
+                throw exc;
+            }
+        }
+
+        public static TRes Send<TRes>(this SynchronizationContext? self, Func<TRes> body)
+        {
+            if (self == null) return body();
+
+            TRes? value = default;
+            Exception? exc = default;
+            self.Send((_) =>
+            {
+                try
+                {
+                    value = body();
+                }
+                catch (Exception ex)
+                {
+                    exc = ex;
+                }
+            }, null);
+            if (exc != null)
+            {
+                throw exc;
+            }
+            return value!;
+        }
+
+        public static TRes Send<T1, TRes>(this SynchronizationContext? self, Func<T1, TRes> body, T1 p1)
+        {
+            if (self == null) return body(p1);
+
+            TRes? value = default;
+            Exception? exc = default;
+            self.Send((_) =>
+            {
+                try
+                {
+                    value = body(p1);
+                }
+                catch (Exception ex)
+                {
+                    exc = ex;
+                }
+            }, null);
+            if (exc != null)
+            {
+                throw exc;
+            }
+            return value!;
+        }
+    }
+}

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -547,6 +547,8 @@
     <!-- Don't want the default smoke tests - just verify that threading works -->
     <SmokeTestProject Remove="@(SmokeTestProject)" />
     <SmokeTestProject Include="$(MonoProjectRoot)sample\wasm\browser-threads-minimal\Wasm.Browser.Threads.Minimal.Sample.csproj" />
+    <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Net.WebSockets.Client\tests\System.Net.WebSockets.Client.Tests.csproj" />
+    <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/mono/sample/wasm/browser-threads-minimal/Program.cs
+++ b/src/mono/sample/wasm/browser-threads-minimal/Program.cs
@@ -276,7 +276,7 @@ namespace Sample
                 Console.WriteLine($"smoke: FetchBackground 2 ManagedThreadId:{Thread.CurrentThread.ManagedThreadId}, SynchronizationContext: {SynchronizationContext.Current?.GetType().FullName ?? "null"}");
                 var x=JSHost.ImportAsync(fetchhelper, "./fetchhelper.js");
                 Console.WriteLine($"smoke: FetchBackground 3A ManagedThreadId:{Thread.CurrentThread.ManagedThreadId}, SynchronizationContext: {SynchronizationContext.Current?.GetType().FullName ?? "null"}");
-                using var import = await x.ConfigureAwait(false);
+                // using var import = await x.ConfigureAwait(false);
                 Console.WriteLine($"smoke: FetchBackground 3B ManagedThreadId:{Thread.CurrentThread.ManagedThreadId}, SynchronizationContext: {SynchronizationContext.Current?.GetType().FullName ?? "null"}");
                 var r = await GlobalThisFetch(url);
                 Console.WriteLine($"smoke: FetchBackground 4 ManagedThreadId:{Thread.CurrentThread.ManagedThreadId}, SynchronizationContext: {SynchronizationContext.Current?.GetType().FullName ?? "null"}");

--- a/src/mono/sample/wasm/browser-threads-minimal/Program.cs
+++ b/src/mono/sample/wasm/browser-threads-minimal/Program.cs
@@ -8,6 +8,8 @@ using System.Threading;
 using System.Reflection;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.WebSockets;
 
 namespace Sample
 {
@@ -18,6 +20,75 @@ namespace Sample
             Console.WriteLine("Hello, World!");
             return 0;
         }
+
+        [JSExport]
+        public static async Task LockTest()
+        {
+            var lck=new Object();
+            Console.WriteLine("LockTest A ManagedThreadId: "+Thread.CurrentThread.ManagedThreadId);
+            Monitor.Enter(lck);
+            Console.WriteLine("LockTest B ManagedThreadId: "+Thread.CurrentThread.ManagedThreadId);
+            Monitor.Exit(lck);
+            Console.WriteLine("LockTest C ManagedThreadId: "+Thread.CurrentThread.ManagedThreadId);
+
+            await Task.Run(() =>
+            {
+                Console.WriteLine("LockTest D ManagedThreadId: "+Thread.CurrentThread.ManagedThreadId);
+                Monitor.Enter(lck);
+                Console.WriteLine("LockTest E ManagedThreadId: "+Thread.CurrentThread.ManagedThreadId);
+                Monitor.Exit(lck);
+                Console.WriteLine("LockTest F ManagedThreadId: "+Thread.CurrentThread.ManagedThreadId);
+            });
+
+            /* deadlock
+            Monitor.Enter(lck);
+            await Task.Run(() =>
+            {
+                Console.WriteLine("LockTest G ManagedThreadId: "+Thread.CurrentThread.ManagedThreadId);
+                Monitor.Enter(lck);
+                Console.WriteLine("LockTest H ManagedThreadId: "+Thread.CurrentThread.ManagedThreadId);
+                Monitor.Exit(lck);
+                Console.WriteLine("LockTest I ManagedThreadId: "+Thread.CurrentThread.ManagedThreadId);
+            });
+            Monitor.Exit(lck);
+            Console.WriteLine("LockTest J ManagedThreadId: "+Thread.CurrentThread.ManagedThreadId);
+            */
+
+            /* deadlock
+            await Task.Run(() =>
+            {
+                Console.WriteLine("LockTest K ManagedThreadId: "+Thread.CurrentThread.ManagedThreadId);
+                Monitor.Enter(lck);
+            });
+            Console.WriteLine("LockTest L ManagedThreadId: "+Thread.CurrentThread.ManagedThreadId);
+            Monitor.Enter(lck);
+            Console.WriteLine("LockTest M ManagedThreadId: "+Thread.CurrentThread.ManagedThreadId);
+            */
+        }
+
+
+        [JSExport]
+        public static async Task DisposeTest()
+        {
+            Console.WriteLine("DisposeTest A ManagedThreadId: "+Thread.CurrentThread.ManagedThreadId);
+            var test1 = JSHost.GlobalThis.GetPropertyAsJSObject("test1");
+            var test2 = JSHost.GlobalThis.GetPropertyAsJSObject("test2");
+            Console.WriteLine("DisposeTest 0 ManagedThreadId: "+Thread.CurrentThread.ManagedThreadId);
+            await Task.Delay(10).ConfigureAwait(false);
+            Console.WriteLine("DisposeTest 1 ManagedThreadId: "+Thread.CurrentThread.ManagedThreadId);
+            test1.Dispose();
+
+            Console.WriteLine("DisposeTest 2 ManagedThreadId: "+Thread.CurrentThread.ManagedThreadId);
+            Console.WriteLine("DisposeTest 3 ManagedThreadId: "+Thread.CurrentThread.ManagedThreadId);
+
+            await Task.Run(() =>
+            {
+                Console.WriteLine("DisposeTest 4 ManagedThreadId: "+Thread.CurrentThread.ManagedThreadId);
+                test2.Dispose();
+                Console.WriteLine("DisposeTest 5 ManagedThreadId: "+Thread.CurrentThread.ManagedThreadId);
+            });
+        }
+
 
         [JSImport("globalThis.setTimeout")]
         static partial void GlobalThisSetTimeout([JSMarshalAs<JSType.Function>] Action cb, int timeoutMs);
@@ -128,16 +199,84 @@ namespace Sample
             Console.WriteLine ($"XYZ: Main Thread caught task tid:{Thread.CurrentThread.ManagedThreadId}");
         }
 
+        private static async Task<string> HttpClientGet(string name, string url)
+        {
+            Console.WriteLine($"smoke: {name} 1 ManagedThreadId:{Thread.CurrentThread.ManagedThreadId}, SynchronizationContext: {SynchronizationContext.Current?.GetType().FullName ?? "null"}");
+            using var client = new HttpClient();
+            using var response = await client.GetAsync(url);
+            response.EnsureSuccessStatusCode();
+            var text = await response.Content.ReadAsStringAsync();
+            Console.WriteLine($"smoke: {name} 2 ManagedThreadId:{Thread.CurrentThread.ManagedThreadId}, SynchronizationContext: {SynchronizationContext.Current?.GetType().FullName ?? "null"}");
+            return text;
+        }
+
+        [JSExport]
+        public static Task<string> HttpClientMain(string url)
+        {
+            return HttpClientGet("HttpClientMain", url);
+        }
+
+        [JSExport]
+        public static Task<string> HttpClientWorker(string url)
+        {
+            return WebWorker.RunAsync(() =>
+            {
+                return HttpClientGet("HttpClientWorker", url);
+            });
+        }
+
+        [JSExport]
+        public static Task<string> HttpClientPool(string url)
+        {
+            return Task.Run(() =>
+            {
+                return HttpClientGet("HttpClientPool", url);
+            });
+        }
+
+        [JSExport]
+        public static Task<string> HttpClientThread(string url)
+        {
+            var tcs = new TaskCompletionSource<string>();
+            var t = new Thread(() => {
+                var t = HttpClientGet("HttpClientThread", url);
+                // this is blocking!
+                tcs.SetResult(t.Result);
+            });
+            t.Start();
+            return tcs.Task;
+        }
+
+        private static async Task<string> WsClientHello(string name, string url)
+        {
+            Console.WriteLine($"smoke: {name} 1 ManagedThreadId:{Thread.CurrentThread.ManagedThreadId}, SynchronizationContext: {SynchronizationContext.Current?.GetType().FullName ?? "null"}");
+            using var client = new ClientWebSocket ();
+            await client.ConnectAsync(new Uri(url), CancellationToken.None);
+            var message=new byte[]{0x68,0x65,0x6C,0x6C,0x6F};// hello
+            var body = new ReadOnlyMemory<byte>(message);
+            await client.SendAsync(body, WebSocketMessageType.Text, true, CancellationToken.None);
+            Console.WriteLine($"smoke: {name} 2 ManagedThreadId:{Thread.CurrentThread.ManagedThreadId}, SynchronizationContext: {SynchronizationContext.Current?.GetType().FullName ?? "null"}");
+            return "ok";
+        }
+
+        [JSExport]
+        public static Task<string> WsClientMain(string url)
+        {
+            return WsClientHello("WsClientHello", url);
+        }
+
         [JSExport]
         public static async Task<string> FetchBackground(string url)
         {
             Console.WriteLine($"smoke: FetchBackground 1 ManagedThreadId:{Thread.CurrentThread.ManagedThreadId}, SynchronizationContext: {SynchronizationContext.Current?.GetType().FullName ?? "null"}");
             var t = WebWorker.RunAsync(async () =>
             {
+                var ctx = SynchronizationContext.Current;
+
                 Console.WriteLine($"smoke: FetchBackground 2 ManagedThreadId:{Thread.CurrentThread.ManagedThreadId}, SynchronizationContext: {SynchronizationContext.Current?.GetType().FullName ?? "null"}");
                 var x=JSHost.ImportAsync(fetchhelper, "./fetchhelper.js");
                 Console.WriteLine($"smoke: FetchBackground 3A ManagedThreadId:{Thread.CurrentThread.ManagedThreadId}, SynchronizationContext: {SynchronizationContext.Current?.GetType().FullName ?? "null"}");
-                using var import = await x;
+                using var import = await x.ConfigureAwait(false);
                 Console.WriteLine($"smoke: FetchBackground 3B ManagedThreadId:{Thread.CurrentThread.ManagedThreadId}, SynchronizationContext: {SynchronizationContext.Current?.GetType().FullName ?? "null"}");
                 var r = await GlobalThisFetch(url);
                 Console.WriteLine($"smoke: FetchBackground 4 ManagedThreadId:{Thread.CurrentThread.ManagedThreadId}, SynchronizationContext: {SynchronizationContext.Current?.GetType().FullName ?? "null"}");

--- a/src/mono/sample/wasm/browser-threads-minimal/main.js
+++ b/src/mono/sample/wasm/browser-threads-minimal/main.js
@@ -9,7 +9,7 @@ const assemblyName = "Wasm.Browser.Threads.Minimal.Sample.dll";
 try {
     const { setModuleImports, getAssemblyExports, runMain } = await dotnet
         //.withEnvironmentVariable("MONO_LOG_LEVEL", "debug")
-        .withDiagnosticTracing(true)
+        //.withDiagnosticTracing(true)
         .withConfig({
             pthreadPoolSize: 6,
         })
@@ -17,7 +17,19 @@ try {
         .withExitCodeLogging()
         .create();
 
+    globalThis.test1 = { a: 1 };
+    globalThis.test2 = { a: 2 };
+
     const exports = await getAssemblyExports(assemblyName);
+
+    console.log("smoke: running LockTest");
+    await exports.Sample.Test.LockTest();
+    console.log("smoke: LockTest done ");
+
+
+    console.log("smoke: running DisposeTest");
+    await exports.Sample.Test.DisposeTest();
+    console.log("smoke: DisposeTest done ");
 
     console.log("smoke: running TestHelloWebWorker");
     await exports.Sample.Test.TestHelloWebWorker();
@@ -44,6 +56,26 @@ try {
     console.log("smoke: running TestCallSetTimeoutOnWorker");
     await exports.Sample.Test.TestCallSetTimeoutOnWorker();
     console.log("smoke: TestCallSetTimeoutOnWorker done");
+
+    console.log("smoke: running HttpClientMain(blurst.txt)");
+    let t = await exports.Sample.Test.HttpClientMain(globalThis.document.baseURI + "blurst.txt");
+    console.log("smoke: HttpClientMain(blurst.txt) done " + t);
+
+    console.log("smoke: running HttpClientWorker(blurst.txt)");
+    let t2 = await exports.Sample.Test.HttpClientWorker(globalThis.document.baseURI + "blurst.txt");
+    console.log("smoke: HttpClientWorker(blurst.txt) done " + t2);
+
+    console.log("smoke: running HttpClientPool(blurst.txt)");
+    let t3 = await exports.Sample.Test.HttpClientPool(globalThis.document.baseURI + "blurst.txt");
+    console.log("smoke: HttpClientPool(blurst.txt) done " + t3);
+
+    console.log("smoke: running HttpClientThread(blurst.txt)");
+    let t4 = await exports.Sample.Test.HttpClientThread(globalThis.document.baseURI + "blurst.txt");
+    console.log("smoke: HttpClientThread(blurst.txt) done " + t4);
+
+    console.log("smoke: running WsClientMain");
+    let w0 = await exports.Sample.Test.WsClientMain("wss://socketsbay.com/wss/v2/1/demo/");
+    console.log("smoke: WsClientMain done " + w0);
 
     console.log("smoke: running FetchBackground(blurst.txt)");
     let s = await exports.Sample.Test.FetchBackground("./blurst.txt");

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -371,8 +371,8 @@
     <Warning Condition="'$(InvariantGlobalization)' != 'true' and '$(WasmIncludeFullIcuData)' == 'true' and '$(WasmIcuDataFileName)' != ''" Text="%24(WasmIcuDataFileName) has no effect when %24(WasmIncludeFullIcuData) is set to true." />
 
     <PropertyGroup>
-      <_WasmAppIncludeThreadsWorker Condition="'$(WasmEnableThreads)' == 'true'">true</_WasmAppIncludeThreadsWorker>
-      <!-- TODO: set this from some user-facing property?  -1 means use the default baked into dotnet.js -->
+      <_WasmAppIncludeThreadsWorker Condition="'$(WasmEnableThreads)' == 'true' or '$(MonoWasmBuildVariant)' == 'multithread'">true</_WasmAppIncludeThreadsWorker>
+      <!-- TODO: set this from some user-facing property?  -1 means use the default baked into dotnet.native.js -->
       <_WasmPThreadPoolSize Condition="'$(_WasmPThreadPoolSize)' == ''">-1</_WasmPThreadPoolSize>
     </PropertyGroup>
 

--- a/src/mono/wasm/runtime/web-socket.ts
+++ b/src/mono/wasm/runtime/web-socket.ts
@@ -108,7 +108,7 @@ export function ws_wasm_receive(ws: WebSocketExtension, buffer_ptr: VoidPtr, buf
 
     const readyState = ws.readyState;
     if (readyState != WebSocket.OPEN && readyState != WebSocket.CLOSING) {
-        throw new Error("InvalidState: The WebSocket is not connected.");
+        throw new Error(`InvalidState: ${readyState} The WebSocket is not connected.`);
     }
 
     if (receive_event_queue.getLength()) {
@@ -130,7 +130,6 @@ export function ws_wasm_receive(ws: WebSocketExtension, buffer_ptr: VoidPtr, buf
 
 export function ws_wasm_close(ws: WebSocketExtension, code: number, reason: string | null, wait_for_close_received: boolean): Promise<void> | null {
     mono_assert(!!ws, "ERR19: expected ws instance");
-
 
     if (ws.readyState == WebSocket.CLOSED) {
         return null;
@@ -186,6 +185,11 @@ export function ws_wasm_abort(ws: WebSocketExtension): void {
 
 // send and return promise
 function _mono_wasm_web_socket_send_and_wait(ws: WebSocketExtension, buffer_view: Uint8Array | string): Promise<void> | null {
+    const readyState = ws.readyState;
+    if (readyState != WebSocket.OPEN && readyState != WebSocket.CLOSING) {
+        throw new Error(`InvalidState: ${readyState} The WebSocket is not connected.`);
+    }
+
     ws.send(buffer_view);
     ws[wasm_ws_pending_send_buffer] = null;
 
@@ -207,16 +211,19 @@ function _mono_wasm_web_socket_send_and_wait(ws: WebSocketExtension, buffer_view
         if (ws.bufferedAmount === 0) {
             promise_control.resolve();
         }
-        else if (ws.readyState != WebSocket.OPEN) {
-            // only reject if the data were not sent
-            // bufferedAmount does not reset to zero once the connection closes
-            promise_control.reject("InvalidState: The WebSocket is not connected.");
-        }
-        else if (!promise_control.isDone) {
-            globalThis.setTimeout(polling_check, nextDelay);
-            // exponentially longer delays, up to 1000ms
-            nextDelay = Math.min(nextDelay * 1.5, 1000);
-            return;
+        else {
+            const readyState = ws.readyState;
+            if (readyState != WebSocket.OPEN && readyState != WebSocket.CLOSING) {
+                // only reject if the data were not sent
+                // bufferedAmount does not reset to zero once the connection closes
+                promise_control.reject(`InvalidState: ${readyState} The WebSocket is not connected.`);
+            }
+            else if (!promise_control.isDone) {
+                globalThis.setTimeout(polling_check, nextDelay);
+                // exponentially longer delays, up to 1000ms
+                nextDelay = Math.min(nextDelay * 1.5, 1000);
+                return;
+            }
         }
         // remove from pending
         const index = pending.indexOf(promise_control);

--- a/src/mono/wasm/runtime/web-socket.ts
+++ b/src/mono/wasm/runtime/web-socket.ts
@@ -185,11 +185,6 @@ export function ws_wasm_abort(ws: WebSocketExtension): void {
 
 // send and return promise
 function _mono_wasm_web_socket_send_and_wait(ws: WebSocketExtension, buffer_view: Uint8Array | string): Promise<void> | null {
-    const readyState = ws.readyState;
-    if (readyState != WebSocket.OPEN && readyState != WebSocket.CLOSING) {
-        throw new Error(`InvalidState: ${readyState} The WebSocket is not connected.`);
-    }
-
     ws.send(buffer_view);
     ws[wasm_ws_pending_send_buffer] = null;
 


### PR DESCRIPTION
## BrowserWebSocket
- `_thisLock` for locking the state for MT access
- use `FEATURE_WASM_THREADS` to conditionaly wrap the calls with `SynchronizationContext.Send` for all calls to JS
- split `ConnectAsyncCore` and `CreateCore` to separate methods. `CreateCore` is synchronous and creates the JS proxy. The other one needs to be executed separately, so that `Abort()` before `await ConnectAsync()` works as expected. Yielding to main loop.


## BrowserHttpHandler
- `WasmFetchResponse.ThisLock` for locking the state for MT access
- use `FEATURE_WASM_THREADS` to conditionaly wrap the calls with `SynchronizationContext.Send` for all calls to JS

## Other
- make `JSSynchronizationContext ` possible to install on multiple threads
- private draft of `SynchronizationContextExtension` hidden from API by `CompatibilitySuppressions.xml`
   - these are sync and async helpers for dispatching call to correct thread and propagating result and exception back
- private draft of `JSHost.CurrentOrMainJSSynchronizationContext`
   - this allows to use main thread as fallback for JS interop, if there is no `JSSynchronizationContext` installed on current thread
- private draft of `JSObject.SynchronizationContext`
   - this allows to dispatch call back to correct thread for the proxy
- private draft of `WebWorker` hidden from API by `CompatibilitySuppressions.xml`
- `JSException` from another thread doesn't have thread affinity and stack trace.
- more thread affinity asserts

Contributes to https://github.com/dotnet/runtime/issues/85592