### PR TITLE
Fix UnsafeAccessors with Relocs

### DIFF
--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -551,8 +551,9 @@ public:
     CalledMethod * GetCalledMethods() { return m_pCalledMethods; }
 #endif
 
-    // Add/Find transient method details.
+    // Add/Remove/Find transient method details.
     void AddTransientMethodDetails(TransientMethodDetails details);
+    TransientMethodDetails RemoveTransientMethodDetails(MethodDesc* pMD);
     bool FindTransientMethodDetails(MethodDesc* pMD, TransientMethodDetails** details);
 
 protected:


### PR DESCRIPTION
This was a use after free when going down the "Relocs" code path. Setting `DOTNET_ForceRelocs=1` forced this and the failure was easily reproducible.

Fixes #87760 