### PR TITLE
[Release/7.0-staging] Allow GetILFunctionBody for dynamic methods

### DIFF
--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -4332,7 +4332,7 @@ HRESULT ProfToEEInterfaceImpl::GetILFunctionBody(ModuleID    moduleId,
 
     PEAssembly *pPEAssembly = pModule->GetPEAssembly();
 
-    if (!pPEAssembly->HasLoadedPEImage())
+    if (!pPEAssembly->IsLoaded())
         return (CORPROF_E_DATAINCOMPLETE);
 
     LPCBYTE pbMethod = NULL;
@@ -4442,7 +4442,7 @@ HRESULT ProfToEEInterfaceImpl::GetILFunctionBodyAllocator(ModuleID         modul
     Module * pModule = (Module *) moduleId;
 
     if (pModule->IsBeingUnloaded() ||
-        !pModule->GetPEAssembly()->HasLoadedPEImage())
+        !pModule->GetPEAssembly()->IsLoaded())
     {
         return (CORPROF_E_DATAINCOMPLETE);
     }


### PR DESCRIPTION
Port #87530 to 7.0

## Customer Impact
We introduced a regression in 7.0 that prevents ICorProfiler implementations from being able to request IL for dynamic methods. This was reported by a 3rd party profiler maintainer and is preventing their product from working on 7.0.

## Testing
Privates of the fix were provided to the customer and verified that they fix the issue.

## Risk
Low risk, it does not introduce any known risk.
