### PR TITLE
Support relative path for ICU_DAT_FILE_PATH on iOS/tvOS/Catalyst

### DIFF
--- a/src/native/libs/System.Globalization.Native/pal_icushim_internal.h
+++ b/src/native/libs/System.Globalization.Native/pal_icushim_internal.h
@@ -341,6 +341,7 @@ FOR_ALL_ICU_FUNCTIONS
 #define ucal_getTimeZoneIDForWindowsID_ptr ucal_getTimeZoneIDForWindowsID
 
 #if defined(TARGET_MACCATALYST) || defined(TARGET_IOS) || defined(TARGET_TVOS)
+const char* GlobalizationNative_GetICUDataPathRelativeToAppBundleRoot(const char* path);
 const char* GlobalizationNative_GetICUDataPathFallback(void);
 #endif
 

--- a/src/native/libs/System.Globalization.Native/pal_icushim_static.c
+++ b/src/native/libs/System.Globalization.Native/pal_icushim_static.c
@@ -171,9 +171,14 @@ int32_t
 GlobalizationNative_LoadICUData(const char* path)
 {
 #if defined(TARGET_MACCATALYST) || defined(TARGET_IOS) || defined(TARGET_TVOS)
+    if (path && path[0] != '/')
+    {
+        // if the path is relative, prepend the app bundle root
+        path = GlobalizationNative_GetICUDataPathRelativeToAppBundleRoot(path);
+    }
     if (!path)
     {
-        // fallback to icudt.dat in the app bundle root in case the path isn't set
+        // fallback to icudt.dat in the app bundle resources in case the path isn't set
         path = GlobalizationNative_GetICUDataPathFallback();
     }
 #endif

--- a/src/native/libs/System.Globalization.Native/pal_locale.m
+++ b/src/native/libs/System.Globalization.Native/pal_locale.m
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #import <Foundation/NSFormatter.h>
 
-char* DetectDefaultAppleLocaleName()
+char* DetectDefaultAppleLocaleName(void)
 {
     NSLocale *currentLocale = [NSLocale currentLocale];
     NSString *localeName = @"";
@@ -571,9 +571,17 @@ const char* GlobalizationNative_GetLocaleTimeFormatNative(const char* localeName
 #endif
 
 #if defined(TARGET_MACCATALYST) || defined(TARGET_IOS) || defined(TARGET_TVOS)
+const char* GlobalizationNative_GetICUDataPathRelativeToAppBundleRoot(const char* path)
+{
+    NSString *bundlePath = [[NSBundle mainBundle] bundlePath];
+    NSString *dataPath = [bundlePath stringByAppendingPathComponent: [NSString stringWithFormat:@"%s", path]];
+
+    return strdup([dataPath UTF8String]);
+}
+
 const char* GlobalizationNative_GetICUDataPathFallback(void)
 {
-    NSString *bundlePath = [[NSBundle mainBundle] pathForResource:@"icudt" ofType:@"dat"];
-    return strdup([bundlePath UTF8String]);
+    NSString *dataPath = [[NSBundle mainBundle] pathForResource:@"icudt" ofType:@"dat"];
+    return strdup([dataPath UTF8String]);
 }
 #endif


### PR DESCRIPTION
We consider it relative to the app bundle root.

Required for https://github.com/xamarin/xamarin-macios/issues/17877 and NativeAOT scenarios.