### PR TITLE
Fix handling recursion over fields

### DIFF
--- a/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
@@ -130,30 +130,6 @@ namespace ILCompiler
         }
 
         /// <summary>
-        /// What is the maximum number of steps that need to be taken from this type to its most contained generic type.
-        /// i.e.
-        /// System.Int32 => 0
-        /// List&lt;System.Int32&gt; => 1
-        /// Dictionary&lt;System.Int32,System.Int32&gt; => 1
-        /// Dictionary&lt;List&lt;System.Int32&gt;,&lt;System.Int32&gt; => 2
-        /// </summary>
-        public static int GetGenericDepth(this TypeDesc type)
-        {
-            if (type.HasInstantiation)
-            {
-                int maxGenericDepthInInstantiation = 0;
-                foreach (TypeDesc instantiationType in type.Instantiation)
-                {
-                    maxGenericDepthInInstantiation = Math.Max(instantiationType.GetGenericDepth(), maxGenericDepthInInstantiation);
-                }
-
-                return maxGenericDepthInInstantiation + 1;
-            }
-
-            return 0;
-        }
-
-        /// <summary>
         /// Determine if a type has a generic depth greater than a given value
         /// </summary>
         public static bool IsGenericDepthGreaterThan(this TypeDesc type, int depth)
@@ -168,23 +144,6 @@ namespace ILCompiler
             }
 
             return false;
-        }
-
-        /// <summary>
-        /// What is the maximum number of steps that need to be taken from this type to its most contained generic type.
-        /// i.e.
-        /// SomeGenericType&lt;System.Int32&gt;.Method&lt;System.Int32&gt; => 1
-        /// SomeType.Method&lt;System.Int32&gt; => 0
-        /// SomeType.Method&lt;List&lt;System.Int32&gt;&gt; => 1
-        /// </summary>
-        public static int GetGenericDepth(this MethodDesc method)
-        {
-            int genericDepth = method.OwningType.GetGenericDepth();
-            foreach (TypeDesc type in method.Instantiation)
-            {
-                genericDepth = Math.Max(genericDepth, type.GetGenericDepth());
-            }
-            return genericDepth;
         }
 
         /// <summary>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectedFieldNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectedFieldNode.cs
@@ -92,10 +92,8 @@ namespace ILCompiler.DependencyAnalysis
                 }
             }
 
-            if (!_field.OwningType.IsCanonicalSubtype(CanonicalFormKind.Any))
-            {
-                dependencies.Add(factory.MaximallyConstructableType(_field.FieldType.NormalizeInstantiation()), "Type of the field");
-            }
+            TypeDesc fieldType = _field.FieldType.NormalizeInstantiation();
+            ReflectionInvokeMapNode.AddSignatureDependency(ref dependencies, factory, fieldType, "Type of the field");
 
             return dependencies;
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
@@ -529,8 +529,7 @@ namespace ILCompiler
 
         private TypeDesc GetDebugType(TypeDesc type)
         {
-            // Types that have some canonical subtypes types should always be represented in normalized canonical form to the binder.
-            // Also, to avoid infinite generic recursion issues, attempt to use canonical form for fields with high generic complexity.
+            // To avoid infinite generic recursion issues, attempt to use canonical form for fields with high generic complexity.
             if (type.IsCanonicalSubtype(CanonicalFormKind.Specific) || ShouldUseCanonicalTypeRecord(type))
             {
                 type = type.ConvertToCanonForm(CanonicalFormKind.Specific);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
@@ -505,32 +505,37 @@ namespace ILCompiler
         private bool ShouldUseCanonicalTypeRecord(TypeDesc type)
         {
             // TODO: check the type's generic complexity
-            return type.GetGenericDepth() > NodeFactory.TypeSystemContext.GenericsConfig.MaxGenericDepthOfDebugRecord;
+            return GetGenericDepth(type) > NodeFactory.TypeSystemContext.GenericsConfig.MaxGenericDepthOfDebugRecord;
+
+            static int GetGenericDepth(TypeDesc type)
+            {
+                if (type.HasInstantiation)
+                {
+                    int maxGenericDepthInInstantiation = 0;
+                    foreach (TypeDesc instantiationType in type.Instantiation)
+                    {
+                        maxGenericDepthInInstantiation = Math.Max(GetGenericDepth(instantiationType), maxGenericDepthInInstantiation);
+                    }
+
+                    return maxGenericDepthInInstantiation + 1;
+                }
+
+                if (type.IsParameterizedType)
+                    return 1 + GetGenericDepth(((ParameterizedType)type).ParameterType);
+
+                return 0;
+            }
         }
 
         private TypeDesc GetDebugType(TypeDesc type)
         {
-            TypeDesc typeGenericComplexityInfo = type;
-
-            // Strip off pointer, array, and byref details.
-            while (typeGenericComplexityInfo is ParameterizedType paramType) {
-                typeGenericComplexityInfo = paramType.ParameterType;
-            }
-
             // Types that have some canonical subtypes types should always be represented in normalized canonical form to the binder.
             // Also, to avoid infinite generic recursion issues, attempt to use canonical form for fields with high generic complexity.
-            if (type.IsCanonicalSubtype(CanonicalFormKind.Specific) || (typeGenericComplexityInfo is DefType defType) && ShouldUseCanonicalTypeRecord(defType))
+            if (type.IsCanonicalSubtype(CanonicalFormKind.Specific) || ShouldUseCanonicalTypeRecord(type))
             {
                 type = type.ConvertToCanonForm(CanonicalFormKind.Specific);
 
-                // Re-check if the canonical subtype has acceptable generic complexity
-                typeGenericComplexityInfo = type;
-
-                while (typeGenericComplexityInfo is ParameterizedType paramType) {
-                    typeGenericComplexityInfo = paramType.ParameterType;
-                }
-
-                if ((typeGenericComplexityInfo is DefType canonDefType) && ShouldUseCanonicalTypeRecord(canonDefType))
+                if (ShouldUseCanonicalTypeRecord(type))
                 {
                     type = type.ConvertToCanonForm(CanonicalFormKind.Universal);
                 }

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
@@ -47,6 +47,7 @@ class Generics
         TestRecursionInGenericVirtualMethods.Run();
         TestRecursionInGenericInterfaceMethods.Run();
         TestRecursionThroughGenericLookups.Run();
+        TestRecursionInFields.Run();
         TestGvmLookupDependency.Run();
         TestInvokeMemberCornerCaseInGenerics.Run();
         TestRefAny.Run();
@@ -3362,6 +3363,24 @@ class Generics
             // There is a generic recursion in the above hierarchy. This just tests that we can compile.
             new ArrayHandler<object>().Write(null);
             new RangeHandler<object>().Write(default);
+        }
+    }
+
+    class TestRecursionInFields
+    {
+        class Chunk<T>
+        {
+            public Chunk<T[]> TheChunk;
+            public Chunk()
+            {
+                if (typeof(T).ToString().Length < 100)
+                    TheChunk = new Chunk<T[]>();
+            }
+        }
+
+        public static void Run()
+        {
+            typeof(Chunk<byte>).GetFields();
         }
     }
 


### PR DESCRIPTION
Fixes #79587.

See the test for an example. C++ would probably tell the user to take a hike for a template like this, but we need to support this in .NET.

* Use the same logic to root types of reflectable fields as we do for methods instead of asking for a concrete type
* Fix another issue in debug info emission. We already had logic to cut off deep generics, but deep arrays weren't considered. Also consider array depth.

Cc @dotnet/ilc-contrib 