### PR TITLE
[nativeaot] Build host bits when targeting iOS platforms with Native AOT

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -300,6 +300,22 @@
                             CMakeArgs=$(CMakeArgs) -DCLR_CROSS_COMPONENTS_BUILD=1" Category="clr" />
   </ItemGroup>
 
+  <!-- When targeting the iOS platforms with Native AOT, build the ClrAllJitsSubset and the Ilc for the host  -->
+  <PropertyGroup>
+    <IsNativeAOTHostBuildEnabled Condition="$(_subset.Contains('+clr.nativeaotruntime+')) and '$(NativeAotSupported)' == 'true' and '$(PrimaryRuntimeFlavor)' == 'CoreCLR' and '$(TargetsAppleMobile)' == 'true'">true</IsNativeAOTHostBuildEnabled>
+    <NativeAOTAdditionalProperties Condition="'$(IsNativeAOTHostBuildEnabled)' == 'true'">TargetOS=osx</NativeAOTAdditionalProperties>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(IsNativeAOTHostBuildEnabled)' == 'true'">
+    <ProjectToBuild
+      Include="$(CoreClrProjectRoot)runtime.proj"
+      AdditionalProperties="$(NativeAOTAdditionalProperties);
+                            ClrAllJitsSubset=true"
+      Category="clr" />
+    <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\ILCompiler\ILCompiler.csproj" Category="clr" AdditionalProperties="$(NativeAOTAdditionalProperties)" />
+    <ProjectToBuild Include="$(CoreClrProjectRoot)nativeaot\BuildIntegration\BuildIntegration.proj" Category="clr" AdditionalProperties="$(NativeAOTAdditionalProperties)" />
+    <ProjectToBuild Condition="'$(CrossBuild)' == 'true' or '$(BuildArchitecture)' != '$(TargetArchitecture)'" Include="$(CoreClrProjectRoot)tools\aot\ILCompiler\ILCompiler_crossarch.csproj" Category="clr" AdditionalProperties="$(NativeAOTAdditionalProperties)" />
+  </ItemGroup>
+
   <ItemGroup Condition="$(_subset.Contains('+crossdacpack+'))">
     <ProjectToBuild Include="$(CoreClrProjectRoot).nuget\Microsoft.CrossOsDiag.Private.CoreCLR\Microsoft.CrossOsDiag.Private.CoreCLR.proj" Category="clr" />
   </ItemGroup>


### PR DESCRIPTION
This PR aims to simplify the build process for Native AOT when targeting iOS. Currently, two separate builds are necessary for iOS-like platforms. The first build is for the host
```sh
./build.sh clr+clr.aot
```
while the second build is for the target platform.
```sh
./build.sh clr.nativeaotruntime+nativeaotlibs+lib -os ios
```

Idea is to build the host each time the `clr.nativeaotruntime` is built for iOS-like platforms. This PR simplifies the CI builds by eliminating the need for additional steps.

Fixes https://github.com/dotnet/runtime/issues/87764