### PR TITLE
[release/7.0-staging][mono][debugger] Showing "Frame not in module" after vscode-js-debug bump on VS

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/Firefox/FirefoxMonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/Firefox/FirefoxMonoProxy.cs
@@ -23,7 +23,7 @@ internal sealed class FirefoxMonoProxy : MonoProxy
 
     public FirefoxExecutionContext GetContextFixefox(SessionId sessionId)
     {
-        if (contexts.TryGetValue(sessionId, out ExecutionContext context))
+        if (TryGetCurrentExecutionContextValue(sessionId, out ExecutionContext context))
             return context as FirefoxExecutionContext;
         throw new ArgumentException($"Invalid Session: \"{sessionId}\"", nameof(sessionId));
     }
@@ -334,7 +334,7 @@ internal sealed class FirefoxMonoProxy : MonoProxy
         {
             case "resume":
                 {
-                    if (!contexts.TryGetValue(sessionId, out ExecutionContext context))
+                    if (!TryGetCurrentExecutionContextValue(sessionId, out ExecutionContext context))
                         return false;
                     context.PausedOnWasm = false;
                     if (context.CallStack == null)
@@ -396,7 +396,7 @@ internal sealed class FirefoxMonoProxy : MonoProxy
                 }
             case "setBreakpoint":
                 {
-                    if (!contexts.TryGetValue(sessionId, out ExecutionContext context))
+                    if (!TryGetCurrentExecutionContextValue(sessionId, out ExecutionContext context))
                         return false;
                     var req = JObject.FromObject(new
                     {
@@ -436,7 +436,7 @@ internal sealed class FirefoxMonoProxy : MonoProxy
                 }
             case "removeBreakpoint":
                 {
-                    if (!contexts.TryGetValue(sessionId, out ExecutionContext context))
+                    if (!TryGetCurrentExecutionContextValue(sessionId, out ExecutionContext context))
                         return false;
                     Result resp = await SendCommand(sessionId, "", args, token);
 


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/87154 to release/7.0-staging

Customer Impact
Fixes https://github.com/dotnet/runtime/issues/87407.

Testing:
Try setting a breakpoint on a page guarded by authentication.

Risk
cc @thaystg. Medium? It's removing the debugging contexts that are not valid anymore.