### PR TITLE
[nativeaot][perf] Simplify the build process for the perf measurements

### DIFF
--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -111,7 +111,7 @@ jobs:
       platforms:
       - ios_arm64
       jobParameters:
-        buildArgs: -s clr.nativeaotruntime+clr.nativeaotlibs+libs -c $(_BuildConfig) -rc $(_BuildConfig)
+        buildArgs: -s clr.nativeaotruntime+clr.nativeaotlibs+libs -c $(_BuildConfig)
         nameSuffix: iOSNativeAOT
         isOfficialBuild: false
         extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml

--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -111,6 +111,7 @@ jobs:
       platforms:
       - ios_arm64
       jobParameters:
+        buildArgs: -s clr.nativeaotruntime+clr.nativeaotlibs+libs -c $(_BuildConfig) -rc $(_BuildConfig)
         nameSuffix: iOSNativeAOT
         isOfficialBuild: false
         extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml

--- a/eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
@@ -124,7 +124,7 @@ steps:
         archiveType: zip
 
   - ${{ if and(eq(parameters.osGroup, 'ios'), eq(parameters.nameSuffix, 'iOSNativeAOT')) }}:
-    - script: make world TARGET_OS=ios TARGET_ARCH=arm64 BUILD_CONFIG=Release DEPLOY_AND_RUN=false STRIP_DEBUG_SYMBOLS=false
+    - script: make hello-app TARGET_OS=ios TARGET_ARCH=arm64 BUILD_CONFIG=Release DEPLOY_AND_RUN=false STRIP_DEBUG_SYMBOLS=false
       env:
         DevTeamProvisioning: '-'
       workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT
@@ -146,7 +146,7 @@ steps:
     - script: rm -r -f $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT/bin
       workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT
       displayName: Clean bindir
-    - script: make world TARGET_OS=ios TARGET_ARCH=arm64 BUILD_CONFIG=Release DEPLOY_AND_RUN=false STRIP_DEBUG_SYMBOLS=true
+    - script: make hello-app TARGET_OS=ios TARGET_ARCH=arm64 BUILD_CONFIG=Release DEPLOY_AND_RUN=false STRIP_DEBUG_SYMBOLS=true
       env:
         DevTeamProvisioning: '-'
       workingDirectory: $(Build.SourcesDirectory)/src/mono/sample/iOS-NativeAOT


### PR DESCRIPTION
This PR aims to simplify the build process by first building the native and host components before building the application.

Fixes the issue of a failing Native AOT perf build. 
```
[ 13%] Building CXX object vm/CMakeFiles/cee_dac.dir/cmake_pch_x86_64.hxx.pch
  In file included from <built-in>:1:
  In file included from /Users/runner/work/1/s/artifacts/obj/coreclr/osx.x64.Release/vm/CMakeFiles/cee_dac.dir/cmake_pch_x86_64.hxx:5:
  In file included from /Users/runner/work/1/s/src/coreclr/vm/common.h:83:
  /Users/runner/work/1/s/src/coreclr/pal/inc/../../debug/inc/dbgtargetcontext.h:296:1: error: static_assert failed due to requirement 'sizeof(DT_CONTEXT) == sizeof(_CONTEXT)' "DT_CONTEXT size must equal the T_CONTEXT size on AMD64"
  static_assert(sizeof(DT_CONTEXT) == sizeof(T_CONTEXT), "DT_CONTEXT size must equal the T_CONTEXT size on AMD64");
  ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```



