### PR TITLE
[wasm] Automatically instrument jiterpreter traces if td->verbose_level > 0

### DIFF
--- a/src/mono/mono/mini/interp/interp-internals.h
+++ b/src/mono/mono/mini/interp/interp-internals.h
@@ -178,6 +178,7 @@ struct InterpMethod {
 	unsigned int needs_thread_attach : 1;
 	// If set, this method is MulticastDelegate.Invoke
 	unsigned int is_invoke : 1;
+	unsigned int is_verbose : 1;
 #if HOST_BROWSER
 	unsigned int contains_traces : 1;
 	guint16 *backward_branch_offsets;

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -7648,7 +7648,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 				 *  JS workers in order to register them at the appropriate slots in the function pointer
 				 *  table. when growing the function pointer table we will also need to synchronize that.
 				 */
-				JiterpreterThunk prepare_result = mono_interp_tier_prepare_jiterpreter_fast(frame, frame->imethod->method, ip, frame->imethod->jinfo->code_start, frame->imethod->jinfo->code_size);
+				JiterpreterThunk prepare_result = mono_interp_tier_prepare_jiterpreter_fast(frame, ip);
 				ptrdiff_t offset;
 				switch ((guint32)(void*)prepare_result) {
 					case JITERPRETER_TRAINING:

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -883,11 +883,15 @@ mono_jiterp_get_trace_hit_count (gint32 trace_index) {
 
 JiterpreterThunk
 mono_interp_tier_prepare_jiterpreter_fast (
-	void *frame, MonoMethod *method, const guint16 *ip,
-	const guint16 *start_of_body, int size_of_body
+	void *_frame, const guint16 *ip
 ) {
 	if (!mono_opt_jiterpreter_traces_enabled)
 		return (JiterpreterThunk)(void*)JITERPRETER_NOT_JITTED;
+
+	InterpFrame *frame = _frame;
+	MonoMethod *method = frame->imethod->method;
+	const guint16 *start_of_body = frame->imethod->jinfo->code_start;
+	int size_of_body = frame->imethod->jinfo->code_size;
 
 	guint32 trace_index = READ32 (ip + 1);
 	TraceInfo *trace_info = trace_info_get (trace_index);
@@ -905,7 +909,7 @@ mono_interp_tier_prepare_jiterpreter_fast (
 	if (count == mono_opt_jiterpreter_minimum_trace_hit_count) {
 		JiterpreterThunk result = mono_interp_tier_prepare_jiterpreter(
 			frame, method, ip, (gint32)trace_index,
-			start_of_body, size_of_body
+			start_of_body, size_of_body, frame->imethod->is_verbose
 		);
 		trace_info->thunk = result;
 		return result;

--- a/src/mono/mono/mini/interp/jiterpreter.h
+++ b/src/mono/mono/mini/interp/jiterpreter.h
@@ -60,8 +60,7 @@ mono_interp_jit_wasm_entry_trampoline (
 // Fast-path implemented in C
 JiterpreterThunk
 mono_interp_tier_prepare_jiterpreter_fast (
-	void *frame, MonoMethod *method, const guint16 *ip,
-	const guint16 *start_of_body, int size_of_body
+	void *_frame, const guint16 *ip
 );
 
 // HACK: Pass void* so that this header can include safely in files without definition for InterpFrame
@@ -69,7 +68,7 @@ mono_interp_tier_prepare_jiterpreter_fast (
 extern JiterpreterThunk
 mono_interp_tier_prepare_jiterpreter (
 	void *frame, MonoMethod *method, const guint16 *ip, gint32 trace_index,
-	const guint16 *start_of_body, int size_of_body
+	const guint16 *start_of_body, int size_of_body, int is_verbose
 );
 
 // HACK: Pass void* so that this header can include safely in files without definition for InterpMethod,

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -11090,6 +11090,8 @@ retry:
 
 	g_assert (td->inline_depth == 0);
 
+	td->rtm->is_verbose = td->verbose_level > 0;
+
 	if (td->has_localloc)
 		interp_fix_localloc_ret (td);
 

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -116,10 +116,12 @@ export class TraceInfo {
     fnPtr: number | undefined;
     bailoutCounts: { [code: number]: number } | undefined;
     bailoutCount: number | undefined;
+    isVerbose: boolean;
 
-    constructor(ip: MintOpcodePtr, index: number) {
+    constructor(ip: MintOpcodePtr, index: number, isVerbose: number) {
         this.ip = ip;
         this.index = index;
+        this.isVerbose = !!isVerbose;
     }
 
     get hitCount() {
@@ -755,15 +757,17 @@ function generate_wasm(
     let compileStarted = 0;
     let rejected = true, threw = false;
 
-    const instrument = methodFullName && (
+    const ti = traceInfo[<any>ip];
+    const instrument = ti.isVerbose || (methodFullName && (
         instrumentedMethodNames.findIndex(
             (filter) => methodFullName.indexOf(filter) >= 0
         ) >= 0
-    );
+    ));
+    mono_assert(!instrument || methodFullName, "Expected methodFullName if trace is instrumented");
     const instrumentedTraceId = instrument ? nextInstrumentedTraceId++ : 0;
     if (instrument) {
         mono_log_info(`instrumenting: ${methodFullName}`);
-        instrumentedTraces[instrumentedTraceId] = new InstrumentedTraceState(methodFullName);
+        instrumentedTraces[instrumentedTraceId] = new InstrumentedTraceState(methodFullName!);
     }
     builder.compressImportNames = compressImportNames && !instrument;
 
@@ -829,7 +833,6 @@ function generate_wasm(
         builder.emitImportsAndFunctions();
 
         if (!keep) {
-            const ti = traceInfo[<any>ip];
             if (ti && (ti.abortReason === "end-of-body"))
                 ti.abortReason = "trace-too-small";
 
@@ -980,7 +983,7 @@ const JITERPRETER_NOT_JITTED = 1;
 
 export function mono_interp_tier_prepare_jiterpreter(
     frame: NativePointer, method: MonoMethod, ip: MintOpcodePtr, index: number,
-    startOfBody: MintOpcodePtr, sizeOfBody: MintOpcodePtr
+    startOfBody: MintOpcodePtr, sizeOfBody: MintOpcodePtr, isVerbose: number
 ): number {
     mono_assert(ip, "expected instruction pointer");
     if (!mostRecentOptions)
@@ -995,11 +998,15 @@ export function mono_interp_tier_prepare_jiterpreter(
     let info = traceInfo[<any>ip];
 
     if (!info)
-        traceInfo[<any>ip] = info = new TraceInfo(ip, index);
+        traceInfo[<any>ip] = info = new TraceInfo(ip, index, isVerbose);
 
     counters.traceCandidates++;
     let methodFullName: string | undefined;
-    if (mostRecentOptions.estimateHeat || (instrumentedMethodNames.length > 0) || useFullNames) {
+    if (
+        mostRecentOptions.estimateHeat ||
+        (instrumentedMethodNames.length > 0) || useFullNames ||
+        info.isVerbose
+    ) {
         const pMethodName = cwraps.mono_wasm_method_get_full_name(method);
         methodFullName = utf8ToString(pMethodName);
         Module._free(<any>pMethodName);
@@ -1033,7 +1040,8 @@ export function mono_interp_tier_prepare_jiterpreter(
     }
 
     const fnPtr = generate_wasm(
-        frame, methodName, ip, startOfBody, sizeOfBody, methodFullName, backwardBranchTable
+        frame, methodName, ip, startOfBody,
+        sizeOfBody, methodFullName, backwardBranchTable
     );
 
     if (fnPtr) {


### PR DESCRIPTION
If we have verbose turned on for an interpreter method, it makes sense to also instrument it on the jiterpreter side.