### PR TITLE
Remove conservative generic scanning logic

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1202,13 +1202,12 @@ namespace Internal.JitInterface
                 }
             }
 
-#if READYTORUN
             // Add an early CanInline check to see if referring to the IL of the target methods is
             // permitted from within this MethodBeingCompiled, the full CanInline check will be performed
             // later.
             if (!_compilation.CanInline(MethodBeingCompiled, method))
                 return false;
-#endif
+
             MethodIL methodIL = method.IsUnboxingThunk() ? null : _compilation.GetMethodIL(method);
             return Get_CORINFO_METHOD_INFO(method, methodIL, info);
         }


### PR DESCRIPTION
@EgorBo's #88025 made it possible to undo conservative scanning logic added in dotnet/corert#7618.

Saves 0.4% in size for Stage1 and Stage2 apps.

Cc @dotnet/ilc-contrib 