### PR TITLE
fix runtime build failures on ppc64le 

### DIFF
--- a/src/native/external/libunwind.cmake
+++ b/src/native/external/libunwind.cmake
@@ -373,7 +373,6 @@ set(libunwind_la_SOURCES_ppc64le_common
 set(libunwind_la_SOURCES_ppc64le
     ${libunwind_la_SOURCES_ppc64le_common}
     ${libunwind_la_SOURCES_local}
-    ppc64/setcontext.S
     ppc64/Lapply_reg_state.c ppc64/Lreg_states_iterate.c
     ppc64/Lcreate_addr_space.c ppc/Lget_save_loc.c ppc64/Lglobal.c
     ppc64/Linit.c ppc/Linit_local.c


### PR DESCRIPTION
Runtime build failing on ppc64le machine with  below error

```
  CMake Error at /home/tester/runtime/src/native/external/libunwind_extras/CMakeLists.txt:169 (add_library):
    Cannot find source file:
  
      /home/tester/runtime/src/native/external/libunwind/src/ppc64/setcontext.S
  
    Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .h .hh .h++
    .hm .hpp .hxx .in .txx .f .F .for .f77 .f90 .f95 .f03 .ispc
  
  
  CMake Error at /home/tester/runtime/src/native/external/libunwind_extras/CMakeLists.txt:169 (add_library):
    No SOURCES given to target: libunwind
  
  
  CMake Generate step failed.  Build files cannot be regenerated correctly.
  ~/runtime/src/coreclr
  ~/runtime/artifacts/obj/coreclr/linux.ppc64le.Release ~/runtime/src/coreclr
  Executing make   iltools  -j 8
  make: *** No rule to make target 'iltools'.  Stop.
  ~/runtime/src/coreclr
  Failed to build "CoreCLR component".
/home/tester/runtime/src/coreclr/runtime.proj(89,5): error MSB3073: The command ""/home/tester/runtime/src/coreclr/build-runtime.sh" -ppc64le -release -portablebuild=false -keepnativesymbols -os linux -outputrid rhel.9-ppc64le -component iltools" exited with code 2.

Build FAILED.
```

This issue has been observed after PR [87426](https://github.com/dotnet/runtime/pull/87426) merged.

Also I am wondering why upstream CI is not failing for ppc64le. [Here](https://dev.azure.com/dnceng-public/public/_build?definitionId=148&_a=summary&repositoryFilter=68&branchFilter=331%2C331%2C331%2C331%2C331%2C331%2C331%2C331%2C331%2C331%2C331%2C331%2C331%2C331%2C331) is link for ppc64le CI. 

cc:
@am11 @tmds @janani66 