### PR TITLE
Improve memory utilization in the case of continuous BGC

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -43680,7 +43680,7 @@ ptrdiff_t gc_heap::estimate_gen_growth (int gen_number, bool for_bgc)
         // In case we were repeatedly unable to use the reserved space for partially used regions, we should 
         // discount the region end space as unusable. This happens rarely in SOH, but could be signficant for
         // pathological LOH/POH usage (e.g. always allocates slightly more than 16M).
-        usable_reserved_not_in_use = (ptrdiff_t)((double)reserved_not_in_use * min((1.0 - (double)uoh_try_fit_segment_end_fail_count/(double)uoh_try_fit_segment_end_count), 0));
+        usable_reserved_not_in_use = (ptrdiff_t)((double)reserved_not_in_use * (1.0 - (double)uoh_try_fit_segment_end_fail_count/(double)uoh_try_fit_segment_end_count));
     }
 
     // compute how much of the allocated space is on the free list

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -2332,6 +2332,10 @@ size_t      gc_heap::current_total_committed_bookkeeping = 0;
 
 BOOL        gc_heap::reset_mm_p = TRUE;
 
+uint32_t    gc_heap::uoh_try_fit_segment_end_fail_count = 0;
+
+uint32_t    gc_heap::uoh_try_fit_segment_end_count = 0;
+
 #ifdef FEATURE_EVENT_TRACE
 bool gc_heap::informational_event_enabled_p = false;
 
@@ -13311,7 +13315,12 @@ void gc_heap::distribute_free_regions()
             const int i = 0;
             const int n_heaps = 1;
 #endif //MULTIPLE_HEAPS
-            ptrdiff_t budget_gen = max (hp->estimate_gen_growth (gen), 0);
+#ifdef BACKGROUND_GC
+            bool bgc_running_p = background_running_p();
+#else
+            bool bgc_running_p = false;
+#endif
+            ptrdiff_t budget_gen = max (hp->estimate_gen_growth (gen, bgc_running_p), 0);
             int kind = gen >= loh_generation;
             size_t budget_gen_in_region_units = (budget_gen + (region_size[kind] - 1)) / region_size[kind];
             dprintf (REGIONS_LOG, ("h%2d gen %d has an estimated growth of %zd bytes (%zd regions)", i, gen, budget_gen, budget_gen_in_region_units));
@@ -13361,11 +13370,7 @@ void gc_heap::distribute_free_regions()
 
         ptrdiff_t balance = total_num_free_regions[kind] + num_huge_region_units_to_consider[kind] - total_budget_in_region_units[kind];
 
-        if (
-#ifdef BACKGROUND_GC
-            background_running_p() ||
-#endif
-            (balance < 0))
+        if (balance < 0)
         {
             dprintf (REGIONS_LOG, ("distributing the %zd %s regions deficit", -balance, kind_name[kind]));
 
@@ -17499,6 +17504,18 @@ BOOL gc_heap::a_fit_segment_end_p (int gen_number,
                                    int align_const,
                                    BOOL* commit_failed_p)
 {
+    if ((gen_number >= loh_generation) && (heap_segment_allocated(seg) != heap_segment_mem(seg)))
+    {
+        // Here we wanted to estimate the probability of the end of a region can fit allocation.
+        // We knew that it always do for new regions, so we only want to count the cases where
+        // we are extending an existing region
+        Interlocked::Increment(&uoh_try_fit_segment_end_count);
+        if (uoh_try_fit_segment_end_count == 0)
+        {
+            uoh_try_fit_segment_end_count = 1;
+            uoh_try_fit_segment_end_fail_count = 0;
+        }
+    }
     *commit_failed_p = FALSE;
     size_t limit = 0;
     bool hard_limit_short_seg_end_p = false;
@@ -17643,7 +17660,10 @@ found_fit:
     return TRUE;
 
 found_no_fit:
-
+    if (gen_number >= loh_generation)
+    {
+        Interlocked::Increment(&uoh_try_fit_segment_end_fail_count);
+    }
     return FALSE;
 }
 
@@ -37751,6 +37771,7 @@ void gc_heap::background_mark_phase ()
     if (bgc_t_join.joined())
 #endif //MULTIPLE_HEAPS
     {
+        distribute_free_regions ();
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
         // Resetting write watch for software write watch is pretty fast, much faster than for hardware write watch. Reset
         // can be done while the runtime is suspended or after the runtime is restarted, the preference was to reset while
@@ -43634,11 +43655,11 @@ void gc_heap::trim_youngest_desired_low_memory()
     }
 }
 
-ptrdiff_t gc_heap::estimate_gen_growth (int gen_number)
+ptrdiff_t gc_heap::estimate_gen_growth (int gen_number, bool for_bgc)
 {
     dynamic_data* dd_gen = dynamic_data_of (gen_number);
     generation *gen = generation_of (gen_number);
-    ptrdiff_t new_allocation_gen = dd_new_allocation (dd_gen);
+    ptrdiff_t new_allocation_gen = for_bgc ? dd_desired_allocation (dd_gen) : dd_new_allocation (dd_gen);
     ptrdiff_t free_list_space_gen = generation_free_list_space (gen);
 
 #ifdef USE_REGIONS
@@ -43652,6 +43673,16 @@ ptrdiff_t gc_heap::estimate_gen_growth (int gen_number)
         reserved_not_in_use += heap_segment_reserved (region) - heap_segment_allocated (region);
     }
 
+    ptrdiff_t usable_reserved_not_in_use = reserved_not_in_use;
+    
+    if (gen_number >= loh_generation)
+    {
+        // In case we were repeatedly unable to use the reserved space for partially used regions, we should 
+        // discount the region end space as unusable. This happens rarely in SOH, but could be signficant for
+        // pathological LOH/POH usage (e.g. always allocates slightly more than 16M).
+        usable_reserved_not_in_use = (ptrdiff_t)((double)reserved_not_in_use * min((1.0 - (double)uoh_try_fit_segment_end_fail_count/(double)uoh_try_fit_segment_end_count), 0));
+    }
+
     // compute how much of the allocated space is on the free list
     double free_list_fraction_gen = (allocated_gen == 0) ? 0.0 : (double)(free_list_space_gen) / (double)allocated_gen;
 
@@ -43660,7 +43691,7 @@ ptrdiff_t gc_heap::estimate_gen_growth (int gen_number)
     // e.g. if 10% of the allocated space is free, assume 10% of these 10% can get used
     ptrdiff_t usable_free_space = (ptrdiff_t)(free_list_fraction_gen * free_list_space_gen);
 
-    ptrdiff_t budget_gen = new_allocation_gen - usable_free_space - reserved_not_in_use;
+    ptrdiff_t budget_gen = new_allocation_gen - usable_free_space - usable_reserved_not_in_use;
 
     dprintf (REGIONS_LOG, ("h%2d gen %d budget %zd allocated: %zd, FL: %zd, reserved_not_in_use %zd budget_gen %zd",
         heap_number, gen_number, new_allocation_gen, allocated_gen, free_list_space_gen, reserved_not_in_use, budget_gen));

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -3048,7 +3048,7 @@ private:
 
     PER_HEAP_METHOD void trim_youngest_desired_low_memory();
 
-    PER_HEAP_METHOD ptrdiff_t estimate_gen_growth (int gen);
+    PER_HEAP_METHOD ptrdiff_t estimate_gen_growth (int gen, bool for_bgc = false);
 
     PER_HEAP_METHOD void decommit_ephemeral_segment_pages();
 
@@ -4295,6 +4295,11 @@ private:
     // See comments for heap_hard_limit.
     PER_HEAP_ISOLATED_FIELD_MAINTAINED_ALLOC size_t current_total_committed;
     PER_HEAP_ISOLATED_FIELD_MAINTAINED_ALLOC size_t committed_by_oh[recorded_committed_bucket_counts];
+
+    // Thess are the numerator and the denominator of our estimate on how likely an existing UOH region 
+    // can fit new allocation.
+    PER_HEAP_ISOLATED_FIELD_MAINTAINED_ALLOC uint32_t uoh_try_fit_segment_end_fail_count;
+    PER_HEAP_ISOLATED_FIELD_MAINTAINED_ALLOC uint32_t uoh_try_fit_segment_end_count;
 
     /********************************************/
     // PER_HEAP_ISOLATED_FIELD_INIT_ONLY fields //


### PR DESCRIPTION
In the [repro](https://github.com/arian2ashk/OOMTest) provided by @arian2ashk in https://github.com/dotnet/runtime/issues/78959, we observed that the GC is utilizing memory poorly. 

This is because the application is continuously allocating large objects, leading to continuous background GC. Before this change, background GC is unable to decommit free regions, leading to them being accumulated. 

This change allows them to be decommitted by calling `distribute_free_regions` at the beginning of background GC while the runtime is still suspended.

To make this actually work nicely, I need to modify the heuristic for generation size growth estimation. This application keeps allocating objects slightly larger than 16M, and so the application almost always wastes half of the 32M regions we default to. In that case, subtracting the reserved portion in the size growth estimation is inappropriate. In this change, I added some counters to estimate how likely we fail to use the reserve portion, and therefore use that to discount the reserved portion for subtraction.

Before this change, this application regularly use 3G of memory on my machine, after this change, it regularly uses less than 1G.

This is a work in progress. I haven't validated it against any other test cases yet.

Here are some typical numbers when running against the repro, these numbers are captured during `estimate_gen_growth` for LOH.

```
new_allocation_gen 17462144
usable_free_space 0
reserved_not_in_use 50331448
budget_gen_old -32869304 
uoh_try_fit_segment_end_fail_count 23805
uoh_try_fit_segment_end_count 24225
usable_reserved_not_in_use 872619
budget_gen 16589525
```

The `budget_gen_old` was computed by `new_allocation_gen - usable_free_space - reserved_not_in_use`, with the large `reserved_not_in_use` space, that make `budget_gen_old` ends up a negative number, leading `distribute_free_region` to free all the available free_region

But looking at the `uoh_try_fit_segment_end_fail_count` compared with the `uoh_try_fit_segment_end_count`, we knew that majority of the time these reserved end space is not usable, so we discounted the  `reserved_not_in_use` by that ratio to a much smaller `usable_reserved_not_in_use`, now the subtraction leads to a positve number, which means `distribute_free_region` will keep 1 free region, and that's sufficient to handle the allocation during background GC execution.

It sounded like a paradox, why we wanted to keep the free regions when we wanted to optimize for space? Here is why:

If we decided to free a region - we put it in the `global_regions_to_decommit` list and let the gradual decommit process to decommit it. The problem is that the regions allocation rate is faster than the decommit rate, so regions end up queuing in the `global_regions_to_decommit` list and increase the memory usage instead of dropping.
