### PR TITLE
Add missing compiler-generated attributes to corelib

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -191,7 +191,7 @@
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <NewtonsoftJsonBsonVersion>1.0.2</NewtonsoftJsonBsonVersion>
     <SQLitePCLRawbundle_greenVersion>2.0.4</SQLitePCLRawbundle_greenVersion>
-    <MoqVersion>4.12.0</MoqVersion>
+    <MoqVersion>4.18.4</MoqVersion>
     <FluentAssertionsVersion>6.7.0</FluentAssertionsVersion>
     <FsCheckVersion>2.14.3</FsCheckVersion>
     <!-- Android gRPC client tests -->

--- a/eng/testing/ILLinkDescriptors/ILLink.Descriptors.Castle.xml
+++ b/eng/testing/ILLinkDescriptors/ILLink.Descriptors.Castle.xml
@@ -3,6 +3,7 @@
     <namespace fullname="Castle.DynamicProxy" />
     <type fullname="Castle.DynamicProxy.Internal.CompositionInvocation" />
     <type fullname="Castle.DynamicProxy.Internal.InheritanceInvocation" />
+    <type fullname="Castle.DynamicProxy.Internal.InheritanceInvocationWithoutTarget" />
     <type fullname="Castle.DynamicProxy.Internal.InterfaceMethodWithoutTargetInvocation" />
   </assembly>
   <assembly fullname="Moq">

--- a/eng/testing/ILLinkDescriptors/ILLink.Descriptors.Castle.xml
+++ b/eng/testing/ILLinkDescriptors/ILLink.Descriptors.Castle.xml
@@ -3,6 +3,7 @@
     <namespace fullname="Castle.DynamicProxy" />
     <type fullname="Castle.DynamicProxy.Internal.CompositionInvocation" />
     <type fullname="Castle.DynamicProxy.Internal.InheritanceInvocation" />
+    <type fullname="Castle.DynamicProxy.Internal.InterfaceMethodWithoutTargetInvocation" />
   </assembly>
   <assembly fullname="Moq">
     <type fullname="Moq.Internals.InterfaceProxy">

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/ILLink.Descriptors.xml
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/ILLink.Descriptors.xml
@@ -9,6 +9,7 @@
       <namespace fullname="Castle.DynamicProxy" />
       <type fullname="Castle.DynamicProxy.Internal.CompositionInvocation" />
       <type fullname="Castle.DynamicProxy.Internal.InheritanceInvocation" />
+    <type fullname="Castle.DynamicProxy.Internal.InterfaceMethodWithoutTargetInvocation" />
   </assembly>
   <assembly fullname="Moq">
       <type fullname="Moq.Internals.InterfaceProxy">

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/ILLink.Descriptors.xml
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/ILLink.Descriptors.xml
@@ -9,7 +9,8 @@
       <namespace fullname="Castle.DynamicProxy" />
       <type fullname="Castle.DynamicProxy.Internal.CompositionInvocation" />
       <type fullname="Castle.DynamicProxy.Internal.InheritanceInvocation" />
-    <type fullname="Castle.DynamicProxy.Internal.InterfaceMethodWithoutTargetInvocation" />
+      <type fullname="Castle.DynamicProxy.Internal.InheritanceInvocationWithoutTarget" />
+      <type fullname="Castle.DynamicProxy.Internal.InterfaceMethodWithoutTargetInvocation" />
   </assembly>
   <assembly fullname="Moq">
       <type fullname="Moq.Internals.InterfaceProxy">

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -813,6 +813,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\InterpolatedStringHandlerAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\InterpolatedStringHandlerArgumentAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\DefaultInterpolatedStringHandler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\IsUnmanagedAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\IteratorStateMachineAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\ITuple.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\LoadHint.cs" />
@@ -821,6 +822,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\MethodImplOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\ModuleInitializerAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\MetadataUpdateOriginalTypeAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\NullableAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\NullableContextAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\NullablePublicOnlyAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\ReferenceAssemblyAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\PoolingAsyncValueTaskMethodBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\PoolingAsyncValueTaskMethodBuilderT.cs" />
@@ -832,6 +836,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\RuntimeFeature.NonNativeAot.cs" Condition="'$(FeatureNativeAot)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\RuntimeHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\RuntimeWrappedException.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\ScopedRefAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\SkipLocalsInitAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\SpecialNameAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\StateMachineAttribute.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/IsByRefLikeAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/IsByRefLikeAttribute.cs
@@ -6,13 +6,14 @@ using System.ComponentModel;
 namespace System.Runtime.CompilerServices
 {
     /// <summary>
-    /// Reserved to be used by the compiler for tracking metadata.
+    /// Reserved for use by a compiler for tracking metadata.
     /// This attribute should not be used by developers in source code.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     [AttributeUsage(AttributeTargets.Struct)]
     public sealed class IsByRefLikeAttribute : Attribute
     {
+        /// <summary>Initializes the attribute.</summary>
         public IsByRefLikeAttribute()
         {
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/IsReadOnlyAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/IsReadOnlyAttribute.cs
@@ -6,13 +6,14 @@ using System.ComponentModel;
 namespace System.Runtime.CompilerServices
 {
     /// <summary>
-    /// Reserved to be used by the compiler for tracking metadata.
+    /// Reserved for use by a compiler for tracking metadata.
     /// This attribute should not be used by developers in source code.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     [AttributeUsage(AttributeTargets.All, Inherited = false)]
     public sealed class IsReadOnlyAttribute : Attribute
     {
+        /// <summary>Initializes the attribute.</summary>
         public IsReadOnlyAttribute()
         {
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/IsUnmanagedAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/IsUnmanagedAttribute.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.CompilerServices
+{
+    public sealed class IsUnmanagedAttribute : Attribute
+    {
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/IsUnmanagedAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/IsUnmanagedAttribute.cs
@@ -1,9 +1,21 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel;
+
 namespace System.Runtime.CompilerServices
 {
+    /// <summary>
+    /// Reserved for use by a compiler for tracking metadata.
+    /// This attribute should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [AttributeUsage(AttributeTargets.All)]
     public sealed class IsUnmanagedAttribute : Attribute
     {
+        /// <summary>Initializes the attribute.</summary>
+        public IsUnmanagedAttribute()
+        {
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/NullableAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/NullableAttribute.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Parameter | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter, AllowMultiple = false, Inherited = false)]
+    public sealed class NullableAttribute : Attribute
+    {
+        public readonly byte[] NullableFlags;
+
+        public NullableAttribute(byte value)
+        {
+            NullableFlags = new[] { value };
+        }
+
+        public NullableAttribute(byte[] value)
+        {
+            NullableFlags = value;
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/NullableAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/NullableAttribute.cs
@@ -1,18 +1,30 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel;
+
 namespace System.Runtime.CompilerServices
 {
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Parameter | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter, AllowMultiple = false, Inherited = false)]
+    /// <summary>
+    /// Reserved for use by a compiler for tracking metadata.
+    /// This attribute should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Parameter | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter, Inherited = false)]
     public sealed class NullableAttribute : Attribute
     {
+        /// <summary>Flags specifying metadata related to nullable reference types.</summary>
         public readonly byte[] NullableFlags;
 
+        /// <summary>Initializes the attribute.</summary>
+        /// <param name="value">The flags value.</param>
         public NullableAttribute(byte value)
         {
             NullableFlags = new[] { value };
         }
 
+        /// <summary>Initializes the attribute.</summary>
+        /// <param name="value">The flags value.</param>
         public NullableAttribute(byte[] value)
         {
             NullableFlags = value;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/NullableContextAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/NullableContextAttribute.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Method | AttributeTargets.Interface | AttributeTargets.Delegate, AllowMultiple = false, Inherited = false)]
+    public sealed class NullableContextAttribute : Attribute
+    {
+        public readonly byte Flag;
+
+        public NullableContextAttribute(byte value)
+        {
+            Flag = value;
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/NullableContextAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/NullableContextAttribute.cs
@@ -1,13 +1,23 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel;
+
 namespace System.Runtime.CompilerServices
 {
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Method | AttributeTargets.Interface | AttributeTargets.Delegate, AllowMultiple = false, Inherited = false)]
+    /// <summary>
+    /// Reserved for use by a compiler for tracking metadata.
+    /// This attribute should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Method | AttributeTargets.Interface | AttributeTargets.Delegate, Inherited = false)]
     public sealed class NullableContextAttribute : Attribute
     {
+        /// <summary>Flag specifying metadata related to nullable reference types.</summary>
         public readonly byte Flag;
 
+        /// <summary>Initializes the attribute.</summary>
+        /// <param name="value">The flag value.</param>
         public NullableContextAttribute(byte value)
         {
             Flag = value;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/NullablePublicOnlyAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/NullablePublicOnlyAttribute.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Module, AllowMultiple = false, Inherited = false)]
+    public sealed class NullablePublicOnlyAttribute : Attribute
+    {
+        public readonly bool IncludesInternals;
+
+        public NullablePublicOnlyAttribute(bool value)
+        {
+            IncludesInternals = value;
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/NullablePublicOnlyAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/NullablePublicOnlyAttribute.cs
@@ -1,13 +1,23 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel;
+
 namespace System.Runtime.CompilerServices
 {
-    [AttributeUsage(AttributeTargets.Module, AllowMultiple = false, Inherited = false)]
+    /// <summary>
+    /// Reserved for use by a compiler for tracking metadata.
+    /// This attribute should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [AttributeUsage(AttributeTargets.Module, Inherited = false)]
     public sealed class NullablePublicOnlyAttribute : Attribute
     {
+        /// <summary>Indicates whether metadata for internal members is included.</summary>
         public readonly bool IncludesInternals;
 
+        /// <summary>Initializes the attribute.</summary>
+        /// <param name="value">Indicates whether metadata for internal members is included.</param>
         public NullablePublicOnlyAttribute(bool value)
         {
             IncludesInternals = value;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RefSafetyRulesAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RefSafetyRulesAttribute.cs
@@ -1,10 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel;
+
 namespace System.Runtime.CompilerServices
 {
     /// <summary>Indicates the language version of the ref safety rules used when the module was compiled.</summary>
-    [AttributeUsage(AttributeTargets.Module, AllowMultiple = false, Inherited = false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [AttributeUsage(AttributeTargets.Module, Inherited = false)]
     public sealed class RefSafetyRulesAttribute : Attribute
     {
         /// <summary>Initializes a new instance of the <see cref="RefSafetyRulesAttribute"/> class.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RequiredMemberAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RequiredMemberAttribute.cs
@@ -1,10 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel;
+
 namespace System.Runtime.CompilerServices
 {
     /// <summary>Specifies that a type has required members or that a member is required.</summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
 #if SYSTEM_PRIVATE_CORELIB
     public
 #else

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ScopedRefAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ScopedRefAttribute.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    public sealed class ScopedRefAttribute : Attribute
+    {
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ScopedRefAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ScopedRefAttribute.cs
@@ -1,10 +1,21 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel;
+
 namespace System.Runtime.CompilerServices
 {
-    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    /// <summary>
+    /// Reserved for use by a compiler for tracking metadata.
+    /// This attribute should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
     public sealed class ScopedRefAttribute : Attribute
     {
+        /// <summary>Initializes the attribute.</summary>
+        public ScopedRefAttribute()
+        {
+        }
     }
 }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -12781,6 +12781,9 @@ namespace System.Runtime.CompilerServices
     {
         object? Value { get; set; }
     }
+    public sealed partial class IsUnmanagedAttribute : Attribute
+    {
+    }
     public static partial class IsVolatile
     {
     }
@@ -12833,6 +12836,26 @@ namespace System.Runtime.CompilerServices
     public sealed partial class ModuleInitializerAttribute : System.Attribute
     {
         public ModuleInitializerAttribute() { }
+    }
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Parameter | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter, AllowMultiple = false, Inherited = false)]
+    public sealed partial class NullableAttribute : Attribute
+    {
+        public readonly byte[] NullableFlags;
+        public NullableAttribute(byte value) { }
+
+        public NullableAttribute(byte[] value) { }
+    }
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Method | AttributeTargets.Interface | AttributeTargets.Delegate, AllowMultiple = false, Inherited = false)]
+    public sealed partial class NullableContextAttribute : Attribute
+    {
+        public readonly byte Flag;
+        public NullableContextAttribute(byte value) { }
+    }
+    [AttributeUsage(AttributeTargets.Module, AllowMultiple = false, Inherited = false)]
+    public sealed partial class NullablePublicOnlyAttribute : Attribute
+    {
+        public readonly bool IncludesInternals;
+        public NullablePublicOnlyAttribute(bool value) { }
     }
     public partial struct PoolingAsyncValueTaskMethodBuilder
     {
@@ -12945,6 +12968,10 @@ namespace System.Runtime.CompilerServices
         [System.ObsoleteAttribute("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId = "SYSLIB0051", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    public sealed partial class ScopedRefAttribute : Attribute
+    {
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Event | System.AttributeTargets.Interface | System.AttributeTargets.Method | System.AttributeTargets.Module | System.AttributeTargets.Property | System.AttributeTargets.Struct, Inherited=false)]
     public sealed partial class SkipLocalsInitAttribute : System.Attribute

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -8283,7 +8283,7 @@ namespace System.Diagnostics.CodeAnalysis
         public ExcludeFromCodeCoverageAttribute() { }
         public string? Justification { get { throw null; } set { } }
     }
-    [System.AttributeUsage(System.AttributeTargets.Assembly |  System.AttributeTargets.Module | System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Event | System.AttributeTargets.Interface | System.AttributeTargets.Delegate, Inherited = false)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly |  System.AttributeTargets.Module | System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Event | System.AttributeTargets.Interface | System.AttributeTargets.Delegate, Inherited = false)]
     public sealed class ExperimentalAttribute : System.Attribute
     {
         public ExperimentalAttribute(string diagnosticId) { }
@@ -8360,7 +8360,7 @@ namespace System.Diagnostics.CodeAnalysis
         public string Message { get { throw null; } }
         public string? Url { get { throw null; } set { } }
     }
-    [System.AttributeUsage(System.AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
     public sealed class SetsRequiredMembersAttribute : System.Attribute
     {
         public SetsRequiredMembersAttribute() { }
@@ -12751,7 +12751,7 @@ namespace System.Runtime.CompilerServices
     {
         public InterpolatedStringHandlerAttribute() { }
     }
-    [AttributeUsage(System.AttributeTargets.Struct, AllowMultiple = false)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Struct, AllowMultiple = false)]
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public sealed partial class InlineArrayAttribute : System.Attribute
     {
@@ -12781,6 +12781,8 @@ namespace System.Runtime.CompilerServices
     {
         object? Value { get; set; }
     }
+    [System.AttributeUsageAttribute(System.AttributeTargets.All)]
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public sealed partial class IsUnmanagedAttribute : Attribute
     {
     }
@@ -12837,7 +12839,8 @@ namespace System.Runtime.CompilerServices
     {
         public ModuleInitializerAttribute() { }
     }
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Parameter | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter, AllowMultiple = false, Inherited = false)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Event | System.AttributeTargets.Parameter | System.AttributeTargets.ReturnValue | System.AttributeTargets.GenericParameter, Inherited = false)]
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public sealed partial class NullableAttribute : Attribute
     {
         public readonly byte[] NullableFlags;
@@ -12845,13 +12848,15 @@ namespace System.Runtime.CompilerServices
 
         public NullableAttribute(byte[] value) { }
     }
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Method | AttributeTargets.Interface | AttributeTargets.Delegate, AllowMultiple = false, Inherited = false)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Method | System.AttributeTargets.Interface | System.AttributeTargets.Delegate, Inherited = false)]
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public sealed partial class NullableContextAttribute : Attribute
     {
         public readonly byte Flag;
         public NullableContextAttribute(byte value) { }
     }
-    [AttributeUsage(AttributeTargets.Module, AllowMultiple = false, Inherited = false)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Module, Inherited = false)]
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public sealed partial class NullablePublicOnlyAttribute : Attribute
     {
         public readonly bool IncludesInternals;
@@ -12889,13 +12894,15 @@ namespace System.Runtime.CompilerServices
     {
         public PreserveBaseOverridesAttribute() { }
     }
-    [System.AttributeUsage(System.AttributeTargets.Module, AllowMultiple=false, Inherited=false)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Module, Inherited=false)]
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public sealed partial class RefSafetyRulesAttribute : System.Attribute
     {
         public RefSafetyRulesAttribute(int version) { }
         public int Version { get { throw null; } }
     }
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Field | System.AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public sealed class RequiredMemberAttribute : System.Attribute
     {
         public RequiredMemberAttribute() { }
@@ -12969,7 +12976,8 @@ namespace System.Runtime.CompilerServices
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
-    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter, Inherited = false)]
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public sealed partial class ScopedRefAttribute : Attribute
     {
     }

--- a/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/AttributesTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/AttributesTests.cs
@@ -192,6 +192,32 @@ namespace System.Runtime.CompilerServices.Tests
             Assert.Equal(MethodImplOptions.Unmanaged, attr3.Value);
         }
 
+        [Fact]
+        public static void NullableAttributeTests()
+        {
+            var attr = new NullableAttribute(42);
+            Assert.Equal(new byte[] { 42 }, attr.NullableFlags);
+
+            attr = new NullableAttribute(new byte[] { 1, 2, 3 });
+            Assert.Equal(new byte[] { 1, 2, 3 }, attr.NullableFlags);
+        }
+
+        [Fact]
+        public static void NullableContextAttributeTests()
+        {
+            var attr = new NullableContextAttribute(42);
+            Assert.Equal(42, attr.Flag);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public static void NullablePublicOnlyAttributeTests(bool includeInternals)
+        {
+            var attr = new NullablePublicOnlyAttribute(includeInternals);
+            Assert.Equal(includeInternals, attr.IncludesInternals);
+        }
+
         [Theory]
         [InlineData(-1)]
         [InlineData(42)]
@@ -300,6 +326,12 @@ namespace System.Runtime.CompilerServices.Tests
         }
 
         [Fact]
+        public static void IsUnmanagedAttributeTests()
+        {
+            new IsUnmanagedAttribute();
+        }
+
+        [Fact]
         public static void EnumeratorCancellationAttributeTests()
         {
             new EnumeratorCancellationAttribute();
@@ -334,6 +366,12 @@ namespace System.Runtime.CompilerServices.Tests
         public static void RequiredMemberAttributeTests()
         {
             new RequiredMemberAttribute();
+        }
+
+        [Fact]
+        public static void ScopedRefAttributeTests()
+        {
+            new ScopedRefAttribute();
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/Common/UnsupportedTypesTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/UnsupportedTypesTests.cs
@@ -170,6 +170,7 @@ namespace System.Text.Json.Serialization.Tests
 
 #if !BUILDING_SOURCE_GENERATOR_TESTS
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, "NullableContextAttribute is public in corelib in .NET 8+")]
         public async Task TypeWithNullConstructorParameterName_ThrowsNotSupportedException()
         {
             // Regression test for https://github.com/dotnet/runtime/issues/58690


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/85612

Cherry-picked @ericstj's commit for adding these and then tweaked it a bit (e.g. added docs and tests).