### PR TITLE
Improve LoggerFactory and Logger debugging

### DIFF
--- a/src/libraries/Common/src/Extensions/Logging/DebuggerDisplayFormatting.cs
+++ b/src/libraries/Common/src/Extensions/Logging/DebuggerDisplayFormatting.cs
@@ -9,31 +9,10 @@ namespace Microsoft.Extensions.Logging
     {
         internal static string DebuggerToString(string name, ILogger logger)
         {
-            ReadOnlySpan<LogLevel> logLevels = stackalloc LogLevel[]
-            {
-                LogLevel.Critical,
-                LogLevel.Error,
-                LogLevel.Warning,
-                LogLevel.Information,
-                LogLevel.Debug,
-                LogLevel.Trace,
-            };
-
-            LogLevel minimumLevel = LogLevel.None;
-
-            // Check log level from highest to lowest. Report the lowest log level.
-            foreach (LogLevel logLevel in logLevels)
-            {
-                if (!logger.IsEnabled(logLevel))
-                {
-                    break;
-                }
-
-                minimumLevel = logLevel;
-            }
+            LogLevel? minimumLevel = CalculateEnabledLogLevel(logger);
 
             var debugText = $@"Name = ""{name}""";
-            if (minimumLevel != LogLevel.None)
+            if (minimumLevel != null)
             {
                 debugText += $", MinLevel = {minimumLevel}";
             }
@@ -48,6 +27,34 @@ namespace Microsoft.Extensions.Logging
             }
 
             return debugText;
+        }
+
+        internal static LogLevel? CalculateEnabledLogLevel(ILogger logger)
+        {
+            ReadOnlySpan<LogLevel> logLevels = stackalloc LogLevel[]
+            {
+                LogLevel.Critical,
+                LogLevel.Error,
+                LogLevel.Warning,
+                LogLevel.Information,
+                LogLevel.Debug,
+                LogLevel.Trace,
+            };
+
+            LogLevel? minimumLevel = null;
+
+            // Check log level from highest to lowest. Report the lowest log level.
+            foreach (LogLevel logLevel in logLevels)
+            {
+                if (!logger.IsEnabled(logLevel))
+                {
+                    break;
+                }
+
+                minimumLevel = logLevel;
+            }
+
+            return minimumLevel;
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging/src/Logger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/Logger.cs
@@ -186,6 +186,7 @@ namespace Microsoft.Extensions.Logging
                     return providers;
                 }
             }
+
             public List<object?>? Scopes
             {
                 get

--- a/src/libraries/Microsoft.Extensions.Logging/src/Logger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/Logger.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Xml.Linq;
 
 namespace Microsoft.Extensions.Logging
 {

--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs
@@ -321,10 +321,10 @@ namespace Microsoft.Extensions.Logging
 
         private string DebuggerToString()
         {
-            return $"Providers = {_providerRegistrations.Count}";
+            return $"Providers = {_providerRegistrations.Count}, {_filterOptions.DebuggerToString()}";
         }
 
-        internal sealed class LoggerFactoryDebugView(LoggerFactory loggerFactory)
+        private sealed class LoggerFactoryDebugView(LoggerFactory loggerFactory)
         {
             public List<ILoggerProvider> Providers => loggerFactory._providerRegistrations.Select(r => r.Provider).ToList();
             public bool Disposed => loggerFactory._disposed;

--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -13,6 +15,8 @@ namespace Microsoft.Extensions.Logging
     /// <summary>
     /// Produces instances of <see cref="ILogger"/> classes based on the given providers.
     /// </summary>
+    [DebuggerDisplay("{DebuggerToString(),nq}")]
+    [DebuggerTypeProxy(typeof(LoggerFactoryDebugView))]
     public class LoggerFactory : ILoggerFactory
     {
         private readonly ConcurrentDictionary<string, Logger> _loggers = new ConcurrentDictionary<string, Logger>(StringComparer.Ordinal);
@@ -313,6 +317,18 @@ namespace Microsoft.Extensions.Logging
             {
                 _loggerFactory.AddProvider(provider);
             }
+        }
+
+        private string DebuggerToString()
+        {
+            return $"Providers = {_providerRegistrations.Count}";
+        }
+
+        internal sealed class LoggerFactoryDebugView(LoggerFactory loggerFactory)
+        {
+            public List<ILoggerProvider> Providers => loggerFactory._providerRegistrations.Select(r => r.Provider).ToList();
+            public bool Disposed => loggerFactory._disposed;
+            public LoggerFilterOptions FilterOptions => loggerFactory._filterOptions;
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactoryOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactoryOptions.cs
@@ -1,13 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Microsoft.Extensions.Logging
 {
     /// <summary>
     /// The options for a LoggerFactory.
     /// </summary>
+    [DebuggerDisplay("ActivityTrackingOptions = {ActivityTrackingOptions}")]
     public class LoggerFactoryOptions
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggerFilterOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggerFilterOptions.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Extensions.Logging
         // Concrete representation of the rule list
         internal List<LoggerFilterRule> RulesInternal { get; } = new List<LoggerFilterRule>();
 
-        private string DebuggerToString()
+        internal string DebuggerToString()
         {
             string debugText = $"Rules = {Rules.Count}";
             if (MinLevel != LogLevel.None)

--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggerFilterOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggerFilterOptions.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Microsoft.Extensions.Logging
 {
     /// <summary>
     /// The options for a LoggerFilter.
     /// </summary>
+    [DebuggerDisplay("{DebuggerToString(),nq}")]
     public class LoggerFilterOptions
     {
         /// <summary>
@@ -32,5 +34,25 @@ namespace Microsoft.Extensions.Logging
 
         // Concrete representation of the rule list
         internal List<LoggerFilterRule> RulesInternal { get; } = new List<LoggerFilterRule>();
+
+        private string DebuggerToString()
+        {
+            string debugText = $"Rules = {Rules.Count}";
+            if (MinLevel != LogLevel.None)
+            {
+                debugText += $", MinLevel = {MinLevel}";
+            }
+            else
+            {
+                // Display "Enabled = false". This makes it clear that the entire ILogger
+                // is disabled and nothing is written.
+                //
+                // If "MinLevel = None" was displayed then someone could think that the
+                // min level is disabled and everything is written.
+                debugText += $", Enabled = false";
+            }
+
+            return debugText;
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggerFilterOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggerFilterOptions.cs
@@ -37,10 +37,10 @@ namespace Microsoft.Extensions.Logging
 
         internal string DebuggerToString()
         {
-            string debugText = $"Rules = {Rules.Count}";
+            string debugText;
             if (MinLevel != LogLevel.None)
             {
-                debugText += $", MinLevel = {MinLevel}";
+                debugText = $"MinLevel = {MinLevel}";
             }
             else
             {
@@ -49,7 +49,12 @@ namespace Microsoft.Extensions.Logging
                 //
                 // If "MinLevel = None" was displayed then someone could think that the
                 // min level is disabled and everything is written.
-                debugText += $", Enabled = false";
+                debugText = $"Enabled = false";
+            }
+
+            if (Rules.Count > 0)
+            {
+                debugText += $", Rules = {Rules.Count}";
             }
 
             return debugText;

--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggerInformation.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggerInformation.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.Logging
 {
     internal readonly struct MessageLogger
     {
-        public MessageLogger(ILogger logger, string? category, string? providerTypeFullName, LogLevel? minLevel, Func<string?, string?, LogLevel, bool>? filter)
+        public MessageLogger(ILogger logger, string category, string? providerTypeFullName, LogLevel? minLevel, Func<string?, string?, LogLevel, bool>? filter)
         {
             Logger = logger;
             Category = category;
@@ -19,7 +19,7 @@ namespace Microsoft.Extensions.Logging
 
         public ILogger Logger { get; }
 
-        public string? Category { get; }
+        public string Category { get; }
 
         private string? ProviderTypeFullName { get; }
 


### PR DESCRIPTION
## LoggerFactory

The changes to `LoggerFactory` make it easy to discover the common configuration for logging:

* What log providers are configured (e.g. event source, console, etc)
* What level filters are configured. This includes the global minimum log level, and rules for customizing logging for individual providers and categories

**Before**

![image](https://github.com/dotnet/runtime/assets/303201/44c17df3-92d9-43e1-9148-10b876665c52)

**After**

![image](https://github.com/dotnet/runtime/assets/303201/27cf9496-f390-4f7d-9e1c-509a63d91255)

## Logger

`Logger` changes denormalize information back to an understandable form. It's now easy to see what providers are enabled for this logger and the min log level for each provider.

**Before**

![image](https://github.com/dotnet/runtime/assets/303201/e787f3dc-82b8-4dae-b114-884084f09775)

**After**

![image](https://github.com/dotnet/runtime/assets/303201/2a656e82-6883-4c75-a092-dbaf3f024181)
