### PR TITLE
Make sure intellisense files are copied to the ref pack output for the current TargetOS

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -144,7 +144,6 @@
     <RepoTasksDir>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'src', 'tasks'))</RepoTasksDir>
     <IbcOptimizationDataDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'ibc'))</IbcOptimizationDataDir>
     <MibcOptimizationDataDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'mibc'))</MibcOptimizationDataDir>
-    <XmlDocDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'docs'))</XmlDocDir>
     <DocsDir>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'docs'))</DocsDir>
 
     <AppleAppBuilderDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AppleAppBuilder', 'Debug', '$(NetCoreAppToolCurrent)'))</AppleAppBuilderDir>

--- a/eng/intellisense.targets
+++ b/eng/intellisense.targets
@@ -25,8 +25,7 @@
     <PackageDownload Include="Microsoft.Private.Intellisense" Version="[$(MicrosoftPrivateIntellisenseVersion)]" />
   </ItemGroup>
 
-  <!-- TODO: Remove this target when no library relies on the intellisense documentation file anymore.-->
-  <!-- Replace the default xml file generated in the obj folder with the one that comes from the docs feed. -->
+  <!-- Replace the compiler generated xml file in the obj folder with the one that comes from the intellisense package. -->
   <Target Name="ChangeDocumentationFileForPackaging"
           BeforeTargets="CopyFilesToOutputDirectory;DocumentationProjectOutputGroup"
           Condition="'$(IntellisensePackageXmlFilePath)' != ''">
@@ -36,15 +35,13 @@
     </ItemGroup>
   </Target>
 
-  <!-- Copy the intellisense file to the folder we use to produce the targeting pack.
-       The condition is for the RID agnostic build of source assemblies that are part of the .NET Core shared framework. -->
-  <Target Name="CopyDocumentationFileToXmlDocDir"
-          AfterTargets="CopyFilesToOutputDirectory"
-          Condition="'$(IsNetCoreAppSrc)' == 'true' and '$(TargetFramework)' == '$(NetCoreAppCurrent)'">
-    <Copy SourceFiles="@(DocFileItem)"
-          DestinationFolder="$(XmlDocDir)"
-          SkipUnchangedFiles="true"
-          UseHardlinksIfPossible="true" />
+  <!-- Allow P2Ps to retrieve the DocFileItem path. -->
+  <Target Name="AnnotateTargetPathWithTargetPlatformMonikerWithDocFileItem"
+          DependsOnTargets="ChangeDocumentationFileForPackaging"
+          AfterTargets="GetTargetPathWithTargetPlatformMoniker">
+    <ItemGroup>
+      <TargetPathWithTargetPlatformMoniker DocFileItem="@(DocFileItem)" />
+    </ItemGroup>
   </Target>
 
 </Project>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Ref.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Ref.sfxproj
@@ -14,7 +14,7 @@
   <Target Name="AddFrameworkFilesToPackage" DependsOnTargets="ResolveLibrariesFromLocalBuild" BeforeTargets="GetFilesToPackage">
     <ItemGroup>
       <ReferencePath Include="@(LibrariesRefAssemblies)" />
-      <DocFilesToPackage Include="$(XmlDocDir)%(LibrariesRefAssemblies.FileName).xml" Condition="Exists('$(XmlDocDir)%(LibrariesRefAssemblies.FileName).xml')"/>
+      <DocFilesToPackage Include="$(MicrosoftNetCoreAppRefPackRefDir)%(LibrariesRefAssemblies.FileName).xml" Condition="Exists('$(MicrosoftNetCoreAppRefPackRefDir)%(LibrariesRefAssemblies.FileName).xml')"/>
       <Analyzer Include="$(MicrosoftNetCoreAppRefPackDir)/analyzers/**/*.*" />
       <FilesToPackage Include="@(Analyzer)" ExcludeFromValidation="true" TargetPath="analyzers/%(RecursiveDir)" />
     </ItemGroup>

--- a/src/libraries/sfx.proj
+++ b/src/libraries/sfx.proj
@@ -21,6 +21,22 @@
 
   <!-- Generate the targeting pack's framework list so that out-of-band projects can leverage it. -->
   <Import Project="frameworklist.targets" />
+
+  <!-- Copy the intellisense file to the targeting pack directory. -->
+  <Target Name="CopyDocumentationFiles"
+          AfterTargets="Build"
+          Condition="'$(RefOnly)' != 'true'">
+    <ItemGroup>
+      <DocumentationFileToCopy Include="@(SharedFrameworkAssembly->Metadata('DocFileItem'))"
+                               Condition="!$(NetCoreAppLibraryNoReference.Contains('%(Filename);'))" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(DocumentationFileToCopy)"
+          DestinationFolder="$(MicrosoftNetCoreAppRefPackRefDir)"
+          SkipUnchangedFiles="true"
+          UseHardlinksIfPossible="true" />
+  </Target>
+
   <!-- Import the illink file which contains some of the logic required to illink the shared framework assemblies. -->
   <Import Project="$(RepositoryEngineeringDir)illink.targets" />
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/87585

When looking at the 8.0 Preview 5 SDK, xml files are missing for certain assemblies. This is likely because of the TargetFramework condition in intellisense.targets. Instead of conditioning on the rid-less net8.0 TFM, use the sfx.proj which already assembles the shared framework and targeting pack layout, to copy the documentation files.

Additionally, remove the XmlDocDir and copy the files into the targeting pack folder which was a difference between the "real" targeting pack and the "fake" one that src/libraries generates.