### PR TITLE
JIT: Don't set patchpoints in methods with CORINFO_DEBUG_CODE

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5810,7 +5810,8 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
 #ifdef FEATURE_ON_STACK_REPLACEMENT
 
-    bool enablePatchpoints = opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER0) && (JitConfig.TC_OnStackReplacement() > 0);
+    bool enablePatchpoints =
+        !opts.compDbgCode && opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER0) && (JitConfig.TC_OnStackReplacement() > 0);
 
 #ifdef DEBUG
 

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -3021,7 +3021,7 @@ bool MethodDesc::DetermineAndSetIsEligibleForTieredCompilation()
         !IsWrapperStub() &&
 
         // Policy - Generating optimized code is not disabled
-        !IsJitOptimizationDisabledForSpecificMethod())
+        !IsJitOptimizationDisabled())
     {
         m_wFlags3AndTokenRemainder |= enum_flag3_IsEligibleForTieredCompilation;
         _ASSERTE(IsVersionable());

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -3021,7 +3021,7 @@ bool MethodDesc::DetermineAndSetIsEligibleForTieredCompilation()
         !IsWrapperStub() &&
 
         // Policy - Generating optimized code is not disabled
-        !IsJitOptimizationDisabled())
+        !IsJitOptimizationDisabledForSpecificMethod())
     {
         m_wFlags3AndTokenRemainder |= enum_flag3_IsEligibleForTieredCompilation;
         _ASSERTE(IsVersionable());


### PR DESCRIPTION
In #88199 the debugger is overriding some jit flags, but has left other flags set that confuse the jit: both `TIER0` and `DEBUG_CODE` end uip set so one part of the jit used logic appropriate for `TIER0` and another part did not.

The JIT ended up creating a patchpoint for OSR in a method with localloc and this combination is not supported by OSR and lead to a crash.

Adjust the runtime so that if optimizations are disabled for a module by the debugger then none of the methods in the module are tiering eligible. This stops the runtime from setting `TIER0` in this case.

Also harden the jit so if the runtime asks for debuggable code, the jit will never generate patchpoints.