### PR TITLE
Shrink column width in `ilc --help`

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -134,9 +134,9 @@ namespace ILCompiler
         public CliOption<bool> RootDefaultAssemblies { get; } =
             new("--defaultrooting") { Description = "Root assemblies that are not marked [IsTrimmable]" };
         public CliOption<TargetArchitecture> TargetArchitecture { get; } =
-            new("--targetarch") { CustomParser = result => Helpers.GetTargetArchitecture(result.Tokens.Count > 0 ? result.Tokens[0].Value : null), DefaultValueFactory = result => Helpers.GetTargetArchitecture(result.Tokens.Count > 0 ? result.Tokens[0].Value : null), Description = "Target architecture for cross compilation" };
+            new("--targetarch") { CustomParser = result => Helpers.GetTargetArchitecture(result.Tokens.Count > 0 ? result.Tokens[0].Value : null), DefaultValueFactory = result => Helpers.GetTargetArchitecture(result.Tokens.Count > 0 ? result.Tokens[0].Value : null), Description = "Target architecture for cross compilation", HelpName = "arg" };
         public CliOption<TargetOS> TargetOS { get; } =
-            new("--targetos") { CustomParser = result => Helpers.GetTargetOS(result.Tokens.Count > 0 ? result.Tokens[0].Value : null), DefaultValueFactory = result => Helpers.GetTargetOS(result.Tokens.Count > 0 ? result.Tokens[0].Value : null), Description = "Target OS for cross compilation" };
+            new("--targetos") { CustomParser = result => Helpers.GetTargetOS(result.Tokens.Count > 0 ? result.Tokens[0].Value : null), DefaultValueFactory = result => Helpers.GetTargetOS(result.Tokens.Count > 0 ? result.Tokens[0].Value : null), Description = "Target OS for cross compilation", HelpName = "arg" };
         public CliOption<string> JitPath { get; } =
             new("--jitpath") { Description = "Path to JIT compiler library" };
         public CliOption<string> SingleMethodTypeName { get; } =


### PR DESCRIPTION
Goes from:
<img width="1363" alt="image" src="https://github.com/dotnet/runtime/assets/3840695/1d3c241f-278f-4802-8543-1719b4bdfd2c">
to:
<img width="1711" alt="image" src="https://github.com/dotnet/runtime/assets/3840695/ec076f5c-aa24-4cd6-8225-0bde20ff1bf2">

Fixes https://github.com/dotnet/runtime/issues/88304

Note: we already print these lines at the bottom of help:
<img width="1144" alt="image" src="https://github.com/dotnet/runtime/assets/3840695/63a38549-d229-4fad-8ac7-56cd101348dd">

so we are not missing this info.