### PR TITLE
minor regex cleanup

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -764,7 +764,7 @@ namespace System.Text.RegularExpressions.Generator
             }
 
             // We're done.  Patch up any additional declarations.
-            ReplaceAdditionalDeclarations(writer, additionalDeclarations, additionalDeclarationsPosition, additionalDeclarationsIndent);
+            InsertAdditionalDeclarations(writer, additionalDeclarations, additionalDeclarationsPosition, additionalDeclarationsIndent);
             return;
 
             // Emit a goto for the specified label.
@@ -1379,7 +1379,7 @@ namespace System.Text.RegularExpressions.Generator
             // We're done with the match.
 
             // Patch up any additional declarations.
-            ReplaceAdditionalDeclarations(writer, additionalDeclarations, additionalDeclarationsPosition, additionalDeclarationsIndent);
+            InsertAdditionalDeclarations(writer, additionalDeclarations, additionalDeclarationsPosition, additionalDeclarationsIndent);
 
             // And emit any required helpers.
             if (additionalLocalFunctions.Count != 0)
@@ -5054,14 +5054,14 @@ namespace System.Text.RegularExpressions.Generator
         }
 
         /// <summary>
-        /// Replaces <see cref="AdditionalDeclarationsPlaceholder"/> in <paramref name="writer"/> with
-        /// all of the variable declarations in <paramref name="declarations"/>.
+        /// Inserts all of the variable declarations in <paramref name="declarations"/> into the
+        /// <paramref name="writer"/> at <paramref name="position"/> with <paramref name="indent"/>.
         /// </summary>
         /// <param name="writer">The writer around a StringWriter to have additional declarations inserted into.</param>
         /// <param name="declarations">The additional declarations to insert.</param>
         /// <param name="position">The position into the writer at which to insert the additional declarations.</param>
         /// <param name="indent">The indentation to use for the additional declarations.</param>
-        private static void ReplaceAdditionalDeclarations(IndentedTextWriter writer, HashSet<string> declarations, int position, int indent)
+        private static void InsertAdditionalDeclarations(IndentedTextWriter writer, HashSet<string> declarations, int position, int indent)
         {
             if (declarations.Count != 0)
             {

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/Strings.resx
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/Strings.resx
@@ -270,10 +270,6 @@
   <data name="UnterminatedComment" xml:space="preserve">
     <value>Unterminated (?#...) comment.</value>
   </data>
-  <data name="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups" xml:space="preserve">
-    <value>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</value>
-    <comment>{Locked="RegexOptions.NonBacktracking"}</comment>
-  </data>
   <data name="UseRegexSourceGeneratorMessage" xml:space="preserve">
     <value>Use 'GeneratedRegexAttribute' to generate the regular expression implementation at compile-time.</value>
   </data>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.cs.xlf
@@ -167,11 +167,6 @@
         <target state="translated">Výsledek nelze volat pro shodu, která se nezdařila.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
-        <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
-        <target state="translated">Nahrazení regulárních výrazů pomocí substitucí skupin se u RegexOptions.NonBacktracking nepodporuje.</target>
-        <note>{Locked="RegexOptions.NonBacktracking"}</note>
-      </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
         <target state="translated">Kolekce je jen pro čtení.</target>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.de.xlf
@@ -167,11 +167,6 @@
         <target state="translated">Das Ergebnis kann nicht für eine fehlgeschlagene Übereinstimmung aufgerufen werden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
-        <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
-        <target state="translated">RegEx-Ersätze durch Austausch von Gruppen werden bei RegexOptions.NonBacktracking nicht unterstützt.</target>
-        <note>{Locked="RegexOptions.NonBacktracking"}</note>
-      </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
         <target state="translated">Die Sammlung ist schreibgeschützt.</target>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.es.xlf
@@ -167,11 +167,6 @@
         <target state="translated">No se puede llamar al resultado si no se encuentra ninguna coincidencia.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
-        <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
-        <target state="translated">Los reemplazos de regex con sustituciones de grupos no se admiten con RegexOptions.NonBacktracking.</target>
-        <note>{Locked="RegexOptions.NonBacktracking"}</note>
-      </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
         <target state="translated">La colección es de sólo lectura.</target>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.fr.xlf
@@ -167,11 +167,6 @@
         <target state="translated">Le résultat ne peut pas être appelé sur un Match ayant échoué.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
-        <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
-        <target state="translated">Les remplacements d'expressions régulières avec des substitutions de groupes ne sont pas pris en charge avec RegexOptions.NonBacktracking.</target>
-        <note>{Locked="RegexOptions.NonBacktracking"}</note>
-      </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
         <target state="translated">La collection est en lecture seule.</target>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.it.xlf
@@ -167,11 +167,6 @@
         <target state="translated">Impossibile chiamare Result su un Match non riuscito.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
-        <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
-        <target state="translated">Le sostituzioni regex con sostituzioni di gruppi non sono supportate con RegexOptions.NonBacktracking.</target>
-        <note>{Locked="RegexOptions.NonBacktracking"}</note>
-      </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
         <target state="translated">La raccolta è di sola lettura.</target>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ja.xlf
@@ -167,11 +167,6 @@
         <target state="translated">失敗した Match で Result を呼び出すことはできません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
-        <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
-        <target state="translated">RegexOptions.NonBacktracking では、グループの置換による正規表現の置換はサポートされていません。</target>
-        <note>{Locked="RegexOptions.NonBacktracking"}</note>
-      </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
         <target state="translated">コレクションは読み取り専用です。</target>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ko.xlf
@@ -167,11 +167,6 @@
         <target state="translated">실패한 Match에서 결과를 호출할 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
-        <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
-        <target state="translated">RegexOptions.NonBacktracking에서는 그룹을 대체하는 Regex 대체가 지원되지 않습니다.</target>
-        <note>{Locked="RegexOptions.NonBacktracking"}</note>
-      </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
         <target state="translated">읽기 전용 컬렉션입니다.</target>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pl.xlf
@@ -167,11 +167,6 @@
         <target state="translated">Nie można wywołać wyniku błędnego dopasowania.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
-        <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
-        <target state="translated">Zamiany wyrażeń regularnych z podstawieniami grup nie są obsługiwane w przypadku metody RegexOptions.NonBacktracking.</target>
-        <note>{Locked="RegexOptions.NonBacktracking"}</note>
-      </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
         <target state="translated">Kolekcja jest tylko do odczytu.</target>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -167,11 +167,6 @@
         <target state="translated">Não é possível chamar resultado quando há falha na correspondência.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
-        <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
-        <target state="translated">Substituições de regex com substituições de grupos não são suportadas com RegexOptions.NonBacktracking.</target>
-        <note>{Locked="RegexOptions.NonBacktracking"}</note>
-      </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
         <target state="translated">A coleção é somente leitura.</target>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ru.xlf
@@ -167,11 +167,6 @@
         <target state="translated">Вызов результата невозможен при сбойном соответствии.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
-        <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
-        <target state="translated">Замена регулярных выражений на группы не поддерживается в RegexOptions.NonBacktracking.</target>
-        <note>{Locked="RegexOptions.NonBacktracking"}</note>
-      </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
         <target state="translated">Данная коллекция предназначена только для чтения.</target>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.tr.xlf
@@ -167,11 +167,6 @@
         <target state="translated">Sonuç, başarısız Eşleştirmede çağrılamaz.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
-        <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
-        <target state="translated">Grup değiştirmeleri içeren normal ifade değiştirmeleri RegexOptions.NonBacktracking ile desteklenmez.</target>
-        <note>{Locked="RegexOptions.NonBacktracking"}</note>
-      </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
         <target state="translated">Koleksiyon salt okunur.</target>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -167,11 +167,6 @@
         <target state="translated">不能对失败的匹配调用结果。</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
-        <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
-        <target state="translated">RegexOptions.NonBacktracking 不支持使用组替换的正则表达式替换。</target>
-        <note>{Locked="RegexOptions.NonBacktracking"}</note>
-      </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
         <target state="translated">集合是只读的。</target>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -167,11 +167,6 @@
         <target state="translated">無法在已失敗的對應 (Match) 上呼叫結果。</target>
         <note />
       </trans-unit>
-      <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
-        <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
-        <target state="translated">RegexOptions.NonBacktracking 不支援以替代群組取代 Regex。</target>
-        <note>{Locked="RegexOptions.NonBacktracking"}</note>
-      </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
         <target state="translated">集合是唯讀的。</target>

--- a/src/libraries/System.Text.RegularExpressions/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.RegularExpressions/src/Resources/Strings.resx
@@ -246,10 +246,6 @@
   <data name="UnterminatedComment" xml:space="preserve">
     <value>Unterminated (?#...) comment.</value>
   </data>
-  <data name="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups" xml:space="preserve">
-    <value>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</value>
-    <comment>{Locked="RegexOptions.NonBacktracking"}</comment>
-  </data>
   <data name="NotSupported_NonBacktrackingConflictingExpression" xml:space="preserve">
     <value>RegexOptions.NonBacktracking is not supported in conjunction with expressions containing: '{0}'.</value>
     <comment>{Locked="RegexOptions.NonBacktracking"}</comment>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1827,11 +1827,6 @@ namespace System.Text.RegularExpressions
                 return DescribeChar(set[SetStartIndex]);
             }
 
-            if (set == AnyClass)
-            {
-                return ".";
-            }
-
             int index = SetStartIndex;
             char ch1;
             char ch2;
@@ -1971,16 +1966,6 @@ namespace System.Text.RegularExpressions
                 >= ' ' and <= '~' => ch.ToString(),
                 _ => $"\\u{(uint)ch:X4}"
             };
-
-        public static string DescribeString(string s)
-        {
-            StringBuilder sb = new StringBuilder();
-            foreach(char c in s)
-            {
-                sb.Append(DescribeChar(c));
-            }
-            return sb.ToString();
-        }
 
         private static string DescribeCategory(char ch) =>
             (short)ch switch

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1827,6 +1827,11 @@ namespace System.Text.RegularExpressions
                 return DescribeChar(set[SetStartIndex]);
             }
 
+            if (set == AnyClass)
+            {
+                return ".";
+            }
+
             int index = SetStartIndex;
             char ch1;
             char ch2;
@@ -1966,6 +1971,16 @@ namespace System.Text.RegularExpressions
                 >= ' ' and <= '~' => ch.ToString(),
                 _ => $"\\u{(uint)ch:X4}"
             };
+
+        public static string DescribeString(string s)
+        {
+            StringBuilder sb = new StringBuilder();
+            foreach(char c in s)
+            {
+                sb.Append(DescribeChar(c));
+            }
+            return sb.ToString();
+        }
 
         private static string DescribeCategory(char ch) =>
             (short)ch switch

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -2893,7 +2893,12 @@ namespace System.Text.RegularExpressions
                     sb.Append(' ').Append($"index = {M}");
                     break;
                 case RegexNodeKind.Multi:
-                    sb.Append(" \"").Append(RegexCharClass.DescribeString(Str!)).Append('"');
+                    sb.Append(" \"");
+                    foreach(char c in Str!)
+                    {
+                        sb.Append(RegexCharClass.DescribeChar(c));
+                    }
+                    sb.Append('"');
                     break;
                 case RegexNodeKind.Set:
                 case RegexNodeKind.Setloop:

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -2893,7 +2893,7 @@ namespace System.Text.RegularExpressions
                     sb.Append(' ').Append($"index = {M}");
                     break;
                 case RegexNodeKind.Multi:
-                    sb.Append(" \"").Append(Str).Append('"');
+                    sb.Append(" \"").Append(RegexCharClass.DescribeString(Str!)).Append('"');
                     break;
                 case RegexNodeKind.Set:
                 case RegexNodeKind.Setloop:

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOpcode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOpcode.cs
@@ -27,9 +27,11 @@ namespace System.Text.RegularExpressions
         /// <summary>Repeater of the specified character.</summary>
         /// <remarks>Operand 0 is the character. Operand 1 is the repetition count.</remarks>
         Onerep = 0,
+
         /// <summary>Repeater of a single character other than the one specified.</summary>
         /// <remarks>Operand 0 is the character. Operand 1 is the repetition count.</remarks>
         Notonerep = 1,
+
         /// <summary>Repeater of a single character matching the specified set</summary>
         /// <remarks>Operand 0 is index into the strings table of the character class description. Operand 1 is the repetition count.</remarks>
         Setrep = 2,
@@ -37,9 +39,11 @@ namespace System.Text.RegularExpressions
         /// <summary>Greedy loop of the specified character.</summary>
         /// <remarks>Operand 0 is the character. Operand 1 is the max iteration count.</remarks>
         Oneloop = 3,
+
         /// <summary>Greedy loop of a single character other than the one specified.</summary>
         /// <remarks>Operand 0 is the character. Operand 1 is the max iteration count.</remarks>
         Notoneloop = 4,
+
         /// <summary>Greedy loop of a single character matching the specified set</summary>
         /// <remarks>Operand 0 is index into the strings table of the character class description. Operand 1 is the repetition count.</remarks>
         Setloop = 5,
@@ -47,9 +51,11 @@ namespace System.Text.RegularExpressions
         /// <summary>Lazy loop of the specified character.</summary>
         /// <remarks>Operand 0 is the character. Operand 1 is the max iteration count.</remarks>
         Onelazy = 6,
+
         /// <summary>Lazy loop of a single character other than the one specified.</summary>
         /// <remarks>Operand 0 is the character. Operand 1 is the max iteration count.</remarks>
         Notonelazy = 7,
+
         /// <summary>Lazy loop of a single character matching the specified set</summary>
         /// <remarks>Operand 0 is index into the strings table of the character class description. Operand 1 is the repetition count.</remarks>
         Setlazy = 8,
@@ -57,9 +63,11 @@ namespace System.Text.RegularExpressions
         /// <summary>Single specified character.</summary>
         /// <remarks>Operand 0 is the character.</remarks>
         One = 9,
+
         /// <summary>Single character other than the one specified.</summary>
         /// <remarks>Operand 0 is the character.</remarks>
         Notone = 10,
+
         /// <summary>Single character matching the specified set.</summary>
         /// <remarks>Operand 0 is index into the strings table of the character class description.</remarks>
         Set = 11,

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -334,7 +334,7 @@ namespace System.Text.RegularExpressions
 
                     if (isQuantifier)
                     {
-                        AddUnitOne(CharAt(endpos - 1));
+                        _unit = RegexNode.CreateOneWithCaseConversion(CharAt(endpos - 1), _options, _culture, ref _caseBehavior);
                     }
                 }
 
@@ -380,7 +380,7 @@ namespace System.Text.RegularExpressions
                         PopGroup();
                         PopOptions();
 
-                        if (Unit() == null)
+                        if (_unit == null)
                         {
                             goto ContinueOuterScan;
                         }
@@ -392,15 +392,15 @@ namespace System.Text.RegularExpressions
                             throw MakeException(RegexParseError.UnescapedEndingBackslash, SR.UnescapedEndingBackslash);
                         }
 
-                        AddUnitNode(ScanBackslash(scanOnly: false)!);
+                        _unit = ScanBackslash(scanOnly: false)!;
                         break;
 
                     case '^':
-                        AddUnitType(UseOptionM() ? RegexNodeKind.Bol : RegexNodeKind.Beginning);
+                        _unit = new RegexNode(UseOptionM() ? RegexNodeKind.Bol : RegexNodeKind.Beginning, _options);
                         break;
 
                     case '$':
-                        AddUnitType(UseOptionM() ? RegexNodeKind.Eol : RegexNodeKind.EndZ);
+                        _unit = new RegexNode(UseOptionM() ? RegexNodeKind.Eol : RegexNodeKind.EndZ, _options);
                         break;
 
                     case '.':
@@ -413,7 +413,7 @@ namespace System.Text.RegularExpressions
                     case '*':
                     case '+':
                     case '?':
-                        if (Unit() == null)
+                        if (_unit == null)
                         {
                             throw wasPrevQuantifier ?
                                 MakeException(RegexParseError.NestedQuantifiersNotParenthesized, SR.Format(SR.NestedQuantifiersNotParenthesized, ch)) :
@@ -438,7 +438,7 @@ namespace System.Text.RegularExpressions
                 ch = RightCharMoveRight();
 
                 // Handle quantifiers
-                while (Unit() != null)
+                while (_unit != null)
                 {
                     int min = 0, max = 0;
 
@@ -514,7 +514,7 @@ namespace System.Text.RegularExpressions
 
             AddGroup();
 
-            return Unit()!.FinalOptimize();
+            return _unit!.FinalOptimize();
         }
 
         /*
@@ -547,7 +547,7 @@ namespace System.Text.RegularExpressions
                     if (RightCharMoveRight() == '$')
                     {
                         RegexNode node = ScanDollar();
-                        AddUnitNode(node);
+                        _unit = node;
                     }
 
                     AddConcatenate();
@@ -2245,18 +2245,6 @@ namespace System.Text.RegularExpressions
             _concatenation!.AddChild(_unit!.MakeQuantifier(lazy, min, max));
             _unit = null;
         }
-
-        /// <summary>Returns the current unit</summary>
-        private RegexNode? Unit() => _unit;
-
-        /// <summary>Sets the current unit to a single char node</summary>
-        private void AddUnitOne(char ch) => _unit = RegexNode.CreateOneWithCaseConversion(ch, _options, _culture, ref _caseBehavior);
-
-        /// <summary>Sets the current unit to a subtree</summary>
-        private void AddUnitNode(RegexNode node) => _unit = node;
-
-        /// <summary>Sets the current unit to an assertion of the specified type</summary>
-        private void AddUnitType(RegexNodeKind type) => _unit = new RegexNode(type, _options);
 
         /// <summary>Finish the current group (in response to a ')' or end)</summary>
         private void AddGroup()

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -2295,8 +2295,6 @@ namespace System.Text.RegularExpressions
         /// <summary>Moves the current position to the right.</summary>
         private void MoveRight() => _currentPos++;
 
-        private void MoveRight(int i) => _currentPos += i;
-
         /// <summary>Moves the current parsing position one to the left.</summary>
         private void MoveLeft() => --_currentPos;
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
@@ -30,7 +30,8 @@ namespace System.Text.RegularExpressions
         protected internal int runtextend;         // Because we now pass in a sliced span of the input into Scan,
                                                    // the runtextend will always match the length of that passed in span except for CompileToAssembly
                                                    // scenario, which still works over the original input.
-        /// <summary> Starting point for search</summary>
+        /// <summary>Index of the starting character for the search.</summary>
+        /// <remarks>The differs from <see cref="runtextbeg"/> in that lookbehinds will be able to see text before <see cref="runtextstart"/> but not before <see cref="runtextbeg"/>.</remarks>
         protected internal int runtextstart;
 
         /// <summary>Text to search. May be null if the input was supplied as a span.</summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
@@ -1,37 +1,48 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// This RegexRunner class is a base class for source-generated regex extensibility
-// (and the old CompileToAssembly extensibility).  It's not intended to be used
-// by anything else.
-
-// Implementation notes:
-
-// It provides the driver code that calls the subclass's Scan
-// method for either scanning or direct execution.
-// It also maintains memory allocation for the backtracking stack,
-// the grouping stack and the longjump crawlstack, and provides
-// methods to push new subpattern match results into (or remove
-// backtracked results from) the Match instance.
-
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
 namespace System.Text.RegularExpressions
 {
+    /// <summary>
+    /// Base class for source-generated regex extensibility
+    /// (and the old CompileToAssembly extensibility).
+    /// It's not intended to be used by anything else.
+    /// </summary>
+    /// <remarks>
+    /// Provides the driver code that calls the subclass's Scan
+    /// method for either scanning or direct execution.
+    /// Also maintains memory allocation for the backtracking stack,
+    /// the grouping stack and the longjump crawlstack, and provides
+    /// methods to push new subpattern match results into (or remove
+    /// backtracked results from) the Match instance.
+    /// </remarks>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class RegexRunner
     {
         /// <summary>Index of the first character to search</summary>
-        protected internal int runtextbeg;         // We now always use a sliced span of the input
-                                                   // from runtextbeg to runtextend, which means that runtextbeg is now always 0 except
-                                                   // for CompiledToAssembly scenario which works over the original input.
+        /// <remarks>
+        /// We now always use a sliced span of the input
+        /// from runtextbeg to runtextend, which means that runtextbeg is now always 0 except
+        /// for CompiledToAssembly scenario which works over the original input.
+        /// </remarks>
+        protected internal int runtextbeg;
+
         /// <summary>Index just past the last character to search</summary>
-        protected internal int runtextend;         // Because we now pass in a sliced span of the input into Scan,
-                                                   // the runtextend will always match the length of that passed in span except for CompileToAssembly
-                                                   // scenario, which still works over the original input.
+        /// <remarks>
+        /// Because we now pass in a sliced span of the input into Scan,
+        /// the runtextend will always match the length of that passed in span except for CompileToAssembly
+        /// scenario, which still works over the original input.
+        /// </remarks>
+        protected internal int runtextend;
+
         /// <summary>Index of the starting character for the search.</summary>
-        /// <remarks>The differs from <see cref="runtextbeg"/> in that lookbehinds will be able to see text before <see cref="runtextstart"/> but not before <see cref="runtextbeg"/>.</remarks>
+        /// <remarks>
+        /// The differs from <see cref="runtextbeg"/> in that lookbehinds will be able to see text before
+        /// <see cref="runtextstart"/> but not before <see cref="runtextbeg"/>.
+        /// </remarks>
         protected internal int runtextstart;
 
         /// <summary>Text to search. May be null if the input was supplied as a span.</summary>
@@ -40,35 +51,35 @@ namespace System.Text.RegularExpressions
         /// <summary>Current position in text</summary>
         protected internal int runtextpos;
 
-        // Backtracking stack.
-        // Opcodes use this to store data regarding
-        // what they have matched and where to backtrack to.  Each "frame" on
-        // the stack takes the form of [CodePosition Data1 Data2...], where
-        // CodePosition is the position of the current opcode and
-        // the data values are all optional.  The CodePosition can be negative, and
-        // these values (also called "back2") are used by the BranchMark family of opcodes
-        // to indicate whether they are backtracking after a successful or failed
-        // match.
-        // When we backtrack, we pop the CodePosition off the stack, set the current
-        // instruction pointer to that code position, and mark the opcode
-        // with a backtracking flag ("Back").  Each opcode then knows how to
-        // handle its own data.
-
         /// <summary>Backtracking stack</summary>
+        /// <remarks>
+        /// Opcodes use this to store data regarding
+        /// what they have matched and where to backtrack to.  Each "frame" on
+        /// the stack takes the form of [CodePosition Data1 Data2...], where
+        /// CodePosition is the position of the current opcode and
+        /// the data values are all optional.  The CodePosition can be negative, and
+        /// these values (also called "back2") are used by the BranchMark family of opcodes
+        /// to indicate whether they are backtracking after a successful or failed
+        /// match.
+        /// When we backtrack, we pop the CodePosition off the stack, set the current
+        /// instruction pointer to that code position, and mark the opcode
+        /// with a backtracking flag ("Back").  Each opcode then knows how to
+        /// handle its own data.
+        /// </remarks>
         protected internal int[]? runtrack;
         /// <summary>Backtracking stack position</summary>
         protected internal int runtrackpos;
 
-        // Utility stack.
-        // This stack is used to track text positions across different opcodes.
-        // For example, in /(a*b)+/, the parentheses result in a SetMark/CaptureMark
-        // pair. SetMark records the text position before we match a*b.  Then
-        // CaptureMark uses that position to figure out where the capture starts.
-        // Opcodes which push onto this stack are always paired with other opcodes
-        // which will pop the value from it later.  A successful match should mean
-        // that this stack is empty.
-
         /// <summary>Utility stack</summary>
+        /// <remarks>
+        /// This stack is used to track text positions across different opcodes.
+        /// For example, in /(a*b)+/, the parentheses result in a SetMark/CaptureMark
+        /// pair. SetMark records the text position before we match a*b.  Then
+        /// CaptureMark uses that position to figure out where the capture starts.
+        /// Opcodes which push onto this stack are always paired with other opcodes
+        /// which will pop the value from it later.  A successful match should mean
+        /// that this stack is empty.
+        /// </remarks>
         protected internal int[]? runstack;
         /// <summary>Utility stack position</summary>
         protected internal int runstackpos;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
@@ -33,7 +33,7 @@ namespace System.Text.RegularExpressions
         /// <summary> Starting point for search</summary>
         protected internal int runtextstart;
 
-        /// <summary>Text to search</summary>
+        /// <summary>Text to search. May be null if the input was supplied as a span.</summary>
         protected internal string? runtext;
 
         /// <summary>Current position in text</summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
@@ -26,7 +26,7 @@ namespace System.Text.RegularExpressions
         protected internal int runtextbeg;         // We now always use a sliced span of the input
                                                    // from runtextbeg to runtextend, which means that runtextbeg is now always 0 except
                                                    // for CompiledToAssembly scenario which works over the original input.
-        /// <summary> End of text to search </summary>
+        /// <summary>Index just past the last character to search</summary>
         protected internal int runtextend;         // Because we now pass in a sliced span of the input into Scan,
                                                    // the runtextend will always match the length of that passed in span except for CompileToAssembly
                                                    // scenario, which still works over the original input.

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
@@ -84,11 +84,11 @@ namespace System.Text.RegularExpressions
         /// <summary>Utility stack position</summary>
         protected internal int runstackpos;
 
-        // Crawl stack.
-        // Every time a group has a capture, we push its group number onto the runcrawl stack.
-        // In the case of a balanced match, we push BOTH groups onto the stack.
-
         /// <summary>Crawl stack</summary>
+        /// <remarks>
+        /// Every time a group has a capture, we push its group number onto the runcrawl stack.
+        /// In the case of a balanced match, we push BOTH groups onto the stack.
+        /// </remarks>
         protected internal int[]? runcrawl;
         /// <summary>Crawl stack position</summary>
         protected internal int runcrawlpos;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
@@ -7,7 +7,7 @@
 
 // Implementation notes:
 
-// It provides the driver code that call's the subclass's Scan
+// It provides the driver code that calls the subclass's Scan
 // method for either scanning or direct execution.
 // It also maintains memory allocation for the backtracking stack,
 // the grouping stack and the longjump crawlstack, and provides
@@ -22,50 +22,78 @@ namespace System.Text.RegularExpressions
     [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class RegexRunner
     {
-        protected internal int runtextbeg;         // Beginning of text to search. We now always use a sliced span of the input
+        /// <summary> Beginning of text to search </summary>
+        protected internal int runtextbeg;         // We now always use a sliced span of the input
                                                    // from runtextbeg to runtextend, which means that runtextbeg is now always 0 except
                                                    // for CompiledToAssembly scenario which works over the original input.
-        protected internal int runtextend;         // End of text to search. Because we now pass in a sliced span of the input into Scan,
+        /// <summary> End of text to search </summary>
+        protected internal int runtextend;         // Because we now pass in a sliced span of the input into Scan,
                                                    // the runtextend will always match the length of that passed in span except for CompileToAssembly
                                                    // scenario, which still works over the original input.
-        protected internal int runtextstart;       // starting point for search
+        /// <summary> Starting point for search</summary>
+        protected internal int runtextstart;
 
-        protected internal string? runtext;        // text to search
-        protected internal int runtextpos;         // current position in text
+        /// <summary>Text to search</summary>
+        protected internal string? runtext;
 
-        protected internal int[]? runtrack;        // The backtracking stack.  Opcodes use this to store data regarding
-        protected internal int runtrackpos;        // what they have matched and where to backtrack to.  Each "frame" on
-                                                   // the stack takes the form of [CodePosition Data1 Data2...], where
-                                                   // CodePosition is the position of the current opcode and
-                                                   // the data values are all optional.  The CodePosition can be negative, and
-                                                   // these values (also called "back2") are used by the BranchMark family of opcodes
-                                                   // to indicate whether they are backtracking after a successful or failed
-                                                   // match.
-                                                   // When we backtrack, we pop the CodePosition off the stack, set the current
-                                                   // instruction pointer to that code position, and mark the opcode
-                                                   // with a backtracking flag ("Back").  Each opcode then knows how to
-                                                   // handle its own data.
+        /// <summary>Current position in text</summary>
+        protected internal int runtextpos;
 
-        protected internal int[]? runstack;        // This stack is used to track text positions across different opcodes.
-        protected internal int runstackpos;        // For example, in /(a*b)+/, the parentheses result in a SetMark/CaptureMark
-                                                   // pair. SetMark records the text position before we match a*b.  Then
-                                                   // CaptureMark uses that position to figure out where the capture starts.
-                                                   // Opcodes which push onto this stack are always paired with other opcodes
-                                                   // which will pop the value from it later.  A successful match should mean
-                                                   // that this stack is empty.
+        // Backtracking stack.
+        // Opcodes use this to store data regarding
+        // what they have matched and where to backtrack to.  Each "frame" on
+        // the stack takes the form of [CodePosition Data1 Data2...], where
+        // CodePosition is the position of the current opcode and
+        // the data values are all optional.  The CodePosition can be negative, and
+        // these values (also called "back2") are used by the BranchMark family of opcodes
+        // to indicate whether they are backtracking after a successful or failed
+        // match.
+        // When we backtrack, we pop the CodePosition off the stack, set the current
+        // instruction pointer to that code position, and mark the opcode
+        // with a backtracking flag ("Back").  Each opcode then knows how to
+        // handle its own data.
 
-        protected internal int[]? runcrawl;        // The crawl stack is used to keep track of captures.  Every time a group
-        protected internal int runcrawlpos;        // has a capture, we push its group number onto the runcrawl stack.  In
-                                                   // the case of a balanced match, we push BOTH groups onto the stack.
+        /// <summary>Backtracking stack</summary>
+        protected internal int[]? runtrack;
+        /// <summary>Backtracking stack position</summary>
+        protected internal int runtrackpos;
 
-        protected internal int runtrackcount;      // count of states that may do backtracking
+        // Utility stack.
+        // This stack is used to track text positions across different opcodes.
+        // For example, in /(a*b)+/, the parentheses result in a SetMark/CaptureMark
+        // pair. SetMark records the text position before we match a*b.  Then
+        // CaptureMark uses that position to figure out where the capture starts.
+        // Opcodes which push onto this stack are always paired with other opcodes
+        // which will pop the value from it later.  A successful match should mean
+        // that this stack is empty.
 
-        protected internal Match? runmatch;        // result object
-        protected internal Regex? runregex;        // regex object
+        /// <summary>Utility stack</summary>
+        protected internal int[]? runstack;
+        /// <summary>Utility stack position</summary>
+        protected internal int runstackpos;
 
-        private protected RegexRunnerMode _mode;   // the mode in which the runner is currently operating
+        // Crawl stack.
+        // Every time a group has a capture, we push its group number onto the runcrawl stack.
+        // In the case of a balanced match, we push BOTH groups onto the stack.
 
-        private int _timeout;                      // timeout in milliseconds
+        /// <summary>Crawl stack</summary>
+        protected internal int[]? runcrawl;
+        /// <summary>Crawl stack position</summary>
+        protected internal int runcrawlpos;
+
+        /// <summary>Count of states that may do backtracking</summary>
+        protected internal int runtrackcount;
+
+        /// <summary>Result object</summary>
+        protected internal Match? runmatch;
+        /// <summary>Regex object</summary>
+        protected internal Regex? runregex;
+
+        /// <summary>Mode in which the runner is operating</summary>
+        private protected RegexRunnerMode _mode;
+
+        /// <summary>Timeout in milliseconds</summary>
+        private int _timeout;
         private bool _checkTimeout;
         private long _timeoutOccursAt;
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
@@ -22,7 +22,7 @@ namespace System.Text.RegularExpressions
     [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class RegexRunner
     {
-        /// <summary> Beginning of text to search </summary>
+        /// <summary>Index of the first character to search</summary>
         protected internal int runtextbeg;         // We now always use a sliced span of the input
                                                    // from runtextbeg to runtextend, which means that runtextbeg is now always 0 except
                                                    // for CompiledToAssembly scenario which works over the original input.

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/MonoRegexTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/MonoRegexTests.cs
@@ -283,8 +283,6 @@ namespace System.Text.RegularExpressions.Tests
                 yield return (@"a[^]b]c", RegexOptions.IgnoreCase, "ADC", "Pass. Group[0]=(0,3)");
                 yield return (@"ab|cd", RegexOptions.IgnoreCase, "ABC", "Pass. Group[0]=(0,2)");
                 yield return (@"ab|cd", RegexOptions.IgnoreCase, "ABCD", "Pass. Group[0]=(0,2)");
-                yield return (@"a{2}|a{3}", RegexOptions.None, "aaa", "Pass. Group[0]=(0,2)");
-                yield return (@"a{3}|a{2}", RegexOptions.None, "aaa", "Pass. Group[0]=(0,3)");
                 yield return (@"()ef", RegexOptions.IgnoreCase, "DEF", "Pass. Group[0]=(1,2) Group[1]=(1,0)");
                 yield return (@"$b", RegexOptions.IgnoreCase, "B", "Fail.");
                 yield return (@"a\(b", RegexOptions.IgnoreCase, "A(B", "Pass. Group[0]=(0,3)");

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/MonoRegexTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/MonoRegexTests.cs
@@ -283,6 +283,8 @@ namespace System.Text.RegularExpressions.Tests
                 yield return (@"a[^]b]c", RegexOptions.IgnoreCase, "ADC", "Pass. Group[0]=(0,3)");
                 yield return (@"ab|cd", RegexOptions.IgnoreCase, "ABC", "Pass. Group[0]=(0,2)");
                 yield return (@"ab|cd", RegexOptions.IgnoreCase, "ABCD", "Pass. Group[0]=(0,2)");
+                yield return (@"a{2}|a{3}", RegexOptions.None, "aaa", "Pass. Group[0]=(0,2)");
+                yield return (@"a{3}|a{2}", RegexOptions.None, "aaa", "Pass. Group[0]=(0,3)");
                 yield return (@"()ef", RegexOptions.IgnoreCase, "DEF", "Pass. Group[0]=(1,2) Group[1]=(1,0)");
                 yield return (@"$b", RegexOptions.IgnoreCase, "B", "Fail.");
                 yield return (@"a\(b", RegexOptions.IgnoreCase, "A(B", "Pass. Group[0]=(0,3)");

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -958,6 +958,9 @@ namespace System.Text.RegularExpressions.Tests
                 yield return ("z(a{0,5}|a{0,10}?)", "xyzaaaaaaaaaxyz", options, 0, 15, true, "zaaaaa");
             }
 
+            yield return (@"a{2}|a{3}", "aaa", RegexOptions.None, 0, 3, true, "aa");
+            yield return (@"a{3}|a{2}", "aaa", RegexOptions.None, 0, 3, true, "aaa");
+
             // Test for a bug in NonBacktracking's subsumption rule for XY subsuming X??Y, which didn't check that X is nullable
             yield return (@"XY|X??Y", "Y", RegexOptions.None, 0, 1, true, "Y");
 

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexAssert.netcoreapp.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexAssert.netcoreapp.cs
@@ -15,7 +15,7 @@ namespace System.Text.RegularExpressions.Tests
     {
         public static void Equal(string expected, Capture actual)
         {
-            Assert.Equal(expected, actual.Value);
+            Assert.True(expected == actual.Value, $"Expected {Regex.Escape(expected)} actual {Regex.Escape(actual.Value)}");
             Assert.Equal(expected, actual.ValueSpan.ToString());
         }
     }


### PR DESCRIPTION
some odds and ends from old branches.
1. remove dead string
2. improve node description
3. improve assertion message
4. inline some methods for clarity/consistency
5. improve intellisense for regexrunner fields
6. spacing some comments.
7. rename a method to match its job
8. add a couple tests (the bug they were for is gone, but they seem to fit)