### PR TITLE
System.IO.Packaging: Avoid setting the general purpose bitflag due to enforced UTF8 encoding on ZipArchive creation

### DIFF
--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipPackage.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipPackage.cs
@@ -258,7 +258,7 @@ namespace System.IO.Packaging
                 else if (packageFileAccess == FileAccess.ReadWrite)
                     zipArchiveMode = ZipArchiveMode.Update;
 
-                zipArchive = new ZipArchive(_containerStream, zipArchiveMode, true, Text.Encoding.UTF8);
+                zipArchive = new ZipArchive(_containerStream, zipArchiveMode, true);
                 _zipStreamManager = new ZipStreamManager(zipArchive, _packageFileMode, _packageFileAccess);
                 contentTypeHelper = new ContentTypeHelper(zipArchive, _packageFileMode, _packageFileAccess, _zipStreamManager);
             }
@@ -325,7 +325,7 @@ namespace System.IO.Packaging
                 else if (packageFileAccess == FileAccess.ReadWrite)
                     zipArchiveMode = ZipArchiveMode.Update;
 
-                zipArchive = new ZipArchive(s, zipArchiveMode, true, Text.Encoding.UTF8);
+                zipArchive = new ZipArchive(s, zipArchiveMode, true);
 
                 _zipStreamManager = new ZipStreamManager(zipArchive, packageFileMode, packageFileAccess);
                 contentTypeHelper = new ContentTypeHelper(zipArchive, packageFileMode, packageFileAccess, _zipStreamManager);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/87658

The ZipArchive constructor is being called by ZipPackage with the `entryNameEncoding` argument set to `Encoding.UTF8`. This is not needed by default, particularly because it's not respecting the Office XML standard which does not expect the general purpose bit flag 11 to be set. The entry name can still be stored using UTF8 if the archive encoding is unset or null, and the general purpose bit flag for entryname and comment encoding can still be changed later if the caller changes the entry name or the comment to a string with an encoding other than ASCII.

This change is relatively safe to make since ZipArchive is capable of handling archives without specifying a particular encoding.

This was verified with a manual test with @ericstj in a video call: we confirmed with reflection that the `_generalPurposeBitFlag` was now left unchanged by default, and an inspection of the generated file using a hex editor showed that the relevant bytes were unset.

We will add tests as a followup of the original issue. https://github.com/dotnet/runtime/issues/87882