### PR TITLE
[mono] Use InlineArrayAttribute for ArgumentData and StackAllocatedByRefs

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/ParamsArray.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ParamsArray.cs
@@ -12,8 +12,6 @@ using System.Runtime.CompilerServices;
 
 namespace System
 {
-#if CORECLR || NATIVEAOT
-
     [InlineArray(Length)]
     internal struct TwoObjects
     {
@@ -46,33 +44,4 @@ namespace System
             this[2] = arg2;
         }
     }
-
-#else
-
-    internal struct TwoObjects
-    {
-        internal object? Arg0;
-        private object? _arg1;
-
-        public TwoObjects(object? arg0, object? arg1)
-        {
-            Arg0 = arg0;
-            _arg1 = arg1;
-        }
-    }
-
-    internal struct ThreeObjects
-    {
-        internal object? Arg0;
-        private object? _arg1;
-        private object? _arg2;
-
-        public ThreeObjects(object? arg0, object? arg1, object? arg2)
-        {
-            Arg0 = arg0;
-            _arg1 = arg1;
-            _arg2 = arg2;
-        }
-    }
-#endif
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
@@ -274,11 +274,11 @@ namespace System.Reflection
 
         internal const int MaxStackAllocArgCount = 4;
 
-
         [InlineArray(MaxStackAllocArgCount)]
         private protected struct ArgumentData<T>
         {
             private T _arg0;
+
             [UnscopedRef]
             public Span<T> AsSpan(int length)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
@@ -274,19 +274,11 @@ namespace System.Reflection
 
         internal const int MaxStackAllocArgCount = 4;
 
-#if CORECLR
+
         [InlineArray(MaxStackAllocArgCount)]
-#endif
         private protected struct ArgumentData<T>
         {
             private T _arg0;
-#if !CORECLR
-#pragma warning disable CA1823, CS0169, IDE0051, IDE0044 // accessed via 'CheckArguments' ref arithmetic
-            private T _arg1;
-            private T _arg2;
-            private T _arg3;
-#pragma warning restore CA1823, CS0169, IDE0051, IDE0044
-#endif
             [UnscopedRef]
             public Span<T> AsSpan(int length)
             {
@@ -308,19 +300,10 @@ namespace System.Reflection
         }
 
         // Helper struct to avoid intermediate IntPtr[] allocation and RegisterForGCReporting in calls to the native reflection stack.
-#if CORECLR
         [InlineArray(MaxStackAllocArgCount)]
-#endif
         private protected ref struct StackAllocatedByRefs
         {
             internal ref byte _arg0;
-#if !CORECLR
-#pragma warning disable CA1823, CS0169, IDE0051 // accessed via 'CheckArguments' ref arithmetic
-            private ref byte _arg1;
-            private ref byte _arg2;
-            private ref byte _arg3;
-#pragma warning restore CA1823, CS0169, IDE0051
-#endif
         }
 #endif
         }


### PR DESCRIPTION

Mono supports InlineArray