### PR TITLE
[wasm] WBT: Re-enable skiasharp test

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
@@ -1241,9 +1241,9 @@ namespace Wasm.Build.Tests
         }
 
         protected static string GetSkiaSharpReferenceItems()
-            => @"<PackageReference Include=""SkiaSharp"" Version=""2.88.3"" />
-                <PackageReference Include=""SkiaSharp.NativeAssets.WebAssembly"" Version=""2.88.3"" />
-                <NativeFileReference Include=""$(SkiaSharpStaticLibraryPath)\3.1.12\st\*.a"" />";
+            => @"<PackageReference Include=""SkiaSharp"" Version=""2.88.4-preview.76"" />
+                <PackageReference Include=""SkiaSharp.NativeAssets.WebAssembly"" Version=""2.88.4-preview.76"" />
+                <NativeFileReference Include=""$(SkiaSharpStaticLibraryPath)\3.1.34\st\*.a"" />";
 
         protected static string s_mainReturns42 = @"
             public class TestClass {

--- a/src/mono/wasm/Wasm.Build.Tests/NativeLibraryTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/NativeLibraryTests.cs
@@ -51,14 +51,11 @@ namespace Wasm.Build.Tests
         [Theory]
         [BuildAndRun(aot: false)]
         [BuildAndRun(aot: true)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/82725")]
         public void ProjectUsingSkiaSharp(BuildArgs buildArgs, RunHost host, string id)
         {
             string projectName = $"AppUsingSkiaSharp";
             buildArgs = buildArgs with { ProjectName = projectName };
             buildArgs = ExpandBuildArgs(buildArgs,
-                            // FIXME: temporary, till `main` is either completely on 3.1.7, or 3.1.12
-                            extraProperties: "<EmccExtraLDFlags>-s ERROR_ON_UNDEFINED_SYMBOLS=0</EmccExtraLDFlags>",
                             extraItems: @$"
                                 {GetSkiaSharpReferenceItems()}
                                 <WasmFilesToIncludeInFileSystem Include=""{Path.Combine(BuildEnvironment.TestAssetsPath, "mono.png")}"" />


### PR DESCRIPTION
.. as a new build of skiasharp native lib is now available.

Fixes issue: https://github.com/dotnet/runtime/issues/82725
