### PR TITLE
[wasm] Use an older sdk for WBT

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -204,7 +204,7 @@
     <GrpcDotnetClientVersion>2.45.0</GrpcDotnetClientVersion>
     <GrpcToolsVersion>2.45.0</GrpcToolsVersion>
     <!-- Uncomment to set a fixed version, else the latest is used -->
-    <!-- <SdkVersionForWorkloadTesting>8.0.100-alpha.1.23077.3</SdkVersionForWorkloadTesting> -->
+    <SdkVersionForWorkloadTesting>8.0.100-preview.6.23314.19</SdkVersionForWorkloadTesting> 
     <CompilerPlatformTestingVersion>1.1.2-beta1.23205.1</CompilerPlatformTestingVersion>
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>7.0.0-preview-20221010.1</MicrosoftPrivateIntellisenseVersion>


### PR DESCRIPTION
Use sdk - `8.0.100-preview.6.23314.19`

The newer ones fail wasm template projects with:
```
                     Microsoft (R) Visual C# Compiler version 4.7.0-3.23315.1 (7a7690ea) (TaskId:107)
                     Copyright (C) Microsoft Corporation. All rights reserved. (TaskId:107)
19:39:42.736   1:7>CSC : error AD0001: Analyzer 'ILLink.RoslynAnalyzer.DynamicallyAccessedMembersAnalyzer' threw an exception of type 'System.IndexOutOfRangeException' with message 'Index was outside the bounds of the array.'. [/workspaces/runtime/artifacts/bin/Wasm.Build.Tests/Release/net8.0/browser-wasm/wbt/Debug_w1hn3hlk.m21/Debug_w1hn3hlk.m21.csproj]
                     Exception occurred with following context: (TaskId:107)
                     Compilation: Debug_w1hn3hlk.m21 (TaskId:107)
                     ISymbol: <Main>$ (Method) (TaskId:107)
                     System.IndexOutOfRangeException: Index was outside the bounds of the array. (TaskId:107)
                     at ILLink.RoslynAnalyzer.DynamicallyAccessedMembersAnalyzer.<>c.<Initialize>b__7_3(SymbolAnalysisContext context) (TaskId:107)
                     at Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor.ExecuteAndCatchIfThrows_NoLock[TArg](DiagnosticAnalyzer analyzer, Action`1 analyze, TArg argument, Nullable`1 info, CancellationToken cancellationToken) (TaskId:107)
                     ----- (TaskId:107)
                     Suppress the following diagnostics to disable this analyzer: IL2026, IL2032, IL2041, IL2043, IL2055, IL2057, IL2058, IL2059, IL2060, IL2062, IL2063, IL2064, IL2065, IL2066, IL2067, IL2068, IL2069, IL2070, IL2071, IL2072, IL2073, IL2074, IL2075, IL2076, IL2077, IL2078, IL2079, IL2080, IL2081, IL2082, IL2083, IL2084, IL2085, IL2086, IL2087, IL2088, IL2089, IL2090, IL2091, IL2092, IL2093, IL2094, IL2095, IL2096, IL2097, IL2098, IL2099, IL2103, IL2106, IL2110, IL2111 (TaskId:107)
                     CompilerServer: server - server processed compilation - 9624bd43-5dab-4d62-9e51-fbed45800538 (TaskId:107)
                   Done executing task "Csc" -- FAILED. (TaskId:107)
```

Issue: https://github.com/dotnet/runtime/issues/87647