### PR TITLE
Faster optimized frozen dictionary creation (2/n)

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenDictionary.cs
@@ -229,15 +229,15 @@ namespace System.Collections.Frozen
             if (typeof(TKey) == typeof(string) &&
                 (ReferenceEquals(comparer, EqualityComparer<TKey>.Default) || ReferenceEquals(comparer, StringComparer.Ordinal) || ReferenceEquals(comparer, StringComparer.OrdinalIgnoreCase)))
             {
-                Dictionary<string, TValue> stringEntries = (Dictionary<string, TValue>)(object)source;
                 IEqualityComparer<string> stringComparer = (IEqualityComparer<string>)(object)comparer;
 
-                // this array is needed for every strategy
-                string[] entries = (string[])(object)source.Keys.ToArray();
+                // keys and values are needed for every strategy
+                string[] keys = (string[])(object)source.Keys.ToArray();
+                TValue[] values = source.Values.ToArray();
 
                 // Calculate the minimum and maximum lengths of the strings in the dictionary. Several of the analyses need this.
                 int minLength = int.MaxValue, maxLength = 0;
-                foreach (string key in entries)
+                foreach (string key in keys)
                 {
                     if (key.Length < minLength) minLength = key.Length;
                     if (key.Length > maxLength) maxLength = key.Length;
@@ -245,14 +245,14 @@ namespace System.Collections.Frozen
                 Debug.Assert(minLength >= 0 && maxLength >= minLength);
 
                 // Try to create an implementation that uses length buckets, where each bucket contains up to only a few strings of the same length.
-                FrozenDictionary<string, TValue>? frozenDictionary = LengthBucketsFrozenDictionary<TValue>.CreateLengthBucketsFrozenDictionaryIfAppropriate(stringEntries, stringComparer, minLength, maxLength, entries);
+                FrozenDictionary<string, TValue>? frozenDictionary = LengthBucketsFrozenDictionary<TValue>.CreateLengthBucketsFrozenDictionaryIfAppropriate(keys, values, stringComparer, minLength, maxLength);
                 if (frozenDictionary is not null)
                 {
                     return (FrozenDictionary<TKey, TValue>)(object)frozenDictionary;
                 }
 
                 // Analyze the keys for unique substrings and create an implementation that minimizes the cost of hashing keys.
-                KeyAnalyzer.AnalysisResults analysis = KeyAnalyzer.Analyze(entries, ReferenceEquals(stringComparer, StringComparer.OrdinalIgnoreCase), minLength, maxLength);
+                KeyAnalyzer.AnalysisResults analysis = KeyAnalyzer.Analyze(keys, ReferenceEquals(stringComparer, StringComparer.OrdinalIgnoreCase), minLength, maxLength);
                 if (analysis.SubstringHashing)
                 {
                     if (analysis.RightJustifiedSubstring)
@@ -260,14 +260,14 @@ namespace System.Collections.Frozen
                         if (analysis.IgnoreCase)
                         {
                             frozenDictionary = analysis.AllAsciiIfIgnoreCase
-                                ? new OrdinalStringFrozenDictionary_RightJustifiedCaseInsensitiveAsciiSubstring<TValue>(stringEntries, entries, stringComparer, analysis.MinimumLength, analysis.MaximumLengthDiff, analysis.HashIndex, analysis.HashCount)
-                                : new OrdinalStringFrozenDictionary_RightJustifiedCaseInsensitiveSubstring<TValue>(stringEntries, entries, stringComparer, analysis.MinimumLength, analysis.MaximumLengthDiff, analysis.HashIndex, analysis.HashCount);
+                                ? new OrdinalStringFrozenDictionary_RightJustifiedCaseInsensitiveAsciiSubstring<TValue>(keys, values, stringComparer, analysis.MinimumLength, analysis.MaximumLengthDiff, analysis.HashIndex, analysis.HashCount)
+                                : new OrdinalStringFrozenDictionary_RightJustifiedCaseInsensitiveSubstring<TValue>(keys, values, stringComparer, analysis.MinimumLength, analysis.MaximumLengthDiff, analysis.HashIndex, analysis.HashCount);
                         }
                         else
                         {
                             frozenDictionary = analysis.HashCount == 1
-                                ? new OrdinalStringFrozenDictionary_RightJustifiedSingleChar<TValue>(stringEntries, entries, stringComparer, analysis.MinimumLength, analysis.MaximumLengthDiff, analysis.HashIndex)
-                                : new OrdinalStringFrozenDictionary_RightJustifiedSubstring<TValue>(stringEntries, entries, stringComparer, analysis.MinimumLength, analysis.MaximumLengthDiff, analysis.HashIndex, analysis.HashCount);
+                                ? new OrdinalStringFrozenDictionary_RightJustifiedSingleChar<TValue>(keys, values, stringComparer, analysis.MinimumLength, analysis.MaximumLengthDiff, analysis.HashIndex)
+                                : new OrdinalStringFrozenDictionary_RightJustifiedSubstring<TValue>(keys, values, stringComparer, analysis.MinimumLength, analysis.MaximumLengthDiff, analysis.HashIndex, analysis.HashCount);
                         }
                     }
                     else
@@ -275,14 +275,14 @@ namespace System.Collections.Frozen
                         if (analysis.IgnoreCase)
                         {
                             frozenDictionary = analysis.AllAsciiIfIgnoreCase
-                                ? new OrdinalStringFrozenDictionary_LeftJustifiedCaseInsensitiveAsciiSubstring<TValue>(stringEntries, entries, stringComparer, analysis.MinimumLength, analysis.MaximumLengthDiff, analysis.HashIndex, analysis.HashCount)
-                                : new OrdinalStringFrozenDictionary_LeftJustifiedCaseInsensitiveSubstring<TValue>(stringEntries, entries, stringComparer, analysis.MinimumLength, analysis.MaximumLengthDiff, analysis.HashIndex, analysis.HashCount);
+                                ? new OrdinalStringFrozenDictionary_LeftJustifiedCaseInsensitiveAsciiSubstring<TValue>(keys, values, stringComparer, analysis.MinimumLength, analysis.MaximumLengthDiff, analysis.HashIndex, analysis.HashCount)
+                                : new OrdinalStringFrozenDictionary_LeftJustifiedCaseInsensitiveSubstring<TValue>(keys, values, stringComparer, analysis.MinimumLength, analysis.MaximumLengthDiff, analysis.HashIndex, analysis.HashCount);
                         }
                         else
                         {
                             frozenDictionary = analysis.HashCount == 1
-                                ? new OrdinalStringFrozenDictionary_LeftJustifiedSingleChar<TValue>(stringEntries, entries, stringComparer, analysis.MinimumLength, analysis.MaximumLengthDiff, analysis.HashIndex)
-                                : new OrdinalStringFrozenDictionary_LeftJustifiedSubstring<TValue>(stringEntries, entries, stringComparer, analysis.MinimumLength, analysis.MaximumLengthDiff, analysis.HashIndex, analysis.HashCount);
+                                ? new OrdinalStringFrozenDictionary_LeftJustifiedSingleChar<TValue>(keys, values, stringComparer, analysis.MinimumLength, analysis.MaximumLengthDiff, analysis.HashIndex)
+                                : new OrdinalStringFrozenDictionary_LeftJustifiedSubstring<TValue>(keys, values, stringComparer, analysis.MinimumLength, analysis.MaximumLengthDiff, analysis.HashIndex, analysis.HashCount);
                         }
                     }
                 }
@@ -291,12 +291,12 @@ namespace System.Collections.Frozen
                     if (analysis.IgnoreCase)
                     {
                         frozenDictionary = analysis.AllAsciiIfIgnoreCase
-                            ? new OrdinalStringFrozenDictionary_FullCaseInsensitiveAscii<TValue>(stringEntries, entries, stringComparer, analysis.MinimumLength, analysis.MaximumLengthDiff)
-                            : new OrdinalStringFrozenDictionary_FullCaseInsensitive<TValue>(stringEntries, entries, stringComparer, analysis.MinimumLength, analysis.MaximumLengthDiff);
+                            ? new OrdinalStringFrozenDictionary_FullCaseInsensitiveAscii<TValue>(keys, values, stringComparer, analysis.MinimumLength, analysis.MaximumLengthDiff)
+                            : new OrdinalStringFrozenDictionary_FullCaseInsensitive<TValue>(keys, values, stringComparer, analysis.MinimumLength, analysis.MaximumLengthDiff);
                     }
                     else
                     {
-                        frozenDictionary = new OrdinalStringFrozenDictionary_Full<TValue>(stringEntries, entries, stringComparer, analysis.MinimumLength, analysis.MaximumLengthDiff);
+                        frozenDictionary = new OrdinalStringFrozenDictionary_Full<TValue>(keys, values, stringComparer, analysis.MinimumLength, analysis.MaximumLengthDiff);
                     }
                 }
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenHashTable.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenHashTable.cs
@@ -36,7 +36,6 @@ namespace System.Collections.Frozen
         }
 
         /// <summary>Initializes a frozen hash table.</summary>
-        /// <param name="entriesLength">The number of entries to track from the hash table.</param>
         /// <param name="hashCodes">Pre-calculated hash codes.</param>
         /// <param name="storeDestIndexFromSrcIndex">A delegate that assigns the index to a specific entry. It's passed the destination and source indices.</param>
         /// <param name="optimizeForReading">true to spend additional effort tuning for subsequent read speed on the table; false to prioritize construction time.</param>
@@ -48,10 +47,8 @@ namespace System.Collections.Frozen
         /// then uses this index to reference individual entries by indexing into <see cref="HashCodes"/>.
         /// </remarks>
         /// <returns>A frozen hash table.</returns>
-        public static FrozenHashTable Create(int entriesLength, ReadOnlySpan<int> hashCodes, Action<int, int> storeDestIndexFromSrcIndex, bool optimizeForReading = true)
+        public static FrozenHashTable Create(ReadOnlySpan<int> hashCodes, Action<int, int> storeDestIndexFromSrcIndex, bool optimizeForReading = true)
         {
-            Debug.Assert(entriesLength != 0);
-
             // Determine how many buckets to use.  This might be fewer than the number of entries
             // if any entries have identical hashcodes (not just different hashcodes that might
             // map to the same bucket).

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenHashTable.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenHashTable.cs
@@ -48,21 +48,13 @@ namespace System.Collections.Frozen
         /// then uses this index to reference individual entries by indexing into <see cref="HashCodes"/>.
         /// </remarks>
         /// <returns>A frozen hash table.</returns>
-#if NET6_0_OR_GREATER
-        [System.Runtime.CompilerServices.SkipLocalsInitAttribute]
-#endif
         public static FrozenHashTable Create(int entriesLength, Func<int, int> hashAtIndex, Action<int, int> storeDestIndexFromSrcIndex, bool optimizeForReading = true)
         {
             Debug.Assert(entriesLength != 0);
 
             // Calculate the hashcodes for every entry.
-            int[]? arrayPoolHashCodes = null, arrayPoolBuckets = null;
-
-            Span<int> hashCodes = entriesLength <= 256
-                    ? stackalloc int[256]
-                    : (arrayPoolHashCodes = ArrayPool<int>.Shared.Rent(entriesLength));
-            hashCodes = hashCodes.Slice(0, entriesLength);
-
+            int[] arrayPoolHashCodes = ArrayPool<int>.Shared.Rent(entriesLength);
+            Span<int> hashCodes = arrayPoolHashCodes.AsSpan(0, entriesLength);
             for (int i = 0; i < entriesLength; i++)
             {
                 hashCodes[i] = hashAtIndex(i);
@@ -78,12 +70,9 @@ namespace System.Collections.Frozen
             // - bucketStarts: initially filled with all -1s, the ith element stores the index
             //   into hashCodes of the head element of that bucket's chain.
             // - nexts: the ith element stores the index of the next item in the chain.
-            Span<int> buckets = numBuckets + hashCodes.Length <= 256
-                ? stackalloc int[256]
-                : (arrayPoolBuckets = ArrayPool<int>.Shared.Rent(numBuckets + hashCodes.Length));
-
-            Span<int> bucketStarts = buckets.Slice(0, numBuckets);
-            Span<int> nexts = buckets.Slice(numBuckets, hashCodes.Length);
+            int[] arrayPoolBuckets = ArrayPool<int>.Shared.Rent(numBuckets + hashCodes.Length);
+            Span<int> bucketStarts = arrayPoolBuckets.AsSpan(0, numBuckets);
+            Span<int> nexts = arrayPoolBuckets.AsSpan(numBuckets, hashCodes.Length);
             bucketStarts.Fill(-1);
 
             // Populate the bucket entries and starts.  For each hash code, compute its bucket,
@@ -134,14 +123,8 @@ namespace System.Collections.Frozen
             }
             Debug.Assert(count == hashtableHashcodes.Length);
 
-            if (arrayPoolBuckets is not null)
-            {
-                ArrayPool<int>.Shared.Return(arrayPoolBuckets);
-            }
-            if (arrayPoolHashCodes is not null)
-            {
-                ArrayPool<int>.Shared.Return(arrayPoolHashCodes);
-            }
+            ArrayPool<int>.Shared.Return(arrayPoolBuckets);
+            ArrayPool<int>.Shared.Return(arrayPoolHashCodes);
 
             return new FrozenHashTable(hashtableHashcodes, hashtableBuckets, fastModMultiplier);
         }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenHashTable.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenHashTable.cs
@@ -37,7 +37,7 @@ namespace System.Collections.Frozen
 
         /// <summary>Initializes a frozen hash table.</summary>
         /// <param name="entriesLength">The number of entries to track from the hash table.</param>
-        /// <param name="hashAtIndex">A delegate that produces a hash code for a given entry. It's passed the index of the entry and returns that entry's hash code.</param>
+        /// <param name="hashCodes">Pre-calculated hash codes.</param>
         /// <param name="storeDestIndexFromSrcIndex">A delegate that assigns the index to a specific entry. It's passed the destination and source indices.</param>
         /// <param name="optimizeForReading">true to spend additional effort tuning for subsequent read speed on the table; false to prioritize construction time.</param>
         /// <remarks>
@@ -48,17 +48,9 @@ namespace System.Collections.Frozen
         /// then uses this index to reference individual entries by indexing into <see cref="HashCodes"/>.
         /// </remarks>
         /// <returns>A frozen hash table.</returns>
-        public static FrozenHashTable Create(int entriesLength, Func<int, int> hashAtIndex, Action<int, int> storeDestIndexFromSrcIndex, bool optimizeForReading = true)
+        public static FrozenHashTable Create(int entriesLength, ReadOnlySpan<int> hashCodes, Action<int, int> storeDestIndexFromSrcIndex, bool optimizeForReading = true)
         {
             Debug.Assert(entriesLength != 0);
-
-            // Calculate the hashcodes for every entry.
-            int[] arrayPoolHashCodes = ArrayPool<int>.Shared.Rent(entriesLength);
-            Span<int> hashCodes = arrayPoolHashCodes.AsSpan(0, entriesLength);
-            for (int i = 0; i < entriesLength; i++)
-            {
-                hashCodes[i] = hashAtIndex(i);
-            }
 
             // Determine how many buckets to use.  This might be fewer than the number of entries
             // if any entries have identical hashcodes (not just different hashcodes that might
@@ -124,7 +116,6 @@ namespace System.Collections.Frozen
             Debug.Assert(count == hashtableHashcodes.Length);
 
             ArrayPool<int>.Shared.Return(arrayPoolBuckets);
-            ArrayPool<int>.Shared.Return(arrayPoolHashCodes);
 
             return new FrozenHashTable(hashtableHashcodes, hashtableBuckets, fastModMultiplier);
         }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Int32/Int32FrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Int32/Int32FrozenDictionary.cs
@@ -36,7 +36,6 @@ namespace System.Collections.Frozen
             }
 
             _hashTable = FrozenHashTable.Create(
-                entries.Length,
                 hashCodes,
                 (destIndex, srcIndex) => _values[destIndex] = entries[srcIndex].Value);
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Int32/Int32FrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Int32/Int32FrozenDictionary.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -27,10 +28,19 @@ namespace System.Collections.Frozen
 
             _values = new TValue[entries.Length];
 
+            int[] arrayPoolHashCodes = ArrayPool<int>.Shared.Rent(entries.Length);
+            Span<int> hashCodes = arrayPoolHashCodes.AsSpan(0, entries.Length);
+            for (int i = 0; i < entries.Length; i++)
+            {
+                hashCodes[i] = entries[i].Key;
+            }
+
             _hashTable = FrozenHashTable.Create(
                 entries.Length,
-                index => entries[index].Key,
+                hashCodes,
                 (destIndex, srcIndex) => _values[destIndex] = entries[srcIndex].Value);
+
+            ArrayPool<int>.Shared.Return(arrayPoolHashCodes);
         }
 
         /// <inheritdoc />

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Int32/Int32FrozenSet.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Int32/Int32FrozenSet.cs
@@ -27,8 +27,8 @@ namespace System.Collections.Frozen
 
             _hashTable = FrozenHashTable.Create(
                 count,
-                index => entries[index],
-                delegate { });
+                new ReadOnlySpan<int>(entries, 0, count),
+                static delegate { });
 
             ArrayPool<int>.Shared.Return(entries);
         }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Int32/Int32FrozenSet.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Int32/Int32FrozenSet.cs
@@ -26,7 +26,6 @@ namespace System.Collections.Frozen
             source.CopyTo(entries);
 
             _hashTable = FrozenHashTable.Create(
-                count,
                 new ReadOnlySpan<int>(entries, 0, count),
                 static delegate { });
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/ItemsFrozenSet.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/ItemsFrozenSet.cs
@@ -31,7 +31,6 @@ namespace System.Collections.Frozen
             }
 
             _hashTable = FrozenHashTable.Create(
-                entries.Length,
                 hashCodes,
                 (destIndex, srcIndex) => _items[destIndex] = entries[srcIndex],
                 optimizeForReading);

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/ItemsFrozenSet.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/ItemsFrozenSet.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -22,11 +23,20 @@ namespace System.Collections.Frozen
 
             _items = new T[entries.Length];
 
+            int[] arrayPoolHashCodes = ArrayPool<int>.Shared.Rent(entries.Length);
+            Span<int> hashCodes = arrayPoolHashCodes.AsSpan(0, entries.Length);
+            for (int i = 0; i < entries.Length; i++)
+            {
+                hashCodes[i] = entries[i] is T t ? Comparer.GetHashCode(t) : 0;
+            }
+
             _hashTable = FrozenHashTable.Create(
                 entries.Length,
-                index => entries[index] is T t ? Comparer.GetHashCode(t) : 0,
+                hashCodes,
                 (destIndex, srcIndex) => _items[destIndex] = entries[srcIndex],
                 optimizeForReading);
+
+            ArrayPool<int>.Shared.Return(arrayPoolHashCodes);
         }
 
         /// <inheritdoc />

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/KeysAndValuesFrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/KeysAndValuesFrozenDictionary.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -24,15 +25,24 @@ namespace System.Collections.Frozen
             _keys = new TKey[entries.Length];
             _values = new TValue[entries.Length];
 
+            int[] arrayPoolHashCodes = ArrayPool<int>.Shared.Rent(entries.Length);
+            Span<int> hashCodes = arrayPoolHashCodes.AsSpan(0, entries.Length);
+            for (int i = 0; i < entries.Length; i++)
+            {
+                hashCodes[i] = Comparer.GetHashCode(entries[i].Key);
+            }
+
             _hashTable = FrozenHashTable.Create(
                 entries.Length,
-                index => Comparer.GetHashCode(entries[index].Key),
+                hashCodes,
                 (destIndex, srcIndex) =>
                 {
                     _keys[destIndex] = entries[srcIndex].Key;
                     _values[destIndex] = entries[srcIndex].Value;
                 },
                 optimizeForReading);
+
+            ArrayPool<int>.Shared.Return(arrayPoolHashCodes);
         }
 
         /// <inheritdoc />

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/KeysAndValuesFrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/KeysAndValuesFrozenDictionary.cs
@@ -33,7 +33,6 @@ namespace System.Collections.Frozen
             }
 
             _hashTable = FrozenHashTable.Create(
-                entries.Length,
                 hashCodes,
                 (destIndex, srcIndex) =>
                 {

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/KeyAnalyzer.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/KeyAnalyzer.cs
@@ -225,7 +225,7 @@ namespace System.Collections.Frozen
         {
             set.Clear();
 
-            // SufficientUniquenessFactor of 95% is good enough.
+            // Sufficient uniqueness factor of 95% is good enough.
             // Instead of ensuring that 95% of data is good, we stop when we know that at least 5% is bad.
             int acceptableNonUniqueCount = uniqueStrings.Length / 20;
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -40,14 +41,23 @@ namespace System.Collections.Frozen
             HashIndex = hashIndex;
             HashCount = hashCount;
 
+            int[] arrayPoolHashCodes = ArrayPool<int>.Shared.Rent(entries.Length);
+            Span<int> hashCodes = arrayPoolHashCodes.AsSpan(0, entries.Length);
+            for (int i = 0; i < entries.Length; i++)
+            {
+                hashCodes[i] = GetHashCode(entries[i].Key);
+            }
+
             _hashTable = FrozenHashTable.Create(
                 entries.Length,
-                index => GetHashCode(entries[index].Key),
+                hashCodes,
                 (destIndex, srcIndex) =>
                 {
                     _keys[destIndex] = entries[srcIndex].Key;
                     _values[destIndex] = entries[srcIndex].Value;
                 });
+
+            ArrayPool<int>.Shared.Return(arrayPoolHashCodes);
         }
 
         private protected int HashIndex { get; }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary.cs
@@ -48,7 +48,6 @@ namespace System.Collections.Frozen
             }
 
             _hashTable = FrozenHashTable.Create(
-                keys.Length,
                 hashCodes,
                 (destIndex, srcIndex) =>
                 {

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_Full.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_Full.cs
@@ -8,12 +8,12 @@ namespace System.Collections.Frozen
     internal sealed class OrdinalStringFrozenDictionary_Full<TValue> : OrdinalStringFrozenDictionary<TValue>
     {
         internal OrdinalStringFrozenDictionary_Full(
-            Dictionary<string, TValue> source,
             string[] keys,
+            TValue[] values,
             IEqualityComparer<string> comparer,
             int minimumLength,
             int maximumLengthDiff)
-            : base(source, keys, comparer, minimumLength, maximumLengthDiff)
+            : base(keys, values, comparer, minimumLength, maximumLengthDiff)
         {
         }
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_FullCaseInsensitive.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_FullCaseInsensitive.cs
@@ -8,12 +8,12 @@ namespace System.Collections.Frozen
     internal sealed class OrdinalStringFrozenDictionary_FullCaseInsensitive<TValue> : OrdinalStringFrozenDictionary<TValue>
     {
         internal OrdinalStringFrozenDictionary_FullCaseInsensitive(
-            Dictionary<string, TValue> source,
             string[] keys,
+            TValue[] values,
             IEqualityComparer<string> comparer,
             int minimumLength,
             int maximumLengthDiff)
-            : base(source, keys, comparer, minimumLength, maximumLengthDiff)
+            : base(keys, values, comparer, minimumLength, maximumLengthDiff)
         {
         }
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_FullCaseInsensitiveAscii.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_FullCaseInsensitiveAscii.cs
@@ -8,12 +8,12 @@ namespace System.Collections.Frozen
     internal sealed class OrdinalStringFrozenDictionary_FullCaseInsensitiveAscii<TValue> : OrdinalStringFrozenDictionary<TValue>
     {
         internal OrdinalStringFrozenDictionary_FullCaseInsensitiveAscii(
-            Dictionary<string, TValue> source,
             string[] keys,
+            TValue[] values,
             IEqualityComparer<string> comparer,
             int minimumLength,
             int maximumLengthDiff)
-            : base(source, keys, comparer, minimumLength, maximumLengthDiff)
+            : base(keys, values, comparer, minimumLength, maximumLengthDiff)
         {
         }
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_LeftJustifiedCaseInsensitiveAsciiSubstring.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_LeftJustifiedCaseInsensitiveAsciiSubstring.cs
@@ -8,14 +8,14 @@ namespace System.Collections.Frozen
     internal sealed class OrdinalStringFrozenDictionary_LeftJustifiedCaseInsensitiveAsciiSubstring<TValue> : OrdinalStringFrozenDictionary<TValue>
     {
         internal OrdinalStringFrozenDictionary_LeftJustifiedCaseInsensitiveAsciiSubstring(
-            Dictionary<string, TValue> source,
             string[] keys,
+            TValue[] values,
             IEqualityComparer<string> comparer,
             int minimumLength,
             int maximumLengthDiff,
             int hashIndex,
             int hashCount)
-            : base(source, keys, comparer, minimumLength, maximumLengthDiff, hashIndex, hashCount)
+            : base(keys, values, comparer, minimumLength, maximumLengthDiff, hashIndex, hashCount)
         {
         }
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_LeftJustifiedCaseInsensitiveSubstring.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_LeftJustifiedCaseInsensitiveSubstring.cs
@@ -8,14 +8,14 @@ namespace System.Collections.Frozen
     internal sealed class OrdinalStringFrozenDictionary_LeftJustifiedCaseInsensitiveSubstring<TValue> : OrdinalStringFrozenDictionary<TValue>
     {
         internal OrdinalStringFrozenDictionary_LeftJustifiedCaseInsensitiveSubstring(
-            Dictionary<string, TValue> source,
             string[] keys,
+            TValue[] values,
             IEqualityComparer<string> comparer,
             int minimumLength,
             int maximumLengthDiff,
             int hashIndex,
             int hashCount)
-            : base(source, keys, comparer, minimumLength, maximumLengthDiff, hashIndex, hashCount)
+            : base(keys, values, comparer, minimumLength, maximumLengthDiff, hashIndex, hashCount)
         {
         }
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_LeftJustifiedSingleChar.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_LeftJustifiedSingleChar.cs
@@ -8,13 +8,13 @@ namespace System.Collections.Frozen
     internal sealed class OrdinalStringFrozenDictionary_LeftJustifiedSingleChar<TValue> : OrdinalStringFrozenDictionary<TValue>
     {
         internal OrdinalStringFrozenDictionary_LeftJustifiedSingleChar(
-            Dictionary<string, TValue> source,
             string[] keys,
+            TValue[] values,
             IEqualityComparer<string> comparer,
             int minimumLength,
             int maximumLengthDiff,
             int hashIndex)
-            : base(source, keys, comparer, minimumLength, maximumLengthDiff, hashIndex, 1)
+            : base(keys, values, comparer, minimumLength, maximumLengthDiff, hashIndex, 1)
         {
         }
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_LeftJustifiedSubstring.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_LeftJustifiedSubstring.cs
@@ -8,14 +8,14 @@ namespace System.Collections.Frozen
     internal sealed class OrdinalStringFrozenDictionary_LeftJustifiedSubstring<TValue> : OrdinalStringFrozenDictionary<TValue>
     {
         internal OrdinalStringFrozenDictionary_LeftJustifiedSubstring(
-            Dictionary<string, TValue> source,
             string[] keys,
+            TValue[] values,
             IEqualityComparer<string> comparer,
             int minimumLength,
             int maximumLengthDiff,
             int hashIndex,
             int hashCount)
-            : base(source, keys, comparer, minimumLength, maximumLengthDiff, hashIndex, hashCount)
+            : base(keys, values, comparer, minimumLength, maximumLengthDiff, hashIndex, hashCount)
         {
         }
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_RightJustifiedCaseInsensitiveAsciiSubstring.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_RightJustifiedCaseInsensitiveAsciiSubstring.cs
@@ -8,14 +8,14 @@ namespace System.Collections.Frozen
     internal sealed class OrdinalStringFrozenDictionary_RightJustifiedCaseInsensitiveAsciiSubstring<TValue> : OrdinalStringFrozenDictionary<TValue>
     {
         internal OrdinalStringFrozenDictionary_RightJustifiedCaseInsensitiveAsciiSubstring(
-            Dictionary<string, TValue> source,
             string[] keys,
+            TValue[] values,
             IEqualityComparer<string> comparer,
             int minimumLength,
             int maximumLengthDiff,
             int hashIndex,
             int hashCount)
-            : base(source, keys, comparer, minimumLength, maximumLengthDiff, hashIndex, hashCount)
+            : base(keys, values, comparer, minimumLength, maximumLengthDiff, hashIndex, hashCount)
         {
         }
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_RightJustifiedCaseInsensitiveSubstring.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_RightJustifiedCaseInsensitiveSubstring.cs
@@ -8,14 +8,14 @@ namespace System.Collections.Frozen
     internal sealed class OrdinalStringFrozenDictionary_RightJustifiedCaseInsensitiveSubstring<TValue> : OrdinalStringFrozenDictionary<TValue>
     {
         internal OrdinalStringFrozenDictionary_RightJustifiedCaseInsensitiveSubstring(
-            Dictionary<string, TValue> source,
             string[] keys,
+            TValue[] values,
             IEqualityComparer<string> comparer,
             int minimumLength,
             int maximumLengthDiff,
             int hashIndex,
             int hashCount)
-            : base(source, keys, comparer, minimumLength, maximumLengthDiff, hashIndex, hashCount)
+            : base(keys, values, comparer, minimumLength, maximumLengthDiff, hashIndex, hashCount)
         {
         }
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_RightJustifiedSingleChar.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_RightJustifiedSingleChar.cs
@@ -8,13 +8,13 @@ namespace System.Collections.Frozen
     internal sealed class OrdinalStringFrozenDictionary_RightJustifiedSingleChar<TValue> : OrdinalStringFrozenDictionary<TValue>
     {
         internal OrdinalStringFrozenDictionary_RightJustifiedSingleChar(
-            Dictionary<string, TValue> source,
             string[] keys,
+            TValue[] values,
             IEqualityComparer<string> comparer,
             int minimumLength,
             int maximumLengthDiff,
             int hashIndex)
-            : base(source, keys, comparer, minimumLength, maximumLengthDiff, hashIndex, 1)
+            : base(keys, values, comparer, minimumLength, maximumLengthDiff, hashIndex, 1)
         {
         }
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_RightJustifiedSubstring.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_RightJustifiedSubstring.cs
@@ -8,14 +8,14 @@ namespace System.Collections.Frozen
     internal sealed class OrdinalStringFrozenDictionary_RightJustifiedSubstring<TValue> : OrdinalStringFrozenDictionary<TValue>
     {
         internal OrdinalStringFrozenDictionary_RightJustifiedSubstring(
-            Dictionary<string, TValue> source,
             string[] keys,
+            TValue[] values,
             IEqualityComparer<string> comparer,
             int minimumLength,
             int maximumLengthDiff,
             int hashIndex,
             int hashCount)
-            : base(source, keys, comparer, minimumLength, maximumLengthDiff, hashIndex, hashCount)
+            : base(keys, values, comparer, minimumLength, maximumLengthDiff, hashIndex, hashCount)
         {
         }
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenSet.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenSet.cs
@@ -39,7 +39,6 @@ namespace System.Collections.Frozen
             }
 
             _hashTable = FrozenHashTable.Create(
-                entries.Length,
                 hashCodes,
                 (destIndex, srcIndex) => _items[destIndex] = entries[srcIndex]);
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenSet.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenSet.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
@@ -30,10 +31,19 @@ namespace System.Collections.Frozen
             HashIndex = hashIndex;
             HashCount = hashCount;
 
+            int[] arrayPoolHashCodes = ArrayPool<int>.Shared.Rent(entries.Length);
+            Span<int> hashCodes = arrayPoolHashCodes.AsSpan(0, entries.Length);
+            for (int i = 0; i < entries.Length; i++)
+            {
+                hashCodes[i] = GetHashCode(entries[i]);
+            }
+
             _hashTable = FrozenHashTable.Create(
                 entries.Length,
-                index => GetHashCode(entries[index]),
+                hashCodes,
                 (destIndex, srcIndex) => _items[destIndex] = entries[srcIndex]);
+
+            ArrayPool<int>.Shared.Return(arrayPoolHashCodes);
         }
 
         private protected int HashIndex { get; }


### PR DESCRIPTION
- let the caller of `FrozenHashTable.Create` provide the hashcodes, it eliminates a closure and boundary checks and one method call (7% gain)
    - in case of hash set of integers it avoids renting and copying all integers to just have a copy of them
    - this is done at a cost of duplicated code, but since it eliminates a closure I hope it's not going to have big impact on the code size
- keys and values are needed for every strategy, lets create them up-front (2% gain)
    - in `CreateLengthBucketsFrozenDictionaryIfAppropriate` iterate over array rather than dictionary
    - in `OrdinalStringFrozenDictionary` ctor avoid creating a copy of all entries (we already have a copy of keys)

```ini
LaunchCount=9  MemoryRandomization=True
```

|                    Method |           Job | Size |     Mean | Ratio | Allocated | Alloc Ratio |
|-------------------------- |-------------- |----- |---------:|------:|----------:|------------:|
| FrozenDictionaryOptimized |       this PR |  512 | 67.22 us |  0.73 |  74.88 KB |        0.88 |
| FrozenDictionaryOptimized |        #87510 |  512 | 75.02 us |  0.82 |  74.91 KB |        0.88 |
| FrozenDictionaryOptimized |  before #87510 |  512 | 91.66 us |  1.00 |  85.21 KB |        1.00 |
