### PR TITLE
Fix ABIStress test hashing padding

### DIFF
--- a/src/tests/JIT/Stress/ABI/Callee.cs
+++ b/src/tests/JIT/Stress/ABI/Callee.cs
@@ -52,13 +52,23 @@ namespace ABIStress
             for (int i = 0; i < Parameters.Count; i++)
             {
                 TypeEx pm = Parameters[i];
-                g.Emit(OpCodes.Ldloca, hashCode);
+                foreach ((int start, int end) in pm.DataSegments)
+                {
+                    g.Emit(OpCodes.Ldloca, hashCode);
 
-                g.Emit(OpCodes.Ldarga, checked((short)i));
-                g.Emit(OpCodes.Ldc_I4, pm.Size);
-                g.Emit(OpCodes.Call, s_memoryMarshalCreateReadOnlySpanMethod);
+                    g.Emit(OpCodes.Ldarga, checked((short)i));
+                    if (start > 0)
+                    {
+                        g.Emit(OpCodes.Ldc_I4, start);
+                        g.Emit(OpCodes.Conv_I);
+                        g.Emit(OpCodes.Add);
+                    }
 
-                g.Emit(OpCodes.Call, s_hashCodeAddBytesMethod);
+                    g.Emit(OpCodes.Ldc_I4, end - start);
+                    g.Emit(OpCodes.Call, s_memoryMarshalCreateReadOnlySpanMethod);
+
+                    g.Emit(OpCodes.Call, s_hashCodeAddBytesMethod);
+                }
             }
 
             g.Emit(OpCodes.Ldloca, hashCode);


### PR DESCRIPTION
ABIStress was storing data inside of padding and hashing it when trying to determine if all values made it through correctly. Make sure we only hash the fields.

With physical promotion enabled this causes the test to fail.  That's because of this type:
https://github.com/dotnet/runtime/blob/19d2e90bf5bf9d602d260a3b292b5ec62096ef19/src/tests/JIT/Stress/ABI/Types.cs#L65
which has 15 bytes of padding in it.  When the constructor is invoked, a temp is created, and physical promotion ends up promoting that temp and only writing the significant "field" parts.

I verified that regular promotion also causes the test to fail if a type is added that is regularly promoted, e.g. with `struct S { public byte F0; public long F1; }` the same problem is hit on main.