### PR TITLE
[RISC-V][JIT] Fix FCVT

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -3241,62 +3241,44 @@ void CodeGen::genFloatToIntCast(GenTree* treeNode)
     {
         if (srcType == TYP_DOUBLE)
         {
-            if (dstSize == EA_4BYTE)
-            {
-                ins = INS_fcvt_wu_d;
-            }
-            else
-            {
-                assert(dstSize == EA_8BYTE);
-                ins = INS_fcvt_lu_d;
-            }
+            ins = INS_fcvt_lu_d;
         }
         else
         {
             assert(srcType == TYP_FLOAT);
-            if (dstSize == EA_4BYTE)
-            {
-                ins = INS_fcvt_wu_s;
-            }
-            else
-            {
-                assert(dstSize == EA_8BYTE);
-                ins = INS_fcvt_lu_s;
-            }
+            ins = INS_fcvt_lu_s;
         }
     }
     else
     {
         if (srcType == TYP_DOUBLE)
         {
-            if (dstSize == EA_4BYTE)
-            {
-                ins = INS_fcvt_w_d;
-            }
-            else
-            {
-                assert(dstSize == EA_8BYTE);
-                ins = INS_fcvt_l_d;
-            }
+            ins = INS_fcvt_l_d;
         }
         else
         {
             assert(srcType == TYP_FLOAT);
-            if (dstSize == EA_4BYTE)
-            {
-                ins = INS_fcvt_w_s;
-            }
-            else
-            {
-                assert(dstSize == EA_8BYTE);
-                ins = INS_fcvt_l_s;
-            }
+            ins = INS_fcvt_l_s;
         }
     }
 
     genConsumeOperands(treeNode->AsOp());
 
-    GetEmitter()->emitIns_R_R(ins, emitActualTypeSize(dstType), treeNode->GetRegNum(), op1->GetRegNum());
+    GetEmitter()->emitIns_R_R(ins, EA_8BYTE, treeNode->GetRegNum(), op1->GetRegNum());
+    if (dstSize == EA_4BYTE)
+
+    {
+        emitAttr attr = emitActualTypeSize(dstType);
+        if (IsUnsigned)
+        {
+            GetEmitter()->emitIns_R_R_I(INS_slli, attr, treeNode->GetRegNum(), treeNode->GetRegNum(), 32);
+            GetEmitter()->emitIns_R_R_I(INS_srli, attr, treeNode->GetRegNum(), treeNode->GetRegNum(), 32);
+        }
+        else
+        {
+            GetEmitter()->emitIns_R_R_I(INS_addiw, attr, treeNode->GetRegNum(), treeNode->GetRegNum(), 0);
+        }
+    }
 
     genProduceReg(treeNode);
 }


### PR DESCRIPTION
Some RISC-V fcvt instructions such as `fcvt_wu_d` which convert f64 to uint32 do not work as what tests intended.
Ex) In mixed1_cs_* tests, `fcvt_wu_d` converts 2930614784 to 2147483647. 

Fixed Tests
```
./JIT/Directed/perffix/primitivevt/mixed1_cs_d/mixed1_cs_d.sh
./JIT/Directed/perffix/primitivevt/mixed1_cs_do/mixed1_cs_do.sh
./JIT/Directed/perffix/primitivevt/mixed1_cs_r/mixed1_cs_r.sh
./JIT/Directed/perffix/primitivevt/mixed1_cs_ro/mixed1_cs_ro.sh
./JIT/Generics/ConstrainedCall/class2_cs_d/class2_cs_d.sh
./JIT/Generics/ConstrainedCall/class2_cs_do/class2_cs_do.sh
./JIT/Generics/ConstrainedCall/class2_cs_r/class2_cs_r.sh
./JIT/Generics/ConstrainedCall/class2_cs_ro/class2_cs_ro.sh
./JIT/Methodical/FPtrunc/convX_d/convX_d.sh
./JIT/Methodical/fp/exgen/1000w1d_cs_d/1000w1d_cs_d.sh
./JIT/Methodical/fp/exgen/1000w1d_cs_do/1000w1d_cs_do.sh
./JIT/Methodical/fp/exgen/1000w1d_cs_r/1000w1d_cs_r.sh
./JIT/Methodical/fp/exgen/1000w1d_cs_ro/1000w1d_cs_ro.sh
./JIT/Methodical/fp/exgen/10w250d_cs_d/10w250d_cs_d.sh
./JIT/Methodical/fp/exgen/10w250d_cs_do/10w250d_cs_do.sh
./JIT/Methodical/fp/exgen/10w250d_cs_r/10w250d_cs_r.sh
./JIT/Methodical/fp/exgen/10w250d_cs_ro/10w250d_cs_ro.sh
./JIT/Methodical/fp/exgen/10w5d_cs_d/10w5d_cs_d.sh
./JIT/Methodical/fp/exgen/10w5d_cs_do/10w5d_cs_do.sh
./JIT/Methodical/fp/exgen/10w5d_cs_r/10w5d_cs_r.sh
./JIT/Methodical/fp/exgen/10w5d_cs_ro/10w5d_cs_ro.sh
./JIT/Methodical/fp/exgen/200w1d-02_cs_d/200w1d-02_cs_d.sh
./JIT/Methodical/fp/exgen/200w1d-02_cs_do/200w1d-02_cs_do.sh
./JIT/Methodical/fp/exgen/200w1d-02_cs_r/200w1d-02_cs_r.sh
./JIT/Methodical/fp/exgen/200w1d-02_cs_ro/200w1d-02_cs_ro.sh
./JIT/Performance/CodeQuality/BenchmarksGame/k-nucleotide/k-nucleotide-9/k-nucleotide-9.sh
./JIT/Performance/CodeQuality/BenchmarksGame/pidigits/pidigits-3/pidigits-3.sh
./JIT/superpmi/superpmicollect/10w5d_cs_do/10w5d_cs_do.sh
```
Part of https://github.com/dotnet/runtime/issues/84834
cc @wscho77 @HJLeee @JongHeonChoi @t-mustafin @alpencolt @gbalykov

