### PR TITLE
[wasm] Use latest sdk for workload testing

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -203,7 +203,7 @@
     <GrpcDotnetClientVersion>2.45.0</GrpcDotnetClientVersion>
     <GrpcToolsVersion>2.45.0</GrpcToolsVersion>
     <!-- Uncomment to set a fixed version, else the latest is used -->
-    <SdkVersionForWorkloadTesting>8.0.100-preview.6.23314.19</SdkVersionForWorkloadTesting>
+    <!--<SdkVersionForWorkloadTesting>8.0.100-preview.6.23314.19</SdkVersionForWorkloadTesting>-->
     <CompilerPlatformTestingVersion>1.1.2-beta1.23205.1</CompilerPlatformTestingVersion>
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>7.0.0-preview-20221010.1</MicrosoftPrivateIntellisenseVersion>


### PR DESCRIPTION
This reverts the earlier change from
7112a41c86ca856dc0a462afafb953be6ac4fcc7 which was working around https://github.com/dotnet/runtime/issues/87647
