### PR TITLE
Permit trailing data after PKCS12 on iOS

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.ImportExport.iOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.ImportExport.iOS.cs
@@ -22,7 +22,9 @@ namespace System.Security.Cryptography.X509Certificates
                     {
                         using (var manager = new PointerMemoryManager<byte>(pin, rawData.Length))
                         {
-                            PfxAsn.Decode(manager.Memory, AsnEncodingRules.BER);
+                            // Permit trailing data after the PKCS12.
+                            AsnValueReader reader = new AsnValueReader(rawData, AsnEncodingRules.BER);
+                            PfxAsn.Decode(ref reader, manager.Memory, out _);
                         }
 
                         return true;

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/PfxIterationCountTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/PfxIterationCountTests.cs
@@ -130,7 +130,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/88050", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void Import_BlobHasMoreThanOnePfx_LoadsOnlyOne()
         {
             // These certs don't use PBES2 so they should be supported everywhere.


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/88050. Reverts https://github.com/dotnet/runtime/pull/88146.