### PR TITLE
feat:  usability suggestion (avoid annoying KeyValuePair)

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -41,6 +41,13 @@ System.Diagnostics.DiagnosticSource</PackageDescription>
     <Compile Include="System\Diagnostics\DiagLinkedList.cs" />
     <Compile Include="System\Diagnostics\DistributedContextPropagator.cs" />
     <Compile Include="System\Diagnostics\LegacyPropagator.cs" />
+    <Compile Include="System\Diagnostics\Metrics\UpDownCounterBuilder.cs" />
+    <Compile Include="System\Diagnostics\Metrics\HistogramBuilder.cs" />
+    <Compile Include="System\Diagnostics\Metrics\CounterBuilder.cs" />
+    <Compile Include="System\Diagnostics\Metrics\IUpDownCounterBuilder.cs" />
+    <Compile Include="System\Diagnostics\Metrics\IHistogramBuilder.cs" />
+    <Compile Include="System\Diagnostics\Metrics\ITagBuilder.cs" />
+    <Compile Include="System\Diagnostics\Metrics\ICounterBuilder.cs" />
     <Compile Include="System\Diagnostics\NoOutputPropagator.cs" />
     <Compile Include="System\Diagnostics\PassThroughPropagator.cs" />
     <Compile Include="System\Diagnostics\RandomNumberGenerator.cs" />
@@ -86,10 +93,8 @@ System.Diagnostics.DiagnosticSource</PackageDescription>
     <Compile Include="System\Diagnostics\Metrics\ObjectSequence.netcore.cs" />
     <Compile Include="System\Diagnostics\Metrics\StringSequence.netcore.cs" />
     <Compile Include="System\Diagnostics\System.Diagnostics.DiagnosticSource.Typeforwards.netcoreapp.cs" />
-    <Compile Include="$(CommonPath)System\LocalAppContextSwitches.Common.cs"
-             Link="Common\System\LocalAppContextSwitches.Common.cs" />
-    <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs"
-             Link="Common\System\Text\ValueStringBuilder.cs" />
+    <Compile Include="$(CommonPath)System\LocalAppContextSwitches.Common.cs" Link="Common\System\LocalAppContextSwitches.Common.cs" />
+    <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs" Link="Common\System\Text\ValueStringBuilder.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
@@ -108,12 +113,11 @@ System.Diagnostics.DiagnosticSource</PackageDescription>
     <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\IsExternalInit.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))" >
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\RequiresDynamicCodeAttribute.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' or
-                        '$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' or&#xD;&#xA;                        '$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="System\Diagnostics\Activity.DateTime.corefx.cs" />
   </ItemGroup>
 
@@ -137,7 +141,7 @@ System.Diagnostics.DiagnosticSource</PackageDescription>
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))" >
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Counter.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Counter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace System.Diagnostics.Metrics
 {
@@ -22,6 +23,20 @@ namespace System.Diagnostics.Metrics
         internal Counter(Meter meter, string name, string? unit, string? description, IEnumerable<KeyValuePair<string, object?>>? tags) : base(meter, name, unit, description, tags)
         {
             Publish();
+        }
+
+        /// <summary>
+        /// using tags builder before adding a delta.
+        /// </summary>
+        /// <typeparam name="TTag"></typeparam>
+        /// <param name="key">The key.</param>
+        /// <param name="value">The value.</param>
+        /// <returns></returns>
+        public ICounterBuilder<T> WithTag<TTag>(string key, TTag value)
+        {
+            var pair = new KeyValuePair<string, object?>(key, value);
+            var list = ImmutableArray.Create(pair);
+            return new CounterBuilder<T>(this, list);
         }
 
         /// <summary>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/CounterBuilder.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/CounterBuilder.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace System.Diagnostics.Metrics
+{
+    /// <summary>
+    /// Builder which appends tags before adding the delta.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal sealed class CounterBuilder<T> : ICounterBuilder<T>  where T : struct
+    {
+        private readonly Counter<T> _target;
+        private readonly ImmutableArray<KeyValuePair<string, object?>> _tags;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CounterBuilder{T}"/> class.
+        /// </summary>
+        /// <param name="target">The target.</param>
+        /// <param name="tags">The tags.</param>
+        public CounterBuilder(Counter<T> target, ImmutableArray<KeyValuePair<string, object?>> tags)
+        {
+            _target = target;
+            _tags = tags;
+        }
+
+        /// <summary>
+        /// Record the increment value of the measurement.
+        /// </summary>
+        /// <param name="delta">The increment measurement.</param>
+        void ICounterBuilder<T>.Add(T delta)
+        {
+            TagList tagList = new TagList(_tags.AsSpan());
+            _target.Add(delta, in tagList);
+        }
+
+        /// <summary>
+        /// Appends tags before adding the delta.
+        /// </summary>
+        /// <typeparam name="TTag"></typeparam>
+        /// <param name="key">The key.</param>
+        /// <param name="value">The value.</param>
+        /// <returns></returns>
+        ICounterBuilder<T> ITagBuilder<T, ICounterBuilder<T>>.WithTag<TTag>(string key, TTag value)
+        {
+            var pair = new KeyValuePair<string, object?>(key, value);
+            var list = _tags.Add(pair);
+            return new CounterBuilder<T>(_target, list);
+        }
+    }
+}

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/CounterBuilder.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/CounterBuilder.cs
@@ -30,10 +30,11 @@ namespace System.Diagnostics.Metrics
         /// Record the increment value of the measurement.
         /// </summary>
         /// <param name="delta">The increment measurement.</param>
-        void ICounterBuilder<T>.Add(T delta)
+        ICounterBuilder<T> ICounterBuilder<T>.Add(T delta)
         {
             TagList tagList = new TagList(_tags.AsSpan());
             _target.Add(delta, in tagList);
+            return this;
         }
 
         /// <summary>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Histogram.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Histogram.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace System.Diagnostics.Metrics
 {
@@ -22,6 +23,20 @@ namespace System.Diagnostics.Metrics
         internal Histogram(Meter meter, string name, string? unit, string? description, IEnumerable<KeyValuePair<string, object?>>? tags) : base(meter, name, unit, description, tags)
         {
             Publish();
+        }
+
+        /// <summary>
+        /// using tags builder before record.
+        /// </summary>
+        /// <typeparam name="TTag"></typeparam>
+        /// <param name="key">The key.</param>
+        /// <param name="value">The value.</param>
+        /// <returns></returns>
+        public IHistogramBuilder<T> WithTag<TTag>(string key, TTag value)
+        {
+            var pair = new KeyValuePair<string, object?>(key, value);
+            var list = ImmutableArray.Create(pair);
+            return new HistogramBuilder<T>(this, list);
         }
 
         /// <summary>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/HistogramBuilder.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/HistogramBuilder.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace System.Diagnostics.Metrics
+{
+    /// <summary>
+    /// Builder which appends tags before adding the delta.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal sealed class HistogramBuilder<T> : IHistogramBuilder<T>  where T : struct
+    {
+        private readonly Histogram<T> _target;
+        private readonly ImmutableArray<KeyValuePair<string, object?>> _tags;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HistogramBuilder{T}"/> class.
+        /// </summary>
+        /// <param name="target">The target.</param>
+        /// <param name="tags">The tags.</param>
+        public HistogramBuilder(Histogram<T> target, ImmutableArray<KeyValuePair<string, object?>> tags)
+        {
+            _target = target;
+            _tags = tags;
+        }
+
+        /// <summary>
+        /// Record a measurement value.
+        /// </summary>
+        /// <param name="value">The measurement value.</param>
+        void IHistogramBuilder<T>.Record(T value)
+        {
+            TagList tagList = new TagList(_tags.AsSpan());
+            _target.Record(value, in tagList);
+        }
+
+        /// <summary>
+        /// Appends tags before adding the delta.
+        /// </summary>
+        /// <typeparam name="TTag"></typeparam>
+        /// <param name="key">The key.</param>
+        /// <param name="value">The value.</param>
+        /// <returns></returns>
+        IHistogramBuilder<T> ITagBuilder<T, IHistogramBuilder<T>>.WithTag<TTag>(string key, TTag value)
+        {
+            var pair = new KeyValuePair<string, object?>(key, value);
+            var list = _tags.Add(pair);
+            return new HistogramBuilder<T>(_target, list);
+        }
+    }
+}

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/HistogramBuilder.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/HistogramBuilder.cs
@@ -30,10 +30,11 @@ namespace System.Diagnostics.Metrics
         /// Record a measurement value.
         /// </summary>
         /// <param name="value">The measurement value.</param>
-        void IHistogramBuilder<T>.Record(T value)
+        IHistogramBuilder<T> IHistogramBuilder<T>.Record(T value)
         {
             TagList tagList = new TagList(_tags.AsSpan());
             _target.Record(value, in tagList);
+            return this;
         }
 
         /// <summary>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/ICounterBuilder.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/ICounterBuilder.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics.Metrics
+{
+    /// <summary>
+    /// Builder which appends tags before adding the delta.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface ICounterBuilder<T>: ITagBuilder<T, ICounterBuilder<T>> where T : struct
+    {
+        /// <summary>
+        /// Record the increment value of the measurement.
+        /// </summary>
+        /// <param name="delta">The increment measurement.</param>
+        public void Add(T delta);
+    }
+}

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/ICounterBuilder.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/ICounterBuilder.cs
@@ -13,6 +13,6 @@ namespace System.Diagnostics.Metrics
         /// Record the increment value of the measurement.
         /// </summary>
         /// <param name="delta">The increment measurement.</param>
-        public void Add(T delta);
+        public ICounterBuilder<T> Add(T delta);
     }
 }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/IHistogramBuilder.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/IHistogramBuilder.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics.Metrics
+{
+    /// <summary>
+    /// Builder which appends tags before adding the record.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface IHistogramBuilder<T>: ITagBuilder<T, IHistogramBuilder<T>> where T : struct
+    {
+        /// <summary>
+        /// Record a measurement value.
+        /// </summary>
+        /// <param name="value">The measurement value.</param>
+        void Record(T value);
+    }
+}

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/IHistogramBuilder.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/IHistogramBuilder.cs
@@ -13,6 +13,6 @@ namespace System.Diagnostics.Metrics
         /// Record a measurement value.
         /// </summary>
         /// <param name="value">The measurement value.</param>
-        void Record(T value);
+        IHistogramBuilder<T> Record(T value);
     }
 }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/ITagBuilder.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/ITagBuilder.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics.Metrics
+{
+    /// <summary>
+    /// Builder which appends tags
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="TReturn">The type of the builder.</typeparam>
+    public interface ITagBuilder<T, out TReturn> where T : struct where TReturn : ITagBuilder<T, TReturn>
+    {
+        /// <summary>
+        /// Append a tag.
+        /// </summary>
+        /// <typeparam name="TTag"></typeparam>
+        /// <param name="key">The key.</param>
+        /// <param name="value">The value.</param>
+        /// <returns></returns>
+        TReturn WithTag<TTag>(string key, TTag value);
+    }
+}

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/IUpDownCounterBuilder.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/IUpDownCounterBuilder.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics.Metrics
+{
+    /// <summary>
+    /// Builder which appends tags before adding the delta.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface IUpDownCounterBuilder<T>: ITagBuilder<T, IUpDownCounterBuilder<T>> where T : struct
+    {
+        /// <summary>
+        /// Record the increment value of the measurement.
+        /// </summary>
+        /// <param name="delta">The increment measurement.</param>
+        public void Add(T delta);
+    }
+}

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/IUpDownCounterBuilder.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/IUpDownCounterBuilder.cs
@@ -13,6 +13,6 @@ namespace System.Diagnostics.Metrics
         /// Record the increment value of the measurement.
         /// </summary>
         /// <param name="delta">The increment measurement.</param>
-        IUpDownCounterBuilder<T> void Add(T delta);
+        IUpDownCounterBuilder<T> Add(T delta);
     }
 }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/IUpDownCounterBuilder.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/IUpDownCounterBuilder.cs
@@ -13,6 +13,6 @@ namespace System.Diagnostics.Metrics
         /// Record the increment value of the measurement.
         /// </summary>
         /// <param name="delta">The increment measurement.</param>
-        public void Add(T delta);
+        IUpDownCounterBuilder<T> void Add(T delta);
     }
 }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/UpDownCounter.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/UpDownCounter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace System.Diagnostics.Metrics
 {
@@ -21,6 +22,20 @@ namespace System.Diagnostics.Metrics
         internal UpDownCounter(Meter meter, string name, string? unit, string? description, IEnumerable<KeyValuePair<string, object?>>? tags) : base(meter, name, unit, description, tags)
         {
             Publish();
+        }
+
+        /// <summary>
+        /// using tags builder before adding a delta.
+        /// </summary>
+        /// <typeparam name="TTag"></typeparam>
+        /// <param name="key">The key.</param>
+        /// <param name="value">The value.</param>
+        /// <returns></returns>
+        public IUpDownCounterBuilder<T> WithTag<TTag>(string key, TTag value)
+        {
+            var pair = new KeyValuePair<string, object?>(key, value);
+            var list = ImmutableArray.Create(pair);
+            return new UpDownCounterBuilder<T>(this, list);
         }
 
         /// <summary>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/UpDownCounterBuilder.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/UpDownCounterBuilder.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace System.Diagnostics.Metrics
+{
+    /// <summary>
+    /// Builder which appends tags before adding the delta.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal sealed class UpDownCounterBuilder<T> : IUpDownCounterBuilder<T>  where T : struct
+    {
+        private readonly UpDownCounter<T> _target;
+        private readonly ImmutableArray<KeyValuePair<string, object?>> _tags;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UpDownCounterBuilder{T}"/> class.
+        /// </summary>
+        /// <param name="target">The target.</param>
+        /// <param name="tags">The tags.</param>
+        public UpDownCounterBuilder(UpDownCounter<T> target, ImmutableArray<KeyValuePair<string, object?>> tags)
+        {
+            _target = target;
+            _tags = tags;
+        }
+
+        /// <summary>
+        /// Record the increment value of the measurement.
+        /// </summary>
+        /// <param name="delta">The increment measurement.</param>
+        void IUpDownCounterBuilder<T>.Add(T delta)
+        {
+            TagList tagList = new TagList(_tags.AsSpan());
+            _target.Add(delta, in tagList);
+        }
+
+        /// <summary>
+        /// Appends tags before adding the delta.
+        /// </summary>
+        /// <typeparam name="TTag"></typeparam>
+        /// <param name="key">The key.</param>
+        /// <param name="value">The value.</param>
+        /// <returns></returns>
+        IUpDownCounterBuilder<T> ITagBuilder<T, IUpDownCounterBuilder<T>>.WithTag<TTag>(string key, TTag value)
+        {
+            var pair = new KeyValuePair<string, object?>(key, value);
+            var list = _tags.Add(pair);
+            return new UpDownCounterBuilder<T>(_target, list);
+        }
+    }
+}

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/UpDownCounterBuilder.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/UpDownCounterBuilder.cs
@@ -30,10 +30,11 @@ namespace System.Diagnostics.Metrics
         /// Record the increment value of the measurement.
         /// </summary>
         /// <param name="delta">The increment measurement.</param>
-        void IUpDownCounterBuilder<T>.Add(T delta)
+        IUpDownCounterBuilder<T> IUpDownCounterBuilder<T>.Add(T delta)
         {
             TagList tagList = new TagList(_tags.AsSpan());
             _target.Add(delta, in tagList);
+            return this;
         }
 
         /// <summary>


### PR DESCRIPTION
This PR is a suggestion for usability improvement when building metrics tags.
The current implementation requires a quit verbose syntax of either `new KeyValuePair<string, object>("color", "red")` or `KeyValuePair.Create<string, object>("color", "red")`

I suggest having the following API:

```cs
c.WithTag("Color", "red")
 .WithTag("Price", "Low")
    .Add(5);
h.WithTag("Size", 123)
    .Record(19);
udc.WithTag("Color", "red")
    .Add(-33);
```

instead of 

```cs
c.Add(5, 
	new KeyValuePair<string,object?>("Color", "red"),
	new KeyValuePair<string, object?>("Price", "Low"));
h.Record(19, 
	new KeyValuePair<string, object?>("Size", 123));
udc.Add(-33, 
	new KeyValuePair<string, object?>("Color", "red"));
```