### PR TITLE
[mono] ILStrip sorts custom attribute table

### DIFF
--- a/src/tasks/MonoTargetsTasks/ILStrip/AssemblyStripper/AssemblyStripper.cs
+++ b/src/tasks/MonoTargetsTasks/ILStrip/AssemblyStripper/AssemblyStripper.cs
@@ -211,7 +211,7 @@ namespace AssemblyStripper
 
             table.Rows.Sort(new CustomAttrRowComparer());
         }
-        
+
         void Write()
         {
             stripped.MetadataRoot.Accept(metadata_writer);

--- a/src/tasks/MonoTargetsTasks/ILStrip/AssemblyStripper/AssemblyStripper.cs
+++ b/src/tasks/MonoTargetsTasks/ILStrip/AssemblyStripper/AssemblyStripper.cs
@@ -229,7 +229,6 @@ namespace AssemblyStripper
         {
             AssemblyDefinition assembly = AssemblyFactory.GetAssembly(assemblyFile);
             AssemblyStripper.StripAssembly(assembly, outputPath);
-
         }
     }
 }

--- a/src/tasks/MonoTargetsTasks/ILStrip/AssemblyStripper/AssemblyStripper.cs
+++ b/src/tasks/MonoTargetsTasks/ILStrip/AssemblyStripper/AssemblyStripper.cs
@@ -203,6 +203,11 @@ namespace AssemblyStripper
             }
         }
 
+        // Types that are trimmed away also have their respective rows removed from the 
+        // custom attribute table. This introduces holes in their places, causing the table 
+        // to no longer be sorted by Parent, corrupting the assembly. Runtimes assume ordering
+        // and may fail to locate the attributes set for a particular type. This step sorts 
+        // the custom attribute table again.
         void SortCustomAttributes()
         {
             CustomAttributeTable table = (CustomAttributeTable)stripped_tables[CustomAttributeTable.RId];

--- a/src/tasks/MonoTargetsTasks/ILStrip/AssemblyStripper/AssemblyStripper.cs
+++ b/src/tasks/MonoTargetsTasks/ILStrip/AssemblyStripper/AssemblyStripper.cs
@@ -12,6 +12,16 @@ using CilStrip.Mono.Cecil.Metadata;
 
 namespace AssemblyStripper
 {
+    class CustomAttrRowComparer : IComparer
+    {
+        public int Compare(object left, object right)
+        {
+            CustomAttributeRow row_left = (CustomAttributeRow)left;
+            CustomAttributeRow row_right = (CustomAttributeRow)right;
+            return row_left.Parent.RID.CompareTo(row_right.Parent.RID);
+        }
+    }
+
     public class AssemblyStripper
     {
         AssemblyDefinition assembly;
@@ -40,6 +50,7 @@ namespace AssemblyStripper
             PatchMethods();
             PatchFields();
             PatchResources();
+            SortCustomAttributes();
             Write();
         }
 
@@ -192,6 +203,15 @@ namespace AssemblyStripper
             }
         }
 
+        void SortCustomAttributes()
+        {
+            CustomAttributeTable table = (CustomAttributeTable)stripped_tables[CustomAttributeTable.RId];
+            if (table == null)
+                return;
+
+            table.Rows.Sort(new CustomAttrRowComparer());
+        }
+        
         void Write()
         {
             stripped.MetadataRoot.Accept(metadata_writer);
@@ -209,7 +229,7 @@ namespace AssemblyStripper
         {
             AssemblyDefinition assembly = AssemblyFactory.GetAssembly(assemblyFile);
             AssemblyStripper.StripAssembly(assembly, outputPath);
-            
+
         }
     }
 }


### PR DESCRIPTION
This prevents custom attribute table corruption by sorting it as the last step when stripping an assembly. Addresses https://github.com/dotnet/runtime/issues/85414.

The PR will have to be backported to net7.0.