### PR TITLE
Augment generated regex XML comment with original pattern and options

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -5190,11 +5190,9 @@ namespace System.Text.RegularExpressions.Generator
             {
                 RegexCharClass.AnyClass => "any character",
                 RegexCharClass.DigitClass => "a Unicode digit",
-                RegexCharClass.ECMADigitClass => "'0' through '9'",
                 RegexCharClass.ECMASpaceClass => "a whitespace character (ECMA)",
                 RegexCharClass.ECMAWordClass => "a word character (ECMA)",
                 RegexCharClass.NotDigitClass => "any character other than a Unicode digit",
-                RegexCharClass.NotECMADigitClass => "any character other than '0' through '9'",
                 RegexCharClass.NotECMASpaceClass => "any character other than a whitespace character (ECMA)",
                 RegexCharClass.NotECMAWordClass => "any character other than a word character (ECMA)",
                 RegexCharClass.NotSpaceClass => "any character other than a whitespace character",

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -55,12 +55,19 @@ namespace System.Text.RegularExpressions.Generator
             }
 
             // Emit the partial method definition.
-            writer.WriteLine("/// <remarks>");
-            writer.WriteLine("/// Pattern explanation:<br/>");
-            writer.WriteLine("/// <code>");
+            writer.WriteLine($"/// <remarks>");
+            writer.WriteLine($"/// Pattern:<br/>");
+            writer.WriteLine($"/// <code>{EscapeXmlComment(Literal(regexMethod.Pattern, quote: false))}</code><br/>");
+            if (regexMethod.Options != RegexOptions.None)
+            {
+                writer.WriteLine($"/// Options:<br/>");
+                writer.WriteLine($"/// <code>{Literal(regexMethod.Options)}</code><br/>");
+            }
+            writer.WriteLine($"/// Explanation:<br/>");
+            writer.WriteLine($"/// <code>");
             DescribeExpressionAsXmlComment(writer, regexMethod.Tree.Root.Child(0), regexMethod); // skip implicit root capture
-            writer.WriteLine("/// </code>");
-            writer.WriteLine("/// </remarks>");
+            writer.WriteLine($"/// </code>");
+            writer.WriteLine($"/// </remarks>");
             writer.WriteLine($"[global::System.CodeDom.Compiler.{s_generatedCodeAttribute}]");
             writer.WriteLine($"{regexMethod.Modifiers} global::System.Text.RegularExpressions.Regex {regexMethod.MethodName}() => global::{GeneratedNamespace}.{regexMethod.GeneratedName}.Instance;");
 
@@ -5084,7 +5091,7 @@ namespace System.Text.RegularExpressions.Generator
         private static string Literal(char c) => SymbolDisplay.FormatLiteral(c, quote: true);
 
         /// <summary>Formats the string as valid C#.</summary>
-        private static string Literal(string s) => SymbolDisplay.FormatLiteral(s, quote: true);
+        private static string Literal(string s, bool quote = true) => SymbolDisplay.FormatLiteral(s, quote);
 
         private static string Literal(RegexOptions options)
         {

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorOutputTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorOutputTests.cs
@@ -70,7 +70,9 @@ namespace System.Text.RegularExpressions.Tests
                 partial class C
                 {
                     /// <remarks>
-                    /// Pattern explanation:<br/>
+                    /// Pattern:<br/>
+                    /// <code>^(?&lt;proto&gt;\\w+)://[^/]+?(?&lt;port&gt;:\\d+)?/</code><br/>
+                    /// Explanation:<br/>
                     /// <code>
                     /// ○ Match if at the beginning of the string.<br/>
                     /// ○ "proto" capture group.<br/>
@@ -431,7 +433,9 @@ namespace System.Text.RegularExpressions.Tests
                 partial class C
                 {
                     /// <remarks>
-                    /// Pattern explanation:<br/>
+                    /// Pattern:<br/>
+                    /// <code>href\\s*=\\s*(?:["'](?&lt;1&gt;[^"']*)["']|(?&lt;1&gt;[^&gt;\\s]+))</code><br/>
+                    /// Explanation:<br/>
                     /// <code>
                     /// ○ Match the string "href".<br/>
                     /// ○ Match a whitespace character atomically any number of times.<br/>
@@ -727,7 +731,9 @@ namespace System.Text.RegularExpressions.Tests
                 partial class C
                 {
                     /// <remarks>
-                    /// Pattern explanation:<br/>
+                    /// Pattern:<br/>
+                    /// <code>[A-Za-z]+</code><br/>
+                    /// Explanation:<br/>
                     /// <code>
                     /// ○ Match a character in the set [A-Za-z] atomically at least once.<br/>
                     /// </code>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/88121

Before:
<img width="470" alt="image" src="https://github.com/dotnet/runtime/assets/2642209/8041b54c-5c40-4410-9f7e-ed9c1cc04934">

After:
<img width="572" alt="image" src="https://github.com/dotnet/runtime/assets/2642209/05926ca0-0f01-4fee-bd65-af9f015ad0d9">
