### PR TITLE
Update CompilerPlatformTestingVersion version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -204,7 +204,7 @@
     <GrpcToolsVersion>2.45.0</GrpcToolsVersion>
     <!-- Uncomment to set a fixed version, else the latest is used -->
     <!--<SdkVersionForWorkloadTesting>8.0.100-preview.6.23314.19</SdkVersionForWorkloadTesting>-->
-    <CompilerPlatformTestingVersion>1.1.2-beta1.23205.1</CompilerPlatformTestingVersion>
+    <CompilerPlatformTestingVersion>1.1.2-beta1.23323.1</CompilerPlatformTestingVersion>
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>7.0.0-preview-20221010.1</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->


### PR DESCRIPTION
Update CompilerPlatformTestingVersion from 1.1.2-beta1.23205.1 to 1.1.2-beta1.23323.1.

Libraries build test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2212181&view=results