### PR TITLE
Add ContainsAny{Except}

### DIFF
--- a/src/libraries/Common/src/System/Globalization/FormatProvider.Number.cs
+++ b/src/libraries/Common/src/System/Globalization/FormatProvider.Number.cs
@@ -596,7 +596,7 @@ namespace System.Globalization
             [MethodImpl(MethodImplOptions.NoInlining)] // rare slow path that shouldn't impact perf of the main use case
             private static bool TrailingZeros(ReadOnlySpan<char> s, int index) =>
                 // For compatibility, we need to allow trailing zeros at the end of a number string
-                s.Slice(index).IndexOfAnyExcept('\0') < 0;
+                !s.Slice(index).ContainsAnyExcept('\0');
 
             internal static unsafe bool TryStringToNumber(ReadOnlySpan<char> str, NumberStyles options, scoped ref NumberBuffer number, StringBuilder sb, NumberFormatInfo numfmt, bool parseDecimal)
             {

--- a/src/libraries/Common/src/System/Net/HttpValidationHelpers.cs
+++ b/src/libraries/Common/src/System/Net/HttpValidationHelpers.cs
@@ -22,7 +22,7 @@ namespace System.Net
         }
 
         internal static bool ContainsNonAsciiChars(string token) =>
-            token.AsSpan().IndexOfAnyExceptInRange((char)0x20, (char)0x7e) >= 0;
+            token.AsSpan().ContainsAnyExceptInRange((char)0x20, (char)0x7e);
 
         internal static bool IsValidToken(string token)
         {

--- a/src/libraries/Common/src/System/Net/Security/TargetHostNameHelper.cs
+++ b/src/libraries/Common/src/System/Net/Security/TargetHostNameHelper.cs
@@ -14,7 +14,7 @@ namespace System.Net.Security
             SearchValues.Create("-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz");
 
         private static bool IsSafeDnsString(ReadOnlySpan<char> name) =>
-            name.IndexOfAnyExcept(s_safeDnsChars) < 0;
+            !name.ContainsAnyExcept(s_safeDnsChars);
 
         internal static string NormalizeHostName(string? targetHost)
         {

--- a/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
@@ -306,7 +306,7 @@ namespace System.Security.Cryptography
                 ValidateParameters(ref parameters);
                 ThrowIfDisposed();
 
-                if (parameters.Exponent == null || parameters.Modulus.AsSpan().IndexOfAnyExcept((byte)0) < 0)
+                if (parameters.Exponent == null || !parameters.Modulus.AsSpan().ContainsAnyExcept((byte)0))
                 {
                     throw new CryptographicException(SR.Cryptography_InvalidRsaParameters);
                 }

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Internal/PathUtils.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Internal/PathUtils.cs
@@ -30,12 +30,12 @@ namespace Microsoft.Extensions.FileProviders.Physical.Internal
 
         internal static bool HasInvalidPathChars(string path)
         {
-            return path.AsSpan().IndexOfAny(_invalidFileNameChars) >= 0;
+            return path.AsSpan().ContainsAny(_invalidFileNameChars);
         }
 
         internal static bool HasInvalidFilterChars(string path)
         {
-            return path.AsSpan().IndexOfAny(_invalidFilterChars) >= 0;
+            return path.AsSpan().ContainsAny(_invalidFilterChars);
         }
 
         internal static string EnsureTrailingSlash(string path)

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Internal/PathUtils.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Internal/PathUtils.cs
@@ -20,23 +20,25 @@ namespace Microsoft.Extensions.FileProviders.Physical.Internal
 #if NET8_0_OR_GREATER
         private static readonly SearchValues<char> _invalidFileNameChars = SearchValues.Create(GetInvalidFileNameChars());
         private static readonly SearchValues<char> _invalidFilterChars = SearchValues.Create(GetInvalidFilterChars());
+
+        internal static bool HasInvalidPathChars(string path) =>
+            path.AsSpan().ContainsAny(_invalidFileNameChars);
+
+        internal static bool HasInvalidFilterChars(string path) =>
+            path.AsSpan().ContainsAny(_invalidFilterChars);
 #else
         private static readonly char[] _invalidFileNameChars = GetInvalidFileNameChars();
         private static readonly char[] _invalidFilterChars = GetInvalidFilterChars();
+
+        internal static bool HasInvalidPathChars(string path) =>
+            path.IndexOfAny(_invalidFileNameChars) >= 0;
+
+        internal static bool HasInvalidFilterChars(string path) =>
+            path.IndexOfAny(_invalidFilterChars) >= 0;
 #endif
 
         private static readonly char[] _pathSeparators = new[]
             {Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar};
-
-        internal static bool HasInvalidPathChars(string path)
-        {
-            return path.AsSpan().ContainsAny(_invalidFileNameChars);
-        }
-
-        internal static bool HasInvalidFilterChars(string path)
-        {
-            return path.AsSpan().ContainsAny(_invalidFilterChars);
-        }
 
         internal static string EnsureTrailingSlash(string path)
         {

--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -1923,7 +1923,7 @@ namespace System.Collections.Concurrent
         #endregion
 
         private bool AreAllBucketsEmpty() =>
-            _tables._countPerLock.AsSpan().IndexOfAnyExcept(0) < 0;
+            !_tables._countPerLock.AsSpan().ContainsAnyExcept(0);
 
         /// <summary>
         /// Replaces the bucket table with a larger one. To prevent multiple threads from resizing the

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/KeyAnalyzer.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/KeyAnalyzer.cs
@@ -207,7 +207,7 @@ namespace System.Collections.Frozen
             Debug.Assert(IsAllAscii(s));
 
 #if NET8_0_OR_GREATER
-            return s.IndexOfAny(s_asciiLetters) >= 0;
+            return s.ContainsAny(s_asciiLetters);
 #else
             foreach (char c in s)
             {

--- a/src/libraries/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/libraries/System.Collections/src/System/Collections/BitArray.cs
@@ -924,7 +924,7 @@ namespace System.Collections
             }
 
             const int AllSetBits = -1; // 0xFF_FF_FF_FF
-            if (m_array.AsSpan(0, intCount).IndexOfAnyExcept(AllSetBits) >= 0)
+            if (m_array.AsSpan(0, intCount).ContainsAnyExcept(AllSetBits))
             {
                 return false;
             }
@@ -954,7 +954,7 @@ namespace System.Collections
                 intCount--;
             }
 
-            if (m_array.AsSpan(0, intCount).IndexOfAnyExcept(0) >= 0)
+            if (m_array.AsSpan(0, intCount).ContainsAnyExcept(0))
             {
                 return true;
             }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
@@ -132,7 +132,7 @@ namespace System.Formats.Tar
 
         // Returns true if all the bytes in the specified array are nulls, false otherwise.
         internal static bool IsAllNullBytes(Span<byte> buffer) =>
-            buffer.IndexOfAnyExcept((byte)0) < 0;
+            !buffer.ContainsAnyExcept((byte)0);
 
         // Converts the specified number of seconds that have passed since the Unix Epoch to a DateTimeOffset.
         internal static DateTimeOffset GetDateTimeOffsetFromSecondsSinceEpoch(long secondsSinceUnixEpoch) =>

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipHelper.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipHelper.cs
@@ -22,7 +22,7 @@ namespace System.IO.Compression
 
         internal static Encoding GetEncoding(string text)
         {
-            if (text.AsSpan().IndexOfAnyExceptInRange((char)32, (char)126) >= 0)
+            if (text.AsSpan().ContainsAnyExceptInRange((char)32, (char)126))
             {
                 // The Zip Format uses code page 437 when the Unicode bit is not set. This format
                 // is the same as ASCII for characters 32-126 but differs otherwise. If we can fit

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -202,14 +202,14 @@ namespace System.IO.Pipes
             // cross-platform with Windows (which has only '\' as an invalid char).
             if (Path.IsPathRooted(pipeName))
             {
-                if (pipeName.ContainsAny(s_invalidPathNameChars) || pipeName.EndsWith(Path.DirectorySeparatorChar))
+                if (pipeName.AsSpan().ContainsAny(s_invalidPathNameChars) || pipeName.EndsWith(Path.DirectorySeparatorChar))
                     throw new PlatformNotSupportedException(SR.PlatformNotSupported_InvalidPipeNameChars);
 
                 // Caller is in full control of file location.
                 return pipeName;
             }
 
-            if (pipeName.ContainsAny(s_invalidFileNameChars))
+            if (pipeName.AsSpan().ContainsAny(s_invalidFileNameChars))
             {
                 throw new PlatformNotSupportedException(SR.PlatformNotSupported_InvalidPipeNameChars);
             }

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -202,14 +202,14 @@ namespace System.IO.Pipes
             // cross-platform with Windows (which has only '\' as an invalid char).
             if (Path.IsPathRooted(pipeName))
             {
-                if (pipeName.IndexOfAny(s_invalidPathNameChars) >= 0 || pipeName.EndsWith(Path.DirectorySeparatorChar))
+                if (pipeName.ContainsAny(s_invalidPathNameChars) || pipeName.EndsWith(Path.DirectorySeparatorChar))
                     throw new PlatformNotSupportedException(SR.PlatformNotSupported_InvalidPipeNameChars);
 
                 // Caller is in full control of file location.
                 return pipeName;
             }
 
-            if (pipeName.IndexOfAny(s_invalidFileNameChars) >= 0)
+            if (pipeName.ContainsAny(s_invalidFileNameChars))
             {
                 throw new PlatformNotSupportedException(SR.PlatformNotSupported_InvalidPipeNameChars);
             }

--- a/src/libraries/System.Memory/ref/System.Memory.cs
+++ b/src/libraries/System.Memory/ref/System.Memory.cs
@@ -234,6 +234,28 @@ namespace System
         public static bool Contains(this System.ReadOnlySpan<char> span, System.ReadOnlySpan<char> value, System.StringComparison comparisonType) { throw null; }
         public static bool Contains<T>(this System.ReadOnlySpan<T> span, T value) where T : System.IEquatable<T>? { throw null; }
         public static bool Contains<T>(this System.Span<T> span, T value) where T : System.IEquatable<T>? { throw null; }
+        public static bool ContainsAny<T>(this System.ReadOnlySpan<T> span, System.Buffers.SearchValues<T> values) where T : System.IEquatable<T>? { throw null; }
+        public static bool ContainsAny<T>(this System.ReadOnlySpan<T> span, System.ReadOnlySpan<T> values) where T : System.IEquatable<T>? { throw null; }
+        public static bool ContainsAny<T>(this System.ReadOnlySpan<T> span, T value0, T value1) where T : System.IEquatable<T>? { throw null; }
+        public static bool ContainsAny<T>(this System.ReadOnlySpan<T> span, T value0, T value1, T value2) where T : System.IEquatable<T>? { throw null; }
+        public static bool ContainsAny<T>(this System.Span<T> span, System.Buffers.SearchValues<T> values) where T : System.IEquatable<T>? { throw null; }
+        public static bool ContainsAny<T>(this System.Span<T> span, System.ReadOnlySpan<T> values) where T : System.IEquatable<T>? { throw null; }
+        public static bool ContainsAny<T>(this System.Span<T> span, T value0, T value1) where T : System.IEquatable<T>? { throw null; }
+        public static bool ContainsAny<T>(this System.Span<T> span, T value0, T value1, T value2) where T : System.IEquatable<T>? { throw null; }
+        public static bool ContainsAnyExcept<T>(this System.ReadOnlySpan<T> span, System.Buffers.SearchValues<T> values) where T : System.IEquatable<T>? { throw null; }
+        public static bool ContainsAnyExcept<T>(this System.ReadOnlySpan<T> span, System.ReadOnlySpan<T> values) where T : System.IEquatable<T>? { throw null; }
+        public static bool ContainsAnyExcept<T>(this System.ReadOnlySpan<T> span, T value) where T : System.IEquatable<T>? { throw null; }
+        public static bool ContainsAnyExcept<T>(this System.ReadOnlySpan<T> span, T value0, T value1) where T : System.IEquatable<T>? { throw null; }
+        public static bool ContainsAnyExcept<T>(this System.ReadOnlySpan<T> span, T value0, T value1, T value2) where T : System.IEquatable<T>? { throw null; }
+        public static bool ContainsAnyExcept<T>(this System.Span<T> span, System.Buffers.SearchValues<T> values) where T : System.IEquatable<T>? { throw null; }
+        public static bool ContainsAnyExcept<T>(this System.Span<T> span, System.ReadOnlySpan<T> values) where T : System.IEquatable<T>? { throw null; }
+        public static bool ContainsAnyExcept<T>(this System.Span<T> span, T value) where T : System.IEquatable<T>? { throw null; }
+        public static bool ContainsAnyExcept<T>(this System.Span<T> span, T value0, T value1) where T : System.IEquatable<T>? { throw null; }
+        public static bool ContainsAnyExcept<T>(this System.Span<T> span, T value0, T value1, T value2) where T : System.IEquatable<T>? { throw null; }
+        public static bool ContainsAnyExceptInRange<T>(this System.ReadOnlySpan<T> span, T lowInclusive, T highInclusive) where T : System.IComparable<T> { throw null; }
+        public static bool ContainsAnyExceptInRange<T>(this System.Span<T> span, T lowInclusive, T highInclusive) where T : System.IComparable<T> { throw null; }
+        public static bool ContainsAnyInRange<T>(this System.ReadOnlySpan<T> span, T lowInclusive, T highInclusive) where T : System.IComparable<T> { throw null; }
+        public static bool ContainsAnyInRange<T>(this System.Span<T> span, T lowInclusive, T highInclusive) where T : System.IComparable<T> { throw null; }
         public static void CopyTo<T>(this T[]? source, System.Memory<T> destination) { }
         public static void CopyTo<T>(this T[]? source, System.Span<T> destination) { }
         public static int Count<T>(this System.Span<T> span, T value) where T : System.IEquatable<T>? { throw null; }

--- a/src/libraries/System.Memory/tests/Span/IndexOfAny.T.cs
+++ b/src/libraries/System.Memory/tests/Span/IndexOfAny.T.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.SpanTests
@@ -11,7 +14,7 @@ namespace System.SpanTests
         public static void ZeroLengthIndexOfAny_TwoInteger()
         {
             var sp = new Span<int>(Array.Empty<int>());
-            int idx = sp.IndexOfAny(0, 0);
+            int idx = IndexOfAny(sp, 0, 0);
             Assert.Equal(-1, idx);
         }
 
@@ -32,7 +35,7 @@ namespace System.SpanTests
                     int index = rnd.Next(0, 2) == 0 ? 0 : 1;
                     int target0 = targets[index];
                     int target1 = targets[(index + 1) % 2];
-                    int idx = span.IndexOfAny(target0, target1);
+                    int idx = IndexOfAny(span, target0, target1);
                     Assert.Equal(0, idx);
                 }
             }
@@ -56,7 +59,7 @@ namespace System.SpanTests
                 {
                     int target0 = a[targetIndex];
                     int target1 = 0;
-                    int idx = span.IndexOfAny(target0, target1);
+                    int idx = IndexOfAny(span, target0, target1);
                     Assert.Equal(targetIndex, idx);
                 }
 
@@ -65,7 +68,7 @@ namespace System.SpanTests
                     int index = rnd.Next(0, 2) == 0 ? 0 : 1;
                     int target0 = a[targetIndex + index];
                     int target1 = a[targetIndex + (index + 1) % 2];
-                    int idx = span.IndexOfAny(target0, target1);
+                    int idx = IndexOfAny(span, target0, target1);
                     Assert.Equal(targetIndex, idx);
                 }
 
@@ -73,7 +76,7 @@ namespace System.SpanTests
                 {
                     int target0 = 0;
                     int target1 = a[targetIndex];
-                    int idx = span.IndexOfAny(target0, target1);
+                    int idx = IndexOfAny(span, target0, target1);
                     Assert.Equal(targetIndex, idx);
                 }
             }
@@ -90,7 +93,7 @@ namespace System.SpanTests
                 int target1 = rnd.Next(1, 256);
                 var span = new Span<int>(a);
 
-                int idx = span.IndexOfAny(target0, target1);
+                int idx = IndexOfAny(span, target0, target1);
                 Assert.Equal(-1, idx);
             }
         }
@@ -112,7 +115,7 @@ namespace System.SpanTests
                 a[length - 3] = 200;
 
                 var span = new Span<int>(a);
-                int idx = span.IndexOfAny(200, 200);
+                int idx = IndexOfAny(span, 200, 200);
                 Assert.Equal(length - 3, idx);
             }
         }
@@ -126,7 +129,7 @@ namespace System.SpanTests
                 a[0] = 99;
                 a[length + 1] = 98;
                 var span = new Span<int>(a, 1, length - 1);
-                int index = span.IndexOfAny(99, 98);
+                int index = IndexOfAny(span, 99, 98);
                 Assert.Equal(-1, index);
             }
 
@@ -136,7 +139,7 @@ namespace System.SpanTests
                 a[0] = 99;
                 a[length + 1] = 99;
                 var span = new Span<int>(a, 1, length - 1);
-                int index = span.IndexOfAny(99, 99);
+                int index = IndexOfAny(span, 99, 99);
                 Assert.Equal(-1, index);
             }
         }
@@ -145,7 +148,7 @@ namespace System.SpanTests
         public static void ZeroLengthIndexOfAny_ThreeInteger()
         {
             var sp = new Span<int>(Array.Empty<int>());
-            int idx = sp.IndexOfAny(0, 0, 0);
+            int idx = IndexOfAny(sp, 0, 0, 0);
             Assert.Equal(-1, idx);
         }
 
@@ -167,7 +170,7 @@ namespace System.SpanTests
                     int target0 = targets[index];
                     int target1 = targets[(index + 1) % 2];
                     int target2 = targets[(index + 1) % 3];
-                    int idx = span.IndexOfAny(target0, target1, target2);
+                    int idx = IndexOfAny(span, target0, target1, target2);
                     Assert.Equal(0, idx);
                 }
             }
@@ -192,7 +195,7 @@ namespace System.SpanTests
                     int target0 = a[targetIndex];
                     int target1 = 0;
                     int target2 = 0;
-                    int idx = span.IndexOfAny(target0, target1, target2);
+                    int idx = IndexOfAny(span, target0, target1, target2);
                     Assert.Equal(targetIndex, idx);
                 }
 
@@ -202,7 +205,7 @@ namespace System.SpanTests
                     int target0 = a[targetIndex + index];
                     int target1 = a[targetIndex + (index + 1) % 2];
                     int target2 = a[targetIndex + (index + 1) % 3];
-                    int idx = span.IndexOfAny(target0, target1, target2);
+                    int idx = IndexOfAny(span, target0, target1, target2);
                     Assert.Equal(targetIndex, idx);
                 }
 
@@ -211,7 +214,7 @@ namespace System.SpanTests
                     int target0 = 0;
                     int target1 = 0;
                     int target2 = a[targetIndex];
-                    int idx = span.IndexOfAny(target0, target1, target2);
+                    int idx = IndexOfAny(span, target0, target1, target2);
                     Assert.Equal(targetIndex, idx);
                 }
             }
@@ -229,7 +232,7 @@ namespace System.SpanTests
                 int target2 = rnd.Next(1, 256);
                 var span = new Span<int>(a);
 
-                int idx = span.IndexOfAny(target0, target1, target2);
+                int idx = IndexOfAny(span, target0, target1, target2);
                 Assert.Equal(-1, idx);
             }
         }
@@ -252,7 +255,7 @@ namespace System.SpanTests
                 a[length - 4] = 200;
 
                 var span = new Span<int>(a);
-                int idx = span.IndexOfAny(200, 200, 200);
+                int idx = IndexOfAny(span, 200, 200, 200);
                 Assert.Equal(length - 4, idx);
             }
         }
@@ -266,7 +269,7 @@ namespace System.SpanTests
                 a[0] = 99;
                 a[length + 1] = 98;
                 var span = new Span<int>(a, 1, length - 1);
-                int index = span.IndexOfAny(99, 98, 99);
+                int index = IndexOfAny(span, 99, 98, 99);
                 Assert.Equal(-1, index);
             }
 
@@ -276,7 +279,7 @@ namespace System.SpanTests
                 a[0] = 99;
                 a[length + 1] = 99;
                 var span = new Span<int>(a, 1, length - 1);
-                int index = span.IndexOfAny(99, 99, 99);
+                int index = IndexOfAny(span, 99, 99, 99);
                 Assert.Equal(-1, index);
             }
         }
@@ -286,11 +289,11 @@ namespace System.SpanTests
         {
             var sp = new Span<int>(Array.Empty<int>());
             var values = new ReadOnlySpan<int>(new int[] { 0, 0, 0, 0 });
-            int idx = sp.IndexOfAny(values);
+            int idx = IndexOfAny(sp, values);
             Assert.Equal(-1, idx);
 
             values = new ReadOnlySpan<int>(new int[] { });
-            idx = sp.IndexOfAny(values);
+            idx = IndexOfAny(sp, values);
             Assert.Equal(-1, idx);
         }
 
@@ -306,7 +309,7 @@ namespace System.SpanTests
 
                 for (int i = 0; i < length; i++)
                 {
-                    int idx = span.IndexOfAny(values);
+                    int idx = IndexOfAny(span, values);
                     Assert.Equal(0, idx);
                 }
             }
@@ -329,7 +332,7 @@ namespace System.SpanTests
                 for (int targetIndex = 0; targetIndex < length; targetIndex++)
                 {
                     var values = new ReadOnlySpan<int>(new int[] { a[targetIndex], 0, 0, 0 });
-                    int idx = span.IndexOfAny(values);
+                    int idx = IndexOfAny(span, values);
                     Assert.Equal(targetIndex, idx);
                 }
 
@@ -343,14 +346,14 @@ namespace System.SpanTests
                             a[targetIndex + (index + 1) % 3],
                             a[targetIndex + (index + 1) % 4]
                         });
-                    int idx = span.IndexOfAny(values);
+                    int idx = IndexOfAny(span, values);
                     Assert.Equal(targetIndex, idx);
                 }
 
                 for (int targetIndex = 0; targetIndex < length; targetIndex++)
                 {
                     var values = new ReadOnlySpan<int>(new int[] { 0, 0, 0, a[targetIndex] });
-                    int idx = span.IndexOfAny(values);
+                    int idx = IndexOfAny(span, values);
                     Assert.Equal(targetIndex, idx);
                 }
             }
@@ -385,7 +388,7 @@ namespace System.SpanTests
                 }
 
                 var values = new ReadOnlySpan<int>(targets);
-                int idx = span.IndexOfAny(values);
+                int idx = IndexOfAny(span, values);
                 Assert.Equal(expectedIndex, idx);
             }
         }
@@ -405,7 +408,7 @@ namespace System.SpanTests
                 var span = new Span<int>(a);
                 var values = new ReadOnlySpan<int>(targets);
 
-                int idx = span.IndexOfAny(values);
+                int idx = IndexOfAny(span, values);
                 Assert.Equal(-1, idx);
             }
         }
@@ -425,7 +428,7 @@ namespace System.SpanTests
                 var span = new Span<int>(a);
                 var values = new ReadOnlySpan<int>(targets);
 
-                int idx = span.IndexOfAny(values);
+                int idx = IndexOfAny(span, values);
                 Assert.Equal(-1, idx);
             }
         }
@@ -450,7 +453,7 @@ namespace System.SpanTests
 
                 var span = new Span<int>(a);
                 var values = new ReadOnlySpan<int>(new int[] { 200, 200, 200, 200, 200, 200, 200, 200, 200 });
-                int idx = span.IndexOfAny(values);
+                int idx = IndexOfAny(span, values);
                 Assert.Equal(length - 5, idx);
             }
         }
@@ -465,7 +468,7 @@ namespace System.SpanTests
                 a[length + 1] = 98;
                 var span = new Span<int>(a, 1, length - 1);
                 var values = new Span<int>(new int[] { 99, 98, 99, 98, 99, 98 });
-                int index = span.IndexOfAny(values);
+                int index = IndexOfAny(span, values);
                 Assert.Equal(-1, index);
             }
 
@@ -476,7 +479,7 @@ namespace System.SpanTests
                 a[length + 1] = 99;
                 var span = new Span<int>(a, 1, length - 1);
                 var values = new ReadOnlySpan<int>(new int[] { 99, 99, 99, 99, 99, 99 });
-                int index = span.IndexOfAny(values);
+                int index = IndexOfAny(span, values);
                 Assert.Equal(-1, index);
             }
         }
@@ -485,7 +488,7 @@ namespace System.SpanTests
         public static void ZeroLengthIndexOfAny_TwoString()
         {
             var sp = new Span<string>(Array.Empty<string>());
-            int idx = sp.IndexOfAny("0", "0");
+            int idx = IndexOfAny(sp, "0", "0");
             Assert.Equal(-1, idx);
         }
 
@@ -508,7 +511,7 @@ namespace System.SpanTests
                     int index = rnd.Next(0, 2) == 0 ? 0 : 1;
                     string target0 = targets[index];
                     string target1 = targets[(index + 1) % 2];
-                    int idx = span.IndexOfAny(target0, target1);
+                    int idx = IndexOfAny(span, target0, target1);
                     Assert.Equal(0, idx);
                 }
             }
@@ -532,7 +535,7 @@ namespace System.SpanTests
                 {
                     string target0 = a[targetIndex];
                     string target1 = "0";
-                    int idx = span.IndexOfAny(target0, target1);
+                    int idx = IndexOfAny(span, target0, target1);
                     Assert.Equal(targetIndex, idx);
                 }
 
@@ -541,7 +544,7 @@ namespace System.SpanTests
                     int index = rnd.Next(0, 2) == 0 ? 0 : 1;
                     string target0 = a[targetIndex + index];
                     string target1 = a[targetIndex + (index + 1) % 2];
-                    int idx = span.IndexOfAny(target0, target1);
+                    int idx = IndexOfAny(span, target0, target1);
                     Assert.Equal(targetIndex, idx);
                 }
 
@@ -549,7 +552,7 @@ namespace System.SpanTests
                 {
                     string target0 = "0";
                     string target1 = a[targetIndex + 1];
-                    int idx = span.IndexOfAny(target0, target1);
+                    int idx = IndexOfAny(span, target0, target1);
                     Assert.Equal(targetIndex + 1, idx);
                 }
             }
@@ -566,7 +569,7 @@ namespace System.SpanTests
                 string target1 = rnd.Next(1, 256).ToString();
                 var span = new Span<string>(a);
 
-                int idx = span.IndexOfAny(target0, target1);
+                int idx = IndexOfAny(span, target0, target1);
                 Assert.Equal(-1, idx);
             }
         }
@@ -588,7 +591,7 @@ namespace System.SpanTests
                 a[length - 3] = "200";
 
                 var span = new Span<string>(a);
-                int idx = span.IndexOfAny("200", "200");
+                int idx = IndexOfAny(span, "200", "200");
                 Assert.Equal(length - 3, idx);
             }
         }
@@ -602,7 +605,7 @@ namespace System.SpanTests
                 a[0] = "99";
                 a[length + 1] = "98";
                 var span = new Span<string>(a, 1, length - 1);
-                int index = span.IndexOfAny("99", "98");
+                int index = IndexOfAny(span, "99", "98");
                 Assert.Equal(-1, index);
             }
 
@@ -612,7 +615,7 @@ namespace System.SpanTests
                 a[0] = "99";
                 a[length + 1] = "99";
                 var span = new Span<string>(a, 1, length - 1);
-                int index = span.IndexOfAny("99", "99");
+                int index = IndexOfAny(span, "99", "99");
                 Assert.Equal(-1, index);
             }
         }
@@ -621,7 +624,7 @@ namespace System.SpanTests
         public static void ZeroLengthIndexOf_ThreeString()
         {
             var sp = new Span<string>(Array.Empty<string>());
-            int idx = sp.IndexOfAny("0", "0", "0");
+            int idx = IndexOfAny(sp, "0", "0", "0");
             Assert.Equal(-1, idx);
         }
 
@@ -645,7 +648,7 @@ namespace System.SpanTests
                     string target0 = targets[index];
                     string target1 = targets[(index + 1) % 2];
                     string target2 = targets[(index + 1) % 3];
-                    int idx = span.IndexOfAny(target0, target1, target2);
+                    int idx = IndexOfAny(span, target0, target1, target2);
                     Assert.Equal(0, idx);
                 }
             }
@@ -670,7 +673,7 @@ namespace System.SpanTests
                     string target0 = a[targetIndex];
                     string target1 = "0";
                     string target2 = "0";
-                    int idx = span.IndexOfAny(target0, target1, target2);
+                    int idx = IndexOfAny(span, target0, target1, target2);
                     Assert.Equal(targetIndex, idx);
                 }
 
@@ -680,7 +683,7 @@ namespace System.SpanTests
                     string target0 = a[targetIndex + index];
                     string target1 = a[targetIndex + (index + 1) % 2];
                     string target2 = a[targetIndex + (index + 1) % 3];
-                    int idx = span.IndexOfAny(target0, target1, target2);
+                    int idx = IndexOfAny(span, target0, target1, target2);
                     Assert.Equal(targetIndex, idx);
                 }
 
@@ -689,7 +692,7 @@ namespace System.SpanTests
                     string target0 = "0";
                     string target1 = "0";
                     string target2 = a[targetIndex];
-                    int idx = span.IndexOfAny(target0, target1, target2);
+                    int idx = IndexOfAny(span, target0, target1, target2);
                     Assert.Equal(targetIndex, idx);
                 }
             }
@@ -707,7 +710,7 @@ namespace System.SpanTests
                 string target2 = rnd.Next(1, 256).ToString();
                 var span = new Span<string>(a);
 
-                int idx = span.IndexOfAny(target0, target1, target2);
+                int idx = IndexOfAny(span, target0, target1, target2);
                 Assert.Equal(-1, idx);
             }
         }
@@ -730,7 +733,7 @@ namespace System.SpanTests
                 a[length - 4] = "200";
 
                 var span = new Span<string>(a);
-                int idx = span.IndexOfAny("200", "200", "200");
+                int idx = IndexOfAny(span, "200", "200", "200");
                 Assert.Equal(length - 4, idx);
             }
         }
@@ -744,7 +747,7 @@ namespace System.SpanTests
                 a[0] = "99";
                 a[length + 1] = "98";
                 var span = new Span<string>(a, 1, length - 1);
-                int index = span.IndexOfAny("99", "98", "99");
+                int index = IndexOfAny(span, "99", "98", "99");
                 Assert.Equal(-1, index);
             }
 
@@ -754,7 +757,7 @@ namespace System.SpanTests
                 a[0] = "99";
                 a[length + 1] = "99";
                 var span = new Span<string>(a, 1, length - 1);
-                int index = span.IndexOfAny("99", "99", "99");
+                int index = IndexOfAny(span, "99", "99", "99");
                 Assert.Equal(-1, index);
             }
         }
@@ -764,11 +767,11 @@ namespace System.SpanTests
         {
             var sp = new Span<string>(Array.Empty<string>());
             var values = new ReadOnlySpan<string>(new string[] { "0", "0", "0", "0" });
-            int idx = sp.IndexOfAny(values);
+            int idx = IndexOfAny(sp, values);
             Assert.Equal(-1, idx);
 
             values = new ReadOnlySpan<string>(new string[] { });
-            idx = sp.IndexOfAny(values);
+            idx = IndexOfAny(sp, values);
             Assert.Equal(-1, idx);
         }
 
@@ -786,7 +789,7 @@ namespace System.SpanTests
 
                 for (int i = 0; i < length; i++)
                 {
-                    int idx = span.IndexOfAny(values);
+                    int idx = IndexOfAny(span, values);
                     Assert.Equal(0, idx);
                 }
             }
@@ -809,7 +812,7 @@ namespace System.SpanTests
                 for (int targetIndex = 0; targetIndex < length; targetIndex++)
                 {
                     var values = new ReadOnlySpan<string>(new string[] { a[targetIndex], "0", "0", "0" });
-                    int idx = span.IndexOfAny(values);
+                    int idx = IndexOfAny(span, values);
                     Assert.Equal(targetIndex, idx);
                 }
 
@@ -823,14 +826,14 @@ namespace System.SpanTests
                         a[targetIndex + (index + 1) % 3],
                         a[targetIndex + (index + 1) % 4]
                     });
-                    int idx = span.IndexOfAny(values);
+                    int idx = IndexOfAny(span, values);
                     Assert.Equal(targetIndex, idx);
                 }
 
                 for (int targetIndex = 0; targetIndex < length; targetIndex++)
                 {
                     var values = new ReadOnlySpan<string>(new string[] { "0", "0", "0", a[targetIndex] });
-                    int idx = span.IndexOfAny(values);
+                    int idx = IndexOfAny(span, values);
                     Assert.Equal(targetIndex, idx);
                 }
             }
@@ -867,7 +870,7 @@ namespace System.SpanTests
                 }
 
                 var values = new ReadOnlySpan<string>(targets);
-                int idx = span.IndexOfAny(values);
+                int idx = IndexOfAny(span, values);
                 Assert.Equal(expectedIndex, idx);
             }
         }
@@ -887,7 +890,7 @@ namespace System.SpanTests
                 var span = new Span<string>(a);
                 var values = new ReadOnlySpan<string>(targets);
 
-                int idx = span.IndexOfAny(values);
+                int idx = IndexOfAny(span, values);
                 Assert.Equal(-1, idx);
             }
         }
@@ -907,7 +910,7 @@ namespace System.SpanTests
                 var span = new Span<string>(a);
                 var values = new ReadOnlySpan<string>(targets);
 
-                int idx = span.IndexOfAny(values);
+                int idx = IndexOfAny(span, values);
                 Assert.Equal(-1, idx);
             }
         }
@@ -932,7 +935,7 @@ namespace System.SpanTests
 
                 var span = new Span<string>(a);
                 var values = new ReadOnlySpan<string>(new string[] { "200", "200", "200", "200", "200", "200", "200", "200", "200" });
-                int idx = span.IndexOfAny(values);
+                int idx = IndexOfAny(span, values);
                 Assert.Equal(length - 5, idx);
             }
         }
@@ -947,7 +950,7 @@ namespace System.SpanTests
                 a[length + 1] = "98";
                 var span = new Span<string>(a, 1, length - 1);
                 var values = new ReadOnlySpan<string>(new string[] { "99", "98", "99", "98", "99", "98" });
-                int index = span.IndexOfAny(values);
+                int index = IndexOfAny(span, values);
                 Assert.Equal(-1, index);
             }
 
@@ -958,7 +961,7 @@ namespace System.SpanTests
                 a[length + 1] = "99";
                 var span = new Span<string>(a, 1, length - 1);
                 var values = new ReadOnlySpan<string>(new string[] { "99", "99", "99", "99", "99", "99" });
-                int index = span.IndexOfAny(values);
+                int index = IndexOfAny(span, values);
                 Assert.Equal(-1, index);
             }
         }
@@ -968,20 +971,83 @@ namespace System.SpanTests
         public static void IndexOfAnyNullSequence_String(string[] spanInput, string[] searchInput, int expected)
         {
             Span<string> theStrings = spanInput;
-            Assert.Equal(expected, theStrings.IndexOfAny(searchInput));
-            Assert.Equal(expected, theStrings.IndexOfAny((ReadOnlySpan<string>)searchInput));
+            Assert.Equal(expected, IndexOfAny(theStrings, searchInput));
 
             if (searchInput != null)
             {
                 if (searchInput.Length >= 3)
                 {
-                    Assert.Equal(expected, theStrings.IndexOfAny(searchInput[0], searchInput[1], searchInput[2]));
+                    Assert.Equal(expected, IndexOfAny(theStrings, searchInput[0], searchInput[1], searchInput[2]));
                 }
 
                 if (searchInput.Length >= 2)
                 {
-                    Assert.Equal(expected, theStrings.IndexOfAny(searchInput[0], searchInput[1]));
+                    Assert.Equal(expected, IndexOfAny(theStrings, searchInput[0], searchInput[1]));
                 }
+            }
+        }
+
+        private static int IndexOf<T>(Span<T> span, T value) where T : IEquatable<T>?
+        {
+            int index = span.IndexOf(value);
+            Assert.Equal(index, ((ReadOnlySpan<T>)span).IndexOf(value));
+
+            Assert.Equal(index >= 0, span.Contains(value));
+            Assert.Equal(index >= 0, ((ReadOnlySpan<T>)span).Contains(value));
+
+            AssertSearchValues(span, new ReadOnlySpan<T>(value), index);
+            return index;
+        }
+
+        private static int IndexOfAny<T>(Span<T> span, T value0, T value1) where T : IEquatable<T>?
+        {
+            int index = span.IndexOfAny(value0, value1);
+            Assert.Equal(index, ((ReadOnlySpan<T>)span).IndexOfAny(value0, value1));
+
+            Assert.Equal(index >= 0, span.ContainsAny(value0, value1));
+            Assert.Equal(index >= 0, ((ReadOnlySpan<T>)span).ContainsAny(value0, value1));
+
+            AssertSearchValues<T>(span, new[] { value0, value1 }, index);
+            return index;
+        }
+
+        private static int IndexOfAny<T>(Span<T> span, T value0, T value1, T value2) where T : IEquatable<T>?
+        {
+            int index = span.IndexOfAny(value0, value1, value2);
+            Assert.Equal(index, ((ReadOnlySpan<T>)span).IndexOfAny(value0, value1, value2));
+
+            Assert.Equal(index >= 0, span.ContainsAny(value0, value1, value2));
+            Assert.Equal(index >= 0, ((ReadOnlySpan<T>)span).ContainsAny(value0, value1, value2));
+
+            AssertSearchValues<T>(span, new[] { value0, value1, value2 }, index);
+            return index;
+        }
+
+        private static int IndexOfAny<T>(Span<T> span, ReadOnlySpan<T> values) where T : IEquatable<T>?
+        {
+            int index = span.IndexOfAny(values);
+            Assert.Equal(index, ((ReadOnlySpan<T>)span).IndexOfAny(values));
+
+            Assert.Equal(index >= 0, span.ContainsAny(values));
+            Assert.Equal(index >= 0, ((ReadOnlySpan<T>)span).ContainsAny(values));
+
+            AssertSearchValues(span, values, index);
+            return index;
+        }
+
+        private static void AssertSearchValues<T>(Span<T> span, ReadOnlySpan<T> values, int expectedIndex) where T : IEquatable<T>?
+        {
+            if (typeof(T) == typeof(byte) || typeof(T) == typeof(char))
+            {
+                SearchValues<T> searchValuesInstance = (SearchValues<T>)(object)(typeof(T) == typeof(byte)
+                    ? SearchValues.Create(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values)), values.Length))
+                    : SearchValues.Create(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(values)), values.Length)));
+
+                Assert.Equal(expectedIndex, span.IndexOfAny(searchValuesInstance));
+                Assert.Equal(expectedIndex, ((ReadOnlySpan<T>)span).IndexOfAny(searchValuesInstance));
+
+                Assert.Equal(expectedIndex >= 0, span.ContainsAny(searchValuesInstance));
+                Assert.Equal(expectedIndex >= 0, ((ReadOnlySpan<T>)span).ContainsAny(searchValuesInstance));
             }
         }
     }

--- a/src/libraries/System.Memory/tests/Span/IndexOfAny.byte.cs
+++ b/src/libraries/System.Memory/tests/Span/IndexOfAny.byte.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Buffers;
 using System.Text;
 using Xunit;
 
@@ -60,7 +59,7 @@ namespace System.SpanTests
         {
             Span<byte> span = new Span<byte>(Array.Empty<byte>());
 
-            Assert.Equal(-1, IndexOfAny(span, 0, 0));
+            Assert.Equal(-1, IndexOfAny<byte>(span, 0, 0));
             Assert.Equal(-1, IndexOfAny(span, new byte[2]));
         }
 
@@ -163,7 +162,7 @@ namespace System.SpanTests
 
                 Span<byte> span = new Span<byte>(a);
 
-                Assert.Equal(length - 3, IndexOfAny(span, 200, 200));
+                Assert.Equal(length - 3, IndexOfAny<byte>(span, 200, 200));
                 Assert.Equal(length - 3, IndexOfAny(span, new byte[] { 200, 200 }));
             }
         }
@@ -178,7 +177,7 @@ namespace System.SpanTests
                 a[length + 1] = 98;
                 Span<byte> span = new Span<byte>(a, 1, length - 1);
 
-                Assert.Equal(-1, IndexOfAny(span, 99, 98));
+                Assert.Equal(-1, IndexOfAny<byte>(span, 99, 98));
                 Assert.Equal(-1, IndexOfAny(span, new byte[] { 99, 98 }));
             }
 
@@ -189,7 +188,7 @@ namespace System.SpanTests
                 a[length + 1] = 99;
                 Span<byte> span = new Span<byte>(a, 1, length - 1);
 
-                Assert.Equal(-1, IndexOfAny(span, 99, 99));
+                Assert.Equal(-1, IndexOfAny<byte>(span, 99, 99));
                 Assert.Equal(-1, IndexOfAny(span, new byte[] { 99, 99 }));
             }
         }
@@ -199,7 +198,7 @@ namespace System.SpanTests
         {
             Span<byte> span = new Span<byte>(Array.Empty<byte>());
 
-            Assert.Equal(-1, IndexOfAny(span, 0, 0, 0));
+            Assert.Equal(-1, IndexOfAny<byte>(span, 0, 0, 0));
             Assert.Equal(-1, IndexOfAny(span, new byte[3]));
         }
 
@@ -308,7 +307,7 @@ namespace System.SpanTests
 
                 Span<byte> span = new Span<byte>(a);
 
-                Assert.Equal(length - 4, IndexOfAny(span, 200, 200, 200));
+                Assert.Equal(length - 4, IndexOfAny<byte>(span, 200, 200, 200));
                 Assert.Equal(length - 4, IndexOfAny(span, new byte[] { 200, 200, 200 }));
             }
         }
@@ -323,7 +322,7 @@ namespace System.SpanTests
                 a[length + 1] = 98;
                 Span<byte> span = new Span<byte>(a, 1, length - 1);
 
-                Assert.Equal(-1, IndexOfAny(span, 99, 98, 99));
+                Assert.Equal(-1, IndexOfAny<byte>(span, 99, 98, 99));
                 Assert.Equal(-1, IndexOfAny(span, new byte[] { 99, 98, 99 }));
             }
 
@@ -334,7 +333,7 @@ namespace System.SpanTests
                 a[length + 1] = 99;
                 Span<byte> span = new Span<byte>(a, 1, length - 1);
 
-                Assert.Equal(-1, IndexOfAny(span, 99, 99, 99));
+                Assert.Equal(-1, IndexOfAny<byte>(span, 99, 99, 99));
                 Assert.Equal(-1, IndexOfAny(span, new byte[] { 99, 99, 99 }));
             }
         }
@@ -528,34 +527,6 @@ namespace System.SpanTests
                 int index = IndexOfAny(span, values);
                 Assert.Equal(-1, index);
             }
-        }
-
-        private static int IndexOf(Span<byte> span, byte value)
-        {
-            int index = span.IndexOf(value);
-            Assert.Equal(index, span.IndexOfAny(SearchValues.Create(stackalloc byte[] { value })));
-            return index;
-        }
-
-        private static int IndexOfAny(Span<byte> span, byte value0, byte value1)
-        {
-            int index = span.IndexOfAny(value0, value1);
-            Assert.Equal(index, span.IndexOfAny(SearchValues.Create(stackalloc byte[] { value0, value1 })));
-            return index;
-        }
-
-        private static int IndexOfAny(Span<byte> span, byte value0, byte value1, byte value2)
-        {
-            int index = span.IndexOfAny(value0, value1, value2);
-            Assert.Equal(index, span.IndexOfAny(SearchValues.Create(stackalloc byte[] { value0, value1, value2 })));
-            return index;
-        }
-
-        private static int IndexOfAny(Span<byte> span, ReadOnlySpan<byte> values)
-        {
-            int index = span.IndexOfAny(values);
-            Assert.Equal(index, span.IndexOfAny(SearchValues.Create(values)));
-            return index;
         }
     }
 }

--- a/src/libraries/System.Memory/tests/Span/IndexOfAny.char.cs
+++ b/src/libraries/System.Memory/tests/Span/IndexOfAny.char.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Buffers;
 using System.Linq;
 using System.Numerics;
 using Xunit;
@@ -771,34 +770,6 @@ namespace System.SpanTests
                 int index = IndexOfAny(span, values);
                 Assert.Equal(-1, index);
             }
-        }
-
-        private static int IndexOf(Span<char> span, char value)
-        {
-            int index = span.IndexOf(value);
-            Assert.Equal(index, span.IndexOfAny(SearchValues.Create(stackalloc char[] { value })));
-            return index;
-        }
-
-        private static int IndexOfAny(Span<char> span, char value0, char value1)
-        {
-            int index = span.IndexOfAny(value0, value1);
-            Assert.Equal(index, span.IndexOfAny(SearchValues.Create(stackalloc char[] { value0, value1 })));
-            return index;
-        }
-
-        private static int IndexOfAny(Span<char> span, char value0, char value1, char value2)
-        {
-            int index = span.IndexOfAny(value0, value1, value2);
-            Assert.Equal(index, span.IndexOfAny(SearchValues.Create(stackalloc char[] { value0, value1, value2 })));
-            return index;
-        }
-
-        private static int IndexOfAny(Span<char> span, ReadOnlySpan<char> values)
-        {
-            int index = span.IndexOfAny(values);
-            Assert.Equal(index, span.IndexOfAny(SearchValues.Create(values)));
-            return index;
         }
     }
 }

--- a/src/libraries/System.Memory/tests/Span/IndexOfAnyExcept.T.cs
+++ b/src/libraries/System.Memory/tests/Span/IndexOfAnyExcept.T.cs
@@ -183,8 +183,11 @@ namespace System.SpanTests
             Assert.Equal(result, MemoryExtensions.IndexOfAnyExcept((ReadOnlySpan<T>)span, value));
             Assert.Equal(result, MemoryExtensions.IndexOfAnyExcept((Span<T>)span, new[] { value }));
             Assert.Equal(result, MemoryExtensions.IndexOfAnyExcept((ReadOnlySpan<T>)span, new[] { value }));
-            if (typeof(T) == typeof(byte)) Assert.Equal(result, Cast<byte>(span).IndexOfAnyExcept(SearchValues.Create(Cast<byte>(new T[] { value }))));
-            if (typeof(T) == typeof(char)) Assert.Equal(result, Cast<char>(span).IndexOfAnyExcept(SearchValues.Create(Cast<char>(new T[] { value }))));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept(span, value));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept((ReadOnlySpan<T>)span, value));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept(span, new[] { value }));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept((ReadOnlySpan<T>)span, new[] { value }));
+            AssertSearchValues(span, new[] { value }, result, last: false);
             return result;
         }
         private static int IndexOfAnyExcept(Span<T> span, T value0, T value1)
@@ -193,8 +196,11 @@ namespace System.SpanTests
             Assert.Equal(result, MemoryExtensions.IndexOfAnyExcept((ReadOnlySpan<T>)span, value0, value1));
             Assert.Equal(result, MemoryExtensions.IndexOfAnyExcept((Span<T>)span, new[] { value0, value1 }));
             Assert.Equal(result, MemoryExtensions.IndexOfAnyExcept((ReadOnlySpan<T>)span, new[] { value0, value1 }));
-            if (typeof(T) == typeof(byte)) Assert.Equal(result, Cast<byte>(span).IndexOfAnyExcept(SearchValues.Create(Cast<byte>(new T[] { value0, value1 }))));
-            if (typeof(T) == typeof(char)) Assert.Equal(result, Cast<char>(span).IndexOfAnyExcept(SearchValues.Create(Cast<char>(new T[] { value0, value1 }))));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept(span, value0, value1));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept((ReadOnlySpan<T>)span, value0, value1));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept(span, new[] { value0, value1 }));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept((ReadOnlySpan<T>)span, new[] { value0, value1 }));
+            AssertSearchValues(span, new[] { value0, value1 }, result, last: false);
             return result;
         }
         private static int IndexOfAnyExcept(Span<T> span, T value0, T value1, T value2)
@@ -203,16 +209,20 @@ namespace System.SpanTests
             Assert.Equal(result, MemoryExtensions.IndexOfAnyExcept((ReadOnlySpan<T>)span, value0, value1, value2));
             Assert.Equal(result, MemoryExtensions.IndexOfAnyExcept((Span<T>)span, new[] { value0, value1, value2 }));
             Assert.Equal(result, MemoryExtensions.IndexOfAnyExcept((ReadOnlySpan<T>)span, new[] { value0, value1, value2 }));
-            if (typeof(T) == typeof(byte)) Assert.Equal(result, Cast<byte>(span).IndexOfAnyExcept(SearchValues.Create(Cast<byte>(new T[] { value0, value1, value2 }))));
-            if (typeof(T) == typeof(char)) Assert.Equal(result, Cast<char>(span).IndexOfAnyExcept(SearchValues.Create(Cast<char>(new T[] { value0, value1, value2 }))));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept(span, value0, value1, value2));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept((ReadOnlySpan<T>)span, value0, value1, value2));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept(span, new[] { value0, value1, value2 }));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept((ReadOnlySpan<T>)span, new[] { value0, value1, value2 }));
+            AssertSearchValues(span, new[] { value0, value1, value2 }, result, last: false);
             return result;
         }
         private static int IndexOfAnyExcept(Span<T> span, params T[] values)
         {
             int result = MemoryExtensions.IndexOfAnyExcept(span, values);
             Assert.Equal(result, MemoryExtensions.IndexOfAnyExcept((ReadOnlySpan<T>)span, values));
-            if (typeof(T) == typeof(byte)) Assert.Equal(result, Cast<byte>(span).IndexOfAnyExcept(SearchValues.Create(Cast<byte>(values))));
-            if (typeof(T) == typeof(char)) Assert.Equal(result, Cast<char>(span).IndexOfAnyExcept(SearchValues.Create(Cast<char>(values))));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept(span, values));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept((ReadOnlySpan<T>)span, values));
+            AssertSearchValues(span, values, result, last: false);
             return result;
         }
         private static int LastIndexOfAnyExcept(Span<T> span, T value)
@@ -221,8 +231,11 @@ namespace System.SpanTests
             Assert.Equal(result, MemoryExtensions.LastIndexOfAnyExcept((ReadOnlySpan<T>)span, value));
             Assert.Equal(result, MemoryExtensions.LastIndexOfAnyExcept((Span<T>)span, new[] { value }));
             Assert.Equal(result, MemoryExtensions.LastIndexOfAnyExcept((ReadOnlySpan<T>)span, new[] { value }));
-            if (typeof(T) == typeof(byte)) Assert.Equal(result, Cast<byte>(span).LastIndexOfAnyExcept(SearchValues.Create(Cast<byte>(new T[] { value }))));
-            if (typeof(T) == typeof(char)) Assert.Equal(result, Cast<char>(span).LastIndexOfAnyExcept(SearchValues.Create(Cast<char>(new T[] { value }))));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept(span, value));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept((ReadOnlySpan<T>)span, value));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept(span, new[] { value }));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept((ReadOnlySpan<T>)span, new[] { value }));
+            AssertSearchValues(span, new[] { value }, result, last: true);
             return result;
         }
         private static int LastIndexOfAnyExcept(Span<T> span, T value0, T value1)
@@ -231,8 +244,11 @@ namespace System.SpanTests
             Assert.Equal(result, MemoryExtensions.LastIndexOfAnyExcept((ReadOnlySpan<T>)span, value0, value1));
             Assert.Equal(result, MemoryExtensions.LastIndexOfAnyExcept((Span<T>)span, new[] { value0, value1 }));
             Assert.Equal(result, MemoryExtensions.LastIndexOfAnyExcept((ReadOnlySpan<T>)span, new[] { value0, value1 }));
-            if (typeof(T) == typeof(byte)) Assert.Equal(result, Cast<byte>(span).LastIndexOfAnyExcept(SearchValues.Create(Cast<byte>(new T[] { value0, value1 }))));
-            if (typeof(T) == typeof(char)) Assert.Equal(result, Cast<char>(span).LastIndexOfAnyExcept(SearchValues.Create(Cast<char>(new T[] { value0, value1 }))));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept(span, value0, value1));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept((ReadOnlySpan<T>)span, value0, value1));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept(span, new[] { value0, value1 }));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept((ReadOnlySpan<T>)span, new[] { value0, value1 }));
+            AssertSearchValues(span, new[] { value0, value1 }, result, last: true);
             return result;
         }
         private static int LastIndexOfAnyExcept(Span<T> span, T value0, T value1, T value2)
@@ -241,20 +257,45 @@ namespace System.SpanTests
             Assert.Equal(result, MemoryExtensions.LastIndexOfAnyExcept((ReadOnlySpan<T>)span, value0, value1, value2));
             Assert.Equal(result, MemoryExtensions.LastIndexOfAnyExcept((Span<T>)span, new[] { value0, value1, value2 }));
             Assert.Equal(result, MemoryExtensions.LastIndexOfAnyExcept((ReadOnlySpan<T>)span, new[] { value0, value1, value2 }));
-            if (typeof(T) == typeof(byte)) Assert.Equal(result, Cast<byte>(span).LastIndexOfAnyExcept(SearchValues.Create(Cast<byte>(new T[] { value0, value1, value2 }))));
-            if (typeof(T) == typeof(char)) Assert.Equal(result, Cast<char>(span).LastIndexOfAnyExcept(SearchValues.Create(Cast<char>(new T[] { value0, value1, value2 }))));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept(span, value0, value1, value2));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept((ReadOnlySpan<T>)span, value0, value1, value2));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept(span, new[] { value0, value1, value2 }));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept((ReadOnlySpan<T>)span, new[] { value0, value1, value2 }));
+            AssertSearchValues(span, new[] { value0, value1, value2 }, result, last: true);
             return result;
         }
         private static int LastIndexOfAnyExcept(Span<T> span, params T[] values)
         {
             int result = MemoryExtensions.LastIndexOfAnyExcept(span, values);
             Assert.Equal(result, MemoryExtensions.LastIndexOfAnyExcept((ReadOnlySpan<T>)span, values));
-            if (typeof(T) == typeof(byte)) Assert.Equal(result, Cast<byte>(span).LastIndexOfAnyExcept(SearchValues.Create(Cast<byte>(values))));
-            if (typeof(T) == typeof(char)) Assert.Equal(result, Cast<char>(span).LastIndexOfAnyExcept(SearchValues.Create(Cast<char>(values))));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept(span, values));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExcept((ReadOnlySpan<T>)span, values));
+            AssertSearchValues(span, values, result, last: true);
             return result;
         }
 
-        private static ReadOnlySpan<TTo> Cast<TTo>(ReadOnlySpan<T> span) =>
-            MemoryMarshal.CreateReadOnlySpan(ref Unsafe.As<T, TTo>(ref MemoryMarshal.GetReference(span)), span.Length);
+        private static void AssertSearchValues(Span<T> span, ReadOnlySpan<T> values, int expectedIndex, bool last)
+        {
+            if (typeof(T) == typeof(byte) || typeof(T) == typeof(char))
+            {
+                SearchValues<T> searchValuesInstance = (SearchValues<T>)(object)(typeof(T) == typeof(byte)
+                    ? SearchValues.Create(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values)), values.Length))
+                    : SearchValues.Create(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(values)), values.Length)));
+
+                if (last)
+                {
+                    Assert.Equal(expectedIndex, span.LastIndexOfAnyExcept(searchValuesInstance));
+                    Assert.Equal(expectedIndex, ((ReadOnlySpan<T>)span).LastIndexOfAnyExcept(searchValuesInstance));
+                }
+                else
+                {
+                    Assert.Equal(expectedIndex, span.IndexOfAnyExcept(searchValuesInstance));
+                    Assert.Equal(expectedIndex, ((ReadOnlySpan<T>)span).IndexOfAnyExcept(searchValuesInstance));
+                }
+
+                Assert.Equal(expectedIndex >= 0, span.ContainsAnyExcept(searchValuesInstance));
+                Assert.Equal(expectedIndex >= 0, ((ReadOnlySpan<T>)span).ContainsAnyExcept(searchValuesInstance));
+            }
+        }
     }
 }

--- a/src/libraries/System.Memory/tests/Span/IndexOfAnyInRange.cs
+++ b/src/libraries/System.Memory/tests/Span/IndexOfAnyInRange.cs
@@ -175,6 +175,8 @@ namespace System.SpanTests
         {
             int result = MemoryExtensions.IndexOfAnyInRange(span, lowInclusive, highInclusive);
             Assert.Equal(result, MemoryExtensions.IndexOfAnyInRange((ReadOnlySpan<T>)span, lowInclusive, highInclusive));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyInRange(span, lowInclusive, highInclusive));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyInRange((ReadOnlySpan<T>)span, lowInclusive, highInclusive));
             return result;
         }
 
@@ -182,6 +184,8 @@ namespace System.SpanTests
         {
             int result = MemoryExtensions.LastIndexOfAnyInRange(span, lowInclusive, highInclusive);
             Assert.Equal(result, MemoryExtensions.LastIndexOfAnyInRange((ReadOnlySpan<T>)span, lowInclusive, highInclusive));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyInRange(span, lowInclusive, highInclusive));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyInRange((ReadOnlySpan<T>)span, lowInclusive, highInclusive));
             return result;
         }
 
@@ -189,6 +193,8 @@ namespace System.SpanTests
         {
             int result = MemoryExtensions.IndexOfAnyExceptInRange(span, lowInclusive, highInclusive);
             Assert.Equal(result, MemoryExtensions.IndexOfAnyExceptInRange((ReadOnlySpan<T>)span, lowInclusive, highInclusive));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExceptInRange(span, lowInclusive, highInclusive));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExceptInRange((ReadOnlySpan<T>)span, lowInclusive, highInclusive));
             return result;
         }
 
@@ -196,6 +202,8 @@ namespace System.SpanTests
         {
             int result = MemoryExtensions.LastIndexOfAnyExceptInRange(span, lowInclusive, highInclusive);
             Assert.Equal(result, MemoryExtensions.LastIndexOfAnyExceptInRange((ReadOnlySpan<T>)span, lowInclusive, highInclusive));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExceptInRange(span, lowInclusive, highInclusive));
+            Assert.Equal(result >= 0, MemoryExtensions.ContainsAnyExceptInRange((ReadOnlySpan<T>)span, lowInclusive, highInclusive));
             return result;
         }
     }

--- a/src/libraries/System.Memory/tests/Span/SearchValues.cs
+++ b/src/libraries/System.Memory/tests/Span/SearchValues.cs
@@ -215,7 +215,8 @@ namespace System.SpanTests
             SearchValuesTestHelper.TestRandomInputs(
                 expected: IndexOfAnyReferenceImpl,
                 indexOfAny: (searchSpace, values) => searchSpace.IndexOfAny(values),
-                searchValues: (searchSpace, values) => searchSpace.IndexOfAny(values));
+                searchValues: (searchSpace, values) => searchSpace.IndexOfAny(values),
+                searchValuesContains: (searchSpace, values) => searchSpace.ContainsAny(values));
 
             static int IndexOfAnyReferenceImpl(ReadOnlySpan<byte> searchSpace, ReadOnlySpan<byte> values)
             {
@@ -238,7 +239,8 @@ namespace System.SpanTests
             SearchValuesTestHelper.TestRandomInputs(
                 expected: IndexOfAnyReferenceImpl,
                 indexOfAny: (searchSpace, values) => searchSpace.IndexOfAny(values),
-                searchValues: (searchSpace, values) => searchSpace.IndexOfAny(values));
+                searchValues: (searchSpace, values) => searchSpace.IndexOfAny(values),
+                searchValuesContains: (searchSpace, values) => searchSpace.ContainsAny(values));
 
             static int IndexOfAnyReferenceImpl(ReadOnlySpan<char> searchSpace, ReadOnlySpan<char> values)
             {
@@ -261,7 +263,8 @@ namespace System.SpanTests
             SearchValuesTestHelper.TestRandomInputs(
                 expected: LastIndexOfAnyReferenceImpl,
                 indexOfAny: (searchSpace, values) => searchSpace.LastIndexOfAny(values),
-                searchValues: (searchSpace, values) => searchSpace.LastIndexOfAny(values));
+                searchValues: (searchSpace, values) => searchSpace.LastIndexOfAny(values),
+                searchValuesContains: (searchSpace, values) => searchSpace.ContainsAny(values));
 
             static int LastIndexOfAnyReferenceImpl(ReadOnlySpan<byte> searchSpace, ReadOnlySpan<byte> values)
             {
@@ -284,7 +287,8 @@ namespace System.SpanTests
             SearchValuesTestHelper.TestRandomInputs(
                 expected: LastIndexOfAnyReferenceImpl,
                 indexOfAny: (searchSpace, values) => searchSpace.LastIndexOfAny(values),
-                searchValues: (searchSpace, values) => searchSpace.LastIndexOfAny(values));
+                searchValues: (searchSpace, values) => searchSpace.LastIndexOfAny(values),
+                searchValuesContains: (searchSpace, values) => searchSpace.ContainsAny(values));
 
             static int LastIndexOfAnyReferenceImpl(ReadOnlySpan<char> searchSpace, ReadOnlySpan<char> values)
             {
@@ -307,7 +311,8 @@ namespace System.SpanTests
             SearchValuesTestHelper.TestRandomInputs(
                 expected: IndexOfAnyExceptReferenceImpl,
                 indexOfAny: (searchSpace, values) => searchSpace.IndexOfAnyExcept(values),
-                searchValues: (searchSpace, values) => searchSpace.IndexOfAnyExcept(values));
+                searchValues: (searchSpace, values) => searchSpace.IndexOfAnyExcept(values),
+                searchValuesContains: (searchSpace, values) => searchSpace.ContainsAnyExcept(values));
 
             static int IndexOfAnyExceptReferenceImpl(ReadOnlySpan<byte> searchSpace, ReadOnlySpan<byte> values)
             {
@@ -330,7 +335,8 @@ namespace System.SpanTests
             SearchValuesTestHelper.TestRandomInputs(
                 expected: IndexOfAnyExceptReferenceImpl,
                 indexOfAny: (searchSpace, values) => searchSpace.IndexOfAnyExcept(values),
-                searchValues: (searchSpace, values) => searchSpace.IndexOfAnyExcept(values));
+                searchValues: (searchSpace, values) => searchSpace.IndexOfAnyExcept(values),
+                searchValuesContains: (searchSpace, values) => searchSpace.ContainsAnyExcept(values));
 
             static int IndexOfAnyExceptReferenceImpl(ReadOnlySpan<char> searchSpace, ReadOnlySpan<char> values)
             {
@@ -353,7 +359,8 @@ namespace System.SpanTests
             SearchValuesTestHelper.TestRandomInputs(
                 expected: LastIndexOfAnyExceptReferenceImpl,
                 indexOfAny: (searchSpace, values) => searchSpace.LastIndexOfAnyExcept(values),
-                searchValues: (searchSpace, values) => searchSpace.LastIndexOfAnyExcept(values));
+                searchValues: (searchSpace, values) => searchSpace.LastIndexOfAnyExcept(values),
+                searchValuesContains: (searchSpace, values) => searchSpace.ContainsAnyExcept(values));
 
             static int LastIndexOfAnyExceptReferenceImpl(ReadOnlySpan<byte> searchSpace, ReadOnlySpan<byte> values)
             {
@@ -376,7 +383,8 @@ namespace System.SpanTests
             SearchValuesTestHelper.TestRandomInputs(
                 expected: LastIndexOfAnyExceptReferenceImpl,
                 indexOfAny: (searchSpace, values) => searchSpace.LastIndexOfAnyExcept(values),
-                searchValues: (searchSpace, values) => searchSpace.LastIndexOfAnyExcept(values));
+                searchValues: (searchSpace, values) => searchSpace.LastIndexOfAnyExcept(values),
+                searchValuesContains: (searchSpace, values) => searchSpace.ContainsAnyExcept(values));
 
             static int LastIndexOfAnyExceptReferenceImpl(ReadOnlySpan<char> searchSpace, ReadOnlySpan<char> values)
             {
@@ -433,36 +441,47 @@ namespace System.SpanTests
 
             public delegate int SearchValuesSearchDelegate<T>(ReadOnlySpan<T> searchSpace, SearchValues<T> values) where T : IEquatable<T>?;
 
-            public static void TestRandomInputs(IndexOfAnySearchDelegate<byte> expected, IndexOfAnySearchDelegate<byte> indexOfAny, SearchValuesSearchDelegate<byte> searchValues)
+            public delegate bool SearchValuesContainsDelegate<T>(ReadOnlySpan<T> searchSpace, SearchValues<T> values) where T : IEquatable<T>?;
+
+            public static void TestRandomInputs(
+                IndexOfAnySearchDelegate<byte> expected,
+                IndexOfAnySearchDelegate<byte> indexOfAny,
+                SearchValuesSearchDelegate<byte> searchValues,
+                SearchValuesContainsDelegate<byte> searchValuesContains)
             {
                 var rng = new Random(42);
 
                 for (int iterations = 0; iterations < 1_000_000; iterations++)
                 {
                     // There are more interesting corner cases with ASCII needles, test those more.
-                    Test(rng, s_randomBytes, s_randomAsciiBytes, expected, indexOfAny, searchValues);
+                    Test(rng, s_randomBytes, s_randomAsciiBytes, expected, indexOfAny, searchValues, searchValuesContains);
 
-                    Test(rng, s_randomBytes, s_randomBytes, expected, indexOfAny, searchValues);
+                    Test(rng, s_randomBytes, s_randomBytes, expected, indexOfAny, searchValues, searchValuesContains);
                 }
             }
 
-            public static void TestRandomInputs(IndexOfAnySearchDelegate<char> expected, IndexOfAnySearchDelegate<char> indexOfAny, SearchValuesSearchDelegate<char> searchValues)
+            public static void TestRandomInputs(
+                IndexOfAnySearchDelegate<char> expected,
+                IndexOfAnySearchDelegate<char> indexOfAny,
+                SearchValuesSearchDelegate<char> searchValues,
+                SearchValuesContainsDelegate<char> searchValuesContains)
             {
                 var rng = new Random(42);
 
                 for (int iterations = 0; iterations < 1_000_000; iterations++)
                 {
                     // There are more interesting corner cases with ASCII needles, test those more.
-                    Test(rng, s_randomChars, s_randomAsciiChars, expected, indexOfAny, searchValues);
+                    Test(rng, s_randomChars, s_randomAsciiChars, expected, indexOfAny, searchValues, searchValuesContains);
 
-                    Test(rng, s_randomChars, s_randomLatin1Chars, expected, indexOfAny, searchValues);
+                    Test(rng, s_randomChars, s_randomLatin1Chars, expected, indexOfAny, searchValues, searchValuesContains);
 
-                    Test(rng, s_randomChars, s_randomChars, expected, indexOfAny, searchValues);
+                    Test(rng, s_randomChars, s_randomChars, expected, indexOfAny, searchValues, searchValuesContains);
                 }
             }
 
             private static void Test<T>(Random rng, ReadOnlySpan<T> haystackRandom, ReadOnlySpan<T> needleRandom,
-                IndexOfAnySearchDelegate<T> expected, IndexOfAnySearchDelegate<T> indexOfAny, SearchValuesSearchDelegate<T> searchValues)
+                IndexOfAnySearchDelegate<T> expected, IndexOfAnySearchDelegate<T> indexOfAny,
+                SearchValuesSearchDelegate<T> searchValues, SearchValuesContainsDelegate<T> searchValuesContains)
                 where T : struct, INumber<T>, IMinMaxValue<T>
             {
                 ReadOnlySpan<T> haystack = GetRandomSlice(rng, haystackRandom, MaxHaystackLength);
@@ -475,6 +494,7 @@ namespace System.SpanTests
                 int expectedIndex = expected(haystack, needle);
                 int indexOfAnyIndex = indexOfAny(haystack, needle);
                 int searchValuesIndex = searchValues(haystack, searchValuesInstance);
+                bool searchValuesContainsResult = searchValuesContains(haystack, searchValuesInstance);
 
                 if (expectedIndex != indexOfAnyIndex)
                 {
@@ -484,6 +504,11 @@ namespace System.SpanTests
                 if (expectedIndex != searchValuesIndex)
                 {
                     AssertionFailed(haystack, needle, expectedIndex, searchValuesIndex, nameof(searchValues));
+                }
+
+                if ((expectedIndex >= 0) != searchValuesContainsResult)
+                {
+                    AssertionFailed(haystack, needle, expectedIndex, searchValuesContainsResult ? 0 : -1, nameof(searchValuesContainsResult));
                 }
             }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/UriHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/UriHeaderParser.cs
@@ -64,7 +64,7 @@ namespace System.Net.Http.Headers
             {
                 int possibleUtf8Pos = input.AsSpan().IndexOfAnyExceptInRange((char)0, (char)127);
                 if (possibleUtf8Pos >= 0 &&
-                    input.AsSpan(possibleUtf8Pos).IndexOfAnyExceptInRange((char)0, (char)255) < 0)
+                    !input.AsSpan(possibleUtf8Pos).ContainsAnyExceptInRange((char)0, (char)255))
                 {
                     Span<byte> rawBytes = input.Length <= 256 ? stackalloc byte[input.Length] : new byte[input.Length];
                     for (int i = 0; i < input.Length; i++)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRuleParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRuleParser.cs
@@ -41,10 +41,10 @@ namespace System.Net.Http
         }
 
         internal static bool IsToken(ReadOnlySpan<char> input) =>
-            input.IndexOfAnyExcept(s_tokenChars) < 0;
+            !input.ContainsAnyExcept(s_tokenChars);
 
         internal static bool IsToken(ReadOnlySpan<byte> input) =>
-            input.IndexOfAnyExcept(s_tokenBytes) < 0;
+            !input.ContainsAnyExcept(s_tokenBytes);
 
         internal static string GetTokenString(ReadOnlySpan<byte> input)
         {
@@ -83,7 +83,7 @@ namespace System.Net.Http
         }
 
         internal static bool ContainsNewLine(string value, int startIndex = 0) =>
-            value.AsSpan(startIndex).IndexOfAny('\r', '\n') >= 0;
+            value.AsSpan(startIndex).ContainsAny('\r', '\n');
 
         internal static int GetNumberLength(string input, int startIndex, bool allowDecimal)
         {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/MultipartContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/MultipartContent.cs
@@ -82,7 +82,7 @@ namespace System.Net.Http
                 throw new ArgumentException(SR.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_headers_invalid_value, boundary), nameof(boundary));
             }
 
-            if (boundary.AsSpan().IndexOfAnyExcept(s_allowedBoundaryChars) >= 0)
+            if (boundary.AsSpan().ContainsAnyExcept(s_allowedBoundaryChars))
             {
                 throw new ArgumentException(SR.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_headers_invalid_value, boundary), nameof(boundary));
             }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpListenerRequest.Managed.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpListenerRequest.Managed.cs
@@ -84,7 +84,7 @@ namespace System.Net
             }
 
             _method = req[parts[0]];
-            if (_method.AsSpan().IndexOfAnyExcept(s_validMethodChars) >= 0)
+            if (_method.AsSpan().ContainsAnyExcept(s_validMethodChars))
             {
                 _context.ErrorMessage = "(Invalid verb)";
                 return;

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/Attachment.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/Attachment.cs
@@ -219,7 +219,7 @@ namespace System.Net.Mail
                 }
                 else
                 {
-                    if (value.AsSpan().IndexOfAny('<', '>') >= 0) // invalid chars
+                    if (value.AsSpan().ContainsAny('<', '>')) // invalid chars
                     {
                         throw new ArgumentException(SR.MailHeaderInvalidCID, nameof(value));
                     }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/MailBnfHelper.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/MailBnfHelper.cs
@@ -146,7 +146,7 @@ namespace System.Net.Mime
 
         internal static void ValidateHeaderName(string data)
         {
-            if (data.Length == 0 || data.AsSpan().IndexOfAnyExcept(s_charactersAllowedInHeaderNames) >= 0)
+            if (data.Length == 0 || data.AsSpan().ContainsAnyExcept(s_charactersAllowedInHeaderNames))
             {
                 throw new FormatException(SR.InvalidHeaderName);
             }
@@ -354,7 +354,7 @@ namespace System.Net.Mime
             c == Tab || c == Space || c == CR || c == LF;
 
         internal static bool HasCROrLF(string data) =>
-            data.AsSpan().IndexOfAny(CR, LF) >= 0;
+            data.AsSpan().ContainsAny(CR, LF);
 
         // Is there a FWS ("\r\n " or "\r\n\t") starting at the given index?
         internal static bool IsFWSAt(string data, int index)

--- a/src/libraries/System.Net.Mail/src/System/Net/Mime/MimeBasePart.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mime/MimeBasePart.cs
@@ -111,7 +111,7 @@ namespace System.Net.Mime
         {
             ArgumentNullException.ThrowIfNull(value);
 
-            return Ascii.IsValid(value) && (permitCROrLF || value.AsSpan().IndexOfAny('\r', '\n') < 0);
+            return Ascii.IsValid(value) && (permitCROrLF || !value.AsSpan().ContainsAny('\r', '\n'));
         }
 
         internal string? ContentID

--- a/src/libraries/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -242,7 +242,7 @@ namespace System.Net
                 || value.StartsWith('$')
                 || value.StartsWith(' ')
                 || value.EndsWith(' ')
-                || value.AsSpan().IndexOfAny(s_reservedToNameChars) >= 0)
+                || value.AsSpan().ContainsAny(s_reservedToNameChars))
             {
                 m_name = string.Empty;
                 return false;
@@ -350,7 +350,7 @@ namespace System.Net
                 m_name.StartsWith('$') ||
                 m_name.StartsWith(' ') ||
                 m_name.EndsWith(' ') ||
-                m_name.AsSpan().IndexOfAny(s_reservedToNameChars) >= 0)
+                m_name.AsSpan().ContainsAny(s_reservedToNameChars))
             {
                 if (shouldThrow)
                 {
@@ -361,7 +361,7 @@ namespace System.Net
 
             // Check the value
             if (m_value == null ||
-                (!(m_value.Length > 2 && m_value.StartsWith('\"') && m_value.EndsWith('\"')) && m_value.AsSpan().IndexOfAny(';', ',') >= 0))
+                (!(m_value.Length > 2 && m_value.StartsWith('\"') && m_value.EndsWith('\"')) && m_value.AsSpan().ContainsAny(';', ',')))
             {
                 if (shouldThrow)
                 {
@@ -372,7 +372,7 @@ namespace System.Net
 
             // Check Comment syntax
             if (Comment != null && !(Comment.Length > 2 && Comment.StartsWith('\"') && Comment.EndsWith('\"'))
-                && (Comment.AsSpan().IndexOfAny(';', ',') >= 0))
+                && (Comment.AsSpan().ContainsAny(';', ',')))
             {
                 if (shouldThrow)
                 {
@@ -383,7 +383,7 @@ namespace System.Net
 
             // Check Path syntax
             if (Path != null && !(Path.Length > 2 && Path.StartsWith('\"') && Path.EndsWith('\"'))
-                && (Path.AsSpan().IndexOfAny(';', ',') != -1))
+                && (Path.AsSpan().ContainsAny(';', ',')))
             {
                 if (shouldThrow)
                 {
@@ -565,7 +565,7 @@ namespace System.Net
         // as per RFC 952 (relaxed on first char could be a digit and string can have '_').
         private static bool DomainCharsTest(string name) =>
             !string.IsNullOrEmpty(name) &&
-            name.AsSpan().IndexOfAnyExcept(s_domainChars) < 0;
+            !name.AsSpan().ContainsAnyExcept(s_domainChars);
 
         [AllowNull]
         public string Port

--- a/src/libraries/System.Private.CoreLib/src/System/Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Byte.cs
@@ -303,7 +303,7 @@ namespace System
                     return false;
                 }
 
-                if ((source.Length > sizeof(byte)) && (source[..^sizeof(byte)].IndexOfAnyExcept((byte)0x00) >= 0))
+                if ((source.Length > sizeof(byte)) && (source[..^sizeof(byte)].ContainsAnyExcept((byte)0x00)))
                 {
                     // When we have any non-zero leading data, we are a large positive and therefore
                     // definitely out of range
@@ -336,7 +336,7 @@ namespace System
                     return false;
                 }
 
-                if ((source.Length > sizeof(byte)) && (source[sizeof(byte)..].IndexOfAnyExcept((byte)0x00) >= 0))
+                if ((source.Length > sizeof(byte)) && (source[sizeof(byte)..].ContainsAnyExcept((byte)0x00)))
                 {
                     // When we have any non-zero leading data, we are a large positive and therefore
                     // definitely out of range

--- a/src/libraries/System.Private.CoreLib/src/System/Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Char.cs
@@ -1197,7 +1197,7 @@ namespace System
                     return false;
                 }
 
-                if ((source.Length > sizeof(char)) && (source[..^sizeof(char)].IndexOfAnyExcept((byte)0x00) >= 0))
+                if ((source.Length > sizeof(char)) && (source[..^sizeof(char)].ContainsAnyExcept((byte)0x00)))
                 {
                     // When we have any non-zero leading data, we are a large positive and therefore
                     // definitely out of range
@@ -1247,7 +1247,7 @@ namespace System
                     return false;
                 }
 
-                if ((source.Length > sizeof(char)) && (source[sizeof(char)..].IndexOfAnyExcept((byte)0x00) >= 0))
+                if ((source.Length > sizeof(char)) && (source[sizeof(char)..].ContainsAnyExcept((byte)0x00)))
                 {
                     // When we have any non-zero leading data, we are a large positive and therefore
                     // definitely out of range

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
@@ -104,14 +104,14 @@ namespace System.Globalization
                 char* a = ap;
                 char* b = bp;
 
-                if (target.IndexOfAnyExcept(s_nonSpecialAsciiChars) >= 0)
+                if (target.ContainsAnyExcept(s_nonSpecialAsciiChars))
                 {
                     goto InteropCall;
                 }
 
                 if (target.Length > source.Length)
                 {
-                    if (source.IndexOfAnyExcept(s_nonSpecialAsciiChars) >= 0)
+                    if (source.ContainsAnyExcept(s_nonSpecialAsciiChars))
                     {
                         goto InteropCall;
                     }
@@ -214,14 +214,14 @@ namespace System.Globalization
                 char* a = ap;
                 char* b = bp;
 
-                if (target.IndexOfAnyExcept(s_nonSpecialAsciiChars) >= 0)
+                if (target.ContainsAnyExcept(s_nonSpecialAsciiChars))
                 {
                     goto InteropCall;
                 }
 
                 if (target.Length > source.Length)
                 {
-                    if (source.IndexOfAnyExcept(s_nonSpecialAsciiChars) >= 0)
+                    if (source.ContainsAnyExcept(s_nonSpecialAsciiChars))
                     {
                         goto InteropCall;
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -2112,7 +2112,7 @@ namespace System.Globalization
         private static int IndexOfTimePart(string format, int startIndex, string timeParts)
         {
             Debug.Assert(startIndex >= 0, "startIndex cannot be negative");
-            Debug.Assert(timeParts.AsSpan().IndexOfAny('\'', '\\') < 0, "timeParts cannot include quote characters");
+            Debug.Assert(!timeParts.AsSpan().ContainsAny('\'', '\\'), "timeParts cannot include quote characters");
             bool inQuote = false;
             for (int i = startIndex; i < format.Length; ++i)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
@@ -1225,7 +1225,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
             else if (ch == '\0')
             {
                 // Nulls are only valid if they are the only trailing character
-                if (str.Value.Slice(str.Index + 1).IndexOfAnyExcept('\0') >= 0)
+                if (str.Value.Slice(str.Index + 1).ContainsAnyExcept('\0'))
                 {
                     return false;
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -466,7 +466,7 @@ namespace System
             // We continue to support these but expect them to be incredibly rare.  As such, we
             // optimize for correctly formed strings where all the digits are valid hex, and only
             // fall back to supporting these other forms if parsing fails.
-            if (guidString.IndexOfAny('X', 'x', '+') >= 0 && TryCompatParsing(guidString, ref result))
+            if (guidString.ContainsAny('X', 'x', '+') && TryCompatParsing(guidString, ref result))
             {
                 return true;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Directory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Directory.cs
@@ -70,7 +70,7 @@ namespace System.IO
 
         private static void EnsureNoDirectorySeparators(string? value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
         {
-            if (value is not null && value.AsSpan().IndexOfAny(PathInternal.DirectorySeparators) >= 0)
+            if (value is not null && value.AsSpan().ContainsAny(PathInternal.DirectorySeparators))
             {
                 throw new ArgumentException(SR.Argument_DirectorySeparatorInvalid, paramName);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerableFactory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerableFactory.cs
@@ -74,7 +74,7 @@ namespace System.IO.Enumeration
                         // is the directory separator and cannot be part of any path segment in Windows). The other three are the
                         // special case wildcards that we'll convert some * and ? into. They're also valid as filenames on Unix,
                         // which is not true in Windows and as such we'll escape any that occur on the input string.
-                        if (Path.DirectorySeparatorChar != '\\' && expression.AsSpan().IndexOfAny(@"\""<>") >= 0)
+                        if (Path.DirectorySeparatorChar != '\\' && expression.AsSpan().ContainsAny(@"\""<>"))
                         {
                             // Backslash isn't the default separator, need to escape (e.g. Unix)
                             expression = expression.Replace("\\", "\\\\");

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemName.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemName.cs
@@ -152,9 +152,9 @@ namespace System.IO.Enumeration
 
                 // [MS - FSA] 2.1.4.4 Algorithm for Determining if a FileName Is in an Expression
                 // https://msdn.microsoft.com/en-us/library/ff469270.aspx
-                bool hasWildcards = (useExtendedWildcards ?
-                    expressionEnd.IndexOfAny("\"<>*?") :
-                    expressionEnd.IndexOfAny('*', '?')) >= 0;
+                bool hasWildcards = useExtendedWildcards ?
+                    expressionEnd.ContainsAny("\"<>*?") :
+                    expressionEnd.ContainsAny('*', '?');
                 if (!hasWildcards)
                 {
                     // Handle the special case of a single starting *, which essentially means "ends with"

--- a/src/libraries/System.Private.CoreLib/src/System/Int128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int128.cs
@@ -792,7 +792,7 @@ namespace System
 
                 if (source.Length > Size)
                 {
-                    if (source[..^Size].IndexOfAnyExcept((byte)sign) >= 0)
+                    if (source[..^Size].ContainsAnyExcept((byte)sign))
                     {
                         // When we are unsigned and have any non-zero leading data or signed with any non-set leading
                         // data, we are a large positive/negative, respectively, and therefore definitely out of range
@@ -874,7 +874,7 @@ namespace System
 
                 if (source.Length > Size)
                 {
-                    if (source[Size..].IndexOfAnyExcept((byte)sign) >= 0)
+                    if (source[Size..].ContainsAnyExcept((byte)sign))
                     {
                         // When we are unsigned and have any non-zero leading data or signed with any non-set leading
                         // data, we are a large positive/negative, respectively, and therefore definitely out of range

--- a/src/libraries/System.Private.CoreLib/src/System/Int16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int16.cs
@@ -316,7 +316,7 @@ namespace System
 
                 if (source.Length > sizeof(short))
                 {
-                    if (source[..^sizeof(short)].IndexOfAnyExcept((byte)sign) >= 0)
+                    if (source[..^sizeof(short)].ContainsAnyExcept((byte)sign))
                     {
                         // When we are unsigned and have any non-zero leading data or signed with any non-set leading
                         // data, we are a large positive/negative, respectively, and therefore definitely out of range
@@ -391,7 +391,7 @@ namespace System
 
                 if (source.Length > sizeof(short))
                 {
-                    if (source[sizeof(short)..].IndexOfAnyExcept((byte)sign) >= 0)
+                    if (source[sizeof(short)..].ContainsAnyExcept((byte)sign))
                     {
                         // When we are unsigned and have any non-zero leading data or signed with any non-set leading
                         // data, we are a large positive/negative, respectively, and therefore definitely out of range

--- a/src/libraries/System.Private.CoreLib/src/System/Int32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int32.cs
@@ -330,7 +330,7 @@ namespace System
 
                 if (source.Length > sizeof(int))
                 {
-                    if (source[..^sizeof(int)].IndexOfAnyExcept((byte)sign) >= 0)
+                    if (source[..^sizeof(int)].ContainsAnyExcept((byte)sign))
                     {
                         // When we are unsigned and have any non-zero leading data or signed with any non-set leading
                         // data, we are a large positive/negative, respectively, and therefore definitely out of range
@@ -412,7 +412,7 @@ namespace System
 
                 if (source.Length > sizeof(int))
                 {
-                    if (source[sizeof(int)..].IndexOfAnyExcept((byte)sign) >= 0)
+                    if (source[sizeof(int)..].ContainsAnyExcept((byte)sign))
                     {
                         // When we are unsigned and have any non-zero leading data or signed with any non-set leading
                         // data, we are a large positive/negative, respectively, and therefore definitely out of range

--- a/src/libraries/System.Private.CoreLib/src/System/Int64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int64.cs
@@ -327,7 +327,7 @@ namespace System
 
                 if (source.Length > sizeof(long))
                 {
-                    if (source[..^sizeof(long)].IndexOfAnyExcept((byte)sign) >= 0)
+                    if (source[..^sizeof(long)].ContainsAnyExcept((byte)sign))
                     {
                         // When we are unsigned and have any non-zero leading data or signed with any non-set leading
                         // data, we are a large positive/negative, respectively, and therefore definitely out of range
@@ -409,7 +409,7 @@ namespace System
 
                 if (source.Length > sizeof(long))
                 {
-                    if (source[sizeof(long)..].IndexOfAnyExcept((byte)sign) >= 0)
+                    if (source[sizeof(long)..].ContainsAnyExcept((byte)sign))
                     {
                         // When we are unsigned and have any non-zero leading data or signed with any non-set leading
                         // data, we are a large positive/negative, respectively, and therefore definitely out of range

--- a/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
@@ -334,7 +334,7 @@ namespace System
 
                 if (source.Length > sizeof(nint_t))
                 {
-                    if (source[..^sizeof(nint_t)].IndexOfAnyExcept((byte)sign) >= 0)
+                    if (source[..^sizeof(nint_t)].ContainsAnyExcept((byte)sign))
                     {
                         // When we are unsigned and have any non-zero leading data or signed with any non-set leading
                         // data, we are a large positive/negative, respectively, and therefore definitely out of range
@@ -416,7 +416,7 @@ namespace System
 
                 if (source.Length > sizeof(nint_t))
                 {
-                    if (source[sizeof(nint_t)..].IndexOfAnyExcept((byte)sign) >= 0)
+                    if (source[sizeof(nint_t)..].ContainsAnyExcept((byte)sign))
                     {
                         // When we are unsigned and have any non-zero leading data or signed with any non-set leading
                         // data, we are a large positive/negative, respectively, and therefore definitely out of range

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -313,12 +313,7 @@ namespace System
             return new ReadOnlyMemory<char>(text, start, length);
         }
 
-        /// <summary>
-        /// Searches for the specified value and returns true if found. If not found, returns false. Values are compared using IEquatable{T}.Equals(T).
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="span">The span to search.</param>
-        /// <param name="value">The value to search for.</param>
+        /// <inheritdoc cref="Contains{T}(ReadOnlySpan{T}, T)"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe bool Contains<T>(this Span<T> span, T value) where T : IEquatable<T>?
         {
@@ -400,6 +395,192 @@ namespace System
 
             return SpanHelpers.Contains(ref MemoryMarshal.GetReference(span), value, span.Length);
         }
+
+        /// <inheritdoc cref="ContainsAny{T}(ReadOnlySpan{T}, T, T)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool ContainsAny<T>(this Span<T> span, T value0, T value1) where T : IEquatable<T>? =>
+            ContainsAny((ReadOnlySpan<T>)span, value0, value1);
+
+        /// <inheritdoc cref="ContainsAny{T}(ReadOnlySpan{T}, T, T, T)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool ContainsAny<T>(this Span<T> span, T value0, T value1, T value2) where T : IEquatable<T>? =>
+            ContainsAny((ReadOnlySpan<T>)span, value0, value1, value2);
+
+        /// <inheritdoc cref="ContainsAny{T}(ReadOnlySpan{T}, ReadOnlySpan{T})"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool ContainsAny<T>(this Span<T> span, ReadOnlySpan<T> values) where T : IEquatable<T>? =>
+            ContainsAny((ReadOnlySpan<T>)span, values);
+
+        /// <inheritdoc cref="ContainsAny{T}(ReadOnlySpan{T}, SearchValues{T})"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool ContainsAny<T>(this Span<T> span, SearchValues<T> values) where T : IEquatable<T>? =>
+            ContainsAny((ReadOnlySpan<T>)span, values);
+
+        /// <inheritdoc cref="ContainsAnyExcept{T}(ReadOnlySpan{T}, T)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool ContainsAnyExcept<T>(this Span<T> span, T value) where T : IEquatable<T>? =>
+            ContainsAnyExcept((ReadOnlySpan<T>)span, value);
+
+        /// <inheritdoc cref="ContainsAnyExcept{T}(ReadOnlySpan{T}, T, T)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool ContainsAnyExcept<T>(this Span<T> span, T value0, T value1) where T : IEquatable<T>? =>
+            ContainsAnyExcept((ReadOnlySpan<T>)span, value0, value1);
+
+        /// <inheritdoc cref="ContainsAnyExcept{T}(ReadOnlySpan{T}, T, T, T)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool ContainsAnyExcept<T>(this Span<T> span, T value0, T value1, T value2) where T : IEquatable<T>? =>
+            ContainsAnyExcept((ReadOnlySpan<T>)span, value0, value1, value2);
+
+        /// <inheritdoc cref="ContainsAnyExcept{T}(ReadOnlySpan{T}, ReadOnlySpan{T})"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool ContainsAnyExcept<T>(this Span<T> span, ReadOnlySpan<T> values) where T : IEquatable<T>? =>
+            ContainsAnyExcept((ReadOnlySpan<T>)span, values);
+
+        /// <inheritdoc cref="ContainsAnyExcept{T}(ReadOnlySpan{T}, SearchValues{T})"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool ContainsAnyExcept<T>(this Span<T> span, SearchValues<T> values) where T : IEquatable<T>? =>
+            ContainsAnyExcept((ReadOnlySpan<T>)span, values);
+
+        /// <inheritdoc cref="ContainsAnyInRange{T}(ReadOnlySpan{T}, T, T)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool ContainsAnyInRange<T>(this Span<T> span, T lowInclusive, T highInclusive) where T : IComparable<T> =>
+            ContainsAnyInRange((ReadOnlySpan<T>)span, lowInclusive, highInclusive);
+
+        /// <inheritdoc cref="ContainsAnyExceptInRange{T}(ReadOnlySpan{T}, T, T)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool ContainsAnyExceptInRange<T>(this Span<T> span, T lowInclusive, T highInclusive) where T : IComparable<T> =>
+            ContainsAnyExceptInRange((ReadOnlySpan<T>)span, lowInclusive, highInclusive);
+
+        /// <summary>
+        /// Searches for any of the specified values and returns true if found. If not found, returns false.
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value0">One of the values to search for.</param>
+        /// <param name="value1">One of the values to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool ContainsAny<T>(this ReadOnlySpan<T> span, T value0, T value1) where T : IEquatable<T>? =>
+            IndexOfAny(span, value0, value1) >= 0;
+
+        /// <summary>
+        /// Searches for any of the specified values and returns true if found. If not found, returns false.
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value0">One of the values to search for.</param>
+        /// <param name="value1">One of the values to search for.</param>
+        /// <param name="value2">One of the values to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool ContainsAny<T>(this ReadOnlySpan<T> span, T value0, T value1, T value2) where T : IEquatable<T>? =>
+            IndexOfAny(span, value0, value1, value2) >= 0;
+
+        /// <summary>
+        /// Searches for any of the specified values and returns true if found. If not found, returns false.
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="values">The set of values to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool ContainsAny<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> values) where T : IEquatable<T>? =>
+            IndexOfAny(span, values) >= 0;
+
+        /// <summary>
+        /// Searches for any of the specified values and returns true if found. If not found, returns false.
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="values">The set of values to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool ContainsAny<T>(this ReadOnlySpan<T> span, SearchValues<T> values) where T : IEquatable<T>? =>
+            IndexOfAny(span, values) >= 0;
+
+        /// <summary>
+        /// Searches for any value other than the specified <paramref name="value"/>.
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value">A value to avoid.</param>
+        /// <returns>
+        /// True if any value other than <paramref name="value"/> is present in the span.
+        /// If all of the values are <paramref name="value"/>, returns false.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool ContainsAnyExcept<T>(this ReadOnlySpan<T> span, T value) where T : IEquatable<T>? =>
+            IndexOfAnyExcept(span, value) >= 0;
+
+        /// <summary>
+        /// Searches for any value other than the specified <paramref name="value0"/> or <paramref name="value1"/>.
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value0">A value to avoid.</param>
+        /// <param name="value1">A value to avoid.</param>
+        /// <returns>
+        /// True if any value other than <paramref name="value0"/> and <paramref name="value1"/> is present in the span.
+        /// If all of the values are <paramref name="value0"/> or <paramref name="value1"/>, returns false.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool ContainsAnyExcept<T>(this ReadOnlySpan<T> span, T value0, T value1) where T : IEquatable<T>? =>
+            IndexOfAnyExcept(span, value0, value1) >= 0;
+
+        /// <summary>
+        /// Searches for any value other than the specified <paramref name="value0"/>, <paramref name="value1"/>, or <paramref name="value2"/>.
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value0">A value to avoid.</param>
+        /// <param name="value1">A value to avoid.</param>
+        /// <param name="value2">A value to avoid.</param>
+        /// <returns>
+        /// True if any value other than <paramref name="value0"/>, <paramref name="value1"/>, and <paramref name="value2"/> is present in the span.
+        /// If all of the values are <paramref name="value0"/>, <paramref name="value1"/>, or <paramref name="value2"/>, returns false.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool ContainsAnyExcept<T>(this ReadOnlySpan<T> span, T value0, T value1, T value2) where T : IEquatable<T>? =>
+            IndexOfAnyExcept(span, value0, value1, value2) >= 0;
+
+        /// <summary>
+        /// Searches for any value other than the specified <paramref name="values"/>.
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="values">The values to avoid.</param>
+        /// <returns>
+        /// True if any value other than those in <paramref name="values"/> is present in the span.
+        /// If all of the values are in <paramref name="values"/>, returns false.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool ContainsAnyExcept<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> values) where T : IEquatable<T>? =>
+            IndexOfAnyExcept(span, values) >= 0;
+
+        /// <summary>
+        /// Searches for any value other than the specified <paramref name="values"/>.
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="values">The values to avoid.</param>
+        /// <returns>
+        /// True if any value other than those in <paramref name="values"/> is present in the span.
+        /// If all of the values are in <paramref name="values"/>, returns false.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool ContainsAnyExcept<T>(this ReadOnlySpan<T> span, SearchValues<T> values) where T : IEquatable<T>? =>
+            IndexOfAnyExcept(span, values) >= 0;
+
+        /// <summary>
+        /// Searches for any value in the range between <paramref name="lowInclusive"/> and <paramref name="highInclusive"/>, inclusive, and returns true if found. If not found, returns false.
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="lowInclusive">A lower bound, inclusive, of the range for which to search.</param>
+        /// <param name="highInclusive">A upper bound, inclusive, of the range for which to search.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool ContainsAnyInRange<T>(this ReadOnlySpan<T> span, T lowInclusive, T highInclusive) where T : IComparable<T> =>
+            IndexOfAnyInRange(span, lowInclusive, highInclusive) >= 0;
+
+        /// <summary>
+        /// Searches for any value outside of the range between <paramref name="lowInclusive"/> and <paramref name="highInclusive"/>, inclusive.
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="lowInclusive">A lower bound, inclusive, of the excluded range.</param>
+        /// <param name="highInclusive">A upper bound, inclusive, of the excluded range.</param>
+        /// <returns>
+        /// True if any value other than those in the specified range is present in the span.
+        /// If all of the values are inside of the specified range, returns false.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool ContainsAnyExceptInRange<T>(this ReadOnlySpan<T> span, T lowInclusive, T highInclusive) where T : IComparable<T> =>
+            IndexOfAnyExceptInRange(span, lowInclusive, highInclusive) >= 0;
 
         /// <summary>
         /// Searches for the specified value and returns the index of its first occurrence. If not found, returns -1. Values are compared using IEquatable{T}.Equals(T).
@@ -572,7 +753,7 @@ namespace System
         /// <param name="value2">A value to avoid</param>
         /// <returns>
         /// The index in the span of the first occurrence of any value other than <paramref name="value0"/>, <paramref name="value1"/>, and <paramref name="value2"/>.
-        /// If all of the values are <paramref name="value0"/>, <paramref name="value1"/>, and <paramref name="value2"/>, returns -1.
+        /// If all of the values are <paramref name="value0"/>, <paramref name="value1"/>, or <paramref name="value2"/>, returns -1.
         /// </returns>
         public static int IndexOfAnyExcept<T>(this Span<T> span, T value0, T value1, T value2) where T : IEquatable<T>? =>
             IndexOfAnyExcept((ReadOnlySpan<T>)span, value0, value1, value2);

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -452,7 +452,7 @@ namespace System
             ContainsAnyExceptInRange((ReadOnlySpan<T>)span, lowInclusive, highInclusive);
 
         /// <summary>
-        /// Searches for any of the specified values and returns true if found. If not found, returns false.
+        /// Searches for any occurance of the specified <paramref name="value0"/> or <paramref name="value1"/>, and returns true if found. If not found, returns false.
         /// </summary>
         /// <param name="span">The span to search.</param>
         /// <param name="value0">One of the values to search for.</param>
@@ -462,7 +462,7 @@ namespace System
             IndexOfAny(span, value0, value1) >= 0;
 
         /// <summary>
-        /// Searches for any of the specified values and returns true if found. If not found, returns false.
+        /// Searches for any occurance of the specified <paramref name="value0"/>, <paramref name="value1"/>, or <paramref name="value2"/>, and returns true if found. If not found, returns false.
         /// </summary>
         /// <param name="span">The span to search.</param>
         /// <param name="value0">One of the values to search for.</param>
@@ -473,7 +473,7 @@ namespace System
             IndexOfAny(span, value0, value1, value2) >= 0;
 
         /// <summary>
-        /// Searches for any of the specified values and returns true if found. If not found, returns false.
+        /// Searches for any occurance of any of the specified <paramref name="values"/> and returns true if found. If not found, returns false.
         /// </summary>
         /// <param name="span">The span to search.</param>
         /// <param name="values">The set of values to search for.</param>
@@ -482,7 +482,7 @@ namespace System
             IndexOfAny(span, values) >= 0;
 
         /// <summary>
-        /// Searches for any of the specified values and returns true if found. If not found, returns false.
+        /// Searches for any occurance of any of the specified <paramref name="values"/> and returns true if found. If not found, returns false.
         /// </summary>
         /// <param name="span">The span to search.</param>
         /// <param name="values">The set of values to search for.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Parsing.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Parsing.cs
@@ -1219,7 +1219,7 @@ namespace System
         [MethodImpl(MethodImplOptions.NoInlining)] // rare slow path that shouldn't impact perf of the main use case
         private static bool TrailingZeros(ReadOnlySpan<char> value, int index) =>
             // For compatibility, we need to allow trailing zeros at the end of a number string
-            value.Slice(index).IndexOfAnyExcept('\0') < 0;
+            !value.Slice(index).ContainsAnyExcept('\0');
 
         private static bool IsSpaceReplacingChar(char c) => c == '\u00a0' || c == '\u202f';
 

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyNameParser.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyNameParser.cs
@@ -90,7 +90,7 @@ namespace System.Reflection
             if (token != Token.String)
                 ThrowInvalidAssemblyName();
 
-            if (string.IsNullOrEmpty(name) || name.AsSpan().IndexOfAny('/', '\\', ':') != -1)
+            if (string.IsNullOrEmpty(name) || name.AsSpan().ContainsAny('/', '\\', ':'))
                 ThrowInvalidAssemblyName();
 
             Version? version = null;

--- a/src/libraries/System.Private.CoreLib/src/System/SByte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SByte.cs
@@ -319,7 +319,7 @@ namespace System
 
                 if (source.Length > sizeof(sbyte))
                 {
-                    if (source[..^sizeof(sbyte)].IndexOfAnyExcept((byte)sign) >= 0)
+                    if (source[..^sizeof(sbyte)].ContainsAnyExcept((byte)sign))
                     {
                         // When we are unsigned and have any non-zero leading data or signed with any non-set leading
                         // data, we are a large positive/negative, respectively, and therefore definitely out of range
@@ -372,7 +372,7 @@ namespace System
 
                 if (source.Length > sizeof(sbyte))
                 {
-                    if (source[sizeof(sbyte)..].IndexOfAnyExcept((byte)sign) >= 0)
+                    if (source[sizeof(sbyte)..].ContainsAnyExcept((byte)sign))
                     {
                         // When we are unsigned and have any non-zero leading data or signed with any non-set leading
                         // data, we are a large positive/negative, respectively, and therefore definitely out of range

--- a/src/libraries/System.Private.CoreLib/src/System/Security/SecurityElement.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Security/SecurityElement.cs
@@ -289,16 +289,16 @@ namespace System.Security
         }
 
         public static bool IsValidTag([NotNullWhen(true)] string? tag) =>
-            tag != null && tag.AsSpan().IndexOfAny(' ', '<', '>') < 0;
+            tag != null && !tag.AsSpan().ContainsAny(' ', '<', '>');
 
         public static bool IsValidText([NotNullWhen(true)] string? text) =>
-            text != null && text.AsSpan().IndexOfAny('<', '>') < 0;
+            text != null && !text.AsSpan().ContainsAny('<', '>');
 
         public static bool IsValidAttributeName([NotNullWhen(true)] string? name) =>
             IsValidTag(name);
 
         public static bool IsValidAttributeValue([NotNullWhen(true)] string? value) =>
-            value != null && value.AsSpan().IndexOfAny('<', '>', '\"') < 0;
+            value != null && !value.AsSpan().ContainsAny('<', '>', '\"');
 
         private static string GetEscapeSequence(char c)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.FullGlobalizationData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.FullGlobalizationData.cs
@@ -12,7 +12,7 @@ namespace System
             if (GlobalizationMode.Invariant ||
                 GlobalizationMode.UseNls ||
                 ianaId is null ||
-                ianaId.AsSpan().IndexOfAny('\\', '\n', '\r') >= 0) // ICU uses these characters as a separator
+                ianaId.AsSpan().ContainsAny('\\', '\n', '\r')) // ICU uses these characters as a separator
             {
                 windowsId = null;
                 return false;
@@ -46,7 +46,7 @@ namespace System
                 return true;
             }
 
-            if (windowsId.AsSpan().IndexOfAny('\\', '\n', '\r') >= 0) // ICU uses these characters as a separator
+            if (windowsId.AsSpan().ContainsAny('\\', '\n', '\r')) // ICU uses these characters as a separator
             {
                 ianaId = null;
                 return false;

--- a/src/libraries/System.Private.CoreLib/src/System/UInt128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt128.cs
@@ -842,7 +842,7 @@ namespace System
                     return false;
                 }
 
-                if ((source.Length > Size) && (source[..^Size].IndexOfAnyExcept((byte)0x00) >= 0))
+                if ((source.Length > Size) && (source[..^Size].ContainsAnyExcept((byte)0x00)))
                 {
                     // When we have any non-zero leading data, we are a large positive and therefore
                     // definitely out of range
@@ -899,7 +899,7 @@ namespace System
                     return false;
                 }
 
-                if ((source.Length > Size) && (source[Size..].IndexOfAnyExcept((byte)0x00) >= 0))
+                if ((source.Length > Size) && (source[Size..].ContainsAnyExcept((byte)0x00)))
                 {
                     // When we have any non-zero leading data, we are a large positive and therefore
                     // definitely out of range

--- a/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
@@ -300,7 +300,7 @@ namespace System
                     return false;
                 }
 
-                if ((source.Length > sizeof(ushort)) && (source[..^sizeof(ushort)].IndexOfAnyExcept((byte)0x00) >= 0))
+                if ((source.Length > sizeof(ushort)) && (source[..^sizeof(ushort)].ContainsAnyExcept((byte)0x00)))
                 {
                     // When we have any non-zero leading data, we are a large positive and therefore
                     // definitely out of range
@@ -350,7 +350,7 @@ namespace System
                     return false;
                 }
 
-                if ((source.Length > sizeof(ushort)) && (source[sizeof(ushort)..].IndexOfAnyExcept((byte)0x00) >= 0))
+                if ((source.Length > sizeof(ushort)) && (source[sizeof(ushort)..].ContainsAnyExcept((byte)0x00)))
                 {
                     // When we have any non-zero leading data, we are a large positive and therefore
                     // definitely out of range

--- a/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
@@ -315,7 +315,7 @@ namespace System
                     return false;
                 }
 
-                if ((source.Length > sizeof(uint)) && (source[..^sizeof(uint)].IndexOfAnyExcept((byte)0x00) >= 0))
+                if ((source.Length > sizeof(uint)) && (source[..^sizeof(uint)].ContainsAnyExcept((byte)0x00)))
                 {
                     // When we have any non-zero leading data, we are a large positive and therefore
                     // definitely out of range
@@ -372,7 +372,7 @@ namespace System
                     return false;
                 }
 
-                if ((source.Length > sizeof(uint)) && (source[sizeof(uint)..].IndexOfAnyExcept((byte)0x00) >= 0))
+                if ((source.Length > sizeof(uint)) && (source[sizeof(uint)..].ContainsAnyExcept((byte)0x00)))
                 {
                     // When we have any non-zero leading data, we are a large positive and therefore
                     // definitely out of range

--- a/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
@@ -314,7 +314,7 @@ namespace System
                     return false;
                 }
 
-                if ((source.Length > sizeof(ulong)) && (source[..^sizeof(ulong)].IndexOfAnyExcept((byte)0x00) >= 0))
+                if ((source.Length > sizeof(ulong)) && (source[..^sizeof(ulong)].ContainsAnyExcept((byte)0x00)))
                 {
                     // When we have any non-zero leading data, we are a large positive and therefore
                     // definitely out of range
@@ -371,7 +371,7 @@ namespace System
                     return false;
                 }
 
-                if ((source.Length > sizeof(ulong)) && (source[sizeof(ulong)..].IndexOfAnyExcept((byte)0x00) >= 0))
+                if ((source.Length > sizeof(ulong)) && (source[sizeof(ulong)..].ContainsAnyExcept((byte)0x00)))
                 {
                     // When we have any non-zero leading data, we are a large positive and therefore
                     // definitely out of range

--- a/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
@@ -320,7 +320,7 @@ namespace System
                     return false;
                 }
 
-                if ((source.Length > sizeof(nuint_t)) && (source[..^sizeof(nuint_t)].IndexOfAnyExcept((byte)0x00) >= 0))
+                if ((source.Length > sizeof(nuint_t)) && (source[..^sizeof(nuint_t)].ContainsAnyExcept((byte)0x00)))
                 {
                     // When we have any non-zero leading data, we are a large positive and therefore
                     // definitely out of range
@@ -377,7 +377,7 @@ namespace System
                     return false;
                 }
 
-                if ((source.Length > sizeof(nuint_t)) && (source[sizeof(nuint_t)..].IndexOfAnyExcept((byte)0x00) >= 0))
+                if ((source.Length > sizeof(nuint_t)) && (source[sizeof(nuint_t)..].ContainsAnyExcept((byte)0x00)))
                 {
                     // When we have any non-zero leading data, we are a large positive and therefore
                     // definitely out of range

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonObjectDataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonObjectDataContract.cs
@@ -70,7 +70,7 @@ namespace System.Runtime.Serialization.Json
                 throw new XmlException(SR.Format(SR.XmlInvalidConversion, value, Globals.TypeOfInt));
             }
 
-            if (value.AsSpan().IndexOfAny('.', 'e', 'E') < 0)
+            if (!value.AsSpan().ContainsAny('.', 'e', 'E'))
             {
                 int intValue;
                 if (int.TryParse(value, NumberStyles.Float, NumberFormatInfo.InvariantInfo, out intValue))

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBaseWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBaseWriter.cs
@@ -962,7 +962,7 @@ namespace System.Xml
 
             ArgumentNullException.ThrowIfNull(whitespace);
 
-            if (whitespace.AsSpan().IndexOfAnyExcept(" \t\r\n") >= 0)
+            if (whitespace.AsSpan().ContainsAnyExcept(" \t\r\n"))
             {
                 throw new ArgumentException(SR.XmlOnlyWhitespace, nameof(whitespace));
             }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlConverter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlConverter.cs
@@ -1085,10 +1085,10 @@ namespace System.Xml
         }
 
         public static bool IsWhitespace(ReadOnlySpan<char> chars) =>
-            chars.IndexOfAnyExcept(s_whitespaceChars) < 0;
+            !chars.ContainsAnyExcept(s_whitespaceChars);
 
         public static bool IsWhitespace(ReadOnlySpan<byte> bytes) =>
-            bytes.IndexOfAnyExcept(s_whitespaceBytes) < 0;
+            !bytes.ContainsAnyExcept(s_whitespaceBytes);
 
         public static bool IsWhitespace(char ch) =>
             ch is <= ' ' and (' ' or '\t' or '\r' or '\n');

--- a/src/libraries/System.Private.Uri/src/System/DomainNameHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/DomainNameHelper.cs
@@ -150,7 +150,7 @@ namespace System
                     {
                         // s_iriInvalidAsciiChars confirmed everything in [0, 7F] range.
                         // Chars in [80, 9F] range are also invalid, check for them now.
-                        if (hostname.IndexOfAnyInRange('\u0080', '\u009F') >= 0)
+                        if (hostname.ContainsAnyInRange('\u0080', '\u009F'))
                         {
                             return false;
                         }
@@ -206,7 +206,7 @@ namespace System
             try
             {
                 string asciiForm = s_idnMapping.GetAscii(bidiStrippedHost);
-                if (asciiForm.AsSpan().IndexOfAny(s_unsafeForNormalizedHostChars) >= 0)
+                if (asciiForm.AsSpan().ContainsAny(s_unsafeForNormalizedHostChars))
                 {
                     throw new UriFormatException(SR.net_uri_BadUnicodeHostForIdn);
                 }

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -1472,7 +1472,7 @@ namespace System
         public static bool CheckSchemeName([NotNullWhen(true)] string? schemeName) =>
             !string.IsNullOrEmpty(schemeName) &&
             char.IsAsciiLetter(schemeName[0]) &&
-            schemeName.AsSpan().IndexOfAnyExcept(s_schemeChars) < 0;
+            !schemeName.AsSpan().ContainsAnyExcept(s_schemeChars);
 
         //
         // IsHexDigit
@@ -3972,7 +3972,7 @@ namespace System
                 flags |= Flags.DnsHostType;
 
                 // Canonical DNS hostnames don't contain uppercase letters
-                if (new ReadOnlySpan<char>(pString + start, domainNameLength).IndexOfAnyInRange('A', 'Z') < 0)
+                if (!new ReadOnlySpan<char>(pString + start, domainNameLength).ContainsAnyInRange('A', 'Z'))
                 {
                     flags |= Flags.CanonicalDnsHost;
                 }

--- a/src/libraries/System.Private.Uri/src/System/UriBuilder.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriBuilder.cs
@@ -262,7 +262,7 @@ namespace System
 
         private static string EncodeUserInfo(string input)
         {
-            if (input.AsSpan().IndexOfAny(s_userInfoReservedChars) < 0)
+            if (!input.AsSpan().ContainsAny(s_userInfoReservedChars))
             {
                 return input;
             }

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XDocument.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XDocument.cs
@@ -936,7 +936,7 @@ namespace System.Xml.Linq
 
         internal override void ValidateString(string s)
         {
-            if (s.AsSpan().IndexOfAnyExcept(" \t\r\n") >= 0)
+            if (s.AsSpan().ContainsAnyExcept(" \t\r\n"))
             {
                 throw new ArgumentException(SR.Argument_AddNonWhitespace);
             }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriter.cs
@@ -411,7 +411,7 @@ namespace System.Xml.Serialization
 #if DEBUG
                 const string escapeChars = "<>\"'&";
                 ReadOnlySpan<char> span = _primitivesBuffer;
-                Debug.Assert(span.Slice(0, charsWritten).IndexOfAny(escapeChars) == -1, "Primitive value contains illegal xml char.");
+                Debug.Assert(!span.Slice(0, charsWritten).ContainsAny(escapeChars), "Primitive value contains illegal xml char.");
 #endif
                 //all the primitive types except string and XmlQualifiedName writes to the buffer
                 _w.WriteRaw(_primitivesBuffer, 0, charsWritten);

--- a/src/libraries/System.Private.Xml/src/System/Xml/XmlCharType.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XmlCharType.cs
@@ -169,7 +169,7 @@ namespace System.Xml
             Debug.Assert(startPos <= str.Length);
             Debug.Assert(startPos + len <= str.Length);
 
-            return str.AsSpan(startPos, len).IndexOfAnyExceptInRange('0', '9') < 0;
+            return !str.AsSpan(startPos, len).ContainsAnyExceptInRange('0', '9');
         }
 
         internal static int IsPublicId(string str) =>

--- a/src/libraries/System.Private.Xml/src/System/Xml/XmlConvert.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XmlConvert.cs
@@ -33,7 +33,7 @@ namespace System.Xml
     /// </devdoc>
     public partial class XmlConvert
     {
-        internal static char[] crt = new char[] { '\n', '\r', '\t' };
+        private const string Crt = "\t\n\r";
 
         /// <devdoc>
         ///    <para>
@@ -408,7 +408,7 @@ namespace System.Xml
 
             if (token.StartsWith(' ') ||
                 token.EndsWith(' ') ||
-                token.IndexOfAny(crt) >= 0 ||
+                token.AsSpan().ContainsAny(Crt) ||
                 token.Contains("  "))
             {
                 throw new XmlException(SR.Sch_NotTokenString, token);
@@ -425,7 +425,7 @@ namespace System.Xml
 
             if (token.StartsWith(' ') ||
                 token.EndsWith(' ') ||
-                token.IndexOfAny(crt) >= 0 ||
+                token.AsSpan().ContainsAny(Crt) ||
                 token.Contains("  "))
             {
                 return new XmlException(SR.Sch_NotTokenString, token);
@@ -480,7 +480,7 @@ namespace System.Xml
 
         internal static Exception? TryVerifyNormalizedString(string str)
         {
-            if (str.IndexOfAny(crt) != -1)
+            if (str.AsSpan().ContainsAny(Crt))
             {
                 return new XmlSchemaException(SR.Sch_NotNormalizedString, str);
             }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/QilGenerator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/QilGenerator.cs
@@ -1061,7 +1061,7 @@ namespace System.Xml.Xsl.Xslt
             {
                 return null;
             }
-            if (avt.AsSpan().IndexOfAny('{', '}') < 0)
+            if (!avt.AsSpan().ContainsAny('{', '}'))
             {
                 return _f.String(avt);
             }
@@ -1071,7 +1071,7 @@ namespace System.Xml.Xsl.Xslt
         private QilNode CompileTextAvt(string avt)
         {
             Debug.Assert(avt != null);
-            if (avt.AsSpan().IndexOfAny('{', '}') < 0)
+            if (!avt.AsSpan().ContainsAny('{', '}'))
             {
                 return _f.TextCtor(_f.String(avt));
             }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Base64Transforms.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Base64Transforms.cs
@@ -240,7 +240,7 @@ namespace System.Security.Cryptography
 
             if (_whitespaces == FromBase64TransformMode.DoNotIgnoreWhiteSpaces)
             {
-                if (inputBuffer.IndexOfAny(s_whiteSpace) >= 0)
+                if (inputBuffer.ContainsAny(s_whiteSpace))
                 {
                     ThrowHelper.ThrowBase64FormatException();
                 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SymmetricPadding.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SymmetricPadding.cs
@@ -164,7 +164,7 @@ namespace System.Security.Cryptography
                     }
 
                     // Verify that all the padding bytes are 0s
-                    if (block.Slice(block.Length - padBytes, padBytes - 1).IndexOfAnyExcept((byte)0) >= 0)
+                    if (block.Slice(block.Length - padBytes, padBytes - 1).ContainsAnyExcept((byte)0))
                     {
                         throw new CryptographicException(SR.Cryptography_InvalidPadding);
                     }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500NameEncoder.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500NameEncoder.cs
@@ -125,7 +125,7 @@ namespace System.Security.Cryptography.X509Certificates
             rdnValue.IsEmpty ||
             IsQuotableWhitespace(rdnValue[0]) ||
             IsQuotableWhitespace(rdnValue[^1]) ||
-            rdnValue.IndexOfAny(s_needsQuotingChars) >= 0;
+            rdnValue.ContainsAny(s_needsQuotingChars);
 
         private static bool IsQuotableWhitespace(char c)
         {

--- a/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
@@ -291,7 +291,7 @@ namespace System.ServiceProcess
         internal static bool ValidServiceName(string serviceName) =>
             !string.IsNullOrEmpty(serviceName) &&
             serviceName.Length <= ServiceBase.MaxNameLength && // not too long
-            !serviceName.AsSpan().ContainsAny('\\', '/'); // no slashes or backslash allowed
+            serviceName.AsSpan().IndexOfAny('\\', '/') < 0; // no slashes or backslash allowed
 
         /// <summary>
         ///    <para>Disposes of the resources (other than memory ) used by

--- a/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
@@ -291,7 +291,7 @@ namespace System.ServiceProcess
         internal static bool ValidServiceName(string serviceName) =>
             !string.IsNullOrEmpty(serviceName) &&
             serviceName.Length <= ServiceBase.MaxNameLength && // not too long
-            serviceName.AsSpan().IndexOfAny('\\', '/') < 0; // no slashes or backslash allowed
+            !serviceName.AsSpan().ContainsAny('\\', '/'); // no slashes or backslash allowed
 
         /// <summary>
         ///    <para>Disposes of the resources (other than memory ) used by

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.cs
@@ -14,11 +14,13 @@ namespace System.Text.Json
         private const string SpecialCharacters = ". '/\"[]()\t\n\r\f\b\\\u0085\u2028\u2029";
 #if NET8_0_OR_GREATER
         private static readonly SearchValues<char> s_specialCharacters = SearchValues.Create(SpecialCharacters);
+
+        public static bool ContainsSpecialCharacters(this ReadOnlySpan<char> text) =>
+            text.ContainsAny(s_specialCharacters);
 #else
-        private static ReadOnlySpan<char> s_specialCharacters => SpecialCharacters.AsSpan();
+        public static bool ContainsSpecialCharacters(this ReadOnlySpan<char> text) =>
+            text.IndexOfAny(SpecialCharacters.AsSpan()) >= 0;
 #endif
-        public static bool ContainsSpecialCharacters(this ReadOnlySpan<char> text)
-            => text.IndexOfAny(s_specialCharacters) >= 0;
 
         public static (int, int) CountNewLines(ReadOnlySpan<byte> data)
         {

--- a/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
@@ -157,7 +157,7 @@ public class TestFilter
 
         if (filterString is not null)
         {
-            if (filterString.ContainsAny("!()~="))
+            if (filterString.IndexOfAny(new[] { '!', '(', ')', '~', '=' }) != -1)
             {
                 throw new ArgumentException("Complex test filter expressions are not supported today. The only filters supported today are the simple form supported in 'dotnet test --filter' (substrings of the test's fully qualified name). If further filtering options are desired, file an issue on dotnet/runtime for support.", nameof(filterArgs));
             }

--- a/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
@@ -157,7 +157,7 @@ public class TestFilter
 
         if (filterString is not null)
         {
-            if (filterString.IndexOfAny(new[] { '!', '(', ')', '~', '=' }) != -1)
+            if (filterString.ContainsAny("!()~="))
             {
                 throw new ArgumentException("Complex test filter expressions are not supported today. The only filters supported today are the simple form supported in 'dotnet test --filter' (substrings of the test's fully qualified name). If further filtering options are desired, file an issue on dotnet/runtime for support.", nameof(filterArgs));
             }


### PR DESCRIPTION
Contributes to #86528 (`SearchValues<string>` and `-WhiteSpace` overloads remain as not yet implemented)

This PR adds `ContainsAny` as a helper around `IndexOfAny >= 0`.
I left out potential optimizations (e.g. dedicated `Contains` paths for `SearchValues`) for future PRs.
