### PR TITLE
Fix build failures when declaring a COM-style enumerable type

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshalAsAttributeParser.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshalAsAttributeParser.cs
@@ -120,9 +120,18 @@ namespace Microsoft.Interop
                 MarshallingInfo elementMarshallingInfo = NoMarshallingInfo.Instance;
                 if (elementUnmanagedType != (UnmanagedType)SizeAndParamIndexInfo.UnspecifiedConstSize)
                 {
-                    elementMarshallingInfo = elementType.SpecialType == SpecialType.System_String
-                        ? CreateStringMarshallingInfo(elementType, elementUnmanagedType)
-                        : new MarshalAsInfo(elementUnmanagedType, _defaultInfo.CharEncoding);
+                    if (elementType.SpecialType == SpecialType.System_String)
+                    {
+                        elementMarshallingInfo = CreateStringMarshallingInfo(elementType, elementUnmanagedType);
+                    }
+                    else if (elementUnmanagedType == UnmanagedType.Interface && elementType is not INamedTypeSymbol { IsComImport: true })
+                    {
+                        elementMarshallingInfo = ComInterfaceMarshallingInfoProvider.CreateComInterfaceMarshallingInfo(_compilation, elementType);
+                    }
+                    else
+                    {
+                        elementMarshallingInfo = new MarshalAsInfo(elementUnmanagedType, _defaultInfo.CharEncoding);
+                    }
                 }
                 else
                 {

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/PointerNativeTypeAssignmentRewriter.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/PointerNativeTypeAssignmentRewriter.cs
@@ -24,6 +24,29 @@ namespace Microsoft.Interop
             _nativeType = nativeType;
         }
 
+        public override SyntaxNode? VisitVariableDeclarator(VariableDeclaratorSyntax node)
+        {
+            if (node.Initializer is null)
+            {
+                return base.VisitVariableDeclarator(node);
+            }
+
+            if (node.Identifier.ToString() == _nativeIdentifier)
+            {
+                return node.WithInitializer(
+                    EqualsValueClause(
+                        CastExpression(MarshallerHelpers.SystemIntPtrType, node.Initializer.Value)));
+            }
+            if (node.Initializer.Value.ToString() == _nativeIdentifier)
+            {
+                return node.WithInitializer(
+                    EqualsValueClause(
+                        CastExpression(_nativeType, node.Initializer.Value)));
+            }
+
+            return base.VisitVariableDeclarator(node);
+        }
+
         public override SyntaxNode VisitAssignmentExpression(AssignmentExpressionSyntax node)
         {
             if (node.Left.ToString() == _nativeIdentifier)

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IEnumUnknown.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IEnumUnknown.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces
+{
+    [GeneratedComInterface(Options = ComInterfaceOptions.ComObjectWrapper)]
+    [Guid("00000100-0000-0000-C000-000000000046")]
+    internal partial interface IEnumUnknown
+    {
+        void Next(uint celt, [Out, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.Interface)] object[] rgelt, out uint pceltFetched);
+        void Skip(uint celt);
+        void Reset();
+        void Clone(out IEnumUnknown ppenum);
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IEnumUnknown.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IEnumUnknown.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices.Marshalling;
 
 namespace SharedTypes.ComInterfaces
 {
-    [GeneratedComInterface(Options = ComInterfaceOptions.ComObjectWrapper)]
+    [GeneratedComInterface]
     [Guid("00000100-0000-0000-C000-000000000046")]
     internal partial interface IEnumUnknown
     {


### PR DESCRIPTION
Fix some marshalling attribute parsing failures to allow explicitly marshalling elements as `UnmanagedType.Interface`.

Contributes to #88253 by fixing the compilation errors for the `void Next(int a, [Out, MarshalAs(UnmanagedType.LPArray)] IElement[] b, out int bc);` signature.