### PR TITLE
[release/7.0-staging][mono][debugger] Showing "Frame not in module" after vscode-js-debug bump on VS

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -407,6 +408,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             AuxData = auxData;
             SdbAgent = sdbAgent;
             PauseOnExceptions = pauseOnExceptions;
+            Destroyed = false;
         }
 
         public string DebugId { get; set; }
@@ -439,6 +441,8 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         internal int TempBreakpointForSetNextIP { get; set; }
         internal bool FirstBreakpoint { get; set; }
+
+        internal bool Destroyed { get; set; }
 
         public DebugStore Store
         {
@@ -485,5 +489,87 @@ namespace Microsoft.WebAssembly.Diagnostics
         public PerScopeCache()
         {
         }
+    }
+
+    internal sealed class ConcurrentExecutionContextDictionary
+    {
+        private ConcurrentDictionary<SessionId, ConcurrentBag<ExecutionContext>> contexts = new ();
+        public ExecutionContext GetCurrentContext(SessionId sessionId)
+            => TryGetCurrentExecutionContextValue(sessionId, out ExecutionContext context)
+                ? context
+                : throw new KeyNotFoundException($"No execution context found for session {sessionId}");
+
+        public bool TryGetCurrentExecutionContextValue(SessionId id, out ExecutionContext executionContext, bool ignoreDestroyedContext = true)
+        {
+            executionContext = null;
+            if (!contexts.TryGetValue(id, out ConcurrentBag<ExecutionContext> contextBag))
+                return false;
+            if (contextBag.IsEmpty)
+                return false;
+            IEnumerable<ExecutionContext> validContexts = null;
+            if (ignoreDestroyedContext)
+                validContexts = contextBag.Where(context => context.Destroyed == false);
+            else
+                validContexts = contextBag;
+            if (!validContexts.Any())
+                return false;
+            int maxId = validContexts.Max(context => context.Id);
+            executionContext = contextBag.FirstOrDefault(context => context.Id == maxId);
+            return executionContext != null;
+        }
+
+        public void OnDefaultContextUpdate(SessionId sessionId, ExecutionContext newContext)
+        {
+            if (TryGetAndAddContext(sessionId, newContext, out ExecutionContext previousContext))
+            {
+                foreach (KeyValuePair<string, BreakpointRequest> kvp in previousContext.BreakpointRequests)
+                {
+                    newContext.BreakpointRequests[kvp.Key] = kvp.Value.Clone();
+                }
+                newContext.PauseOnExceptions = previousContext.PauseOnExceptions;
+            }
+        }
+
+        public bool TryGetAndAddContext(SessionId sessionId, ExecutionContext newExecutionContext, out ExecutionContext previousExecutionContext)
+        {
+            bool hasExisting = TryGetCurrentExecutionContextValue(sessionId, out previousExecutionContext, ignoreDestroyedContext: false);
+            ConcurrentBag<ExecutionContext> bag = contexts.GetOrAdd(sessionId, _ => new ConcurrentBag<ExecutionContext>());
+            bag.Add(newExecutionContext);
+            return hasExisting;
+        }
+
+        public void CreateWorkerExecutionContext(SessionId workerSessionId, SessionId originSessionId, ILogger logger)
+        {
+            if (!TryGetCurrentExecutionContextValue(originSessionId, out ExecutionContext context))
+            {
+                logger.LogDebug($"Origin sessionId does not exist - {originSessionId}");
+                return;
+            }
+            if (contexts.ContainsKey(workerSessionId))
+            {
+                logger.LogDebug($"Worker sessionId already exists - {originSessionId}");
+                return;
+            }
+            contexts[workerSessionId] = new();
+            contexts[workerSessionId].Add(context.CreateChildAsyncExecutionContext(workerSessionId));
+             }
+
+        public void DestroyContext(SessionId sessionId, int id)
+        {
+            if (!contexts.TryGetValue(sessionId, out ConcurrentBag<ExecutionContext> contextBag))
+                return;
+            foreach (ExecutionContext context in contextBag.Where(x => x.Id == id).ToList())
+                context.Destroyed = true;
+        }
+
+        public void ClearContexts(SessionId sessionId)
+        {
+            if (!contexts.TryGetValue(sessionId, out ConcurrentBag<ExecutionContext> contextBag))
+                return;
+            foreach (ExecutionContext context in contextBag)
+                context.Destroyed = true;
+        }
+
+        public bool ContainsKey(SessionId sessionId) => contexts.ContainsKey(sessionId);
     }
 }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -538,22 +538,6 @@ namespace Microsoft.WebAssembly.Diagnostics
             return hasExisting;
         }
 
-        public void CreateWorkerExecutionContext(SessionId workerSessionId, SessionId originSessionId, ILogger logger)
-        {
-            if (!TryGetCurrentExecutionContextValue(originSessionId, out ExecutionContext context))
-            {
-                logger.LogDebug($"Origin sessionId does not exist - {originSessionId}");
-                return;
-            }
-            if (contexts.ContainsKey(workerSessionId))
-            {
-                logger.LogDebug($"Worker sessionId already exists - {originSessionId}");
-                return;
-            }
-            contexts[workerSessionId] = new();
-            contexts[workerSessionId].Add(context.CreateChildAsyncExecutionContext(workerSessionId));
-             }
-
         public void DestroyContext(SessionId sessionId, int id)
         {
             if (!contexts.TryGetValue(sessionId, out ConcurrentBag<ExecutionContext> contextBag))

--- a/src/mono/wasm/debugger/BrowserDebugProxy/Firefox/FirefoxMonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/Firefox/FirefoxMonoProxy.cs
@@ -23,7 +23,7 @@ internal sealed class FirefoxMonoProxy : MonoProxy
 
     public FirefoxExecutionContext GetContextFixefox(SessionId sessionId)
     {
-        if (contexts.TryGetValue(sessionId, out ExecutionContext context))
+        if (Contexts.TryGetCurrentExecutionContextValue(sessionId, out ExecutionContext context))
             return context as FirefoxExecutionContext;
         throw new ArgumentException($"Invalid Session: \"{sessionId}\"", nameof(sessionId));
     }
@@ -254,7 +254,7 @@ internal sealed class FirefoxMonoProxy : MonoProxy
         }
         if (args["frame"] != null && args["type"] == null)
         {
-            OnDefaultContextUpdate(sessionId, new FirefoxExecutionContext(new MonoSDBHelper (this, logger, sessionId), 0, args["frame"]["consoleActor"].Value<string>()));
+            Contexts.OnDefaultContextUpdate(sessionId, new FirefoxExecutionContext(new MonoSDBHelper (this, logger, sessionId), 0, args["frame"]["consoleActor"].Value<string>()));
             return false;
         }
 
@@ -317,7 +317,7 @@ internal sealed class FirefoxMonoProxy : MonoProxy
                 }
             case "target-available-form":
                 {
-                    OnDefaultContextUpdate(sessionId, new FirefoxExecutionContext(new MonoSDBHelper (this, logger, sessionId), 0, args["target"]["consoleActor"].Value<string>()));
+                    Contexts.OnDefaultContextUpdate(sessionId, new FirefoxExecutionContext(new MonoSDBHelper (this, logger, sessionId), 0, args["target"]["consoleActor"].Value<string>()));
                     break;
                 }
         }
@@ -334,7 +334,7 @@ internal sealed class FirefoxMonoProxy : MonoProxy
         {
             case "resume":
                 {
-                    if (!contexts.TryGetValue(sessionId, out ExecutionContext context))
+                    if (!Contexts.TryGetCurrentExecutionContextValue(sessionId, out ExecutionContext context))
                         return false;
                     context.PausedOnWasm = false;
                     if (context.CallStack == null)
@@ -396,7 +396,7 @@ internal sealed class FirefoxMonoProxy : MonoProxy
                 }
             case "setBreakpoint":
                 {
-                    if (!contexts.TryGetValue(sessionId, out ExecutionContext context))
+                    if (!Contexts.TryGetCurrentExecutionContextValue(sessionId, out ExecutionContext context))
                         return false;
                     var req = JObject.FromObject(new
                     {
@@ -436,7 +436,7 @@ internal sealed class FirefoxMonoProxy : MonoProxy
                 }
             case "removeBreakpoint":
                 {
-                    if (!contexts.TryGetValue(sessionId, out ExecutionContext context))
+                    if (!Contexts.TryGetCurrentExecutionContextValue(sessionId, out ExecutionContext context))
                         return false;
                     Result resp = await SendCommand(sessionId, "", args, token);
 

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -160,6 +160,12 @@ namespace Microsoft.WebAssembly.Diagnostics
                         return false;
                     }
 
+                case "Runtime.executionContextsCleared":
+                    {
+                        Contexts.ClearContexts(sessionId);
+                        return false;
+                    }
+
                 case "Debugger.paused":
                     {
                         // Don't process events from sessions we aren't tracking
@@ -1466,7 +1472,16 @@ namespace Microsoft.WebAssembly.Diagnostics
             {
                 if (req.TryResolve(source))
                 {
-                    await SetBreakpoint(sessionId, context.store, req, true, false, token);
+                    try
+                    {
+                        await SetBreakpoint(sessionId, context.store, req, true, false, token);
+                    }
+                    catch (DebuggerAgentException e)
+                    {
+                        //it's not a wasm page then the command throws an error
+                        if (!e.Message.Contains("getDotnetRuntime is not defined"))
+                            logger.LogDebug($"Unexpected error on OnSourceFileAdded {e}");
+                    }
                 }
             }
         }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -20,7 +20,7 @@ namespace Microsoft.WebAssembly.Diagnostics
     {
         private IList<string> urlSymbolServerList;
         private HashSet<SessionId> sessions = new HashSet<SessionId>();
-        protected Dictionary<SessionId, ExecutionContext> contexts = new Dictionary<SessionId, ExecutionContext>();
+        internal ConcurrentExecutionContextDictionary Contexts = new ();
 
         public static HttpClient HttpClient => new HttpClient();
 
@@ -39,26 +39,11 @@ namespace Microsoft.WebAssembly.Diagnostics
             _defaultPauseOnExceptions = PauseOnExceptionsKind.Unset;
         }
 
-        internal ExecutionContext GetContext(SessionId sessionId)
-        {
-            if (contexts.TryGetValue(sessionId, out ExecutionContext context))
-                return context;
-
-            throw new ArgumentException($"Invalid Session: \"{sessionId}\"", nameof(sessionId));
-        }
-
-        private bool UpdateContext(SessionId sessionId, ExecutionContext executionContext, out ExecutionContext previousExecutionContext)
-        {
-            bool previous = contexts.TryGetValue(sessionId, out previousExecutionContext);
-            contexts[sessionId] = executionContext;
-            return previous;
-        }
-
         internal virtual Task<Result> SendMonoCommand(SessionId id, MonoCommands cmd, CancellationToken token) => SendCommand(id, "Runtime.evaluate", JObject.FromObject(cmd), token);
 
         internal void SendLog(SessionId sessionId, string message, CancellationToken token, string type = "warning")
         {
-            if (!contexts.TryGetValue(sessionId, out ExecutionContext context))
+            if (!Contexts.TryGetCurrentExecutionContextValue(sessionId, out ExecutionContext context))
                 return;
             /*var o = JObject.FromObject(new
             {
@@ -93,7 +78,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 case "Runtime.consoleAPICalled":
                     {
                         // Don't process events from sessions we aren't tracking
-                        if (!contexts.TryGetValue(sessionId, out ExecutionContext context))
+                        if (!Contexts.TryGetCurrentExecutionContextValue(sessionId, out ExecutionContext context))
                             return false;
                         string type = args["type"]?.ToString();
                         if (type == "debug")
@@ -169,10 +154,16 @@ namespace Microsoft.WebAssembly.Diagnostics
                         return true;
                     }
 
+                case "Runtime.executionContextDestroyed":
+                    {
+                        Contexts.DestroyContext(sessionId, args["executionContextId"].Value<int>());
+                        return false;
+                    }
+
                 case "Debugger.paused":
                     {
                         // Don't process events from sessions we aren't tracking
-                        if (!contexts.ContainsKey(sessionId))
+                        if (!Contexts.ContainsKey(sessionId))
                             return false;
 
                         if (args?["callFrames"]?.Value<JArray>()?.Count == 0)
@@ -254,7 +245,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         }
         protected async Task<bool> IsRuntimeAlreadyReadyAlready(SessionId sessionId, CancellationToken token)
         {
-            if (contexts.TryGetValue(sessionId, out ExecutionContext context) && context.IsRuntimeReady)
+            if (Contexts.TryGetCurrentExecutionContextValue(sessionId, out ExecutionContext context) && context.IsRuntimeReady)
                 return true;
 
             Result res = await SendMonoCommand(sessionId, MonoCommands.IsRuntimeReady(RuntimeId), token);
@@ -277,7 +268,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             if (id == SessionId.Null)
                 await AttachToTarget(id, token);
 
-            if (!contexts.TryGetValue(id, out ExecutionContext context))
+            if (!Contexts.TryGetCurrentExecutionContextValue(id, out ExecutionContext context))
             {
                 if  (method == "Debugger.setPauseOnExceptions")
                 {
@@ -595,7 +586,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         private async Task<bool> ApplyUpdates(MessageId id, JObject args, CancellationToken token)
         {
-            var context = GetContext(id);
+            var context = Contexts.GetCurrentContext(id);
             string moduleGUID = args["moduleGUID"]?.Value<string>();
             string dmeta = args["dmeta"]?.Value<string>();
             string dil = args["dil"]?.Value<string>();
@@ -664,7 +655,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         private async Task<bool> CallOnFunction(MessageId id, JObject args, CancellationToken token)
         {
-            var context = GetContext(id);
+            var context = Contexts.GetCurrentContext(id);
             if (!DotnetObjectId.TryParse(args["objectId"], out DotnetObjectId objectId)) {
                 return false;
             }
@@ -728,7 +719,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         private async Task<bool> OnSetVariableValue(MessageId id, int scopeId, string varName, JToken varValue, CancellationToken token)
         {
-            ExecutionContext context = GetContext(id);
+            ExecutionContext context = Contexts.GetCurrentContext(id);
             Frame scope = context.CallStack.FirstOrDefault(s => s.Id == scopeId);
             if (scope == null)
                 return false;
@@ -748,7 +739,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         internal async Task<ValueOrError<GetMembersResult>> RuntimeGetObjectMembers(SessionId id, DotnetObjectId objectId, JToken args, CancellationToken token, bool sortByAccessLevel = false)
         {
-            var context = GetContext(id);
+            var context = Contexts.GetCurrentContext(id);
             GetObjectCommandOptions getObjectOptions = GetObjectCommandOptions.WithProperties;
             if (args != null)
             {
@@ -1072,7 +1063,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             if (!res.IsOk)
                 return false;
 
-            ExecutionContext context = GetContext(sessionId);
+            ExecutionContext context = Contexts.GetCurrentContext(sessionId);
             byte[] newBytes = Convert.FromBase64String(res.Value?["result"]?["value"]?["value"]?.Value<string>());
             using var retDebuggerCmdReader = new MonoBinaryReader(newBytes);
             retDebuggerCmdReader.ReadBytes(11); //skip HEADER_LEN
@@ -1148,7 +1139,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         internal async Task<MethodInfo> LoadSymbolsOnDemand(AssemblyInfo asm, int method_token, SessionId sessionId, CancellationToken token)
         {
-            ExecutionContext context = GetContext(sessionId);
+            ExecutionContext context = Contexts.GetCurrentContext(sessionId);
             if (urlSymbolServerList.Count == 0)
                 return null;
             if (asm.TriedToLoadSymbolsOnDemand || !asm.CodeViewInformationAvailable)
@@ -1189,29 +1180,17 @@ namespace Microsoft.WebAssembly.Diagnostics
             return null;
         }
 
-        protected void OnDefaultContextUpdate(SessionId sessionId, ExecutionContext context)
-        {
-            if (UpdateContext(sessionId, context, out ExecutionContext previousContext))
-            {
-                foreach (KeyValuePair<string, BreakpointRequest> kvp in previousContext.BreakpointRequests)
-                {
-                    context.BreakpointRequests[kvp.Key] = kvp.Value.Clone();
-                }
-                context.PauseOnExceptions = previousContext.PauseOnExceptions;
-            }
-        }
-
         protected async Task OnDefaultContext(SessionId sessionId, ExecutionContext context, CancellationToken token)
         {
             Log("verbose", "Default context created, clearing state and sending events");
-            OnDefaultContextUpdate(sessionId, context);
+            Contexts.OnDefaultContextUpdate(sessionId, context);
             if (await IsRuntimeAlreadyReadyAlready(sessionId, token))
                 await RuntimeReady(sessionId, token);
         }
 
         protected async Task OnResume(MessageId msg_id, CancellationToken token)
         {
-            ExecutionContext context = GetContext(msg_id);
+            ExecutionContext context = Contexts.GetCurrentContext(msg_id);
             if (context.CallStack != null)
             {
                 // Stopped on managed code
@@ -1219,13 +1198,13 @@ namespace Microsoft.WebAssembly.Diagnostics
             }
 
             //discard managed frames
-            GetContext(msg_id).ClearState();
+            Contexts.GetCurrentContext(msg_id).ClearState();
         }
 
 
         protected async Task<bool> Step(MessageId msgId, StepKind kind, CancellationToken token)
         {
-            ExecutionContext context = GetContext(msgId);
+            ExecutionContext context = Contexts.GetCurrentContext(msgId);
             if (context.CallStack == null)
                 return false;
 
@@ -1295,7 +1274,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 var assembly_data = Convert.FromBase64String(assembly_b64);
                 var pdb_data = string.IsNullOrEmpty(pdb_b64) ? null : Convert.FromBase64String(pdb_b64);
 
-                var context = GetContext(sessionId);
+                var context = Contexts.GetCurrentContext(sessionId);
                 foreach (var source in store.Add(sessionId, assembly_name, assembly_data, pdb_data, token))
                 {
                     await OnSourceFileAdded(sessionId, source, context, token);
@@ -1314,7 +1293,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         {
             try
             {
-                ExecutionContext context = GetContext(sessionId);
+                ExecutionContext context = Contexts.GetCurrentContext(sessionId);
 
                 var argsNew = JObject.FromObject(new
                 {
@@ -1380,7 +1359,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         {
             try
             {
-                ExecutionContext context = GetContext(msg_id);
+                ExecutionContext context = Contexts.GetCurrentContext(msg_id);
                 if (context.CallStack == null)
                     return false;
 
@@ -1426,7 +1405,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         {
             try
             {
-                ExecutionContext context = GetContext(msg_id);
+                ExecutionContext context = Contexts.GetCurrentContext(msg_id);
                 Frame scope = context.CallStack.FirstOrDefault(s => s.Id == scopeId);
                 if (scope == null)
                     return Result.Err(JObject.FromObject(new { message = $"Could not find scope with id #{scopeId}" }));
@@ -1457,7 +1436,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         private async Task<Breakpoint> SetMonoBreakpoint(SessionId sessionId, string reqId, SourceLocation location, string condition, CancellationToken token)
         {
-            var context = GetContext(sessionId);
+            var context = Contexts.GetCurrentContext(sessionId);
             var bp = new Breakpoint(reqId, location, condition, BreakpointState.Pending);
             string asm_name = bp.Location.IlLocation.Method.Assembly.Name;
             int method_token = bp.Location.IlLocation.Method.Token;
@@ -1494,7 +1473,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         internal virtual async Task<DebugStore> LoadStore(SessionId sessionId, bool tryUseDebuggerProtocol, CancellationToken token)
         {
-            ExecutionContext context = GetContext(sessionId);
+            ExecutionContext context = Contexts.GetCurrentContext(sessionId);
 
             if (Interlocked.CompareExchange(ref context.store, new DebugStore(this, logger), null) != null)
                 return await context.Source.Task;
@@ -1555,7 +1534,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         {
             try
             {
-                ExecutionContext context = GetContext(sessionId);
+                ExecutionContext context = Contexts.GetCurrentContext(sessionId);
                 if (Interlocked.CompareExchange(ref context.ready, new TaskCompletionSource<DebugStore>(), null) != null)
                     return await context.ready.Task;
                 await context.SdbAgent.SendDebuggerAgentCommand(CmdEventRequest.ClearAllBreakpoints, null, token);
@@ -1607,7 +1586,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         private async Task ResetBreakpoint(SessionId msg_id, DebugStore store, MethodInfo method, CancellationToken token)
         {
-            ExecutionContext context = GetContext(msg_id);
+            ExecutionContext context = Contexts.GetCurrentContext(msg_id);
             foreach (var req in context.BreakpointRequests.Values)
             {
                 if (req.Method != null)
@@ -1632,7 +1611,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         {
             string bpid = args?["breakpointId"]?.Value<string>();
 
-            ExecutionContext context = GetContext(msg_id);
+            ExecutionContext context = Contexts.GetCurrentContext(msg_id);
             if (!context.BreakpointRequests.TryGetValue(bpid, out BreakpointRequest breakpointRequest))
                 return;
 
@@ -1654,7 +1633,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         protected async Task SetBreakpoint(SessionId sessionId, DebugStore store, BreakpointRequest req, bool sendResolvedEvent, bool fromEnC, CancellationToken token)
         {
-            ExecutionContext context = GetContext(sessionId);
+            ExecutionContext context = Contexts.GetCurrentContext(sessionId);
             if ((!fromEnC && req.Locations.Any()) || (fromEnC && req.Locations.Any(bp => bp.State == BreakpointState.Active)))
             {
                 if (!fromEnC)
@@ -1737,7 +1716,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         private async Task<bool> OnSetNextIP(MessageId sessionId, SourceLocation targetLocation, CancellationToken token)
         {
             DebugStore store = await RuntimeReady(sessionId, token);
-            ExecutionContext context = GetContext(sessionId);
+            ExecutionContext context = Contexts.GetCurrentContext(sessionId);
             Frame scope = context.CallStack.First<Frame>();
 
             SourceLocation foundLocation = DebugStore.FindBreakpointLocations(targetLocation, targetLocation, scope.Method.Info)

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -1581,7 +1581,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         public JToken GetEvaluationResultProperties(string id)
         {
-            ExecutionContext context = proxy.GetContext(sessionId);
+            ExecutionContext context = proxy.Contexts.GetCurrentContext(sessionId);
             var resolver = new MemberReferenceResolver(proxy, context, sessionId, context.CallStack.First().Id, logger);
             var evaluationResult = resolver.TryGetEvaluationResult(id);
             return evaluationResult["value"];
@@ -1602,7 +1602,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
                 var stringId = getCAttrsRetReader.ReadInt32();
                 var dispAttrStr = await GetStringValue(stringId, token);
-                ExecutionContext context = proxy.GetContext(sessionId);
+                ExecutionContext context = proxy.Contexts.GetCurrentContext(sessionId);
                 GetMembersResult members = await GetTypeMemberValues(
                     dotnetObjectId,
                     GetObjectCommandOptions.WithProperties | GetObjectCommandOptions.ForDebuggerDisplayAttribute,


### PR DESCRIPTION
Backport #87154 #87870 #87979

Customer Impact
Fixes https://github.com/dotnet/runtime/issues/87407.
ExecutionContextDestroy and ExecutionContextCleared were CDP messages ignored by vscode-js-debug, and now they implemented the correct support for it, so we also need to implement the correct support on BrowserDebugProxy otherwise it will not be possible to debug Blazor apps with authentication.

Testing:
Try setting a breakpoint on a page guarded by authentication.

Risk
Medium, It's removing the debugging contexts that are not valid anymore.