### PR TITLE
[RISC-V][JIT] Disable promotion for splitted args

### DIFF
--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -2017,6 +2017,14 @@ bool Compiler::StructPromotionHelper::CanPromoteStructVar(unsigned lclNum)
         return false;
     }
 
+#if defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
+    if (varDsc->lvIsSplit)
+    {
+        JITDUMP("  struct promotion of V%02u is disabled because it is splitted\n", lclNum);
+        return false;
+    }
+#endif // TARGET_LOONGARCH64 || TARGET_RISCV64
+
     CORINFO_CLASS_HANDLE typeHnd = varDsc->GetLayout()->GetClassHandle();
     assert(typeHnd != NO_CLASS_HANDLE);
 
@@ -2502,13 +2510,6 @@ void Compiler::StructPromotionHelper::PromoteStructVar(unsigned lclNum)
                     {
                         assert(index == 1);
                         fieldRegNum = varDsc->GetOtherArgReg();
-#ifdef TARGET_RISCV64
-                        if (varDsc->lvIsSplit)
-                        {
-                            assert(fieldRegNum == REG_STK);
-                            fieldVarDsc->lvIsRegArg = 0;
-                        }
-#endif // TARGET_RISCV64
                     }
                     fieldVarDsc->SetArgReg(fieldRegNum);
                 }

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -2502,6 +2502,13 @@ void Compiler::StructPromotionHelper::PromoteStructVar(unsigned lclNum)
                     {
                         assert(index == 1);
                         fieldRegNum = varDsc->GetOtherArgReg();
+#if defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
+                        if (varDsc->lvIsSplit)
+                        {
+                            assert(fieldRegNum == REG_STK);
+                            fieldVarDsc->lvIsRegArg = 0;
+                        }
+#endif // TARGET_LOONGARCH64 || TARGET_RISCV64
                     }
                     fieldVarDsc->SetArgReg(fieldRegNum);
                 }

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -2502,13 +2502,13 @@ void Compiler::StructPromotionHelper::PromoteStructVar(unsigned lclNum)
                     {
                         assert(index == 1);
                         fieldRegNum = varDsc->GetOtherArgReg();
-#if defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
+#ifdef TARGET_RISCV64
                         if (varDsc->lvIsSplit)
                         {
                             assert(fieldRegNum == REG_STK);
                             fieldVarDsc->lvIsRegArg = 0;
                         }
-#endif // TARGET_LOONGARCH64 || TARGET_RISCV64
+#endif // TARGET_RISCV64
                     }
                     fieldVarDsc->SetArgReg(fieldRegNum);
                 }

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -2017,14 +2017,6 @@ bool Compiler::StructPromotionHelper::CanPromoteStructVar(unsigned lclNum)
         return false;
     }
 
-#if defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
-    if (varDsc->lvIsSplit)
-    {
-        JITDUMP("  struct promotion of V%02u is disabled because it is splitted\n", lclNum);
-        return false;
-    }
-#endif // TARGET_LOONGARCH64 || TARGET_RISCV64
-
     CORINFO_CLASS_HANDLE typeHnd = varDsc->GetLayout()->GetClassHandle();
     assert(typeHnd != NO_CLASS_HANDLE);
 
@@ -2183,6 +2175,13 @@ bool Compiler::StructPromotionHelper::ShouldPromoteStructVar(unsigned lclNum)
                         lclNum);
                 shouldPromote = false;
             }
+#if defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
+            else if (varDsc->lvIsSplit)
+            {
+                JITDUMP("Not promoting multireg struct local V%02u, because it is splitted.\n", lclNum);
+                shouldPromote = false;
+            }
+#endif // TARGET_LOONGARCH64 || TARGET_RISCV64
         }
         else
 #endif // !FEATURE_MULTIREG_STRUCT_PROMOTE


### PR DESCRIPTION
Fix an assert in `src/coreclr/jit/regalloc.cpp line 133`
- `Assertion failed 'inArgMask & RBM_ARG_REGS'` because `inArgReg` is 64 and `inArgMask` is 0
- Fixed two tests on CHECKED build (neither DEBUG nor RELEASE)
`./JIT/Performance/CodeQuality/BenchmarksGame/regex-redux/regex-redux-1/regex-redux-1.sh`
`./JIT/Performance/CodeQuality/BenchmarksGame/regex-redux/regex-redux-5/regex-redux-5.sh`
- In `PromoteStructVar`, it sets `lvIsRegArg` to 1 even if its register is `REG_STK`. It calls `updateRegStateForArg` for `REG_STK` like below. Then it crashes in `raUpdateRegStateForArg`
https://github.com/dotnet/runtime/blob/f3b599e5777eb1db7c396fdc1597c390f22879e6/src/coreclr/jit/lsrabuild.cpp#L2270-L2273

Part of https://github.com/dotnet/runtime/issues/84834
cc @wscho77 @HJLeee @JongHeonChoi @t-mustafin @alpencolt @gbalykov