### PR TITLE
[mono][tests] Add SelfContained property to the iOS sample app

### DIFF
--- a/src/mono/sample/iOS/Program.csproj
+++ b/src/mono/sample/iOS/Program.csproj
@@ -8,6 +8,7 @@
     <DefineConstants Condition="'$(ArchiveTests)' == 'true'">$(DefineConstants);CI_TEST</DefineConstants>
     <AppName>HelloiOS</AppName>
     <MainLibraryFileName>$(AssemblyName).dll</MainLibraryFileName>
+    <SelfContained Condition="'$(ArchiveTests)' == 'true'">true</SelfContained>
 
     <RunAOTCompilation Condition="'$(RunAOTCompilation)' == ''">true</RunAOTCompilation>
     <PublishTrimmed>true</PublishTrimmed>


### PR DESCRIPTION
This PR aims to fix the failing functional test on the iossimulator in the `runtime-extra-platforms` pipeline by adding the `SelfContained` property to run ILLink targets.

https://dev.azure.com/dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649/_apis/build/builds/320422/logs/975