### PR TITLE
ZipArchive now disposes given stream only once

### DIFF
--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -164,7 +164,7 @@ namespace System.IO.Compression
                 if (mode == ZipArchiveMode.Create)
                     _archiveReader = null;
                 else
-                    _archiveReader = new BinaryReader(_archiveStream);
+                    _archiveReader = new BinaryReader(_archiveStream, Encoding.UTF8, leaveOpen: true);
                 _entries = new List<ZipArchiveEntry>();
                 _entriesCollection = new ReadOnlyCollection<ZipArchiveEntry>(_entries);
                 _entriesDictionary = new Dictionary<string, ZipArchiveEntry>();

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
@@ -250,7 +250,6 @@ namespace System.IO.Compression.Tests
             Assert.Equal(expectedEntries, entriesEncrypted);
         }
 
-
         [Fact]
         public static async Task EnsureDisposeIsCalledOnlyOnce()
         {


### PR DESCRIPTION
Fixes #79695

Even though the `IDisposable` contract says that you should be able to call `Dispose` multiple times, be forgiving for implementations that throw when `Dispose` is called multiple times.
