### PR TITLE
[arm64]Use pairwise store in `WidenAsciiToUtf16`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -1670,9 +1670,9 @@ namespace System.Text
                             break;
                         }
 
-                        (Vector256<ushort> low, Vector256<ushort> upper) = Vector256.Widen(asciiVector);
-                        low.Store(pCurrentWriteAddress);
-                        upper.Store(pCurrentWriteAddress + Vector256<ushort>.Count);
+                        (Vector256<ushort> utf16LowVector, Vector256<ushort> utf16HighVector) = Vector256.Widen(asciiVector);
+                        utf16LowVector.Store(pCurrentWriteAddress);
+                        utf16HighVector.Store(pCurrentWriteAddress + Vector256<ushort>.Count);
 
                         currentOffset += (nuint)Vector256<byte>.Count;
                         pCurrentWriteAddress += (nuint)Vector256<byte>.Count;
@@ -1694,11 +1694,9 @@ namespace System.Text
                             break;
                         }
 
-                        // Vector128.Widen is not used here as it less performant on ARM64
-                        Vector128<ushort> utf16HalfVector = Vector128.WidenLower(asciiVector);
-                        utf16HalfVector.Store(pCurrentWriteAddress);
-                        utf16HalfVector = Vector128.WidenUpper(asciiVector);
-                        utf16HalfVector.Store(pCurrentWriteAddress + Vector128<ushort>.Count);
+                        (Vector128<ushort> utf16LowVector, Vector128<ushort> utf16HighVector) = Vector128.Widen(asciiVector);
+                        utf16LowVector.Store(pCurrentWriteAddress);
+                        utf16HighVector.Store(pCurrentWriteAddress + Vector128<ushort>.Count);
 
                         currentOffset += (nuint)Vector128<byte>.Count;
                         pCurrentWriteAddress += (nuint)Vector128<byte>.Count;


### PR DESCRIPTION
Since #85032, a pair of consecutive stores is optimized to a single pairwise store.

```diff
LOOP:
             ldr     q16, [x0, x3]
             mov     v17.16b, v16.16b
             uxtl    v17.8h, v17.8b
-            str     q17, [x1]
             uxtl2   v16.8h, v16.16b
-            str     q16, [x1, #0x10]
+            stp     q17, q16, [x1]
             add     x3, x3, #16
             add     x1, x1, #32
             cmp     x3, x2
             bls     LOOP
-		 				;; size=40 bbWeight=8 PerfScore 80.00
+			 			;; size=36 bbWeight=8 PerfScore 72.00
```

cc: @adamsitnik