### PR TITLE
fixing an assert in GetGCMemoryInfo 

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -50271,22 +50271,25 @@ void GCHeap::GetMemoryInfo(uint64_t* highMemLoadThresholdBytes,
     }
 
 #ifdef _DEBUG
-    if ((gc_kind)kind == gc_kind_ephemeral)
+    if (VolatileLoadWithoutBarrier (&last_gc_info->index) != 0)
     {
-        assert (last_gc_info->condemned_generation < max_generation);
-    }
-    else if ((gc_kind)kind == gc_kind_full_blocking)
-    {
-        assert (last_gc_info->condemned_generation == max_generation);
-        assert (last_gc_info->concurrent == false);
-    }
+        if ((gc_kind)kind == gc_kind_ephemeral)
+        {
+            assert (last_gc_info->condemned_generation < max_generation);
+        }
+        else if ((gc_kind)kind == gc_kind_full_blocking)
+        {
+            assert (last_gc_info->condemned_generation == max_generation);
+            assert (last_gc_info->concurrent == false);
+        }
 #ifdef BACKGROUND_GC
-    else if ((gc_kind)kind == gc_kind_background)
-    {
-        assert (last_gc_info->condemned_generation == max_generation);
-        assert (last_gc_info->concurrent == true);
-    }
+        else if ((gc_kind)kind == gc_kind_background)
+        {
+            assert (last_gc_info->condemned_generation == max_generation);
+            assert (last_gc_info->concurrent == true);
+        }
 #endif //BACKGROUND_GC
+    }
 #endif //_DEBUG
 }
 

--- a/src/tests/GC/API/GC/GetGCMemoryInfo.cs
+++ b/src/tests/GC/API/GC/GetGCMemoryInfo.cs
@@ -95,6 +95,10 @@ public class Test_GetGCMemoryInfo
         // We will keep executing the test in case of a failure to see if we have multiple failures.
         bool isTestSucceeded = true;
 
+        // Before any GCs happen, this should not assert
+        GCMemoryInfo memoryInfoNoGC = GC.GetGCMemoryInfo(GCKind.Background);
+        Console.WriteLine("BGC index is {0}", memoryInfoNoGC.Index);
+
         try
         {
             GCMemoryInfo memoryInfoInvalid = GC.GetGCMemoryInfo((GCKind)(-1));


### PR DESCRIPTION
when there hasn't been any GC of that kind yet, we cannot validate the info as it's all 0's.