### PR TITLE
[DO NOT MERGE] Don't block Android builds from configuring/using a cross compiler

### DIFF
--- a/eng/native/build-commons.sh
+++ b/eng/native/build-commons.sh
@@ -78,7 +78,7 @@ build_native()
         cmakeArgs="-DCMAKE_SYSTEM_VARIANT=maccatalyst $cmakeArgs"
     fi
 
-    if [[ ( "$targetOS" == android || "$targetOS" == linux-bionic ) && -z "$ROOTFS_DIR" ]]; then
+    if [[ ( "$targetOS" == android || "$targetOS" == linux-bionic )]]; then
         if [[ -z "$ANDROID_NDK_ROOT" ]]; then
             echo "Error: You need to set the ANDROID_NDK_ROOT environment variable pointing to the Android NDK root."
             exit 1

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -772,7 +772,7 @@
 
     <!-- Android specific options -->
     <PropertyGroup Condition="'$(TargetsAndroid)' == 'true' or '$(TargetsLinuxBionic)' == 'true'">
-      <_MonoSkipInitCompiler>true</_MonoSkipInitCompiler>
+      <_MonoSkipInitCompiler>false</_MonoSkipInitCompiler>
 
       <MonoUseCrossTool>true</MonoUseCrossTool>
       <MonoAotCMakeSysroot Condition="Exists('$(ANDROID_NDK_ROOT)/sysroot')">$(ANDROID_NDK_ROOT)/sysroot</MonoAotCMakeSysroot>


### PR DESCRIPTION
Closes: https://github.com/dotnet/runtime/issues/88344
Blocking on: https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/901