### PR TITLE
Clone AllowTlsResume as part of SslClientAuthenticationOptionsExtensions.ShallowClone

### DIFF
--- a/src/libraries/Common/src/System/Net/Security/SslClientAuthenticationOptionsExtensions.cs
+++ b/src/libraries/Common/src/System/Net/Security/SslClientAuthenticationOptionsExtensions.cs
@@ -17,6 +17,7 @@ namespace System.Net.Security
             var clone = new SslClientAuthenticationOptions()
             {
                 AllowRenegotiation = options.AllowRenegotiation,
+                AllowTlsResume = options.AllowTlsResume,
                 ApplicationProtocols = options.ApplicationProtocols != null ? new List<SslApplicationProtocol>(options.ApplicationProtocols) : null,
                 CertificateRevocationCheckMode = options.CertificateRevocationCheckMode,
                 CertificateChainPolicy = options.CertificateChainPolicy,


### PR DESCRIPTION
Looks like this was missed as part of adding AllowTlsResume.  This helper is used by HttpClient and friends to clone all the settings of an SslClientAuthenticationOptions instance into a new instance.