### PR TITLE
Add support for including System.Index and System.Range downlevel within dotnet/runtime

### DIFF
--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -190,6 +190,12 @@
     </When>
   </Choose>
 
+  <ItemGroup Condition="'$(IncludeIndexRangeTypes)' == 'true' and '$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+    <Compile Include="$(CoreLibSharedDir)System\Index.cs" Link="System\Index.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Range.cs" Link="System\Range.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Numerics\Hashing.cs" Link="System\Numerics\Hashing.cs" />
+  </ItemGroup>
+
   <PropertyGroup>
     <SkipLocalsInit Condition="'$(SkipLocalsInit)' == '' and '$(MSBuildProjectExtension)' == '.csproj' and '$(IsNETCoreAppSrc)' == 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">true</SkipLocalsInit>
   </PropertyGroup>

--- a/src/libraries/System.Private.CoreLib/src/System/Index.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Index.cs
@@ -15,7 +15,12 @@ namespace System
     /// int lastElement = someArray[^1]; // lastElement = 5
     /// </code>
     /// </remarks>
-    public readonly struct Index : IEquatable<Index>
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+    readonly struct Index : IEquatable<Index>
     {
         private readonly int _value;
 
@@ -30,7 +35,7 @@ namespace System
         {
             if (value < 0)
             {
-                ThrowHelper.ThrowValueArgumentOutOfRange_NeedNonNegNumException();
+                ThrowValueArgumentOutOfRange_NeedNonNegNumException();
             }
 
             if (fromEnd)
@@ -58,7 +63,7 @@ namespace System
         {
             if (value < 0)
             {
-                ThrowHelper.ThrowValueArgumentOutOfRange_NeedNonNegNumException();
+                ThrowValueArgumentOutOfRange_NeedNonNegNumException();
             }
 
             return new Index(value);
@@ -71,7 +76,7 @@ namespace System
         {
             if (value < 0)
             {
-                ThrowHelper.ThrowValueArgumentOutOfRange_NeedNonNegNumException();
+                ThrowValueArgumentOutOfRange_NeedNonNegNumException();
             }
 
             return new Index(~value);
@@ -136,6 +141,15 @@ namespace System
                 return ToStringFromEnd();
 
             return ((uint)Value).ToString();
+        }
+
+        private void ThrowValueArgumentOutOfRange_NeedNonNegNumException()
+        {
+#if SYSTEM_PRIVATE_CORELIB
+            ThrowHelper.ThrowValueArgumentOutOfRange_NeedNonNegNumException();
+#else
+            throw new ArgumentOutOfRangeException("value", "value must be non-negative");
+#endif
         }
 
         private string ToStringFromEnd()

--- a/src/libraries/System.Private.CoreLib/src/System/Index.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Index.cs
@@ -146,7 +146,7 @@ namespace System
         private static void ThrowValueArgumentOutOfRange_NeedNonNegNumException()
         {
 #if SYSTEM_PRIVATE_CORELIB
-            throw new ArgumentOutOfRangeException("value", SR.ArgumentOutOfRange_NeedNonNegNum)
+            throw new ArgumentOutOfRangeException("value", SR.ArgumentOutOfRange_NeedNonNegNum);
 #else
             throw new ArgumentOutOfRangeException("value", "value must be non-negative");
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/Index.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Index.cs
@@ -143,7 +143,7 @@ namespace System
             return ((uint)Value).ToString();
         }
 
-        private void ThrowValueArgumentOutOfRange_NeedNonNegNumException()
+        private static void ThrowValueArgumentOutOfRange_NeedNonNegNumException()
         {
 #if SYSTEM_PRIVATE_CORELIB
             ThrowHelper.ThrowValueArgumentOutOfRange_NeedNonNegNumException();

--- a/src/libraries/System.Private.CoreLib/src/System/Index.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Index.cs
@@ -146,7 +146,7 @@ namespace System
         private static void ThrowValueArgumentOutOfRange_NeedNonNegNumException()
         {
 #if SYSTEM_PRIVATE_CORELIB
-            ThrowHelper.ThrowValueArgumentOutOfRange_NeedNonNegNumException();
+            throw new ArgumentOutOfRangeException("value", SR.ArgumentOutOfRange_NeedNonNegNum)
 #else
             throw new ArgumentOutOfRangeException("value", "value must be non-negative");
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/Range.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Range.cs
@@ -20,7 +20,12 @@ namespace System
     /// int[] subArray2 = someArray[1..^0]; // { 2, 3, 4, 5 }
     /// </code>
     /// </remarks>
-    public readonly struct Range : IEquatable<Range>
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+    readonly struct Range : IEquatable<Range>
     {
         /// <summary>Represent the inclusive start index of the Range.</summary>
         public Index Start { get; }
@@ -126,10 +131,19 @@ namespace System
 
             if ((uint)end > (uint)length || (uint)start > (uint)end)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
+                ThrowArgumentOutOfRangeException();
             }
 
             return (start, end - start);
+        }
+
+        private void ThrowArgumentOutOfRangeException()
+        {
+#if SYSTEM_PRIVATE_CORELIB
+            ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
+#else
+            throw new ArgumentOutOfRangeException("length");
+#endif
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Range.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Range.cs
@@ -137,7 +137,7 @@ namespace System
             return (start, end - start);
         }
 
-        private void ThrowArgumentOutOfRangeException()
+        private static void ThrowArgumentOutOfRangeException()
         {
 #if SYSTEM_PRIVATE_CORELIB
             ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);

--- a/src/libraries/System.Private.CoreLib/src/System/Range.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Range.cs
@@ -140,7 +140,7 @@ namespace System
         private static void ThrowArgumentOutOfRangeException()
         {
 #if SYSTEM_PRIVATE_CORELIB
-            ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
+            throw new ArgumentOutOfRangeException(ExceptionArgument.length);
 #else
             throw new ArgumentOutOfRangeException("length");
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/Range.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Range.cs
@@ -139,11 +139,7 @@ namespace System
 
         private static void ThrowArgumentOutOfRangeException()
         {
-#if SYSTEM_PRIVATE_CORELIB
-            throw new ArgumentOutOfRangeException(ExceptionArgument.length);
-#else
             throw new ArgumentOutOfRangeException("length");
-#endif
         }
     }
 }


### PR DESCRIPTION
This will enable using range patterns in downlevel libraries like source-generators and analyzers to help make the code clearer and more concise.