### PR TITLE
JIT: Induce more physical promotions

### DIFF
--- a/src/coreclr/jit/promotion.cpp
+++ b/src/coreclr/jit/promotion.cpp
@@ -2127,7 +2127,7 @@ void ReplaceVisitor::ReplaceLocal(GenTree** use, GenTree* user)
         {
             // Source of store. Will be handled by decomposition when we get to
             // the store, so we should not introduce any writebacks.
-            assert(effectiveUser->Data() == lcl);
+            assert(effectiveUser->Data()->gtEffectiveVal() == lcl);
             return;
         }
 

--- a/src/coreclr/jit/promotion.cpp
+++ b/src/coreclr/jit/promotion.cpp
@@ -859,9 +859,9 @@ public:
 
         if (tree->OperIsAnyLocal())
         {
-            GenTreeLclVarCommon* lcl = tree->AsLclVarCommon();
-            LclVarDsc*           dsc = m_compiler->lvaGetDesc(lcl);
-            bool isCandidate = Promotion::IsCandidateForPhysicalPromotion(dsc);
+            GenTreeLclVarCommon* lcl         = tree->AsLclVarCommon();
+            LclVarDsc*           dsc         = m_compiler->lvaGetDesc(lcl);
+            bool                 isCandidate = Promotion::IsCandidateForPhysicalPromotion(dsc);
             if (isCandidate)
             {
                 var_types       accessType;
@@ -898,10 +898,10 @@ public:
             if (tree->OperIsLocalStore() && tree->TypeIs(TYP_STRUCT))
             {
                 GenTree* data = tree->Data()->gtEffectiveVal();
-                if (data->OperIsLocalRead() &&
-                    (isCandidate || Promotion::IsCandidateForPhysicalPromotion(m_compiler->lvaGetDesc(data->AsLclVarCommon()))))
+                if (data->OperIsLocalRead() && (isCandidate || Promotion::IsCandidateForPhysicalPromotion(
+                                                                   m_compiler->lvaGetDesc(data->AsLclVarCommon()))))
                 {
-                    m_candidateStores.Push(CandidateStore{ tree->AsLclVarCommon(), m_curBB });
+                    m_candidateStores.Push(CandidateStore{tree->AsLclVarCommon(), m_curBB});
                 }
             }
         }

--- a/src/coreclr/jit/promotion.cpp
+++ b/src/coreclr/jit/promotion.cpp
@@ -861,7 +861,8 @@ public:
         {
             GenTreeLclVarCommon* lcl = tree->AsLclVarCommon();
             LclVarDsc*           dsc = m_compiler->lvaGetDesc(lcl);
-            if (Promotion::IsCandidateForPhysicalPromotion(dsc))
+            bool isCandidate = Promotion::IsCandidateForPhysicalPromotion(dsc);
+            if (isCandidate)
             {
                 var_types       accessType;
                 ClassLayout*    accessLayout;
@@ -887,21 +888,21 @@ public:
                     accessType   = lcl->TypeGet();
                     accessLayout = accessType == TYP_STRUCT ? lcl->GetLayout(m_compiler) : nullptr;
                     accessFlags  = ClassifyLocalAccess(lcl, effectiveUser);
-
-                    if (lcl->TypeIs(TYP_STRUCT) &&
-                        ((user != nullptr) && user->OperIsLocalStore() && user->Data()->OperIsLocalRead()))
-                    {
-                        // Make sure we add it only once if both the destination and source are candidates.
-                        if ((m_candidateStores.Height() <= 0) || (m_candidateStores.Top().Store != user))
-                        {
-                            m_candidateStores.Push(CandidateStore{user->AsLclVarCommon(), m_curBB});
-                        }
-                    }
                 }
 
                 LocalUses* uses = GetOrCreateUses(lcl->GetLclNum());
                 unsigned   offs = lcl->GetLclOffs();
                 uses->RecordAccess(offs, accessType, accessLayout, accessFlags, m_curBB->getBBWeight(m_compiler));
+            }
+
+            if (tree->OperIsLocalStore() && tree->TypeIs(TYP_STRUCT))
+            {
+                GenTree* data = tree->Data()->gtEffectiveVal();
+                if (data->OperIsLocalRead() &&
+                    (isCandidate || Promotion::IsCandidateForPhysicalPromotion(m_compiler->lvaGetDesc(data->AsLclVarCommon()))))
+                {
+                    m_candidateStores.Push(CandidateStore{ tree->AsLclVarCommon(), m_curBB });
+                }
             }
         }
 
@@ -966,11 +967,6 @@ public:
             }
         }
 
-        if (totalNumPromotions <= 0)
-        {
-            return false;
-        }
-
         if ((m_candidateStores.Height() > 0) && (totalNumPromotions < maxTotalNumPromotions))
         {
             // Now look for induced accesses due to assignment decomposition.
@@ -989,9 +985,9 @@ public:
                     GenTreeLclVarCommon*  store          = candidateStore.Store;
 
                     assert(store->TypeIs(TYP_STRUCT));
-                    assert(store->Data()->OperIsLocalRead());
+                    assert(store->Data()->gtEffectiveVal()->OperIsLocalRead());
 
-                    GenTreeLclVarCommon* src = store->Data()->AsLclVarCommon();
+                    GenTreeLclVarCommon* src = store->Data()->gtEffectiveVal()->AsLclVarCommon();
 
                     LclVarDsc* dstDsc = m_compiler->lvaGetDesc(store);
                     LclVarDsc* srcDsc = m_compiler->lvaGetDesc(src);
@@ -1064,6 +1060,11 @@ public:
             }
         }
 
+        if (totalNumPromotions <= 0)
+        {
+            return false;
+        }
+
         for (AggregateInfo* agg : aggregates)
         {
             if (agg == nullptr)
@@ -1126,7 +1127,7 @@ public:
             }
         }
 
-        return totalNumPromotions > 0;
+        return true;
     }
 
 private:

--- a/src/coreclr/scripts/superpmi_diffs_summarize.py
+++ b/src/coreclr/scripts/superpmi_diffs_summarize.py
@@ -14,6 +14,7 @@
 ################################################################################
 
 import argparse
+import html
 import os
 import re
 from coreclr_arguments import *
@@ -213,9 +214,9 @@ def main(main_args):
             inside_diff = False
             new_lines.append(html_color_diff(cur_diff_lines))
         elif inside_diff:
-            cur_diff_lines.append(line)
+            cur_diff_lines.append(html.escape(line))
         else:
-            new_lines.append(line)
+            new_lines.append(html.escape(line))
 
     with open(final_md_path, "w") as f:
         for line in new_lines:

--- a/src/coreclr/scripts/superpmi_diffs_summarize.py
+++ b/src/coreclr/scripts/superpmi_diffs_summarize.py
@@ -214,9 +214,9 @@ def main(main_args):
             inside_diff = False
             new_lines.append(html_color_diff(cur_diff_lines))
         elif inside_diff:
-            cur_diff_lines.append(html.escape(line))
+            cur_diff_lines.append(html.escape(line, False))
         else:
-            new_lines.append(html.escape(line))
+            new_lines.append(line)
 
     with open(final_md_path, "w") as f:
         for line in new_lines:


### PR DESCRIPTION
Two improvements:
1. Even if we haven't made any physical promotions it is still
   beneficial to go through and try to induce promotions from
   assignments between regular promotions and physical promotion
   candidates (e.g. STORE_LCL_FLD(V00, LCL_VAR(V01)) where V00 is a
   candidate and V01 is regularly promoted).
2. The logic to save candidate stores was missing the case where the
   regularly promoted struct is the destination and the source is the
   physical promotion candidate. Fix this by handling stores separately
   from candidates.

This shows up as a TP regression, but the regression mainly comes from
the work around the new promotions (new IR, more work as part of
replacement), not from actually picking the promotions themselves.

<details>

<summary>Detailed TP breakdown of `realworld`</summary>

```scala
Base: 56872431912, Diff: 57057349972, +0.3251%

?EndBlock@ReplaceVisitor@@QEAAXXZ                                                                                                                                                                                                  : 22936042 : +28.05%  : 10.07% : +0.0403%
?WalkTree@?$GenTreeVisitor@VReplaceVisitor@@@@QEAA?AW4fgWalkResult@Compiler@@PEAPEAUGenTree@@PEAU4@@Z                                                                                                                              : 8403186  : +17.59%  : 3.69%  : +0.0148%
?fgMorphSmpOp@Compiler@@AEAAPEAUGenTree@@PEAU2@PEAUMorphAddrContext@1@PEA_N@Z                                                                                                                                                      : 5674395  : +0.62%   : 2.49%  : +0.0100%
?optCopyProp@Compiler@@QEAA_NPEAUBasicBlock@@PEAUStatement@@PEAUGenTreeLclVarCommon@@IPEAV?$JitHashTable@IU?$JitSmallPrimitiveKeyFuncs@I@@PEAV?$ArrayStack@VCopyPropSsaDef@Compiler@@@@VCompAllocator@@VJitHashTableBehavior@@@@@Z : 5271969  : +0.45%   : 2.31%  : +0.0093%
?gtSetEvalOrder@Compiler@@QEAAIPEAUGenTree@@@Z                                                                                                                                                                                     : 4722500  : +0.46%   : 2.07%  : +0.0083%
?PickPromotions@LocalsUseVisitor@@QEAA_NAEAV?$vector@PEAUAggregateInfo@@V?$allocator@PEAUAggregateInfo@@@jitstd@@@jitstd@@@Z                                                                                                       : 4538607  : +51.41%  : 1.99%  : +0.0080%
?optAssertionProp_LclVar@Compiler@@QEAAPEAUGenTree@@AEBQEA_KPEAUGenTreeLclVarCommon@@PEAUStatement@@@Z                                                                                                                             : 4090828  : +1.40%   : 1.80%  : +0.0072%
GenTreeVisitor<`Compiler::fgSetTreeSeq'::`2'::SetTreeSeqVisitor>::WalkTree                                                                                                                                                         : 3831868  : +0.82%   : 1.68%  : +0.0067%
GenTreeVisitor<`Compiler::gtUpdateStmtSideEffects'::`2'::UpdateSideEffectsWalker>::WalkTree                                                                                                                                        : 3771560  : +2.98%   : 1.66%  : +0.0066%
?optCopyAssertionProp@Compiler@@QEAAPEAUGenTree@@PEAUAssertionDsc@1@PEAUGenTreeLclVarCommon@@PEAUStatement@@@Z                                                                                                                     : 3579443  : +6.79%   : 1.57%  : +0.0063%
?Push@?$ArrayStack@PEAUGenTree@@@@QEAAXPEAUGenTree@@@Z                                                                                                                                                                             : 3023848  : +2.02%   : 1.33%  : +0.0053%
jitstd::`anonymous namespace'::quick_sort<unsigned int *,LclVarDsc_BlendedCode_Less>                                                                                                                                               : 2822860  : +0.78%   : 1.24%  : +0.0050%
?fgInterBlockLocalVarLiveness@Compiler@@QEAAXXZ                                                                                                                                                                                    : 2800703  : +0.89%   : 1.23%  : +0.0049%
?fgMorphTree@Compiler@@QEAAPEAUGenTree@@PEAU2@PEAUMorphAddrContext@1@@Z                                                                                                                                                            : 2793398  : +0.57%   : 1.23%  : +0.0049%
?fgComputeLife@Compiler@@QEAAXAEAPEA_KPEAUGenTree@@1AEBQEA_KPEA_N@Z                                                                                                                                                                : 2691816  : +1.42%   : 1.18%  : +0.0047%
?optAddAssertion@Compiler@@QEAAGPEAUAssertionDsc@1@@Z                                                                                                                                                                              : 2668040  : +0.71%   : 1.17%  : +0.0047%
?fgPerBlockLocalVarLiveness@Compiler@@QEAAXXZ                                                                                                                                                                                      : 2643111  : +0.82%   : 1.16%  : +0.0046%
?fgMarkUseDef@Compiler@@AEAAXPEAUGenTreeLclVarCommon@@@Z                                                                                                                                                                           : 2597416  : +0.68%   : 1.14%  : +0.0046%
?PerBlockAnalysis@LiveVarAnalysis@@AEAA_NPEAUBasicBlock@@_N1@Z                                                                                                                                                                     : 2544526  : +0.59%   : 1.12%  : +0.0045%
?fgPerNodeLocalVarLiveness@Compiler@@QEAAXPEAUGenTree@@@Z                                                                                                                                                                          : 2538902  : +0.87%   : 1.11%  : +0.0045%
?FillInLiveness@PromotionLiveness@@AEAAXAEAPEA_KPEA_KPEAUGenTreeLclVarCommon@@@Z                                                                                                                                                   : 2249071  : +21.47%  : 0.99%  : +0.0040%
?PickInducedPromotions@LocalUses@@QEAAHPEAVCompiler@@IPEAPEAUAggregateInfo@@@Z                                                                                                                                                     : 2200270  : +111.37% : 0.97%  : +0.0039%
?UnionD@?$BitSetOps@PEA_K$00PEAVCompiler@@VTrackedVarBitSetTraits@@@@SAXPEAVCompiler@@AEAPEA_KPEA_K@Z                                                                                                                              : 2081201  : +1.07%   : 0.91%  : +0.0037%
?allocateMemory@ArenaAllocator@@QEAAPEAX_K@Z                                                                                                                                                                                       : 2011989  : +0.17%   : 0.88%  : +0.0035%
?optAssertionProp@Compiler@@QEAAPEAUGenTree@@AEBQEA_KPEAU2@PEAUStatement@@PEAUBasicBlock@@@Z                                                                                                                                       : 1975426  : +0.64%   : 0.87%  : +0.0035%
?OperExceptions@GenTree@@QEAA?AW4ExceptionSetFlags@@PEAVCompiler@@@Z                                                                                                                                                               : 1885689  : +0.93%   : 0.83%  : +0.0033%
?WalkTree@?$GenTreeVisitor@VLocalSequencer@@@@QEAA?AW4fgWalkResult@Compiler@@PEAPEAUGenTree@@PEAU4@@Z                                                                                                                              : 1779816  : +5.53%   : 0.78%  : +0.0031%
?optAssertionGen@Compiler@@QEAAXPEAUGenTree@@@Z                                                                                                                                                                                    : 1758645  : +0.43%   : 0.77%  : +0.0031%
?MarkUseDef@PromotionLiveness@@AEAAXPEAUGenTreeLclVarCommon@@AEAPEA_K1@Z                                                                                                                                                           : 1712769  : +19.04%  : 0.75%  : +0.0030%
?ComputeUseDefSets@PromotionLiveness@@AEAAXXZ                                                                                                                                                                                      : 1662009  : +21.48%  : 0.73%  : +0.0029%
?FillInLiveness@PromotionLiveness@@AEAAXXZ                                                                                                                                                                                         : 1660971  : +20.88%  : 0.73%  : +0.0029%
BasicBlock::VisitAllSuccs<`PromotionLiveness::PerBlockLiveness'::`2'::<lambda_1> >                                                                                                                                                 : 1654685  : +20.56%  : 0.73%  : +0.0029%
?InsertMidTreeReadBacksIfNecessary@ReplaceVisitor@@AEAAPEAPEAUGenTree@@PEAPEAU2@@Z                                                                                                                                                 : 1633578  : +17.64%  : 0.72%  : +0.0029%
memset                                                                                                                                                                                                                             : 1633308  : +0.36%   : 0.72%  : +0.0029%
?gtUpdateNodeOperSideEffects@Compiler@@QEAAXPEAUGenTree@@@Z                                                                                                                                                                        : 1629838  : +0.78%   : 0.72%  : +0.0029%
?optLocalAssertionIsEqualOrNotEqual@Compiler@@QEAAGW4optOp1Kind@1@IW4optOp2Kind@1@_JAEBQEA_K@Z                                                                                                                                     : 1551164  : +3.85%   : 0.68%  : +0.0027%
?RewriteNode@Rationalizer@@AEAA?AW4fgWalkResult@Compiler@@PEAPEAUGenTree@@AEAV?$ArrayStack@PEAUGenTree@@@@@Z                                                                                                                       : 1533783  : +0.43%   : 0.67%  : +0.0027%
?FinalizeCopy@DecompositionPlan@@AEAAXPEAVDecompositionStatementList@@@Z                                                                                                                                                           : 1527293  : +54.55%  : 0.67%  : +0.0027%
?OverlappingReplacements@AggregateInfo@@QEAA_NIIPEAPEAUReplacement@@0@Z                                                                                                                                                            : 1480169  : +82.04%  : 0.65%  : +0.0026%
?ReplaceLocal@ReplaceVisitor@@AEAAXPEAPEAUGenTree@@PEAU2@@Z                                                                                                                                                                        : 1456054  : +16.68%  : 0.64%  : +0.0026%
?Run@Promotion@@QEAA?AW4PhaseStatus@@XZ                                                                                                                                                                                            : 1364603  : +5.47%   : 0.60%  : +0.0024%
?LivenessDLong@?$BitSetOps@PEA_K$00PEAVCompiler@@VTrackedVarBitSetTraits@@@@CAXPEAVCompiler@@AEAPEA_KQEA_K22@Z                                                                                                                     : 1360068  : +1.42%   : 0.60%  : +0.0024%
?InterBlockLiveness@PromotionLiveness@@AEAAXXZ                                                                                                                                                                                     : 1345362  : +21.37%  : 0.59%  : +0.0024%
?OperRequiresCallFlag@GenTree@@QEAA_NPEAVCompiler@@@Z                                                                                                                                                                              : 1326260  : +1.29%   : 0.58%  : +0.0023%
?fgComputeLifeLIR@Compiler@@QEAAXAEAPEA_KPEAUBasicBlock@@AEBQEA_K@Z                                                                                                                                                                : 1320987  : +0.57%   : 0.58%  : +0.0023%
?gtFoldExpr@Compiler@@QEAAPEAUGenTree@@PEAU2@@Z                                                                                                                                                                                    : 1243912  : +0.44%   : 0.55%  : +0.0022%
?fgValueNumberTree@Compiler@@QEAAXPEAUGenTree@@@Z                                                                                                                                                                                  : 1242943  : +0.31%   : 0.55%  : +0.0022%
??$VisitAllSuccs@V<lambda_1>@?1??PerBlockAnalysis@LiveVarAnalysis@@AEAA_NPEAUBasicBlock@@_N1@Z@@BasicBlock@@QEAA?AW4BasicBlockVisit@@PEAVCompiler@@V<lambda_1>@?1??PerBlockAnalysis@LiveVarAnalysis@@AEAA_NPEAU0@_N2@Z@@Z          : 1216605  : +0.53%   : 0.53%  : +0.0021%
?OperRequiresAsgFlag@GenTree@@QEAA_NXZ                                                                                                                                                                                             : 1198356  : +1.14%   : 0.53%  : +0.0021%
?lvaMarkLclRefs@Compiler@@IEAAXPEAUGenTree@@PEAUBasicBlock@@PEAUStatement@@_N@Z                                                                                                                                                    : 1189511  : +0.52%   : 0.52%  : +0.0021%
?fgMorphSmpOpOptional@Compiler@@AEAAPEAUGenTree@@PEAUGenTreeOp@@PEA_N@Z                                                                                                                                                            : 1159452  : +0.58%   : 0.51%  : +0.0020%
?Subtract@StructSegments@@QEAAXAEBUSegment@1@@Z                                                                                                                                                                                    : 1150970  : +62.59%  : 0.51%  : +0.0020%
?HandleStructStore@ReplaceVisitor@@AEAAXPEAPEAUGenTree@@PEAU2@@Z                                                                                                                                                                   : 1146139  : +36.39%  : 0.50%  : +0.0020%
?Assign@?$BitSetOps@PEA_K$00PEAVCompiler@@VTrackedVarBitSetTraits@@@@SAXPEAVCompiler@@AEAPEA_KPEA_K@Z                                                                                                                              : 1105830  : +0.65%   : 0.49%  : +0.0019%
GenTreeVisitor<`Compiler::lvaMarkLocalVars'::`2'::MarkLocalVarsVisitor>::WalkTree                                                                                                                                                  : 1077547  : +0.44%   : 0.47%  : +0.0019%
?optCreateAssertion@Compiler@@QEAAGPEAUGenTree@@0W4optAssertionKind@1@_N@Z                                                                                                                                                         : 1035548  : +0.51%   : 0.45%  : +0.0018%
?fgComputeLifeTrackedLocalDef@Compiler@@QEAA_NAEAPEA_KAEBQEA_KAEAVLclVarDsc@@PEAUGenTreeLclVarCommon@@@Z                                                                                                                           : 965589   : +0.85%   : 0.42%  : +0.0017%
?optVNAssertionPropCurStmtVisitor@Compiler@@KA?AW4fgWalkResult@1@PEAPEAUGenTree@@PEAUfgWalkData@1@@Z                                                                                                                               : 965363   : +0.32%   : 0.42%  : +0.0017%
?EnsureCoversInd@?$JitExpandArray@PEAUChunk@ValueNumStore@@@@IEAAXI@Z                                                                                                                                                              : 927840   : +0.52%   : 0.41%  : +0.0016%
?ClearD@?$BitSetOps@PEA_K$00PEAVCompiler@@VTrackedVarBitSetTraits@@@@SAXPEAVCompiler@@AEAPEA_K@Z                                                                                                                                   : 918138   : +0.89%   : 0.40%  : +0.0016%
?insert@?$vector@UReplacement@@V?$allocator@UReplacement@@@jitstd@@@jitstd@@QEAA?AViterator@12@V312@AEBUReplacement@@@Z                                                                                                            : 905064   : +119.24% : 0.40%  : +0.0016%
?WalkTree@?$GenTreeVisitor@V?$GenericTreeWalker@$0A@$00$0A@$00@@@@QEAA?AW4fgWalkResult@Compiler@@PEAPEAUGenTree@@PEAU4@@Z                                                                                                          : 888334   : +0.35%   : 0.39%  : +0.0016%
?emitUpdateLiveGCvars@emitter@@QEAAXAEBQEA_KPEAE@Z                                                                                                                                                                                 : 828237   : +0.48%   : 0.36%  : +0.0015%
jitstd::`anonymous namespace'::insertion_sort<unsigned int *,LclVarDsc_BlendedCode_Less>                                                                                                                                           : 827243   : +0.46%   : 0.36%  : +0.0015%
GenTreeVisitor<`Rationalizer::DoPhase'::`2'::RationalizeVisitor>::WalkTree                                                                                                                                                         : 823804   : +0.30%   : 0.36%  : +0.0014%
?lvaSortByRefCount@Compiler@@QEAAXXZ                                                                                                                                                                                               : 804050   : +0.45%   : 0.35%  : +0.0014%
?incRefCnts@LclVarDsc@@QEAAXNPEAVCompiler@@W4RefCountState@@_N@Z                                                                                                                                                                   : 794232   : +0.39%   : 0.35%  : +0.0014%
`PromotionLiveness::PerBlockLiveness'::`2'::<lambda_1>::operator()                                                                                                                                                                 : 791175   : +20.48%  : 0.35%  : +0.0014%
?MakeCopy@?$BitSetOps@PEA_K$00PEAVCompiler@@VTrackedVarBitSetTraits@@@@SAPEA_KPEAVCompiler@@PEA_K@Z                                                                                                                                : 783401   : +0.57%   : 0.34%  : +0.0014%
?CopyBetweenFields@ReplaceVisitor@@AEAAXPEAUGenTree@@PEAUReplacement@@1011PEAVDecompositionStatementList@@PEAVDecompositionPlan@@@Z                                                                                                : 764039   : +66.85%  : 0.34%  : +0.0013%
?fgComputeLifeTrackedLocalUse@Compiler@@QEAAXAEAPEA_KAEAVLclVarDsc@@PEAUGenTreeLclVarCommon@@@Z                                                                                                                                    : 761572   : +0.60%   : 0.33%  : +0.0013%
?GetAssertionDep@Compiler@@QEAAAEAPEA_KI@Z                                                                                                                                                                                         : 711600   : +1.55%   : 0.31%  : +0.0013%
memcpy_repmovs                                                                                                                                                                                                                     : 625552   : +2.13%   : 0.27%  : +0.0011%
?gtMarkAddrMode@Compiler@@QEAA_NPEAUGenTree@@PEAH1W4var_types@@@Z                                                                                                                                                                  : 623974   : +0.41%   : 0.27%  : +0.0011%
??R<lambda_1>@?1??PerBlockAnalysis@LiveVarAnalysis@@AEAA_NPEAUBasicBlock@@_N1@Z@QEBA@0@Z                                                                                                                                           : 605924   : +0.54%   : 0.27%  : +0.0011%
__security_check_cookie                                                                                                                                                                                                            : 600642   : +0.22%   : 0.26%  : +0.0011%
?gtNewStoreLclVarNode@Compiler@@QEAAPEAUGenTreeLclVar@@IPEAUGenTree@@@Z                                                                                                                                                            : 595163   : +0.94%   : 0.26%  : +0.0010%
?lvaComputeRefCounts@Compiler@@QEAAX_N0@Z                                                                                                                                                                                          : 584027   : +0.12%   : 0.26%  : +0.0010%
VisitEHSuccessors<`PromotionLiveness::PerBlockLiveness'::`2'::<lambda_1> >                                                                                                                                                         : 566423   : +21.02%  : 0.25%  : +0.0010%
?getBBWeight@BasicBlock@@QEAANPEAVCompiler@@@Z                                                                                                                                                                                     : 558278   : +0.61%   : 0.25%  : +0.0010%
VisitSuccessorEHSuccessors<`PromotionLiveness::PerBlockLiveness'::`2'::<lambda_1> >                                                                                                                                                : 558062   : +20.38%  : 0.24%  : +0.0010%
?MarkIndex@PromotionLiveness@@AEAAXI_N0AEAPEA_K1@Z                                                                                                                                                                                 : 519813   : +36.57%  : 0.23%  : +0.0009%
?optAssertionIsSubrange@Compiler@@QEAAGPEAUGenTree@@VIntegralRange@@AEBQEA_K@Z                                                                                                                                                     : 489377   : +2.47%   : 0.21%  : +0.0009%
??0NodeInfo@AliasSet@@QEAA@PEAVCompiler@@PEAUGenTree@@@Z                                                                                                                                                                           : 483116   : +0.36%   : 0.21%  : +0.0008%
?ClearD@?$BitSetOps@PEA_K$00PEAUBitVecTraits@@U1@@@SAXPEAUBitVecTraits@@AEAPEA_K@Z                                                                                                                                                 : 476788   : +3.47%   : 0.21%  : +0.0008%
?UnionD@?$BitSetOps@PEA_K$00PEAUBitVecTraits@@U1@@@SAXPEAUBitVecTraits@@AEAPEA_KPEA_K@Z                                                                                                                                            : 472467   : +25.00%  : 0.21%  : +0.0008%
?optEarlyPropRewriteTree@Compiler@@QEAAPEAUGenTree@@PEAU2@PEAV?$JitHashTable@IU?$JitSmallPrimitiveKeyFuncs@I@@PEAUGenTree@@VCompAllocator@@VJitHashTableBehavior@@@@@Z                                                             : 469259   : +1.00%   : 0.21%  : +0.0008%
?fgMorphExpandImplicitByRefArg@Compiler@@AEAAPEAUGenTree@@PEAUGenTreeLclVarCommon@@@Z                                                                                                                                              : 464134   : +0.66%   : 0.20%  : +0.0008%
?InduceAccess@LocalsUseVisitor@@AEAAXAEAV?$vector@PEAUAggregateInfo@@V?$allocator@PEAUAggregateInfo@@@jitstd@@@jitstd@@IIW4var_types@@PEAUBasicBlock@@@Z                                                                           : 459560   : +50.62%  : 0.20%  : +0.0008%
?doLinearScan@LinearScan@@UEAA?AW4PhaseStatus@@XZ                                                                                                                                                                                  : 457240   : +0.21%   : 0.20%  : +0.0008%
?ehGetBlockExnFlowDsc@Compiler@@QEAAPEAUEHblkDsc@@PEAUBasicBlock@@@Z                                                                                                                                                               : 454267   : +0.60%   : 0.20%  : +0.0008%
VisitSuccessorEHSuccessors<`LiveVarAnalysis::PerBlockAnalysis'::`2'::<lambda_1> >                                                                                                                                                  : 437573   : +0.52%   : 0.19%  : +0.0008%
?genCreateAddrMode@CodeGen@@UEAA_NPEAUGenTree@@_NPEA_NPEAPEAU2@3PEAIPEA_J@Z                                                                                                                                                        : 436251   : +0.35%   : 0.19%  : +0.0008%
?optBlockCopyProp@Compiler@@QEAA_NPEAUBasicBlock@@PEAV?$JitHashTable@IU?$JitSmallPrimitiveKeyFuncs@I@@PEAV?$ArrayStack@VCopyPropSsaDef@Compiler@@@@VCompAllocator@@VJitHashTableBehavior@@@@@Z                                     : 433642   : +0.22%   : 0.19%  : +0.0008%
?fgMorphExpandLocal@Compiler@@AEAAPEAUGenTree@@PEAUGenTreeLclVarCommon@@@Z                                                                                                                                                         : 432528   : +0.67%   : 0.19%  : +0.0008%
?gtExtractSideEffList@Compiler@@QEAAXPEAUGenTree@@PEAPEAU2@W4GenTreeFlags@@_N@Z                                                                                                                                                    : 419184   : +6.93%   : 0.18%  : +0.0007%
?fgMorphLeaf@Compiler@@AEAAPEAUGenTree@@PEAU2@@Z                                                                                                                                                                                   : 408513   : +0.46%   : 0.18%  : +0.0007%
?SizeofSlotStateVarLengthVector@GcInfoEncoder@@AEAAXAEBVBitArray@@IIPEAI11@Z                                                                                                                                                       : 393178   : +0.28%   : 0.17%  : +0.0007%
?lvaGetFieldLocal@Compiler@@QEAAIPEBVLclVarDsc@@I@Z                                                                                                                                                                                : 393156   : +4.86%   : 0.17%  : +0.0007%
?resolveLocalRef@LinearScan@@AEAAXPEAUBasicBlock@@PEAUGenTreeLclVar@@PEAVRefPosition@@@Z                                                                                                                                           : 392707   : +0.18%   : 0.17%  : +0.0007%
VisitEHSuccessors<`LiveVarAnalysis::PerBlockAnalysis'::`2'::<lambda_1> >                                                                                                                                                           : 390977   : +0.49%   : 0.17%  : +0.0007%
?SignificantSegments@Promotion@@AEAA?AVStructSegments@@PEAVClassLayout@@@Z                                                                                                                                                         : 388618   : +36.91%  : 0.17%  : +0.0007%
?OptimizeRangeCheck@RangeCheck@@QEAAXPEAUBasicBlock@@PEAUStatement@@PEAUGenTree@@@Z                                                                                                                                                : 379620   : +0.30%   : 0.17%  : +0.0007%
?fgRemoveDeadStore@Compiler@@QEAA_NPEAPEAUGenTree@@PEAVLclVarDsc@@AEBQEA_KPEA_N33@Z                                                                                                                                                : 379606   : +9.68%   : 0.17%  : +0.0007%
?Run@LiveVarAnalysis@@AEAAX_N@Z                                                                                                                                                                                                    : 376756   : +0.48%   : 0.17%  : +0.0007%
jitstd::`anonymous namespace'::quick_sort<GcInfoEncoder::LifetimeTransition *,CompareLifetimeTransitionsByOffsetThenSlot>                                                                                                          : 369858   : +0.22%   : 0.16%  : +0.0007%
GenTree::VisitOperands<`Compiler::gtUpdateNodeSideEffects'::`2'::<lambda_1> >                                                                                                                                                      : 335819   : +1.60%   : 0.15%  : +0.0006%
GenTreeVisitor<`Compiler::gtFindLink'::`2'::FindLinkWalker>::WalkTree                                                                                                                                                              : 321332   : +1.07%   : 0.14%  : +0.0006%
??$BinarySearch@UReplacement@@$0A@@Promotion@@CA_KAEBV?$vector@UReplacement@@V?$allocator@UReplacement@@@jitstd@@@jitstd@@I@Z                                                                                                      : 319219   : +14.05%  : 0.14%  : +0.0006%
?fgTryRemoveNonLocal@Compiler@@QEAA_NPEAUGenTree@@PEAVRange@LIR@@@Z                                                                                                                                                                : 306933   : +0.49%   : 0.13%  : +0.0005%
?optAssertionReset@Compiler@@QEAAXG@Z                                                                                                                                                                                              : 302047   : +0.74%   : 0.13%  : +0.0005%
`Compiler::gtExtractSideEffList'::`2'::SideEffectExtractor::PreOrderVisit                                                                                                                                                          : 299461   : +1.52%   : 0.13%  : +0.0005%
?UpdateLifeVar@?$TreeLifeUpdater@$00@@AEAAXPEAUGenTree@@PEAUGenTreeLclVarCommon@@@Z                                                                                                                                                : 283462   : +0.18%   : 0.12%  : +0.0005%
?RenameVariables@SsaBuilder@@AEAAXXZ                                                                                                                                                                                               : 283187   : +0.47%   : 0.12%  : +0.0005%
?optVNConstantPropOnTree@Compiler@@QEAAPEAUGenTree@@PEAUBasicBlock@@PEAU2@@Z                                                                                                                                                       : 281627   : +0.18%   : 0.12%  : +0.0005%
?raMarkStkVars@Compiler@@QEAAXXZ                                                                                                                                                                                                   : 281303   : +0.74%   : 0.12%  : +0.0005%
?VNWithExc@ValueNumStore@@QEAAIII@Z                                                                                                                                                                                                : 280045   : +0.22%   : 0.12%  : +0.0005%
?Push@?$ArrayStack@UEntry@DecompositionPlan@@@@QEAAXUEntry@DecompositionPlan@@@Z                                                                                                                                                   : 274124   : +70.77%  : 0.12%  : +0.0005%
?VNPExceptionSet@ValueNumStore@@QEAA?AUValueNumPair@@U2@@Z                                                                                                                                                                         : 273204   : +1.36%   : 0.12%  : +0.0005%
?optImpliedAssertions@Compiler@@QEAAXGAEAPEA_K@Z                                                                                                                                                                                   : 269118   : +0.24%   : 0.12%  : +0.0005%
?lvaAssignVirtualFrameOffsetsToLocals@Compiler@@QEAAXXZ                                                                                                                                                                            : 266526   : +0.50%   : 0.12%  : +0.0005%
?BlockRenameVariables@SsaBuilder@@AEAAXPEAUBasicBlock@@@Z                                                                                                                                                                          : 265466   : +0.16%   : 0.12%  : +0.0005%
?optValnumCSE_Locate@Compiler@@IEAA_NXZ                                                                                                                                                                                            : 263284   : +0.14%   : 0.12%  : +0.0005%
?optAssertionPropMain@Compiler@@QEAA?AW4PhaseStatus@@XZ                                                                                                                                                                            : 258293   : +0.12%   : 0.11%  : +0.0005%
?InsertPhiFunctions@SsaBuilder@@AEAAXPEAPEAUBasicBlock@@H@Z                                                                                                                                                                        : 258140   : +0.35%   : 0.11%  : +0.0005%
?optEarlyProp@Compiler@@QEAA?AW4PhaseStatus@@XZ                                                                                                                                                                                    : 257198   : +0.79%   : 0.11%  : +0.0005%
??RLclVarDsc_BlendedCode_Less@@QEAA_NII@Z                                                                                                                                                                                          : 254706   : +0.62%   : 0.11%  : +0.0004%
?ComputeRemainder@DecompositionPlan@@AEAA?AVStructSegments@@XZ                                                                                                                                                                     : 249904   : +74.47%  : 0.11%  : +0.0004%
?WalkTree@?$GenTreeVisitor@VForwardSubVisitor@@@@QEAA?AW4fgWalkResult@Compiler@@PEAPEAUGenTree@@PEAU4@@Z                                                                                                                           : 246147   : +0.64%   : 0.11%  : +0.0004%
?Initialize@CSE_Heuristic@@QEAAXXZ                                                                                                                                                                                                 : 244804   : +0.80%   : 0.11%  : +0.0004%
?fgValueNumberAddExceptionSet@Compiler@@QEAAXPEAUGenTree@@@Z                                                                                                                                                                       : 243217   : +0.44%   : 0.11%  : +0.0004%
?AddHandlerLiveVars@PromotionLiveness@@AEAAXPEAUBasicBlock@@AEAPEA_K@Z                                                                                                                                                             : 238224   : +20.39%  : 0.10%  : +0.0004%
?genConsumeReg@CodeGen@@IEAA?AW4_regNumber_enum@@PEAUGenTree@@@Z                                                                                                                                                                   : 231599   : +0.10%   : 0.10%  : +0.0004%
??$VisitOperands@V<lambda_1>@?6???$GetMarkedRange@$0A@@Range@LIR@@AEBA?AVReadOnlyRange@3@IPEAUGenTree@@PEA_NPEAI@Z@@GenTree@@QEAAXV<lambda_1>@?6???$GetMarkedRange@$0A@@Range@LIR@@AEBA?AVReadOnlyRange@3@IPEAU0@PEA_NPEAI@Z@@Z    : 231345   : +2.61%   : 0.10%  : +0.0004%
?fgValueNumberBlock@Compiler@@QEAAXPEAUBasicBlock@@@Z                                                                                                                                                                              : 230734   : +0.19%   : 0.10%  : +0.0004%
?AddNode@AliasSet@@QEAAXPEAVCompiler@@PEAUGenTree@@@Z                                                                                                                                                                              : 227895   : +0.34%   : 0.10%  : +0.0004%
?VNForLoad@ValueNumStore@@QEAAIW4ValueNumKind@@IIW4var_types@@_JI@Z                                                                                                                                                                : -239880  : -2.47%   : 0.11%  : -0.0004%
??$ConstantValueInternal@_K@ValueNumStore@@AEAA_KI@Z                                                                                                                                                                               : -258759  : -36.11%  : 0.11%  : -0.0005%
?emitAllocAnyInstr@emitter@@AEAAPEAX_KW4emitAttr@@@Z                                                                                                                                                                               : -259773  : -0.11%   : 0.11%  : -0.0005%
?MorphStructCases@MorphCopyBlockHelper@@MEAAXXZ                                                                                                                                                                                    : -305601  : -2.70%   : 0.13%  : -0.0005%
?emitOutputRexOrSimdPrefixIfNeeded@emitter@@QEAAIW4instruction@@PEAEAEA_K@Z                                                                                                                                                        : -332391  : -0.27%   : 0.15%  : -0.0006%
?VNForFunc@ValueNumStore@@QEAAIW4var_types@@W4VNFunc@@III@Z                                                                                                                                                                        : -351963  : -1.12%   : 0.15%  : -0.0006%
?emitOutputInstr@emitter@@IEAA_KPEAUinsGroup@@PEAUinstrDesc@1@PEAPEAE@Z                                                                                                                                                            : -367877  : -0.12%   : 0.16%  : -0.0006%
??$VnForConst@_JV?$VNMap@_JU?$JitLargePrimitiveKeyFuncs@_J@@@ValueNumStore@@@ValueNumStore@@AEAAI_JPEAV?$VNMap@_JU?$JitLargePrimitiveKeyFuncs@_J@@@0@W4var_types@@@Z                                                               : -411118  : -0.86%   : 0.18%  : -0.0007%
?CopyFieldByField@MorphCopyBlockHelper@@IEAAPEAUGenTree@@XZ                                                                                                                                                                        : -518829  : -4.02%   : 0.23%  : -0.0009%
?emitOutputSV@emitter@@QEAAPEAEPEAEPEAUinstrDesc@1@_KPEAUCnsVal@1@@Z                                                                                                                                                               : -540485  : -0.66%   : 0.24%  : -0.0010%
?TakesEvexPrefix@emitter@@QEBA_NPEBUinstrDesc@1@@Z                                                                                                                                                                                 : -1082252 : -0.87%   : 0.48%  : -0.0019%
??$select@$0A@@RegisterSelection@LinearScan@@QEAA_KPEAVInterval@@PEAVRefPosition@@@Z                                                                                                                                               : -1148905 : -0.10%   : 0.50%  : -0.0020%
?VNForMapSelectWork@ValueNumStore@@QEAAIW4ValueNumKind@@W4var_types@@IIPEAHPEA_N@Z                                                                                                                                                 : -1862529 : -1.02%   : 0.82%  : -0.0033%
?processBlockStartLocations@LinearScan@@AEAAXPEAUBasicBlock@@@Z                                                                                                                                                                    : -4483742 : -0.78%   : 1.97%  : -0.0079%
```

</details>