### PR TITLE
Fix TimeProvider Timer with Infinity Timeout

### DIFF
--- a/src/libraries/Common/src/System/TimeProvider.cs
+++ b/src/libraries/Common/src/System/TimeProvider.cs
@@ -263,12 +263,12 @@ namespace System
 
                 if (periodTm < -1)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(periodTm), periodTm, SR.Format(SR.ArgumentOutOfRange_Generic_MustBeGreaterOrEqual, nameof(periodTm), -1));
+                    throw new ArgumentOutOfRangeException(nameof(periodTm), periodTm, SR.Format(SR.ArgumentOutOfRange_Generic_MustBeGreaterOrEqual, nameof(periodTime), -1));
                 }
 
                 if (periodTm > MaxAllowedTimeout)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(periodTm), periodTm, SR.Format(SR.ArgumentOutOfRange_Generic_MustBeLessOrEqual, nameof(periodTm), MaxAllowedTimeout));
+                    throw new ArgumentOutOfRangeException(nameof(periodTm), periodTm, SR.Format(SR.ArgumentOutOfRange_Generic_MustBeLessOrEqual, nameof(periodTime), MaxAllowedTimeout));
                 }
 #endif // SYSTEM_PRIVATE_CORELIB
 

--- a/src/libraries/Common/src/System/TimeProvider.cs
+++ b/src/libraries/Common/src/System/TimeProvider.cs
@@ -183,9 +183,8 @@ namespace System
 #endif // SYSTEM_PRIVATE_CORELIB
             public SystemTimeProviderTimer(TimeSpan dueTime, TimeSpan period, TimerCallback callback, object? state)
             {
-                (uint duration, uint periodTime) = CheckAndGetValues(dueTime, period);
 #if SYSTEM_PRIVATE_CORELIB
-                _timer = new TimerQueueTimer(callback, state, duration, periodTime, flowExecutionContext: true);
+                _timer = new TimerQueueTimer(callback, state, dueTime, period, flowExecutionContext: true);
 #else
                 // We need to ensure the timer roots itself. Timer created with a duration and period argument
                 // only roots the state object, so to root the timer we need the state object to reference the
@@ -195,7 +194,7 @@ namespace System
                 {
                     TimerState ts = (TimerState)s!;
                     ts.Callback(ts.State);
-                }, timerState, duration, periodTime);
+                }, timerState, dueTime, period);
 #endif // SYSTEM_PRIVATE_CORELIB
             }
 
@@ -210,10 +209,9 @@ namespace System
 
             public bool Change(TimeSpan dueTime, TimeSpan period)
             {
-                (uint duration, uint periodTime) = CheckAndGetValues(dueTime, period);
                 try
                 {
-                    return _timer.Change(duration, periodTime);
+                    return _timer.Change(dueTime, period);
                 }
                 catch (ObjectDisposedException)
                 {
@@ -233,47 +231,6 @@ namespace System
                 return default;
             }
 #endif // SYSTEM_PRIVATE_CORELIB
-
-            private static (uint duration, uint periodTime) CheckAndGetValues(TimeSpan dueTime, TimeSpan periodTime)
-            {
-                long dueTm = (long)dueTime.TotalMilliseconds;
-                long periodTm = (long)periodTime.TotalMilliseconds;
-
-                // MaxAllowedTimeout = 0xffffffff
-                // We have MaxSupportedTimeout = 0xfffffffe but we need to allow TimeSpan = Timeout.InfiniteTimeSpan which
-                // is -1. So we need to allow -1 milliseconds which equal to 0xffffffff.
-                const long MaxAllowedTimeout = (long)(unchecked((uint)Timeout.Infinite));
-
-#if SYSTEM_PRIVATE_CORELIB
-                ArgumentOutOfRangeException.ThrowIfLessThan(dueTm, -1, nameof(dueTime));
-                ArgumentOutOfRangeException.ThrowIfGreaterThan(dueTm, MaxAllowedTimeout, nameof(dueTime));
-
-                ArgumentOutOfRangeException.ThrowIfLessThan(periodTm, -1, nameof(periodTime));
-                ArgumentOutOfRangeException.ThrowIfGreaterThan(periodTm, MaxAllowedTimeout, nameof(periodTime));
-#else
-                if (dueTm < -1)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(dueTime), dueTm, SR.Format(SR.ArgumentOutOfRange_Generic_MustBeGreaterOrEqual, nameof(dueTime), -1));
-                }
-
-                if (dueTm > MaxAllowedTimeout)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(dueTime), dueTm, SR.Format(SR.ArgumentOutOfRange_Generic_MustBeLessOrEqual, nameof(dueTime), MaxAllowedTimeout));
-                }
-
-                if (periodTm < -1)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(periodTm), periodTm, SR.Format(SR.ArgumentOutOfRange_Generic_MustBeGreaterOrEqual, nameof(periodTime), -1));
-                }
-
-                if (periodTm > MaxAllowedTimeout)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(periodTm), periodTm, SR.Format(SR.ArgumentOutOfRange_Generic_MustBeLessOrEqual, nameof(periodTime), MaxAllowedTimeout));
-                }
-#endif // SYSTEM_PRIVATE_CORELIB
-
-                return ((uint)dueTm, (uint)periodTm);
-            }
         }
 
         /// <summary>

--- a/src/libraries/Common/src/System/TimeProvider.cs
+++ b/src/libraries/Common/src/System/TimeProvider.cs
@@ -239,23 +239,26 @@ namespace System
                 long dueTm = (long)dueTime.TotalMilliseconds;
                 long periodTm = (long)periodTime.TotalMilliseconds;
 
+                // MaxAllowedTimeout = 0xffffffff
+                // We have MaxSupportedTimeout = 0xfffffffe but we need to allow TimeSpan = Timeout.InfiniteTimeSpan which
+                // is -1. So we need to allow -1 milliseconds which equal to 0xffffffff.
+                const long MaxAllowedTimeout = (long)(unchecked((uint)Timeout.Infinite));
+
 #if SYSTEM_PRIVATE_CORELIB
                 ArgumentOutOfRangeException.ThrowIfLessThan(dueTm, -1, nameof(dueTime));
-                ArgumentOutOfRangeException.ThrowIfGreaterThan(dueTm, Timer.MaxSupportedTimeout, nameof(dueTime));
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(dueTm, MaxAllowedTimeout, nameof(dueTime));
 
                 ArgumentOutOfRangeException.ThrowIfLessThan(periodTm, -1, nameof(periodTime));
-                ArgumentOutOfRangeException.ThrowIfGreaterThan(periodTm, Timer.MaxSupportedTimeout, nameof(periodTime));
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(periodTm, MaxAllowedTimeout, nameof(periodTime));
 #else
-                const uint MaxSupportedTimeout = 0xfffffffe;
-
                 if (dueTm < -1)
                 {
                     throw new ArgumentOutOfRangeException(nameof(dueTime), dueTm, SR.Format(SR.ArgumentOutOfRange_Generic_MustBeGreaterOrEqual, nameof(dueTime), -1));
                 }
 
-                if (dueTm > MaxSupportedTimeout)
+                if (dueTm > MaxAllowedTimeout)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(dueTime), dueTm, SR.Format(SR.ArgumentOutOfRange_Generic_MustBeLessOrEqual, nameof(dueTime), MaxSupportedTimeout));
+                    throw new ArgumentOutOfRangeException(nameof(dueTime), dueTm, SR.Format(SR.ArgumentOutOfRange_Generic_MustBeLessOrEqual, nameof(dueTime), MaxAllowedTimeout));
                 }
 
                 if (periodTm < -1)
@@ -263,9 +266,9 @@ namespace System
                     throw new ArgumentOutOfRangeException(nameof(periodTm), periodTm, SR.Format(SR.ArgumentOutOfRange_Generic_MustBeGreaterOrEqual, nameof(periodTm), -1));
                 }
 
-                if (periodTm > MaxSupportedTimeout)
+                if (periodTm > MaxAllowedTimeout)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(periodTm), periodTm, SR.Format(SR.ArgumentOutOfRange_Generic_MustBeLessOrEqual, nameof(periodTm), MaxSupportedTimeout));
+                    throw new ArgumentOutOfRangeException(nameof(periodTm), periodTm, SR.Format(SR.ArgumentOutOfRange_Generic_MustBeLessOrEqual, nameof(periodTm), MaxAllowedTimeout));
                 }
 #endif // SYSTEM_PRIVATE_CORELIB
 

--- a/src/libraries/Common/tests/System/TimeProviderTests.cs
+++ b/src/libraries/Common/tests/System/TimeProviderTests.cs
@@ -174,10 +174,15 @@ namespace Tests.System
             Assert.Equal(stamp2 - stamp1, fastClock.GetElapsedTime(stamp1, stamp2).Ticks);
         }
 
+        public class DerivedTimeProvider : TimeProvider
+        {
+        }
+
         public static IEnumerable<object[]> TimersProvidersListData()
         {
             yield return new object[] { TimeProvider.System };
             yield return new object[] { new FastClock() };
+            yield return new object[] { new DerivedTimeProvider() };
         }
 
         public static IEnumerable<object[]> TimersProvidersWithTaskFactorData()

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
@@ -161,7 +161,7 @@ namespace System.Threading
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.delay);
             }
 
-            InitializeWithTimer((uint)totalMilliseconds, timeProvider);
+            InitializeWithTimer(delay, timeProvider);
         }
 
         /// <summary>
@@ -190,16 +190,16 @@ namespace System.Threading
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.millisecondsDelay);
             }
 
-            InitializeWithTimer((uint)millisecondsDelay, TimeProvider.System);
+            InitializeWithTimer(TimeSpan.FromMilliseconds(millisecondsDelay), TimeProvider.System);
         }
 
         /// <summary>
         /// Common initialization logic when constructing a CTS with a delay parameter.
         /// A zero delay will result in immediate cancellation.
         /// </summary>
-        private void InitializeWithTimer(uint millisecondsDelay, TimeProvider timeProvider)
+        private void InitializeWithTimer(TimeSpan millisecondsDelay, TimeProvider timeProvider)
         {
-            if (millisecondsDelay == 0)
+            if (millisecondsDelay == TimeSpan.Zero)
             {
                 _state = NotifyingCompleteState;
             }
@@ -207,13 +207,13 @@ namespace System.Threading
             {
                 if (timeProvider == TimeProvider.System)
                 {
-                    _timer = new TimerQueueTimer(s_timerCallback, this, millisecondsDelay, Timeout.UnsignedInfinite, flowExecutionContext: false);
+                    _timer = new TimerQueueTimer(s_timerCallback, this, millisecondsDelay, Timeout.InfiniteTimeSpan, flowExecutionContext: false);
                 }
                 else
                 {
                     using (ExecutionContext.SuppressFlow())
                     {
-                        _timer = timeProvider.CreateTimer(s_timerCallback, this, TimeSpan.FromMilliseconds(millisecondsDelay), Timeout.InfiniteTimeSpan);
+                        _timer = timeProvider.CreateTimer(s_timerCallback, this, millisecondsDelay, Timeout.InfiniteTimeSpan);
                     }
                 }
                 // The timer roots this CTS instance while it's scheduled.  That is by design, so


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/88000

For the time provider timer using the default implementation, we verify that the specified duration and periods are within the maximum allowed timeout milliseconds of 0xfffffffe. However, when dealing with an infinite timeout, represented by the value 0xffffffff, we incorrectly throw an out-of-range exception. To address this issue, we need to modify the code so that it does not throw an exception in such cases.

It's worth noting that this problem does not arise with the system time provider, as it directly creates a TimerQueueTimer and handles the infinity value as a special case.