### PR TITLE
CurrencyNegativePattern can be 16

### DIFF
--- a/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyNegativePattern.cs
+++ b/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyNegativePattern.cs
@@ -13,6 +13,11 @@ namespace System.Globalization.Tests
         {
             yield return new object[] { NumberFormatInfo.InvariantInfo, new int[] { 0 } };
             yield return new object[] { CultureInfo.GetCultureInfo("bg-BG").NumberFormat, new int[] { 0, 8 } };
+            if (PlatformDetection.IsNotUsingLimitedCultures)
+            {
+                // ICU for mobile / browser do not contain these locales
+            	yield return new object[] { CultureInfo.GetCultureInfo("luy-KE").NumberFormat, new int[] { 16 } };
+            }
         }
 
         [Theory]
@@ -35,6 +40,7 @@ namespace System.Globalization.Tests
                 // ICU for mobile / browser do not contain these locales
                 yield return new object[] { "as" };
                 yield return new object[] { "es-BO" };
+                yield return new object[] { "luy-KE" };
             }
         }
 
@@ -60,6 +66,7 @@ namespace System.Globalization.Tests
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(15)]
+        [InlineData(16)]
         public void CurrencyNegativePattern_Set_GetReturnsExpected(int newCurrencyNegativePattern)
         {
             NumberFormatInfo format = new NumberFormatInfo();
@@ -69,7 +76,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [InlineData(-1)]
-        [InlineData(16)]
+        [InlineData(17)]
         public void CurrencyNegativePattern_SetInvalid_ThrowsArgumentOutOfRangeException(int value)
         {
             var format = new NumberFormatInfo();

--- a/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyNegativePattern.cs
+++ b/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyNegativePattern.cs
@@ -13,11 +13,6 @@ namespace System.Globalization.Tests
         {
             yield return new object[] { NumberFormatInfo.InvariantInfo, new int[] { 0 } };
             yield return new object[] { CultureInfo.GetCultureInfo("bg-BG").NumberFormat, new int[] { 0, 8 } };
-            if (PlatformDetection.IsNotUsingLimitedCultures)
-            {
-                // ICU for mobile / browser do not contain these locales
-            	yield return new object[] { CultureInfo.GetCultureInfo("luy-KE").NumberFormat, new int[] { 16 } };
-            }
         }
 
         [Theory]
@@ -40,7 +35,6 @@ namespace System.Globalization.Tests
                 // ICU for mobile / browser do not contain these locales
                 yield return new object[] { "as" };
                 yield return new object[] { "es-BO" };
-                yield return new object[] { "luy-KE" };
             }
         }
 

--- a/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
+++ b/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
@@ -73,6 +73,9 @@ namespace System.Globalization.Tests
 
                 case "fr-CA":
                     return PlatformDetection.IsNlsGlobalization ? new int[] { 15 } : new int[] { 8, 15 };
+
+                case "luy-KE":
+                    return new int[] { 16 };
             }
 
             throw DateTimeFormatInfoData.GetCultureNotSupportedException(CultureInfo.GetCultureInfo(localeName));

--- a/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
+++ b/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
@@ -73,9 +73,6 @@ namespace System.Globalization.Tests
 
                 case "fr-CA":
                     return PlatformDetection.IsNlsGlobalization ? new int[] { 15 } : new int[] { 8, 15 };
-
-                case "luy-KE":
-                    return new int[] { 16 };
             }
 
             throw DateTimeFormatInfoData.GetCultureNotSupportedException(CultureInfo.GetCultureInfo(localeName));

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/NumberFormatInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/NumberFormatInfo.cs
@@ -244,10 +244,7 @@ namespace System.Globalization
             {
                 if (value < 0 || value > 99)
                 {
-                    throw new ArgumentOutOfRangeException(
-                        nameof(value),
-                        value,
-                        SR.Format(SR.ArgumentOutOfRange_Range, 0, 99));
+                    ThrowHelper.ThrowArgumentOutOfRange_Range(nameof(value), value, 0, 99);
                 }
 
                 VerifyWritable();
@@ -443,10 +440,7 @@ namespace System.Globalization
             {
                 if (value < 0 || value > 16)
                 {
-                    throw new ArgumentOutOfRangeException(
-                        nameof(value),
-                        value,
-                        SR.Format(SR.ArgumentOutOfRange_Range, 0, 16));
+                    ThrowHelper.ThrowArgumentOutOfRange_Range(nameof(value), value, 0, 16);
                 }
 
                 VerifyWritable();
@@ -462,10 +456,7 @@ namespace System.Globalization
                 // NOTENOTE: the range of value should correspond to negNumberFormats[] in vm\COMNumber.cpp.
                 if (value < 0 || value > 4)
                 {
-                    throw new ArgumentOutOfRangeException(
-                        nameof(value),
-                        value,
-                        SR.Format(SR.ArgumentOutOfRange_Range, 0, 4));
+                    ThrowHelper.ThrowArgumentOutOfRange_Range(nameof(value), value, 0, 4);
                 }
 
                 VerifyWritable();
@@ -481,10 +472,7 @@ namespace System.Globalization
                 // NOTENOTE: the range of value should correspond to posPercentFormats[] in vm\COMNumber.cpp.
                 if (value < 0 || value > 3)
                 {
-                    throw new ArgumentOutOfRangeException(
-                        nameof(value),
-                        value,
-                        SR.Format(SR.ArgumentOutOfRange_Range, 0, 3));
+                    ThrowHelper.ThrowArgumentOutOfRange_Range(nameof(value), value, 0, 3);
                 }
 
                 VerifyWritable();
@@ -500,10 +488,7 @@ namespace System.Globalization
                 // NOTENOTE: the range of value should correspond to posPercentFormats[] in vm\COMNumber.cpp.
                 if (value < 0 || value > 11)
                 {
-                    throw new ArgumentOutOfRangeException(
-                        nameof(value),
-                        value,
-                        SR.Format(SR.ArgumentOutOfRange_Range, 0, 11));
+                    ThrowHelper.ThrowArgumentOutOfRange_Range(nameof(value), value, 0, 11);
                 }
 
                 VerifyWritable();
@@ -563,10 +548,7 @@ namespace System.Globalization
             {
                 if (value < 0 || value > 99)
                 {
-                    throw new ArgumentOutOfRangeException(
-                        nameof(value),
-                        value,
-                        SR.Format(SR.ArgumentOutOfRange_Range, 0, 99));
+                    ThrowHelper.ThrowArgumentOutOfRange_Range(nameof(value), value, 0, 99);
                 }
 
                 VerifyWritable();
@@ -623,10 +605,7 @@ namespace System.Globalization
             {
                 if (value < 0 || value > 3)
                 {
-                    throw new ArgumentOutOfRangeException(
-                        nameof(value),
-                        value,
-                        SR.Format(SR.ArgumentOutOfRange_Range, 0, 3));
+                    ThrowHelper.ThrowArgumentOutOfRange_Range(nameof(value), value, 0, 3);
                 }
 
                 VerifyWritable();
@@ -686,10 +665,7 @@ namespace System.Globalization
             {
                 if (value < 0 || value > 99)
                 {
-                    throw new ArgumentOutOfRangeException(
-                        nameof(value),
-                        value,
-                        SR.Format(SR.ArgumentOutOfRange_Range, 0, 99));
+                    ThrowHelper.ThrowArgumentOutOfRange_Range(nameof(value), value, 0, 99);
                 }
 
                 VerifyWritable();

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/NumberFormatInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/NumberFormatInfo.cs
@@ -441,12 +441,12 @@ namespace System.Globalization
             get => _currencyNegativePattern;
             set
             {
-                if (value < 0 || value > 15)
+                if (value < 0 || value > 16)
                 {
                     throw new ArgumentOutOfRangeException(
                         nameof(value),
                         value,
-                        SR.Format(SR.ArgumentOutOfRange_Range, 0, 15));
+                        SR.Format(SR.ArgumentOutOfRange_Range, 0, 16));
                 }
 
                 VerifyWritable();

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
@@ -210,9 +210,12 @@ namespace System.Numerics.Tests
         [SkipOnCoreClr("Long running tests: https://github.com/dotnet/runtime/issues/11980", TestPlatforms.Linux, ~RuntimeConfiguration.Release)]
         public static void RunRegionSpecificStandardFormatToStringTests()
         {
-            CultureInfo[] cultures = new CultureInfo[] { new CultureInfo("en-US"), new CultureInfo("en-GB"), new CultureInfo("fr-CA"),
+            List<CultureInfo> cultures = new () { new CultureInfo("en-US"), new CultureInfo("en-GB"), new CultureInfo("fr-CA"),
                                                             new CultureInfo("ar-SA"), new CultureInfo("de-DE"), new CultureInfo("he-IL"),
-                                                            new CultureInfo("ru-RU"), new CultureInfo("zh-CN") };
+                                                            new CultureInfo("ru-RU"), new CultureInfo("zh-CN"), };
+            if (PlatformDetection.IsNotUsingLimitedCultures)
+                cultures.AddRange(new[] { new CultureInfo("as"), new CultureInfo("es-BO"), new CultureInfo("luy-KE") });
+
             long intMaxPlus1 = ((long)int.MaxValue + 1);
             string intMaxPlus1String = intMaxPlus1.ToString();
             foreach (CultureInfo culture in cultures)
@@ -717,6 +720,9 @@ namespace System.Numerics.Tests
                     case 15:
                         pre = "(";
                         post = " " + nfi.CurrencySymbol + ")";
+                        break;
+                    case 16:
+                        pre = nfi.NegativeSign + nfi.CurrencySymbol + " ";
                         break;
                 }
             }

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
@@ -210,12 +210,9 @@ namespace System.Numerics.Tests
         [SkipOnCoreClr("Long running tests: https://github.com/dotnet/runtime/issues/11980", TestPlatforms.Linux, ~RuntimeConfiguration.Release)]
         public static void RunRegionSpecificStandardFormatToStringTests()
         {
-            List<CultureInfo> cultures = new () { new CultureInfo("en-US"), new CultureInfo("en-GB"), new CultureInfo("fr-CA"),
+            CultureInfo[] cultures = new CultureInfo[] { new CultureInfo("en-US"), new CultureInfo("en-GB"), new CultureInfo("fr-CA"),
                                                             new CultureInfo("ar-SA"), new CultureInfo("de-DE"), new CultureInfo("he-IL"),
                                                             new CultureInfo("ru-RU"), new CultureInfo("zh-CN") };
-            if (PlatformDetection.IsNotUsingLimitedCultures)
-                cultures.AddRange(new[] { new CultureInfo("as"), new CultureInfo("es-BO"), new CultureInfo("luy-KE") });
-
             long intMaxPlus1 = ((long)int.MaxValue + 1);
             string intMaxPlus1String = intMaxPlus1.ToString();
             foreach (CultureInfo culture in cultures)

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
@@ -722,7 +722,7 @@ namespace System.Numerics.Tests
                         post = " " + nfi.CurrencySymbol + ")";
                         break;
                     case 16:
-                        pre = nfi.NegativeSign + nfi.CurrencySymbol + " ";
+                        pre = nfi.CurrencySymbol + nfi.NegativeSign + " ";
                         break;
                 }
             }

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
@@ -212,7 +212,7 @@ namespace System.Numerics.Tests
         {
             List<CultureInfo> cultures = new () { new CultureInfo("en-US"), new CultureInfo("en-GB"), new CultureInfo("fr-CA"),
                                                             new CultureInfo("ar-SA"), new CultureInfo("de-DE"), new CultureInfo("he-IL"),
-                                                            new CultureInfo("ru-RU"), new CultureInfo("zh-CN"), };
+                                                            new CultureInfo("ru-RU"), new CultureInfo("zh-CN") };
             if (PlatformDetection.IsNotUsingLimitedCultures)
                 cultures.AddRange(new[] { new CultureInfo("as"), new CultureInfo("es-BO"), new CultureInfo("luy-KE") });
 


### PR DESCRIPTION
See https://github.com/dotnet/runtime/issues/87643 issue.

I updated tests for cultures where `CurrencyNegativePattern == 16` ("luy" and "luy-KE").