### PR TITLE
Add clr.tools subset to runtime-community

### DIFF
--- a/eng/pipelines/runtime-community.yml
+++ b/eng/pipelines/runtime-community.yml
@@ -63,7 +63,7 @@ extends:
           jobParameters:
             testGroup: innerloop
             nameSuffix: AllSubsets_Mono
-            buildArgs: -s mono+libs+host+packs+libs.tests+clr.tools -c $(_BuildConfig) /p:ArchiveTests=true
+            buildArgs: -s mono+libs+host+packs+libs.tests+clr.iltools+clr.packages -c $(_BuildConfig) /p:ArchiveTests=true
             timeoutInMinutes: 180
             condition: >-
               or(

--- a/eng/pipelines/runtime-community.yml
+++ b/eng/pipelines/runtime-community.yml
@@ -63,7 +63,7 @@ extends:
           jobParameters:
             testGroup: innerloop
             nameSuffix: AllSubsets_Mono
-            buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true
+            buildArgs: -s mono+libs+host+packs+libs.tests+clr.tools -c $(_BuildConfig) /p:ArchiveTests=true
             timeoutInMinutes: 180
             condition: >-
               or(


### PR DESCRIPTION
This will help us catch failures like https://github.com/dotnet/runtime/pull/88145

CC @am11 @janani66