### PR TITLE
Email addresses in same domain not equal

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -1636,6 +1636,11 @@ namespace System
                     return false;
             }
 
+            if (this.Scheme.Equals(UriSchemeMailto))
+            {
+                return this.ToString().Equals(obj.ToString());
+            }
+
             if (DisablePathAndQueryCanonicalization != obj.DisablePathAndQueryCanonicalization)
                 return false;
 

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -1737,6 +1737,7 @@ namespace System
             MoreInfo selfInfo = _info.MoreInfo;
             MoreInfo otherInfo = obj._info.MoreInfo;
 
+            // Fragment AND UserInfo (for non-mailto URIs) are ignored
             UriComponents components = UriComponents.HttpRequestUrl;
 
             if (_syntax.InFact(UriSyntaxFlags.MailToLikeUri))
@@ -1747,7 +1748,6 @@ namespace System
                 components |= UriComponents.UserInfo;
             }
 
-            // Fragment AND UserInfo are ignored
             string selfUrl = selfInfo.RemoteUrl ??= GetParts(components, UriFormat.SafeUnescaped);
             string otherUrl = otherInfo.RemoteUrl ??= obj.GetParts(components, UriFormat.SafeUnescaped);
 

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -1522,7 +1522,15 @@ namespace System
             else
             {
                 MoreInfo info = EnsureUriInfo().MoreInfo;
-                string remoteUrl = info.RemoteUrl ??= GetParts(UriComponents.HttpRequestUrl, UriFormat.SafeUnescaped);
+
+                UriComponents components = UriComponents.HttpRequestUrl;
+
+                if (_syntax.InFact(UriSyntaxFlags.MailToLikeUri))
+                {
+                    components |= UriComponents.UserInfo;
+                }
+
+                string remoteUrl = info.RemoteUrl ??= GetParts(components, UriFormat.SafeUnescaped);
 
                 if (IsUncOrDosPath)
                 {
@@ -1636,11 +1644,6 @@ namespace System
                     return false;
             }
 
-            if (this.Scheme.Equals(UriSchemeMailto))
-            {
-                return this.ToString().Equals(obj.ToString());
-            }
-
             if (DisablePathAndQueryCanonicalization != obj.DisablePathAndQueryCanonicalization)
                 return false;
 
@@ -1734,9 +1737,19 @@ namespace System
             MoreInfo selfInfo = _info.MoreInfo;
             MoreInfo otherInfo = obj._info.MoreInfo;
 
+            UriComponents components = UriComponents.HttpRequestUrl;
+
+            if (_syntax.InFact(UriSyntaxFlags.MailToLikeUri))
+            {
+                if (!obj._syntax.InFact(UriSyntaxFlags.MailToLikeUri))
+                    return false;
+
+                components |= UriComponents.UserInfo;
+            }
+
             // Fragment AND UserInfo are ignored
-            string selfUrl = selfInfo.RemoteUrl ??= GetParts(UriComponents.HttpRequestUrl, UriFormat.SafeUnescaped);
-            string otherUrl = otherInfo.RemoteUrl ??= obj.GetParts(UriComponents.HttpRequestUrl, UriFormat.SafeUnescaped);
+            string selfUrl = selfInfo.RemoteUrl ??= GetParts(components, UriFormat.SafeUnescaped);
+            string otherUrl = otherInfo.RemoteUrl ??= obj.GetParts(components, UriFormat.SafeUnescaped);
 
             // if IsUncOrDosPath is true then we ignore case in the path comparison
             return string.Equals(selfUrl, otherUrl, IsUncOrDosPath ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UriMailToTest.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UriMailToTest.cs
@@ -178,5 +178,14 @@ namespace System.PrivateUri.Tests
             Assert.Equal("", uri.AbsolutePath);
             Assert.Equal("\u30AF@\u30AF", uri.GetComponents(UriComponents.UserInfo | UriComponents.Host, UriFormat.SafeUnescaped));
         }
+
+        [Fact]
+        public void UriMailTo_DifferentEmailAddressesNotEqual_Success()
+        {
+            var uri1 = new Uri("mailto:first@contoso.com");
+            var uri2 = new Uri("mailto:second@contoso.com");
+
+            Assert.NotEqual(uri1, uri2);
+        }
     }
 }


### PR DESCRIPTION
Fixes #87564 

The user information in the URI for email addresses in same domain be ignored when comparing equality.