### PR TITLE
Remove TODO from a comment in System.Guid.cs

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -1420,7 +1420,6 @@ namespace System
                     // Now we can create a "z" vector by selecting 12 values starting from the 9th element (index 0x08) and
                     // leaving gaps for dashes. Thus, the wider look-up table allows combining two shuffles, as used in the
                     // generic else-case, into a single instruction on Arm64.
-                    // TODO: Check if the JIT can merge the consecutive table look-ups and avoid the Arm64 specific if-case.
                     Vector128<byte> mid = AdvSimd.Arm64.VectorTableLookup((hexLow, hexHigh),
                         Vector128.Create(0x0D0CFF0B0A0908FF, 0xFF13121110FF0F0E).AsByte());
                     vecZ = (mid | dashesMask);


### PR DESCRIPTION
As requested in a review [comment](https://github.com/dotnet/runtime/pull/87126#discussion_r1246508468).