### PR TITLE
Allow inlining array methods

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
@@ -636,6 +636,11 @@ namespace ILCompiler
                     {
                         TypeDesc type = eetypeNode.Type;
                         _constructedTypes.Add(type);
+
+                        // It's convenient to also see Array<T> as constructed for each T[]
+                        DefType closestDefType = type.GetClosestDefType();
+                        if (closestDefType != type)
+                            _constructedTypes.Add(closestDefType);
                     }
                 }
             }


### PR DESCRIPTION
`CanInline` would return false to methods that implement generic interfaces on arrays because we didn't consider the magic `Array<T>` types constructed.

For:

```csharp
static int Main()
{
    IReadOnlyCollection<int> l = new int[] { 1, 2, 3 };
    return l.Count;
}
```

Before:

```asm
       sub      rsp, 40
                                                ;; size=4 bbWeight=1 PerfScore 0.25
G_M24375_IG02:  ;; offset=0004H
       lea      rcx, [(reloc 0x4000000000420a70)]      ; int[]
       mov      edx, 3
       call     CORINFO_HELP_NEWARR_1_VC
       lea      rcx, [(reloc 0x4000000000420aa8)]      ; const ptr
       mov      rdx, qword ptr [rcx]
       mov      qword ptr [rax+10H], rdx
       mov      rdx, qword ptr [rcx+04H]
       mov      qword ptr [rax+14H], rdx
       mov      rcx, rax
       call     System.Array`1[int]:get_Count():int:this
       nop
                                                ;; size=48 bbWeight=1 PerfScore 9.75
G_M24375_IG03:  ;; offset=0034H
       add      rsp, 40
       ret
```

After:

```asm
       sub      rsp, 40
                                                ;; size=4 bbWeight=1 PerfScore 0.25
G_M24375_IG02:  ;; offset=0004H
       lea      rcx, [(reloc 0x4000000000420a70)]      ; int[]
       mov      edx, 3
       call     CORINFO_HELP_NEWARR_1_VC
       lea      rcx, [(reloc 0x4000000000420aa8)]      ; const ptr
       mov      rdx, qword ptr [rcx]
       mov      qword ptr [rax+10H], rdx
       mov      rdx, qword ptr [rcx+04H]
       mov      qword ptr [rax+14H], rdx
       mov      eax, 3
                                                ;; size=44 bbWeight=1 PerfScore 8.50
G_M24375_IG03:  ;; offset=0030H
       add      rsp, 40
       ret
```

Cc @EgorBo if the useless array allocation is something worth going after.

Also, I was mildly surprised we're writing past the end of the array here, but I guess it's okay?

Cc @dotnet/ilc-contrib 