### PR TITLE
[HTTP/3] Fix handling cancelation during QUIC connection establishment

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -130,6 +130,10 @@ namespace System.Net.Http
             }
             catch (Exception ex)
             {
+                if (ex is OperationCanceledException)
+                {
+                    throw;
+                }
                 throw CreateWrappedException(ex, endPoint.Host, endPoint.Port, cancellationToken);
             }
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -128,12 +128,8 @@ namespace System.Net.Http
                     ClientAuthenticationOptions = clientAuthenticationOptions
                 }, cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                if (ex is OperationCanceledException)
-                {
-                    throw;
-                }
                 throw CreateWrappedException(ex, endPoint.Host, endPoint.Port, cancellationToken);
             }
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -925,19 +925,16 @@ namespace System.Net.Http
                 {
                     quicConnection = await ConnectHelper.ConnectQuicAsync(request, new DnsEndPoint(authority.IdnHost, authority.Port), _poolManager.Settings._pooledConnectionIdleTimeout, _sslOptionsHttp3!, cancellationToken).ConfigureAwait(false);
                 }
-                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested && oce.CancellationToken == cancellationToken)
-                {
-                    if (NetEventSource.Log.IsEnabled()) Trace($"QUIC connection cancelled: {oce}");
-
-                    // Do not block list authority if the connection attempt was cancelled.
-                    throw;
-                }
                 catch (Exception ex)
                 {
                     if (NetEventSource.Log.IsEnabled()) Trace($"QUIC connection failed: {ex}");
 
-                    // Disables HTTP/3 until server announces it can handle it via Alt-Svc.
-                    BlocklistAuthority(authority, ex);
+                    // Block list authority only if the connection attempt was not cancelled.
+                    if (ex is not OperationCanceledException oce || !cancellationToken.IsCancellationRequested || oce.CancellationToken != cancellationToken)
+                    {
+                        // Disables HTTP/3 until server announces it can handle it via Alt-Svc.
+                        BlocklistAuthority(authority, ex);
+                    }
                     throw;
                 }
 

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
@@ -140,10 +140,10 @@ namespace HttpStress
 
             async Task SendTestRequestToServer(int maxRetries)
             {
-                using HttpClient client = CreateHttpClient();
-                client.Timeout = TimeSpan.FromSeconds(5);
                 for (int remainingRetries = maxRetries; ; remainingRetries--)
                 {
+                    using HttpClient client = CreateHttpClient();
+                    client.Timeout = TimeSpan.FromSeconds(5);
                     var sw = Stopwatch.StartNew();
                     try
                     {


### PR DESCRIPTION
When a new `QuicConnection` is being established for HTTP/3 and it fails, we block the remote authority and remember why. Any further attempt to connect to that authority gets failed with that reason for a while.
We shouldn't do that if the failure is because we decided to stop the attempt, i.e. we (timeout) or user cancelled the passed in token.

Discovered in stress test as they randomly cancel requests.

Fixes #87957