### PR TITLE
Fix using ICU with Bionic and NativeAOT

### DIFF
--- a/src/coreclr/nativeaot/CMakeLists.txt
+++ b/src/coreclr/nativeaot/CMakeLists.txt
@@ -45,7 +45,6 @@ endif()
 
 if(CLR_CMAKE_TARGET_ANDROID)
     add_definitions(-DFEATURE_EMULATED_TLS)
-    add_definitions(-DANDROID_FORCE_ICU_DATA_DIR)
 endif()
 
 add_subdirectory(Bootstrap)

--- a/src/native/libs/System.Globalization.Native/CMakeLists.txt
+++ b/src/native/libs/System.Globalization.Native/CMakeLists.txt
@@ -1,6 +1,10 @@
 project(System.Globalization.Native C)
 
 if(CLR_CMAKE_TARGET_UNIX OR CLR_CMAKE_TARGET_WASI)
+    if (ANDROID_FORCE_ICU_DATA_DIR)
+        add_definitions(-DANDROID_FORCE_ICU_DATA_DIR)
+    endif()
+
     add_compile_options(-Wno-switch-enum)
     add_compile_options(-Wno-covered-switch-default)
 

--- a/src/native/libs/build-native.sh
+++ b/src/native/libs/build-native.sh
@@ -101,7 +101,7 @@ if [[ "$__TargetOS" == android && -z "$ROOTFS_DIR" ]]; then
     __CMakeArgs="-DANDROID_STL=none $__CMakeArgs"
 elif [[ "$__TargetOS" == linux-bionic && -z "$ROOTFS_DIR" ]]; then
     # Android SDK defaults to c++_static; we only need C support
-    __CMakeArgs="-DFORCE_ANDROID_OPENSSL=1 -DANDROID_STL=none $__CMakeArgs"
+    __CMakeArgs="-DFORCE_ANDROID_OPENSSL=1 -DANDROID_STL=none -DANDROID_FORCE_ICU_DATA_DIR=1 $__CMakeArgs"
 elif [[ "$__TargetOS" == iossimulator ]]; then
     # set default iOS simulator deployment target
     # keep in sync with SetOSTargetMinVersions in the root Directory.Build.props


### PR DESCRIPTION
I blindly copied a piece of configuration from Mono but System.Globalization.Native is built elsewhere for NativeAOT and the copied piece did nothing.

Cc @dotnet/ilc-contrib 