### PR TITLE
Set the CORINFO_EH_CLAUSE_SAMETRY on CORINFO_EH_CLAUSE

### DIFF
--- a/docs/design/coreclr/botr/clr-abi.md
+++ b/docs/design/coreclr/botr/clr-abi.md
@@ -588,7 +588,7 @@ If the handlers were in a different order, then clause 6 might appear before cla
 ## Clauses covering the same try region
 
 Several consecutive clauses may cover the same `try` block. A clause covering the same region as the previous one is marked by the `COR_ILEXCEPTION_CLAUSE_SAMETRY` flag. During collided unwind when an exception is thrown while running handler for another exception, this enables the runtime to skip clauses that that cover the same `try` block as the clause that handled the original exception.
-This flag is used by the NativeAOT compiler and also a new exception handling mechanism in CoreCLR. The NativeAOT compiler doesn't store that flag in the encoded clause data, but rather injects a dummy clause between the clauses with same `try` block. CoreCLR keeps that flag as part of the runtime representation of the clause data. The current CoreCLR exception handling doesn't use it, but [a new exception handling mechanism](https://github.com/dotnet/runtime/issues/77568) that's being developed is taking advantage of it.
+This flag is used by the NativeAOT and also a new exception handling mechanism in CoreCLR. The NativeAOT doesn't store that flag in the encoded clause data, but rather injects a dummy clause between the clauses with same `try` block. CoreCLR keeps that flag as part of the runtime representation of the clause data. The current CoreCLR exception handling doesn't use it, but [a new exception handling mechanism](https://github.com/dotnet/runtime/issues/77568) that's being developed is taking advantage of it.
 
 ## GC Interruptibility and EH
 

--- a/docs/design/coreclr/botr/clr-abi.md
+++ b/docs/design/coreclr/botr/clr-abi.md
@@ -585,6 +585,11 @@ The native EH clauses would be listed as follows:
 
 If the handlers were in a different order, then clause 6 might appear before clauses 4 and 5, but never in between.
 
+## Clauses covering the same try region
+
+Several consecutive clauses may cover the same `try` block. A clause covering the same region as the previous one is marked by the `COR_ILEXCEPTION_CLAUSE_SAMETRY` flag. During collided unwind when an exception is thrown while running handler for another exception, this enables the runtime to skip clauses that that cover the same `try` block as the clause that handled the original exception. 
+This flag is used by the NativeAOT compiler and also a new exception handling mechanism in CoreCLR. The NativeAOT compiler doesn't store that flag in the encoded clause data, but rather injects a dummy clause between the clauses with same `try` block. CoreCLR keeps that flag as part of the runtime representation of the clause data. The current CoreCLR exception handling doesn't use it, but a new exception handling mechanism that's being developed is taking advantage of it.
+
 ## GC Interruptibility and EH
 
 The VM assumes that anytime a thread is stopped, it must be at a GC safe point, or the current frame is non-resumable (i.e. a throw that will never be caught in the same frame). Thus effectively all methods with EH must be fully interruptible (or at a minimum all try bodies). Currently the GC info appears to support mixing of partially interruptible and fully-interruptible regions within the same method, but no JIT uses this, so use at your own risk.

--- a/docs/design/coreclr/botr/clr-abi.md
+++ b/docs/design/coreclr/botr/clr-abi.md
@@ -587,7 +587,7 @@ If the handlers were in a different order, then clause 6 might appear before cla
 
 ## Clauses covering the same try region
 
-Several consecutive clauses may cover the same `try` block. A clause covering the same region as the previous one is marked by the `COR_ILEXCEPTION_CLAUSE_SAMETRY` flag. During collided unwind when an exception is thrown while running handler for another exception, this enables the runtime to skip clauses that that cover the same `try` block as the clause that handled the original exception.
+Several consecutive clauses may cover the same `try` block. A clause covering the same region as the previous one is marked by the `COR_ILEXCEPTION_CLAUSE_SAMETRY` flag. When exception ex1 is thrown while running handler for another exception ex2 and the exception ex2 escapes the ex1's handler frame, this enables the runtime to skip clauses that cover the same `try` block as the clause that handled the ex1.
 This flag is used by the NativeAOT and also a new exception handling mechanism in CoreCLR. The NativeAOT doesn't store that flag in the encoded clause data, but rather injects a dummy clause between the clauses with same `try` block. CoreCLR keeps that flag as part of the runtime representation of the clause data. The current CoreCLR exception handling doesn't use it, but [a new exception handling mechanism](https://github.com/dotnet/runtime/issues/77568) that's being developed is taking advantage of it.
 
 ## GC Interruptibility and EH

--- a/docs/design/coreclr/botr/clr-abi.md
+++ b/docs/design/coreclr/botr/clr-abi.md
@@ -587,7 +587,7 @@ If the handlers were in a different order, then clause 6 might appear before cla
 
 ## Clauses covering the same try region
 
-Several consecutive clauses may cover the same `try` block. A clause covering the same region as the previous one is marked by the `COR_ILEXCEPTION_CLAUSE_SAMETRY` flag. During collided unwind when an exception is thrown while running handler for another exception, this enables the runtime to skip clauses that that cover the same `try` block as the clause that handled the original exception. 
+Several consecutive clauses may cover the same `try` block. A clause covering the same region as the previous one is marked by the `COR_ILEXCEPTION_CLAUSE_SAMETRY` flag. During collided unwind when an exception is thrown while running handler for another exception, this enables the runtime to skip clauses that that cover the same `try` block as the clause that handled the original exception.
 This flag is used by the NativeAOT compiler and also a new exception handling mechanism in CoreCLR. The NativeAOT compiler doesn't store that flag in the encoded clause data, but rather injects a dummy clause between the clauses with same `try` block. CoreCLR keeps that flag as part of the runtime representation of the clause data. The current CoreCLR exception handling doesn't use it, but a new exception handling mechanism that's being developed is taking advantage of it.
 
 ## GC Interruptibility and EH

--- a/docs/design/coreclr/botr/clr-abi.md
+++ b/docs/design/coreclr/botr/clr-abi.md
@@ -588,7 +588,7 @@ If the handlers were in a different order, then clause 6 might appear before cla
 ## Clauses covering the same try region
 
 Several consecutive clauses may cover the same `try` block. A clause covering the same region as the previous one is marked by the `COR_ILEXCEPTION_CLAUSE_SAMETRY` flag. During collided unwind when an exception is thrown while running handler for another exception, this enables the runtime to skip clauses that that cover the same `try` block as the clause that handled the original exception.
-This flag is used by the NativeAOT compiler and also a new exception handling mechanism in CoreCLR. The NativeAOT compiler doesn't store that flag in the encoded clause data, but rather injects a dummy clause between the clauses with same `try` block. CoreCLR keeps that flag as part of the runtime representation of the clause data. The current CoreCLR exception handling doesn't use it, but a new exception handling mechanism that's being developed is taking advantage of it.
+This flag is used by the NativeAOT compiler and also a new exception handling mechanism in CoreCLR. The NativeAOT compiler doesn't store that flag in the encoded clause data, but rather injects a dummy clause between the clauses with same `try` block. CoreCLR keeps that flag as part of the runtime representation of the clause data. The current CoreCLR exception handling doesn't use it, but [a new exception handling mechanism](https://github.com/dotnet/runtime/issues/77568) that's being developed is taking advantage of it.
 
 ## GC Interruptibility and EH
 

--- a/src/coreclr/inc/corinfo.h
+++ b/src/coreclr/inc/corinfo.h
@@ -907,7 +907,7 @@ enum CORINFO_EH_CLAUSE_FLAGS
     CORINFO_EH_CLAUSE_FINALLY   = 0x0002, // This clause is a finally clause
     CORINFO_EH_CLAUSE_FAULT     = 0x0004, // This clause is a fault clause
     CORINFO_EH_CLAUSE_DUPLICATE = 0x0008, // Duplicated clause. This clause was duplicated to a funclet which was pulled out of line
-    CORINFO_EH_CLAUSE_SAMETRY   = 0x0010, // This clause covers same try block as the previous one. (Used by NativeAOT ABI.)
+    CORINFO_EH_CLAUSE_SAMETRY   = 0x0010, // This clause covers same try block as the previous one
 };
 
 // This enumeration is passed to InternalThrow

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2317,7 +2317,7 @@ void CodeGen::genReportEH()
 
         if (XTnum > 0)
         {
-            // For NativeAOT, CORINFO_EH_CLAUSE_SAMETRY flag means that the current clause covers same
+            // CORINFO_EH_CLAUSE_SAMETRY flag means that the current clause covers same
             // try block as the previous one. The runtime cannot reliably infer this information from
             // native code offsets because of different try blocks can have same offsets. Alternative
             // solution to this problem would be inserting extra nops to ensure that different try

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2315,7 +2315,7 @@ void CodeGen::genReportEH()
 
         CORINFO_EH_CLAUSE_FLAGS flags = ToCORINFO_EH_CLAUSE_FLAGS(HBtab->ebdHandlerType);
 
-        if (isNativeAOT && (XTnum > 0))
+        if (XTnum > 0)
         {
             // For NativeAOT, CORINFO_EH_CLAUSE_SAMETRY flag means that the current clause covers same
             // try block as the previous one. The runtime cannot reliably infer this information from

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/EHInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/EHInfo.cs
@@ -26,6 +26,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         COR_ILEXCEPTION_CLAUSE_FINALLY = 0x0002,        // This clause is a finally clause
         COR_ILEXCEPTION_CLAUSE_FAULT = 0x0004,          // Fault clause (finally that is called on exception only)
         COR_ILEXCEPTION_CLAUSE_DUPLICATED = 0x0008,     // duplicated clause. This clause was duplicated to a funclet which was pulled out of line
+        COR_ILEXCEPTION_CLAUSE_SAMETRY = 0x0010,        // This clause covers same try block as the previous one
 
         COR_ILEXCEPTION_CLAUSE_KIND_MASK = COR_ILEXCEPTION_CLAUSE_FILTER | COR_ILEXCEPTION_CLAUSE_FINALLY | COR_ILEXCEPTION_CLAUSE_FAULT,
     }
@@ -153,6 +154,11 @@ namespace ILCompiler.Reflection.ReadyToRun
             if ((Flags & CorExceptionFlag.COR_ILEXCEPTION_CLAUSE_DUPLICATED) != (CorExceptionFlag)0)
             {
                 writer.Write(" DUPLICATED");
+            }
+
+            if ((Flags & CorExceptionFlag.COR_ILEXCEPTION_CLAUSE_SAMETRY) != (CorExceptionFlag)0)
+            {
+                writer.Write(" SAMETRY");
             }
         }
     }


### PR DESCRIPTION
This change makes setting the `CORINFO_EH_CLAUSE_SAMETRY` on `CORINFO_EH_CLAUSE` to happen for coreclr to. It is a prerequisity for the port of exception handling from nativeaot to coreclr and it is a noop on coreclr with the old exception handling.