### PR TITLE
Fix CoreCLR tests build with skipmanaged option

### DIFF
--- a/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.csproj
+++ b/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.csproj
@@ -8,17 +8,22 @@
     <CMakeProjectReference Include="../NativeLibrary/NativeLibraryToLoad/CMakeLists.txt" />
   </ItemGroup>
 
-  <Target Name="SetUpSubdirectory" AfterTargets="CopyNativeProjectBinaries">
-    <PropertyGroup>
-      <NativeLibrarySubdirectory>$(OutDir)/subdirectory</NativeLibrarySubdirectory>
-      <FileNameSuffix>-in-subdirectory</FileNameSuffix>
-    </PropertyGroup>
+  <PropertyGroup>
+    <LibrarySubdirectory>$(OutputPath)/subdirectory</LibrarySubdirectory>
+  </PropertyGroup>
+
+  <Target Name="SetUpSubdirectoryNative" AfterTargets="CopyNativeProjectBinaries">
     <ItemGroup>
-      <_FilesToCopy Include="$(OutDir)/$(TargetName).dll" />
       <_FilesToMove Include="$(OutDir)/libNativeLibrary.*" />
       <_FilesToMove Include="$(OutDir)/NativeLibrary.*" />
     </ItemGroup>
-    <Copy SourceFiles="@(_FilesToCopy)" DestinationFiles="@(_FilesToCopy -> '$(NativeLibrarySubdirectory)/%(Filename)%(Extension)')" />
-    <Move SourceFiles="@(_FilesToMove)" DestinationFiles="@(_FilesToMove -> '$(NativeLibrarySubdirectory)/%(Filename)%(Extension)')" />
+    <Move SourceFiles="@(_FilesToMove)" DestinationFiles="@(_FilesToMove -> '$(LibrarySubdirectory)/%(Filename)%(Extension)')"/>
+  </Target>
+
+  <Target Name="SetUpSubdirectoryManaged" AfterTargets="Build">
+    <ItemGroup>
+      <_FilesToCopy Include="$(OutDir)/$(TargetName).dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_FilesToCopy)" DestinationFiles="@(_FilesToCopy -> '$(LibrarySubdirectory)/%(Filename)%(Extension)')"/>
   </Target>
 </Project>

--- a/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.csproj
+++ b/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.csproj
@@ -17,17 +17,23 @@
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <CMakeProjectReference Include="../NativeLibraryToLoad/CMakeLists.txt" />
   </ItemGroup>
+  <PropertyGroup>
+    <LibrarySubdirectory>$(OutputPath)/subdirectory</LibrarySubdirectory>
+    <FileNameSuffix>-in-subdirectory</FileNameSuffix>
+  </PropertyGroup>
 
-  <Target Name="SetUpSubdirectory" AfterTargets="CopyNativeProjectBinaries">
-    <PropertyGroup>
-      <NativeLibrarySubdirectory>$(OutDir)/subdirectory</NativeLibrarySubdirectory>
-      <FileNameSuffix>-in-subdirectory</FileNameSuffix>
-    </PropertyGroup>
+  <Target Name="SetUpSubdirectoryNative" AfterTargets="CopyNativeProjectBinaries">
     <ItemGroup>
       <AssembliesToCopy Include="$(OutDir)/libNativeLibrary.*" />
       <AssembliesToCopy Include="$(OutDir)/NativeLibrary.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(AssembliesToCopy)" DestinationFiles="@(AssembliesToCopy -> '$(LibrarySubdirectory)/%(Filename)$(FileNameSuffix)%(Extension)')" />
+  </Target>
+
+  <Target Name="SetUpSubdirectoryManaged" AfterTargets="Build">
+    <ItemGroup>
       <AssembliesToCopy Include="$(OutDir)/$(TargetName).dll" />
     </ItemGroup>
-    <Copy SourceFiles="@(AssembliesToCopy)" DestinationFiles="@(AssembliesToCopy -> '$(NativeLibrarySubdirectory)/%(Filename)$(FileNameSuffix)%(Extension)')" />
+    <Copy SourceFiles="@(AssembliesToCopy)" DestinationFiles="@(AssembliesToCopy -> '$(LibrarySubdirectory)/%(Filename)$(FileNameSuffix)%(Extension)')" />
   </Target>
 </Project>


### PR DESCRIPTION
tests build command
```
ROOTFS_DIR=`pwd`/.tools/rootfs/armel ./src/tests/build.sh -Release portablebuild=false -cross -armel -clang-10 -priority1 skipmanaged skipgeneratelayout skiprestorepackages /p:__SkipPackageRestore=true /p:UseSharedCompilation=false 
ROOTFS_DIR=`pwd`/.tools/rootfs/armel ./src/tests/build.sh -Release -cross -armel -clang-10 -priority1 copynativeonly /p:UseSharedCompilation=false
ROOTFS_DIR=`pwd`/.tools/rootfs/armel ./src/tests/build.sh -Release -cross -armel -clang-10 -priority1 skipnative skipgeneratelayout skiptestwrappers /p:UseSharedCompilation=false
ROOTFS_DIR=`pwd`/.tools/rootfs/armel ./src/tests/build.sh -Release -cross -armel -clang-10 -priority1 generatelayoutonly /p:UseSharedCompilation=false
```
Fix https://github.com/dotnet/runtime/issues/85170
cc @gbalykov 