### PR TITLE
Faster optimized frozen dictionary creation (3/n)

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenHashTable.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenHashTable.cs
@@ -38,18 +38,19 @@ namespace System.Collections.Frozen
         /// <summary>Initializes a frozen hash table.</summary>
         /// <param name="hashCodes">Pre-calculated hash codes. When the method finishes, it assigns each value to destination index.</param>
         /// <param name="optimizeForReading">true to spend additional effort tuning for subsequent read speed on the table; false to prioritize construction time.</param>
+        /// <param name="hashCodesAreUnique">True when the input hash codes are already unique (provided from a dictionary of integers for example).</param>
         /// <remarks>
         /// It will then determine the optimal number of hash buckets to allocate and will populate the
         /// bucket table. The caller is responsible to consume the values written to <paramref name="hashCodes"/> and update the destination (if desired).
         /// <see cref="FindMatchingEntries(int, out int, out int)"/> then uses this index to reference individual entries by indexing into <see cref="HashCodes"/>.
         /// </remarks>
         /// <returns>A frozen hash table.</returns>
-        public static FrozenHashTable Create(Span<int> hashCodes, bool optimizeForReading = true)
+        public static FrozenHashTable Create(Span<int> hashCodes, bool optimizeForReading = true, bool hashCodesAreUnique = false)
         {
             // Determine how many buckets to use.  This might be fewer than the number of entries
             // if any entries have identical hashcodes (not just different hashcodes that might
             // map to the same bucket).
-            int numBuckets = CalcNumBuckets(hashCodes, optimizeForReading);
+            int numBuckets = CalcNumBuckets(hashCodes, optimizeForReading, hashCodesAreUnique);
             ulong fastModMultiplier = HashHelpers.GetFastModMultiplier((uint)numBuckets);
 
             // Create two spans:
@@ -143,9 +144,10 @@ namespace System.Collections.Frozen
         /// sizes, starting at the exact number of hash codes and incrementing the bucket count by 1 per trial,
         /// this is a trade-off between speed of determining a good number of buckets and maximal density.
         /// </remarks>
-        private static int CalcNumBuckets(ReadOnlySpan<int> hashCodes, bool optimizeForReading)
+        private static int CalcNumBuckets(ReadOnlySpan<int> hashCodes, bool optimizeForReading, bool hashCodesAreUnique)
         {
             Debug.Assert(hashCodes.Length != 0);
+            Debug.Assert(!hashCodesAreUnique || new HashSet<int>(hashCodes.ToArray()).Count == hashCodes.Length);
 
             const int LargeInputSizeThreshold = 1000;     // What is the limit for an input to be considered "small"?
             const int MaxSmallBucketTableMultiplier = 16; // How large a bucket table should be allowed for small inputs?
@@ -157,38 +159,42 @@ namespace System.Collections.Frozen
             }
 
             // Filter out duplicate codes, since no increase in buckets will avoid collisions from duplicate input hash codes.
-            var codes =
+            HashSet<int>? codes = hashCodesAreUnique ? null :
 #if NETCOREAPP2_0_OR_GREATER
                 new HashSet<int>(hashCodes.Length);
 #else
                 new HashSet<int>();
 #endif
-            foreach (int hashCode in hashCodes)
+            if (codes is not null)
             {
-                codes.Add(hashCode);
+                foreach (int hashCode in hashCodes)
+                {
+                    codes.Add(hashCode);
+                }
             }
-            Debug.Assert(codes.Count != 0);
+            int uniqueCodesCount = hashCodesAreUnique ? hashCodes.Length : codes!.Count;
+            Debug.Assert(uniqueCodesCount != 0);
 
             // In our precomputed primes table, find the index of the smallest prime that's at least as large as our number of
             // hash codes. If there are more codes than in our precomputed primes table, which accommodates millions of values,
             // give up and just use the next prime.
             ReadOnlySpan<int> primes = HashHelpers.Primes;
             int minPrimeIndexInclusive = 0;
-            while ((uint)minPrimeIndexInclusive < (uint)primes.Length && codes.Count > primes[minPrimeIndexInclusive])
+            while ((uint)minPrimeIndexInclusive < (uint)primes.Length && uniqueCodesCount > primes[minPrimeIndexInclusive])
             {
                 minPrimeIndexInclusive++;
             }
 
             if (minPrimeIndexInclusive >= primes.Length)
             {
-                return HashHelpers.GetPrime(codes.Count);
+                return HashHelpers.GetPrime(uniqueCodesCount);
             }
 
             // Determine the largest number of buckets we're willing to use, based on a multiple of the number of inputs.
             // For smaller inputs, we allow for a larger multiplier.
             int maxNumBuckets =
-                codes.Count *
-                (codes.Count >= LargeInputSizeThreshold ? MaxLargeBucketTableMultiplier : MaxSmallBucketTableMultiplier);
+                uniqueCodesCount *
+                (uniqueCodesCount >= LargeInputSizeThreshold ? MaxLargeBucketTableMultiplier : MaxSmallBucketTableMultiplier);
 
             // Find the index of the smallest prime that accommodates our max buckets.
             int maxPrimeIndexExclusive = minPrimeIndexInclusive;
@@ -208,7 +214,7 @@ namespace System.Collections.Frozen
 
             int bestNumBuckets = maxNumBuckets;
             // just one more collision than the acceptable collision rate (5%)
-            int bestNumCollisions = (codes.Count / 20) + 1;
+            int bestNumCollisions = (uniqueCodesCount / 20) + 1;
 
             // Iterate through each available prime between the min and max discovered. For each, compute
             // the collision ratio.
@@ -221,22 +227,50 @@ namespace System.Collections.Frozen
                 // Determine the bucket for each hash code and mark it as seen. If it was already seen,
                 // track it as a collision.
                 int numCollisions = 0;
-                foreach (int code in codes)
+
+                if (codes is not null && uniqueCodesCount != hashCodes.Length)
                 {
-                    uint bucketNum = (uint)code % (uint)numBuckets;
-                    if ((seenBuckets[bucketNum / BitsPerInt32] & (1 << (int)bucketNum)) != 0)
+                    foreach (int code in codes)
                     {
-                        numCollisions++;
-                        if (numCollisions >= bestNumCollisions)
+                        uint bucketNum = (uint)code % (uint)numBuckets;
+                        if ((seenBuckets[bucketNum / BitsPerInt32] & (1 << (int)bucketNum)) != 0)
                         {
-                            // If we've already hit the previously known best number of collisions,
-                            // there's no point in continuing as worst case we'd just use that.
-                            break;
+                            numCollisions++;
+                            if (numCollisions >= bestNumCollisions)
+                            {
+                                // If we've already hit the previously known best number of collisions,
+                                // there's no point in continuing as worst case we'd just use that.
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            seenBuckets[bucketNum / BitsPerInt32] |= 1 << (int)bucketNum;
                         }
                     }
-                    else
+                }
+                else
+                {
+                    // We can get here in two cases:
+                    // 1. hashCodesAreUnique was true (the input comes from a unique collection of integers), so we have skipped the hash set creation.
+                    // 2. all hash codes turned out to be unique. In such scenario, it's faster to iterate over a span.
+                    foreach (int code in hashCodes)
                     {
-                        seenBuckets[bucketNum / BitsPerInt32] |= 1 << (int)bucketNum;
+                        uint bucketNum = (uint)code % (uint)numBuckets;
+                        if ((seenBuckets[bucketNum / BitsPerInt32] & (1 << (int)bucketNum)) != 0)
+                        {
+                            numCollisions++;
+                            if (numCollisions >= bestNumCollisions)
+                            {
+                                // If we've already hit the previously known best number of collisions,
+                                // there's no point in continuing as worst case we'd just use that.
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            seenBuckets[bucketNum / BitsPerInt32] |= 1 << (int)bucketNum;
+                        }
                     }
                 }
 
@@ -246,7 +280,7 @@ namespace System.Collections.Frozen
                 {
                     bestNumBuckets = numBuckets;
 
-                    if (numCollisions <= (codes.Count / 20))
+                    if (numCollisions <= (uniqueCodesCount / 20))
                     {
                         break;
                     }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenHashTable.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenHashTable.cs
@@ -253,9 +253,7 @@ namespace System.Collections.Frozen
                 }
                 else
                 {
-                    // We can get here in two cases:
-                    // 1. hashCodesAreUnique was true (the input comes from a unique collection of integers), so we have skipped the hash set creation.
-                    // 2. all hash codes turned out to be unique. In such scenario, it's faster to iterate over a span.
+                    // All of the hash codes in hashCodes are unique. In such scenario, it's faster to iterate over a span.
                     foreach (int code in hashCodes)
                     {
                         uint bucketNum = (uint)code % (uint)numBuckets;

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenHashTable.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenHashTable.cs
@@ -149,6 +149,7 @@ namespace System.Collections.Frozen
             Debug.Assert(hashCodes.Length != 0);
             Debug.Assert(!hashCodesAreUnique || new HashSet<int>(hashCodes.ToArray()).Count == hashCodes.Length);
 
+            const double AcceptableCollisionRate = 0.05;  // What is a satisfactory rate of hash collisions?
             const int LargeInputSizeThreshold = 1000;     // What is the limit for an input to be considered "small"?
             const int MaxSmallBucketTableMultiplier = 16; // How large a bucket table should be allowed for small inputs?
             const int MaxLargeBucketTableMultiplier = 3;  // How large a bucket table should be allowed for large inputs?
@@ -213,8 +214,7 @@ namespace System.Collections.Frozen
             int[] seenBuckets = ArrayPool<int>.Shared.Rent((maxNumBuckets / BitsPerInt32) + 1);
 
             int bestNumBuckets = maxNumBuckets;
-            // just one more collision than the acceptable collision rate (5%)
-            int bestNumCollisions = (uniqueCodesCount / 20) + 1;
+            int bestNumCollisions = uniqueCodesCount;
 
             // Iterate through each available prime between the min and max discovered. For each, compute
             // the collision ratio.
@@ -280,7 +280,7 @@ namespace System.Collections.Frozen
                 {
                     bestNumBuckets = numBuckets;
 
-                    if (numCollisions <= (uniqueCodesCount / 20))
+                    if (numCollisions / (double)uniqueCodesCount <= AcceptableCollisionRate)
                     {
                         break;
                     }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenHashTable.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenHashTable.cs
@@ -160,20 +160,22 @@ namespace System.Collections.Frozen
             }
 
             // Filter out duplicate codes, since no increase in buckets will avoid collisions from duplicate input hash codes.
-            HashSet<int>? codes = hashCodesAreUnique ? null :
-#if NETCOREAPP2_0_OR_GREATER
-                new HashSet<int>(hashCodes.Length);
-#else
-                new HashSet<int>();
-#endif
-            if (codes is not null)
+            HashSet<int>? codes = null;
+            int uniqueCodesCount = hashCodes.Length;
+            if (!hashCodesAreUnique)
             {
+                codes =
+#if NETCOREAPP2_0_OR_GREATER
+                    new HashSet<int>(hashCodes.Length);
+#else
+                    new HashSet<int>();
+#endif
                 foreach (int hashCode in hashCodes)
                 {
                     codes.Add(hashCode);
                 }
+                uniqueCodesCount = codes.Count;
             }
-            int uniqueCodesCount = hashCodesAreUnique ? hashCodes.Length : codes!.Count;
             Debug.Assert(uniqueCodesCount != 0);
 
             // In our precomputed primes table, find the index of the smallest prime that's at least as large as our number of

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenHashTable.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenHashTable.cs
@@ -147,7 +147,6 @@ namespace System.Collections.Frozen
         {
             Debug.Assert(hashCodes.Length != 0);
 
-            const double AcceptableCollisionRate = 0.05;  // What is a satisfactory rate of hash collisions?
             const int LargeInputSizeThreshold = 1000;     // What is the limit for an input to be considered "small"?
             const int MaxSmallBucketTableMultiplier = 16; // How large a bucket table should be allowed for small inputs?
             const int MaxLargeBucketTableMultiplier = 3;  // How large a bucket table should be allowed for large inputs?
@@ -208,7 +207,8 @@ namespace System.Collections.Frozen
             int[] seenBuckets = ArrayPool<int>.Shared.Rent((maxNumBuckets / BitsPerInt32) + 1);
 
             int bestNumBuckets = maxNumBuckets;
-            int bestNumCollisions = codes.Count;
+            // just one more collision than the acceptable collision rate (5%)
+            int bestNumCollisions = (codes.Count / 20) + 1;
 
             // Iterate through each available prime between the min and max discovered. For each, compute
             // the collision ratio.
@@ -246,7 +246,7 @@ namespace System.Collections.Frozen
                 {
                     bestNumBuckets = numBuckets;
 
-                    if (numCollisions / (double)codes.Count <= AcceptableCollisionRate)
+                    if (numCollisions <= (codes.Count / 20))
                     {
                         break;
                     }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Int32/Int32FrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Int32/Int32FrozenDictionary.cs
@@ -35,7 +35,7 @@ namespace System.Collections.Frozen
                 hashCodes[i] = entries[i].Key;
             }
 
-            _hashTable = FrozenHashTable.Create(hashCodes);
+            _hashTable = FrozenHashTable.Create(hashCodes, hashCodesAreUnique: true);
 
             for (int srcIndex = 0; srcIndex < hashCodes.Length; srcIndex++)
             {

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Int32/Int32FrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Int32/Int32FrozenDictionary.cs
@@ -35,9 +35,14 @@ namespace System.Collections.Frozen
                 hashCodes[i] = entries[i].Key;
             }
 
-            _hashTable = FrozenHashTable.Create(
-                hashCodes,
-                (destIndex, srcIndex) => _values[destIndex] = entries[srcIndex].Value);
+            _hashTable = FrozenHashTable.Create(hashCodes);
+
+            for (int srcIndex = 0; srcIndex < hashCodes.Length; srcIndex++)
+            {
+                int destIndex = hashCodes[srcIndex];
+
+                _values[destIndex] = entries[srcIndex].Value;
+            }
 
             ArrayPool<int>.Shared.Return(arrayPoolHashCodes);
         }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Int32/Int32FrozenSet.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Int32/Int32FrozenSet.cs
@@ -25,9 +25,7 @@ namespace System.Collections.Frozen
             int[] entries = ArrayPool<int>.Shared.Rent(count);
             source.CopyTo(entries);
 
-            _hashTable = FrozenHashTable.Create(
-                new ReadOnlySpan<int>(entries, 0, count),
-                static delegate { });
+            _hashTable = FrozenHashTable.Create(new Span<int>(entries, 0, count));
 
             ArrayPool<int>.Shared.Return(entries);
         }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Int32/Int32FrozenSet.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Int32/Int32FrozenSet.cs
@@ -25,7 +25,7 @@ namespace System.Collections.Frozen
             int[] entries = ArrayPool<int>.Shared.Rent(count);
             source.CopyTo(entries);
 
-            _hashTable = FrozenHashTable.Create(new Span<int>(entries, 0, count));
+            _hashTable = FrozenHashTable.Create(new Span<int>(entries, 0, count), hashCodesAreUnique: true);
 
             ArrayPool<int>.Shared.Return(entries);
         }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/ItemsFrozenSet.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/ItemsFrozenSet.cs
@@ -30,10 +30,14 @@ namespace System.Collections.Frozen
                 hashCodes[i] = entries[i] is T t ? Comparer.GetHashCode(t) : 0;
             }
 
-            _hashTable = FrozenHashTable.Create(
-                hashCodes,
-                (destIndex, srcIndex) => _items[destIndex] = entries[srcIndex],
-                optimizeForReading);
+            _hashTable = FrozenHashTable.Create(hashCodes, optimizeForReading);
+
+            for (int srcIndex = 0; srcIndex < hashCodes.Length; srcIndex++)
+            {
+                int destIndex = hashCodes[srcIndex];
+
+                _items[destIndex] = entries[srcIndex];
+            }
 
             ArrayPool<int>.Shared.Return(arrayPoolHashCodes);
         }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/KeysAndValuesFrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/KeysAndValuesFrozenDictionary.cs
@@ -32,14 +32,15 @@ namespace System.Collections.Frozen
                 hashCodes[i] = Comparer.GetHashCode(entries[i].Key);
             }
 
-            _hashTable = FrozenHashTable.Create(
-                hashCodes,
-                (destIndex, srcIndex) =>
-                {
-                    _keys[destIndex] = entries[srcIndex].Key;
-                    _values[destIndex] = entries[srcIndex].Value;
-                },
-                optimizeForReading);
+            _hashTable = FrozenHashTable.Create(hashCodes, optimizeForReading);
+
+            for (int srcIndex = 0; srcIndex < hashCodes.Length; srcIndex++)
+            {
+                int destIndex = hashCodes[srcIndex];
+
+                _keys[destIndex] = entries[srcIndex].Key;
+                _values[destIndex] = entries[srcIndex].Value;
+            }
 
             ArrayPool<int>.Shared.Return(arrayPoolHashCodes);
         }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary.cs
@@ -47,13 +47,15 @@ namespace System.Collections.Frozen
                 hashCodes[i] = GetHashCode(keys[i]);
             }
 
-            _hashTable = FrozenHashTable.Create(
-                hashCodes,
-                (destIndex, srcIndex) =>
-                {
-                    _keys[destIndex] = keys[srcIndex];
-                    _values[destIndex] = values[srcIndex];
-                });
+            _hashTable = FrozenHashTable.Create(hashCodes);
+
+            for (int srcIndex = 0; srcIndex < hashCodes.Length; srcIndex++)
+            {
+                int destIndex = hashCodes[srcIndex];
+
+                _keys[destIndex] = keys[srcIndex];
+                _values[destIndex] = values[srcIndex];
+            }
 
             ArrayPool<int>.Shared.Return(arrayPoolHashCodes);
         }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenSet.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenSet.cs
@@ -38,9 +38,14 @@ namespace System.Collections.Frozen
                 hashCodes[i] = GetHashCode(entries[i]);
             }
 
-            _hashTable = FrozenHashTable.Create(
-                hashCodes,
-                (destIndex, srcIndex) => _items[destIndex] = entries[srcIndex]);
+            _hashTable = FrozenHashTable.Create(hashCodes);
+
+            for (int srcIndex = 0; srcIndex < hashCodes.Length; srcIndex++)
+            {
+                int destIndex = hashCodes[srcIndex];
+
+                _items[destIndex] = entries[srcIndex];
+            }
 
             ArrayPool<int>.Shared.Return(arrayPoolHashCodes);
         }


### PR DESCRIPTION
- avoid the need of having `Action<int, int> storeDestIndexFromSrcIndex` by writing the destination indexes to the provided buffer with hashcodes after we are done using the hashcodes, move the responsibility of updating the destination to the caller (1-4% gain)
    - I know it's hacky and it's just 1-4%, so please let me know what you think.
- For cases where the key is an integer and we know the input is already unique (because it comes from a dictionary or a hash set) there is no need to create another hash set.
    - +15% gain for scenarios where the key was an integer (time), 13-19% allocations drop
    - Also, in cases where simply all hash codes are unique, we can iterate over a span rather than a hash set. Up to +5% gain where string keys turned out to have unique hash codes

|                       Type |                    Method | Toolchain | Size |     Mean | Ratio | Allocated | Alloc Ratio |
|--------------------------- |-------------------------- |---------- |----- |---------:|------:|----------:|------------:|
|  CtorFromCollection&lt;Int32&gt; | FrozenDictionaryOptimized |   this PR |  512 | 38.95 us |  0.84 |  34.48 KB |        0.81 |
|  CtorFromCollection&lt;Int32&gt; | FrozenDictionaryOptimized |    #87630 |  512 | 46.29 us |  1.00 |  42.84 KB |        1.00 |
|                            |                           |           |      |          |       |           |             |
| CtorFromCollection&lt;String&gt; | FrozenDictionaryOptimized |   this PR |  512 | 63.21 us |  0.94 |  74.77 KB |        1.00 |
| CtorFromCollection&lt;String&gt; | FrozenDictionaryOptimized |    #87630 |  512 | 67.59 us |  1.00 |  74.88 KB |        1.00 |
|                            |                           |           |      |          |       |           |             |
|  CtorFromCollection&lt;Int32&gt; |        FrozenSetOptimized |   this PR |  512 | 52.80 us |  0.85 |  56.01 KB |        0.87 |
|  CtorFromCollection&lt;Int32&gt; |        FrozenSetOptimized |    #87630 |  512 | 62.19 us |  1.00 |  64.27 KB |        1.00 |
|                            |                           |           |      |          |       |           |             |
| CtorFromCollection&lt;String&gt; |        FrozenSetOptimized |   this PR |  512 | 79.05 us |  0.94 |  77.05 KB |        1.00 |
| CtorFromCollection&lt;String&gt; |        FrozenSetOptimized |    #87630 |  512 | 83.85 us |  1.00 |  77.14 KB |        1.00 |

