### PR TITLE
Mark a new test as NativeAotIncompatible

### DIFF
--- a/src/tests/Regressions/coreclr/GitHub_86865/test86865.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_86865/test86865.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!-- Non-intrinsic implementation of RuntimeHelpers.GetSpanDataFrom -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test86865.cs" />


### PR DESCRIPTION
We don't intend to implement non-intrinsic expansion of GetSpanDataFrom, same as InitializeArray.

Cc @dotnet/ilc-contrib 