### PR TITLE
Add DebuggerDisplay to Logger and Logger<T>

### DIFF
--- a/src/libraries/Common/src/Extensions/Logging/DebuggerDisplayFormatting.cs
+++ b/src/libraries/Common/src/Extensions/Logging/DebuggerDisplayFormatting.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Extensions.Logging
+{
+    internal static class DebuggerDisplayFormatting
+    {
+        internal static string DebuggerToString(string name, ILogger logger)
+        {
+            ReadOnlySpan<LogLevel> logLevels = stackalloc LogLevel[]
+            {
+                LogLevel.Critical,
+                LogLevel.Error,
+                LogLevel.Warning,
+                LogLevel.Information,
+                LogLevel.Debug,
+                LogLevel.Trace,
+            };
+
+            LogLevel minimumLevel = LogLevel.None;
+
+            // Check log level from highest to lowest. Report the lowest log level.
+            foreach (LogLevel logLevel in logLevels)
+            {
+                if (!logger.IsEnabled(logLevel))
+                {
+                    break;
+                }
+
+                minimumLevel = logLevel;
+            }
+
+            var enabled = minimumLevel != LogLevel.None;
+            var debugText = $@"Name = ""{name}"", Enabled = {(enabled ? "true" : "false")}";
+            if (enabled)
+            {
+                debugText += $", MinLevel = {minimumLevel}";
+            }
+
+            return debugText;
+        }
+    }
+}

--- a/src/libraries/Common/src/Extensions/Logging/DebuggerDisplayFormatting.cs
+++ b/src/libraries/Common/src/Extensions/Logging/DebuggerDisplayFormatting.cs
@@ -39,6 +39,11 @@ namespace Microsoft.Extensions.Logging
             }
             else
             {
+                // Display "Enabled = false". This makes it clear that the entire ILogger
+                // is disabled and nothing is written.
+                //
+                // If "MinLevel = None" was displayed then someone could think that the
+                // min level is disabled and everything is written.
                 debugText += $", Enabled = false";
             }
 

--- a/src/libraries/Common/src/Extensions/Logging/DebuggerDisplayFormatting.cs
+++ b/src/libraries/Common/src/Extensions/Logging/DebuggerDisplayFormatting.cs
@@ -32,11 +32,14 @@ namespace Microsoft.Extensions.Logging
                 minimumLevel = logLevel;
             }
 
-            var enabled = minimumLevel != LogLevel.None;
-            var debugText = $@"Name = ""{name}"", Enabled = {(enabled ? "true" : "false")}";
-            if (enabled)
+            var debugText = $@"Name = ""{name}""";
+            if (minimumLevel != LogLevel.None)
             {
                 debugText += $", MinLevel = {minimumLevel}";
+            }
+            else
+            {
+                debugText += $", Enabled = false";
             }
 
             return debugText;

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerT.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerT.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.Extensions.Logging
@@ -11,6 +12,7 @@ namespace Microsoft.Extensions.Logging
     /// provided <see cref="ILoggerFactory"/>.
     /// </summary>
     /// <typeparam name="T">The type.</typeparam>
+    [DebuggerDisplay("{DebuggerToString(),nq}")]
     public class Logger<T> : ILogger<T>
     {
         private readonly ILogger _logger;
@@ -23,7 +25,7 @@ namespace Microsoft.Extensions.Logging
         {
             ThrowHelper.ThrowIfNull(factory);
 
-            _logger = factory.CreateLogger(TypeNameHelper.GetTypeDisplayName(typeof(T), includeGenericParameters: false, nestedTypeDelimiter: '.'));
+            _logger = factory.CreateLogger(GetCategoryName());
         }
 
         /// <inheritdoc />
@@ -42,6 +44,13 @@ namespace Microsoft.Extensions.Logging
         void ILogger.Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
         {
             _logger.Log(logLevel, eventId, state, exception, formatter);
+        }
+
+        private static string GetCategoryName() => TypeNameHelper.GetTypeDisplayName(typeof(T), includeGenericParameters: false, nestedTypeDelimiter: '.');
+
+        internal string DebuggerToString()
+        {
+            return DebuggerDisplayFormatting.DebuggerToString(GetCategoryName(), this);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/Microsoft.Extensions.Logging.Abstractions.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/Microsoft.Extensions.Logging.Abstractions.csproj
@@ -25,6 +25,8 @@ Microsoft.Extensions.Logging.Abstractions.NullLogger</PackageDescription>
              Link="Common\src\Extensions\Logging\NullExternalScopeProvider.cs" />
     <Compile Include="$(CommonPath)Extensions\Logging\NullScope.cs"
              Link="Common\src\Extensions\Logging\NullScope.cs" />
+    <Compile Include="$(CommonPath)Extensions\Logging\DebuggerDisplayFormatting.cs"
+             Link="Common\src\Extensions\Logging\DebuggerDisplayFormatting.cs" />
     <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs"
              Link="Common\System\Text\ValueStringBuilder.cs" />
     <Compile Include="$(CommonPath)System\ThrowHelper.cs"

--- a/src/libraries/Microsoft.Extensions.Logging/src/Logger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/Logger.cs
@@ -3,12 +3,20 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Microsoft.Extensions.Logging
 {
+    [DebuggerDisplay("{DebuggerToString(),nq}")]
     internal sealed class Logger : ILogger
     {
-        public Logger(LoggerInformation[] loggers) => Loggers = loggers;
+        private readonly string _categoryName;
+
+        public Logger(string categoryName, LoggerInformation[] loggers)
+        {
+            _categoryName = categoryName;
+            Loggers = loggers;
+        }
 
         public LoggerInformation[] Loggers { get; set; }
         public MessageLogger[]? MessageLoggers { get; set; }
@@ -140,6 +148,40 @@ namespace Microsoft.Extensions.Logging
             }
 
             return scope;
+        }
+
+        internal string DebuggerToString()
+        {
+            var logLevels = new LogLevel[]
+            {
+                LogLevel.Trace,
+                LogLevel.Debug,
+                LogLevel.Information,
+                LogLevel.Warning,
+                LogLevel.Error,
+                LogLevel.Critical
+            };
+
+            LogLevel minimumLevel = LogLevel.None;
+
+            foreach (LogLevel logLevel in logLevels)
+            {
+                if (!IsEnabled(logLevel))
+                {
+                    break;
+                }
+
+                minimumLevel = logLevel;
+            }
+
+            var enabled = minimumLevel != LogLevel.None;
+            var debugText = $@"CategoryName = ""{_categoryName}"", Enabled = {(enabled ? "true" : "false")}";
+            if (enabled)
+            {
+                debugText += ", MinimumLevel = {minimumLevel}";
+            }
+
+            return debugText;
         }
 
         private static void ThrowLoggingError(List<Exception> exceptions)

--- a/src/libraries/Microsoft.Extensions.Logging/src/Logger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/Logger.cs
@@ -152,36 +152,7 @@ namespace Microsoft.Extensions.Logging
 
         internal string DebuggerToString()
         {
-            var logLevels = new LogLevel[]
-            {
-                LogLevel.Trace,
-                LogLevel.Debug,
-                LogLevel.Information,
-                LogLevel.Warning,
-                LogLevel.Error,
-                LogLevel.Critical
-            };
-
-            LogLevel minimumLevel = LogLevel.None;
-
-            foreach (LogLevel logLevel in logLevels)
-            {
-                if (!IsEnabled(logLevel))
-                {
-                    break;
-                }
-
-                minimumLevel = logLevel;
-            }
-
-            var enabled = minimumLevel != LogLevel.None;
-            var debugText = $@"CategoryName = ""{_categoryName}"", Enabled = {(enabled ? "true" : "false")}";
-            if (enabled)
-            {
-                debugText += ", MinimumLevel = {minimumLevel}";
-            }
-
-            return debugText;
+            return DebuggerDisplayFormatting.DebuggerToString(_categoryName, this);
         }
 
         private static void ThrowLoggingError(List<Exception> exceptions)

--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Extensions.Logging
             {
                 if (!_loggers.TryGetValue(categoryName, out Logger? logger))
                 {
-                    logger = new Logger(CreateLoggers(categoryName));
+                    logger = new Logger(categoryName, CreateLoggers(categoryName));
 
                     (logger.MessageLoggers, logger.ScopeLoggers) = ApplyFilters(logger.Loggers);
 

--- a/src/libraries/Microsoft.Extensions.Logging/src/Microsoft.Extensions.Logging.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging/src/Microsoft.Extensions.Logging.csproj
@@ -14,6 +14,8 @@
              Link="Common\src\Extensions\Logging\NullExternalScopeProvider.cs" />
     <Compile Include="$(CommonPath)Extensions\Logging\NullScope.cs"
              Link="Common\src\Extensions\Logging\NullScope.cs" />
+    <Compile Include="$(CommonPath)Extensions\Logging\DebuggerDisplayFormatting.cs"
+             Link="Common\src\Extensions\Logging\DebuggerDisplayFormatting.cs" />
     <Compile Include="$(CommonPath)System\ThrowHelper.cs"
              Link="Common\System\ThrowHelper.cs" />
   </ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerTest.cs
@@ -254,6 +254,25 @@ namespace Microsoft.Extensions.Logging.Test
             }
         }
 
+        [Fact]
+        public void LoggerDebuggerToString()
+        {
+            // Arrange
+            var loggerFactory = new LoggerFactory();
+            var logger = (Logger<LoggerTest>)loggerFactory.CreateLogger<LoggerTest>();
+
+            // Act
+            var beforeProvider = logger.DebuggerToString();
+
+            loggerFactory.AddProvider(new CustomLoggerProvider("provider1", ThrowExceptionAt.None, new List<string>()));
+
+            var afterProvider = logger.DebuggerToString();
+
+            // Assert
+            Assert.Equal(@"Name = ""Microsoft.Extensions.Logging.Test.LoggerTest"", Enabled = false", beforeProvider);
+            Assert.Equal(@"Name = ""Microsoft.Extensions.Logging.Test.LoggerTest"", Enabled = true, MinLevel = Trace", afterProvider);
+        }
+
         private class CustomLoggerProvider : ILoggerProvider
         {
             private readonly string _providerName;

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerTest.cs
@@ -270,7 +270,7 @@ namespace Microsoft.Extensions.Logging.Test
 
             // Assert
             Assert.Equal(@"Name = ""Microsoft.Extensions.Logging.Test.LoggerTest"", Enabled = false", beforeProvider);
-            Assert.Equal(@"Name = ""Microsoft.Extensions.Logging.Test.LoggerTest"", Enabled = true, MinLevel = Trace", afterProvider);
+            Assert.Equal(@"Name = ""Microsoft.Extensions.Logging.Test.LoggerTest"", MinLevel = Trace", afterProvider);
         }
 
         private class CustomLoggerProvider : ILoggerProvider


### PR DESCRIPTION
Loggers now display their name, whether they are enabled, and if they are enabled, their minimum log level.

![image](https://github.com/dotnet/runtime/assets/303201/4a7f52d1-1612-4216-af1e-3eee20429696)