### PR TITLE
Enable scoped parameters in signatures of source-generated interop methods

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
@@ -66,6 +66,8 @@ namespace Microsoft.Interop
 
         public bool IsByRef => RefKind != RefKind.None;
 
+        public ScopedKind ScopedKind { get; init; } = ScopedKind.None;
+
         public ByValueContentsMarshalKind ByValueContentsMarshalKind { get; init; }
 
         public bool IsManagedReturnPosition { get => ManagedIndex == ReturnIndex; }
@@ -82,7 +84,8 @@ namespace Microsoft.Interop
                 InstanceIdentifier = ParseToken(paramSymbol.Name).IsReservedKeyword() ? $"@{paramSymbol.Name}" : paramSymbol.Name,
                 RefKind = paramSymbol.RefKind,
                 RefKindSyntax = RefKindToSyntax(paramSymbol.RefKind),
-                ByValueContentsMarshalKind = GetByValueContentsMarshalKind(paramSymbol.GetAttributes(), compilation)
+                ByValueContentsMarshalKind = GetByValueContentsMarshalKind(paramSymbol.GetAttributes(), compilation),
+                ScopedKind = paramSymbol.ScopedKind
             };
 
             return typeInfo;

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CodeSnippets.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CodeSnippets.cs
@@ -503,6 +503,21 @@ namespace LibraryImportGenerator.UnitTests
         public static string ByValueParameterWithModifier<T>(string attributeName, string preDeclaration = "") => ByValueParameterWithModifier(typeof(T).ToString(), attributeName, preDeclaration);
 
         /// <summary>
+        /// Declaration with one parameter with custom modifiers.
+        /// </summary>
+        public static string SingleParameterWithModifier(string typeName, string modifiers, string preDeclaration = "") => $$"""
+            using System.Runtime.InteropServices;
+            using System.Runtime.InteropServices.Marshalling;
+            {{preDeclaration}}
+            partial class Test
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial void Method(
+                    {{modifiers}} {{typeName}} {|#0:p|});
+            }
+            """;
+
+        /// <summary>
         /// Declaration with by-value parameter with custom name.
         /// </summary>
         public static string ByValueParameterWithName(string methodName, string paramName) => $$"""

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
@@ -248,6 +248,9 @@ namespace LibraryImportGenerator.UnitTests
 
             // Type-level interop generator trigger attributes
             yield return new[] { ID(), CodeSnippets.GeneratedComInterface };
+
+            // Parameter modifiers
+            yield return new[] { ID(), CodeSnippets.SingleParameterWithModifier("int", "scoped ref") };
         }
 
         public static IEnumerable<object[]> CustomCollections()


### PR DESCRIPTION
Fixes #77624
