### PR TITLE
Include liblog in linker command line for Bionic

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -124,6 +124,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-lswiftFoundation" Condition="'$(_targetOS)' == 'osx'" />
       <LinkerArg Include="-lz" />
       <LinkerArg Include="-lrt" Condition="'$(_IsApplePlatform)' != 'true' and '$(_linuxLibcFlavor)' != 'bionic'" />
+      <LinkerArg Include="-llog" Condition="'$(_linuxLibcFlavor)' == 'bionic'" />
       <LinkerArg Include="-licucore" Condition="'$(_IsApplePlatform)' == 'true'" />
       <LinkerArg Include="-L/usr/lib/swift" Condition="'$(_targetOS)' == 'osx'" />
       <LinkerArg Include="@(StaticICULibs)" Condition="'$(StaticICULinking)' == 'true'" />


### PR DESCRIPTION
Fixes issue reported in https://github.com/dotnet/runtime/issues/87340#issuecomment-1600401747.

Cc @dotnet/ilc-contrib 