### PR TITLE
Unconditionally suppress IL2026 for StartupHookProvider.CallStartupHook

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Suppressions.LibraryBuild.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Suppressions.LibraryBuild.xml
@@ -19,13 +19,6 @@
       <argument>ILLink</argument>
       <argument>IL2026</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.StartupHookProvider.CallStartupHook(System.Char*)</property>
-      <property name="Justification">This warning is left in the product so developers get an ILLink warning when trimming an app with System.StartupHookProvider.IsSupported=true.</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2026</argument>
-      <property name="Scope">member</property>
       <property name="Target">M:System.StartupHookProvider.ProcessStartupHooks(System.String)</property>
       <property name="Justification">This warning is left in the product so developers get an ILLink warning when trimming an app with System.StartupHookProvider.IsSupported=true.</property>
     </attribute>

--- a/src/libraries/System.Private.CoreLib/src/System/StartupHookProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/StartupHookProvider.cs
@@ -67,6 +67,8 @@ namespace System
 
         // Parse a string specifying a single entry containing a startup hook,
         // and call the hook.
+        [UnconditionalSuppressMessageAttribute("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+            Justification = "An ILLink warning when trimming an app with System.StartupHookProvider.IsSupported=true already exists for ProcessStartupHooks.")]
         private static unsafe void CallStartupHook(char* pStartupHookPart)
         {
             if (!IsSupported)


### PR DESCRIPTION
A recent change in #87490 causes two ILLink warnings to be emitted for the same issue (enabling startup hooks in trimmed applications):

```
ILLink : Trim analysis warning IL2026: System.StartupHookProvider.CallStartupHook(Char*): Using member 'System.StartupHookProvider.CallStartupHook(StartupHookProvider.StartupHookNameOrPath)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The StartupHookSupport feature switch has been enabled for this app which is being trimmed. Startup hook code is not observable by the trimmer and so required assemblies, types and members may be removed. 
ILLink : Trim analysis warning IL2026: System.StartupHookProvider.ProcessStartupHooks(String): Using member 'System.StartupHookProvider.CallStartupHook(StartupHookProvider.StartupHookNameOrPath)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The StartupHookSupport feature switch has been enabled for this app which is being trimmed. Startup hook code is not observable by the trimmer and so required assemblies, types and members may be removed. 
```

This is causing test failures in the SDK repo for tests that are counting warnings. More importantly (arguably), this almost looks like a duplicate warning to developer who enables startup hooks in their trimmed applications and the mitigations are exactly the same.

This change unconditionally suppresses the IL2026 since it is already covered by the warning for ProcessStartupHooks.