### PR TITLE
Use internal `BitOperations.ResetLowestSetBit`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
@@ -536,8 +536,7 @@ namespace System.Globalization
                         // Do a full IgnoreCase equality comparison. SpanHelpers.IndexOf skips comparing the two characters in some cases,
                         // but we don't actually know that the two characters are equal, since we compared with | 0x20. So we just compare
                         // the full string always.
-                        int bitPos = BitOperations.TrailingZeroCount(mask);
-                        int charPos = (int)((uint)bitPos / 2); // div by 2 (shr) because we work with 2-byte chars
+                        nint charPos = BitOperations.TrailingZeroCount(mask) >> 2;
                         if (EqualsIgnoreCase(ref Unsafe.Add(ref searchSpace, offset + charPos), ref valueRef, value.Length))
                         {
                             // Match! Return the index.
@@ -546,14 +545,7 @@ namespace System.Globalization
 
                         // Clear the two lowest set bits in the mask. If there are no more set bits, we're done.
                         // If any remain, we loop around to do the next comparison.
-                        if (Bmi1.IsSupported)
-                        {
-                            mask = Bmi1.ResetLowestSetBit(Bmi1.ResetLowestSetBit(mask));
-                        }
-                        else
-                        {
-                            mask &= ~(uint)(0b11 << bitPos);
-                        }
+                        mask = BitOperations.ResetLowestSetBit(BitOperations.ResetLowestSetBit(mask));
                     } while (mask != 0);
                     goto LoopFooter;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
@@ -462,8 +462,7 @@ namespace System.Globalization
                         // Do a full IgnoreCase equality comparison. SpanHelpers.IndexOf skips comparing the two characters in some cases,
                         // but we don't actually know that the two characters are equal, since we compared with | 0x20. So we just compare
                         // the full string always.
-                        int bitPos = BitOperations.TrailingZeroCount(mask);
-                        nint charPos = (nint)((uint)bitPos / 2); // div by 2 (shr) because we work with 2-byte chars
+                        nint charPos = BitOperations.TrailingZeroCount(mask) >> 2;
                         if (EqualsIgnoreCase(ref Unsafe.Add(ref searchSpace, offset + charPos), ref valueRef, value.Length))
                         {
                             // Match! Return the index.
@@ -472,14 +471,7 @@ namespace System.Globalization
 
                         // Clear the two lowest set bits in the mask. If there are no more set bits, we're done.
                         // If any remain, we loop around to do the next comparison.
-                        if (Bmi1.IsSupported)
-                        {
-                            mask = Bmi1.ResetLowestSetBit(Bmi1.ResetLowestSetBit(mask));
-                        }
-                        else
-                        {
-                            mask &= ~(uint)(0b11 << bitPos);
-                        }
+                        mask = BitOperations.ResetLowestSetBit(BitOperations.ResetLowestSetBit(mask));
                     } while (mask != 0);
                     goto LoopFooter;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
@@ -462,7 +462,7 @@ namespace System.Globalization
                         // Do a full IgnoreCase equality comparison. SpanHelpers.IndexOf skips comparing the two characters in some cases,
                         // but we don't actually know that the two characters are equal, since we compared with | 0x20. So we just compare
                         // the full string always.
-                        nint charPos = BitOperations.TrailingZeroCount(mask) >> 2;
+                        nint charPos = (nint)((uint)BitOperations.TrailingZeroCount(mask) / sizeof(ushort));
                         if (EqualsIgnoreCase(ref Unsafe.Add(ref searchSpace, offset + charPos), ref valueRef, value.Length))
                         {
                             // Match! Return the index.
@@ -528,7 +528,7 @@ namespace System.Globalization
                         // Do a full IgnoreCase equality comparison. SpanHelpers.IndexOf skips comparing the two characters in some cases,
                         // but we don't actually know that the two characters are equal, since we compared with | 0x20. So we just compare
                         // the full string always.
-                        nint charPos = BitOperations.TrailingZeroCount(mask) >> 2;
+                        nint charPos = (nint)((uint)BitOperations.TrailingZeroCount(mask) / sizeof(ushort));
                         if (EqualsIgnoreCase(ref Unsafe.Add(ref searchSpace, offset + charPos), ref valueRef, value.Length))
                         {
                             // Match! Return the index.

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
@@ -462,7 +462,7 @@ namespace System.Globalization
                         // Do a full IgnoreCase equality comparison. SpanHelpers.IndexOf skips comparing the two characters in some cases,
                         // but we don't actually know that the two characters are equal, since we compared with | 0x20. So we just compare
                         // the full string always.
-                        nint charPos = (nint)((uint)BitOperations.TrailingZeroCount(mask) / sizeof(ushort));
+                        nint charPos = (nint)(uint.TrailingZeroCount(mask) / sizeof(ushort));
                         if (EqualsIgnoreCase(ref Unsafe.Add(ref searchSpace, offset + charPos), ref valueRef, value.Length))
                         {
                             // Match! Return the index.
@@ -528,7 +528,7 @@ namespace System.Globalization
                         // Do a full IgnoreCase equality comparison. SpanHelpers.IndexOf skips comparing the two characters in some cases,
                         // but we don't actually know that the two characters are equal, since we compared with | 0x20. So we just compare
                         // the full string always.
-                        nint charPos = (nint)((uint)BitOperations.TrailingZeroCount(mask) / sizeof(ushort));
+                        nint charPos = (nint)(uint.TrailingZeroCount(mask) / sizeof(ushort));
                         if (EqualsIgnoreCase(ref Unsafe.Add(ref searchSpace, offset + charPos), ref valueRef, value.Length))
                         {
                             // Match! Return the index.

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -114,9 +114,7 @@ namespace System
                     uint mask = cmpAnd.ExtractMostSignificantBits();
                     do
                     {
-                        int bitPos = BitOperations.TrailingZeroCount(mask);
-                        // div by 2 (shr) because we work with 2-byte chars
-                        nint charPos = (nint)((uint)bitPos / 2);
+                        nint charPos = BitOperations.TrailingZeroCount(mask) >> 2;
                         if (valueLength == 2 || // we already matched two chars
                             SequenceEqual(
                                 ref Unsafe.As<char, byte>(ref Unsafe.Add(ref searchSpace, offset + charPos)),
@@ -126,10 +124,7 @@ namespace System
                         }
 
                         // Clear two the lowest set bits
-                        if (Bmi1.IsSupported)
-                            mask = Bmi1.ResetLowestSetBit(Bmi1.ResetLowestSetBit(mask));
-                        else
-                            mask &= ~(uint)(0b11 << bitPos);
+                        mask = BitOperations.ResetLowestSetBit(BitOperations.ResetLowestSetBit(mask));
                     } while (mask != 0);
                     goto LOOP_FOOTER;
 

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -176,9 +176,7 @@ namespace System
                     uint mask = cmpAnd.ExtractMostSignificantBits();
                     do
                     {
-                        int bitPos = BitOperations.TrailingZeroCount(mask);
-                        // div by 2 (shr) because we work with 2-byte chars
-                        int charPos = (int)((uint)bitPos / 2);
+                        nint charPos = BitOperations.TrailingZeroCount(mask) >> 2;
                         if (valueLength == 2 || // we already matched two chars
                             SequenceEqual(
                                 ref Unsafe.As<char, byte>(ref Unsafe.Add(ref searchSpace, offset + charPos)),
@@ -188,10 +186,7 @@ namespace System
                         }
 
                         // Clear two lowest set bits
-                        if (Bmi1.IsSupported)
-                            mask = Bmi1.ResetLowestSetBit(Bmi1.ResetLowestSetBit(mask));
-                        else
-                            mask &= ~(uint)(0b11 << bitPos);
+                        mask = BitOperations.ResetLowestSetBit(BitOperations.ResetLowestSetBit(mask));
                     } while (mask != 0);
                     goto LOOP_FOOTER;
 

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -114,7 +114,7 @@ namespace System
                     uint mask = cmpAnd.ExtractMostSignificantBits();
                     do
                     {
-                        nint charPos = BitOperations.TrailingZeroCount(mask) >> 2;
+                        nint charPos = (nint)((uint)BitOperations.TrailingZeroCount(mask) / sizeof(ushort));
                         if (valueLength == 2 || // we already matched two chars
                             SequenceEqual(
                                 ref Unsafe.As<char, byte>(ref Unsafe.Add(ref searchSpace, offset + charPos)),
@@ -176,7 +176,7 @@ namespace System
                     uint mask = cmpAnd.ExtractMostSignificantBits();
                     do
                     {
-                        nint charPos = BitOperations.TrailingZeroCount(mask) >> 2;
+                        nint charPos = (nint)((uint)BitOperations.TrailingZeroCount(mask) / sizeof(ushort));
                         if (valueLength == 2 || // we already matched two chars
                             SequenceEqual(
                                 ref Unsafe.As<char, byte>(ref Unsafe.Add(ref searchSpace, offset + charPos)),

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -114,7 +114,7 @@ namespace System
                     uint mask = cmpAnd.ExtractMostSignificantBits();
                     do
                     {
-                        nint charPos = (nint)((uint)BitOperations.TrailingZeroCount(mask) / sizeof(ushort));
+                        nint charPos = (nint)(uint.TrailingZeroCount(mask) / sizeof(ushort));
                         if (valueLength == 2 || // we already matched two chars
                             SequenceEqual(
                                 ref Unsafe.As<char, byte>(ref Unsafe.Add(ref searchSpace, offset + charPos)),
@@ -176,7 +176,7 @@ namespace System
                     uint mask = cmpAnd.ExtractMostSignificantBits();
                     do
                     {
-                        nint charPos = (nint)((uint)BitOperations.TrailingZeroCount(mask) / sizeof(ushort));
+                        nint charPos = (nint)(uint.TrailingZeroCount(mask) / sizeof(ushort));
                         if (valueLength == 2 || // we already matched two chars
                             SequenceEqual(
                                 ref Unsafe.As<char, byte>(ref Unsafe.Add(ref searchSpace, offset + charPos)),


### PR DESCRIPTION
https://github.com/dotnet/runtime/blob/05e25ff8c3a623df74720f430c270eba0f1d41b0/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs#L941-L945

Without any lowering, the implementation is still likely more efficient than `mask &= ~(uint)(0b11 << bitPos)` as it avoids a loop-carried dependency.