### PR TITLE
Clean up Guid.DecodeByte

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -727,9 +727,14 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static byte DecodeByte(nuint ch1, nuint ch2, ref int invalidIfNegative)
+        private static byte DecodeByte(char ch1, char ch2, ref int invalidIfNegative)
         {
-            int result = (CharToHexLookup[(byte)ch1] << 4) | CharToHexLookup[(byte)ch1];
+            ReadOnlySpan<byte> lookup = HexConverter.CharToHexLookup;
+            Debug.Assert(lookup.Length == 256);
+
+            int upper = (sbyte)lookup[(byte)ch1];
+            int lower = (sbyte)lookup[(byte)ch2];
+            int result = (upper << 4) | lower;
 
             // Result will be negative if ch1 or/and ch2 are greater than 0xFF
             result = (ch1 | ch2) >> 8 == 0 ? result : -1;

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -729,25 +729,10 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static byte DecodeByte(nuint ch1, nuint ch2, ref int invalidIfNegative)
         {
-            // TODO https://github.com/dotnet/runtime/issues/13464:
-            // Replace the Unsafe.Add with HexConverter.FromChar once the bounds checks are eliminated.
+            int result = (CharToHexLookup[(byte)ch1] << 4) | CharToHexLookup[(byte)ch1];
 
-            ReadOnlySpan<byte> lookup = HexConverter.CharToHexLookup;
-
-            int h1 = -1;
-            if (ch1 < (nuint)lookup.Length)
-            {
-                h1 = (sbyte)Unsafe.Add(ref MemoryMarshal.GetReference(lookup), (nint)ch1);
-            }
-            h1 <<= 4;
-
-            int h2 = -1;
-            if (ch2 < (nuint)lookup.Length)
-            {
-                h2 = (sbyte)Unsafe.Add(ref MemoryMarshal.GetReference(lookup), (nint)ch2);
-            }
-
-            int result = h1 | h2;
+            // Result will be negative if ch1 or/and ch2 are greater than 0xFF
+            result = (ch1 | ch2) >> 8 == 0 ? result : -1;
             invalidIfNegative |= result;
             return (byte)result;
         }


### PR DESCRIPTION
Mainly just to remove `TODO https://github.com/dotnet/runtime/issues/13464` but also making it more efficient along the way.

Closes https://github.com/dotnet/runtime/issues/13464

This function is only used in `Guid.TryParse*` so the new codegen for e.g. `TryParseExactN` is:

<details>
  <summary>new codegen</summary>
 
```asm
; Method RefImplNew:TryParseExactN(System.ReadOnlySpan`1[ushort],byref):bool (FullOpts)
G_M23672_IG01:  ;; offset=0000H
       push     rsi
       push     rbx
       sub      rsp, 40
       mov      rax, rdx
G_M23672_IG02:  ;; offset=0009H
       mov      rbx, bword ptr [rcx]
       mov      ecx, dword ptr [rcx+08H]
       cmp      ecx, 32
       je       SHORT G_M23672_IG05
G_M23672_IG03:  ;; offset=0014H
       mov      rcx, rax
       call     [RefImplNew+GuidResult:SetFailure():this]
       xor      eax, eax
G_M23672_IG04:  ;; offset=001FH
       add      rsp, 40
       pop      rbx
       pop      rsi
       ret      
G_M23672_IG05:  ;; offset=0026H
       movzx    rcx, word  ptr [rbx+0CH]
       movzx    rdx, word  ptr [rbx+0EH]
       movzx    r8, cl
       mov      r10, 0x1F630F23D18      ; static handle
       movzx    r8, byte  ptr [r8+r10]
       mov      r9d, r8d
       shl      r9d, 4
       or       r8d, r9d
       or       ecx, edx
       sar      ecx, 8
       mov      edx, -1
       test     ecx, ecx
       cmovne   r8d, edx
       mov      byte  ptr [rax], r8b
       lea      rcx, bword ptr [rax+01H]
       movzx    rdx, word  ptr [rbx+08H]
       movzx    r9, word  ptr [rbx+0AH]
       movzx    r11, dl
       movzx    r11, byte  ptr [r11+r10]
       mov      esi, r11d
       shl      esi, 4
       or       r11d, esi
       or       edx, r9d
       sar      edx, 8
       mov      r9d, -1
       test     edx, edx
       cmovne   r11d, r9d
       or       r8d, r11d
       mov      byte  ptr [rcx], r11b
       lea      rcx, bword ptr [rax+02H]
       movzx    rdx, word  ptr [rbx+04H]
       movzx    r9, word  ptr [rbx+06H]
       movzx    r11, dl
       movzx    r11, byte  ptr [r11+r10]
       mov      esi, r11d
       shl      esi, 4
       or       r11d, esi
       or       edx, r9d
       sar      edx, 8
       mov      r9d, -1
       test     edx, edx
       cmovne   r11d, r9d
       or       r8d, r11d
       mov      byte  ptr [rcx], r11b
       lea      rcx, bword ptr [rax+03H]
       movzx    rdx, word  ptr [rbx]
       movzx    r9, word  ptr [rbx+02H]
       movzx    r11, dl
       movzx    r11, byte  ptr [r11+r10]
       mov      esi, r11d
       shl      esi, 4
       or       r11d, esi
       or       edx, r9d
       sar      edx, 8
       mov      r9d, -1
       test     edx, edx
       cmovne   r11d, r9d
       or       r8d, r11d
       mov      byte  ptr [rcx], r11b
       lea      rcx, bword ptr [rax+04H]
       movzx    rdx, word  ptr [rbx+14H]
       movzx    r9, word  ptr [rbx+16H]
       movzx    r11, dl
       movzx    r11, byte  ptr [r11+r10]
       mov      esi, r11d
       shl      esi, 4
       or       r11d, esi
       or       edx, r9d
       sar      edx, 8
       mov      r9d, -1
       test     edx, edx
       cmovne   r11d, r9d
       or       r8d, r11d
       mov      byte  ptr [rcx], r11b
       lea      rcx, bword ptr [rax+05H]
G_M23672_IG06:  ;; offset=013DH
       movzx    rdx, word  ptr [rbx+10H]
       movzx    r9, word  ptr [rbx+12H]
       movzx    r11, dl
       movzx    r11, byte  ptr [r11+r10]
       mov      esi, r11d
       shl      esi, 4
       or       r11d, esi
       or       edx, r9d
       sar      edx, 8
       mov      r9d, -1
       test     edx, edx
       cmovne   r11d, r9d
       or       r8d, r11d
       mov      byte  ptr [rcx], r11b
       lea      rcx, bword ptr [rax+06H]
       movzx    rdx, word  ptr [rbx+1CH]
       movzx    r9, word  ptr [rbx+1EH]
       movzx    r11, dl
       movzx    r11, byte  ptr [r11+r10]
       mov      esi, r11d
       shl      esi, 4
       or       r11d, esi
       or       edx, r9d
       sar      edx, 8
       mov      r9d, -1
       test     edx, edx
       cmovne   r11d, r9d
       or       r8d, r11d
       mov      byte  ptr [rcx], r11b
       lea      rcx, bword ptr [rax+07H]
       movzx    rdx, word  ptr [rbx+18H]
       movzx    r9, word  ptr [rbx+1AH]
       movzx    r11, dl
       movzx    r11, byte  ptr [r11+r10]
       mov      esi, r11d
       shl      esi, 4
       or       r11d, esi
       or       edx, r9d
       sar      edx, 8
       mov      r9d, -1
       test     edx, edx
       cmovne   r11d, r9d
       or       r8d, r11d
       mov      byte  ptr [rcx], r11b
       lea      rcx, bword ptr [rax+08H]
       movzx    rdx, word  ptr [rbx+20H]
       movzx    r9, word  ptr [rbx+22H]
       movzx    r11, dl
       movzx    r11, byte  ptr [r11+r10]
       mov      esi, r11d
       shl      esi, 4
       or       r11d, esi
       or       edx, r9d
       sar      edx, 8
       mov      r9d, -1
       test     edx, edx
       cmovne   r11d, r9d
       or       r8d, r11d
       mov      byte  ptr [rcx], r11b
       lea      rcx, bword ptr [rax+09H]
       movzx    rdx, word  ptr [rbx+24H]
       movzx    r9, word  ptr [rbx+26H]
       movzx    r11, dl
       movzx    r11, byte  ptr [r11+r10]
       mov      esi, r11d
       shl      esi, 4
       or       r11d, esi
       or       edx, r9d
       sar      edx, 8
       mov      r9d, -1
       test     edx, edx
       cmovne   r11d, r9d
       or       r8d, r11d
       mov      byte  ptr [rcx], r11b
       lea      rcx, bword ptr [rax+0AH]
G_M23672_IG07:  ;; offset=0250H
       movzx    rdx, word  ptr [rbx+28H]
       movzx    r9, word  ptr [rbx+2AH]
       movzx    r11, dl
       movzx    r11, byte  ptr [r11+r10]
       mov      esi, r11d
       shl      esi, 4
       or       r11d, esi
       or       edx, r9d
       sar      edx, 8
       mov      r9d, -1
       test     edx, edx
       cmovne   r11d, r9d
       or       r8d, r11d
       mov      byte  ptr [rcx], r11b
       lea      rcx, bword ptr [rax+0BH]
       movzx    rdx, word  ptr [rbx+2CH]
       movzx    r9, word  ptr [rbx+2EH]
       movzx    r11, dl
       movzx    r11, byte  ptr [r11+r10]
       mov      esi, r11d
       shl      esi, 4
       or       r11d, esi
       or       edx, r9d
       sar      edx, 8
       mov      r9d, -1
       test     edx, edx
       cmovne   r11d, r9d
       or       r8d, r11d
       mov      byte  ptr [rcx], r11b
       lea      rcx, bword ptr [rax+0CH]
       movzx    rdx, word  ptr [rbx+30H]
       movzx    r9, word  ptr [rbx+32H]
       movzx    r11, dl
       movzx    r11, byte  ptr [r11+r10]
       mov      esi, r11d
       shl      esi, 4
       or       r11d, esi
       or       edx, r9d
       sar      edx, 8
       mov      r9d, -1
       test     edx, edx
       cmovne   r11d, r9d
       or       r8d, r11d
       mov      byte  ptr [rcx], r11b
       lea      rcx, bword ptr [rax+0DH]
       movzx    rdx, word  ptr [rbx+34H]
       movzx    r9, word  ptr [rbx+36H]
       movzx    r11, dl
       movzx    r11, byte  ptr [r11+r10]
       mov      esi, r11d
       shl      esi, 4
       or       r11d, esi
       or       edx, r9d
       sar      edx, 8
       mov      r9d, -1
       test     edx, edx
       cmovne   r11d, r9d
       or       r8d, r11d
       mov      byte  ptr [rcx], r11b
       lea      rcx, bword ptr [rax+0EH]
       movzx    rdx, word  ptr [rbx+38H]
       movzx    r9, word  ptr [rbx+3AH]
       movzx    r11, dl
       movzx    r11, byte  ptr [r11+r10]
       mov      esi, r11d
       shl      esi, 4
       or       r11d, esi
       or       edx, r9d
       sar      edx, 8
       mov      r9d, -1
       test     edx, edx
       cmovne   r11d, r9d
       or       r8d, r11d
       mov      byte  ptr [rcx], r11b
       lea      rcx, bword ptr [rax+0FH]
G_M23672_IG08:  ;; offset=0363H
       movzx    rdx, word  ptr [rbx+3CH]
       movzx    r9, word  ptr [rbx+3EH]
       movzx    r11, dl
       movzx    r10, byte  ptr [r11+r10]
       mov      r11d, r10d
       shl      r11d, 4
       or       r10d, r11d
       or       edx, r9d
       sar      edx, 8
       mov      r9d, -1
       test     edx, edx
       cmovne   r10d, r9d
       or       r8d, r10d
       mov      byte  ptr [rcx], r10b
       test     r8d, r8d
       jl       SHORT G_M23672_IG10
       mov      eax, 1
G_M23672_IG09:  ;; offset=03A1H
       add      rsp, 40
       pop      rbx
       pop      rsi
       ret      
G_M23672_IG10:  ;; offset=03A8H
       mov      rcx, rax
       call     [RefImplNew+GuidResult:SetFailure():this]
       xor      eax, eax
G_M23672_IG11:  ;; offset=03B3H
       add      rsp, 40
       pop      rbx
       pop      rsi
       ret      
; Total bytes of code: 954
```

</details>

which is better (branchless) compared to current codegen.