### PR TITLE
Fix NativeAOT rethrow bug

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
@@ -586,7 +586,7 @@ namespace System.Runtime
             object rethrownException = activeExInfo.ThrownException;
 
             exInfo.Init(rethrownException, ref activeExInfo);
-            DispatchEx(ref exInfo._frameIter, ref exInfo, activeExInfo._idxCurClause);
+            DispatchEx(ref exInfo._frameIter, ref exInfo, MaxTryRegionIdx);
             FallbackFailFast(RhFailFastReason.InternalError, null);
         }
 

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
@@ -547,7 +547,7 @@ namespace System.Runtime
             }
 
             exInfo.Init(exceptionToThrow!, instructionFault);
-            DispatchEx(ref exInfo._frameIter, ref exInfo, MaxTryRegionIdx);
+            DispatchEx(ref exInfo._frameIter, ref exInfo);
             FallbackFailFast(RhFailFastReason.InternalError, null);
         }
 
@@ -569,7 +569,7 @@ namespace System.Runtime
             }
 
             exInfo.Init(exceptionObj);
-            DispatchEx(ref exInfo._frameIter, ref exInfo, MaxTryRegionIdx);
+            DispatchEx(ref exInfo._frameIter, ref exInfo);
             FallbackFailFast(RhFailFastReason.InternalError, null);
         }
 
@@ -586,11 +586,11 @@ namespace System.Runtime
             object rethrownException = activeExInfo.ThrownException;
 
             exInfo.Init(rethrownException, ref activeExInfo);
-            DispatchEx(ref exInfo._frameIter, ref exInfo, MaxTryRegionIdx);
+            DispatchEx(ref exInfo._frameIter, ref exInfo);
             FallbackFailFast(RhFailFastReason.InternalError, null);
         }
 
-        private static void DispatchEx(scoped ref StackFrameIterator frameIter, ref ExInfo exInfo, uint startIdx)
+        private static void DispatchEx(scoped ref StackFrameIterator frameIter, ref ExInfo exInfo)
         {
             Debug.Assert(exInfo._passNumber == 1, "expected asm throw routine to set the pass");
             object exceptionObj = exInfo.ThrownException;
@@ -619,6 +619,7 @@ namespace System.Runtime
 
             OnFirstChanceExceptionViaClassLib(exceptionObj);
 
+            uint startIdx = MaxTryRegionIdx;
             for (; isValid; isValid = frameIter.Next(&startIdx, &unwoundReversePInvoke))
             {
                 // For GC stackwalking, we'll happily walk across native code blocks, but for EH dispatch, we

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
@@ -604,7 +604,7 @@ namespace System.Runtime
             byte* pCatchHandler = null;
             uint catchingTryRegionIdx = MaxTryRegionIdx;
 
-            bool isFirstRethrowFrame = (startIdx != MaxTryRegionIdx);
+            bool isFirstRethrowFrame = (exInfo._kind & ExKind.RethrowFlag) != 0;
             bool isFirstFrame = true;
 
             byte* prevControlPC = null;

--- a/src/tests/Regressions/coreclr/GitHub_88128/test88128.cs
+++ b/src/tests/Regressions/coreclr/GitHub_88128/test88128.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Reflection;
 

--- a/src/tests/Regressions/coreclr/GitHub_88128/test88128.cs
+++ b/src/tests/Regressions/coreclr/GitHub_88128/test88128.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Reflection;
+
+public class test88113
+{
+    public static int Main()
+    {
+        try
+        {
+            throw new Exception("boo");
+        }
+        catch (Exception ex2)
+        {
+            Console.WriteLine($"1: {ex2}");
+            try
+            {
+                throw;
+            }
+            catch (Exception ex3)
+            {
+                Console.WriteLine($"2: {ex3}");
+            }
+        }
+
+        return 100;
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_88128/test88128.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_88128/test88128.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test88128.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The rethrowing incorrectly starts searching for exception clause based on the previously searched clause for the exception being rethrown. It should always start from the beginning.

Close #88128 