### PR TITLE
Fix unsafe walking of DacEnumerableHash

### DIFF
--- a/src/coreclr/vm/dacenumerablehash.h
+++ b/src/coreclr/vm/dacenumerablehash.h
@@ -302,7 +302,7 @@ private:
     {
         SUPPORTS_DAC;
 
-        return m_pBuckets;
+        return VolatileLoadWithoutBarrier(&m_pBuckets);
     }
 
     // our bucket table uses two extra slots - slot [0] contains the length of the table,
@@ -325,7 +325,7 @@ private:
 
     static DPTR(PTR_VolatileEntry) GetNext(DPTR(PTR_VolatileEntry) buckets)
     {
-        return dac_cast<DPTR(PTR_VolatileEntry)>(buckets[SLOT_NEXT]);
+        return dac_cast<DPTR(PTR_VolatileEntry)>(VolatileLoadWithoutBarrier(&buckets[SLOT_NEXT]));
     }
 
     // Loader heap provided at construction time. May be NULL (in which case m_pModule must *not* be NULL).

--- a/src/coreclr/vm/dacenumerablehash.inl
+++ b/src/coreclr/vm/dacenumerablehash.inl
@@ -48,6 +48,17 @@ DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::DacEnumerableHashTable(Module *pModu
     m_cEntries = 0;
     PTR_VolatileEntry* pBuckets = (PTR_VolatileEntry*)(void*)GetHeap()->AllocMem(cbBuckets);
     ((size_t*)pBuckets)[SLOT_LENGTH] = cInitialBuckets;
+    ((size_t*)pBuckets)[SLOT_BUCKETSINDEX] = 1;
+
+    TADDR endSentinel = CreateEndSentinel(pBuckets);
+
+    // All buckets are initially empty.
+    // Note: Memory allocated on loader heap is zero filled, and since we need end sentinels, fill them in now
+    for (DWORD i = 0; i < cInitialBuckets; i++)
+    {
+        DWORD dwCurBucket = i + SKIP_SPECIAL_SLOTS;
+        pBuckets[dwCurBucket] = dac_cast<PTR_VolatileEntry>(endSentinel);
+    }
 
     // publish after setting the length
     VolatileStore(&m_pBuckets, pBuckets);
@@ -184,13 +195,26 @@ void DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::GrowTable()
 
     // element 0 stores the length of the table
     ((size_t*)pNewBuckets)[SLOT_LENGTH] = cNewBuckets;
+    ((size_t*)pNewBuckets)[SLOT_BUCKETSINDEX] = BucketsIndex(curBuckets) + 1;
     // element 1 stores the next version of the table (after length is written)
     // NOTE: DAC does not call add/grow, so this cast is ok.
     VolatileStore(&((PTR_VolatileEntry**)curBuckets)[SLOT_NEXT], pNewBuckets);
 
+    TADDR newEndSentinel = CreateEndSentinel(pNewBuckets);
+
+    _ASSERTE(BucketsIndex(curBuckets) != BucketsIndex(pNewBuckets));
+
+    // It is acceptable to walk a chain and find a sentinel from an older bucket, but not vice versa
+    _ASSERTE(AcceptableEndSentinel(dac_cast<PTR_VolatileEntry>(CreateEndSentinel(curBuckets)), CreateEndSentinel(pNewBuckets)));
+    _ASSERTE(!AcceptableEndSentinel(dac_cast<PTR_VolatileEntry>(CreateEndSentinel(pNewBuckets)), CreateEndSentinel(curBuckets)));
+
     // All buckets are initially empty.
-    // Note: Memory allocated on loader heap is zero filled
-    // memset(pNewBuckets, 0, cNewBuckets * sizeof(PTR_VolatileEntry));
+    // Note: Memory allocated on loader heap is zero filled, and since we need end sentinels, fill them in now
+    for (DWORD i = 0; i < cNewBuckets; i++)
+    {
+        DWORD dwCurBucket = i + SKIP_SPECIAL_SLOTS;
+        pNewBuckets[dwCurBucket] = dac_cast<PTR_VolatileEntry>(newEndSentinel);
+    }
 
     // Run through the old table and transfer all the entries. Be sure not to mess with the integrity of the
     // old table while we are doing this, as there can be concurrent readers!
@@ -203,7 +227,7 @@ void DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::GrowTable()
         DWORD dwCurBucket = i + SKIP_SPECIAL_SLOTS;
         PTR_VolatileEntry pEntry = curBuckets[dwCurBucket];
 
-        while (pEntry != NULL)
+        while (!IsEndSentinel(pEntry))
         {
             DWORD dwNewBucket = (pEntry->m_iHashValue % cNewBuckets) + SKIP_SPECIAL_SLOTS;
             PTR_VolatileEntry pNextEntry  = pEntry->m_pNextEntry;
@@ -211,13 +235,13 @@ void DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::GrowTable()
             PTR_VolatileEntry pTail = pNewBuckets[dwNewBucket];
 
             // make the pEntry reachable in the new bucket, together with all the chain (that is temporary and ok)
-            if (pTail == NULL)
+            if (IsEndSentinel(pTail))
             {
                 pNewBuckets[dwNewBucket] = pEntry;
             }
             else
             {
-                while (pTail->m_pNextEntry)
+                while (!IsEndSentinel(pTail->m_pNextEntry))
                 {
                     pTail = pTail->m_pNextEntry;
                 }
@@ -229,7 +253,10 @@ void DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::GrowTable()
             VolatileStore(&curBuckets[dwCurBucket], pNextEntry);
 
             // drop the rest of the bucket after old table starts referring to it
-            VolatileStore(&pEntry->m_pNextEntry, (PTR_VolatileEntry)NULL);
+            // NOTE: this can cause a race condition where a reader thread (which is unlocked relative to this logic)
+            //       can be walking this list, and stop early, failing to walk the rest of the chain. We use an incrementing
+            //       end sentinel to detect that case, and repeat the entire walk.
+            VolatileStore(&pEntry->m_pNextEntry, dac_cast<PTR_VolatileEntry>(newEndSentinel));
 
             pEntry = pNextEntry;
         }
@@ -311,9 +338,10 @@ DPTR(VALUE) DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::BaseFindFirstEntryByHash
 
         // Point at the first entry in the bucket chain that stores entries with the given hash code.
         PTR_VolatileEntry pEntry = VolatileLoadWithoutBarrier(&curBuckets[dwBucket]);
+        TADDR expectedEndSentinel = CreateEndSentinel(curBuckets);
 
         // Walk the bucket chain one entry at a time.
-        while (pEntry)
+        while (!IsEndSentinel(pEntry))
         {
             if (pEntry->m_iHashValue == iHash)
             {
@@ -323,6 +351,7 @@ DPTR(VALUE) DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::BaseFindFirstEntryByHash
                 // BaseFindNextEntryByHash can pick up the search where it left off.
                 pContext->m_pEntry = dac_cast<TADDR>(pEntry);
                 pContext->m_curBuckets = curBuckets;
+                pContext->m_expectedEndSentinel = dac_cast<TADDR>(expectedEndSentinel);
 
                 // Return the address of the sub-classes' embedded entry structure.
                 return VALUE_FROM_VOLATILE_ENTRY(pEntry);
@@ -330,6 +359,17 @@ DPTR(VALUE) DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::BaseFindFirstEntryByHash
 
             // Move to the next entry in the chain.
             pEntry = VolatileLoadWithoutBarrier(&pEntry->m_pNextEntry);
+        }
+
+        if (!AcceptableEndSentinel(pEntry, expectedEndSentinel))
+        {
+            // If we hit this logic, we've managed to hit a case where the linked list was in the process of being
+            // moved to a new set of buckets while we were walking the list, and we walked part of the list of the
+            // bucket in the old hash table (which is fine), and part of the list in the new table, which may not
+            // be the correct bucket to walk. Most notably, the situation that can cause this will cause the list in
+            // the old bucket to be missing items. Restart the lookup, as the linked list is unlikely to still be under
+            // edit a second time.
+            continue;
         }
 
         // in a rare case if resize is in progress, look in the new table as well.
@@ -368,7 +408,7 @@ DPTR(VALUE) DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::BaseFindNextEntryByHash(
     iHash = pVolatileEntry->m_iHashValue;
 
     // Iterate over the rest ot the bucket chain.
-    while ((pVolatileEntry = VolatileLoadWithoutBarrier(&pVolatileEntry->m_pNextEntry)) != nullptr)
+    while (!IsEndSentinel(pVolatileEntry = VolatileLoadWithoutBarrier(&pVolatileEntry->m_pNextEntry)))
     {
         if (pVolatileEntry->m_iHashValue == iHash)
         {
@@ -377,6 +417,11 @@ DPTR(VALUE) DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::BaseFindNextEntryByHash(
             pContext->m_pEntry = dac_cast<TADDR>(pVolatileEntry);
             return VALUE_FROM_VOLATILE_ENTRY(pVolatileEntry);
         }
+    }
+
+    if (!AcceptableEndSentinel(pVolatileEntry, pContext->m_expectedEndSentinel))
+    {
+        return BaseFindFirstEntryByHashCore(pContext->m_curBuckets, iHash, pContext);
     }
 
     // check for next table must happen after we looked through the current.
@@ -446,7 +491,7 @@ void DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::EnumMemoryRegions(CLRDataEnumMe
         {
             //+2 to skip "length" and "next" slots
             PTR_VolatileEntry pEntry = curBuckets[i + SKIP_SPECIAL_SLOTS];
-            while (pEntry.IsValid())
+            while (!IsEndSentinel(pEntry) && pEntry.IsValid())
             {
                 pEntry.EnumMem();
 
@@ -513,11 +558,12 @@ DPTR(VALUE) DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::BaseIterator::Next()
         }
 
         // If we found an entry in the last step return with it.
-        if (m_pEntry)
+        if (!IsEndSentinel(m_pEntry))
             return VALUE_FROM_VOLATILE_ENTRY(dac_cast<PTR_VolatileEntry>(m_pEntry));
 
         // Otherwise we found the end of a bucket chain. Increment the current bucket and, if there are
         // buckets left to scan go back around again.
+        m_pEntry = NULL;
         m_dwBucket++;
     }
 

--- a/src/coreclr/vm/dacenumerablehash.inl
+++ b/src/coreclr/vm/dacenumerablehash.inl
@@ -192,7 +192,7 @@ void DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::GrowTable()
     // or the bucket age has already reached its maximum value,
     // just don't expand the table
     if ((cNewBuckets == cBuckets) || 
-        (cBuckets > DWORD_MAX - SKIP_SPECIAL_SLOTS) ||
+        (cBuckets > UINT32_MAX - SKIP_SPECIAL_SLOTS) ||
         (SKIP_SPECIAL_SLOTS + cBuckets > MaxBucketCountRepresentableWithEndSentinel()) ||
         (BucketsAgeFromEndSentinel(BaseEndSentinel(curBuckets)) == MaxBucketAge()))
         return;

--- a/src/coreclr/vm/dacenumerablehash.inl
+++ b/src/coreclr/vm/dacenumerablehash.inl
@@ -209,8 +209,6 @@ void DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::GrowTable()
     ((size_t*)pNewBuckets)[SLOT_LENGTH] = cNewBuckets;
     ((size_t*)pNewBuckets)[SLOT_ENDSENTINEL] = IncrementBaseEndSentinel(BaseEndSentinel(curBuckets));
     // element 1 stores the next version of the table (after length is written)
-    // NOTE: DAC does not call add/grow, so this cast is ok.
-    VolatileStore(&((PTR_VolatileEntry**)curBuckets)[SLOT_NEXT], pNewBuckets);
 
     TADDR newEndSentinel = BaseEndSentinel(pNewBuckets);
 
@@ -227,6 +225,9 @@ void DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::GrowTable()
         DWORD dwCurBucket = i + SKIP_SPECIAL_SLOTS;
         pNewBuckets[dwCurBucket] = dac_cast<PTR_VolatileEntry>(ComputeEndSentinel(newEndSentinel, dwCurBucket));
     }
+
+    // NOTE: DAC does not call add/grow, so this cast is ok.
+    VolatileStore(&((PTR_VolatileEntry**)curBuckets)[SLOT_NEXT], pNewBuckets);
 
     // Run through the old table and transfer all the entries. Be sure not to mess with the integrity of the
     // old table while we are doing this, as there can be concurrent readers!


### PR DESCRIPTION
Under the following set of conditions, it is possible for a lookup in the `DacEnumerableHash` to fail to find already present entries. 

Given Thread A which is growing the table, and thread B which is attempting to perform a lookup.

1. Thread B reads an `VolatileEntry*` from a bucket in the hashtable. Let this be EntryB. EntryB will have a next pointer which points to EntryThatWeNeedToFind, but it will not yet read that pointer value from EntryB.
2. Thread A reads the pointer to EntryB from the same bucket in the hashtable.
3. Thread A adds EntryB to the new hashtable
4. Thread A sets the bucket in the old hashtable to point to EntryThatWeNeedToFind
5. Thread A sets the next pointer in EntryB to point to NULL.
6. Thread B reads the next pointer, sees that the next pointer is NULL, and falls back to looking in the "new" hashtable for any possible updates
7. Thread B looks in the appropriate bucket in the "new" hashtable. That bucket does not yet contain EntryThatWeNeedToFind, as it hasn't yet been moved from the old hashtable.
8. Thread B returns NULL __*INCORRECTLY*__, indicating that there are no entries with the matching in them.

This change adjust how these linked lists work, but giving each one a version number which can be checked as the linked list finishes reading. The fix allows finding entries from an earlier set of buckets (as those can be in the new list temporarily, and will not interfere with finding the correct result), but will actively detect walking entries in the new list when attempting to walk the old entries. 

In addition, there is a drive by fix for an issue where if there are more than ~14,000,000 entries in the table, it allocates a full new list each time the list is added to.

Fixes #85688