### PR TITLE
[RISC-V] Fix floating point

### DIFF
--- a/src/coreclr/vm/argdestination.h
+++ b/src/coreclr/vm/argdestination.h
@@ -29,7 +29,7 @@ public:
         LIMITED_METHOD_CONTRACT;
 #if defined(UNIX_AMD64_ABI)
         _ASSERTE((argLocDescForStructInRegs != NULL) || (offset != TransitionBlock::StructInRegsOffset));
-#elif defined(TARGET_ARM64) || defined(TARGET_LOONGARCH64)
+#elif defined(TARGET_ARM64) || defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
         // This assert is not interesting on arm64/loongarch64. argLocDescForStructInRegs could be
         // initialized if the args are being enregistered.
 #else
@@ -83,7 +83,7 @@ public:
 #endif // !DACCESS_COMPILE
 #endif // defined(TARGET_ARM64)
 
-#if defined(TARGET_LOONGARCH64)
+#if defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
     bool IsStructPassedInRegs()
     {
         return m_argLocDescForStructInRegs != NULL;
@@ -174,7 +174,7 @@ public:
         int argOfs = TransitionBlock::GetOffsetOfArgumentRegisters() + m_argLocDescForStructInRegs->m_idxGenReg * 8;
         return dac_cast<PTR_VOID>(dac_cast<TADDR>(m_base) + argOfs);
     }
-#endif // defined(TARGET_LOONGARCH64)
+#endif // defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
 
 #if defined(UNIX_AMD64_ABI)
 

--- a/src/coreclr/vm/callhelpers.cpp
+++ b/src/coreclr/vm/callhelpers.cpp
@@ -459,19 +459,19 @@ void MethodDescCallSite::CallTargetWorker(const ARG_SLOT *pArguments, ARG_SLOT *
                 argDest.CopyStructToRegisters(pSrc, th.AsMethodTable()->GetNumInstanceFieldBytes(), 0);
             }
             else
-#elif defined(TARGET_LOONGARCH64)
+#elif defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
             if (argDest.IsStructPassedInRegs())
             {
                 argDest.CopyStructToRegisters(pSrc, stackSize, 0);
             }
             else
-#endif // TARGET_LOONGARCH64
+#endif // TARGET_LOONGARCH64 || TARGET_RISCV64
             {
                 PVOID pDest = argDest.GetDestinationAddress();
 
                 switch (stackSize)
                 {
-#if defined(TARGET_LOONGARCH64)
+#if defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
                     case 1:
                         if (m_argIt.GetArgType() == ELEMENT_TYPE_U1 || m_argIt.GetArgType() == ELEMENT_TYPE_BOOLEAN)
                             *((INT64*)pDest) = (UINT8)pArguments[arg];

--- a/src/coreclr/vm/object.cpp
+++ b/src/coreclr/vm/object.cpp
@@ -392,7 +392,7 @@ void STDCALL CopyValueClassArgUnchecked(ArgDestination *argDest, void* src, Meth
         return;
     }
 
-#elif defined(TARGET_LOONGARCH64)
+#elif defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
 
     if (argDest->IsStructPassedInRegs())
     {
@@ -425,7 +425,7 @@ void InitValueClassArg(ArgDestination *argDest, MethodTable *pMT)
 
 #endif
 
-#if defined(TARGET_LOONGARCH64)
+#if defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
     if (argDest->IsStructPassedInRegs())
     {
         *(UINT64*)(argDest->GetStructGenRegDestinationAddress()) = 0;

--- a/src/coreclr/vm/riscv64/calldescrworkerriscv64.S
+++ b/src/coreclr/vm/riscv64/calldescrworkerriscv64.S
@@ -124,7 +124,7 @@ LOCAL_LABEL(NotCorrectReturn):
     EMIT_BREAKPOINT // Unreachable
 
 LOCAL_LABEL(FloatReturn):
-    fsw  f0, CallDescrData__returnValue(s1)
+    fsw  fa0, CallDescrData__returnValue(s1)
     j  LOCAL_LABEL(ReturnDone)
 
 LOCAL_LABEL(DoubleReturn):


### PR DESCRIPTION
- Add `TARGET_RISCV64` definition and fix a typo.

Below tests pass
```
./JIT/HardwareIntrinsics/General/Vector64_1/Vector64_1_r/Vector64_1_r.sh
./JIT/HardwareIntrinsics/General/Vector64_1/Vector64_1_ro/Vector64_1_ro.sh
./JIT/HardwareIntrinsics/General/Vector128_1/Vector128_1_r/Vector128_1_r.sh
./JIT/HardwareIntrinsics/General/Vector128_1/Vector128_1_ro/Vector128_1_ro.sh
./JIT/HardwareIntrinsics/General/Vector256_1/Vector256_1_r/Vector256_1_r.sh
./JIT/HardwareIntrinsics/General/Vector256_1/Vector256_1_ro/Vector256_1_ro.sh
./JIT/HardwareIntrinsics/General/Vector512_1/Vector512_1_r/Vector512_1_r.sh
./JIT/HardwareIntrinsics/General/Vector512_1/Vector512_1_ro/Vector512_1_ro.sh
```

Part of https://github.com/dotnet/runtime/issues/84834
cc @wscho77 @HJLeee @JongHeonChoi @t-mustafin @alpencolt @gbalykov