### PR TITLE
[nativeaot][perf] Remove unused _LinkerFlagsToDrop property from the sample app

### DIFF
--- a/src/mono/sample/iOS-NativeAOT/Program.csproj
+++ b/src/mono/sample/iOS-NativeAOT/Program.csproj
@@ -69,7 +69,6 @@
 
     <ItemGroup>
       <_LinkerFlagsToDrop Include="@(NativeFramework->'-framework %(Identity)')" />
-      <_LinkerFlagsToDrop Include="@(LinkerArg)" Condition="$([System.String]::new('%(Identity)').Contains('swift'))" />
       <LinkerArg Remove="@(_LinkerFlagsToDrop)" />
       <ExtraLinkerArguments Include="@(LinkerArg)" />
       <_NativeDependencies Include="%(ManagedBinary.IlcOutputFile)" />


### PR DESCRIPTION
This PR removes the unused `_LinkerFlagsToDrop` property from the sample app that was causing a failure with the following error: `"[System.String]::new(''-Wl, -rpath, @executable_path'')" cannot be evaluated`.

Fixes https://github.com/dotnet/runtime/issues/87886