### PR TITLE
Remove redundant call to ConvertToCanonForm

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
@@ -108,7 +108,7 @@ namespace ILCompiler.DependencyAnalysis
             if (canonType.IsCanonicalSubtype(CanonicalFormKind.Any))
                 GenericTypesTemplateMap.GetTemplateTypeDependencies(ref dependencies, factory, canonType);
             else
-                dependencies.Add(factory.MaximallyConstructableType(canonType), reason);
+                dependencies.Add(factory.MaximallyConstructableType(type), reason);
         }
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
@@ -106,7 +106,7 @@ namespace ILCompiler.DependencyAnalysis
 
             TypeDesc canonType = type.ConvertToCanonForm(CanonicalFormKind.Specific);
             if (canonType.IsCanonicalSubtype(CanonicalFormKind.Any))
-                GenericTypesTemplateMap.GetTemplateTypeDependencies(ref dependencies, factory, type.ConvertToCanonForm(CanonicalFormKind.Specific));
+                GenericTypesTemplateMap.GetTemplateTypeDependencies(ref dependencies, factory, canonType);
             else
                 dependencies.Add(factory.MaximallyConstructableType(canonType), reason);
         }


### PR DESCRIPTION
Call to `type.ConvertToCanonForm(CanonicalFormKind.Specific)` is redundant as we just computed the `canonType` [two lines up](https://github.com/dotnet/runtime/pull/88083/files#diff-3dcbf6471d7684e53a20ea7c269edd4789596d7f89132db9a1086a552a3f63d0R107).
 
Reuse the computed value.