### PR TITLE
JIT: Use compGetTieringName for disassembly output

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1785,7 +1785,7 @@ void CodeGen::genGenerateMachineCode()
 
         printf("\n");
 
-        printf("; %s\n", compiler->compGetTieringName(false));
+        printf("; %s code\n", compiler->compGetTieringName(false));
 
         if (compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_READYTORUN))
         {

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1809,7 +1809,8 @@ void CodeGen::genGenerateMachineCode()
         {
             printf("; debuggable code\n");
         }
-        else if (compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_BBOPT) && compiler->fgHaveProfileWeights())
+
+        if (compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_BBOPT) && compiler->fgHaveProfileWeights())
         {
             printf("; optimized using %s\n", compiler->compGetPgoSourceName());
         }

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1713,7 +1713,7 @@ void CodeGen::genGenerateMachineCode()
         const char* fullName = compiler->eeGetMethodFullName(compiler->info.compMethodHnd);
 #endif
 
-        printf("; Assembly listing for method %s\n", fullName);
+        printf("; Assembly listing for method %s (%s)\n", fullName, compiler->compGetTieringName(true));
 
         printf("; Emitting ");
 
@@ -1785,15 +1785,9 @@ void CodeGen::genGenerateMachineCode()
 
         printf("\n");
 
-        if (compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER0))
-        {
-            printf("; Tier-0 compilation\n");
-        }
-        else if (compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER1))
-        {
-            printf("; Tier-1 compilation\n");
-        }
-        else if (compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_READYTORUN))
+        printf("; %s\n", compiler->compGetTieringName(false));
+
+        if (compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_READYTORUN))
         {
             printf("; ReadyToRun compilation\n");
         }
@@ -1814,19 +1808,6 @@ void CodeGen::genGenerateMachineCode()
         else if (compiler->opts.compDbgCode)
         {
             printf("; debuggable code\n");
-        }
-        else if (compiler->opts.MinOpts())
-        {
-            printf("; MinOpts code\n");
-        }
-        else
-        {
-            printf("; unknown optimization flags\n");
-        }
-
-        if (compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_BBINSTR))
-        {
-            printf("; instrumented for collecting profile data\n");
         }
         else if (compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_BBOPT) && compiler->fgHaveProfileWeights())
         {
@@ -2014,7 +1995,8 @@ void CodeGen::genEmitMachineCode()
         }
 #endif // TRACK_LSRA_STATS
 
-        printf(" (MethodHash=%08x) for method %s\n", compiler->info.compMethodHash(), compiler->info.compFullName);
+        printf(" (MethodHash=%08x) for method %s (%s)\n", compiler->info.compMethodHash(), compiler->info.compFullName,
+               compiler->compGetTieringName(true));
 
         printf("; ============================================================\n\n");
         printf(""); // in our logic this causes a flush

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1787,7 +1787,11 @@ void CodeGen::genGenerateMachineCode()
 
         printf("; %s code\n", compiler->compGetTieringName(false));
 
-        if (compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_READYTORUN))
+        if (compiler->IsTargetAbi(CORINFO_NATIVEAOT_ABI))
+        {
+            printf("; NativeAOT compilation\n");
+        }
+        else if (compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_READYTORUN))
         {
             printf("; ReadyToRun compilation\n");
         }


### PR DESCRIPTION
Also add the code type to the method names, which makes jit-analyze able to differentiate between them.

For example:
```asm
; Assembly listing for method System.Numerics.Tests.Perf_Matrix3x2:MultiplyByMatrixOperatorBenchmark():System.Numerics.Matrix3x2:this (Tier0)
; Emitting BLENDED_CODE for X64 with AVX - Windows
; Tier0 code
; rbp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 this         [V00    ] (  1,  1   )     ref  ->  [rbp+10H]   do-not-enreg[] this class-hnd
;  V01 RetBuf       [V01    ] (  1,  1   )   byref  ->  [rbp+18H]   do-not-enreg[]
;  V02 OutArgs      [V02    ] (  1,  1   )  struct (32) [rsp+00H]   do-not-enreg[XS] addr-exposed "OutgoingArgSpace"
;  V03 tmp1         [V03    ] (  1,  1   )  struct (24) [rbp-18H]   do-not-enreg[HS] hidden-struct-arg "non-inline candidate call"
;  V04 tmp2         [V04    ] (  1,  1   )  struct (24) [rbp-30H]   do-not-enreg[HS] hidden-struct-arg "spilled call-like call argument"
;  V05 tmp3         [V05    ] (  1,  1   )  struct (24) [rbp-48H]   do-not-enreg[XS] addr-exposed "by-value struct argument"
;  V06 tmp4         [V06    ] (  1,  1   )  struct (24) [rbp-60H]   do-not-enreg[XS] addr-exposed "by-value struct argument"
;  V07 tmp5         [V07    ] (  1,  1   )   byref  ->  [rbp-68H]   do-not-enreg[] must-init "argument with side effect"
;
; Lcl frame size = 144
```

Example jit-analyze output:
```scala
Found 1 files with textual diffs.

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 1179
Total bytes of diff: 1220
Total bytes of delta: 41 (3.48 % of base)
Total relative delta: 0.14
    diff is a regression.
    relative diff is a regression.


Top file regressions (bytes):
          41 : diff.dasm (3.48% of base)

1 total files with Code Size differences (0 improved, 1 regressed), 0 unchanged.

Top method regressions (bytes):
          41 (13.67% of base) : base.dasm - System.Numerics.Tests.Perf_Matrix3x2:MultiplyByMatrixOperatorBenchmark():System.Numerics.Matrix3x2:this (Tier1)

Top method regressions (percentages):
          41 (13.67% of base) : base.dasm - System.Numerics.Tests.Perf_Matrix3x2:MultiplyByMatrixOperatorBenchmark():System.Numerics.Matrix3x2:this (Tier1)

1 total methods with Code Size differences (0 improved, 1 regressed), 3 unchanged.

--------------------------------------------------------------------------------
```
