### PR TITLE
Add custom hosts file support to Dns

### DIFF
--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionTelemetry.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionTelemetry.cs
@@ -17,6 +17,8 @@ namespace System.Net
         private const int ResolutionStartEventId = 1;
         private const int ResolutionStopEventId = 2;
         private const int ResolutionFailedEventId = 3;
+        private const int HostsOverrideMappingAddedId = 4;
+        private const int HostsOverrideErrorEventId = 5;
 
         private PollingCounter? _lookupsRequestedCounter;
         private PollingCounter? _currentLookupsCounter;
@@ -58,6 +60,11 @@ namespace System.Net
         [Event(ResolutionFailedEventId, Level = EventLevel.Informational)]
         private void ResolutionFailed() => WriteEvent(ResolutionFailedEventId);
 
+        [Event(HostsOverrideMappingAddedId, Level = EventLevel.Informational)]
+        public void HostsOverrideMappingAdded(string hostname, string address) => WriteEvent(HostsOverrideMappingAddedId, hostname, address);
+
+        [Event(HostsOverrideErrorEventId, Level = EventLevel.Error)]
+        public void HostsOverrideError(string hostsPath, string errorDescription) => WriteEvent(HostsOverrideErrorEventId, hostsPath, errorDescription);
 
         [NonEvent]
         public long BeforeResolution(object hostNameOrAddress)

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
@@ -14,10 +14,10 @@ namespace System.Net.NameResolution.Tests
     public class GetHostAddressesTest
     {
         [Fact]
-        public Task Dns_GetHostAddressesAsync_HostString_Ok() => TestGetHostAddressesAsync(() => Dns.GetHostAddressesAsync(TestSettings.LocalHost));
+        public static Task Dns_GetHostAddressesAsync_HostString_Ok() => TestGetHostAddressesAsync(() => Dns.GetHostAddressesAsync(TestSettings.LocalHost));
 
         [Fact]
-        public Task Dns_GetHostAddressesAsync_IPString_Ok() => TestGetHostAddressesAsync(() => Dns.GetHostAddressesAsync(TestSettings.LocalIPString));
+        public static Task Dns_GetHostAddressesAsync_IPString_Ok() => TestGetHostAddressesAsync(() => Dns.GetHostAddressesAsync(TestSettings.LocalIPString));
 
         private static async Task TestGetHostAddressesAsync(Func<Task<IPAddress[]>> getHostAddressesFunc)
         {

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/HostOverridesTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/HostOverridesTest.cs
@@ -1,0 +1,151 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.RemoteExecutor;
+using Xunit;
+
+namespace System.Net.NameResolution.Tests
+{
+    public class HostAliasesTest : FileCleanupTestBase
+    {
+        private const string HostsEnvironmentVariableName = "DOTNET_SYSTEM_NET_HOSTS";
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void AllHookedEntrypoints_LookupsFindExpectedData()
+        {
+            string hostsPath = CreateTestFile();
+            File.WriteAllText(hostsPath, $"""
+                # This is a sample HOSTS file
+                #
+                102.54.94.97     rhino.acme.com  # something
+                 38.25.63.10     x.acme.com      # something else
+                ::1              example
+
+                nonparsableip
+                .....
+                1.2..3 test
+
+                ::1  invalid$$$host$@
+                1.1.1.1 firstnameonline    secondnameonline   thirdnameonline secondnameonline
+
+                1.2.3.4          example2
+                ::2          example2
+                ::1  localhost
+                ::1  anothermappedto1
+                """);
+
+            var options = new RemoteInvokeOptions();
+            options.StartInfo.EnvironmentVariables[HostsEnvironmentVariableName] = hostsPath;
+            options.TimeOut = -1;
+
+            RemoteExecutor.Invoke(async () =>
+            {
+                // Validate name-to-addresses lookups
+                await AssertExpectedAddresses("rhino.acme.com", new[] { IPAddress.Parse("102.54.94.97") });
+                await AssertExpectedAddresses("example", new[] { IPAddress.IPv6Loopback });
+                await AssertExpectedAddresses("example2", new[] { IPAddress.Parse("1.2.3.4"), IPAddress.Parse("::2") });
+                await AssertExpectedAddresses("localhost", new[] { IPAddress.Parse("::1") });
+                await AssertExpectedAddresses("firstnameonline", new[] { IPAddress.Parse("1.1.1.1") });
+                await AssertExpectedAddresses("secondnameonline", new[] { IPAddress.Parse("1.1.1.1") });
+                await AssertExpectedAddresses("thirdnameonline", new[] { IPAddress.Parse("1.1.1.1") });
+                await AssertExpectedAddressesFiltered("rhino.acme.com", new[] { IPAddress.Parse("102.54.94.97") }, AddressFamily.InterNetwork);
+                await AssertExpectedAddressesFiltered("example", new[] { IPAddress.IPv6Loopback }, AddressFamily.InterNetworkV6);
+                await AssertExpectedAddressesFiltered("example2", new[] { IPAddress.Parse("1.2.3.4") }, AddressFamily.InterNetwork);
+                await AssertExpectedAddressesFiltered("example2", new[] { IPAddress.Parse("1.2.3.4"), IPAddress.Parse("::2") }, AddressFamily.Unspecified);
+                await AssertExpectedAddressesFiltered("example2", new[] { IPAddress.Parse("::2") }, AddressFamily.InterNetworkV6);
+                await AssertExpectedAddressesFiltered("localhost", new[] { IPAddress.Parse("::1") }, AddressFamily.InterNetworkV6);
+                await AssertExpectedAddressesFiltered("anothermappedto1", new[] { IPAddress.Parse("::1") }, AddressFamily.InterNetworkV6);
+                static async Task AssertExpectedAddresses(string hostName, IPAddress[] expected)
+                {
+                    Assert.Equal(expected, Dns.GetHostAddresses(hostName));
+                    Assert.Equal(expected, await Dns.GetHostAddressesAsync(hostName));
+                    Assert.Equal(expected, await Dns.GetHostAddressesAsync(hostName, AddressFamily.Unspecified));
+                    Assert.Equal(expected, await Dns.GetHostAddressesAsync(hostName, CancellationToken.None));
+                    Assert.Equal(expected, Dns.EndGetHostAddresses(Dns.BeginGetHostAddresses(hostName, null, null)));
+                }
+                static async Task AssertExpectedAddressesFiltered(string hostName, IPAddress[] expected, AddressFamily addressFamily)
+                {
+                    Assert.Equal(expected, await Dns.GetHostAddressesAsync(hostName, addressFamily));
+                }
+
+                IPHostEntry expectedEntry = new IPHostEntry { HostName = "rhino.acme.com", AddressList = new[] { IPAddress.Parse("102.54.94.97") }, Aliases = Array.Empty<string>() };
+                AssertExpectedHostEntries(expectedEntry, Dns.GetHostEntry("rhino.acme.com"));
+                AssertExpectedHostEntries(expectedEntry, Dns.GetHostEntry("rhino.acme.com", AddressFamily.Unspecified));
+                AssertExpectedHostEntries(expectedEntry, await Dns.GetHostEntryAsync("rhino.acme.com"));
+                AssertExpectedHostEntries(expectedEntry, await Dns.GetHostEntryAsync("rhino.acme.com", AddressFamily.Unspecified));
+                AssertExpectedHostEntries(expectedEntry, await Dns.GetHostEntryAsync("rhino.acme.com", CancellationToken.None));
+                AssertExpectedHostEntries(expectedEntry, Dns.EndGetHostEntry(Dns.BeginGetHostEntry("rhino.acme.com", null, null)));
+                AssertExpectedHostEntries(expectedEntry, Dns.GetHostEntry(IPAddress.Parse("102.54.94.97")));
+                AssertExpectedHostEntries(expectedEntry, await Dns.GetHostEntryAsync(IPAddress.Parse("102.54.94.97")));
+#pragma warning disable CS0618 // Type or member is obsolete
+                AssertExpectedHostEntries(expectedEntry, Dns.GetHostByName("rhino.acme.com"));
+                AssertExpectedHostEntries(expectedEntry, Dns.Resolve("rhino.acme.com"));
+                AssertExpectedHostEntries(expectedEntry, Dns.EndResolve(Dns.BeginResolve("rhino.acme.com", null, null)));
+                AssertExpectedHostEntries(expectedEntry, Dns.EndGetHostByName(Dns.BeginGetHostByName("rhino.acme.com", null, null)));
+                AssertExpectedHostEntries(expectedEntry, Dns.GetHostByAddress(IPAddress.Parse("102.54.94.97")));
+#pragma warning restore CS0618
+
+                AssertExpectedHostEntries(new IPHostEntry { HostName = "example", AddressList = new[] { IPAddress.Parse("::1") }, Aliases = Array.Empty<string>() }, Dns.GetHostEntry("example"));
+                AssertExpectedHostEntries(new IPHostEntry { HostName = "localhost", AddressList = new[] { IPAddress.Parse("::1") }, Aliases = Array.Empty<string>() }, Dns.GetHostEntry("localhost"));
+                AssertExpectedHostEntries(new IPHostEntry { HostName = "anothermappedto1", AddressList = new[] { IPAddress.Parse("::1") }, Aliases = Array.Empty<string>() }, Dns.GetHostEntry("anothermappedto1"));
+                AssertExpectedHostEntries(new IPHostEntry { HostName = "example", AddressList = new[] { IPAddress.Parse("::1") }, Aliases = new[] { "localhost", "anothermappedto1" } }, Dns.GetHostEntry(IPAddress.Parse("::1")));
+                AssertExpectedHostEntries(new IPHostEntry { HostName = "firstnameonline", AddressList = new[] { IPAddress.Parse("1.1.1.1") }, Aliases = new[] { "secondnameonline", "thirdnameonline" } }, Dns.GetHostEntry(IPAddress.Parse("1.1.1.1")));
+
+                static void AssertExpectedHostEntries(IPHostEntry expected, IPHostEntry actual)
+                {
+                    Assert.Equal(expected.HostName, actual.HostName);
+                    Assert.Equal(expected.AddressList, actual.AddressList);
+                    Assert.Equal(expected.Aliases, actual.Aliases);
+                }
+            }, options).Dispose();
+        }
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void MissingHostsFile_DnsNotImpacted()
+        {
+            var options = new RemoteInvokeOptions();
+            options.StartInfo.EnvironmentVariables[HostsEnvironmentVariableName] = Guid.NewGuid().ToString("N");
+
+            RemoteExecutor.Invoke(async () =>
+            {
+                await GetHostAddressesTest.Dns_GetHostAddressesAsync_HostString_Ok();
+                await GetHostAddressesTest.Dns_GetHostAddressesAsync_IPString_Ok();
+            }, options).Dispose();
+        }
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void EmptyHostsFile_DnsNotImpacted()
+        {
+            string hostsPath = CreateTestFile();
+
+            var options = new RemoteInvokeOptions();
+            options.StartInfo.EnvironmentVariables[HostsEnvironmentVariableName] = hostsPath;
+
+            RemoteExecutor.Invoke(async () =>
+            {
+                await GetHostAddressesTest.Dns_GetHostAddressesAsync_HostString_Ok();
+                await GetHostAddressesTest.Dns_GetHostAddressesAsync_IPString_Ok();
+            }, options).Dispose();
+        }
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void CorruptedHostsFile_DnsNotImpacted()
+        {
+            string hostsPath = CreateTestFile();
+            File.WriteAllBytes(hostsPath, new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 });
+
+            var options = new RemoteInvokeOptions();
+            options.StartInfo.EnvironmentVariables[HostsEnvironmentVariableName] = hostsPath;
+
+            RemoteExecutor.Invoke(async () =>
+            {
+                await GetHostAddressesTest.Dns_GetHostAddressesAsync_HostString_Ok();
+                await GetHostAddressesTest.Dns_GetHostAddressesAsync_IPString_Ok();
+            }, options).Dispose();
+        }
+    }
+}

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/System.Net.NameResolution.Functional.Tests.csproj
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/System.Net.NameResolution.Functional.Tests.csproj
@@ -13,6 +13,7 @@
     <Compile Include="GetHostNameTest.cs" />
     <Compile Include="GetHostEntryTest.cs" />
     <Compile Include="GetHostAddressesTest.cs" />
+    <Compile Include="HostOverridesTest.cs" />
     <Compile Include="LoggingTest.cs" />
     <Compile Include="TelemetryTest.cs" />
     <Compile Include="TestSettings.cs" />


### PR DESCRIPTION
This PR teaches System.Net.Dns about a new DOTNET_SYSTEM_NET_HOSTS environment variable.  When set, Dns will load a hosts file at a path specified in the environment variable and will use that hosts file as part of queries.  For any queries that result in hits against that hosts file, only the data from the hosts file will be used; otherwise, as happens with the system-wide hosts file, it falls through to the OS functionality.

Replaces https://github.com/dotnet/runtime/pull/87786