### PR TITLE
Add LoggerMessageAttribute constructor's overloads

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/ref/Microsoft.Extensions.Logging.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/ref/Microsoft.Extensions.Logging.Abstractions.cs
@@ -129,6 +129,9 @@ namespace Microsoft.Extensions.Logging
     {
         public LoggerMessageAttribute() { }
         public LoggerMessageAttribute(int eventId, Microsoft.Extensions.Logging.LogLevel level, string message) { }
+        public LoggerMessageAttribute(Microsoft.Extensions.Logging.LogLevel level) { }
+        public LoggerMessageAttribute(Microsoft.Extensions.Logging.LogLevel level, string message) { }
+        public LoggerMessageAttribute(string message) { }
         public int EventId { get { throw null; } set { } }
         public string? EventName { get { throw null; } set { } }
         public Microsoft.Extensions.Logging.LogLevel Level { get { throw null; } set { } }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessageAttribute.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerMessageAttribute.cs
@@ -52,6 +52,38 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="LoggerMessageAttribute"/> class
+        /// which is used to guide the production of a strongly-typed logging method.
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        /// <param name="message">Format string of the log message.</param>
+        public LoggerMessageAttribute(LogLevel level, string message)
+        {
+            Level = level;
+            Message = message;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoggerMessageAttribute"/> class
+        /// which is used to guide the production of a strongly-typed logging method.
+        /// </summary>
+        /// <param name="level">The log level.</param>
+        public LoggerMessageAttribute(LogLevel level)
+        {
+            Level = level;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoggerMessageAttribute"/> class
+        /// which is used to guide the production of a strongly-typed logging method.
+        /// </summary>
+        /// <param name="message">Format string of the log message.</param>
+        public LoggerMessageAttribute(string message)
+        {
+            Message = message;
+        }
+
+        /// <summary>
         /// Gets the logging event id for the logging method.
         /// </summary>
         public int EventId { get; set; } = -1;

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratedCodeTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratedCodeTests.cs
@@ -282,6 +282,27 @@ namespace Microsoft.Extensions.Logging.Generators.Tests
             Assert.Equal("M1 Foo", logger.LastFormattedString);
             Assert.Equal(LogLevel.Trace, logger.LastLogLevel);
             Assert.Equal(1, logger.CallCount);
+
+            logger.Reset();
+            o.M2("Bar");
+            Assert.Null(logger.LastException);
+            Assert.Equal("M2 Bar", logger.LastFormattedString);
+            Assert.Equal(LogLevel.Information, logger.LastLogLevel);
+            Assert.Equal(-1, logger.LastEventId.Id);
+
+            logger.Reset();
+            o.M3(LogLevel.Critical, "Foo Bar");
+            Assert.Null(logger.LastException);
+            Assert.Equal("M3 Foo Bar", logger.LastFormattedString);
+            Assert.Equal(LogLevel.Critical, logger.LastLogLevel);
+            Assert.Equal(-1, logger.LastEventId.Id);
+
+            logger.Reset();
+            o.M4();
+            Assert.Null(logger.LastException);
+            Assert.Equal("", logger.LastFormattedString);
+            Assert.Equal(LogLevel.Debug, logger.LastLogLevel);
+            Assert.Equal(-1, logger.LastEventId.Id);
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/TestClasses/TestInstances.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/TestClasses/TestInstances.cs
@@ -17,5 +17,16 @@ namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses
 
         [LoggerMessage(EventId = 1, Level = LogLevel.Trace, Message = "M1 {p1}")]
         public partial void M1(string p1);
+
+        // Test LoggerMessage Constructor's overloads
+
+        [LoggerMessage(LogLevel.Information, "M2 {p1}")]
+        public partial void M2(string p1);
+
+        [LoggerMessage("M3 {p1}")]
+        public partial void M3(LogLevel level, string p1);
+
+        [LoggerMessage(LogLevel.Debug)]
+        public partial void M4();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/87254