### PR TITLE
Improve Microsoft.Extensions.DependencyInjection debugging

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/AsyncServiceScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/AsyncServiceScope.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -9,6 +10,7 @@ namespace Microsoft.Extensions.DependencyInjection
     /// <summary>
     /// An <see cref="IServiceScope" /> implementation that implements <see cref="IAsyncDisposable" />.
     /// </summary>
+    [DebuggerDisplay("{ServiceProvider,nq}")]
     public readonly struct AsyncServiceScope : IServiceScope, IAsyncDisposable
     {
         private readonly IServiceScope _serviceScope;

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceCollection.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceCollection.cs
@@ -4,12 +4,15 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// Default implementation of <see cref="IServiceCollection"/>.
     /// </summary>
+    [DebuggerDisplay("{DebuggerToString(),nq}")]
+    [DebuggerTypeProxy(typeof(ServiceCollectionDebugView))]
     public class ServiceCollection : IServiceCollection
     {
         private readonly List<ServiceDescriptor> _descriptors = new List<ServiceDescriptor>();
@@ -119,5 +122,36 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static void ThrowReadOnlyException() =>
             throw new InvalidOperationException(SR.ServiceCollectionReadOnly);
+
+        private string DebuggerToString()
+        {
+            string debugText = $"Count = {_descriptors.Count}";
+            if (_isReadOnly)
+            {
+                debugText += $", IsReadOnly = true";
+            }
+            return debugText;
+        }
+
+        private sealed class ServiceCollectionDebugView
+        {
+            private readonly ServiceCollection _services;
+
+            public ServiceCollectionDebugView(ServiceCollection services)
+            {
+                _services = services;
+            }
+
+            [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+            public ServiceDescriptor[] Items
+            {
+                get
+                {
+                    ServiceDescriptor[] items = new ServiceDescriptor[_services.Count];
+                    _services.CopyTo(items, 0);
+                    return items;
+                }
+            }
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceDescriptor.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceDescriptor.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.DependencyInjection
     /// <summary>
     /// Describes a service with its service type, implementation, and lifetime.
     /// </summary>
-    [DebuggerDisplay("Lifetime = {Lifetime}, ServiceType = {ServiceType}, ImplementationType = {ImplementationType}")]
+    [DebuggerDisplay("{DebuggerToString(),nq}")]
     public class ServiceDescriptor
     {
         /// <summary>
@@ -466,6 +466,27 @@ namespace Microsoft.Extensions.DependencyInjection
         public static ServiceDescriptor Describe(Type serviceType, Func<IServiceProvider, object> implementationFactory, ServiceLifetime lifetime)
         {
             return new ServiceDescriptor(serviceType, implementationFactory, lifetime);
+        }
+
+        private string DebuggerToString()
+        {
+            string debugText = $@"Lifetime = {Lifetime}, ServiceType = ""{ServiceType.FullName}""";
+
+            // Either implementation type, factory or instance is set.
+            if (ImplementationType != null)
+            {
+                debugText += $@", ImplementationType = ""{ImplementationType.FullName}""";
+            }
+            else if (ImplementationFactory != null)
+            {
+                debugText += $@", ImplementationFactory = {ImplementationFactory.Method}";
+            }
+            else
+            {
+                debugText += $@", ImplementationInstance = {ImplementationInstance}";
+            }
+
+            return debugText;
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
@@ -3,15 +3,19 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
+    [DebuggerDisplay("{DebuggerToString(),nq}")]
+    [DebuggerTypeProxy(typeof(ServiceProviderEngineScopeDebugView))]
     internal sealed class ServiceProviderEngineScope : IServiceScope, IServiceProvider, IAsyncDisposable, IServiceScopeFactory
     {
-        // For testing only
+        // For testing and debugging only
         internal IList<object> Disposables => _disposables ?? (IList<object>)Array.Empty<object>();
 
         private bool _disposed;
@@ -25,6 +29,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         }
 
         internal Dictionary<ServiceCacheKey, object?> ResolvedServices { get; }
+
+        internal bool Disposed => _disposed;
 
         // This lock protects state on the scope, in particular, for the root scope, it protects
         // the list of disposable entries only, since ResolvedServices are cached on CallSites
@@ -202,6 +208,35 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             // trying to get a cached singleton service. If it doesn't find it
             // it will try to create a new one which will result in an ObjectDisposedException.
             return _disposables;
+        }
+
+        internal string DebuggerToString()
+        {
+            string debugText = $"ServiceDescriptors = {RootProvider.CallSiteFactory.Descriptors.Length}";
+            if (!IsRootScope)
+            {
+                debugText += $", IsScope = true";
+            }
+            if (_disposed)
+            {
+                debugText += $", Disposed = true";
+            }
+            return debugText;
+        }
+
+        private sealed class ServiceProviderEngineScopeDebugView
+        {
+            private readonly ServiceProviderEngineScope _serviceProvider;
+
+            public ServiceProviderEngineScopeDebugView(ServiceProviderEngineScope serviceProvider)
+            {
+                _serviceProvider = serviceProvider;
+            }
+
+            public List<ServiceDescriptor> ServiceDescriptors => new List<ServiceDescriptor>(_serviceProvider.RootProvider.CallSiteFactory.Descriptors);
+            public List<object> Disposables => new List<object>(_serviceProvider._disposables ?? Enumerable.Empty<object>());
+            public bool Disposed => _serviceProvider._disposed;
+            public bool IsScope => !_serviceProvider.IsRootScope;
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Internal;
 
@@ -234,7 +233,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             }
 
             public List<ServiceDescriptor> ServiceDescriptors => new List<ServiceDescriptor>(_serviceProvider.RootProvider.CallSiteFactory.Descriptors);
-            public List<object> Disposables => new List<object>(_serviceProvider._disposables ?? Enumerable.Empty<object>());
+            public List<object> Disposables => new List<object>(_serviceProvider._disposables ?? (IEnumerable<object>)Array.Empty<object>());
             public bool Disposed => _serviceProvider._disposed;
             public bool IsScope => !_serviceProvider.IsRootScope;
         }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             }
 
             public List<ServiceDescriptor> ServiceDescriptors => new List<ServiceDescriptor>(_serviceProvider.RootProvider.CallSiteFactory.Descriptors);
-            public List<object> Disposables => new List<object>(_serviceProvider._disposables ?? (IEnumerable<object>)Array.Empty<object>());
+            public List<object> Disposables => new List<object>(_serviceProvider.Disposables);
             public bool Disposed => _serviceProvider._disposed;
             public bool IsScope => !_serviceProvider.IsRootScope;
         }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
@@ -6,7 +6,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection.ServiceLookup;
@@ -237,7 +236,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             public List<ServiceDescriptor> ServiceDescriptors => new List<ServiceDescriptor>(_serviceProvider.Root.RootProvider.CallSiteFactory.Descriptors);
-            public List<object> Disposables => new List<object>(_serviceProvider.Root.Disposables ?? Enumerable.Empty<object>());
+            public List<object> Disposables => new List<object>(_serviceProvider.Root.Disposables);
             public bool Disposed => _serviceProvider.Root.Disposed;
             public bool IsScope => !_serviceProvider.Root.IsRootScope;
         }


### PR DESCRIPTION
This PR adds debugging attributes to commonly used Microsoft.Extensions.DependencyInjection types.

## ServiceCollection

Before:
![image](https://github.com/dotnet/runtime/assets/303201/55ddc507-2e48-4159-8200-407e159b97ba)

After:
![image](https://github.com/dotnet/runtime/assets/303201/3f6f9192-1a6e-42e1-82ec-0ff2f35c0518)

## ServiceProvider (root)

Before:
![image](https://github.com/dotnet/runtime/assets/303201/e5fed5f2-e111-4697-b6b8-249d120fae40)

After:
![image](https://github.com/dotnet/runtime/assets/303201/d34b9462-0374-4ad6-8765-a810b12bcfbf)

## ServiceProvider (scope)

Before:
![image](https://github.com/dotnet/runtime/assets/303201/3ddaa047-a101-4f84-ba44-acb77ba3ba14)

After:
![image](https://github.com/dotnet/runtime/assets/303201/3c474891-cce2-424d-8c07-0670293734f1)
