### PR TITLE
Fix ProfileEnter / ProfileLeave

### DIFF
--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -10938,21 +10938,11 @@ LExit:
 HCIMPLEND
 
 HCIMPL2_RAW(EXTERN_C void, ProfileLeave, UINT_PTR clientData, void * platformSpecificHandle)
-GCX_COOP_THREAD_EXISTS(GET_THREAD());
+GCX_COOP();
 HCIMPL_PROLOG(ProfileLeave)
 {
     FCALL_CONTRACT;
 
-    if (GetThreadNULLOk() == NULL)
-    {
-        Thread *pThread = SetupThreadNoThrow();
-        if (pThread == NULL)
-        {
-            return;
-        }
-    }
-
-    GCX_COOP();
     FC_GC_POLL_NOT_NEEDED();            // we pulse GC mode, so we are doing a poll
 
 #ifdef PROFILING_SUPPORTED

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -10760,10 +10760,16 @@ HCIMPL_PROLOG(ProfileEnter)
 {
     FCALL_CONTRACT;
 
-    if (GET_THREAD() == NULL)
+    if (GetThreadNULLOk() == NULL)
     {
-        return;
+        Thread *pThread = SetupThreadNoThrow();
+        if (pThread == NULL)
+        {
+            return;
+        }
     }
+
+    GCX_COOP();
 
 #ifdef PROFILING_SUPPORTED
 
@@ -10937,11 +10943,16 @@ HCIMPL_PROLOG(ProfileLeave)
 {
     FCALL_CONTRACT;
 
-    if (GET_THREAD() == NULL)
+    if (GetThreadNULLOk() == NULL)
     {
-        return;
+        Thread *pThread = SetupThreadNoThrow();
+        if (pThread == NULL)
+        {
+            return;
+        }
     }
 
+    GCX_COOP();
     FC_GC_POLL_NOT_NEEDED();            // we pulse GC mode, so we are doing a poll
 
 #ifdef PROFILING_SUPPORTED

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -10754,9 +10754,16 @@ void __stdcall ProfilerUnmanagedToManagedTransitionMD(MethodDesc *pMD,
 // These do a lot of work for us, setting up Frames, gathering arg info and resolving generics.
   //*******************************************************************************************
 
-HCIMPL2(EXTERN_C void, ProfileEnter, UINT_PTR clientData, void * platformSpecificHandle)
+HCIMPL2_RAW(EXTERN_C void, ProfileEnter, UINT_PTR clientData, void * platformSpecificHandle)
+GCX_COOP_THREAD_EXISTS(GET_THREAD());
+HCIMPL_PROLOG(ProfileEnter)
 {
     FCALL_CONTRACT;
+
+    if (GET_THREAD() == NULL)
+    {
+        return;
+    }
 
 #ifdef PROFILING_SUPPORTED
 
@@ -10924,9 +10931,16 @@ LExit:
 }
 HCIMPLEND
 
-HCIMPL2(EXTERN_C void, ProfileLeave, UINT_PTR clientData, void * platformSpecificHandle)
+HCIMPL2_RAW(EXTERN_C void, ProfileLeave, UINT_PTR clientData, void * platformSpecificHandle)
+GCX_COOP_THREAD_EXISTS(GET_THREAD());
+HCIMPL_PROLOG(ProfileLeave)
 {
     FCALL_CONTRACT;
+
+    if (GET_THREAD() == NULL)
+    {
+        return;
+    }
 
     FC_GC_POLL_NOT_NEEDED();            // we pulse GC mode, so we are doing a poll
 


### PR DESCRIPTION
These two functions can be entered in preemptive mode for UnmanagedCallersOnly methods and also on thread that was not known to runtime. This change switches to cooperative mode if the thread is known to runtime and early outs when the thread was not known.