### PR TITLE
Update missing runtime/framework install URL to use host RID

### DIFF
--- a/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
@@ -367,6 +367,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
                 result.Should().Fail()
                     .And.HaveStdErrContaining($"https://aka.ms/dotnet-core-applaunch?{expectedUrlQuery}")
+                    .And.HaveStdErrContaining($"&rid={RepoDirectoriesProvider.Default.BuildRID}")
                     .And.HaveStdErrContaining(expectedStdErr);
 
                 // Some Unix systems will have 8 bit exit codes.
@@ -414,6 +415,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                     .And.HaveStdErrContaining($"Showing error dialog for application: '{Path.GetFileName(appExe)}' - error code: 0x{expectedErrorCode}")
                     .And.HaveStdErrContaining($"url: 'https://aka.ms/dotnet-core-applaunch?{expectedUrlQuery}")
                     .And.HaveStdErrContaining("&gui=true")
+                    .And.HaveStdErrContaining($"&rid={RepoDirectoriesProvider.Default.BuildRID}")
                     .And.HaveStdErrMatching($"details: (?>.|\\s)*{System.Text.RegularExpressions.Regex.Escape(expectedMissingFramework)}");
             }
         }

--- a/src/native/corehost/fxr/command_line.cpp
+++ b/src/native/corehost/fxr/command_line.cpp
@@ -282,14 +282,17 @@ int command_line::parse_args_for_sdk_command(
 
 void command_line::print_muxer_info(const pal::string_t &dotnet_root, const pal::string_t &global_json_path)
 {
+    const pal::char_t* arch = get_current_arch_name();
     pal::string_t commit = _STRINGIFY(REPO_COMMIT_HASH);
     trace::println(_X("\n")
         _X("Host:\n")
         _X("  Version:      ") _STRINGIFY(HOST_FXR_PKG_VER) _X("\n")
         _X("  Architecture: %s\n")
-        _X("  Commit:       %s"),
-        get_current_arch_name(),
-        commit.substr(0, 10).c_str());
+        _X("  Commit:       %s\n")
+        _X("  RID:          ") _STRINGIFY(HOST_RID_PLATFORM) _X("-%s"),
+        arch,
+        commit.substr(0, 10).c_str(),
+        arch);
 
     trace::println(_X("\n")
         _X(".NET SDKs installed:"));

--- a/src/native/corehost/hostmisc/pal.h
+++ b/src/native/corehost/hostmisc/pal.h
@@ -90,6 +90,15 @@
 #define PATH_MAX    4096
 #endif
 
+#if defined(TARGET_WINDOWS)
+    #define HOST_RID_PLATFORM "win"
+#elif defined(TARGET_OSX)
+    #define HOST_RID_PLATFORM "osx"
+#elif defined(TARGET_ANDROID)
+    #define HOST_RID_PLATFORM "linux-bionic"
+#else
+    #define HOST_RID_PLATFORM FALLBACK_HOST_OS
+#endif
 
 namespace pal
 {

--- a/src/native/corehost/hostmisc/utils.cpp
+++ b/src/native/corehost/hostmisc/utils.cpp
@@ -465,11 +465,18 @@ pal::string_t get_download_url(const pal::char_t* framework_name, const pal::cha
         url.append(_X("missing_runtime=true"));
     }
 
+    const pal::char_t* arch = get_current_arch_name();
     url.append(_X("&arch="));
-    url.append(get_current_arch_name());
-    pal::string_t rid = get_current_runtime_id(true /*use_fallback*/);
-    url.append(_X("&rid="));
-    url.append(rid);
+    url.append(arch);
+    url.append(_X("&rid=") _STRINGIFY(HOST_RID_PLATFORM) _X("-"));
+    url.append(arch);
+
+    pal::string_t os = pal::get_current_os_rid_platform();
+    if (os.empty())
+        os = pal::get_current_os_fallback_rid();
+
+    url.append(_X("&os="));
+    url.append(os);
 
     return url;
 }

--- a/src/native/corehost/hostpolicy/deps_format.cpp
+++ b/src/native/corehost/hostpolicy/deps_format.cpp
@@ -190,17 +190,17 @@ namespace
     const pal::char_t* s_host_rids[] =
     {
 #if defined(TARGET_WINDOWS)
-        RID_CURRENT_ARCH_LIST("win")
+        RID_CURRENT_ARCH_LIST(HOST_RID_PLATFORM)
 #elif defined(TARGET_OSX)
-        RID_CURRENT_ARCH_LIST("osx")
+        RID_CURRENT_ARCH_LIST(HOST_RID_PLATFORM)
         RID_CURRENT_ARCH_LIST("unix")
 #elif defined(TARGET_ANDROID)
-        RID_CURRENT_ARCH_LIST("linux-bionic")
+        RID_CURRENT_ARCH_LIST(HOST_RID_PLATFORM)
         RID_CURRENT_ARCH_LIST("linux")
         RID_CURRENT_ARCH_LIST("unix")
 #else
         // Covers non-portable RIDs
-        RID_CURRENT_ARCH_LIST(FALLBACK_HOST_OS)
+        RID_CURRENT_ARCH_LIST(HOST_RID_PLATFORM)
 #if defined(TARGET_LINUX_MUSL)
         RID_CURRENT_ARCH_LIST("linux-musl")
         RID_CURRENT_ARCH_LIST("linux")


### PR DESCRIPTION
Update the install URL to use the host RID instead of the computed current RID.

Examples:
```
https://aka.ms/dotnet-core-applaunch?missing_runtime=true&arch=x64&rid=linux-x64&os=ubuntu.22.04&apphost_version=8.0.0-dev
https://aka.ms/dotnet-core-applaunch?missing_runtime=true&arch=x64&rid=win-x64&os=win10&apphost_version=8.0.0-dev

https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=7.0.0&arch=x64&rid=linux-x64&os=ubuntu.22.04
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=7.0.0&arch=x64&rid=win-x64&os=win10
```

cc @richlander

Fixes https://github.com/dotnet/runtime/issues/88223