### PR TITLE
JIT: Remove a quirk in regular promotion

### DIFF
--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -1789,13 +1789,6 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
         return false;
     }
 
-    // TODO-Quirk: The old logic disallowed promotion for "custom layout" HFAs.
-    // The equivalent check now is the following, but it is quite meaningless.
-    if (treeNodes[0].hasSignificantPadding && compiler->IsHfa(typeHnd))
-    {
-        return false;
-    }
-
     assert(treeNodes[0].size == structSize);
 
     structPromotionInfo.fieldCnt = 0;

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -1922,6 +1922,9 @@ void           LinearScan::identifyCandidates()
                             fieldVarDsc->lvLRACandidate                = 0;
                             localVarIntervals[fieldVarDsc->lvVarIndex] = nullptr;
                             VarSetOps::RemoveElemD(compiler, registerCandidateVars, fieldVarDsc->lvVarIndex);
+#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+                            VarSetOps::RemoveElemD(compiler, largeVectorVars, fieldVarDsc->lvVarIndex);
+#endif
                             JITDUMP("*");
                         }
                         // This is not accurate, but we need a non-zero refCnt for the parent so that it will
@@ -2003,12 +2006,6 @@ void           LinearScan::identifyCandidates()
             }
             JITDUMP("  ");
             DBEXEC(VERBOSE, newInt->dump(compiler));
-        }
-        else
-        {
-            // Added code just to check if we ever reach here. If not delete this if-else.
-            assert(false);
-            localVarIntervals[varDsc->lvVarIndex] = nullptr;
         }
     }
 


### PR DESCRIPTION
Also fix a bug in LSRA: if we undo promotion of one field of a multi-reg struct and as a result undo for the other fields as well, we must also clear out the largeVectorVars bitset to indicate these are no longer candidates. This was hitting crashes with some of the new promotions done by this change.