### PR TITLE
[RISC-V] Fix .cfi directives for ThePreStub

### DIFF
--- a/src/coreclr/pal/inc/unixasmmacrosriscv64.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosriscv64.inc
@@ -43,11 +43,12 @@ C_FUNC(\Name\()_End):
 
 .macro PROLOG_STACK_ALLOC Size
     addi sp, sp, -\Size
+    .cfi_adjust_cfa_offset \Size
 .endm
 
 .macro EPILOG_STACK_FREE Size
     addi sp, sp, \Size
-    .cfi_def_cfa sp,-\Size
+    .cfi_adjust_cfa_offset -\Size
 .endm
 
 .macro EPILOG_STACK_RESTORE
@@ -64,7 +65,7 @@ C_FUNC(\Name\()_End):
     sd \reg1, \ofs(sp)
     sd \reg2, (\ofs+8)(sp)
     .cfi_rel_offset \reg1, \ofs
-    .cfi_rel_offset \reg1, \ofs + 8
+    .cfi_rel_offset \reg2, \ofs + 8
     .if (\__def_cfa_save ==  1)
         addi fp, sp, 0
         .cfi_def_cfa_register fp
@@ -73,11 +74,11 @@ C_FUNC(\Name\()_End):
 
 .macro PROLOG_SAVE_REG_PAIR_INDEXED reg1, reg2, ssize, __def_cfa_save=1
     addi sp, sp, -\ssize
+    .cfi_adjust_cfa_offset \ssize
 
     sd \reg1, 0(sp)
     sd \reg2, 8(sp)
 
-    .cfi_adjust_cfa_offset -\ssize
     .cfi_rel_offset \reg1, 0
     .cfi_rel_offset \reg2, 8
     .if (\__def_cfa_save ==  1)
@@ -89,7 +90,6 @@ C_FUNC(\Name\()_End):
 .macro EPILOG_RESTORE_REG reg, ofs
     ld  \reg, (\ofs)(sp)
     .cfi_restore \reg
-    .cfi_def_cfa_register sp
 .endm
 
 .macro EPILOG_RESTORE_REG_PAIR reg1, reg2, ofs
@@ -106,7 +106,7 @@ C_FUNC(\Name\()_End):
     .cfi_restore \reg1
 
     addi  sp, sp, \ssize
-    .cfi_def_cfa sp,-\ssize
+    .cfi_adjust_cfa_offset -\ssize
 .endm
 
 .macro EPILOG_RETURN

--- a/src/coreclr/pal/src/arch/riscv64/callsignalhandlerwrapper.S
+++ b/src/coreclr/pal/src/arch/riscv64/callsignalhandlerwrapper.S
@@ -16,7 +16,6 @@ C_FUNC(SignalHandlerWorkerReturnOffset\Alignment):
 NESTED_ENTRY CallSignalHandlerWrapper\Alignment, _TEXT, NoHandler
 __StackAllocationSize = (128 + 8 + 8 + \Alignment) // red zone + fp + ra + alignment
     PROLOG_STACK_ALLOC __StackAllocationSize
-    .cfi_adjust_cfa_offset __StackAllocationSize
 
     PROLOG_SAVE_REG_PAIR fp, ra, 0
 
@@ -25,7 +24,6 @@ __StackAllocationSize = (128 + 8 + 8 + \Alignment) // red zone + fp + ra + align
 LOCAL_LABEL(SignalHandlerWorkerReturn\Alignment):
     EPILOG_RESTORE_REG_PAIR fp, ra, 0
     EPILOG_STACK_FREE __StackAllocationSize
-    .cfi_adjust_cfa_offset -__StackAllocationSize
     ret
 
 NESTED_END CallSignalHandlerWrapper\Alignment, _TEXT

--- a/src/coreclr/pal/src/arch/riscv64/context2.S
+++ b/src/coreclr/pal/src/arch/riscv64/context2.S
@@ -121,13 +121,11 @@ LEAF_END RtlRestoreContext, _TEXT
 
 LEAF_ENTRY RtlCaptureContext, _TEXT
     PROLOG_STACK_ALLOC 16
-    .cfi_adjust_cfa_offset 16
     sd  t1, 0(sp)
     li  t1, CONTEXT_FULL
     sw  t1, CONTEXT_ContextFlags(a0)
     ld  t1, 0(sp)
     EPILOG_STACK_FREE 16
-    .cfi_adjust_cfa_offset -16
     tail CONTEXT_CaptureContext
 LEAF_END RtlCaptureContext, _TEXT
 
@@ -137,7 +135,6 @@ LEAF_END RtlCaptureContext, _TEXT
 
 LEAF_ENTRY CONTEXT_CaptureContext, _TEXT
     PROLOG_STACK_ALLOC 24
-    .cfi_adjust_cfa_offset 24
     sd  t0, 0(sp)
     sd  t1, 8(sp)
     sd  t3, 16(sp)
@@ -241,6 +238,5 @@ LOCAL_LABEL(Done_CONTEXT_INTEGER):
 LOCAL_LABEL(Done_CONTEXT_FLOATING_POINT):
 
     EPILOG_STACK_FREE 24
-    .cfi_adjust_cfa_offset -24
     ret
 LEAF_END CONTEXT_CaptureContext, _TEXT

--- a/src/coreclr/vm/riscv64/asmhelpers.S
+++ b/src/coreclr/vm/riscv64/asmhelpers.S
@@ -366,7 +366,6 @@ LOCAL_LABEL(NoRestore_\reg):
 
 NESTED_ENTRY ThePreStub, _TEXT, NoHandler
     PROLOG_WITH_TRANSITION_BLOCK
-    .cfi_adjust_cfa_offset __PWTB_StackAlloc
 
     addi  a1, METHODDESC_REGISTER, 0 // pMethodDesc
 
@@ -375,7 +374,6 @@ NESTED_ENTRY ThePreStub, _TEXT, NoHandler
     addi  t4, a0, 0
 
     EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
-    .cfi_adjust_cfa_offset -__PWTB_StackAlloc
     EPILOG_BRANCH_REG  t4
 NESTED_END ThePreStub, _TEXT
 
@@ -610,7 +608,6 @@ NESTED_END ResolveWorkerChainLookupAsmStub, _TEXT
 // The stub dispatch thunk which transfers control to VSD_ResolveWorker.
 NESTED_ENTRY ResolveWorkerAsmStub, _TEXT, NoHandler
     PROLOG_WITH_TRANSITION_BLOCK
-    .cfi_adjust_cfa_offset __PWTB_StackAlloc
 
     addi  a2, t2, 0                 // DispatchToken
     addi  a0, sp, __PWTB_TransitionBlock        // pTransitionBlock
@@ -621,7 +618,6 @@ NESTED_ENTRY ResolveWorkerAsmStub, _TEXT, NoHandler
     addi  t4, a0, 0
 
     EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
-    .cfi_adjust_cfa_offset -__PWTB_StackAlloc
 
     EPILOG_BRANCH_REG  t4
 NESTED_END ResolveWorkerAsmStub, _TEXT
@@ -835,7 +831,6 @@ NESTED_ENTRY DelayLoad_MethodCall_FakeProlog, _TEXT, NoHandler
 C_FUNC(DelayLoad_MethodCall):
     .global C_FUNC(DelayLoad_MethodCall)
     PROLOG_WITH_TRANSITION_BLOCK
-    .cfi_adjust_cfa_offset __PWTB_StackAlloc
 
     addi  a1, t5, 0      // Indirection cell
     addi  a2, t0, 0      // sectionIndex
@@ -846,7 +841,6 @@ C_FUNC(DelayLoad_MethodCall):
     addi  t4, a0, 0
 
     EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
-    .cfi_adjust_cfa_offset -__PWTB_StackAlloc
     PATCH_LABEL ExternalMethodFixupPatchLabel
     EPILOG_BRANCH_REG   t4
 NESTED_END DelayLoad_MethodCall_FakeProlog, _TEXT
@@ -858,7 +852,6 @@ DelayLoad_Helper\suffix:
     .global DelayLoad_Helper\suffix
 
     PROLOG_WITH_TRANSITION_BLOCK
-    .cfi_adjust_cfa_offset __PWTB_StackAlloc
 
     //DynamicHelperWorker(TransitionBlock * pTransitionBlock, TADDR * pCell,
     //                    DWORD sectionIndex, Module * pModule, INT frameFlags)
@@ -874,12 +867,10 @@ DelayLoad_Helper\suffix:
 
     ld  a0, __PWTB_ArgumentRegisters(sp)
     EPILOG_WITH_TRANSITION_BLOCK_RETURN
-    .cfi_adjust_cfa_offset -__PWTB_StackAlloc
 
 LOCAL_LABEL(FakeProlog\suffix\()_0):
     addi t4, a0, 0
     EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
-    .cfi_adjust_cfa_offset -__PWTB_StackAlloc
     EPILOG_BRANCH_REG  t4
 
 NESTED_END DelayLoad_Helper\suffix\()_FakeProlog, _TEXT
@@ -952,7 +943,6 @@ GenerateProfileHelper ProfileTailcall, PROFILE_TAILCALL
 
 NESTED_ENTRY OnCallCountThresholdReachedStub, _TEXT, NoHandler
     PROLOG_WITH_TRANSITION_BLOCK
-    .cfi_adjust_cfa_offset __PWTB_StackAlloc
 
     addi  a0, sp, __PWTB_TransitionBlock // TransitionBlock *
     addi  a1, t3, 0 // stub-identifying token
@@ -960,7 +950,6 @@ NESTED_ENTRY OnCallCountThresholdReachedStub, _TEXT, NoHandler
     addi  t4, a0, 0
 
     EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
-    .cfi_adjust_cfa_offset -__PWTB_StackAlloc
     EPILOG_BRANCH_REG t4
 NESTED_END OnCallCountThresholdReachedStub, _TEXT
 

--- a/src/coreclr/vm/riscv64/pinvokestubs.S
+++ b/src/coreclr/vm/riscv64/pinvokestubs.S
@@ -42,7 +42,6 @@
         NESTED_ENTRY \__PInvokeGenStubFuncName, _TEXT, NoHandler
 
         PROLOG_WITH_TRANSITION_BLOCK 0, 0, \SaveFPArgs
-        .cfi_adjust_cfa_offset __PWTB_StackAlloc
 
         // a2 = Umanaged Target\MethodDesc
         addi  a2, \HiddenArg, 0
@@ -68,7 +67,6 @@
         addi  \HiddenArg, s1, 0
 
         EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
-        .cfi_adjust_cfa_offset -__PWTB_StackAlloc
 
         EPILOG_BRANCH       C_FUNC(\__PInvokeStubFuncName)
         NESTED_END \__PInvokeGenStubFuncName, _TEXT


### PR DESCRIPTION
This fixes test `tests/JIT/Directed/callconv/ThisCall/EmptyThisCallTest.cs`.