### PR TITLE
Reduce allocations in Microsoft.Extensions.Configuration

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Abstractions/src/ConfigurationPath.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Abstractions/src/ConfigurationPath.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Extensions.Configuration
             }
 
             int lastDelimiterIndex = path.LastIndexOf(':');
-            return lastDelimiterIndex == -1 ? null : path.Substring(0, lastDelimiterIndex);
+            return lastDelimiterIndex < 0 ? null : path.Substring(0, lastDelimiterIndex);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Abstractions/src/ConfigurationPath.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Abstractions/src/ConfigurationPath.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Extensions.Configuration
             }
 
             int lastDelimiterIndex = path.LastIndexOf(':');
-            return lastDelimiterIndex == -1 ? path : path.Substring(lastDelimiterIndex + 1);
+            return lastDelimiterIndex < 0 ? path : path.Substring(lastDelimiterIndex + 1);
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Configuration.Abstractions/src/ConfigurationPath.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Abstractions/src/ConfigurationPath.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Extensions.Configuration
                 return path;
             }
 
-            int lastDelimiterIndex = path.LastIndexOf(KeyDelimiter, StringComparison.OrdinalIgnoreCase);
+            int lastDelimiterIndex = path.LastIndexOf(':');
             return lastDelimiterIndex == -1 ? path : path.Substring(lastDelimiterIndex + 1);
         }
 
@@ -70,7 +70,7 @@ namespace Microsoft.Extensions.Configuration
                 return null;
             }
 
-            int lastDelimiterIndex = path.LastIndexOf(KeyDelimiter, StringComparison.OrdinalIgnoreCase);
+            int lastDelimiterIndex = path.LastIndexOf(':');
             return lastDelimiterIndex == -1 ? null : path.Substring(0, lastDelimiterIndex);
         }
     }

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationBuilder.cs
@@ -11,10 +11,12 @@ namespace Microsoft.Extensions.Configuration
     /// </summary>
     public class ConfigurationBuilder : IConfigurationBuilder
     {
+        private readonly List<IConfigurationSource> _sources = new();
+
         /// <summary>
         /// Returns the sources used to obtain configuration values.
         /// </summary>
-        public IList<IConfigurationSource> Sources { get; } = new List<IConfigurationSource>();
+        public IList<IConfigurationSource> Sources => _sources;
 
         /// <summary>
         /// Gets a key/value collection that can be used to share data between the <see cref="IConfigurationBuilder"/>
@@ -31,7 +33,7 @@ namespace Microsoft.Extensions.Configuration
         {
             ThrowHelper.ThrowIfNull(source);
 
-            Sources.Add(source);
+            _sources.Add(source);
             return this;
         }
 
@@ -43,7 +45,7 @@ namespace Microsoft.Extensions.Configuration
         public IConfigurationRoot Build()
         {
             var providers = new List<IConfigurationProvider>();
-            foreach (IConfigurationSource source in Sources)
+            foreach (IConfigurationSource source in _sources)
             {
                 IConfigurationProvider provider = source.Build(this);
                 providers.Add(provider);

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationManager.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationManager.cs
@@ -229,10 +229,7 @@ namespace Microsoft.Extensions.Configuration
                 _sources.CopyTo(array, arrayIndex);
             }
 
-            public IEnumerator<IConfigurationSource> GetEnumerator()
-            {
-                return _sources.GetEnumerator();
-            }
+            public List<IConfigurationSource>.Enumerator GetEnumerator() => _sources.GetEnumerator();
 
             public int IndexOf(IConfigurationSource source)
             {
@@ -258,10 +255,9 @@ namespace Microsoft.Extensions.Configuration
                 _config.ReloadSources();
             }
 
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return GetEnumerator();
-            }
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            IEnumerator<IConfigurationSource> IEnumerable<IConfigurationSource>.GetEnumerator() => GetEnumerator();
         }
 
         private sealed class ConfigurationBuilderProperties : IDictionary<string, object>

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationProvider.cs
@@ -95,7 +95,8 @@ namespace Microsoft.Extensions.Configuration
 
         private static string Segment(string key, int prefixLength)
         {
-            int indexOf = key.IndexOf(ConfigurationPath.KeyDelimiter, prefixLength, StringComparison.OrdinalIgnoreCase);
+            Debug.Assert(ConfigurationPath.KeyDelimiter == ":");
+            int indexOf = key.IndexOf(':', prefixLength);
             return indexOf < 0 ? key.Substring(prefixLength) : key.Substring(prefixLength, indexOf - prefixLength);
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationSection.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationSection.cs
@@ -69,11 +69,11 @@ namespace Microsoft.Extensions.Configuration
         {
             get
             {
-                return _root[ConfigurationPath.Combine(Path, key)];
+                return _root[Path + ConfigurationPath.KeyDelimiter + key];
             }
             set
             {
-                _root[ConfigurationPath.Combine(Path, key)] = value;
+                _root[Path + ConfigurationPath.KeyDelimiter + key] = value;
             }
         }
 
@@ -86,7 +86,7 @@ namespace Microsoft.Extensions.Configuration
         ///     This method will never return <c>null</c>. If no matching sub-section is found with the specified key,
         ///     an empty <see cref="IConfigurationSection"/> will be returned.
         /// </remarks>
-        public IConfigurationSection GetSection(string key) => _root.GetSection(ConfigurationPath.Combine(Path, key));
+        public IConfigurationSection GetSection(string key) => _root.GetSection(Path + ConfigurationPath.KeyDelimiter + key);
 
         /// <summary>
         /// Gets the immediate descendant configuration sub-sections.

--- a/src/libraries/Microsoft.Extensions.Configuration/src/InternalConfigurationRootExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/InternalConfigurationRootExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Extensions.Configuration
                 .Aggregate(Enumerable.Empty<string>(),
                     (seed, source) => source.GetChildKeys(seed, path))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
-                .Select(key => root.GetSection(path == null ? key : ConfigurationPath.Combine(path, key)));
+                .Select(key => root.GetSection(path == null ? key : path + ConfigurationPath.KeyDelimiter + key));
 
             if (reference is null)
             {


### PR DESCRIPTION
Currently calculating paths always allocates a `string[]` just to concatenate 3 strings.