### PR TITLE
JIT: don't set edge weights to zero for inconsistent profiles

### DIFF
--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -3341,6 +3341,11 @@ void EfficientEdgeCountReconstructor::Solve()
     unsigned       nPasses = 0;
     unsigned const nLimit  = 10;
 
+    // If we end up with negative edge weights because of inconsistent counts, we use this factor to
+    // substitute a small positive one.
+    //
+    weight_t const smallFactor = 0.001;
+
     JITDUMP("\nSolver: %u blocks, %u unknown; %u edges, %u unknown, %u zero\n", m_blocks, m_unknownBlocks, m_edges,
             m_unknownEdges, m_zeroEdges);
 
@@ -3449,13 +3454,16 @@ void EfficientEdgeCountReconstructor::Solve()
                                "\n",
                         resolvedEdge->m_sourceBlock->bbNum, resolvedEdge->m_targetBlock->bbNum, weight);
 
-                // If we arrive at a negative count for this edge, set it to zero.
+                // If we arrive at a negative count for this edge, set it to 1% of the block weight.
+                //
+                // Note this can happen somewhat frequently because of inconsistent counts from
+                // scalable or racing counters.
                 //
                 if (weight < 0)
                 {
-                    JITDUMP(" .... weight was negative, setting to zero\n");
                     NegativeCount();
-                    weight = 0;
+                    weight = info->m_weight * smallFactor;
+                    JITDUMP(" .... weight was negative, setting it to " FMT_WT "\n", weight);
                 }
 
                 resolvedEdge->m_weight      = weight;
@@ -3496,13 +3504,16 @@ void EfficientEdgeCountReconstructor::Solve()
                                "\n",
                         resolvedEdge->m_sourceBlock->bbNum, resolvedEdge->m_targetBlock->bbNum, weight);
 
-                // If we arrive at a negative count for this edge, set it to zero.
+                // If we arrive at a negative count for this edge, set it to 1% of the block weight.
+                //
+                // Note this can happen somewhat frequently because of inconsistent counts from
+                // scalable or racing counters.
                 //
                 if (weight < 0)
                 {
-                    JITDUMP(" .... weight was negative, setting to zero\n");
                     NegativeCount();
-                    weight = 0;
+                    weight = info->m_weight * smallFactor;
+                    JITDUMP(" .... weight was negative, setting it to " FMT_WT "\n", weight);
                 }
 
                 resolvedEdge->m_weight      = weight;

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -3341,11 +3341,6 @@ void EfficientEdgeCountReconstructor::Solve()
     unsigned       nPasses = 0;
     unsigned const nLimit  = 10;
 
-    // If we end up with negative edge weights because of inconsistent counts, we use this factor to
-    // substitute a small positive one.
-    //
-    weight_t const smallFactor = 0.001;
-
     JITDUMP("\nSolver: %u blocks, %u unknown; %u edges, %u unknown, %u zero\n", m_blocks, m_unknownBlocks, m_edges,
             m_unknownEdges, m_zeroEdges);
 
@@ -3454,7 +3449,7 @@ void EfficientEdgeCountReconstructor::Solve()
                                "\n",
                         resolvedEdge->m_sourceBlock->bbNum, resolvedEdge->m_targetBlock->bbNum, weight);
 
-                // If we arrive at a negative count for this edge, set it to 1% of the block weight.
+                // If we arrive at a negative count for this edge, set it to a small fraction of the block weight.
                 //
                 // Note this can happen somewhat frequently because of inconsistent counts from
                 // scalable or racing counters.
@@ -3462,7 +3457,7 @@ void EfficientEdgeCountReconstructor::Solve()
                 if (weight < 0)
                 {
                     NegativeCount();
-                    weight = info->m_weight * smallFactor;
+                    weight = info->m_weight * ProfileSynthesis::epsilon;
                     JITDUMP(" .... weight was negative, setting it to " FMT_WT "\n", weight);
                 }
 
@@ -3504,7 +3499,7 @@ void EfficientEdgeCountReconstructor::Solve()
                                "\n",
                         resolvedEdge->m_sourceBlock->bbNum, resolvedEdge->m_targetBlock->bbNum, weight);
 
-                // If we arrive at a negative count for this edge, set it to 1% of the block weight.
+                // If we arrive at a negative count for this edge, set it to a small fraction of the block weight.
                 //
                 // Note this can happen somewhat frequently because of inconsistent counts from
                 // scalable or racing counters.
@@ -3512,7 +3507,7 @@ void EfficientEdgeCountReconstructor::Solve()
                 if (weight < 0)
                 {
                     NegativeCount();
-                    weight = info->m_weight * smallFactor;
+                    weight = info->m_weight * ProfileSynthesis::epsilon;
                     JITDUMP(" .... weight was negative, setting it to " FMT_WT "\n", weight);
                 }
 

--- a/src/coreclr/jit/fgprofilesynthesis.h
+++ b/src/coreclr/jit/fgprofilesynthesis.h
@@ -64,6 +64,8 @@ public:
         p.Run(option);
     }
 
+    static constexpr weight_t epsilon = 0.001;
+
 private:
     ProfileSynthesis(Compiler* compiler)
         : m_comp(compiler)
@@ -74,10 +76,8 @@ private:
     {
     }
 
-    static constexpr weight_t exceptionScale = 0.001;
-    static constexpr weight_t blendFactor    = 0.99;
-    static constexpr weight_t epsilon        = 0.001;
-
+    static constexpr weight_t exceptionScale     = 0.001;
+    static constexpr weight_t blendFactor        = 0.99;
     static constexpr weight_t cappedLikelihood   = 0.999;
     static constexpr weight_t returnLikelihood   = 0.2;
     static constexpr weight_t ilNextLikelihood   = 0.52;


### PR DESCRIPTION
With the advent of scalable profile counters (or even with the old racing counters) counts might be approximate or inconsistent. When we run across a negative count during reconstruction, set the afflicted count to a small positive value instead of to zero, since zero has special meaning to the JIT.

The aim is to reduce some of the benchmark instability we are seeing in #87324. Depending on exact counter values, we can see different sets of edge weights (and hence block weights) from run to run.