### PR TITLE
[PoC] surface Quic transport errors

### DIFF
--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -61,12 +61,14 @@ namespace System.Net.Quic
         ProtocolError = 11,
         OperationAborted = 12,
         AlpnInUse = 13,
+        TransportError = 14,
     }
     public sealed partial class QuicException : System.IO.IOException
     {
         public QuicException(System.Net.Quic.QuicError error, long? applicationErrorCode, string message) { }
         public long? ApplicationErrorCode { get { throw null; } }
         public System.Net.Quic.QuicError QuicError { get { throw null; } }
+        public long? TransportErrorCode { get { throw null; } }
     }
     public sealed partial class QuicListener : System.IAsyncDisposable
     {

--- a/src/libraries/System.Net.Quic/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Quic/src/Resources/Strings.resx
@@ -207,6 +207,9 @@
   <data name="net_quic_protocol_error" xml:space="preserve">
     <value>A QUIC protocol error was encountered</value>
   </data>
+  <data name="net_quic_transport_error" xml:space="preserve">
+    <value>QUIC encountered transport error '{0}'</value>
+  </data>
   <data name="net_quic_alpn_in_use" xml:space="preserve">
     <value>Another QUIC listener is already listening on one of the requested application protocols on the same port.</value>
   </data>

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -479,9 +479,6 @@ public sealed partial class QuicConnection : IAsyncDisposable
     }
     private unsafe int HandleEventShutdownInitiatedByTransport(ref SHUTDOWN_INITIATED_BY_TRANSPORT_DATA data)
     {
-        // TODO: we should propagate transport error code.
-        // https://github.com/dotnet/runtime/issues/72666
-
         Exception exception = ExceptionDispatchInfo.SetCurrentStackTrace(ThrowHelper.GetExceptionForMsQuicStatus(data.Status, null, (long)data.ErrorCode));
         _connectedTcs.TrySetException(exception);
         _acceptQueue.Writer.TryComplete(exception);

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -481,7 +481,8 @@ public sealed partial class QuicConnection : IAsyncDisposable
     {
         // TODO: we should propagate transport error code.
         // https://github.com/dotnet/runtime/issues/72666
-        Exception exception = ExceptionDispatchInfo.SetCurrentStackTrace(ThrowHelper.GetExceptionForMsQuicStatus(data.Status));
+
+        Exception exception = ExceptionDispatchInfo.SetCurrentStackTrace(ThrowHelper.GetExceptionForMsQuicStatus(data.Status, null, (long)data.ErrorCode));
         _connectedTcs.TrySetException(exception);
         _acceptQueue.Writer.TryComplete(exception);
         return QUIC_STATUS_SUCCESS;

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicError.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicError.cs
@@ -77,5 +77,10 @@ namespace System.Net.Quic
         /// Another QUIC listener is already listening on one of the requested application protocols on the same port.
         /// </summary>
         AlpnInUse,
+
+        /// <summary>
+        /// Quic operation failed because of Quic transport error.
+        /// </summary>
+        TransportError,
     }
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicException.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicException.cs
@@ -34,6 +34,14 @@ namespace System.Net.Quic
             ApplicationErrorCode = applicationErrorCode;
         }
 
+        internal QuicException(QuicError error, long? applicationErrorCode, long? transportErrorCode, string message, Exception? innerException)
+            : base(message, innerException)
+        {
+            QuicError = error;
+            ApplicationErrorCode = applicationErrorCode;
+            TransportErrorCode = transportErrorCode;
+        }
+
         /// <summary>
         /// Gets the error which is associated with this exception.
         /// </summary>
@@ -46,5 +54,10 @@ namespace System.Net.Quic
         /// This property contains the error code set by the application layer when closing the connection (<see cref="QuicError.ConnectionAborted"/>) or closing a read/write direction of a QUIC stream (<see cref="QuicError.StreamAborted"/>). Contains null for all other errors.
         /// </remarks>
         public long? ApplicationErrorCode { get; }
+
+        /// <summary>
+        /// The transport error code as described in Quic RFC.
+        /// </summary>
+        public long? TransportErrorCode { get; }
     }
 }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicCipherSuitesPolicyTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicCipherSuitesPolicyTests.cs
@@ -71,12 +71,10 @@ namespace System.Net.Quic.Tests
         [Fact]
         public async Task MismatchedCipherPolicies_ConnectAsync_ThrowsQuicException()
         {
-            QuicException ex = await Assert.ThrowsAsync<QuicException>(() => TestConnection(
+            await AssertThrowsQuicExceptionAsync(QuicError.TransportError, () => TestConnection(
                new CipherSuitesPolicy(new[] { TlsCipherSuite.TLS_AES_128_GCM_SHA256 }),
                new CipherSuitesPolicy(new[] { TlsCipherSuite.TLS_AES_256_GCM_SHA384 })
             ));
-
-            Assert.Equal(QuicError.TransportError, ex.QuicError);
         }
     }
 }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicCipherSuitesPolicyTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicCipherSuitesPolicyTests.cs
@@ -71,10 +71,12 @@ namespace System.Net.Quic.Tests
         [Fact]
         public async Task MismatchedCipherPolicies_ConnectAsync_ThrowsQuicException()
         {
-            await Assert.ThrowsAsync<QuicException>(() => TestConnection(
+            QuicException ex = await Assert.ThrowsAsync<QuicException>(() => TestConnection(
                new CipherSuitesPolicy(new[] { TlsCipherSuite.TLS_AES_128_GCM_SHA256 }),
                new CipherSuitesPolicy(new[] { TlsCipherSuite.TLS_AES_256_GCM_SHA384 })
             ));
+
+            Assert.Equal(QuicError.TransportError, ex.QuicError);
         }
     }
 }


### PR DESCRIPTION
This implements  proposal from #72666.

We would currently surface TransportError on cipher mismatch. I suspect that both MsQuic and other implementations may have more codes that we do not handle so the actual set may be bigger.

Looking at the cases again when we throw on transport error, I would like to prose change on QUIC_STATUS_USER_CANCELED.

While that maps to MsQuic status, I feel cancellation has specific meaning in .NET around cancellation tokens. 
In tests where this happens there is no cancellation nor user. Typically this is failure to complete handshake operation. (like callback failure) 

```diff
-  System.Security.Authentication.AuthenticationException: Authentication failed because the remote party sent a TLS alert: 'UserCanceled'.
+  System.Net.Quic.QuicException: QUIC encountered transport error '346'
```

I also feel that when we would surface as transport error, we would be more following RFC than MsQuic internals. In either case there is not much the code can do e.g. this is purely diagnostic. 


