### PR TITLE
Fix make repro cli command

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -263,8 +263,8 @@ namespace ILCompiler
 
 #pragma warning disable CA1861 // Avoid constant arrays as arguments. Only executed once during the execution of the program.
                         Helpers.MakeReproPackage(makeReproPath, result.GetValue(OutputFilePath), args, result,
-                            inputOptions : new[] { "r", "reference", "m", "mibc", "rdxml", "directpinvokelist", "descriptor" },
-                            outputOptions : new[] { "o", "out", "exportsfile" });
+                            inputOptions : new[] { "-r", "--reference", "-m", "--mibc", "--rdxml", "--directpinvokelist", "--descriptor", "--satellite" },
+                            outputOptions : new[] { "-o", "--out", "--exportsfile" });
 #pragma warning restore CA1861 // Avoid constant arrays as arguments
                     }
 

--- a/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
+++ b/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
@@ -255,7 +255,7 @@ namespace ILCompiler
                         // + a rsp file that should work to directly run out of the zip file
 
                         Helpers.MakeReproPackage(makeReproPath, result.GetValue(OutputFilePath), args,
-                            result, new[] { "r", "reference", "u", "unrooted-input-file-paths", "m", "mibc", "inputbubbleref" });
+                            result, new[] { "-r", "--reference", "-u", "--unrooted-input-file-paths", "-m", "--mibc", "--inputbubbleref" });
                     }
 
                     return new Program(this).Run();


### PR DESCRIPTION
With the version update https://github.com/dotnet/runtime/commit/c5b27d63a80212abae73df85deae80a458b6e7f2, we needed to use the original argument names. It was a breaking change which I missed.

Also added satellite to the list of "treat as path" arguments to resolve #88285.

cc @filipnavara @adamsitnik