### PR TITLE
Fix redundant MethodInfo lookup in UnixNativeCodeManager

### DIFF
--- a/src/coreclr/nativeaot/Runtime/unix/UnixNativeCodeManager.h
+++ b/src/coreclr/nativeaot/Runtime/unix/UnixNativeCodeManager.h
@@ -59,11 +59,11 @@ public:
                           PInvokeTransitionFrame**      ppPreviousTransitionFrame);   // out
 
     uintptr_t GetConservativeUpperBoundForOutgoingArgs(MethodInfo *   pMethodInfo,
-                                                        REGDISPLAY *   pRegisterSet);
+                                                       REGDISPLAY *   pRegisterSet);
 
     bool IsUnwindable(PTR_VOID pvAddress);
 
-    int TrailingEpilogueInstructionsCount(PTR_VOID pvAddress); 
+    int TrailingEpilogueInstructionsCount(MethodInfo * pMethodInfo, PTR_VOID pvAddress);
 
     bool GetReturnAddressHijackInfo(MethodInfo *    pMethodInfo,
                                     REGDISPLAY *    pRegisterSet,       // in


### PR DESCRIPTION
Fixes #75807