### PR TITLE
Suppress System.Drawing.Common dependency from System.Windows.Extensions

### DIFF
--- a/src/libraries/System.Windows.Extensions/ref/System.Windows.Extensions.csproj
+++ b/src/libraries/System.Windows.Extensions/ref/System.Windows.Extensions.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
+    <!-- Avoid a PackageReference to System.Drawing.Common this reference is only needed for TypeForwards -->
+    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Windows.Extensions/src/System.Windows.Extensions.csproj
+++ b/src/libraries/System.Windows.Extensions/src/System.Windows.Extensions.csproj
@@ -93,6 +93,7 @@ System.Security.Cryptography.X509Certificates.X509SelectionFlag</PackageDescript
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
+    <!-- Avoid a PackageReference to System.Drawing.Common this reference is only needed for TypeForwards -->
+    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Windows.Extensions/tests/System.Windows.Extensions.Tests.csproj
+++ b/src/libraries/System.Windows.Extensions/tests/System.Windows.Extensions.Tests.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ComponentModel.TypeConverter.TestData" Version="$(SystemComponentModelTypeConverterTestDataVersion)" />
+    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
     <PackageReference Include="System.Drawing.Common.TestData" Version="$(SystemDrawingCommonTestDataVersion)" />
     <PackageReference Include="System.Windows.Extensions.TestData" Version="$(SystemWindowsExtensionsTestDataVersion)" />
     <ProjectReference Include="..\src\System.Windows.Extensions.csproj" />

--- a/src/libraries/testPackages/packageSettings/System.Security.Permissions/settings.targets
+++ b/src/libraries/testPackages/packageSettings/System.Security.Permissions/settings.targets
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <!-- intentional dangling ref from System.Windows.Extensions -->
+    <IgnoredReference Include="System.Drawing.Common" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/testPackages/packageSettings/System.Windows.Extensions/settings.targets
+++ b/src/libraries/testPackages/packageSettings/System.Windows.Extensions/settings.targets
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <!-- intentional dangling ref -->
+    <IgnoredReference Include="System.Drawing.Common" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Dropping the package reference for System.Drawing.Common from System.Windows.Extensions.

This retains the type-forwards to avoid binary breaking changes but drops the package reference in the shipping product.

Related: https://github.com/dotnet/msbuild/issues/8962