### PR TITLE
[mono] Remove mono_loader_save_bundled_library()

### DIFF
--- a/src/mono/mono/eglib/eglib-remap.h
+++ b/src/mono/mono/eglib/eglib-remap.h
@@ -209,7 +209,6 @@
 #define g_strndup monoeg_g_strndup
 #define g_strnfill monoeg_g_strnfill
 #define g_strnlen monoeg_g_strnlen
-#define g_str_from_file_region monoeg_g_str_from_file_region
 #define g_strreverse monoeg_g_strreverse
 #define g_strsplit monoeg_g_strsplit
 #define g_strsplit_set monoeg_g_strsplit_set

--- a/src/mono/mono/eglib/glib.h
+++ b/src/mono/mono/eglib/glib.h
@@ -362,7 +362,6 @@ gchar       *g_strchug        (gchar *str);
 gchar       *g_strchomp       (gchar *str);
 gchar       *g_strnfill       (gsize length, gchar fill_char);
 gsize        g_strnlen        (const char*, gsize);
-char        *g_str_from_file_region (int fd, guint64 offset, gsize size);
 
 void	     g_strdelimit     (char *string, char delimiter, char new_delimiter);
 

--- a/src/mono/mono/eglib/gstr.c
+++ b/src/mono/mono/eglib/gstr.c
@@ -904,35 +904,3 @@ g_strnlen (const char* s, gsize n)
 	for (i = 0; i < n && s [i]; ++i) ;
 	return i;
 }
-
-/**
- * Loads a chunk of data from the file pointed to by the
- * @fd starting at the file offset @offset for @size bytes
- * and returns an allocated version of that string, or NULL
- * on error.
- */
-char *
-g_str_from_file_region (int fd, guint64 offset, gsize size)
-{
-	char *buffer;
-	off_t loc;
-	int status;
-
-	do {
-		loc = lseek (fd, GUINT64_TO_LONG (offset), SEEK_SET);
-	} while (loc == -1 && errno == EINTR);
-	if (loc == -1)
-		return NULL;
-	buffer = (char *)g_malloc (size + 1);
-	if (buffer == NULL)
-		return NULL;
-	buffer [size] = 0;
-	do {
-		status = g_read (fd, buffer, size);
-	} while (status == -1 && errno == EINTR);
-	if (status == -1){
-		g_free (buffer);
-		return NULL;
-	}
-	return buffer;
-}

--- a/src/mono/mono/metadata/loader-internals.h
+++ b/src/mono/mono/metadata/loader-internals.h
@@ -309,9 +309,6 @@ mono_alc_get_all_loaded_assemblies (void);
 GPtrArray*
 mono_alc_get_all (void);
 
-MONO_API void
-mono_loader_save_bundled_library (int fd, uint64_t offset, uint64_t size, const char *destfname);
-
 MonoMemoryManager *
 mono_mem_manager_new (MonoAssemblyLoadContext **alcs, int nalcs, gboolean collectible);
 

--- a/src/mono/mono/metadata/native-library.c
+++ b/src/mono/mono/metadata/native-library.c
@@ -61,16 +61,6 @@ static MonoDl *internal_module; // used when pinvoking `__Internal`
 
 static PInvokeOverrideFn pinvoke_override;
 
-// Did we initialize the temporary directory for dynamic libraries
-// FIXME: this is racy
-static gboolean bundle_save_library_initialized;
-
-// List of bundled libraries we unpacked
-static GSList *bundle_library_paths;
-
-// Directory where we unpacked dynamic libraries
-static char *bundled_dylibrary_directory;
-
 /* Class lazy loading functions */
 GENERATE_GET_CLASS_WITH_CACHE (appdomain_unloaded_exception, "System", "AppDomainUnloadedException")
 GENERATE_TRY_GET_CLASS_WITH_CACHE (appdomain_unloaded_exception, "System", "AppDomainUnloadedException")
@@ -1461,63 +1451,6 @@ leave:
 	g_free (lib_path);
 
 	return handle;
-}
-
-#ifdef HAVE_ATEXIT
-static void
-delete_bundled_libraries (void)
-{
-	GSList *list;
-
-	for (list = bundle_library_paths; list != NULL; list = list->next){
-		unlink ((const char*)list->data);
-	}
-	rmdir (bundled_dylibrary_directory);
-}
-#endif
-
-static void
-bundle_save_library_initialize (void)
-{
-	bundle_save_library_initialized = TRUE;
-	char *path = g_build_filename (g_get_tmp_dir (), "mono-bundle-XXXXXX", (const char*)NULL);
-	bundled_dylibrary_directory = g_mkdtemp (path);
-	g_free (path);
-	if (bundled_dylibrary_directory == NULL)
-		return;
-#ifdef HAVE_ATEXIT
-	atexit (delete_bundled_libraries);
-#endif
-}
-
-void
-mono_loader_save_bundled_library (int fd, uint64_t offset, uint64_t size, const char *destfname)
-{
-	MonoDl *lib;
-	char *file, *buffer, *internal_path;
-	if (!bundle_save_library_initialized)
-		bundle_save_library_initialize ();
-
-	file = g_build_filename (bundled_dylibrary_directory, destfname, (const char*)NULL);
-	buffer = g_str_from_file_region (fd, offset, GUINT64_TO_SIZE (size));
-	g_file_set_contents (file, buffer, GUINT64_TO_SIZE (size), NULL);
-
-	ERROR_DECL (load_error);
-	lib = mono_dl_open (file, MONO_DL_LAZY, load_error);
-	if (!lib) {
-		fprintf (stderr, "Error loading shared library: %s %s\n", file, mono_error_get_message_without_fields (load_error));
-		mono_error_cleanup (load_error);
-		exit (1);
-	}
-	mono_error_assert_ok (load_error);
-
-	// Register the name with "." as this is how it will be found when embedded
-	internal_path = g_build_filename (".", destfname, (const char*)NULL);
- 	mono_loader_register_module (internal_path, lib);
-	g_free (internal_path);
-	bundle_library_paths = g_slist_append (bundle_library_paths, file);
-
-	g_free (buffer);
 }
 
 void


### PR DESCRIPTION
It was used by mkbundle in legacy Mono and is not used anymore in dotnet/runtime.