### PR TITLE
JIT: Fix LocalUses::FindAccess

### DIFF
--- a/src/coreclr/jit/promotion.cpp
+++ b/src/coreclr/jit/promotion.cpp
@@ -765,7 +765,7 @@ private:
             }
 
             index++;
-        } while ((index < m_inducedAccesses.size()) && (m_inducedAccesses[index].Offset == offs));
+        } while ((index < m_accesses.size()) && (m_accesses[index].Offset == offs));
 
         return nullptr;
     }


### PR DESCRIPTION
The function is looking for access information with a specified type at a specified offset, but was using the wrong list here. That would in some cases with overlapping accesses cause us to fail to find the Access. The net result is that we rarely end up not promoting some induced accesses that we would otherwise promote.