### PR TITLE
[mono][simd] Add MONO_TYPE_I and MONO_TYPE_U types for OP_NEGATION on amd64

### DIFF
--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -6777,7 +6777,9 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				amd64_sse_movaps_reg_reg (code, ins->dreg, SIMD_TEMP_REG);
 				break;
 			case MONO_TYPE_I8:
+			case MONO_TYPE_I:
 			case MONO_TYPE_U8:
+			case MONO_TYPE_U:
 				amd64_sse_pxor_reg_reg (code, SIMD_TEMP_REG, SIMD_TEMP_REG);
 				amd64_sse_psubq_reg_reg (code, SIMD_TEMP_REG, ins->sreg1);
 				amd64_sse_movaps_reg_reg (code, ins->dreg, SIMD_TEMP_REG);
@@ -6798,18 +6800,6 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				amd64_sse_xorps_reg_reg (code, ins->dreg, SIMD_TEMP_REG);
 				break;
 			}
-			case MONO_TYPE_I:
-			case MONO_TYPE_U:
-#if TARGET_SIZEOF_VOID_P == 8
-				amd64_sse_pxor_reg_reg (code, SIMD_TEMP_REG, SIMD_TEMP_REG);
-				amd64_sse_psubq_reg_reg (code, SIMD_TEMP_REG, ins->sreg1);
-				amd64_sse_movaps_reg_reg (code, ins->dreg, SIMD_TEMP_REG);
-#else
-				amd64_sse_pxor_reg_reg (code, SIMD_TEMP_REG, SIMD_TEMP_REG);
-				amd64_sse_psubd_reg_reg (code, SIMD_TEMP_REG, ins->sreg1);
-				amd64_sse_movaps_reg_reg (code, ins->dreg, SIMD_TEMP_REG);
-#endif
-				break;
 			default:
 				g_assert_not_reached ();
 				break;

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -6798,6 +6798,18 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				amd64_sse_xorps_reg_reg (code, ins->dreg, SIMD_TEMP_REG);
 				break;
 			}
+			case MONO_TYPE_I:
+			case MONO_TYPE_U:
+#if TARGET_SIZEOF_VOID_P == 8
+				amd64_sse_pxor_reg_reg (code, SIMD_TEMP_REG, SIMD_TEMP_REG);
+				amd64_sse_psubq_reg_reg (code, SIMD_TEMP_REG, ins->sreg1);
+				amd64_sse_movaps_reg_reg (code, ins->dreg, SIMD_TEMP_REG);
+#else
+				amd64_sse_pxor_reg_reg (code, SIMD_TEMP_REG, SIMD_TEMP_REG);
+				amd64_sse_psubd_reg_reg (code, SIMD_TEMP_REG, ins->sreg1);
+				amd64_sse_movaps_reg_reg (code, ins->dreg, SIMD_TEMP_REG);
+#endif
+				break;
 			default:
 				g_assert_not_reached ();
 				break;


### PR DESCRIPTION
The Mono functional tests are failing during AOT compilation on iossimulator/tvossimulator. It appears that there is an issue with decoding the ins->inst_c1 type in OP_NEGATION. Assumption is that the MONO_TYPE_I and MONO_TYPE_U types for OP_NEGATION on amd64 are missing.

Fixes https://github.com/dotnet/runtime/issues/87606

This PR should verify whether the change resolves the issue causing the CI failures.

/cc: @vargaz @jandupej 