### PR TITLE
Port FrozenDictionary's length bucket optimizations to FrozenSet

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenSet.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenSet.cs
@@ -160,10 +160,12 @@ namespace System.Collections.Frozen
                 !source.Contains(default!) &&
                 (ReferenceEquals(comparer, EqualityComparer<T>.Default) || ReferenceEquals(comparer, StringComparer.Ordinal) || ReferenceEquals(comparer, StringComparer.OrdinalIgnoreCase)))
             {
+                IEqualityComparer<string> stringComparer = (IEqualityComparer<string>)(object)comparer;
+
+                // Entries are needed for every strategy
                 HashSet<string> stringValues = (HashSet<string>)(object)source;
                 var entries = new string[stringValues.Count];
                 stringValues.CopyTo(entries);
-                IEqualityComparer<string> stringComparer = (IEqualityComparer<string>)(object)comparer;
 
                 // Calculate the minimum and maximum lengths of the strings in the set. Several of the analyses need this.
                 int minLength = int.MaxValue, maxLength = 0;

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/LengthBucketsFrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/LengthBucketsFrozenDictionary.cs
@@ -150,8 +150,8 @@ namespace System.Collections.Frozen
                 {
                     for (; bucketIndex < bucketEndIndex; bucketIndex++)
                     {
-                        uint index = (uint)lengthBuckets[bucketIndex];
-                        if (index < keys.Length)
+                        int index = lengthBuckets[bucketIndex];
+                        if ((uint)index < (uint)keys.Length)
                         {
                             if (key == keys[index])
                             {
@@ -169,8 +169,8 @@ namespace System.Collections.Frozen
                 {
                     for (; bucketIndex < bucketEndIndex; bucketIndex++)
                     {
-                        uint index = (uint)lengthBuckets[bucketIndex];
-                        if (index < keys.Length)
+                        int index = lengthBuckets[bucketIndex];
+                        if ((uint)index < (uint)keys.Length)
                         {
                             if (StringComparer.OrdinalIgnoreCase.Equals(key, keys[index]))
                             {

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/LengthBucketsFrozenSet.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/LengthBucketsFrozenSet.cs
@@ -1,9 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 
 namespace System.Collections.Frozen
 {
@@ -12,16 +12,16 @@ namespace System.Collections.Frozen
     {
         /// <summary>Allowed ratio between buckets with values and total buckets.  Under this ratio, this implementation won't be used due to too much wasted space.</summary>
         private const double EmptyLengthsRatio = 0.2;
-
         /// <summary>The maximum number of items allowed per bucket.  The larger the value, the longer it can take to search a bucket, which is sequentially examined.</summary>
         private const int MaxPerLength = 5;
 
-        private readonly KeyValuePair<string, int>[][] _lengthBuckets;
+        private readonly int[] _lengthBuckets;
         private readonly int _minLength;
         private readonly string[] _items;
         private readonly bool _ignoreCase;
 
-        private LengthBucketsFrozenSet(string[] items, KeyValuePair<string, int>[][] lengthBuckets, int minLength, IEqualityComparer<string> comparer)
+        private LengthBucketsFrozenSet(
+            string[] items, int[] lengthBuckets, int minLength, IEqualityComparer<string> comparer)
             : base(comparer)
         {
             Debug.Assert(comparer == EqualityComparer<string>.Default || comparer == StringComparer.Ordinal || comparer == StringComparer.OrdinalIgnoreCase);
@@ -32,72 +32,91 @@ namespace System.Collections.Frozen
             _ignoreCase = ReferenceEquals(comparer, StringComparer.OrdinalIgnoreCase);
         }
 
-        internal static LengthBucketsFrozenSet? CreateLengthBucketsFrozenSetIfAppropriate(string[] entries, IEqualityComparer<string> comparer, int minLength, int maxLength)
+        internal static LengthBucketsFrozenSet? CreateLengthBucketsFrozenSetIfAppropriate(
+            string[] items, IEqualityComparer<string> comparer, int minLength, int maxLength)
         {
-            Debug.Assert(entries.Length != 0);
+            Debug.Assert(items.Length != 0);
             Debug.Assert(comparer == EqualityComparer<string>.Default || comparer == StringComparer.Ordinal || comparer == StringComparer.OrdinalIgnoreCase);
             Debug.Assert(minLength >= 0 && maxLength >= minLength);
 
             // If without even looking at the keys we know that some bucket will exceed the max per-bucket
             // limit (pigeon hole principle), we can early-exit out without doing any further work.
             int spread = maxLength - minLength + 1;
-            if (entries.Length / spread > MaxPerLength)
+            if (items.Length / spread > MaxPerLength)
             {
                 return null;
             }
 
-            // Iterate through all of the inputs, bucketing them based on the length of the string.
-            var groupedByLength = new Dictionary<int, List<string>>();
-            foreach (string s in entries)
-            {
-                Debug.Assert(s is not null, "This implementation should not be used with null source values.");
-                Debug.Assert(s.Length >= minLength && s.Length <= maxLength);
-
+            int arraySize = spread * MaxPerLength;
 #if NET6_0_OR_GREATER
-                List<string> list = CollectionsMarshal.GetValueRefOrAddDefault(groupedByLength, s.Length, out _) ??= new List<string>(MaxPerLength);
+            if (arraySize > Array.MaxLength)
 #else
-                if (!groupedByLength.TryGetValue(s.Length, out List<string>? list))
-                {
-                    groupedByLength[s.Length] = list = new List<string>(MaxPerLength);
-                }
+            if (arraySize > 0X7FFFFFC7)
 #endif
+            {
+                // In the future we may lower the value, as it may be quite unlikely
+                // to have a LOT of strings of different sizes.
+                return null;
+            }
 
-                // If we've already hit the max per-bucket limit, bail.
-                if (list.Count == MaxPerLength)
+            // Instead of creating a dictionary of lists or a multi-dimensional array
+            // we rent a single dimension array, where every bucket has five slots.
+            // The bucket starts at (key.Length - minLength) * 5.
+            // Each value is an index of the key from _keys array
+            // or just -1, which represents "null".
+            int[] buckets = ArrayPool<int>.Shared.Rent(arraySize);
+            buckets.AsSpan(0, arraySize).Fill(-1);
+
+            int nonEmptyCount = 0;
+            for (int i = 0; i < items.Length; i++)
+            {
+                string key = items[i];
+                int startIndex = (key.Length - minLength) * MaxPerLength;
+                int endIndex = startIndex + MaxPerLength;
+                int index = startIndex;
+
+                while (index < endIndex)
                 {
+                    ref int bucket = ref buckets[index];
+                    if (bucket < 0)
+                    {
+                        if (index == startIndex)
+                        {
+                            nonEmptyCount++;
+                        }
+
+                        bucket = i;
+                        break;
+                    }
+
+                    index++;
+                }
+
+                if (index == endIndex)
+                {
+                    // If we've already hit the max per-bucket limit, bail.
+                    ArrayPool<int>.Shared.Return(buckets);
                     return null;
                 }
-
-                list.Add(s);
             }
 
             // If there would be too much empty space in the lookup array, bail.
-            if (groupedByLength.Count / (double)spread < EmptyLengthsRatio)
+            if (nonEmptyCount / (double)spread < EmptyLengthsRatio)
             {
+                ArrayPool<int>.Shared.Return(buckets);
                 return null;
             }
 
-            var lengthBuckets = new KeyValuePair<string, int>[spread][];
+#if NET6_0_OR_GREATER
+            // We don't need an array with every value initialized to zero if we are just about to overwrite every value anyway.
+            int[] copy = GC.AllocateUninitializedArray<int>(arraySize);
+            Array.Copy(buckets, copy, arraySize);
+#else
+            int[] copy = buckets.AsSpan(0, arraySize).ToArray();
+#endif
+            ArrayPool<int>.Shared.Return(buckets);
 
-            // Iterate through each bucket, filling the items array, and creating a lookup array such that
-            // given a string length we can index into that array to find the array of string,int pairs: the string
-            // is the key and the int is the index into the items array for the corresponding entry.
-            int index = 0;
-            foreach (KeyValuePair<int, List<string>> group in groupedByLength)
-            {
-                KeyValuePair<string, int>[] length = lengthBuckets[group.Key - minLength] = new KeyValuePair<string, int>[group.Value.Count];
-                int i = 0;
-                foreach (string value in group.Value)
-                {
-                    length[i] = new KeyValuePair<string, int>(value, index);
-                    entries[index] = value;
-
-                    i++;
-                    index++;
-                }
-            }
-
-            return new LengthBucketsFrozenSet(entries, lengthBuckets, minLength, comparer);
+            return new LengthBucketsFrozenSet(items, copy, minLength, comparer);
         }
 
         /// <inheritdoc />
@@ -114,33 +133,49 @@ namespace System.Collections.Frozen
         {
             if (item is not null) // this implementation won't be constructed from null values, but Contains may still be called with one
             {
-                // If the length doesn't have an associated bucket, the key isn't in the set.
-                int length = item.Length - _minLength;
-                if (length >= 0)
+                // If the length doesn't have an associated bucket, the key isn't in the dictionary.
+                int bucketIndex = (item.Length - _minLength) * MaxPerLength;
+                int bucketEndIndex = bucketIndex + MaxPerLength;
+                int[] lengthBuckets = _lengthBuckets;
+                if (bucketIndex >= 0 && bucketEndIndex <= lengthBuckets.Length)
                 {
-                    // Get the bucket for this key's length.  If it's null, the key isn't in the set.
-                    KeyValuePair<string, int>[][] lengths = _lengthBuckets;
-                    if ((uint)length < (uint)lengths.Length && lengths[length] is KeyValuePair<string, int>[] subset)
+                    string[] items = _items;
+
+                    if (!_ignoreCase)
                     {
-                        // Now iterate through every key in the bucket to see whether this is a match.
-                        if (_ignoreCase)
+                        for (; bucketIndex < bucketEndIndex; bucketIndex++)
                         {
-                            foreach (KeyValuePair<string, int> kvp in subset)
+                            int index = lengthBuckets[bucketIndex];
+                            if ((uint)index < (uint)items.Length)
                             {
-                                if (StringComparer.OrdinalIgnoreCase.Equals(item, kvp.Key))
+                                if (item == items[index])
                                 {
-                                    return kvp.Value;
+                                    return index;
                                 }
                             }
-                        }
-                        else
-                        {
-                            foreach (KeyValuePair<string, int> kvp in subset)
+                            else
                             {
-                                if (item == kvp.Key)
+                                // -1 is used to indicate a null, when it's casted to uint it becomes > keys.Length
+                                break;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        for (; bucketIndex < bucketEndIndex; bucketIndex++)
+                        {
+                            int index = lengthBuckets[bucketIndex];
+                            if ((uint)index < (uint)items.Length)
+                            {
+                                if (StringComparer.OrdinalIgnoreCase.Equals(item, items[index]))
                                 {
-                                    return kvp.Value;
+                                    return index;
                                 }
+                            }
+                            else
+                            {
+                                // -1 is used to indicate a null, when it's casted to unit it becomes > keys.Length
+                                break;
                             }
                         }
                     }


### PR DESCRIPTION
Improvements were recently made for construction perf to the length bucket strategy in FrozenDictionary, but the same for FrozenSet were missed.  Port them over.