### PR TITLE
Ensure that parsed JsonElement values are never marked as disposable.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.Parse.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.Parse.cs
@@ -673,7 +673,7 @@ namespace System.Text.Json
             {
                 MetadataDb database = MetadataDb.CreateLocked(utf8Json.Length);
                 database.Append(tokenType, startLocation: 0, utf8Json.Length);
-                return new JsonDocument(utf8Json, database);
+                return new JsonDocument(utf8Json, database, isDisposable: false);
             }
         }
 
@@ -739,7 +739,7 @@ namespace System.Text.Json
                 }
             }
 
-            return new JsonDocument(utf8Json, database);
+            return new JsonDocument(utf8Json, database, isDisposable: false);
         }
 
         private static ArraySegment<byte> ReadToEnd(Stream stream)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonElementCloneTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonElementCloneTests.cs
@@ -25,6 +25,9 @@ namespace System.Text.Json.Tests
                 Assert.Equal(json, clone.GetRawText());
                 Assert.NotSame(doc, clone.SniffDocument());
                 Assert.NotSame(doc, clone2.SniffDocument());
+
+                Assert.False(clone.SniffDocument().IsDisposable());
+                Assert.False(clone2.SniffDocument().IsDisposable());
             }
 
             // After document Dispose
@@ -50,6 +53,7 @@ namespace System.Text.Json.Tests
                 Assert.NotSame(doc, clone.SniffDocument());
                 Assert.Same(middle.SniffDocument(), clone.SniffDocument());
                 Assert.Same(inner.SniffDocument(), clone.SniffDocument());
+                Assert.False(clone.SniffDocument().IsDisposable());
             }
 
             // After document Dispose
@@ -160,11 +164,18 @@ null
             Assert.Equal(innerJson, clone.GetRawText());
         }
 
-        private static JsonDocument SniffDocument(this JsonElement element)
+        internal static JsonDocument SniffDocument(this JsonElement element)
         {
-            return (JsonDocument)typeof(JsonElement).
-                GetField("_parent", BindingFlags.Instance|BindingFlags.NonPublic).
-                GetValue(element);
+            return (JsonDocument)typeof(JsonElement)
+                .GetField("_parent", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(element);
+        }
+
+        internal static bool IsDisposable(this JsonDocument document)
+        {
+            return (bool)typeof(JsonDocument)
+                .GetProperty("IsDisposable", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(document);
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonElementParseTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonElementParseTests.cs
@@ -30,9 +30,10 @@ namespace System.Text.Json.Tests
         {
             var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json));
 
-            JsonElement? element = JsonElement.ParseValue(ref reader);
-            Assert.Equal(kind, element!.Value.ValueKind);
+            JsonElement element = JsonElement.ParseValue(ref reader);
+            Assert.Equal(kind, element.ValueKind);
             Assert.Equal(json.Length, reader.BytesConsumed);
+            Assert.False(element.SniffDocument().IsDisposable());
         }
 
         [Theory]
@@ -45,6 +46,7 @@ namespace System.Text.Json.Tests
             Assert.True(success);
             Assert.Equal(kind, element!.Value.ValueKind);
             Assert.Equal(json.Length, reader.BytesConsumed);
+            Assert.False(element!.Value.SniffDocument().IsDisposable());
         }
 
         public static IEnumerable<object[]> ElementParsePartialDataCases


### PR DESCRIPTION
Fix #87751.