### PR TITLE
Claims identity and principal debugging update

### DIFF
--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
@@ -951,8 +951,8 @@ namespace System.Security.Claims
             {
                 // The ClaimsIdentity.Name property requires that ClaimsIdentity.NameClaimType is correctly
                 // configured to match the name of the logical name claim type of the identity.
-                // Only include name if the ClaimsIdentity.Name property has a value.
-                // Seeing a null name on an authenticated claim could create a confusion.
+                // Because of this, only include name if the ClaimsIdentity.Name property has a value.
+                // Not including the name is to avoid developer confusion at seeing "Name = (null)" on an authenticated identity.
                 debugText += $", Name = {Name}";
             }
             if (claimsCount > 0)

--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsIdentity.cs
@@ -946,7 +946,21 @@ namespace System.Security.Claims
                 claimsCount++;
             }
 
-            return $"Identity Name = {Name ?? "(null)"}, IsAuthenticated = {(IsAuthenticated ? "true" : "false")}, Claims Count = {claimsCount}";
+            string debugText = $"IsAuthenticated = {(IsAuthenticated ? "true" : "false")}";
+            if (Name != null)
+            {
+                // The ClaimsIdentity.Name property requires that ClaimsIdentity.NameClaimType is correctly
+                // configured to match the name of the logical name claim type of the identity.
+                // Only include name if the ClaimsIdentity.Name property has a value.
+                // Seeing a null name on an authenticated claim could create a confusion.
+                debugText += $", Name = {Name}";
+            }
+            if (claimsCount > 0)
+            {
+                debugText += $", Claims = {claimsCount}";
+            }
+
+            return debugText;
         }
 
         private sealed class ClaimsIdentityDebugProxy

--- a/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsPrincipal.cs
+++ b/src/libraries/System.Security.Claims/src/System/Security/Claims/ClaimsPrincipal.cs
@@ -580,19 +580,19 @@ namespace System.Security.Claims
                 identitiesCount++;
             }
 
+            // Return debug string optimized for the case of one identity.
+            if (identitiesCount == 1 && Identity is ClaimsIdentity claimsIdentity)
+            {
+                return claimsIdentity.DebuggerToString();
+            }
+
             int claimsCount = 0;
             foreach (Claim item in Claims)
             {
                 claimsCount++;
             }
 
-            // Return debug string optimized for the case of one identity.
-            if (identitiesCount == 1 && Identity is ClaimsIdentity claimsIdentity)
-            {
-                return $"Principal {claimsIdentity.DebuggerToString()}";
-            }
-
-            return $"Principal Identities Count: {identitiesCount}, Claims Count: {claimsCount}";
+            return $"Identities = {identitiesCount}, Claims = {claimsCount}";
         }
 
         private sealed class ClaimsPrincipalDebugProxy


### PR DESCRIPTION
Some [community feedback](https://anthonygiretti.com/2023/06/18/asp-net-core-8-better-contextual-debugging-experience/) showed there is confusion when a principal/identity is authenticated and has a name claim, but the identity doesn't have the right `NameClaimType` value to make the `ClaimsIdentity.Name` property work. In other words, the identity has a name, but we don't know what it is.

To reduce confusion and generally reduce what is shown in the debugging text, I've updated the display value to only add `ClaimsIdentity.Name` if the identity is correctly configured to have a known name value.

Example of an identity that is authenticated without a name, so it isn't displayed by the debugger:

![image](https://github.com/dotnet/runtime/assets/303201/a3741ce0-96b5-433b-b5dc-f044c6f1184f)

