### PR TITLE
Fix writing of WCHAR strings to event pipe buffer in nativeaot

### DIFF
--- a/src/coreclr/nativeaot/Runtime/eventpipe/dotnetruntime.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/dotnetruntime.cpp
@@ -64,6 +64,23 @@ bool WriteToBuffer(const BYTE *src, size_t len, BYTE *&buffer, size_t& offset, s
     return true;
 }
 
+bool WriteToBuffer(const WCHAR* str, BYTE *&buffer, size_t& offset, size_t& size, bool &fixedBuffer)
+{
+    if (str == NULL)
+        return true;
+
+    size_t byteCount = (ep_rt_utf16_string_len(reinterpret_cast<const ep_char16_t*>(str)) + 1) * sizeof(*str);
+    if (offset + byteCount > size)
+    {
+        if (!ResizeBuffer(buffer, size, offset, size + byteCount, fixedBuffer))
+            return false;
+    }
+
+    memcpy(buffer + offset, str, byteCount);
+    offset += byteCount;
+    return true;
+}
+
 bool ResizeBuffer(BYTE *&buffer, size_t& size, size_t currLen, size_t newSize, bool &fixedBuffer)
 {
     newSize = (size_t)(newSize * 1.5);


### PR DESCRIPTION
Add an overload of `WriteToBuffer` specifically for handling `const WCHAR*` (treating it as a string instead of a single value).

Tested manually by taking the part of https://github.com/dotnet/runtime/pull/87785 for `ExceptionThrown_V1` (existing events before that PR don't have values of interest).

@LakshanF feel free to roll this into your PR and get rid of this one if you want

Fixes https://github.com/dotnet/runtime/issues/87978