### PR TITLE
Relaxing IsConnected Check for Datagram Sockets

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -797,12 +797,7 @@ namespace System.Net.Sockets
                 throw new InvalidOperationException(SR.net_sockets_mustnotlisten);
             }
 
-            // We're ignoring datagram sockets even if it's connected.
-            // Because, we can disconnect some protocols by connecting another endpoint. (for ex: UDP)
-            if (_isConnected && _socketType == SocketType.Stream)
-            {
-                throw new SocketException((int)SocketError.IsConnected);
-            }
+            ThrowIfConnectedStreamSocket();
 
             ValidateBlockingMode();
 
@@ -841,10 +836,7 @@ namespace System.Net.Sockets
                 throw new ArgumentOutOfRangeException(nameof(port));
             }
 
-            if (_isConnected && _socketType == SocketType.Stream)
-            {
-                throw new SocketException((int)SocketError.IsConnected);
-            }
+            ThrowIfConnectedStreamSocket();
 
             ValidateForMultiConnect(isMultiEndpoint: false); // needs to come before CanTryAddressFamily call
 
@@ -904,10 +896,7 @@ namespace System.Net.Sockets
                 throw new NotSupportedException(SR.net_invalidversion);
             }
 
-            if (_isConnected && _socketType == SocketType.Stream)
-            {
-                throw new SocketException((int)SocketError.IsConnected);
-            }
+            ThrowIfConnectedStreamSocket();
 
             ValidateForMultiConnect(isMultiEndpoint: true); // needs to come before CanTryAddressFamily call
 
@@ -2650,10 +2639,7 @@ namespace System.Net.Sockets
                 throw new InvalidOperationException(SR.net_sockets_mustnotlisten);
             }
 
-            if (_isConnected && _socketType == SocketType.Stream)
-            {
-                throw new SocketException((int)SocketError.IsConnected);
-            }
+            ThrowIfConnectedStreamSocket();
 
             // Prepare SocketAddress.
             EndPoint? endPointSnapshot = e.RemoteEndPoint;
@@ -3736,6 +3722,14 @@ namespace System.Net.Sockets
         private void ThrowIfDisposed()
         {
             ObjectDisposedException.ThrowIf(Disposed, this);
+        }
+
+        private void ThrowIfConnectedStreamSocket()
+        {
+            if (_isConnected && _socketType == SocketType.Stream)
+            {
+                throw new SocketException((int)SocketError.IsConnected);
+            }
         }
 
         private bool IsConnectionOriented => _socketType == SocketType.Stream;

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -797,7 +797,9 @@ namespace System.Net.Sockets
                 throw new InvalidOperationException(SR.net_sockets_mustnotlisten);
             }
 
-            if (_isConnected)
+            // We're ignoring datagram sockets even if it's connected.
+            // Because, we can disconnect some protocols by connecting another endpoint. (for ex: UDP)
+            if (_isConnected && _socketType != SocketType.Dgram)
             {
                 throw new SocketException((int)SocketError.IsConnected);
             }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -799,7 +799,7 @@ namespace System.Net.Sockets
 
             // We're ignoring datagram sockets even if it's connected.
             // Because, we can disconnect some protocols by connecting another endpoint. (for ex: UDP)
-            if (_isConnected && _socketType != SocketType.Dgram)
+            if (_isConnected && _socketType == SocketType.Stream)
             {
                 throw new SocketException((int)SocketError.IsConnected);
             }
@@ -841,7 +841,7 @@ namespace System.Net.Sockets
                 throw new ArgumentOutOfRangeException(nameof(port));
             }
 
-            if (_isConnected)
+            if (_isConnected && _socketType == SocketType.Stream)
             {
                 throw new SocketException((int)SocketError.IsConnected);
             }
@@ -904,7 +904,7 @@ namespace System.Net.Sockets
                 throw new NotSupportedException(SR.net_invalidversion);
             }
 
-            if (_isConnected)
+            if (_isConnected && _socketType == SocketType.Stream)
             {
                 throw new SocketException((int)SocketError.IsConnected);
             }
@@ -2650,7 +2650,7 @@ namespace System.Net.Sockets
                 throw new InvalidOperationException(SR.net_sockets_mustnotlisten);
             }
 
-            if (_isConnected)
+            if (_isConnected && _socketType == SocketType.Stream)
             {
                 throw new SocketException((int)SocketError.IsConnected);
             }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -228,7 +228,7 @@ namespace System.Net.Sockets.Tests
 
             await ConnectAsync(s, new IPEndPoint(listenAt, ((IPEndPoint)listener.LocalEndPoint).Port));
             Assert.True(s.Connected);
-
+            // According to the OSX man page, it's enough connecting to an invalid address to dissolve the connection. (0 port connection returns error on OSX)
             await ConnectAsync(s, new IPEndPoint(secondConnection, PlatformDetection.IsOSX ? 1 : 0));
             Assert.True(s.Connected);
         }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -228,8 +228,8 @@ namespace System.Net.Sockets.Tests
 
             await ConnectAsync(s, new IPEndPoint(listenAt, ((IPEndPoint)listener.LocalEndPoint).Port));
             Assert.True(s.Connected);
-            
-            await ConnectAsync(s, new IPEndPoint(secondConnection, 0));
+
+            await ConnectAsync(s, new IPEndPoint(secondConnection, PlatformDetection.IsOSX ? 1 : 0));
             Assert.True(s.Connected);
         }
     }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -226,7 +226,7 @@ namespace System.Net.Sockets.Tests
             using Socket s = new Socket(listenAt.AddressFamily, SocketType.Dgram, ProtocolType.Udp);
             listener.Bind(new IPEndPoint(listenAt, 0));
 
-            await ConnectAsync(s, new IPEndPoint(IPAddress.Loopback, ((IPEndPoint)listener.LocalEndPoint).Port));
+            await ConnectAsync(s, new IPEndPoint(listenAt, ((IPEndPoint)listener.LocalEndPoint).Port));
             Assert.True(s.Connected);
             
             await ConnectAsync(s, new IPEndPoint(secondConnection, 0));

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -221,8 +221,11 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public async Task Connect_DatagramSockets_DontThrowConnectedException_OnSecondAttempt()
         {
+            using Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
             using Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
-            await ConnectAsync(s, new IPEndPoint(IPAddress.Loopback, 1));
+            listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+
+            await ConnectAsync(s, new IPEndPoint(IPAddress.Loopback, ((IPEndPoint)listener.LocalEndPoint).Port));
             Assert.True(s.Connected);
             
             await ConnectAsync(s, new IPEndPoint(IPAddress.Any, 0));

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -217,6 +217,17 @@ namespace System.Net.Sockets.Tests
                 Assert.Contains(a.LocalEndPoint.ToString(), ex.Message);
             }
         }
+
+        [Fact]
+        public async Task Connect_DatagramSockets_DontThrowConnectedException_OnSecondAttempt()
+        {
+            using Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            await ConnectAsync(s, new IPEndPoint(IPAddress.Loopback, 1));
+            Assert.True(s.Connected);
+            
+            await ConnectAsync(s, new IPEndPoint(IPAddress.Any, 0));
+            Assert.True(s.Connected);
+        }
     }
 
     public sealed class ConnectSync : Connect<SocketHelperArraySync>

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -218,17 +218,18 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [Fact]
-        public async Task Connect_DatagramSockets_DontThrowConnectedException_OnSecondAttempt()
+        [Theory]
+        [MemberData(nameof(LoopbacksAndAny))]
+        public async Task Connect_DatagramSockets_DontThrowConnectedException_OnSecondAttempt(IPAddress listenAt, IPAddress secondConnection)
         {
-            using Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
-            using Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
-            listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            using Socket listener = new Socket(listenAt.AddressFamily, SocketType.Dgram, ProtocolType.Udp);
+            using Socket s = new Socket(listenAt.AddressFamily, SocketType.Dgram, ProtocolType.Udp);
+            listener.Bind(new IPEndPoint(listenAt, 0));
 
             await ConnectAsync(s, new IPEndPoint(IPAddress.Loopback, ((IPEndPoint)listener.LocalEndPoint).Port));
             Assert.True(s.Connected);
             
-            await ConnectAsync(s, new IPEndPoint(IPAddress.Any, 0));
+            await ConnectAsync(s, new IPEndPoint(secondConnection, 0));
             Assert.True(s.Connected);
         }
     }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketTestHelper.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketTestHelper.cs
@@ -598,6 +598,12 @@ namespace System.Net.Sockets.Tests
             new object[] { IPAddress.Loopback, true },
             new object[] { IPAddress.Loopback, false },
         };
+
+        public static readonly object[][] LoopbacksAndAny = new object[][]
+        {
+            new object[] { IPAddress.IPv6Loopback, IPAddress.IPv6Any },
+            new object[] { IPAddress.Loopback, IPAddress.Any },
+        };
     }
 
     //


### PR DESCRIPTION
Fixes #77962

.NET Framework's behavior may be different for `SocketType.Stream`, but this PR will match the behavior for other socket types.

According to [linux connect man page](https://man7.org/linux/man-pages/man2/connect.2.html)
```
Some protocol sockets (e.g., datagram sockets in the UNIX and
Internet domains) may use connect() multiple times to change
their association.
```

According to [WinSock2 connect api](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect#remarks)

```
For a connectionless socket:
The default destination can be changed by simply calling connect again, even if the socket is already connected.
```

According to [OSX connect man page](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/connect.2.html):
```
Each communications space interprets the address parameter in its own
way.  Generally, stream sockets may successfully connect() only once;
datagram sockets may use connect() multiple times to change their association. 
Datagram sockets may dissolve the association by connecting to an
invalid address, such as a null address or an address with the address
family set to AF_UNSPEC (the error EAFNOSUPPORT will be harmlessly
returned).
```