### PR TITLE
Fall back to the forwarder generator for invalid [In, Out] attributes instead of using the already-selected generator with additional diagnostics

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ByValueContentsMarshalKindValidator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ByValueContentsMarshalKindValidator.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Interop
     /// </summary>
     public class ByValueContentsMarshalKindValidator : IMarshallingGeneratorFactory
     {
+        private static readonly Forwarder s_forwarder = new();
+
         private readonly IMarshallingGeneratorFactory _inner;
 
         public ByValueContentsMarshalKindValidator(IMarshallingGeneratorFactory inner)
@@ -35,34 +37,25 @@ namespace Microsoft.Interop
 
             if (info.IsByRef && info.ByValueContentsMarshalKind != ByValueContentsMarshalKind.Default)
             {
-                return generator with
+                return ResolvedGenerator.ResolvedWithDiagnostics(s_forwarder, generator.Diagnostics.Add(new GeneratorDiagnostic.NotSupported(info, context)
                 {
-                    Diagnostics = generator.Diagnostics.Add(new GeneratorDiagnostic.NotSupported(info, context)
-                    {
-                        NotSupportedDetails = SR.InOutAttributeByRefNotSupported
-                    })
-                };
+                    NotSupportedDetails = SR.InOutAttributeByRefNotSupported
+                }));
             }
             else if (info.ByValueContentsMarshalKind == ByValueContentsMarshalKind.In)
             {
-                return generator with
+                return ResolvedGenerator.ResolvedWithDiagnostics(s_forwarder, generator.Diagnostics.Add(new GeneratorDiagnostic.NotSupported(info, context)
                 {
-                    Diagnostics = generator.Diagnostics.Add(new GeneratorDiagnostic.NotSupported(info, context)
-                    {
-                        NotSupportedDetails = SR.InAttributeNotSupportedWithoutOut
-                    })
-                };
+                    NotSupportedDetails = SR.InAttributeNotSupportedWithoutOut
+                }));
             }
             else if (info.ByValueContentsMarshalKind != ByValueContentsMarshalKind.Default
                 && !generator.Generator.SupportsByValueMarshalKind(info.ByValueContentsMarshalKind, context))
             {
-                return generator with
+                return ResolvedGenerator.ResolvedWithDiagnostics(s_forwarder, generator.Diagnostics.Add(new GeneratorDiagnostic.NotSupported(info, context)
                 {
-                    Diagnostics = generator.Diagnostics.Add(new GeneratorDiagnostic.NotSupported(info, context)
-                    {
-                        NotSupportedDetails = SR.InOutAttributeMarshalerNotSupported
-                    })
-                };
+                    NotSupportedDetails = SR.InOutAttributeMarshalerNotSupported
+                }));
             }
             return generator;
         }


### PR DESCRIPTION
Fixes #87999