### PR TITLE
Fixing a concurrency bug in ManagedWebSocket which may cause memory corruption

### DIFF
--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/Compression/WebSocketDeflater.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/Compression/WebSocketDeflater.cs
@@ -26,11 +26,7 @@ namespace System.Net.WebSockets.Compression
 
         public void Dispose()
         {
-            if (_stream is not null)
-            {
-                _stream.Dispose();
-                _stream = null;
-            }
+            _stream?.Dispose();
         }
 
         public void ReleaseBuffer()

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/Compression/WebSocketInflater.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/Compression/WebSocketInflater.cs
@@ -58,11 +58,7 @@ namespace System.Net.WebSockets.Compression
 
         public void Dispose()
         {
-            if (_stream is not null)
-            {
-                _stream.Dispose();
-                _stream = null;
-            }
+            _stream?.Dispose();
             ReleaseBuffer();
         }
 

--- a/src/libraries/System.Net.WebSockets/tests/WebSocketDeflateTests.cs
+++ b/src/libraries/System.Net.WebSockets/tests/WebSocketDeflateTests.cs
@@ -646,6 +646,41 @@ namespace System.Net.WebSockets.Tests
             Assert.Equal(frame1.Length + frame2.Length, messageSize);
         }
 
+        [Fact]
+        public async Task DisposeShouldNotCorruptStateWhileReceiving()
+        {
+            WebSocketTestStream stream = new();
+            using WebSocket server = WebSocket.CreateFromStream(stream, new WebSocketCreationOptions
+            {
+                IsServer = true,
+                KeepAliveInterval = TimeSpan.Zero,
+                DangerousDeflateOptions = new WebSocketDeflateOptions()
+            });
+            using WebSocket client = WebSocket.CreateFromStream(stream.Remote, new WebSocketCreationOptions
+            {
+                IsServer = false,
+                KeepAliveInterval = TimeSpan.Zero,
+                DangerousDeflateOptions = new WebSocketDeflateOptions()
+            });
+
+            byte[] buffer = new byte[64];
+
+            // Send two messages so that the zlib stream has data in its internal dictionary
+            await SendTextAsync("Hello World", client);
+            await server.ReceiveAsync(buffer, CancellationToken.None);
+            buffer.AsSpan().Clear();
+
+            stream.DelayForNextRead = TimeSpan.FromSeconds(1);
+            stream.IgnoreCancellationToken = true;
+            await SendTextAsync("Hello Worlds", client);
+
+            Task<WebSocketReceiveResult> receiveTask = server.ReceiveAsync(buffer, CancellationToken.None);
+            server.Dispose();
+
+            var result = await receiveTask;
+            Assert.Equal("Hello Worlds", Encoding.UTF8.GetString(buffer.AsSpan(0, result.Count)));
+        }
+
         private ValueTask SendTextAsync(string text, WebSocket websocket, bool disableCompression = false)
         {
             WebSocketMessageFlags flags = WebSocketMessageFlags.EndOfMessage;


### PR DESCRIPTION
When a websocket with compression enabled is created we have two additional zlib streams inside - one for sending and one for receiving. They should only be accessed through Read and Write methods of the websocket.

However, since they contain unmanaged resources (zlib), when the websocket is disposed, those objects will be disposed as well. But Dispose and respectfully Abort methods are allowed to be called at any time for the websocket. This would cause all kinds of troubles if there are inflight send or receive operations which use the zlib streams.

I wrote a test that checks the implementation works for the receive case where I can use the test websocket stream and stimulate artificial delays. Without the current implementation the test will fail.

However for the send case it's very hard to do this, because the websocket needs to be disposed exactly when there is a message being compressed.

Fixes #86960 

//cc @CarnaViire @stephentoub 