### PR TITLE
Fix runtime-extra-platforms failures related to HybridGlobalization

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.OSX.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.OSX.cs
@@ -11,6 +11,13 @@ namespace System.Globalization
 {
     public partial class CompareInfo
     {
+        private enum ErrorCodes
+        {
+            ERROR_INDEX_NOT_FOUND = -1,
+            ERROR_COMPARISON_OPTIONS_NOT_FOUND = -2,
+            ERROR_MIXED_COMPOSITION_NOT_FOUND = -3,
+        }
+
         private unsafe int CompareStringNative(ReadOnlySpan<char> string1, ReadOnlySpan<char> string2, CompareOptions options)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
@@ -27,7 +34,7 @@ namespace System.Globalization
                 result = Interop.Globalization.CompareStringNative(m_name, m_name.Length, pString1, string1.Length, pString2, string2.Length, options);
             }
 
-            Debug.Assert(result != -2);
+            Debug.Assert(result != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
 
             return result;
         }
@@ -37,8 +44,8 @@ namespace System.Globalization
             AssertComparisonSupported(options);
 
             Interop.Range result = Interop.Globalization.IndexOfNative(m_name, m_name.Length, target, cwTargetLength, pSource, cwSourceLength, options, fromBeginning);
-            Debug.Assert(result.Location != -2);
-            if (result.Location == -3)
+            Debug.Assert(result.Location != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
+            if (result.Location == (int)ErrorCodes.ERROR_MIXED_COMPOSITION_NOT_FOUND)
                 throw new PlatformNotSupportedException(SR.PlatformNotSupported_HybridGlobalizationWithMixedCompositions);
             if (matchLengthPtr != null)
                 *matchLengthPtr = result.Length;
@@ -51,7 +58,7 @@ namespace System.Globalization
             AssertComparisonSupported(options);
 
             int result = Interop.Globalization.StartsWithNative(m_name, m_name.Length, pPrefix, cwPrefixLength, pSource, cwSourceLength, options);
-            Debug.Assert(result != -2);
+            Debug.Assert(result != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
 
             return result > 0 ? true : false;
         }
@@ -61,7 +68,7 @@ namespace System.Globalization
             AssertComparisonSupported(options);
 
             int result = Interop.Globalization.EndsWithNative(m_name, m_name.Length, pSuffix, cwSuffixLength, pSource, cwSourceLength, options);
-            Debug.Assert(result != -2);
+            Debug.Assert(result != (int)ErrorCodes.ERROR_COMPARISON_OPTIONS_NOT_FOUND);
 
             return result > 0 ? true : false;
         }

--- a/src/native/libs/System.Globalization.Native/pal_collation.m
+++ b/src/native/libs/System.Globalization.Native/pal_collation.m
@@ -19,6 +19,13 @@ typedef enum
     StringSort = 536870912,
 } CompareOptions;
 
+typedef enum
+{
+    ERROR_INDEX_NOT_FOUND = -1,
+    ERROR_COMPARISON_OPTIONS_NOT_FOUND = -2,
+    ERROR_MIXED_COMPOSITION_NOT_FOUND = -3,
+} ErrorCodes;
+
 static NSLocale* GetCurrentLocale(const uint16_t* localeName, int32_t lNameLength)
 {
     NSLocale *currentLocale;
@@ -74,7 +81,7 @@ int32_t GlobalizationNative_CompareStringNative(const uint16_t* localeName, int3
     
     // in case mapping is not found
     if (options == 0)
-        return -2;
+        return ERROR_COMPARISON_OPTIONS_NOT_FOUND;
 
     return [sourceStrPrecomposed compare:targetStrPrecomposed
                               options:options
@@ -114,13 +121,13 @@ Range GlobalizationNative_IndexOfNative(const uint16_t* localeName, int32_t lNam
                                         const uint16_t* lpSource, int32_t cwSourceLength, int32_t comparisonOptions, int32_t fromBeginning)
 {
     assert(cwTargetLength >= 0);
-    Range result = {-1, 0};
+    Range result = {ERROR_INDEX_NOT_FOUND, 0};
     NSStringCompareOptions options = ConvertFromCompareOptionsToNSStringCompareOptions(comparisonOptions);
     
     // in case mapping is not found
     if (options == 0)
     {
-        result.location = -2;
+        result.location = ERROR_COMPARISON_OPTIONS_NOT_FOUND;
         return result;
     }
     
@@ -155,7 +162,7 @@ Range GlobalizationNative_IndexOfNative(const uint16_t* localeName, int32_t lNam
         return result;
 
     // in case search string is inside source string but we can't find the index return -3
-    result.location = -3;
+    result.location = ERROR_MIXED_COMPOSITION_NOT_FOUND;
     // sourceString and searchString possibly have the same composition of characters
     rangeOfReceiverToSearch = NSMakeRange(0, sourceStrCleaned.length);
     NSRange nsRange = [sourceStrCleaned rangeOfString:searchStrCleaned
@@ -228,7 +235,7 @@ int32_t GlobalizationNative_StartsWithNative(const uint16_t* localeName, int32_t
     
     // in case mapping is not found
     if (options == 0)
-        return -2;
+        return ERROR_COMPARISON_OPTIONS_NOT_FOUND;
 
     NSLocale *currentLocale = GetCurrentLocale(localeName, lNameLength);
     NSString *prefixString = [NSString stringWithCharacters: lpPrefix length: cwPrefixLength];
@@ -255,7 +262,7 @@ int32_t GlobalizationNative_EndsWithNative(const uint16_t* localeName, int32_t l
     
     // in case mapping is not found
     if (options == 0)
-        return -2;
+        return ERROR_COMPARISON_OPTIONS_NOT_FOUND;
 
     NSLocale *currentLocale = GetCurrentLocale(localeName, lNameLength);
     NSString *suffixString = [NSString stringWithCharacters: lpSuffix length: cwSuffixLength];

--- a/src/native/libs/System.Globalization.Native/pal_collation.m
+++ b/src/native/libs/System.Globalization.Native/pal_collation.m
@@ -114,12 +114,15 @@ Range GlobalizationNative_IndexOfNative(const uint16_t* localeName, int32_t lNam
                                         const uint16_t* lpSource, int32_t cwSourceLength, int32_t comparisonOptions, int32_t fromBeginning)
 {
     assert(cwTargetLength >= 0);
-    Range result = {-2, 0};
+    Range result = {-1, 0};
     NSStringCompareOptions options = ConvertFromCompareOptionsToNSStringCompareOptions(comparisonOptions);
     
     // in case mapping is not found
     if (options == 0)
+    {
+        result.location = -2;
         return result;
+    }
     
     NSString *searchString = [NSString stringWithCharacters: lpTarget length: cwTargetLength];
     NSString *searchStrCleaned = RemoveWeightlessCharacters(searchString);


### PR DESCRIPTION
Fix failures on runtime-extra-platforms after merging #86895
Return ERROR_COMPARISON_OPTIONS_NOT_FOUND only when options are not found and ERROR_INDEX_NOT_FOUND when substring is not found.

