### PR TITLE
Add DebuggerDisplay to some hosting types

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/ApplicationLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/ApplicationLifetime.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 
@@ -10,6 +11,9 @@ namespace Microsoft.Extensions.Hosting.Internal
     /// <summary>
     /// Allows consumers to perform cleanup during a graceful shutdown.
     /// </summary>
+    [DebuggerDisplay("ApplicationStarted = {ApplicationStarted.IsCancellationRequested}, " +
+        "ApplicationStopping = {ApplicationStopping.IsCancellationRequested}, " +
+        "ApplicationStopped = {ApplicationStopped.IsCancellationRequested}")]
 #pragma warning disable CS0618 // Type or member is obsolete
     public class ApplicationLifetime : IApplicationLifetime, IHostApplicationLifetime
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/HostingEnvironment.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/HostingEnvironment.cs
@@ -1,15 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Microsoft.Extensions.FileProviders;
 
 namespace Microsoft.Extensions.Hosting.Internal
 {
-#pragma warning disable CS0618 // Type or member is obsolete
     /// <summary>
     /// This API supports infrastructure and is not intended to be used
     /// directly from your code. This API may change or be removed in future releases.
     /// </summary>
+    [DebuggerDisplay("ApplicationName = {ApplicationName}, EnvironmentName = {EnvironmentName}")]
+#pragma warning disable CS0618 // Type or member is obsolete
     public class HostingEnvironment : IHostingEnvironment, IHostEnvironment
 #pragma warning restore CS0618 // Type or member is obsolete
     {


### PR DESCRIPTION
Add debugger display to:
* ApplicationLifetime 
* HostingEnvironment 

I'm improving these two types as ASP.NET Core's WebApplication uses them. PR to improve its debugging [here](https://github.com/dotnet/aspnetcore/pull/48827).

There is much more that can be done in Microsoft.Extensions.Hosting for debugging. Can be done in the future.

After:

![image](https://github.com/dotnet/runtime/assets/303201/fef69aee-c325-407e-ae1f-9aa7891f6957)
