### PR TITLE
Fully qualify return type on UnreachableException methods

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComMethodContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComMethodContext.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Interop
 
         private MethodDeclarationSyntax CreateUnreachableExceptionStub()
         {
-            // DeclarationCopiedFromBaseDeclaration(<Arguments>) => throw new UnreachableException("This method should not be reached");
+            // DeclarationCopiedFromBaseDeclaration(<Arguments>) => throw new UnreachableException();
             return MethodInfo.Syntax
                 .WithReturnType(GenerationContext.SignatureContext.StubReturnType)
                 .WithModifiers(TokenList())

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComMethodContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComMethodContext.cs
@@ -105,6 +105,7 @@ namespace Microsoft.Interop
         {
             // DeclarationCopiedFromBaseDeclaration(<Arguments>) => throw new UnreachableException("This method should not be reached");
             return MethodInfo.Syntax
+                .WithReturnType(GenerationContext.SignatureContext.StubReturnType)
                 .WithModifiers(TokenList())
                 .WithAttributeLists(List<AttributeListSyntax>())
                 .WithExplicitInterfaceSpecifier(ExplicitInterfaceSpecifier(

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/CodeSnippets.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/CodeSnippets.cs
@@ -285,6 +285,33 @@ namespace ComInterfaceGenerator.Unit.Tests
             }
             """;
 
+        public string DerivedWithParametersDeclaredInOtherNamespace => $$"""
+            using System.Runtime.CompilerServices;
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            using OtherNS;
+
+            namespace OtherNS
+            {
+                public struct NewType;
+            }
+
+            namespace Test
+            {
+                {{GeneratedComInterface()}}
+                partial interface IComInterface
+                {
+                     NewType Method(NewType p);
+                }
+
+                {{GeneratedComInterface()}}
+                partial interface IComInterface2 : IComInterface
+                {
+                    NewType Method2(NewType p);
+                }
+            }
+            """;
+
         public string DerivedWithStringMarshalling(params
             (StringMarshalling StringMarshalling, Type? StringMarshallingCustomType)[] attributeArguments)
         {

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/Compiles.cs
@@ -8,9 +8,8 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Interop.UnitTests;
 using Xunit;
-
-using VerifyVTableGenerator = Microsoft.Interop.UnitTests.Verifiers.CSharpSourceGeneratorVerifier<Microsoft.Interop.VtableIndexStubGenerator>;
 using VerifyComInterfaceGenerator = Microsoft.Interop.UnitTests.Verifiers.CSharpSourceGeneratorVerifier<Microsoft.Interop.ComInterfaceGenerator>;
+using VerifyVTableGenerator = Microsoft.Interop.UnitTests.Verifiers.CSharpSourceGeneratorVerifier<Microsoft.Interop.VtableIndexStubGenerator>;
 
 namespace ComInterfaceGenerator.Unit.Tests
 {
@@ -334,6 +333,7 @@ namespace ComInterfaceGenerator.Unit.Tests
         {
             CodeSnippets codeSnippets = new(new GeneratedComInterfaceAttributeProvider());
             yield return new object[] { ID(), codeSnippets.DerivedComInterfaceType };
+            yield return new object[] { ID(), codeSnippets.DerivedWithParametersDeclaredInOtherNamespace };
             yield return new object[] { ID(), codeSnippets.ComInterfaceParameters };
         }
 


### PR DESCRIPTION
We weren't fully qualifying the return type for shadowing stubs, causing issues if the type wasn't in the interface or a built in type.