### PR TITLE
Tar: set directory modification times while extracting.

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -551,7 +551,7 @@ namespace System.Formats.Tar
             AttemptSetLastWriteTime(destinationFileName, ModificationTime);
         }
 
-        internal static void AttemptSetLastWriteTime(string destinationFileName, DateTimeOffset lastWriteTime)
+        private static void AttemptSetLastWriteTime(string destinationFileName, DateTimeOffset lastWriteTime)
         {
             try
             {

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -285,42 +285,44 @@ namespace System.Formats.Tar
         internal abstract bool IsDataStreamSetterSupported();
 
         // Extracts the current entry to a location relative to the specified directory.
-        internal void ExtractRelativeToDirectory(string destinationDirectoryPath, bool overwrite, SortedDictionary<string, UnixFileMode>? pendingModes)
+        internal void ExtractRelativeToDirectory(string destinationDirectoryPath, bool overwrite, SortedDictionary<string, UnixFileMode>? pendingModes, Stack<(string, DateTimeOffset)> directoryModificationTimes)
         {
-            (string fileDestinationPath, string? linkTargetPath) = GetDestinationAndLinkPaths(destinationDirectoryPath);
+            (string destinationFullPath, string? linkTargetPath) = GetDestinationAndLinkPaths(destinationDirectoryPath);
 
             if (EntryType == TarEntryType.Directory)
             {
-                TarHelpers.CreateDirectory(fileDestinationPath, Mode, pendingModes);
+                TarHelpers.CreateDirectory(destinationFullPath, Mode, pendingModes);
+                TarHelpers.UpdatePendingModificationTimes(directoryModificationTimes, destinationFullPath, ModificationTime);
             }
             else
             {
                 // If it is a file, create containing directory.
-                TarHelpers.CreateDirectory(Path.GetDirectoryName(fileDestinationPath)!, mode: null, pendingModes);
-                ExtractToFileInternal(fileDestinationPath, linkTargetPath, overwrite);
+                TarHelpers.CreateDirectory(Path.GetDirectoryName(destinationFullPath)!, mode: null, pendingModes);
+                ExtractToFileInternal(destinationFullPath, linkTargetPath, overwrite);
             }
         }
 
         // Asynchronously extracts the current entry to a location relative to the specified directory.
-        internal Task ExtractRelativeToDirectoryAsync(string destinationDirectoryPath, bool overwrite, SortedDictionary<string, UnixFileMode>? pendingModes, CancellationToken cancellationToken)
+        internal Task ExtractRelativeToDirectoryAsync(string destinationDirectoryPath, bool overwrite, SortedDictionary<string, UnixFileMode>? pendingModes, Stack<(string, DateTimeOffset)> directoryModificationTimes, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
                 return Task.FromCanceled(cancellationToken);
             }
 
-            (string fileDestinationPath, string? linkTargetPath) = GetDestinationAndLinkPaths(destinationDirectoryPath);
+            (string destinationFullPath, string? linkTargetPath) = GetDestinationAndLinkPaths(destinationDirectoryPath);
 
             if (EntryType == TarEntryType.Directory)
             {
-                TarHelpers.CreateDirectory(fileDestinationPath, Mode, pendingModes);
+                TarHelpers.CreateDirectory(destinationFullPath, Mode, pendingModes);
+                TarHelpers.UpdatePendingModificationTimes(directoryModificationTimes, destinationFullPath, ModificationTime);
                 return Task.CompletedTask;
             }
             else
             {
                 // If it is a file, create containing directory.
-                TarHelpers.CreateDirectory(Path.GetDirectoryName(fileDestinationPath)!, mode: null, pendingModes);
-                return ExtractToFileInternalAsync(fileDestinationPath, linkTargetPath, overwrite, cancellationToken);
+                TarHelpers.CreateDirectory(Path.GetDirectoryName(destinationFullPath)!, mode: null, pendingModes);
+                return ExtractToFileInternalAsync(destinationFullPath, linkTargetPath, overwrite, cancellationToken);
             }
         }
 
@@ -549,7 +551,7 @@ namespace System.Formats.Tar
             AttemptSetLastWriteTime(destinationFileName, ModificationTime);
         }
 
-        private static void AttemptSetLastWriteTime(string destinationFileName, DateTimeOffset lastWriteTime)
+        internal static void AttemptSetLastWriteTime(string destinationFileName, DateTimeOffset lastWriteTime)
         {
             try
             {

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarFile.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarFile.cs
@@ -412,6 +412,7 @@ namespace System.Formats.Tar
         private static IEnumerable<(string fullpath, string entryname)> GetFilesForCreation(string sourceDirectoryName, int basePathLength)
         {
             // The default order to write a tar archive is to recurse into subdirectories first.
+            // This order is expected by 'tar' to restore directory timestamps properly without the user explicitly specifying `--delay-directory-restore`.
             // FileSystemEnumerable RecurseSubdirectories will first write further entries before recursing, so we don't use it here.
 
             var fse = new FileSystemEnumerable<(string fullpath, string entryname, bool recurse)>(

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
@@ -449,14 +449,14 @@ namespace System.Formats.Tar
 
         private static void AttemptDirectorySetLastWriteTime(string fullPath, DateTimeOffset lastWriteTime)
         {
-            // try
-            // {
+            try
+            {
                 Directory.SetLastWriteTime(fullPath, lastWriteTime.LocalDateTime); // SetLastWriteTime expects local time
-            // }
-            // catch
-            // {
-            //     // Some OSes like Android might not support setting the last write time, the extraction should not fail because of that
-            // }
+            }
+            catch
+            {
+                // Some OSes like Android might not support setting the last write time, the extraction should not fail because of that
+            }
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
@@ -392,7 +392,7 @@ namespace System.Formats.Tar
             // note: these are ordered child to parent.
             while (directoryModificationTimes.TryPop(out (string Path, DateTimeOffset Modified) item))
             {
-                TarEntry.AttemptSetLastWriteTime(item.Path, item.Modified);
+                AttemptDirectorySetLastWriteTime(item.Path, item.Modified);
             }
         }
 
@@ -409,7 +409,7 @@ namespace System.Formats.Tar
                    !IsChildPath(previous.Path, fullPath))
             {
                 directoryModificationTimes.TryPop(out previous);
-                TarEntry.AttemptSetLastWriteTime(previous.Path, previous.Modified);
+                AttemptDirectorySetLastWriteTime(previous.Path, previous.Modified);
             }
 
             directoryModificationTimes.Push((fullPath, modified));
@@ -445,6 +445,18 @@ namespace System.Formats.Tar
             // We don't need to check for AltDirectorySeparatorChar, full paths are normalized to DirectorySeparatorChar.
             static bool IsDirectorySeparatorChar(char c)
                 => c == Path.DirectorySeparatorChar;
+        }
+
+        private static void AttemptDirectorySetLastWriteTime(string fullPath, DateTimeOffset lastWriteTime)
+        {
+            // try
+            // {
+                Directory.SetLastWriteTime(fullPath, lastWriteTime.LocalDateTime); // SetLastWriteTime expects local time
+            // }
+            // catch
+            // {
+            //     // Some OSes like Android might not support setting the last write time, the extraction should not fail because of that
+            // }
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
@@ -442,8 +442,9 @@ namespace System.Formats.Tar
 
             return childFullPath.StartsWith(parentFullPath, PathInternal.StringComparison);
 
+            // We don't need to check for AltDirectorySeparatorChar, full paths are normalized to DirectorySeparatorChar.
             static bool IsDirectorySeparatorChar(char c)
-                => c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar;
+                => c == Path.DirectorySeparatorChar;
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
@@ -442,9 +442,8 @@ namespace System.Formats.Tar
 
             return childFullPath.StartsWith(parentFullPath, PathInternal.StringComparison);
 
-            // We don't need to check for AltDirectorySeparatorChar, full paths are normalized to DirectorySeparatorChar.
             static bool IsDirectorySeparatorChar(char c)
-                => c == Path.DirectorySeparatorChar;
+                => c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar;
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
@@ -444,7 +444,7 @@ namespace System.Formats.Tar
 
             // We don't need to check for AltDirectorySeparatorChar, full paths are normalized to DirectorySeparatorChar.
             static bool IsDirectorySeparatorChar(char c)
-                => c ==  Path.DirectorySeparatorChar;
+                => c == Path.DirectorySeparatorChar;
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
@@ -386,5 +386,65 @@ namespace System.Formats.Tar
 
             throw new ArgumentException(SR.Format(SR.TarEntryTypeNotSupportedInFormat, entryType, archiveFormat), paramName);
         }
+
+        public static void SetPendingModificationTimes(Stack<(string, DateTimeOffset)> directoryModificationTimes)
+        {
+            // note: these are ordered child to parent.
+            while (directoryModificationTimes.TryPop(out (string Path, DateTimeOffset Modified) item))
+            {
+                TarEntry.AttemptSetLastWriteTime(item.Path, item.Modified);
+            }
+        }
+
+        public static void UpdatePendingModificationTimes(Stack<(string, DateTimeOffset)> directoryModificationTimes, string fullPath, DateTimeOffset modified)
+        {
+            // We can't set the modification time when we create the directory because extracting entries into it
+            // will cause that time to change. Instead, we track the times to set them later.
+
+            // We take into account that regular tar files are ordered:
+            // when we see a new directory which is not a child of the previous directory
+            // we can set the parent directory timestamps, and stop tracking them.
+            // This avoids having to track all directory entries until we've finished extracting the entire archive.
+            while (directoryModificationTimes.TryPeek(out (string Path, DateTimeOffset Modified) previous) &&
+                   !IsChildPath(previous.Path, fullPath))
+            {
+                directoryModificationTimes.TryPop(out previous);
+                TarEntry.AttemptSetLastWriteTime(previous.Path, previous.Modified);
+            }
+
+            directoryModificationTimes.Push((fullPath, modified));
+        }
+
+        private static bool IsChildPath(string parentFullPath, string childFullPath)
+        {
+            // Both paths may end with an additional separator.
+
+            // Verify that either the parent path ends with a separator
+            // or the child path has a separator where the parent path ends.
+            if (IsDirectorySeparatorChar(parentFullPath[^1]))
+            {
+                // The child needs to be at least a char longer than the parent for the name.
+                if (childFullPath.Length <= parentFullPath.Length)
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                // The child needs to be at least 2 chars longer than the parent:
+                // one for the separator, and one for the name.
+                if ((childFullPath.Length < parentFullPath.Length + 2) ||
+                    !IsDirectorySeparatorChar(childFullPath[parentFullPath.Length]))
+                {
+                    return false;
+                }
+            }
+
+            return childFullPath.StartsWith(parentFullPath, PathInternal.StringComparison);
+
+            // We don't need to check for AltDirectorySeparatorChar, full paths are normalized to DirectorySeparatorChar.
+            static bool IsDirectorySeparatorChar(char c)
+                => c ==  Path.DirectorySeparatorChar;
+        }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectory.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectory.File.Tests.cs
@@ -219,7 +219,7 @@ namespace System.Formats.Tar.Tests
 
             TarEntry entry = reader.GetNextEntry();
             Assert.NotNull(entry);
-            Assert.Equal("subDirectory/", entry.Name);
+            Assert.Equal("subDirectory", entry.Name);
             Assert.Equal(TarEntryType.SymbolicLink, entry.EntryType);
 
             Assert.Null(reader.GetNextEntry()); // file.txt should not be found

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectoryAsync.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectoryAsync.File.Tests.cs
@@ -263,7 +263,7 @@ namespace System.Formats.Tar.Tests
 
             TarEntry entry = await reader.GetNextEntryAsync();
             Assert.NotNull(entry);
-            Assert.Equal("subDirectory/", entry.Name);
+            Assert.Equal("subDirectory", entry.Name);
             Assert.Equal(TarEntryType.SymbolicLink, entry.EntryType);
 
             Assert.Null(await reader.GetNextEntryAsync()); // file.txt should not be found

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
@@ -83,6 +83,8 @@ namespace System.Formats.Tar.Tests
                 Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir")),                      // 'fromdir/dir'
                 Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir", "child")),             // 'fromdir/dir/child'
                 Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir", "child", "subchild")), // 'fromdir/dir/child/subchild'
+                Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir2")),                     // 'fromdir/dir2'
+                Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir2", "child2")),           // 'fromdir/dir2/child'
             };
             var dt = new DateTime[directories.Length];
             for (int i = directories.Length - 1; i >= 0; i--) // Reverse order to preserve parent timestamps.
@@ -103,10 +105,12 @@ namespace System.Formats.Tar.Tests
             TarFile.ExtractToDirectory(sourceFileName: tarFile, destinationDirectoryName: toDir, overwriteFiles: false);
 
             string[] extractedDirectories = Directory.GetDirectories(toDir, "*", new EnumerationOptions() { RecurseSubdirectories = true });
+            Array.Sort(extractedDirectories);
             Assert.Equal(directories.Length, extractedDirectories.Length);
             for (int i = 0; i < extractedDirectories.Length; i++)
             {
-                Assert.InRange(Directory.GetLastWriteTime(extractedDirectories[i]).Ticks, dt[i].AddSeconds(-3).Ticks, dt[i].AddSeconds(3).Ticks); // include some slop for filesystem granularity
+                Assert.Equal(Path.GetFileName(directories[i].FullName), Path.GetFileName(extractedDirectories[i]));
+                Assert.Equal(Directory.GetLastWriteTime(extractedDirectories[i]).Year, dt[i].Year);
             }
         }
 

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
@@ -84,7 +84,7 @@ namespace System.Formats.Tar.Tests
                 Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir", "child")),             // 'fromdir/dir/child'
                 Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir", "child", "subchild")), // 'fromdir/dir/child/subchild'
                 Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir2")),                     // 'fromdir/dir2'
-                Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir2", "child2")),           // 'fromdir/dir2/child'
+                Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir2", "child2")),           // 'fromdir/dir2/child2'
             };
             var dt = new DateTime[directories.Length];
             for (int i = directories.Length - 1; i >= 0; i--) // Reverse order to preserve parent timestamps.
@@ -93,7 +93,7 @@ namespace System.Formats.Tar.Tests
                 File.Create(Path.Combine(directories[i].FullName, "file")).Dispose();
 
                 // Set the directory timestamp.
-                dt[i] = new DateTime(2000 + i, 1, 2, 3, 4, 5, DateTimeKind.Local);
+                dt[i] = new DateTime(2000 + i, 1 + i, 2 + i, 3 + i, 4 + i, 5 + i, DateTimeKind.Local);
                 directories[i].LastWriteTime = dt[i];
             }
 
@@ -110,7 +110,7 @@ namespace System.Formats.Tar.Tests
             for (int i = 0; i < extractedDirectories.Length; i++)
             {
                 Assert.Equal(Path.GetFileName(directories[i].FullName), Path.GetFileName(extractedDirectories[i]));
-                Assert.Equal(Directory.GetLastWriteTime(extractedDirectories[i]).Year, dt[i].Year);
+                Assert.InRange(Directory.GetLastWriteTime(extractedDirectories[i]).Ticks, dt[i].AddSeconds(-3).Ticks, dt[i].AddSeconds(3).Ticks); // include some slop for filesystem granularity
             }
         }
 

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
@@ -71,6 +71,45 @@ namespace System.Formats.Tar.Tests
             Assert.InRange(File.GetLastWriteTime(outFile).Ticks, dt.AddSeconds(-3).Ticks, dt.AddSeconds(3).Ticks); // include some slop for filesystem granularity
         }
 
+        [Fact]
+        public void SetsLastModifiedTimeOnExtractedDirectories()
+        {
+            using TempDirectory root = new TempDirectory();
+
+            DirectoryInfo fromDir = Directory.CreateDirectory(Path.Combine(root.Path, "fromdir"));
+            // Create a hierarcy of directories.
+            var directories = new DirectoryInfo[]
+            {
+                Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir")),                      // 'fromdir/dir'
+                Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir", "child")),             // 'fromdir/dir/child'
+                Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir", "child", "subchild")), // 'fromdir/dir/child/subchild'
+            };
+            var dt = new DateTime[directories.Length];
+            for (int i = directories.Length - 1; i >= 0; i--) // Reverse order to preserve parent timestamps.
+            {
+                // Add a file.
+                File.Create(Path.Combine(directories[i].FullName, "file")).Dispose();
+
+                // Set the directory timestamp.
+                dt[i] = new DateTime(2000 + i, 1, 2, 3, 4, 5, DateTimeKind.Local);
+                directories[i].LastWriteTime = dt[i];
+            }
+
+            string tarFile = Path.Join(root.Path, "file.tar");
+            TarFile.CreateFromDirectory(sourceDirectoryName: fromDir.FullName, destinationFileName: tarFile, includeBaseDirectory: false);
+
+            string toDir = Path.Join(root.Path, "todir");
+            Directory.CreateDirectory(toDir);
+            TarFile.ExtractToDirectory(sourceFileName: tarFile, destinationDirectoryName: toDir, overwriteFiles: false);
+
+            string[] extractedDirectories = Directory.GetDirectories(toDir, "*", new EnumerationOptions() { RecurseSubdirectories = true });
+            Assert.Equal(directories.Length, extractedDirectories.Length);
+            for (int i = 0; i < extractedDirectories.Length; i++)
+            {
+                Assert.InRange(Directory.GetLastWriteTime(extractedDirectories[i]).Ticks, dt[i].AddSeconds(-3).Ticks, dt[i].AddSeconds(3).Ticks); // include some slop for filesystem granularity
+            }
+        }
+
         [Theory]
         [InlineData(TestTarFormat.v7)]
         [InlineData(TestTarFormat.ustar)]

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
@@ -122,7 +122,7 @@ namespace System.Formats.Tar.Tests
             for (int i = 0; i < extractedDirectories.Length; i++)
             {
                 Assert.Equal(Path.GetFileName(directories[i].FullName), Path.GetFileName(extractedDirectories[i]));
-                Assert.Equal(Directory.GetLastWriteTime(extractedDirectories[i]).Year, dt[i].Year);
+                Assert.InRange(Directory.GetLastWriteTime(extractedDirectories[i]).Ticks, dt[i].AddSeconds(-3).Ticks, dt[i].AddSeconds(3).Ticks); // include some slop for filesystem granularity
             }
         }
 

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
@@ -95,6 +95,8 @@ namespace System.Formats.Tar.Tests
                 Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir")),                      // 'fromdir/dir'
                 Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir", "child")),             // 'fromdir/dir/child'
                 Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir", "child", "subchild")), // 'fromdir/dir/child/subchild'
+                Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir2")),                     // 'fromdir/dir2'
+                Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir2", "child2")),            // 'fromdir/dir2/child'
             };
             var dt = new DateTime[directories.Length];
             for (int i = directories.Length - 1; i >= 0; i--) // Reverse order to preserve parent timestamps.
@@ -116,9 +118,11 @@ namespace System.Formats.Tar.Tests
 
             string[] extractedDirectories = Directory.GetDirectories(toDir, "*", new EnumerationOptions() { RecurseSubdirectories = true });
             Assert.Equal(directories.Length, extractedDirectories.Length);
+            Array.Sort(extractedDirectories);
             for (int i = 0; i < extractedDirectories.Length; i++)
             {
-                Assert.InRange(Directory.GetLastWriteTime(extractedDirectories[i]).Ticks, dt[i].AddSeconds(-3).Ticks, dt[i].AddSeconds(3).Ticks); // include some slop for filesystem granularity
+                Assert.Equal(Path.GetFileName(directories[i].FullName), Path.GetFileName(extractedDirectories[i]));
+                Assert.Equal(Directory.GetLastWriteTime(extractedDirectories[i]).Year, dt[i].Year);
             }
         }
 

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
@@ -89,7 +89,7 @@ namespace System.Formats.Tar.Tests
             using TempDirectory root = new TempDirectory();
 
             DirectoryInfo fromDir = Directory.CreateDirectory(Path.Combine(root.Path, "fromdir"));
-            // Create a hierarcy of directories.
+            // Create a hierarchy of directories.
             var directories = new DirectoryInfo[]
             {
                 Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir")),                      // 'fromdir/dir'

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
@@ -83,6 +83,45 @@ namespace System.Formats.Tar.Tests
             Assert.InRange(File.GetLastWriteTime(outFile).Ticks, dt.AddSeconds(-3).Ticks, dt.AddSeconds(3).Ticks); // include some slop for filesystem granularity
         }
 
+        [Fact]
+        public async Task SetsLastModifiedTimeOnExtractedDirectories()
+        {
+            using TempDirectory root = new TempDirectory();
+
+            DirectoryInfo fromDir = Directory.CreateDirectory(Path.Combine(root.Path, "fromdir"));
+            // Create a hierarcy of directories.
+            var directories = new DirectoryInfo[]
+            {
+                Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir")),                      // 'fromdir/dir'
+                Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir", "child")),             // 'fromdir/dir/child'
+                Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir", "child", "subchild")), // 'fromdir/dir/child/subchild'
+            };
+            var dt = new DateTime[directories.Length];
+            for (int i = directories.Length - 1; i >= 0; i--) // Reverse order to preserve parent timestamps.
+            {
+                // Add a file.
+                File.Create(Path.Combine(directories[i].FullName, "file")).Dispose();
+
+                // Set the directory timestamp.
+                dt[i] = new DateTime(2000 + i, 1, 2, 3, 4, 5, DateTimeKind.Local);
+                directories[i].LastWriteTime = dt[i];
+            }
+
+            string tarFile = Path.Join(root.Path, "file.tar");
+            await TarFile.CreateFromDirectoryAsync(sourceDirectoryName: fromDir.FullName, destinationFileName: tarFile, includeBaseDirectory: false);
+
+            string toDir = Path.Join(root.Path, "todir");
+            Directory.CreateDirectory(toDir);
+            await TarFile.ExtractToDirectoryAsync(sourceFileName: tarFile, destinationDirectoryName: toDir, overwriteFiles: false);
+
+            string[] extractedDirectories = Directory.GetDirectories(toDir, "*", new EnumerationOptions() { RecurseSubdirectories = true });
+            Assert.Equal(directories.Length, extractedDirectories.Length);
+            for (int i = 0; i < extractedDirectories.Length; i++)
+            {
+                Assert.InRange(Directory.GetLastWriteTime(extractedDirectories[i]).Ticks, dt[i].AddSeconds(-3).Ticks, dt[i].AddSeconds(3).Ticks); // include some slop for filesystem granularity
+            }
+        }
+
         [Theory]
         [InlineData(TestTarFormat.v7)]
         [InlineData(TestTarFormat.ustar)]

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
@@ -96,7 +96,7 @@ namespace System.Formats.Tar.Tests
                 Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir", "child")),             // 'fromdir/dir/child'
                 Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir", "child", "subchild")), // 'fromdir/dir/child/subchild'
                 Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir2")),                     // 'fromdir/dir2'
-                Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir2", "child2")),            // 'fromdir/dir2/child'
+                Directory.CreateDirectory(Path.Combine(fromDir.FullName, "dir2", "child2")),           // 'fromdir/dir2/child'
             };
             var dt = new DateTime[directories.Length];
             for (int i = directories.Length - 1; i >= 0; i--) // Reverse order to preserve parent timestamps.
@@ -105,7 +105,7 @@ namespace System.Formats.Tar.Tests
                 File.Create(Path.Combine(directories[i].FullName, "file")).Dispose();
 
                 // Set the directory timestamp.
-                dt[i] = new DateTime(2000 + i, 1, 2, 3, 4, 5, DateTimeKind.Local);
+                dt[i] = new DateTime(2000 + i, 1 + i, 2 + i, 3 + i, 4 + i, 5 + i, DateTimeKind.Local);
                 directories[i].LastWriteTime = dt[i];
             }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/74398.