### PR TITLE
Fix contention in LoggerFactory.CreateLogger

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,7 +15,7 @@ namespace Microsoft.Extensions.Logging
     /// </summary>
     public class LoggerFactory : ILoggerFactory
     {
-        private readonly Dictionary<string, Logger> _loggers = new Dictionary<string, Logger>(StringComparer.Ordinal);
+        private readonly ConcurrentDictionary<string, Logger> _loggers = new ConcurrentDictionary<string, Logger>(StringComparer.Ordinal);
         private readonly List<ProviderRegistration> _providerRegistrations = new List<ProviderRegistration>();
         private readonly object _sync = new object();
         private volatile bool _disposed;
@@ -138,19 +139,22 @@ namespace Microsoft.Extensions.Logging
                 throw new ObjectDisposedException(nameof(LoggerFactory));
             }
 
-            lock (_sync)
+            if (!_loggers.TryGetValue(categoryName, out Logger? logger))
             {
-                if (!_loggers.TryGetValue(categoryName, out Logger? logger))
+                lock (_sync)
                 {
-                    logger = new Logger(categoryName, CreateLoggers(categoryName));
+                    if (!_loggers.TryGetValue(categoryName, out logger))
+                    {
+                        logger = new Logger(categoryName, CreateLoggers(categoryName));
 
-                    (logger.MessageLoggers, logger.ScopeLoggers) = ApplyFilters(logger.Loggers);
+                        (logger.MessageLoggers, logger.ScopeLoggers) = ApplyFilters(logger.Loggers);
 
-                    _loggers[categoryName] = logger;
+                        _loggers[categoryName] = logger;
+                    }
                 }
-
-                return logger;
             }
+
+            return logger;
         }
 
         /// <summary>


### PR DESCRIPTION
Some ASP.NET code paths end up calling this _a lot_, and it takes a lock on every call, even though the vast majority are satisifed by the cache and require no mutation.  We can use a ConcurrentDictionary instead of a Dictionary, with double-checked locking.  Nothing is ever removed from or overwritten in the dictionary, so there's no problem doing the hot-path read outside of the lock; we still do the mutation inside of the lock so that all of the mutation work is performed atomically and synchronized with the actions from AddProvider and RefreshFilter.

|   Method |         Toolchain |               Mean | Ratio |
|--------- |------------------ |-------------------:|------:|
|   Serial | \main\corerun.exe |          21.646 ns |  1.00 |
|   Serial |   \pr\corerun.exe |           8.408 ns |  0.39 |
|          |                   |                    |       |
| Parallel | \main\corerun.exe | 371,691,606.667 ns |  1.00 |
| Parallel |   \pr\corerun.exe |  19,181,294.940 ns |  0.05 |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using Microsoft.Extensions.Logging;
using System.Linq;
using System.Threading;
using System.Threading.Tasks;

[MemoryDiagnoser(false)]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    private LoggerFactory _factory = new LoggerFactory();

    [Benchmark]
    public ILogger Serial() => _factory.CreateLogger("test");

    [Benchmark]
    public async Task Parallel()
    {
        var b = new Barrier(12);
        await Task.WhenAll(from i in Enumerable.Range(0, b.ParticipantCount)
                           select Task.Run(() =>
                           {
                               b.SignalAndWait();
                               for (int j = 0; j < 1_000_000; j++)
                               {
                                   _factory.CreateLogger("test");
                               }
                           }));
    }
}
```

Fixes https://github.com/dotnet/runtime/issues/83609