### PR TITLE
Fix incorrect sequence number used in NTLM signature calculation

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/NTAuthentication.Managed.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NTAuthentication.Managed.cs
@@ -785,7 +785,7 @@ namespace System.Net
             Span<byte> signature)
         {
             BinaryPrimitives.WriteInt32LittleEndian(signature, 1);
-            BinaryPrimitives.WriteUInt32LittleEndian(signature.Slice(12), _serverSequenceNumber);
+            BinaryPrimitives.WriteUInt32LittleEndian(signature.Slice(12), sequenceNumber);
             using (var hmac = IncrementalHash.CreateHMAC(HashAlgorithmName.MD5, signingKey))
             {
                 hmac.AppendData(signature.Slice(12, 4));


### PR DESCRIPTION
This affects `NegotiateStream` and SMTP GSSAPI authentication on platforms that rely on managed NTLM (Android, tvOS). It was discovered when running the full battery of test against managed NTLM and managed Negotiate on normal Linux.