### PR TITLE
[LoongArch64] The REG_SCRATCH is not conflict with REG_PINVOKE_FRAME.

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -5778,7 +5778,7 @@ void CodeGen::genFnProlog()
 
 #ifndef TARGET_LOONGARCH64
     // For LoongArch64's OSR root frames, we may need a scratch register for large
-    // offset addresses. But this is not conflict with REG_PINVOKE_FRAME.
+    // offset addresses. But this does not conflict with the REG_PINVOKE_FRAME.
     noway_assert(!compiler->compMethodRequiresPInvokeFrame() || (initReg != REG_PINVOKE_FRAME));
 #endif
 

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -5774,17 +5774,13 @@ void CodeGen::genFnProlog()
     {
         initReg = REG_IP1;
     }
-#elif defined(TARGET_LOONGARCH64)
-    // For loongarch64 OSR root frames, we may need a scratch register for large
-    // offset addresses. Use a register that won't be allocated.
-    //
-    if (isRoot && compiler->opts.IsOSR())
-    {
-        initReg = REG_SCRATCH;
-    }
 #endif
 
+#ifndef TARGET_LOONGARCH64
+    // For LoongArch64's OSR root frames, we may need a scratch register for large
+    // offset addresses. But this is not conflict with REG_PINVOKE_FRAME.
     noway_assert(!compiler->compMethodRequiresPInvokeFrame() || (initReg != REG_PINVOKE_FRAME));
+#endif
 
 #if defined(TARGET_AMD64)
     // If we are a varargs call, in order to set up the arguments correctly this


### PR DESCRIPTION
This PR is part of the issue https://github.com/dotnet/runtime/issues/69705 to amend the LA's port.

The REG_SCRATCH is not conflict with REG_PINVOKE_FRAME for LoongArch64.