### PR TITLE
Make DoesConsoleSupportAnsi respect DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
@@ -68,6 +68,14 @@ namespace Microsoft.Extensions.Logging.Console
         [UnsupportedOSPlatformGuard("windows")]
         private static bool DoesConsoleSupportAnsi()
         {
+            string? envVar = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION");
+            if (envVar is not null && (envVar == "1" || envVar.Equals("true", StringComparison.OrdinalIgnoreCase)))
+            {
+                // ANSI color support forcibly enabled via environment variable. This logic matches the behaviour
+                // found in System.ConsoleUtils.EmitAnsiColorCodes.
+                return true;
+            }
+        
             if (
 #if NETFRAMEWORK
                 Environment.OSVersion.Platform != PlatformID.Win32NT

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
@@ -75,7 +75,6 @@ namespace Microsoft.Extensions.Logging.Console
                 // found in System.ConsoleUtils.EmitAnsiColorCodes.
                 return true;
             }
-        
             if (
 #if NETFRAMEWORK
                 Environment.OSVersion.Platform != PlatformID.Win32NT


### PR DESCRIPTION
Fixes #88236.

I just did this straight from the GitHub web interface, since I don't really have the time to go and properly set up a developer environment for building and testing code in the `runtime` repository.