### PR TITLE
[mono][exceptions] Don't attempt to catch StackOverflowException

### DIFF
--- a/src/mono/mono/metadata/exception.c
+++ b/src/mono/mono/metadata/exception.c
@@ -1219,27 +1219,37 @@ mono_invoke_unhandled_exception_hook (MonoObject *exc)
 		unhandled_exception_hook (exc, unhandled_exception_hook_data);
 	} else {
 		ERROR_DECL (inner_error);
-		MonoObject *other = NULL;
-		MonoString *str = mono_object_try_to_string (exc, &other, inner_error);
 		char *msg = NULL;
 
-		if (str && is_ok (inner_error)) {
-			msg = mono_string_to_utf8_checked_internal (str, inner_error);
-			if (!is_ok (inner_error)) {
-				msg = g_strdup_printf ("Nested exception while formatting original exception");
-				mono_error_cleanup (inner_error);
-			}
-		} else if (other) {
-			char *original_backtrace = mono_exception_get_managed_backtrace ((MonoException*)exc);
-			char *nested_backtrace = mono_exception_get_managed_backtrace ((MonoException*)other);
+		if (exc == (MonoObject*)mono_domain_get ()->stack_overflow_ex) {
+			// Build stack trace directly instead of calling ToString so we don't put
+			// additional pressure on the limited stack
+			char *backtrace = mono_exception_get_managed_backtrace ((MonoException*)exc);
 
-			msg = g_strdup_printf ("Nested exception detected.\nOriginal Exception: %s\nNested exception:%s\n",
-				original_backtrace, nested_backtrace);
-
-			g_free (original_backtrace);
-			g_free (nested_backtrace);
+			msg = g_strdup_printf ("System.StackOverflowException: The requested operation caused a stack overflow.\n%s\n",
+				backtrace);
 		} else {
-			msg = g_strdup ("Nested exception trying to figure out what went wrong");
+			MonoObject *other = NULL;
+			MonoString *str = mono_object_try_to_string (exc, &other, inner_error);
+
+			if (str && is_ok (inner_error)) {
+				msg = mono_string_to_utf8_checked_internal (str, inner_error);
+				if (!is_ok (inner_error)) {
+					msg = g_strdup_printf ("Nested exception while formatting original exception");
+					mono_error_cleanup (inner_error);
+				}
+			} else if (other) {
+				char *original_backtrace = mono_exception_get_managed_backtrace ((MonoException*)exc);
+				char *nested_backtrace = mono_exception_get_managed_backtrace ((MonoException*)other);
+
+				msg = g_strdup_printf ("Nested exception detected.\nOriginal Exception: %s\nNested exception:%s\n",
+					original_backtrace, nested_backtrace);
+
+				g_free (original_backtrace);
+				g_free (nested_backtrace);
+			} else {
+				msg = g_strdup ("Nested exception trying to figure out what went wrong");
+			}
 		}
 		mono_runtime_printf_err ("[ERROR] FATAL UNHANDLED EXCEPTION: %s", msg);
 		g_free (msg);

--- a/src/mono/mono/mini/mini-exceptions.c
+++ b/src/mono/mono/mini/mini-exceptions.c
@@ -2076,7 +2076,6 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 	MonoLMF *lmf = mono_get_lmf ();
 	MonoException *mono_ex;
 	gboolean stack_overflow = FALSE;
-	MonoContext initial_ctx;
 	MonoMethod *method;
 	// int frame_count = 0; // used for debugging
 	gint32 filter_idx, first_filter_idx = 0;
@@ -2261,7 +2260,6 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 	if (out_ji)
 		*out_ji = NULL;
 	filter_idx = 0;
-	initial_ctx = *ctx;
 
 	unwinder_init (&unwinder);
 


### PR DESCRIPTION
Instead we just print the stack trace and abort the runtime.

This follows CoreCLR behavior, not catching stack overflow exception or invoking any handlers. In https://learn.microsoft.com/en-us/dotnet/api/system.stackoverflowexception?view=net-7.0 it is mentioned that starting with .NET 2, SOE is no longer handled. Our code dated before this time.

On desktop amd64 we don't seem to properly handle stack overflow exception because `ENABLE_SIGALTSTACK` is not defined. Nevertheless, the second fix makes the stack trace dumping not crash, in case we use an altstack.