### PR TITLE
Fix `File.Copy` onto a symlink on macOS

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.OpenFlags.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.OpenFlags.cs
@@ -11,16 +11,17 @@ internal static partial class Interop
         internal enum OpenFlags
         {
             // Access modes (mutually exclusive)
-            O_RDONLY = 0x0000,
-            O_WRONLY = 0x0001,
-            O_RDWR   = 0x0002,
+            O_RDONLY  = 0x0000,
+            O_WRONLY  = 0x0001,
+            O_RDWR    = 0x0002,
 
             // Flags (combinable)
-            O_CLOEXEC = 0x0010,
-            O_CREAT   = 0x0020,
-            O_EXCL    = 0x0040,
-            O_TRUNC   = 0x0080,
-            O_SYNC    = 0x0100,
+            O_CLOEXEC  = 0x0010,
+            O_CREAT    = 0x0020,
+            O_EXCL     = 0x0040,
+            O_TRUNC    = 0x0080,
+            O_SYNC     = 0x0100,
+            O_NOFOLLOW = 0x0200,
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/Copy.cs
@@ -253,6 +253,24 @@ namespace System.IO.Tests
             Assert.Equal(File.ReadAllText(path), File.ReadAllText(testFile)); // assumes chosen files won't change between reads
         }
         #endregion
+
+        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        public void OverwriteCopyOntoLink()
+        {
+            string file1 = GetTestFilePath();
+            string file2 = GetTestFilePath();
+            string link = GetTestFilePath();
+
+            File.Create(file1).Dispose();
+            File.Create(file2).Dispose();
+            File.CreateSymbolicLink(link, file2);
+
+            File.WriteAllText(file1, "abc");
+            File.WriteAllText(file2, "def");
+
+            File.Copy(file1, link);
+            Assert.Equal("abc", File.ReadAllText(file2));
+        }
     }
 
     public class File_Copy_str_str_b : File_Copy_str_str

--- a/src/libraries/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/Copy.cs
@@ -268,7 +268,7 @@ namespace System.IO.Tests
             File.WriteAllText(file1, "abc");
             File.WriteAllText(file2, "def");
 
-            File.Copy(file1, link);
+            File.Copy(file1, link, true);
             Assert.Equal("abc", File.ReadAllText(file2));
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -239,6 +239,7 @@ namespace Microsoft.Win32.SafeHandles
         /// <param name="access">The FileAccess provided to the stream's constructor</param>
         /// <param name="share">The FileShare provided to the stream's constructor</param>
         /// <param name="options">The FileOptions provided to the stream's constructor</param>
+        /// <param name="failForSymlink">Whether to cause ELOOP error when opening a symlink</param>
         /// <returns>The flags value to be passed to the open system call.</returns>
         private static Interop.Sys.OpenFlags PreOpenConfigurationFromOptions(FileMode mode, FileAccess access, FileShare share, FileOptions options, bool failForSymlink)
         {

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -88,9 +88,10 @@ namespace Microsoft.Win32.SafeHandles
         }
 #pragma warning restore CA1822
 
-        private static SafeFileHandle Open(string path, Interop.Sys.OpenFlags flags, int mode,
+        private static SafeFileHandle Open(string path, Interop.Sys.OpenFlags flags, int mode, bool failForSymlink, out bool wasSymlink,
                                            Func<Interop.ErrorInfo, Interop.Sys.OpenFlags, string, Exception?>? createOpenException)
         {
+            wasSymlink = false;
             Debug.Assert(path != null);
             SafeFileHandle handle = Interop.Sys.Open(path, flags, mode);
             handle._path = path;
@@ -99,6 +100,12 @@ namespace Microsoft.Win32.SafeHandles
             {
                 Interop.ErrorInfo error = Interop.Sys.GetLastErrorInfo();
                 handle.Dispose();
+
+                if (failForSymlink && error.Error == Interop.Error.ELOOP)
+                {
+                    wasSymlink = true;
+                    return handle;
+                }
 
                 if (createOpenException?.Invoke(error, flags, path) is Exception ex)
                 {
@@ -169,7 +176,7 @@ namespace Microsoft.Win32.SafeHandles
         // This information is retrieved from the 'stat' syscall that must be performed to ensure the path is not a directory.
         internal static SafeFileHandle OpenReadOnly(string fullPath, FileOptions options, out long fileLength, out UnixFileMode filePermissions)
         {
-            SafeFileHandle handle = Open(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read, options, preallocationSize: 0, DefaultCreateMode, out fileLength, out filePermissions, null);
+            SafeFileHandle handle = Open(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read, options, preallocationSize: 0, DefaultCreateMode, out fileLength, out filePermissions, false, out _, null);
             Debug.Assert(fileLength >= 0);
             return handle;
         }
@@ -177,22 +184,33 @@ namespace Microsoft.Win32.SafeHandles
         internal static SafeFileHandle Open(string fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, long preallocationSize, UnixFileMode? unixCreateMode = null,
                                             Func<Interop.ErrorInfo, Interop.Sys.OpenFlags, string, Exception?>? createOpenException = null)
         {
-            return Open(fullPath, mode, access, share, options, preallocationSize, unixCreateMode ?? DefaultCreateMode, out _, out _, createOpenException);
+            return Open(fullPath, mode, access, share, options, preallocationSize, unixCreateMode ?? DefaultCreateMode, out _, out _, false, out _, createOpenException);
+        }
+
+        internal static SafeFileHandle? Open(string fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, long preallocationSize, out bool wasSymlink, UnixFileMode? unixCreateMode = null,
+                                            Func<Interop.ErrorInfo, Interop.Sys.OpenFlags, string, Exception?>? createOpenException = null)
+        {
+            return Open(fullPath, mode, access, share, options, preallocationSize, unixCreateMode ?? DefaultCreateMode, out _, out _, true, out wasSymlink, createOpenException);
         }
 
         private static SafeFileHandle Open(string fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, long preallocationSize, UnixFileMode openPermissions,
-                                            out long fileLength, out UnixFileMode filePermissions,
+                                            out long fileLength, out UnixFileMode filePermissions, bool failForSymlink, out bool wasSymlink,
                                             Func<Interop.ErrorInfo, Interop.Sys.OpenFlags, string, Exception?>? createOpenException = null)
         {
             // Translate the arguments into arguments for an open call.
-            Interop.Sys.OpenFlags openFlags = PreOpenConfigurationFromOptions(mode, access, share, options);
+            Interop.Sys.OpenFlags openFlags = PreOpenConfigurationFromOptions(mode, access, share, options, failForSymlink);
 
             SafeFileHandle? safeFileHandle = null;
             try
             {
                 while (true)
                 {
-                    safeFileHandle = Open(fullPath, openFlags, (int)openPermissions, createOpenException);
+                    safeFileHandle = Open(fullPath, openFlags, failForSymlink, out wasSymlink, (int)openPermissions, createOpenException);
+
+                    if (failForSymlink && wasSymlink)
+                    {
+                        return safeFileHandle;
+                    }
 
                     // When Init return false, the path has changed to another file entry, and
                     // we need to re-open the path to reflect that.
@@ -220,10 +238,14 @@ namespace Microsoft.Win32.SafeHandles
         /// <param name="share">The FileShare provided to the stream's constructor</param>
         /// <param name="options">The FileOptions provided to the stream's constructor</param>
         /// <returns>The flags value to be passed to the open system call.</returns>
-        private static Interop.Sys.OpenFlags PreOpenConfigurationFromOptions(FileMode mode, FileAccess access, FileShare share, FileOptions options)
+        private static Interop.Sys.OpenFlags PreOpenConfigurationFromOptions(FileMode mode, FileAccess access, FileShare share, FileOptions options, bool failForSymlink)
         {
             // Translate FileMode.  Most of the values map cleanly to one or more options for open.
             Interop.Sys.OpenFlags flags = default;
+            if (failForSymlink)
+            {
+                flags |= Interop.Sys.OpenFlags.O_NOFOLLOW;
+            }
             switch (mode)
             {
                 default:

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Win32.SafeHandles
             return Open(fullPath, mode, access, share, options, preallocationSize, unixCreateMode ?? DefaultCreateMode, out _, out _, false, out _, createOpenException);
         }
 
-        internal static SafeFileHandle? Open(string fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, long preallocationSize, out bool wasSymlink, UnixFileMode? unixCreateMode = null,
+        internal static SafeFileHandle? OpenNoFollowSymlink(string fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, long preallocationSize, out bool wasSymlink, UnixFileMode? unixCreateMode = null,
                                             Func<Interop.ErrorInfo, Interop.Sys.OpenFlags, string, Exception?>? createOpenException = null)
         {
             return Open(fullPath, mode, access, share, options, preallocationSize, unixCreateMode ?? DefaultCreateMode, out _, out _, true, out wasSymlink, createOpenException);

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -205,10 +205,12 @@ namespace Microsoft.Win32.SafeHandles
             {
                 while (true)
                 {
-                    safeFileHandle = Open(fullPath, openFlags, failForSymlink, out wasSymlink, (int)openPermissions, createOpenException);
+                    safeFileHandle = Open(fullPath, openFlags, (int)openPermissions, failForSymlink, out wasSymlink, createOpenException);
 
                     if (failForSymlink && wasSymlink)
                     {
+                        fileLength = default;
+                        filePermissions = default;
                         return safeFileHandle;
                     }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.TryCloneFile.OSX.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.TryCloneFile.OSX.cs
@@ -53,7 +53,7 @@ namespace System.IO
                 // it's locked by something else, and then delete it. It should also fail if destination == source since it's already locked.
                 try
                 {
-                    using SafeFileHandle? dstHandle = SafeFileHandle.Open(destFullPath, FileMode.Open, FileAccess.ReadWrite,
+                    using SafeFileHandle? dstHandle = SafeFileHandle.OpenNoFollowSymlink(destFullPath, FileMode.Open, FileAccess.ReadWrite,
                         FileShare.None, FileOptions.None, preallocationSize: 0, out bool wasSymlink, createOpenException: CreateOpenExceptionForCopyFile);
                     if (wasSymlink)
                     {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.TryCloneFile.OSX.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.TryCloneFile.OSX.cs
@@ -54,11 +54,11 @@ namespace System.IO
                 try
                 {
                     using SafeFileHandle? dstHandle = SafeFileHandle.Open(destFullPath, FileMode.Open, FileAccess.ReadWrite,
-                        FileShare.None, FileOptions.None, out bool wasSymlink, preallocationSize: 0, createOpenException: CreateOpenExceptionForCopyFile);
+                        FileShare.None, FileOptions.None, preallocationSize: 0, out bool wasSymlink, createOpenException: CreateOpenExceptionForCopyFile);
                     if (wasSymlink)
                     {
                         // Don't try if it's a symlink.
-                        return false;
+                        return;
                     }
                     else
                     {

--- a/src/native/libs/System.Native/pal_io.c
+++ b/src/native/libs/System.Native/pal_io.c
@@ -289,7 +289,7 @@ static int32_t ConvertOpenFlags(int32_t flags)
             return -1;
     }
 
-    if (flags & ~(PAL_O_ACCESS_MODE_MASK | PAL_O_CLOEXEC | PAL_O_CREAT | PAL_O_EXCL | PAL_O_TRUNC | PAL_O_SYNC))
+    if (flags & ~(PAL_O_ACCESS_MODE_MASK | PAL_O_CLOEXEC | PAL_O_CREAT | PAL_O_EXCL | PAL_O_TRUNC | PAL_O_SYNC | PAL_O_NOFOLLOW))
     {
         assert_msg(false, "Unknown Open flag", (int)flags);
         return -1;
@@ -307,6 +307,8 @@ static int32_t ConvertOpenFlags(int32_t flags)
         ret |= O_TRUNC;
     if (flags & PAL_O_SYNC)
         ret |= O_SYNC;
+    if (flags & PAL_O_NOFOLLOW)
+        ret |= O_NOFOLLOW;
 
     assert(ret != -1);
     return ret;

--- a/src/native/libs/System.Native/pal_io.h
+++ b/src/native/libs/System.Native/pal_io.h
@@ -151,11 +151,12 @@ enum
 
     // Flags (combinable)
     // These numeric values are not defined by POSIX and vary across targets.
-    PAL_O_CLOEXEC = 0x0010, // Close-on-exec
-    PAL_O_CREAT = 0x0020,   // Create file if it doesn't already exist
-    PAL_O_EXCL = 0x0040,    // When combined with CREAT, fails if file already exists
-    PAL_O_TRUNC = 0x0080,   // Truncate file to length 0 if it already exists
-    PAL_O_SYNC = 0x0100,    // Block writes call will block until physically written
+    PAL_O_CLOEXEC = 0x0010,  // Close-on-exec
+    PAL_O_CREAT = 0x0020,    // Create file if it doesn't already exist
+    PAL_O_EXCL = 0x0040,     // When combined with CREAT, fails if file already exists
+    PAL_O_TRUNC = 0x0080,    // Truncate file to length 0 if it already exists
+    PAL_O_SYNC = 0x0100,     // Block writes call will block until physically written
+    PAL_O_NOFOLLOW = 0x0200, // Fails to open the target if it's a symlink, parent symlinks are allowed
 };
 
 /**


### PR DESCRIPTION
Resolve s the discussion at https://github.com/dotnet/runtime/pull/79243#discussion_r1230618993.

I introduced a minor bug in https://github.com/dotnet/runtime/pull/79243, which meant that using `File.Copy` onto a symlink won't produce the expected behaviour of modifying what the symlink points to, as opposed to what I implemented, which was to replace the symlink.

This fix should be basically zero additional cost currently, as it doesn't introduce any additional syscalls (except for the case we're fixing). Also adds a test to catch this in the future.