### PR TITLE
Adjust the costs for floating-point/simd to better reflect reality

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -3899,7 +3899,7 @@ unsigned Compiler::gtSetMultiOpOrder(GenTreeMultiOp* multiOp)
     int costEx = 1;
     int costSz = 1;
 
-    unsigned level  = 0;
+    unsigned level = 0;
 
 #if defined(FEATURE_HW_INTRINSICS)
     if (multiOp->OperIs(GT_HWINTRINSIC))
@@ -3971,8 +3971,8 @@ unsigned Compiler::gtSetMultiOpOrder(GenTreeMultiOp* multiOp)
         }
         else
         {
-            // Most encountered HWI nodes are simple arithmetic operations
-            // so default to the same cost as something like add/subtract
+// Most encountered HWI nodes are simple arithmetic operations
+// so default to the same cost as something like add/subtract
 
 #if defined(TARGET_XARCH)
             costEx = 1;

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -4078,7 +4078,7 @@ unsigned Compiler::gtSetMultiOpOrder(GenTreeMultiOp* multiOp)
            such cases, both sides have a level of 0. So encourage constants
            to be evaluated last in such cases */
 
-        if ((level == 0) && (level == lvl2) && op1->OperIsConst() &&
+        if ((level == 0) && (level == lvl2) && op1->OperIsConst() && !op2->OperIsConst() &&
             (multiOp->OperIsCommutative() || multiOp->OperIsCompare()))
         {
             lvl2++;
@@ -4091,7 +4091,7 @@ unsigned Compiler::gtSetMultiOpOrder(GenTreeMultiOp* multiOp)
         {
             if (multiOp->IsReverseOp())
             {
-                tryToSwap = (level > lvl2);
+                tryToSwap = (lvl2 < level);
             }
             else
             {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -5395,6 +5395,7 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
             }
             break;
 
+#if defined(FEATURE_SIMD)
             case GT_CNS_VEC:
             {
                 level = 0;
@@ -5476,6 +5477,7 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
 #endif
                 break;
             }
+#endif // FEATURE_SIMD
 
             case GT_LCL_VAR:
                 level = 1;


### PR DESCRIPTION
For floating-point and SIMD constants, they were originally modeled after the `GT_IND` costs. However, on xarch they take more cycles to execute and more bytes to encode. This ensures they accurately represent the size and execution costs, including taking into account its a RIP relative encoding and so significantly larger.

For HWIntrinsics, it was missing some common optimizations that were taken. This minimally ensures that memory accesess are correct and the base size costs are more accurate. The execution costs have a lot of room for improvement.