### PR TITLE
[browser][MT] Make WebSockets work

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -116,7 +116,8 @@ namespace System
         public static bool FileCreateCaseSensitive => IsCaseSensitiveOS;
 #endif
 
-        public static bool IsThreadingSupported => !IsWasi && IsEnvironmentVariableTrue("IsBrowserThreadingSupported");
+        public static bool IsThreadingSupported => (!IsWasi && !IsBrowser) || IsWasmThreadingSupported;
+        public static bool IsWasmThreadingSupported => IsBrowser && IsEnvironmentVariableTrue("IsBrowserThreadingSupported");
         public static bool IsBinaryFormatterSupported => IsNotMobile && !IsNativeAot;
 
         public static bool IsStartingProcessesSupported => !IsiOS && !IstvOS;

--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -427,8 +427,6 @@
     <Compile Include="System\Net\Http\BrowserHttpHandler\BrowserHttpInterop.cs" />
     <Compile Include="$(CommonPath)System\Net\Http\HttpHandlerDefaults.cs"
              Link="Common\System\Net\Http\HttpHandlerDefaults.cs" />
-    <Compile Include="$(LibrariesProjectRoot)System.Runtime.InteropServices.JavaScript\src\System\Runtime\InteropServices\JavaScript\CancelablePromise.cs"
-             Link="InteropServices\JavaScript\CancelablePromise.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Win32.Primitives" />
@@ -461,9 +459,9 @@
     <Reference Include="System.Security.Cryptography" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'browser'">
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices.JavaScript\src\System.Runtime.InteropServices.JavaScript.csproj" SkipUseReferenceAssembly="true" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\Microsoft.Interop.SourceGeneration\Microsoft.Interop.SourceGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices.JavaScript\gen\JSImportGenerator\JSImportGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-    <Reference Include="System.Runtime.InteropServices.JavaScript" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseManagedNtlm)' == 'true'">
     <ProjectReference Include="$(LibrariesProjectRoot)System.Formats.Asn1\src\System.Formats.Asn1.csproj" />

--- a/src/libraries/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
+++ b/src/libraries/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
@@ -3,8 +3,13 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppCurrent)-browser</TargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetPlatformIdentifier)' == 'browser'">
-    <DefineConstants>$(DefineConstants);TARGET_BROWSER</DefineConstants>
+  <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
+  <PropertyGroup>
+    <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
+    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetPlatformIdentifier)' == ''">SR.PlatformNotSupported_NetHttp</GeneratePlatformNotSupportedAssemblyMessage>
+    <FeatureWasmThreads Condition="'$(TargetPlatformIdentifier)' == 'browser' and '$(MonoWasmBuildVariant)' == 'multithread'">true</FeatureWasmThreads>
+    <DefineConstants Condition="'$(TargetPlatformIdentifier)' == 'browser'">$(DefineConstants);TARGET_BROWSER</DefineConstants>
+    <DefineConstants Condition="'$(FeatureWasmThreads)' == 'true'" >$(DefineConstants);FEATURE_WASM_THREADS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,7 +29,6 @@
     <Compile Include="System\Net\WebSockets\BrowserWebSockets\BrowserInterop.cs" />
     <Compile Include="System\Net\WebSockets\BrowserWebSockets\BrowserWebSocket.cs" />
     <Compile Include="System\Net\WebSockets\BrowserWebSockets\ClientWebSocketOptions.cs" />
-    <Compile Include="$(LibrariesProjectRoot)System.Runtime.InteropServices.JavaScript\src\System\Runtime\InteropServices\JavaScript\CancelablePromise.cs" Link="InteropServices\JavaScript\CancelablePromise.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Win32.Primitives" />
@@ -44,8 +48,8 @@
     <Reference Include="System.Memory" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'browser'">
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices.JavaScript\src\System.Runtime.InteropServices.JavaScript.csproj" SkipUseReferenceAssembly="true" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\Microsoft.Interop.SourceGeneration\Microsoft.Interop.SourceGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices.JavaScript\gen\JSImportGenerator\JSImportGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-    <Reference Include="System.Runtime.InteropServices.JavaScript" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
+++ b/src/libraries/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
@@ -6,7 +6,6 @@
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>
     <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetPlatformIdentifier)' == ''">SR.PlatformNotSupported_NetHttp</GeneratePlatformNotSupportedAssemblyMessage>
     <FeatureWasmThreads Condition="'$(TargetPlatformIdentifier)' == 'browser' and '$(MonoWasmBuildVariant)' == 'multithread'">true</FeatureWasmThreads>
     <DefineConstants Condition="'$(TargetPlatformIdentifier)' == 'browser'">$(DefineConstants);TARGET_BROWSER</DefineConstants>
     <DefineConstants Condition="'$(FeatureWasmThreads)' == 'true'" >$(DefineConstants);FEATURE_WASM_THREADS</DefineConstants>

--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
@@ -54,7 +54,7 @@ namespace System.Net.WebSockets
                     } //lock
                 }, this);
 #else
-                return FastState = GetReadyState();
+                return FastState = GetReadyState(_innerWebSocket!);
 #endif
             }
         }

--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
@@ -14,7 +14,9 @@ namespace System.Net.WebSockets
     /// </summary>
     internal sealed class BrowserWebSocket : WebSocket
     {
+#if FEATURE_WASM_THREADS
         private readonly object _thisLock = new object();
+#endif
 
         private WebSocketCloseStatus? _closeStatus;
         private string? _closeStatusDescription;

--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
@@ -14,6 +14,8 @@ namespace System.Net.WebSockets
     /// </summary>
     internal sealed class BrowserWebSocket : WebSocket
     {
+        private readonly object _thisLock = new object();
+
         private WebSocketCloseStatus? _closeStatus;
         private string? _closeStatusDescription;
         private JSObject? _innerWebSocket;
@@ -29,29 +31,115 @@ namespace System.Net.WebSockets
         {
             get
             {
-                if (_innerWebSocket != null && !_disposed && (_state == WebSocketState.Connecting || _state == WebSocketState.Open || _state == WebSocketState.CloseSent))
+#if FEATURE_WASM_THREADS
+                lock (_thisLock)
                 {
-                    _state = GetReadyState();
-                }
-                return _state;
+#endif
+                    if (_innerWebSocket == null || _disposed || (_state != WebSocketState.Connecting && _state != WebSocketState.Open && _state != WebSocketState.CloseSent))
+                    {
+                        return _state;
+                    }
+#if FEATURE_WASM_THREADS
+                } //lock
+#endif
+
+#if FEATURE_WASM_THREADS
+                return FastState = _innerWebSocket!.SynchronizationContext.Send(static (BrowserWebSocket self) =>
+                {
+                    lock (self._thisLock)
+                    {
+                        return GetReadyState(self._innerWebSocket!);
+                    } //lock
+                }, this);
+#else
+                return FastState = GetReadyState();
+#endif
+            }
+        }
+
+        private WebSocketState FastState
+        {
+            get
+            {
+#if FEATURE_WASM_THREADS
+                lock (_thisLock)
+                {
+#endif
+                    return _state;
+#if FEATURE_WASM_THREADS
+                } //lock
+#endif
+            }
+            set
+            {
+#if FEATURE_WASM_THREADS
+                lock (_thisLock)
+                {
+#endif
+                    _state = value;
+#if FEATURE_WASM_THREADS
+                } //lock
+#endif
             }
         }
 
         public override WebSocketCloseStatus? CloseStatus => _closeStatus;
         public override string? CloseStatusDescription => _closeStatusDescription;
-        public override string? SubProtocol => BrowserInterop.GetProtocol(_innerWebSocket);
+        public override string? SubProtocol
+        {
+            get
+            {
+#if FEATURE_WASM_THREADS
+                lock (_thisLock)
+                {
+#endif
+                    ThrowIfDisposed();
+                    if (_innerWebSocket == null) throw new InvalidOperationException(SR.net_WebSockets_NotConnected);
+#if FEATURE_WASM_THREADS
+                } //lock
+#endif
+
+#if FEATURE_WASM_THREADS
+                return _innerWebSocket.SynchronizationContext.Send(BrowserInterop.GetProtocol, _innerWebSocket);
+#else
+                return BrowserInterop.GetProtocol(_innerWebSocket);
+#endif
+
+            }
+        }
 
         #endregion Properties
 
         internal Task ConnectAsync(Uri uri, List<string>? requestedSubProtocols, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
-            if (_state != WebSocketState.None)
+            if (FastState != WebSocketState.None)
             {
                 throw new InvalidOperationException(SR.net_WebSockets_AlreadyStarted);
             }
-            _state = WebSocketState.Connecting;
-            return ConnectAsyncCore(uri, requestedSubProtocols, cancellationToken);
+#if FEATURE_WASM_THREADS
+            JSHost.CurrentOrMainJSSynchronizationContext!.Send(_ =>
+            {
+                lock (_thisLock)
+                {
+                    ThrowIfDisposed();
+                    FastState = WebSocketState.Connecting;
+                    CreateCore(uri, requestedSubProtocols);
+                }
+            }, null);
+
+            return JSHost.CurrentOrMainJSSynchronizationContext.SendAsync(() =>
+            {
+                lock (_thisLock)
+                {
+                    return ConnectAsyncCore(cancellationToken);
+                } //lock will unlock synchronously before tasks are resolved!
+            });
+#else
+            FastState = WebSocketState.Connecting;
+            CreateCore(uri, requestedSubProtocols);
+            return ConnectAsyncCore(cancellationToken);
+#endif
         }
 
         public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
@@ -61,7 +149,7 @@ namespace System.Net.WebSockets
             ThrowIfDisposed();
 
             // fast check of previous _state instead of GetReadyState(), the readyState would be validated on JS side
-            if (_state != WebSocketState.Open)
+            if (FastState != WebSocketState.Open)
             {
                 throw new InvalidOperationException(SR.net_WebSockets_NotConnected);
             }
@@ -79,7 +167,18 @@ namespace System.Net.WebSockets
 
             WebSocketValidate.ValidateArraySegment(buffer, nameof(buffer));
 
-            return SendAsyncCore(buffer, messageType, endOfMessage, cancellationToken);
+#if FEATURE_WASM_THREADS
+            return _innerWebSocket!.SynchronizationContext.SendAsync(() =>
+            {
+                ThrowIfDisposed();
+                lock (_thisLock)
+                {
+#endif
+                    return SendAsyncCore(buffer, messageType, endOfMessage, cancellationToken);
+#if FEATURE_WASM_THREADS
+                } //lock will unlock synchronously before task is resolved!
+            });
+#endif
         }
 
         public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
@@ -90,14 +189,26 @@ namespace System.Net.WebSockets
             }
             ThrowIfDisposed();
             // fast check of previous _state instead of GetReadyState(), the readyState would be validated on JS side
-            if (_state != WebSocketState.Open && _state != WebSocketState.CloseSent)
+            var fastState = FastState;
+            if (fastState != WebSocketState.Open && fastState != WebSocketState.CloseSent)
             {
-                throw new WebSocketException(WebSocketError.InvalidState, SR.Format(SR.net_WebSockets_InvalidState, _state, "Open, CloseSent"));
+                throw new WebSocketException(WebSocketError.InvalidState, SR.Format(SR.net_WebSockets_InvalidState, fastState, "Open, CloseSent"));
             }
 
             WebSocketValidate.ValidateArraySegment(buffer, nameof(buffer));
 
-            return ReceiveAsyncCore(buffer, cancellationToken);
+#if FEATURE_WASM_THREADS
+            return _innerWebSocket!.SynchronizationContext.SendAsync(() =>
+            {
+                lock (_thisLock)
+                {
+                    ThrowIfDisposed();
+#endif
+                    return ReceiveAsyncCore(buffer, cancellationToken);
+#if FEATURE_WASM_THREADS
+                } //lock will unlock synchronously before task is resolved!
+            });
+#endif
         }
 
         public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken)
@@ -106,16 +217,32 @@ namespace System.Net.WebSockets
             ThrowIfDisposed();
 
             WebSocketValidate.ValidateCloseStatus(closeStatus, statusDescription);
-
-            var state = State;
-            if (state == WebSocketState.None || state == WebSocketState.Closed)
+            var fastState = FastState;
+            if (fastState == WebSocketState.None || fastState == WebSocketState.Closed)
             {
-                throw new WebSocketException(WebSocketError.InvalidState, SR.Format(SR.net_WebSockets_InvalidState, state, "Connecting, Open, CloseSent, Aborted"));
+                throw new WebSocketException(WebSocketError.InvalidState, SR.Format(SR.net_WebSockets_InvalidState, fastState, "Connecting, Open, CloseSent, Aborted"));
             }
 
-            return state == WebSocketState.Open || state == WebSocketState.Connecting || state == WebSocketState.Aborted
-                ? CloseAsyncCore(closeStatus, statusDescription, false, cancellationToken)
-                : Task.CompletedTask;
+#if FEATURE_WASM_THREADS
+            return _innerWebSocket!.SynchronizationContext.SendAsync(() =>
+            {
+                lock (_thisLock)
+                {
+                    ThrowIfDisposed();
+#endif
+                    var state = State;
+                    if (state == WebSocketState.None || state == WebSocketState.Closed)
+                    {
+                        throw new WebSocketException(WebSocketError.InvalidState, SR.Format(SR.net_WebSockets_InvalidState, state, "Connecting, Open, CloseSent, Aborted"));
+                    }
+
+                    return state == WebSocketState.Open || state == WebSocketState.Connecting || state == WebSocketState.Aborted
+                    ? CloseAsyncCore(closeStatus, statusDescription, false, cancellationToken)
+                    : Task.CompletedTask;
+#if FEATURE_WASM_THREADS
+                } //lock will unlock synchronously before task is resolved!
+            });
+#endif
         }
 
         public override Task CloseAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken)
@@ -125,51 +252,120 @@ namespace System.Net.WebSockets
 
             WebSocketValidate.ValidateCloseStatus(closeStatus, statusDescription);
 
-            var state = State;
-            if (state == WebSocketState.None || state == WebSocketState.Closed)
+            var fastState = FastState;
+            if (fastState == WebSocketState.None || fastState == WebSocketState.Closed)
             {
-                throw new WebSocketException(WebSocketError.InvalidState, SR.Format(SR.net_WebSockets_InvalidState, state, "Connecting, Open, CloseSent, Aborted"));
+                throw new WebSocketException(WebSocketError.InvalidState, SR.Format(SR.net_WebSockets_InvalidState, fastState, "Connecting, Open, CloseSent, Aborted"));
             }
 
-            return state == WebSocketState.Open || state == WebSocketState.Connecting || state == WebSocketState.Aborted || state == WebSocketState.CloseSent
-                ? CloseAsyncCore(closeStatus, statusDescription, state != WebSocketState.Aborted, cancellationToken)
-                : Task.CompletedTask;
+#if FEATURE_WASM_THREADS
+            return _innerWebSocket!.SynchronizationContext.SendAsync(() =>
+            {
+                ThrowIfDisposed();
+                lock (_thisLock)
+                {
+#endif
+                    var state = State;
+                    if (state == WebSocketState.None || state == WebSocketState.Closed)
+                    {
+                        throw new WebSocketException(WebSocketError.InvalidState, SR.Format(SR.net_WebSockets_InvalidState, state, "Connecting, Open, CloseSent, Aborted"));
+                    }
+
+                    return state == WebSocketState.Open || state == WebSocketState.Connecting || state == WebSocketState.Aborted || state == WebSocketState.CloseSent
+                        ? CloseAsyncCore(closeStatus, statusDescription, state != WebSocketState.Aborted, cancellationToken)
+                        : Task.CompletedTask;
+#if FEATURE_WASM_THREADS
+                } //lock will unlock synchronously before task is resolved!
+            });
+#endif
         }
 
         public override void Abort()
         {
-            if (!_disposed && State != WebSocketState.Closed)
+#if FEATURE_WASM_THREADS
+            if (_disposed)
             {
-                _state = WebSocketState.Aborted;
-                _aborted = true;
-                if (_innerWebSocket != null)
-                {
-                    BrowserInterop.WebSocketAbort(_innerWebSocket!);
-                }
+                return;
             }
+            _innerWebSocket?.SynchronizationContext.Send(static (BrowserWebSocket self) =>
+            {
+                lock (self._thisLock)
+                {
+                    AbortCore(self, self.State);
+                }
+            }, this);
+#else
+            AbortCore(this, this.State);
+#endif
         }
 
         public override void Dispose()
         {
-            if (!_disposed)
+#if FEATURE_WASM_THREADS
+            if (_disposed)
             {
-                var state = State;
-                _disposed = true;
+                return;
+            }
+            _innerWebSocket?.SynchronizationContext.Send(static (BrowserWebSocket self) =>
+            {
+                lock (self._thisLock)
+                {
+                    DisposeCore(self);
+                }
+            }, this);
+#else
+            DisposeCore(this);
+#endif
+        }
+
+        private void ThrowIfDisposed()
+        {
+#if FEATURE_WASM_THREADS
+            lock (_thisLock)
+            {
+#endif
+                ObjectDisposedException.ThrowIf(_disposed, this);
+#if FEATURE_WASM_THREADS
+            } //lock
+#endif
+        }
+
+        #region methods always called on one thread only, exclusively
+
+        private static void DisposeCore(BrowserWebSocket self)
+        {
+            if (!self._disposed)
+            {
+                var state = self.State;
+                self._disposed = true;
                 if (state < WebSocketState.Aborted && state != WebSocketState.None)
                 {
-                    Abort();
+                    AbortCore(self, state);
                 }
-                if (state != WebSocketState.Aborted)
+                if (self.FastState != WebSocketState.Aborted)
                 {
-                    _state = WebSocketState.Closed;
+                    self.FastState = WebSocketState.Closed;
                 }
-                _innerWebSocket?.Dispose();
-                _innerWebSocket = null;
-                responseStatusHandle?.Dispose();
+                self._innerWebSocket?.Dispose();
+                self._innerWebSocket = null;
+                self.responseStatusHandle?.Dispose();
             }
         }
 
-        private async Task ConnectAsyncCore(Uri uri, List<string>? requestedSubProtocols, CancellationToken cancellationToken)
+        private static void AbortCore(BrowserWebSocket self, WebSocketState currentState)
+        {
+            if (!self._disposed && currentState != WebSocketState.Closed)
+            {
+                self.FastState = WebSocketState.Aborted;
+                self._aborted = true;
+                if (self._innerWebSocket != null)
+                {
+                    BrowserInterop.WebSocketAbort(self._innerWebSocket!);
+                }
+            }
+        }
+
+        private void CreateCore(Uri uri, List<string>? requestedSubProtocols)
         {
             try
             {
@@ -178,32 +374,85 @@ namespace System.Net.WebSockets
                 {
                     _closeStatus = (WebSocketCloseStatus)code;
                     _closeStatusDescription = reason;
-                    WebSocketState state = State;
-                    if (state == WebSocketState.Connecting || state == WebSocketState.Open || state == WebSocketState.CloseSent)
+#if FEATURE_WASM_THREADS
+                    lock (_thisLock)
                     {
-                        _state = WebSocketState.Closed;
-                    }
+#endif
+                        WebSocketState state = State;
+                        if (state == WebSocketState.Connecting || state == WebSocketState.Open || state == WebSocketState.CloseSent)
+                        {
+                            FastState = WebSocketState.Closed;
+                        }
+#if FEATURE_WASM_THREADS
+                    } //lock
+#endif
                 };
 
                 Memory<int> responseMemory = new Memory<int>(responseStatus);
-                responseStatusHandle = responseMemory.Pin();
 
-                _innerWebSocket = BrowserInterop.UnsafeCreate(uri.ToString(), subProtocols, responseStatusHandle.Value, onClose);
-                var openTask = BrowserInterop.WebSocketOpen(_innerWebSocket);
-
-                await CancelationHelper(openTask!, cancellationToken, _state).ConfigureAwait(true);
-                if (State == WebSocketState.Connecting)
+#if FEATURE_WASM_THREADS
+                lock (_thisLock)
                 {
-                    _state = WebSocketState.Open;
+#endif
+                    responseStatusHandle = responseMemory.Pin();
+                    _innerWebSocket = BrowserInterop.UnsafeCreate(uri.ToString(), subProtocols, responseStatusHandle.Value, onClose);
+#if FEATURE_WASM_THREADS
+                } //lock
+#endif
+            }
+            catch (Exception)
+            {
+                Dispose();
+                throw;
+            }
+        }
+
+        private async Task ConnectAsyncCore(CancellationToken cancellationToken)
+        {
+#if FEATURE_WASM_THREADS
+            lock (_thisLock)
+            {
+#endif
+                if (_aborted)
+                {
+                    FastState = WebSocketState.Closed;
+                    throw new WebSocketException(WebSocketError.Faulted, SR.net_webstatus_ConnectFailure);
                 }
+                ThrowIfDisposed();
+#if FEATURE_WASM_THREADS
+            } //lock
+#endif
+            try
+            {
+                var openTask = BrowserInterop.WebSocketOpen(_innerWebSocket!);
+
+                await CancelationHelper(openTask!, cancellationToken, FastState).ConfigureAwait(true);
+#if FEATURE_WASM_THREADS
+                lock (_thisLock)
+                {
+#endif
+                    if (State == WebSocketState.Connecting)
+                    {
+                        FastState = WebSocketState.Open;
+                    }
+#if FEATURE_WASM_THREADS
+                } //lock
+#endif
             }
             catch (OperationCanceledException ex)
             {
-                _state = WebSocketState.Closed;
-                if (_aborted)
+#if FEATURE_WASM_THREADS
+                lock (_thisLock)
                 {
-                    throw new WebSocketException(WebSocketError.Faulted, SR.net_webstatus_ConnectFailure, ex);
-                }
+#endif
+                    FastState = WebSocketState.Closed;
+                    if (_aborted)
+                    {
+                        throw new WebSocketException(WebSocketError.Faulted, SR.net_webstatus_ConnectFailure, ex);
+                    }
+#if FEATURE_WASM_THREADS
+                } //lock
+#endif
                 throw;
             }
             catch (Exception)
@@ -224,7 +473,7 @@ namespace System.Net.WebSockets
                     return;
                 }
 
-                await CancelationHelper(sendTask, cancellationToken, _state).ConfigureAwait(true);
+                await CancelationHelper(sendTask, cancellationToken, FastState).ConfigureAwait(true);
             }
             catch (JSException ex)
             {
@@ -247,12 +496,25 @@ namespace System.Net.WebSockets
                     if (receiveTask == null)
                     {
                         // return synchronously
-                        return ConvertResponse();
+#if FEATURE_WASM_THREADS
+                        lock (_thisLock)
+                        {
+#endif
+                            return ConvertResponse(this);
+#if FEATURE_WASM_THREADS
+                        } //lock
+#endif
                     }
+                    await CancelationHelper(receiveTask, cancellationToken, FastState).ConfigureAwait(true);
 
-                    await CancelationHelper(receiveTask, cancellationToken, _state).ConfigureAwait(true);
-
-                    return ConvertResponse();
+#if FEATURE_WASM_THREADS
+                    lock (_thisLock)
+                    {
+#endif
+                        return ConvertResponse(this);
+#if FEATURE_WASM_THREADS
+                    } //lock
+#endif
                 }
             }
             catch (JSException ex)
@@ -265,18 +527,18 @@ namespace System.Net.WebSockets
             }
         }
 
-        private WebSocketReceiveResult ConvertResponse()
+        private static WebSocketReceiveResult ConvertResponse(BrowserWebSocket self)
         {
             const int countIndex = 0;
             const int typeIndex = 1;
             const int endIndex = 2;
 
-            WebSocketMessageType messageType = (WebSocketMessageType)responseStatus[typeIndex];
+            WebSocketMessageType messageType = (WebSocketMessageType)self.responseStatus[typeIndex];
             if (messageType == WebSocketMessageType.Close)
             {
-                return new WebSocketReceiveResult(responseStatus[countIndex], messageType, responseStatus[endIndex] != 0, CloseStatus, CloseStatusDescription);
+                return new WebSocketReceiveResult(self.responseStatus[countIndex], messageType, self.responseStatus[endIndex] != 0, self.CloseStatus, self.CloseStatusDescription);
             }
-            return new WebSocketReceiveResult(responseStatus[countIndex], messageType, responseStatus[endIndex] != 0);
+            return new WebSocketReceiveResult(self.responseStatus[countIndex], messageType, self.responseStatus[endIndex] != 0);
         }
 
         private async Task CloseAsyncCore(WebSocketCloseStatus closeStatus, string? statusDescription, bool waitForCloseReceived, CancellationToken cancellationToken)
@@ -284,20 +546,24 @@ namespace System.Net.WebSockets
             _closeStatus = closeStatus;
             _closeStatusDescription = statusDescription;
 
-            var closeTask = BrowserInterop.WebSocketClose(_innerWebSocket!, (int)closeStatus, statusDescription, waitForCloseReceived);
-            if (closeTask != null)
-            {
-                await CancelationHelper(closeTask, cancellationToken, _state).ConfigureAwait(true);
-            }
+            var closeTask = BrowserInterop.WebSocketClose(_innerWebSocket!, (int)closeStatus, statusDescription, waitForCloseReceived) ?? Task.CompletedTask;
+            await CancelationHelper(closeTask, cancellationToken, FastState).ConfigureAwait(true);
 
-            var state = State;
-            if (state == WebSocketState.Open || state == WebSocketState.Connecting || state == WebSocketState.CloseSent)
+#if FEATURE_WASM_THREADS
+            lock (_thisLock)
             {
-                _state = waitForCloseReceived ? WebSocketState.Closed : WebSocketState.CloseSent;
-            }
+#endif
+                var state = State;
+                if (state == WebSocketState.Open || state == WebSocketState.Connecting || state == WebSocketState.CloseSent)
+                {
+                    FastState = waitForCloseReceived ? WebSocketState.Closed : WebSocketState.CloseSent;
+                }
+#if FEATURE_WASM_THREADS
+            } //lock
+#endif
         }
 
-        private async ValueTask CancelationHelper(Task jsTask, CancellationToken cancellationToken, WebSocketState previousState)
+        private async Task CancelationHelper(Task jsTask, CancellationToken cancellationToken, WebSocketState previousState)
         {
             if (jsTask.IsCompletedSuccessfully)
             {
@@ -323,12 +589,12 @@ namespace System.Net.WebSockets
 
                 if (cancellationToken.IsCancellationRequested)
                 {
-                    _state = WebSocketState.Aborted;
+                    FastState = WebSocketState.Aborted;
                     throw new OperationCanceledException(cancellationToken);
                 }
                 if (ex.Message == "OperationCanceledException")
                 {
-                    _state = WebSocketState.Aborted;
+                    FastState = WebSocketState.Aborted;
                     throw new OperationCanceledException("The operation was cancelled.", ex, cancellationToken);
                 }
                 if (previousState == WebSocketState.Connecting)
@@ -339,15 +605,9 @@ namespace System.Net.WebSockets
             }
         }
 
-        private void ThrowIfDisposed()
+        private static WebSocketState GetReadyState(JSObject innerWebSocket)
         {
-            ObjectDisposedException.ThrowIf(_disposed, this);
-        }
-
-        private WebSocketState GetReadyState()
-        {
-            int readyState = BrowserInterop.GetReadyState(_innerWebSocket);
-
+            var readyState = BrowserInterop.GetReadyState(innerWebSocket);
             // https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/readyState
             return readyState switch
             {
@@ -358,5 +618,7 @@ namespace System.Net.WebSockets
                 _ => WebSocketState.None
             };
         }
+
+        #endregion
     }
 }

--- a/src/libraries/System.Net.WebSockets.Client/tests/CloseTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/CloseTest.cs
@@ -225,6 +225,7 @@ namespace System.Net.WebSockets.Client.Tests
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/83517", typeof(PlatformDetection), nameof(PlatformDetection.IsNodeJS))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/87839", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task CloseOutputAsync_ClientInitiated_CanReceive_CanClose(Uri server)
         {
             string message = "Hello WebSockets!";

--- a/src/libraries/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
@@ -492,6 +492,7 @@ namespace System.Net.WebSockets.Client.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/87839", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task ZeroByteReceive_CompletesWhenDataAvailable(Uri server)
         {
             using (ClientWebSocket cws = await GetConnectedWebSocket(server, TimeOutMilliseconds, _output))

--- a/src/libraries/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
+++ b/src/libraries/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
@@ -16,6 +16,7 @@
     <TestArchiveTestsDir>$(TestArchiveTestsRoot)$(OSPlatformConfig)/</TestArchiveTestsDir>
     <DefineConstants>$(DefineConstants);TARGET_BROWSER</DefineConstants>
     <WasmXHarnessMonoArgs>--setenv=XHARNESS_LOG_TEST_START=true --no-memory-snapshot</WasmXHarnessMonoArgs>
+    <_WasmPThreadPoolSize Condition="'$(MonoWasmBuildVariant)' == 'multithread'">10</_WasmPThreadPoolSize>
 
     <!-- This WASM test is problematic and slow right now. This sets the xharness timeout but there is also override in sendtohelix-wasm.targets -->
     <WasmXHarnessTestsTimeout>01:15:00</WasmXHarnessTestsTimeout>
@@ -72,5 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Net.TestData" Version="$(SystemNetTestDataVersion)" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Net.WebSockets.Client\src\System.Net.WebSockets.Client.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/CompatibilitySuppressions.xml
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/CompatibilitySuppressions.xml
@@ -36,4 +36,35 @@
     <Left>ref/net8.0/System.Runtime.InteropServices.JavaScript.dll</Left>
     <Right>runtimes/browser/lib/net8.0/System.Runtime.InteropServices.JavaScript.dll</Right>
   </Suppression>
+
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:System.Runtime.InteropServices.JavaScript.SynchronizationContextExtension</Target>
+    <Left>ref/net8.0/System.Runtime.InteropServices.JavaScript.dll</Left>
+    <Right>runtimes/browser/lib/net8.0/System.Runtime.InteropServices.JavaScript.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:System.Runtime.InteropServices.JavaScript.WebWorker</Target>
+    <Left>ref/net8.0/System.Runtime.InteropServices.JavaScript.dll</Left>
+    <Right>runtimes/browser/lib/net8.0/System.Runtime.InteropServices.JavaScript.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:System.Runtime.InteropServices.JavaScript.CancelablePromise</Target>
+    <Left>ref/net8.0/System.Runtime.InteropServices.JavaScript.dll</Left>
+    <Right>runtimes/browser/lib/net8.0/System.Runtime.InteropServices.JavaScript.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Runtime.InteropServices.JavaScript.JSObject.get_SynchronizationContext</Target>
+    <Left>ref/net8.0/System.Runtime.InteropServices.JavaScript.dll</Left>
+    <Right>runtimes/browser/lib/net8.0/System.Runtime.InteropServices.JavaScript.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Runtime.InteropServices.JavaScript.JSHost.get_CurrentOrMainJSSynchronizationContext</Target>
+    <Left>ref/net8.0/System.Runtime.InteropServices.JavaScript.dll</Left>
+    <Right>runtimes/browser/lib/net8.0/System.Runtime.InteropServices.JavaScript.dll</Right>
+  </Suppression>
 </Suppressions>

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System.Runtime.InteropServices.JavaScript.csproj
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System.Runtime.InteropServices.JavaScript.csproj
@@ -39,6 +39,7 @@
     <Compile Include="System\Runtime\InteropServices\JavaScript\JSExportAttribute.cs" />
     <Compile Include="System\Runtime\InteropServices\JavaScript\JSImportAttribute.cs" />
     <Compile Include="System\Runtime\InteropServices\JavaScript\CancelablePromise.cs" />
+    <Compile Include="System\Runtime\InteropServices\JavaScript\SynchronizationContextExtensions.cs" />
 
     <Compile Include="System\Runtime\InteropServices\JavaScript\MarshalerType.cs" />
     <Compile Include="System\Runtime\InteropServices\JavaScript\Marshaling\JSMarshalerArgument.BigInt64.cs" />

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/CancelablePromise.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/CancelablePromise.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace System.Runtime.InteropServices.JavaScript
 {
-    internal static partial class CancelablePromise
+    public static partial class CancelablePromise
     {
         [JSImport("INTERNAL.mono_wasm_cancel_promise")]
         private static partial void _CancelPromise(IntPtr promiseGCHandle);
@@ -18,19 +18,19 @@ namespace System.Runtime.InteropServices.JavaScript
             {
                 return;
             }
-            GCHandle? promiseGCHandle = promise.AsyncState as GCHandle?;
-            if (promiseGCHandle == null) throw new InvalidOperationException("Expected Task converted from JS Promise");
+            JSHostImplementation.TaskCallback? holder = promise.AsyncState as JSHostImplementation.TaskCallback;
+            if (holder == null) throw new InvalidOperationException("Expected Task converted from JS Promise");
+
 
 #if FEATURE_WASM_THREADS
-            // TODO JSObject.AssertThreadAffinity(promise);
-            // in order to remember the thread ID of the promise, we would have to allocate holder object for any Task,
-            // which would hold thread ID and the GCHandle
-            // that would be pretty expensive, so we don't do it for now
-            // the consequences are that calling CancelPromise on wrong thread would do nothing
-            // because there would not be any object on JS registered under the same GCHandle
-            // perhaps that's the point when we could throw an exception on JS side.
+            holder.SynchronizationContext!.Send(static (JSHostImplementation.TaskCallback holder) =>
+            {
 #endif
-            _CancelPromise((IntPtr)promiseGCHandle.Value);
+                var handle = JSHostImplementation.GetJSOwnedObjectGCHandle(holder);
+                _CancelPromise(handle);
+#if FEATURE_WASM_THREADS
+            }, holder);
+#endif
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 
 namespace System.Runtime.InteropServices.JavaScript
 {
@@ -126,8 +127,13 @@ namespace System.Runtime.InteropServices.JavaScript
             try
             {
                 JSHostImplementation.TaskCallback holder = new JSHostImplementation.TaskCallback();
+                holder.GCHandle = JSHostImplementation.GetJSOwnedObjectGCHandle(holder);
+#if FEATURE_WASM_THREADS
+                holder.OwnerThreadId = Thread.CurrentThread.ManagedThreadId;
+                holder.SynchronizationContext = SynchronizationContext.Current ?? new SynchronizationContext();
+#endif
                 arg_return.slot.Type = MarshalerType.Object;
-                arg_return.slot.GCHandle = JSHostImplementation.GetJSOwnedObjectGCHandle(holder);
+                arg_return.slot.GCHandle = holder.GCHandle;
             }
             catch (Exception ex)
             {
@@ -225,7 +231,7 @@ namespace System.Runtime.InteropServices.JavaScript
             ref JSMarshalerArgument arg_exc = ref arguments_buffer[0]; // initialized by caller in alloc_stack_frame()
             try
             {
-                JSHostImplementation.InstallWebWorkerInterop(true);
+                JSHostImplementation.InstallWebWorkerInterop(true, true);
             }
             catch (Exception ex)
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSException.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSException.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.Versioning;
+using System.Threading;
 
 namespace System.Runtime.InteropServices.JavaScript
 {
@@ -37,6 +38,13 @@ namespace System.Runtime.InteropServices.JavaScript
                 {
                     return bs;
                 }
+
+#if FEATURE_WASM_THREADS
+                if (jsException.OwnerThreadId != Thread.CurrentThread.ManagedThreadId)
+                {
+                    return null;
+                }
+#endif
                 string? jsStackTrace = jsException.GetPropertyAsString("stack");
                 if (jsStackTrace == null)
                 {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSFunctionBinding.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSFunctionBinding.cs
@@ -205,10 +205,12 @@ namespace System.Runtime.InteropServices.JavaScript
 
         internal static unsafe JSFunctionBinding BindJSFunctionImpl(string functionName, string moduleName, ReadOnlySpan<JSMarshalerType> signatures)
         {
+#if FEATURE_WASM_THREADS
             if (JSSynchronizationContext.CurrentJSSynchronizationContext == null)
             {
                 throw new InvalidOperationException("Please use dedicated worker for working with JavaScript interop. See https://github.com/dotnet/runtime/blob/main/src/mono/wasm/threads.md#JS-interop-on-dedicated-threads " + Thread.CurrentThread.ManagedThreadId);
             }
+#endif
 
             var signature = JSHostImplementation.GetMethodSignature(signatures);
 

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSFunctionBinding.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSFunctionBinding.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
+using System.Threading;
 
 namespace System.Runtime.InteropServices.JavaScript
 {
@@ -204,6 +205,11 @@ namespace System.Runtime.InteropServices.JavaScript
 
         internal static unsafe JSFunctionBinding BindJSFunctionImpl(string functionName, string moduleName, ReadOnlySpan<JSMarshalerType> signatures)
         {
+            if (JSSynchronizationContext.CurrentJSSynchronizationContext == null)
+            {
+                throw new InvalidOperationException("Please use dedicated worker for working with JavaScript interop. See https://github.com/dotnet/runtime/blob/main/src/mono/wasm/threads.md#JS-interop-on-dedicated-threads " + Thread.CurrentThread.ManagedThreadId);
+            }
+
             var signature = JSHostImplementation.GetMethodSignature(signatures);
 
             Interop.Runtime.BindJSFunction(functionName, moduleName, signature.Header, out IntPtr jsFunctionHandle, out int isException, out object exceptionMessage);

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHost.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHost.cs
@@ -49,5 +49,18 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             return JSHostImplementation.ImportAsync(moduleName, moduleUrl, cancellationToken);
         }
+
+        public static SynchronizationContext? CurrentOrMainJSSynchronizationContext
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+#if FEATURE_WASM_THREADS
+                return JSSynchronizationContext.CurrentJSSynchronizationContext ?? JSSynchronizationContext.MainJSSynchronizationContext ?? null;
+#else
+                return null;
+#endif
+            }
+        }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.Types.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.Types.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Threading;
+
 namespace System.Runtime.InteropServices.JavaScript
 {
     internal static partial class JSHostImplementation
@@ -10,6 +12,12 @@ namespace System.Runtime.InteropServices.JavaScript
         public sealed class TaskCallback
         {
             public ToManagedCallback? Callback;
+            public IntPtr GCHandle;
+#if FEATURE_WASM_THREADS
+            // the JavaScript object could only exist on the single web worker and can't migrate to other workers
+            internal int OwnerThreadId;
+            internal SynchronizationContext? SynchronizationContext;
+#endif
         }
 
         [StructLayout(LayoutKind.Explicit)]

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.cs
@@ -199,7 +199,7 @@ namespace System.Runtime.InteropServices.JavaScript
         }
 
 #if FEATURE_WASM_THREADS
-        public static void InstallWebWorkerInterop(bool installJSSynchronizationContext)
+        public static void InstallWebWorkerInterop(bool installJSSynchronizationContext, bool isMainThread)
         {
             Interop.Runtime.InstallWebWorkerInterop(installJSSynchronizationContext);
             if (installJSSynchronizationContext)
@@ -212,6 +212,10 @@ namespace System.Runtime.InteropServices.JavaScript
                     ctx.previousSynchronizationContext = SynchronizationContext.Current;
                     JSSynchronizationContext.CurrentJSSynchronizationContext = ctx;
                     SynchronizationContext.SetSynchronizationContext(ctx);
+                    if (isMainThread)
+                    {
+                        JSSynchronizationContext.MainJSSynchronizationContext = ctx;
+                    }
                 }
                 else if (ctx.TargetThreadId != currentThreadId)
                 {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
@@ -39,6 +39,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public string GetTypeOfProperty(string propertyName)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             return JavaScriptImports.GetTypeOfProperty(this, propertyName);
         }
 
@@ -54,6 +57,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public bool GetPropertyAsBoolean(string propertyName)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             return JavaScriptImports.GetPropertyAsBoolean(this, propertyName);
         }
 
@@ -69,6 +75,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public int GetPropertyAsInt32(string propertyName)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             return JavaScriptImports.GetPropertyAsInt32(this, propertyName);
         }
 
@@ -84,6 +93,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public double GetPropertyAsDouble(string propertyName)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             return JavaScriptImports.GetPropertyAsDouble(this, propertyName);
         }
 
@@ -99,6 +111,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public string? GetPropertyAsString(string propertyName)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             return JavaScriptImports.GetPropertyAsString(this, propertyName);
         }
 
@@ -114,6 +129,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public JSObject? GetPropertyAsJSObject(string propertyName)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             return JavaScriptImports.GetPropertyAsJSObject(this, propertyName);
         }
 
@@ -130,6 +148,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public byte[]? GetPropertyAsByteArray(string propertyName)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             return JavaScriptImports.GetPropertyAsByteArray(this, propertyName);
         }
 
@@ -142,6 +163,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public void SetProperty(string propertyName, bool value)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             JavaScriptImports.SetPropertyBool(this, propertyName, value);
         }
 
@@ -154,6 +178,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public void SetProperty(string propertyName, int value)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             JavaScriptImports.SetPropertyInt(this, propertyName, value);
         }
 
@@ -166,6 +193,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public void SetProperty(string propertyName, double value)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             JavaScriptImports.SetPropertyDouble(this, propertyName, value);
         }
 
@@ -190,6 +220,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public void SetProperty(string propertyName, JSObject? value)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             JavaScriptImports.SetPropertyJSObject(this, propertyName, value);
         }
 
@@ -203,6 +236,9 @@ namespace System.Runtime.InteropServices.JavaScript
         public void SetProperty(string propertyName, byte[]? value)
         {
             ObjectDisposedException.ThrowIf(IsDisposed, this);
+#if FEATURE_WASM_THREADS
+            JSObject.AssertThreadAffinity(this);
+#endif
             JavaScriptImports.SetPropertyBytes(this, propertyName, value);
         }
     }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSSynchronizationContext.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSSynchronizationContext.cs
@@ -24,6 +24,8 @@ namespace System.Runtime.InteropServices.JavaScript
         public readonly IntPtr TargetThreadId;
         private readonly WorkItemQueueType Queue;
 
+        internal static JSSynchronizationContext? MainJSSynchronizationContext;
+
         [ThreadStatic]
         internal static JSSynchronizationContext? CurrentJSSynchronizationContext;
         internal SynchronizationContext? previousSynchronizationContext;

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Func.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Func.cs
@@ -19,6 +19,10 @@ namespace System.Runtime.InteropServices.JavaScript
                 // JSObject (held by this lambda) would be collected by GC after the lambda is collected
                 // and would also allow the JS function to be collected
 
+#if FEATURE_WASM_THREADS
+                JSObject.AssertThreadAffinity(JSObject);
+#endif
+
                 Span<JSMarshalerArgument> arguments = stackalloc JSMarshalerArgument[4];
                 ref JSMarshalerArgument args_exception = ref arguments[0];
                 ref JSMarshalerArgument args_return = ref arguments[1];
@@ -43,6 +47,10 @@ namespace System.Runtime.InteropServices.JavaScript
 
             public void InvokeJS(T arg1)
             {
+#if FEATURE_WASM_THREADS
+                JSObject.AssertThreadAffinity(JSObject);
+#endif
+
                 Span<JSMarshalerArgument> arguments = stackalloc JSMarshalerArgument[4];
                 ref JSMarshalerArgument args_exception = ref arguments[0];
                 ref JSMarshalerArgument args_return = ref arguments[1];
@@ -71,6 +79,10 @@ namespace System.Runtime.InteropServices.JavaScript
 
             public void InvokeJS(T1 arg1, T2 arg2)
             {
+#if FEATURE_WASM_THREADS
+                JSObject.AssertThreadAffinity(JSObject);
+#endif
+
                 Span<JSMarshalerArgument> arguments = stackalloc JSMarshalerArgument[4];
                 ref JSMarshalerArgument args_exception = ref arguments[0];
                 ref JSMarshalerArgument args_return = ref arguments[1];
@@ -103,6 +115,10 @@ namespace System.Runtime.InteropServices.JavaScript
 
             public void InvokeJS(T1 arg1, T2 arg2, T3 arg3)
             {
+#if FEATURE_WASM_THREADS
+                JSObject.AssertThreadAffinity(JSObject);
+#endif
+
                 Span<JSMarshalerArgument> arguments = stackalloc JSMarshalerArgument[5];
                 ref JSMarshalerArgument args_exception = ref arguments[0];
                 ref JSMarshalerArgument args_return = ref arguments[1];
@@ -209,6 +225,10 @@ namespace System.Runtime.InteropServices.JavaScript
 
             public TResult InvokeJS()
             {
+#if FEATURE_WASM_THREADS
+                JSObject.AssertThreadAffinity(JSObject);
+#endif
+
                 // JSObject (held by this lambda) would be collected by GC after the lambda is collected
                 // and would also allow the JS function to be collected
 
@@ -241,6 +261,10 @@ namespace System.Runtime.InteropServices.JavaScript
 
             public TResult InvokeJS(T arg1)
             {
+#if FEATURE_WASM_THREADS
+                JSObject.AssertThreadAffinity(JSObject);
+#endif
+
                 Span<JSMarshalerArgument> arguments = stackalloc JSMarshalerArgument[4];
                 ref JSMarshalerArgument args_exception = ref arguments[0];
                 ref JSMarshalerArgument args_return = ref arguments[1];
@@ -274,6 +298,10 @@ namespace System.Runtime.InteropServices.JavaScript
 
             public TResult InvokeJS(T1 arg1, T2 arg2)
             {
+#if FEATURE_WASM_THREADS
+                JSObject.AssertThreadAffinity(JSObject);
+#endif
+
                 Span<JSMarshalerArgument> arguments = stackalloc JSMarshalerArgument[4];
                 ref JSMarshalerArgument args_exception = ref arguments[0];
                 ref JSMarshalerArgument args_return = ref arguments[1];
@@ -311,6 +339,10 @@ namespace System.Runtime.InteropServices.JavaScript
 
             public TResult InvokeJS(T1 arg1, T2 arg2, T3 arg3)
             {
+#if FEATURE_WASM_THREADS
+                JSObject.AssertThreadAffinity(JSObject);
+#endif
+
                 Span<JSMarshalerArgument> arguments = stackalloc JSMarshalerArgument[5];
                 ref JSMarshalerArgument args_exception = ref arguments[0];
                 ref JSMarshalerArgument args_return = ref arguments[1];

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
@@ -46,7 +46,7 @@ namespace System.Runtime.InteropServices.JavaScript
             JSHostImplementation.TaskCallback? holder = (JSHostImplementation.TaskCallback?)gcHandle.Target;
             if (holder == null) throw new InvalidOperationException(SR.FailedToMarshalTaskCallback);
 
-            TaskCompletionSource tcs = new TaskCompletionSource(gcHandle);
+            TaskCompletionSource tcs = new TaskCompletionSource(holder);
             JSHostImplementation.ToManagedCallback callback = (JSMarshalerArgument* arguments_buffer) =>
             {
                 ref JSMarshalerArgument arg_2 = ref arguments_buffer[3]; // set by caller when this is SetException call
@@ -85,7 +85,7 @@ namespace System.Runtime.InteropServices.JavaScript
             JSHostImplementation.TaskCallback? holder = (JSHostImplementation.TaskCallback?)gcHandle.Target;
             if (holder == null) throw new InvalidOperationException(SR.FailedToMarshalTaskCallback);
 
-            TaskCompletionSource<T> tcs = new TaskCompletionSource<T>(gcHandle);
+            TaskCompletionSource<T> tcs = new TaskCompletionSource<T>(holder);
             JSHostImplementation.ToManagedCallback callback = (JSMarshalerArgument* arguments_buffer) =>
             {
                 ref JSMarshalerArgument arg_2 = ref arguments_buffer[3]; // set by caller when this is SetException call
@@ -139,16 +139,14 @@ namespace System.Runtime.InteropServices.JavaScript
             slot.JSHandle = jsHandle;
             JSObject promise = JSHostImplementation.CreateCSOwnedProxy(jsHandle);
 
-            task.GetAwaiter().OnCompleted(Complete);
-
-            /* TODO multi-threading
-             * tasks could resolve on any thread and so this code will have race condition between task.IsCompleted and OnCompleted(Complete) callback
-             * This probably needs SynchronizationContext to marshal this call to main thread
-             */
-            Debug.Assert(!task.IsCompleted, "multithreading race condition");
+            task.ContinueWith(_ => Complete(), TaskScheduler.FromCurrentSynchronizationContext());
 
             void Complete()
             {
+#if FEATURE_WASM_THREADS
+                JSObject.AssertThreadAffinity(promise);
+#endif
+
                 // When this task was never resolved/rejected
                 // promise (held by this lambda) would be collected by GC after the Task is collected
                 // and would also allow the JS promise to be collected
@@ -218,13 +216,7 @@ namespace System.Runtime.InteropServices.JavaScript
             slot.JSHandle = jsHandle;
             JSObject promise = JSHostImplementation.CreateCSOwnedProxy(jsHandle);
 
-            task.GetAwaiter().OnCompleted(Complete);
-
-            /* TODO multi-threading
-             * tasks could resolve on any thread and so this code will have race condition between task.IsCompleted and OnCompleted(Complete) callback
-             * This probably needs SynchronizationContext to marshal this call to main thread
-             */
-            Debug.Assert(!task.IsCompleted, "multithreading race condition");
+            task.ContinueWith(_ => Complete(), TaskScheduler.FromCurrentSynchronizationContext());
 
             void Complete()
             {
@@ -298,13 +290,7 @@ namespace System.Runtime.InteropServices.JavaScript
             slot.JSHandle = jsHandle;
             JSObject promise = JSHostImplementation.CreateCSOwnedProxy(jsHandle);
 
-            task.GetAwaiter().OnCompleted(Complete);
-
-            /* TODO multi-threading
-             * tasks could resolve on any thread and so this code will have race condition between task.IsCompleted and OnCompleted(Complete) callback
-             * This probably needs SynchronizationContext to marshal this call to main thread
-             */
-            Debug.Assert(!task.IsCompleted, "multithreading race condition");
+            task.ContinueWith(_ => Complete(), TaskScheduler.FromCurrentSynchronizationContext());
 
             void Complete()
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
@@ -139,7 +139,11 @@ namespace System.Runtime.InteropServices.JavaScript
             slot.JSHandle = jsHandle;
             JSObject promise = JSHostImplementation.CreateCSOwnedProxy(jsHandle);
 
+#if FEATURE_WASM_THREADS
             task.ContinueWith(_ => Complete(), TaskScheduler.FromCurrentSynchronizationContext());
+#else
+            task.GetAwaiter().OnCompleted(Complete);
+#endif
 
             void Complete()
             {
@@ -216,7 +220,11 @@ namespace System.Runtime.InteropServices.JavaScript
             slot.JSHandle = jsHandle;
             JSObject promise = JSHostImplementation.CreateCSOwnedProxy(jsHandle);
 
+#if FEATURE_WASM_THREADS
             task.ContinueWith(_ => Complete(), TaskScheduler.FromCurrentSynchronizationContext());
+#else
+            task.GetAwaiter().OnCompleted(Complete);
+#endif
 
             void Complete()
             {
@@ -290,7 +298,11 @@ namespace System.Runtime.InteropServices.JavaScript
             slot.JSHandle = jsHandle;
             JSObject promise = JSHostImplementation.CreateCSOwnedProxy(jsHandle);
 
+#if FEATURE_WASM_THREADS
             task.ContinueWith(_ => Complete(), TaskScheduler.FromCurrentSynchronizationContext());
+#else
+            task.GetAwaiter().OnCompleted(Complete);
+#endif
 
             void Complete()
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/SynchronizationContextExtensions.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/SynchronizationContextExtensions.cs
@@ -1,0 +1,172 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Runtime.InteropServices.JavaScript
+{
+    /// <summary>
+    /// This is draft for possible public API of SynchronizationContext
+    /// </summary>
+    public static class SynchronizationContextExtension
+    {
+        public static Task<T> SendAsync<T>(this SynchronizationContext? self, Func<Task<T>> body)
+        {
+            if (self == null) return body();
+
+            TaskCompletionSource<T> tcs = new TaskCompletionSource<T>();
+            self.Send((_) =>
+            {
+                try
+                {
+                    var promise = body();
+                    promise.ContinueWith(done =>
+                    {
+                        PropagateCompletion(tcs, done);
+                    }, TaskScheduler.Current);
+                }
+                catch (Exception ex)
+                {
+                    tcs.SetException(ex);
+                }
+            }, null);
+            return tcs.Task;
+        }
+
+        public static Task SendAsync(this SynchronizationContext? self, Func<Task> body)
+        {
+            if (self == null) return body();
+
+            TaskCompletionSource tcs = new TaskCompletionSource();
+            self.Send((_) =>
+            {
+                try
+                {
+                    var promise = body();
+                    promise.ContinueWith(done =>
+                    {
+                        PropagateCompletion(tcs, done);
+                    }, TaskScheduler.Current);
+                }
+                catch (Exception ex)
+                {
+                    tcs.SetException(ex);
+                }
+            }, null);
+            return tcs.Task;
+        }
+
+        public static void Send<T>(this SynchronizationContext? self, Action<T> body, T value)
+        {
+            if (self == null)
+            {
+                body(value);
+                return;
+            }
+
+            Exception? exc = default;
+            self.Send((_value) =>
+            {
+                try
+                {
+                    body((T)_value!);
+                }
+                catch (Exception ex)
+                {
+                    exc = ex;
+                }
+            }, value);
+            if (exc != null)
+            {
+                throw exc;
+            }
+        }
+
+        public static TRes Send<TRes>(this SynchronizationContext? self, Func<TRes> body)
+        {
+            if (self == null) return body();
+
+            TRes? value = default;
+            Exception? exc = default;
+            self.Send((_) =>
+            {
+                try
+                {
+                    value = body();
+                }
+                catch (Exception ex)
+                {
+                    exc = ex;
+                }
+            }, null);
+            if (exc != null)
+            {
+                throw exc;
+            }
+            return value!;
+        }
+
+        public static TRes Send<T1, TRes>(this SynchronizationContext? self, Func<T1, TRes> body, T1 p1)
+        {
+            if (self == null) return body(p1);
+
+            TRes? value = default;
+            Exception? exc = default;
+            self.Send((_) =>
+            {
+                try
+                {
+                    value = body(p1);
+                }
+                catch (Exception ex)
+                {
+                    exc = ex;
+                }
+            }, null);
+            if (exc != null)
+            {
+                throw exc;
+            }
+            return value!;
+        }
+
+        public static void PropagateCompletion<T>(this TaskCompletionSource<T> tcs, Task<T> done)
+        {
+            if (done.IsFaulted)
+            {
+                if(done.Exception is AggregateException ag && ag.InnerException!=null)
+                {
+                    tcs.SetException(ag.InnerException);
+                }
+                else
+                {
+                    tcs.SetException(done.Exception);
+                }
+            }
+            else if (done.IsCanceled)
+                tcs.SetCanceled();
+            else
+                tcs.SetResult(done.Result);
+        }
+
+        public static void PropagateCompletion(this TaskCompletionSource tcs, Task done)
+        {
+            if (done.IsFaulted)
+            {
+                if (done.Exception is AggregateException ag && ag.InnerException != null)
+                {
+                    tcs.SetException(ag.InnerException);
+                }
+                else
+                {
+                    tcs.SetException(done.Exception);
+                }
+            }
+            else if (done.IsCanceled)
+                tcs.SetCanceled();
+            else
+                tcs.SetResult();
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/WebWorker.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/WebWorker.cs
@@ -14,7 +14,7 @@ namespace System.Runtime.InteropServices.JavaScript
     /// This is draft for possible public API of browser thread (web worker) dedicated to JS interop workloads.
     /// The method names are unique to make it easy to call them via reflection for now. All of them should be just `RunAsync` probably.
     /// </summary>
-    internal static class WebWorker
+    public static class WebWorker
     {
         public static Task<T> RunAsync<T>(Func<Task<T>> body, CancellationToken cancellationToken)
         {
@@ -31,7 +31,7 @@ namespace System.Runtime.InteropServices.JavaScript
                         return;
                     }
 
-                    JSHostImplementation.InstallWebWorkerInterop(true);
+                    JSHostImplementation.InstallWebWorkerInterop(true, false);
                     var childScheduler = TaskScheduler.FromCurrentSynchronizationContext();
                     Task<T> res = body();
                     // This code is exiting thread main() before all promises are resolved.
@@ -42,9 +42,9 @@ namespace System.Runtime.InteropServices.JavaScript
                         JSHostImplementation.UninstallWebWorkerInterop();
                     }, childScheduler);
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    Environment.FailFast("WebWorker.RunAsync failed", e);
+                    PostWhenException(parentContext, tcs, ex);
                 }
 
             });
@@ -68,7 +68,7 @@ namespace System.Runtime.InteropServices.JavaScript
                         return;
                     }
 
-                    JSHostImplementation.InstallWebWorkerInterop(true);
+                    JSHostImplementation.InstallWebWorkerInterop(true, false);
                     var childScheduler = TaskScheduler.FromCurrentSynchronizationContext();
                     Task res = body();
                     // This code is exiting thread main() before all promises are resolved.
@@ -79,9 +79,9 @@ namespace System.Runtime.InteropServices.JavaScript
                         JSHostImplementation.UninstallWebWorkerInterop();
                     }, childScheduler);
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    Environment.FailFast("WebWorker.RunAsync failed", e);
+                    PostWhenException(parentContext, tcs, ex);
                 }
 
             });
@@ -105,7 +105,7 @@ namespace System.Runtime.InteropServices.JavaScript
                         return;
                     }
 
-                    JSHostImplementation.InstallWebWorkerInterop(false);
+                    JSHostImplementation.InstallWebWorkerInterop(false, false);
                     try
                     {
                         body();
@@ -117,9 +117,9 @@ namespace System.Runtime.InteropServices.JavaScript
                     }
                     JSHostImplementation.UninstallWebWorkerInterop();
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    tcs.SetException(e);
+                    PostWhenException(parentContext, tcs, ex);
                 }
 
             });
@@ -160,13 +160,7 @@ namespace System.Runtime.InteropServices.JavaScript
             {
                 ctx.Post((_) =>
                 {
-                    if (done.IsFaulted)
-                        tcs.SetException(done.Exception);
-                    else if (done.IsCanceled)
-                        tcs.SetCanceled();
-                    else
-                        tcs.SetResult();
-
+                    tcs.PropagateCompletion(done);
                 }, null);
             }
             catch (Exception e)
@@ -199,19 +193,25 @@ namespace System.Runtime.InteropServices.JavaScript
             }
         }
 
+        private static void PostWhenException<T>(SynchronizationContext ctx, TaskCompletionSource<T> tcs, Exception ex)
+        {
+            try
+            {
+                ctx.Post((_) => tcs.SetException(ex), null);
+            }
+            catch (Exception e)
+            {
+                Environment.FailFast("WebWorker.RunAsync failed", e);
+            }
+        }
+
         private static void PostWhenDone<T>(SynchronizationContext ctx, TaskCompletionSource<T> tcs, Task<T> done)
         {
             try
             {
                 ctx.Post((_) =>
                 {
-                    if (done.IsFaulted)
-                        tcs.SetException(done.Exception);
-                    else if (done.IsCanceled)
-                        tcs.SetCanceled();
-                    else
-                        tcs.SetResult(done.Result);
-
+                    tcs.PropagateCompletion(done);
                 }, null);
             }
             catch (Exception e)

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -547,6 +547,7 @@
     <!-- Don't want the default smoke tests - just verify that threading works -->
     <SmokeTestProject Remove="@(SmokeTestProject)" />
     <SmokeTestProject Include="$(MonoProjectRoot)sample\wasm\browser-threads-minimal\Wasm.Browser.Threads.Minimal.Sample.csproj" />
+    <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Net.WebSockets.Client\tests\System.Net.WebSockets.Client.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -371,8 +371,8 @@
     <Warning Condition="'$(InvariantGlobalization)' != 'true' and '$(WasmIncludeFullIcuData)' == 'true' and '$(WasmIcuDataFileName)' != ''" Text="%24(WasmIcuDataFileName) has no effect when %24(WasmIncludeFullIcuData) is set to true." />
 
     <PropertyGroup>
-      <_WasmAppIncludeThreadsWorker Condition="'$(WasmEnableThreads)' == 'true'">true</_WasmAppIncludeThreadsWorker>
-      <!-- TODO: set this from some user-facing property?  -1 means use the default baked into dotnet.js -->
+      <_WasmAppIncludeThreadsWorker Condition="'$(WasmEnableThreads)' == 'true' or '$(MonoWasmBuildVariant)' == 'multithread'">true</_WasmAppIncludeThreadsWorker>
+      <!-- TODO: set this from some user-facing property?  -1 means use the default baked into dotnet.native.js -->
       <_WasmPThreadPoolSize Condition="'$(_WasmPThreadPoolSize)' == ''">-1</_WasmPThreadPoolSize>
     </PropertyGroup>
 


### PR DESCRIPTION
## BrowserWebSocket
- `_thisLock` for locking the state for MT access
- use `FEATURE_WASM_THREADS` to conditionaly wrap the calls with `SynchronizationContext.Send` for all calls to JS
- split `ConnectAsyncCore` and `CreateCore` to separate methods. `CreateCore` is synchronous and creates the JS proxy. The other one needs to be executed separately, so that `Abort()` before `await ConnectAsync()` works as expected. Yielding to main loop.
- few edge test cases `[ActiveIssue]` as https://github.com/dotnet/runtime/issues/87839

## Other
- make `JSSynchronizationContext ` possible to install on multiple threads
- private draft of `SynchronizationContextExtension` hidden from API by `CompatibilitySuppressions.xml`
   - these are sync and async helpers for dispatching call to correct thread and propagating result and exception back
- private draft of `JSHost.CurrentOrMainJSSynchronizationContext`
   - this allows to use main thread as fallback for JS interop, if there is no `JSSynchronizationContext` installed on current thread
- private draft of `JSObject.SynchronizationContext`
   - this allows to dispatch call back to correct thread for the proxy
- private draft of `WebWorker` hidden from API by `CompatibilitySuppressions.xml`
- `JSException` from another thread doesn't have thread affinity and stack trace.
- more thread affinity asserts

