### PR TITLE
JIT: Handle primitive-sized remainders overlapping padding/promotions in physical promotion

### DIFF
--- a/src/coreclr/jit/promotion.cpp
+++ b/src/coreclr/jit/promotion.cpp
@@ -1627,28 +1627,6 @@ bool StructSegments::IsEmpty()
 }
 
 //------------------------------------------------------------------------
-// IsSingleSegment:
-//   Check if the segment tree contains only a single segment, and return
-//   it if so.
-//
-// Parameters:
-//   result - [out] The single segment. Only valid if the method returns true.
-//
-// Returns:
-//   True if so.
-//
-bool StructSegments::IsSingleSegment(Segment* result)
-{
-    if (m_segments.size() == 1)
-    {
-        *result = m_segments[0];
-        return true;
-    }
-
-    return false;
-}
-
-//------------------------------------------------------------------------
 // CoveringSegment:
 //   Compute a segment that covers all contained segments in this segment tree.
 //

--- a/src/coreclr/jit/promotion.h
+++ b/src/coreclr/jit/promotion.h
@@ -75,7 +75,6 @@ public:
     void Add(const Segment& segment);
     void Subtract(const Segment& segment);
     bool IsEmpty();
-    bool IsSingleSegment(Segment* result);
     bool CoveringSegment(Segment* result);
 
 #ifdef DEBUG

--- a/src/coreclr/jit/promotiondecomposition.cpp
+++ b/src/coreclr/jit/promotiondecomposition.cpp
@@ -308,7 +308,7 @@ private:
 
         StructSegments::Segment segment;
         // See if we can "plug the hole" with a single primitive.
-        if (remainder.IsSingleSegment(&segment))
+        if (remainder.CoveringSegment(&segment))
         {
             var_types primitiveType = TYP_UNDEF;
             unsigned  size          = segment.End - segment.Start;
@@ -606,26 +606,15 @@ private:
             statements->AddStatement(nullCheck);
         }
 
-        if (remainderStrategy.Type == RemainderStrategy::FullBlock)
+        bool handledRemainder = false;
+        // We prefer to do the remainder at the end, if possible, since CQ
+        // analysis shows that this is best. However, handling the remainder
+        // may overwrite the destination with stale bits if the source has
+        // replacements (since handling the remainder copies from the struct,
+        // and the fresh values are usually in the replacement locals).
+        if (RemainderOverwritesDestinationWithStaleBits(remainderStrategy, dstDeaths))
         {
-            // We will reuse the existing block op. Rebase the address off of the new local we created.
-            if (m_src->OperIs(GT_BLK))
-            {
-                m_src->AsIndir()->Addr() = indirAccess->GrabAddress(0, m_compiler);
-            }
-            else if (m_store->OperIs(GT_STORE_BLK))
-            {
-                m_store->AsIndir()->Addr() = indirAccess->GrabAddress(0, m_compiler);
-            }
-        }
-
-        // If the source involves replacements then do the struct op first --
-        // we would overwrite the destination with stale bits if we did it last.
-        // If the source does not involve replacements then CQ analysis shows
-        // that it's best to do it last.
-        if ((remainderStrategy.Type == RemainderStrategy::FullBlock) && m_srcInvolvesReplacements)
-        {
-            statements->AddStatement(m_store);
+            CopyRemainder(storeAccess, srcAccess, remainderStrategy, statements);
 
             if (m_src->OperIs(GT_LCL_VAR, GT_LCL_FLD))
             {
@@ -633,6 +622,7 @@ private:
                 // copy is no longer the last use if it was before.
                 m_src->gtFlags &= ~GTF_VAR_DEATH;
             }
+            handledRemainder = true;
         }
 
         StructDeaths srcDeaths;
@@ -693,34 +683,9 @@ private:
             statements->AddStatement(store);
         }
 
-        if ((remainderStrategy.Type == RemainderStrategy::FullBlock) && !m_srcInvolvesReplacements)
+        if (!handledRemainder)
         {
-            statements->AddStatement(m_store);
-        }
-
-        if (remainderStrategy.Type == RemainderStrategy::Primitive)
-        {
-            var_types primitiveType = remainderStrategy.PrimitiveType;
-            // The remainder might match a regularly promoted field exactly. If
-            // it does then use the promoted field's type so we can create a
-            // direct access.
-            unsigned srcPromField = srcAccess.FindRegularlyPromotedField(remainderStrategy.PrimitiveOffset, m_compiler);
-            unsigned storePromField =
-                storeAccess.FindRegularlyPromotedField(remainderStrategy.PrimitiveOffset, m_compiler);
-
-            if ((srcPromField != BAD_VAR_NUM) || (storePromField != BAD_VAR_NUM))
-            {
-                var_types regPromFieldType =
-                    m_compiler->lvaGetDesc(srcPromField != BAD_VAR_NUM ? srcPromField : storePromField)->TypeGet();
-                if (genTypeSize(regPromFieldType) == genTypeSize(primitiveType))
-                {
-                    primitiveType = regPromFieldType;
-                }
-            }
-
-            GenTree* src   = srcAccess.CreateRead(remainderStrategy.PrimitiveOffset, primitiveType, m_compiler);
-            GenTree* store = storeAccess.CreateStore(remainderStrategy.PrimitiveOffset, primitiveType, src, m_compiler);
-            statements->AddStatement(store);
+            CopyRemainder(storeAccess, srcAccess, remainderStrategy, statements);
         }
 
         INDEBUG(storeAccess.CheckFullyUsed());
@@ -730,7 +695,7 @@ private:
     //------------------------------------------------------------------------
     // CanSkipEntry:
     //   Check if the specified entry can be skipped because it is writing to a
-    //   death replacement or because the remainder would handle it anyway.
+    //   dead replacement or because the remainder would handle it anyway.
     //
     // Parameters:
     //   entry             - The init/copy entry
@@ -861,7 +826,71 @@ private:
         return addrNode->IsInvariant();
     }
 
-private:
+    //------------------------------------------------------------------------
+    // RemainderOverwritesDestinationWithStaleBits:
+    //   Check if handling the remainder is going to write stale bits to the
+    //   destination.
+    //
+    // Parameters:
+    //   remainderStrategy - The remainder strategy
+    //   dstDeaths         - Destination liveness
+    //
+    // Returns:
+    //   True if so.
+    //
+    // Remarks:
+    //   We usually prefer to write the remainder last as CQ analysis shows
+    //   that to be most beneficial. However, if we do that we may overwrite
+    //   the destination with stale bits. This occurs if the source has
+    //   replacements. Handling the remainder copies from the source struct
+    //   local, but the up-to-date values may be in its replacement locals. So
+    //   we must take care to write the replacement locals _after_ the
+    //   remainder has been written.
+    //
+    bool RemainderOverwritesDestinationWithStaleBits(const RemainderStrategy& remainderStrategy,
+                                                     const StructDeaths&      dstDeaths)
+    {
+        if (!m_srcInvolvesReplacements)
+        {
+            return false;
+        }
+
+        switch (remainderStrategy.Type)
+        {
+            case RemainderStrategy::FullBlock:
+                return true;
+            case RemainderStrategy::Primitive:
+                for (int i = 0; i < m_entries.Height(); i++)
+                {
+                    const Entry& entry = m_entries.BottomRef(i);
+                    if (entry.Offset + genTypeSize(entry.Type) <= remainderStrategy.PrimitiveOffset)
+                    {
+                        // Entry ends before remainder starts
+                        continue;
+                    }
+
+                    // Remainder ends before entry starts
+                    if (remainderStrategy.PrimitiveOffset + genTypeSize(remainderStrategy.PrimitiveType) <=
+                        entry.Offset)
+                    {
+                        continue;
+                    }
+
+                    // Are we even going to write the entry?
+                    if (!CanSkipEntry(entry, dstDeaths, remainderStrategy))
+                    {
+                        // Yep, so we need to be careful.
+                        return true;
+                    }
+                }
+
+                // No entry overlaps.
+                return false;
+            default:
+                return false;
+        }
+    }
+
     // Helper class to create derived accesses off of a location: either a
     // local, or as indirections off of an address.
     class LocationAccess
@@ -1080,6 +1109,51 @@ private:
             return m_indirFlags;
         }
     };
+
+    void CopyRemainder(LocationAccess&             storeAccess,
+                       LocationAccess&             srcAccess,
+                       const RemainderStrategy&    remainderStrategy,
+                       DecompositionStatementList* statements)
+    {
+        if (remainderStrategy.Type == RemainderStrategy::FullBlock)
+        {
+            // We will reuse the existing block op. Rebase the address off of the new local we created.
+            if (m_src->OperIs(GT_BLK))
+            {
+                m_src->AsIndir()->Addr() = srcAccess.GrabAddress(0, m_compiler);
+            }
+            else if (m_store->OperIs(GT_STORE_BLK))
+            {
+                m_store->AsIndir()->Addr() = storeAccess.GrabAddress(0, m_compiler);
+            }
+
+            statements->AddStatement(m_store);
+        }
+        else if (remainderStrategy.Type == RemainderStrategy::Primitive)
+        {
+            var_types primitiveType = remainderStrategy.PrimitiveType;
+            // The remainder might match a regularly promoted field exactly. If
+            // it does then use the promoted field's type so we can create a
+            // direct access.
+            unsigned srcPromField = srcAccess.FindRegularlyPromotedField(remainderStrategy.PrimitiveOffset, m_compiler);
+            unsigned storePromField =
+                storeAccess.FindRegularlyPromotedField(remainderStrategy.PrimitiveOffset, m_compiler);
+
+            if ((srcPromField != BAD_VAR_NUM) || (storePromField != BAD_VAR_NUM))
+            {
+                var_types regPromFieldType =
+                    m_compiler->lvaGetDesc(srcPromField != BAD_VAR_NUM ? srcPromField : storePromField)->TypeGet();
+                if (genTypeSize(regPromFieldType) == genTypeSize(primitiveType))
+                {
+                    primitiveType = regPromFieldType;
+                }
+            }
+
+            GenTree* src   = srcAccess.CreateRead(remainderStrategy.PrimitiveOffset, primitiveType, m_compiler);
+            GenTree* store = storeAccess.CreateStore(remainderStrategy.PrimitiveOffset, primitiveType, src, m_compiler);
+            statements->AddStatement(store);
+        }
+    }
 };
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/promotiondecomposition.cpp
+++ b/src/coreclr/jit/promotiondecomposition.cpp
@@ -1110,6 +1110,16 @@ private:
         }
     };
 
+    //------------------------------------------------------------------------
+    // CopyRemainder:
+    //   Create IR to copy the remainder.
+    //
+    // Parameters:
+    //   storeAccess       - Helper class to create derived stores
+    //   srcAccess         - Helper class to create derived source accesses
+    //   remainderStrategy - The strategy to generate IR for
+    //   statements        - List to add IR to.
+    //
     void CopyRemainder(LocationAccess&             storeAccess,
                        LocationAccess&             srcAccess,
                        const RemainderStrategy&    remainderStrategy,


### PR DESCRIPTION
The remainder may be separated by a bit of padding or other promoted fields but still fit into a primitive; in this case it is still beneficial to copy it all as a primitive, instead of falling back to a full block copy.

Example.
```csharp
private S _s;

void Foo()
{
    S s = new();
    s.A = 10;
    s.D = 20;
    s.F = 30; // A, D, F gets promoted
    _s = s;
}

private struct S
{
    public byte A;
    public byte B;
    public byte C;
    public byte D;
    public byte E;
    public byte F;
}
```

```diff
 Processing block operation [000018] that involves replacements
   dst+003 <- V04 (V01.[003..004)) (last use)
   dst+005 <- V05 (V01.[005..006)) (last use)
   Block op remainder: [001..003) [004..005)
-  => Remainder strategy: retain a full block op
+  => Remainder strategy: int at +001
```

```diff
 ;  V00 this         [V00,T01] (  3,  3   )     ref  ->  rcx         this class-hnd single-def
 ;* V01 loc0         [V01    ] (  0,  0   )  struct ( 8) zero-ref    do-not-enreg[SF] ld-addr-op
 ;# V02 OutArgs      [V02    ] (  1,  1   )  struct ( 0) [rsp+00H]   do-not-enreg[XS] addr-exposed "OutgoingArgSpace"
 ;* V03 tmp1         [V03    ] (  0,  0   )   ubyte  ->  zero-ref    "V01.[000..001)"
 ;* V04 tmp2         [V04    ] (  0,  0   )   ubyte  ->  zero-ref    "V01.[003..004)"
 ;* V05 tmp3         [V05    ] (  0,  0   )   ubyte  ->  zero-ref    "V01.[005..006)"
 ;  V06 tmp4         [V06,T00] (  5, 10   )   byref  ->  rcx         single-def "Spilling address for field-by-field copy"
 ;
 ; Lcl frame size = 0
 
 G_M52879_IG01:  ;; offset=0000H
 						;; size=0 bbWeight=1 PerfScore 0.00
 G_M52879_IG02:  ;; offset=0000H
        add      rcx, 8
        xor      eax, eax
-       mov      dword ptr [rcx], eax
-       mov      dword ptr [rcx+02H], eax
+       mov      dword ptr [rcx+01H], eax
        mov      byte  ptr [rcx], 10
        mov      byte  ptr [rcx+03H], 20
        mov      byte  ptr [rcx+05H], 30
-						;; size=22 bbWeight=1 PerfScore 5.50
-G_M52879_IG03:  ;; offset=0016H
+						;; size=20 bbWeight=1 PerfScore 4.50
+G_M52879_IG03:  ;; offset=0014H
        ret      
 						;; size=1 bbWeight=1 PerfScore 1.00
 
-; Total bytes of code 23, prolog size 0, PerfScore 8.80, instruction count 8, allocated bytes for code 23 (MethodHash=1da13170) for method Program:Foo():this (FullOpts)
+; Total bytes of code 21, prolog size 0, PerfScore 7.60, instruction count 7, allocated bytes for code 21 (MethodHash=1da13170) for method Program:Foo():this (FullOpts)
 ; ============================================================

```

We have to be careful, however, since the covering segment can now contain promoted fields. If this happens we need to make sure we write the promoted field _after_ the remainder.