### PR TITLE
Return Matrix.Identity from static field instead of creating it every time

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix3x2.Impl.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix3x2.Impl.cs
@@ -48,19 +48,11 @@ namespace System.Numerics
                 Z = new Vector2(m31, m32);
             }
 
+            private static readonly Impl _identity = new Impl () { X = Vector2.UnitX, Y = Vector2.UnitY, Z = Vector2.Zero };
+
             public static Impl Identity
             {
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                get
-                {
-                    Impl result;
-
-                    result.X = Vector2.UnitX;
-                    result.Y = Vector2.UnitY;
-                    result.Z = Vector2.Zero;
-
-                    return result;
-                }
+                get => _identity;
             }
 
             public float this[int row, int column]

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.Impl.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.Impl.cs
@@ -67,20 +67,11 @@ namespace System.Numerics
                 W = new Vector4(value.Z, 0, 1);
             }
 
+            private static readonly Impl _identity = new Impl () { X = Vector4.UnitX, Y = Vector4.UnitY, Z = Vector4.UnitZ, W = Vector4.UnitW };
+
             public static Impl Identity
             {
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                get
-                {
-                    Impl result;
-
-                    result.X = Vector4.UnitX;
-                    result.Y = Vector4.UnitY;
-                    result.Z = Vector4.UnitZ;
-                    result.W = Vector4.UnitW;
-
-                    return result;
-                }
+                get => _identity;
             }
 
             public float this[int row, int column]


### PR DESCRIPTION
This significantly improves the performance when using this field, even on CoreCLR it is about 33% improvement. Quite a bit of matrix benchmarks from our suite rely on this property.

This is how it was originally implemented but has since been changed to creating a matrix on the fly in https://github.com/dotnet/runtime/commit/f8218f9c4aaf4d6725524dc5d9e14c985e0f1b51 leading to some reported regressions on mono.