### PR TITLE
Remove stack trace metadata decoder if stack trace data disabled

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -104,7 +104,7 @@ The .NET Foundation licenses this file to you under the MIT license.
   <ItemGroup Condition="$(IlcSystemModule) == ''">
     <UnmanagedEntryPointsAssembly Include="System.Private.CoreLib" />
     <AutoInitializedAssemblies Include="System.Private.CoreLib" />
-    <AutoInitializedAssemblies Include="System.Private.StackTraceMetadata" Condition="$(IlcDisableReflection) != 'true' or $(IlcGenerateStackTraceData) == 'true'" />
+    <AutoInitializedAssemblies Include="System.Private.StackTraceMetadata" Condition="$(IlcGenerateStackTraceData) == 'true'" />
     <AutoInitializedAssemblies Include="System.Private.TypeLoader" />
     <AutoInitializedAssemblies Include="System.Private.Reflection.Execution" Condition="$(IlcDisableReflection) != 'true'" />
     <AutoInitializedAssemblies Include="System.Private.DisabledReflection" Condition="$(IlcDisableReflection) == 'true'" />


### PR DESCRIPTION
We have an opt-in feature (currently not officially supported) to disable generation of stack trace metadata. This metadata is used to print the stack trace in places like `Exception.ToString`. This metadata is only generated for methods that are not visible reflection targets. If a method _is_ a visible reflection target, we obtain this data from reflection metadata. So currently it's possible for partial stack traces to be printed even if stack trace metadata was turned off.

I'm not sure it makes sense to do it this way now that very little surface area is actually visible from reflection. This PR conditions stack trace metadata decoding support on the same configuration option - so we'd no longer print info on methods that have this info in reflection metadata.

Before (with stack trace metadata disabled):

```
Unhandled Exception: System.Exception: Exception of type 'System.Exception' was thrown.
   at Program.<Main>$(String[] args) + 0x24
   at HelloBionic!<BaseAddress>+0x8a9e0
```

After:

```
Unhandled Exception: System.Exception: Exception of type 'System.Exception' was thrown.
   at HelloBionic!<BaseAddress>+0x4e958
   at HelloBionic!<BaseAddress>+0x85d5b
```

(Notice we had metadata for Main because we implicitly make `Assembly.EntryPoint` reflection visible. But if there was more code on stack, most of it would look like the "after" case.)

I think the new behavior is easier to comprehend.

This also shrinks the size of a size-optimized app (with stack trace data disabled) that only throws an exception from 972,288 bytes to 945,152 bytes (the size of stack trace decoding support).

We should consider making this a supported option. It was a supported option in .NET Native and apps like the Windows Store actually ship like this.

Cc @dotnet/ilc-contrib 