### PR TITLE
Add Uri : ISpanFormattable

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
@@ -147,7 +147,14 @@ namespace System.Net.Http
             sb.Append(_method);
 
             sb.Append(", RequestUri: '");
-            sb.Append(_requestUri == null ? "<null>" : _requestUri.ToString());
+            if (_requestUri is null)
+            {
+                sb.Append("<null>");
+            }
+            else
+            {
+                sb.Append($"{_requestUri}");
+            }
 
             sb.Append("', Version: ");
             sb.Append(_version);

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -1673,7 +1673,7 @@ namespace System.Runtime.Serialization.DataContracts
             {
                 string trimmedNs = dataContractNs.Trim();
                 // Code similar to XmlConvert.ToUri (string.Empty is a valid uri but not "   ")
-                if (trimmedNs.Length == 0 || trimmedNs.IndexOf("##", StringComparison.Ordinal) >= 0)
+                if (trimmedNs.Length == 0 || trimmedNs.Contains("##", StringComparison.Ordinal))
                 {
                     ThrowInvalidDataContractException(SR.Format(SR.DataContractNamespaceIsNotValid, dataContractNs), type);
                 }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -1673,17 +1673,27 @@ namespace System.Runtime.Serialization.DataContracts
             {
                 string trimmedNs = dataContractNs.Trim();
                 // Code similar to XmlConvert.ToUri (string.Empty is a valid uri but not "   ")
-                if (trimmedNs.Length == 0 || trimmedNs.IndexOf("##", StringComparison.Ordinal) != -1)
+                if (trimmedNs.Length == 0 || trimmedNs.IndexOf("##", StringComparison.Ordinal) >= 0)
+                {
                     ThrowInvalidDataContractException(SR.Format(SR.DataContractNamespaceIsNotValid, dataContractNs), type);
+                }
+
                 dataContractNs = trimmedNs;
             }
             if (Uri.TryCreate(dataContractNs, UriKind.RelativeOrAbsolute, out Uri? uri))
             {
-                if (uri.ToString() == Globals.SerializationNamespace)
+                Span<char> formatted = stackalloc char[Globals.SerializationNamespace.Length];
+                if (uri.TryFormat(formatted, out int charsWritten) &&
+                    charsWritten == Globals.SerializationNamespace.Length &&
+                    formatted.SequenceEqual(Globals.SerializationNamespace))
+                {
                     ThrowInvalidDataContractException(SR.Format(SR.DataContractNamespaceReserved, Globals.SerializationNamespace), type);
+                }
             }
             else
+            {
                 ThrowInvalidDataContractException(SR.Format(SR.DataContractNamespaceIsNotValid, dataContractNs), type);
+            }
         }
 
         internal static string GetClrTypeFullName(Type type)

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -13,6 +13,7 @@ namespace System
         //
         // All public ctors go through here
         //
+        [MemberNotNull(nameof(_string))]
         private void CreateThis(string? uri, bool dontEscape, UriKind uriKind, in UriCreationOptions creationOptions = default)
         {
             DebugAssertInCtor();
@@ -910,6 +911,7 @@ namespace System
         //
         // Only a ctor time call
         //
+        [MemberNotNull(nameof(_string))]
         private void CreateThisFromUri(Uri otherUri)
         {
             DebugAssertInCtor();

--- a/src/libraries/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriHelper.cs
@@ -269,7 +269,7 @@ namespace System
                 UnescapeString(pStr, start, end, ref dest, rsvd1, rsvd2, rsvd3, unescapeMode, syntax, isQuery);
             }
         }
-        internal static unsafe void UnescapeString(ReadOnlySpan<char> input, ref ValueStringBuilder dest,
+        internal static unsafe void UnescapeString(scoped ReadOnlySpan<char> input, scoped ref ValueStringBuilder dest,
            char rsvd1, char rsvd2, char rsvd3, UnescapeMode unescapeMode, UriParser? syntax, bool isQuery)
         {
             fixed (char* pStr = &MemoryMarshal.GetReference(input))

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -15544,7 +15544,7 @@ namespace System
     {
         public NewsStyleUriParser() { }
     }
-    public partial class Uri : System.Runtime.Serialization.ISerializable
+    public partial class Uri : System.ISpanFormattable, System.Runtime.Serialization.ISerializable
     {
         public static readonly string SchemeDelimiter;
         public static readonly string UriSchemeFile;
@@ -15639,10 +15639,13 @@ namespace System
         protected virtual void Parse() { }
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public override string ToString() { throw null; }
+        string System.IFormattable.ToString(string? format, System.IFormatProvider? formatProvider) { throw null; }
         public static bool TryCreate([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true), System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("Uri")] string? uriString, in System.UriCreationOptions creationOptions, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Uri? result) { throw null; }
         public static bool TryCreate([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true), System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("Uri", "uriKind")] string? uriString, System.UriKind uriKind, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Uri? result) { throw null; }
         public static bool TryCreate(System.Uri? baseUri, string? relativeUri, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Uri? result) { throw null; }
         public static bool TryCreate(System.Uri? baseUri, System.Uri? relativeUri, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Uri? result) { throw null; }
+        public bool TryFormat(System.Span<char> destination, out int charsWritten) { throw null; }
+        bool System.ISpanFormattable.TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) { throw null; }
         [System.ObsoleteAttribute("Uri.Unescape has been deprecated. Use GetComponents() or Uri.UnescapeDataString() to unescape a Uri component or a string.")]
         protected virtual string Unescape(string path) { throw null; }
         public static string UnescapeDataString(string stringToUnescape) { throw null; }


### PR DESCRIPTION
Implemented TryFormat by copying in the ToString implementation, manually expanding out each call, deleting all the cruft, and switching return strings to be span copies / writes.

Fixes https://github.com/dotnet/runtime/issues/87151