### PR TITLE
fix mono HelloWorld sample

### DIFF
--- a/src/mono/sample/HelloWorld/HelloWorld.csproj
+++ b/src/mono/sample/HelloWorld/HelloWorld.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <!-- always set SelfContained when running to use Mono on desktop -->
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
 
   <UsingTask TaskName="MonoAOTCompiler"

--- a/src/mono/sample/HelloWorld/Makefile
+++ b/src/mono/sample/HelloWorld/Makefile
@@ -19,7 +19,6 @@ publish:
 	$(DOTNET) publish \
 	-c $(MONO_CONFIG) \
 	-r $(TARGET_OS)-$(MONO_ARCH) \
-	/p:SelfContained=true \
 	/p:RunAOTCompilation=$(AOT) \
 	/p:StripILCode=$(StripILCode) \
 	/p:CompiledMethodsOutputDirectory=$(CompiledMethodsOutputDirectory) \

--- a/src/mono/sample/HelloWorld/Makefile
+++ b/src/mono/sample/HelloWorld/Makefile
@@ -19,6 +19,7 @@ publish:
 	$(DOTNET) publish \
 	-c $(MONO_CONFIG) \
 	-r $(TARGET_OS)-$(MONO_ARCH) \
+	/p:SelfContained=true \
 	/p:RunAOTCompilation=$(AOT) \
 	/p:StripILCode=$(StripILCode) \
 	/p:CompiledMethodsOutputDirectory=$(CompiledMethodsOutputDirectory) \

--- a/src/mono/sample/mbr/console/ConsoleDelta.csproj
+++ b/src/mono/sample/mbr/console/ConsoleDelta.csproj
@@ -3,6 +3,8 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <!-- always set SelfContained when running to use Mono on desktop -->
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Set SelfContained=true.  Otherwise we get this when trying to run the app:

```console
$ ./artifacts/bin/HelloWorld/arm64/Release/osx-arm64/publish/HelloWorld
You must install or update .NET to run this application.

App: /Users/alklig/work/dotnet-runtime/runtime-review/artifacts/bin/HelloWorld/arm64/Release/osx-arm64/publish/HelloWorld
```