### PR TITLE
Remove object[] allocation from CustomAttribute.AddCustomAttributes

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
@@ -1241,9 +1241,9 @@ namespace System.Reflection
                                 }
                             }
 
-                            PropertyInfo? property = type is null ?
+                            RuntimePropertyInfo? property = (RuntimePropertyInfo?)(type is null ?
                                 attributeType.GetProperty(name) :
-                                attributeType.GetProperty(name, type, Type.EmptyTypes);
+                                attributeType.GetProperty(name, type, Type.EmptyTypes));
 
                             // Did we get a valid property reference?
                             if (property is null)
@@ -1251,7 +1251,7 @@ namespace System.Reflection
                                 throw new CustomAttributeFormatException(SR.Format(SR.RFLCT_InvalidPropFail, name));
                             }
 
-                            MethodInfo setMethod = property.GetSetMethod(true)!;
+                            RuntimeMethodInfo setMethod = property.GetSetMethod(true)!;
 
                             // Public properties may have non-public setter methods
                             if (!setMethod.IsPublic)
@@ -1259,7 +1259,7 @@ namespace System.Reflection
                                 continue;
                             }
 
-                            setMethod.Invoke(attribute, BindingFlags.Default, null, new object?[] { value }, null);
+                            setMethod.InvokeOneParameter(attribute, BindingFlags.Default, null, value, null);
                         }
                         else
                         {


### PR DESCRIPTION
|              Method |         Toolchain |     Mean | Ratio | Allocated | Alloc Ratio |
|-------------------- |------------------ |---------:|------:|----------:|------------:|
| GetCustomAttributes | \main\corerun.exe | 888.7 ns |  1.00 |     296 B |        1.00 |
| GetCustomAttributes |   \pr\corerun.exe | 829.7 ns |  0.94 |     232 B |        0.78 |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System;

[MemoryDiagnoser(false)]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    [Benchmark]
    public object[] GetCustomAttributes() => typeof(C).GetCustomAttributes(typeof(MyAttribute), true);
}

[My(Value1 = 1, Value2 = 2)]
class C { }

[AttributeUsage(AttributeTargets.All)]
public class MyAttribute : Attribute
{
    public int Value1 { get; set; }
    public int Value2 { get; set; }
}
```