### PR TITLE
Fix a minor race condition in Monitor's AwareLock regarding tracking of waiter starvation

### DIFF
--- a/src/coreclr/vm/syncblk.inl
+++ b/src/coreclr/vm/syncblk.inl
@@ -273,8 +273,8 @@ FORCEINLINE bool AwareLock::LockState::InterlockedTryLock_Or_RegisterWaiter(Awar
             _ASSERTE(state.HasAnyWaiters() || waiterStarvationStartTimeWasReset);
             if (!state.HasAnyWaiters() || waiterStarvationStartTimeWasReset)
             {
-                // This was the first waiter or the waiter starvation start time was reset, record the waiter starvation start
-                // time
+                // This was the first waiter or the waiter starvation start time was reset. Record the waiter starvation start
+                // time.
                 awareLock->RecordWaiterStarvationStartTime();
             }
             return false;

--- a/src/coreclr/vm/syncblk.inl
+++ b/src/coreclr/vm/syncblk.inl
@@ -270,10 +270,11 @@ FORCEINLINE bool AwareLock::LockState::InterlockedTryLock_Or_RegisterWaiter(Awar
                 return true;
             }
 
-            if (!state.HasAnyWaiters())
+            _ASSERTE(state.HasAnyWaiters() || waiterStarvationStartTimeWasReset);
+            if (!state.HasAnyWaiters() || waiterStarvationStartTimeWasReset)
             {
-                // This was the first waiter, record the waiter starvation start time
-                _ASSERTE(waiterStarvationStartTimeWasReset);
+                // This was the first waiter or the waiter starvation start time was reset, record the waiter starvation start
+                // time
                 awareLock->RecordWaiterStarvationStartTime();
             }
             return false;


### PR DESCRIPTION
- When the first waiter is starting to wait, the waiter starvation start time is reset before registering the waiter, and the waiter starvation start time is updated after a successful CAS. In the CAS loop it may be determined initially that this thread wasn't the first waiter, and after a successful CAS, it may end up being the first waiter. It's remotely possible that the waiter starvation start time is reset before the CAS loop and that after a successful CAS, this thread was not actually the first waiter, in which case the waiter starvation start time would not be updated, which can lead to waiter starvation.
- Fixed to always update the waiter starvation start time after the CAS if it was reset before the CAS