### PR TITLE
Update WCF package versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -131,7 +131,7 @@
     <SystemSecurityCryptographyOpenSslVersion>5.0.0</SystemSecurityCryptographyOpenSslVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
     <SystemSecurityPermissionsVersion>7.0.0</SystemSecurityPermissionsVersion>
-    <SystemServiceModelPrimitivesVersion>4.9.0</SystemServiceModelPrimitivesVersion>
+    <SystemServiceModelPrimitivesVersion>6.0.0</SystemServiceModelPrimitivesVersion>
     <SystemTextJsonVersion>8.0.0-preview.6.23309.7</SystemTextJsonVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>6.0.0</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemThreadingAccessControlVersion>7.0.0</SystemThreadingAccessControlVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -131,7 +131,6 @@
     <SystemSecurityCryptographyOpenSslVersion>5.0.0</SystemSecurityCryptographyOpenSslVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
     <SystemSecurityPermissionsVersion>7.0.0</SystemSecurityPermissionsVersion>
-    <SystemServiceModelPrimitivesVersion>6.0.0</SystemServiceModelPrimitivesVersion>
     <SystemTextJsonVersion>8.0.0-preview.6.23309.7</SystemTextJsonVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>6.0.0</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemThreadingAccessControlVersion>7.0.0</SystemThreadingAccessControlVersion>


### PR DESCRIPTION
... as wcf participates in darc / bar we might want to define a subscription going forward to auto-update this version. Alternatively, we could leverage dependabot to only update when the package changes on nuget.org.