### PR TITLE
fix TLS resume with HttpClientHandler on Linux

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.IO;
+using System.Net.Security;
 using System.Net.Sockets;
 using System.Net.WebSockets;
 using System.Threading;
@@ -174,6 +175,7 @@ namespace System.Net.Test.Common
                 SslProtocols.Tls12;
 
         public int ListenBacklog { get; set; } = 1;
+        public SslStreamCertificateContext? CertificateContext { get; set; }
     }
 
     public struct HttpHeaderData

--- a/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs
@@ -175,7 +175,9 @@ namespace System.Net.Test.Common
                 SslProtocols.Tls12;
 
         public int ListenBacklog { get; set; } = 1;
+#if !NETSTANDARD2_0 && !NETFRAMEWORK
         public SslStreamCertificateContext? CertificateContext { get; set; }
+#endif
     }
 
     public struct HttpHeaderData

--- a/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -477,7 +477,7 @@ namespace System.Net.Test.Common
                     SslServerAuthenticationOptions sslOptions = new SslServerAuthenticationOptions()
                     {
                         EnabledSslProtocols = httpOptions.SslProtocols,
-                        ServerCertificateContext = httpOptions.CertificateContext,
+                        ServerCertificateContext = httpOptions.CertificateContext ?? SslStreamCertificateContext.Create(Configuration.Certificates.GetServerCertificate(), null),
                         ClientCertificateRequired = true,
                     };
 

--- a/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -489,11 +489,11 @@ namespace System.Net.Test.Common
 #else
                     using (X509Certificate2 cert = httpOptions.Certificate ?? Configuration.Certificates.GetServerCertificate())
                     {
-                         await sslStream.AuthenticateAsServerAsync(
-                             cert,
-                             clientCertificateRequired: true, // allowed but not required
-                             enabledSslProtocols: httpOptions.SslProtocols,
-                             checkCertificateRevocation: false).ConfigureAwait(false);
+                        await sslStream.AuthenticateAsServerAsync(
+                            cert,
+                            clientCertificateRequired: true, // allowed but not required
+                            enabledSslProtocols: httpOptions.SslProtocols,
+                            checkCertificateRevocation: false).ConfigureAwait(false);
                     }
 #endif
                     stream = sslStream;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -107,6 +107,8 @@ namespace System.Net.Http
             }
         }
 
+        internal ClientCertificateOption ClientCertificateOptions;
+
         public const bool SupportsAutomaticDecompression = false;
         public const bool SupportsProxy = false;
         public const bool SupportsRedirectConfiguration = true;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
@@ -205,6 +205,13 @@ namespace System.Net.Http
             set => _underlyingHandler.MaxResponseHeadersLength = value;
         }
 
+#if TARGET_BROWSER
+#else
+        private X509Certificate2 GetEligibleClientCertificate(object _, string _2, X509CertificateCollection _3, X509Certificate? _4, string[] _5)
+        {
+            return CertificateHelper.GetEligibleClientCertificate(_underlyingHandler.SslOptions.ClientCertificates)!;
+        }
+#endif
         public ClientCertificateOption ClientCertificateOptions
         {
             get => _clientCertificateOptions;
@@ -218,7 +225,7 @@ namespace System.Net.Http
 #else
                         ThrowForModifiedManagedSslOptionsIfStarted();
                         _clientCertificateOptions = value;
-                        _underlyingHandler.SslOptions.LocalCertificateSelectionCallback = (sender, targetHost, localCertificates, remoteCertificate, acceptableIssuers) => CertificateHelper.GetEligibleClientCertificate(_underlyingHandler.SslOptions.ClientCertificates)!;
+                        _underlyingHandler.SslOptions.LocalCertificateSelectionCallback = GetEligibleClientCertificate;
 #endif
                         break;
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
@@ -42,6 +42,8 @@ namespace System.Net.Http
             {
                 Handler = new DiagnosticsHandler(Handler, DistributedContextPropagator.Current);
             }
+#else
+            _underlyingHandler.HttpClientHandlerCompat = true;
 #endif
 
             ClientCertificateOptions = ClientCertificateOption.Manual;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
@@ -207,13 +207,6 @@ namespace System.Net.Http
             set => _underlyingHandler.MaxResponseHeadersLength = value;
         }
 
-#if TARGET_BROWSER
-#else
-        private X509Certificate2 GetEligibleClientCertificate(object _, string _2, X509CertificateCollection _3, X509Certificate? _4, string[] _5)
-        {
-            return CertificateHelper.GetEligibleClientCertificate(_underlyingHandler.SslOptions.ClientCertificates)!;
-        }
-#endif
         public ClientCertificateOption ClientCertificateOptions
         {
             get => _clientCertificateOptions;
@@ -227,7 +220,7 @@ namespace System.Net.Http
 #else
                         ThrowForModifiedManagedSslOptionsIfStarted();
                         _clientCertificateOptions = value;
-                        _underlyingHandler.SslOptions.LocalCertificateSelectionCallback = GetEligibleClientCertificate;
+                        _underlyingHandler.SslOptions.LocalCertificateSelectionCallback = (sender, targetHost, localCertificates, remoteCertificate, acceptableIssuers) => CertificateHelper.GetEligibleClientCertificate(_underlyingHandler.SslOptions.ClientCertificates)!;
 #endif
                         break;
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
@@ -28,8 +28,6 @@ namespace System.Net.Http
         private HttpHandlerType Handler => _underlyingHandler;
 #endif
 
-        private ClientCertificateOption _clientCertificateOptions;
-
         private volatile bool _disposed;
 
         public HttpClientHandler()
@@ -42,8 +40,6 @@ namespace System.Net.Http
             {
                 Handler = new DiagnosticsHandler(Handler, DistributedContextPropagator.Current);
             }
-#else
-            _underlyingHandler.HttpClientHandlerCompat = true;
 #endif
 
             ClientCertificateOptions = ClientCertificateOption.Manual;
@@ -209,27 +205,21 @@ namespace System.Net.Http
 
         public ClientCertificateOption ClientCertificateOptions
         {
-            get => _clientCertificateOptions;
+            get => _underlyingHandler.ClientCertificateOptions;
             set
             {
                 switch (value)
                 {
                     case ClientCertificateOption.Manual:
-#if TARGET_BROWSER
-                        _clientCertificateOptions = value;
-#else
+#if !TARGET_BROWSER
                         ThrowForModifiedManagedSslOptionsIfStarted();
-                        _clientCertificateOptions = value;
                         _underlyingHandler.SslOptions.LocalCertificateSelectionCallback = (sender, targetHost, localCertificates, remoteCertificate, acceptableIssuers) => CertificateHelper.GetEligibleClientCertificate(_underlyingHandler.SslOptions.ClientCertificates)!;
 #endif
                         break;
 
                     case ClientCertificateOption.Automatic:
-#if TARGET_BROWSER
-                        _clientCertificateOptions = value;
-#else
+#if !TARGET_BROWSER
                         ThrowForModifiedManagedSslOptionsIfStarted();
-                        _clientCertificateOptions = value;
                         _underlyingHandler.SslOptions.LocalCertificateSelectionCallback = (sender, targetHost, localCertificates, remoteCertificate, acceptableIssuers) => CertificateHelper.GetEligibleClientCertificate()!;
 #endif
                         break;
@@ -237,6 +227,7 @@ namespace System.Net.Http
                     default:
                         throw new ArgumentOutOfRangeException(nameof(value));
                 }
+                _underlyingHandler.ClientCertificateOptions = value;
             }
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -327,7 +327,8 @@ namespace System.Net.Http
 
             SslClientAuthenticationOptions sslOptions = poolManager.Settings._sslOptions?.ShallowClone() ?? new SslClientAuthenticationOptions();
 
-            if (poolManager.Settings._httpClientHandlerCompat && sslOptions.LocalCertificateSelectionCallback != null &&
+            // This is only set if we are underlying handler for HttpClientHandler
+            if (poolManager.Settings._clientCertificateOptions == ClientCertificateOption.Manual && sslOptions.LocalCertificateSelectionCallback != null &&
                     (sslOptions.ClientCertificates == null || sslOptions.ClientCertificates.Count == 0))
             {
                 // If we have no client certificates do not set callback when internal selection is used.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -12,7 +12,6 @@ using System.Net.Http.QPack;
 using System.Net.Quic;
 using System.Net.Security;
 using System.Net.Sockets;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Runtime.Versioning;
@@ -26,8 +25,6 @@ namespace System.Net.Http
     /// <summary>Provides a pool of connections to the same endpoint.</summary>
     internal sealed class HttpConnectionPool : IDisposable
     {
-        private static readonly MethodInfo? internalCertificateSelectionCallback = typeof(HttpClientHandler).GetMethod("GetEligibleClientCertificate", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-
         private static readonly bool s_isWindows7Or2008R2 = GetIsWindows7Or2008R2();
 
         private readonly HttpConnectionPoolManager _poolManager;
@@ -330,18 +327,12 @@ namespace System.Net.Http
 
             SslClientAuthenticationOptions sslOptions = poolManager.Settings._sslOptions?.ShallowClone() ?? new SslClientAuthenticationOptions();
 
-            if (sslOptions.LocalCertificateSelectionCallback != null && (sslOptions.ClientCertificates == null || sslOptions.ClientCertificates.Count == 0))
+            if (poolManager.Settings._httpClientHandlerCompat && sslOptions.LocalCertificateSelectionCallback != null &&
+                    (sslOptions.ClientCertificates == null || sslOptions.ClientCertificates.Count == 0))
             {
                 // If we have no client certificates do not set callback when internal selection is used.
                 // It breaks TLS resume on Linux
-                if (sslOptions.LocalCertificateSelectionCallback.Method.Equals(internalCertificateSelectionCallback))
-                {
-                    sslOptions.LocalCertificateSelectionCallback = null;
-                    if (poolManager.Settings._sslOptions != null)
-                    {
-                        poolManager.Settings._sslOptions.LocalCertificateSelectionCallback = null;
-                    }
-                }
+                sslOptions.LocalCertificateSelectionCallback = null;
             }
 
             // Set TargetHost for SNI

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -63,6 +63,8 @@ namespace System.Net.Http
         // Http2 flow control settings:
         internal int _initialHttp2StreamWindowSize = HttpHandlerDefaults.DefaultInitialHttp2StreamWindowSize;
 
+        internal bool _httpClientHandlerCompat;
+
         public HttpConnectionSettings()
         {
             bool allowHttp2 = GlobalHttpSettings.SocketsHttpHandler.AllowHttp2;
@@ -117,6 +119,7 @@ namespace System.Net.Http
                 _activityHeadersPropagator = _activityHeadersPropagator,
                 _defaultCredentialsUsedForProxy = _proxy != null && (_proxy.Credentials == CredentialCache.DefaultCredentials || _defaultProxyCredentials == CredentialCache.DefaultCredentials),
                 _defaultCredentialsUsedForServer = _credentials == CredentialCache.DefaultCredentials,
+                _httpClientHandlerCompat = _httpClientHandlerCompat
             };
 
             return settings;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -63,7 +63,7 @@ namespace System.Net.Http
         // Http2 flow control settings:
         internal int _initialHttp2StreamWindowSize = HttpHandlerDefaults.DefaultInitialHttp2StreamWindowSize;
 
-        internal bool _httpClientHandlerCompat;
+        internal ClientCertificateOption _clientCertificateOptions;
 
         public HttpConnectionSettings()
         {
@@ -73,6 +73,8 @@ namespace System.Net.Http
                 allowHttp3 && allowHttp2 ? HttpVersion.Version30 :
                 allowHttp2 ? HttpVersion.Version20 :
                 HttpVersion.Version11;
+
+            _clientCertificateOptions = ClientCertificateOption.Automatic;
         }
 
         /// <summary>Creates a copy of the settings but with some values normalized to suit the implementation.</summary>
@@ -119,7 +121,7 @@ namespace System.Net.Http
                 _activityHeadersPropagator = _activityHeadersPropagator,
                 _defaultCredentialsUsedForProxy = _proxy != null && (_proxy.Credentials == CredentialCache.DefaultCredentials || _defaultProxyCredentials == CredentialCache.DefaultCredentials),
                 _defaultCredentialsUsedForServer = _credentials == CredentialCache.DefaultCredentials,
-                _httpClientHandlerCompat = _httpClientHandlerCompat
+                _clientCertificateOptions = _clientCertificateOptions,
             };
 
             return settings;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -450,17 +450,15 @@ namespace System.Net.Http
             }
         }
 
-        /// <summary>
-        ///  Indicates that we are wrapped by HttpClientHandler and we want compatible behavior
-        /// </summary>
-        internal bool HttpClientHandlerCompat
+        internal ClientCertificateOption ClientCertificateOptions
         {
+            get => _settings._clientCertificateOptions;
             set
             {
-                _settings._httpClientHandlerCompat = value;
+                CheckDisposedOrStarted();
+                _settings._clientCertificateOptions = value;
             }
         }
-
         protected override void Dispose(bool disposing)
         {
             if (disposing && !_disposed)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -450,6 +450,17 @@ namespace System.Net.Http
             }
         }
 
+        /// <summary>
+        ///  Indicates that we are wrapped by HttpClientHandler and we want compatible behavior
+        /// </summary>
+        internal bool HttpClientHandlerCompat
+        {
+            set
+            {
+                _settings._httpClientHandlerCompat = value;
+            }
+        }
+
         protected override void Dispose(bool disposing)
         {
             if (disposing && !_disposed)

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -4294,7 +4294,8 @@ namespace System.Net.Http.Functional.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task Https_MultipleRequests_Resume(bool useSocketHandler)
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.Linux)]
+        public async Task Https_MultipleRequests_TlsResumed(bool useSocketHandler)
         {
             await LoopbackServer.CreateClientAndServerAsync(async uri =>
             {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -11,6 +11,7 @@ using System.Net.Security;
 using System.Net.Sockets;
 using System.Net.Test.Common;
 using System.Numerics;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
@@ -4288,6 +4289,50 @@ namespace System.Net.Http.Functional.Tests
     {
         public SocketsHttpHandler_SocketsHttpHandler_SecurityTest_Http11(ITestOutputHelper output) : base(output) { }
         protected override Version UseVersion => HttpVersion.Version11;
+
+#if DEBUG
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Https_MultipleRequests_Resume(bool useSocketHandler)
+        {
+            await LoopbackServer.CreateClientAndServerAsync(async uri =>
+            {
+                HttpMessageHandler handler = useSocketHandler ? CreateSocketsHttpHandler(allowAllCertificates: true) : CreateHttpClientHandler();
+                using (HttpClient client = CreateHttpClient(handler))
+                {
+                    HttpRequestMessage request = new  HttpRequestMessage(HttpMethod.Get,uri);
+                    request.Headers.Add("Host", "foo.bar");
+                    request.Headers.Add("Connection", "close");
+
+                    HttpResponseMessage response = await client.SendAsync(request);
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                    request = new  HttpRequestMessage(HttpMethod.Get,uri);
+                    request.Headers.Add("Host", "foo.bar");
+                    response = await client.SendAsync(request);
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                }
+            },
+            async server =>
+            {
+                await server.AcceptConnectionSendResponseAndCloseAsync();
+                await server.AcceptConnectionAsync(async connection =>
+                {
+                    SslStream ssl = (SslStream)connection.Stream;
+                    object connectionInfo = typeof(SslStream).GetField(
+                                     "_connectionInfo",
+                                     BindingFlags.Instance | BindingFlags.NonPublic).GetValue(ssl);
+
+                    bool resumed = (bool)connectionInfo.GetType().GetProperty("TlsResumed").GetValue(connectionInfo);
+                    Assert.True(resumed);
+
+                    await connection.ReadRequestHeaderAndSendResponseAsync();
+                });
+            },
+            new LoopbackServer.Options { UseSsl = true, SslProtocols = SslProtocols.Tls12 });
+        }
+#endif
     }
 
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]


### PR DESCRIPTION
fixes #75434
contributes to #75545  

The existing code prevents TLS resume on Linux when `HttpClientHandler` is used (works fine if `SocketsHttpHandler` is used directly)

I updated test loopback server with `CertificateContext`. I was debating if we should add while ssl options but decided not to as there is currently no other use for it.  