### PR TITLE
Ensure runtime thread for diagnostic server thread

### DIFF
--- a/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
@@ -348,6 +348,10 @@ ds_rt_apply_startup_hook (const ep_char16_t *startup_hook_path)
 		// and executed.
 		IfFailRet(EnsureEEStarted());
 
+		// Ensure runtime thread for diagnostic server thread
+		SetupThreadNoThrow(&hr);
+		IfFailRet(hr);
+
 		EX_TRY {
 			GCX_COOP();
 


### PR DESCRIPTION
When using the ApplyStartupHook diagnostic command on a real application, it would fail to execute the startup hook due to the diagnostic server thread not being a runtime thread. A debug build of the runtime exhibits the following failed assertion:

```
Assert failure(PID 31948 [0x00007ccc], Thread: 25100 [0x620c]): pThread

CORECLR! GetThread + 0x49 (0x00007ff9`acb9ad99)
CORECLR! GCCoop::GCCoop + 0x1E (0x00007ff9`acb6b72e)
CORECLR! ds_rt_apply_startup_hook + 0xF3 (0x00007ff9`ad8757a3)
CORECLR! process_protocol_helper_apply_startup_hook + 0xBC (0x00007ff9`ad87b21c)
CORECLR! ds_process_protocol_helper_handle_ipc_message + 0x144 (0x00007ff9`ad875584)
CORECLR! server_thread + 0x30C (0x00007ff9`ad87caec)
KERNEL32! BaseThreadInitThunk + 0x1D (0x00007ffa`374926ad)
NTDLL! RtlUserThreadStart + 0x28 (0x00007ffa`390ea9f8)
    File: C:\src\dotnet\runtime\src\coreclr\vm\threads.inl Line: 43
    Image: C:\src\projects\ConsoleApp3\ConsoleApp3\bin\Release\net8.0\publish\win-x64\ConsoleApp3.exe
```

This isn't exhibited in the [TEST_ApplyStartupHookDuringExecution](https://github.com/dotnet/runtime/blob/main/src/tests/tracing/eventpipe/applystartuphook/ApplyStartupHookValidation.cs#L79) for some reason even though it is executing the startup hook after the runtime has been resumed.

The fix here is to setup the diagnostic server thread as a runtime thread when the ApplyStartupHook command is used during managed execution.

cc @dotnet/dotnet-monitor @davmason