### PR TITLE
JIT: Insert readbacks eagerly in physical promotion

### DIFF
--- a/src/coreclr/jit/promotion.h
+++ b/src/coreclr/jit/promotion.h
@@ -292,6 +292,11 @@ public:
     fgWalkResult PostOrderVisit(GenTree** use, GenTree* user);
 
 private:
+    void SetNeedsWriteBack(Replacement& rep);
+    void ClearNeedsWriteBack(Replacement& rep);
+    void SetNeedsReadBack(Replacement& rep);
+    void ClearNeedsReadBack(Replacement& rep);
+
     GenTree** InsertMidTreeReadBacksIfNecessary(GenTree** use);
     void ReadBackAfterCall(GenTreeCall* call, GenTree* user);
     bool IsPromotedStructLocalDying(GenTreeLclVarCommon* structLcl);

--- a/src/coreclr/jit/promotion.h
+++ b/src/coreclr/jit/promotion.h
@@ -257,7 +257,7 @@ class ReplaceVisitor : public GenTreeVisitor<ReplaceVisitor>
     jitstd::vector<AggregateInfo*>& m_aggregates;
     PromotionLiveness*              m_liveness;
     bool                            m_madeChanges         = false;
-    bool                            m_hasPendingReadBacks = false;
+    unsigned                        m_numPendingReadBacks = 0;
     bool                            m_mayHaveForwardSub   = false;
     Statement*                      m_currentStmt         = nullptr;
     BasicBlock*                     m_currentBlock        = nullptr;
@@ -287,13 +287,7 @@ public:
 
     void StartBlock(BasicBlock* block);
     void EndBlock();
-
-    void StartStatement(Statement* stmt)
-    {
-        m_currentStmt       = stmt;
-        m_madeChanges       = false;
-        m_mayHaveForwardSub = false;
-    }
+    void StartStatement(Statement* stmt);
 
     fgWalkResult PostOrderVisit(GenTree** use, GenTree* user);
 

--- a/src/coreclr/jit/promotiondecomposition.cpp
+++ b/src/coreclr/jit/promotiondecomposition.cpp
@@ -1099,9 +1099,13 @@ void ReplaceVisitor::HandleStructStore(GenTree** use, GenTree* user)
                     dstFirstRep->NeedsWriteBack = false;
                 }
 
+                if (!dstFirstRep->NeedsReadBack)
+                {
+                    dstFirstRep->NeedsReadBack = true;
+                    m_numPendingReadBacks++;
+                }
+
                 plan.MarkNonRemainderUseOfStructLocal();
-                dstFirstRep->NeedsReadBack = true;
-                m_hasPendingReadBacks      = true;
                 dstFirstRep++;
             }
 
@@ -1119,9 +1123,13 @@ void ReplaceVisitor::HandleStructStore(GenTree** use, GenTree* user)
                         dstLastRep->NeedsWriteBack = false;
                     }
 
+                    if (!dstLastRep->NeedsReadBack)
+                    {
+                        dstLastRep->NeedsReadBack = true;
+                        m_numPendingReadBacks++;
+                    }
+
                     plan.MarkNonRemainderUseOfStructLocal();
-                    dstLastRep->NeedsReadBack = true;
-                    m_hasPendingReadBacks     = true;
                     dstEndRep--;
                 }
             }

--- a/src/coreclr/jit/promotiondecomposition.cpp
+++ b/src/coreclr/jit/promotiondecomposition.cpp
@@ -427,8 +427,8 @@ private:
                 statements->AddStatement(store);
             }
 
-            entry.ToReplacement->NeedsWriteBack = true;
-            entry.ToReplacement->NeedsReadBack  = false;
+            m_replacer->ClearNeedsReadBack(*entry.ToReplacement);
+            m_replacer->SetNeedsWriteBack(*entry.ToReplacement);
         }
 
         RemainderStrategy remainderStrategy = DetermineRemainderStrategy(deaths);
@@ -520,7 +520,7 @@ private:
                         // The loop below will skip these replacements as an
                         // optimization if it is going to copy the struct
                         // anyway.
-                        rep->NeedsWriteBack = false;
+                        m_replacer->ClearNeedsWriteBack(*rep);
                     }
                 }
             }
@@ -690,8 +690,8 @@ private:
 
             if (entry.ToReplacement != nullptr)
             {
-                entry.ToReplacement->NeedsWriteBack = true;
-                entry.ToReplacement->NeedsReadBack  = false;
+                m_replacer->ClearNeedsReadBack(*entry.ToReplacement);
+                m_replacer->SetNeedsWriteBack(*entry.ToReplacement);
             }
 
             if (CanSkipEntry(entry, dstDeaths, remainderStrategy DEBUGARG(/* dump */ true)))
@@ -1096,14 +1096,10 @@ void ReplaceVisitor::HandleStructStore(GenTree** use, GenTree* user)
                     // We accomplish this by an initial write back, the struct copy, followed by a later read back.
                     // TODO-CQ: This is expensive and unreflected in heuristics, but it is also very rare.
                     result.AddStatement(Promotion::CreateWriteBack(m_compiler, dstLcl->GetLclNum(), *dstFirstRep));
-                    dstFirstRep->NeedsWriteBack = false;
+                    ClearNeedsWriteBack(*dstFirstRep);
                 }
 
-                if (!dstFirstRep->NeedsReadBack)
-                {
-                    dstFirstRep->NeedsReadBack = true;
-                    m_numPendingReadBacks++;
-                }
+                SetNeedsReadBack(*dstFirstRep);
 
                 plan.MarkNonRemainderUseOfStructLocal();
                 dstFirstRep++;
@@ -1120,14 +1116,10 @@ void ReplaceVisitor::HandleStructStore(GenTree** use, GenTree* user)
                     if (dstLastRep->NeedsWriteBack)
                     {
                         result.AddStatement(Promotion::CreateWriteBack(m_compiler, dstLcl->GetLclNum(), *dstLastRep));
-                        dstLastRep->NeedsWriteBack = false;
+                        ClearNeedsWriteBack(*dstLastRep);
                     }
 
-                    if (!dstLastRep->NeedsReadBack)
-                    {
-                        dstLastRep->NeedsReadBack = true;
-                        m_numPendingReadBacks++;
-                    }
+                    SetNeedsReadBack(*dstLastRep);
 
                     plan.MarkNonRemainderUseOfStructLocal();
                     dstEndRep--;
@@ -1148,7 +1140,7 @@ void ReplaceVisitor::HandleStructStore(GenTree** use, GenTree* user)
                 if (srcFirstRep->NeedsWriteBack)
                 {
                     result.AddStatement(Promotion::CreateWriteBack(m_compiler, srcLcl->GetLclNum(), *srcFirstRep));
-                    srcFirstRep->NeedsWriteBack = false;
+                    ClearNeedsWriteBack(*srcFirstRep);
                 }
 
                 srcFirstRep++;
@@ -1165,7 +1157,7 @@ void ReplaceVisitor::HandleStructStore(GenTree** use, GenTree* user)
                     if (srcLastRep->NeedsWriteBack)
                     {
                         result.AddStatement(Promotion::CreateWriteBack(m_compiler, srcLcl->GetLclNum(), *srcLastRep));
-                        srcLastRep->NeedsWriteBack = false;
+                        ClearNeedsWriteBack(*srcLastRep);
                     }
 
                     srcEndRep--;
@@ -1316,8 +1308,8 @@ void ReplaceVisitor::InitFields(GenTreeLclVarCommon* dstStore,
                     rep->Description);
 
             // We will need to read this one back after initing the struct.
-            rep->NeedsWriteBack = false;
-            rep->NeedsReadBack  = true;
+            ClearNeedsWriteBack(*rep);
+            SetNeedsReadBack(*rep);
             plan->MarkNonRemainderUseOfStructLocal();
             continue;
         }
@@ -1403,7 +1395,7 @@ void ReplaceVisitor::CopyBetweenFields(GenTree*                    store,
 
             assert(srcLcl != nullptr);
             statements->AddStatement(Promotion::CreateReadBack(m_compiler, srcLcl->GetLclNum(), *srcRep));
-            srcRep->NeedsReadBack = false;
+            ClearNeedsReadBack(*srcRep);
             assert(!srcRep->NeedsWriteBack);
         }
 

--- a/src/tests/JIT/Directed/physicalpromotion/readbackbeforeqmark.cs
+++ b/src/tests/JIT/Directed/physicalpromotion/readbackbeforeqmark.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Xunit;
+
+public class Runtime_87508
+{
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        return new Runtime_87508().WriteBlock("1234");
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public int WriteBlock(string source)
+    {
+        ReadOnlySpan<char> line = GetNextLine();
+        Trash();
+        // Unrolling of this creates a QMARK with LCL_FLD uses in the arms. The
+        // JIT must be careful to read the fields of the promoted 'line' back
+        // before the conditional nature of the QMARK.
+        if (line.StartsWith("{"))
+        {
+            Console.WriteLine("FAIL: succeeded");
+            return -1;
+        }
+
+        if (!Unsafe.AreSame(ref MemoryMarshal.GetReference(line), ref MemoryMarshal.GetArrayDataReference(_emptyChars)))
+        {
+            Console.WriteLine("FAIL: References were not equal");
+            return -2;
+        }
+
+        Console.WriteLine("PASS");
+        return 100;
+    }
+
+    private char[] _emptyChars = new char[0];
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private ReadOnlySpan<char> GetNextLine()
+    {
+        return _emptyChars;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private nint Trash() => 0;
+}

--- a/src/tests/JIT/Directed/physicalpromotion/readbackbeforeqmark.csproj
+++ b/src/tests/JIT/Directed/physicalpromotion/readbackbeforeqmark.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitEnablePhysicalPromotion" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitStressModeNames" Value="STRESS_NO_OLD_PROMOTION STRESS_PHYSICAL_PROMOTION_COST" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Physical promotion currently inserts readbacks (reading the struct local back into the field local) as COMMAs right before a local that needs it. This is not right for QMARKs where it may mean we only end up reading back the local in one of the branches.

This change makes physical promotion insert readbacks as new statements before any statement that is going to need it. While we could do this for QMARKs only, it is done for any statement indiscriminately since it has two benefits:
1. It allows forward-sub to kick in for the readbacks, which can lead to a contained LCL_FLDs
2. It stops us from disabling local copy prop by avoiding the creation of embedded stores.

The existing logic is still necessary to keep in case the readback was marked within the same tree.

Fix #87508
Fix #87506
Fix #87755