### PR TITLE
Do not quote rpath passed to linker for Bionic

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -111,7 +111,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-arch $(CrossCompileArch)" Condition="'$(_IsApplePlatform)' == 'true' and '$(CrossCompileArch)' != ''" />
       <LinkerArg Include="-g" Condition="$(NativeDebugSymbols) == 'true'" />
       <LinkerArg Include="-Wl,--strip-debug" Condition="$(NativeDebugSymbols) != 'true' and '$(_IsApplePlatform)' != 'true'" />
-      <LinkerArg Include="-Wl,-rpath,'$(IlcRPath)'" Condition="'$(StaticExecutable)' != 'true'" />
+      <LinkerArg Include="-Wl,-rpath,$(IlcRPath)" Condition="'$(StaticExecutable)' != 'true'" />
       <LinkerArg Include="-Wl,--build-id=sha1" Condition="'$(_IsApplePlatform)' != 'true'" />
       <LinkerArg Include="-Wl,--as-needed" Condition="'$(_IsApplePlatform)' != 'true'" />
       <LinkerArg Include="-Wl,-e0x0" Condition="'$(NativeLib)' == 'Shared' and '$(_IsApplePlatform)' != 'true'" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -44,9 +44,8 @@ The .NET Foundation licenses this file to you under the MIT license.
       <TargetTriple Condition="'$(CrossCompileArch)' != '' and ($(CrossCompileRid.StartsWith('linux-musl')) or $(CrossCompileRid.StartsWith('alpine')))">$(CrossCompileArch)-alpine-linux-musl</TargetTriple>
       <TargetTriple Condition="'$(CrossCompileArch)' != '' and ($(CrossCompileRid.StartsWith('freebsd')))">$(CrossCompileArch)-unknown-freebsd12</TargetTriple>
 
-      <IlcRPath Condition="'$(IlcRPath)' == '' and '$(_IsApplePlatform)' != 'true' and '$(_linuxLibcFlavor)' != 'bionic'">'$ORIGIN'</IlcRPath>
-      <IlcRPath Condition="'$(IlcRPath)' == '' and '$(_linuxLibcFlavor)' == 'bionic'">$ORIGIN</IlcRPath>
-      <IlcRPath Condition="'$(IlcRPath)' == '' and '$(_IsApplePlatform)' == 'true'">'@executable_path'</IlcRPath>
+      <IlcRPath Condition="'$(IlcRPath)' == '' and '$(_IsApplePlatform)' != 'true'">$ORIGIN</IlcRPath>
+      <IlcRPath Condition="'$(IlcRPath)' == '' and '$(_IsApplePlatform)' == 'true'">@executable_path</IlcRPath>
 
       <EventPipeName>libeventpipe-disabled</EventPipeName>
       <EventPipeName Condition="'$(EnableNativeEventPipe)' == 'true' or '$(EventSourceSupport)' == 'true'">libeventpipe-enabled</EventPipeName>
@@ -112,7 +111,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-arch $(CrossCompileArch)" Condition="'$(_IsApplePlatform)' == 'true' and '$(CrossCompileArch)' != ''" />
       <LinkerArg Include="-g" Condition="$(NativeDebugSymbols) == 'true'" />
       <LinkerArg Include="-Wl,--strip-debug" Condition="$(NativeDebugSymbols) != 'true' and '$(_IsApplePlatform)' != 'true'" />
-      <LinkerArg Include="-Wl,-rpath,$(IlcRPath)" Condition="'$(StaticExecutable)' != 'true'" />
+      <LinkerArg Include="'-Wl,-rpath,$(IlcRPath)'" Condition="'$(StaticExecutable)' != 'true'" />
       <LinkerArg Include="-Wl,--build-id=sha1" Condition="'$(_IsApplePlatform)' != 'true'" />
       <LinkerArg Include="-Wl,--as-needed" Condition="'$(_IsApplePlatform)' != 'true'" />
       <LinkerArg Include="-Wl,-e0x0" Condition="'$(NativeLib)' == 'Shared' and '$(_IsApplePlatform)' != 'true'" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -44,8 +44,9 @@ The .NET Foundation licenses this file to you under the MIT license.
       <TargetTriple Condition="'$(CrossCompileArch)' != '' and ($(CrossCompileRid.StartsWith('linux-musl')) or $(CrossCompileRid.StartsWith('alpine')))">$(CrossCompileArch)-alpine-linux-musl</TargetTriple>
       <TargetTriple Condition="'$(CrossCompileArch)' != '' and ($(CrossCompileRid.StartsWith('freebsd')))">$(CrossCompileArch)-unknown-freebsd12</TargetTriple>
 
-      <IlcRPath Condition="'$(IlcRPath)' == '' and '$(_IsApplePlatform)' != 'true'">$ORIGIN</IlcRPath>
-      <IlcRPath Condition="'$(IlcRPath)' == '' and '$(_IsApplePlatform)' == 'true'">@executable_path</IlcRPath>
+      <IlcRPath Condition="'$(IlcRPath)' == '' and '$(_IsApplePlatform)' != 'true' and '$(_linuxLibcFlavor)' != 'bionic'">'$ORIGIN'</IlcRPath>
+      <IlcRPath Condition="'$(IlcRPath)' == '' and '$(_linuxLibcFlavor)' == 'bionic'">$ORIGIN</IlcRPath>
+      <IlcRPath Condition="'$(IlcRPath)' == '' and '$(_IsApplePlatform)' == 'true'">'@executable_path'</IlcRPath>
 
       <EventPipeName>libeventpipe-disabled</EventPipeName>
       <EventPipeName Condition="'$(EnableNativeEventPipe)' == 'true' or '$(EventSourceSupport)' == 'true'">libeventpipe-enabled</EventPipeName>


### PR DESCRIPTION
Looks like this is preserved literally, with the `'`.

The Android loader doesn't like this: `WARNING: linker: Warning: unable to normalize "'/data/data/com.termux/files/home'" (ignoring)`.

Cc @dotnet/ilc-contrib 