### PR TITLE
[Crossgen] Don't display list of enum values in help

### DIFF
--- a/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
+++ b/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
@@ -80,7 +80,7 @@ namespace ILCompiler
         public CliOption<string> ImageBase { get; } =
             new("--imagebase") { Description = SR.ImageBase };
         public CliOption<TargetArchitecture> TargetArchitecture { get; } =
-            new("--targetarch") { CustomParser = MakeTargetArchitecture, DefaultValueFactory = MakeTargetArchitecture, Description = SR.TargetArchOption, Arity = ArgumentArity.OneOrMore };
+            new("--targetarch") { CustomParser = MakeTargetArchitecture, DefaultValueFactory = MakeTargetArchitecture, Description = SR.TargetArchOption, Arity = ArgumentArity.OneOrMore, HelpName = "arg" };
         public CliOption<bool> EnableGenericCycleDetection { get; } =
             new("--enable-generic-cycle-detection") { Description = SR.EnableGenericCycleDetection };
         public CliOption<int> GenericCycleDepthCutoff { get; } =
@@ -88,7 +88,7 @@ namespace ILCompiler
         public CliOption<int> GenericCycleBreadthCutoff { get; } =
             new("--maxgenericcyclebreadth") { DefaultValueFactory = _ => ReadyToRunCompilerContext.DefaultGenericCycleBreadthCutoff, Description = SR.GenericCycleBreadthCutoff };
         public CliOption<TargetOS> TargetOS { get; } =
-            new("--targetos") { CustomParser = result => Helpers.GetTargetOS(result.Tokens.Count > 0 ? result.Tokens[0].Value : null), DefaultValueFactory = result => Helpers.GetTargetOS(result.Tokens.Count > 0 ? result.Tokens[0].Value : null), Description = SR.TargetOSOption };
+            new("--targetos") { CustomParser = result => Helpers.GetTargetOS(result.Tokens.Count > 0 ? result.Tokens[0].Value : null), DefaultValueFactory = result => Helpers.GetTargetOS(result.Tokens.Count > 0 ? result.Tokens[0].Value : null), Description = SR.TargetOSOption, HelpName = "arg" };
         public CliOption<string> JitPath { get; } =
             new("--jitpath") { Description = SR.JitPathOption };
         public CliOption<bool> PrintReproInstructions { get; } =


### PR DESCRIPTION
By default S.CL list all enum values for every enum in help. It also list different kind of completions if they were defined. Example:

![image](https://github.com/dotnet/runtime/assets/6011991/5837366b-026d-4af3-bc3d-9f7d06824c31)

If we don't want that, we need to set what should be displayed in explicit way by using the `HelpName` property.

FWIW the code: https://github.com/dotnet/command-line-api/blob/f6ff2f1a94a58617e744f8fe0d469a2a420a6259/src/System.CommandLine/Help/HelpBuilder.Default.cs#L53-L73

fixes #88304