### PR TITLE
Fix libraries Windows test runner script

### DIFF
--- a/eng/testing/RunnerTemplate.cmd
+++ b/eng/testing/RunnerTemplate.cmd
@@ -1,5 +1,5 @@
 ﻿@echo off
-setlocal enabledelayedexpansion
+setlocal ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
 
 set EXECUTION_DIR=%~dp0
 
@@ -44,6 +44,9 @@ set EXECUTION_DIR=%~dp0
 :: Don't use a globally installed SDK.
 set DOTNET_MULTILEVEL_LOOKUP=0
 
+:: Assume failure
+set HAS_TEST_RESULTS=0
+
 :: ========================= BEGIN Test Execution =============================
 echo ----- start %DATE% %TIME% ===============  To repro directly: =====================================================
 echo pushd %EXECUTION_DIR%
@@ -53,22 +56,23 @@ echo ===========================================================================
 pushd %EXECUTION_DIR%
 @echo on
 [[RunCommands]]
+@set _exit_code=%ERRORLEVEL%
 @echo off
 if exist testResults.xml (
-  set "HAS_TEST_RESULTS=1"
+  set HAS_TEST_RESULTS=1
 )
 popd
-echo ----- end %DATE% %TIME% ----- exit code %ERRORLEVEL% ----------------------------------------------------------
+echo ----- end %DATE% %TIME% ----- exit code %_exit_code% ----------------------------------------------------------
 :: The helix work item should not exit with non-zero if tests ran and produced results
 :: The special console runner for runtime returns 1 when tests fail
-if %ERRORLEVEL%==1 (
+if %_exit_code%==1 (
   if %HAS_TEST_RESULTS%==1 (
     if not "%HELIX_WORKITEM_PAYLOAD%"=="" (
       exit /b 0
     )
   )
 )
-exit /b %ERRORLEVEL%
+exit /b %_exit_code%
 :: ========================= END Test Execution =================================
 
 :usage


### PR DESCRIPTION
Having HAS_TEST_RESULTS unset leads to a Windows CMD script syntax error.

Clean up a few other things while there:
1. Explicitly set ENABLEEXTENSIONS
2. Set a variable to the test exit code. There's an unsafe assumption currently that `%ERRORLEVEL%` doesn't change between the test run and all of the subsequent uses.
3. Remove unnecessary quotes around setting `HAS_TEST_RESULTS=1`

Fixes #88353