### PR TITLE
Support displaying AttributeValue in binary form

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -530,7 +530,7 @@
     <Compile Include="System\Security\Cryptography\X509Certificates\StoreName.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\StorePal.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\SubjectAlternativeNameBuilder.cs" />
-    <Compile Include="System\Security\Cryptography\X509Certificates\X500DictionaryStringHelper.cs" />
+    <Compile Include="System\Security\Cryptography\X509Certificates\X500DirectoryStringHelper.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\X500DistinguishedName.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\X500DistinguishedNameBuilder.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\X500DistinguishedNameFlags.cs" />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500DirectoryStringHelper.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500DirectoryStringHelper.cs
@@ -5,7 +5,7 @@ using System.Formats.Asn1;
 
 namespace System.Security.Cryptography.X509Certificates
 {
-    internal static class X500DictionaryStringHelper
+    internal static class X500DirectoryStringHelper
     {
         internal static string ReadAnyAsnString(this AsnReader tavReader)
         {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500NameEncoder.ManagedDecode.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500NameEncoder.ManagedDecode.cs
@@ -92,7 +92,7 @@ namespace System.Security.Cryptography.X509Certificates
                     {
                         AsnReader tavReader = rdnReader.ReadSequence();
                         string oid = tavReader.ReadObjectIdentifier();
-                        string attributeValue = tavReader.ReadAnyAsnString();
+                        string attributeValue = ReadAttributeValue(tavReader, out bool fallback);
 
                         tavReader.ThrowIfNotEmpty();
 
@@ -110,7 +110,7 @@ namespace System.Security.Cryptography.X509Certificates
                             AppendOid(ref decodedName, oid);
                         }
 
-                        bool quote = quoteIfNeeded && NeedsQuoting(attributeValue);
+                        bool quote = quoteIfNeeded && NeedsQuoting(attributeValue) && !fallback;
 
                         if (quote)
                         {
@@ -142,6 +142,51 @@ namespace System.Security.Cryptography.X509Certificates
             catch (AsnContentException e)
             {
                 throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
+            }
+        }
+
+        private static string ReadAttributeValue(AsnReader tavReader, out bool binaryFallback)
+        {
+            Asn1Tag tag = tavReader.PeekTag();
+
+            if (tag.TagClass == TagClass.Universal)
+            {
+                switch ((UniversalTagNumber)tag.TagValue)
+                {
+                    case UniversalTagNumber.BMPString:
+                    case UniversalTagNumber.IA5String:
+                    case UniversalTagNumber.NumericString:
+                    case UniversalTagNumber.PrintableString:
+                    case UniversalTagNumber.UTF8String:
+                    case UniversalTagNumber.T61String:
+                        // .NET's string comparisons start by checking the length, so a trailing
+                        // NULL character which was literally embedded in the DER would cause a
+                        // failure in .NET whereas it wouldn't have with strcmp.
+                        binaryFallback = false;
+                        return tavReader.ReadCharacterString((UniversalTagNumber)tag.TagValue).TrimEnd('\0');
+                    case UniversalTagNumber.OctetString:
+                        // Windows will implicitly unwrap one OCTET STRING and display only the contents.
+                        binaryFallback = true;
+
+                        if (tavReader.TryReadPrimitiveOctetString(out ReadOnlyMemory<byte> contents))
+                        {
+                            return BinaryEncode(contents);
+                        }
+
+                        return BinaryEncode(tavReader.ReadOctetString());
+                }
+            }
+
+            binaryFallback = true;
+            return BinaryEncode(tavReader.ReadEncodedValue());
+
+            static string BinaryEncode(ReadOnlyMemory<byte> data)
+            {
+                return string.Create(1 + data.Length * 2, data, static (buff, state) =>
+                {
+                    buff[0] = '#';
+                    HexConverter.EncodeToUtf16(state.Span, buff.Slice(1));
+                });
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/X500DistinguishedNameTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/X500DistinguishedNameTests.cs
@@ -470,6 +470,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData(new [] { "2.5.4.3", "2.5.4.8" }, new [] { "0101FF", "3000" }, "CN=#0101FF, S=#3000")]
         [InlineData(new [] { "2.5.4.3", "2.5.4.8" }, new [] { "0C02504A", "3000" }, "CN=PJ, S=#3000")]
         [InlineData(new [] { "2.5.4.3", "2.5.4.8" }, new [] { "0C03233030", "3000" }, "CN=\"#00\", S=#3000")]
+        [SkipOnPlatform(TestPlatforms.Browser, "Browser doesn't support an X.509 PAL")]
         public static void Format_ComponentWithNonStringContent(string[] oids, string[] attributeValues, string expected)
         {
             AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
@@ -496,6 +497,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Browser doesn't support an X.509 PAL")]
         public static void Format_MultiValueComponentWithNonStringContent()
         {
             AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);


### PR DESCRIPTION
If an `X500DistinguishedName` contains an AttributeValue that is not a DirectoryString, the managed decoder will currently throw, catch the error, and return an empty string.

This changes the managed decoding to match the behavior of Windows. If an attribute is a binary value, then it is displayed in a hex encoded value, prefixed with a hash.

There is special handling if the binary value is an OCTET STRING. If the binary content is an octet string, the hex value displayed is the inner content. The outer OCTET STRING bytes are not displayed.

Fixes https://github.com/dotnet/runtime/issues/88037.

Note: This only changes displaying binary content. Handling the reverse, parsing the strings like `new X500DistinguishedName("CN=#1234")` will be a separate pull request. That will be a breaking change on non-Windows, and we may decide not to take it. This pull request is not a breaking change and simply unblocks a scenario.