### PR TITLE
[RISC-V] Workaround for __clear_cache()

### DIFF
--- a/src/coreclr/pal/src/thread/context.cpp
+++ b/src/coreclr/pal/src/thread/context.cpp
@@ -1858,6 +1858,17 @@ DBG_FlushInstructionCache(
         __builtin___clear_cache((char *)begin, (char *)endOrNextPageBegin);
         begin = endOrNextPageBegin;
     }
+#elif defined(HOST_RISCV64)
+    // __clear_cache() expanded from __builtin___clear_cache() is not implemented
+    // on Linux/RISCV64, at least in Clang 14, and we have to make syscall directly.
+    //
+    // TODO-RISCV64: use __builtin___clear_cache() in future. See https://github.com/llvm/llvm-project/issues/63551
+
+#ifndef __NR_riscv_flush_icache
+    #define __NR_riscv_flush_icache 259
+#endif
+
+    syscall(__NR_riscv_flush_icache, (char *)lpBaseAddress, (char *)((INT_PTR)lpBaseAddress + dwSize), 0 /* all harts */);
 #else
     __builtin___clear_cache((char *)lpBaseAddress, (char *)((INT_PTR)lpBaseAddress + dwSize));
 #endif


### PR DESCRIPTION
Some tests failed with `SIGILL` wrapped to `SEHException`  when enabled Tiered JIT. The reason is that `__clear_cache()` expanded from `__builtin___clear_cache()` is not implemented on Linux/RISC-V64, at least in GLIBC 2.36, and we have to make syscall directly.

Part of https://github.com/dotnet/runtime/issues/84834

cc @jakobbotsch @wscho77 @HJLeee @JongHeonChoi @t-mustafin @clamp03 @gbalykov