### PR TITLE
SPMI: HTML escape lines inside diffs

### DIFF
--- a/src/coreclr/scripts/superpmi_diffs_summarize.py
+++ b/src/coreclr/scripts/superpmi_diffs_summarize.py
@@ -14,6 +14,7 @@
 ################################################################################
 
 import argparse
+import html
 import os
 import re
 from coreclr_arguments import *
@@ -213,7 +214,7 @@ def main(main_args):
             inside_diff = False
             new_lines.append(html_color_diff(cur_diff_lines))
         elif inside_diff:
-            cur_diff_lines.append(line)
+            cur_diff_lines.append(html.escape(line))
         else:
             new_lines.append(line)
 

--- a/src/coreclr/scripts/superpmi_diffs_summarize.py
+++ b/src/coreclr/scripts/superpmi_diffs_summarize.py
@@ -214,7 +214,7 @@ def main(main_args):
             inside_diff = False
             new_lines.append(html_color_diff(cur_diff_lines))
         elif inside_diff:
-            cur_diff_lines.append(html.escape(line))
+            cur_diff_lines.append(html.escape(line, False))
         else:
             new_lines.append(line)
 


### PR DESCRIPTION
The summarize script will convert markdown diff code blocks into manually colored HTML tags because AzDO does not support proper highlighting in its preview. However, when we do this we should also take care to escape the contents as otherwise it can start being interpreted as HTML tags. For example, in a recent case a field named `<Option>k__BackingField` caused the preview to be truncated because <option> was interpreted as a HTML tag.